### PR TITLE
Show running containers after the pipeline has failed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,6 +351,9 @@ jobs:
       - name: Run End to End Tests
         working-directory: ./frontend
         run: npm run cypress:run:e2e
+      - name: Containers after failure
+        if: failure()
+        run: docker ps -a
       - name: Upload cypress screenshots
         if: failure()
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
I realized that we list the running container prior to running the tests and then when we show the logs afterwards we don't actually see if the database container has crashed. This should help with any finger pointing.