### PR TITLE
Increase default timeout for the SDK to 30 sec

### DIFF
--- a/python_sdk/infrahub_client/client.py
+++ b/python_sdk/infrahub_client/client.py
@@ -37,7 +37,7 @@ class BaseClient:
     def __init__(
         self,
         address: str = "http://localhost:8000",
-        default_timeout: int = 10,
+        default_timeout: int = 30,
         retry_on_failure: bool = False,
         retry_delay: int = 5,
         log: Optional[Logger] = None,


### PR DESCRIPTION
The recent changes to the demo script have highlighted an underlying issue we have with some queries taking a long time to respond when they are executed for the first time. This is surfacing now because the script is now creating some branches, and most queries will be different if they are executed in main or in a branch.

As a result, the demo script is currently timing out from time to time after creating a branch. it's more likely to happen if the database just got started and hasn't built a cache yet.

Until we have a better solution to improve the execution time of all queries, even the first one, I think we should increase the default_timeout to 30s to be safe. 

> I'll open a separate discussion to share some ideas on how we could fix the underlying problems


