### PR TITLE
Add basic labels for our issue-template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,6 +2,7 @@
 name: 🐛 Bug Report
 description: Create a report to help us improve Infrahub
 title: 'bug: '
+labels: ["type/bug"]
 body:
   - type: dropdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,6 +2,7 @@
 name: 💡 Feature Request
 description: Suggest a feature for Infrahub
 title: 'feature: '
+labels: ["type/feature"]
 body:
   - type: dropdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -2,6 +2,7 @@
 name: ✅ Task
 description: Create a task for minor issues that isn't a feature or a bug
 title: 'task: '
+labels: ["type/task"]
 body:
   - type: dropdown
     attributes:


### PR DESCRIPTION
Our template were not including the related labels (type/bug for bug, etc)