### PR TITLE
Add frontend in restart command

### DIFF
--- a/tasks/demo.py
+++ b/tasks/demo.py
@@ -121,6 +121,9 @@ def restart(context: Context, database: str = "memgraph"):
             f"{ENV_VARS} docker compose {compose_files_cmd} -p {BUILD_NAME} restart infrahub-git",
             pty=True,
         )
+        context.run(
+            f"{ENV_VARS} docker compose {compose_files_cmd} -p {BUILD_NAME} restart frontend",
+        )
 
 
 @task(optional=["database"])


### PR DESCRIPTION
Add the frontend in the restart command, to restart it with new local changes

Output:
```
[+] Running 1/1
 ⠿ Container infrahub-infrahub-server-1  Started                                                                                                                                                                                                                                                                         1.2s
[+] Running 1/1
 ⠿ Container infrahub-infrahub-git-1  Started                                                                                                                                                                                                                                                                           10.4s
Container infrahub-frontend-1  Restarting
Container infrahub-frontend-1  Started
```