### PR TITLE
Configure API container with the INFO log level

### DIFF
--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     environment:
       - "INFRAHUB_CONFIG=/source/development/infrahub.toml"
       - "INFRAHUB_PRODUCTION=false"
-      - "INFRAHUB_LOG_LEVEL=DEBUG"
+      - "INFRAHUB_LOG_LEVEL=INFO"
       - "PROMETHEUS_MULTIPROC_DIR=/prom_shared"
     volumes:
       - ../:/source


### PR DESCRIPTION
Fixes #603

For now we just set the log level to info to avoid getting lots of debug messages for neo4j. For the next milestone we'll review this again and come up with a better way to allow for debug logging of Infrahub without getting debug logs for everything.