### PR TITLE
Add authentication checks to endpoints

### DIFF
--- a/backend/infrahub/api/dependencies.py
+++ b/backend/infrahub/api/dependencies.py
@@ -1,7 +1,12 @@
-from fastapi import Request
+from fastapi import Depends, Request
+from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBearer
 from neo4j import AsyncSession
 
-import infrahub.config as config
+from infrahub import config
+from infrahub.auth import validate_authentication_token
+
+jwt_scheme = HTTPBearer(auto_error=False)
+api_key_scheme = APIKeyHeader(name="X-INFRAHUB-KEY", auto_error=False)
 
 
 async def get_session(request: Request) -> AsyncSession:
@@ -10,3 +15,15 @@ async def get_session(request: Request) -> AsyncSession:
         yield session
     finally:
         await session.close()
+
+
+async def get_current_user(
+    jwt_token: HTTPAuthorizationCredentials = Depends(jwt_scheme),
+    session: AsyncSession = Depends(get_session),
+    api_key: str = Depends(api_key_scheme),
+) -> str:
+    """Return current user"""
+    if jwt_token:
+        return await validate_authentication_token(session=session, jwt_token=jwt_token.credentials, api_key=api_key)
+
+    return await validate_authentication_token(session=session, api_key=api_key)

--- a/backend/infrahub/api/diff.py
+++ b/backend/infrahub/api/diff.py
@@ -8,7 +8,7 @@ from fastapi.logger import logger
 from neo4j import AsyncSession
 from pydantic import BaseModel, Field
 
-from infrahub.api.dependencies import get_session
+from infrahub.api.dependencies import get_current_user, get_session
 from infrahub.core import get_branch, registry
 from infrahub.core.branch import Branch, Diff, RelationshipDiffElement
 from infrahub.core.constants import DiffAction
@@ -445,6 +445,7 @@ async def get_diff_data(  # pylint: disable=too-many-branches,too-many-statement
     time_from: Optional[str] = None,
     time_to: Optional[str] = None,
     branch_only: bool = True,
+    _: str = Depends(get_current_user),
 ) -> Dict[str, List[BranchDiffNode]]:
     branch: Branch = await get_branch(session=session, branch=branch)
 
@@ -460,6 +461,7 @@ async def get_diff_schema(  # pylint: disable=too-many-branches,too-many-stateme
     time_from: Optional[str] = None,
     time_to: Optional[str] = None,
     branch_only: bool = True,
+    _: str = Depends(get_current_user),
 ) -> Dict[str, List[BranchDiffNode]]:
     branch: Branch = await get_branch(session=session, branch=branch)
 
@@ -475,6 +477,7 @@ async def get_diff_files(
     time_from: Optional[str] = None,
     time_to: Optional[str] = None,
     branch_only: bool = True,
+    _: str = Depends(get_current_user),
 ) -> Dict[str, Dict[str, BranchDiffRepository]]:
     branch: Branch = await get_branch(session=session, branch=branch)
 

--- a/backend/infrahub/api/main.py
+++ b/backend/infrahub/api/main.py
@@ -19,7 +19,7 @@ import infrahub.config as config
 from infrahub import __version__
 from infrahub.api import auth, diff, internal, schema, transformation
 from infrahub.api.background import BackgroundRunner
-from infrahub.api.dependencies import get_session
+from infrahub.api.dependencies import get_current_user, get_session
 from infrahub.auth import BaseTokenAuth
 from infrahub.core import get_branch, registry
 from infrahub.core.initialization import initialization
@@ -128,6 +128,7 @@ async def graphql_query(
     branch: Optional[str] = None,
     at: Optional[str] = None,
     rebase: bool = False,
+    _: str = Depends(get_current_user),
 ):
     branch = await get_branch(session=session, branch=branch)
 

--- a/backend/infrahub/api/schema.py
+++ b/backend/infrahub/api/schema.py
@@ -6,7 +6,7 @@ from neo4j import AsyncSession
 from pydantic import BaseModel
 from starlette.responses import JSONResponse
 
-from infrahub.api.dependencies import get_session
+from infrahub.api.dependencies import get_current_user, get_session
 from infrahub.core import get_branch, registry
 from infrahub.core.branch import Branch
 from infrahub.core.schema import GenericSchema, NodeSchema, SchemaRoot
@@ -48,6 +48,7 @@ async def load_schema(
     schema: SchemaLoadAPI,
     session: AsyncSession = Depends(get_session),
     branch: Optional[str] = None,
+    _: str = Depends(get_current_user),
 ):
     branch: Branch = await get_branch(session=session, branch=branch)
 

--- a/backend/infrahub/api/transformation.py
+++ b/backend/infrahub/api/transformation.py
@@ -5,7 +5,7 @@ from graphql import graphql
 from neo4j import AsyncSession
 from starlette.responses import JSONResponse, PlainTextResponse
 
-from infrahub.api.dependencies import get_session
+from infrahub.api.dependencies import get_current_user, get_session
 from infrahub.core import get_branch, registry
 from infrahub.core.manager import NodeManager
 from infrahub.core.timestamp import Timestamp
@@ -28,6 +28,7 @@ async def transform_python(
     branch: Optional[str] = None,
     at: Optional[str] = None,
     rebase: Optional[bool] = False,
+    _: str = Depends(get_current_user),
 ):
     branch = await get_branch(session=session, branch=branch)
 
@@ -104,6 +105,7 @@ async def generate_rfile(
     branch: Optional[str] = None,
     at: Optional[str] = None,
     rebase: Optional[bool] = False,
+    _: str = Depends(get_current_user),
 ):
     branch = await get_branch(session=session, branch=branch)
 

--- a/backend/infrahub/auth.py
+++ b/backend/infrahub/auth.py
@@ -21,8 +21,6 @@ if TYPE_CHECKING:
 # from ..datatypes import AuthResult
 # from ..exceptions import InvalidCredentials
 
-# Code copied from https://github.com/florimondmanca/starlette-auth-toolkit/
-
 
 async def authenticate_with_password(
     session: AsyncSession, credentials: models.PasswordCredential, branch: Optional[str] = None
@@ -60,6 +58,41 @@ async def authenticate_with_password(
     }
     access_token = jwt.encode(access_data, config.SETTINGS.security.secret_key, algorithm="HS256")
     return models.UserToken(access_token=access_token)
+
+
+async def validate_authentication_token(
+    session: AsyncSession, jwt_token: Optional[str] = None, api_key: Optional[str] = None
+) -> str:
+    if api_key:
+        return await validate_api_key(session=session, token=api_key)
+    if jwt_token:
+        await validate_jwt_access_token(token=jwt_token)
+    return "anonymous"
+
+
+async def validate_jwt_access_token(token: str) -> str:
+    try:
+        payload = jwt.decode(token, config.SETTINGS.security.secret_key, algorithms=["HS256"])
+        user_id = payload["sub"]
+
+    except Exception:
+        raise AuthorizationError("Invalid token") from None
+
+    if payload["type"] == "access":
+        return str(user_id)
+
+    raise AuthorizationError("Invalid token, current token is not an access token")
+
+
+async def validate_api_key(session: AsyncSession, token: str) -> str:
+    user = await validate_token(token=token, session=session)
+    if not user:
+        raise AuthorizationError("Invalid token")
+
+    return user
+
+
+# Code copied from https://github.com/florimondmanca/starlette-auth-toolkit/
 
 
 class InvalidCredentials(AuthenticationError):

--- a/backend/infrahub/core/schema.py
+++ b/backend/infrahub/core/schema.py
@@ -1026,11 +1026,11 @@ core_models = {
             "name": "account_token",
             "kind": "AccountToken",
             "default_filter": "token__value",
-            "display_labels": ["name__value"],
+            "display_labels": ["token__value"],
             "branch": True,
             "attributes": [
                 {"name": "token", "kind": "Text", "unique": True},
-                {"name": "expiration_date", "kind": "Text", "optional": True},  # Should be date here
+                {"name": "expiration", "kind": "DateTime", "optional": True},
             ],
             "relationships": [
                 {"name": "account", "peer": "Account", "optional": False, "cardinality": "one"},


### PR DESCRIPTION
This PR enables optional authentication on a number of the api endpoints in the REST interface and also within the GraphQL app.

The way the authentication works now is that if you submit a JWT token that is invalid or has expired the request will be denied. Likewise if you try to access a resource with an API key/token (by setting an HTTP header called `X-INFRAHUB-KEY`) the request will fail if the supplied token doesn't exist in the database.

Check http://localhost:8000/docs to review what endpoints we want to later enforce authentication on.

In the current iteration the authentication verification will only return the name of the user if token based authentication is used, or the id of the user if JWT is used. That part is just temporary. Later this will probably be some type of user object that includes any roles that the user has.

Also fixes an issue in the schema that caused the AccountToken to not work as the name field currently doesn't exist (later we might want to add that name in order to separate different user tokens). Also renamed the expiration_date to just expiration as I'm thinking it will be a timestamp and not a date.

@dgarros, can you look at the overall structure of this one? If you think it's fine I'll add some tests around it.
