### PR TITLE
Add tag-prefix and tag-template statements to release drafter configs

### DIFF
--- a/.github/infrahub-release-drafter.yml
+++ b/.github/infrahub-release-drafter.yml
@@ -13,6 +13,8 @@ exclude-labels:
   - 'ci/skip-changelog'
   - 'group/python-sdk'
 change-title-escapes: '\<*_&'  # You can add # and @ to disable mentions, and add ` to disable code blocks.
+tag-prefix: infrahub-v
+tag-template: infrahub-v
 template: |
   ## Changelog
 

--- a/.github/python_sdk-release-drafter.yml
+++ b/.github/python_sdk-release-drafter.yml
@@ -18,6 +18,8 @@ exclude-labels:
 include-labels:
   - 'group/python-sdk'
 change-title-escapes: '\<*_&'  # You can add # and @ to disable mentions, and add ` to disable code blocks.
+tag-prefix: python-sdk-v
+tag-template: python-sdk-v
 template: |
   ## Changelog
 


### PR DESCRIPTION
Add tag-prefix and tag-template configuration statements for release drafter.
This is needed to determine the previous release based on the git tag (infrahub-v or python-sdk-v).
