### PR TITLE
Adds initial task logs for request.proposed_change messages

### DIFF
--- a/backend/infrahub/message_bus/operations/__init__.py
+++ b/backend/infrahub/message_bus/operations/__init__.py
@@ -79,7 +79,7 @@ async def execute_message(routing_key: str, message_body: bytes, service: Infrah
             await service.reply(message=response, initiator=message)
             return
         if message.reached_max_retries:
-            service.log.error("Message failed after maximum number of retries", error=str(exc))
+            service.log.exception("Message failed after maximum number of retries", error=exc)
             await set_check_status(message, conclusion="failure", service=service)
             return
         message.increase_retry_count()


### PR DESCRIPTION
Also adds verbosity for messages when they fail the last time for easier troubleshooting. We will scale this down again later. Probably also need to catch other type of errors before we get there so that we keep this kind of verbosity for unhandled errors and otherwise print a friendly message for errors that are expected.

For now I've mostly just indented the code in these messages to include the most basic of Task report. Will add it to the following messages and include more details in a later step.