### PR TITLE
Centered form in docs login page

### DIFF
--- a/functions/template.ts
+++ b/functions/template.ts
@@ -20,6 +20,7 @@ export function getTemplate({
 
       <style>
         body > main {
+          margin: auto;
           display: flex;
           flex-direction: column;
           justify-content: center;


### PR DESCRIPTION
Before:
<img width="1722" alt="image" src="https://github.com/opsmill/infrahub/assets/15261980/b83d4603-9d1d-420b-9b8c-32bc9a57cfc1">

After:
<img width="1722" alt="image" src="https://github.com/opsmill/infrahub/assets/15261980/2fc32bc7-5c1b-46e2-b802-581f7147118f">
