### PR TITLE
Switch to durable quorum queues and exchanges, add DLX

### DIFF
--- a/backend/infrahub/cli/git_agent.py
+++ b/backend/infrahub/cli/git_agent.py
@@ -62,10 +62,12 @@ async def subscribe_rpcs_queue(client: InfrahubClient):
 
     # Create a channel and subscribe to the incoming RPC queue
     channel = await connection.channel()
-    queue = await channel.declare_queue(f"{config.SETTINGS.broker.namespace}.rpcs")
+    queue = await channel.declare_queue(
+        f"{config.SETTINGS.broker.namespace}.rpcs", durable=True, arguments={"x-queue-type": "quorum"}
+    )
     events_queue = await channel.declare_queue(name=f"worker-events-{WORKER_IDENTITY}", exclusive=True)
 
-    exchange = await channel.declare_exchange(f"{config.SETTINGS.broker.namespace}.events", type="topic")
+    exchange = await channel.declare_exchange(f"{config.SETTINGS.broker.namespace}.events", type="topic", durable=True)
     await events_queue.bind(exchange, routing_key="refresh.registry.*")
 
     driver = await get_db()

--- a/backend/infrahub/message_bus/events.py
+++ b/backend/infrahub/message_bus/events.py
@@ -585,7 +585,7 @@ async def get_event_exchange(channel=None) -> Generator:
         channel = await broker.channel()
 
     exchange_name = f"{config.SETTINGS.broker.namespace}.events"
-    return await channel.declare_exchange(exchange_name, ExchangeType.TOPIC)
+    return await channel.declare_exchange(exchange_name, ExchangeType.TOPIC, durable=True)
 
 
 async def send_event(msg: Message):

--- a/backend/infrahub/message_bus/types.py
+++ b/backend/infrahub/message_bus/types.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import List
+
+
+class MessageTTL(int, Enum):
+    """Defines the message TTL in seconds, the values themselves are in milliseconds."""
+
+    TEN = 10000
+    TWENTY = 20000
+
+    @classmethod
+    def variations(cls) -> List[MessageTTL]:
+        """Return available variations of message time to live."""
+        return [cls(cls.__members__[member].value) for member in list(cls.__members__)]


### PR DESCRIPTION
* Changes the queues and exchanges we want to live across restarts of the RabbitMQ server to be durable
* Changes the non-exclusive queues to be declared as quorum queues (not as relevant now but we want this in place in the future when we run in a clustered RabbitMQ environment)
* Adds internal routing within RabbitMQ to delay messages and a dead letter exchange where messages end up after the delay

*This PR modifies the existing queues and exchanges in RabbitMQ, which isn't possible. Due to this an `invoke demo.destroy` will have to be issued in order to get the new settings to work.*

This is something that we'll want to have in place to schedule checks for the user defined repository checks.

It will also be useful for when we want to retry messages due to failures. For example when implementing webhooks it could be that we fail to reach the external service for the first try so we retry the message with a delay.

This approach with dead letter exchanges was choosen in favor of the Delayed Message Exchange plugin
(https://github.com/rabbitmq/rabbitmq-delayed-message-exchange), mainly due to the fact that we'll always be able to see messages within a queue whereas the delayed exchange hides them from view during the waiting period.

A downside of the dead message approach is that we need to define a new queue for each delay timer as the x-message-ttl is global for the queue. Because of this the new Python class MessageTTL has been introduced, we'll use this enum as an input parameter to the function where we want to have a delayed message. If this optional param has a value we will publish the message to the delayed queue and insert the expected `delay` header so that the message is routed to the correct queue. Once the timer has reached 0, the message gets rerouted to the final queue and gets picked up by the git-worker.