### PR TITLE
Add restart policy for git-agent container

### DIFF
--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       dockerfile: development/Dockerfile-backend
     image: "opsmill/infrahub-backend-py${PYTHON_VER}:${IMAGE_VER}"
     command: infrahub git-agent start --debug
+    restart: unless-stopped
     depends_on:
       - infrahub-server
     environment:


### PR DESCRIPTION
Allows the git-agent container to recover from critical failures.

Fixes #254