### PR TITLE
Fix type checking import

### DIFF
--- a/backend/infrahub/core/registry.py
+++ b/backend/infrahub/core/registry.py
@@ -15,8 +15,8 @@ if TYPE_CHECKING:
     from infrahub.core.attribute import BaseAttribute
     from infrahub.core.branch import Branch
     from infrahub.core.definitions import Brancher
-    from infrahub.core.manager import SchemaManager
     from infrahub.core.schema import GenericSchema, GroupSchema, NodeSchema
+    from infrahub.core.schema_manager import SchemaManager
     from infrahub.graphql.mutations import BaseAttributeInput
     from infrahub.graphql.types import InfrahubObject
     from infrahub.types import InfrahubDataType


### PR DESCRIPTION
I missed this in the previous PR and it slipped through as we don't have mypy checks enabled for the backend.