### PR TITLE
Clean up ruff rules for readability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -439,12 +439,44 @@ select = [
     "F",    # pyflakes
     "I",    # isort-like checks
     "ICN",  # flake8-import-conventions
-    "TCH",  # flake8-type-checking
+    "PL",   # pylint
     "Q",    # flake8-quotes
+    "TCH",  # flake8-type-checking
     "TRIO", # flake8-trio
     "T10",  # flake8-debugger
     "W",    # pycodestyle warnings
     "YTT",  # flake8-2020
+]
+
+ignore = [
+
+##################################################################################################
+# The ignored rules below should be removed once the code has been updated, they are included    #
+# like this so that we can reactivate them one by one. Alternatively ignored after further       #
+# investigation if they are deemed to not make sense.                                            #
+##################################################################################################
+    "PLC0415", # `import` should be at the top-level of a file
+    "PLC1901", # `display_label.strip() == ""` can be simplified to `not display_label.strip()` as an empty string is falsey
+    "PLR0402", # [*] Use `from infrahub import config` in lieu of alias
+    "PLR0904", # Too many public methods
+    "PLR0912", # Too many branches
+    "PLR0913", # Too many arguments in function definition
+    "PLR0915", # Too many statements
+    "PLR0916", # Too many Boolean expressions
+    "PLR0917", # Too many positional arguments
+    "PLR1704", # Redefining argument with the local name `db`
+    "PLR1706", # Consider using if-else expression
+    "PLR1722", # Use `sys.exit()` instead of `exit`
+    "PLR2004", # Magic value used in comparison this could possibly be fine in the tests folders
+    "PLR5501", # Use `elif` instead of `else` then `if`, to reduce indentation
+    "PLR6201", # Use a `set` literal when testing for membership
+    "PLR6301", # Method could be a function, class method, or static method
+    "PLW0602", # Using global for `validated_database` but no assignment is done
+    "PLW0603", # Using the global statement to update `SETTINGS` is discouraged
+    "PLW1508", # Invalid type for environment variable default; expected `str` or `None`
+    "PLW1514", # `open` in text mode without explicit `encoding` argument
+    "PLW2901", # `for` loop variable `path` overwritten by assignment target
+    "PLW3201", # Bad or misspelled dunder method name `__init_subclass_with_meta__`
 ]
 
 #https://docs.astral.sh/ruff/formatter/black/

--- a/python_sdk/pyproject.toml
+++ b/python_sdk/pyproject.toml
@@ -187,13 +187,33 @@ select = [
     "F",    # pyflakes
     "I",    # isort-like checks
     "ICN",  # flake8-import-conventions
-    "TCH",  # flake8-type-checking
+    "PL",   # pylint
     "Q",    # flake8-quotes
+    "TCH",  # flake8-type-checking
     "TRIO", # flake8-trio
     "T10",  # flake8-debugger
     "W",    # pycodestyle warnings
     "YTT",  # flake8-2020
 ]
+
+ignore = [
+
+##################################################################################################
+# The ignored rules below should be removed once the code has been updated, they are included    #
+# like this so that we can reactivate them one by one. Alternatively ignored after further       #
+# investigation if they are deemed to not make sense.                                            #
+##################################################################################################
+    "PLC0415", # `import` should be at the top-level of a file
+    "PLR0912", # Too many branches
+    "PLR0913", # Too many arguments in function definition
+    "PLR0917", # Too many positional arguments
+    "PLR2004", # Magic value used in comparison this could possibly be fine in the tests folders
+    "PLR6201", # Use a `set` literal when testing for membership
+    "PLR6301", # Method could be a function, class method, or static method
+    "PLW0603", # Using the global statement to update `SETTINGS` is discouraged
+    "PLW1641", # Object does not implement `__hash__` method
+]
+
 
 #https://docs.astral.sh/ruff/formatter/black/
 [tool.ruff.format]

--- a/sync/pyproject.toml
+++ b/sync/pyproject.toml
@@ -158,12 +158,26 @@ select = [
     "F",    # pyflakes
     "I",    # isort-like checks
     "ICN",  # flake8-import-conventions
-    "TCH",  # flake8-type-checking
+    "PL",   # pylint
     "Q",    # flake8-quotes
+    "TCH",  # flake8-type-checking
     "TRIO", # flake8-trio
     "T10",  # flake8-debugger
     "W",    # pycodestyle warnings
     "YTT",  # flake8-2020
+]
+
+ignore = [
+
+##################################################################################################
+# The ignored rules below should be removed once the code has been updated, they are included    #
+# like this so that we can reactivate them one by one. Alternatively ignored after further       #
+# investigation if they are deemed to not make sense.                                            #
+##################################################################################################
+    "PLR0912", # Too many branches
+    "PLR0913", # Too many arguments in function definition
+    "PLR0917", # Too many positional arguments
+    "PLR6301", # Method could be a function, class method, or static method
 ]
 
 #https://docs.astral.sh/ruff/formatter/black/


### PR DESCRIPTION
* Also activates some additional rules that aren't producing any warnings. This is mainly to not have to care about those rules in the future if we look for other stuff to activate
* Make the complexity requirements for the SDK and sync stricter compared to the backend code
* Added the pylint rule set, though the failing checks are ignored for now. 