### PR TITLE
Call child refetch in details view

### DIFF
--- a/frontend/src/screens/artifacts/object-item-details-paginated.tsx
+++ b/frontend/src/screens/artifacts/object-item-details-paginated.tsx
@@ -38,7 +38,7 @@ import AddObjectToGroup from "../groups/add-object-to-group";
 import LoadingScreen from "../loading-screen/loading-screen";
 import NoDataFound from "../no-data-found/no-data-found";
 import RelationshipDetails from "../object-item-details/relationship-details-paginated";
-import RelationshipsDetails from "../object-item-details/relationships-details-paginated";
+import { RelationshipsDetails } from "../object-item-details/relationships-details-paginated";
 import ObjectItemEditComponent from "../object-item-edit/object-item-edit-paginated";
 import ObjectItemMetaEdit from "../object-item-meta-edit/object-item-meta-edit";
 import { Generate } from "./generate";

--- a/frontend/src/screens/object-item-details/relationships-details-paginated.tsx
+++ b/frontend/src/screens/object-item-details/relationships-details-paginated.tsx
@@ -1,6 +1,7 @@
 import { gql } from "@apollo/client";
 import { useAtom } from "jotai";
 import { useAtomValue } from "jotai/index";
+import { forwardRef, useImperativeHandle } from "react";
 import { useParams } from "react-router-dom";
 import { toast } from "react-toastify";
 import { StringParam, useQueryParam } from "use-query-params";
@@ -27,7 +28,8 @@ interface RelationshipsDetailsProps {
   refetchObjectDetails: Function;
 }
 
-export default function RelationshipsDetails(props: RelationshipsDetailsProps) {
+// Forward ref needed to provide ref to parent to refetch
+export const RelationshipsDetails = forwardRef((props: RelationshipsDetailsProps, ref) => {
   const { parentNode, refetchObjectDetails } = props;
 
   const { objectname, objectid } = useParams();
@@ -76,6 +78,9 @@ export default function RelationshipsDetails(props: RelationshipsDetailsProps) {
   `;
 
   const { loading, error, data, refetch } = useQuery(query, { skip: !relationshipTab });
+
+  // Provide refetch function to parent
+  useImperativeHandle(ref, () => ({ refetch }));
 
   const updatePageData = () => {
     return Promise.all([refetch(), refetchObjectDetails()]);
@@ -140,4 +145,4 @@ export default function RelationshipsDetails(props: RelationshipsDetailsProps) {
       <Pagination count={count} />
     </div>
   );
-}
+});

--- a/frontend/src/screens/tasks/task-item-details.tsx
+++ b/frontend/src/screens/tasks/task-item-details.tsx
@@ -2,7 +2,7 @@ import { gql } from "@apollo/client";
 import { TASK_OBJECT } from "../../config/constants";
 import useQuery from "../../hooks/useQuery";
 
-import { useState } from "react";
+import { forwardRef, useImperativeHandle, useState } from "react";
 import { useParams } from "react-router-dom";
 import { StringParam, useQueryParam } from "use-query-params";
 import { BADGE_TYPES, Badge } from "../../components/display/badge";
@@ -23,7 +23,7 @@ export const getConclusionBadge: { [key: string]: any } = {
   failure: <Badge type={BADGE_TYPES.CANCEL}>failure</Badge>,
 };
 
-export const TaskItemDetails = () => {
+export const TaskItemDetails = forwardRef((props, ref) => {
   const [taskId] = useQueryParam(QSP.TASK_ID, StringParam);
   const [search, setSearch] = useState("");
 
@@ -38,7 +38,10 @@ export const TaskItemDetails = () => {
     ${queryString}
   `;
 
-  const { loading, error, data = {} } = useQuery(query);
+  const { loading, error, data = {}, refetch } = useQuery(query);
+
+  // Provide refetch function to parent
+  useImperativeHandle(ref, () => ({ refetch }));
 
   if (error) {
     return <ErrorScreen message="Something went wrong when fetching list." />;
@@ -124,4 +127,4 @@ export const TaskItemDetails = () => {
       </div>
     </div>
   );
-};
+});

--- a/frontend/src/screens/tasks/task-items.tsx
+++ b/frontend/src/screens/tasks/task-items.tsx
@@ -4,6 +4,7 @@ import { Pagination } from "../../components/utils/pagination";
 import { TASK_OBJECT } from "../../config/constants";
 import useQuery from "../../hooks/useQuery";
 
+import { forwardRef, useImperativeHandle } from "react";
 import { useLocation, useParams } from "react-router-dom";
 import { DateDisplay } from "../../components/display/date-display";
 import { DurationDisplay } from "../../components/display/duration-display";
@@ -15,7 +16,7 @@ import ErrorScreen from "../error-screen/error-screen";
 import LoadingScreen from "../loading-screen/loading-screen";
 import { getConclusionBadge } from "./task-item-details";
 
-export const TaskItems = () => {
+export const TaskItems = forwardRef((props, ref) => {
   const { objectid } = useParams();
   const location = useLocation();
 
@@ -30,7 +31,10 @@ export const TaskItems = () => {
     ${queryString}
   `;
 
-  const { loading, error, data = {} } = useQuery(query);
+  const { loading, error, data = {}, refetch } = useQuery(query);
+
+  // Provide refetch function to parent
+  useImperativeHandle(ref, () => ({ refetch }));
 
   if (error) {
     return <ErrorScreen message="Something went wrong when fetching list." />;
@@ -104,4 +108,4 @@ export const TaskItems = () => {
       )}
     </div>
   );
-};
+});


### PR DESCRIPTION
Related issue: https://github.com/opsmill/infrahub/issues/1734

* Calls child refetch in details view to refetch data in the tabs

Next step: find a way to refactor the details view to avoid the use of refs