### PR TITLE
Refactor pipeline and enable selective artifact generation

### DIFF
--- a/backend/infrahub/message_bus/messages/request_artifactdefinition_check.py
+++ b/backend/infrahub/message_bus/messages/request_artifactdefinition_check.py
@@ -1,12 +1,17 @@
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 from infrahub.message_bus import InfrahubMessage
+from infrahub.message_bus.types import ProposedChangeArtifactDefinition, ProposedChangeBranchDiff
 
 
 class RequestArtifactDefinitionCheck(InfrahubMessage):
     """Sent to validate the generation of artifacts in relation to a proposed change."""
 
-    artifact_definition: str = Field(..., description="The unique ID of the Artifact Definition")
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    artifact_definition: ProposedChangeArtifactDefinition = Field(..., description="The Artifact Definition")
+    branch_diff: ProposedChangeBranchDiff = Field(..., description="The calculated diff between the two branches")
     proposed_change: str = Field(..., description="The unique ID of the Proposed Change")
     source_branch: str = Field(..., description="The source branch")
-    target_branch: str = Field(..., description="The target branch")
+    source_branch_data_only: bool = Field(..., description="Indicates if the source branch is a data only branch")
+    destination_branch: str = Field(..., description="The target branch")

--- a/backend/infrahub/message_bus/operations/requests/artifact_definition.py
+++ b/backend/infrahub/message_bus/operations/requests/artifact_definition.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from infrahub_sdk import UUIDT
 
@@ -11,22 +11,20 @@ from infrahub.services import InfrahubServices
 log = get_logger()
 
 
-async def check(  # pylint: disable=too-many-statements
-    message: messages.RequestArtifactDefinitionCheck, service: InfrahubServices
-) -> None:
+async def check(message: messages.RequestArtifactDefinitionCheck, service: InfrahubServices) -> None:
     log.info(
         "Validating generation of artifacts",
-        artifact_definition=message.artifact_definition,
+        artifact_definition=message.artifact_definition.definition_id,
         source_branch=message.source_branch,
     )
     events: List[InfrahubMessage] = []
 
     artifact_definition = await service.client.get(
-        kind=InfrahubKind.ARTIFACTDEFINITION, id=message.artifact_definition, branch=message.source_branch
+        kind=InfrahubKind.ARTIFACTDEFINITION, id=message.artifact_definition.definition_id, branch=message.source_branch
     )
     proposed_change = await service.client.get(kind=InfrahubKind.PROPOSEDCHANGE, id=message.proposed_change)
 
-    validator_name = f"Artifact Validator: {artifact_definition.name.value}"
+    validator_name = f"Artifact Validator: {message.artifact_definition.definition_name}"
     validator_execution_id = str(UUIDT())
     check_execution_ids: List[str] = []
 
@@ -37,7 +35,7 @@ async def check(  # pylint: disable=too-many-statements
         existing_validator = relationship.peer
         if (
             existing_validator.typename == InfrahubKind.ARTIFACTVALIDATOR
-            and existing_validator.definition.id == message.artifact_definition
+            and existing_validator.definition.id == message.artifact_definition.definition_id
         ):
             validator = existing_validator
 
@@ -53,7 +51,7 @@ async def check(  # pylint: disable=too-many-statements
             data={
                 "label": validator_name,
                 "proposed_change": message.proposed_change,
-                "definition": message.artifact_definition,
+                "definition": message.artifact_definition.definition_id,
             },
         )
         await validator.save()
@@ -64,7 +62,7 @@ async def check(  # pylint: disable=too-many-statements
 
     existing_artifacts = await service.client.filters(
         kind=InfrahubKind.ARTIFACT,
-        definition__ids=[message.artifact_definition],
+        definition__ids=[message.artifact_definition.definition_id],
         include=["object"],
         branch=message.source_branch,
     )
@@ -72,55 +70,43 @@ async def check(  # pylint: disable=too-many-statements
     for artifact in existing_artifacts:
         artifacts_by_member[artifact.object.peer.id] = artifact.id
 
-    await artifact_definition.transformation.fetch()
-    transformation_repository = artifact_definition.transformation.peer.repository
+    repository = message.branch_diff.get_repository(repository_id=message.artifact_definition.repository_id)
 
-    await transformation_repository.fetch()
-
-    transform = artifact_definition.transformation.peer
-    await transform.query.fetch()
-    query = transform.query.peer
-    repository = transformation_repository.peer
-    branch = await service.client.branch.get(branch_name=message.source_branch)
-    if not branch.is_data_only:
-        repository = await service.client.get(
-            kind=InfrahubKind.GENERICREPOSITORY, id=repository.id, branch=message.source_branch, fragment=True
-        )
-    transform_location = ""
-
-    if transform.typename == InfrahubKind.TRANSFORMJINJA2:
-        transform_location = transform.template_path.value
-    elif transform.typename == "CoreTransformPython":
-        transform_location = f"{transform.file_path.value}::{transform.class_name.value}"
-
+    impacted_artifacts = message.branch_diff.get_subscribers_ids(kind=InfrahubKind.ARTIFACT)
     for relationship in group.members.peers:
         member = relationship.peer
-        check_execution_id = str(UUIDT())
-        check_execution_ids.append(check_execution_id)
+        artifact_id = artifacts_by_member.get(member.id)
+        if _render_artifact(
+            artifact_id=artifact_id,
+            managed_branch=not message.source_branch_data_only,
+            impacted_artifacts=impacted_artifacts,
+        ):
+            check_execution_id = str(UUIDT())
+            check_execution_ids.append(check_execution_id)
 
-        events.append(
-            messages.CheckArtifactCreate(
-                artifact_name=artifact_definition.name.value,
-                artifact_id=artifacts_by_member.get(member.id),
-                artifact_definition=message.artifact_definition,
-                commit=repository.commit.value,
-                content_type=artifact_definition.content_type.value,
-                transform_type=transform.typename,
-                transform_location=transform_location,
-                repository_id=repository.id,
-                repository_name=repository.name.value,
-                repository_kind=repository.get_kind(),
-                branch_name=message.source_branch,
-                query=query.name.value,
-                variables=member.extract(params=artifact_definition.parameters.value),
-                target_id=member.id,
-                target_name=member.name.value,
-                timeout=transform.timeout.value,
-                rebase=transform.rebase.value,
-                validator_id=validator.id,
-                meta=Meta(validator_execution_id=validator_execution_id, check_execution_id=check_execution_id),
+            events.append(
+                messages.CheckArtifactCreate(
+                    artifact_name=message.artifact_definition.definition_name,
+                    artifact_id=artifact_id,
+                    artifact_definition=message.artifact_definition.definition_id,
+                    commit=repository.source_commit,
+                    content_type=message.artifact_definition.content_type,
+                    transform_type=message.artifact_definition.transform_kind,
+                    transform_location=message.artifact_definition.transform_location,
+                    repository_id=repository.repository_id,
+                    repository_name=repository.repository_name,
+                    repository_kind=repository.kind,
+                    branch_name=message.source_branch,
+                    query=message.artifact_definition.query_name,
+                    variables=member.extract(params=artifact_definition.parameters.value),
+                    target_id=member.id,
+                    target_name=member.name.value,
+                    timeout=message.artifact_definition.timeout,
+                    rebase=message.artifact_definition.rebase,
+                    validator_id=validator.id,
+                    meta=Meta(validator_execution_id=validator_execution_id, check_execution_id=check_execution_id),
+                )
             )
-        )
 
     checks_in_execution = ",".join(check_execution_ids)
     await service.cache.set(
@@ -218,3 +204,17 @@ async def generate(message: messages.RequestArtifactDefinitionGenerate, service:
     for event in events:
         event.assign_meta(parent=message)
         await service.send(message=event)
+
+
+def _render_artifact(artifact_id: Optional[str], managed_branch: bool, impacted_artifacts: list[str]) -> bool:
+    """Returns a boolean to indicate if an artifact should be generated or not.
+    Will return true if:
+        * The artifact_id wasn't set which could be that it's a new object that doesn't have a previous artifact
+        * The source brance is not data only which would indicate that it could contain updates in git to the transform
+        * The artifact_id exists in the impaced_artifacts list
+    Will return false if:
+        * The source branch is a data only branch and the artifact_id exists and is not in the impacted list
+    """
+    if not artifact_id or managed_branch:
+        return True
+    return artifact_id in impacted_artifacts

--- a/backend/infrahub/message_bus/types.py
+++ b/backend/infrahub/message_bus/types.py
@@ -7,6 +7,9 @@ from typing import List
 from infrahub_sdk.client import NodeDiff  # noqa: TCH002
 from pydantic import BaseModel, Field
 
+from infrahub.core.constants import InfrahubKind
+from infrahub.exceptions import NodeNotFound
+
 SCHEMA_CHANGE = re.compile("^Schema[A-Z]")
 
 
@@ -43,10 +46,55 @@ class ProposedChangeRepository(BaseModel):
             return True
         return False
 
+    @property
+    def kind(self) -> str:
+        if self.read_only:
+            return InfrahubKind.READONLYREPOSITORY
+        return InfrahubKind.REPOSITORY
+
+
+class ProposedChangeSubscriber(BaseModel):
+    subscriber_id: str
+    kind: str
+
+
+class ProposedChangeArtifactDefinition(BaseModel):
+    definition_id: str
+    definition_name: str
+    query_name: str
+    query_models: list[str]
+    repository_id: str
+    transform_kind: str
+    template_path: str = Field(default="")
+    class_name: str = Field(default="")
+    content_type: str
+    file_path: str = Field(default="")
+    timeout: int
+    rebase: bool
+
+    @property
+    def transform_location(self) -> str:
+        if InfrahubKind.TRANSFORMJINJA2:
+            return self.template_path
+        if InfrahubKind.TRANSFORMPYTHON:
+            return f"{self.file_path}::{self.class_name}"
+
+        raise ValueError("Invalid kind for Transform")
+
 
 class ProposedChangeBranchDiff(BaseModel):
     diff_summary: list[NodeDiff] = Field(default_factory=list, description="The DiffSummary between two branches")
     repositories: list[ProposedChangeRepository] = Field(default_factory=list)
+    subscribers: list[ProposedChangeSubscriber] = Field(default_factory=list)
+
+    def get_repository(self, repository_id: str) -> ProposedChangeRepository:
+        for repository in self.repositories:
+            if repository_id == repository.repository_id:
+                return repository
+        raise NodeNotFound(node_type="Repository", identifier=repository_id)
+
+    def get_subscribers_ids(self, kind: str) -> list[str]:
+        return [subscriber.subscriber_id for subscriber in self.subscribers if subscriber.kind == kind]
 
     def has_node_changes(self, branch: str) -> bool:
         """Indicates if there is at least one node object that has been modified in the branch"""
@@ -61,3 +109,21 @@ class ProposedChangeBranchDiff(BaseModel):
     def has_data_changes(self, branch: str) -> bool:
         """Indicates if there are node or schema changes within the branch."""
         return bool([entry for entry in self.diff_summary if entry["branch"] == branch])
+
+    def modified_nodes(self, branch: str) -> list[str]:
+        """Return a list of non schema nodes that have been modified on the branch"""
+        return [
+            entry["node"]
+            for entry in self.diff_summary
+            if entry["branch"] == branch and not SCHEMA_CHANGE.match(entry["kind"])
+        ]
+
+    def modified_kinds(self, branch: str) -> list[str]:
+        """Return a list of non schema kinds that have been modified on the branch"""
+        return list(
+            {
+                entry["kind"]
+                for entry in self.diff_summary
+                if entry["branch"] == branch and not SCHEMA_CHANGE.match(entry["kind"])
+            }
+        )


### PR DESCRIPTION
* Refactors some of the messages to reuse the information that has already been gathered by `request.proposed_change.pipeline`.

* Changes to `request.proposed_change.refresh_artifacts` to query for all artifact definition and provide an early way to completely ignore artifact definitions in the pipeline (if the branch is data-only and the query doesn't contain any models that have been modified)

### Todo

- [x] Use the information about existing nodes that have been changed to avoid regenerating all targets

### Future changes

* Implement the same type of selective runs for Python Checks (type types defined under infrahub_sdk.checks)
* I think we should gather information about the existing Validators within the `request.proposed_change.pipeline` to avoid having to query for them within each message that manages validators.