### PR TITLE
Validate values during creation of attributes

### DIFF
--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -140,20 +140,7 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
         # If the object is new, we need to ensure that all mandatory attributes and relationships have been provided
         if not self.id:
             for mandatory_attr in self._schema.mandatory_attribute_names:
-                if mandatory_attr in fields.keys():
-                    defined_value = fields[mandatory_attr]
-                    if isinstance(fields[mandatory_attr], dict):
-                        defined_value = fields[mandatory_attr].get("value")
-
-                    if defined_value is None:
-                        errors.append(
-                            ValidationError(
-                                {
-                                    mandatory_attr: f"{mandatory_attr} is mandatory for {self.get_kind()} and must contain a value"
-                                }
-                            )
-                        )
-                else:
+                if mandatory_attr not in fields.keys():
                     errors.append(
                         ValidationError({mandatory_attr: f"{mandatory_attr} is mandatory for {self.get_kind()}"})
                     )
@@ -191,6 +178,9 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
                         data=fields.get(attr_schema.name, None),
                     ),
                 )
+                if not self.id:
+                    attribute = getattr(self, attr_schema.name)
+                    attribute.validate(value=attribute.value, name=attribute.name, schema=attribute.schema)
             except ValidationError as exc:
                 errors.append(exc)
 

--- a/backend/tests/unit/core/test_node.py
+++ b/backend/tests/unit/core/test_node.py
@@ -83,8 +83,8 @@ async def test_node_init_mandatory_field_null(session, default_branch: Branch, c
     with pytest.raises(ValidationError) as dict_exc:
         await obj.new(session=session, name={"value": None}, level=4)
 
-    assert "name is mandatory for TestCriticality and must contain a value at name" in str(direct_exc.value)
-    assert "name is mandatory for TestCriticality and must contain a value at name" in str(dict_exc.value)
+    assert "A value must be provided for name at name" in str(direct_exc.value)
+    assert "A value must be provided for name at name" in str(dict_exc.value)
 
 
 async def test_node_init_invalid_attribute(session, default_branch: Branch, criticality_schema):


### PR DESCRIPTION
Initially I thought this was only for DateTime but it seems to be any kind of attribute.

Fixes #921

Previously we only ran this validation on update operations which made it possible to create an object that didn't follow the schema requirement. As TextField doesn't require a value and the value can be blank graphene allows the mutation.