### PR TITLE
For select dropdown search, in case of criticality.level the option values were numbers instead of string. In that case .toLowerCase() method was failing. Added fix for that.

### DIFF
--- a/frontend/src/components/select.tsx
+++ b/frontend/src/components/select.tsx
@@ -30,7 +30,7 @@ export const Select = (props: SelectProps) => {
       ? options
       : options
       .filter(
-        (option: any) => option?.name.toLowerCase().includes(query.toLowerCase())
+        (option: any) => option?.name?.toString().toLowerCase().includes(query.toLowerCase())
       );
 
   return (


### PR DESCRIPTION
…alues were numbers instead of string. In that case .toLowerCase() method was failing. Added fix for that.