### PR TITLE
Docs: Fix broken headers in reference

### DIFF
--- a/docs/_templates/schema/attribute.j2
+++ b/docs/_templates/schema/attribute.j2
@@ -1,9 +1,9 @@
-<!-- vale off -->
 ---
 label: Attribute
 layout: default
 order: 800
 ---
+<!-- vale off -->
 {% macro attribute_constraints(attr) -%}
 {% if attr.regex %} Regex: `{{attr.regex}}`{% endif %}{% if attr.regex and (attr.min_length or attr.max_length) %}<br>{% endif %}{% if attr.min_length or attr.max_length %} Length: min {{attr.min_length | default("-")}}, max {{attr.max_length | default("-")}}{% endif %}
 {%- endmacro %}

--- a/docs/_templates/schema/generic.j2
+++ b/docs/_templates/schema/generic.j2
@@ -1,9 +1,9 @@
-<!-- vale off -->
 ---
 label: Generic
 layout: default
 order: 600
 ---
+<!-- vale off -->
 {% macro attribute_constraints(attr) -%}
 {% if attr.regex %} Regex: `{{attr.regex}}`{% endif %}{% if attr.regex and (attr.min_length or attr.max_length) %}<br>{% endif %}{% if attr.min_length or attr.max_length %} Length: min {{attr.min_length | default("-")}}, max {{attr.max_length | default("-")}}{% endif %}
 {%- endmacro %}

--- a/docs/_templates/schema/node.j2
+++ b/docs/_templates/schema/node.j2
@@ -1,9 +1,9 @@
-<!-- vale off -->
 ---
 label: Node
 layout: default
 order: 900
 ---
+<!-- vale off -->
 {% macro attribute_constraints(attr) -%}
 {% if attr.regex %} Regex: `{{attr.regex}}`{% endif %}{% if attr.regex and (attr.min_length or attr.max_length) %}<br>{% endif %}{% if attr.min_length or attr.max_length %} Length: min {{attr.min_length | default("-")}}, max {{attr.max_length | default("-")}}{% endif %}
 {%- endmacro %}

--- a/docs/_templates/schema/relationship.j2
+++ b/docs/_templates/schema/relationship.j2
@@ -1,9 +1,9 @@
-<!-- vale off -->
 ---
 label: Relationship
 layout: default
 order: 700
 ---
+<!-- vale off -->
 {% macro attribute_constraints(attr) -%}
 {% if attr.regex %} Regex: `{{attr.regex}}`{% endif %}{% if attr.regex and (attr.min_length or attr.max_length) %}<br>{% endif %}{% if attr.min_length or attr.max_length %} Length: min {{attr.min_length | default("-")}}, max {{attr.max_length | default("-")}}{% endif %}
 {%- endmacro %}

--- a/docs/reference/schema/attribute.md
+++ b/docs/reference/schema/attribute.md
@@ -1,9 +1,9 @@
-<!-- vale off -->
 ---
 label: Attribute
 layout: default
 order: 800
 ---
+<!-- vale off -->
 
 
 

--- a/docs/reference/schema/generic.md
+++ b/docs/reference/schema/generic.md
@@ -1,9 +1,9 @@
-<!-- vale off -->
 ---
 label: Generic
 layout: default
 order: 600
 ---
+<!-- vale off -->
 
 
 

--- a/docs/reference/schema/node.md
+++ b/docs/reference/schema/node.md
@@ -1,9 +1,9 @@
-<!-- vale off -->
 ---
 label: Node
 layout: default
 order: 900
 ---
+<!-- vale off -->
 
 
 

--- a/docs/reference/schema/relationship.md
+++ b/docs/reference/schema/relationship.md
@@ -1,9 +1,9 @@
-<!-- vale off -->
 ---
 label: Relationship
 layout: default
 order: 700
 ---
+<!-- vale off -->
 
 
 


### PR DESCRIPTION
Seems like the rule to ignore vale got in the way of Retype when rentering the page so the metadata turned out incorrect.