### PR TITLE
Add source and protection to the commit attribute on update

### DIFF
--- a/python_sdk/infrahub_sdk/queries.py
+++ b/python_sdk/infrahub_sdk/queries.py
@@ -52,7 +52,7 @@ query GetBranch($branch_name: String!) {
 
 MUTATION_COMMIT_UPDATE = """
 mutation ($repository_id: String!, $commit: String!) {
-    CoreRepositoryUpdate(data: { id: $repository_id, commit: { value: $commit } }) {
+    CoreRepositoryUpdate(data: { id: $repository_id, commit: { is_protected: true, source: $repository_id, value: $commit } }) {
         ok
         object {
             commit {


### PR DESCRIPTION
A temporary change so that we ensure that the commit value is marked as protected with the repository as owner. Might be that we should remove this method from the client and handle it through the git-agent instead.