### PR TITLE
Add rich's `inspect` for debug

### DIFF
--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,5 +1,7 @@
 import builtins
 
+from rich import inspect as rinspect
 from rich import print as rprint
 
+builtins.rinspect = rinspect  # type: ignore
 builtins.rprint = rprint  # type: ignore


### PR DESCRIPTION
Add the useful `inspect` function from the `rich` module for debugging using breakpoints (for example). It will be exposed as `rinspect` to avoid conflicts.