### PR TITLE
Add function to validate_database with support for retry

### DIFF
--- a/backend/tests/unit/test_database.py
+++ b/backend/tests/unit/test_database.py
@@ -1,0 +1,26 @@
+import pytest
+from neo4j.exceptions import ClientError
+
+import infrahub.config as config
+from infrahub.database import validate_database
+
+
+@pytest.fixture
+async def dbs_for_test(db):
+    databases = ["test41735", "test850e5"]
+    default_db = db.session()
+    await default_db.run(f"CREATE DATABASE {databases[0]} IF NOT EXISTS WAIT")
+
+    yield databases
+
+    # Delete both databases after the test
+    default_db = db.session()
+    for database in databases:
+        await default_db.run(f"DROP DATABASE {database} IF EXISTS")
+
+
+async def test_validate_database(db, dbs_for_test):
+    await validate_database(driver=db, database_name=config.SETTINGS.database.database, retry=2)
+
+    with pytest.raises(ClientError):
+        await validate_database(driver=db, database_name=dbs_for_test[1])


### PR DESCRIPTION
I was tired of having intermittent failure in CI so I implemented a validation mechanism in `get_db()` to validate if the db has been properly created before moving forward