### PR TITLE
Disallow the name of a schema kind to be a keyword

### DIFF
--- a/backend/infrahub/core/schema.py
+++ b/backend/infrahub/core/schema.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import keyword
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from pydantic import BaseModel, Extra, Field, root_validator, validator
@@ -399,6 +400,13 @@ class BaseNodeSchema(BaseSchemaModel):
                 raise ValueError(f"Unexpected value for display_labels, {item} is not valid.")
 
         return fields
+
+    @validator("name")
+    def name_is_not_keyword(cls, value: str) -> str:
+        if keyword.iskeyword(value):
+            raise ValueError(f"Name can not be set to a reserved keyword '{value}' is not allowed.")
+
+        return value
 
 
 class GenericSchema(BaseNodeSchema):

--- a/backend/tests/fixtures/schemas/not_valid_simple_05.json
+++ b/backend/tests/fixtures/schemas/not_valid_simple_05.json
@@ -1,0 +1,30 @@
+{
+    "version": "1.0",
+    "nodes": [
+        {
+            "name": "class",
+            "kind": "Class",
+            "default_filter": "name__value",
+            "display_labels": [
+                "name__value"
+            ],
+            "attributes": [
+                {
+                    "name": "name",
+                    "kind": "Text",
+                    "unique": true
+                },
+                {
+                    "name": "description",
+                    "kind": "Text",
+                    "optional": true
+                },
+                {
+                    "name": "type",
+                    "kind": "Text"
+                }
+            ],
+            "relationships": []
+        }
+    ]
+}

--- a/backend/tests/unit/api/test_40_schema_api.py
+++ b/backend/tests/unit/api/test_40_schema_api.py
@@ -162,6 +162,21 @@ async def test_schema_load_endpoint_not_valid_simple_04(
     assert response.status_code == 422
 
 
+async def test_schema_load_endpoint_not_valid_simple_05(
+    session,
+    client: TestClient,
+    client_headers,
+    default_branch: Branch,
+    register_core_models_schema,
+    schema_file_not_valid_simple_05,
+):
+    with client:
+        response = client.post("/schema/load", headers=client_headers, json=schema_file_not_valid_simple_05)
+
+    assert response.status_code == 422
+    response.json()["detail"][0]["msg"] == "Name can not be set to a reserved keyword 'class' is not allowed."
+
+
 async def test_schema_load_endpoint_not_valid_with_generics_02(
     session,
     client: TestClient,

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -1244,6 +1244,13 @@ async def schema_file_not_valid_simple_04() -> dict:
 
 
 @pytest.fixture
+async def schema_file_not_valid_simple_05() -> dict:
+    file_content = Path(os.path.join(get_fixtures_dir(), "schemas/not_valid_simple_05.json")).read_text()
+
+    return ujson.loads(file_content)
+
+
+@pytest.fixture
 async def schema_file_not_valid_w_generics_02() -> dict:
     file_content = Path(os.path.join(get_fixtures_dir(), "schemas/not_valid_w_generics_02.json")).read_text()
 


### PR DESCRIPTION
Fixes #303

I think that we might want to revert this at some point so that it's possible to use reserved keywords for names, perhaps something that can be done when introducing namespaces. Not sure if there's a big need to use any of these names but it can also be problematic with names that might be introduced in future versions of Python.