### PR TITLE
Fix typo after changing field names

### DIFF
--- a/backend/infrahub/message_bus/operations/event/node.py
+++ b/backend/infrahub/message_bus/operations/event/node.py
@@ -14,5 +14,5 @@ async def mutated(
         node_id=message.node_id,
         action=message.action,
         kind=message.kind,
-        attributes=message.attributes,
+        data=message.data,
     )


### PR DESCRIPTION
Attributes was renamed to data, seems like I missed to change this field in the operation.