### PR TITLE
Run Python SDK tests when the backend is changed

### DIFF
--- a/.github/workflows/python-sdk.yml
+++ b/.github/workflows/python-sdk.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - ".github/**"
+      - "backend/**"
       - "python_sdk/**"
       - pyproject.toml
       - poetry.lock


### PR DESCRIPTION
As we use the backend code within the test framework of the SDK things can break if we don't retest.