### PR TITLE
Update schema for Python checks in .infrahub.yml

### DIFF
--- a/python_sdk/infrahub_sdk/checks.py
+++ b/python_sdk/infrahub_sdk/checks.py
@@ -10,7 +10,20 @@ from git.repo import Repo
 
 from infrahub_sdk import InfrahubClient
 
+try:
+    from pydantic import v1 as pydantic  # type: ignore[attr-defined]
+except ImportError:
+    import pydantic  # type: ignore[no-redef]
+
 INFRAHUB_CHECK_VARIABLE_TO_IMPORT = "INFRAHUB_CHECKS"
+
+
+class InfrahubCheckInitializer(pydantic.BaseModel):
+    """Information about the originator of the check."""
+
+    proposed_change_id: str = pydantic.Field(
+        default="", description="If available the ID of the proposed change that requested the check"
+    )
 
 
 class InfrahubCheck:
@@ -19,9 +32,16 @@ class InfrahubCheck:
     timeout: int = 10
     rebase: bool = True
 
-    def __init__(self, branch: str = "", root_directory: str = "", output: Optional[str] = None):
+    def __init__(
+        self,
+        branch: str = "",
+        root_directory: str = "",
+        output: Optional[str] = None,
+        initializer: Optional[InfrahubCheckInitializer] = None,
+    ):
         self.data: Dict = {}
         self.git: Optional[Repo] = None
+        self.initializer = initializer or InfrahubCheckInitializer()
 
         self.logs: List[Dict[str, Any]] = []
         self.passed = False

--- a/python_sdk/infrahub_sdk/schema.py
+++ b/python_sdk/infrahub_sdk/schema.py
@@ -65,6 +65,12 @@ class InfrahubRepositoryRFileConfig(pydantic.BaseModel):
 
 class InfrahubCheckDefinitionConfig(pydantic.BaseModel):
     file_path: Path = pydantic.Field(..., description="The file within the repo with the check code.")
+    parameters: Dict[str, Any] = pydantic.Field(
+        default_factory=dict, description="The input parameters required to run this check"
+    )
+    targets: Optional[str] = pydantic.Field(
+        default=None, description="The group to target when running this check, leave blank for global checks"
+    )
 
 
 class InfrahubPythonTransformConfig(pydantic.BaseModel):


### PR DESCRIPTION
Add parameters and targets. If targets is empty this will be a global check, otherwise it will target a specific group.

Also introduces InfrahubCheckInitializer, this is to provide information to the check that user created code could act upon. For now it contains information about which proposed change (if any) triggered the check to run. The reason for this is to support that use case with checking something within an external system such as ServiceNow to see if a given proposed change has been approved. We don't yet inject the proposed change into the check that will come in a follow up PR.

Related to #1049, will move out User checks from the RepositoryValidators as a next step and also add the ability to target groups of devices for these checks.