### PR TITLE
Merge branch when proposed change state is updated to merged

### DIFF
--- a/backend/infrahub/core/constants.py
+++ b/backend/infrahub/core/constants.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import enum
 from typing import List
 
+from infrahub.exceptions import ValidationError
 from infrahub.utils import InfrahubNumberEnum, InfrahubStringEnum
 
 GLOBAL_BRANCH_NAME = "-global-"
@@ -88,6 +91,21 @@ class ProposedChangeState(InfrahubStringEnum):
     MERGED = "merged"
     CLOSED = "closed"
     CANCELED = "canceled"
+
+    def validate_state_transition(self, updated_state: ProposedChangeState) -> None:
+        if self == ProposedChangeState.OPEN:
+            return
+        if self in [ProposedChangeState.CANCELED, ProposedChangeState.MERGED]:
+            raise ValidationError(
+                input_value=f"A proposed change is not allowed to transition from the {self.value} state"
+            )
+        if self == ProposedChangeState.CLOSED and updated_state not in [
+            ProposedChangeState.CANCELED,
+            ProposedChangeState.OPEN,
+        ]:
+            raise ValidationError(
+                input_value="A closed proposed change is only allowed to transition to the open state"
+            )
 
 
 class RelationshipCardinality(InfrahubStringEnum):

--- a/backend/infrahub/graphql/mutations/graphql_query.py
+++ b/backend/infrahub/graphql/mutations/graphql_query.py
@@ -4,7 +4,9 @@ from graphene import InputObjectType, Mutation
 from graphql import GraphQLResolveInfo
 
 from infrahub.core.branch import Branch
+from infrahub.core.node import Node
 from infrahub.core.schema import NodeSchema
+from infrahub.database import InfrahubDatabase
 from infrahub.graphql.analyzer import GraphQLQueryAnalyzer
 from infrahub.graphql.mutations.main import InfrahubMutationMixin
 
@@ -77,6 +79,8 @@ class InfrahubGraphQLQueryMutation(InfrahubMutationMixin, Mutation):
         data: InputObjectType,
         branch: Optional[str] = None,
         at: Optional[str] = None,
+        database: Optional[InfrahubDatabase] = None,
+        node: Optional[Node] = None,
     ):
         branch_obj: Branch = info.context.get("infrahub_branch")
 

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -3,15 +3,23 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 from graphene import Boolean, Enum, InputObjectType, Mutation, String
 from graphql import GraphQLResolveInfo
 
+from infrahub import config, lock
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.constants import ProposedChangeState
 from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
 from infrahub.core.schema import NodeSchema
+from infrahub.database import InfrahubDatabase
 from infrahub.graphql.mutations.main import InfrahubMutationMixin
-from infrahub.message_bus import messages
+from infrahub.log import get_log_data
+from infrahub.message_bus import Meta, messages
+from infrahub.services import services
+from infrahub.worker import WORKER_IDENTITY
 
 from .main import InfrahubMutationOptions
 
 if TYPE_CHECKING:
-    from infrahub.database import InfrahubDatabase
     from infrahub.message_bus.rpc import InfrahubRpcClient
 
 
@@ -59,6 +67,66 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
         ]
         for event in events:
             await rpc_client.send(event)
+
+        return proposed_change, result
+
+    @classmethod
+    async def mutate_update(
+        cls,
+        root: dict,
+        info: GraphQLResolveInfo,
+        data: InputObjectType,
+        branch: Optional[str] = None,
+        at: Optional[str] = None,
+        database: Optional[InfrahubDatabase] = None,
+        node: Optional[Node] = None,
+    ):
+        db: InfrahubDatabase = info.context.get("infrahub_database")
+        rpc_client: InfrahubRpcClient = info.context.get("infrahub_rpc_client")
+
+        obj = await NodeManager.get_one_by_id_or_default_filter(
+            db=db,
+            schema_name=cls._meta.schema.kind,
+            id=data.get("id"),
+            branch=branch,
+            at=at,
+            include_owner=True,
+            include_source=True,
+        )
+        state = ProposedChangeState(obj.state.value)
+        updated_state = None
+        if state_update := data.get("state", {}).get("value"):
+            updated_state = ProposedChangeState(state_update)
+            state.validate_state_transition(updated_state)
+
+        async with db.start_transaction() as dbt:
+            proposed_change, result = await super().mutate_update(
+                root=root, info=info, data=data, branch=branch, at=at, database=dbt, node=obj
+            )
+
+            if updated_state == ProposedChangeState.MERGED:
+                source_branch = await Branch.get_by_name(db=dbt, name=proposed_change.source_branch.value)
+
+                async with lock.registry.global_graph_lock():
+                    await source_branch.merge(rpc_client=rpc_client, db=dbt)
+
+                    # Copy the schema from the origin branch and set the hash and the schema_changed_at value
+                    origin_branch = await source_branch.get_origin_branch(db=dbt)
+                    updated_schema = await registry.schema.load_schema_from_db(db=dbt, branch=origin_branch)
+                    registry.schema.set_schema_branch(name=origin_branch.name, schema=updated_schema)
+                    origin_branch.update_schema_hash()
+
+                    await origin_branch.save(db=dbt)
+
+                if config.SETTINGS.broker.enable and info.context.get("background"):
+                    log_data = get_log_data()
+                    request_id = log_data.get("request_id", "")
+                    message = messages.EventBranchMerge(
+                        source_branch=source_branch.name,
+                        target_branch=config.SETTINGS.main.default_branch,
+                        meta=Meta(initiator_id=WORKER_IDENTITY, request_id=request_id),
+                    )
+                    info.context.get("background").add_task(services.send, message)
 
         return proposed_change, result
 

--- a/backend/infrahub/message_bus/operations/event/branch.py
+++ b/backend/infrahub/message_bus/operations/event/branch.py
@@ -22,7 +22,10 @@ async def create(message: messages.EventBranchCreate, service: InfrahubServices)
 async def merge(message: messages.EventBranchMerge, service: InfrahubServices) -> None:
     log.info("Branch merged", source_branch=message.source_branch, target_branch=message.target_branch)
 
-    events: List[InfrahubMessage] = [messages.TriggerArtifactDefinitionGenerate(branch=message.target_branch)]
+    events: List[InfrahubMessage] = [
+        messages.RefreshRegistryBranches(),
+        messages.TriggerArtifactDefinitionGenerate(branch=message.target_branch),
+    ]
 
     for event in events:
         event.assign_meta(parent=message)

--- a/backend/tests/unit/core/test_constants.py
+++ b/backend/tests/unit/core/test_constants.py
@@ -1,0 +1,29 @@
+import pytest
+
+from infrahub.core.constants import ProposedChangeState
+from infrahub.exceptions import ValidationError
+
+
+def test_proposed_state_transitions() -> None:
+    opened = ProposedChangeState.OPEN
+    closed = ProposedChangeState.CLOSED
+    canceled = ProposedChangeState.CANCELED
+    merged = ProposedChangeState.MERGED
+
+    for allowed in ProposedChangeState.available_types():
+        opened.validate_state_transition(ProposedChangeState(allowed))
+
+    closed.validate_state_transition(opened)
+    closed.validate_state_transition(canceled)
+
+    for error_state in [ProposedChangeState.CLOSED, ProposedChangeState.MERGED]:
+        with pytest.raises(ValidationError):
+            closed.validate_state_transition(error_state)
+
+    for disallowed in ProposedChangeState.available_types():
+        with pytest.raises(ValidationError):
+            canceled.validate_state_transition(ProposedChangeState(disallowed))
+
+    for disallowed in ProposedChangeState.available_types():
+        with pytest.raises(ValidationError):
+            merged.validate_state_transition(ProposedChangeState(disallowed))

--- a/frontend/src/screens/proposed-changes/conversations.tsx
+++ b/frontend/src/screens/proposed-changes/conversations.tsx
@@ -24,7 +24,6 @@ import {
 } from "../../config/constants";
 import { AuthContext } from "../../decorators/withAuth";
 import graphqlClient from "../../graphql/graphqlClientApollo";
-import { mergeBranch } from "../../graphql/mutations/branches/mergeBranch";
 import { createObject } from "../../graphql/mutations/objects/createObject";
 import { deleteObject } from "../../graphql/mutations/objects/deleteObject";
 import { updateObjectWithId } from "../../graphql/mutations/objects/updateObjectWithId";
@@ -35,7 +34,6 @@ import useQuery from "../../hooks/useQuery";
 import { branchesState } from "../../state/atoms/branches.atom";
 import { proposedChangedState } from "../../state/atoms/proposedChanges.atom";
 import { schemaState } from "../../state/atoms/schema.atom";
-import { objectToString } from "../../utils/common";
 import { constructPath } from "../../utils/fetch";
 import { getProposedChangesStateBadgeType } from "../../utils/proposed-changes";
 import { stringifyWithoutQuotes } from "../../utils/string";
@@ -309,23 +307,6 @@ export const Conversations = (props: tConversations) => {
 
     try {
       setIsLoadingMerge(true);
-
-      const mergeData = {
-        name: proposedChangesDetails?.source_branch?.value,
-      };
-
-      const mergeMutationString = mergeBranch({ data: objectToString(mergeData) });
-
-      const mergeMutation = gql`
-        ${mergeMutationString}
-      `;
-
-      await graphqlClient.mutate({
-        mutation: mergeMutation,
-        context: {
-          date,
-        },
-      });
 
       const stateData = {
         state: {


### PR DESCRIPTION
Also combines the update to the proposed change and merging of a branch into a single transaction

Adds some checks to ensure that a proposed change that have been merged or canceled can't be reopened or transition into another state.

As part of this I changed to use the get_one_by_id_or_default_filter as that function raises an error if the node isn't found. This might be a bit more costly as it can result in multiple queries if the object isn't found. I didn't want to have to query for the object both in the proposed_change update and in the generic update function. We could also introduce a new function called something like .get_by_id_or_raise() that would do the same.

Changed the frontend code so that it doesn't send in two mutations when merging a proposed changed (one to merge the branch and one to update the state of the proposed change)

This is related to #1211 but doesn't yet change the logic only ensures that we can do the merge within one transaction and one mutation.