### PR TITLE
Configure position of meta-details tooltip. Add tooltip for meta-data of relationships.

### DIFF
--- a/frontend/src/components/meta-details-tooltips.tsx
+++ b/frontend/src/components/meta-details-tooltips.tsx
@@ -6,6 +6,7 @@ import { Fragment } from "react";
 import { useNavigate } from "react-router-dom";
 import { schemaKindNameState } from "../state/atoms/schemaKindName.atom";
 import { constructPath } from "../utils/fetch";
+import { classNames } from "../utils/common";
 
 export type TooltipDetailItemType = "date" | "text" | "link";
 
@@ -18,6 +19,7 @@ interface TooltipListItem {
 interface Props {
     items: TooltipListItem[];
     header?: React.ReactNode;
+    position?: "LEFT" | "RIGHT";
 }
 
 export default function MetaDetailsTooltip(props: Props) {
@@ -28,7 +30,7 @@ export default function MetaDetailsTooltip(props: Props) {
 
   return <Popover className="relative mt-1.5 ml-2">
     <Popover.Button>
-      <InformationCircleIcon className="w-5 h-5 text-gray-500" />
+      <InformationCircleIcon className="w-6 h-6 text-gray-500" />
     </Popover.Button>
     <Transition
       as={Fragment}
@@ -39,7 +41,7 @@ export default function MetaDetailsTooltip(props: Props) {
       leaveFrom="opacity-100 translate-y-0"
       leaveTo="opacity-0 translate-y-1"
     >
-      <Popover.Panel className="absolute z-10 bg-white rounded-lg border shadow-xl">
+      <Popover.Panel className={classNames("absolute z-10 bg-white rounded-lg border shadow-xl", props.position === "LEFT" ? "right-0" : "")}>
         <div className="w-80 text-sm divide-y px-4">
           {!!props.header && (props.header)}
           {props.items.map(item => {

--- a/frontend/src/screens/object-item-details/relationship-details.tsx
+++ b/frontend/src/screens/object-item-details/relationship-details.tsx
@@ -1,4 +1,4 @@
-import { EyeSlashIcon, InformationCircleIcon, LockClosedIcon, PencilSquareIcon, PlusIcon } from "@heroicons/react/24/outline";
+import { EyeSlashIcon, LockClosedIcon, PencilSquareIcon, PlusIcon } from "@heroicons/react/24/outline";
 import { useAtom } from "jotai";
 import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
@@ -276,7 +276,35 @@ export default function RelationshipDetails(props: iRelationDetailsProps) {
                                         setRowForMetaEdit(row);
                                         setShowRelationMetaEditModal(true);
                                       }}>
-                                        <InformationCircleIcon className="w-6 h-6 text-gray-600 hover:w-7 hover:h-7" />
+                                        <MetaDetailsTooltip
+                                          position="LEFT"
+                                          items={[
+                                            {
+                                              label: "Updated at",
+                                              value: row._updated_at,
+                                              type: "date",
+                                            },
+                                            {
+                                              label: "Update time",
+                                              value: `${new Date(row._updated_at).toLocaleDateString()} ${new Date(row._updated_at).toLocaleTimeString()}`,
+                                              type: "text",
+                                            },
+                                            {
+                                              label: "Source",
+                                              value: row._relation__source,
+                                              type: "link"
+                                            },
+                                            {
+                                              label: "Owner",
+                                              value: row._relation__owner,
+                                              type: "link"
+                                            },
+                                            {
+                                              label: "Is protected",
+                                              value: row._relation__is_protected ? "True" : "False",
+                                              type: "text"
+                                            },
+                                          ]} />
                                       </div>
                                       <div className="cursor-pointer w-7 h-7 flex items-center justify-center" onClick={(e) => {
                                         e.preventDefault();


### PR DESCRIPTION
Configure position of meta-details tooltip. Add tooltip for meta-data of relationships.

<img width="1680" alt="Screenshot 2023-05-01 at 11 05 05 PM" src="https://user-images.githubusercontent.com/6818367/235498279-343b784a-9b3e-4cab-9a2e-2bf16b099a20.png">
