### PR TITLE
Impose query limit for internal queries and properties

### DIFF
--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -74,7 +74,7 @@ class DatabaseSettings(BaseSettings):
     address: str = "localhost"
     port: int = 7687
     database: Optional[str] = Field(regex=VALID_DATABASE_NAME_REGEX, description="Name of the database")
-    imposed_query_limit: int = Field(
+    query_size_limit: int = Field(
         1000,
         description="The max number of records to fetch in a single query before performing internal pagination.",
         min=1,
@@ -92,7 +92,7 @@ class DatabaseSettings(BaseSettings):
             "address": {"env": "NEO4J_ADDRESS"},
             "port": {"env": "NEO4J_PORT"},
             "database": {"env": "NEO4J_DATABASE"},
-            "imposed_query_limit": {"env": "INFRAHUB_DB_IMPOSED_QUERY_LIMIT"},
+            "query_size_limit": {"env": "INFRAHUB_DB_QUERY_SIZE_LIMIT"},
         }
 
     @root_validator(pre=False)

--- a/backend/infrahub/core/query/__init__.py
+++ b/backend/infrahub/core/query/__init__.py
@@ -274,9 +274,12 @@ class Query(ABC):
         Trailing and leading spaces per line will be removed."""
         self.query_lines.extend([line.strip() for line in query.split("\n") if line.strip()])
 
-    def get_query(self, var: bool = False, inline: bool = False) -> str:
+    def get_query(
+        self, var: bool = False, inline: bool = False, limit: Optional[int] = None, offset: Optional[int] = None
+    ) -> str:
         # Make a local copy of the _query_lines
-
+        limit = limit or self.limit
+        offset = offset or self.offset
         tmp_query_lines = self.query_lines.copy()
 
         if self.insert_return:
@@ -285,11 +288,11 @@ class Query(ABC):
         if self.order_by:
             tmp_query_lines.append("ORDER BY " + ",".join(self.order_by))
 
-        if self.offset:
-            tmp_query_lines.append(f"SKIP {self.offset}")
+        if offset:
+            tmp_query_lines.append(f"SKIP {offset}")
 
-        if self.limit:
-            tmp_query_lines.append(f"LIMIT {self.limit}")
+        if limit:
+            tmp_query_lines.append(f"LIMIT {limit}")
 
         query_str = "\n".join(tmp_query_lines)
 
@@ -351,7 +354,7 @@ class Query(ABC):
                     query=self.get_query(), params=self.params, session=session, name=self.name
                 )
             else:
-                results = await self.query_with_imposed_limit(session=session)
+                results = await self.query_with_size_limit(session=session)
         elif self.type == QueryType.WRITE:
             results = await execute_write_query_async(
                 query=self.get_query(), params=self.params, session=session, name=self.name
@@ -367,26 +370,22 @@ class Query(ABC):
 
         return self
 
-    async def query_with_imposed_limit(self, session: AsyncSession):
-        imposed_limit = config.SETTINGS.database.imposed_query_limit
-        self.offset = 0
-        self.limit = imposed_limit
-        results = await execute_read_query_async(
-            query=self.get_query(), params=self.params, session=session, name=self.name
-        )
-
-        if len(results) < imposed_limit:
-            return results
-
+    async def query_with_size_limit(self, session: AsyncSession):
+        query_limit = config.SETTINGS.database.query_size_limit
+        offset = 0
+        results = []
         remaining = True
         while remaining:
-            self.offset += imposed_limit
             offset_results = await execute_read_query_async(
-                query=self.get_query(), params=self.params, session=session, name=self.name
+                query=self.get_query(limit=query_limit, offset=offset),
+                params=self.params,
+                session=session,
+                name=self.name,
             )
             results.extend(offset_results)
+            offset += query_limit
 
-            if len(offset_results) < imposed_limit:
+            if len(offset_results) < query_limit:
                 remaining = False
 
         return results


### PR DESCRIPTION
Fixes #981

Not quite sure what to set the internal limit to. Left some print statements in there to see what's happening. The largest responses I see in my environment have 4046 results. I see this a number of times when running with infra schema and data. I would assume it's when we are loading the branches.