### PR TITLE
Add uuidt to Python SDK

### DIFF
--- a/python_sdk/infrahub_client/__init__.py
+++ b/python_sdk/infrahub_client/__init__.py
@@ -26,6 +26,7 @@ from infrahub_client.schema import (
 )
 from infrahub_client.store import NodeStore, NodeStoreSync
 from infrahub_client.timestamp import Timestamp
+from infrahub_client.uuidt import UUIDT
 
 __all__ = [
     "AttributeSchema",
@@ -54,5 +55,6 @@ __all__ = [
     "ServerNotReacheableError",
     "ServerNotResponsiveError",
     "Timestamp",
+    "UUIDT",
     "ValidationError",
 ]

--- a/python_sdk/infrahub_client/utils.py
+++ b/python_sdk/infrahub_client/utils.py
@@ -5,6 +5,28 @@ from typing import Any, List, Optional, Tuple
 from uuid import UUID, uuid4
 
 
+def base36encode(number: int) -> str:
+    if not isinstance(number, (int)):
+        raise TypeError("number must be an integer")
+    is_negative = number < 0
+    number = abs(number)
+
+    alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    base36 = ""
+
+    while number:
+        number, i = divmod(number, 36)
+        base36 = alphabet[i] + base36
+    if is_negative:
+        base36 = "-" + base36
+
+    return base36 or alphabet[0]
+
+
+def base36decode(data: str) -> int:
+    return int(data, 36)
+
+
 def get_fixtures_dir() -> Path:
     """Get the directory which stores fixtures that are common to multiple unit/integration tests."""
     here = os.path.abspath(os.path.dirname(__file__))

--- a/python_sdk/infrahub_client/uuidt.py
+++ b/python_sdk/infrahub_client/uuidt.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import os
+import random
+import socket
+import time
+from typing import TYPE_CHECKING, Optional
+
+from infrahub_client.utils import base36encode
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
+
+BASE = 36
+DIVISOR = BASE - 1
+CHARACTERS = list("0123456789abcdefghijklmnopqrstuvwxyz")[:BASE]
+
+# Code inspired from https://github.com/isaacharrisholt/uuidt
+
+
+class UUIDT:
+    def __init__(self, namespace: str, timestamp: int, hostname: str, random_chars: str):
+        self.namespace = namespace
+        self.timestamp = timestamp
+        self.hostname = hostname
+        self.random_chars = random_chars
+
+    def __str__(self) -> str:
+        hostname_enc = sum(self.hostname.encode("utf-8"))
+        namespace_enc = sum(self.namespace.encode("utf-8"))
+
+        timestamp_str = base36encode(number=self.timestamp).lower()
+        hostname_str = base36encode(number=hostname_enc).lower()
+        namespace_str = base36encode(number=namespace_enc).lower()
+
+        return f"{timestamp_str[:8]}-{timestamp_str[8:]}-{hostname_str:0>4}-" f"{namespace_str:0>4}-{self.random_chars}"
+
+    @classmethod
+    def new(cls, namespace: Optional[str] = None) -> Self:
+        namespace = namespace or os.path.abspath(os.path.dirname(__file__))
+        timestamp = time.time_ns()
+        hostname = socket.gethostname()
+        random_chars = "".join(random.choices(CHARACTERS, k=4))
+
+        return cls(namespace, timestamp, hostname, random_chars)

--- a/python_sdk/tests/unit/test_utils.py
+++ b/python_sdk/tests/unit/test_utils.py
@@ -3,6 +3,8 @@ import uuid
 import pytest
 
 from infrahub_client.utils import (
+    base36decode,
+    base36encode,
     compare_lists,
     deep_merge_dict,
     duplicates,
@@ -82,3 +84,10 @@ def test_str_to_bool():
 
     with pytest.raises(TypeError):
         str_to_bool(tuple("a", "b", "c"))
+
+
+def test_base36():
+    assert base36encode(1412823931503067241) == "AQF8AA0006EH"
+    assert base36decode("AQF8AA0006EH") == 1412823931503067241
+    assert base36decode(base36encode(-9223372036721928027)) == -9223372036721928027
+    assert base36decode(base36encode(1412823931503067241)) == 1412823931503067241

--- a/python_sdk/tests/unit/test_uuidt.py
+++ b/python_sdk/tests/unit/test_uuidt.py
@@ -1,0 +1,11 @@
+from infrahub_client.uuidt import UUIDT
+
+
+def test_uuidt():
+    uuid1 = str(UUIDT.new())
+    uuid2 = str(UUIDT.new())
+    uuid3 = str(UUIDT.new())
+
+    assert len(uuid1) == 28
+    assert uuid1 != uuid2
+    assert sorted([uuid3, uuid2, uuid1]) == [uuid1, uuid2, uuid3]


### PR DESCRIPTION
This PR adds the ability to generate Timestamp-orderable UUID, it's inspired by the project [isaacharrisholt/uuidt](https://github.com/isaacharrisholt/uuidt) on Github

Since the code base isn't that big and since speed isn't the most important factor for us when generating UUID, it felt like reimplementing it ourselves was an acceptable option in this case.

The example code on Github was using numpy to convert the timestamp to a base36 string. Numpy is a very powerful library but it felt like it was an overkill just to convert numbers to base36 so replaced that part.

The next step will be to replace all UUID across the project with this new class.  