### PR TITLE
Merge stable into develop after #1844

### DIFF
--- a/.github/infrahub-release-drafter.yml
+++ b/.github/infrahub-release-drafter.yml
@@ -1,6 +1,4 @@
 ---
-# name-template: 'v$RESOLVED_VERSION'
-# tag-template: 'v$RESOLVED_VERSION'
 categories:
   - title: '🚀 Features'
     labels:
@@ -13,18 +11,8 @@ categories:
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 exclude-labels:
   - 'ci/skip-changelog'
+  - 'group/python-sdk'
 change-title-escapes: '\<*_&'  # You can add # and @ to disable mentions, and add ` to disable code blocks.
-# version-resolver:
-#   major:
-#     labels:
-#       - 'major'
-#   minor:
-#     labels:
-#       - 'minor'
-#   patch:
-#     labels:
-#       - 'patch'
-#   default: patch
 template: |
   ## Changelog
 

--- a/.github/python_sdk-release-drafter.yml
+++ b/.github/python_sdk-release-drafter.yml
@@ -1,0 +1,24 @@
+---
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'type/feature'
+      - 'type/feature/py-sdk'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'type/bug'
+      - 'type/bug/py-sdk'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'type/housekeeping'
+      - 'type/housekeeping/py-sdk'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+exclude-labels:
+  - 'ci/skip-changelog'
+include-labels:
+  - 'group/python-sdk'
+change-title-escapes: '\<*_&'  # You can add # and @ to disable mentions, and add ` to disable code blocks.
+template: |
+  ## Changelog
+
+  $CHANGES

--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -1,7 +1,7 @@
 ---
 name: Publish Infrahub Python SDK
 
-on:
+on:  # yamllint disable rule:truthy
   push:
     tags:
       - "python-sdk-v*"

--- a/.github/workflows/release-note.yml
+++ b/.github/workflows/release-note.yml
@@ -3,6 +3,7 @@
 name: Release Note
 
 on:
+  workflow_dispatch:
   push:
     # branches to consider in the event; optional, defaults to all
     branches:
@@ -10,28 +11,36 @@ on:
       - stable
   # pull_request event is required only for autolabeler
   pull_request:
-    # Only following types are handled by the action, but one can default to all as well
     types: [opened, reopened, synchronize]
 
 permissions:
   contents: read
 
 jobs:
-  update_release_draft:
+  update_infrahub_release_draft:
     permissions:
-      # write permission is required to create a github release
       contents: write
-      # write permission is required for autolabeler
-      # otherwise, read permission is required at least
-      pull-requests: write
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
-
-      # Drafts your next Release notes as Pull Requests are merged into "develop"
       - uses: release-drafter/release-drafter@v5
-        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
         with:
-          config-name: release-note.yml
+          config-name: infrahub-release-drafter.yml
           disable-autolabeler: true
+          name: infrahub-draft
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  update_python_sdk_release_draft:
+    permissions:
+      contents: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: python_sdk-release-drafter.yml
+          disable-autolabeler: true
+          name: python_sdk-draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#1844 renames the release-drafter configuration file in the stable branch.

These changes have to be merged back into develop to make sure the release-drafter CI workflow can properly work from the development branch. The release-drafter looks for the referenced configuration file in the stable branch.