### PR TITLE
Add retry counter to get_db and change logic for validation

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -50,8 +50,6 @@ jobs:
         run: "poetry run invoke backend.flake8"
       - name: "Pylint Tests"
         run: "poetry run invoke backend.pylint"
-      - name: "Await healthy containers"
-        run: "poetry run invoke demo.wait-healthy"
       - name: "Unit Tests"
         run: "poetry run pytest --cov=infrahub backend/tests/unit"
       - name: "Coveralls : Unit Tests"

--- a/.github/workflows/python-sdk.yml
+++ b/.github/workflows/python-sdk.yml
@@ -51,8 +51,6 @@ jobs:
         run: "poetry run invoke sdk.pylint"
       - name: "Mypy Tests"
         run: "poetry run invoke sdk.mypy"
-      - name: "Await healthy containers"
-        run: "poetry run invoke demo.wait-healthy"
       - name: "Unit Tests"
         run: "poetry run pytest --cov=infrahub_client python_sdk/tests/unit"
       - name: "Coveralls : Unit Tests"

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -25,7 +25,7 @@ def event_loop():
 
 @pytest.fixture(scope="module")
 async def db():
-    driver = await get_db()
+    driver = await get_db(retry=1)
 
     yield driver
 

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -46,7 +46,7 @@ def event_loop():
 
 @pytest.fixture(scope="module")
 async def db() -> AsyncDriver:
-    driver = await get_db()
+    driver = await get_db(retry=1)
 
     yield driver
 

--- a/python_sdk/tests/integration/conftest.py
+++ b/python_sdk/tests/integration/conftest.py
@@ -33,7 +33,7 @@ def execute_before_any_test():
 
 @pytest.fixture(scope="module")
 async def db():
-    driver = await get_db()
+    driver = await get_db(retry=1)
 
     yield driver
 


### PR DESCRIPTION
* Moved around the logic a bit so that create_database doesn't call validate_database, also changed the logic for how databases are created so that it's validate_database that triggers the creation but only on the first time it's called not on concurrent tries.

* Added retry=1 to the fixtures that use this function.

* Removed the wait-for healthy containers in the CI jobs as they never worked.

@dgarros, I'm a bit unsure of the removed `ServiceUnavailable` exception. When I was testing I could never see this error and a missing database raised the `ClientError`. Did you actually see the first one? In that case I'm wondering if there's some version mismatch or other type of issue..