### PR TITLE
Fix functions for sync examples

### DIFF
--- a/python_sdk/examples/branch_create_sync.py
+++ b/python_sdk/examples/branch_create_sync.py
@@ -1,7 +1,7 @@
 from infrahub_client import InfrahubClientSync
 
 
-async def main():
+def main():
     client = InfrahubClientSync.init(address="http://localhost:8000")
     client.branch.create(branch_name="new-branch2", description="description", data_only=True)
     print("New branch created")

--- a/python_sdk/examples/branch_merge_sync.py
+++ b/python_sdk/examples/branch_merge_sync.py
@@ -1,7 +1,7 @@
 from infrahub_client import InfrahubClientSync
 
 
-async def main():
+def main():
     client = InfrahubClientSync.init(address="http://localhost:8000")
     client.branch.merge(branch_name="new-branch")
 

--- a/python_sdk/examples/branch_rebase_sync.py
+++ b/python_sdk/examples/branch_rebase_sync.py
@@ -1,9 +1,10 @@
 from infrahub_client import InfrahubClientSync
 
 
-async def main():
+def main():
     client = InfrahubClientSync.init(address="http://localhost:8000")
     client.branch.rebase(branch_name="new-branch")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Noticed that some of the functions in the sync examples were incorrectly declared as async functions.