### PR TITLE
Add targeted checks for infrahubctl and enforce name

### DIFF
--- a/backend/tests/fixtures/repos/infrahub-demo-edge/.infrahub.yml
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge/.infrahub.yml
@@ -30,7 +30,9 @@ artifact_definitions:
     transformation: "device_startup"
 
 check_definitions:
-  - file_path: "checks/check_backbone_link_redundancy.py"
+  - name: "backbone_link_redundancy"
+    file_path: "checks/check_backbone_link_redundancy.py"
+    class_name: "InfrahubCheckBackboneLinkRedundancy"
 
 python_transforms:
   - file_path: "transforms/openconfig.py"

--- a/backend/tests/fixtures/repos/infrahub-demo-edge/checks/check_backbone_link_redundancy.py
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge/checks/check_backbone_link_redundancy.py
@@ -28,8 +28,3 @@ class InfrahubCheckBackboneLinkRedundancy(InfrahubCheck):
                     object_id=site_id_by_name[site_name],
                     object_type="site",
                 )
-
-        # rprint(backbone_links_per_site)
-
-
-INFRAHUB_CHECKS = [InfrahubCheckBackboneLinkRedundancy]

--- a/docs/infrahubctl/infrahubctl-check.md
+++ b/docs/infrahubctl/infrahubctl-check.md
@@ -38,5 +38,5 @@ $ infrahubctl check run [OPTIONS] [PATH]
 * `--debug / --no-debug`: [default: no-debug]
 * `--format-json / --no-format-json`: [default: no-format-json]
 * `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]
-* `--check-file TEXT`
+* `--name TEXT`
 * `--help`: Show this message and exit.

--- a/python_sdk/infrahub_ctl/check.py
+++ b/python_sdk/infrahub_ctl/check.py
@@ -3,17 +3,21 @@ import logging
 import os
 import sys
 from asyncio import run as aiorun
+from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
-from typing import List, Optional, TypedDict
+from typing import Dict, List, Optional
 
 import typer
 from rich.logging import RichHandler
 
 from infrahub_ctl import config
 from infrahub_ctl.client import initialize_client
+from infrahub_ctl.exceptions import QueryNotFoundError
 from infrahub_ctl.repository import get_repository_config
+from infrahub_ctl.utils import execute_graphql_query
 from infrahub_sdk import InfrahubClient
+from infrahub_sdk.checks import InfrahubCheck
 from infrahub_sdk.schema import InfrahubCheckDefinitionConfig
 
 app = typer.Typer()
@@ -22,9 +26,14 @@ app = typer.Typer()
 INFRAHUB_CHECK_VARIABLE_TO_IMPORT = "INFRAHUB_CHECKS"
 
 
-class CheckModule(TypedDict):
+@dataclass
+class CheckModule:
     name: str
     module: ModuleType
+    definition: InfrahubCheckDefinitionConfig
+
+    def get_check(self) -> InfrahubCheck:
+        return getattr(self.module, self.definition.class_name)
 
 
 @app.callback()
@@ -41,7 +50,7 @@ def run(
     debug: bool = False,
     format_json: bool = False,
     config_file: str = typer.Option(config.DEFAULT_CONFIG_FILE, envvar=config.ENVVAR_CONFIG_FILE),
-    check_file: Optional[str] = None,
+    name: Optional[str] = None,
 ) -> None:
     """Locate and execute all checks under the defined path."""
 
@@ -52,39 +61,84 @@ def run(
     if not config.SETTINGS:
         config.load_and_exit(config_file=config_file)
 
-    check_definitions = get_available_checks(check_file=check_file)
+    check_definitions = get_available_checks(name=name)
     check_modules = get_modules(check_definitions=check_definitions)
     aiorun(run_checks(check_modules=check_modules, format_json=format_json, path=path, branch=branch))
 
 
 async def run_check(
-    check_module: CheckModule, client: InfrahubClient, format_json: bool, path: str, branch: Optional[str] = None
+    check_module: CheckModule,
+    client: InfrahubClient,
+    format_json: bool,
+    path: str,
+    branch: Optional[str] = None,
+    params: Optional[Dict] = None,
 ) -> bool:
-    module_name = check_module["name"]
-    module = check_module["module"]
+    module_name = check_module.name
     output = "stdout" if format_json else None
     log = logging.getLogger("infrahub")
     passed = True
-    for check_class in getattr(module, INFRAHUB_CHECK_VARIABLE_TO_IMPORT):
-        check = await check_class.init(client=client, output=output, root_directory=path, branch=branch)
-        try:
-            passed = await check.run()
-
-            if passed:
-                if not format_json:
-                    log.info(f"{module_name}::{check}: [green]PASSED[/]", extra={"markup": True})
-            else:
-                passed = False
-                if not format_json:
-                    log.error(f"{module_name}::{check}: [red]FAILED[/]", extra={"markup": True})
-
-                    for log_message in check.logs:
-                        log.error(f"  {log_message['message']}")
-
-        except Exception as exc:  # pylint: disable=broad-except
-            log.warning(f"{module_name}::{check}: An error occured during execution ({exc})")
+    check_class = check_module.get_check()
+    check = await check_class.init(client=client, params=params, output=output, root_directory=path, branch=branch)
+    param_log = f" - {params}" if params else ""
+    try:
+        check.data = {
+            "data": execute_graphql_query(query=check.query, variables_dict=check.params, branch=branch, debug=False)
+        }
+        passed = await check.run()
+        if passed:
+            if not format_json:
+                log.info(f"{module_name}::{check}: [green]PASSED[/]{param_log}", extra={"markup": True})
+        else:
             passed = False
+            if not format_json:
+                log.error(f"{module_name}::{check}: [red]FAILED[/]{param_log}", extra={"markup": True})
+
+                for log_message in check.logs:
+                    log.error(f"  {log_message['message']}")
+
+    except QueryNotFoundError as exc:
+        log.warning(f"{module_name}::{check}: unable to find query ({str(exc)})")
+        passed = False
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        log.warning(f"{module_name}::{check}: An error occured during execution ({exc})")
+        passed = False
+
     return passed
+
+
+async def run_targeted_check(
+    check_module: CheckModule, client: InfrahubClient, format_json: bool, path: str, branch: Optional[str] = None
+) -> bool:
+    filters = {}
+    param_value = list(check_module.definition.parameters.values())
+    if param_value:
+        filters[param_value[0]] = check_module.definition.targets
+
+    param_key = list(check_module.definition.parameters.keys())
+    identifier = None
+    if param_key:
+        identifier = param_key[0]
+
+    check_summary: List[bool] = []
+    targets = await client.get(kind="CoreGroup", include=["members"], **filters)
+    await targets.members.fetch()
+    for member in targets.members.peers:
+        check_parameter = {}
+        if identifier:
+            attribute = getattr(member.peer, identifier)
+            check_parameter = {identifier: attribute.value}
+        result = await run_check(
+            check_module=check_module,
+            client=client,
+            format_json=format_json,
+            path=path,
+            branch=branch,
+            params=check_parameter,
+        )
+        check_summary.append(result)
+
+    return all(check_summary)
 
 
 async def run_checks(
@@ -95,10 +149,16 @@ async def run_checks(
     check_summary: List[bool] = []
     client = await initialize_client()
     for check_module in check_modules:
-        result = await run_check(
-            check_module=check_module, client=client, format_json=format_json, path=path, branch=branch
-        )
-        check_summary.append(result)
+        if check_module.definition.targets:
+            result = await run_targeted_check(
+                check_module=check_module, client=client, format_json=format_json, path=path, branch=branch
+            )
+            check_summary.append(result)
+        else:
+            result = await run_check(
+                check_module=check_module, client=client, format_json=format_json, path=path, branch=branch
+            )
+            check_summary.append(result)
 
     if not check_modules:
         if not format_json:
@@ -127,27 +187,27 @@ def get_modules(check_definitions: List[InfrahubCheckDefinitionConfig]) -> List[
             log.error(f"Unable to load {check_definition.file_path}")
             continue
 
-        if INFRAHUB_CHECK_VARIABLE_TO_IMPORT not in dir(module):
-            log.error(f"{INFRAHUB_CHECK_VARIABLE_TO_IMPORT} variable not find in {check_definition.file_path}")
+        if check_definition.class_name not in dir(module):
+            log.error(f"{check_definition.class_name} class not found in {check_definition.file_path}")
             continue
-        modules.append({"name": module_name, "module": module})
+        modules.append(CheckModule(name=module_name, module=module, definition=check_definition))
 
     return modules
 
 
-def get_available_checks(check_file: Optional[str] = None) -> List[InfrahubCheckDefinitionConfig]:
+def get_available_checks(name: Optional[str] = None) -> List[InfrahubCheckDefinitionConfig]:
     repository_config = get_repository_config(Path(config.INFRAHUB_REPO_CONFIG_FILE))
     log = logging.getLogger("infrahub")
-    if check_file:
+    if name:
         matched = [
             check_definition
             for check_definition in repository_config.check_definitions
-            if check_definition.file_path == check_file
+            if check_definition.name == name
         ]
         if matched:
             return matched
-
-        log.error(f"Unable to find check definition for {check_file} in .infrahub.yml")
+        available_checks = [check_definition.name for check_definition in repository_config.check_definitions]
+        log.error(f"Unable to find check definition for {name} in .infrahub.yml {available_checks}")
         sys.exit(1)
 
     return repository_config.check_definitions

--- a/python_sdk/infrahub_ctl/cli.py
+++ b/python_sdk/infrahub_ctl/cli.py
@@ -7,7 +7,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 import jinja2
 import typer
@@ -19,12 +19,12 @@ from rich.traceback import Frame, Traceback
 import infrahub_ctl.config as config
 from infrahub_ctl.branch import app as branch_app
 from infrahub_ctl.check import app as check_app
-from infrahub_ctl.client import initialize_client, initialize_client_sync
+from infrahub_ctl.client import initialize_client
 from infrahub_ctl.exceptions import InfrahubTransformNotFoundError, QueryNotFoundError
 from infrahub_ctl.repository import get_repository_config
 from infrahub_ctl.schema import app as schema
 from infrahub_ctl.utils import (
-    find_graphql_query,
+    execute_graphql_query,
     parse_cli_vars,
 )
 from infrahub_ctl.validate import app as validate_app
@@ -123,26 +123,6 @@ def get_transform_class_instance(
         raise InfrahubTransformNotFoundError(name=transform_class_name)
 
     return transform_instance
-
-
-def execute_graphql_query(
-    query: str, variables_dict: Dict[str, Any], branch: Optional[str] = None, debug: bool = False
-) -> str:
-    query_str = find_graphql_query(query)
-
-    client = initialize_client_sync()
-    response = client.execute_graphql(
-        query=query_str,
-        branch_name=branch,
-        variables=variables_dict,
-        raise_for_error=False,
-    )
-
-    if debug:
-        message = ("-" * 40, f"Response for GraphQL Query {query}", response, "-" * 40)
-        console.print("\n".join(message))
-
-    return response
 
 
 def render_jinja2_template(template_path: Path, variables: Dict[str, str], data: str) -> str:

--- a/python_sdk/infrahub_ctl/utils.py
+++ b/python_sdk/infrahub_ctl/utils.py
@@ -1,7 +1,7 @@
 import glob
 import os
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import pendulum
 from pendulum.datetime import DateTime
@@ -9,6 +9,29 @@ from rich.console import Console
 from rich.markup import escape
 
 from infrahub_ctl.exceptions import QueryNotFoundError
+
+from .client import initialize_client_sync
+
+
+def execute_graphql_query(
+    query: str, variables_dict: Dict[str, Any], branch: Optional[str] = None, debug: bool = False
+) -> Dict:
+    console = Console()
+    query_str = find_graphql_query(query)
+
+    client = initialize_client_sync()
+    response = client.execute_graphql(
+        query=query_str,
+        branch_name=branch,
+        variables=variables_dict,
+        raise_for_error=False,
+    )
+
+    if debug:
+        message = ("-" * 40, f"Response for GraphQL Query {query}", response, "-" * 40)
+        console.print("\n".join(message))
+
+    return response
 
 
 def print_graphql_errors(console: Console, errors: List) -> None:

--- a/python_sdk/infrahub_sdk/checks.py
+++ b/python_sdk/infrahub_sdk/checks.py
@@ -38,6 +38,7 @@ class InfrahubCheck:
         root_directory: str = "",
         output: Optional[str] = None,
         initializer: Optional[InfrahubCheckInitializer] = None,
+        params: Optional[Dict] = None,
     ):
         self.data: Dict = {}
         self.git: Optional[Repo] = None
@@ -49,6 +50,7 @@ class InfrahubCheck:
         self.output = output
 
         self.branch = branch
+        self.params = params or {}
 
         self.root_directory = root_directory or os.getcwd()
 
@@ -128,8 +130,12 @@ class InfrahubCheck:
 
     async def collect_data(self) -> None:
         """Query the result of the GraphQL Query defined in self.query and store the result in self.data"""
+        if self.data:
+            return
 
-        data = await self.client.query_gql_query(name=self.query, branch_name=self.branch_name, rebase=self.rebase)
+        data = await self.client.query_gql_query(
+            name=self.query, branch_name=self.branch_name, params=self.params, rebase=self.rebase
+        )
         self.data = data
 
     async def run(self) -> bool:

--- a/python_sdk/infrahub_sdk/schema.py
+++ b/python_sdk/infrahub_sdk/schema.py
@@ -63,6 +63,7 @@ class InfrahubRepositoryRFileConfig(pydantic.BaseModel):
 
 
 class InfrahubCheckDefinitionConfig(pydantic.BaseModel):
+    name: str = pydantic.Field(..., description="The name of the Check Definition")
     file_path: Path = pydantic.Field(..., description="The file within the repo with the check code.")
     parameters: Dict[str, Any] = pydantic.Field(
         default_factory=dict, description="The input parameters required to run this check"
@@ -70,6 +71,7 @@ class InfrahubCheckDefinitionConfig(pydantic.BaseModel):
     targets: Optional[str] = pydantic.Field(
         default=None, description="The group to target when running this check, leave blank for global checks"
     )
+    class_name: str = pydantic.Field(default="Check", description="The name of the check class to run.")
 
 
 class InfrahubPythonTransformConfig(pydantic.BaseModel):


### PR DESCRIPTION
Related to #1049.

As described in #1559 this PR removes the notion of having a INFRAHUB_CHECKS instead users will have to specify each class to import within .infrahub.yml. This is to provide consistency and clarity for the .infrahub.yml file as well as simplify the importer.

The other benefit of this is that it would allow us to reuse the same class for different checks with different targets. 

Also from infrahubctl we now support running checks on multiple targets. An example of what this looks like:

```sh
❯ infrahubctl check run --name RpgCheck
[11:29:58] ERROR    run_rpg::RpgCheck: FAILED - {'name': 'Degarion'}                                                                                                                                                                                                                                                                                                                                                          check.py:95
           ERROR      Only wizards are suitable for this adventure                                                                                                                                                                                                                                                                                                                                                            check.py:98
           INFO     run_rpg::RpgCheck: PASSED - {'name': 'Susitara'}                                                                                                                                                                                                                                                                                                                                                          check.py:91
           INFO     run_rpg::RpgCheck: PASSED - {'name': 'Suvi'}                                                                                                                                                                                                                                                                                                                                                              check.py:91
```

Alternatively when you run all the checks in the repository:

```sh
❯ infrahubctl check run
[11:30:35] ERROR    black_tags::BlackTag: FAILED                                                                                                                                                                                                                                                                                                                                                                              check.py:95
           ERROR      Red tag was found                                                                                                                                                                                                                                                                                                                                                                                       check.py:98
           ERROR      The black tag was not found                                                                                                                                                                                                                                                                                                                                                                             check.py:98
           INFO     red_tags::RedTag: PASSED                                                                                                                                                                                                                                                                                                                                                                                  check.py:91
[11:30:37] ERROR    run_rpg::RpgCheck: FAILED - {'name': 'Degarion'}                                                                                                                                                                                                                                                                                                                                                          check.py:95
           ERROR      Only wizards are suitable for this adventure                                                                                                                                                                                                                                                                                                                                                            check.py:98
           INFO     run_rpg::RpgCheck: PASSED - {'name': 'Susitara'}                                                                                                                                                                                                                                                                                                                                                          check.py:91
           INFO     run_rpg::RpgCheck: PASSED - {'name': 'Suvi'}                                                                                                                                                                                                                                                                                                                                                              check.py:91
```

Another change in this PR is that the GraphQL query is no longer required to exist in Infrahub when running checks, so it works in the same way as when rendering a transform from infrahubctl. Due to this I moved the code to read the query.

Here the RpgCheck is using a group with three members. In this iteration the backend still doesn't support running checks againt multiple targets. That will come as a followup once this is merged.