### PR TITLE
Add TestHelper fixture

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,9 @@
 import asyncio
+import os
+from pathlib import Path
 
 import pytest
+import ujson
 
 import infrahub.config as config
 
@@ -22,3 +25,27 @@ def execute_before_any_test():
     config.SETTINGS.database.database = TEST_DATABASE
     config.SETTINGS.broker.enable = False
     config.SETTINGS.main.internal_address = "http://mock"
+
+
+class TestHelper:
+    """TestHelper profiles functions that can be used as a fixture throughout the test framework"""
+
+    @staticmethod
+    def schema_file(file_name: str) -> dict:
+        """Return the contents of a schema file as a dictionary"""
+        file_content = Path(os.path.join(TestHelper.get_fixtures_dir(), f"schemas/{file_name}")).read_text()
+
+        return ujson.loads(file_content)
+
+    @staticmethod
+    def get_fixtures_dir():
+        """Get the directory which stores fixtures that are common to multiple unit/integration tests."""
+        here = os.path.abspath(os.path.dirname(__file__))
+        fixtures_dir = os.path.join(here, "fixtures")
+
+        return os.path.abspath(fixtures_dir)
+
+
+@pytest.fixture()
+def helper() -> TestHelper:
+    return TestHelper()

--- a/backend/tests/unit/api/test_40_schema_api.py
+++ b/backend/tests/unit/api/test_40_schema_api.py
@@ -67,11 +67,11 @@ async def test_schema_load_endpoint_valid_simple(
     client_headers,
     default_branch: Branch,
     register_core_models_schema,
-    schema_file_infra_simple_01,
+    helper,
 ):
     # Must execute in a with block to execute the startup/shutdown events
     with client:
-        creation = client.post("/schema/load", headers=client_headers, json=schema_file_infra_simple_01)
+        creation = client.post("/schema/load", headers=client_headers, json=helper.schema_file("infra_simple_01.json"))
         read = client.get("/schema", headers=client_headers)
 
     assert creation.status_code == 202
@@ -95,11 +95,13 @@ async def test_schema_load_endpoint_valid_with_generics(
     client_headers,
     default_branch: Branch,
     register_core_models_schema,
-    schema_file_infra_w_generics_01,
+    helper,
 ):
     # Must execute in a with block to execute the startup/shutdown events
     with client:
-        response1 = client.post("/schema/load", headers=client_headers, json=schema_file_infra_w_generics_01)
+        response1 = client.post(
+            "/schema/load", headers=client_headers, json=helper.schema_file("infra_w_generics_01.json")
+        )
         assert response1.status_code == 202
 
         response2 = client.get("/schema", headers=client_headers)
@@ -115,14 +117,16 @@ async def test_schema_load_endpoint_valid_with_extensions(
     client_headers,
     default_branch: Branch,
     register_core_models_schema,
-    schema_file_infra_w_extensions_01,
+    helper,
 ):
     org_schema = registry.schema.get(name="Organization", branch=default_branch.name)
     initial_nbr_relationships = len(org_schema.relationships)
 
     # Must execute in a with block to execute the startup/shutdown events
     with client:
-        response = client.post("/schema/load", headers=client_headers, json=schema_file_infra_w_extensions_01)
+        response = client.post(
+            "/schema/load", headers=client_headers, json=helper.schema_file("infra_w_extensions_01.json")
+        )
 
     assert response.status_code == 202
 
@@ -136,11 +140,13 @@ async def test_schema_load_endpoint_not_valid_simple_02(
     client_headers,
     default_branch: Branch,
     register_core_models_schema,
-    schema_file_not_valid_simple_02,
+    helper,
 ):
     # Must execute in a with block to execute the startup/shutdown events
     with client:
-        response = client.post("/schema/load", headers=client_headers, json=schema_file_not_valid_simple_02)
+        response = client.post(
+            "/schema/load", headers=client_headers, json=helper.schema_file("not_valid_simple_02.json")
+        )
 
     assert response.status_code == 422
 
@@ -151,11 +157,13 @@ async def test_schema_load_endpoint_not_valid_simple_03(
     client_headers,
     default_branch: Branch,
     register_core_models_schema,
-    schema_file_not_valid_simple_03,
+    helper,
 ):
     # Must execute in a with block to execute the startup/shutdown events
     with client:
-        response = client.post("/schema/load", headers=client_headers, json=schema_file_not_valid_simple_03)
+        response = client.post(
+            "/schema/load", headers=client_headers, json=helper.schema_file("not_valid_simple_03.json")
+        )
 
     assert response.status_code == 422
 
@@ -166,11 +174,13 @@ async def test_schema_load_endpoint_not_valid_simple_04(
     client_headers,
     default_branch: Branch,
     register_core_models_schema,
-    schema_file_not_valid_simple_04,
+    helper,
 ):
     # Must execute in a with block to execute the startup/shutdown events
     with client:
-        response = client.post("/schema/load", headers=client_headers, json=schema_file_not_valid_simple_04)
+        response = client.post(
+            "/schema/load", headers=client_headers, json=helper.schema_file("not_valid_simple_04.json")
+        )
 
     assert response.status_code == 422
 
@@ -181,10 +191,12 @@ async def test_schema_load_endpoint_not_valid_simple_05(
     client_headers,
     default_branch: Branch,
     register_core_models_schema,
-    schema_file_not_valid_simple_05,
+    helper,
 ):
     with client:
-        response = client.post("/schema/load", headers=client_headers, json=schema_file_not_valid_simple_05)
+        response = client.post(
+            "/schema/load", headers=client_headers, json=helper.schema_file("not_valid_simple_05.json")
+        )
 
     assert response.status_code == 422
     response.json()["detail"][0]["msg"] == "Name can not be set to a reserved keyword 'class' is not allowed."
@@ -196,10 +208,12 @@ async def test_schema_load_endpoint_not_valid_with_generics_02(
     client_headers,
     default_branch: Branch,
     register_core_models_schema,
-    schema_file_not_valid_w_generics_02,
+    helper,
 ):
     # Must execute in a with block to execute the startup/shutdown events
     with client:
-        response = client.post("/schema/load", headers=client_headers, json=schema_file_not_valid_w_generics_02)
+        response = client.post(
+            "/schema/load", headers=client_headers, json=helper.schema_file("not_valid_w_generics_02.json")
+        )
 
     assert response.status_code == 422

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -1210,62 +1210,6 @@ async def register_account_schema(session) -> None:
 
 
 @pytest.fixture
-async def schema_file_infra_w_generics_01() -> dict:
-    file_content = Path(os.path.join(get_fixtures_dir(), "schemas/infra_w_generics_01.json")).read_text()
-
-    return ujson.loads(file_content)
-
-
-@pytest.fixture
-async def schema_file_infra_w_extensions_01() -> dict:
-    file_content = Path(os.path.join(get_fixtures_dir(), "schemas/infra_w_extensions_01.json")).read_text()
-
-    return ujson.loads(file_content)
-
-
-@pytest.fixture
-async def schema_file_infra_simple_01() -> dict:
-    file_content = Path(os.path.join(get_fixtures_dir(), "schemas/infra_simple_01.json")).read_text()
-
-    return ujson.loads(file_content)
-
-
-@pytest.fixture
-async def schema_file_not_valid_simple_02() -> dict:
-    file_content = Path(os.path.join(get_fixtures_dir(), "schemas/not_valid_simple_02.json")).read_text()
-
-    return ujson.loads(file_content)
-
-
-@pytest.fixture
-async def schema_file_not_valid_simple_03() -> dict:
-    file_content = Path(os.path.join(get_fixtures_dir(), "schemas/not_valid_simple_03.json")).read_text()
-
-    return ujson.loads(file_content)
-
-
-@pytest.fixture
-async def schema_file_not_valid_simple_04() -> dict:
-    file_content = Path(os.path.join(get_fixtures_dir(), "schemas/not_valid_simple_04.json")).read_text()
-
-    return ujson.loads(file_content)
-
-
-@pytest.fixture
-async def schema_file_not_valid_simple_05() -> dict:
-    file_content = Path(os.path.join(get_fixtures_dir(), "schemas/not_valid_simple_05.json")).read_text()
-
-    return ujson.loads(file_content)
-
-
-@pytest.fixture
-async def schema_file_not_valid_w_generics_02() -> dict:
-    file_content = Path(os.path.join(get_fixtures_dir(), "schemas/not_valid_w_generics_02.json")).read_text()
-
-    return ujson.loads(file_content)
-
-
-@pytest.fixture
 async def first_account(session: AsyncSession, register_account_schema) -> Node:
     obj = await Node.init(session=session, schema="Account")
     await obj.new(session=session, name="First Account", type="Git")

--- a/backend/tests/unit/core/test_manager_schema.py
+++ b/backend/tests/unit/core/test_manager_schema.py
@@ -171,9 +171,7 @@ async def test_schema_branch_generate_identifiers(schema_all_in_one):
     assert generic.relationships[1].identifier == "genericinterface__status"
 
 
-async def test_schema_branch_load_schema_extension(
-    session: AsyncSession, default_branch, schema_file_infra_w_extensions_01
-):
+async def test_schema_branch_load_schema_extension(session: AsyncSession, default_branch, helper):
     schema = SchemaRoot(**core_models)
 
     schema_branch = SchemaBranch(cache={}, name="test")
@@ -183,7 +181,7 @@ async def test_schema_branch_load_schema_extension(
     org = schema_branch.get(name="Organization")
     initial_nbr_relationships = len(org.relationships)
 
-    schema_branch.load_schema(schema=SchemaRoot(**schema_file_infra_w_extensions_01))
+    schema_branch.load_schema(schema=SchemaRoot(**helper.schema_file("infra_w_extensions_01.json")))
 
     org = schema_branch.get(name="Organization")
     assert len(org.relationships) == initial_nbr_relationships + 1
@@ -560,9 +558,9 @@ async def test_load_schema_to_db_simple_01(
     session: AsyncSession,
     default_branch: Branch,
     register_core_models_schema: SchemaBranch,
-    schema_file_infra_simple_01,
+    helper,
 ):
-    schema = SchemaRoot(**schema_file_infra_simple_01)
+    schema = SchemaRoot(**helper.schema_file("infra_simple_01.json"))
     new_schema = registry.schema.register_schema(schema=schema, branch=default_branch.name)
     await registry.schema.load_schema_to_db(schema=new_schema, session=session, branch=default_branch)
 
@@ -577,9 +575,9 @@ async def test_load_schema_to_db_w_generics_01(
     session: AsyncSession,
     default_branch: Branch,
     register_core_models_schema: SchemaBranch,
-    schema_file_infra_w_generics_01,
+    helper,
 ):
-    schema = SchemaRoot(**schema_file_infra_w_generics_01)
+    schema = SchemaRoot(**helper.schema_file("infra_w_generics_01.json"))
     new_schema = registry.schema.register_schema(schema=schema, branch=default_branch.name)
     await registry.schema.load_schema_to_db(schema=new_schema, session=session, branch=default_branch)
 


### PR DESCRIPTION
* Introduces a TestHelper class where we can add functions that can be relevant within the testing framwork.

I noticed this when working on #326 but didn't want to change something unrelated in that PR.

It seemed a bit redundant to have a separate fixture to load each of the schema files. I think it's quite handy to have a test class where we can add other functions when needed.