### PR TITLE
Add feature flag to enable pagination

### DIFF
--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -103,6 +103,7 @@ class AnalyticsSettings(BaseSettings):
 
 class ExperimentalFeaturesSettings(BaseSettings):
     pull_request: bool = False
+    paginated: bool = False
 
     class Config:
         env_prefix = "INFRAHUB_EXPERIMENTAL_"

--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -351,11 +351,16 @@ class SchemaBranch:
 
     async def get_graphql_schema(self, session: AsyncSession) -> GraphQLSchema:
         from infrahub.graphql import (  # pylint: disable=import-outside-toplevel
+            generate_graphql_paginated_schema,
             generate_graphql_schema,
         )
 
+        schema_creator = generate_graphql_schema
+        if config.SETTINGS.experimental_features.paginated:
+            schema_creator = generate_graphql_paginated_schema
+
         if not self._graphql_schema:
-            self._graphql_schema = await generate_graphql_schema(session=session, branch=self.name)
+            self._graphql_schema = await schema_creator(session=session, branch=self.name)
 
         return self._graphql_schema
 

--- a/backend/infrahub/core/registry.py
+++ b/backend/infrahub/core/registry.py
@@ -108,7 +108,7 @@ class Registry:
     def set_graphql_type(
         self,
         name: str,
-        graphql_type: Union[Type[InfrahubObject], Type[graphene.Interface]],
+        graphql_type: Union[Type[InfrahubObject], Type[graphene.Interface], Type[graphene.ObjectType]],
         branch: Optional[str] = None,
     ) -> bool:
         return self.set_item(kind="graphql_type", name=name, item=graphql_type, branch=branch)

--- a/backend/infrahub/graphql/__init__.py
+++ b/backend/infrahub/graphql/__init__.py
@@ -7,8 +7,12 @@ from graphql import GraphQLSchema
 
 from infrahub.core import registry
 
-from .generator import generate_mutation_mixin, generate_object_types
-from .query import get_gql_query
+from .generator import (
+    generate_mutation_mixin,
+    generate_object_types,
+    generate_paginated_object_types,
+)
+from .query import get_gql_query, get_paginated_gql_query
 from .schema import InfrahubBaseMutation
 from .subscription import InfrahubBaseSubscription
 
@@ -34,6 +38,32 @@ async def generate_graphql_schema(
         types = []
 
     query = await get_gql_query(session=session, branch=branch) if include_query else None
+    mutation = await get_gql_mutation(session=session, branch=branch) if include_mutation else None
+    subscription = await get_gql_subscription(session=session, branch=branch) if include_subscription else None
+
+    graphene_schema = graphene.Schema(
+        query=query, mutation=mutation, subscription=subscription, types=types, auto_camelcase=False
+    )
+
+    return graphene_schema.graphql_schema
+
+
+async def generate_graphql_paginated_schema(
+    session: AsyncSession,
+    branch: Union[Branch, str],
+    include_query: bool = True,
+    include_mutation: bool = True,
+    include_subscription: bool = True,
+    include_types: bool = True,
+) -> GraphQLSchema:
+    if include_types:
+        await generate_paginated_object_types(session=session, branch=branch)
+        types_dict = registry.get_all_graphql_type(branch=branch)
+        types = list(types_dict.values())
+    else:
+        types = []
+
+    query = await get_paginated_gql_query(session=session, branch=branch) if include_query else None
     mutation = await get_gql_mutation(session=session, branch=branch) if include_mutation else None
     subscription = await get_gql_subscription(session=session, branch=branch) if include_subscription else None
 

--- a/backend/infrahub/graphql/generator.py
+++ b/backend/infrahub/graphql/generator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import TYPE_CHECKING, Dict, List, Tuple, Type, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Type, Union
 
 import graphene
 from graphql import GraphQLResolveInfo
@@ -13,7 +13,7 @@ from infrahub.core.schema import GenericSchema, GroupSchema, NodeSchema
 from infrahub.types import ATTRIBUTE_TYPES
 
 from .mutations import InfrahubMutation, InfrahubRepositoryMutation
-from .schema import default_list_resolver
+from .schema import default_list_resolver, default_paginated_list_resolver
 from .types import (
     InfrahubInterface,
     InfrahubObject,
@@ -190,7 +190,7 @@ async def generate_object_types(
             continue
 
         related_interface = generate_related_interface_object(
-            schema=node_schema, branch=branch, data_source=data_source, data_owner=data_owner
+            schema=node_schema, branch=branch, data_source=data_source, data_owner=data_owner, name_prefix="Related"
         )
 
         registry.set_graphql_type(name=related_interface._meta.name, graphql_type=related_interface, branch=branch.name)
@@ -262,6 +262,137 @@ async def generate_object_types(
                 )
 
 
+async def generate_paginated_object_types(
+    session: AsyncSession, branch: Union[Branch, str]
+):  # pylint: disable=too-many-branches,too-many-statements
+    """Generate all GraphQL objects for the schema and store them in the internal registry."""
+
+    branch = await get_branch(session=session, branch=branch)
+
+    full_schema = await registry.schema.get_full_safe(branch=branch)
+
+    group_memberships = defaultdict(list)
+
+    load_attribute_types_in_registry(branch=branch)
+
+    # Generate all GraphQL Interface & RelatedInterface Object first and store them in the registry
+    for node_name, node_schema in full_schema.items():
+        if not isinstance(node_schema, GenericSchema):
+            continue
+        interface = generate_interface_object(schema=node_schema, branch=branch)
+        registry.set_graphql_type(name=interface._meta.name, graphql_type=interface, branch=branch.name)
+
+    # Define DataOwner and DataOwner
+    data_source = registry.get_graphql_type(name="DataSource", branch=branch)
+    data_owner = registry.get_graphql_type(name="DataOwner", branch=branch)
+    define_relationship_property(branch=branch, data_source=data_source, data_owner=data_owner)
+    relationship_property = registry.get_graphql_type(name="RelationshipProperty", branch=branch)
+    for data_type in ATTRIBUTE_TYPES.values():
+        gql_type = registry.get_graphql_type(name=data_type.get_graphql_type_name(), branch=branch)
+        gql_type._meta.fields["source"] = graphene.Field(data_source)
+        gql_type._meta.fields["owner"] = graphene.Field(data_owner)
+
+    # Generate all RelatedInterfaceType and store them in the registry
+    for node_name, node_schema in full_schema.items():
+        if not isinstance(node_schema, GenericSchema):
+            continue
+
+        related_interface = generate_related_interface_object(
+            schema=node_schema, branch=branch, data_source=data_source, data_owner=data_owner, name_prefix="Related"
+        )
+        nested_interface = generate_related_interface_object(
+            schema=node_schema,
+            branch=branch,
+            data_source=data_source,
+            data_owner=data_owner,
+            name_prefix="NestedPaginated",
+        )
+
+        registry.set_graphql_type(name=related_interface._meta.name, graphql_type=related_interface, branch=branch.name)
+        registry.set_graphql_type(name=nested_interface._meta.name, graphql_type=nested_interface, branch=branch.name)
+
+    # Generate all GraphQL ObjectType & RelatedObjectType and store them in the registry
+    for node_name, node_schema in full_schema.items():
+        if isinstance(node_schema, NodeSchema):
+            node_type = generate_graphql_object(schema=node_schema, branch=branch)
+            related_node_type = generate_related_graphql_object(
+                schema=node_schema, branch=branch, data_source=data_source, data_owner=data_owner
+            )
+
+            node_type_edged = generate_graphql_edged_object(schema=node_schema, node=node_type)
+            nested_node_type_edged = generate_graphql_edged_object(
+                schema=node_schema, node=node_type, relation_property=relationship_property
+            )
+
+            node_type_paginated = generate_graphql_paginated_object(schema=node_schema, edge=node_type_edged)
+            node_type_nested_paginated = generate_graphql_paginated_object(
+                schema=node_schema, edge=nested_node_type_edged, nested=True
+            )
+
+            registry.set_graphql_type(name=node_type._meta.name, graphql_type=node_type, branch=branch.name)
+            registry.set_graphql_type(
+                name=related_node_type._meta.name, graphql_type=related_node_type, branch=branch.name
+            )
+            registry.set_graphql_type(name=node_type_edged._meta.name, graphql_type=node_type_edged, branch=branch.name)
+            registry.set_graphql_type(
+                name=nested_node_type_edged._meta.name, graphql_type=nested_node_type_edged, branch=branch.name
+            )
+
+            registry.set_graphql_type(
+                name=node_type_paginated._meta.name, graphql_type=node_type_paginated, branch=branch.name
+            )
+            registry.set_graphql_type(
+                name=node_type_nested_paginated._meta.name, graphql_type=node_type_nested_paginated, branch=branch.name
+            )
+
+            # Register this model to all the groups it belongs to.
+            if node_schema.groups:
+                for group_name in node_schema.groups:
+                    group_memberships[group_name].append(f"Related{node_schema.kind}")
+
+    # Generate all the Groups with associated ObjectType / RelatedObjectType
+    for node_name, node_schema in full_schema.items():
+        if (
+            not isinstance(node_schema, GroupSchema)
+            or node_name not in group_memberships
+            or not group_memberships[node_name]
+        ):
+            continue
+        group = generate_union_object(schema=node_schema, members=group_memberships.get(node_name, []), branch=branch)
+        registry.set_graphql_type(name=group._meta.name, graphql_type=group, branch=branch.name)
+
+    # Extend all types and related types with Relationships
+    for node_name, node_schema in full_schema.items():
+        if not isinstance(node_schema, (NodeSchema, GenericSchema)):
+            continue
+        node_type = registry.get_graphql_type(name=node_name, branch=branch.name)
+        related_node_type = registry.get_graphql_type(name=f"NestedPaginated{node_name}", branch=branch.name)
+
+        for rel in node_schema.relationships:
+            peer_schema = await rel.get_peer_schema()
+
+            peer_filters = await generate_filters(session=session, schema=peer_schema, top_level=False)
+
+            if rel.cardinality == "one":
+                if isinstance(peer_schema, GroupSchema):
+                    peer_type = registry.get_graphql_type(name=peer_schema.kind, branch=branch.name)
+                else:
+                    peer_type = registry.get_graphql_type(name=f"NestedEdged{peer_schema.kind}", branch=branch.name)
+                node_type._meta.fields[rel.name] = graphene.Field(peer_type, resolver=default_resolver)
+                related_node_type._meta.fields[rel.name] = graphene.Field(peer_type, resolver=default_resolver)
+
+            elif rel.cardinality == "many":
+                if isinstance(peer_schema, GroupSchema):
+                    peer_type = registry.get_graphql_type(name=peer_schema.kind, branch=branch.name)
+                else:
+                    peer_type = registry.get_graphql_type(name=f"NestedPaginated{peer_schema.kind}", branch=branch.name)
+                node_type._meta.fields[rel.name] = graphene.Field(
+                    peer_type, required=False, resolver=default_paginated_list_resolver, **peer_filters
+                )
+
+                related_node_type._meta.fields[rel.name] = graphene.Field(peer_type, required=False, **peer_filters)
+
+
 async def generate_query_mixin(session: AsyncSession, branch: Union[Branch, str] = None) -> Type[object]:
     class_attrs = {}
 
@@ -280,6 +411,30 @@ async def generate_query_mixin(session: AsyncSession, branch: Union[Branch, str]
         class_attrs[node_schema.name] = graphene.List(
             of_type=node_type,
             resolver=default_list_resolver,
+            **node_filters,
+        )
+
+    return type("QueryMixin", (object,), class_attrs)
+
+
+async def generate_paginated_query_mixin(session: AsyncSession, branch: Union[Branch, str] = None) -> Type[object]:
+    class_attrs = {}
+
+    full_schema = await registry.schema.get_full_safe(branch=branch)
+
+    # Generate all Graphql objectType and store them in the registry
+    await generate_object_types(session=session, branch=branch)
+
+    for node_name, node_schema in full_schema.items():
+        if not isinstance(node_schema, NodeSchema):
+            continue
+
+        node_type = registry.get_graphql_type(name=f"Paginated{node_name}", branch=branch)
+        node_filters = await generate_filters(session=session, schema=node_schema, top_level=True)
+
+        class_attrs[node_schema.name] = graphene.Field(
+            node_type,
+            resolver=default_paginated_list_resolver,
             **node_filters,
         )
 
@@ -341,12 +496,39 @@ def generate_graphql_object(schema: NodeSchema, branch: Branch) -> Type[Infrahub
     return type(schema.kind, (InfrahubObject,), main_attrs)
 
 
-def generate_graphql_edged_object(schema: NodeSchema, node: Type[InfrahubObject]) -> Type[InfrahubObject]:
+def define_relationship_property(branch: Branch, data_source: InfrahubObject, data_owner: InfrahubObject) -> None:
+    type_name = "RelationshipProperty"
+
+    meta_attrs = {
+        "name": type_name,
+        "description": "Defines properties for relationships",
+    }
+
+    main_attrs = {
+        "is_visible": graphene.Boolean(required=False),
+        "is_protected": graphene.Boolean(required=False),
+        "source": graphene.Field(data_source),
+        "owner": graphene.Field(data_owner),
+        "Meta": type("Meta", (object,), meta_attrs),
+    }
+
+    relationship_property = type(type_name, (graphene.ObjectType,), main_attrs)
+
+    registry.set_graphql_type(name=type_name, graphql_type=relationship_property, branch=branch.name)
+
+
+def generate_graphql_edged_object(
+    schema: NodeSchema, node: Type[InfrahubObject], relation_property: Optional[graphene.ObjectType] = None
+) -> Type[InfrahubObject]:
     """Generate a ednged GraphQL object Type from a Infrahub NodeSchema for pagination."""
+
+    object_name = f"Edged{schema.kind}"
+    if relation_property:
+        object_name = f"NestedEdged{schema.kind}"
 
     meta_attrs = {
         "schema": schema,
-        "name": f"Edged{schema.kind}",
+        "name": object_name,
         "description": schema.description,
         "default_resolver": default_resolver,
         "interfaces": set(),
@@ -354,18 +536,28 @@ def generate_graphql_edged_object(schema: NodeSchema, node: Type[InfrahubObject]
 
     main_attrs = {
         "node": graphene.Field(node, required=False),
+        "updated_at": graphene.DateTime(required=False),
         "Meta": type("Meta", (object,), meta_attrs),
     }
 
-    return type(f"Edged{schema.kind}", (InfrahubObject,), main_attrs)
+    if relation_property:
+        main_attrs["properties"] = graphene.Field(relation_property)
+
+    return type(object_name, (InfrahubObject,), main_attrs)
 
 
-def generate_graphql_paginated_object(schema: NodeSchema, edge: Type[InfrahubObject]) -> Type[InfrahubObject]:
+def generate_graphql_paginated_object(
+    schema: NodeSchema, edge: Type[InfrahubObject], nested: bool = False
+) -> Type[InfrahubObject]:
     """Generate a paginated GraphQL object Type from a Infrahub NodeSchema."""
+
+    object_name = f"Paginated{schema.kind}"
+    if nested:
+        object_name = f"NestedPaginated{schema.kind}"
 
     meta_attrs = {
         "schema": schema,
-        "name": f"Paginated{schema.kind}",
+        "name": object_name,
         "description": schema.description,
         "default_resolver": default_resolver,
         "interfaces": set(),
@@ -374,11 +566,11 @@ def generate_graphql_paginated_object(schema: NodeSchema, edge: Type[InfrahubObj
     main_attrs = {
         "count": graphene.Int(required=False),
         "has_next": graphene.Boolean(required=False),
-        "edges": graphene.Field.mounted(graphene.List(of_type=edge, required=True)),
+        "edges": graphene.List(of_type=edge),
         "Meta": type("Meta", (object,), meta_attrs),
     }
 
-    return type(f"Paginated{schema.kind}", (InfrahubObject,), main_attrs)
+    return type(object_name, (InfrahubObject,), main_attrs)
 
 
 def generate_union_object(
@@ -428,10 +620,10 @@ def generate_interface_object(schema: GenericSchema, branch: Branch) -> Type[gra
 
 
 def generate_related_interface_object(
-    schema: GenericSchema, branch: Branch, data_source: InfrahubObject, data_owner: InfrahubObject
+    schema: GenericSchema, branch: Branch, data_source: InfrahubObject, data_owner: InfrahubObject, name_prefix: str
 ) -> Type[graphene.Interface]:
     meta_attrs = {
-        "name": f"Related{schema.kind}",
+        "name": f"{name_prefix}{schema.kind}",
         "description": schema.description,
     }
 
@@ -454,7 +646,7 @@ def generate_related_interface_object(
 
     main_attrs["id"] = graphene.Field(graphene.String, required=False, description="Unique identifier")
 
-    return type(f"Related{schema.kind}", (InfrahubInterface,), main_attrs)
+    return type(f"{name_prefix}{schema.kind}", (InfrahubInterface,), main_attrs)
 
 
 def generate_related_graphql_object(

--- a/backend/infrahub/graphql/query.py
+++ b/backend/infrahub/graphql/query.py
@@ -9,7 +9,7 @@ from infrahub.core import get_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.timestamp import Timestamp
 
-from .generator import generate_query_mixin
+from .generator import generate_paginated_query_mixin, generate_query_mixin
 from .schema import InfrahubBaseQuery
 
 if TYPE_CHECKING:
@@ -53,6 +53,15 @@ async def execute_query(
 
 async def get_gql_query(session: AsyncSession, branch: Union[Branch, str] = None) -> type[InfrahubBaseQuery]:
     QueryMixin = await generate_query_mixin(session=session, branch=branch)
+
+    class Query(InfrahubBaseQuery, QueryMixin):
+        pass
+
+    return Query
+
+
+async def get_paginated_gql_query(session: AsyncSession, branch: Union[Branch, str]) -> type[InfrahubBaseQuery]:
+    QueryMixin = await generate_paginated_query_mixin(session=session, branch=branch)
 
     class Query(InfrahubBaseQuery, QueryMixin):
         pass

--- a/backend/infrahub/graphql/schema.py
+++ b/backend/infrahub/graphql/schema.py
@@ -23,6 +23,11 @@ async def default_list_resolver(root, info: GraphQLResolveInfo, **kwargs):
     return await info.return_type.of_type.graphene_type.get_list(**kwargs, fields=fields, context=info.context)
 
 
+async def default_paginated_list_resolver(root, info: GraphQLResolveInfo, **kwargs):
+    fields = await extract_fields(info.field_nodes[0].selection_set)
+    return await info.return_type.graphene_type.get_paginated_list(**kwargs, fields=fields, context=info.context)
+
+
 class InfrahubBaseQuery(ObjectType):
     branch = List(BranchType, ids=List(ID), name=String())
 

--- a/backend/tests/unit/graphql/test_graphql_paginated_query.py
+++ b/backend/tests/unit/graphql/test_graphql_paginated_query.py
@@ -1,0 +1,40 @@
+from graphql import graphql
+
+from infrahub.core.branch import Branch
+from infrahub.core.node import Node
+from infrahub.graphql import generate_graphql_paginated_schema
+
+
+async def test_simple_query(db, session, default_branch: Branch, criticality_schema):
+    obj1 = await Node.init(session=session, schema=criticality_schema)
+    await obj1.new(session=session, name="low", level=4)
+    await obj1.save(session=session)
+    obj2 = await Node.init(session=session, schema=criticality_schema)
+    await obj2.new(session=session, name="medium", level=3, description="My desc", color="#333333")
+    await obj2.save(session=session)
+
+    query = """
+    query {
+        criticality {
+            edges {
+            node {
+                name {
+                value
+                }
+            }
+            }
+        }
+    }
+    """
+    result = await graphql(
+        await generate_graphql_paginated_schema(
+            session=session, include_mutation=False, include_subscription=False, branch=default_branch
+        ),
+        source=query,
+        context_value={"infrahub_session": session, "infrahub_database": db, "infrahub_branch": default_branch},
+        root_value=None,
+        variable_values={},
+    )
+
+    assert result.errors is None
+    assert len(result.data["criticality"]["edges"]) == 2


### PR DESCRIPTION
Temporarily duplicates some code that will later be removed, all the old functions will eventually be deleted and the new ones that include the paginated name will be removed.

In order to use this the experimental feature flag "paginated" must be set to true, for example with an environment variable.
```
export INFRAHUB_EXPERIMENTAL_PAGINATED=true
```

The focus on this PR is to get the overall responses back in a correct way. It's missing the ability to actually count responses, also the relationships isn't mapped in this version. It also only includes one of the old tests.