### PR TITLE
Add missing documentation for infrahubctl and automate rendering

### DIFF
--- a/docs/infrahubctl/infrahubctl-render.md
+++ b/docs/infrahubctl/infrahubctl-render.md
@@ -1,0 +1,23 @@
+# `infrahubctl render`
+
+Render a local Jinja Template (RFile) for debugging purpose.
+
+**Usage**:
+
+```console
+$ infrahubctl render [OPTIONS] RFILE [VARIABLES]...
+```
+
+**Arguments**:
+
+* `RFILE`: [required]
+* `[VARIABLES]...`: Variables to pass along with the query. Format key=value key=value.
+
+**Options**:
+
+* `--branch TEXT`: Branch on which to rendre the RFile.
+* `--debug / --no-debug`: [default: no-debug]
+* `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]
+* `--install-completion`: Install completion for the current shell.
+* `--show-completion`: Show completion for the current shell, to copy it or customize the installation.
+* `--help`: Show this message and exit.

--- a/docs/infrahubctl/infrahubctl-run.md
+++ b/docs/infrahubctl/infrahubctl-run.md
@@ -17,4 +17,9 @@ $ infrahubctl run [OPTIONS] SCRIPT
 * `--method TEXT`: [default: run]
 * `--debug / --no-debug`: [default: no-debug]
 * `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]
+* `--branch TEXT`: Branch on which to run the script.  [default: main]
+* `--concurrent INTEGER`: Maximum number of requets to execute at the same time.  [env var: INFRAHUBCTL_CONCURRENT_EXECUTION; default: 4]
+* `--timeout INTEGER`: Timeout in sec  [env var: INFRAHUBCTL_TIMEOUT; default: 60]
+* `--install-completion`: Install completion for the current shell.
+* `--show-completion`: Show completion for the current shell, to copy it or customize the installation.
 * `--help`: Show this message and exit.

--- a/python_sdk/infrahub_ctl/cli.py
+++ b/python_sdk/infrahub_ctl/cli.py
@@ -104,7 +104,7 @@ def identify_faulty_jinja_code(traceback: Traceback, nbr_context_lines: int = 3)
     return response
 
 
-@app.command()
+@app.command(name="render")
 def render(  # pylint: disable=too-many-branches,too-many-statements
     rfile: str,
     variables: Optional[List[str]] = typer.Argument(
@@ -220,7 +220,7 @@ def render(  # pylint: disable=too-many-branches,too-many-statements
     print(rendered_tpl)
 
 
-@app.command()
+@app.command(name="run")
 def run(
     script: Path,
     method: str = "run",

--- a/python_sdk/tests/unit/ctl/test_cli.py
+++ b/python_sdk/tests/unit/ctl/test_cli.py
@@ -9,3 +9,15 @@ def test_main_app():
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "[OPTIONS] COMMAND [ARGS]" in result.stdout
+
+
+def test_validate_all_commands_have_names():
+    assert app.registered_commands
+    for command in app.registered_commands:
+        assert command.name
+
+
+def test_validate_all_groups_have_names():
+    assert app.registered_groups
+    for group in app.registered_groups:
+        assert group.name

--- a/tasks/ctl.py
+++ b/tasks/ctl.py
@@ -20,16 +20,17 @@ NAMESPACE = "CTL"
 @task
 def generate_doc(context: Context):
     """Generate the documentation for infrahubctl using typer-cli."""
+    from infrahub_ctl.cli import app
 
-    CLI_COMMANDS = (
-        ("infrahub_ctl.branch", "infrahubctl branch", "infrahubctl-branch"),
-        ("infrahub_ctl.schema", "infrahubctl schema", "infrahubctl-schema"),
-        ("infrahub_ctl.validate", "infrahubctl validate", "infrahubctl-validate"),
-        ("infrahub_ctl.check", "infrahubctl check", "infrahubctl-check"),
-    )
     print(f" - [{NAMESPACE}] Generate CLI documentation")
-    for command in CLI_COMMANDS:
-        exec_cmd = f'typer  {command[0]} utils docs --name "{command[1]}" --output docs/infrahubctl/{command[2]}.md'
+    for cmd in app.registered_commands:
+        exec_cmd = f'typer --func {cmd.name} infrahub_ctl.cli utils docs --name "infrahubctl {cmd.name}"'
+        exec_cmd += f" --output docs/infrahubctl/infrahubctl-{cmd.name}.md"
+        with context.cd(ESCAPED_REPO_PATH):
+            context.run(exec_cmd)
+
+    for cmd in app.registered_groups:
+        exec_cmd = f'typer infrahub_ctl.{cmd.name} utils docs --name "infrahubctl {cmd.name}" --output docs/infrahubctl/infrahubctl-{cmd.name}.md'
         with context.cd(ESCAPED_REPO_PATH):
             context.run(exec_cmd)
 


### PR DESCRIPTION
Previously the commands had to be statically defined, with this change new commands would be picked up automatically so we don't miss commands in the future.

Fixes #1101 