### PR TITLE
Fixes typo and clarifies filter error

### DIFF
--- a/python_sdk/infrahub_client/exceptions.py
+++ b/python_sdk/infrahub_client/exceptions.py
@@ -67,8 +67,9 @@ class NodeNotFound(Error):
 
 
 class FilterNotFound(Error):
-    def __init__(self, identifier: str, kind: str, message: Optional[str] = None):
+    def __init__(self, identifier: str, kind: str, message: Optional[str] = None, filters: Optional[List[str]] = None):
         self.identifier = identifier
         self.kind = kind
-        self.message = message or f"{identifier!r} is not a valid filter for {self.identifier!r}."
+        self.filters = filters or []
+        self.message = message or f"{identifier!r} is not a valid filter for {self.kind!r} ({', '.join(self.filters)})."
         super().__init__(self.message)

--- a/python_sdk/infrahub_client/node.py
+++ b/python_sdk/infrahub_client/node.py
@@ -89,7 +89,8 @@ class InfrahubNodeBase:
                     found = True
                     break
             if not found:
-                raise FilterNotFound(identifier=filter_name, kind=self._schema.kind)
+                valid_filters = [entry.name for entry in self._schema.filters]
+                raise FilterNotFound(identifier=filter_name, kind=self._schema.kind, filters=valid_filters)
 
         return True
 

--- a/python_sdk/tests/unit/test_client.py
+++ b/python_sdk/tests/unit/test_client.py
@@ -192,11 +192,14 @@ async def test_method_get_found_many(
 async def test_method_get_invalid_filter(
     httpx_mock: HTTPXMock, clients, mock_schema_query_01, client_type
 ):  # pylint: disable=unused-argument
-    with pytest.raises(FilterNotFound):
+    with pytest.raises(FilterNotFound) as excinfo:
         if client_type == "standard":
             await clients.standard.get(kind="Repository", name__name="infrahub-demo-core")
         else:
             clients.sync.get(kind="Repository", name__name="infrahub-demo-core")
+    assert "'name__name' is not a valid filter for 'Repository'" in excinfo.value.message
+    assert "default_branch__value" in excinfo.value.message
+    assert "default_branch__value" in excinfo.value.filters
 
 
 @pytest.mark.parametrize("client_type", client_types)


### PR DESCRIPTION
Makes it easier for the end user to figure out what was wrong. We can also get rid of the filter list in the error, though I think it might be helpful to have.

Fixes #256