### PR TITLE
Move infrahub devonctainer 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,8 @@
 {
     "name": "infrahub",
     "build": {
-        "dockerfile": "../Dockerfile",
-        "context": ".."
+        "dockerfile": "./Dockerfile",
+        "context": "."
     },
     "customizations": {
         "settings": {


### PR DESCRIPTION
Follow up of #1778 fixes.

Move infrahub bare-bones configuration directly under `.devcontainer` to use it as default configuration option