### PR TITLE
Modify error levels when logging GraphQL errors

### DIFF
--- a/backend/infrahub/exceptions.py
+++ b/backend/infrahub/exceptions.py
@@ -66,6 +66,8 @@ class CommitNotFoundError(Error):
 
 
 class DataTypeNotFound(Error):
+    HTTP_CODE: int = 400
+
     def __init__(self, name, message=None):
         self.name = name
         self.message = message or f"Unable to find the DataType '{name}'."
@@ -73,6 +75,8 @@ class DataTypeNotFound(Error):
 
 
 class FileNotFound(Error):
+    HTTP_CODE: int = 404
+
     def __init__(self, repository_name, location, commit, message=None):
         self.repository_name = repository_name
         self.location = location
@@ -207,6 +211,8 @@ class QueryValidationError(Error):
 
 
 class ValidationError(Error):
+    HTTP_CODE = 422
+
     def __init__(self, input_value):
         self.message: Optional[str] = None
         self.location = None


### PR DESCRIPTION
Some errors are currently very noisy with regards to what is logged. If a user requests a node that doesn't exist it shouldn't look like an error occured in the server.

For how any of our own errors defined at HTTP level 500 will be logged in the same way as before. For any permission denied error we log them at the info level to not have them completely silent.

Other errors that are strictly user errors that we don't want to have in the logs have been moved to the debug level for now. I'm sure we will have to move them back and forth a bit to find the correct level for each type.

Any unhandled exception that we didn't account for is treated as an actual error.

Fixes #2318.