### PR TITLE
Fix tests that started failing after unique constraint

### DIFF
--- a/python_sdk/tests/integration/test_infrahub_client.py
+++ b/python_sdk/tests/integration/test_infrahub_client.py
@@ -143,7 +143,7 @@ class TestInfrahubClient:
 
         await client.create_rfile(
             branch_name=branch_name,
-            name="rfile1",
+            name="rfile2",
             description="test rfile2",
             template_path="mytemplate.j2",
             template_repository=str(repositories[0].id),

--- a/python_sdk/tests/integration/test_node.py
+++ b/python_sdk/tests/integration/test_node.py
@@ -67,7 +67,7 @@ class TestInfrahubNode:
         first_account: Node,
     ):
         data = {
-            "name": {"value": "rfile01", "is_protected": True, "source": first_account.id, "owner": first_account.id},
+            "name": {"value": "rfile02", "is_protected": True, "source": first_account.id, "owner": first_account.id},
             "template_path": {"value": "mytemplate.j2"},
             "query": {"id": gqlquery01.id},  # "source": first_account.id, "owner": first_account.id},
             "template_repository": {"id": repo01.id},  # "source": first_account.id, "owner": first_account.id},


### PR DESCRIPTION
Changes tests to create rfile02 instead of rfile01 as they started to fail after the unique constraint was put in place