### PR TITLE
Convert sdk tests to use config instead of test_client param

### DIFF
--- a/python_sdk/tests/integration/test_infrahub_client.py
+++ b/python_sdk/tests/integration/test_infrahub_client.py
@@ -1,29 +1,14 @@
-import json
-from typing import Any, Dict, Optional
-
-import httpx
 import pytest
-from fastapi.testclient import TestClient
 
 from infrahub.core import registry
 from infrahub.core.initialization import create_branch
 from infrahub.core.node import Node
 from infrahub_client import Config, InfrahubClient
 from infrahub_client.node import InfrahubNode
-from infrahub_client.types import HTTPMethod
+
+from .conftest import InfrahubTestClient
 
 # pylint: disable=unused-argument
-
-
-class InfrahubTestClient(TestClient):
-    async def async_request(
-        self, url: str, method: HTTPMethod, headers: Dict[str, Any], timeout: int, payload: Optional[Dict] = None
-    ) -> httpx.Response:
-        content = None
-        if payload:
-            content = str(json.dumps(payload)).encode("UTF-8")
-        with self as client:
-            return client.request(method=method.value, url=url, headers=headers, timeout=timeout, content=content)
 
 
 class TestInfrahubClient:

--- a/python_sdk/tests/integration/test_infrahub_client_sync.py
+++ b/python_sdk/tests/integration/test_infrahub_client_sync.py
@@ -1,10 +1,11 @@
 import pytest
-from fastapi.testclient import TestClient
 
 from infrahub.core.initialization import create_branch
 from infrahub.core.node import Node
-from infrahub_client import InfrahubClientSync
+from infrahub_client import Config, InfrahubClientSync
 from infrahub_client.node import InfrahubNodeSync
+
+from .conftest import InfrahubTestClient
 
 # pylint: disable=unused-argument
 
@@ -15,11 +16,12 @@ class TestInfrahubClientSync:
         # pylint: disable=import-outside-toplevel
         from infrahub.server import app
 
-        return TestClient(app)
+        return InfrahubTestClient(app)
 
     @pytest.fixture
     def client(self, test_client):
-        return InfrahubClientSync.init(test_client=test_client)
+        config = Config(sync_requester=test_client.sync_request)
+        return InfrahubClientSync.init(config=config)
 
     @pytest.fixture(scope="class")
     async def base_dataset(self, session):

--- a/python_sdk/tests/integration/test_node.py
+++ b/python_sdk/tests/integration/test_node.py
@@ -1,11 +1,12 @@
 import pytest
-from fastapi.testclient import TestClient
 
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
-from infrahub_client import InfrahubClient
+from infrahub_client import Config, InfrahubClient
 from infrahub_client.exceptions import NodeNotFound
 from infrahub_client.node import InfrahubNode
+
+from .conftest import InfrahubTestClient
 
 # pylint: disable=unused-argument
 
@@ -17,11 +18,12 @@ class TestInfrahubNode:
 
         from infrahub.server import app
 
-        return TestClient(app)
+        return InfrahubTestClient(app)
 
     @pytest.fixture
     async def client(self, test_client):
-        return await InfrahubClient.init(test_client=test_client)
+        config = Config(requester=test_client.async_request)
+        return await InfrahubClient.init(config=config)
 
     async def test_node_create(self, client: InfrahubClient, init_db_base, location_schema):
         data = {"name": {"value": "JFK1"}, "description": {"value": "JFK Airport"}, "type": {"value": "SITE"}}

--- a/python_sdk/tests/integration/test_object_store.py
+++ b/python_sdk/tests/integration/test_object_store.py
@@ -1,7 +1,8 @@
 import pytest
-from fastapi.testclient import TestClient
 
-from infrahub_client import InfrahubClient
+from infrahub_client import Config, InfrahubClient
+
+from .conftest import InfrahubTestClient
 
 FILE_CONTENT_01 = """
     any content
@@ -16,11 +17,12 @@ class TestObjectStore:
 
         from infrahub.server import app
 
-        return TestClient(app)
+        return InfrahubTestClient(app)
 
     @pytest.fixture
     async def client(self, test_client):
-        return await InfrahubClient.init(test_client=test_client)
+        config = Config(requester=test_client.async_request)
+        return await InfrahubClient.init(config=config)
 
     async def test_upload_and_get(self, client: InfrahubClient):
         response = await client.object_store.upload(content=FILE_CONTENT_01)

--- a/python_sdk/tests/integration/test_schema.py
+++ b/python_sdk/tests/integration/test_schema.py
@@ -1,9 +1,10 @@
 import pytest
-from fastapi.testclient import TestClient
 
 from infrahub.core.schema import core_models
-from infrahub_client import InfrahubClient
+from infrahub_client import Config, InfrahubClient
 from infrahub_client.schema import NodeSchema
+
+from .conftest import InfrahubTestClient
 
 # pylint: disable=unused-argument
 
@@ -14,10 +15,11 @@ class TestInfrahubSchema:
         # pylint: disable=import-outside-toplevel
         from infrahub.server import app
 
-        return TestClient(app)
+        return InfrahubTestClient(app)
 
     async def test_schema_all(self, client, init_db_base):
-        ifc = await InfrahubClient.init(test_client=client)
+        config = Config(requester=client.async_request)
+        ifc = await InfrahubClient.init(config=config)
         schema_nodes = await ifc.schema.all()
 
         assert len(schema_nodes) == len(core_models["nodes"])


### PR DESCRIPTION
Related to #919

In a future PR we'll remove the test_client param from the backend and tests. After that we can clean up the SDK and remove this option completely.