### PR TITLE
Fix slow GraphQL query when counting the number of peers in a relationship

### DIFF
--- a/backend/infrahub/graphql/generator.py
+++ b/backend/infrahub/graphql/generator.py
@@ -85,7 +85,7 @@ async def generate_object_types(db: InfrahubDatabase, branch: Union[Branch, str]
             name=paginated_interface._meta.name, graphql_type=paginated_interface, branch=branch.name
         )
 
-    # Define DataOwner and DataOwner
+    # Define LineageSource and LineageOwner
     data_source = registry.get_graphql_type(name="LineageSource", branch=branch)
     data_owner = registry.get_graphql_type(name="LineageOwner", branch=branch)
     define_relationship_property(branch=branch, data_source=data_source, data_owner=data_owner)

--- a/backend/infrahub/graphql/resolver.py
+++ b/backend/infrahub/graphql/resolver.py
@@ -215,6 +215,10 @@ async def many_relationship_resolver(
                 at=at,
                 branch=branch,
             )
+
+        if not node_fields:
+            return response
+
         objs = await NodeManager.query_peers(
             db=db,
             ids=ids,
@@ -302,6 +306,10 @@ async def hierarchy_resolver(
                 at=at,
                 branch=branch,
             )
+
+        if not node_fields:
+            return response
+
         objs = await NodeManager.query_hierarchy(
             db=db,
             id=parent["id"],


### PR DESCRIPTION
Fixes #1933

This PR fixes an issue related to counting the number of peers on the other side of a relationship of cardinality many (number of members for a given group etc ,..)
The issue was that we weren't checking if additional information were required for the peer in addition to count so we would always query all the peers even if it was not required.

I noticed that the same issue was present for the new resolver specific to the hierarchical mode so I fixed it too.

