### PR TITLE
Fix cursor on refresh button

### DIFF
--- a/frontend/src/components/buttons/retry.tsx
+++ b/frontend/src/components/buttons/retry.tsx
@@ -27,9 +27,9 @@ export const Retry = (props: tRetryProps) => {
   return (
     <div
       className={classNames(
-        "flex items-center p-1 rounded-full",
-        isLoading ? "cursor-not-allowed animate-spin" : "",
-        !isLoading && isDisabled ? "cursor-pointer hover:bg-gray-200" : "cursor-not-allowed"
+        "flex items-center p-1 rounded-full cursor-pointer",
+        isLoading ? "animate-spin" : "",
+        isLoading || isDisabled ? "!cursor-not-allowed" : "hover:bg-gray-200"
       )}
       onClick={handleClick}>
       <Icon


### PR DESCRIPTION
Cusor was on "not-allowed" style.

Now:
- "not allowed" cursor is only disabled when state is loading or button disabled
- background gray on hover is displayed only when button is active

https://github.com/opsmill/infrahub/assets/15261980/d0b47f8e-944d-4c5b-8f1c-f5e0b491afdb

