### PR TITLE
Replace RabbitMQ publish call from InfrahubRpcClient

### DIFF
--- a/backend/infrahub/message_bus/rpc.py
+++ b/backend/infrahub/message_bus/rpc.py
@@ -3,17 +3,14 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any, List, MutableMapping
 
-from infrahub.log import get_log_data, get_logger
-
-from . import InfrahubMessage, Meta
-from .messages import ROUTING_KEY_MAP
+from infrahub.services import services
 
 if TYPE_CHECKING:
     from aio_pika.abc import (
         AbstractExchange,
     )
 
-log = get_logger()
+    from . import InfrahubMessage
 
 
 class InfrahubRpcClientBase:
@@ -24,15 +21,7 @@ class InfrahubRpcClientBase:
         self.loop = asyncio.get_running_loop()
 
     async def send(self, message: InfrahubMessage) -> None:
-        routing_key = ROUTING_KEY_MAP.get(type(message))
-
-        if not routing_key:
-            raise ValueError("Unable to determine routing key")
-
-        log_data = get_log_data()
-        request_id = log_data.get("request_id", "")
-        message.meta = message.meta or Meta(request_id=request_id)
-        await self.exchange.publish(message, routing_key=routing_key)
+        await services.send(message=message)
 
 
 class InfrahubRpcClient(InfrahubRpcClientBase):


### PR DESCRIPTION
Removes the call to self.exchange.publish from InfrahubRpcClient and instead calls a similar function from the services object.

Relates to #1797 and aims to limit the number of locations where we call the publish method on an exchange to the RabbitMQ adapter so that we can create an aio_pika Message from that adapter and convert the InfrahubMessage to Pydantic v2 after #1720 has been merged.

Also adds a new method to main send function to inject the request_id, this was missed in some instances when we had two locations where this needed to be done.

For now the AbstractExchange exchange object has been left in InfrahubRpcClient even though it is not needed. The reason for this is to avoid a merge conflict with #1720 that changes the startup/shutdown events to lifespan. I will clear this out later. 