### PR TITLE
chore: add label for internal tooling

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -161,6 +161,10 @@
   description: "The redaction of the issue is still a work in progress"
   color: "dcb518"
 
+- name: "state/referenced"
+  description: "This issue is referenced in our internal tooling"
+  color: "c9510c"
+
 # ----------------------------------
 # CI
 # ----------------------------------


### PR DESCRIPTION
Add a label to indicate when an issue is being referenced in our internal tooling (clickup at the moment)

It will be used for automation between the two systems.