### PR TITLE
Add recorder and playback features to the SDK

### DIFF
--- a/python_sdk/infrahub_client/config.py
+++ b/python_sdk/infrahub_client/config.py
@@ -2,11 +2,24 @@ from typing import Any, Dict, Optional
 
 from pydantic import BaseSettings, Field, root_validator
 
+from infrahub_client.playback import JSONPlayback
+from infrahub_client.recorder import JSONRecorder, Recorder, RecorderType
+from infrahub_client.types import AsyncRequester, RequesterTransport, SyncRequester
+
 
 class Config(BaseSettings):
     api_token: Optional[str] = Field(default=None, description="API token for authentication against Infrahub.")
     username: Optional[str] = Field(default=None, description="Username for accessing Infrahub", min_length=1)
     password: Optional[str] = Field(default=None, description="Password for accessing Infrahub", min_length=1)
+    recorder: RecorderType = Field(default=RecorderType.NONE, description="Select builtin recorder for later replay.")
+    custom_recorder: Optional[Recorder] = Field(
+        default=None, description="Provides a way to record responses from the Infrahub API"
+    )
+    requester: Optional[AsyncRequester] = None
+    transport: RequesterTransport = Field(
+        default=RequesterTransport.HTTPX, description="Set an alternate transport using a predefined option"
+    )
+    sync_requester: Optional[SyncRequester] = None
 
     class Config:
         env_prefix = "INFRAHUB_SDK_"
@@ -19,6 +32,25 @@ class Config(BaseSettings):
         has_password = "password" in values
         if has_username != has_password:
             raise ValueError("Both 'username' and 'password' needs to be set")
+        return values
+
+    @root_validator(pre=True)
+    @classmethod
+    def set_custom_recorder(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        if values.get("recorder") == RecorderType.JSON and "custom_recorder" not in values:
+            values["custom_recorder"] = JSONRecorder()
+        return values
+
+    @root_validator(pre=True)
+    @classmethod
+    def set_transport(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        if values.get("transport") == RequesterTransport.JSON:
+            playback = JSONPlayback()
+            if "requester" not in values:
+                values["requester"] = playback.async_request
+            if "sync_requester" not in values:
+                values["sync_requester"] = playback.sync_request
+
         return values
 
     @root_validator(pre=True)

--- a/python_sdk/infrahub_client/playback.py
+++ b/python_sdk/infrahub_client/playback.py
@@ -1,0 +1,50 @@
+import json
+from typing import Any, Dict, Optional
+
+import httpx
+from pydantic import BaseSettings, Field
+
+from infrahub_client.types import HTTPMethod
+from infrahub_client.utils import generate_request_filename
+
+
+class JSONPlayback(BaseSettings):
+    directory: str = Field(default=".", description="Directory to read recorded files from")
+
+    async def async_request(
+        self, url: str, method: HTTPMethod, headers: Dict[str, Any], timeout: int, payload: Optional[Dict] = None
+    ) -> httpx.Response:
+        return self._read_request(url=url, method=method, headers=headers, payload=payload, timeout=timeout)
+
+    def sync_request(
+        self, url: str, method: HTTPMethod, headers: Dict[str, Any], timeout: int, payload: Optional[Dict] = None
+    ) -> httpx.Response:
+        return self._read_request(url=url, method=method, headers=headers, payload=payload, timeout=timeout)
+
+    def _read_request(
+        self,
+        url: str,
+        method: HTTPMethod,
+        headers: Dict[str, Any],
+        timeout: int,  # pylint: disable=unused-argument
+        payload: Optional[Dict] = None,
+    ) -> httpx.Response:
+        content: Optional[bytes] = None
+        if payload:
+            content = str(json.dumps(payload)).encode("UTF-8")
+        request = httpx.Request(method=method.value, url=url, headers=headers, content=content)
+
+        filename = generate_request_filename(request)
+        with open(f"{self.directory}/{filename}.json", "r", encoding="UTF-8") as fobj:
+            data = json.load(fobj)
+
+        response = httpx.Response(
+            status_code=data["status_code"],
+            content=data["response_content"],
+            request=request,
+        )
+        return response
+
+    class Config:
+        env_prefix = "INFRAHUB_SDK_PLAYBACK_"
+        case_sensitive = False

--- a/python_sdk/infrahub_client/recorder.py
+++ b/python_sdk/infrahub_client/recorder.py
@@ -1,0 +1,60 @@
+import enum
+import json
+from typing import Protocol, runtime_checkable
+
+import httpx
+from pydantic import BaseSettings
+
+from infrahub_client.utils import generate_request_filename
+
+
+class RecorderType(str, enum.Enum):
+    NONE = "none"
+    JSON = "json"
+
+
+@runtime_checkable
+class Recorder(Protocol):
+    def record(self, response: httpx.Response) -> None:
+        ...
+
+
+class JSONRecorder(BaseSettings):
+    directory: str = "."
+    host: str = ""
+
+    def record(self, response: httpx.Response) -> None:
+        self._set_url_host(response)
+        filename = generate_request_filename(response.request)
+        data = {
+            "status_code": response.status_code,
+            "method": response.request.method,
+            "url": str(response.request.url),
+            "headers": dict(response.request.headers),
+            "response_content": response.content.decode("UTF-8"),
+            "request_content": response.request.content.decode("UTF-8"),
+        }
+
+        with open(f"{self.directory}/{filename}.json", "w", encoding="UTF-8") as fobj:
+            json.dump(data, fobj, indent=4, sort_keys=True)
+
+    def _set_url_host(self, response: httpx.Response) -> None:
+        if not self.host:
+            return
+        original = str(response.request.url)
+        if response.request.url.port:
+            modified = original.replace(
+                f"{response.request.url.scheme}://{response.request.url.host}:",
+                f"{response.request.url.scheme}://{self.host}:",
+            )
+        else:
+            modified = original.replace(
+                f"{response.request.url.scheme}://{response.request.url.host}/",
+                f"{response.request.url.scheme}://{self.host}/",
+            )
+
+        response.request.url = httpx.URL(url=modified)
+
+    class Config:
+        env_prefix = "INFRAHUB_SDK_JSON_RECORDER_"
+        case_sensitive = False

--- a/python_sdk/infrahub_client/types.py
+++ b/python_sdk/infrahub_client/types.py
@@ -1,0 +1,30 @@
+import enum
+from typing import Any, Dict, Optional, Protocol, runtime_checkable
+
+import httpx
+
+
+class HTTPMethod(str, enum.Enum):
+    GET = "get"
+    POST = "post"
+
+
+class RequesterTransport(str, enum.Enum):
+    HTTPX = "httpx"
+    JSON = "json"
+
+
+@runtime_checkable
+class SyncRequester(Protocol):
+    def __call__(
+        self, url: str, method: HTTPMethod, headers: Dict[str, Any], timeout: int, payload: Optional[Dict] = None
+    ) -> httpx.Response:
+        ...
+
+
+@runtime_checkable
+class AsyncRequester(Protocol):
+    async def __call__(
+        self, url: str, method: HTTPMethod, headers: Dict[str, Any], timeout: int, payload: Optional[Dict] = None
+    ) -> httpx.Response:
+        ...


### PR DESCRIPTION
Fixes #577.

* Adds an option to record API requests and store them in JSON files
* Adds an option to play back recorded events in an offline setting
* Adds an example of how we could remove the "test_client" option from the SDK and instead just provide a custom request method, it should make some functions within the SDK cleaner (Later I think we should remove all places where we initialize an SDK client using the test_client option)

# A few notes:

* The previous SDK I wrote that used this approach was based on a REST-API, this doesn't quite work with GraphQL as we always reuse the same API endpoint, to solve this I included a hash of the payload in the generated filenames. If the payload order of the payload dictionary changes this might cause a problem, but I think it should be mostly safe.
* In this iteration each request and payload combination produces a unique file. So it's not possible to issue the same request twice and crete different results. With the changes in place it would be easy enough to add support for this. It could be useful later to test idempotent tasks.
* As credentials are part of the payload it should mainly be used with test systems or without authentication to avoid storing sensitive passwords in these files.

# Testing the recorder and playback feature

## 1. Create the directory where files will be stored

mkdir output

## 2. Start Infrahub

## 3. Run this Python script

```python
import os
from infrahub_client import InfrahubClientSync

os.environ["INFRAHUB_SDK_RECORDER"] = "json" # Indicate that we want to record the api calls
os.environ["INFRAHUB_SDK_JSON_RECORDER_HOST"] = "ci-testing" # Rename the servername in the files
os.environ["INFRAHUB_SDK_JSON_RECORDER_DIRECTORY"] = "output" # Directory to store files

client = InfrahubClientSync.init(address="http://localhost:8000")
branches = client.branch.all()
```

## 4. Stop Infrahub

## 5. List files in ./output

```
❯ ls ./output
post_http_ci-testing_8000__api__auth__login_bc88961ac50f1cd228483dc9cabe212204752e94d98635e03a419615.json
post_http_ci-testing_8000__graphql_183c1329a910473db45e44702924aeb0df07c00b9206b6585f513abc.json
```

## 6. Run the client again and read from the config

```python
import os
from rich import print as rprint

from infrahub_client import InfrahubClientSync

os.environ["INFRAHUB_SDK_TRANSPORT"] = "json" # Indicate that we want to read requests from json files
os.environ["INFRAHUB_SDK_PLAYBACK_DIRECTORY"] = "output" # Directory to read files from

client = InfrahubClientSync.init(address="http://ci-testing:8000")  # Use the "ci-testing" hostname we changed above
branches = client.branch.all()

rprint(branches)
```

```json
{
    'main': BranchData(
        id='616a2690-4b29-4931-a7d7-8e1de86452ac',
        name='main',
        description='Default Branch',
        is_data_only=False,
        is_default=True,
        origin_branch='main',
        branched_from='2023-08-01T05:45:10.223908Z'
    )
}
```
