### PR TITLE
Add environment variables for development logging

### DIFF
--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - "INFRAHUB_CONFIG=/source/development/infrahub.toml"
       - "INFRAHUB_ADDRESS=http://infrahub-server:8000"
       - "INFRAHUB_PRODUCTION=false"
-      - "INFRAHUB_LOG_LEVEL=debug"
+      - "INFRAHUB_LOG_LEVEL=DEBUG"
     volumes:
       - ../:/source
       - "git_data:/opt/infrahub/git"


### PR DESCRIPTION
Ensure that our development containers are set to log using text in colored format instead of json.

Fixes #460