### PR TITLE
Disable flaky E2E test: merge proposed change

### DIFF
--- a/frontend/tests/e2e/proposed-changes/proposed-changes.spec.ts
+++ b/frontend/tests/e2e/proposed-changes/proposed-changes.spec.ts
@@ -91,7 +91,7 @@ test.describe("/proposed-changes", () => {
         });
       });
 
-      test("merged proposed change", async () => {
+      test.fixme("merged proposed change", async () => {
         await test.step("merge proposed change and update UI", async () => {
           await page.getByRole("button", { name: "Merge" }).click();
           await expect(page.getByText("Proposed changes merged successfully!")).toBeVisible();


### PR DESCRIPTION
we disable it for now and will enable it again in a separate branch once we get to looking at that one.