### PR TITLE
Use memgraph-platform for the dev environment

### DIFF
--- a/development/docker-compose.dev-override.yml
+++ b/development/docker-compose.dev-override.yml
@@ -2,6 +2,8 @@
 version: "3.4"
 services:
   database:
+    image: "memgraph/memgraph-platform:2.10.0-memgraph2.10.0-lab2.8.0"
+    entrypoint: ["/usr/bin/supervisord"]
     ports:
       - "7687:7687"
       - "7474:3000"


### PR DESCRIPTION
I think a bigger refactoring of the dev environment would be great but for now this is a quick fix to add back the web ui for memgraph when we use the dev environment `demo.dev-start`, `demo.dev-stop`