### PR TITLE
Modifications to client timeout (targets stable)

### DIFF
--- a/ctl/infrahub_ctl/cli.py
+++ b/ctl/infrahub_ctl/cli.py
@@ -140,7 +140,7 @@ def run(
     concurrent: int = typer.Option(
         4, help="Maximum number of requets to execute at the same time.", envvar="INFRAHUBCTL_CONCURRENT_EXECUTION"
     ),
-    timeout: int = typer.Option(10, help="Timeout in sec", envvar="INFRAHUBCTL_TIMEOUT"),
+    timeout: int = typer.Option(30, help="Timeout in sec", envvar="INFRAHUBCTL_TIMEOUT"),
 ) -> None:
     """Execute a script."""
     config.load_and_exit(config_file=config_file)

--- a/python_sdk/infrahub_client/client.py
+++ b/python_sdk/infrahub_client/client.py
@@ -37,7 +37,7 @@ class BaseClient:
     def __init__(
         self,
         address: str = "http://localhost:8000",
-        default_timeout: int = 30,
+        default_timeout: int = 10,
         retry_on_failure: bool = False,
         retry_delay: int = 5,
         log: Optional[Logger] = None,

--- a/tasks/demo.py
+++ b/tasks/demo.py
@@ -201,7 +201,7 @@ def load_infra_data(context: Context):
     """Load some demo data."""
     compose_files_cmd = build_compose_files_cmd()
     context.run(
-        f"{ENV_VARS} docker compose {compose_files_cmd} -p {BUILD_NAME} run infrahub-git infrahubctl run models/infrastructure_edge.py --timeout 20",
+        f"{ENV_VARS} docker compose {compose_files_cmd} -p {BUILD_NAME} run infrahub-git infrahubctl run models/infrastructure_edge.py",
         pty=True,
     )
 


### PR DESCRIPTION
* Revert SDK default timeout to 10 seconds
* Remove timeout parameter from invoke command
* Increase infrahubctl run timeout for sdk client to 30 seconds

This change makes the timeout of infrahubctl behave in the same way regardless of if the command is run as a standalone command or from invoke.