### PR TITLE
add branch naming documentation

### DIFF
--- a/docs/tutorial/branches.md
+++ b/docs/tutorial/branches.md
@@ -15,6 +15,8 @@ To get started, let's create a new branch that we'll call `cr1234`.
 
 You can create a new branch in the frontend by using the button with a plus sign in the top right corner, next to the name of the current branch, i.e. 'main'.
 
+Branch names are fairly permissive, but must conform to [git ref format](https://git-scm.com/docs/git-check-ref-format). For example, slashes (`/`) are allowed, tildes (`~`) are not.
+
 ![](../media/tutorial/tutorial-1-branch-and-version-control.cy.ts/tutorial_1_branch_creation.png)
 
 ##### Other options available


### PR DESCRIPTION
Does this work? Or do we want a page dedicated to the naming convention? Since we mirrored the restrictions in git-ref I figure it just makes more sense to link to it...

Added the blurb into the tutorial/branching section, since we don't really address branches outside of that.