### PR TITLE
Add timeout value in ServerNotResponsiveError message

### DIFF
--- a/python_sdk/infrahub_client/client.py
+++ b/python_sdk/infrahub_client/client.py
@@ -392,7 +392,7 @@ class InfrahubClient(BaseClient):  # pylint: disable=too-many-public-methods
             except httpx.ConnectError as exc:
                 raise ServerNotReacheableError(address=self.address) from exc
             except httpx.ReadTimeout as exc:
-                raise ServerNotResponsiveError(url=url) from exc
+                raise ServerNotResponsiveError(url=url, timeout=timeout) from exc
         self._record(response)
         return response
 
@@ -832,7 +832,7 @@ class InfrahubClientSync(BaseClient):  # pylint: disable=too-many-public-methods
             except httpx.ConnectError as exc:
                 raise ServerNotReacheableError(address=self.address) from exc
             except httpx.ReadTimeout as exc:
-                raise ServerNotResponsiveError(url=url) from exc
+                raise ServerNotResponsiveError(url=url, timeout=timeout) from exc
         self._record(response)
         return response
 

--- a/python_sdk/infrahub_client/exceptions.py
+++ b/python_sdk/infrahub_client/exceptions.py
@@ -17,9 +17,12 @@ class ServerNotReacheableError(Error):
 
 
 class ServerNotResponsiveError(Error):
-    def __init__(self, url: str, message: Optional[str] = None):
+    def __init__(self, url: str, timeout: Optional[int] = None, message: Optional[str] = None):
         self.url = url
+        self.timeout = timeout
         self.message = message or f"Unable to read from '{url}'."
+        if timeout:
+            self.message += f" (timeout: {timeout} sec)"
         super().__init__(self.message)
 
 


### PR DESCRIPTION
Recently the step to load the demo data in CI has been failing randomly ... I tried to troubleshoot it locally but I couldn't reproduce it.

In order to help (a little bit) with the troubleshooting this PR adds the value of the timeout in the ServerNotResponsiveError message, at least it will tell us how long it's waiting before failing

