### PR TITLE
Proposal for logging class

### DIFF
--- a/backend/infrahub/cli/git_agent.py
+++ b/backend/infrahub/cli/git_agent.py
@@ -6,11 +6,11 @@ from asyncio import run as aiorun
 
 import typer
 from aio_pika import IncomingMessage
-from rich.logging import RichHandler
 
 import infrahub.config as config
 from infrahub.git import handle_message, initialize_repositories_directory
 from infrahub.git.actions import sync_remote_repositories
+from infrahub.log import log
 from infrahub.message_bus import get_broker
 from infrahub.message_bus.events import (
     InfrahubMessage,
@@ -94,12 +94,6 @@ async def monitor_remote_activity(client: InfrahubClient, interval: int, log: lo
 async def _start(debug: bool, interval: int, config_file: str):
     """Start Infrahub Git Agent."""
 
-    log_level = "DEBUG" if debug else "INFO"
-
-    FORMAT = "%(name)s | %(message)s" if debug else "%(message)s"
-    logging.basicConfig(level=log_level, format=FORMAT, datefmt="[%X]", handlers=[RichHandler()])
-    log = logging.getLogger("infrahub.git")
-
     log.debug(f"Config file : {config_file}")
 
     config.load_and_exit(config_file)
@@ -125,11 +119,13 @@ def start(
     debug: bool = False,
     config_file: str = typer.Argument("infrahub.toml", envvar="INFRAHUB_CONFIG"),
 ):
-    logging.getLogger("httpx").setLevel(logging.ERROR)
-    logging.getLogger("httpcore").setLevel(logging.ERROR)
-    logging.getLogger("neo4j").setLevel(logging.ERROR)
-    logging.getLogger("aio_pika").setLevel(logging.ERROR)
-    logging.getLogger("aiormq").setLevel(logging.ERROR)
-    logging.getLogger("git").setLevel(logging.ERROR)
+    log.set_name("infrahub.git")
+    log.set_handler("rich")
+    # logging.getLogger("httpx").setLevel(logging.ERROR)
+    # logging.getLogger("httpcore").setLevel(logging.ERROR)
+    # logging.getLogger("neo4j").setLevel(logging.ERROR)
+    # logging.getLogger("aio_pika").setLevel(logging.ERROR)
+    # logging.getLogger("aiormq").setLevel(logging.ERROR)
+    # logging.getLogger("git").setLevel(logging.ERROR)
 
     aiorun(_start(interval=interval, debug=debug, config_file=config_file))

--- a/backend/infrahub/log.py
+++ b/backend/infrahub/log.py
@@ -1,0 +1,116 @@
+import logging
+import logging.config
+from typing import Any
+
+
+class DefaultFilter(logging.Filter):
+    """Default Filter"""
+
+    def filter(self, _: logging.LogRecord) -> bool:
+        """Log everything"""
+        return True
+
+
+class InfrahubLog:
+    """Infrahub Logging"""
+
+    logger: logging.Logger
+
+    def __init__(self):
+        self.logger_name = "infrahub"
+        self.handler = "console"
+        self.level = "DEBUG"
+        self._apply_configuration()
+        self.logger = logging.getLogger(self.logger_name)
+        self.info = self.logger.info
+        self.debug = self.logger.debug
+        self.warning = self.logger.warning
+        self.error = self.logger.error
+        self.critical = self.logger.critical
+
+    def _apply_configuration(self) -> None:
+        log_config: dict[str, Any] = {
+            "version": 1,
+            "formatters": {
+                "simple": {"format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s"},
+                "rich_formatter": {"format": "%(name)s | %(message)s", "datefmt": "[%X]"},
+            },
+            "handlers": {
+                "console": {
+                    "class": "logging.StreamHandler",
+                    "level": "DEBUG",
+                    "formatter": "simple",
+                    "filters": ["default"],
+                    "stream": "ext://sys.stdout",
+                },
+                "rich": {
+                    "class": "rich.logging.RichHandler",
+                    "level": "DEBUG",
+                    "formatter": "rich_formatter",
+                    "filters": ["default"],
+                },
+            },
+            "loggers": {
+                self.logger_name: {
+                    "level": self.level,
+                    "handlers": [
+                        self.handler,
+                    ],
+                    "propagate": False,
+                },
+                "neo4j": {
+                    "level": "ERROR",
+                    "handlers": [self.handler],
+                    "propagate": False,
+                },
+                "httpx": {
+                    "level": "ERROR",
+                    "handlers": [self.handler],
+                    "propagate": False,
+                },
+                "httpcore": {
+                    "level": "ERROR",
+                    "handlers": [self.handler],
+                    "propagate": False,
+                },
+                "aio_pika": {
+                    "level": "ERROR",
+                    "handlers": [self.handler],
+                    "propagate": False,
+                },
+                "aiormq": {
+                    "level": "ERROR",
+                    "handlers": [self.handler],
+                    "propagate": False,
+                },
+                "git": {
+                    "level": "ERROR",
+                    "handlers": [self.handler],
+                    "propagate": False,
+                },
+            },
+            "filters": {
+                "default": {
+                    "()": DefaultFilter,
+                },
+            },
+            "root": {"level": "INFO", "handlers": ["console"]},
+        }
+        logging.config.dictConfig(log_config)
+        self.logger = logging.getLogger(self.logger_name)
+        self.info = self.logger.info
+        self.debug = self.logger.debug
+        self.warning = self.logger.warning
+        self.error = self.logger.error
+        self.critical = self.logger.critical
+
+    def set_name(self, name: str) -> None:
+        self.logger_name = name
+        self._apply_configuration()
+
+    def set_handler(self, name: str) -> None:
+        self.handler = name
+        self._apply_configuration()
+
+
+log = InfrahubLog()


### PR DESCRIPTION
This isn't meant to be merged, more it's an example of how we could move forward.

The idea is that anywhere within the code were we want to do logging we'd:

```python
from infrahub.log import log

log.info("some important thing")
```

The entry points under cli would initialise the logging settings. For now we only have the methods .set_name() and .set_handler(), where set_name can be anything and set_handler must be either "console" or "rich". Once finished we might not have .set_name() or .set_handler() instead just .update_config() or similar. What we apply in terms of logging config could be set from git-agent or the api server. Using a log object like this that both supports the regular logging operations such as .info, .warning, .debug along with a way to reconfigure the settings would also allow us to update things such as log levels based on settings in the database. In the same way that a background process tracks changes in the schema we could check for changes (or subscribe to them from the message queue) and then reload the configuration on the fly.