### PR TITLE
Update Readme, Add links to doc and codespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Leveraging a service name [`Codespace` from Github](https://docs.github.com/en/c
 
 > The cost for running an Infrahub in Codespace is covered by OpsMill
 
-See the table below to select the right environment for you, based on the Branch and the initial data you would like in your instance.
+See the table below to select the right environment for you, based on the branch and the initial data you would like in your instance.
 
 |  | Branch `stable` | Branch `develop` |
 |---|---|---|


### PR DESCRIPTION
This PR adds a bit more information to the readme with direct links to the documentation for both `stable` and `develop` as well as some instructions and links to directly launch Infrahub in Codespace, with or without data

![image](https://github.com/opsmill/infrahub/assets/304126/e08e0c8a-fa87-4251-b7fe-7cb78711a4cc)
