### PR TITLE
Add message to sync repositories and change schedule of git agent

### DIFF
--- a/backend/infrahub/cli/git_agent.py
+++ b/backend/infrahub/cli/git_agent.py
@@ -80,15 +80,7 @@ async def initialize_git_agent(service: InfrahubServices) -> None:
     await sync_remote_repositories(service=service)
 
 
-async def monitor_remote_activity(service: InfrahubServices, interval: int) -> None:
-    log.info("Monitoring remote repository for updates .. ")
-
-    while True:
-        await sync_remote_repositories(service=service)
-        await asyncio.sleep(interval)
-
-
-async def _start(debug: bool, interval: int, port: int) -> None:
+async def _start(debug: bool, port: int) -> None:
     """Start Infrahub Git Agent."""
 
     log_level = "DEBUG" if debug else "INFO"
@@ -124,7 +116,6 @@ async def _start(debug: bool, interval: int, port: int) -> None:
 
     tasks = [
         asyncio.create_task(subscribe_rpcs_queue(service=service)),
-        asyncio.create_task(monitor_remote_activity(service=service, interval=interval)),
     ]
 
     await asyncio.gather(*tasks)
@@ -132,7 +123,6 @@ async def _start(debug: bool, interval: int, port: int) -> None:
 
 @app.command()
 def start(
-    interval: int = typer.Option(10, help="Interval in sec between remote repositories update."),
     debug: bool = typer.Option(False, help="Enable advanced logging and troubleshooting"),
     config_file: str = typer.Option(
         "infrahub.toml", envvar="INFRAHUB_CONFIG", help="Location of the configuration file to use for Infrahub"
@@ -151,4 +141,4 @@ def start(
 
     config.load_and_exit(config_file_name=config_file)
 
-    aiorun(_start(interval=interval, debug=debug, port=port))
+    aiorun(_start(debug=debug, port=port))

--- a/backend/infrahub/message_bus/messages/__init__.py
+++ b/backend/infrahub/message_bus/messages/__init__.py
@@ -21,6 +21,7 @@ from .request_artifact_generate import RequestArtifactGenerate
 from .request_artifactdefinition_check import RequestArtifactDefinitionCheck
 from .request_artifactdefinition_generate import RequestArtifactDefinitionGenerate
 from .request_git_createbranch import RequestGitCreateBranch
+from .request_git_sync import RequestGitSync
 from .request_proposed_change_cancel import RequestProposedChangeCancel
 from .request_proposedchange_dataintegrity import RequestProposedChangeDataIntegrity
 from .request_proposedchange_refreshartifacts import RequestProposedChangeRefreshArtifacts
@@ -47,11 +48,12 @@ MESSAGE_MAP: Dict[str, Type[InfrahubMessage]] = {
     "git.file.get": GitFileGet,
     "git.repository.add": GitRepositoryAdd,
     "git.repository.merge": GitRepositoryMerge,
-    "request.git.create_branch": RequestGitCreateBranch,
     "refresh.registry.branches": RefreshRegistryBranches,
     "request.artifact.generate": RequestArtifactGenerate,
     "request.artifact_definition.check": RequestArtifactDefinitionCheck,
     "request.artifact_definition.generate": RequestArtifactDefinitionGenerate,
+    "request.git.create_branch": RequestGitCreateBranch,
+    "request.git.sync": RequestGitSync,
     "request.proposed_change.cancel": RequestProposedChangeCancel,
     "request.proposed_change.data_integrity": RequestProposedChangeDataIntegrity,
     "request.proposed_change.refresh_artifacts": RequestProposedChangeRefreshArtifacts,

--- a/backend/infrahub/message_bus/messages/request_git_sync.py
+++ b/backend/infrahub/message_bus/messages/request_git_sync.py
@@ -1,0 +1,5 @@
+from infrahub.message_bus import InfrahubMessage
+
+
+class RequestGitSync(InfrahubMessage):
+    """Request remote repositories to be synced."""

--- a/backend/infrahub/message_bus/operations/__init__.py
+++ b/backend/infrahub/message_bus/operations/__init__.py
@@ -26,6 +26,7 @@ COMMAND_MAP = {
     "git.repository.merge": git.repository.merge,
     "refresh.registry.branches": refresh.registry.branches,
     "request.git.create_branch": requests.git.create_branch,
+    "request.git.sync": requests.git.sync,
     "request.artifact.generate": requests.artifact.generate,
     "request.artifact_definition.check": requests.artifact_definition.check,
     "request.artifact_definition.generate": requests.artifact_definition.generate,

--- a/backend/infrahub/message_bus/operations/requests/git.py
+++ b/backend/infrahub/message_bus/operations/requests/git.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from infrahub.git.actions import sync_remote_repositories
 from infrahub.log import get_logger
 from infrahub.message_bus import messages
 from infrahub.services import InfrahubServices
@@ -7,7 +8,7 @@ from infrahub.services import InfrahubServices
 log = get_logger()
 
 
-async def create_branch(message: messages.RequestGitCreateBranch, service: InfrahubServices):
+async def create_branch(message: messages.RequestGitCreateBranch, service: InfrahubServices) -> None:
     """Request to the creation of git branches in available repositories."""
     log.info("Querying repositories for branch creation")
     repositories = await service.client.filters(kind="CoreRepository")
@@ -24,3 +25,11 @@ async def create_branch(message: messages.RequestGitCreateBranch, service: Infra
     for event in events:
         event.assign_meta(parent=message)
         await service.send(message=event)
+
+
+async def sync(
+    message: messages.RequestGitSync,  # pylint: disable=unused-argument
+    service: InfrahubServices,
+) -> None:
+    """Sync remote repositories."""
+    await sync_remote_repositories(service)

--- a/backend/infrahub/tasks/recurring.py
+++ b/backend/infrahub/tasks/recurring.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from infrahub.message_bus import messages
 from infrahub.worker import WORKER_IDENTITY
 
 from .registry import refresh_branches
@@ -22,3 +23,4 @@ async def resync_repositories(service: InfrahubServices) -> None:
         service.log.debug(
             f"Primary identity={primary_identity} matches my identity={WORKER_IDENTITY}. Posting sync of repo message."
         )
+        await service.send(message=messages.RequestGitSync())

--- a/docs/reference/infrahub-cli/infrahub-git-agent.md
+++ b/docs/reference/infrahub-cli/infrahub-git-agent.md
@@ -34,7 +34,6 @@ $ infrahub git-agent start [OPTIONS] [PORT]
 
 **Options**:
 
-* `--interval INTEGER`: Interval in sec between remote repositories update.  [default: 10]
 * `--debug / --no-debug`: Enable advanced logging and troubleshooting  [default: no-debug]
 * `--config-file TEXT`: Location of the configuration file to use for Infrahub  [env var: INFRAHUB_CONFIG; default: infrahub.toml]
 * `--help`: Show this message and exit.


### PR DESCRIPTION
* Adds a message to sync repositories that the primary API server is responsible for sending out
* Modify the schedule on the git-agents so they don't all sync remote repositories, only one worker will pick up this task

Future thoughts:

* Perhaps we should remove the startup sync of remote repositories from the git agent to avoid the same issue at startup and instead let the agent wait until the next message arrives
* A future change could also be to split this task into several messages so that request.git.sync would instead query the repositories and send a new message per repo so that the sync could be spread out across multiple agents

Fixes #1447