### PR TITLE
Fix broken links in docs

### DIFF
--- a/docs/02_tutorial/04_lineage_information.md
+++ b/docs/02_tutorial/04_lineage_information.md
@@ -31,9 +31,6 @@ If you navigate to the detailed page of any device you'll be able to see that:
 
 When a field is marked as protected, all users that aren't listed as the owner won't be able to modify this specific attribute when trying to edit the object but they will still be able to modify the other one.
 
-![](../media/tutorial/tutorial-4-data.cy.ts/tutorial_4_metadata_edit_protected.png)
-
-
 ## Update the metadata for any given data point
 
 It's possible to update the metadata by selecting the pencil on the top right corner of each metadata panel 

--- a/docs/20_knowledge_base/80_local_demo_environment.md
+++ b/docs/20_knowledge_base/80_local_demo_environment.md
@@ -33,7 +33,7 @@ It's designed to be controlled by `invoke` using a list of predefined commands
 | **infrahub-git**    | Dockerfile               | Instance of the Git Agent, managing the Git Repository |
 | **frontend**        | Dockerfile               | Instance of the Frontend                               |
 
-[!ref Check the architecture diagram to have more information about each component](architecture.md)
+[!ref Check the architecture diagram to have more information about each component](./10_architecture.md)
 
 ## Getting Started
 

--- a/docs/20_knowledge_base/readme.md
+++ b/docs/20_knowledge_base/readme.md
@@ -1,6 +1,5 @@
 # Knowledge Base
 
-- [Architecture](architecture.md)
-- [Demo Environment](local_demo_environment.md)
-- [Branch](branch.md)
-- [Repository](repository.md)
+- [Architecture](./10_architecture.md)
+- [Demo Environment](./80_local_demo_environment.md)
+

--- a/docs/25_python_sdk/20_branches.md
+++ b/docs/25_python_sdk/20_branches.md
@@ -10,19 +10,19 @@ The Python SDK can be used for all standard operations on the branches : list, m
 
 ## List all the branches
 
-:::code source="../../python_sdk/examples/example_branch_list.py" :::
+:::code source="../../python_sdk/examples/branch_list.py" :::
 
 
 ## Create a Branch
 
-:::code source="../../python_sdk/examples/example_branch_create.py" :::
+:::code source="../../python_sdk/examples/branch_create.py" :::
 
 
 ## Rebase a branch
 
-:::code source="../../python_sdk/examples/example_branch_rebase.py" :::
+:::code source="../../python_sdk/examples/branch_rebase.py" :::
 
 
 ## Merge a branch
 
-:::code source="../../python_sdk/examples/example_branch_merge.py" :::
+:::code source="../../python_sdk/examples/branch_merge.py" :::


### PR DESCRIPTION
Changed some broken links and removed parts that don't exist.

Also removed an image that I can't find a reference to `../media/tutorial/tutorial-4-data.cy.ts/tutorial_4_metadata_edit_protected.png` think it's better without it for now we can add a new one once they are generated as part of the tutorial.

Fixes #1000