### PR TITLE
Allow the metrics port to be set with an environment variable

### DIFF
--- a/backend/infrahub/cli/git_agent.py
+++ b/backend/infrahub/cli/git_agent.py
@@ -167,7 +167,7 @@ def start(
     config_file: str = typer.Option(
         "infrahub.toml", envvar="INFRAHUB_CONFIG", help="Location of the configuration file to use for Infrahub"
     ),
-    port: int = typer.Argument(8000, help="Port used to expose a metrics endpoint"),
+    port: int = typer.Argument(8000, envvar="INFRAHUB_METRICS_PORT", help="Port used to expose a metrics endpoint"),
 ):
     """Start Infrahub Git Agent."""
     logging.getLogger("httpx").setLevel(logging.ERROR)


### PR DESCRIPTION
Fixes #977

This would get rid of the problem for me and allow me to just set the port using `direnv`.

I think this is the easiest as we don't need to change anything else.