### PR TITLE
Activate ruff rule for mccabe complexity checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,6 +181,7 @@ disallow_untyped_defs = true
 [tool.ruff]
 
 select = [
+    "C90",
     "DTZ",
     "E",
     "F",
@@ -189,6 +190,10 @@ select = [
 ]
 
 line-length = 215
+
+[tool.ruff.mccabe]
+# Target max-complexity=10
+max-complexity = 33
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Activates a check for the cyclomatic complexity within the code. For now it's set to 33 which is the number of the currently most complex function by this measure.

The idea is that we can work on these on a rainy day to simplify them and aim to not raise this number instead start to lower it.

If the max-complexity was set to 10 instead the current output would look like this:

```bash
❯ ruff check .
backend/infrahub/api/diff.py:292:11: C901 `generate_diff_payload` is too complex (33 > 10)
backend/infrahub/core/branch.py:524:15: C901 `merge_graph` is too complex (20 > 10)
backend/infrahub/core/branch.py:931:15: C901 `get_modified_paths_graph` is too complex (11 > 10)
backend/infrahub/core/branch.py:1061:15: C901 `_calculate_diff_nodes` is too complex (21 > 10)
backend/infrahub/core/manager.py:241:15: C901 `get_many` is too complex (20 > 10)
backend/infrahub/core/manager.py:792:15: C901 `update_node_in_db` is too complex (11 > 10)
backend/infrahub/core/node/__init__.py:115:15: C901 `_process_fields` is too complex (20 > 10)
backend/infrahub/core/relationship.py:74:15: C901 `_process_data` is too complex (12 > 10)
backend/infrahub/graphql/generator.py:288:11: C901 `generate_object_types` is too complex (18 > 10)
backend/infrahub/graphql/generator.py:394:11: C901 `generate_paginated_object_types` is too complex (19 > 10)
backend/infrahub/graphql/types.py:467:15: C901 `get_diff` is too complex (11 > 10)
backend/infrahub/test_data/dataset01.py:76:11: C901 `load_data` is too complex (12 > 10)
ctl/infrahub_ctl/check.py:27:5: C901 `run` is too complex (14 > 10)
python_sdk/infrahub_client/client.py:354:15: C901 `execute_graphql` is too complex (13 > 10)
python_sdk/infrahub_client/client.py:639:9: C901 `execute_graphql` is too complex (13 > 10)
python_sdk/infrahub_client/schema.py:185:9: C901 `generate_payload_create` is too complex (11 > 10)
sync/diffsync/diffsync/__init__.py:104:9: C901 `__init_subclass__` is too complex (12 > 10)
sync/diffsync/diffsync/helpers.py:160:9: C901 `diff_object_pair` is too complex (11 > 10)
sync/diffsync/diffsync/helpers.py:396:15: C901 `sync_model` is too complex (14 > 10)
Found 19 errors.
```