### PR TITLE
Add carryforward statements for Coveralls

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -54,11 +54,17 @@ jobs:
         run: "poetry run pytest --cov=infrahub backend/tests/unit"
       - name: "Coveralls : Unit Tests"
         uses: coverallsapp/github-action@v2.0.0
+        env:
+          COVERALLS_SERVICE_NUMBER: ${{ github.sha }}
         with:
           flag-name: backend-unit
+          parallel: true
       - name: "Integration Tests : User Workflows"
         run: "poetry run pytest --cov=infrahub backend/tests/integration/user_workflows/"
       - name: "Coveralls : Integration Tests"
         uses: coverallsapp/github-action@v2.0.0
+        env:
+          COVERALLS_SERVICE_NUMBER: ${{ github.sha }}
         with:
           flag-name: backend-integration
+          parallel: true

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -1,0 +1,42 @@
+---
+# yamllint disable rule:truthy
+name: Coveralls report
+on:
+  push:
+    branches:
+      - develop
+      - stable
+  pull_request:
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      # NOTE: The ref value should be different when triggered by pull_request event.
+      #       See: https://github.com/lewagon/wait-on-check-action/issues/25.
+      - name: Wait on tests (PR)
+        uses: lewagon/wait-on-check-action@e106e5c43e8ca1edea6383a39a01c5ca495fd812
+        if: github.event_name == 'pull_request'
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+          running-workflow-name: report
+          allowed-conclusions: success,skipped,cancelled,failure
+
+      - name: Wait on tests (push)
+        if: github.event_name != 'pull_request'
+        uses: lewagon/wait-on-check-action@e106e5c43e8ca1edea6383a39a01c5ca495fd812
+        with:
+          ref: ${{ github.sha }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+          running-workflow-name: report
+          allowed-conclusions: success,skipped,cancelled,failure
+
+      - uses: coverallsapp/github-action@v2
+        env:
+          COVERALLS_SERVICE_NUMBER: ${{ github.sha }}
+        with:
+          carryforward: "backend-unit,backend-integration,infrahubctl-unit,python-sdk-unit,python-sdk-integration"
+          parallel-finished: true

--- a/.github/workflows/infrahubctl.yml
+++ b/.github/workflows/infrahubctl.yml
@@ -44,5 +44,8 @@ jobs:
         run: "poetry run pytest --cov=infrahub_ctl infrahub_ctl/tests/unit"
       - name: "Coveralls : Unit Tests"
         uses: coverallsapp/github-action@v2.0.0
+        env:
+          COVERALLS_SERVICE_NUMBER: ${{ github.sha }}
         with:
           flag-name: infrahubctl-unit
+          parallel: true

--- a/.github/workflows/python-sdk.yml
+++ b/.github/workflows/python-sdk.yml
@@ -54,11 +54,17 @@ jobs:
         run: "poetry run pytest --cov=infrahub_client python_sdk/tests/unit"
       - name: "Coveralls : Unit Tests"
         uses: coverallsapp/github-action@v2.0.0
+        env:
+          COVERALLS_SERVICE_NUMBER: ${{ github.sha }}
         with:
           flag-name: python-sdk-unit
+          parallel: true
       - name: "Integration Tests"
         run: "poetry run pytest --cov=infrahub_client python_sdk/tests/integration"
       - name: "Coveralls : Integration Tests"
         uses: coverallsapp/github-action@v2.0.0
+        env:
+          COVERALLS_SERVICE_NUMBER: ${{ github.sha }}
         with:
           flag-name: python-sdk-integration
+          parallel: true


### PR DESCRIPTION
Adds a job waits until the other jobs are completed and then combines the coverage reports.