### PR TITLE
Add auditing of frontend packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,8 +318,29 @@ jobs:
           parallel: true
           file: frontend/coverage/lcov.info
 
+  frontend-security:
+    if: |
+      always() &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled') &&
+      needs.files-changed.outputs.frontend == 'true'
+    needs: ["files-changed", "yaml-lint", "javascript-lint"]
+    runs-on: "ubuntu-20.04"
+    steps:
+      - name: "Check out repository code"
+        uses: "actions/checkout@v3"
+      - name: Install NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - name: "Security: Check packages"
+        working-directory: ./frontend
+        run: npm audit
+
   E2E-testing:
-    needs: ["frontend-tests", "ctl-tests", "backend-tests-default", "python-sdk-tests"]
+    needs: ["frontend-security", "frontend-tests", "ctl-tests", "backend-tests-default", "python-sdk-tests"]
     if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
     runs-on: "runner-ubuntu-8-32"
     steps:


### PR DESCRIPTION
Adds a CI check to see if any of our javascript dependencies have reported vulnerabilities.

At this moment the pipeline is failing due to vulnerable packages.