### PR TITLE
Prevent set state for previous loading query

### DIFF
--- a/frontend/src/screens/object-items/object-items.tsx
+++ b/frontend/src/screens/object-items/object-items.tsx
@@ -89,8 +89,18 @@ export default function ObjectItems() {
         `;
 
         const data: any = await graphQLClient.request(query);
-        const rows = data[schema.name];
-        setObjectRows(rows);
+
+        // Get actual param from pathname to get current object
+        const params = window.location.pathname.split("/");
+        const currentObject = params[params.length - 1];
+
+        // Update state only if the query is for the current object
+        // TODO: Update that when switching to new graphql client and cancel query
+        if (currentObject === objectname) {
+          const rows = data[schema.name];
+          setObjectRows(rows);
+        }
+
         setIsLoading(false);
 
       } catch(e) {
@@ -99,7 +109,7 @@ export default function ObjectItems() {
         setIsLoading(false);
       };
     }
-  }, [filterString, schema]);
+  }, [filterString, schema, objectname]);
 
   useEffect(
     () => {


### PR DESCRIPTION
Related issue:
* https://github.com/opsmill/infrahub/issues/309

Get pathname to check if we need to set the state or not for async data