### PR TITLE
Refine type hints for SDK function signatures

### DIFF
--- a/python_sdk/infrahub_client/__init__.py
+++ b/python_sdk/infrahub_client/__init__.py
@@ -179,7 +179,7 @@ class RelatedNode:
 
             setattr(self, prop, data.get(f"_relation__{prop}", None))
 
-    def _generate_input_data(self):
+    def _generate_input_data(self) -> Dict[str, Any]:
         data = {}
 
         if self.id is not None:
@@ -221,7 +221,7 @@ class RelationshipManager:
         for item in data:
             self.peers.append(RelatedNode(name=name, schema=schema, data=item))
 
-    def add(self, data: Union[str, RelatedNode, dict]):
+    def add(self, data: Union[str, RelatedNode, dict]) -> None:
         """Add a new peer to this relationship.
         Need to check if the peer is already present
         """
@@ -230,7 +230,7 @@ class RelationshipManager:
         # that we are not adding a node that already exist
         self.peers.append(RelatedNode(schema=self.schema, data=data))
 
-    def remove(self, data):
+    def remove(self, data: Any) -> None:
         pass
 
     def _generate_input_data(self) -> List[Dict]:
@@ -421,10 +421,12 @@ class InfrahubClient:  # pylint: disable=too-many-public-methods
             self.address = ""
 
     @classmethod
-    async def init(cls, *args, **kwargs):
+    async def init(cls, *args: Any, **kwargs: Any) -> InfrahubClient:
         return cls(*args, **kwargs)
 
-    async def create(self, kind: str, data: Optional[dict] = None, branch: Optional[str] = None, **kwargs):
+    async def create(
+        self, kind: str, data: Optional[dict] = None, branch: Optional[str] = None, **kwargs: Any
+    ) -> InfrahubNode:
         branch = branch or self.default_branch
         schema = await self.schema.get(kind=kind, branch=branch)
 
@@ -439,7 +441,7 @@ class InfrahubClient:  # pylint: disable=too-many-public-methods
         at: Optional[Timestamp] = None,
         branch: Optional[str] = None,
         id: Optional[str] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> InfrahubNode:
         branch = branch or self.default_branch
         schema = await self.schema.get(kind=kind, branch=branch)
@@ -493,7 +495,7 @@ class InfrahubClient:  # pylint: disable=too-many-public-methods
         return [InfrahubNode(client=self, schema=schema, branch=branch, data=item) for item in response[schema.name]]
 
     async def filters(
-        self, kind: str, at: Optional[Timestamp] = None, branch: Optional[str] = None, **kwargs
+        self, kind: str, at: Optional[Timestamp] = None, branch: Optional[str] = None, **kwargs: Any
     ) -> List[InfrahubNode]:
         schema = await self.schema.get(kind=kind)
 
@@ -893,7 +895,7 @@ class InfrahubClient:  # pylint: disable=too-many-public-methods
         description: str = "",
         timeout: int = 10,
         rebase: bool = False,
-    ):
+    ) -> bool:
         variables = {
             "id": id,
             "name": name,
@@ -955,7 +957,7 @@ class InfrahubClient:  # pylint: disable=too-many-public-methods
         description: str = "",
         timeout: int = 10,
         rebase: bool = False,
-    ):
+    ) -> bool:
         variables = {
             "id": id,
             "name": name,
@@ -976,7 +978,7 @@ class InfrahubClient:  # pylint: disable=too-many-public-methods
 
         return True
 
-    async def repository_update_commit(self, branch_name, repository_id: str, commit: str) -> bool:
+    async def repository_update_commit(self, branch_name: str, repository_id: str, commit: str) -> bool:
         variables = {"repository_id": str(repository_id), "commit": str(commit)}
         await self.execute_graphql(
             query=MUTATION_COMMIT_UPDATE,

--- a/python_sdk/infrahub_client/branch.py
+++ b/python_sdk/infrahub_client/branch.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from pydantic import BaseModel
 
@@ -107,7 +107,7 @@ class InfrahubBranchManager:
         branch_only: bool = True,
         diff_from: Optional[str] = None,
         diff_to: Optional[str] = None,
-    ):
+    ) -> Dict[Any, Any]:
         variables = {"branch_name": branch_name, "branch_only": branch_only, "diff_from": diff_from, "diff_to": diff_to}
         response = await self.client.execute_graphql(
             query=QUERY_BRANCH_DIFF, variables=variables, tracker="query-branch-diff"

--- a/python_sdk/infrahub_client/exceptions.py
+++ b/python_sdk/infrahub_client/exceptions.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 
 class Error(Exception):
@@ -8,14 +8,14 @@ class Error(Exception):
 
 
 class ServerNotReacheableError(Error):
-    def __init__(self, address, message=None):
+    def __init__(self, address: str, message: Optional[str] = None):
         self.address = address
         self.message = message or f"Unable to connect to '{address}'."
         super().__init__(self.message)
 
 
 class ServerNotResponsiveError(Error):
-    def __init__(self, url, message=None):
+    def __init__(self, url: str, message: Optional[str] = None):
         self.url = url
         self.message = message or f"Unable to read from '{url}'."
         super().__init__(self.message)
@@ -31,21 +31,27 @@ class GraphQLError(Error):
 
 
 class BranchNotFound(Error):
-    def __init__(self, identifier, message=None):
+    def __init__(self, identifier: str, message: Optional[str] = None):
         self.identifier = identifier
         self.message = message or f"Unable to find the branch '{identifier}' in the Database."
         super().__init__(self.message)
 
 
 class SchemaNotFound(Error):
-    def __init__(self, identifier, message=None):
+    def __init__(self, identifier: str, message: Optional[str] = None):
         self.identifier = identifier
         self.message = message or f"Unable to find the schema '{identifier}'."
         super().__init__(self.message)
 
 
 class NodeNotFound(Error):
-    def __init__(self, branch_name, node_type, identifier, message="Unable to find the node in the database."):
+    def __init__(
+        self,
+        branch_name: str,
+        node_type: str,
+        identifier: Dict[str, List[str]],
+        message: str = "Unable to find the node in the database.",
+    ):
         self.branch_name = branch_name
         self.node_type = node_type
         self.identifier = identifier
@@ -53,7 +59,7 @@ class NodeNotFound(Error):
         self.message = message
         super().__init__(self.message)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"""
         {self.message}
         {self.branch_name} | {self.node_type} | {self.identifier}
@@ -61,7 +67,7 @@ class NodeNotFound(Error):
 
 
 class FilterNotFound(Error):
-    def __init__(self, identifier, kind, message=None):
+    def __init__(self, identifier: str, kind: str, message: Optional[str] = None):
         self.identifier = identifier
         self.kind = kind
         self.message = message or f"{identifier!r} is not a valid filter for {self.identifier!r}."

--- a/python_sdk/infrahub_client/graphql.py
+++ b/python_sdk/infrahub_client/graphql.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 VARIABLE_TYPE_MAPPING = (
     (str, "String!"),
@@ -10,7 +10,7 @@ VARIABLE_TYPE_MAPPING = (
 )
 
 
-def convert_to_graphql_as_string(value) -> str:
+def convert_to_graphql_as_string(value: Union[str, bool, list]) -> str:
     if isinstance(value, str) and value.startswith("$"):
         return value
     if isinstance(value, str):
@@ -137,7 +137,7 @@ class BaseGraphQLQuery:
 class Query(BaseGraphQLQuery):
     query_type = "query"
 
-    def render(self):
+    def render(self) -> str:
         lines = [self.render_first_line()]
         lines.extend(render_query_block(data=self.query, indentation=self.indentation, offset=self.indentation))
         lines.append("}")
@@ -148,12 +148,12 @@ class Query(BaseGraphQLQuery):
 class Mutation(BaseGraphQLQuery):
     query_type = "mutation"
 
-    def __init__(self, *args, mutation: str, input_data: dict, **kwargs):
+    def __init__(self, *args: Any, mutation: str, input_data: dict, **kwargs: Any):
         self.input_data = input_data
         self.mutation = mutation
         super().__init__(*args, **kwargs)
 
-    def render(self):
+    def render(self) -> str:
         lines = [self.render_first_line()]
         lines.append(" " * self.indentation + f"{self.mutation}(")
         lines.extend(

--- a/python_sdk/infrahub_client/schema.py
+++ b/python_sdk/infrahub_client/schema.py
@@ -105,7 +105,7 @@ class InfrahubSchema:
         self.client = client
         self.cache: dict = defaultdict(lambda: dict)
 
-    def validate(self, data):
+    def validate(self, data: dict[str, Any]) -> bool:
         SchemaRoot(**data)
 
         # Add additional validation to ensure that all nodes references in relationships and extensions are present in the schema
@@ -150,7 +150,7 @@ class InfrahubSchema:
 
         return self.cache[branch]
 
-    async def load(self, schema, branch: Optional[str] = None) -> Tuple[bool, Optional[dict]]:
+    async def load(self, schema: dict, branch: Optional[str] = None) -> Tuple[bool, Optional[dict]]:
         branch = branch or self.client.default_branch
         url = f"{self.client.address}/schema/load/?branch={branch}"
         response = await self.client._post(url=url, timeout=30, payload=schema)

--- a/python_sdk/infrahub_client/timestamp.py
+++ b/python_sdk/infrahub_client/timestamp.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from typing import Optional, Union
 
 import pendulum
 from pendulum.datetime import DateTime
@@ -13,7 +14,7 @@ REGEX_MAPPING = {
 
 
 class Timestamp:
-    def __init__(self, value=None):
+    def __init__(self, value: Optional[Union[str, DateTime, Timestamp]] = None):
         if value and isinstance(value, DateTime):
             self.obj = value
         elif value and isinstance(value, self.__class__):
@@ -24,7 +25,7 @@ class Timestamp:
             self.obj = DateTime.now(tz="UTC")
 
     @classmethod
-    def _parse_string(cls, value):
+    def _parse_string(cls, value: str):
         try:
             return pendulum.parse(value)
         except pendulum.parsing.exceptions.ParserError:
@@ -44,26 +45,36 @@ class Timestamp:
     def __repr__(self) -> str:
         return f"Timestamp: {self.to_string()}"
 
-    def to_string(self):
+    def to_string(self) -> str:
         return self.obj.to_iso8601_string()
 
-    def to_timestamp(self):
+    def to_timestamp(self) -> str:
         return self.obj.int_timestamp
 
     async def to_graphql(self, *args, **kwargs):  # pylint: disable=unused-argument
         return self.obj
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Timestamp):
+            return NotImplemented
         return self.obj == other.obj
 
-    def __lt__(self, other):
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, Timestamp):
+            return NotImplemented
         return self.obj < other.obj
 
-    def __gt__(self, other):
+    def __gt__(self, other: object) -> bool:
+        if not isinstance(other, Timestamp):
+            return NotImplemented
         return self.obj > other.obj
 
-    def __le__(self, other):
+    def __le__(self, other: object) -> bool:
+        if not isinstance(other, Timestamp):
+            return NotImplemented
         return self.obj <= other.obj
 
-    def __ge__(self, other):
+    def __ge__(self, other: object) -> bool:
+        if not isinstance(other, Timestamp):
+            return NotImplemented
         return self.obj >= other.obj

--- a/python_sdk/tests/integration/test_node.py
+++ b/python_sdk/tests/integration/test_node.py
@@ -51,9 +51,9 @@ class TestInfrahubNode:
         assert node.id is not None
 
         nodedb = await NodeManager.get_one(id=node.id, session=session, include_owner=True, include_source=True)
-        assert nodedb.name.value == node.name.value
+        assert nodedb.name.value == node.name.value  # type: ignore[attr-defined]
         querydb = await nodedb.query.get_peer(session=session)
-        assert node.query.id == querydb.id
+        assert node.query.id == querydb.id  # type: ignore[attr-defined]
 
     async def test_node_create_with_properties(
         self,
@@ -80,7 +80,7 @@ class TestInfrahubNode:
         assert node.id is not None
 
         nodedb = await NodeManager.get_one(id=node.id, session=session, include_owner=True, include_source=True)
-        assert nodedb.name.value == node.name.value
+        assert nodedb.name.value == node.name.value  # type: ignore[attr-defined]
         assert nodedb.name.is_protected is True
 
     async def test_node_update(


### PR DESCRIPTION
This pull requests add function signatures to most of the functions within the Python SDK.

The idea is to add this to pyproject.toml when the rest are fixed:

```toml
[[tool.mypy.overrides]]
module = "infrahub_client.*"
disallow_untyped_defs = true
```

Currently there are a few remaining functions that are failing the type checks that I want to look closer at in a separate PR:

```
infrahub on  type_hints is 📦 v0.2.0 via  via 🐍 v3.10.10 (infrahub)
❯ invoke sdk.mypy
 - [SDK] Check code with mypy
python_sdk/infrahub_client/timestamp.py:28: error: Function is missing a return type annotation  [no-untyped-def]
        def _parse_string(cls, value: str):
        ^
python_sdk/infrahub_client/timestamp.py:54: error: Function is missing a type annotation  [no-untyped-def]
        async def to_graphql(self, *args, **kwargs):  # pylint: disable=unused-argument
        ^
python_sdk/infrahub_client/__init__.py:250: error: Function is missing a type annotation  [no-untyped-def]
    def generate_relationship_property(name):
    ^
python_sdk/infrahub_client/__init__.py:256: error: Function is missing a return type annotation  [no-untyped-def]
        def prop(self):
        ^
python_sdk/infrahub_client/__init__.py:260: error: Function is missing a type annotation  [no-untyped-def]
        def prop(self, value):
        ^
python_sdk/infrahub_client/__init__.py:394: error: Function is missing a type annotation for one or more arguments  [no-untyped-def]
        def __init__(
        ^
Found 6 errors in 2 files (checked 27 source files)
```