### PR TITLE
Change indentation of disabled coverage job

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -8,31 +8,31 @@ on:
       - stable
   pull_request:
 
-  jobs:
-    report:
-      runs-on: ubuntu-latest
-      steps:
-        # NOTE: The ref value should be different when triggered by pull_request event.
-        #       See: https://github.com/lewagon/wait-on-check-action/issues/25.
-        - name: Wait on tests (PR)
-          uses: lewagon/wait-on-check-action@e106e5c43e8ca1edea6383a39a01c5ca495fd812
-          if: github.event_name == 'pull_request'
-          with:
-            ref: ${{ github.event.pull_request.head.sha }}
-            repo-token: ${{ secrets.GITHUB_TOKEN }}
-            wait-interval: 10
-            running-workflow-name: report
-            allowed-conclusions: success,skipped,cancelled,failure
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      # NOTE: The ref value should be different when triggered by pull_request event.
+      #       See: https://github.com/lewagon/wait-on-check-action/issues/25.
+      - name: Wait on tests (PR)
+        uses: lewagon/wait-on-check-action@e106e5c43e8ca1edea6383a39a01c5ca495fd812
+        if: github.event_name == 'pull_request'
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+          running-workflow-name: report
+          allowed-conclusions: success,skipped,cancelled,failure
 
-        - name: Wait on tests (push)
-          if: github.event_name != 'pull_request'
-          uses: lewagon/wait-on-check-action@e106e5c43e8ca1edea6383a39a01c5ca495fd812
-          with:
-            ref: ${{ github.sha }}
-            repo-token: ${{ secrets.GITHUB_TOKEN }}
-            wait-interval: 10
-            running-workflow-name: report
-            allowed-conclusions: success,skipped,cancelled,failure
+      - name: Wait on tests (push)
+        if: github.event_name != 'pull_request'
+        uses: lewagon/wait-on-check-action@e106e5c43e8ca1edea6383a39a01c5ca495fd812
+        with:
+          ref: ${{ github.sha }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+          running-workflow-name: report
+          allowed-conclusions: success,skipped,cancelled,failure
 
 #       - uses: coverallsapp/github-action@v2
 #         env:


### PR DESCRIPTION
Looks like the coverage file doesn't get run for pull requests but does fail in develop. I got tricked by yamllint after removing the comments so "jobs" was indented to far. Will see if it's run on this PR..