### PR TITLE
Remove mypy override rule for infrahub.message_bus

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -352,10 +352,6 @@ module = "infrahub.lock"
 ignore_errors = true
 
 [[tool.mypy.overrides]]
-module = "infrahub.message_bus"
-ignore_errors = true
-
-[[tool.mypy.overrides]]
 module = "infrahub.message_bus.operations.*"
 ignore_errors = true
 


### PR DESCRIPTION
Seems like these exceptions have already been taken care of.