### PR TITLE
Relationships with no associated object were not being shown on the details page.

### DIFF
--- a/frontend/src/screens/object-item-details/relationship-details.tsx
+++ b/frontend/src/screens/object-item-details/relationship-details.tsx
@@ -96,10 +96,6 @@ export default function RelationshipDetails(props: iRelationDetailsProps) {
 
   const columns = getAttributeColumnsFromNodeOrGenericSchema(schemaList, generics, relationshipSchema.peer);
 
-  if(!relationshipsData) {
-    return null;
-  }
-
   if(relationshipsData && relationshipsData._relation__is_visible === false) {
     return null;
   }
@@ -129,6 +125,16 @@ export default function RelationshipDetails(props: iRelationDetailsProps) {
     <div
       key={relationshipSchema?.name}
     >
+      {!relationshipsData && (
+        <div className="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:py-4 sm:px-6">
+          <dt className="text-sm font-medium text-gray-500 flex items-center">
+            {relationshipSchema?.label}
+          </dt>
+          <dd className="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0 flex items-center">
+            -
+          </dd>
+        </div>
+      )}
       {
         relationshipsData
         && (


### PR DESCRIPTION
Relationships with no associated object were not being shown on the details page. Added an empty "-" in that case


<img width="1680" alt="Screenshot 2023-05-01 at 10 51 30 PM" src="https://user-images.githubusercontent.com/6818367/235496454-63fd6a94-91a0-4f8f-989a-83c41236896a.png">
