### PR TITLE
Add ability to echo queries for troubleshooting

### DIFF
--- a/python_sdk/infrahub_sdk/client.py
+++ b/python_sdk/infrahub_sdk/client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import json
 import logging
 from logging import Logger
 from time import sleep
@@ -113,6 +114,13 @@ class BaseClient:
 
     def _record(self, response: httpx.Response) -> None:
         self.config.custom_recorder.record(response)
+
+    def _echo(self, url: str, query: str, variables: Optional[dict] = None) -> None:
+        if self.config.echo_graphql_queries:
+            print(f"URL: {url}")
+            print(f"QUERY:\n{query}")
+            if variables:
+                print(f"VARIABLES:\n{json.dumps(variables, indent=4)}\n")
 
 
 class InfrahubClient(BaseClient):  # pylint: disable=too-many-public-methods
@@ -412,7 +420,7 @@ class InfrahubClient(BaseClient):  # pylint: disable=too-many-public-methods
         if self.insert_tracker and tracker:
             headers["X-Infrahub-Tracker"] = tracker
 
-        # self.log.error(payload)
+        self._echo(url=url, query=query, variables=variables)
 
         retry = True
         resp = None
@@ -787,6 +795,8 @@ class InfrahubClientSync(BaseClient):  # pylint: disable=too-many-public-methods
         headers = copy.copy(self.headers or {})
         if self.insert_tracker and tracker:
             headers["X-Infrahub-Tracker"] = tracker
+
+        self._echo(url=url, query=query, variables=variables)
 
         retry = True
         resp = None

--- a/python_sdk/infrahub_sdk/config.py
+++ b/python_sdk/infrahub_sdk/config.py
@@ -19,6 +19,9 @@ class Config(pydantic.BaseSettings):
     api_token: Optional[str] = pydantic.Field(
         default=None, description="API token for authentication against Infrahub."
     )
+    echo_graphql_queries: bool = pydantic.Field(
+        default=False, description="If set the GraphQL query and variables will be echoed to the screen"
+    )
     username: Optional[str] = pydantic.Field(default=None, description="Username for accessing Infrahub", min_length=1)
     password: Optional[str] = pydantic.Field(default=None, description="Password for accessing Infrahub", min_length=1)
     recorder: RecorderType = pydantic.Field(

--- a/python_sdk/pyproject.toml
+++ b/python_sdk/pyproject.toml
@@ -234,6 +234,9 @@ max-complexity = 17
 
 [tool.ruff.per-file-ignores]
 
+"tests/unit/sdk/test_client.py" = [
+    "W293", # Blank line contains whitespace (used within output check)
+]
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
At times it's nice to see what GraphQL queries are being used for both queries and mutations from the SDK. This new setting allows us to have the queries printed to the screen.

Fixes #1863