### PR TITLE
Experiment to add Type Checking for objects in Core

### DIFF
--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -514,6 +514,10 @@ class String(BaseAttribute):
     type = str
 
 
+class StringMandatory(BaseAttribute):
+    value: str
+
+
 class HashedPassword(BaseAttribute):
     type = str
 
@@ -522,6 +526,10 @@ class HashedPassword(BaseAttribute):
         """Serialize the value before storing it in the database."""
 
         return hash_password(value)
+
+
+class HashedPasswordMandatory(HashedPassword):
+    value: str
 
 
 class Integer(BaseAttribute):

--- a/backend/infrahub/core/definitions.py
+++ b/backend/infrahub/core/definitions.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Optional, Protocol, runtime_checkable
 
+from infrahub.core.node import Node
+
 if TYPE_CHECKING:
     from neo4j import AsyncSession
 
+    from infrahub.core.attribute import HashedPassword, String, StringMandatory
     from infrahub.core.branch import Branch
+    from infrahub.core.relationship import RelationshipManager
     from infrahub.database import InfrahubDatabase
 
 
@@ -20,3 +24,32 @@ class Brancher(Protocol):
     @classmethod
     def isinstance(cls, obj: Any) -> bool:
         return isinstance(obj, cls)
+
+
+# implemented using standard inheritance
+class CoreAccountNode(Node):
+    name: String
+    password: HashedPassword
+    label: String
+    description: String
+    type: String
+    role: StringMandatory
+    tokens: RelationshipManager
+
+
+# implemented using Protocol
+class CoreNode(Protocol):
+    id: str
+
+    async def save(self):
+        ...
+
+
+class CoreAccountProtocol(CoreNode):
+    name: String
+    password: HashedPassword
+    label: String
+    description: String
+    type: String
+    role: StringMandatory
+    tokens: RelationshipManager

--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, List, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
 
 from infrahub.core import get_branch, registry
 from infrahub.core.node import Node
@@ -23,7 +23,6 @@ if TYPE_CHECKING:
 
     from infrahub.core.branch import Branch
     from infrahub.database import InfrahubDatabase
-
 
 # pylint: disable=redefined-builtin
 
@@ -62,7 +61,7 @@ class NodeManager:
         include_owner: bool = False,
         prefetch_relationships: bool = False,
         account=None,
-    ) -> List[Node]:  # pylint: disable=unused-argument
+    ) -> List[Any]:  # pylint: disable=unused-argument
         """Query one or multiple nodes of a given type based on filter arguments.
 
         Args:
@@ -285,7 +284,7 @@ class NodeManager:
         include_owner: bool = False,
         prefetch_relationships: bool = False,
         account=None,
-    ) -> Node:
+    ) -> Any:
         """Return one node based on its ID."""
         result = await cls.get_many(
             ids=[id],
@@ -316,7 +315,7 @@ class NodeManager:
         include_owner: bool = False,
         prefetch_relationships: bool = False,
         account=None,
-    ) -> Dict[str, Node]:
+    ) -> Dict[str, Any]:
         """Return a list of nodes based on their IDs."""
 
         branch = await get_branch(branch=branch, db=db)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,10 +209,6 @@ module = "infrahub.api.*"
 ignore_errors = true
 
 [[tool.mypy.overrides]]
-module = "infrahub.auth"
-ignore_errors = true
-
-[[tool.mypy.overrides]]
 module = "infrahub.checks"
 ignore_errors = true
 


### PR DESCRIPTION
This PR is an experiment to see how we could implement better Typing internally for some of our Core & Internal objects.
This is something we discussed few weeks back with @ogenstad 

>I have a lot to learn on Python Typing so this was a good exercise for me

I tried 2 methods which both seams to work, the code is using the first one right now but I tried both with similar results
For this experiment I implemented some Typing for the `CoreAccount` node and I used it in the `auth.py` file. WIth these changes, Mypy isn't complaining anymore

> Once we have defined how we want to implement this we'll have to build a tool to automatically generate these class/protocol from the internal schema

## Method 1 - Standard inheritance

Using standard python inheritance, we can create a new Object with all the attributes and the relationship explicitly defined

```python
class CoreAccountNode(Node):
    name: String
    password: HashedPassword
    label: String
    description: String
    type: String
    role: StringMandatory
    tokens: RelationshipManager
```

## Method 2 - Protocol

Using Python Protocol we can create a new Protocol class with the same signature as the object itself.

```python
# implemented using Protocol
class CoreNode(Protocol):
    id: str

    async def save(self):
        ...

class CoreAccountProtocol(CoreNode):
    name: String
    password: HashedPassword
    label: String
    description: String
    type: String
    role: StringMandatory
    tokens: RelationshipManager
```

## Lessons learned from this exercice

- Mypy doesn't like to have different objects in a list even if they are inheriting from the same class. 
The problem is documented here https://stackoverflow.com/questions/50305636/mypy-trouble-with-inheritance-of-objects-in-lists. 
To workaround this situation I had to set the returned Type on the NodeManager as `List[Any]` instead of `List[Node]`
- By default the value on an attribute is defined as `Optional` which generates some false positive when we try to manipulate the value without checking if it's null first. One solution is to implement specific class/protocol for attribute  that are mandatory to avoid having to deal with an optional value.

## Summary 

Not sure which which one is best honestly. 
The protocol is probably cleaner but it means we have to reimplement and maintain a protocol of the Node class, I couldn't find a way to mix protocol and python classes.
For standard Typing. We have to import Node which could lead to some unexpected import loop.
~~All imports in the `definitions.py` file are under a TYPE_CHECKING block so that shouldn't impact the runtime but I'm not 100% sure.~~

