### PR TITLE
Do not start test for data-only branch

### DIFF
--- a/backend/infrahub/message_bus/operations/requests/proposed_change.py
+++ b/backend/infrahub/message_bus/operations/requests/proposed_change.py
@@ -380,13 +380,13 @@ async def run_tests(message: messages.RequestProposedChangeRunTests, service: In
             commit = repo.get_commit_value(proposed_change.source_branch.value)
             worktree_directory = Path(repo.get_commit_worktree(commit=commit).directory)
 
-        return_code = await asyncio.to_thread(_execute, worktree_directory, repository, proposed_change)
-        log.info(
-            "repository_tests_completed",
-            proposed_change=message.proposed_change,
-            repository=repository.repository_name,
-            return_code=return_code,
-        )
+            return_code = await asyncio.to_thread(_execute, worktree_directory, repository, proposed_change)
+            log.info(
+                "repository_tests_completed",
+                proposed_change=message.proposed_change,
+                repository=repository.repository_name,
+                return_code=return_code,
+            )
 
 
 DESTINATION_ALLREPOSITORIES = """


### PR DESCRIPTION
User defined tests should not run for data-only branch proposed changes. This issue was due to a missing indentation level in the code starting the pytest thread.