### PR TITLE
Remove has_next in GraphQL Paginated Objects

### DIFF
--- a/backend/infrahub/graphql/generator.py
+++ b/backend/infrahub/graphql/generator.py
@@ -570,7 +570,6 @@ def generate_graphql_paginated_object(
 
     main_attrs = {
         "count": graphene.Int(required=False),
-        "has_next": graphene.Boolean(required=False),
         "edges": graphene.List(of_type=edge),
         "Meta": type("Meta", (object,), meta_attrs),
     }
@@ -690,7 +689,6 @@ def generate_paginated_interface_object(
 
     main_attrs = {
         "count": graphene.Int(required=False),
-        "has_next": graphene.Boolean(required=False),
         "edges": graphene.List(of_type=base_interface),
         "Meta": type("Meta", (object,), meta_attrs),
     }


### PR DESCRIPTION
As far as I can tell we are not using or supporting `has_next` on the Paginaged Object 
If I remember correctly it is useful in a cursor based pagination but not for us.

I search the code base for it and I didn't found any reference to it apart from the 2 lines that are being removed by this PR