### PR TITLE
Reenable artefact test and use InfrahubService instead of rpcclient mapping

### DIFF
--- a/backend/infrahub/api/artifact.py
+++ b/backend/infrahub/api/artifact.py
@@ -15,7 +15,7 @@ from infrahub.log import get_logger
 from infrahub.message_bus import messages
 
 if TYPE_CHECKING:
-    from infrahub.message_bus.rpc import InfrahubRpcClient
+    from infrahub.services import InfrahubServices
 
 log = get_logger()
 router = APIRouter(prefix="/artifact")
@@ -67,8 +67,8 @@ async def generate_artifact(
         branch=branch_params.branch,
     )
 
-    rpc_client: InfrahubRpcClient = request.app.state.rpc_client
-    await rpc_client.send(
+    service: InfrahubServices = request.app.state.service
+    await service.send(
         message=messages.RequestArtifactDefinitionGenerate(
             artifact_definition=artifact_definition.id, branch=branch_params.branch.name, limit=payload.nodes
         )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -72,14 +72,16 @@ def execute_before_any_test(worker_id, tmpdir_factory):
 class BusRPCMock(InfrahubMessageBus):
     def __init__(self):
         self.response: List[InfrahubResponse] = []
+        self.messages: List[InfrahubMessage] = []
 
     async def publish(self, message: InfrahubMessage, routing_key: str, delay: Optional[MessageTTL] = None) -> None:
-        pass
+        self.messages.append(message)
 
     def add_mock_reply(self, response: InfrahubResponse):
         self.response.append(response)
 
     async def rpc(self, message: InfrahubMessage) -> InfrahubResponse:
+        self.messages.append(message)
         return self.response.pop()
 
 

--- a/backend/tests/unit/api/test_11_artifact.py
+++ b/backend/tests/unit/api/test_11_artifact.py
@@ -1,26 +1,16 @@
-import pytest
 from fastapi.testclient import TestClient
 
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
 from infrahub.message_bus import messages
-from infrahub.message_bus.rpc import InfrahubRpcClientTesting
 
 
-@pytest.fixture
-def patch_rpc_client():
-    import infrahub.message_bus.rpc
-
-    infrahub.message_bus.rpc.InfrahubRpcClient = InfrahubRpcClientTesting
-
-
-@pytest.mark.xfail(reason="FIXME: #1627, working in standalone but failing when it's part of the testsuite")
 async def test_artifact_definition_endpoint(
     db: InfrahubDatabase,
     admin_headers,
     default_branch,
-    patch_rpc_client,
+    rpc_bus,
     register_core_models_schema,
     register_builtin_models_schema,
     car_person_data_generic,
@@ -68,6 +58,6 @@ async def test_artifact_definition_endpoint(
 
     assert response.status_code == 200
     assert (
-        messages.RequestArtifactDefinitionGenerate(meta=None, artifact_definition=ad1.id, branch="main", limit=[])
-        in client.app.state.rpc_client.sent
+        messages.RequestArtifactDefinitionGenerate(artifact_definition=ad1.id, branch="main", limit=[])
+        in rpc_bus.messages
     )


### PR DESCRIPTION
Fixes #1627

There are some other changes that might already have fixed this, but this should be safe now.