### PR TITLE
Add ability to control ordering of node attributes

### DIFF
--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -591,7 +591,6 @@ class SchemaManager(NodeManager):
         """Load all nodes, generics and groups from a SchemaRoot object into the database."""
 
         branch = await get_branch(branch=branch, session=session)
-
         for item_kind in list(schema.generics.keys()) + list(schema.nodes.keys()) + list(schema.groups.keys()):
             if limit and item_kind not in limit:
                 continue

--- a/backend/tests/fixtures/schemas/infra_simple_01.json
+++ b/backend/tests/fixtures/schemas/infra_simple_01.json
@@ -8,7 +8,7 @@
             "display_labels": ["name__value"],
             "attributes": [
                 {"name": "name", "kind": "Text", "unique": true},
-                {"name": "description", "kind": "Text", "optional": true},
+                {"name": "description", "kind": "Text", "optional": true, "order_weight": 900},
                 {"name": "type", "kind": "Text"}
             ],
             "relationships": [

--- a/backend/tests/unit/api/test_40_schema_api.py
+++ b/backend/tests/unit/api/test_40_schema_api.py
@@ -71,9 +71,19 @@ async def test_schema_load_endpoint_valid_simple(
 ):
     # Must execute in a with block to execute the startup/shutdown events
     with client:
-        response = client.post("/schema/load", headers=client_headers, json=schema_file_infra_simple_01)
+        creation = client.post("/schema/load", headers=client_headers, json=schema_file_infra_simple_01)
+        read = client.get("/schema", headers=client_headers)
 
-    assert response.status_code == 202
+    assert creation.status_code == 202
+    assert read.status_code == 200
+    nodes = read.json()["nodes"]
+    device = [node for node in nodes if node["name"] == "device"]
+    assert device
+    device = device[0]
+    attributes = {attrib["name"]: attrib["order_weight"] for attrib in device["attributes"]}
+    assert attributes["name"] == 1000
+    assert attributes["description"] == 900
+    assert attributes["type"] == 3000
 
 
 async def test_schema_load_endpoint_valid_with_generics(


### PR DESCRIPTION
The current implementation needs to be reworked once it's possible to update existing nodes in the schema and not just create new ones. SchemaBranch.load_schema() will have to first load existing nodes to determine if the value is set in the existing schema.

Related to #134, adds support for it in the backend.

@dgarros, we wanted to add this in a similar way to relationships within the attribute_schema object right?