### PR TITLE
Enforce authentication in SDK integration tests

### DIFF
--- a/python_sdk/tests/integration/conftest.py
+++ b/python_sdk/tests/integration/conftest.py
@@ -65,6 +65,7 @@ def execute_before_any_test(worker_id):
         config.SETTINGS.database.address = f"{BUILD_NAME}-database-{db_id}"
         config.SETTINGS.storage.settings = {"directory": "/opt/infrahub/storage"}
 
+    config.SETTINGS.experimental_features.ignore_authentication_requirements = False
     config.SETTINGS.broker.enable = False
     config.SETTINGS.cache.enable = False
     config.SETTINGS.miscellaneous.start_background_runner = False

--- a/python_sdk/tests/integration/test_infrahub_client.py
+++ b/python_sdk/tests/integration/test_infrahub_client.py
@@ -23,7 +23,7 @@ class TestInfrahubClient:
 
     @pytest.fixture
     async def client(self, test_client):
-        config = Config(requester=test_client.async_request)
+        config = Config(username="admin", password="infrahub", requester=test_client.async_request)
         return await InfrahubClient.init(config=config)
 
     @pytest.fixture(scope="class")

--- a/python_sdk/tests/integration/test_infrahub_client_sync.py
+++ b/python_sdk/tests/integration/test_infrahub_client_sync.py
@@ -20,7 +20,7 @@ class TestInfrahubClientSync:
 
     @pytest.fixture
     def client(self, test_client):
-        config = Config(sync_requester=test_client.sync_request)
+        config = Config(username="admin", password="infrahub", sync_requester=test_client.sync_request)
         return InfrahubClientSync.init(config=config)
 
     @pytest.fixture(scope="class")

--- a/python_sdk/tests/integration/test_node.py
+++ b/python_sdk/tests/integration/test_node.py
@@ -22,7 +22,7 @@ class TestInfrahubNode:
 
     @pytest.fixture
     async def client(self, test_client):
-        config = Config(requester=test_client.async_request)
+        config = Config(username="admin", password="infrahub", requester=test_client.async_request)
         return await InfrahubClient.init(config=config)
 
     async def test_node_create(self, client: InfrahubClient, init_db_base, location_schema):

--- a/python_sdk/tests/integration/test_object_store.py
+++ b/python_sdk/tests/integration/test_object_store.py
@@ -21,7 +21,7 @@ class TestObjectStore:
 
     @pytest.fixture
     async def client(self, test_client):
-        config = Config(requester=test_client.async_request)
+        config = Config(username="admin", password="infrahub", requester=test_client.async_request)
         return await InfrahubClient.init(config=config)
 
     async def test_upload_and_get(self, client: InfrahubClient):


### PR DESCRIPTION
Prepares for #1057 so that the SDK code is ready once authentication is enforced for operations that modify data.