### PR TITLE
pylint: Disable rule too-many-return-statements since it's now covered by ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ disable = """,
     unsubscriptable-object,
     unsupported-assignment-operation,
     not-an-iterable,
+    too-many-return-statements,
     """
 
 [tool.pylint.miscellaneous]


### PR DESCRIPTION
This rule has been activated in ruff in #2198 so no need for pylint to check it too 