### PR TITLE
Changes -> Changelog in release note drafter

### DIFF
--- a/.github/release-note.yml
+++ b/.github/release-note.yml
@@ -26,6 +26,6 @@ change-title-escapes: '\<*_&'  # You can add # and @ to disable mentions, and ad
 #       - 'patch'
 #   default: patch
 template: |
-  ## Changes
+  ## Changelog
 
   $CHANGES


### PR DESCRIPTION
We typically have a written section above these changes and replace this title with Changelog, might as well change the template so that it's correct from the start.