### PR TITLE
Demo schema changes to support implementation of a Nornir inventory plugin

### DIFF
--- a/models/infrastructure_base.yml
+++ b/models/infrastructure_base.yml
@@ -133,9 +133,9 @@ nodes:
         optional: true
         cardinality: many
         kind: Attribute
-      - name: ip_address
+      - name: primary_address
         peer: IPAddress
-        label: IP Address
+        label: Primary IP Address
         optional: true
         cardinality: one
         kind: Attribute

--- a/models/infrastructure_edge.py
+++ b/models/infrastructure_edge.py
@@ -290,7 +290,7 @@ async def generate_site(client: InfrahubClient, log: logging.Logger, branch: str
         await ip.save()
 
         # set the IP address of the device to the management interface IP address
-        obj.ip_address = ip
+        obj.primary_address = ip
         await obj.save()
 
         # L3 Interfaces


### PR DESCRIPTION
Nornir's host model requires an IP address and platform to be defined.

This PR implements a Platform node and defines an `ip_address` relation between a Device Node and an IPAddress Node.

A platform is a representation of a type of operating system that runs on a device (IOS, Junos, Sonic, ...) 
It has attributes that allow you to couple the platform to a Nornir platform, Napalm driver, Netmiko device-type, Ansible network os, ...  

The Device to IPAddress relation is now loosely defined. Ideally we would be able to define a constraint, that defines that the  IPAddress has to be an IPAddress that is related to one of the Device's interfaces in the future.