### PR TITLE
Add log handler httpcore for httpx

### DIFF
--- a/backend/infrahub/cli/git_agent.py
+++ b/backend/infrahub/cli/git_agent.py
@@ -135,6 +135,7 @@ def start(
     config_file: str = typer.Argument("infrahub.toml", envvar="INFRAHUB_CONFIG"),
 ):
     logging.getLogger("httpx").setLevel(logging.ERROR)
+    logging.getLogger("httpcore").setLevel(logging.ERROR)
     logging.getLogger("neo4j").setLevel(logging.ERROR)
     logging.getLogger("aio_pika").setLevel(logging.ERROR)
     logging.getLogger("aiormq").setLevel(logging.ERROR)

--- a/ctl/infrahub_ctl/schema.py
+++ b/ctl/infrahub_ctl/schema.py
@@ -63,6 +63,7 @@ def load(
 
     logging.getLogger("infrahub_client").setLevel(logging.CRITICAL)
     logging.getLogger("httpx").setLevel(logging.ERROR)
+    logging.getLogger("httpcore").setLevel(logging.ERROR)
 
     log_level = "DEBUG" if debug else "INFO"
     FORMAT = "%(message)s"


### PR DESCRIPTION
Since the latest release (0.24.0), `httpx` uses 2 log handlers `httpx` and `httpcore`
As a result the logs of the git-agent is not catching the `httpcore` logs anymore which make our logs unusable.

https://github.com/encode/httpx/releases/tag/0.24.0