### PR TITLE
Fix remaining instances of using default_branch_name Optional[str]

### DIFF
--- a/backend/infrahub/git/actions.py
+++ b/backend/infrahub/git/actions.py
@@ -33,7 +33,7 @@ async def sync_remote_repositories(service: InfrahubServices) -> None:
                         location=repository_data.repository.location.value,
                         client=service.client,
                     )
-                    await repo.import_objects_from_files(branch_name=repo.default_branch_name)
+                    await repo.import_objects_from_files(branch_name=repo.default_branch)
                 except RepositoryError as exc:
                     service.log.error(str(exc))
                     continue

--- a/backend/infrahub/message_bus/operations/git/repository.py
+++ b/backend/infrahub/message_bus/operations/git/repository.py
@@ -14,7 +14,7 @@ async def add(message: messages.GitRepositoryAdd, service: InfrahubServices) -> 
         repo = await InfrahubRepository.new(
             id=message.repository_id, name=message.repository_name, location=message.location, client=service.client
         )
-        await repo.import_objects_from_files(branch_name=repo.default_branch_name)
+        await repo.import_objects_from_files(branch_name=repo.default_branch)
         await repo.sync()
 
 

--- a/backend/tests/unit/git/test_git_rpc.py
+++ b/backend/tests/unit/git/test_git_rpc.py
@@ -42,7 +42,7 @@ class TestAddRepository:
         )
         self.mock_repo_class = repo_class_patcher.start()
         self.mock_repo = AsyncMock(spec=InfrahubRepository)
-        self.mock_repo.default_branch_name = self.default_branch_name
+        self.mock_repo.default_branch = self.default_branch_name
         self.mock_repo_class.new.return_value = self.mock_repo
 
     def teardown_method(self):


### PR DESCRIPTION
Use property that always returns a string instead (for type hinting)