### PR TITLE
Run Backend and infrahubctl CI on changes to sdk

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -4,8 +4,10 @@ name: "Backend"
 on:
   pull_request:
     paths:
+      - ".github/**"
       - "backend/**"
       - "development/**"
+      - "python_sdk/**"
       - pyproject.toml
       - poetry.lock
       - "tasks/**"

--- a/.github/workflows/infrahubctl.yml
+++ b/.github/workflows/infrahubctl.yml
@@ -4,7 +4,9 @@ name: "infrahubctl"
 on:
   pull_request:
     paths:
+      - ".github/**"
       - "infrahub_ctl/**"
+      - "python_sdk/**"
       - pyproject.toml
       - poetry.lock
       - "tasks/**"


### PR DESCRIPTION
As both the backend and infrahubctl use the SDK code internally it makes sense to rerun those tests if there are any changes to the SDK itself.

Also ensures that all pipelines are run if we make changes to the CI files themselves.