### PR TITLE
Remove confusing account relationship for repositories

### DIFF
--- a/backend/infrahub/core/schema.py
+++ b/backend/infrahub/core/schema.py
@@ -1574,14 +1574,6 @@ core_models = {
             ],
             "relationships": [
                 {
-                    "name": "account",
-                    "peer": InfrahubKind.ACCOUNT,
-                    "branch": BranchSupportType.AGNOSTIC.value,
-                    "kind": "Attribute",
-                    "optional": True,
-                    "cardinality": "one",
-                },
-                {
                     "name": "tags",
                     "peer": InfrahubKind.TAG,
                     "kind": "Attribute",


### PR DESCRIPTION
I'm guessing that the account was at some point meant to be a reference to the creator of the repository within Infrahub. But as it is now it's not use and just adds confusion.

Fixes #2093