### PR TITLE
Ignore "Deprecated call to" in pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,8 @@ testpaths = [
 ]
 filterwarnings = [
     "ignore:Module already imported so cannot be rewritten",
-    "ignore:the imp module is deprecated"
+    "ignore:the imp module is deprecated",
+    "ignore:Deprecated call to",
 ]
 addopts = "-vs --cov-report term-missing --cov-report xml"
 


### PR DESCRIPTION
Not sure if there is a better way to fix that but I'm getting some annoying warning messages when I'm running pytest that look mostly harmless but they are taking a lot of space on my screen

```
========================================================================== warnings summary ===========================================================================
../../Library/Caches/pypoetry/virtualenvs/infrahub-5zZD-XQa-py3.9/lib/python3.9/site-packages/pkg_resources/__init__.py:2804
  /Users/damien/Library/Caches/pypoetry/virtualenvs/infrahub-5zZD-XQa-py3.9/lib/python3.9/site-packages/pkg_resources/__init__.py:2804: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('google')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

../../Library/Caches/pypoetry/virtualenvs/infrahub-5zZD-XQa-py3.9/lib/python3.9/site-packages/pkg_resources/__init__.py:2804
../../Library/Caches/pypoetry/virtualenvs/infrahub-5zZD-XQa-py3.9/lib/python3.9/site-packages/pkg_resources/__init__.py:2804
  /Users/damien/Library/Caches/pypoetry/virtualenvs/infrahub-5zZD-XQa-py3.9/lib/python3.9/site-packages/pkg_resources/__init__.py:2804: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('zope')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```