### PR TITLE
Initialize git-agent with services object

### DIFF
--- a/backend/infrahub/git/actions.py
+++ b/backend/infrahub/git/actions.py
@@ -1,25 +1,28 @@
 import logging
 
-from infrahub_sdk import InfrahubClient
-
 from infrahub import lock
 from infrahub.exceptions import RepositoryError
+from infrahub.services import InfrahubServices
 
 from .repository import InfrahubRepository
 
 LOGGER = logging.getLogger("infrahub.git")
 
 
-async def sync_remote_repositories(client: InfrahubClient) -> None:
-    branches = await client.branch.all()
-    repositories = await client.get_list_repositories(branches=branches)
+async def sync_remote_repositories(service: InfrahubServices) -> None:
+    branches = await service.client.branch.all()
+    repositories = await service.client.get_list_repositories(branches=branches)
 
     for repo_name, repository in repositories.items():
         async with lock.registry.get(name=repo_name, namespace="repository"):
             init_failed = False
             try:
                 repo = await InfrahubRepository.init(
-                    id=repository.id, name=repository.name, location=repository.location, client=client
+                    service=service,
+                    id=repository.id,
+                    name=repository.name,
+                    location=repository.location,
+                    client=service.client,
                 )
             except RepositoryError as exc:
                 LOGGER.error(exc)
@@ -28,7 +31,11 @@ async def sync_remote_repositories(client: InfrahubClient) -> None:
             if init_failed:
                 try:
                     repo = await InfrahubRepository.new(
-                        id=repository.id, name=repository.name, location=repository.location, client=client
+                        service=service,
+                        id=repository.id,
+                        name=repository.name,
+                        location=repository.location,
+                        client=service.client,
                     )
                     await repo.import_objects_from_files(branch_name=repo.default_branch_name)
                 except RepositoryError as exc:

--- a/backend/infrahub/git/repository.py
+++ b/backend/infrahub/git/repository.py
@@ -40,6 +40,7 @@ from infrahub.exceptions import (
     TransformError,
 )
 from infrahub.log import get_logger
+from infrahub.services import InfrahubServices
 
 if TYPE_CHECKING:
     from infrahub_sdk.branch import BranchData
@@ -340,6 +341,7 @@ class InfrahubRepository(BaseModel):  # pylint: disable=too-many-public-methods
     client: Optional[InfrahubClient]
 
     cache_repo: Optional[Repo]
+    service: InfrahubServices
 
     class Config:
         arbitrary_types_allowed = True
@@ -513,15 +515,17 @@ class InfrahubRepository(BaseModel):  # pylint: disable=too-many-public-methods
         return True
 
     @classmethod
-    async def new(cls, **kwargs):
-        self = cls(**kwargs)
+    async def new(cls, service: Optional[InfrahubServices] = None, **kwargs):
+        service = service or InfrahubServices()
+        self = cls(service=service, **kwargs)
         await self.create_locally()
         LOGGER.info(f"{self.name} | Created the new project locally.")
         return self
 
     @classmethod
-    async def init(cls, **kwargs):
-        self = cls(**kwargs)
+    async def init(cls, service: Optional[InfrahubServices] = None, **kwargs):
+        service = service or InfrahubServices()
+        self = cls(service=service, **kwargs)
         self.validate_local_directories()
         LOGGER.debug(f"{self.name} | Initiated the object on an existing directory.")
         return self


### PR DESCRIPTION
Make the services object available throughout the git-agent. The main reason for this is to be able to initialize repositories and supply the service object. This PR is related to the changes in #1429.

In this iteration the code to initialize RabbitMQ has just been copied as they were before. A future step will be to have the RabbitMQ adapter take care of this for both the git-agent and api-server and remove this code from the git-agent all together.