### PR TITLE
Add support for password based authentication to the SDK

### DIFF
--- a/python_sdk/examples/branch_list_sync.py
+++ b/python_sdk/examples/branch_list_sync.py
@@ -1,13 +1,13 @@
-
 from rich import print as rprint
 
 from infrahub_client import InfrahubClientSync
 
 
-async def main():
+def main():
     client = InfrahubClientSync.init(address="http://localhost:8000")
     branches = client.branch.all()
     rprint(branches)
+
 
 if __name__ == "__main__":
     main()

--- a/python_sdk/infrahub_client/config.py
+++ b/python_sdk/infrahub_client/config.py
@@ -1,11 +1,35 @@
-from typing import Optional
+from typing import Any, Dict, Optional
 
-from pydantic import BaseSettings, Field
+from pydantic import BaseSettings, Field, root_validator
 
 
 class Config(BaseSettings):
     api_token: Optional[str] = Field(default=None, description="API token for authentication against Infrahub.")
+    username: Optional[str] = Field(default=None, description="Username for accessing Infrahub", min_length=1)
+    password: Optional[str] = Field(default=None, description="Password for accessing Infrahub", min_length=1)
 
     class Config:
         env_prefix = "INFRAHUB_SDK_"
         case_sensitive = False
+
+    @root_validator(pre=True)
+    @classmethod
+    def validate_credentials_input(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        has_username = "username" in values
+        has_password = "password" in values
+        if has_username != has_password:
+            raise ValueError("Both 'username' and 'password' needs to be set")
+        return values
+
+    @root_validator(pre=True)
+    @classmethod
+    def validate_mix_authentication_schemes(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        if values.get("password") and values.get("api_token"):
+            raise ValueError("Unable to combine password with token based authentication")
+        return values
+
+    @property
+    def password_authentication(self) -> bool:
+        if self.username:
+            return True
+        return False

--- a/python_sdk/tests/unit/test_config.py
+++ b/python_sdk/tests/unit/test_config.py
@@ -1,0 +1,28 @@
+import pytest
+from pydantic.error_wrappers import ValidationError
+
+from infrahub_client.config import Config
+
+
+def test_combine_authentications():
+    with pytest.raises(ValidationError) as exc:
+        Config(api_token="testing", username="test", password="testpassword")
+
+    assert "Unable to combine password with token based authentication" in str(exc.value)
+
+
+def test_missing_password():
+    with pytest.raises(ValidationError) as exc:
+        Config(username="test")
+
+    assert "Both 'username' and 'password' needs to be set" in str(exc.value)
+
+
+def test_password_authentication():
+    config = Config(username="test", password="test-password")
+    assert config.password_authentication
+
+
+def test_not_password_authentication():
+    config = Config()
+    assert not config.password_authentication


### PR DESCRIPTION
Related to #743

This adds support for username and password based authentication. For now it doesn't handle refreshing JWT tokens I think we should do #837 first. For now the default lifetime for an access token is 1 hour, which we'll want a much shorter time once we reach production the current setting would allow this authentication to work for any scripts that are running for one hour or less which I think would be most current scripts.

While the SDK tests are passing locally I can see that they haven't been run in the pipeline. I'm not sure if this is due to the failing cloudflare build or if something happened after consolidating the pipelines.

I think this would be safe to merge as is and then we can add the ability to refresh tokens in an upcoming PR.