### PR TITLE
Add support for webhooks

### DIFF
--- a/backend/infrahub/api/menu.py
+++ b/backend/infrahub/api/menu.py
@@ -117,7 +117,11 @@ async def get_menu(
         ],
     )
     admin = InterfaceMenu(
-        title="Admin", children=[InterfaceMenu(title="Accounts", path="/objects/CoreAccount", icon="mdi:account")]
+        title="Admin",
+        children=[
+            InterfaceMenu(title="Accounts", path="/objects/CoreAccount", icon="mdi:account"),
+            InterfaceMenu(title="Webhook", path="/objects/CoreWebhook", icon="mdi:webhook"),
+        ],
     )
 
     return [objects, groups, unified_storage, change_control, deployment, admin]

--- a/backend/infrahub/core/schema.py
+++ b/backend/infrahub/core/schema.py
@@ -2255,5 +2255,28 @@ core_models = {
                 },
             ],
         },
+        {
+            "name": "Webhook",
+            "namespace": "Core",
+            "description": "A webhook that connects to an external integration",
+            "label": "Webhook",
+            "default_filter": "name__value",
+            "order_by": ["name__value"],
+            "display_labels": ["name__value"],
+            "include_in_menu": False,
+            "branch": BranchSupportType.AGNOSTIC.value,
+            "attributes": [
+                {"name": "name", "kind": "Text", "unique": True},
+                {"name": "shared_key", "kind": "Password", "unique": False},
+                {"name": "description", "kind": "Text", "optional": True},
+                {"name": "url", "kind": "URL"},
+                {
+                    "name": "validate_certificates",
+                    "kind": "Boolean",
+                    "default_value": True,
+                    "optional": True,
+                },
+            ],
+        },
     ],
 }

--- a/backend/infrahub/message_bus/messages/__init__.py
+++ b/backend/infrahub/message_bus/messages/__init__.py
@@ -11,6 +11,7 @@ from .event_branch_delete import EventBranchDelete
 from .event_branch_merge import EventBranchMerge
 from .event_node_mutated import EventNodeMutated
 from .event_schema_update import EventSchemaUpdate
+from .event_worker_newprimaryapi import EventWorkerNewPrimaryAPI
 from .finalize_validator_execution import FinalizeValidatorExecution
 from .git_branch_create import GitBranchCreate
 from .git_diff_namesonly import GitDiffNamesOnly
@@ -18,6 +19,7 @@ from .git_file_get import GitFileGet
 from .git_repository_add import GitRepositoryAdd
 from .git_repository_merge import GitRepositoryMerge
 from .refresh_registry_branches import RefreshRegistryBranches
+from .refresh_webhook_configuration import RefreshWebhookConfiguration
 from .request_artifact_generate import RequestArtifactGenerate
 from .request_artifactdefinition_check import RequestArtifactDefinitionCheck
 from .request_artifactdefinition_generate import RequestArtifactDefinitionGenerate
@@ -30,10 +32,12 @@ from .request_proposedchange_repositorychecks import RequestProposedChangeReposi
 from .request_proposedchange_schemaintegrity import RequestProposedChangeSchemaIntegrity
 from .request_repository_checks import RequestRepositoryChecks
 from .request_repository_userchecks import RequestRepositoryUserChecks
+from .send_webhook_event import SendWebhookEvent
 from .transform_jinja_template import TransformJinjaTemplate
 from .transform_python_data import TransformPythonData
 from .trigger_artifact_definition_generate import TriggerArtifactDefinitionGenerate
 from .trigger_proposed_change_cancel import TriggerProposedChangeCancel
+from .trigger_webhook_actions import TriggerWebhookActions
 
 MESSAGE_MAP: Dict[str, Type[InfrahubMessage]] = {
     "check.artifact.create": CheckArtifactCreate,
@@ -45,6 +49,7 @@ MESSAGE_MAP: Dict[str, Type[InfrahubMessage]] = {
     "event.branch.merge": EventBranchMerge,
     "event.node.mutated": EventNodeMutated,
     "event.schema.update": EventSchemaUpdate,
+    "event.worker.new_primary_api": EventWorkerNewPrimaryAPI,
     "finalize.validator.execution": FinalizeValidatorExecution,
     "git.branch.create": GitBranchCreate,
     "git.diff.names_only": GitDiffNamesOnly,
@@ -52,6 +57,7 @@ MESSAGE_MAP: Dict[str, Type[InfrahubMessage]] = {
     "git.repository.add": GitRepositoryAdd,
     "git.repository.merge": GitRepositoryMerge,
     "refresh.registry.branches": RefreshRegistryBranches,
+    "refresh.webhook.configuration": RefreshWebhookConfiguration,
     "request.artifact.generate": RequestArtifactGenerate,
     "request.artifact_definition.check": RequestArtifactDefinitionCheck,
     "request.artifact_definition.generate": RequestArtifactDefinitionGenerate,
@@ -64,10 +70,12 @@ MESSAGE_MAP: Dict[str, Type[InfrahubMessage]] = {
     "request.proposed_change.schema_integrity": RequestProposedChangeSchemaIntegrity,
     "request.repository.checks": RequestRepositoryChecks,
     "request.repository.user_checks": RequestRepositoryUserChecks,
+    "send.webhook.event": SendWebhookEvent,
     "transform.jinja.template": TransformJinjaTemplate,
     "transform.python.data": TransformPythonData,
     "trigger.artifact_definition.generate": TriggerArtifactDefinitionGenerate,
     "trigger.proposed_change.cancel": TriggerProposedChangeCancel,
+    "trigger.webhook.actions": TriggerWebhookActions,
 }
 
 

--- a/backend/infrahub/message_bus/messages/event_worker_newprimaryapi.py
+++ b/backend/infrahub/message_bus/messages/event_worker_newprimaryapi.py
@@ -1,0 +1,9 @@
+from pydantic.v1 import Field
+
+from infrahub.message_bus import InfrahubMessage
+
+
+class EventWorkerNewPrimaryAPI(InfrahubMessage):
+    """Sent on startup or when a new primary API worker is elected."""
+
+    worker_id: str = Field(..., description="The worker ID that got elected")

--- a/backend/infrahub/message_bus/messages/refresh_webhook_configuration.py
+++ b/backend/infrahub/message_bus/messages/refresh_webhook_configuration.py
@@ -1,0 +1,5 @@
+from infrahub.message_bus import InfrahubMessage
+
+
+class RefreshWebhookConfiguration(InfrahubMessage):
+    """Sent to indicate that configuration in the cache for webhooks should be refreshed."""

--- a/backend/infrahub/message_bus/messages/send_webhook_event.py
+++ b/backend/infrahub/message_bus/messages/send_webhook_event.py
@@ -1,0 +1,11 @@
+from pydantic.v1 import Field
+
+from infrahub.message_bus import InfrahubMessage
+
+
+class SendWebhookEvent(InfrahubMessage):
+    """Sent a webhook to an external source."""
+
+    webhook_id: str = Field(..., description="The unique ID of the webhook")
+    event_type: str = Field(..., description="The event type")
+    event_data: dict = Field(..., description="The data tied to the event")

--- a/backend/infrahub/message_bus/messages/trigger_webhook_actions.py
+++ b/backend/infrahub/message_bus/messages/trigger_webhook_actions.py
@@ -1,0 +1,10 @@
+from pydantic.v1 import Field
+
+from infrahub.message_bus import InfrahubMessage
+
+
+class TriggerWebhookActions(InfrahubMessage):
+    """Triggers webhooks to be sent for the given action"""
+
+    event_type: str = Field(..., description="The event type")
+    event_data: dict = Field(..., description="The webhook payload")

--- a/backend/infrahub/message_bus/operations/__init__.py
+++ b/backend/infrahub/message_bus/operations/__init__.py
@@ -2,7 +2,7 @@ import json
 
 from infrahub.log import get_logger
 from infrahub.message_bus import InfrahubResponse, messages
-from infrahub.message_bus.operations import check, event, finalize, git, refresh, requests, transform, trigger
+from infrahub.message_bus.operations import check, event, finalize, git, refresh, requests, send, transform, trigger
 from infrahub.message_bus.types import MessageTTL
 from infrahub.services import InfrahubServices
 from infrahub.tasks.check import set_check_status
@@ -19,6 +19,7 @@ COMMAND_MAP = {
     "event.branch.merge": event.branch.merge,
     "event.node.mutated": event.node.mutated,
     "event.schema.update": event.schema.update,
+    "event.worker.new_primary_api": event.worker.new_primary_api,
     "finalize.validator.execution": finalize.validator.execution,
     "git.branch.create": git.branch.create,
     "git.diff.names_only": git.diff.names_only,
@@ -26,6 +27,7 @@ COMMAND_MAP = {
     "git.repository.add": git.repository.add,
     "git.repository.merge": git.repository.merge,
     "refresh.registry.branches": refresh.registry.branches,
+    "refresh.webhook.configuration": refresh.webhook.configuration,
     "request.git.create_branch": requests.git.create_branch,
     "request.git.sync": requests.git.sync,
     "request.artifact.generate": requests.artifact.generate,
@@ -38,10 +40,12 @@ COMMAND_MAP = {
     "request.proposed_change.schema_integrity": requests.proposed_change.schema_integrity,
     "request.repository.checks": requests.repository.checks,
     "request.repository.user_checks": requests.repository.user_checks,
+    "send.webhook.event": send.webhook.event,
     "transform.jinja.template": transform.jinja.template,
     "transform.python.data": transform.python.data,
     "trigger.artifact_definition.generate": trigger.artifact_definition.generate,
     "trigger.proposed_change.cancel": trigger.proposed_change.cancel,
+    "trigger.webhook.actions": trigger.webhook.actions,
 }
 
 

--- a/backend/infrahub/message_bus/operations/event/__init__.py
+++ b/backend/infrahub/message_bus/operations/event/__init__.py
@@ -1,3 +1,3 @@
-from . import branch, node, schema
+from . import branch, node, schema, worker
 
-__all__ = ["branch", "node", "schema"]
+__all__ = ["branch", "node", "schema", "worker"]

--- a/backend/infrahub/message_bus/operations/event/node.py
+++ b/backend/infrahub/message_bus/operations/event/node.py
@@ -1,5 +1,7 @@
+from typing import List
+
 from infrahub.log import get_logger
-from infrahub.message_bus import messages
+from infrahub.message_bus import InfrahubMessage, messages
 from infrahub.services import InfrahubServices
 
 log = get_logger()
@@ -7,7 +9,7 @@ log = get_logger()
 
 async def mutated(
     message: messages.EventNodeMutated,
-    service: InfrahubServices,  # pylint: disable=unused-argument
+    service: InfrahubServices,
 ) -> None:
     log.debug(
         "Mutation on node",
@@ -17,3 +19,12 @@ async def mutated(
         kind=message.kind,
         data=message.data,
     )
+    events: List[InfrahubMessage] = []
+    kind_map = {"CoreWebhook": [messages.RefreshWebhookConfiguration()]}
+    events.extend(kind_map.get(message.kind, []))
+    events.append(
+        messages.TriggerWebhookActions(event_type=f"{message.kind}.{message.action}", event_data=message.data)
+    )
+    for event in events:
+        event.assign_meta(parent=message)
+        await service.send(message=event)

--- a/backend/infrahub/message_bus/operations/event/worker.py
+++ b/backend/infrahub/message_bus/operations/event/worker.py
@@ -1,0 +1,11 @@
+from infrahub.message_bus import messages
+from infrahub.services import InfrahubServices
+
+
+async def new_primary_api(message: messages.EventWorkerNewPrimaryAPI, service: InfrahubServices) -> None:
+    service.log.info("api_worker promoted to primary", worker_id=message.worker_id)
+
+    msg = messages.RefreshWebhookConfiguration()
+
+    msg.assign_meta(parent=message)
+    await service.send(message=msg)

--- a/backend/infrahub/message_bus/operations/refresh/__init__.py
+++ b/backend/infrahub/message_bus/operations/refresh/__init__.py
@@ -1,3 +1,3 @@
-from . import registry
+from . import registry, webhook
 
-__all__ = ["registry"]
+__all__ = ["registry", "webhook"]

--- a/backend/infrahub/message_bus/operations/refresh/webhook.py
+++ b/backend/infrahub/message_bus/operations/refresh/webhook.py
@@ -1,0 +1,29 @@
+import json
+
+from infrahub.message_bus import messages
+from infrahub.services import InfrahubServices
+
+
+async def configuration(
+    message: messages.RefreshWebhookConfiguration,  # pylint: disable=unused-argument
+    service: InfrahubServices,
+) -> None:
+    webhooks = await service.client.all(kind="CoreWebhook")
+    expected_webhooks = []
+    for webhook in webhooks:
+        webhook_key = f"webhook:active:{webhook.id}"
+        expected_webhooks.append(webhook_key)
+        payload = {
+            "webhook_type": "standard",
+            "webhook_configuration": {
+                "url": webhook.url.value,
+                "shared_key": webhook.shared_key.value,
+                "validate_certificates": webhook.validate_certificates.value,
+            },
+        }
+        await service.cache.set(key=webhook_key, value=json.dumps(payload))
+
+    cached_webhooks = await service.cache.list_keys(filter_pattern="webhook:active:*")
+    for cached_webhook in cached_webhooks:
+        if cached_webhook not in expected_webhooks:
+            await service.cache.delete(key=cached_webhook)

--- a/backend/infrahub/message_bus/operations/send/__init__.py
+++ b/backend/infrahub/message_bus/operations/send/__init__.py
@@ -1,0 +1,3 @@
+from . import webhook
+
+__all__ = ["webhook"]

--- a/backend/infrahub/message_bus/operations/send/webhook.py
+++ b/backend/infrahub/message_bus/operations/send/webhook.py
@@ -1,0 +1,19 @@
+import json
+
+import httpx
+
+from infrahub.message_bus import messages
+from infrahub.services import InfrahubServices
+
+
+async def event(message: messages.SendWebhookEvent, service: InfrahubServices) -> None:
+    webhook_definition = await service.cache.get(key=f"webhook:active:{message.webhook_id}")
+    if not webhook_definition:
+        service.log.warning("Webhook not found", webhook_id=message.webhook_id)
+        return
+
+    webhook = json.loads(webhook_definition)
+    payload = {"event_type": message.event_type, "data": message.event_data}
+
+    async with httpx.AsyncClient(verify=webhook["webhook_configuration"]["validate_certificates"]) as client:
+        await client.post(webhook["webhook_configuration"]["url"], json=payload)

--- a/backend/infrahub/message_bus/operations/trigger/__init__.py
+++ b/backend/infrahub/message_bus/operations/trigger/__init__.py
@@ -1,3 +1,3 @@
-from . import artifact_definition, proposed_change
+from . import artifact_definition, proposed_change, webhook
 
-__all__ = ["artifact_definition", "proposed_change"]
+__all__ = ["artifact_definition", "proposed_change", "webhook"]

--- a/backend/infrahub/message_bus/operations/trigger/webhook.py
+++ b/backend/infrahub/message_bus/operations/trigger/webhook.py
@@ -1,0 +1,19 @@
+from typing import List
+
+from infrahub.message_bus import InfrahubMessage, messages
+from infrahub.services import InfrahubServices
+
+
+async def actions(message: messages.TriggerWebhookActions, service: InfrahubServices) -> None:
+    webhooks = await service.cache.list_keys(filter_pattern="webhook:active:*")
+    events: List[InfrahubMessage] = []
+    for webhook in webhooks:
+        webhook_id = webhook.split(":")[-1]
+        events.append(
+            messages.SendWebhookEvent(
+                webhook_id=webhook_id, event_type=message.event_type, event_data=message.event_data
+            )
+        )
+    for event in events:
+        event.assign_meta(parent=message)
+        await service.send(message=event)

--- a/backend/infrahub/services/adapters/cache/__init__.py
+++ b/backend/infrahub/services/adapters/cache/__init__.py
@@ -4,6 +4,10 @@ from typing import List, Optional
 class InfrahubCache:
     """Base class for caching services"""
 
+    async def delete(self, key: str) -> None:
+        """Delete a key from the cache."""
+        raise NotImplementedError()
+
     async def get(self, key: str) -> Optional[str]:
         """Retrieve a value from the cache."""
         raise NotImplementedError()

--- a/backend/infrahub/services/adapters/cache/redis.py
+++ b/backend/infrahub/services/adapters/cache/redis.py
@@ -14,6 +14,9 @@ class RedisCache(InfrahubCache):
             db=config.SETTINGS.cache.database,
         )
 
+    async def delete(self, key: str) -> None:
+        await self.connection.delete(key)
+
     async def get(self, key: str) -> Optional[str]:
         value = await self.connection.get(name=key)
         if value is not None:

--- a/backend/infrahub/services/adapters/message_bus/rabbitmq.py
+++ b/backend/infrahub/services/adapters/message_bus/rabbitmq.py
@@ -99,7 +99,9 @@ class RabbitMQMessageBus(InfrahubMessageBus):
             "event.*.*",
             "finalize.*.*",
             "git.*.*",
+            "refresh.webhook.*",
             "request.*.*",
+            "send.*.*",
             "transform.*.*",
             "trigger.*.*",
         ]

--- a/backend/infrahub/tasks/keepalive.py
+++ b/backend/infrahub/tasks/keepalive.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from infrahub.core.timestamp import Timestamp
+from infrahub.message_bus import messages
 from infrahub.worker import WORKER_IDENTITY
 
 if TYPE_CHECKING:
@@ -23,7 +24,9 @@ async def refresh_api_server_components(service: InfrahubServices) -> None:
     await service.cache.set(key=f"api_server:{WORKER_IDENTITY}", value=str(Timestamp()), expires=15)
 
     result = await service.cache.set(key="primary_api_server_id", value=WORKER_IDENTITY, expires=15, not_exists=True)
-    if not result:
+    if result:
+        await service.send(message=messages.EventWorkerNewPrimaryAPI(worker_id=WORKER_IDENTITY))
+    else:
         service.log.debug("Primary node already set")
         primary_id = await service.cache.get(key="primary_api_server_id")
         if primary_id == WORKER_IDENTITY:


### PR DESCRIPTION
Adds initial framework for supporting Webhooks.

I've thought about ways to support "standard Webhooks" (https://www.standardwebhooks.com) which while I don't think is any form of standard yet it looks sensible. We'll also want to support custom webhooks that can tie in with a transform. Probably the webhook object will change to be a generic later on as the fields will be different.

Also more work will need to be done with regards to what events to trigger on. This is just to get the building blocks in place.

For now we don't use the shared secret, but there are changes in a number of files already and I want to keep this fairly small.

I also introduced a new message that gets sent when a new primary api worker is selected. The main reason for this is that I want to have a trigger that happens during startup of the system.

A future addition might also include adding a schedule that refreshes the webhooks every five mintues or so. Then we can enable expiration in the cache so that existing webhooks expire after 10 minutes if they haven't been refreshed. This will mostly be relevant if we need additional keys in Redis for each webhook which might be applicable when we want to enable webhooks based on specific events.

Related to #1448 