### PR TITLE
fix tranform_location property of ProposedChangeArtifactDefinition

### DIFF
--- a/backend/infrahub/message_bus/types.py
+++ b/backend/infrahub/message_bus/types.py
@@ -74,9 +74,9 @@ class ProposedChangeArtifactDefinition(BaseModel):
 
     @property
     def transform_location(self) -> str:
-        if InfrahubKind.TRANSFORMJINJA2:
+        if self.transform_kind == InfrahubKind.TRANSFORMJINJA2:
             return self.template_path
-        if InfrahubKind.TRANSFORMPYTHON:
+        if self.transform_kind == InfrahubKind.TRANSFORMPYTHON:
             return f"{self.file_path}::{self.class_name}"
 
         raise ValueError("Invalid kind for Transform")


### PR DESCRIPTION
This was causing an issue for artifact_definitions that were using a Python Transform, when the artifact was getting generated as part of the "artifact validator" check in a proposed change.