### PR TITLE
Increase gunicorn default timeout to 90s

### DIFF
--- a/backend/infrahub/serve/gunicorn_config.py
+++ b/backend/infrahub/serve/gunicorn_config.py
@@ -1,4 +1,4 @@
 bind = "0.0.0.0:8000"
-timeout = 45
+timeout = 90
 workers = 4
 worker_class = "infrahub.serve.worker.InfrahubUvicorn"


### PR DESCRIPTION
This PR increases the default timeout for gunicorn to 90s
This value is high but it's mainly for the demo environment, for a production environment we would use a different value

In the short term, I think it will help with the instability we've been seeing in Github when we are building the demo environment