### PR TITLE
Remove display_label on GraphQL Nested Interface Object

### DIFF
--- a/backend/infrahub/graphql/generator.py
+++ b/backend/infrahub/graphql/generator.py
@@ -666,7 +666,6 @@ def generate_nested_interface_object(
     }
 
     main_attrs = {
-        "display_label": graphene.String(required=False),
         "node": graphene.Field(base_interface, required=False),
         "_updated_at": graphene.DateTime(required=False),
         "Meta": type("Meta", (object,), meta_attrs),


### PR DESCRIPTION
I think the property display label on the Nested Interface Object in GraphQL is not used currently so I removed it.
We also have it on the node itself 

![Screenshot 2023-06-18 at 6 15 33 PM](https://github.com/opsmill/infrahub/assets/304126/65f01461-8544-4568-8fb2-a0013bbe4f62)
