### PR TITLE
Add SDK tests for data validation and update payload

### DIFF
--- a/python_sdk/tests/unit/test_schema.py
+++ b/python_sdk/tests/unit/test_schema.py
@@ -2,7 +2,7 @@ import inspect
 
 import pytest
 
-from infrahub_client import InfrahubClient, InfrahubClientSync
+from infrahub_client import InfrahubClient, InfrahubClientSync, ValidationError
 from infrahub_client.schema import InfrahubSchema, InfrahubSchemaSync, NodeSchema
 
 async_schema_methods = [method for method in dir(InfrahubSchema) if not method.startswith("_")]
@@ -39,3 +39,22 @@ async def test_fetch_schema(mock_schema_query_01, client_type):  # pylint: disab
     assert len(nodes) == 3
     assert sorted(nodes.keys()) == ["GraphQLQuery", "Repository", "Tag"]
     assert isinstance(nodes["Tag"], NodeSchema)
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_schema_data_validation(rfile_schema, client_type):
+    if client_type == "standard":
+        client = await InfrahubClient.init(address="http://mock", insert_tracker=True)
+    else:
+        client = InfrahubClientSync.init(address="http://mock", insert_tracker=True)
+
+    client.schema.validate_data_against_schema(
+        schema=rfile_schema, data={"name": "some-name", "description": "Some description"}
+    )
+
+    with pytest.raises(ValidationError) as excinfo:
+        client.schema.validate_data_against_schema(
+            schema=rfile_schema, data={"name": "some-name", "invalid_field": "yes"}
+        )
+
+    assert "invalid_field is not a valid value for RFile" == excinfo.value.message


### PR DESCRIPTION
Adding some tests for data validation and update payload. Later once we add a function to generate the payload for update in the same way as create we can add this to the integration test in this PR as an addition after checking the value of the source key.