### PR TITLE
Fix CI by adding the empty request_id

### DIFF
--- a/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
+++ b/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
@@ -1,7 +1,7 @@
 import os
 from typing import Dict, List
 
-from infrahub.message_bus import InfrahubBaseMessage, messages
+from infrahub.message_bus import InfrahubBaseMessage, Meta, messages
 from infrahub.message_bus.operations.requests.proposed_change import repository_checks
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.message_bus import InfrahubMessageBus
@@ -45,7 +45,7 @@ async def test_repository_checks():
     assert ["request.repository.checks"] == bus_recorder.seen_routing_keys
     assert (
         messages.RequestRepositoryChecks(
-            meta=None,
+            meta=Meta(request_id=""),
             proposed_change="13a49493-b186-4f7e-a1bb-cd015ed0bdb0",
             repository="b002c0e6-78e6-4a8b-812f-8aa41d89d386",
             branch="test-pc-1",
@@ -54,7 +54,7 @@ async def test_repository_checks():
     )
     assert (
         messages.RequestRepositoryChecks(
-            meta=None,
+            meta=Meta(request_id=""),
             proposed_change="13a49493-b186-4f7e-a1bb-cd015ed0bdb0",
             repository="0af9707a-9c53-450d-96db-d721bfd0350b",
             branch="test-pc-1",


### PR DESCRIPTION
The `msg.assign_meta(parent=message)` line that was added in #962 wasn't compatible with the tests as defined in #964. As the test for #964 had already been run prior to #962 being merged we didn't catch this problem previously.

At some point we might want to enforce an update against develop before merging a PR, but would be nice if the CI was quicker in that case. We can revisit this again if we see the problem in the future, I'm sure it will resurface every now and again.