### PR TITLE
Move data validation checks into git-agent

### DIFF
--- a/backend/infrahub/cli/git_agent.py
+++ b/backend/infrahub/cli/git_agent.py
@@ -9,7 +9,9 @@ import typer
 from prometheus_client import start_http_server
 from rich.logging import RichHandler
 
-import infrahub.config as config
+from infrahub import config
+from infrahub.core.initialization import initialization
+from infrahub.database import get_db
 from infrahub.git import handle_message, initialize_repositories_directory
 from infrahub.git.actions import sync_remote_repositories
 from infrahub.lock import initialize_lock
@@ -22,6 +24,7 @@ from infrahub.message_bus.events import (
 )
 from infrahub.message_bus.operations import execute_message
 from infrahub.services import InfrahubServices
+from infrahub.services.adapters.database.graph_database import GraphDatabase
 from infrahub.services.adapters.message_bus.rabbitmq import RabbitMQMessageBus
 from infrahub_client import InfrahubClient
 
@@ -59,7 +62,11 @@ async def subscribe_rpcs_queue(client: InfrahubClient):
     channel = await connection.channel()
     queue = await channel.declare_queue(f"{config.SETTINGS.broker.namespace}.rpcs")
     exchange = await channel.declare_exchange(f"{config.SETTINGS.broker.namespace}.events", type="topic")
-    service = InfrahubServices(client=client, message_bus=RabbitMQMessageBus(exchange=exchange))
+    driver = await get_db()
+    database = GraphDatabase(driver=driver)
+    service = InfrahubServices(client=client, database=database, message_bus=RabbitMQMessageBus(exchange=exchange))
+    async with service.database.session as session:
+        await initialization(session=session)
     log.info("Waiting for RPC instructions to execute .. ")
     async with queue.iterator() as qiterator:
         message: IncomingMessage

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -1,21 +1,18 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from graphene import Boolean, Enum, InputObjectType, Mutation, String
 from graphql import GraphQLResolveInfo
-from neo4j import AsyncSession
 
-from infrahub.core.branch import ObjectConflict
 from infrahub.core.manager import NodeManager
-from infrahub.core.node import Node
-from infrahub.core.registry import registry
-from infrahub.core.schema import NodeSchema, ValidatorConclusion, ValidatorState
-from infrahub.core.timestamp import Timestamp
+from infrahub.core.schema import NodeSchema
 from infrahub.graphql.mutations.main import InfrahubMutationMixin
 from infrahub.message_bus import messages
 
 from .main import InfrahubMutationOptions
 
 if TYPE_CHECKING:
+    from neo4j import AsyncSession
+
     from infrahub.message_bus.rpc import InfrahubRpcClient
 
 
@@ -24,110 +21,6 @@ class CheckType(Enum):
     REPOSITORY = "repository"
     SCHEMA = "schema"
     ALL = "all"
-
-
-async def _get_conflicts(session: AsyncSession, proposed_change: Node) -> List[ObjectConflict]:
-    source_branch = await registry.get_branch(session=session, branch=proposed_change.source_branch.value)
-    diff = await source_branch.diff(session=session, branch_only=False)
-    return await diff.get_conflicts_graph(session=session)
-
-
-async def create_data_check(session: AsyncSession, proposed_change: Node) -> None:
-    conflicts = await _get_conflicts(session=session, proposed_change=proposed_change)
-
-    validator_obj = await Node.init(session=session, schema="CoreDataValidator")
-
-    initial_state = ValidatorState.COMPLETED
-    initial_conclusion = ValidatorConclusion.SUCCESS
-    started_at = Timestamp().to_string()
-    params = {"completed_at": Timestamp().to_string()}
-    if conflicts:
-        initial_state = ValidatorState.IN_PROGRESS
-        initial_conclusion = ValidatorConclusion.UNKNOWN
-        params.pop("completed_at")
-
-    await validator_obj.new(
-        session=session,
-        proposed_change=proposed_change.id,
-        state=initial_state.value,
-        conclusion=initial_conclusion.value,
-        started_at=started_at,
-        **params,
-    )
-    await validator_obj.save(session=session)
-
-    for conflict in conflicts:
-        conflict_obj = await Node.init(session=session, schema="CoreDataCheck")
-        await conflict_obj.new(
-            session=session,
-            origin="internal",
-            kind="DataIntegrity",
-            validator=validator_obj.id,
-            conclusion="failure",
-            severity="critical",
-            paths=[str(conflict)],
-            **params,
-        )
-        await conflict_obj.save(session=session)
-
-    if conflicts:
-        updated_validator_obj = await NodeManager.get_one_by_id_or_default_filter(
-            id=validator_obj.id, schema_name="CoreDataValidator", session=session
-        )
-        updated_validator_obj.state.value = ValidatorState.COMPLETED.value
-        updated_validator_obj.conclusion.value = ValidatorConclusion.FAILURE.value
-        updated_validator_obj.completed_at.value = Timestamp().to_string()
-        await updated_validator_obj.save(session=session)
-
-
-async def update_data_check(session: AsyncSession, proposed_change: Node) -> None:
-    validations = await proposed_change.validations.get_peers(session=session)
-    data_check = None
-    for validation in validations.values():
-        if validation._schema.kind == "CoreDataValidator":
-            data_check = validation
-            break
-
-    if not data_check:
-        await create_data_check(session=session, proposed_change=proposed_change)
-        return
-
-    conflicts = await _get_conflicts(session=session, proposed_change=proposed_change)
-
-    state = ValidatorState.COMPLETED
-    conclusion = ValidatorConclusion.SUCCESS
-
-    started_at = Timestamp().to_string()
-    completed_at = Timestamp().to_string()
-    if conflicts:
-        state = ValidatorState.COMPLETED
-        conclusion = ValidatorConclusion.FAILURE
-
-    conflict_objects = []
-    for conflict in conflicts:
-        conflict_obj = await Node.init(session=session, schema="CoreDataCheck")
-        await conflict_obj.new(
-            session=session,
-            origin="internal",
-            kind="DataIntegrity",
-            validator=data_check.id,
-            conclusion="failure",
-            severity="critical",
-            paths=[str(conflict)],
-        )
-        await conflict_obj.save(session=session)
-        conflict_objects.append(conflict_obj.id)
-
-    previous_relationships = await data_check.checks.get_relationships(session=session)
-    for rel in previous_relationships:
-        await rel.delete(session=session)
-
-    data_check.state_value = state.value
-    data_check.conclusion.value = conclusion.value
-    data_check.checks.update = conflict_objects
-    data_check.started_at.value = started_at
-    data_check.completed_at.value = completed_at
-    await data_check.save(session=session)
 
 
 class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
@@ -154,12 +47,9 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
         branch: Optional[str] = None,
         at: Optional[str] = None,
     ):
-        session: AsyncSession = info.context.get("infrahub_session")
         rpc_client: InfrahubRpcClient = info.context.get("infrahub_rpc_client")
 
         proposed_change, result = await super().mutate_create(root=root, info=info, data=data, branch=branch, at=at)
-
-        await create_data_check(session=session, proposed_change=proposed_change)
 
         events = [
             messages.RequestProposedChangeDataIntegrity(proposed_change=proposed_change.id),
@@ -229,8 +119,6 @@ class ProposedChangeRequestRunCheck(Mutation):
         )
         if check_type == CheckType.DATA:
             await rpc_client.send(messages.RequestProposedChangeDataIntegrity(proposed_change=proposed_change.id))
-            # Once the data integrity check is handled in the worker nodes the below call will be removed
-            await update_data_check(session=session, proposed_change=proposed_change)
         elif check_type == CheckType.REPOSITORY:
             await rpc_client.send(messages.RequestProposedChangeRepositoryChecks(proposed_change=proposed_change.id))
         elif check_type == CheckType.SCHEMA:

--- a/backend/infrahub/message_bus/operations/requests/proposed_change.py
+++ b/backend/infrahub/message_bus/operations/requests/proposed_change.py
@@ -1,3 +1,13 @@
+from typing import List
+
+from neo4j import AsyncSession
+
+from infrahub.core.branch import ObjectConflict
+from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
+from infrahub.core.registry import registry
+from infrahub.core.schema import ValidatorConclusion, ValidatorState
+from infrahub.core.timestamp import Timestamp
 from infrahub.log import get_logger
 from infrahub.message_bus import messages
 from infrahub.services import InfrahubServices
@@ -5,10 +15,114 @@ from infrahub.services import InfrahubServices
 log = get_logger()
 
 
-async def data_integrity(
-    message: messages.RequestProposedChangeDataIntegrity, service: InfrahubServices  # pylint: disable=unused-argument
-) -> None:
+async def _create_data_check(session: AsyncSession, proposed_change: Node) -> None:
+    conflicts = await _get_conflicts(session=session, proposed_change=proposed_change)
+
+    validator_obj = await Node.init(session=session, schema="CoreDataValidator")
+
+    initial_state = ValidatorState.COMPLETED
+    initial_conclusion = ValidatorConclusion.SUCCESS
+    started_at = Timestamp().to_string()
+    params = {"completed_at": Timestamp().to_string()}
+    if conflicts:
+        initial_state = ValidatorState.IN_PROGRESS
+        initial_conclusion = ValidatorConclusion.UNKNOWN
+        params.pop("completed_at")
+
+    await validator_obj.new(
+        session=session,
+        proposed_change=proposed_change.id,
+        state=initial_state.value,
+        conclusion=initial_conclusion.value,
+        started_at=started_at,
+        **params,
+    )
+    await validator_obj.save(session=session)
+
+    for conflict in conflicts:
+        conflict_obj = await Node.init(session=session, schema="CoreDataCheck")
+        await conflict_obj.new(
+            session=session,
+            origin="internal",
+            kind="DataIntegrity",
+            validator=validator_obj.id,
+            conclusion="failure",
+            severity="critical",
+            paths=[str(conflict)],
+            **params,
+        )
+        await conflict_obj.save(session=session)
+
+    if conflicts:
+        updated_validator_obj = await NodeManager.get_one_by_id_or_default_filter(
+            id=validator_obj.id, schema_name="CoreDataValidator", session=session
+        )
+        updated_validator_obj.state.value = ValidatorState.COMPLETED.value
+        updated_validator_obj.conclusion.value = ValidatorConclusion.FAILURE.value
+        updated_validator_obj.completed_at.value = Timestamp().to_string()
+        await updated_validator_obj.save(session=session)
+
+
+async def _get_conflicts(session: AsyncSession, proposed_change: Node) -> List[ObjectConflict]:
+    source_branch = await registry.get_branch(session=session, branch=proposed_change.source_branch.value)
+    diff = await source_branch.diff(session=session, branch_only=False)
+    return await diff.get_conflicts_graph(session=session)
+
+
+async def data_integrity(message: messages.RequestProposedChangeDataIntegrity, service: InfrahubServices) -> None:
+    """Triggers a data integrity validation check on the provided proposed change to start."""
     log.info(f"Got a request to process data integrity defined in proposed_change: {message.proposed_change}")
+    async with service.database.session as session:
+        proposed_change = await NodeManager.get_one_by_id_or_default_filter(
+            id=message.proposed_change, schema_name="CoreProposedChange", session=session
+        )
+        validations = await proposed_change.validations.get_peers(session=session)
+        data_check = None
+        for validation in validations.values():
+            if validation._schema.kind == "CoreDataValidator":
+                data_check = validation
+                break
+
+        if not data_check:
+            await _create_data_check(session=session, proposed_change=proposed_change)
+            return
+
+        conflicts = await _get_conflicts(session=session, proposed_change=proposed_change)
+
+        state = ValidatorState.COMPLETED
+        conclusion = ValidatorConclusion.SUCCESS
+
+        started_at = Timestamp().to_string()
+        completed_at = Timestamp().to_string()
+        if conflicts:
+            state = ValidatorState.COMPLETED
+            conclusion = ValidatorConclusion.FAILURE
+
+        conflict_objects = []
+        for conflict in conflicts:
+            conflict_obj = await Node.init(session=session, schema="CoreDataCheck")
+            await conflict_obj.new(
+                session=session,
+                origin="internal",
+                kind="DataIntegrity",
+                validator=data_check.id,
+                conclusion="failure",
+                severity="critical",
+                paths=[str(conflict)],
+            )
+            await conflict_obj.save(session=session)
+            conflict_objects.append(conflict_obj.id)
+
+        previous_relationships = await data_check.checks.get_relationships(session=session)
+        for rel in previous_relationships:
+            await rel.delete(session=session)
+
+        data_check.state_value = state.value
+        data_check.conclusion.value = conclusion.value
+        data_check.checks.update = conflict_objects
+        data_check.started_at.value = started_at
+        data_check.completed_at.value = completed_at
+        await data_check.save(session=session)
 
 
 async def schema_integrity(

--- a/backend/infrahub/services/__init__.py
+++ b/backend/infrahub/services/__init__.py
@@ -5,12 +5,19 @@ from infrahub.message_bus import InfrahubBaseMessage
 from infrahub.message_bus.messages import ROUTING_KEY_MAP
 from infrahub_client import InfrahubClient
 
+from .adapters.database import InfrahubDatabase
 from .adapters.message_bus import InfrahubMessageBus
 
 
 class InfrahubServices:
-    def __init__(self, client: Optional[InfrahubClient] = None, message_bus: Optional[InfrahubMessageBus] = None):
+    def __init__(
+        self,
+        client: Optional[InfrahubClient] = None,
+        database: Optional[InfrahubDatabase] = None,
+        message_bus: Optional[InfrahubMessageBus] = None,
+    ):
         self._client = client
+        self.database = database or InfrahubDatabase()
         self.message_bus = message_bus or InfrahubMessageBus()
 
     @property

--- a/backend/infrahub/services/adapters/database/__init__.py
+++ b/backend/infrahub/services/adapters/database/__init__.py
@@ -1,0 +1,9 @@
+from neo4j import AsyncSession
+
+
+class InfrahubDatabase:
+    """Base class for database access"""
+
+    @property
+    def session(self) -> AsyncSession:
+        raise NotImplementedError()

--- a/backend/infrahub/services/adapters/database/graph_database.py
+++ b/backend/infrahub/services/adapters/database/graph_database.py
@@ -1,0 +1,13 @@
+from neo4j import AsyncDriver, AsyncSession
+
+from infrahub import config
+from infrahub.services.adapters.database import InfrahubDatabase
+
+
+class GraphDatabase(InfrahubDatabase):
+    def __init__(self, driver: AsyncDriver) -> None:
+        self.driver = driver
+
+    @property
+    def session(self) -> AsyncSession:
+        return self.driver.session(database=config.SETTINGS.database.database)


### PR DESCRIPTION
This PR moves the data validation checks so that they happen in the git-agent instead of within the API. To be able to do this we had to allow the git-agent to have direct database access.

In the current implementation there's one problem with that which is the lack of a background job to update the schema like we have in the API. I didn't look at it at all for this PR, mainly because it's not really related and I don't think we'll have a problem as all of the nodes we are interested in comes from the core schema and we only modify them in the global branch. However we should probably add it later.

I added the database access to the service object. I would have wanted to make it more generic but we can return to that part later.

Also I've just copied the code as is from the API and there are a few improvements I'd like to make in later iterations.

1. It still behaves in the same way where it doesn't set the checks to be in progress before starting and instead just mimics what it did before. I didn't want to introduce any changes to the logic and think we should first confirm that we agree upon the overall approach for the database access within the git-agent
2. I want to add additional messages for this and would like that we try to stick to a rule that we only have one transaction per message, after that we should send a new message for further instructions. The reason for this is that it can be hard to recover to the same state if a message fails after having completed two out of three transactions. At this point we'll want to reschedule the message to try again later(*), and when we do we don't want it to perform the first two transactions again.

(*) For the retry parts I want to add some logic to that within the Meta object of each message. As part of that I'd also want to remove the Python pickle based messages and replace them all together with this json format. I think it will be easier to keep track of each message type and also easier to troubleshot within RabbitMQ if we have a json payload, and of course if we add non-python agents.