### PR TITLE
Modify Python transforms to require a name in .infrahub.yml

### DIFF
--- a/backend/infrahub/git/repository.py
+++ b/backend/infrahub/git/repository.py
@@ -24,8 +24,11 @@ from infrahub_sdk import (
     InfrahubRepositoryConfig,
     ValidationError,
 )
-from infrahub_sdk.schema import InfrahubCheckDefinitionConfig, InfrahubRepositoryRFileConfig
-from infrahub_sdk.transforms import INFRAHUB_TRANSFORM_VARIABLE_TO_IMPORT
+from infrahub_sdk.schema import (
+    InfrahubCheckDefinitionConfig,
+    InfrahubPythonTransformConfig,
+    InfrahubRepositoryRFileConfig,
+)
 from infrahub_sdk.utils import YamlFile, compare_lists
 from pydantic import BaseModel, validator
 from pydantic import ValidationError as PydanticValidationError
@@ -1464,6 +1467,7 @@ class InfrahubRepository(BaseModel):  # pylint: disable=too-many-public-methods
                     branch_name=branch_name,
                     module=module,
                     file_path=file_info.relative_path_file,
+                    transform=transform,
                 )
             )
 
@@ -1542,36 +1546,36 @@ class InfrahubRepository(BaseModel):  # pylint: disable=too-many-public-methods
         return checks
 
     async def get_python_transforms(
-        self, branch_name: str, module: types.ModuleType, file_path: str
+        self, branch_name: str, module: types.ModuleType, file_path: str, transform: InfrahubPythonTransformConfig
     ) -> List[TransformPythonInformation]:
-        if INFRAHUB_TRANSFORM_VARIABLE_TO_IMPORT not in dir(module):
+        if transform.class_name not in dir(module):
             return []
 
         transforms = []
-        for transform_class in getattr(module, INFRAHUB_TRANSFORM_VARIABLE_TO_IMPORT):
-            graphql_query = await self.client.get(
-                kind="CoreGraphQLQuery", branch=branch_name, id=str(transform_class.query), populate_store=True
+        transform_class = getattr(module, transform.class_name)
+        graphql_query = await self.client.get(
+            kind="CoreGraphQLQuery", branch=branch_name, id=str(transform_class.query), populate_store=True
+        )
+        try:
+            transforms.append(
+                TransformPythonInformation(
+                    name=transform.name,
+                    repository=str(self.id),
+                    class_name=transform.class_name,
+                    transform_class=transform_class,
+                    file_path=file_path,
+                    query=str(graphql_query.id),
+                    timeout=transform_class.timeout,
+                    rebase=transform_class.rebase,
+                    url=transform_class.url,
+                )
             )
-            try:
-                transforms.append(
-                    TransformPythonInformation(
-                        name=transform_class.__name__,
-                        repository=str(self.id),
-                        class_name=transform_class.__name__,
-                        transform_class=transform_class,
-                        file_path=file_path,
-                        query=str(graphql_query.id),
-                        timeout=transform_class.timeout,
-                        rebase=transform_class.rebase,
-                        url=transform_class.url,
-                    )
-                )
 
-            except Exception as exc:  # pylint: disable=broad-exception-caught
-                LOGGER.error(
-                    f"{self.name} | An error occured while processing the PythonTransform {transform_class.__name__} from {file_path} : {exc} "
-                )
-                continue
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            LOGGER.error(
+                f"{self.name} | An error occured while processing the PythonTransform {transform.name} from {file_path} : {exc} "
+            )
+
         return transforms
 
     async def create_python_check_definition(self, branch_name: str, check: CheckDefinitionInformation) -> InfrahubNode:

--- a/backend/tests/fixtures/repos/infrahub-demo-edge/.infrahub.yml
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge/.infrahub.yml
@@ -19,7 +19,7 @@ artifact_definitions:
       device: "name__value"
     content_type: "application/json"
     targets: "arista_devices"
-    transformation: "OCInterfaces"
+    transformation: "oc_interfaces"
 
   - name: "Startup Config for Edge devices"
     artifact_name: "startup-config"
@@ -35,4 +35,9 @@ check_definitions:
     class_name: "InfrahubCheckBackboneLinkRedundancy"
 
 python_transforms:
-  - file_path: "transforms/openconfig.py"
+  - name: oc_interfaces
+    class_name: OCInterfaces
+    file_path: "transforms/openconfig.py"
+  - name: oc_bgp
+    class_name: OCBGPNeighbors
+    file_path: "transforms/openconfig.py"

--- a/backend/tests/fixtures/repos/infrahub-demo-edge/transforms/openconfig.py
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge/transforms/openconfig.py
@@ -78,6 +78,3 @@ class OCBGPNeighbors(InfrahubTransform):
             response_payload["openconfig-bgp:neighbors"]["neighbor"].append(session_data)
 
         return response_payload
-
-
-INFRAHUB_TRANSFORMS = [OCInterfaces, OCBGPNeighbors]

--- a/docs/infrahubctl/infrahubctl-transform.md
+++ b/docs/infrahubctl/infrahubctl-transform.md
@@ -18,6 +18,7 @@ $ infrahubctl transform [OPTIONS] [TRANSFORM_NAME] [VARIABLES]...
 * `--branch TEXT`: Branch on which to run the transformation
 * `--debug / --no-debug`: [default: no-debug]
 * `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]
+* `--list`: Show available transforms
 * `--install-completion`: Install completion for the current shell.
 * `--show-completion`: Show completion for the current shell, to copy it or customize the installation.
 * `--help`: Show this message and exit.

--- a/python_sdk/infrahub_ctl/cli.py
+++ b/python_sdk/infrahub_ctl/cli.py
@@ -7,7 +7,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import jinja2
 import typer
@@ -23,6 +23,7 @@ from infrahub_ctl.client import initialize_client
 from infrahub_ctl.exceptions import InfrahubTransformNotFoundError, QueryNotFoundError
 from infrahub_ctl.repository import get_repository_config
 from infrahub_ctl.schema import app as schema
+from infrahub_ctl.transform import list_transforms
 from infrahub_ctl.utils import (
     execute_graphql_query,
     parse_cli_vars,
@@ -102,25 +103,19 @@ def identify_faulty_jinja_code(traceback: Traceback, nbr_context_lines: int = 3)
     return response
 
 
-def get_transform_class_instance(
-    transform_class_name: str, python_transforms: List[InfrahubPythonTransformConfig]
-) -> InfrahubTransform:
-    for transform_config in python_transforms:
-        try:
-            spec = importlib.util.spec_from_file_location(transform_class_name, transform_config.file_path)
-            module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)
+def get_transform_class_instance(transform_config: InfrahubPythonTransformConfig) -> InfrahubTransform:
+    try:
+        spec = importlib.util.spec_from_file_location(transform_config.class_name, transform_config.file_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
 
-            # Get the specified class from the module
-            transform_class = getattr(module, transform_class_name)
+        # Get the specified class from the module
+        transform_class = getattr(module, transform_config.class_name)
 
-            # Create an instance of the class
-            transform_instance = transform_class()
-            break
-        except (FileNotFoundError, AttributeError):
-            continue
-    else:
-        raise InfrahubTransformNotFoundError(name=transform_class_name)
+        # Create an instance of the class
+        transform_instance = transform_class()
+    except (FileNotFoundError, AttributeError) as exc:
+        raise InfrahubTransformNotFoundError(name=transform_config.name) from exc
 
     return transform_instance
 
@@ -164,7 +159,7 @@ def find_rfile_in_repository_config(
     return filtered[0]
 
 
-def _run_transform(query: str, variables: List[str], transformer: Callable, branch: str, debug: bool):
+def _run_transform(query: str, variables: Dict[str, Any], transformer: Callable, branch: str, debug: bool):
     branch = get_branch(branch)
 
     try:
@@ -228,6 +223,7 @@ def transform(
     branch: str = typer.Option(None, help="Branch on which to run the transformation"),
     debug: bool = False,
     config_file: str = typer.Option(config.DEFAULT_CONFIG_FILE, envvar=config.ENVVAR_CONFIG_FILE),
+    list_available: bool = typer.Option(False, "--list", help="Show available transforms"),
 ) -> None:
     """Render a local transform (TransformPython) for debugging purpose."""
 
@@ -237,14 +233,29 @@ def transform(
     variables_dict = parse_cli_vars(variables)
     repository_config = get_repository_config(Path(config.INFRAHUB_REPO_CONFIG_FILE))
 
+    if list_available:
+        list_transforms(config=repository_config)
+        return
+
+    matched = [transform for transform in repository_config.python_transforms if transform.name == transform_name]
+
+    if not matched:
+        console.print(f"[red]Unable to find requested transform: {transform_name}")
+        list_transforms(config=repository_config)
+        return
+
+    transform_config = matched[0]
+
     try:
-        transform_instance = get_transform_class_instance(transform_name, repository_config.python_transforms)
+        transform_instance = get_transform_class_instance(transform_config=transform_config)
     except InfrahubTransformNotFoundError as exc:
-        console.print(f"Unable to load {transform} from python_transforms")
+        console.print(f"Unable to load {transform_name} from python_transforms")
         raise typer.Exit(1) from exc
 
     transformer = functools.partial(transform_instance.transform)
-    result = _run_transform(transform_instance.query, variables_dict, transformer, branch, debug)
+    result = _run_transform(
+        query=transform_instance.query, variables=variables_dict, transformer=transformer, branch=branch, debug=debug
+    )
     console.print(json.dumps(result, indent=2))
 
 

--- a/python_sdk/infrahub_ctl/transform.py
+++ b/python_sdk/infrahub_ctl/transform.py
@@ -1,0 +1,11 @@
+from rich.console import Console
+
+from infrahub_sdk.schema import InfrahubRepositoryConfig
+
+
+def list_transforms(config: InfrahubRepositoryConfig) -> None:
+    console = Console()
+    console.print(f"Python transforms defined in repository: {len(config.python_transforms)}")
+
+    for transform in config.python_transforms:
+        console.print(f"{transform.name} ({transform.file_path}::{transform.class_name})")

--- a/python_sdk/infrahub_sdk/schema.py
+++ b/python_sdk/infrahub_sdk/schema.py
@@ -75,7 +75,9 @@ class InfrahubCheckDefinitionConfig(pydantic.BaseModel):
 
 
 class InfrahubPythonTransformConfig(pydantic.BaseModel):
+    name: str = pydantic.Field(..., description="The name of the Transform")
     file_path: Path = pydantic.Field(..., description="The file within the repo with the transform code.")
+    class_name: str = pydantic.Field(default="Transform", description="The name of the transform class to run.")
 
 
 class InfrahubRepositoryConfig(pydantic.BaseModel):


### PR DESCRIPTION
Related to #1559 and done in preparation for #1338. 

Changes infrahubctl so that you can specify a given name to the transforms, also adds an option to list available transforms in the current repo using infrahubctl.