### PR TITLE
Rework settings to avoid various type-hint issues

### DIFF
--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -291,6 +291,15 @@ class ConfiguredSettings:
         if not config_file:
             config_file_name = os.environ.get("INFRAHUB_CONFIG", "infrahub.toml")
             config_file = os.path.abspath(config_file_name)
+        load(config_file)
+
+    def initialize_and_exit(self, config_file: Optional[str] = None) -> None:
+        """Initialize the settings if they have not been initialized, exit on failures."""
+        if self.initialized:
+            return
+        if not config_file:
+            config_file_name = os.environ.get("INFRAHUB_CONFIG", "infrahub.toml")
+            config_file = os.path.abspath(config_file_name)
         load_and_exit(config_file)
 
     @property

--- a/backend/infrahub/git_credential/askpass.py
+++ b/backend/infrahub/git_credential/askpass.py
@@ -19,7 +19,7 @@ def askpass(
     text: Optional[List[str]] = typer.Argument(None),
     config_file: str = typer.Option("infrahub.toml", envvar="INFRAHUB_CONFIG"),
 ):
-    config.SETTINGS.initialize(config_file=config_file)
+    config.SETTINGS.initialize_and_exit(config_file=config_file)
 
     text = text or sys.stdin.read().strip()
     request_type = None

--- a/backend/infrahub/git_credential/helper.py
+++ b/backend/infrahub/git_credential/helper.py
@@ -40,7 +40,7 @@ def get(
     input_str: str = typer.Argument(... if sys.stdin.isatty() else sys.stdin.read().strip()),
     config_file: str = typer.Option("infrahub.toml", envvar="INFRAHUB_CONFIG"),
 ) -> None:
-    config.SETTINGS.initialize(config_file=config_file)
+    config.SETTINGS.initialize_and_exit(config_file=config_file)
 
     try:
         location = parse_helper_get_input(text=input_str)

--- a/backend/infrahub/middleware.py
+++ b/backend/infrahub/middleware.py
@@ -8,7 +8,7 @@ from infrahub import config
 
 class InfrahubCORSMiddleware(CORSMiddleware):
     def __init__(self, app: ASGIApp, *args: Any, **kwargs: Any):
-        config.SETTINGS.initialize()
+        config.SETTINGS.initialize_and_exit()
         kwargs["allow_origins"] = config.SETTINGS.api.cors_allow_origins
         kwargs["allow_credentials"] = config.SETTINGS.api.cors_allow_credentials
         kwargs["allow_methods"] = config.SETTINGS.api.cors_allow_methods

--- a/backend/infrahub/server.py
+++ b/backend/infrahub/server.py
@@ -37,7 +37,7 @@ from infrahub.worker import WORKER_IDENTITY
 
 
 async def app_initialization(application: FastAPI) -> None:
-    config.SETTINGS.initialize()
+    config.SETTINGS.initialize_and_exit()
 
     # Initialize trace
     if config.SETTINGS.trace.enable:


### PR DESCRIPTION
Within infrahub/config.py the settings is currently defined like this:

```python
SETTINGS: Settings = None
```

Within other files we typically access the settings with something like:

```python
from infrahub import config

print(config.SETTINGS.broker.address)
```

This causes typing issues as `config.SETTINGS` starts out as a `None` value and as such doesn't have any `broker` property.

This PR contains a suggestion for an alternate approach. It's a bit more verbose as we'd need to add a property to the `ConfiguredSettings` class for each sub section that we use. But I think it would solve some typing issues throughout the codebase.

Any thoughts around this?