### PR TITLE
Ignore imports from TYPE_CHECKING in coverage reports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,11 @@ known_first_party = [ "infrahub" , "infrahub_client", "infrahub_ctl" ]
 [tool.coverage.run]
 branch = true
 
+[tool.coverage.report]
+exclude_lines = [
+    "if TYPE_CHECKING:"
+]
+
 [tool.pylint.general]
 extension-pkg-whitelist = [
     "pydantic",


### PR DESCRIPTION
Ignores that the imports when using TYPE_CHECKING isn't covered when producing coverage reports.

I.e:

```python
if TYPE_CHECKING:
    from neo4j import AsyncSession

    from infrahub.core.attribute import BaseAttribute
    from infrahub.core.branch import Branch
    from infrahub.core.schema import GenericSchema, GroupSchema, NodeSchema
    from infrahub.graphql.mutations import BaseAttributeInput
    from infrahub.graphql.types import InfrahubObject
    from infrahub.types import InfrahubDataType
```