### PR TITLE
Update InfraRack schema to use Dropdown for status and role

### DIFF
--- a/models/infrastructure_extension_rack.yml
+++ b/models/infrastructure_extension_rack.yml
@@ -36,11 +36,11 @@ nodes:
         choices:
           - name: active
             label: Active
-            description: "Fonctional and ready for production"
+            description: "Functional and ready for production"
             color: "#009933"
           - name: planned
             label: Planned
-            description: "Not physically present yet."
+            description: "Not physically present yet"
             color: "#cc66ff"
         default_value: "active"
       - name: role


### PR DESCRIPTION
This PR updates the InfraRack schema to use Dropdown for status and role instead of the builtin models BuiltinStatus and BuiltinRole.
I mainly did it for testing but at some point that would be good to merge it

@BeArchiTek, do you think it will impact the sync engine ?