### PR TITLE
Split backend unit and integration test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,7 +253,7 @@ jobs:
       needs.files-changed.outputs.backend == 'true'
     needs: ["files-changed", "yaml-lint", "python-lint"]
     runs-on: "runner-ubuntu-4-16"
-    timeout-minutes: 45
+    timeout-minutes: 30
     env:
       INFRAHUB_DB_TYPE: memgraph
     steps:


### PR DESCRIPTION
Run separate jobs for unit and integration tests to speed up the pipeline.

I left the linting jobs in the integration section as that job runs faster.