### PR TITLE
Allow urls & file paths as safe graphql variables

### DIFF
--- a/python_sdk/infrahub_client/node.py
+++ b/python_sdk/infrahub_client/node.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 PROPERTIES_FLAG = ["is_visible", "is_protected"]
 PROPERTIES_OBJECT = ["source", "owner"]
-SAFE_VALUE = re.compile(r"(^[\. a-zA-Z0-9_-]+$)|(^$)")
+SAFE_VALUE = re.compile(r"(^[\. /:a-zA-Z0-9_-]+$)|(^$)")
 
 
 class Attribute:

--- a/python_sdk/tests/unit/test_node.py
+++ b/python_sdk/tests/unit/test_node.py
@@ -27,6 +27,8 @@ SAFE_GRAPHQL_VALUES = [
     pytest.param("User Lastname", id="allow-space"),
     pytest.param("020a1c39-6071-4bf8-9336-ffb7a001e665", id="allow-uuid"),
     pytest.param("user.lastname", id="allow-dots"),
+    pytest.param("/opt/repos/backbone-links", id="allow-filepaths"),
+    pytest.param("https://github.com/opsmill/infrahub-demo-edge", id="allow-urls"),
 ]
 
 UNSAFE_GRAPHQL_VALUES = [


### PR DESCRIPTION
Currently we mask file paths and urls within the client before sending them as a query, but we don't need to do this for these variables. This PR makes any query that uses them a bit easier to read when debugging.