### PR TITLE
Remove test_client argument and functionality from SDK

### DIFF
--- a/backend/infrahub/checks.py
+++ b/backend/infrahub/checks.py
@@ -40,7 +40,7 @@ class InfrahubCheck:
             raise ValueError("A query must be provided")
 
     @classmethod
-    async def init(cls, client=None, test_client=None, *args, **kwargs):
+    async def init(cls, client=None, *args, **kwargs):
         """Async init method, If an existing InfrahubClient client hasn't been provided, one will be created automatically."""
 
         item = cls(*args, **kwargs)
@@ -48,7 +48,7 @@ class InfrahubCheck:
         if client:
             item.client = client
         else:
-            item.client = await InfrahubClient.init(address=item.server_url, test_client=test_client)
+            item.client = await InfrahubClient.init(address=item.server_url)
 
         return item
 

--- a/backend/infrahub/transforms.py
+++ b/backend/infrahub/transforms.py
@@ -39,7 +39,7 @@ class InfrahubTransform:
             raise ValueError("A url must be provided")
 
     @classmethod
-    async def init(cls, client=None, test_client=None, *args, **kwargs):
+    async def init(cls, client=None, *args, **kwargs):
         """Async init method, If an existing InfrahubClient client hasn't been provided, one will be created automatically."""
 
         item = cls(*args, **kwargs)
@@ -47,7 +47,7 @@ class InfrahubTransform:
         if client:
             item.client = client
         else:
-            item.client = await InfrahubClient.init(address=item.server_url, test_client=test_client)
+            item.client = await InfrahubClient.init(address=item.server_url)
 
         return item
 

--- a/python_sdk/infrahub_client/client.py
+++ b/python_sdk/infrahub_client/client.py
@@ -5,7 +5,7 @@ import copy
 import logging
 from logging import Logger
 from time import sleep
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import httpx
 
@@ -30,9 +30,6 @@ from infrahub_client.timestamp import Timestamp
 from infrahub_client.types import AsyncRequester, HTTPMethod, SyncRequester
 from infrahub_client.utils import is_valid_uuid
 
-if TYPE_CHECKING:
-    from fastapi.testclient import TestClient
-
 # pylint: disable=redefined-builtin
 
 
@@ -46,7 +43,6 @@ class BaseClient:
         retry_on_failure: bool = False,
         retry_delay: int = 5,
         log: Optional[Logger] = None,
-        test_client: Optional[TestClient] = None,
         default_branch: str = "main",
         insert_tracker: bool = False,
         pagination_size: int = 50,
@@ -55,7 +51,6 @@ class BaseClient:
     ):
         self.client = None
         self.default_timeout = default_timeout
-        self.test_client = test_client
         self.retry_on_failure = retry_on_failure
         self.retry_delay = retry_delay
         self.default_branch = default_branch
@@ -316,36 +311,31 @@ class InfrahubClient(BaseClient):  # pylint: disable=too-many-public-methods
 
         # self.log.error(payload)
 
-        if not self.test_client:
-            retry = True
-            while retry:
-                retry = self.retry_on_failure
-                try:
-                    resp = await self._post(url=url, payload=payload, headers=headers, timeout=timeout)
+        retry = True
+        while retry:
+            retry = self.retry_on_failure
+            try:
+                resp = await self._post(url=url, payload=payload, headers=headers, timeout=timeout)
 
-                    if raise_for_error:
-                        resp.raise_for_status()
+                if raise_for_error:
+                    resp.raise_for_status()
 
-                    retry = False
-                except ServerNotReacheableError:
-                    if retry:
-                        self.log.warning(
-                            f"Unable to connect to {self.address}, will retry in {self.retry_delay} seconds .."
-                        )
-                        await asyncio.sleep(delay=self.retry_delay)
-                    else:
-                        self.log.error(f"Unable to connect to {self.address} .. ")
-                        raise
-                except httpx.HTTPStatusError as exc:
-                    if exc.response.status_code in [401, 403]:
-                        response = exc.response.json()
-                        errors = response.get("errors")
-                        messages = [error.get("message") for error in errors]
-                        raise AuthenticationError(" | ".join(messages)) from exc
-
-        else:
-            with self.test_client as client:
-                resp = client.post(url=url, json=payload, headers=headers)
+                retry = False
+            except ServerNotReacheableError:
+                if retry:
+                    self.log.warning(
+                        f"Unable to connect to {self.address}, will retry in {self.retry_delay} seconds .."
+                    )
+                    await asyncio.sleep(delay=self.retry_delay)
+                else:
+                    self.log.error(f"Unable to connect to {self.address} .. ")
+                    raise
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code in [401, 403]:
+                    response = exc.response.json()
+                    errors = response.get("errors")
+                    messages = [error.get("message") for error in errors]
+                    raise AuthenticationError(" | ".join(messages)) from exc
 
         response = resp.json()
 
@@ -384,13 +374,9 @@ class InfrahubClient(BaseClient):  # pylint: disable=too-many-public-methods
         headers = headers or {}
         base_headers = copy.copy(self.headers or {})
         headers.update(base_headers)
-        if not self.test_client:
-            return await self._request(
-                url=url, method=HTTPMethod.GET, headers=headers, timeout=timeout or self.default_timeout
-            )
-
-        with self.test_client as client:
-            return client.get(url=url, headers=headers)
+        return await self._request(
+            url=url, method=HTTPMethod.GET, headers=headers, timeout=timeout or self.default_timeout
+        )
 
     async def _default_request_method(
         self, url: str, method: HTTPMethod, headers: Dict[str, Any], timeout: int, payload: Optional[Dict] = None
@@ -455,14 +441,9 @@ class InfrahubClient(BaseClient):  # pylint: disable=too-many-public-methods
         if url_params:
             url += "?" + "&".join([f"{key}={value}" for key, value in url_params.items()])
 
-        if not self.test_client:
-            resp = await self._request(
-                url=url, method=HTTPMethod.GET, headers=headers, timeout=timeout or self.default_timeout
-            )
-
-        else:
-            with self.test_client as client:
-                resp = client.get(url=url)
+        resp = await self._request(
+            url=url, method=HTTPMethod.GET, headers=headers, timeout=timeout or self.default_timeout
+        )
 
         if raise_for_error:
             resp.raise_for_status()
@@ -599,36 +580,31 @@ class InfrahubClientSync(BaseClient):  # pylint: disable=too-many-public-methods
         if self.insert_tracker and tracker:
             headers["X-Infrahub-Tracker"] = tracker
 
-        if not self.test_client:
-            retry = True
-            while retry:
-                retry = self.retry_on_failure
-                try:
-                    resp = self._post(url=url, payload=payload, headers=headers, timeout=timeout)
+        retry = True
+        while retry:
+            retry = self.retry_on_failure
+            try:
+                resp = self._post(url=url, payload=payload, headers=headers, timeout=timeout)
 
-                    if raise_for_error:
-                        resp.raise_for_status()
+                if raise_for_error:
+                    resp.raise_for_status()
 
-                    retry = False
-                except ServerNotReacheableError:
-                    if retry:
-                        self.log.warning(
-                            f"Unable to connect to {self.address}, will retry in {self.retry_delay} seconds .."
-                        )
-                        sleep(self.retry_delay)
-                    else:
-                        self.log.error(f"Unable to connect to {self.address} .. ")
-                        raise
-                except httpx.HTTPStatusError as exc:
-                    if exc.response.status_code in [401, 403]:
-                        response = exc.response.json()
-                        errors = response.get("errors")
-                        messages = [error.get("message") for error in errors]
-                        raise AuthenticationError(" | ".join(messages)) from exc
-
-        else:
-            with self.test_client as client:
-                resp = client.post(url=url, json=payload, headers=headers)
+                retry = False
+            except ServerNotReacheableError:
+                if retry:
+                    self.log.warning(
+                        f"Unable to connect to {self.address}, will retry in {self.retry_delay} seconds .."
+                    )
+                    sleep(self.retry_delay)
+                else:
+                    self.log.error(f"Unable to connect to {self.address} .. ")
+                    raise
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code in [401, 403]:
+                    response = exc.response.json()
+                    errors = response.get("errors")
+                    messages = [error.get("message") for error in errors]
+                    raise AuthenticationError(" | ".join(messages)) from exc
 
         response = resp.json()
 
@@ -816,17 +792,11 @@ class InfrahubClientSync(BaseClient):  # pylint: disable=too-many-public-methods
             ServerNotReacheableError if we are not able to connect to the server
             ServerNotResponsiveError if the server didnd't respond before the timeout expired
         """
-        if not self.test_client:
-            self.login()
-            headers = headers or {}
-            base_headers = copy.copy(self.headers or {})
-            headers.update(base_headers)
-            return self._request(
-                url=url, method=HTTPMethod.GET, headers=headers, timeout=timeout or self.default_timeout
-            )
-
-        with self.test_client as client:
-            return client.get(url=url, headers=headers)
+        self.login()
+        headers = headers or {}
+        base_headers = copy.copy(self.headers or {})
+        headers.update(base_headers)
+        return self._request(url=url, method=HTTPMethod.GET, headers=headers, timeout=timeout or self.default_timeout)
 
     def _post(
         self, url: str, payload: dict, headers: Optional[dict] = None, timeout: Optional[int] = None

--- a/python_sdk/infrahub_client/object_store.py
+++ b/python_sdk/infrahub_client/object_store.py
@@ -25,23 +25,19 @@ class ObjectStore(ObjectStoreBase):
         if self.client.insert_tracker and tracker:
             headers["X-Infrahub-Tracker"] = tracker
 
-        if not self.client.test_client:
-            try:
-                resp = await self.client._get(url=url, headers=headers)
-                resp.raise_for_status()
+        try:
+            resp = await self.client._get(url=url, headers=headers)
+            resp.raise_for_status()
 
-            except ServerNotReacheableError:
-                self.client.log.error(f"Unable to connect to {self.client.address} .. ")
-                raise
-            except httpx.HTTPStatusError as exc:
-                if exc.response.status_code in [401, 403]:
-                    response = exc.response.json()
-                    errors = response.get("errors")
-                    messages = [error.get("message") for error in errors]
-                    raise AuthenticationError(" | ".join(messages)) from exc
-        else:
-            with self.client.test_client as client:
-                resp = client.get(url=url, headers=headers)
+        except ServerNotReacheableError:
+            self.client.log.error(f"Unable to connect to {self.client.address} .. ")
+            raise
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code in [401, 403]:
+                response = exc.response.json()
+                errors = response.get("errors")
+                messages = [error.get("message") for error in errors]
+                raise AuthenticationError(" | ".join(messages)) from exc
 
         return resp.text
 
@@ -51,22 +47,18 @@ class ObjectStore(ObjectStoreBase):
         if self.client.insert_tracker and tracker:
             headers["X-Infrahub-Tracker"] = tracker
 
-        if not self.client.test_client:
-            try:
-                resp = await self.client._post(url=url, payload={"content": content}, headers=headers)
-                resp.raise_for_status()
-            except ServerNotReacheableError:
-                self.client.log.error(f"Unable to connect to {self.client.address} .. ")
-                raise
-            except httpx.HTTPStatusError as exc:
-                if exc.response.status_code in [401, 403]:
-                    response = exc.response.json()
-                    errors = response.get("errors")
-                    messages = [error.get("message") for error in errors]
-                    raise AuthenticationError(" | ".join(messages)) from exc
-        else:
-            with self.client.test_client as client:
-                resp = client.post(url=url, json={"content": content}, headers=headers)
+        try:
+            resp = await self.client._post(url=url, payload={"content": content}, headers=headers)
+            resp.raise_for_status()
+        except ServerNotReacheableError:
+            self.client.log.error(f"Unable to connect to {self.client.address} .. ")
+            raise
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code in [401, 403]:
+                response = exc.response.json()
+                errors = response.get("errors")
+                messages = [error.get("message") for error in errors]
+                raise AuthenticationError(" | ".join(messages)) from exc
 
         return resp.json()
 
@@ -81,23 +73,19 @@ class ObjectStoreSync(ObjectStoreBase):
         if self.client.insert_tracker and tracker:
             headers["X-Infrahub-Tracker"] = tracker
 
-        if not self.client.test_client:
-            try:
-                resp = self.client._get(url=url, headers=headers)
-                resp.raise_for_status()
+        try:
+            resp = self.client._get(url=url, headers=headers)
+            resp.raise_for_status()
 
-            except ServerNotReacheableError:
-                self.client.log.error(f"Unable to connect to {self.client.address} .. ")
-                raise
-            except httpx.HTTPStatusError as exc:
-                if exc.response.status_code in [401, 403]:
-                    response = exc.response.json()
-                    errors = response.get("errors")
-                    messages = [error.get("message") for error in errors]
-                    raise AuthenticationError(" | ".join(messages)) from exc
-        else:
-            with self.client.test_client as client:
-                resp = client.get(url=url, headers=headers)
+        except ServerNotReacheableError:
+            self.client.log.error(f"Unable to connect to {self.client.address} .. ")
+            raise
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code in [401, 403]:
+                response = exc.response.json()
+                errors = response.get("errors")
+                messages = [error.get("message") for error in errors]
+                raise AuthenticationError(" | ".join(messages)) from exc
 
         return resp.text
 
@@ -107,21 +95,17 @@ class ObjectStoreSync(ObjectStoreBase):
         if self.client.insert_tracker and tracker:
             headers["X-Infrahub-Tracker"] = tracker
 
-        if not self.client.test_client:
-            try:
-                resp = self.client._post(url=url, payload={"content": content}, headers=headers)
-                resp.raise_for_status()
-            except ServerNotReacheableError:
-                self.client.log.error(f"Unable to connect to {self.client.address} .. ")
-                raise
-            except httpx.HTTPStatusError as exc:
-                if exc.response.status_code in [401, 403]:
-                    response = exc.response.json()
-                    errors = response.get("errors")
-                    messages = [error.get("message") for error in errors]
-                    raise AuthenticationError(" | ".join(messages)) from exc
-        else:
-            with self.client.test_client as client:
-                resp = client.post(url=url, json={"content": content}, headers=headers)
+        try:
+            resp = self.client._post(url=url, payload={"content": content}, headers=headers)
+            resp.raise_for_status()
+        except ServerNotReacheableError:
+            self.client.log.error(f"Unable to connect to {self.client.address} .. ")
+            raise
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code in [401, 403]:
+                response = exc.response.json()
+                errors = response.get("errors")
+                messages = [error.get("message") for error in errors]
+                raise AuthenticationError(" | ".join(messages)) from exc
 
         return resp.json()

--- a/python_sdk/tests/integration/test_schema.py
+++ b/python_sdk/tests/integration/test_schema.py
@@ -27,7 +27,8 @@ class TestInfrahubSchema:
         assert isinstance(schema_nodes["BuiltinLocation"], NodeSchema)
 
     async def test_schema_get(self, client, init_db_base):
-        ifc = await InfrahubClient.init(test_client=client)
+        config = Config(requester=client.async_request)
+        ifc = await InfrahubClient.init(config=config)
         schema_node = await ifc.schema.get(kind="BuiltinLocation")
 
         assert isinstance(schema_node, NodeSchema)


### PR DESCRIPTION
The previous test_client is replaced by the custom transport function provided by the config.

Fixes #919