### PR TITLE
Replace TypeVar with typing_extensions to define Self

### DIFF
--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from typing import TYPE_CHECKING, Any, List, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Union
 from uuid import UUID
 
 from infrahub.core import get_branch, registry
@@ -18,6 +18,7 @@ from .base import BaseNode, BaseNodeMeta, BaseNodeOptions
 
 if TYPE_CHECKING:
     from neo4j import AsyncSession
+    from typing_extensions import Self
 
     from infrahub.core.branch import Branch
 
@@ -31,8 +32,6 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------------------
 
 # pylint: disable=redefined-builtin,too-many-branches
-
-SelfNode = TypeVar("SelfNode", bound="Node")
 
 
 class Node(BaseNode, metaclass=BaseNodeMeta):
@@ -90,7 +89,7 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
         schema: Union[NodeSchema, str],
         branch: Optional[Union[Branch, str]] = None,
         at: Optional[Union[Timestamp, str]] = None,
-    ) -> Node:
+    ) -> Self:
         attrs = {}
 
         branch = await get_branch(branch=branch, session=session)
@@ -239,7 +238,7 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
             if self.label.value is None and self.name.value:
                 self.label.value = " ".join([word.title() for word in self.name.value.split("_")])
 
-    async def new(self, session: AsyncSession, **kwargs) -> SelfNode:
+    async def new(self, session: AsyncSession, **kwargs) -> Self:
         await self._process_fields(session=session, fields=kwargs)
         return self
 
@@ -250,7 +249,7 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
         db_id: Optional[int] = None,
         updated_at: Union[Timestamp, str] = None,
         **kwargs,
-    ) -> SelfNode:
+    ) -> Self:
         self.id = id
         self.db_id = db_id
 
@@ -306,7 +305,7 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
         self,
         session: AsyncSession,
         at: Optional[Timestamp] = None,
-    ) -> SelfNode:
+    ) -> Self:
         """Create or Update the Node in the database."""
 
         save_at = Timestamp(at)

--- a/backend/infrahub/core/node/standard.py
+++ b/backend/infrahub/core/node/standard.py
@@ -1,15 +1,14 @@
 import uuid
-from typing import List, Optional, TypeVar
+from typing import List, Optional
 from uuid import UUID
 
 from neo4j import AsyncSession
 from pydantic import BaseModel
+from typing_extensions import Self
 
 from infrahub.core.query import Query, QueryType
 from infrahub.database import execute_read_query_async, execute_write_query_async
 from infrahub.exceptions import QueryError
-
-SelfNode = TypeVar("SelfNode", bound="StandardNode")
 
 # pylint: disable=redefined-builtin
 
@@ -188,7 +187,7 @@ class StandardNode(BaseModel):
         return cls(**attrs)
 
     @classmethod
-    async def get_list(cls, session: AsyncSession, limit: int = 1000, **kwargs) -> List[SelfNode]:
+    async def get_list(cls, session: AsyncSession, limit: int = 1000, **kwargs) -> List[Self]:
         params = {"limit": limit}
 
         filters = []

--- a/backend/infrahub/core/query/__init__.py
+++ b/backend/infrahub/core/query/__init__.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Generator, List, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Generator, List, Optional, Union
 
 from neo4j.graph import Node, Relationship
 
@@ -16,10 +16,9 @@ from infrahub.exceptions import QueryError
 
 if TYPE_CHECKING:
     from neo4j import AsyncSession
+    from typing_extensions import Self
 
     from infrahub.core.branch import Branch
-
-SelfQuery = TypeVar("SelfQuery", bound="Query")
 
 
 def sort_results_by_time(results: List[QueryResult], rel_label: str) -> List[QueryResult]:
@@ -260,7 +259,7 @@ class Query(ABC):
         offset: Optional[int] = None,
         *args,
         **kwargs,
-    ):
+    ) -> Self:
         query = cls(branch=branch, at=at, limit=limit, offset=offset, *args, **kwargs)
 
         await query.query_init(session=session, **kwargs)
@@ -340,7 +339,7 @@ class Query(ABC):
 
         return ":params { " + ", ".join(params) + " }"
 
-    async def execute(self, session: AsyncSession) -> SelfQuery:
+    async def execute(self, session: AsyncSession) -> Self:
         # Ensure all mandatory params have been provided
         # Ensure at least 1 return obj has been defined
 

--- a/backend/infrahub/core/relationship.py
+++ b/backend/infrahub/core/relationship.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from infrahub.core import registry
 from infrahub.core.property import FlagPropertyMixin, NodePropertyMixin
@@ -22,16 +22,13 @@ if TYPE_CHECKING:
     from uuid import UUID
 
     from neo4j import AsyncSession
+    from typing_extensions import Self
 
     from infrahub.core.branch import Branch
     from infrahub.core.node import Node
     from infrahub.core.schema import NodeSchema, RelationshipSchema
 
 # pylint: disable=redefined-builtin
-
-
-SelfRelationship = TypeVar("SelfRelationship", bound="Relationship")
-SelfRelationshipManager = TypeVar("SelfRelationshipManager", bound="RelationshipManager")
 
 
 PREFIX_PROPERTY = "_relation__"
@@ -106,7 +103,7 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin):
         session: AsyncSession,
         data: Union[dict, RelationshipPeerData, Any] = None,
         **kwargs,
-    ) -> SelfRelationship:
+    ) -> Self:
         await self._process_data(data=data)
 
         return self
@@ -118,7 +115,7 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin):
         db_id: Optional[int] = None,
         updated_at: Union[Timestamp, str] = None,
         data: Union[dict, RelationshipPeerData, Any] = None,
-    ) -> SelfRelationship:
+    ) -> Self:
         self.id = id
         self.db_id = db_id
 
@@ -319,7 +316,7 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin):
         )
         await query.execute(session=session)
 
-    async def save(self, at: Optional[Timestamp] = None, session: Optional[AsyncSession] = None) -> SelfRelationship:
+    async def save(self, at: Optional[Timestamp] = None, session: Optional[AsyncSession] = None) -> Self:
         """Create or Update the Relationship in the database."""
 
         save_at = Timestamp(at)
@@ -629,7 +626,7 @@ class RelationshipManager:
         )
         await query.execute(session=session)
 
-    async def save(self, session: AsyncSession, at: Optional[Timestamp] = None) -> SelfRelationshipManager:
+    async def save(self, session: AsyncSession, at: Optional[Timestamp] = None) -> Self:
         """Create or Update the Relationship in the database."""
 
         save_at = Timestamp(at)

--- a/backend/infrahub/message_bus/events.py
+++ b/backend/infrahub/message_bus/events.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import importlib
 import pickle
-from typing import TYPE_CHECKING, Any, Generator, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Generator, Optional
 
 from aio_pika import DeliveryMode, ExchangeType, IncomingMessage, Message
 from aio_pika.patterns.base import Base as PickleSerializer
@@ -14,6 +14,8 @@ from infrahub.utils import BaseEnum
 from . import get_broker
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from infrahub.core.node import Node
 
 # pylint: disable=arguments-differ
@@ -108,9 +110,6 @@ class RPCStatusCode(int, BaseEnum):
     NOT_IMPLEMENTED = 501
 
 
-SelfInfrahubMessage = TypeVar("SelfInfrahubMessage", bound="InfrahubMessage")
-
-
 class InfrahubMessage(PickleSerializer):
     """
     Generic Object to help send and receive message over the message Bus (RabbitMQ)
@@ -127,7 +126,7 @@ class InfrahubMessage(PickleSerializer):
         self.request_id = request_id
 
     @classmethod
-    def convert(cls, message: IncomingMessage) -> SelfInfrahubMessage:
+    def convert(cls, message: IncomingMessage) -> Self:
         """
         Convert an IncomingMessage into its proper InfrahubMessage class
         """
@@ -143,7 +142,7 @@ class InfrahubMessage(PickleSerializer):
         return message_class.init(message=message, **body)
 
     @classmethod
-    def init(cls, message: IncomingMessage, *args, **kwargs) -> SelfInfrahubMessage:
+    def init(cls, message: IncomingMessage, *args, **kwargs) -> Self:
         """Initialize an Message from an Incoming Message."""
 
         return cls(message=message, *args, **kwargs)


### PR DESCRIPTION
While working on the group I noticed that the type hint for Node where not always correct and shouldn't work with inheritance, especially `Node.init()` would always return `Node`

So while fixing that I took the opportunity to replace the existing TypeVar that were meant to define Self when we have inheritance with the typehint `Self` from `typing_extensions`.