### PR TITLE
Auto ack RPC responses in RabbitMQ

### DIFF
--- a/backend/infrahub/message_bus/rpc.py
+++ b/backend/infrahub/message_bus/rpc.py
@@ -34,7 +34,7 @@ class InfrahubRpcClientBase:
 
         self.channel = await self.connection.channel()
         self.callback_queue = await self.channel.declare_queue(exclusive=True)
-        await self.callback_queue.consume(self.on_response)
+        await self.callback_queue.consume(self.on_response, no_ack=True)
 
         return self
 


### PR DESCRIPTION
As the queues are exclusive to the current API worker and won't be retried again we might as well auto acknowledge the messages as we pick them off the queue.

Fixes #227