### PR TITLE
Codespace : Add git pull to postCreate script

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+git pull
 invoke demo.build demo.start


### PR DESCRIPTION
when we are using prebuild images in codespace it looks like it won't automatically pull the latest commit from the branch and instead we need to manually do it in the postCreate script