### PR TITLE
Remove breakpoint

### DIFF
--- a/models/idempotent.py
+++ b/models/idempotent.py
@@ -119,5 +119,4 @@ async def run(client: InfrahubClient, log: logging.Logger, branch: str):
     # ax.set_axis_off()
     # plt.colorbar(pc, ax=ax)
     # list(reversed(list(nx.topological_sort(G))))
-    # breakpoint()
     # plt.show()


### PR DESCRIPTION
At times I search the codebase for breakpoint() if I've added some for debugging and I want to avoid finding this one in the list.