### PR TITLE
Fix token tab from profile page

### DIFF
--- a/frontend/src/config/constants.tsx
+++ b/frontend/src/config/constants.tsx
@@ -32,7 +32,7 @@ export const DATA_CHECK_OBJECT = "CoreDataCheck";
 
 export const ACCOUNT_OBJECT = "CoreAccount";
 
-export const ACCOUNT_TOKEN_OBJECT = "CoreAccountToken";
+export const ACCOUNT_TOKEN_OBJECT = "InternalAccountToken";
 
 export const ARTIFACT_DEFINITION_OBJECT = "CoreArtifactDefinition";
 

--- a/frontend/src/screens/object-items/object-items-paginated.tsx
+++ b/frontend/src/screens/object-items/object-items-paginated.tsx
@@ -40,7 +40,11 @@ import ObjectItemCreate from "../object-item-create/object-item-create-paginated
 export default function ObjectItems(props: any) {
   const { objectname: objectnameFromParams } = useParams();
 
-  const { objectname: objectnameFromProps = "", filters: filtersFromProps = [] } = props;
+  const {
+    objectname: objectnameFromProps = "",
+    filters: filtersFromProps = [],
+    preventBlock,
+  } = props;
 
   const objectname = objectnameFromProps || objectnameFromParams;
 
@@ -68,7 +72,7 @@ export default function ObjectItems(props: any) {
     navigate("/");
   }
 
-  if (schemaData && MENU_EXCLUDELIST.includes(schemaData.kind)) {
+  if (schemaData && MENU_EXCLUDELIST.includes(schemaData.kind) && !preventBlock) {
     navigate("/");
   }
 

--- a/frontend/src/screens/user-profile/tab-tokens.tsx
+++ b/frontend/src/screens/user-profile/tab-tokens.tsx
@@ -9,7 +9,7 @@ export default function TabProfile() {
 
   const accountId = tokenData?.sub;
 
-  const filters = [`account__id: "${accountId}"`];
+  const filters = [`account__ids: "${accountId}"`];
 
-  return <ObjectItems objectname={ACCOUNT_TOKEN_OBJECT} filters={filters} />;
+  return <ObjectItems objectname={ACCOUNT_TOKEN_OBJECT} filters={filters} preventBlock />;
 }


### PR DESCRIPTION
The token tab in the profile page now works again (it was blocked previously, because we wanted to prevent people to access to the InternalAccountToken view)