### PR TITLE
Replace registry.get_schema with registry.schema.get

### DIFF
--- a/backend/infrahub/api/diff/diff.py
+++ b/backend/infrahub/api/diff/diff.py
@@ -309,7 +309,7 @@ class BranchDiffArtifact(BaseModel):
 async def get_display_labels_per_kind(kind: str, ids: List[str], branch_name: str, db: InfrahubDatabase):
     """Return the display_labels of a list of nodes of a specific kind."""
     branch = await get_branch(branch=branch_name, db=db)
-    schema = registry.get_schema(name=kind, branch=branch)
+    schema = registry.schema.get(name=kind, branch=branch)
     fields = schema.generate_fields_for_display_label()
     nodes = await NodeManager.get_many(ids=ids, fields=fields, db=db, branch=branch)
     return {node_id: await node.render_display_label(db=db) for node_id, node in nodes.items()}
@@ -643,7 +643,7 @@ class DiffPayload:
                 self._add_node_to_diff(node_id=item_dict["id"], kind=item_dict["kind"])
                 self._set_display_label(node_id=item_dict["id"], branch=branch_name, display_label=display_label)
                 self._set_node_action(node_id=item_dict["id"], branch=branch_name, action=item_dict["action"])
-                schema = registry.get_schema(name=node_diff.kind, branch=node_diff.branch)
+                schema = registry.schema.get(name=node_diff.kind, branch=node_diff.branch)
 
                 # Extract the value from the list of properties
                 for _, element in node_diff.elements.items():
@@ -708,7 +708,7 @@ class DiffPayload:
                     if self.kinds_to_include and node_kind not in self.kinds_to_include:
                         continue
 
-                    schema = registry.get_schema(name=node_kind, branch=branch_name)
+                    schema = registry.schema.get(name=node_kind, branch=branch_name)
                     rel_schema = schema.get_relationship_by_identifier(id=rel_name, raise_on_error=False)
                     if not rel_schema:
                         continue
@@ -810,7 +810,7 @@ async def generate_diff_payload(  # pylint: disable=too-many-branches,too-many-s
                 **item_dict, elements=item_elements, display_label=branch_display_labels.get(item.id, "")
             )
 
-            schema = registry.get_schema(name=node_diff.kind, branch=node_diff.branch)
+            schema = registry.schema.get(name=node_diff.kind, branch=node_diff.branch)
 
             # Extract the value from the list of properties
             for _, element in node_diff.elements.items():
@@ -868,7 +868,7 @@ async def generate_diff_payload(  # pylint: disable=too-many-branches,too-many-s
                 if kinds_to_include and node_kind not in kinds_to_include:
                     continue
 
-                schema = registry.get_schema(name=node_kind, branch=branch_name)
+                schema = registry.schema.get(name=node_kind, branch=branch_name)
                 rel_schema = schema.get_relationship_by_identifier(id=rel_name, raise_on_error=False)
                 if not rel_schema:
                     continue

--- a/backend/infrahub/core/account.py
+++ b/backend/infrahub/core/account.py
@@ -102,7 +102,7 @@ async def get_account(
     if account in registry.account:
         return registry.account[account]
 
-    account_schema = registry.get_schema(name=InfrahubKind.ACCOUNT)
+    account_schema = registry.schema.get(name=InfrahubKind.ACCOUNT)
 
     obj = await NodeManager.query(
         schema=account_schema, filters={account_schema.default_filter: account}, branch=branch, at=at, db=db

--- a/backend/infrahub/core/branch.py
+++ b/backend/infrahub/core/branch.py
@@ -1296,7 +1296,7 @@ class Diff:
                 for _, rel in rels.items():
                     for node_id in rel.nodes:
                         neighbor_id = [neighbor for neighbor in rel.nodes.keys() if neighbor != node_id][0]
-                        schema = registry.get_schema(name=rel.nodes[node_id].kind, branch=branch_name)
+                        schema = registry.schema.get(name=rel.nodes[node_id].kind, branch=branch_name)
                         matching_relationship = [r for r in schema.relationships if r.identifier == rel_name]
                         if (
                             matching_relationship
@@ -1349,7 +1349,7 @@ class Diff:
 
         for branch_name, entries in branch_kind_node.items():
             for kind, ids in entries.items():
-                schema = registry.get_schema(name=kind, branch=branch_name)
+                schema = registry.schema.get(name=kind, branch=branch_name)
                 fields = schema.generate_fields_for_display_label()
                 nodes = await NodeManager.get_many(ids=ids, fields=fields, db=db, branch=branch_name)
                 for node_id, node in nodes.items():
@@ -1942,7 +1942,7 @@ class Diff:
         neighbor_map = {node_ids[0]: node_ids[1], node_ids[1]: node_ids[0]}
         relationship_paths = RelationshipPath()
         for relationship in nodes.values():
-            schema = registry.get_schema(name=relationship.kind, branch=branch_name)
+            schema = registry.schema.get(name=relationship.kind, branch=branch_name)
             matching_relationship = [r for r in schema.relationships if r.identifier == relationship_name]
             relationship_path_name = "-undefined-"
             if matching_relationship:

--- a/backend/infrahub/core/initialization.py
+++ b/backend/infrahub/core/initialization.py
@@ -106,7 +106,7 @@ async def initialization(db: InfrahubDatabase):
     # ---------------------------------------------------
     # Load all existing Groups into the registry
     # ---------------------------------------------------
-    # group_schema = await registry.get_schema(db=db, name="Group")
+    # group_schema = await registry.schema.get(db=db, name="Group")
     # groups = await NodeManager.query(group_schema, db=db)
     # for group in groups:
     #     registry.node_group[group.name.value] = group
@@ -215,18 +215,7 @@ async def first_time_initialization(db: InfrahubDatabase):
     # --------------------------------------------------
     # Create Default Users and Groups
     # --------------------------------------------------
-    token_schema = registry.get_schema(name=InfrahubKind.ACCOUNTTOKEN)
-    # admin_grp = await Node.init(db=db, schema=group_schema)
-    # await admin_grp.new(db=db, name="admin")
-    # await admin_grp.save(db=db)
-    # ----
-    # group_schema = registry.get_schema(name="Group")
-
-    # admin_grp = await Node.init(db=db, schema=group_schema)
-    # await admin_grp.new(db=db, name="admin")
-    # await admin_grp.save(db=db)
-    # default_grp = obj = Node(group_schema).new(name="default").save()
-    # account_schema = registry.get_schema(name="Account")
+    token_schema = registry.schema.get(name=InfrahubKind.ACCOUNTTOKEN)
     obj = await Node.init(db=db, schema=InfrahubKind.ACCOUNT)
     await obj.new(
         db=db,

--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -82,7 +82,7 @@ class NodeManager:
         at = Timestamp(at)
 
         if isinstance(schema, str):
-            schema = registry.get_schema(name=schema, branch=branch.name)
+            schema = registry.schema.get(name=schema, branch=branch.name)
         elif not isinstance(schema, (NodeSchema, GenericSchema)):
             raise ValueError(f"Invalid schema provided {schema}")
 
@@ -302,7 +302,7 @@ class NodeManager:
         branch = await get_branch(branch=branch, db=db)
         at = Timestamp(at)
 
-        node_schema = registry.get_node_schema(name=schema_name, branch=branch)
+        node_schema = registry.schema.get(name=schema_name, branch=branch)
         if not node_schema.default_filter:
             raise NodeNotFound(branch_name=branch.name, node_type=schema_name, identifier=id)
 

--- a/backend/infrahub/core/registry.py
+++ b/backend/infrahub/core/registry.py
@@ -129,15 +129,6 @@ class Registry:
         default_branch = config.SETTINGS.main.default_branch
         return attr[default_branch]
 
-    def set_schema(self, name: str, schema: Union[NodeSchema, GenericSchema], branch: Optional[str] = None) -> int:
-        return self.schema.set(name=name, schema=schema, branch=branch)
-
-    def has_schema(self, name: str, branch: Optional[Union[Branch, str]] = None) -> bool:
-        return self.schema.has(name=name, branch=branch)
-
-    def get_schema(self, name: str, branch: Optional[Union[Branch, str]] = None) -> Union[NodeSchema, GenericSchema]:
-        return self.schema.get(name=name, branch=branch)
-
     def get_node_schema(self, name: str, branch: Optional[Union[Branch, str]] = None) -> NodeSchema:
         return self.schema.get(name=name, branch=branch)
 

--- a/backend/infrahub/core/relationship.py
+++ b/backend/infrahub/core/relationship.py
@@ -248,7 +248,7 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin):
         self.peer_id = self._peer.id
 
     async def get_peer_schema(self) -> NodeSchema:
-        return registry.get_schema(name=self.schema.peer, branch=self.branch)
+        return registry.schema.get(name=self.schema.peer, branch=self.branch)
 
     def compare_properties_with_data(self, data: RelationshipPeerData) -> List[str]:
         different_properties = []

--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -248,7 +248,7 @@ class InfrahubMutationMixin:
             attr = getattr(node, unique_attr.name)
             if unique_attr.inherited:
                 for generic_parent_schema_name in cls._meta.schema.inherit_from:
-                    generic_parent_schema = registry.get_schema(generic_parent_schema_name, branch=branch)
+                    generic_parent_schema = registry.schema.get(generic_parent_schema_name, branch=branch)
                     parent_attr = generic_parent_schema.get_attribute(unique_attr.name, raise_on_error=False)
                     if parent_attr is None:
                         continue

--- a/backend/infrahub/graphql/mutations/schema.py
+++ b/backend/infrahub/graphql/mutations/schema.py
@@ -55,7 +55,7 @@ class SchemaDropdownAdd(Mutation):
     ):
         db: InfrahubDatabase = info.context.get("infrahub_database")
         branch: Branch = info.context.get("infrahub_branch")
-        kind = registry.get_schema(name=str(data.kind), branch=branch.name)
+        kind = registry.schema.get(name=str(data.kind), branch=branch.name)
         attribute = str(data.attribute)
         validate_kind_dropdown(kind=kind, attribute=attribute)
         dropdown = str(data.dropdown)
@@ -71,7 +71,7 @@ class SchemaDropdownAdd(Mutation):
 
         await update_registry(kind=kind, branch=branch, db=db)
 
-        kind = registry.get_schema(name=str(data.kind), branch=branch.name)
+        kind = registry.schema.get(name=str(data.kind), branch=branch.name)
         attrib = kind.get_attribute(attribute)
         dropdown_entry = {}
         success = False
@@ -104,7 +104,7 @@ class SchemaDropdownRemove(Mutation):
     ) -> Dict[str, bool]:
         db: InfrahubDatabase = info.context.get("infrahub_database")
         branch: Branch = info.context.get("infrahub_branch")
-        kind = registry.get_schema(name=str(data.kind), branch=branch.name)
+        kind = registry.schema.get(name=str(data.kind), branch=branch.name)
 
         attribute = str(data.attribute)
         validate_kind_dropdown(kind=kind, attribute=attribute)
@@ -145,7 +145,7 @@ class SchemaEnumAdd(Mutation):
     ) -> Dict[str, bool]:
         db: InfrahubDatabase = info.context.get("infrahub_database")
         branch: Branch = info.context.get("infrahub_branch")
-        kind = registry.get_schema(name=str(data.kind), branch=branch.name)
+        kind = registry.schema.get(name=str(data.kind), branch=branch.name)
 
         attribute = str(data.attribute)
         enum = str(data.enum)
@@ -179,7 +179,7 @@ class SchemaEnumRemove(Mutation):
     ) -> Dict[str, bool]:
         db: InfrahubDatabase = info.context.get("infrahub_database")
         branch: Branch = info.context.get("infrahub_branch")
-        kind = registry.get_schema(name=str(data.kind), branch=branch.name)
+        kind = registry.schema.get(name=str(data.kind), branch=branch.name)
 
         attribute = str(data.attribute)
         enum = str(data.enum)

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -1475,9 +1475,9 @@ async def car_person_schema_generics(
 
 @pytest.fixture
 async def car_person_generics_data(db: InfrahubDatabase, car_person_schema_generics) -> Dict[str, Node]:
-    ecar = registry.get_schema(name="TestElectricCar")
-    gcar = registry.get_schema(name="TestGazCar")
-    person = registry.get_schema(name="TestPerson")
+    ecar = registry.schema.get(name="TestElectricCar")
+    gcar = registry.schema.get(name="TestGazCar")
+    person = registry.schema.get(name="TestPerson")
 
     p1 = await Node.init(db=db, schema=person)
     await p1.new(db=db, name="John", height=180)

--- a/backend/tests/unit/core/test_account.py
+++ b/backend/tests/unit/core/test_account.py
@@ -6,8 +6,8 @@ from infrahub.database import InfrahubDatabase
 
 
 async def test_validate_user_create(db: InfrahubDatabase, default_branch, register_core_models_schema):
-    account_schema = registry.get_schema(name=InfrahubKind.ACCOUNT, branch=default_branch)
-    account_token_schema = registry.get_schema(name=InfrahubKind.ACCOUNTTOKEN, branch=default_branch)
+    account_schema = registry.schema.get(name=InfrahubKind.ACCOUNT, branch=default_branch)
+    account_token_schema = registry.schema.get(name=InfrahubKind.ACCOUNTTOKEN, branch=default_branch)
 
     user1 = await Node.init(db=db, schema=account_schema)
     await user1.new(db=db, name="user1", password="User1Password123")
@@ -18,8 +18,8 @@ async def test_validate_user_create(db: InfrahubDatabase, default_branch, regist
 
 
 async def test_validate_token(db: InfrahubDatabase, default_branch, register_core_models_schema):
-    account_schema = registry.get_schema(name=InfrahubKind.ACCOUNT, branch=default_branch)
-    account_token_schema = registry.get_schema(name=InfrahubKind.ACCOUNTTOKEN, branch=default_branch)
+    account_schema = registry.schema.get(name=InfrahubKind.ACCOUNT, branch=default_branch)
+    account_token_schema = registry.schema.get(name=InfrahubKind.ACCOUNTTOKEN, branch=default_branch)
 
     user1 = await Node.init(db=db, schema=account_schema)
     await user1.new(db=db, name="user1", password="User1Password123", role="read-write")

--- a/backend/tests/unit/core/test_manager_node.py
+++ b/backend/tests/unit/core/test_manager_node.py
@@ -110,8 +110,8 @@ async def test_get_one_attribute_with_flag_property(
 
 
 async def test_get_one_relationship(db: InfrahubDatabase, default_branch: Branch, car_person_schema):
-    car = registry.get_schema(name="TestCar")
-    person = registry.get_schema(name="TestPerson")
+    car = registry.schema.get(name="TestCar")
+    person = registry.schema.get(name="TestPerson")
 
     p1 = await Node.init(db=db, schema=person)
     await p1.new(db=db, name="John", height=180)
@@ -277,7 +277,7 @@ async def test_query_with_filter_bool_rel(
     car_camry_main,
     branch: Branch,
 ):
-    car = registry.get_schema(name="TestCar")
+    car = registry.schema.get(name="TestCar")
 
     # Check filter with a boolean
     nodes = await NodeManager.query(db=db, schema=car, branch=branch, filters={"is_electric__value": False})
@@ -298,7 +298,7 @@ async def test_query_filter_with_multiple_values_rel(
     car_camry_main,
     branch: Branch,
 ):
-    car = registry.get_schema(name="TestCar")
+    car = registry.schema.get(name="TestCar")
 
     nodes = await NodeManager.query(db=db, schema=car, branch=branch, filters={"owner__name__values": ["John", "Jane"]})
     assert len(nodes) == 4
@@ -314,7 +314,7 @@ async def test_qeury_with_multiple_values_invalid_type(
     car_camry_main,
     branch: Branch,
 ):
-    car = registry.get_schema(name="TestCar")
+    car = registry.schema.get(name="TestCar")
 
     with pytest.raises(TypeError):
         await NodeManager.query(db=db, schema=car, branch=branch, filters={"owner__name__values": [1.0]})

--- a/backend/tests/unit/core/test_manager_schema.py
+++ b/backend/tests/unit/core/test_manager_schema.py
@@ -1400,7 +1400,7 @@ async def test_load_schema_to_db_core_models(
 
     await registry.schema.load_schema_to_db(schema=new_schema, db=db)
 
-    node_schema = registry.get_schema(name="SchemaGeneric")
+    node_schema = registry.schema.get(name="SchemaGeneric")
     results = await SchemaManager.query(schema=node_schema, db=db)
     assert len(results) > 1
 

--- a/backend/tests/unit/core/test_node.py
+++ b/backend/tests/unit/core/test_node.py
@@ -59,7 +59,7 @@ async def test_node_init(
 
 
 async def test_node_init_schema_name(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
-    registry.set_schema(name="TestCriticality", schema=criticality_schema)
+    registry.schema.set(name="TestCriticality", schema=criticality_schema)
     obj = await Node.init(db=db, schema="TestCriticality")
     await obj.new(db=db, name="low", level=4)
 
@@ -70,7 +70,7 @@ async def test_node_init_schema_name(db: InfrahubDatabase, default_branch: Branc
 
 
 async def test_node_init_id(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
-    registry.set_schema(name="TestCriticality", schema=criticality_schema)
+    registry.schema.set(name="TestCriticality", schema=criticality_schema)
 
     uuid1 = str(UUIDT())
     obj = await Node.init(db=db, schema="TestCriticality")
@@ -81,7 +81,7 @@ async def test_node_init_id(db: InfrahubDatabase, default_branch: Branch, critic
 
 
 async def test_node_init_id_conflict(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
-    registry.set_schema(name="TestCriticality", schema=criticality_schema)
+    registry.schema.set(name="TestCriticality", schema=criticality_schema)
 
     uuid1 = str(UUIDT())
     obj1 = await Node.init(db=db, schema="TestCriticality")
@@ -96,7 +96,7 @@ async def test_node_init_id_conflict(db: InfrahubDatabase, default_branch: Branc
 
 
 async def test_node_init_invalid_id(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
-    registry.set_schema(name="TestCriticality", schema=criticality_schema)
+    registry.schema.set(name="TestCriticality", schema=criticality_schema)
 
     obj = await Node.init(db=db, schema="TestCriticality")
     with pytest.raises(ValidationError) as exc:
@@ -169,7 +169,7 @@ async def test_node_default_value(db: InfrahubDatabase, default_branch: Branch):
     }
 
     node_schema = NodeSchema(**SCHEMA)
-    registry.set_schema(name=node_schema.kind, schema=node_schema)
+    registry.schema.set(name=node_schema.kind, schema=node_schema)
 
     obj = await Node.init(db=db, schema=node_schema)
     await obj.new(db=db, name="test01", myint=100, mybool=False, mystr="test02")
@@ -223,8 +223,8 @@ async def test_render_display_label(db: InfrahubDatabase, default_branch: Branch
 
 
 async def test_node_init_with_single_relationship(db: InfrahubDatabase, default_branch: Branch, car_person_schema):
-    car = registry.get_schema(name="TestCar")
-    person = registry.get_schema(name="TestPerson")
+    car = registry.schema.get(name="TestCar")
+    person = registry.schema.get(name="TestPerson")
 
     p1 = await Node.init(db=db, schema=person)
     await p1.new(db=db, name="John", height=180)
@@ -254,8 +254,8 @@ async def test_node_init_with_single_relationship(db: InfrahubDatabase, default_
 
 
 async def test_to_graphql(db: InfrahubDatabase, default_branch: Branch, car_person_schema):
-    car = registry.get_schema(name="TestCar")
-    person = registry.get_schema(name="TestPerson")
+    car = registry.schema.get(name="TestCar")
+    person = registry.schema.get(name="TestPerson")
 
     p1 = await Node.init(db=db, schema=person)
     await p1.new(db=db, name="John", height=180)
@@ -289,8 +289,8 @@ async def test_to_graphql(db: InfrahubDatabase, default_branch: Branch, car_pers
 
 
 async def test_to_graphql_no_fields(db: InfrahubDatabase, default_branch: Branch, car_person_schema):
-    car = registry.get_schema(name="TestCar")
-    person = registry.get_schema(name="TestPerson")
+    car = registry.schema.get(name="TestCar")
+    person = registry.schema.get(name="TestPerson")
 
     p1 = await Node.init(db=db, schema=person)
     await p1.new(db=db, name="John", height=180)
@@ -493,8 +493,8 @@ async def test_node_create_attribute_with_different_owner(
 
 
 async def test_node_create_with_single_relationship(db: InfrahubDatabase, default_branch: Branch, car_person_schema):
-    car = registry.get_schema(name="TestCar")
-    person = registry.get_schema(name="TestPerson")
+    car = registry.schema.get(name="TestCar")
+    person = registry.schema.get(name="TestPerson")
 
     p1 = await Node.init(db=db, schema=person)
     await p1.new(db=db, name="John", height=180)
@@ -563,8 +563,8 @@ async def test_node_create_with_single_relationship(db: InfrahubDatabase, defaul
 
 
 async def test_node_create_with_multiple_relationship(db: InfrahubDatabase, default_branch: Branch, fruit_tag_schema):
-    fruit = registry.get_schema(name="GardenFruit")
-    tag = registry.get_schema(name=InfrahubKind.TAG)
+    fruit = registry.schema.get(name="GardenFruit")
+    tag = registry.schema.get(name=InfrahubKind.TAG)
 
     t1 = await Node.init(db=db, schema=tag)
     await t1.new(db=db, name="tag1")
@@ -1069,7 +1069,7 @@ async def test_node_relationship_interface(db: InfrahubDatabase, default_branch:
 
 
 async def test_node_serialize_prefix(db: InfrahubDatabase, default_branch: Branch, prefix_schema):
-    prefix = registry.get_schema(name="TestPrefix")
+    prefix = registry.schema.get(name="TestPrefix")
 
     p1 = await Node.init(db=db, schema=prefix)
     await p1.new(db=db, prefix="192.0.2.1", name="prefix1")
@@ -1094,7 +1094,7 @@ async def test_node_serialize_prefix(db: InfrahubDatabase, default_branch: Branc
 
 
 async def test_node_serialize_address(db: InfrahubDatabase, default_branch: Branch, prefix_schema):
-    ip = registry.get_schema(name="TestIp")
+    ip = registry.schema.get(name="TestIp")
 
     i1 = await Node.init(db=db, schema=ip)
     await i1.new(db=db, address="192.0.2.1", name="ip1")

--- a/backend/tests/unit/core/test_relationship.py
+++ b/backend/tests/unit/core/test_relationship.py
@@ -13,7 +13,7 @@ from infrahub.database import InfrahubDatabase
 async def test_relationship_init(
     db: InfrahubDatabase, default_branch: Branch, tag_blue_main: Node, person_jack_main: Node, branch: Branch
 ):
-    person_schema = registry.get_schema(name="TestPerson")
+    person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
     rel = Relationship(schema=rel_schema, branch=branch, node=person_jack_main)
@@ -45,7 +45,7 @@ async def test_relationship_init_w_node_property(
     person_jack_main: Node,
     branch: Branch,
 ):
-    person_schema = registry.get_schema(name="TestPerson")
+    person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
     rel = Relationship(
@@ -79,7 +79,7 @@ async def car_smart_properties_main(db: InfrahubDatabase, default_branch: Branch
 async def test_relationship_load_existing(
     db: InfrahubDatabase, person_john_main: Node, car_smart_properties_main: Node, branch: Branch
 ):
-    car_schema = registry.get_schema(name="TestCar")
+    car_schema = registry.schema.get(name="TestCar")
     rel_schema = car_schema.get_relationship("owner")
 
     rel = Relationship(schema=rel_schema, branch=branch, node=car_smart_properties_main)
@@ -107,7 +107,7 @@ async def test_relationship_load_existing(
 
 
 async def test_relationship_peer(db: InfrahubDatabase, tag_blue_main: Node, person_jack_main: Node, branch: Branch):
-    person_schema = registry.get_schema(name="TestPerson")
+    person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
     rel = Relationship(schema=rel_schema, branch=branch, node=person_jack_main)
@@ -123,7 +123,7 @@ async def test_relationship_peer(db: InfrahubDatabase, tag_blue_main: Node, pers
 
 
 async def test_relationship_save(db: InfrahubDatabase, tag_blue_main: Node, person_jack_main: Node, branch: Branch):
-    person_schema = registry.get_schema(name="TestPerson")
+    person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
     rel = Relationship(schema=rel_schema, branch=branch, node=person_jack_main)
@@ -139,7 +139,7 @@ async def test_relationship_save(db: InfrahubDatabase, tag_blue_main: Node, pers
 async def test_relationship_hash(
     db: InfrahubDatabase, tag_blue_main: Node, person_jack_main: Node, branch: Branch, first_account
 ):
-    person_schema = registry.get_schema(name="TestPerson")
+    person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
     rel = Relationship(schema=rel_schema, branch=branch, node=person_jack_main)

--- a/backend/tests/unit/core/test_relationship_manager.py
+++ b/backend/tests/unit/core/test_relationship_manager.py
@@ -10,7 +10,7 @@ from infrahub.database import InfrahubDatabase
 
 
 async def test_one_init_no_input_no_rel(db: InfrahubDatabase, person_jack_main: Node, branch: Branch):
-    person_schema = registry.get_schema(name="TestPerson")
+    person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("primary_tag")
 
     relm = await RelationshipManager.init(
@@ -27,7 +27,7 @@ async def test_one_init_no_input_no_rel(db: InfrahubDatabase, person_jack_main: 
 async def test_one_init_no_input_existing_rel(
     db: InfrahubDatabase, tag_blue_main: Node, person_jack_primary_tag_main: Node, branch: Branch
 ):
-    person_schema = registry.get_schema(name="TestPerson")
+    person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("primary_tag")
 
     relm = await RelationshipManager.init(
@@ -44,7 +44,7 @@ async def test_one_init_no_input_existing_rel(
 
 
 async def test_many_init_no_input_no_rel(db: InfrahubDatabase, person_jack_main: Node, branch: Branch):
-    person_schema = registry.get_schema(name="TestPerson")
+    person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
     relm = await RelationshipManager.init(
@@ -59,7 +59,7 @@ async def test_many_init_no_input_no_rel(db: InfrahubDatabase, person_jack_main:
 
 
 async def test_many_init_no_input_existing_rel(db: InfrahubDatabase, person_jack_tags_main: Node, branch: Branch):
-    person_schema = registry.get_schema(name="TestPerson")
+    person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
     relm = await RelationshipManager.init(
@@ -70,7 +70,7 @@ async def test_many_init_no_input_existing_rel(db: InfrahubDatabase, person_jack
 
 
 async def test_one_init_input_obj(db: InfrahubDatabase, tag_blue_main: Node, person_jack_main: Node, branch: Branch):
-    person_schema = registry.get_schema(name="TestPerson")
+    person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("primary_tag")
 
     relm = await RelationshipManager.init(
@@ -88,7 +88,7 @@ async def test_one_init_input_obj(db: InfrahubDatabase, tag_blue_main: Node, per
 
 
 async def test_one_save_input_obj(db: InfrahubDatabase, tag_blue_main: Node, person_jack_main: Node, branch: Branch):
-    person_schema = registry.get_schema(name="TestPerson")
+    person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("primary_tag")
 
     # We should have only 1 paths between t1 and p1 via the branch
@@ -119,7 +119,7 @@ async def test_one_save_input_obj(db: InfrahubDatabase, tag_blue_main: Node, per
 async def test_one_udpate(
     db: InfrahubDatabase, tag_blue_main: Node, person_jack_primary_tag_main: Node, branch: Branch
 ):
-    person_schema = registry.get_schema(name="TestPerson")
+    person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("primary_tag")
 
     # We should have only 1 paths between t1 and p1 via the branch
@@ -150,7 +150,7 @@ async def test_one_udpate(
 async def test_many_init_input_obj(
     db: InfrahubDatabase, tag_blue_main: Node, tag_red_main: Node, person_jack_main: Node, branch: Branch
 ):
-    person_schema = registry.get_schema(name="TestPerson")
+    person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
     relm = await RelationshipManager.init(
@@ -169,7 +169,7 @@ async def test_many_init_input_obj(
 async def test_many_save_input_obj(
     db: InfrahubDatabase, tag_blue_main: Node, tag_red_main: Node, person_jack_main: Node, branch: Branch
 ):
-    person_schema = registry.get_schema(name="TestPerson")
+    person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
     # We should have only 1 paths between t1 and p1 via the branch
@@ -208,7 +208,7 @@ async def test_many_save_input_obj(
 async def test_many_update(
     db: InfrahubDatabase, tag_blue_main: Node, tag_red_main: Node, person_jack_main: Node, branch: Branch
 ):
-    person_schema = registry.get_schema(name="TestPerson")
+    person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
     relm = await RelationshipManager.init(

--- a/backend/tests/unit/core/test_relationship_query.py
+++ b/backend/tests/unit/core/test_relationship_query.py
@@ -29,7 +29,7 @@ class DummyRelationshipQuery(RelationshipQuery):
 async def test_RelationshipQuery_init(
     db: InfrahubDatabase, tag_blue_main: Node, person_jack_main: Node, branch: Branch
 ):
-    person_schema = registry.get_schema(name="TestPerson")
+    person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
     with pytest.raises(ValueError) as exc:
@@ -71,7 +71,7 @@ async def test_RelationshipQuery_init(
 async def test_query_RelationshipCreateQuery(
     db: InfrahubDatabase, tag_blue_main: Node, person_jack_main: Node, branch: Branch
 ):
-    person_schema = registry.get_schema(name="TestPerson")
+    person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
     query = await RelationshipCreateQuery.init(
@@ -96,7 +96,7 @@ async def test_query_RelationshipCreateQuery(
 async def test_query_RelationshipCreateQuery_w_node_property(
     db: InfrahubDatabase, tag_blue_main: Node, person_jack_main: Node, first_account: Node, branch: Branch
 ):
-    person_schema = registry.get_schema(name="TestPerson")
+    person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
     paths = await get_paths_between_nodes(
@@ -129,7 +129,7 @@ async def test_query_RelationshipCreateQuery_w_node_property(
 async def test_query_RelationshipDeleteQuery(
     db: InfrahubDatabase, tag_blue_main: Node, person_jack_tags_main: Node, branch: Branch
 ):
-    person_schema = registry.get_schema(name="TestPerson")
+    person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
     # We should have 2 paths between t1 and p1
@@ -252,7 +252,7 @@ async def test_query_RelationshipDeleteQuery(
 async def test_query_RelationshipGetPeerQuery(
     db: InfrahubDatabase, tag_blue_main: Node, person_jack_tags_main: Node, branch: Branch
 ):
-    person_schema = registry.get_schema(name="TestPerson")
+    person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
     query = await RelationshipGetPeerQuery.init(
@@ -289,7 +289,7 @@ async def test_query_RelationshipGetPeerQuery_with_filter(
     car_yaris_main,
     branch: Branch,
 ):
-    person_schema = registry.get_schema(name="TestPerson")
+    person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("cars")
 
     query = await RelationshipGetPeerQuery.init(
@@ -317,7 +317,7 @@ async def test_query_RelationshipGetPeerQuery_with_id(
     car_yaris_main,
     branch: Branch,
 ):
-    person_schema = registry.get_schema(name="TestPerson")
+    person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("cars")
 
     query = await RelationshipGetPeerQuery.init(
@@ -344,7 +344,7 @@ async def test_query_RelationshipGetPeerQuery_with_ids(
     car_yaris_main,
     branch: Branch,
 ):
-    person_schema = registry.get_schema(name="TestPerson")
+    person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("cars")
 
     query = await RelationshipGetPeerQuery.init(
@@ -405,7 +405,7 @@ async def test_query_RelationshipGetPeerQuery_deleted_node(
     node = await NodeManager.get_one(id=car_volt_main.id, db=db, branch=branch)
     await node.delete(db=db)
 
-    person_schema = registry.get_schema(name="TestPerson")
+    person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("cars")
 
     query = await RelationshipGetPeerQuery.init(
@@ -431,7 +431,7 @@ async def test_query_RelationshipGetPeerQuery_with_multiple_filter(
     car_yaris_main,
     branch: Branch,
 ):
-    person_schema = registry.get_schema(name="TestPerson")
+    person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("cars")
 
     query = await RelationshipGetPeerQuery.init(
@@ -452,7 +452,7 @@ async def test_query_RelationshipGetPeerQuery_with_multiple_filter(
 async def test_query_RelationshipDataDeleteQuery(
     db: InfrahubDatabase, tag_blue_main: Node, person_jack_tags_main: Node, branch: Branch
 ):
-    person_schema = registry.get_schema(name="TestPerson")
+    person_schema = registry.schema.get(name="TestPerson")
     rel_schema = person_schema.get_relationship("tags")
 
     # We should have 2 paths between t1 and p1

--- a/backend/tests/unit/core/test_schema.py
+++ b/backend/tests/unit/core/test_schema.py
@@ -220,7 +220,7 @@ async def test_node_schema_generate_fields_for_display_label():
 
 
 async def test_rel_schema_query_filter(db: InfrahubDatabase, default_branch, car_person_schema):
-    person = registry.get_schema(name="TestPerson")
+    person = registry.schema.get(name="TestPerson")
     rel = person.relationships[0]
 
     # Filter relationships by NAME__VALUE
@@ -255,7 +255,7 @@ async def test_rel_schema_query_filter(db: InfrahubDatabase, default_branch, car
 
 
 async def test_rel_schema_query_filter_no_value(db: InfrahubDatabase, default_branch, car_person_schema):
-    person = registry.get_schema(name="TestPerson")
+    person = registry.schema.get(name="TestPerson")
     rel = person.relationships[0]
 
     # Filter relationships by NAME__VALUE

--- a/backend/tests/unit/graphql/test_generator.py
+++ b/backend/tests/unit/graphql/test_generator.py
@@ -163,7 +163,7 @@ async def test_generate_object_types(
 async def test_generate_filters(
     db: InfrahubDatabase, default_branch: Branch, data_schema, group_graphql, car_person_schema_generics
 ):
-    person = registry.get_schema(name="TestPerson")
+    person = registry.schema.get(name="TestPerson")
     filters = await generate_filters(db=db, schema=person, top_level=True)
     expected_filters = [
         "offset",

--- a/backend/tests/unit/graphql/test_graphql_query.py
+++ b/backend/tests/unit/graphql/test_graphql_query.py
@@ -319,8 +319,8 @@ async def test_all_attributes(db: InfrahubDatabase, default_branch: Branch, data
 
 
 async def test_nested_query(db: InfrahubDatabase, default_branch: Branch, car_person_schema):
-    car = registry.get_schema(name="TestCar")
-    person = registry.get_schema(name="TestPerson")
+    car = registry.schema.get(name="TestCar")
+    person = registry.schema.get(name="TestPerson")
 
     p1 = await Node.init(db=db, schema=person)
     await p1.new(db=db, name="John", height=180)
@@ -385,8 +385,8 @@ async def test_nested_query(db: InfrahubDatabase, default_branch: Branch, car_pe
 
 
 async def test_double_nested_query(db: InfrahubDatabase, default_branch: Branch, car_person_schema):
-    car = registry.get_schema(name="TestCar")
-    person = registry.get_schema(name="TestPerson")
+    car = registry.schema.get(name="TestCar")
+    person = registry.schema.get(name="TestPerson")
 
     p1 = await Node.init(db=db, schema=person)
     await p1.new(db=db, name="John", height=180)
@@ -462,8 +462,8 @@ async def test_double_nested_query(db: InfrahubDatabase, default_branch: Branch,
 
 
 async def test_display_label_nested_query(db: InfrahubDatabase, default_branch: Branch, car_person_schema):
-    car = registry.get_schema(name="TestCar")
-    person = registry.get_schema(name="TestPerson")
+    car = registry.schema.get(name="TestCar")
+    person = registry.schema.get(name="TestPerson")
 
     p1 = await Node.init(db=db, schema=person)
     await p1.new(db=db, name="John", height=180)
@@ -555,8 +555,8 @@ async def test_display_label_nested_query(db: InfrahubDatabase, default_branch: 
 
 
 async def test_query_diffsummary(db: InfrahubDatabase, default_branch: Branch, car_person_schema):
-    car = registry.get_schema(name="TestCar")
-    person = registry.get_schema(name="TestPerson")
+    car = registry.schema.get(name="TestCar")
+    person = registry.schema.get(name="TestPerson")
 
     p1_main = await Node.init(db=db, schema=person)
     await p1_main.new(db=db, name="John", height=180)
@@ -623,8 +623,8 @@ async def test_query_diffsummary(db: InfrahubDatabase, default_branch: Branch, c
 
 
 async def test_query_typename(db: InfrahubDatabase, default_branch: Branch, car_person_schema):
-    car = registry.get_schema(name="TestCar")
-    person = registry.get_schema(name="TestPerson")
+    car = registry.schema.get(name="TestCar")
+    person = registry.schema.get(name="TestPerson")
 
     p1 = await Node.init(db=db, schema=person)
     await p1.new(db=db, name="John", height=180)
@@ -814,7 +814,7 @@ async def test_query_filter_on_enum(
     db: InfrahubDatabase, default_branch: Branch, person_john_main, car_person_schema, graphql_enums_on, enum_value
 ):
     config.SETTINGS.experimental_features.graphql_enums = graphql_enums_on
-    car = registry.get_schema(name="TestCar")
+    car = registry.schema.get(name="TestCar")
 
     c1 = await Node.init(db=db, schema=car)
     await c1.new(db=db, name="GoKart", nbr_seats=1, is_electric=True, owner=person_john_main, transmission="manual")
@@ -848,9 +848,9 @@ async def test_query_filter_on_enum(
 
 
 async def test_query_multiple_filters(db: InfrahubDatabase, default_branch: Branch, car_person_manufacturer_schema):
-    car = registry.get_schema(name="TestCar")
-    person = registry.get_schema(name="TestPerson")
-    manufacturer = registry.get_schema(name="TestManufacturer")
+    car = registry.schema.get(name="TestCar")
+    person = registry.schema.get(name="TestPerson")
+    manufacturer = registry.schema.get(name="TestManufacturer")
 
     p1 = await Node.init(db=db, schema=person)
     await p1.new(db=db, name="John", height=180)
@@ -986,8 +986,8 @@ async def test_query_multiple_filters(db: InfrahubDatabase, default_branch: Bran
 
 
 async def test_query_filter_relationships(db: InfrahubDatabase, default_branch: Branch, car_person_schema):
-    car = registry.get_schema(name="TestCar")
-    person = registry.get_schema(name="TestPerson")
+    car = registry.schema.get(name="TestCar")
+    person = registry.schema.get(name="TestPerson")
 
     p1 = await Node.init(db=db, schema=person)
     await p1.new(db=db, name="John", height=180)
@@ -1136,8 +1136,8 @@ async def test_query_filter_relationships_with_generic_filter(
 
 
 async def test_query_filter_relationship_id(db: InfrahubDatabase, default_branch: Branch, car_person_schema):
-    car = registry.get_schema(name="TestCar")
-    person = registry.get_schema(name="TestPerson")
+    car = registry.schema.get(name="TestCar")
+    person = registry.schema.get(name="TestPerson")
 
     p1 = await Node.init(db=db, schema=person)
     await p1.new(db=db, name="John", height=180)
@@ -1240,7 +1240,7 @@ async def test_query_filter_relationship_id(db: InfrahubDatabase, default_branch
 
 
 async def test_query_attribute_multiple_values(db: InfrahubDatabase, default_branch: Branch, car_person_schema):
-    person = registry.get_schema(name="TestPerson")
+    person = registry.schema.get(name="TestPerson")
 
     p1 = await Node.init(db=db, schema=person)
     await p1.new(db=db, name="John", height=180)
@@ -1271,8 +1271,8 @@ async def test_query_attribute_multiple_values(db: InfrahubDatabase, default_bra
 
 
 async def test_query_relationship_multiple_values(db: InfrahubDatabase, default_branch: Branch, car_person_schema):
-    car = registry.get_schema(name="TestCar")
-    person = registry.get_schema(name="TestPerson")
+    car = registry.schema.get(name="TestCar")
+    person = registry.schema.get(name="TestPerson")
 
     p1 = await Node.init(db=db, schema=person)
     await p1.new(db=db, name="John", height=180)
@@ -1728,8 +1728,8 @@ async def test_query_attribute_node_property_owner(
 async def test_query_relationship_node_property(
     db: InfrahubDatabase, default_branch: Branch, car_person_schema, first_account
 ):
-    car = registry.get_schema(name="TestCar")
-    person = registry.get_schema(name="TestPerson")
+    car = registry.schema.get(name="TestCar")
+    person = registry.schema.get(name="TestPerson")
 
     p1 = await Node.init(db=db, schema=person)
     await p1.new(db=db, name="John", height=180)


### PR DESCRIPTION
I noticed that we are still using `registry.get_schema` in a number of places which is a wrapper around `registry.schema.get`

This function was created before the Introduction of the `SchemaManager` when all the schema were stored directly in the registry

This PR removes the methods `registry.get_schema`, `registry.has_schema` and `registry.set_schema`
