### PR TITLE
Add code to enforce authentication on change operations

### DIFF
--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -21,6 +21,9 @@ class MainSettings(BaseSettings):
     # default_account_perm: str = "CAN_READ"
 
     internal_address: str = "http://localhost:8000"
+    allow_anonymous_access: bool = Field(
+        default=True, description="Indicates if the system allows anonymous read access"
+    )
 
     class Config:
         env_prefix = "INFRAHUB_"
@@ -113,6 +116,10 @@ class AnalyticsSettings(BaseSettings):
 
 class ExperimentalFeaturesSettings(BaseSettings):
     pull_request: bool = False
+    ignore_authentication_requirements: bool = Field(
+        default=True,
+        description="If set to true operations that would have been denied due to lack of authentication still works.",
+    )
 
     class Config:
         env_prefix = "INFRAHUB_EXPERIMENTAL_"

--- a/backend/infrahub/core/initialization.py
+++ b/backend/infrahub/core/initialization.py
@@ -168,6 +168,7 @@ async def first_time_initialization(session: AsyncSession):
         session=session,
         name="admin",
         type="User",
+        role="admin",
         password=config.SETTINGS.security.initial_admin_password,
         groups=[admin_grp],
     )

--- a/backend/infrahub/core/schema.py
+++ b/backend/infrahub/core/schema.py
@@ -1064,6 +1064,12 @@ core_models = {
                     "default_value": "User",
                     "enum": ["User", "Script", "Bot", "Git"],
                 },
+                {
+                    "name": "role",
+                    "kind": "Text",
+                    "default_value": "read-only",
+                    "enum": ["admin", "read-only", "read-write"],
+                },
             ],
             "relationships": [
                 {"name": "tokens", "peer": "AccountToken", "optional": True, "cardinality": "many"},

--- a/backend/infrahub/exceptions.py
+++ b/backend/infrahub/exceptions.py
@@ -116,6 +116,15 @@ class AuthorizationError(Error):
         super().__init__(self.message)
 
 
+class PermissionDeniedError(Error):
+    HTTP_CODE: int = 403
+    message: str = "The requested operation was not authorized"
+
+    def __init__(self, message: Optional[str] = None):
+        self.message = message or self.message
+        super().__init__(self.message)
+
+
 class SchemaNotFound(Error):
     def __init__(self, branch_name, identifier, message=None):
         self.branch_name = branch_name

--- a/backend/tests/unit/core/test_account.py
+++ b/backend/tests/unit/core/test_account.py
@@ -20,11 +20,11 @@ async def test_validate_token(session, default_branch, register_core_models_sche
     account_token_schema = registry.get_schema(name="AccountToken", branch=default_branch)
 
     user1 = await Node.init(session=session, schema=account_schema)
-    await user1.new(session=session, name="user1", password="User1Password123")
+    await user1.new(session=session, name="user1", password="User1Password123", role="read-write")
     await user1.save(session=session)
     token1 = await Node.init(session=session, schema=account_token_schema)
     await token1.new(session=session, token="123456789", account=user1)
     await token1.save(session=session)
 
-    assert await validate_token(token="123456789", session=session) == "user1"
-    assert await validate_token(token="987654321", session=session) is False
+    assert await validate_token(token="123456789", session=session) == (user1.id, "read-write")
+    assert await validate_token(token="987654321", session=session) == (None, "read-only")


### PR DESCRIPTION
* Modifies the response to auth requests to return a user session object that contain the permissions
* Adds two new options for the configuration one to allow anonymous read access and one to ignore authentication (will be removed when the frontend and SDK supports authentication)
* Modifies the current auth middleware backend with a slight change of format
* Adds "role" to account and assigns the default admin user to the role of "admin"

For now there are no added tests for the authentication (aside from the changed one to fix the format), this is mainly due to the config option to ignore authentication. Next week I'll look at changing the tests so that those are authenticated and review the test coverage of the authentication in general.