### PR TITLE
Add confirmation modal when deleting a relationship

### DIFF
--- a/frontend/src/components/modal-delete.tsx
+++ b/frontend/src/components/modal-delete.tsx
@@ -6,7 +6,7 @@ interface iProps {
     open: boolean;
     setOpen: React.Dispatch<React.SetStateAction<boolean>>;
     title: string;
-    description: string;
+    description: string | React.ReactNode;
     onDelete: Function;
     onCancel: Function;
 }

--- a/frontend/src/screens/layout/desktop-menu.tsx
+++ b/frontend/src/screens/layout/desktop-menu.tsx
@@ -6,8 +6,8 @@ import { schemaState } from "../../state/atoms/schema.atom";
 import DropDownMenuHeader from "./desktop-menu-header";
 import { DropDownMenuItem } from "./desktop-menu-item";
 
-import logo from "./logo.png";
 import { constructPath } from "../../utils/fetch";
+import logo from "./logo.png";
 
 export default function DesktopMenu() {
   const [schema] = useAtom(schemaState);
@@ -48,7 +48,7 @@ export default function DesktopMenu() {
   );
 
   return (
-    <div className="hidden md:fixed md:inset-y-0 md:flex md:w-64 md:flex-col z-20">
+    <div className="hidden md:fixed md:inset-y-0 md:flex md:w-64 md:flex-col">
       <div className="flex flex-grow flex-col overflow-y-auto border-r border-gray-200 bg-white pt-5">
         <div className="flex flex-shrink-0 items-center px-4">
           <img className="h-10 w-auto" src={logo} alt="Your Company" />

--- a/frontend/src/screens/object-item-details/relationship-details.tsx
+++ b/frontend/src/screens/object-item-details/relationship-details.tsx
@@ -22,6 +22,7 @@ import updateObjectWithId from "../../utils/updateObjectWithId";
 import { DynamicFieldData } from "../edit-form-hook/dynamic-control-types";
 import EditFormHookComponent from "../edit-form-hook/edit-form-hook-component";
 import NoDataFound from "../no-data-found/no-data-found";
+import ObjectItemEditComponent from "../object-item-edit/object-item-edit.component";
 import ObjectItemMetaEdit from "../object-item-meta-edit/object-item-meta-edit";
 
 type iRelationDetailsProps = {
@@ -33,6 +34,8 @@ type iRelationDetailsProps = {
   mode: "TABLE" | "DESCRIPTION-LIST";
 }
 
+const regex = /^Related/; // starts with Related
+
 export default function RelationshipDetails(props: iRelationDetailsProps) {
   const {objectname, objectid} = useParams();
   const {relationshipsData, relationshipSchema, refreshObject} = props;
@@ -42,7 +45,8 @@ export default function RelationshipDetails(props: iRelationDetailsProps) {
   const schema = schemaList.filter((s) => s.name === objectname)[0];
   const [showRelationMetaEditModal, setShowRelationMetaEditModal] = useState(false);
   const [rowForMetaEdit, setRowForMetaEdit] = useState();
-  const [relatedRowIdToDelete, setRelatedRowIdToDelete] = useState();
+  const [relatedRowToDelete, setRelatedRowToDelete] = useState<any>();
+  const [relatedObjectToEdit, setRelatedObjectToEdit] = useState<any>();
 
   let options: SelectOption[] = [];
 
@@ -237,6 +241,9 @@ export default function RelationshipDetails(props: iRelationDetailsProps) {
                                 <span className="sr-only">Meta</span>
                               </th>
                               <th scope="col" className="relative py-3.5 pl-3 w-24 border-b border-gray-300">
+                                <span className="sr-only">Edit</span>
+                              </th>
+                              <th scope="col" className="relative py-3.5 pl-3 w-24 border-b border-gray-300">
                                 <span className="sr-only">Delete</span>
                               </th>
                             </tr>
@@ -274,7 +281,15 @@ export default function RelationshipDetails(props: iRelationDetailsProps) {
                                       </Button>
                                     </td>
                                     <td className="relative py-4 px-5 text-right text-sm font-medium w-24 border-b border-gray-300">
-                                      <Button buttonType={BUTTON_TYPES.CANCEL} onClick={() => setRelatedRowIdToDelete(row.id)}>
+                                      <Button onClick={(event: any) => {
+                                        console.log("Edit: ", row);
+                                        setRelatedObjectToEdit(row);
+                                      }}>
+                                        Edit
+                                      </Button>
+                                    </td>
+                                    <td className="relative py-4 px-5 text-right text-sm font-medium w-24 border-b border-gray-300">
+                                      <Button buttonType={BUTTON_TYPES.CANCEL} onClick={() => setRelatedRowToDelete(row)}>
                                         Delete
                                       </Button>
                                     </td>
@@ -408,18 +423,45 @@ export default function RelationshipDetails(props: iRelationDetailsProps) {
           props.refreshObject();
         }} attributeOrRelationshipToEdit={rowForMetaEdit} schemaList={schemaList} schema={schema} attributeOrRelationshipName={relationshipSchema.name} type="relationship" row={{...props.parentNode, [relationshipSchema.name]: relationshipsData}}  />
       </SlideOver>
-      <ModalDelete
+      {relatedRowToDelete && <ModalDelete
         title="Delete"
-        description="Are you sure you want to delete the relationship? This action cannot be undone."
-        onCancel={() => setRelatedRowIdToDelete(undefined)}
+        description={<>
+          Are you sure you want to remove the association between <b>`{props.parentNode.display_label}`</b> and <b>`{relatedRowToDelete.display_label}`</b>?
+          The <b>`{relatedRowToDelete.__typename.replace(regex, "")}`</b> <b>`{relatedRowToDelete.display_label}`</b> won&apos;t be deleted in the process.
+        </>}
+        onCancel={() => setRelatedRowToDelete(undefined)}
         onDelete={() => {
-          if(relatedRowIdToDelete) {
-            handleDeleteRelationship(relatedRowIdToDelete);
+          if(relatedRowToDelete?.id) {
+            handleDeleteRelationship(relatedRowToDelete.id);
           }
         }}
-        open={!!relatedRowIdToDelete}
-        setOpen={() => setRelatedRowIdToDelete(undefined)}
-      />
+        open={!!relatedRowToDelete}
+        setOpen={() => setRelatedRowToDelete(undefined)}
+      />}
+      {relatedObjectToEdit && <SlideOver title={`Edit ${relatedObjectToEdit?.display_label}`} subtitle={relatedObjectToEdit.display_label} open={!!relatedObjectToEdit} setOpen={() => setRelatedObjectToEdit(undefined)}>
+        <ObjectItemEditComponent
+          closeDrawer={
+            () => {
+              setRelatedObjectToEdit(undefined);
+            }
+          }
+          onUpdateComplete={
+            async () => {
+              setRelatedObjectToEdit(undefined);
+              await refreshObject();
+            }
+          }
+          objectid={relatedObjectToEdit.id}
+          objectname={(() => {
+            const relatedKind = relatedObjectToEdit.__typename.replace(regex, "");
+            console.log(relatedKind);
+            const relatedSchema = schemaList.find(s => s.kind === relatedKind);
+            const kind = schemaKindName[relatedSchema!.kind];
+            console.log("Kind: ", kind);
+            return kind;
+          })()}
+        />
+      </SlideOver>}
     </div>
   </>;
 };


### PR DESCRIPTION
Earlier, just by clicking on the delete button, the relationship used to gets removed. We have added a confirmation popup/modal which shows a warning message to the user before deleting the relationship. Clicking outside the modal will also close it. Or user can click on the cancel button to cancel. Delete button is shown in red background.

<img width="1680" alt="Screenshot 2023-04-25 at 12 36 08 PM" src="https://user-images.githubusercontent.com/6818367/234200923-ace4b5c6-7678-48e4-9564-d7a7d31e0926.png">
