### PR TITLE
Upgrade actions/checkout@2 -> actions/checkout@3

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: "ubuntu-20.04"
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "Setup Python environment"
         run: "pip install poetry==1.3.2 toml invoke"
       - name: "Setup Git"

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: "ubuntu-20.04"
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "Setup Python environment"
         run: "pip install poetry==1.3.2 toml invoke"
       - name: "Setup Git"

--- a/.github/workflows/infrahubctl.yml
+++ b/.github/workflows/infrahubctl.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: "ubuntu-20.04"
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "Setup Python environment"
         run: "pip install poetry==1.3.2 toml invoke"
       - name: "Setup Git"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "Setup environment"
         run: "pip install yamllint==1.29.0"
       - name: "Linting: yamllint"
@@ -22,7 +22,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "Setup environment"
         run: "pip install black==23.1.0"
       - name: "Linting: BLACK"
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: Install NodeJS
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/python-sdk.yml
+++ b/.github/workflows/python-sdk.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: "ubuntu-20.04"
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "Setup Python environment"
         run: "pip install poetry==1.3.2 toml invoke"
       - name: "Setup Git"


### PR DESCRIPTION
We are getting warnings in the output from the CI pipelines stating that Node 12 which the current action uses is being phased out:

"Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/."