### PR TITLE
Remove ability to run non paginated app

### DIFF
--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -404,15 +404,10 @@ class SchemaBranch:
     async def get_graphql_schema(self, session: AsyncSession) -> GraphQLSchema:
         from infrahub.graphql import (  # pylint: disable=import-outside-toplevel
             generate_graphql_paginated_schema,
-            generate_graphql_schema,
         )
 
-        schema_creator = generate_graphql_schema
-        if config.SETTINGS.experimental_features.paginated:
-            schema_creator = generate_graphql_paginated_schema
-
         if not self._graphql_schema:
-            self._graphql_schema = await schema_creator(session=session, branch=self.name)
+            self._graphql_schema = await generate_graphql_paginated_schema(session=session, branch=self.name)
 
         return self._graphql_schema
 

--- a/backend/tests/unit/graphql/test_graphql_branch.py
+++ b/backend/tests/unit/graphql/test_graphql_branch.py
@@ -8,7 +8,9 @@ from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.timestamp import Timestamp
-from infrahub.graphql import generate_graphql_schema
+from infrahub.graphql import (
+    generate_graphql_paginated_schema as generate_graphql_schema,
+)
 from infrahub.message_bus.events import (
     CheckMessageAction,
     GitMessageAction,
@@ -58,7 +60,7 @@ async def repos_and_checks_in_main(session, register_core_models_schema):
 
 
 async def test_branch_create(db, session, default_branch: Branch, car_person_schema, register_core_models_schema):
-    schema = await generate_graphql_schema(session=session, include_subscription=False)
+    schema = await generate_graphql_schema(branch=default_branch, session=session, include_subscription=False)
 
     query = """
     mutation {
@@ -142,7 +144,7 @@ async def test_branch_create(db, session, default_branch: Branch, car_person_sch
 
 
 async def test_branch_query(db, session, default_branch: Branch, car_person_schema, register_core_models_schema):
-    schema = await generate_graphql_schema(session=session, include_subscription=False)
+    schema = await generate_graphql_schema(branch=default_branch, session=session, include_subscription=False)
 
     create_branch = """
     mutation {
@@ -226,7 +228,7 @@ async def test_branch_query(db, session, default_branch: Branch, car_person_sche
 async def test_branch_create_invalid_names(
     db, session, default_branch: Branch, car_person_schema, register_core_models_schema
 ):
-    schema = await generate_graphql_schema(session=session, include_subscription=False)
+    schema = await generate_graphql_schema(branch=default_branch, session=session, include_subscription=False)
 
     query = """
     mutation($branch_name: String!) {
@@ -274,7 +276,7 @@ async def test_branch_create_with_repositories(
     }
     """
     result = await graphql(
-        await generate_graphql_schema(session=session, include_subscription=False),
+        await generate_graphql_schema(branch=default_branch, session=session, include_subscription=False),
         source=query,
         context_value={"infrahub_session": session, "infrahub_database": db, "infrahub_rpc_client": rpc_client},
         root_value=None,
@@ -302,7 +304,7 @@ async def test_branch_rebase(db, session, default_branch: Branch, car_person_sch
     }
     """
     result = await graphql(
-        await generate_graphql_schema(session=session, include_subscription=False),
+        await generate_graphql_schema(branch=default_branch, session=session, include_subscription=False),
         source=query,
         context_value={"infrahub_session": session, "infrahub_database": db},
         root_value=None,
@@ -329,7 +331,7 @@ async def test_branch_rebase_wrong_branch(db, session, default_branch: Branch, c
     }
     """
     result = await graphql(
-        await generate_graphql_schema(session=session, include_subscription=False),
+        await generate_graphql_schema(branch=default_branch, session=session, include_subscription=False),
         source=query,
         context_value={"infrahub_session": session, "infrahub_database": db},
         root_value=None,
@@ -354,7 +356,7 @@ async def test_branch_validate(db, session, base_dataset_02, register_core_model
     }
     """
     result = await graphql(
-        await generate_graphql_schema(session=session, include_subscription=False),
+        await generate_graphql_schema(branch=branch1, session=session, include_subscription=False),
         source=query,
         context_value={"infrahub_session": session, "infrahub_database": db},
         root_value=None,
@@ -390,7 +392,7 @@ async def test_branch_validate_with_repositories_success(
     }
     """
     result = await graphql(
-        await generate_graphql_schema(session=session, include_subscription=False),
+        await generate_graphql_schema(branch=branch2, session=session, include_subscription=False),
         source=query,
         context_value={"infrahub_session": session, "infrahub_database": db, "infrahub_rpc_client": rpc_client},
         root_value=None,
@@ -431,7 +433,7 @@ async def test_branch_validate_with_repositories_failed(
     }
     """
     result = await graphql(
-        await generate_graphql_schema(session=session, include_subscription=False),
+        await generate_graphql_schema(branch=branch2, session=session, include_subscription=False),
         source=query,
         context_value={"infrahub_session": session, "infrahub_database": db, "infrahub_rpc_client": rpc_client},
         root_value=None,
@@ -459,7 +461,7 @@ async def test_branch_merge(db, session, base_dataset_02, register_core_models_s
     }
     """
     result = await graphql(
-        await generate_graphql_schema(session=session, include_subscription=False),
+        await generate_graphql_schema(branch=branch1, session=session, include_subscription=False),
         source=query,
         context_value={"infrahub_session": session, "infrahub_database": db},
         root_value=None,
@@ -501,7 +503,7 @@ async def test_branch_merge_with_repositories(db, session, rpc_client, base_data
     }
     """
     result = await graphql(
-        await generate_graphql_schema(session=session, include_subscription=False),
+        await generate_graphql_schema(branch=branch2, session=session, include_subscription=False),
         source=query,
         context_value={"infrahub_session": session, "infrahub_database": db, "infrahub_rpc_client": rpc_client},
         root_value=None,
@@ -604,7 +606,7 @@ async def test_branch_diff_with_repositories(db, session, rpc_client, base_datas
     }
     """
     result = await graphql(
-        await generate_graphql_schema(session=session, include_subscription=False),
+        await generate_graphql_schema(branch=branch2, session=session, include_subscription=False),
         source=query,
         context_value={"infrahub_session": session, "infrahub_database": db, "infrahub_rpc_client": rpc_client},
         root_value=None,

--- a/backend/tests/unit/graphql/test_mutation_create.py
+++ b/backend/tests/unit/graphql/test_mutation_create.py
@@ -2,7 +2,9 @@ from graphql import graphql
 
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
-from infrahub.graphql import generate_graphql_schema
+from infrahub.graphql import (
+    generate_graphql_paginated_schema as generate_graphql_schema,
+)
 
 
 async def test_create_simple_object(db, session, default_branch, car_person_schema):
@@ -130,13 +132,17 @@ async def test_create_object_with_flag_property(db, session, default_branch, car
     query = """
         query {
             person {
-                id
-                name {
-                    value
-                    is_protected
-                }
-                height {
-                    is_visible
+                edges {
+                    node {
+                        id
+                        name {
+                            value
+                            is_protected
+                        }
+                        height {
+                            is_visible
+                        }
+                    }
                 }
             }
         }
@@ -150,8 +156,8 @@ async def test_create_object_with_flag_property(db, session, default_branch, car
     )
 
     assert result1.errors is None
-    assert result1.data["person"][0]["name"]["is_protected"] is True
-    assert result1.data["person"][0]["height"]["is_visible"] is False
+    assert result1.data["person"]["edges"][0]["node"]["name"]["is_protected"] is True
+    assert result1.data["person"]["edges"][0]["node"]["height"]["is_visible"] is False
 
 
 async def test_create_object_with_node_property(
@@ -194,20 +200,24 @@ async def test_create_object_with_node_property(
     query = """
         query {
             person {
-                id
-                name {
-                    value
-                    source {
+                edges {
+                    node {
+                        id
                         name {
                             value
+                            source {
+                                name {
+                                    value
+                                }
+                            }
                         }
-                    }
-                }
-                height {
-                    id
-                    owner {
-                        name {
-                            value
+                        height {
+                            id
+                            owner {
+                                name {
+                                    value
+                                }
+                            }
                         }
                     }
                 }
@@ -223,8 +233,8 @@ async def test_create_object_with_node_property(
     )
 
     assert result1.errors is None
-    assert result1.data["person"][0]["name"]["source"]["name"]["value"] == "First Account"
-    assert result1.data["person"][0]["height"]["owner"]["name"]["value"] == "Second Account"
+    assert result1.data["person"]["edges"][0]["node"]["name"]["source"]["name"]["value"] == "First Account"
+    assert result1.data["person"]["edges"][0]["node"]["height"]["owner"]["name"]["value"] == "Second Account"
 
 
 async def test_create_object_with_single_relationship(db, session, default_branch, car_person_schema):

--- a/backend/tests/unit/graphql/test_mutation_delete.py
+++ b/backend/tests/unit/graphql/test_mutation_delete.py
@@ -2,7 +2,9 @@ from graphql import graphql
 
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
-from infrahub.graphql import generate_graphql_schema
+from infrahub.graphql import (
+    generate_graphql_paginated_schema as generate_graphql_schema,
+)
 
 
 async def test_delete_object(db, session, default_branch, car_person_schema):

--- a/backend/tests/unit/graphql/test_mutation_update.py
+++ b/backend/tests/unit/graphql/test_mutation_update.py
@@ -5,7 +5,9 @@ from neo4j import AsyncSession
 from infrahub.core.branch import Branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
-from infrahub.graphql import generate_graphql_schema
+from infrahub.graphql import (
+    generate_graphql_paginated_schema as generate_graphql_schema,
+)
 
 
 async def test_update_simple_object(db, session: AsyncSession, person_john_main: Node, branch: Branch):
@@ -229,8 +231,10 @@ async def test_update_single_relationship(
             object {
                 id
                 owner {
-                    name {
-                        value
+                    node {
+                        name {
+                            value
+                        }
                     }
                 }
             }
@@ -250,7 +254,7 @@ async def test_update_single_relationship(
 
     assert result.errors is None
     assert result.data["car_update"]["ok"] is True
-    assert result.data["car_update"]["object"]["owner"]["name"]["value"] == "Jim"
+    assert result.data["car_update"]["object"]["owner"]["node"]["name"]["value"] == "Jim"
 
     car = await NodeManager.get_one(session=session, id=car_accord_main.id, branch=branch)
     car_peer = await car.owner.get_peer(session=session)
@@ -267,8 +271,10 @@ async def test_update_new_single_relationship_flag_property(
             object {
                 id
                 owner {
-                    name {
-                        value
+                    node {
+                        name {
+                            value
+                        }
                     }
                 }
             }
@@ -288,7 +294,7 @@ async def test_update_new_single_relationship_flag_property(
 
     assert result.errors is None
     assert result.data["car_update"]["ok"] is True
-    assert result.data["car_update"]["object"]["owner"]["name"]["value"] == "Jim"
+    assert result.data["car_update"]["object"]["owner"]["node"]["name"]["value"] == "Jim"
 
     car = await NodeManager.get_one(session=session, id=car_accord_main.id, branch=branch)
     car_peer = await car.owner.get_peer(session=session)
@@ -307,8 +313,10 @@ async def test_update_delete_optional_relationship_cardinality_one(
             object {
                 id
                 owner {
-                    name {
-                        value
+                    node {
+                        name {
+                            value
+                        }
                     }
                 }
             }
@@ -328,7 +336,7 @@ async def test_update_delete_optional_relationship_cardinality_one(
 
     assert result.errors is None
     assert result.data["car_update"]["ok"] is True
-    assert result.data["car_update"]["object"]["owner"]["name"]["value"] == "Jim"
+    assert result.data["car_update"]["object"]["owner"]["node"]["name"]["value"] == "Jim"
 
     car = await NodeManager.get_one(session=session, id=car_accord_main.id, branch=branch)
     car_peer = await car.owner.get_peer(session=session)
@@ -340,8 +348,10 @@ async def test_update_delete_optional_relationship_cardinality_one(
             object {
                 id
                 owner {
-                    name {
-                        value
+                    node {
+                        name {
+                            value
+                        }
                     }
                 }
             }
@@ -360,7 +370,7 @@ async def test_update_delete_optional_relationship_cardinality_one(
 
     assert result.errors is None
     assert result.data["car_update"]["ok"] is True
-    assert result.data["car_update"]["object"]["owner"] is None
+    assert result.data["car_update"]["object"]["owner"]["node"] is None
     car = await NodeManager.get_one(session=session, id=car_accord_main.id, branch=branch)
     car_peer = await car.owner.get_peer(session=session)
     assert car_peer is None
@@ -376,8 +386,10 @@ async def test_update_existing_single_relationship_flag_property(
             object {
                 id
                 owner {
-                    name {
-                        value
+                    node {
+                        name {
+                            value
+                        }
                     }
                 }
             }
@@ -397,7 +409,7 @@ async def test_update_existing_single_relationship_flag_property(
 
     assert result.errors is None
     assert result.data["car_update"]["ok"] is True
-    assert result.data["car_update"]["object"]["owner"]["name"]["value"] == "John"
+    assert result.data["car_update"]["object"]["owner"]["node"]["name"]["value"] == "John"
 
     car = await NodeManager.get_one(session=session, id=car_accord_main.id, branch=branch)
     car_peer = await car.owner.get_peer(session=session)
@@ -439,8 +451,10 @@ async def test_update_existing_single_relationship_node_property(
             object {
                 id
                 owner {
-                    name {
-                        value
+                    node {
+                        name {
+                            value
+                        }
                     }
                 }
             }
@@ -461,7 +475,7 @@ async def test_update_existing_single_relationship_node_property(
 
     assert result.errors is None
     assert result.data["car_update"]["ok"] is True
-    assert result.data["car_update"]["object"]["owner"]["name"]["value"] == "John"
+    assert result.data["car_update"]["object"]["owner"]["node"]["name"]["value"] == "John"
 
     car = await NodeManager.get_one(session=session, id=car_accord_with_source_main.id, branch=branch)
     car_peer = await car.owner.get_peer(session=session)
@@ -488,8 +502,12 @@ async def test_update_relationship_many(
             object {
                 id
                 tags {
-                    name {
-                        value
+                    edges {
+                        node {
+                            name {
+                                value
+                            }
+                        }
                     }
                 }
             }
@@ -509,7 +527,7 @@ async def test_update_relationship_many(
 
     assert result.errors is None
     assert result.data["person_update"]["ok"] is True
-    assert len(result.data["person_update"]["object"]["tags"]) == 1
+    assert len(result.data["person_update"]["object"]["tags"]["edges"]) == 1
 
     p11 = await NodeManager.get_one(session=session, id=person_jack_main.id, branch=branch)
     assert len(list(await p11.tags.get(session=session))) == 1
@@ -522,8 +540,12 @@ async def test_update_relationship_many(
             object {
                 id
                 tags {
-                    name {
-                        value
+                    edges {
+                        node {
+                            name {
+                                value
+                            }
+                        }
                     }
                 }
             }
@@ -544,7 +566,7 @@ async def test_update_relationship_many(
 
     assert result.errors is None
     assert result.data["person_update"]["ok"] is True
-    assert len(result.data["person_update"]["object"]["tags"]) == 2
+    assert len(result.data["person_update"]["object"]["tags"]["edges"]) == 2
 
     p12 = await NodeManager.get_one(session=session, id=person_jack_main.id, branch=branch)
     tags = await p12.tags.get(session=session)
@@ -559,8 +581,12 @@ async def test_update_relationship_many(
             object {
                 id
                 tags {
-                    name {
-                        value
+                    edges {
+                        node {
+                            name {
+                                value
+                            }
+                        }
                     }
                 }
             }
@@ -581,7 +607,7 @@ async def test_update_relationship_many(
 
     assert result.errors is None
     assert result.data["person_update"]["ok"] is True
-    assert len(result.data["person_update"]["object"]["tags"]) == 2
+    assert len(result.data["person_update"]["object"]["tags"]["edges"]) == 2
 
     p13 = await NodeManager.get_one(session=session, id=person_jack_main.id, branch=branch)
     tags = await p13.tags.get(session=session)
@@ -605,8 +631,12 @@ async def test_update_relationship_many2(
             object {
                 id
                 tags {
-                    name {
-                        value
+                    edges {
+                        node {
+                            name {
+                                value
+                            }
+                        }
                     }
                 }
             }
@@ -626,7 +656,7 @@ async def test_update_relationship_many2(
 
     assert result.errors is None
     assert result.data["person_update"]["ok"] is True
-    assert len(result.data["person_update"]["object"]["tags"]) == 1
+    assert len(result.data["person_update"]["object"]["tags"]["edges"]) == 1
 
     p11 = await NodeManager.get_one(session=session, id=person_jack_main.id, branch=branch)
     assert len(list(await p11.tags.get(session=session))) == 1
@@ -639,8 +669,12 @@ async def test_update_relationship_many2(
             object {
                 id
                 tags {
-                    name {
-                        value
+                    edges {
+                        node {
+                            name {
+                                value
+                            }
+                        }
                     }
                 }
             }
@@ -661,7 +695,7 @@ async def test_update_relationship_many2(
 
     assert result.errors is None
     assert result.data["person_update"]["ok"] is True
-    assert len(result.data["person_update"]["object"]["tags"]) == 2
+    assert len(result.data["person_update"]["object"]["tags"]["edges"]) == 2
 
     p12 = await NodeManager.get_one(session=session, id=person_jack_main.id, branch=branch)
     tags = await p12.tags.get(session=session)


### PR DESCRIPTION
Also corrects some of the tests that were still using the non paginated generator. This caused the old format of queries to work on these tests.

Related to #562 but doesn't remove all references to the non-paginated version. Doing it in steps to keep down the size of each PR.