### PR TITLE
Add a timeout of 1s when running demo.destroy to speed up containers tear down

### DIFF
--- a/tasks/demo.py
+++ b/tasks/demo.py
@@ -129,7 +129,7 @@ def destroy(context: Context, database: str = INFRAHUB_DATABASE):
     with context.cd(ESCAPED_REPO_PATH):
         compose_files_cmd = build_compose_files_cmd(database=database)
 
-        command = f"{get_env_vars(context)} docker compose {compose_files_cmd} -p {BUILD_NAME} down --remove-orphans --volumes"
+        command = f"{get_env_vars(context)} docker compose {compose_files_cmd} -p {BUILD_NAME} down --remove-orphans --volumes --timeout 1"
         execute_command(context=context, command=command)
 
 


### PR DESCRIPTION
Since the goal is to destroy everything there is no need to wait for the containers to gracefully shutdown.