### PR TITLE
fix `fetch` method not using branch for RelatedNodeSync and RelationshipManagerSync

### DIFF
--- a/python_sdk/infrahub_sdk/node.py
+++ b/python_sdk/infrahub_sdk/node.py
@@ -606,6 +606,7 @@ class RelationshipManagerSync(RelationshipManagerBase):
             node = self.client.get(
                 kind=self.node._schema.kind,
                 id=self.node.id,
+                branch=self.branch,
                 include=[self.schema.name],
                 exclude=exclude,
             )


### PR DESCRIPTION
This was implemented in https://github.com/opsmill/infrahub/pull/1794/commits/80979efbbedcb92ed0bcc452b7ce05e1832f8ea5 for the async variants.