### PR TITLE
Update NodeManager to use Base Class from Generics if present

### DIFF
--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -100,7 +100,7 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
             # TODO need to raise a proper exception for this, right now it will raise a generic ValueError
             attrs["schema"] = registry.get_schema(name=schema, branch=branch)
         else:
-            raise ValueError(f"Invalid schema provided {schema}")
+            raise ValueError(f"Invalid schema provided {type(schema)}, expected NodeSchema")
 
         if not attrs["schema"].branch:
             attrs["branch"] = None


### PR DESCRIPTION
Related to #495, this PR extend the NodeManager to use a base class defined for a Generic