### PR TITLE
Raise an error when no account is found for the profile

### DIFF
--- a/backend/infrahub/graphql/schema.py
+++ b/backend/infrahub/graphql/schema.py
@@ -6,6 +6,7 @@ from graphene import ID, Boolean, Field, List, ObjectType, String
 
 from infrahub import config
 from infrahub.core.manager import NodeManager
+from infrahub.exceptions import NodeNotFound
 
 from .mutations import (
     BranchCreate,
@@ -50,6 +51,10 @@ async def account_resolver(root, info: GraphQLResolveInfo):
         if results:
             account_profile = await results[0].to_graphql(session=session, fields=fields)
             return account_profile
+
+    raise NodeNotFound(
+        branch_name=config.SETTINGS.main.default_branch, node_type="CoreAccount", identifier=account_session.account_id
+    )
 
 
 class InfrahubBaseQuery(ObjectType):


### PR DESCRIPTION
Fixes #804

@dgarros, I renamed the query account_profile to CoreAccountProfile for consistency in #746 but it seems to have been reverted. Did this change cause any issues or was it a mistake?