### PR TITLE
Remove public queries & mutations for namespace Internal

### DIFF
--- a/backend/tests/unit/api/test_40_schema_api.py
+++ b/backend/tests/unit/api/test_40_schema_api.py
@@ -27,11 +27,11 @@ async def test_schema_read_endpoint_default_branch(
     assert response.json() is not None
 
     schema = response.json()
+    core_nodes = [node for node in core_models["nodes"] if node["namespace"] != "Internal"]
+    core_generics = [node for node in core_models["generics"] if node["namespace"] != "Internal"]
 
-    expected_nodes = set([dict(item).get("name") for item in core_models["nodes"] + car_person_schema_generics.nodes])
-    expected_generics = set(
-        [dict(item).get("name") for item in core_models["generics"] + car_person_schema_generics.generics]
-    )
+    expected_nodes = set([dict(item).get("name") for item in core_nodes + car_person_schema_generics.nodes])
+    expected_generics = set([dict(item).get("name") for item in core_generics + car_person_schema_generics.generics])
 
     assert "nodes" in schema
     assert "generics" in schema
@@ -64,7 +64,9 @@ async def test_schema_read_endpoint_branch1(
 
     schema = response.json()
 
-    expected_nodes = set([dict(node).get("name") for node in core_models["nodes"] + car_person_schema_generics.nodes])
+    core_nodes = [node for node in core_models["nodes"] if node["namespace"] != "Internal"]
+
+    expected_nodes = set([dict(node).get("name") for node in core_nodes + car_person_schema_generics.nodes])
     assert "nodes" in schema
     assert len(schema["nodes"]) == len(expected_nodes)
 

--- a/frontend/tests/e2e/tutorial/tutorial-3_schema.spec.ts
+++ b/frontend/tests/e2e/tutorial/tutorial-3_schema.spec.ts
@@ -7,7 +7,7 @@ test.describe("Getting started with Infrahub - Data lineage and metadata", () =>
   test("1. Visualize the active schema", async ({ page }) => {
     await page.goto("/");
     await page.getByTestId("sidebar-menu").getByRole("link", { name: "Schema" }).click();
-    await expect(page.getByText("Account Token")).toBeVisible();
+    await expect(page.getByText("Artifact Check")).toBeVisible();
     await saveScreenshotForDocs(page, "tutorial/tutorial-3-schema.cy.ts/tutorial_3_schema");
   });
 });

--- a/python_sdk/tests/integration/test_schema.py
+++ b/python_sdk/tests/integration/test_schema.py
@@ -22,7 +22,10 @@ class TestInfrahubSchema:
         ifc = await InfrahubClient.init(config=config)
         schema_nodes = await ifc.schema.all()
 
-        assert len(schema_nodes) == len(core_models["nodes"]) + len(core_models["generics"])
+        nodes = [node for node in core_models["nodes"] if node["namespace"] != "Internal"]
+        generics = [node for node in core_models["generics"] if node["namespace"] != "Internal"]
+
+        assert len(schema_nodes) == len(nodes) + len(generics)
         assert "BuiltinTag" in schema_nodes
         assert isinstance(schema_nodes["BuiltinTag"], NodeSchema)
 
@@ -33,7 +36,10 @@ class TestInfrahubSchema:
 
         assert isinstance(schema_node, NodeSchema)
         assert ifc.default_branch in ifc.schema.cache
-        assert len(ifc.schema.cache[ifc.default_branch]) == len(core_models["nodes"]) + len(core_models["generics"])
+        nodes = [node for node in core_models["nodes"] if node["namespace"] != "Internal"]
+        generics = [node for node in core_models["generics"] if node["namespace"] != "Internal"]
+
+        assert len(ifc.schema.cache[ifc.default_branch]) == len(nodes) + len(generics)
 
     async def test_schema_load_many(self, client, init_db_base, schema_extension_01, schema_extension_02):
         config = Config(username="admin", password="infrahub", requester=client.async_request)


### PR DESCRIPTION
Fixes #684. This PR prevents anything from the Internal namespace to be exposed through GraphQL queries and mutations.

We want to prevent anyone from querying InternalAccountToken to list all API tokens, or create tokens for other users.

