### PR TITLE
Add back restart after `load-infra-schema` command

### DIFF
--- a/tasks/demo.py
+++ b/tasks/demo.py
@@ -196,6 +196,11 @@ def load_infra_schema(context: Context):
             pty=True,
         )
 
+        context.run(
+            f"{ENV_VARS} docker compose {compose_files_cmd} -p {BUILD_NAME} restart infrahub-server",
+            pty=True,
+        )
+
 
 @task
 def load_infra_data(context: Context):


### PR DESCRIPTION
While we technically don't need to restart the server after loading a new schema anymore, there is still a delay of up to 10s for the change to propagate to all the workers.
So currently if we execute `load-infra-schema` and `load-infra-data` together, the second command will fail because it won't be able to find the schema right away

The right long term solution would be to implement have an event driven architecture that will automatically react to the update but for now I think the easiest solution is still to force the server to restart after  `load-infra-schema` to guarantee that all workers have the latest version