### PR TITLE
Trim spaces before requesting search

### DIFF
--- a/frontend/src/components/search/search-bar.tsx
+++ b/frontend/src/components/search/search-bar.tsx
@@ -81,19 +81,21 @@ export const SearchBar = () => {
   const branch = useAtomValue(currentBranchAtom);
   const date = useAtomValue(datetimeAtom);
 
-  const handleSearch = async (newValue: string) => {
+  const handleSearch = async (newValue: string = "") => {
+    const cleanedValue = newValue.trim();
+
     try {
       // Set search to set open / close if empty
-      setSearch(newValue);
+      setSearch(cleanedValue);
 
-      if (!newValue) return;
+      if (!cleanedValue) return;
 
       setIsLoading(true);
 
       const { data } = await graphqlClient.query({
         query: SEARCH,
         variables: {
-          search: newValue,
+          search: cleanedValue,
         },
         context: {
           date,


### PR DESCRIPTION
Related issue: https://github.com/opsmill/infrahub/issues/2081

* Removes spaces before and after the search query