### PR TITLE
Add vscode section in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,23 +5,24 @@
     "context": "."
   },
   "customizations": {
-
-  "settings": {
-    "python.pythonPath": "/usr/bin/python3",
-    "terminal.integrated.shell.linux": "/bin/bash",
-    "python.venvPath": "/workspace/.venv",
-    "python.linting.enabled": true
+    "settings": {
+      "python.pythonPath": "/usr/bin/python3",
+      "terminal.integrated.shell.linux": "/bin/bash",
+      "python.venvPath": "/workspace/.venv",
+      "python.linting.enabled": true
+    },
+    "vscode": {
+      "extensions": [
+        "pomdtr.excalidraw-editor",
+        "wholroyd.jinja",
+        "ms-python.vscode-pylance",
+        "shardulm94.trailing-spaces",
+        "nickmillerdev.pytest-fixtures",
+        "yzhang.markdown-all-in-one",
+        "GraphQL.vscode-graphql-syntax"
+      ]
+    }
   },
-  "extensions": [
-    "pomdtr.excalidraw-editor",
-    "wholroyd.jinja",
-    "ms-python.vscode-pylance",
-    "shardulm94.trailing-spaces",
-    "nickmillerdev.pytest-fixtures",
-    "yzhang.markdown-all-in-one",
-    "GraphQL.vscode-graphql-syntax"
-  ]
-},
   "remoteUser": "vscode",
   "remoteEnv": {
       "INFRAHUB_SDK_API_TOKEN": "06438eb2-8019-4776-878c-0941b1f1d1ec"


### PR DESCRIPTION
I noticed that VS code doesn't have any extensions installed in Codespace. 
Looking at this doc, https://code.visualstudio.com/docs/devcontainers/containers#_create-a-devcontainerjson-file
it looks like we need to add one `vscode` container around `extensions`