### PR TITLE
Add build step when we start a new codespace

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-invoke demo.start
+invoke demo.build demo.start


### PR DESCRIPTION
I've enabled prebuild on the `stable` and the `develop` branches for Codespace but to avoid rebuilding the image for every commit, the image is only being rebuilt when there is a change in the Codespace definition file (devcontainer.json file)

As far as I understand, today, when we are using prebuild, Github will execute the script `onCreateCommand` when it is creating the prebuild image but it won't execute it when it starts a new instance of Codespace from that image.
https://docs.github.com/en/codespaces/prebuilding-your-codespaces/about-github-codespaces-prebuilds#the-prebuild-process

In our case, it means that the docker image for infrahub that we are using to run the demo will be created when we prebuild the image (which is good) but it won't be updated when we start a new instance of codespace.
This could lead to some unexpected situation where the codespace won't run the latest version of the frontend or we could miss some Python dependancies inside the container.

This PR adds a new build command when we start a new codespace (postCreate), assuming the docker cache is already populated in the prebuild image it should be really fast if there aren't that many changes.