### PR TITLE
Fix type hints on main graphql mutation

### DIFF
--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from graphql import GraphQLResolveInfo
 
     from infrahub.auth import AccountSession
+    from infrahub.core.branch import Branch
     from infrahub.database import InfrahubDatabase
 
 # pylint: disable=unused-argument
@@ -91,8 +92,8 @@ class InfrahubMutationMixin:
         root: dict,
         info: GraphQLResolveInfo,
         data: InputObjectType,
-        branch: Optional[str] = None,
-        at: Optional[str] = None,
+        branch: Branch,
+        at: str,
     ):
         db: InfrahubDatabase = info.context.get("infrahub_database")
 
@@ -122,8 +123,8 @@ class InfrahubMutationMixin:
         root: dict,
         info: GraphQLResolveInfo,
         data: InputObjectType,
-        branch: Optional[str] = None,
-        at: Optional[str] = None,
+        branch: Branch,
+        at: str,
         database: Optional[InfrahubDatabase] = None,
         node: Optional[Node] = None,
     ):
@@ -185,8 +186,8 @@ class InfrahubMutationMixin:
         root,
         info: GraphQLResolveInfo,
         data: InputObjectType,
-        branch: Optional[str] = None,
-        at: Optional[str] = None,
+        branch: Branch,
+        at: str,
     ):
         db: InfrahubDatabase = info.context.get("infrahub_database")
 

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -76,8 +76,8 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
         root: dict,
         info: GraphQLResolveInfo,
         data: InputObjectType,
-        branch: Optional[str] = None,
-        at: Optional[str] = None,
+        branch: Branch,
+        at: str,
         database: Optional[InfrahubDatabase] = None,
         node: Optional[Node] = None,
     ):


### PR DESCRIPTION
The `at` and `branch` parameters should always be set earlier and branch was set as a `Branch` object and not as a string.