### PR TITLE
Add a wait in CI to ensure containers are healthy

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -50,6 +50,8 @@ jobs:
         run: "poetry run invoke backend.flake8"
       - name: "Pylint Tests"
         run: "poetry run invoke backend.pylint"
+      - name: "Await healthy containers"
+        run: "poetry run invoke demo.wait-healthy"
       - name: "Unit Tests"
         run: "poetry run pytest --cov=infrahub backend/tests/unit"
       - name: "Coveralls : Unit Tests"

--- a/.github/workflows/python-sdk.yml
+++ b/.github/workflows/python-sdk.yml
@@ -50,6 +50,8 @@ jobs:
         run: "poetry run invoke sdk.pylint"
       - name: "Mypy Tests"
         run: "poetry run invoke sdk.mypy"
+      - name: "Await healthy containers"
+        run: "poetry run invoke demo.wait-healthy"
       - name: "Unit Tests"
         run: "poetry run pytest --cov=infrahub_client python_sdk/tests/unit"
       - name: "Coveralls : Unit Tests"


### PR DESCRIPTION
* Adds a command to invoke to ensure that we have the expected number of healthy containers before continuing
* Changes the CI to use this command

I think this would fix the problem, but it's hard to test as it's only something that happens on occasion. Figured it might be easier with a check outside the testing as we might want it for integration tests with the frontend later as well.