### PR TITLE
Correct SDK _strip_unmodified_dict() issue with Parent

### DIFF
--- a/python_sdk/infrahub_sdk/node.py
+++ b/python_sdk/infrahub_sdk/node.py
@@ -784,8 +784,8 @@ class InfrahubNodeBase:
 
     @staticmethod
     def _strip_unmodified_dict(data: dict, original_data: dict, variables: dict, item: str) -> None:
-        for item_key in original_data[item].keys():
-            if isinstance(data[item], dict):
+        if item in original_data and isinstance(original_data[item], dict) and isinstance(data.get(item), dict):
+            for item_key in original_data[item].keys():
                 for property_name in PROPERTIES_OBJECT:
                     if item_key == property_name and isinstance(original_data[item][property_name], dict):
                         if original_data[item][property_name].get("id"):
@@ -795,13 +795,18 @@ class InfrahubNodeBase:
                         # Related nodes typically require an ID. So the ID is only
                         # removed if it's the last key in the current context
                         continue
+
                     variable_key = None
-                    if isinstance(data[item][item_key], str):
+                    if isinstance(data[item].get(item_key), str):
                         variable_key = data[item][item_key][1:]
 
-                    if original_data[item][item_key] == data[item][item_key]:
+                    if original_data[item].get(item_key) == data[item].get(item_key):
                         data[item].pop(item_key)
-                    elif variable_key in variables and original_data[item][item_key] == variables[variable_key]:
+                    elif (
+                        variable_key
+                        and variable_key in variables
+                        and original_data[item].get(item_key) == variables.get(variable_key)
+                    ):
                         data[item].pop(item_key)
                         variables.pop(variable_key)
 


### PR DESCRIPTION
when trying to change the parent of a GenericLocation for the same node, I got a 'KeyError' on the parent

I saw that we were not checking if the `item` was present in the data when accessing it. (KeyError line 786)

Replace https://github.com/opsmill/infrahub/pull/2021