### PR TITLE
Fix pagination display for smaller pagination

### DIFF
--- a/frontend/src/components/pagination.tsx
+++ b/frontend/src/components/pagination.tsx
@@ -24,9 +24,15 @@ export const Pagination = (props: tPaginationType) => {
   const handlePageChange = (page: any) => {
     const { nextSelectedPage } = page;
 
+    const newOffset = nextSelectedPage * limit || 0;
+
+    if (newOffset === offset) {
+      return;
+    }
+
     const newPagination = {
       limit,
-      offset: nextSelectedPage * limit,
+      offset: newOffset,
     };
 
     setPagination(newPagination);


### PR DESCRIPTION
Related issue:
* https://github.com/opsmill/infrahub/issues/563
* https://github.com/opsmill/infrahub/issues/534

Done:
* Fix the count of the results on the left
* Fix the number of pages on the right
* Do not put the pagination params in the URL if it's not needed

<img width="2039" alt="image" src="https://github.com/opsmill/infrahub/assets/16644715/c5336d99-096c-4d76-b1c7-085db3d7baa6">
