### PR TITLE
Remove if condition as we already have need

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,8 +167,7 @@ jobs:
     if: |
       always() && !cancelled() &&
       !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled') &&
-      needs.files-changed.outputs.sdk == 'true'
+      !contains(needs.*.result, 'cancelled')
     needs: ["python-sdk-unit-tests"]
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
I was getting some linting comments in my editor due to this.

![Screenshot 2023-11-24 at 16 44 19](https://github.com/opsmill/infrahub/assets/6694669/32cfffc0-4ed0-4476-8b5a-ccc2a3ce4c62)

As the job "needs" python-sdk-unit-tests I don't think we need to care about the changed files.

