### PR TITLE
Add InfrahubLogger object to services

### DIFF
--- a/backend/infrahub/services/__init__.py
+++ b/backend/infrahub/services/__init__.py
@@ -4,12 +4,14 @@ from infrahub_sdk import InfrahubClient
 
 from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import InitializationError
+from infrahub.log import get_logger
 from infrahub.message_bus import InfrahubMessage, InfrahubResponse, Meta
 from infrahub.message_bus.messages import ROUTING_KEY_MAP
 from infrahub.message_bus.types import MessageTTL
 
 from .adapters.cache import InfrahubCache
 from .adapters.message_bus import InfrahubMessageBus
+from .protocols import InfrahubLogger
 
 
 class InfrahubServices:
@@ -19,11 +21,13 @@ class InfrahubServices:
         client: Optional[InfrahubClient] = None,
         database: Optional[InfrahubDatabase] = None,
         message_bus: Optional[InfrahubMessageBus] = None,
+        log: Optional[InfrahubLogger] = None,
     ):
         self.cache = cache or InfrahubCache()
         self._client = client
         self._database = database
         self.message_bus = message_bus or InfrahubMessageBus()
+        self.log = log or get_logger()
 
     @property
     def client(self) -> InfrahubClient:

--- a/backend/infrahub/services/protocols.py
+++ b/backend/infrahub/services/protocols.py
@@ -1,0 +1,21 @@
+from typing import Any, Optional, Protocol
+
+
+class InfrahubLogger(Protocol):
+    def debug(self, event: Optional[str] = None, *args: Any, **kw: Any) -> Any:
+        """Send a debug event"""
+
+    def info(self, event: Optional[str] = None, *args: Any, **kw: Any) -> Any:
+        """Send an info event"""
+
+    def warning(self, event: Optional[str] = None, *args: Any, **kw: Any) -> Any:
+        """Send a warning event"""
+
+    def error(self, event: Optional[str] = None, *args: Any, **kw: Any) -> Any:
+        """Send an error event."""
+
+    def critical(self, event: Optional[str] = None, *args: Any, **kw: Any) -> Any:
+        """Send a critical event."""
+
+    def exception(self, event: Optional[str] = None, *args: Any, **kw: Any) -> Any:
+        """Send an exception event."""


### PR DESCRIPTION
This PR adds an InfrahubLogger protocol class to the service object, if none is specified we'll just use the normal get_logger.

One benefit of this is that within the message bus operations we don't need to import the logger and define it in each file i.e.

```python
from infrahub.log import get_logger

log = get_logger()
```

Though the main reason is for testing. While looking at the repository imports we have some parts that look like this:

```python
        # Process the list of local RFile to organize them by name
        for artdef in data:
            try:
                item = ArtifactDefinitionInformation(**artdef)
                self.client.schema.validate_data_against_schema(schema=schema, data=artdef)
            except PydanticValidationError as exc:
                for error in exc.errors():
                    LOGGER.error(f"  {'/'.join(error['loc'])} | {error['msg']} ({error['type']})")
                continue
            except ValidationError as exc:
                LOGGER.error(exc.message)
                continue
```

Here we might want to check to see what parts of the code has been covered. While structlog was written with [testing in mind](https://www.structlog.org/en/stable/testing.html) the setup still requires that get_logger is called before the test part is triggered. With this protocol in place we can add the service object to the repo in the same way we to with the client (later replacing the client option) and just have a simple test class that stores the log entries in a dictionary.