### PR TITLE
Password is optional when editing an account

### DIFF
--- a/frontend/src/screens/object-item-edit/object-item-edit-paginated.tsx
+++ b/frontend/src/screens/object-item-edit/object-item-edit-paginated.tsx
@@ -109,7 +109,8 @@ export default function ObjectItemEditComponent(props: Props) {
       genericsList,
       peerDropdownOptions,
       objectDetailsData,
-      user
+      user,
+      true
     );
 
   async function onSubmit(data: any) {

--- a/frontend/src/utils/formStructureForCreateEdit.ts
+++ b/frontend/src/utils/formStructureForCreateEdit.ts
@@ -86,7 +86,8 @@ const getFormStructureForCreateEdit = (
   generics: iGenericSchema[],
   dropdownOptions: iPeerDropdownOptions,
   row?: any,
-  user?: any
+  user?: any,
+  isUpdate?: boolean
 ): DynamicFieldData[] => {
   if (!schema) {
     return [];
@@ -102,6 +103,10 @@ const getFormStructureForCreateEdit = (
 
     const fieldValue = getFieldValue(row, attribute);
 
+    // Quick fix to prevent password in update field,
+    // TODO: remove after new mutations are available to better handle accounts
+    const isOptional = attribute.optional || (isUpdate && attribute.kind === "HashedPassword");
+
     formFields.push({
       name: attribute.name + ".value",
       kind: attribute.kind as SchemaAttributeType,
@@ -112,9 +117,9 @@ const getFormStructureForCreateEdit = (
         values: getOptionsFromAttribute(attribute, fieldValue),
       },
       config: {
-        validate: (value: any) => validate(value, attribute, attribute.optional),
+        validate: (value: any) => validate(value, attribute, isOptional),
       },
-      isOptional: attribute.optional,
+      isOptional,
       isReadOnly: attribute.read_only,
       isProtected: getIsDisabled({
         owner: row && row[attribute.name]?.owner,


### PR DESCRIPTION
Related issue: https://github.com/opsmill/infrahub/issues/1851

* Fixes the account form when editing an account to prevent the user to fill the password input since it's mandatory
* The password field will now optional in the edit form for the accounts