### PR TITLE
Change to session fixtures instead of module

### DIFF
--- a/python_sdk/tests/integration/conftest.py
+++ b/python_sdk/tests/integration/conftest.py
@@ -31,7 +31,7 @@ def execute_before_any_test():
     config.SETTINGS.main.internal_address = "http://mock"
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 async def db():
     driver = await get_db()
 
@@ -40,7 +40,7 @@ async def db():
     await driver.close()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 async def session(db):
     session = db.session(database=config.SETTINGS.database.database)
 
@@ -49,7 +49,7 @@ async def session(db):
     await session.close()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 async def init_db_base(session: AsyncSession):
     await delete_all_nodes(session=session)
     await first_time_initialization(session=session)


### PR DESCRIPTION
The tests doesn't seem to get in each others way and recreating the environment takes up quite a lot of time as a percentage of the test run for the SDK integration tests.

Can we run these fixtures as session fixtures instead of module ones?

Looks like it lowers the test time for the SDK integration test from 80-90 seconds to 60-65 seconds.