### PR TITLE
Diff responsive UI

### DIFF
--- a/frontend/src/screens/diff/data-diff-element.tsx
+++ b/frontend/src/screens/diff/data-diff-element.tsx
@@ -43,23 +43,26 @@ export const DataDiffElement = (props: tDataDiffNodeElementProps) => {
 
   const renderTitleDisplay = (diffValue: tDataDiffNodeValueChange) => {
     return (
-      <div className="p-1 pr-0 grid grid-cols-3 gap-4">
-        <div className="flex items-center group">
-          <span className="mr-2 font-semibold">{name}</span>
+      <div className="p-1 pr-0 flex flex-col lg:flex-row">
+        <div className="flex flex-1 items-center">
+          <div className="flex flex-1 items-center group">
+            <span className="mr-2 font-semibold">{name}</span>
 
-          {/* Do not display comment button if we are on the branch details view */}
-          {!branchname && <DataDiffThread path={path} />}
+            {/* Do not display comment button if we are on the branch details view */}
+            {!branchname && <DataDiffThread path={path} />}
+          </div>
+
+          <div className="flex flex-1">
+            <span className="font-semibold">{renderDiffDisplay(diffValue)}</span>
+          </div>
         </div>
 
-        <div className="flex">
-          <span className="font-semibold">{renderDiffDisplay(diffValue)}</span>
-        </div>
-
-        <div className="flex justify-end font-normal">
+        <div className="flex flex-1 lg:justify-end items-center mt-2 lg:mt-0">
           <DiffPill {...summary} />
 
-          <div className="w-[380px] flex justify-end">
-            {changed_at && <DateDisplay date={changed_at} hideDefault />}
+          <div className="lg:w-[380px] flex">
+            {/* {changed_at && <DateDisplay date={changed_at} hideDefault />} */}
+            <DateDisplay date={changed_at} />
           </div>
         </div>
       </div>

--- a/frontend/src/screens/diff/data-diff-node.tsx
+++ b/frontend/src/screens/diff/data-diff-node.tsx
@@ -183,7 +183,7 @@ export const DataDiffNode = (props: tDataDiffNodeProps) => {
   const display_label = nodeDisplayLabels[currentBranch] ?? nodeDisplayLabels?.main;
 
   const renderTitle = () => (
-    <div className={"p-1 pr-0 flex flex-1 group"}>
+    <div className={"p-1 pr-0 flex flex-col lg:flex-row"}>
       <div className="flex flex-1 items-center">
         <Badge className="mr-2" type={getBadgeType(action)}>
           {action?.toUpperCase()}
@@ -204,10 +204,13 @@ export const DataDiffNode = (props: tDataDiffNodeProps) => {
         </div>
       )}
 
-      <DiffPill {...summary} />
+      <div className="flex items-center mt-2 lg:mt-0">
+        <DiffPill {...summary} />
 
-      <div className="w-[380px] flex justify-end">
-        {changed_at && <DateDisplay date={changed_at} hideDefault />}
+        <div className="flex lg:w-[380px]">
+          {/* {changed_at && <DateDisplay date={changed_at} hideDefault />} */}
+          <DateDisplay date={changed_at} />
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/screens/diff/data-diff-peer.tsx
+++ b/frontend/src/screens/diff/data-diff-peer.tsx
@@ -81,8 +81,8 @@ export const DataDiffPeer = (props: tDataDiffNodePeerProps) => {
     if (branches?.length) {
       return branches.map((branch: string, index: number) => {
         return (
-          <div className="p-1 pr-0 grid grid-cols-3 gap-4 mr-2 last:mr-0" key={index}>
-            <div className="flex">
+          <div className="p-1 pr-0 flex flex-col lg:flex-row last:mr-0" key={index}>
+            <div className="flex flex-1 items-center">
               {peerChange?.kind && <Badge>{peerChange?.kind}</Badge>}
 
               <span className="mr-2 font-semibold">{peerChange?.display_label}</span>
@@ -91,11 +91,11 @@ export const DataDiffPeer = (props: tDataDiffNodePeerProps) => {
             {/* Do not display comment button if we are on the branch details view */}
             {!branchname && <DataDiffThread path={path} />}
 
-            <div className="flex">
+            <div className="flex flex-1 items-center">
               <span className="font-semibold">{renderDiffDisplay(peerChange, branch)}</span>
             </div>
 
-            <div className="flex justify-end font-normal">
+            <div className="flex flex-1 lg:justify-end mt-2 lg:mt-0">
               <DiffPill {...summary} />
 
               <div className="w-[380px] flex justify-end">
@@ -109,22 +109,24 @@ export const DataDiffPeer = (props: tDataDiffNodePeerProps) => {
 
     if (peerBranch) {
       return (
-        <div className="p-1 pr-0 grid grid-cols-3 gap-4 mr-2 last:mr-0">
-          <div className="flex">
-            {newPeer?.kind && <Badge>{newPeer?.kind}</Badge>}
-            {previousPeer?.kind && <Badge>{previousPeer?.kind}</Badge>}
+        <div className="p-1 pr-0 flex flex-col lg:flex-row last:mr-0">
+          <div className="flex flex-1 items-center">
+            <div className="flex flex-1 items-center">
+              {newPeer?.kind && <Badge>{newPeer?.kind}</Badge>}
+              {previousPeer?.kind && <Badge>{previousPeer?.kind}</Badge>}
 
-            <span className="mr-2 font-semibold">{newPeer?.display_label}</span>
-            <span className="mr-2 font-semibold">{previousPeer?.display_label}</span>
+              <span className="mr-2 font-semibold">{newPeer?.display_label}</span>
+              <span className="mr-2 font-semibold">{previousPeer?.display_label}</span>
+            </div>
+
+            <div className="flex flex-1 items-center">
+              <span className="font-semibold">
+                {renderDiffDisplay({ new: newPeer, previous: previousPeer }, peerBranch)}
+              </span>
+            </div>
           </div>
 
-          <div className="flex">
-            <span className="font-semibold">
-              {renderDiffDisplay({ new: newPeer, previous: previousPeer }, peerBranch)}
-            </span>
-          </div>
-
-          <div className="flex justify-end font-normal">
+          <div className="flex flex-1 lg:justify-end items-center mt-2 lg:mt-0">
             <DiffPill {...summary} />
 
             <div className="w-[380px] flex justify-end">

--- a/frontend/src/screens/diff/data-diff-property.tsx
+++ b/frontend/src/screens/diff/data-diff-property.tsx
@@ -6,6 +6,7 @@ import { QSP } from "../../config/qsp";
 import { classNames } from "../../utils/common";
 import { diffContent } from "../../utils/diff";
 import { getNodeClassName, tDataDiffNodePropertyChange } from "./data-diff-node";
+import { DiffPill } from "./diff-pill";
 import { DataDiffThread } from "./diff-thread";
 
 export type tDataDiffNodePropertyProps = {
@@ -28,21 +29,26 @@ export const DataDiffProperty = (props: tDataDiffNodePropertyProps) => {
 
       <div
         className={classNames(
-          "flex-1 p-1 pr-0 grid grid-cols-3 gap-4",
+          "flex-1 p-1 pr-0 flex flex-col lg:flex-row",
           getNodeClassName([], branch, branchOnly)
         )}>
-        <div className="flex items-center group">
-          <span className="mr-4">{type}</span>
+        <div className="flex flex-1 items-center">
+          <div className="flex flex-1 items-center group">
+            <span className="">{type}</span>
 
-          {/* Do not display comment button if we are on the branch details view */}
-          {!branchname && <DataDiffThread path={path} />}
+            {/* Do not display comment button if we are on the branch details view */}
+            {!branchname && <DataDiffThread path={path} />}
+          </div>
+
+          <div className="flex flex-1 items-center">{diffContent[action](property)}</div>
         </div>
 
-        <div className="flex items-center">{diffContent[action](property)}</div>
+        <div className="flex flex-1 lg:justify-end items-center mt-2 lg:mt-0">
+          <DiffPill hidden />
 
-        <div className="flex items-center justify-end">
-          <div className="min-w-[330px]">
-            {changed_at && <DateDisplay date={changed_at} hideDefault />}
+          <div className="lg:w-[380px] flex">
+            {/* {changed_at && <DateDisplay date={changed_at} hideDefault />} */}
+            <DateDisplay date={changed_at} />
           </div>
         </div>
       </div>

--- a/frontend/src/screens/diff/diff-pill.tsx
+++ b/frontend/src/screens/diff/diff-pill.tsx
@@ -4,10 +4,17 @@ type DiffPillProps = {
   added?: number;
   updated?: number;
   removed?: number;
+  hidden?: boolean;
 };
 
 export const DiffPill = (props: DiffPillProps) => {
-  const { added, updated, removed } = props;
+  const { added, updated, removed, hidden } = props;
+
+  if (hidden) {
+    return (
+      <div className="lg:flex items-center text-gray-300 mr-2 w-[85px] text-sm font-normal hidden lg:visible" />
+    );
+  }
 
   return (
     <Pill className="flex items-center text-gray-300 mr-2 w-[85px] text-sm font-normal">

--- a/frontend/src/screens/layout/desktop-menu.tsx
+++ b/frontend/src/screens/layout/desktop-menu.tsx
@@ -46,7 +46,7 @@ export default function DesktopMenu() {
   ));
 
   return (
-    <div className="hidden md:fixed md:inset-y-0 md:flex md:w-64 md:flex-col">
+    <div className="z-10 hidden md:fixed md:inset-y-0 md:flex md:w-64 md:flex-col">
       <div className="flex flex-grow flex-col overflow-y-auto border-r border-gray-200 bg-custom-white pt-5">
         <div
           className="flex flex-shrink-0 items-center px-4 cursor-pointer"


### PR DESCRIPTION
Related issue: https://github.com/opsmill/infrahub/issues/978

Fix responsive UI for diff nodes, dates and diff summary will go inline

<img width="2513" alt="image" src="https://github.com/opsmill/infrahub/assets/16644715/8cb9953b-83b8-4024-9825-a5b867bcdb4f">

<img width="2513" alt="image" src="https://github.com/opsmill/infrahub/assets/16644715/ac6f1851-fc59-4139-afa2-f89fd1933227">
