### PR TITLE
Show a confirm popup when deleting a relationship

### DIFF
--- a/frontend/src/components/modal-delete.tsx
+++ b/frontend/src/components/modal-delete.tsx
@@ -1,0 +1,86 @@
+import { Dialog, Transition } from "@headlessui/react";
+import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
+import { Fragment, useRef } from "react";
+
+interface iProps {
+    open: boolean;
+    setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    title: string;
+    description: string;
+    onDelete: Function;
+    onCancel: Function;
+}
+
+export default function ModalDelete(props: iProps) {
+  const { title, description, onCancel, onDelete, open, setOpen } = props;
+  const cancelButtonRef = useRef(null);
+
+  return (
+    <Transition.Root show={open} as={Fragment}>
+      <Dialog as="div" className="relative z-10" initialFocus={cancelButtonRef} onClose={setOpen}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 z-10 overflow-y-auto">
+          <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+              enterTo="opacity-100 translate-y-0 sm:scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 translate-y-0 sm:scale-100"
+              leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+            >
+              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
+                <div className="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4">
+                  <div className="sm:flex sm:items-start">
+                    <div className="mx-auto flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-red-100 sm:mx-0 sm:h-10 sm:w-10">
+                      <ExclamationTriangleIcon className="h-6 w-6 text-red-600" aria-hidden="true" />
+                    </div>
+                    <div className="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
+                      <Dialog.Title as="h3" className="text-base font-semibold leading-6 text-gray-900">
+                        {title}
+                      </Dialog.Title>
+                      <div className="mt-2">
+                        <p className="text-sm text-gray-500">
+                          {description}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div className="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6">
+                  <button
+                    type="button"
+                    className="inline-flex w-full justify-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500 sm:ml-3 sm:w-auto"
+                    onClick={() => onDelete()}
+                  >
+                    Delete
+                  </button>
+                  <button
+                    type="button"
+                    className="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto"
+                    onClick={() => onCancel()}
+                    ref={cancelButtonRef}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition.Root>
+  );
+}

--- a/frontend/src/screens/object-item-details/relationship-details.tsx
+++ b/frontend/src/screens/object-item-details/relationship-details.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { Link } from "../../components/link";
 import MetaDetailsTooltip from "../../components/meta-details-tooltips";
+import ModalDelete from "../../components/modal-delete";
 import { RoundedButton } from "../../components/rounded-button";
 import { SelectOption } from "../../components/select";
 import SlideOver from "../../components/slide-over";
@@ -47,6 +48,7 @@ export default function RelationshipDetails(props: iRelationDetailsProps) {
   const schema = schemaList.filter((s) => s.name === objectname)[0];
   const [showRelationMetaEditModal, setShowRelationMetaEditModal] = useState(false);
   const [rowForMetaEdit, setRowForMetaEdit] = useState();
+  const [relatedRowIdToDelete, setRelatedRowIdToDelete] = useState();
 
   let options: SelectOption[] = [];
 
@@ -257,12 +259,7 @@ export default function RelationshipDetails(props: iRelationDetailsProps) {
                                     </td>
                                     <td className="relative py-4 px-5 text-right text-sm font-medium w-24">
                                       <div className="text-indigo-600 hover:text-indigo-900 cursor-pointer" onClick={async () => {
-                                        const newList  = relationshipsData.map((item: any) => ({ id: item.id })).filter((item: any) =>  item.id !== row.id);
-                                        await updateObjectWithId(objectid!, schema, {
-                                          [relationshipSchema.name]: newList
-                                        });
-                                        props.refreshObject();
-                                        setShowAddDrawer(false);
+                                        setRelatedRowIdToDelete(row.id);
                                       }}>
                                         Delete
                                       </div>
@@ -397,6 +394,20 @@ export default function RelationshipDetails(props: iRelationDetailsProps) {
           props.refreshObject();
         }} attributeOrRelationshipToEdit={rowForMetaEdit} schemaList={schemaList} schema={schema} attributeOrRelationshipName={relationshipSchema.name} type="relationship" row={{...props.parentNode, [relationshipSchema.name]: relationshipsData}}  />
       </SlideOver>
+      <ModalDelete
+        title="Delete"
+        description="Are you sure you want to delete the relationship? This action cannot be undone."
+        onCancel={() => setRelatedRowIdToDelete(undefined)}
+        onDelete={async () => {
+          const newList  = relationshipsData.map((item: any) => ({ id: item.id })).filter((item: any) =>  item.id !== relatedRowIdToDelete);
+          await updateObjectWithId(objectid!, schema, {
+            [relationshipSchema.name]: newList
+          });
+          props.refreshObject();
+        }}
+        open={!!relatedRowIdToDelete}
+        setOpen={() => setRelatedRowIdToDelete(undefined)}
+      />
     </div>
   </>;
 };


### PR DESCRIPTION
<img width="1680" alt="Screenshot 2023-04-25 at 12 36 08 PM" src="https://user-images.githubusercontent.com/6818367/234200284-24cdb30e-3cc7-498a-95f6-958e221f14a4.png">

Earlier, just by clicking on the delete button, the relationship used to gets removed. We have added a confirmation popup/modal which shows a warning message to the user before deleting the relationship. Clicking outside the modal will also close it. Or user can click on the cancel button to cancel. Delete button is shown in red background.