### PR TITLE
Set default pytest command line options

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,6 +1,5 @@
 ---
 # yamllint disable rule:truthy
-# yamllint disable rule:line-length
 name: "Backend"
 on:
   pull_request:
@@ -52,13 +51,13 @@ jobs:
       - name: "Pylint Tests"
         run: "poetry run invoke backend.pylint"
       - name: "Unit Tests"
-        run: "poetry run pytest -v --cov=infrahub --cov-report term-missing --cov-report xml backend/tests/unit"
+        run: "poetry run pytest --cov=infrahub backend/tests/unit"
       - name: "Coveralls : Unit Tests"
         uses: coverallsapp/github-action@v2.0.0
         with:
           flag-name: backend-unit
       - name: "Integration Tests : User Workflows"
-        run: "poetry run pytest -v --cov=infrahub --cov-report term-missing --cov-report xml backend/tests/integration/user_workflows/"
+        run: "poetry run pytest --cov=infrahub backend/tests/integration/user_workflows/"
       - name: "Coveralls : Integration Tests"
         uses: coverallsapp/github-action@v2.0.0
         with:

--- a/.github/workflows/infrahubctl.yml
+++ b/.github/workflows/infrahubctl.yml
@@ -1,6 +1,5 @@
 ---
 # yamllint disable rule:truthy
-# yamllint disable rule:line-length
 name: "infrahubctl"
 on:
   pull_request:
@@ -42,7 +41,7 @@ jobs:
       - name: "Mypy Tests"
         run: "poetry run invoke ctl.mypy"
       - name: "Unit Tests"
-        run: "poetry run pytest -v --cov=infrahub_ctl --cov-report term-missing --cov-report xml infrahub_ctl/tests/unit"
+        run: "poetry run pytest --cov=infrahub_ctl infrahub_ctl/tests/unit"
       - name: "Coveralls : Unit Tests"
         uses: coverallsapp/github-action@v2.0.0
         with:

--- a/.github/workflows/python-sdk.yml
+++ b/.github/workflows/python-sdk.yml
@@ -1,6 +1,5 @@
 ---
 # yamllint disable rule:truthy
-# yamllint disable rule:line-length
 name: "Python SDK"
 on:
   pull_request:
@@ -52,13 +51,13 @@ jobs:
       - name: "Mypy Tests"
         run: "poetry run invoke sdk.mypy"
       - name: "Unit Tests"
-        run: "poetry run pytest -v --cov=infrahub_client --cov-report term-missing --cov-report xml python_sdk/tests/unit"
+        run: "poetry run pytest --cov=infrahub_client python_sdk/tests/unit"
       - name: "Coveralls : Unit Tests"
         uses: coverallsapp/github-action@v2.0.0
         with:
           flag-name: python-sdk-unit
       - name: "Integration Tests"
-        run: "poetry run pytest -v --cov=infrahub_client --cov-report term-missing --cov-report xml python_sdk/tests/integration"
+        run: "poetry run pytest --cov=infrahub_client python_sdk/tests/integration"
       - name: "Coveralls : Integration Tests"
         uses: coverallsapp/github-action@v2.0.0
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,8 @@ filterwarnings = [
     "ignore:Module already imported so cannot be rewritten",
     "ignore:the imp module is deprecated"
 ]
+addopts = "-vs --cov-report term-missing --cov-report xml"
+
 
 [tool.mypy]
 pretty = true


### PR DESCRIPTION
Allows for shorter commands and we can re-enable yaml linting rule for line length