### PR TITLE
Replace deprecated pkg_resources with importlib

### DIFF
--- a/backend/infrahub/__init__.py
+++ b/backend/infrahub/__init__.py
@@ -1,3 +1,3 @@
-import pkg_resources
+import importlib.metadata
 
-__version__ = pkg_resources.get_distribution("infrahub").version
+__version__ = importlib.metadata.version("infrahub")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,10 +206,6 @@ module = "infrahub_ctl.*"
 disallow_untyped_defs = true
 
 [[tool.mypy.overrides]]
-module = "infrahub"
-ignore_errors = true
-
-[[tool.mypy.overrides]]
 module = "infrahub.api.*"
 ignore_errors = true
 


### PR DESCRIPTION
Fix mypy exception and replace deprecated pkg_resources (https://setuptools.pypa.io/en/latest/pkg_resources.html) with importlib