### PR TITLE
Comment tag-prefix to have the proper Changelog

### DIFF
--- a/.github/infrahub-release-drafter.yml
+++ b/.github/infrahub-release-drafter.yml
@@ -13,7 +13,7 @@ exclude-labels:
   - 'ci/skip-changelog'
   - 'group/python-sdk'
 change-title-escapes: '\<*_&'  # You can add # and @ to disable mentions, and add ` to disable code blocks.
-tag-prefix: infrahub-v
+# tag-prefix: infrahub-v
 tag-template: infrahub-v
 template: |
   ## Changelog


### PR DESCRIPTION
We can't use the Tag-Prefix, until we have a first release using it.

If we put it now, the `Changelog` Section of the Release Note will match all the PR without the propers labels from the beginning instead of "since the last one"