### PR TITLE
Fix storage path for local testing

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -128,7 +128,7 @@ def execute_before_any_test(worker_id, tmpdir_factory):
         config.SETTINGS.storage.local = config.FileSystemStorageSettings(path="/opt/infrahub/storage")
     else:
         storage_dir = tmpdir_factory.mktemp("storage")
-        config.SETTINGS.storage.local = config.FileSystemStorageSettings(path=str(storage_dir))
+        config.SETTINGS.storage.local._path = str(storage_dir)
 
     config.SETTINGS.broker.enable = False
     config.SETTINGS.cache.enable = True


### PR DESCRIPTION
Since some time ago I'm not able to run both `infrahub server start` and `pytest backend/tests/unit/xyz` at the same time when I have a storage variable enabled.

```bash
❯ printenv | grep STORAGE
INFRAHUB_STORAGE_LOCAL_PATH=/Users/patrick/Code/opsmill/infrahub/storage
```

```python
❯ pytest backend/tests/unit/message_bus/operations/requests/test_proposed_change.py

    @pytest.fixture(scope="module", autouse=True)
    def execute_before_any_test(worker_id, tmpdir_factory):
        config.load_and_exit()

        config.SETTINGS.storage.driver = config.StorageDriver.FileSystemStorage

        if TEST_IN_DOCKER:
            try:
                db_id = int(worker_id[2]) + 1
            except (ValueError, IndexError):
                db_id = 1

            config.SETTINGS.cache.address = f"{BUILD_NAME}-cache-{db_id}"
            config.SETTINGS.database.address = f"{BUILD_NAME}-database-{db_id}"
            config.SETTINGS.storage.local = config.FileSystemStorageSettings(path="/opt/infrahub/storage")
        else:
            storage_dir = tmpdir_factory.mktemp("storage")
>           config.SETTINGS.storage.local._path = config.FileSystemStorageSettings(path=str(storage_dir))

backend/tests/conftest.py:131:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

__pydantic_self__ = FileSystemStorageSettings(), _case_sensitive = None, _env_prefix = None, _env_file = PosixPath('.'), _env_file_encoding = None, _env_nested_delimiter = None, _secrets_dir = None
values = {'path': '/private/var/folders/zv/vq9k9v817zd_81_r7rdn648c0000gn/T/pytest-of-patrick/pytest-150/storage0'}

    def __init__(
        __pydantic_self__,
        _case_sensitive: bool | None = None,
        _env_prefix: str | None = None,
        _env_file: DotenvType | None = ENV_FILE_SENTINEL,
        _env_file_encoding: str | None = None,
        _env_nested_delimiter: str | None = None,
        _secrets_dir: str | Path | None = None,
        **values: Any,
    ) -> None:
        # Uses something other than `self` the first arg to allow "self" as a settable attribute
>       super().__init__(
            **__pydantic_self__._settings_build_values(
                values,
                _case_sensitive=_case_sensitive,
                _env_prefix=_env_prefix,
                _env_file=_env_file,
                _env_file_encoding=_env_file_encoding,
                _env_nested_delimiter=_env_nested_delimiter,
                _secrets_dir=_secrets_dir,
            )
        )
E       pydantic_core._pydantic_core.ValidationError: 1 validation error for FileSystemStorageSettings
E       path
E         Extra inputs are not permitted [type=extra_forbidden, input_value='/private/var/folders/zv/...ick/pytest-150/storage0', input_type=str]
E           For further information visit https://errors.pydantic.dev/2.5/v/extra_forbidden

../../../.virtualenvs/infrahub/lib/python3.10/site-packages/pydantic_settings/main.py:71: ValidationError
============================================================================================================= short test summary info =============================================================================================================
ERROR backend/tests/unit/message_bus/operations/requests/test_proposed_change.py::test_repository_checks - pydantic_core._pydantic_core.ValidationError: 1 validation error for FileSystemStorageSettings
================================================================================================================ 1 error in 0.13s =================================================================================================================

```

Without this variable I'm not able to start infrahub due to the default path:

```bash
❯ unset INFRAHUB_STORAGE_LOCAL_PATH

infrahub on  pog-test-storage-path [$] is 📦 v0.10.1 via  v20.6.1 via 🐍 v3.10.12 (infrahub)
❯ infrahub server start
2024-02-06T15:41:11.047855Z [info     ] Started server process [91510] [uvicorn.error]
2024-02-06T15:41:11.047941Z [info     ] Waiting for application startup. [uvicorn.error]
2024-02-06T15:41:11.048260Z [info     ] Loading the configuration from /Users/patrick/Code/opsmill/infrahub/infrahub.toml [fastapi]
2024-02-06T15:41:11.084370Z [error    ] Traceback (most recent call last):
  File "/nix/store/zmk12p33784bpcan0nfnji3agxy2z8wg-python3-3.10.12/lib/python3.10/pathlib.py", line 1175, in mkdir
    self._accessor.mkdir(self, mode)
FileNotFoundError: [Errno 2] No such file or directory: '/opt/infrahub/storage'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/patrick/.virtualenvs/infrahub/lib/python3.10/site-packages/starlette/routing.py", line 705, in lifespan
    async with self.lifespan_context(app) as maybe_state:
  File "/nix/store/zmk12p33784bpcan0nfnji3agxy2z8wg-python3-3.10.12/lib/python3.10/contextlib.py", line 199, in __aenter__
    return await anext(self.gen)
  File "/Users/patrick/Code/opsmill/infrahub/backend/infrahub/server.py", line 86, in lifespan
    await app_initialization(application)
  File "/Users/patrick/Code/opsmill/infrahub/backend/infrahub/server.py", line 61, in app_initialization
    await initialization(db=db)
  File "/Users/patrick/Code/opsmill/infrahub/backend/infrahub/core/initialization.py", line 56, in initialization
    registry.storage = await InfrahubObjectStorage.init(settings=config.SETTINGS.storage)
  File "/Users/patrick/Code/opsmill/infrahub/backend/infrahub/storage.py", line 44, in init
    return cls(settings)
  File "/Users/patrick/Code/opsmill/infrahub/backend/infrahub/storage.py", line 40, in __init__
    self._storage = driver(**driver_settings.model_dump(by_alias=True))
  File "/Users/patrick/.virtualenvs/infrahub/lib/python3.10/site-packages/fastapi_storages/filesystem.py", line 18, in __init__
    self._path.mkdir(parents=True, exist_ok=True)
  File "/nix/store/zmk12p33784bpcan0nfnji3agxy2z8wg-python3-3.10.12/lib/python3.10/pathlib.py", line 1179, in mkdir
    self.parent.mkdir(parents=True, exist_ok=True)
  File "/nix/store/zmk12p33784bpcan0nfnji3agxy2z8wg-python3-3.10.12/lib/python3.10/pathlib.py", line 1175, in mkdir
    self._accessor.mkdir(self, mode)
PermissionError: [Errno 13] Permission denied: '/opt/infrahub'
 [uvicorn.error]
2024-02-06T15:41:11.084595Z [error    ] Application startup failed. Exiting. [uvicorn.error]

```

It's a bit annoying to go back and forth between the two, this PR changes the test_setup so that it works for me.