### PR TITLE
Change rpc callback function to be async

### DIFF
--- a/backend/infrahub/message_bus/rpc.py
+++ b/backend/infrahub/message_bus/rpc.py
@@ -50,7 +50,7 @@ class InfrahubRpcClientBase:
 
         return self
 
-    def on_response(self, message: AbstractIncomingMessage) -> None:
+    async def on_response(self, message: AbstractIncomingMessage) -> None:
         if message.correlation_id is None:
             print(f"Bad message {message!r}")
             return


### PR DESCRIPTION
The channel.consume method was getting a callable where it expected an awaitable. I don't think it matters much in the code right now but will be relevant when we want to run other type of tasks within the API workers.