### PR TITLE
Catch network errors from httpx

### DIFF
--- a/python_sdk/infrahub_sdk/client.py
+++ b/python_sdk/infrahub_sdk/client.py
@@ -440,12 +440,10 @@ class InfrahubClient(BaseClient):  # pylint: disable=too-many-public-methods
                     timeout=timeout,
                     **params,
                 )
-            except httpx.ConnectError as exc:
+            except httpx.NetworkError as exc:
                 raise ServerNotReacheableError(address=self.address) from exc
             except httpx.ReadTimeout as exc:
                 raise ServerNotResponsiveError(url=url, timeout=timeout) from exc
-            except httpx.NetworkError as exc:
-                raise ServerNotReacheableError(address=self.address) from exc
 
         self._record(response)
         return response
@@ -941,12 +939,10 @@ class InfrahubClientSync(BaseClient):  # pylint: disable=too-many-public-methods
                     timeout=timeout,
                     **params,
                 )
-            except httpx.ConnectError as exc:
+            except httpx.NetworkError as exc:
                 raise ServerNotReacheableError(address=self.address) from exc
             except httpx.ReadTimeout as exc:
                 raise ServerNotResponsiveError(url=url, timeout=timeout) from exc
-            except httpx.NetworkError as exc:
-                raise ServerNotReacheableError(address=self.address) from exc
 
         self._record(response)
         return response


### PR DESCRIPTION
Fixes #1344.

Since we removed the need to run "invoke demo.init" the issue in #1344 is actually no longer a problem in that context however it can occur in other places.

The problem is that we're not catching enough errors from httpx. In this instance it was raising a ReadError which inherits from NetworkError which is why I just added the network error to the client. We should go through the rest of the errors that httpx can raise in various situations to ensure that we have all of them covered.

When running with the code in this PR together with a commit before the removal of demo.init we would have instead gotten this error which is a lot easier to understand:


```python
│ /source/python_sdk/infrahub_sdk/client.py:397 in _post                                           │
│                                                                                                  │
│   394 │   │   headers = headers or {}                                                            │
│   395 │   │   base_headers = copy.copy(self.headers or {})                                       │
│   396 │   │   headers.update(base_headers)                                                       │
│ ❱ 397 │   │   return await self._request(                                                        │
│   398 │   │   │   url=url,                                                                       │
│   399 │   │   │   method=HTTPMethod.POST,                                                        │
│   400 │   │   │   headers=headers,                                                               │
│                                                                                                  │
│ /source/python_sdk/infrahub_sdk/client.py:448 in _default_request_method                         │
│                                                                                                  │
│   445 │   │   │   except httpx.ReadTimeout as exc:                                               │
│   446 │   │   │   │   raise ServerNotResponsiveError(url=url, timeout=timeout) from exc          │
│   447 │   │   │   except httpx.NetworkError as exc:                                              │
│ ❱ 448 │   │   │   │   raise ServerNotReacheableError(address=self.address) from exc              │
│   449 │   │                                                                                      │
│   450 │   │   self._record(response)                                                             │
│   451 │   │   return response                                                                    │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
ServerNotReacheableError: Unable to connect to 'http://infrahub-server:8000'.

```