### PR TITLE
Add RPCError exception for more detailed errors from RPC

### DIFF
--- a/backend/infrahub/exceptions.py
+++ b/backend/infrahub/exceptions.py
@@ -14,6 +14,13 @@ class Error(Exception):
         }
 
 
+class RPCError(Error):
+    HTTP_CODE: int = 502
+
+    def __init__(self, message: str):
+        self.message = message
+
+
 class InitializationError(Error):
     DESCRIPTION: str = "The application hasn't been initialized properly"
 

--- a/backend/infrahub/message_bus/__init__.py
+++ b/backend/infrahub/message_bus/__init__.py
@@ -5,7 +5,7 @@ import aiormq
 from pydantic import BaseModel, Field
 
 from infrahub import config
-from infrahub.exceptions import Error
+from infrahub.exceptions import Error, RPCError
 from infrahub.log import set_log_data
 from infrahub.message_bus.responses import RESPONSE_MAP
 
@@ -124,7 +124,7 @@ class InfrahubResponse(InfrahubBaseMessage):
             return
 
         # Later we would load information about the error based on the response_class and response_data
-        raise Error(f"An error occured during the request: {self.response_data}")
+        raise RPCError(message=self.response_data.get("error", "Unknown Error"))
 
     def parse(self, response_class: type[ResponseClass]) -> ResponseClass:
         self.raise_for_status()


### PR DESCRIPTION
Related to #1132. Only adds a simple catch all error, but one that actually shows any error to the end users.

This PR adds some context information when things fall outside of the happy path. As an example when requesting a file from a git repository called `blue` before this change:

```bash
❯ curl -v -X 'GET' \
  'http://localhost:8000/api/file/blue/file-does-not-exist' \
  -H 'accept: text/plain'
Note: Unnecessary use of -X or --request, GET is already inferred.
*   Trying 127.0.0.1:8000...
* Connected to localhost (127.0.0.1) port 8000 (#0)
> GET /api/file/blue/file-does-not-exist HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/8.1.2
> accept: text/plain
>
< HTTP/1.1 500 Internal Server Error
< date: Thu, 21 Sep 2023 17:38:07 GMT
< server: uvicorn
< content-length: 78
< content-type: application/json
< x-process-time: 0.18317866325378418
< x-request-id: c982e864ba474add835dd0401fdf920d
<
* Connection #0 to host localhost left intact
{"data":null,"errors":[{"message":"Unknown Error","extensions":{"code":500}}]}%
```

After this change:

```bash
❯ curl -v -X 'GET' \
  'http://localhost:8000/api/file/blue/file-does-not-exist' \
  -H 'accept: text/plain'
Note: Unnecessary use of -X or --request, GET is already inferred.
*   Trying 127.0.0.1:8000...
* Connected to localhost (127.0.0.1) port 8000 (#0)
> GET /api/file/blue/file-does-not-exist HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/8.1.2
> accept: text/plain
>
< HTTP/1.1 502 Bad Gateway
< date: Thu, 21 Sep 2023 17:39:19 GMT
< server: uvicorn
< content-length: 162
< content-type: application/json
< x-process-time: 0.17155790328979492
< x-request-id: 46e022294f934040bc0d226e8a7a5f19
<
* Connection #0 to host localhost left intact
{"data":null,"errors":[{"message":"Unable to find the file at 'blue::a7e3b93bb00de50d14180a736e4414d3f0318d67::file-does-not-exist'.","extensions":{"code":502}}]}%
```

The idea is that this will return a 404 error when finished as well as more context about the error. For now this should improve any troubleshooting with the json rpc responses.