### PR TITLE
Move RabbitMQ subscription logic away from git-agent CLI

### DIFF
--- a/backend/infrahub/services/adapters/message_bus/__init__.py
+++ b/backend/infrahub/services/adapters/message_bus/__init__.py
@@ -26,3 +26,6 @@ class InfrahubMessageBus:
 
     async def rpc(self, message: InfrahubMessage) -> InfrahubResponse:
         raise NotImplementedError()
+
+    async def subscribe(self) -> None:
+        raise NotImplementedError()

--- a/backend/infrahub/services/adapters/message_bus/rabbitmq.py
+++ b/backend/infrahub/services/adapters/message_bus/rabbitmq.py
@@ -133,7 +133,7 @@ class RabbitMQMessageBus(InfrahubMessageBus):
         connection = await get_broker()
         # Create a channel and subscribe to the incoming RPC queue
         self.channel = await connection.channel()
-
+        await self.channel.set_qos(prefetch_count=1)
         events_queue = await self.channel.declare_queue(name=f"worker-events-{WORKER_IDENTITY}", exclusive=True)
 
         self.exchange = await self.channel.declare_exchange(
@@ -172,3 +172,25 @@ class RabbitMQMessageBus(InfrahubMessageBus):
         response = await future
         data = json.loads(response.body)
         return InfrahubResponse(**data)
+
+    async def subscribe(self) -> None:
+        queue = await self.channel.get_queue(f"{config.SETTINGS.broker.namespace}.rpcs")
+        self.service.log.info("Waiting for RPC instructions to execute .. ")
+        async with queue.iterator() as qiterator:
+            async for message in qiterator:
+                try:
+                    async with message.process(requeue=False):
+                        clear_log_context()
+                        if message.routing_key in messages.MESSAGE_MAP:
+                            await execute_message(
+                                routing_key=message.routing_key, message_body=message.body, service=self.service
+                            )
+                        else:
+                            self.service.log.error(
+                                "Unhandled routing key for message",
+                                routing_key=message.routing_key,
+                                message=message.body,
+                            )
+
+                except Exception:  # pylint: disable=broad-except
+                    self.service.log.exception("Processing error for message %r" % message)


### PR DESCRIPTION
Consolidates the RabbitMQ code to the RabbitMQ adapter and moves away logic from the CLI entrypoint.

One of the goals is to start to move away from the calls to get_broker() which has invalid type hints:

```python
async def get_broker() -> aio_pika.abc.AbstractRobustConnection:
    if not config.SETTINGS.broker.enable:
        return False
    if not broker.client:
        await connect_to_broker()

    return broker.client
```

I.e. it can return `False` instead of an `AbstractRobustConnection` as declared.

Was fixing some stuff while waiting for the pydantic PR to be merged :) 

