### PR TITLE
Add endpoint to read files from git repositories

### DIFF
--- a/backend/infrahub/api/file.py
+++ b/backend/infrahub/api/file.py
@@ -1,0 +1,53 @@
+from typing import TYPE_CHECKING, Optional
+
+from fastapi import APIRouter, Depends, Request
+from neo4j import AsyncSession
+from starlette.responses import PlainTextResponse
+
+from infrahub import config
+from infrahub.api.dependencies import get_current_user, get_session
+from infrahub.core.manager import NodeManager
+from infrahub.exceptions import CommitNotFoundError, NodeNotFound
+from infrahub.message_bus.events import (
+    GitMessageAction,
+    InfrahubGitRPC,
+    InfrahubRPCResponse,
+)
+
+if TYPE_CHECKING:
+    from infrahub.message_bus.rpc import InfrahubRpcClient
+
+
+router = APIRouter(prefix="/file")
+
+
+@router.get("/{repository_id:str}/{file_path:path}", response_class=PlainTextResponse)
+async def get_file(
+    request: Request,
+    repository_id: str,
+    file_path: str,
+    session: AsyncSession = Depends(get_session),
+    commit: Optional[str] = None,
+    _: str = Depends(get_current_user),
+) -> PlainTextResponse:
+    """Retrieve a file from a git repository."""
+    rpc_client: InfrahubRpcClient = request.app.state.rpc_client
+
+    repo = await NodeManager.get_one(session=session, id=repository_id)
+    if not repo:
+        raise NodeNotFound(
+            branch_name=config.SETTINGS.main.default_branch, node_type="Repository", identifier=repository_id
+        )
+    if not commit and repo.commit is None:
+        raise CommitNotFoundError(identifier=repository_id, commit="", message="No commits found on this repository")
+
+    commit = commit or repo.commit.value
+
+    response: InfrahubRPCResponse = await rpc_client.call(
+        message=InfrahubGitRPC(
+            action=GitMessageAction.GET_FILE, repository=repo, location=file_path, params={"commit": commit}
+        )
+    )
+    response.raise_for_status()
+
+    return PlainTextResponse(content=response.response["content"])

--- a/backend/infrahub/api/main.py
+++ b/backend/infrahub/api/main.py
@@ -17,7 +17,7 @@ from starlette_exporter import PrometheusMiddleware, handle_metrics
 
 import infrahub.config as config
 from infrahub import __version__
-from infrahub.api import auth, diff, internal, schema, transformation
+from infrahub.api import auth, diff, file, internal, schema, transformation
 from infrahub.api.background import BackgroundRunner
 from infrahub.api.dependencies import (
     BranchParams,
@@ -53,6 +53,7 @@ gunicorn_logger = logging.getLogger("gunicorn.error")
 logger.handlers = gunicorn_logger.handlers
 
 app.include_router(auth.router)
+app.include_router(file.router)
 app.include_router(schema.router)
 app.include_router(transformation.router)
 app.include_router(internal.router)

--- a/backend/infrahub/exceptions.py
+++ b/backend/infrahub/exceptions.py
@@ -30,7 +30,7 @@ class RepositoryError(Error):
 
 
 class CommitNotFoundError(Error):
-    def __init__(self, identifier, commit, message=None):
+    def __init__(self, identifier: str, commit: str, message=None):
         self.identifier = identifier
         self.commit = commit
         self.message = message or f"Commit {commit} not found with GitRepository '{identifier}'."
@@ -123,6 +123,14 @@ class AuthorizationError(Error):
 class PermissionDeniedError(Error):
     HTTP_CODE: int = 403
     message: str = "The requested operation was not authorized"
+
+    def __init__(self, message: Optional[str] = None):
+        self.message = message or self.message
+        super().__init__(self.message)
+
+
+class ProcessingError(Error):
+    message: str = "Unable to process the request"
 
     def __init__(self, message: Optional[str] = None):
         self.message = message or self.message

--- a/backend/infrahub/git/handlers.py
+++ b/backend/infrahub/git/handlers.py
@@ -94,6 +94,16 @@ async def handle_git_message_action_diff(message: InfrahubGitRPC, client: Infrah
     )
 
 
+async def handle_git_message_action_get_file(message: InfrahubGitRPC, client: InfrahubClient) -> InfrahubRPCResponse:
+    repo = await InfrahubRepository.init(id=message.repository_id, name=message.repository_name, client=client)
+    content = await repo.get_file(commit=message.params["commit"], location=message.location)
+
+    return InfrahubRPCResponse(
+        status=RPCStatusCode.OK,
+        response={"content": content},
+    )
+
+
 async def handle_git_message_action_merge(message: InfrahubGitRPC, client: InfrahubClient) -> InfrahubRPCResponse:
     repo = await InfrahubRepository.init(id=message.repository_id, name=message.repository_name, client=client)
     async with lock_registry.get(message.repository_name):
@@ -164,6 +174,7 @@ async def handle_git_rpc_message(  # pylint: disable=too-many-return-statements
         GitMessageAction.BRANCH_ADD: handle_git_message_action_branch_add,
         GitMessageAction.DIFF: handle_git_message_action_diff,
         GitMessageAction.MERGE: handle_git_message_action_merge,
+        GitMessageAction.GET_FILE: handle_git_message_action_get_file,
         GitMessageAction.REBASE: handle_not_implemented,
         GitMessageAction.PUSH: handle_not_implemented,
         GitMessageAction.PULL: handle_not_implemented,

--- a/backend/infrahub/message_bus/events.py
+++ b/backend/infrahub/message_bus/events.py
@@ -8,7 +8,7 @@ from aio_pika import DeliveryMode, ExchangeType, IncomingMessage, Message
 from aio_pika.patterns.base import Base as PickleSerializer
 
 import infrahub.config as config
-from infrahub.exceptions import ValidationError
+from infrahub.exceptions import ProcessingError, ValidationError
 from infrahub.utils import BaseEnum
 
 from . import get_broker
@@ -81,6 +81,7 @@ class GitMessageAction(str, BaseEnum):
     DIFF = "diff"
     REPO_ADD = "repo-add"
     BRANCH_ADD = "branch-add"
+    GET_FILE = "get-file"
 
 
 class TransformMessageAction(str, BaseEnum):
@@ -293,6 +294,10 @@ class InfrahubRPCResponse(InfrahubMessage):
         body["response"] = self.response
         body["errors"] = self.errors
         return body
+
+    def raise_for_status(self) -> None:
+        if self.errors:
+            raise ProcessingError("\n".join(self.errors))
 
 
 class InfrahubGitRPC(InfrahubRPC):


### PR DESCRIPTION
Will initially be used by the frontend to diff files between two commits.

* Adds an endpoint to read text files from Git repositories
* Add message and handler to read file
* Introduce a method to validate that a file exists and removes some duplicated code

I'm not to happy with the generic error handling of this one (i.e. raise ProcessingError). At some point I think we should specify the names of the errors in a better way before responding back from the git-agent. For now at least there is an error returned that is somewhat readable but always returns HTTP 500.

This doesn't have any tests yet, I'm not sure if this was the format that we talked about?

Related to #640