### PR TITLE
Fix invalid function signatures

### DIFF
--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -346,7 +346,7 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
         query = await NodeDeleteQuery.init(session=session, node=self, at=delete_at)
         await query.execute(session=session)
 
-    async def to_graphql(self, session: AsyncSession, fields: dict = None) -> dict:
+    async def to_graphql(self, session: AsyncSession, fields: dict) -> dict:
         """Generate GraphQL Payload for all attributes
 
         Returns:

--- a/backend/infrahub/core/node/standard.py
+++ b/backend/infrahub/core/node/standard.py
@@ -25,7 +25,7 @@ class StandardNode(BaseModel):
     def get_type(cls) -> str:
         return cls.__name__
 
-    async def to_graphql(self, fields: dict = None) -> dict:
+    async def to_graphql(self, fields: dict) -> dict:
         response = {"id": self.uuid}
 
         for field_name in fields.keys():


### PR DESCRIPTION
Both of these functions has "fields" as an optional argument and defaulting it to `None` however both functions calls fields.keys() which would raise an AttributeError for a `None` value making these fields required so I'm guessing this was just a typo.