### PR TITLE
Fix infrahubctl transform after change in data format

### DIFF
--- a/python_sdk/infrahub_sdk/ctl/cli.py
+++ b/python_sdk/infrahub_sdk/ctl/cli.py
@@ -109,7 +109,7 @@ def _run_transform(query: str, variables: Dict[str, Any], transformer: Callable,
     branch = get_branch(branch)
 
     try:
-        response = execute_graphql_query(query, variables, branch, debug)
+        response = {"data": execute_graphql_query(query, variables, branch, debug)}
     except QueryNotFoundError as exc:
         console.print(f"[red]Unable to find query : {exc}")
         raise typer.Exit(1) from exc


### PR DESCRIPTION
A follow up to #2077 that also fixes the data format for infrahubctl render.

This feels a bit weird as the SDK client execute_graphql strips away the data and we add it back again here. But might be fine since it's for a specific usecase..