### PR TITLE
Disable yamllint for "on" keyword in publish python sdk CI workflow

### DIFF
--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -1,7 +1,7 @@
 ---
 name: Publish Infrahub Python SDK
 
-on:
+on:  # yamllint disable rule:truthy
   push:
     tags:
       - "python-sdk-v*"


### PR DESCRIPTION
Github actions "on" keyword seems to trigger yamllints truthy rule. 
Disabling the rule on the line with they keyword.

https://github.com/adrienverge/yamllint/issues/430