### PR TITLE
Move logic to connect / disconnect to RabbitMQ to adapter

### DIFF
--- a/backend/infrahub/message_bus/__init__.py
+++ b/backend/infrahub/message_bus/__init__.py
@@ -2,46 +2,11 @@ from __future__ import annotations
 
 from typing import Any, Dict, Optional, Union
 
-import aio_pika
 from pydantic import BaseModel, Field
 
 from infrahub import config
 from infrahub.exceptions import RPCError
 from infrahub.log import set_log_data
-
-
-class Broker:
-    client: aio_pika.abc.AbstractRobustConnection = None
-
-
-broker = Broker()
-
-
-async def connect_to_broker():
-    if not config.SETTINGS.broker.enable:
-        return False
-
-    broker.client = await aio_pika.connect_robust(
-        host=config.SETTINGS.broker.address,
-        login=config.SETTINGS.broker.username,
-        password=config.SETTINGS.broker.password,
-        port=config.SETTINGS.broker.service_port,
-    )
-
-
-async def close_broker_connection():
-    if not config.SETTINGS.broker.enable:
-        return False
-    await broker.client.close()
-
-
-async def get_broker() -> aio_pika.abc.AbstractRobustConnection:
-    if not config.SETTINGS.broker.enable:
-        return False
-    if not broker.client:
-        await connect_to_broker()
-
-    return broker.client
 
 
 class Meta(BaseModel):

--- a/backend/infrahub/server.py
+++ b/backend/infrahub/server.py
@@ -26,7 +26,6 @@ from infrahub.exceptions import Error
 from infrahub.graphql.api.endpoints import router as graphql_router
 from infrahub.lock import initialize_lock
 from infrahub.log import clear_log_context, get_logger, set_log_data
-from infrahub.message_bus import close_broker_connection
 from infrahub.message_bus.rpc import InfrahubRpcClient
 from infrahub.middleware import InfrahubCORSMiddleware
 from infrahub.services import InfrahubServices, services
@@ -74,7 +73,7 @@ async def app_initialization(application: FastAPI) -> None:
 
 
 async def shutdown(application: FastAPI) -> None:
-    await close_broker_connection()
+    await services.service.shutdown()
     await application.state.db.close()
 
 

--- a/backend/infrahub/services/__init__.py
+++ b/backend/infrahub/services/__init__.py
@@ -53,6 +53,11 @@ class InfrahubServices:
         await self.message_bus.initialize(service=self)
         await self.scheduler.initialize(service=self)
 
+    async def shutdown(self) -> None:
+        """Initialize the Services"""
+        await self.scheduler.shutdown()
+        await self.message_bus.shutdown()
+
     async def send(self, message: InfrahubMessage, delay: Optional[MessageTTL] = None) -> None:
         routing_key = ROUTING_KEY_MAP.get(type(message))
         if not routing_key:

--- a/backend/infrahub/services/adapters/message_bus/__init__.py
+++ b/backend/infrahub/services/adapters/message_bus/__init__.py
@@ -14,6 +14,9 @@ class InfrahubMessageBus:
     async def initialize(self, service: InfrahubServices) -> None:
         """Initialize the Message bus"""
 
+    async def shutdown(self) -> None:
+        """Shutdown the Message bus"""
+
     async def publish(self, message: InfrahubMessage, routing_key: str, delay: Optional[MessageTTL] = None) -> None:
         raise NotImplementedError()
 

--- a/backend/infrahub/services/adapters/message_bus/rabbitmq.py
+++ b/backend/infrahub/services/adapters/message_bus/rabbitmq.py
@@ -10,7 +10,7 @@ from infrahub_sdk import UUIDT
 from infrahub import config
 from infrahub.components import ComponentType
 from infrahub.log import clear_log_context, get_log_data
-from infrahub.message_bus import InfrahubMessage, Meta, get_broker, messages
+from infrahub.message_bus import InfrahubMessage, Meta, messages
 from infrahub.message_bus.operations import execute_message
 from infrahub.message_bus.types import MessageTTL
 from infrahub.services.adapters.message_bus import InfrahubMessageBus
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
         AbstractRobustConnection,
     )
 
+    from infrahub.config import BrokerSettings
     from infrahub.services import InfrahubServices
 
 MessageFunction = Callable[[InfrahubMessage], Awaitable[None]]
@@ -37,9 +38,8 @@ async def _add_request_id(message: InfrahubMessage) -> None:
 
 
 class RabbitMQMessageBus(InfrahubMessageBus):
-    def __init__(
-        self,
-    ) -> None:
+    def __init__(self, settings: Optional[BrokerSettings] = None) -> None:
+        self.settings = settings or config.SETTINGS.broker
         self.channel: AbstractChannel
         self.exchange: AbstractExchange
         self.delayed_exchange: AbstractExchange
@@ -55,12 +55,21 @@ class RabbitMQMessageBus(InfrahubMessageBus):
 
     async def initialize(self, service: InfrahubServices) -> None:
         self.service = service
-        self.connection = await get_broker()
+        self.connection = await aio_pika.connect_robust(
+            host=self.settings.address,
+            login=self.settings.username,
+            password=self.settings.password,
+            port=self.settings.service_port,
+        )
+
         self.channel = await self.connection.channel()
         if self.service.component_type == ComponentType.API_SERVER:
             await self._initialize_api_server()
         elif self.service.component_type == ComponentType.GIT_AGENT:
             await self._initialize_git_worker()
+
+    async def shutdown(self) -> None:
+        await self.connection.close()
 
     async def on_callback(self, message: AbstractIncomingMessage) -> None:
         if message.correlation_id:

--- a/backend/infrahub/services/scheduler.py
+++ b/backend/infrahub/services/scheduler.py
@@ -61,6 +61,9 @@ class InfrahubScheduler:
                 run_schedule(schedule=schedule, service=self.service), name=f"scheduled_task_{schedule.name}"
             )
 
+    async def shutdown(self) -> None:
+        self.running = False
+
 
 async def run_schedule(schedule: Schedule, service: InfrahubServices) -> None:
     """Execute the task provided in the schedule as per the defined interval


### PR DESCRIPTION
* Removes old connection logic to RabbitMQ and use a new implementation with the adapter
* Adds a .shutdown() method to the services object that will shutdown or disconnect each adapter. For now it only touches the scheduler and RabbitMQ

Related to make it easier to tests our interactions with RabbitMQ in #2180.

Later on I think we should expand on this shutdown method so that it handles all of our adapter types and also manage the database using the same along with Redis.