### PR TITLE
Move the setting of the address to the config object

### DIFF
--- a/python_sdk/infrahub_client/client.py
+++ b/python_sdk/infrahub_client/client.py
@@ -41,7 +41,7 @@ class BaseClient:
 
     def __init__(
         self,
-        address: str = "http://localhost:8000",
+        address: str = "",
         default_timeout: int = 10,
         retry_on_failure: bool = False,
         retry_delay: int = 5,
@@ -53,7 +53,6 @@ class BaseClient:
         max_concurrent_execution: int = 5,
         config: Optional[Config] = None,
     ):
-        self.address = address
         self.client = None
         self.default_timeout = default_timeout
         self.test_client = test_client
@@ -73,13 +72,13 @@ class BaseClient:
         else:
             self.config = Config()
 
+        self.config.address = address or self.config.address
+        self.address = self.config.address
+
         if self.config.api_token:
             self.headers["X-INFRAHUB-KEY"] = self.config.api_token
 
         self.max_concurrent_execution = max_concurrent_execution
-
-        if test_client:
-            self.address = ""
 
         self._initialize()
 

--- a/python_sdk/infrahub_client/utils.py
+++ b/python_sdk/infrahub_client/utils.py
@@ -167,3 +167,11 @@ def generate_request_filename(request: httpx.Request) -> str:
         filename += f"_{content_hash.hexdigest()}"
 
     return filename.lower()
+
+
+def is_valid_url(url: str) -> bool:
+    try:
+        parsed = httpx.URL(url)
+        return all([parsed.scheme, parsed.netloc])
+    except TypeError:
+        return False

--- a/python_sdk/tests/integration/test_infrahub_client.py
+++ b/python_sdk/tests/integration/test_infrahub_client.py
@@ -39,7 +39,7 @@ class TestInfrahubClient:
     @pytest.fixture
     async def client(self, test_client):
         config = Config(requester=test_client.async_request)
-        return await InfrahubClient.init(address="", config=config)
+        return await InfrahubClient.init(config=config)
 
     @pytest.fixture(scope="class")
     async def base_dataset(self, session):

--- a/python_sdk/tests/unit/test_client.py
+++ b/python_sdk/tests/unit/test_client.py
@@ -63,6 +63,13 @@ async def test_init_client_sync():
     assert True
 
 
+async def test_init_with_invalid_address():
+    with pytest.raises(ValueError) as exc:
+        await InfrahubClient.init(address="missing-schema")
+
+    assert "The configured address is not a valid url" in str(exc.value)
+
+
 async def test_get_repositories(
     client, mock_branches_list_query, mock_repositories_query
 ):  # pylint: disable=unused-argument

--- a/python_sdk/tests/unit/test_utils.py
+++ b/python_sdk/tests/unit/test_utils.py
@@ -10,6 +10,7 @@ from infrahub_client.utils import (
     deep_merge_dict,
     duplicates,
     get_flat_value,
+    is_valid_url,
     is_valid_uuid,
     str_to_bool,
 )
@@ -25,6 +26,15 @@ def test_is_valid_uuid():
     assert is_valid_uuid(False) is False
     assert is_valid_uuid("Not a valid UUID") is False
     assert is_valid_uuid(uuid.UUID) is False
+
+
+def test_is_valid_url():
+    assert is_valid_url(55) is False
+    assert is_valid_url("https://") is False
+    assert is_valid_url("my-server") is False
+    assert is_valid_url("https://my-server") is True
+    assert is_valid_url("http://my-server:8080") is True
+    assert is_valid_url("http://192.168.1.10") is True
 
 
 def test_duplicates():


### PR DESCRIPTION
Makes it easier to set the Infrahub API using an environment variable. Also adds a check to validate that the string that forms the URL is valid.

Fixes #888