### PR TITLE
Disallow untyped defs in SDK

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,6 +161,11 @@ filterwarnings = [
 pretty = true
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = "infrahub_client.*"
+disallow_untyped_defs = true
+
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/python_sdk/infrahub_client/client.py
+++ b/python_sdk/infrahub_client/client.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import asyncio
 import copy
 import logging
 from logging import Logger
-from typing import Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import httpx
 
@@ -42,6 +44,9 @@ from infrahub_client.queries import (
 from infrahub_client.schema import InfrahubSchema
 from infrahub_client.timestamp import Timestamp
 
+if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
+
 # pylint: disable=redefined-builtin
 
 
@@ -55,7 +60,7 @@ class InfrahubClient:  # pylint: disable=too-many-public-methods
         retry_on_failure: bool = False,
         retry_delay: int = 5,
         log: Optional[Logger] = None,
-        test_client=None,
+        test_client: Optional[TestClient] = None,
         default_branch: str = "main",
         insert_tracker: bool = False,
     ):

--- a/python_sdk/infrahub_client/node.py
+++ b/python_sdk/infrahub_client/node.py
@@ -287,17 +287,17 @@ class RelationshipManager:
         return data
 
 
-def generate_relationship_property(name):
+def generate_relationship_property(name: str):  # type: ignore
     """Return a property that stores values under a private non-public name."""
     internal_name = "_" + name.lower()
     external_name = name
 
-    @property
-    def prop(self):
+    @property  # type: ignore
+    def prop(self):  # type: ignore
         return getattr(self, internal_name)
 
     @prop.setter
-    def prop(self, value):
+    def prop(self, value):  # type: ignore
         if isinstance(value, RelatedNode) or value is None:
             setattr(self, internal_name, value)
         else:

--- a/python_sdk/infrahub_client/timestamp.py
+++ b/python_sdk/infrahub_client/timestamp.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 import pendulum
 from pendulum.datetime import DateTime
@@ -25,9 +25,11 @@ class Timestamp:
             self.obj = DateTime.now(tz="UTC")
 
     @classmethod
-    def _parse_string(cls, value: str):
+    def _parse_string(cls, value: str) -> DateTime:
         try:
-            return pendulum.parse(value)
+            parsed_date = pendulum.parse(value)
+            if isinstance(parsed_date, DateTime):
+                return parsed_date
         except pendulum.parsing.exceptions.ParserError:
             pass
 
@@ -51,7 +53,7 @@ class Timestamp:
     def to_timestamp(self) -> str:
         return self.obj.int_timestamp
 
-    async def to_graphql(self, *args, **kwargs):  # pylint: disable=unused-argument
+    async def to_graphql(self, *args: Any, **kwargs: Any) -> DateTime:  # pylint: disable=unused-argument
         return self.obj
 
     def __eq__(self, other: object) -> bool:


### PR DESCRIPTION
For now the function generate_relationship_property is ignored from typing checks.

I'm thinking that the HTTP test client type hint can be replaced with a protocol as part of the introduction of the sync sdk.