### PR TITLE
Add end to end tests in CI based on Cypress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
       !contains(needs.*.result, 'cancelled') &&
       needs.files-changed.outputs.backend == 'true'
     needs: ["files-changed", "yaml-lint", "python-lint"]
-    runs-on: "ubuntu-20.04"
+    runs-on: "runner-ubuntu-4-16"
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v3"
@@ -231,7 +231,7 @@ jobs:
       !contains(needs.*.result, 'cancelled') &&
       needs.files-changed.outputs.backend == 'true'
     needs: ["files-changed", "yaml-lint", "python-lint"]
-    runs-on: "ubuntu-20.04"
+    runs-on: "runner-ubuntu-4-16"
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v3"


### PR DESCRIPTION
This PR adds the execution of the End to End tests based on Cypress at the end of the workflow

In order to make it work I had to provision some additional runners with more CPU and more memory.
