### PR TITLE
Make tokens branch agnostic

### DIFF
--- a/backend/infrahub/core/schema.py
+++ b/backend/infrahub/core/schema.py
@@ -1277,14 +1277,20 @@ core_models = {
             "label": "Account Token",
             "default_filter": "token__value",
             "display_labels": ["token__value"],
-            "branch": BranchSupportType.AWARE.value,
+            "branch": BranchSupportType.AGNOSTIC.value,
             "attributes": [
                 {"name": "name", "kind": "Text", "optional": True},
                 {"name": "token", "kind": "Text", "unique": True},
                 {"name": "expiration", "kind": "DateTime", "optional": True},
             ],
             "relationships": [
-                {"name": "account", "peer": "CoreAccount", "optional": False, "cardinality": "one"},
+                {
+                    "name": "account",
+                    "peer": "CoreAccount",
+                    "optional": False,
+                    "cardinality": "one",
+                    "branch": BranchSupportType.AGNOSTIC.value,
+                },
             ],
         },
         {
@@ -1293,12 +1299,18 @@ core_models = {
             "description": "Refresh Token",
             "label": "Refresh Token",
             "display_labels": [],
-            "branch": BranchSupportType.AWARE.value,
+            "branch": BranchSupportType.AGNOSTIC.value,
             "attributes": [
                 {"name": "expiration", "kind": "DateTime", "optional": False},
             ],
             "relationships": [
-                {"name": "account", "peer": "CoreAccount", "optional": False, "cardinality": "one"},
+                {
+                    "name": "account",
+                    "peer": "CoreAccount",
+                    "optional": False,
+                    "cardinality": "one",
+                    "branch": BranchSupportType.AGNOSTIC.value,
+                },
             ],
         },
         {


### PR DESCRIPTION
Changes AccountToken and Refresh token to be branch agnostic.

Related to #930, just so that tokens don't show up in the diff, this can be done prior to #929.