### PR TITLE
Fixes Release Drafter labels issue

### DIFF
--- a/.github/infrahub-release-drafter.yml
+++ b/.github/infrahub-release-drafter.yml
@@ -11,7 +11,11 @@ categories:
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 exclude-labels:
   - 'ci/skip-changelog'
-  - 'group/python-sdk'
+include-labels:
+  - 'group/backend'
+  - 'group/ci'
+  - 'group/frontend'
+  - 'type/documentation'
 change-title-escapes: '\<*_&'  # You can add # and @ to disable mentions, and add ` to disable code blocks.
 tag-prefix: infrahub-v
 tag-template: infrahub-v


### PR DESCRIPTION
Change exlude_labels to include_labels

Instead of excluding a PR if the SDK is flagged, it will add the one with the "main" labels

It will solved the issue of some PR being exclude when the SDK is flagged even if 90% of the work is in Inrahub

- [Fixes] https://github.com/opsmill/infrahub/issues/1917