### PR TITLE
Fix type-hints for api.schema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,10 +172,6 @@ module = "infrahub.api.exception_handlers"
 ignore_errors = true
 
 [[tool.mypy.overrides]]
-module = "infrahub.api.schema"
-ignore_errors = true
-
-[[tool.mypy.overrides]]
 module = "infrahub.api.storage"
 ignore_errors = true
 


### PR DESCRIPTION
Within async def load_schema the call to schema_validators_checker was shadowing the `_` variable from Depends(get_current_user). So I added a union there. It doesn't look that great. In the future we should perhaps have a schema_validatiors_checker alternative that only returns the list of strings that we need in this case, the other function can call the first and just throw away the extra info before returning a list[str].