### PR TITLE
feat(db_backup): add host network mode option

### DIFF
--- a/utilities/db_backup/__main__.py
+++ b/utilities/db_backup/__main__.py
@@ -43,6 +43,9 @@ def parse() -> argparse.Namespace:
     neo4j_backup_subparser.add_argument(
         "--keep-helper-container", default=False, action="store_true", help="Keep docker container used to run backup"
     )
+    neo4j_backup_subparser.add_argument(
+        "--host-network", default=False, action="store_true", help="Use host network mode for the helper container"
+    )
 
     neo4j_restore_subparser = neo4j_subparsers.add_parser("restore", help="Backup Neo4J database")
     neo4j_restore_subparser.add_argument(
@@ -67,7 +70,9 @@ def run_utility(parsed_args: argparse.Namespace) -> None:
     backup_path = Path(parsed_args.backup_directory)
     if parsed_args.database_action == "backup":
         backup_runner = Neo4jBackupRunner(
-            be_quiet=parsed_args.quiet, keep_helper_container=parsed_args.keep_helper_container
+            be_quiet=parsed_args.quiet,
+            keep_helper_container=parsed_args.keep_helper_container,
+            use_host_network=parsed_args.host_network,
         )
         do_aggregate_backups = not parsed_args.no_aggregate
         backup_runner.backup(
@@ -111,10 +116,13 @@ class Neo4jBackupRestoreBase:
     container_backup_dir = "/neo4jbackups"
     backup_helper_container_name = "neo4j-infrahub-helper"
 
-    def __init__(self, be_quiet: bool = False, keep_helper_container: bool = False) -> None:
+    def __init__(
+        self, be_quiet: bool = False, keep_helper_container: bool = False, use_host_network: bool = False
+    ) -> None:
         self.be_quiet = be_quiet
         self.keep_helper_container = keep_helper_container
         self.docker_client = docker.from_env()
+        self.use_host_network = use_host_network
         self.neo4j_docker_image = os.getenv("NEO4J_BACKUP_DOCKER_IMAGE", "neo4j/neo4j-admin:5.16.0-enterprise")
 
     def _print_message(self, message: str, force_print: bool = False, with_timestamp: bool = True) -> None:
@@ -216,6 +224,7 @@ class Neo4jBackupRestoreBase:
                 detach=True,
                 command="/bin/bash",
                 user="neo4j",
+                network_mode="host" if self.use_host_network else None,
             )
             for v in volumes.values():
                 backup_helper_container.exec_run(["chown", "neo4j", v["bind"]], user="root")


### PR DESCRIPTION
This is useful when the network configuration requires DNS resolutions on third party resolvers that cannot be correctly configured when using Docker's bridged mode.