### PR TITLE
Use bigger runner for E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,7 +360,7 @@ jobs:
       always() && !cancelled() &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
-    runs-on: "runner-ubuntu-8-32"
+    runs-on: "runner-ubuntu-16-64"
     timeout-minutes: 30
     steps:
       - name: "Check out repository code"


### PR DESCRIPTION
Not sure if this is gonna help but at this point, anything is worth trying
moving from `runner-ubuntu-8-32` to `runner-ubuntu-16-64`