### PR TITLE
Update cypress type options for proposed-changes test

### DIFF
--- a/frontend/tests/e2e/proposed-changes.cy.ts
+++ b/frontend/tests/e2e/proposed-changes.cy.ts
@@ -26,7 +26,7 @@ describe("Main application", () => {
     cy.get(".bg-white > .p-2").click();
 
     // Type the PC name
-    cy.get(".grid > :nth-child(1) > .relative > .block").type(PROPOSED_CHANGES_NAME);
+    cy.get(".grid > :nth-child(1) > .relative > .block").type(PROPOSED_CHANGES_NAME, { delay: 0 });
     cy.get(".grid > :nth-child(1) > .relative > .block").should(
       "have.value",
       PROPOSED_CHANGES_NAME
@@ -97,8 +97,8 @@ describe("Main application", () => {
     cy.contains("Just a moment").should("not.exist");
 
     // Type the first comment in the add comment section
-    cy.get("textarea").type(PROPOSED_CHANGE_COMMENT_1);
-    cy.get("textarea").should("have.value", PROPOSED_CHANGE_COMMENT_1);
+    cy.get("textarea").first().type(PROPOSED_CHANGE_COMMENT_1, { delay: 0 });
+    cy.get("textarea").first().should("have.value", PROPOSED_CHANGE_COMMENT_1);
 
     cy.intercept("/graphql/main").as("CreateComment1");
 
@@ -118,8 +118,8 @@ describe("Main application", () => {
       // Add reply
       cy.contains("Reply").click();
 
-      cy.get("textarea").type(PROPOSED_CHANGE_COMMENT_2);
-      cy.get("textarea").should("have.value", PROPOSED_CHANGE_COMMENT_2);
+      cy.get("textarea").first().type(PROPOSED_CHANGE_COMMENT_2, { delay: 0 });
+      cy.get("textarea").first().should("have.value", PROPOSED_CHANGE_COMMENT_2);
 
       cy.intercept("/graphql/main").as("CreateComment2");
 
@@ -137,7 +137,7 @@ describe("Main application", () => {
 
       // Add third comment
       cy.get("textarea").should("have.value", "");
-      cy.get("textarea").type(PROPOSED_CHANGE_COMMENT_3);
+      cy.get("textarea").type(PROPOSED_CHANGE_COMMENT_3, { delay: 0 });
       cy.get("textarea").should("have.value", PROPOSED_CHANGE_COMMENT_3);
 
       // Mark as resolved once commented


### PR DESCRIPTION
It adds an option to remove the delay between each key down, to prevent weird behaviours where the input doesn't have all the text

The check to verify if the input contains all the text was failing if the type action was not done correctly by cypress, so we couldn't wait for the input value to be entirely defined by the type action