### PR TITLE
Temporary switch to enterprise versions due to backup config

### DIFF
--- a/development/docker-compose-database-neo4j.yml
+++ b/development/docker-compose-database-neo4j.yml
@@ -2,7 +2,7 @@
 version: "3.4"
 services:
   database:
-    image: "${DATABASE_DOCKER_IMAGE:-neo4j:community}"
+    image: "${DATABASE_DOCKER_IMAGE:-neo4j:enterprise}"
     environment:
       - "NEO4J_AUTH=neo4j/admin"
       - "NEO4J_dbms_security_procedures_unrestricted=apoc.*"

--- a/development/docker-compose-test-database-neo4j.yml
+++ b/development/docker-compose-test-database-neo4j.yml
@@ -8,6 +8,7 @@ services:
     image: "${DATABASE_DOCKER_IMAGE:-neo4j:community}"
     environment:
       - "NEO4J_AUTH=neo4j/admin"
+      - "NEO4J_ACCEPT_LICENSE_AGREEMENT=yes"
       - "NEO4J_dbms_security_procedures_unrestricted=apoc.*"
       - "NEO4J_dbms_security_auth__minimum__password__length=4"
     volumes:

--- a/tasks/shared.py
+++ b/tasks/shared.py
@@ -23,7 +23,7 @@ DATABASE_DOCKER_IMAGE = os.getenv("DATABASE_DOCKER_IMAGE", None)
 MEMGRAPH_DOCKER_IMAGE = os.getenv(
     "MEMGRAPH_DOCKER_IMAGE", "memgraph/memgraph-platform:2.14.0-memgraph2.14.0-lab2.11.1-mage1.14"
 )
-NEO4J_DOCKER_IMAGE = os.getenv("NEO4J_DOCKER_IMAGE", "neo4j:5.16.0-community")
+NEO4J_DOCKER_IMAGE = os.getenv("NEO4J_DOCKER_IMAGE", "neo4j:5.16.0-enterprise")
 MESSAGE_QUEUE_DOCKER_IMAGE = os.getenv("MESSAGE_QUEUE_DOCKER_IMAGE", "rabbitmq:3.12.12-management")
 CACHE_DOCKER_IMAGE = os.getenv("CACHE_DOCKER_IMAGE", "redis:7.2.4")
 


### PR DESCRIPTION
The backup configuration isn't supported on the community versions. Use enterprise for now until we create proper docker compose files for each environment type.