### PR TITLE
Add an error handler for BranchNotFound

### DIFF
--- a/backend/infrahub/api/diff.py
+++ b/backend/infrahub/api/diff.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, Request
 from neo4j import AsyncSession
 from pydantic import BaseModel, Field
 
@@ -10,7 +10,6 @@ from infrahub.core import get_branch, registry
 from infrahub.core.branch import Branch, RelationshipDiffElement
 from infrahub.core.constants import DiffAction
 from infrahub.core.manager import NodeManager
-from infrahub.exceptions import BranchNotFound
 from infrahub.message_bus.rpc import InfrahubRpcClient
 
 # pylint    : disable=too-many-branches
@@ -128,10 +127,7 @@ async def get_diff_data(  # pylint: disable=too-many-branches
     time_to: Optional[str] = None,
     branch_only: bool = True,
 ) -> Dict[str, List[BranchDiffNode]]:
-    try:
-        branch: Branch = await get_branch(session=session, branch=branch)
-    except BranchNotFound as exc:
-        raise HTTPException(status_code=400, detail=exc.message) from exc
+    branch: Branch = await get_branch(session=session, branch=branch)
 
     response = defaultdict(list)
     nodes_in_diff = []
@@ -215,10 +211,7 @@ async def get_diff_files(
     time_to: Optional[str] = None,
     branch_only: bool = True,
 ) -> Dict[str, Dict[str, BranchDiffRepository]]:
-    try:
-        branch: Branch = await get_branch(session=session, branch=branch)
-    except BranchNotFound as exc:
-        raise HTTPException(status_code=400, detail=exc.message) from exc
+    branch: Branch = await get_branch(session=session, branch=branch)
 
     response = defaultdict(lambda: defaultdict(list))
     rpc_client: InfrahubRpcClient = request.app.state.rpc_client

--- a/backend/infrahub/api/schema.py
+++ b/backend/infrahub/api/schema.py
@@ -1,7 +1,7 @@
 import copy
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from fastapi.logger import logger
 from neo4j import AsyncSession
 from pydantic import BaseModel
@@ -11,7 +11,6 @@ from infrahub.api.dependencies import get_session
 from infrahub.core import get_branch, registry
 from infrahub.core.manager import SchemaManager
 from infrahub.core.schema import GenericSchema, NodeSchema, SchemaRoot
-from infrahub.exceptions import BranchNotFound
 
 router = APIRouter(prefix="/schema")
 
@@ -30,10 +29,7 @@ async def get_schema(
     session: AsyncSession = Depends(get_session),
     branch: Optional[str] = None,
 ) -> SchemaReadAPI:
-    try:
-        branch = await get_branch(session=session, branch=branch)
-    except BranchNotFound as exc:
-        raise HTTPException(status_code=400, detail=exc.message) from exc
+    branch = await get_branch(session=session, branch=branch)
 
     # Make a local copy of the schema to ensure that any modification won't touch the objects in the registry
     full_schema = copy.deepcopy(registry.get_full_schema(branch=branch))
@@ -64,10 +60,7 @@ async def load_schema(
     session: AsyncSession = Depends(get_session),
     branch: Optional[str] = None,
 ):
-    try:
-        branch = await get_branch(session=session, branch=branch)
-    except BranchNotFound as exc:
-        raise HTTPException(status_code=400, detail=exc.message) from exc
+    branch = await get_branch(session=session, branch=branch)
 
     schema.extend_nodes_with_interfaces()
     await SchemaManager.register_schema_to_registry(schema)

--- a/backend/infrahub/api/transformation.py
+++ b/backend/infrahub/api/transformation.py
@@ -9,7 +9,6 @@ from starlette.responses import JSONResponse, PlainTextResponse
 from infrahub.api.dependencies import get_session
 from infrahub.core import get_branch, registry
 from infrahub.core.manager import NodeManager
-from infrahub.exceptions import BranchNotFound
 from infrahub.graphql import get_gql_mutation, get_gql_query
 from infrahub.message_bus.events import (
     InfrahubRPCResponse,
@@ -32,10 +31,7 @@ async def transform_python(
     at: Optional[str] = None,
     rebase: Optional[bool] = False,
 ):
-    try:
-        branch = await get_branch(session=session, branch=branch)
-    except BranchNotFound as exc:
-        raise HTTPException(status_code=400, detail=exc.message) from exc
+    branch = await get_branch(session=session, branch=branch)
 
     branch.ephemeral_rebase = rebase
     at = Timestamp(at)
@@ -112,10 +108,7 @@ async def generate_rfile(
     at: Optional[str] = None,
     rebase: Optional[bool] = False,
 ):
-    try:
-        branch = await get_branch(session=session, branch=branch)
-    except BranchNotFound as exc:
-        raise HTTPException(status_code=400, detail=exc.message) from exc
+    branch = await get_branch(session=session, branch=branch)
 
     branch.ephemeral_rebase = rebase
     at = Timestamp(at)

--- a/backend/infrahub/exceptions.py
+++ b/backend/infrahub/exceptions.py
@@ -1,5 +1,16 @@
+from typing import Any, Dict, Tuple
+
+
 class Error(Exception):
-    pass
+    HTTP_CODE: int = 500
+    DESCRIPTION: str = "Unknown Error"
+    message: str = ""
+
+    def api_response(self) -> Tuple[int, Dict[str, Any]]:
+        """Return error code and response."""
+        return self.HTTP_CODE, {
+            "detail": str(self.message) or self.DESCRIPTION,
+        }
 
 
 class DatabaseError(Error):
@@ -70,6 +81,8 @@ class TransformNotFoundError(TransformError):
 
 
 class BranchNotFound(Error):
+    HTTP_CODE: int = 400
+
     def __init__(self, identifier, message=None):
         self.identifier = identifier
         self.message = message or f"Branch: {identifier} not found."


### PR DESCRIPTION
I noticed this snippet in the diff PR and saw that we replicated the same check for the error handling of branches that aren't found in multiple places. I think this approach would be easier.

This is something that I've done for my previous projects, in that case I'd add `Error` as a global exception to catch and not just the BranchNotFound one as done here. The reason is that I don't know if we want to catch all errors from within the API in this way. Though I think it would probably make sense to do so.