### PR TITLE
Pull database option from environment variable to simplify how to run NEO4J

### DIFF
--- a/development/docker-compose-database-neo4j.yml
+++ b/development/docker-compose-database-neo4j.yml
@@ -20,6 +20,17 @@ services:
       timeout: 10s
       retries: 20
       start_period: 3s
+
+  infrahub-server:
+    environment:
+      - "INFRAHUB_DB_TYPE=neo4j"
+      - "INFRAHUB_DB_QUERY_SIZE_LIMIT=4999"
+
+  infrahub-git:
+    environment:
+      - "INFRAHUB_DB_TYPE=neo4j"
+      - "INFRAHUB_DB_QUERY_SIZE_LIMIT=4999"
+
 volumes:
   database_data:
   database_logs:

--- a/tasks/backend.py
+++ b/tasks/backend.py
@@ -3,6 +3,7 @@ from invoke import Context, task
 from .shared import (
     BUILD_NAME,
     NBR_WORKERS,
+    INFRAHUB_DATABASE,
     build_test_compose_files_cmd,
     build_test_envs,
     execute_command,
@@ -174,7 +175,7 @@ def lint(context: Context, docker: bool = False):
 
 
 @task(optional=["database"])
-def test_unit(context: Context, database: str = "memgraph"):
+def test_unit(context: Context, database: str = INFRAHUB_DATABASE):
     with context.cd(REPO_BASE):
         compose_files_cmd = build_test_compose_files_cmd(database=database)
         base_cmd = f"{get_env_vars(context)} docker compose {compose_files_cmd} -p {BUILD_NAME} run {build_test_envs()} infrahub-test"
@@ -186,7 +187,7 @@ def test_unit(context: Context, database: str = "memgraph"):
 
 
 @task(optional=["database"])
-def test_core(context: Context, database: str = "memgraph"):
+def test_core(context: Context, database: str = INFRAHUB_DATABASE):
     with context.cd(REPO_BASE):
         compose_files_cmd = build_test_compose_files_cmd(database=database)
         base_cmd = f"{get_env_vars(context)} docker compose {compose_files_cmd} -p {BUILD_NAME} run {build_test_envs()} infrahub-test"
@@ -198,7 +199,7 @@ def test_core(context: Context, database: str = "memgraph"):
 
 
 @task(optional=["database"])
-def test_integration(context: Context, database: str = "memgraph"):
+def test_integration(context: Context, database: str = INFRAHUB_DATABASE):
     with context.cd(REPO_BASE):
         compose_files_cmd = build_test_compose_files_cmd(database=database)
         base_cmd = f"{get_env_vars(context)} docker compose {compose_files_cmd} -p {BUILD_NAME} run {build_test_envs()} infrahub-test"

--- a/tasks/demo.py
+++ b/tasks/demo.py
@@ -8,6 +8,7 @@ from .shared import (
     AVAILABLE_SERVICES,
     BUILD_NAME,
     PYTHON_VER,
+    INFRAHUB_DATABASE,
     build_compose_files_cmd,
     build_dev_compose_files_cmd,
     execute_command,
@@ -31,7 +32,7 @@ mutation($name: String!, $location: String!){
 
 @task(optional=["database"])
 def build(
-    context, service: str = None, python_ver: str = PYTHON_VER, nocache: bool = False, database: str = "memgraph"
+    context, service: str = None, python_ver: str = PYTHON_VER, nocache: bool = False, database: str = INFRAHUB_DATABASE
 ):  # pylint: disable=too-many-arguments
     """Build an image with the provided name and python version.
 
@@ -64,7 +65,7 @@ def build(
 
 
 @task(optional=["database"])
-def pull(context: Context, database: str = "memgraph"):
+def pull(context: Context, database: str = INFRAHUB_DATABASE):
     """Pull external containers from registry."""
     with context.cd(REPO_BASE):
         compose_files_cmd = build_compose_files_cmd(database=database)
@@ -80,7 +81,7 @@ def pull(context: Context, database: str = "memgraph"):
 # Local Environment tasks
 # ----------------------------------------------------------------------------
 @task(optional=["database"])
-def debug(context: Context, database: str = "memgraph"):
+def debug(context: Context, database: str = INFRAHUB_DATABASE):
     """Start a local instance of Infrahub in debug mode."""
     with context.cd(REPO_BASE):
         compose_files_cmd = build_compose_files_cmd(database=database)
@@ -89,7 +90,7 @@ def debug(context: Context, database: str = "memgraph"):
 
 
 @task(optional=["database"])
-def start(context: Context, database: str = "memgraph"):
+def start(context: Context, database: str = INFRAHUB_DATABASE):
     """Start a local instance of Infrahub within docker compose."""
     with context.cd(REPO_BASE):
         compose_files_cmd = build_compose_files_cmd(database=database)
@@ -98,7 +99,7 @@ def start(context: Context, database: str = "memgraph"):
 
 
 @task(optional=["database"])
-def restart(context: Context, database: str = "memgraph"):
+def restart(context: Context, database: str = INFRAHUB_DATABASE):
     """Restart Infrahub API Server and Git Agent within docker compose."""
     with context.cd(REPO_BASE):
         compose_files_cmd = build_compose_files_cmd(database=database)
@@ -109,7 +110,7 @@ def restart(context: Context, database: str = "memgraph"):
 
 
 @task(optional=["database"])
-def stop(context: Context, database: str = "memgraph"):
+def stop(context: Context, database: str = INFRAHUB_DATABASE):
     """Stop the running instance of Infrahub."""
     with context.cd(REPO_BASE):
         compose_files_cmd = build_compose_files_cmd(database=database)
@@ -118,7 +119,7 @@ def stop(context: Context, database: str = "memgraph"):
 
 
 @task
-def destroy(context: Context, database: str = "memgraph"):
+def destroy(context: Context, database: str = INFRAHUB_DATABASE):
     """Destroy all containers and volumes."""
     with context.cd(REPO_BASE):
         compose_files_cmd = build_compose_files_cmd(database=database)
@@ -128,7 +129,7 @@ def destroy(context: Context, database: str = "memgraph"):
 
 
 @task(optional=["database"])
-def cli_server(context: Context, database: str = "memgraph"):
+def cli_server(context: Context, database: str = INFRAHUB_DATABASE):
     """Launch a bash shell inside the running Infrahub container."""
     with context.cd(REPO_BASE):
         compose_files_cmd = build_compose_files_cmd(database=database)
@@ -137,7 +138,7 @@ def cli_server(context: Context, database: str = "memgraph"):
 
 
 @task(optional=["database"])
-def cli_git(context: Context, database: str = "memgraph"):
+def cli_git(context: Context, database: str = INFRAHUB_DATABASE):
     """Launch a bash shell inside the running Infrahub container."""
     with context.cd(REPO_BASE):
         compose_files_cmd = build_compose_files_cmd(database=database)
@@ -146,7 +147,7 @@ def cli_git(context: Context, database: str = "memgraph"):
 
 
 @task
-def init(context: Context, database: str = "memgraph"):
+def init(context: Context, database: str = INFRAHUB_DATABASE):
     """Initialize Infrahub database before using it the first time."""
     with context.cd(REPO_BASE):
         compose_files_cmd = build_compose_files_cmd(database=database)
@@ -155,7 +156,7 @@ def init(context: Context, database: str = "memgraph"):
 
 
 @task(optional=["database"])
-def status(context: Context, database: str = "memgraph"):
+def status(context: Context, database: str = INFRAHUB_DATABASE):
     """Display the status of all containers."""
     with context.cd(REPO_BASE):
         compose_files_cmd = build_compose_files_cmd(database=database)
@@ -164,7 +165,7 @@ def status(context: Context, database: str = "memgraph"):
 
 
 @task(optional=["database"])
-def load_infra_schema(context: Context, database: str = "memgraph"):
+def load_infra_schema(context: Context, database: str = INFRAHUB_DATABASE):
     """Load the base schema for infrastructure."""
     with context.cd(REPO_BASE):
         compose_files_cmd = build_compose_files_cmd(database=database)
@@ -177,7 +178,7 @@ def load_infra_schema(context: Context, database: str = "memgraph"):
 
 
 @task(optional=["database"])
-def load_infra_data(context: Context, database: str = "memgraph"):
+def load_infra_data(context: Context, database: str = INFRAHUB_DATABASE):
     """Load some demo data."""
     with context.cd(REPO_BASE):
         compose_files_cmd = build_compose_files_cmd(database=database)
@@ -187,7 +188,7 @@ def load_infra_data(context: Context, database: str = "memgraph"):
 
 
 @task(optional=["database"])
-def infra_git_import(context: Context, database: str = "memgraph"):
+def infra_git_import(context: Context, database: str = INFRAHUB_DATABASE):
     """Load some demo data."""
     PACKAGE_NAME = "infrahub-demo-edge-b635811.tar.gz"
     with context.cd(REPO_BASE):
@@ -205,7 +206,7 @@ def infra_git_import(context: Context, database: str = "memgraph"):
 
 @task(optional=["database"])
 def infra_git_create(
-    context: Context, database: str = "memgraph", name="demo-edge", location="/remote/infrahub-demo-edge"
+    context: Context, database: str = INFRAHUB_DATABASE, name="demo-edge", location="/remote/infrahub-demo-edge"
 ):
     """Load some demo data."""
     clean_query = re.sub(r"\n\s*", "", ADD_REPO_QUERY)
@@ -229,7 +230,7 @@ def infra_git_create(
 # Dev Environment tasks
 # ----------------------------------------------------------------------------
 @task(optional=["database"])
-def dev_start(context: Context, database: str = "memgraph"):
+def dev_start(context: Context, database: str = INFRAHUB_DATABASE):
     """Start a local instance of NEO4J & RabbitMQ."""
     with context.cd(REPO_BASE):
         dev_compose_files_cmd = build_dev_compose_files_cmd(database=database)
@@ -238,7 +239,7 @@ def dev_start(context: Context, database: str = "memgraph"):
 
 
 @task(optional=["database"])
-def dev_stop(context: Context, database: str = "memgraph"):
+def dev_stop(context: Context, database: str = INFRAHUB_DATABASE):
     """Start a local instance of NEO4J & RabbitMQ."""
     with context.cd(REPO_BASE):
         dev_compose_files_cmd = build_dev_compose_files_cmd(database=database)

--- a/tasks/sdk.py
+++ b/tasks/sdk.py
@@ -3,6 +3,7 @@ from invoke import Context, task
 from .shared import (
     BUILD_NAME,
     NBR_WORKERS,
+    INFRAHUB_DATABASE,
     build_test_compose_files_cmd,
     build_test_envs,
     execute_command,
@@ -174,7 +175,7 @@ def test_unit(context: Context):
 
 
 @task(optional=["database"])
-def test_integration(context: Context, database: str = "memgraph"):
+def test_integration(context: Context, database: str = INFRAHUB_DATABASE):
     with context.cd(REPO_BASE):
         compose_files_cmd = build_test_compose_files_cmd(database=database)
         base_cmd = f"{get_env_vars(context)} docker compose {compose_files_cmd} -p {BUILD_NAME} run {build_test_envs()} infrahub-test"

--- a/tasks/shared.py
+++ b/tasks/shared.py
@@ -15,7 +15,7 @@ class DatabaseType(str, Enum):
 
 INVOKE_SUDO = os.getenv("INVOKE_SUDO", None)
 INVOKE_PTY = os.getenv("INVOKE_PTY", None)
-
+INFRAHUB_DATABASE = os.getenv("INFRAHUB_DB_TYPE", DatabaseType.MEMGRAPH.value)
 
 here = os.path.abspath(os.path.dirname(__file__))
 TOP_DIRECTORY_NAME = os.path.basename(os.path.abspath(os.path.join(here, "..")))


### PR DESCRIPTION
Small change but it should help if we want to switch back to Neo4j as the main database for the E2E tests
I did it a few weeks back but I forgot to open the PR