### PR TITLE
Changes to SDK recorder, enable recording of all requests regardless of configured request method

### DIFF
--- a/python_sdk/infrahub_sdk/recorder.py
+++ b/python_sdk/infrahub_sdk/recorder.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import enum
 import json
 from typing import Protocol, runtime_checkable
@@ -16,7 +18,17 @@ class RecorderType(str, enum.Enum):
 @runtime_checkable
 class Recorder(Protocol):
     def record(self, response: httpx.Response) -> None:
-        ...
+        """Record the response from Infrahub"""
+
+
+class NoRecorder:
+    @staticmethod
+    def record(response: httpx.Response) -> None:
+        """The NoRecorder just silently returns"""
+
+    @classmethod
+    def default(cls) -> NoRecorder:
+        return cls()
 
 
 class JSONRecorder(BaseSettings):


### PR DESCRIPTION
Adds a NoRecorder class which is default to avoid an unnecessary if-statement. Fixes #920.

Also moves the recorder logic out from the default request methods, this enables us to record all requests if desired and not just live requests. This will make it easier to test the recorder using unittests.