### PR TITLE
Restrict available namespaces for user schemas

### DIFF
--- a/backend/infrahub/api/schema.py
+++ b/backend/infrahub/api/schema.py
@@ -75,6 +75,7 @@ async def load_schema(
     branch: Branch = Depends(get_branch_dep),
     _: str = Depends(get_current_user),
 ) -> JSONResponse:
+    schema.validate_namespaces()
     async with lock.registry.global_schema_lock():
         branch_schema = registry.schema.get_schema_branch(name=branch.name)
 

--- a/backend/infrahub/core/constants.py
+++ b/backend/infrahub/core/constants.py
@@ -1,4 +1,5 @@
 import enum
+from typing import List
 
 from infrahub.utils import InfrahubNumberEnum, InfrahubStringEnum
 
@@ -110,3 +111,16 @@ class ValidatorState(InfrahubStringEnum):
     QUEUED = "queued"
     IN_PROGRESS = "in_progress"
     COMPLETED = "completed"
+
+
+RESTRICTED_NAMESPACES: List[str] = [
+    "Account",
+    "Branch",
+    "Builtin",
+    # "Core",
+    "Deprecated",
+    "Diff",
+    "Infrahub",
+    "Internal",
+    "Lineage",
+]

--- a/backend/tests/fixtures/schemas/restricted_namespace_01.json
+++ b/backend/tests/fixtures/schemas/restricted_namespace_01.json
@@ -1,0 +1,25 @@
+{
+    "version": "1.0",
+    "generics": [],
+    "nodes":
+      [
+        {
+          "name": "Timestamp",
+          "namespace": "Internal",
+          "label": "Timestamp",
+          "display_labels": ["name__value"],
+          "attributes": [
+             {
+               "name": "name",
+               "kind": "Text",
+               "optional": false
+             },
+             {
+              "name": "timestamp",
+              "kind": "DateTime",
+              "optional": false
+            }
+          ]
+        }
+      ]
+  }

--- a/backend/tests/unit/api/test_40_schema_api.py
+++ b/backend/tests/unit/api/test_40_schema_api.py
@@ -112,6 +112,23 @@ async def test_schema_load_endpoint_valid_simple(
     assert relationships["tags"] == 5000
 
 
+async def test_schema_load_restricted_namespace(
+    session,
+    client: TestClient,
+    admin_headers,
+    default_branch: Branch,
+    authentication_base,
+    helper,
+):
+    with client:
+        response = client.post(
+            "/api/schema/load", headers=admin_headers, json=helper.schema_file("restricted_namespace_01.json")
+        )
+
+    assert response.status_code == 403
+    assert response.json()["errors"][0]["message"] == "Restricted namespace 'Internal' used on 'Timestamp'"
+
+
 async def test_schema_load_endpoint_idempotent_simple(
     session,
     client: TestClient,


### PR DESCRIPTION
Creates a list of namespaces that should be restricted and ensures that end users can't create models based on these using the API.

Fixes #935

Note: For now "Core" isn't on the restricted list as there are a number of tests that are using the "Core" namespace. This will be addressed in a future PR.