### PR TITLE
Add documentation for message format and refactor priority

### DIFF
--- a/backend/infrahub/message_bus/__init__.py
+++ b/backend/infrahub/message_bus/__init__.py
@@ -10,6 +10,8 @@ from infrahub.exceptions import Error, RPCError
 from infrahub.log import set_log_data
 from infrahub.message_bus.responses import RESPONSE_MAP
 
+from .types import MessagePriority
+
 ResponseClass = TypeVar("ResponseClass")
 
 
@@ -73,6 +75,7 @@ class Meta(BaseModel):
 class InfrahubMessage(BaseModel):
     """Base Model for messages"""
 
+    _priority: MessagePriority = MessagePriority.NORMAL
     meta: Meta = Field(default_factory=Meta.default, description="Meta properties for the message")
 
     def assign_meta(self, parent: "InfrahubMessage") -> None:
@@ -100,6 +103,10 @@ class InfrahubMessage(BaseModel):
         if self.meta.reply_to:
             return True
         return False
+
+    @property
+    def priority(self) -> MessagePriority:
+        return self._priority
 
     @property
     def body(self) -> bytes:

--- a/backend/infrahub/message_bus/messages/event_branch_create.py
+++ b/backend/infrahub/message_bus/messages/event_branch_create.py
@@ -1,11 +1,13 @@
 from pydantic import Field
 
 from infrahub.message_bus import InfrahubMessage
+from infrahub.message_bus.types import MessagePriority
 
 
 class EventBranchCreate(InfrahubMessage):
-    """Sent a new branch is created."""
+    """Sent when a new branch is created."""
 
+    _priority: MessagePriority = MessagePriority.HIGEST
     branch: str = Field(..., description="The branch that was created")
     branch_id: str = Field(..., description="The unique ID of the branch")
     data_only: bool = Field(

--- a/backend/infrahub/message_bus/types.py
+++ b/backend/infrahub/message_bus/types.py
@@ -15,3 +15,13 @@ class MessageTTL(int, Enum):
     def variations(cls) -> List[MessageTTL]:
         """Return available variations of message time to live."""
         return [cls(cls.__members__[member].value) for member in list(cls.__members__)]
+
+
+class MessagePriority(int, Enum):
+    """Defines the message priority."""
+
+    LOWEST = 1
+    LOW = 2
+    NORMAL = 3
+    HIGH = 4
+    HIGEST = 5

--- a/backend/infrahub/services/adapters/message_bus/rabbitmq.py
+++ b/backend/infrahub/services/adapters/message_bus/rabbitmq.py
@@ -150,7 +150,7 @@ class RabbitMQMessageBus(InfrahubMessageBus):
     async def publish(self, message: InfrahubMessage, routing_key: str, delay: Optional[MessageTTL] = None) -> None:
         for enricher in self.message_enrichers:
             await enricher(message)
-        message.assign_priority(priority=messages.message_priority(routing_key=routing_key))
+
         if delay:
             message.assign_header(key="delay", value=delay.value)
             await self.delayed_exchange.publish(self.format_message(message=message), routing_key=routing_key)
@@ -206,7 +206,7 @@ class RabbitMQMessageBus(InfrahubMessageBus):
             content_encoding="utf-8",
             correlation_id=message.meta.correlation_id,
             reply_to=message.meta.reply_to,
-            priority=message.meta.priority,
+            priority=message.priority,
             headers=message.meta.headers,
             expiration=message.meta.expiration,
         )

--- a/docs/_templates/messages.j2
+++ b/docs/_templates/messages.j2
@@ -1,0 +1,22 @@
+---
+label: Messages
+icon: mail
+layout: default
+---
+# Infrahub Messages
+{% for message in messages %}
+## {{ message.title }}
+
+{{ message.description }}
+
+Priority: {{ message.priority.name }} ({{ message.priority.value }})
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+{%- for property in message.schema.properties %}
+{%- if property != "meta" %}
+{{ property }} | {{ message.schema.properties[property].type }} | {{ message.schema.properties[property].description }} | {{ property in message.schema.required }} |
+{%- endif %}
+{%- endfor %}
+
+{% endfor %}

--- a/docs/reference/messages.md
+++ b/docs/reference/messages.md
@@ -1,0 +1,561 @@
+---
+label: Messages
+icon: mail
+layout: default
+---
+# Infrahub Messages
+
+## check.artifact.create
+
+Runs a check to verify the creation of an artifact.
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+artifact_name | string | Name of the artifact | True |
+artifact_definition | string | The the ID of the artifact definition | True |
+commit | string | The commit to target | True |
+content_type | string | Content type of the artifact | True |
+transform_type | string | The type of transform associated with this artifact | True |
+transform_location | string | The transforms location within the repository | True |
+repository_id | string | The unique ID of the Repository | True |
+repository_name | string | The name of the Repository | True |
+repository_kind | string | The kind of the Repository | True |
+branch_name | string | The branch where the check is run | True |
+target_id | string | The ID of the target object for this artifact | True |
+target_name | string | Name of the artifact target | True |
+artifact_id |  | The id of the artifact if it previously existed | False |
+query | string | The name of the query to use when collecting data | True |
+rebase | boolean | Indicates if a rebase should be done | True |
+timeout | integer | Timeout for requests used to generate this artifact | True |
+variables | object | Input variables when generating the artifact | True |
+validator_id | string | The ID of the validator | True |
+
+
+## check.repository.check_definition
+
+Triggers user defined checks to run based on a Check Definition.
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+check_definition_id | string | The unique ID of the check definition | True |
+commit | string | The commit to target | True |
+repository_id | string | The unique ID of the Repository | True |
+repository_name | string | The name of the Repository | True |
+branch_name | string | The branch where the check is run | True |
+file_path | string | The path and filename of the check | True |
+class_name | string | The name of the class containing the check | True |
+proposed_change | string | The unique ID of the Proposed Change | True |
+
+
+## check.repository.merge_conflicts
+
+Runs a check to validate if there are merge conflicts for a proposed change between two branches.
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+validator_id | string | The id of the validator associated with this check | True |
+validator_execution_id | string | The id of current execution of the associated validator | True |
+check_execution_id | string | The unique ID for the current execution of this check | True |
+proposed_change | string | The unique ID of the Proposed Change | True |
+repository_id | string | The unique ID of the Repository | True |
+repository_name | string | The name of the Repository | True |
+source_branch | string | The source branch | True |
+target_branch | string | The target branch | True |
+
+
+## check.repository.user_check
+
+Runs a check as defined within a CoreCheckDefinition within a repository.
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+validator_id | string | The id of the validator associated with this check | True |
+validator_execution_id | string | The id of current execution of the associated validator | True |
+check_execution_id | string | The unique ID for the current execution of this check | True |
+check_definition_id | string | The unique ID of the check definition | True |
+commit | string | The commit to target | True |
+repository_id | string | The unique ID of the Repository | True |
+repository_name | string | The name of the Repository | True |
+branch_name | string | The branch where the check is run | True |
+file_path | string | The path and filename of the check | True |
+class_name | string | The name of the class containing the check | True |
+proposed_change | string | The unique ID of the Proposed Change | True |
+variables | object | Input variables when running the check | False |
+name | string | The name of the check | True |
+
+
+## event.branch.create
+
+Sent when a new branch is created.
+
+Priority: HIGEST (5)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+branch | string | The branch that was created | True |
+branch_id | string | The unique ID of the branch | True |
+data_only | boolean | Indicates if this is a data only branch, or repositories can be tied to it. | True |
+
+
+## event.branch.delete
+
+Sent when a branch has been deleted.
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+branch | string | The branch that was deleted | True |
+branch_id | string | The unique ID of the branch | True |
+data_only | boolean | Indicates if this is a data only branch, or repositories can be tied to it. | True |
+
+
+## event.branch.merge
+
+Sent when a branch has been merged.
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+source_branch | string | The source branch | True |
+target_branch | string | The target branch | True |
+
+
+## event.node.mutated
+
+Sent when a node has been mutated
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+branch | string | The branch that was created | True |
+kind | string | The type of object modified | True |
+node_id | string | The ID of the mutated node | True |
+action | string | The action taken on the node | True |
+data | object | Data on modified object | True |
+
+
+## event.schema.update
+
+Sent when the schema on a branch has been updated.
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+branch | string | The branch where the update occured | True |
+
+
+## event.worker.new_primary_api
+
+Sent on startup or when a new primary API worker is elected.
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+worker_id | string | The worker ID that got elected | True |
+
+
+## finalize.validator.execution
+
+Update the status of a validator after all checks have been completed.
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+validator_id | string | The id of the validator associated with this check | True |
+validator_execution_id | string | The id of current execution of the associated validator | True |
+start_time | string | Start time when the message was first created | True |
+validator_type | string | The type of validator to complete | True |
+
+
+## git.branch.create
+
+Create a branch in a Git repository.
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+branch | string | Name of the branch to create | True |
+branch_id | string | The unique ID of the branch | True |
+repository_id | string | The unique ID of the Repository | True |
+repository_name | string | The name of the Repository | True |
+
+
+## git.diff.names_only
+
+Request a list of modified files between two commits.
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+repository_id | string | The unique ID of the Repository | True |
+repository_name | string | The name of the repository | True |
+repository_kind | string | The kind of the repository | True |
+first_commit | string | The first commit | True |
+second_commit | string | The second commit | True |
+
+
+## git.file.get
+
+Read a file from a Git repository.
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+commit | string | The commit id to use to access the file | True |
+file | string | The path and filename within the repository | True |
+repository_id | string | The unique ID of the Repository | True |
+repository_name | string | The name of the repository | True |
+repository_kind | string | The kind of the repository | True |
+
+
+## git.repository.add
+
+Clone and sync an external repository after creation.
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+location | string | The external URL of the repository | True |
+repository_id | string | The unique ID of the Repository | True |
+repository_name | string | The name of the repository | True |
+default_branch_name |  | Default branch for this repository | False |
+
+
+## git.repository.add_read_only
+
+Clone and sync an external repository after creation.
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+location | string | The external URL of the repository | True |
+repository_id | string | The unique ID of the Repository | True |
+repository_name | string | The name of the repository | True |
+ref | string | Ref to track on the external repository | True |
+infrahub_branch_name | string | Infrahub branch on which to sync the remote repository | True |
+
+
+## git.repository.merge
+
+Merge one branch into another.
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+repository_id | string | The unique ID of the Repository | True |
+repository_name | string | The name of the repository | True |
+source_branch | string | The source branch | True |
+destination_branch | string | The source branch | True |
+
+
+## git.repository.pull_read_only
+
+Update a read-only repository to the latest commit for its ref
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+location | string | The external URL of the repository | True |
+repository_id | string | The unique ID of the Repository | True |
+repository_name | string | The name of the repository | True |
+ref |  | Ref to track on the external repository | False |
+commit |  | Specific commit to pull | False |
+infrahub_branch_name | string | Infrahub branch on which to sync the remote repository | True |
+
+
+## refresh.registry.branches
+
+Sent to indicate that the registry should be refreshed and new branch data loaded.
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+
+
+## refresh.webhook.configuration
+
+Sent to indicate that configuration in the cache for webhooks should be refreshed.
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+
+
+## request.artifact.generate
+
+Runs to generate an artifact
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+artifact_name | string | Name of the artifact | True |
+artifact_definition | string | The the ID of the artifact definition | True |
+commit | string | The commit to target | True |
+content_type | string | Content type of the artifact | True |
+transform_type | string | The type of transform associated with this artifact | True |
+transform_location | string | The transforms location within the repository | True |
+repository_id | string | The unique ID of the Repository | True |
+repository_name | string | The name of the Repository | True |
+repository_kind | string | The kind of the Repository | True |
+branch_name | string | The branch where the check is run | True |
+target_id | string | The ID of the target object for this artifact | True |
+target_name | string | Name of the artifact target | True |
+artifact_id |  | The id of the artifact if it previously existed | False |
+query | string | The name of the query to use when collecting data | True |
+rebase | boolean | Indicates if a rebase should be done | True |
+timeout | integer | Timeout for requests used to generate this artifact | True |
+variables | object | Input variables when generating the artifact | True |
+
+
+## request.artifact_definition.check
+
+Sent to validate the generation of artifacts in relation to a proposed change.
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+artifact_definition | string | The unique ID of the Artifact Definition | True |
+proposed_change | string | The unique ID of the Proposed Change | True |
+source_branch | string | The source branch | True |
+target_branch | string | The target branch | True |
+
+
+## request.artifact_definition.generate
+
+Sent to trigger the generation of artifacts for a given branch.
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+artifact_definition | string | The unique ID of the Artifact Definition | True |
+branch | string | The branch to target | True |
+limit | array | List of targets to limit the scope of the generation, if populated only the included artifacts will be regenerated | False |
+
+
+## request.git.create_branch
+
+Sent to trigger the creation of a branch in git repositories.
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+branch | string | The branch to target | True |
+branch_id | string | The unique ID of the branch | True |
+
+
+## request.git.sync
+
+Request remote repositories to be synced.
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+
+
+## request.graphql_query_group.update
+
+Sent to create or update a GraphQLQueryGroup associated with a given GraphQLQuery.
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+branch | string | The branch to target | True |
+query_name | string | The name of the GraphQLQuery that should be associated with the group | True |
+query_id | string | The ID of the GraphQLQuery that should be associated with the group | True |
+related_node_ids | array | List of nodes related to the GraphQLQuery | True |
+subscribers | array | List of subscribers to add to the group | True |
+params | object | Params sent with the query | True |
+
+
+## request.proposed_change.cancel
+
+Cancel the proposed change
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+proposed_change | string | The unique ID of the Proposed Change | True |
+
+
+## request.proposed_change.data_integrity
+
+Sent trigger data integrity checks for a proposed change
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+proposed_change | string | The unique ID of the Proposed Change | True |
+
+
+## request.proposed_change.refresh_artifacts
+
+Sent trigger the refresh of artifacts that are impacted by the proposed change.
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+proposed_change | string | The unique ID of the Proposed Change | True |
+
+
+## request.proposed_change.repository_checks
+
+Sent when a proposed change is created to trigger additional checks
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+proposed_change | string | The unique ID of the Proposed Change | True |
+
+
+## request.proposed_change.schema_integrity
+
+Sent trigger schema integrity checks for a proposed change
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+proposed_change | string | The unique ID of the Proposed Change | True |
+
+
+## request.repository.checks
+
+Sent to trigger the checks for a repository to be executed.
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+proposed_change | string | The unique ID of the Proposed Change | True |
+repository | string | The unique ID of the Repository | True |
+source_branch | string | The source branch | True |
+target_branch | string | The target branch | True |
+
+
+## request.repository.user_checks
+
+Sent to trigger the user defined checks on a repository.
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+proposed_change | string | The unique ID of the Proposed Change | True |
+repository | string | The unique ID of the Repository | True |
+source_branch | string | The source branch | True |
+target_branch | string | The target branch | True |
+
+
+## send.webhook.event
+
+Sent a webhook to an external source.
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+webhook_id | string | The unique ID of the webhook | True |
+event_type | string | The event type | True |
+event_data | object | The data tied to the event | True |
+
+
+## transform.jinja.template
+
+Sent to trigger the checks for a repository to be executed.
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+repository_id | string | The unique ID of the Repository | True |
+repository_name | string | The name of the repository | True |
+repository_kind | string | The kind of the repository | True |
+data | object | Input data for the template | True |
+branch | string | The branch to target | True |
+template_location | string | Location of the template within the repository | True |
+commit | string | The commit id to use when rendering the template | True |
+
+
+## transform.python.data
+
+Sent to run a Python transform.
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+repository_id | string | The unique ID of the Repository | True |
+repository_name | string | The name of the repository | True |
+repository_kind | string | The kind of the repository | True |
+data | object | Input data for the template | True |
+branch | string | The branch to target | True |
+transform_location | string | Location of the transform within the repository | True |
+commit | string | The commit id to use when rendering the template | True |
+
+
+## trigger.artifact_definition.generate
+
+Sent after a branch has been merged to start the regeneration of artifacts
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+branch | string | The impacted branch | True |
+
+
+## trigger.proposed_change.cancel
+
+Triggers request to cancel any open or closed proposed changes for a given branch
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+branch | string | The impacted branch | True |
+
+
+## trigger.webhook.actions
+
+Triggers webhooks to be sent for the given action
+
+Priority: NORMAL (3)
+
+| Property | Type | Description | Mandatory | { class="compact" }
+| -------- | ---- | ----------- | --------- |
+event_type | string | The event type | True |
+event_data | object | The webhook payload | True |
+


### PR DESCRIPTION
Adds generation of message documentation.
Refactors message priority so that we have priority as a field that you can set to each message instead of having it in an external map.

This PR is mostly to serve as example, there are a few more things that would need to be done in order to merge it.

* The old priority map still exists
* Only one message has gotten the correct (non default) priority assigned
* There are a few problems with the generation of some attributes for example the default_branch_name on the `git.repository.add` message, so a bit more time would need to be spend on the rendering with Jinja2.

My idea is that we'll use the same concept to generate the documentation for the main config files for Infrahub, the .infrahub.yml file (@wvandeun, I think you got assigned to this one), and the config file for the SDK.

@dgarros, you had some objections to using the priority map in the first place. It was mainly meant as a temporary placeholder until we had a place where we could see a list of all messages with priorities. Do you prefer this implementation?

A comment here is that just like anything you touch with Jinja2 it can get a bit messy quite fast. Once we start to add more models we want to document in a similar way I think we should spend a little more time to write a Python object that provides a better approach to the simplistic method I did in this PR i.e. this:

```python
        messages.append(
            {
                "title": entry,
                "description": message.__doc__,
                "priority": message._priority.default,
                "schema": message.model_json_schema(),
            }
        )
```

We could have something that structures the schema in a way that's easy to parse from Jinja2 and also takes care of the logic I mentioned above with `default_branch_name` and others, along with other stuff as default values etc. That way we don't have to reuse the same logic throughout all Jinja templates where we want this.

Check: https://pog-message-documentation.infrahub.pages.dev/reference/messages/

Related to #1166