### PR TITLE
Catch database connection errors and raise Infrahub error

### DIFF
--- a/backend/infrahub/exceptions.py
+++ b/backend/infrahub/exceptions.py
@@ -26,7 +26,12 @@ class InitializationError(Error):
 
 
 class DatabaseError(Error):
-    pass
+    HTTP_CODE: int = 503
+    DESCRIPTION = "Database unavailable"
+
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(self.message)
 
 
 class LockError(Error):


### PR DESCRIPTION
Extends the DatabaseError to include an HTTP response code and instead returns a 503 error instead of a 500 server crash if the database is unavailable.

Sets a new variable called execution_method in order to capture the same type of errors with either transaction or session.

Note the API won't yet raise these errors due to #1235 getting in the way but I had this branch locally and figured that it could be good to get it in regardless so there's less to address later.