### PR TITLE
Add ability to authenticate with SDK using token

### DIFF
--- a/python_sdk/infrahub_client/client.py
+++ b/python_sdk/infrahub_client/client.py
@@ -47,6 +47,7 @@ class BaseClient:
         insert_tracker: bool = False,
         pagination_size: int = 50,
         max_concurrent_execution: int = 5,
+        api_token: Optional[str] = None,
     ):
         self.address = address
         self.client = None
@@ -59,6 +60,9 @@ class BaseClient:
         self.insert_tracker = insert_tracker
         self.pagination_size = pagination_size
         self.headers = {"content-type": "application/json"}
+        if api_token:
+            self.headers["X-INFRAHUB-KEY"] = api_token
+
         self.max_concurrent_execution = max_concurrent_execution
 
         if test_client:


### PR DESCRIPTION
Also change the way the mutations vs queries are identified by the GraphQL app.

With this change there are quite a few available parameters to initialising an SDK client. I think it would be nice to replace

```python
class BaseClient:
    """Base class for InfrahubClient and InfrahubClientSync"""

    def __init__(
        self,
        address: str = "http://localhost:8000",
        default_timeout: int = 10,
        retry_on_failure: bool = False,
        retry_delay: int = 5,
        log: Optional[Logger] = None,
        test_client: Optional[TestClient] = None,
        default_branch: str = "main",
        insert_tracker: bool = False,
        pagination_size: int = 50,
        max_concurrent_execution: int = 5,
        api_token: Optional[str] = None,
    ):
```

With:


```python
from pydantic import BaseSettings

class Config(BaseSettings):
    ...

    class Config:
        env_prefix = "INFRAHUB_SDK_"

class BaseClient:
    """Base class for InfrahubClient and InfrahubClientSync"""

    def __init__(
        self,
        config: Optional[Config] = None,
    ):
    self.config = config or Config()
```


