### PR TITLE
Remove RelatedNode in GraphQL

### DIFF
--- a/backend/infrahub/graphql/generator.py
+++ b/backend/infrahub/graphql/generator.py
@@ -20,7 +20,6 @@ from .types import (
     InfrahubObject,
     InfrahubUnion,
     RelatedNodeInput,
-    RelatedNodeInterface,
 )
 from .utils import extract_fields
 
@@ -298,7 +297,7 @@ async def generate_object_types(
 
     load_attribute_types_in_registry(branch=branch)
 
-    # Generate all GraphQL Interface & RelatedInterface Object first and store them in the registry
+    # Generate all GraphQL Interface  Object first and store them in the registry
     for node_name, node_schema in full_schema.items():
         if not isinstance(node_schema, GenericSchema):
             continue
@@ -315,14 +314,11 @@ async def generate_object_types(
         gql_type._meta.fields["source"] = graphene.Field(data_source)
         gql_type._meta.fields["owner"] = graphene.Field(data_owner)
 
-    # Generate all RelatedInterfaceType and store them in the registry
+    # Generate all Nested, Edged and NestedEdged Interfaces and store them in the registry
     for node_name, node_schema in full_schema.items():
         if not isinstance(node_schema, GenericSchema):
             continue
 
-        related_interface = generate_related_interface_object(
-            schema=node_schema, branch=branch, data_source=data_source, data_owner=data_owner, name_prefix="Related"
-        )
         node_interface = registry.get_graphql_type(name=node_name, branch=branch)
 
         nested_edged_interface = generate_nested_interface_object(
@@ -336,20 +332,15 @@ async def generate_object_types(
             base_interface=nested_edged_interface,
         )
 
-        registry.set_graphql_type(name=related_interface._meta.name, graphql_type=related_interface, branch=branch.name)
         registry.set_graphql_type(name=nested_interface._meta.name, graphql_type=nested_interface, branch=branch.name)
         registry.set_graphql_type(
             name=nested_edged_interface._meta.name, graphql_type=nested_edged_interface, branch=branch.name
         )
 
-    # Generate all GraphQL ObjectType & RelatedObjectType and store them in the registry
+    # Generate all GraphQL ObjectType, Nested, Paginated & NestedPaginated and store them in the registry
     for node_name, node_schema in full_schema.items():
         if isinstance(node_schema, NodeSchema):
             node_type = generate_graphql_object(schema=node_schema, branch=branch)
-            related_node_type = generate_related_graphql_object(
-                schema=node_schema, branch=branch, data_source=data_source, data_owner=data_owner
-            )
-
             node_type_edged = generate_graphql_edged_object(schema=node_schema, node=node_type)
             nested_node_type_edged = generate_graphql_edged_object(
                 schema=node_schema, node=node_type, relation_property=relationship_property
@@ -361,9 +352,6 @@ async def generate_object_types(
             )
 
             registry.set_graphql_type(name=node_type._meta.name, graphql_type=node_type, branch=branch.name)
-            registry.set_graphql_type(
-                name=related_node_type._meta.name, graphql_type=related_node_type, branch=branch.name
-            )
             registry.set_graphql_type(name=node_type_edged._meta.name, graphql_type=node_type_edged, branch=branch.name)
             registry.set_graphql_type(
                 name=nested_node_type_edged._meta.name, graphql_type=nested_node_type_edged, branch=branch.name
@@ -377,9 +365,9 @@ async def generate_object_types(
             )
 
             # Register this model to all the groups it belongs to.
-            if node_schema.groups:
-                for group_name in node_schema.groups:
-                    group_memberships[group_name].append(f"Related{node_schema.kind}")
+            # if node_schema.groups:
+            #     for group_name in node_schema.groups:
+            #         group_memberships[group_name].append(f"Related{node_schema.kind}")
 
     # Generate all the Groups with associated ObjectType / RelatedObjectType
     for node_name, node_schema in full_schema.items():
@@ -624,36 +612,6 @@ def generate_interface_object(schema: GenericSchema, branch: Branch) -> Type[gra
     return type(schema.kind, (InfrahubInterface,), main_attrs)
 
 
-def generate_related_interface_object(
-    schema: GenericSchema, branch: Branch, data_source: InfrahubObject, data_owner: InfrahubObject, name_prefix: str
-) -> Type[graphene.Interface]:
-    meta_attrs = {
-        "name": f"{name_prefix}{schema.kind}",
-        "description": schema.description,
-    }
-
-    main_attrs = {
-        "display_label": graphene.String(required=False),
-        "_updated_at": graphene.DateTime(required=False),
-        "_relation__updated_at": graphene.DateTime(required=False),
-        "_relation__is_visible": graphene.Boolean(required=False),
-        "_relation__is_protected": graphene.Boolean(required=False),
-        "_relation__source": graphene.Field(data_source),
-        "_relation__owner": graphene.Field(data_owner),
-        "Meta": type("Meta", (object,), meta_attrs),
-    }
-
-    for attr in schema.attributes:
-        attr_type = registry.get_graphql_type(
-            name=ATTRIBUTE_TYPES[attr.kind].get_graphql_type_name(), branch=branch.name
-        )
-        main_attrs[attr.name] = graphene.Field(attr_type, required=not attr.optional, description=attr.description)
-
-    main_attrs["id"] = graphene.Field(graphene.String, required=False, description="Unique identifier")
-
-    return type(f"{name_prefix}{schema.kind}", (InfrahubInterface,), main_attrs)
-
-
 def generate_nested_interface_object(
     schema: GenericSchema,
     relation_property: graphene.ObjectType,
@@ -696,44 +654,6 @@ def generate_paginated_interface_object(
     }
 
     return type(f"NestedPaginated{schema.kind}", (InfrahubObject,), main_attrs)
-
-
-def generate_related_graphql_object(
-    schema: NodeSchema, branch: Branch, data_source: InfrahubObject, data_owner: InfrahubObject
-) -> Type[InfrahubObject]:
-    """Generate a GraphQL object Type from a Infrahub NodeSchema for a Related Node."""
-
-    meta_attrs = {
-        "schema": schema,
-        "name": f"Related{schema.kind}",
-        "description": schema.description,
-        "interfaces": {RelatedNodeInterface},
-    }
-
-    if schema.inherit_from:
-        for generic in schema.inherit_from:
-            try:
-                generic = registry.get_graphql_type(name=f"Related{generic}", branch=branch.name)
-                meta_attrs["interfaces"].add(generic)
-            except ValueError:
-                # If the object is not present it might be because the generic is a group, will need to carefully test that.
-                pass
-
-    main_attrs = {
-        "id": graphene.String(required=True),
-        "display_label": graphene.String(required=False),
-        "_updated_at": graphene.DateTime(required=False),
-        "_relation__source": graphene.Field(data_source),
-        "_relation__owner": graphene.Field(data_owner),
-        "Meta": type("Meta", (object,), meta_attrs),
-    }
-    for attr in schema.attributes:
-        attr_type = registry.get_graphql_type(
-            name=ATTRIBUTE_TYPES[attr.kind].get_graphql_type_name(), branch=branch.name
-        )
-        main_attrs[attr.name] = graphene.Field(attr_type, required=not attr.optional, description=attr.description)
-
-    return type(f"Related{schema.kind}", (InfrahubObject,), main_attrs)
 
 
 def generate_graphql_mutations(

--- a/backend/infrahub/graphql/types.py
+++ b/backend/infrahub/graphql/types.py
@@ -171,9 +171,6 @@ class InfrahubInterface(Interface, GetListMixin):
     def resolve_type(cls, instance, info):
         branch = info.context["infrahub_branch"]
 
-        if "Related" in cls.__name__ and "type" in instance:
-            return registry.get_graphql_type(name=f"Related{instance['type']}", branch=branch)
-
         if "type" in instance:
             return registry.get_graphql_type(name=instance["type"], branch=branch)
 
@@ -269,16 +266,6 @@ class RelatedNodeInput(InputObjectType):
     _relation__is_protected = Boolean(required=False)
     _relation__owner = String(required=False)
     _relation__source = String(required=False)
-
-
-class RelatedNodeInterface(InfrahubInterface):
-    _relation__updated_at = DateTime(required=False)
-    _relation__is_visible = Boolean(required=False)
-    _relation__is_protected = Boolean(required=False)
-    # Since _relation__owner and _relation__source are using a Type that is generated dynamically
-    # these 2 fields will be dynamically inserted when we generate the GraphQL Schema
-    # _relation__owner = Field("DataOwner", required=False)
-    # _relation__source = Field("DataSource", required=False)
 
 
 class AttributeInterface(InfrahubInterface):


### PR DESCRIPTION
This PR completely removes the RelatedNode and RelatedInterfaces from GraphQL since we are not using them anymore.
