### PR TITLE
Enforce authentication for api modifications in backend tests

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -28,6 +28,7 @@ def execute_before_any_test():
     config.SETTINGS.database.database = TEST_DATABASE
     config.SETTINGS.broker.enable = False
     config.SETTINGS.security.secret_key = "4e26b3d9-b84f-42c9-a03f-fee3ada3b2fa"
+    config.SETTINGS.experimental_features.ignore_authentication_requirements = False
     config.SETTINGS.main.internal_address = "http://mock"
 
 

--- a/backend/tests/integration/git/test_git_repository.py
+++ b/backend/tests/integration/git/test_git_repository.py
@@ -17,15 +17,20 @@ class TestInfrahubClient:
         await first_time_initialization(session=session)
 
     @pytest.fixture(scope="class")
-    async def test_client(self, base_dataset):
+    async def test_client(
+        self,
+        base_dataset,
+    ):
         # pylint: disable=import-outside-toplevel
         from infrahub.api import main
 
         return TestClient(main.app)
 
     @pytest.fixture
-    async def client(self, test_client):
-        return await InfrahubClient.init(test_client=test_client)
+    async def client(self, test_client, integration_helper):
+        admin_token = await integration_helper.create_token()
+
+        return await InfrahubClient.init(test_client=test_client, api_token=admin_token)
 
     @pytest.fixture(scope="class")
     async def query_99(self, session, test_client):

--- a/backend/tests/unit/api/conftest.py
+++ b/backend/tests/unit/api/conftest.py
@@ -21,6 +21,11 @@ def client_headers():
 
 
 @pytest.fixture
+def admin_headers():
+    return {"X-INFRAHUB-KEY": "admin-security"}
+
+
+@pytest.fixture
 async def car_person_data(session, register_core_models_schema, car_person_schema, first_account):
     p1 = await Node.init(session=session, schema="Person")
     await p1.new(session=session, name="John", height=180)

--- a/backend/tests/unit/api/test_40_schema_api.py
+++ b/backend/tests/unit/api/test_40_schema_api.py
@@ -65,15 +65,16 @@ async def test_schema_read_endpoint_wrong_branch(
 async def test_schema_load_endpoint_valid_simple(
     session,
     client: TestClient,
-    client_headers,
+    admin_headers,
     default_branch: Branch,
-    register_core_schema_db,
+    authentication_base,
     helper,
 ):
     # Must execute in a with block to execute the startup/shutdown events
+
     with client:
-        creation = client.post("/schema/load", headers=client_headers, json=helper.schema_file("infra_simple_01.json"))
-        read = client.get("/schema", headers=client_headers)
+        creation = client.post("/schema/load", headers=admin_headers, json=helper.schema_file("infra_simple_01.json"))
+        read = client.get("/schema", headers=admin_headers)
 
     assert creation.status_code == 202
     assert read.status_code == 200
@@ -93,15 +94,16 @@ async def test_schema_load_endpoint_valid_simple(
 async def test_schema_load_endpoint_idempotent_simple(
     session,
     client: TestClient,
-    client_headers,
+    admin_headers,
     default_branch: Branch,
     register_core_schema_db,
+    authentication_base,
     helper,
 ):
     # Must execute in a with block to execute the startup/shutdown events
     with client:
-        creation = client.post("/schema/load", headers=client_headers, json=helper.schema_file("infra_simple_01.json"))
-        read = client.get("/schema", headers=client_headers)
+        creation = client.post("/schema/load", headers=admin_headers, json=helper.schema_file("infra_simple_01.json"))
+        read = client.get("/schema", headers=admin_headers)
 
         nbr_rels = await count_relationships(session=session)
 
@@ -119,8 +121,8 @@ async def test_schema_load_endpoint_idempotent_simple(
         assert relationships["interfaces"] == 450
         assert relationships["tags"] == 101000
 
-        creation = client.post("/schema/load", headers=client_headers, json=helper.schema_file("infra_simple_01.json"))
-        read = client.get("/schema", headers=client_headers)
+        creation = client.post("/schema/load", headers=admin_headers, json=helper.schema_file("infra_simple_01.json"))
+        read = client.get("/schema", headers=admin_headers)
 
         assert creation.status_code == 202
         assert read.status_code == 200
@@ -131,19 +133,19 @@ async def test_schema_load_endpoint_idempotent_simple(
 async def test_schema_load_endpoint_valid_with_generics(
     session,
     client: TestClient,
-    client_headers,
+    admin_headers,
     default_branch: Branch,
-    register_core_schema_db,
+    authentication_base,
     helper,
 ):
     # Must execute in a with block to execute the startup/shutdown events
     with client:
         response1 = client.post(
-            "/schema/load", headers=client_headers, json=helper.schema_file("infra_w_generics_01.json")
+            "/schema/load", headers=admin_headers, json=helper.schema_file("infra_w_generics_01.json")
         )
         assert response1.status_code == 202
 
-        response2 = client.get("/schema", headers=client_headers)
+        response2 = client.get("/schema", headers=admin_headers)
         assert response2.status_code == 200
 
     schema = response2.json()
@@ -153,19 +155,19 @@ async def test_schema_load_endpoint_valid_with_generics(
 async def test_schema_load_endpoint_idempotent_with_generics(
     session,
     client: TestClient,
-    client_headers,
+    admin_headers,
     default_branch: Branch,
-    register_core_schema_db,
+    authentication_base,
     helper,
 ):
     # Must execute in a with block to execute the startup/shutdown events
     with client:
         response1 = client.post(
-            "/schema/load", headers=client_headers, json=helper.schema_file("infra_w_generics_01.json")
+            "/schema/load", headers=admin_headers, json=helper.schema_file("infra_w_generics_01.json")
         )
         assert response1.status_code == 202
 
-        response2 = client.get("/schema", headers=client_headers)
+        response2 = client.get("/schema", headers=admin_headers)
         assert response2.status_code == 200
 
         schema = response2.json()
@@ -174,11 +176,11 @@ async def test_schema_load_endpoint_idempotent_with_generics(
         nbr_rels = await count_relationships(session=session)
 
         response3 = client.post(
-            "/schema/load", headers=client_headers, json=helper.schema_file("infra_w_generics_01.json")
+            "/schema/load", headers=admin_headers, json=helper.schema_file("infra_w_generics_01.json")
         )
         assert response3.status_code == 202
 
-        response4 = client.get("/schema", headers=client_headers)
+        response4 = client.get("/schema", headers=admin_headers)
         assert response4.status_code == 200
 
         assert nbr_rels == await count_relationships(session=session)
@@ -187,9 +189,9 @@ async def test_schema_load_endpoint_idempotent_with_generics(
 async def test_schema_load_endpoint_valid_with_extensions(
     session,
     client: TestClient,
-    client_headers,
+    admin_headers,
     default_branch: Branch,
-    register_core_schema_db,
+    authentication_base,
     helper,
 ):
     org_schema = registry.schema.get(name="Organization", branch=default_branch.name)
@@ -198,7 +200,7 @@ async def test_schema_load_endpoint_valid_with_extensions(
     # Must execute in a with block to execute the startup/shutdown events
     with client:
         response = client.post(
-            "/schema/load", headers=client_headers, json=helper.schema_file("infra_w_extensions_01.json")
+            "/schema/load", headers=admin_headers, json=helper.schema_file("infra_w_extensions_01.json")
         )
 
     assert response.status_code == 202
@@ -210,15 +212,15 @@ async def test_schema_load_endpoint_valid_with_extensions(
 async def test_schema_load_endpoint_not_valid_simple_02(
     session,
     client: TestClient,
-    client_headers,
+    admin_headers,
     default_branch: Branch,
-    register_core_models_schema,
+    authentication_base,
     helper,
 ):
     # Must execute in a with block to execute the startup/shutdown events
     with client:
         response = client.post(
-            "/schema/load", headers=client_headers, json=helper.schema_file("not_valid_simple_02.json")
+            "/schema/load", headers=admin_headers, json=helper.schema_file("not_valid_simple_02.json")
         )
 
     assert response.status_code == 422
@@ -227,15 +229,15 @@ async def test_schema_load_endpoint_not_valid_simple_02(
 async def test_schema_load_endpoint_not_valid_simple_03(
     session,
     client: TestClient,
-    client_headers,
+    admin_headers,
     default_branch: Branch,
-    register_core_models_schema,
+    authentication_base,
     helper,
 ):
     # Must execute in a with block to execute the startup/shutdown events
     with client:
         response = client.post(
-            "/schema/load", headers=client_headers, json=helper.schema_file("not_valid_simple_03.json")
+            "/schema/load", headers=admin_headers, json=helper.schema_file("not_valid_simple_03.json")
         )
 
     assert response.status_code == 422
@@ -244,15 +246,15 @@ async def test_schema_load_endpoint_not_valid_simple_03(
 async def test_schema_load_endpoint_not_valid_simple_04(
     session,
     client: TestClient,
-    client_headers,
+    admin_headers,
     default_branch: Branch,
-    register_core_models_schema,
+    authentication_base,
     helper,
 ):
     # Must execute in a with block to execute the startup/shutdown events
     with client:
         response = client.post(
-            "/schema/load", headers=client_headers, json=helper.schema_file("not_valid_simple_04.json")
+            "/schema/load", headers=admin_headers, json=helper.schema_file("not_valid_simple_04.json")
         )
 
     assert response.status_code == 422
@@ -261,32 +263,32 @@ async def test_schema_load_endpoint_not_valid_simple_04(
 async def test_schema_load_endpoint_not_valid_simple_05(
     session,
     client: TestClient,
-    client_headers,
+    admin_headers,
     default_branch: Branch,
-    register_core_models_schema,
+    authentication_base,
     helper,
 ):
     with client:
         response = client.post(
-            "/schema/load", headers=client_headers, json=helper.schema_file("not_valid_simple_05.json")
+            "/schema/load", headers=admin_headers, json=helper.schema_file("not_valid_simple_05.json")
         )
 
     assert response.status_code == 422
-    response.json()["detail"][0]["msg"] == "Name can not be set to a reserved keyword 'class' is not allowed."
+    assert response.json()["detail"][0]["msg"] == "Name can not be set to a reserved keyword 'class' is not allowed."
 
 
 async def test_schema_load_endpoint_not_valid_with_generics_02(
     session,
     client: TestClient,
-    client_headers,
+    admin_headers,
     default_branch: Branch,
-    register_core_models_schema,
+    authentication_base,
     helper,
 ):
     # Must execute in a with block to execute the startup/shutdown events
     with client:
         response = client.post(
-            "/schema/load", headers=client_headers, json=helper.schema_file("not_valid_w_generics_02.json")
+            "/schema/load", headers=admin_headers, json=helper.schema_file("not_valid_w_generics_02.json")
         )
 
     assert response.status_code == 422


### PR DESCRIPTION
Changes the configuration in the backend tests so that authentication is requires for any API access that modifies a resource. I.e. POST requests for REST-API or mutations for the GraphQL API.

I ended up not adding test code directly within the project like I talked about and just added another fixture instead. One of the reasons I wanted to add it was for the type hints that are made possible. However it's still not very helpful as typehints aren't enforced in the backend so might revisit that later instead.