### PR TITLE
Increase timeout (again) of infrahubctl run and change logging settings for httpx lib

### DIFF
--- a/ctl/infrahub_ctl/cli.py
+++ b/ctl/infrahub_ctl/cli.py
@@ -140,12 +140,14 @@ def run(
     concurrent: int = typer.Option(
         4, help="Maximum number of requets to execute at the same time.", envvar="INFRAHUBCTL_CONCURRENT_EXECUTION"
     ),
-    timeout: int = typer.Option(30, help="Timeout in sec", envvar="INFRAHUBCTL_TIMEOUT"),
+    timeout: int = typer.Option(60, help="Timeout in sec", envvar="INFRAHUBCTL_TIMEOUT"),
 ) -> None:
     """Execute a script."""
     config.load_and_exit(config_file=config_file)
 
     logging.getLogger("infrahub_client").setLevel(logging.CRITICAL)
+    logging.getLogger("httpx").setLevel(logging.ERROR)
+    logging.getLogger("httpcore").setLevel(logging.ERROR)
 
     log_level = "DEBUG" if debug else "INFO"
     FORMAT = "%(message)s"


### PR DESCRIPTION
This PR fixes couple of issues related to the `infrahubctl run` command 

Occasionally I'm still seeing the timeout issue with the `invoke demo.load-infra-data`, so I've increase the default timeout for the infrahubctl run command to 60 seconds

In the latest `develop`, when running `invoke demo.load-infra-data` I've noticed some httpx internal logs are visible in the CLI and they are making it hard to see the output of the script. Not sure what triggered this change but I've increased to ERROR the logging level for httpx and httpcore by default when running `infrahubctl run`