### PR TITLE
constraint validator for AttributeSchema.enum

### DIFF
--- a/backend/infrahub/core/validators/__init__.py
+++ b/backend/infrahub/core/validators/__init__.py
@@ -1,6 +1,7 @@
 from typing import Dict, Optional, Type
 
 from .attribute.choices import AttributeChoicesChecker
+from .attribute.enum import AttributeEnumChecker
 from .attribute.optional import AttributeOptionalChecker
 from .attribute.regex import AttributeRegexChecker
 from .attribute.unique import AttributeUniquenessChecker
@@ -10,7 +11,7 @@ from .uniqueness.checker import UniquenessChecker
 
 CONSTRAINT_VALIDATOR_MAP: Dict[str, Optional[Type[ConstraintCheckerInterface]]] = {
     "attribute.regex.update": AttributeRegexChecker,
-    "attribute.enum.update": None,
+    "attribute.enum.update": AttributeEnumChecker,
     "attribute.min_length.update": None,
     "attribute.max_length.update": None,
     "attribute.unique.update": AttributeUniquenessChecker,

--- a/backend/infrahub/core/validators/attribute/enum.py
+++ b/backend/infrahub/core/validators/attribute/enum.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from infrahub.core.constants import PathType
+from infrahub.core.path import DataPath, GroupedDataPaths
+
+from ..interface import ConstraintCheckerInterface
+from ..shared import AttributeSchemaValidatorQuery
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.database import InfrahubDatabase
+
+    from ..model import SchemaConstraintValidatorRequest
+
+
+class AttributeEnumUpdateValidatorQuery(AttributeSchemaValidatorQuery):
+    name: str = "attribute_constraints_enum_validator"
+
+    async def query_init(self, db: InfrahubDatabase, *args: Any, **kwargs: Dict[str, Any]) -> None:
+        if self.attribute_schema.enum is None:
+            return
+
+        branch_filter, branch_params = self.branch.get_query_filter_path(at=self.at.to_string())
+        self.params.update(branch_params)
+
+        self.params["node_kind"] = self.node_schema.kind
+        self.params["attr_name"] = self.attribute_schema.name
+        self.params["allowed_values"] = self.attribute_schema.enum
+
+        query = """
+        MATCH p = (n:Node)
+        WHERE $node_kind IN LABELS(n)
+        CALL {
+            WITH n
+            MATCH path = (root:Root)<-[rr:IS_PART_OF]-(n)-[ra:HAS_ATTRIBUTE]-(:Attribute { name: $attr_name } )-[rv:HAS_VALUE]-(av:AttributeValue)
+            WHERE all(
+                r in relationships(path)
+                WHERE %(branch_filter)s
+            )
+            RETURN path as full_path, n as node, rv as value_relationship, av.value as attribute_value
+            ORDER BY rv.branch_level DESC, ra.branch_level DESC, rr.branch_level DESC, rv.from DESC, ra.from DESC, rr.from DESC
+            LIMIT 1
+        }
+        WITH full_path, node, attribute_value, value_relationship
+        WITH full_path, node, attribute_value, value_relationship
+        WHERE all(r in relationships(full_path) WHERE r.status = "active")
+        AND attribute_value IS NOT NULL
+        AND attribute_value <> "NULL"
+        AND NOT (attribute_value IN $allowed_values)
+        """ % {"branch_filter": branch_filter}
+
+        self.add_to_query(query)
+        self.return_labels = ["node.uuid", "attribute_value", "value_relationship"]
+
+    async def get_paths(self) -> GroupedDataPaths:
+        grouped_data_paths = GroupedDataPaths()
+        for result in self.results:
+            value = str(result.get("attribute_value"))
+            grouped_data_paths.add_data_path(
+                DataPath(
+                    branch=str(result.get("value_relationship").get("branch")),
+                    path_type=PathType.ATTRIBUTE,
+                    node_id=str(result.get("node.uuid")),
+                    field_name=self.attribute_schema.name,
+                    kind=self.node_schema.kind,
+                    value=value,
+                ),
+                grouping_key=value,
+            )
+
+        return grouped_data_paths
+
+
+class AttributeEnumChecker(ConstraintCheckerInterface):
+    query_classes = [AttributeEnumUpdateValidatorQuery]
+
+    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch]):
+        self.db = db
+        self.branch = branch
+
+    @property
+    def name(self) -> str:
+        return "attribute.enum.update"
+
+    def supports(self, request: SchemaConstraintValidatorRequest) -> bool:
+        return request.constraint_name == self.name
+
+    async def check(self, request: SchemaConstraintValidatorRequest) -> List[GroupedDataPaths]:
+        grouped_data_paths_list: List[GroupedDataPaths] = []
+        attribute_schema = request.node_schema.get_attribute(name=request.schema_path.field_name)
+        if attribute_schema.enum is None:
+            return grouped_data_paths_list
+
+        for query_class in self.query_classes:
+            # TODO add exception handling
+            query = await query_class.init(
+                db=self.db, branch=self.branch, node_schema=request.node_schema, schema_path=request.schema_path
+            )
+
+            await query.execute(db=self.db)
+            grouped_data_paths_list.append(await query.get_paths())
+        return grouped_data_paths_list

--- a/backend/infrahub/dependencies/builder/constraint/schema/aggregated.py
+++ b/backend/infrahub/dependencies/builder/constraint/schema/aggregated.py
@@ -2,6 +2,7 @@ from infrahub.core.validators.aggregated_checker import AggregatedConstraintChec
 
 from ....interface import DependencyBuilder, DependencyBuilderContext
 from .attribute_choices import SchemaAttributeChoicesConstraintDependency
+from .attribute_enum import SchemaAttributeEnumConstraintDependency
 from .attribute_optional import SchemaAttributeOptionalConstraintDependency
 from .attribute_regex import SchemaAttributeRegexConstraintDependency
 from .attribute_uniqueness import SchemaAttributeUniqueConstraintDependency
@@ -20,6 +21,7 @@ class AggregatedSchemaConstraintsDependency(DependencyBuilder[AggregatedConstrai
                 SchemaAttributeUniqueConstraintDependency.build(context=context),
                 SchemaAttributeOptionalConstraintDependency.build(context=context),
                 SchemaAttributeChoicesConstraintDependency.build(context=context),
+                SchemaAttributeEnumConstraintDependency.build(context=context),
             ],
             db=context.db,
             branch=context.branch,

--- a/backend/infrahub/dependencies/builder/constraint/schema/attribute_enum.py
+++ b/backend/infrahub/dependencies/builder/constraint/schema/attribute_enum.py
@@ -1,0 +1,9 @@
+from infrahub.core.validators.attribute.enum import AttributeEnumChecker
+
+from ....interface import DependencyBuilder, DependencyBuilderContext
+
+
+class SchemaAttributeEnumConstraintDependency(DependencyBuilder[AttributeEnumChecker]):
+    @classmethod
+    def build(cls, context: DependencyBuilderContext) -> AttributeEnumChecker:
+        return AttributeEnumChecker(db=context.db, branch=context.branch)

--- a/backend/tests/unit/core/constraint_validators/test_attribute_enum_update.py
+++ b/backend/tests/unit/core/constraint_validators/test_attribute_enum_update.py
@@ -1,0 +1,179 @@
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.constants import PathType, SchemaPathType
+from infrahub.core.manager import NodeManager
+from infrahub.core.path import DataPath, SchemaPath
+from infrahub.core.validators.attribute.enum import AttributeEnumChecker, AttributeEnumUpdateValidatorQuery
+from infrahub.core.validators.model import SchemaConstraintValidatorRequest
+from infrahub.database import InfrahubDatabase
+
+
+async def test_query_new_choice_value(db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main):
+    car_schema = registry.schema.get(name="TestCar")
+    transmission_attr = car_schema.get_attribute(name="transmission")
+    transmission_attr.enum.append("warp-drive")
+
+    schema_path = SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="transmission")
+
+    query = await AttributeEnumUpdateValidatorQuery.init(
+        db=db, branch=default_branch, node_schema=car_schema, schema_path=schema_path
+    )
+
+    await query.execute(db=db)
+
+    grouped_paths = await query.get_paths()
+    all_data_paths = grouped_paths.get_all_data_paths()
+    assert len(all_data_paths) == 0
+
+
+async def test_query_remove_choice(db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main):
+    car = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=default_branch)
+    car.transmission.value = "manual"
+    await car.save(db=db)
+
+    car_schema = registry.schema.get(name="TestCar", branch=default_branch)
+    transmission_attr = car_schema.get_attribute(name="transmission")
+    transmission_attr.enum = ["flintstone-feet"]
+
+    schema_path = SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="transmission")
+
+    query = await AttributeEnumUpdateValidatorQuery.init(
+        db=db, branch=default_branch, node_schema=car_schema, schema_path=schema_path
+    )
+
+    await query.execute(db=db)
+
+    grouped_paths = await query.get_paths()
+    all_data_paths = grouped_paths.get_all_data_paths()
+    assert len(all_data_paths) == 1
+    assert (
+        DataPath(
+            branch=default_branch.name,
+            path_type=PathType.ATTRIBUTE,
+            node_id=car_accord_main.id,
+            kind="TestCar",
+            field_name="transmission",
+            value="manual",
+        )
+        in all_data_paths
+    )
+
+
+async def test_query_convert_to_enum(db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main):
+    car = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=default_branch)
+    car.color.value = "#123123"
+    await car.save(db=db)
+
+    car_schema = registry.schema.get(name="TestCar", branch=default_branch)
+    color_attr = car_schema.get_attribute(name="color")
+    color_attr.enum = ["#444444", "#123123"]
+
+    schema_path = SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="color")
+
+    query = await AttributeEnumUpdateValidatorQuery.init(
+        db=db, branch=default_branch, node_schema=car_schema, schema_path=schema_path
+    )
+
+    await query.execute(db=db)
+
+    grouped_paths = await query.get_paths()
+    all_data_paths = grouped_paths.get_all_data_paths()
+    assert len(all_data_paths) == 0
+
+
+async def test_query_update_on_branch(db: InfrahubDatabase, branch: Branch, car_accord_main, car_camry_main):
+    car_accord_main.color.value = "#654654"
+    await car_accord_main.save(db=db)
+    await branch.rebase(db=db)
+    car = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
+    car.color.value = "#123123"
+    await car.save(db=db)
+
+    car_schema = registry.schema.get(name="TestCar", branch=branch)
+    color_attr = car_schema.get_attribute(name="color")
+    color_attr.enum = ["#444444", "#123123"]
+
+    schema_path = SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="color")
+
+    query = await AttributeEnumUpdateValidatorQuery.init(
+        db=db, branch=branch, node_schema=car_schema, schema_path=schema_path
+    )
+
+    await query.execute(db=db)
+
+    grouped_paths = await query.get_paths()
+    all_data_paths = grouped_paths.get_all_data_paths()
+    assert len(all_data_paths) == 0
+
+
+async def test_query_delete_on_branch(db: InfrahubDatabase, branch: Branch, car_accord_main, car_camry_main):
+    car_accord_main.color.value = "#654654"
+    await car_accord_main.save(db=db)
+    await branch.rebase(db=db)
+    car = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
+    await car.delete(db=db)
+
+    car_schema = registry.schema.get(name="TestCar", branch=branch)
+    color_attr = car_schema.get_attribute(name="color")
+    color_attr.enum = ["#444444", "#123123"]
+
+    schema_path = SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="color")
+
+    query = await AttributeEnumUpdateValidatorQuery.init(
+        db=db, branch=branch, node_schema=car_schema, schema_path=schema_path
+    )
+
+    await query.execute(db=db)
+
+    grouped_paths = await query.get_paths()
+    all_data_paths = grouped_paths.get_all_data_paths()
+    assert len(all_data_paths) == 0
+
+
+async def test_validator(
+    db: InfrahubDatabase, branch: Branch, default_branch: Branch, car_accord_main, car_camry_main, car_prius_main
+):
+    await branch.rebase(db=db)
+    car = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
+    car.color.value = "#123123"
+    await car.save(db=db)
+
+    car_schema = registry.schema.get(name="TestCar", branch=branch)
+    color_attr = car_schema.get_attribute(name="color")
+    color_attr.enum = ["#123123"]
+
+    request = SchemaConstraintValidatorRequest(
+        branch=branch,
+        constraint_name="attribute.enum.update",
+        node_schema=car_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="color"),
+    )
+
+    constraint_checker = AttributeEnumChecker(db=db, branch=branch)
+    grouped_data_paths = await constraint_checker.check(request)
+
+    assert len(grouped_data_paths) == 1
+    data_paths = grouped_data_paths[0].get_all_data_paths()
+    assert len(data_paths) == 2
+    assert (
+        DataPath(
+            branch=default_branch.name,
+            path_type=PathType.ATTRIBUTE,
+            node_id=car_camry_main.id,
+            kind="TestCar",
+            field_name="color",
+            value="#444444",
+        )
+        in data_paths
+    )
+    assert (
+        DataPath(
+            branch=default_branch.name,
+            path_type=PathType.ATTRIBUTE,
+            node_id=car_prius_main.id,
+            kind="TestCar",
+            field_name="color",
+            value="#444444",
+        )
+        in data_paths
+    )


### PR DESCRIPTION
completes #2232 

adds new constraint validator for changes to the `enum` property of `AttributeSchema`. it does almost the exact same thing as the `choices` validator in #2365
