### PR TITLE
Remove the label AttributeLocal on Attribute Node

### DIFF
--- a/backend/infrahub/core/graph/schema.py
+++ b/backend/infrahub/core/graph/schema.py
@@ -144,7 +144,7 @@ class GraphAttributeRelationships(BaseModel):
 
 
 class GraphAttributeNode(BaseModel):
-    default_label: str = "Attribute"  # We are also using "AttributeLocal" today but we should probably remove it
+    default_label: str = "Attribute"
     properties: GraphAttributeProperties
     relationships: GraphAttributeRelationships
 

--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -513,26 +513,25 @@ class NodeManager:
             # Attributes
             # --------------------------------------------------------
             for attr_name, attr in node_attributes.get(node_id, {}).get("attrs", {}).items():
-                if "AttributeLocal" in attr.attr_labels:
-                    attrs[attr_name] = {
-                        "db_id": attr.attr_id,
-                        "id": attr.attr_uuid,
-                        "name": attr_name,
-                        "value": attr.value,
-                        "updated_at": attr.updated_at,
-                    }
+                attrs[attr_name] = {
+                    "db_id": attr.attr_id,
+                    "id": attr.attr_uuid,
+                    "name": attr_name,
+                    "value": attr.value,
+                    "updated_at": attr.updated_at,
+                }
 
-                    if attr.is_protected is not None:
-                        attrs[attr_name]["is_protected"] = attr.is_protected
+                if attr.is_protected is not None:
+                    attrs[attr_name]["is_protected"] = attr.is_protected
 
-                    if attr.is_visible is not None:
-                        attrs[attr_name]["is_visible"] = attr.is_visible
+                if attr.is_visible is not None:
+                    attrs[attr_name]["is_visible"] = attr.is_visible
 
-                    if attr.source_uuid:
-                        attrs[attr_name]["source"] = attr.source_uuid
+                if attr.source_uuid:
+                    attrs[attr_name]["source"] = attr.source_uuid
 
-                    if attr.owner_uuid:
-                        attrs[attr_name]["owner"] = attr.owner_uuid
+                if attr.owner_uuid:
+                    attrs[attr_name]["owner"] = attr.owner_uuid
 
             # --------------------------------------------------------
             # Relationships

--- a/backend/infrahub/core/migrations/schema/node_attribute_add.py
+++ b/backend/infrahub/core/migrations/schema/node_attribute_add.py
@@ -70,7 +70,7 @@ class NodeAttributeAddMigrationQuery01(Query):
         MERGE (is_protected_value:Boolean { value: $is_protected_default })
         MERGE (is_visible_value:Boolean { value: $is_visible_default })
         WITH n, av, is_protected_value, is_visible_value
-        CREATE (a:Attribute:AttributeLocal { name: $attr_name, type: $attr_type, branch_support: $branch_support })
+        CREATE (a:Attribute { name: $attr_name, type: $attr_type, branch_support: $branch_support })
         CREATE (n)-[:HAS_ATTRIBUTE $rel_props ]->(a)
         CREATE (a)-[:HAS_VALUE $rel_props ]->(av)
         CREATE (a)-[:IS_PROTECTED $rel_props]->(is_protected_value)

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -154,7 +154,7 @@ class NodeCreateAllQuery(NodeQuery):
         CREATE (n)-[r:IS_PART_OF $node_branch_prop ]->(root)
         WITH distinct n
         FOREACH ( attr IN $attrs |
-            CREATE (a:Attribute:AttributeLocal { uuid: attr.uuid, name: attr.name, type: attr.type, branch_support: attr.branch_support })
+            CREATE (a:Attribute { uuid: attr.uuid, name: attr.name, type: attr.type, branch_support: attr.branch_support })
             CREATE (n)-[:HAS_ATTRIBUTE { branch: attr.branch, branch_level: attr.branch_level, status: attr.status, from: $at, to: null }]->(a)
             MERGE (av:AttributeValue { type: attr.type, value: attr.value })
             CREATE (a)-[:HAS_VALUE { branch: attr.branch, branch_level: attr.branch_level, status: attr.status, from: $at, to: null }]->(av)

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -133,8 +133,8 @@ async def simple_dataset_01(db: InfrahubDatabase, empty_database) -> dict:
     CREATE (c:Car { uuid: "5ffa45d4" })
     CREATE (c)-[r:IS_PART_OF {branch: $branch, branch_level: 1, from: $time1}]->(root)
 
-    CREATE (at1:Attribute:AttributeLocal { uuid: "ee04c93a", type: "Str", name: "name"})
-    CREATE (at2:Attribute:AttributeLocal { uuid: "924786c3", type: "Int", name: "nbr_seats"})
+    CREATE (at1:Attribute { uuid: "ee04c93a", type: "Str", name: "name"})
+    CREATE (at2:Attribute { uuid: "924786c3", type: "Int", name: "nbr_seats"})
     CREATE (c)-[:HAS_ATTRIBUTE {branch: $branch, branch_level: 1, from: $time1}]->(at1)
     CREATE (c)-[:HAS_ATTRIBUTE {branch: $branch, branch_level: 1, from: $time1}]->(at2)
 
@@ -229,10 +229,10 @@ async def base_dataset_02(db: InfrahubDatabase, default_branch: Branch, car_pers
     CREATE (atvt:AttributeValue { value: true })
     CREATE (atv44:AttributeValue { value: "#444444" })
 
-    CREATE (c1at1:Attribute:AttributeLocal { uuid: "c1at1", type: "Str", name: "name", branch_support: "aware"})
-    CREATE (c1at2:Attribute:AttributeLocal { uuid: "c1at2", type: "Int", name: "nbr_seats", branch_support: "aware"})
-    CREATE (c1at3:Attribute:AttributeLocal { uuid: "c1at3", type: "Bool", name: "is_electric", branch_support: "aware"})
-    CREATE (c1at4:Attribute:AttributeLocal { uuid: "c1at4", type: "Str", name: "color", branch_support: "aware"})
+    CREATE (c1at1:Attribute { uuid: "c1at1", type: "Str", name: "name", branch_support: "aware"})
+    CREATE (c1at2:Attribute { uuid: "c1at2", type: "Int", name: "nbr_seats", branch_support: "aware"})
+    CREATE (c1at3:Attribute { uuid: "c1at3", type: "Bool", name: "is_electric", branch_support: "aware"})
+    CREATE (c1at4:Attribute { uuid: "c1at4", type: "Str", name: "color", branch_support: "aware"})
     CREATE (c1)-[:HAS_ATTRIBUTE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m60}]->(c1at1)
     CREATE (c1)-[:HAS_ATTRIBUTE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m60}]->(c1at2)
     CREATE (c1)-[:HAS_ATTRIBUTE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m60}]->(c1at3)
@@ -265,10 +265,10 @@ async def base_dataset_02(db: InfrahubDatabase, default_branch: Branch, car_pers
     CREATE (c2:Node:TestCar { uuid: "c2", namespace: "Test", kind: "TestCar", branch_support: "aware" })
     CREATE (c2)-[:IS_PART_OF {branch: $main_branch, branch_level: 1, from: $time_m20, status: "active"}]->(root)
 
-    CREATE (c2at1:Attribute:AttributeLocal { uuid: "c2at1", type: "Str", name: "name", branch_support: "aware"})
-    CREATE (c2at2:Attribute:AttributeLocal { uuid: "c2at2", type: "Int", name: "nbr_seats", branch_support: "aware"})
-    CREATE (c2at3:Attribute:AttributeLocal { uuid: "c2at3", type: "Bool", name: "is_electric", branch_support: "aware"})
-    CREATE (c2at4:Attribute:AttributeLocal { uuid: "c2at4", type: "Str", name: "color", branch_support: "aware"})
+    CREATE (c2at1:Attribute { uuid: "c2at1", type: "Str", name: "name", branch_support: "aware"})
+    CREATE (c2at2:Attribute { uuid: "c2at2", type: "Int", name: "nbr_seats", branch_support: "aware"})
+    CREATE (c2at3:Attribute { uuid: "c2at3", type: "Bool", name: "is_electric", branch_support: "aware"})
+    CREATE (c2at4:Attribute { uuid: "c2at4", type: "Str", name: "color", branch_support: "aware"})
     CREATE (c2)-[:HAS_ATTRIBUTE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m20}]->(c2at1)
     CREATE (c2)-[:HAS_ATTRIBUTE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m20}]->(c2at2)
     CREATE (c2)-[:HAS_ATTRIBUTE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m20}]->(c2at3)
@@ -296,10 +296,10 @@ async def base_dataset_02(db: InfrahubDatabase, default_branch: Branch, car_pers
     CREATE (c3:Node:TestCar { uuid: "c3", namespace: "Test", kind: "TestCar", branch_support: "aware" })
     CREATE (c3)-[:IS_PART_OF {branch: $branch1, branch_level: 2, from: $time_m40, status: "active"}]->(root)
 
-    CREATE (c3at1:Attribute:AttributeLocal { uuid: "c3at1", type: "Str", name: "name", branch_support: "aware"})
-    CREATE (c3at2:Attribute:AttributeLocal { uuid: "c3at2", type: "Int", name: "nbr_seats", branch_support: "aware"})
-    CREATE (c3at3:Attribute:AttributeLocal { uuid: "c3at3", type: "Bool", name: "is_electric", branch_support: "aware"})
-    CREATE (c3at4:Attribute:AttributeLocal { uuid: "c3at4", type: "Str", name: "color", branch_support: "aware"})
+    CREATE (c3at1:Attribute { uuid: "c3at1", type: "Str", name: "name", branch_support: "aware"})
+    CREATE (c3at2:Attribute { uuid: "c3at2", type: "Int", name: "nbr_seats", branch_support: "aware"})
+    CREATE (c3at3:Attribute { uuid: "c3at3", type: "Bool", name: "is_electric", branch_support: "aware"})
+    CREATE (c3at4:Attribute { uuid: "c3at4", type: "Str", name: "color", branch_support: "aware"})
     CREATE (c3)-[:HAS_ATTRIBUTE {branch: $branch1, branch_level: 2, status: "active", from: $time_m40}]->(c3at1)
     CREATE (c3)-[:HAS_ATTRIBUTE {branch: $branch1, branch_level: 2, status: "active", from: $time_m40}]->(c3at2)
     CREATE (c3)-[:HAS_ATTRIBUTE {branch: $branch1, branch_level: 2, status: "active", from: $time_m40}]->(c3at3)
@@ -326,7 +326,7 @@ async def base_dataset_02(db: InfrahubDatabase, default_branch: Branch, car_pers
 
     CREATE (p1:Node:TestPerson { uuid: "p1", namespace: "Test", kind: "TestPerson", branch_support: "aware" })
     CREATE (p1)-[:IS_PART_OF { branch: $main_branch, branch_level: 1, from: $time_m60, status: "active"}]->(root)
-    CREATE (p1at1:Attribute:AttributeLocal { uuid: "p1at1", type: "Str", name: "name", branch_support: "aware"})
+    CREATE (p1at1:Attribute { uuid: "p1at1", type: "Str", name: "name", branch_support: "aware"})
     CREATE (p1)-[:HAS_ATTRIBUTE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m60}]->(p1at1)
     CREATE (p1av11:AttributeValue { uuid: "p1av11", value: "John Doe"})
     CREATE (p1at1)-[:HAS_VALUE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m60 }]->(p1av11)
@@ -335,7 +335,7 @@ async def base_dataset_02(db: InfrahubDatabase, default_branch: Branch, car_pers
 
     CREATE (p2:Node:TestPerson { uuid: "p2", namespace: "Test", kind: "TestPerson", branch_support: "aware" })
     CREATE (p2)-[:IS_PART_OF {branch: $main_branch, branch_level: 1, from: $time_m60, status: "active"}]->(root)
-    CREATE (p2at1:Attribute:AttributeLocal { uuid: "p2at1", type: "Str", name: "name", branch_support: "aware"})
+    CREATE (p2at1:Attribute { uuid: "p2at1", type: "Str", name: "name", branch_support: "aware"})
     CREATE (p2)-[:HAS_ATTRIBUTE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m60}]->(p2at1)
     CREATE (p2av11:AttributeValue { uuid: "p2av11", value: "Jane Doe"})
     CREATE (p2at1)-[:HAS_VALUE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m60 }]->(p2av11)
@@ -344,7 +344,7 @@ async def base_dataset_02(db: InfrahubDatabase, default_branch: Branch, car_pers
 
     CREATE (p3:Node:TestPerson { uuid: "p3", namespace: "Test", kind: "TestPerson", branch_support: "aware" })
     CREATE (p3)-[:IS_PART_OF {branch: $main_branch, branch_level: 1, from: $time_m60, status: "active"}]->(root)
-    CREATE (p3at1:Attribute:AttributeLocal { uuid: "p3at1", type: "Str", name: "name", branch_support: "aware"})
+    CREATE (p3at1:Attribute { uuid: "p3at1", type: "Str", name: "name", branch_support: "aware"})
     CREATE (p3)-[:HAS_ATTRIBUTE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m60}]->(p3at1)
     CREATE (p3av11:AttributeValue { uuid: "p3av11", value: "Bill"})
     CREATE (p3at1)-[:HAS_VALUE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m60 }]->(p3av11)
@@ -449,10 +449,10 @@ async def base_dataset_12(db: InfrahubDatabase, default_branch: Branch, car_pers
     CREATE (atvt:AttributeValue { value: true })
     CREATE (atv44:AttributeValue { value: "#444444" })
 
-    CREATE (c1at1:Attribute:AttributeLocal { uuid: "c1at1", type: "Str", name: "name", branch_support: "aware"})
-    CREATE (c1at2:Attribute:AttributeLocal { uuid: "c1at2", type: "Int", name: "nbr_seats", branch_support: "agnostic"})
-    CREATE (c1at3:Attribute:AttributeLocal { uuid: "c1at3", type: "Bool", name: "is_electric", branch_support: "aware"})
-    CREATE (c1at4:Attribute:AttributeLocal { uuid: "c1at4", type: "Str", name: "color", branch_support: "aware"})
+    CREATE (c1at1:Attribute { uuid: "c1at1", type: "Str", name: "name", branch_support: "aware"})
+    CREATE (c1at2:Attribute { uuid: "c1at2", type: "Int", name: "nbr_seats", branch_support: "agnostic"})
+    CREATE (c1at3:Attribute { uuid: "c1at3", type: "Bool", name: "is_electric", branch_support: "aware"})
+    CREATE (c1at4:Attribute { uuid: "c1at4", type: "Str", name: "color", branch_support: "aware"})
     CREATE (c1)-[:HAS_ATTRIBUTE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m60}]->(c1at1)
     CREATE (c1)-[:HAS_ATTRIBUTE {branch: $global_branch, branch_level: 1, status: "active", from: $time_m60}]->(c1at2)
     CREATE (c1)-[:HAS_ATTRIBUTE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m60}]->(c1at3)
@@ -485,10 +485,10 @@ async def base_dataset_12(db: InfrahubDatabase, default_branch: Branch, car_pers
     CREATE (c2:Node:TestCar { uuid: "c2", namespace: "Test", kind: "TestCar", branch_support: "aware" })
     CREATE (c2)-[:IS_PART_OF {branch: $main_branch, branch_level: 1, from: $time_m20, status: "active"}]->(root)
 
-    CREATE (c2at1:Attribute:AttributeLocal { uuid: "c2at1", type: "Str", name: "name", branch_support: "aware"})
-    CREATE (c2at2:Attribute:AttributeLocal { uuid: "c2at2", type: "Int", name: "nbr_seats", branch_support: "agnostic"})
-    CREATE (c2at3:Attribute:AttributeLocal { uuid: "c2at3", type: "Bool", name: "is_electric", branch_support: "aware"})
-    CREATE (c2at4:Attribute:AttributeLocal { uuid: "c2at4", type: "Str", name: "color", branch_support: "aware"})
+    CREATE (c2at1:Attribute { uuid: "c2at1", type: "Str", name: "name", branch_support: "aware"})
+    CREATE (c2at2:Attribute { uuid: "c2at2", type: "Int", name: "nbr_seats", branch_support: "agnostic"})
+    CREATE (c2at3:Attribute { uuid: "c2at3", type: "Bool", name: "is_electric", branch_support: "aware"})
+    CREATE (c2at4:Attribute { uuid: "c2at4", type: "Str", name: "color", branch_support: "aware"})
     CREATE (c2)-[:HAS_ATTRIBUTE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m20}]->(c2at1)
     CREATE (c2)-[:HAS_ATTRIBUTE {branch: $global_branch, branch_level: 1, status: "active", from: $time_m20}]->(c2at2)
     CREATE (c2)-[:HAS_ATTRIBUTE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m20}]->(c2at3)
@@ -516,10 +516,10 @@ async def base_dataset_12(db: InfrahubDatabase, default_branch: Branch, car_pers
     CREATE (c3:Node:TestCar { uuid: "c3", namespace: "Test", kind: "TestCar", branch_support: "aware" })
     CREATE (c3)-[:IS_PART_OF {branch: $branch1, branch_level: 2, from: $time_m40, status: "active"}]->(root)
 
-    CREATE (c3at1:Attribute:AttributeLocal { uuid: "c3at1", type: "Str", name: "name", branch_support: "aware"})
-    CREATE (c3at2:Attribute:AttributeLocal { uuid: "c3at2", type: "Int", name: "nbr_seats", branch_support: "agnostic"})
-    CREATE (c3at3:Attribute:AttributeLocal { uuid: "c3at3", type: "Bool", name: "is_electric", branch_support: "aware"})
-    CREATE (c3at4:Attribute:AttributeLocal { uuid: "c3at4", type: "Str", name: "color", branch_support: "aware"})
+    CREATE (c3at1:Attribute { uuid: "c3at1", type: "Str", name: "name", branch_support: "aware"})
+    CREATE (c3at2:Attribute { uuid: "c3at2", type: "Int", name: "nbr_seats", branch_support: "agnostic"})
+    CREATE (c3at3:Attribute { uuid: "c3at3", type: "Bool", name: "is_electric", branch_support: "aware"})
+    CREATE (c3at4:Attribute { uuid: "c3at4", type: "Str", name: "color", branch_support: "aware"})
     CREATE (c3)-[:HAS_ATTRIBUTE {branch: $branch1, branch_level: 2, status: "active", from: $time_m40}]->(c3at1)
     CREATE (c3)-[:HAS_ATTRIBUTE {branch: $global_branch, branch_level: 1, status: "active", from: $time_m40}]->(c3at2)
     CREATE (c3)-[:HAS_ATTRIBUTE {branch: $branch1, branch_level: 2, status: "active", from: $time_m40}]->(c3at3)
@@ -546,7 +546,7 @@ async def base_dataset_12(db: InfrahubDatabase, default_branch: Branch, car_pers
 
     CREATE (p1:Node:TestPerson { uuid: "p1", namespace: "Test", kind: "TestPerson", branch_support: "agnostic" })
     CREATE (p1)-[:IS_PART_OF { branch: $global_branch, branch_level: 1, from: $time_m60, status: "active"}]->(root)
-    CREATE (p1at1:Attribute:AttributeLocal { uuid: "p1at1", type: "Str", name: "name", branch_support: "agnostic"})
+    CREATE (p1at1:Attribute { uuid: "p1at1", type: "Str", name: "name", branch_support: "agnostic"})
     CREATE (p1)-[:HAS_ATTRIBUTE {branch: $global_branch, branch_level: 1, status: "active", from: $time_m60}]->(p1at1)
     CREATE (p1av11:AttributeValue { uuid: "p1av11", value: "John Doe"})
     CREATE (p1at1)-[:HAS_VALUE {branch: $global_branch, branch_level: 1, status: "active", from: $time_m60 }]->(p1av11)
@@ -555,7 +555,7 @@ async def base_dataset_12(db: InfrahubDatabase, default_branch: Branch, car_pers
 
     CREATE (p2:Node:TestPerson { uuid: "p2", namespace: "Test", kind: "TestPerson", branch_support: "agnostic" })
     CREATE (p2)-[:IS_PART_OF {branch: $global_branch, branch_level: 1, from: $time_m60, status: "active"}]->(root)
-    CREATE (p2at1:Attribute:AttributeLocal { uuid: "p2at1", type: "Str", name: "name", branch_support: "agnostic"})
+    CREATE (p2at1:Attribute { uuid: "p2at1", type: "Str", name: "name", branch_support: "agnostic"})
     CREATE (p2)-[:HAS_ATTRIBUTE {branch: $global_branch, branch_level: 1, status: "active", from: $time_m60}]->(p2at1)
     CREATE (p2av11:AttributeValue { uuid: "p2av11", value: "Jane Doe"})
     CREATE (p2at1)-[:HAS_VALUE {branch: $global_branch, branch_level: 1, status: "active", from: $time_m60 }]->(p2av11)
@@ -564,7 +564,7 @@ async def base_dataset_12(db: InfrahubDatabase, default_branch: Branch, car_pers
 
     CREATE (p3:Node:TestPerson { uuid: "p3", namespace: "Test", kind: "TestPerson", branch_support: "agnostic" })
     CREATE (p3)-[:IS_PART_OF {branch: $global_branch, branch_level: 1, from: $time_m60, status: "active"}]->(root)
-    CREATE (p3at1:Attribute:AttributeLocal { uuid: "p3at1", type: "Str", name: "name", branch_support: "agnostic"})
+    CREATE (p3at1:Attribute { uuid: "p3at1", type: "Str", name: "name", branch_support: "agnostic"})
     CREATE (p3)-[:HAS_ATTRIBUTE {branch: $global_branch, branch_level: 1, status: "active", from: $time_m60}]->(p3at1)
     CREATE (p3av11:AttributeValue { uuid: "p3av11", value: "Bill"})
     CREATE (p3at1)-[:HAS_VALUE {branch: $global_branch, branch_level: 1, status: "active", from: $time_m60 }]->(p3av11)
@@ -743,7 +743,7 @@ async def base_dataset_03(db: InfrahubDatabase, default_branch: Branch, person_t
     CREATE (t1:Node:Tag { uuid: "t1", kind: "Tag", branch_support: "aware"})
     CREATE (t1)-[:IS_PART_OF { branch: $main_branch, branch_level: 1, from: $time_m120, status: "active" }]->(root)
 
-    CREATE (t1at1:Attribute:AttributeLocal { uuid: "t1at1", type: "Str", name: "name", branch_support: "aware"})
+    CREATE (t1at1:Attribute { uuid: "t1at1", type: "Str", name: "name", branch_support: "aware"})
     CREATE (t1)-[:HAS_ATTRIBUTE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m120}]->(t1at1)
 
     CREATE (t1at1)-[:HAS_VALUE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m120, to: $time_m20}]->(blue)
@@ -754,7 +754,7 @@ async def base_dataset_03(db: InfrahubDatabase, default_branch: Branch, person_t
     CREATE (t2:Node:Tag { uuid: "t2", kind: "Tag", branch_support: "aware" })
     CREATE (t2)-[:IS_PART_OF { branch: $main_branch, branch_level: 1, from: $time_m120, status: "active" }]->(root)
 
-    CREATE (t2at1:Attribute:AttributeLocal { uuid: "t2at1", type: "Str", name: "name", branch_support: "aware"})
+    CREATE (t2at1:Attribute { uuid: "t2at1", type: "Str", name: "name", branch_support: "aware"})
     CREATE (t2)-[:HAS_ATTRIBUTE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m120}]->(t2at1)
 
     CREATE (t2at1)-[:HAS_VALUE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m120, to: $time_m20}]->(red)
@@ -765,7 +765,7 @@ async def base_dataset_03(db: InfrahubDatabase, default_branch: Branch, person_t
     CREATE (t3:Node:Tag { uuid: "t3", kind: "Tag", branch_support: "aware" })
     CREATE (t3)-[:IS_PART_OF { branch: $main_branch, branch_level: 1, from: $time_m120, status: "active" }]->(root)
 
-    CREATE (t3at1:Attribute:AttributeLocal { uuid: "t3at1", type: "Str", name: "name", branch_support: "aware"})
+    CREATE (t3at1:Attribute { uuid: "t3at1", type: "Str", name: "name", branch_support: "aware"})
     CREATE (t3)-[:HAS_ATTRIBUTE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m120}]->(t3at1)
 
     CREATE (t3at1)-[:HAS_VALUE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m120, to: $time_m20}]->(green)
@@ -825,8 +825,8 @@ async def base_dataset_03(db: InfrahubDatabase, default_branch: Branch, person_t
     CREATE (p1:Node:Person { uuid: "p1", kind: "Person", branch_support: "aware" })
     CREATE (p1)-[:IS_PART_OF { branch: $main_branch, branch_level: 1, from: $time_m120, status: "active" }]->(root)
 
-    CREATE (p1at1:Attribute:AttributeLocal { uuid: "p1at1", type: "Str", name: "firstname", branch_support: "aware"})
-    CREATE (p1at2:Attribute:AttributeLocal { uuid: "p1at2", type: "Str", name: "lastname", branch_support: "aware"})
+    CREATE (p1at1:Attribute { uuid: "p1at1", type: "Str", name: "firstname", branch_support: "aware"})
+    CREATE (p1at2:Attribute { uuid: "p1at2", type: "Str", name: "lastname", branch_support: "aware"})
     CREATE (p1)-[:HAS_ATTRIBUTE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m120}]->(p1at1)
     CREATE (p1)-[:HAS_ATTRIBUTE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m120}]->(p1at2)
 
@@ -878,8 +878,8 @@ async def base_dataset_03(db: InfrahubDatabase, default_branch: Branch, person_t
     CREATE (p2:Node:Person { uuid: "p2", kind: "Person", branch_support: "aware" })
     CREATE (p2)-[:IS_PART_OF { branch: $main_branch, branch_level: 1, from: $time_m120, status: "active" }]->(root)
 
-    CREATE (p2at1:Attribute:AttributeLocal { uuid: "p1at1", type: "Str", name: "firstname", branch_support: "aware"})
-    CREATE (p2at2:Attribute:AttributeLocal { uuid: "p1at2", type: "Str", name: "lastname", branch_support: "aware"})
+    CREATE (p2at1:Attribute { uuid: "p1at1", type: "Str", name: "firstname", branch_support: "aware"})
+    CREATE (p2at2:Attribute { uuid: "p1at2", type: "Str", name: "lastname", branch_support: "aware"})
     CREATE (p2)-[:HAS_ATTRIBUTE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m120}]->(p2at1)
     CREATE (p2)-[:HAS_ATTRIBUTE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m120}]->(p2at2)
 
@@ -913,8 +913,8 @@ async def base_dataset_03(db: InfrahubDatabase, default_branch: Branch, person_t
     CREATE (p3:Node:Person { uuid: "p3", kind: "Person", branch_support: "aware" })
     CREATE (p3)-[:IS_PART_OF { branch: $main_branch, branch_level: 1, from: $time_m120, status: "active" }]->(root)
 
-    CREATE (p3at1:Attribute:AttributeLocal { uuid: "p1at1", type: "Str", name: "firstname", branch_support: "aware"})
-    CREATE (p3at2:Attribute:AttributeLocal { uuid: "p1at2", type: "Str", name: "lastname", branch_support: "aware"})
+    CREATE (p3at1:Attribute { uuid: "p1at1", type: "Str", name: "firstname", branch_support: "aware"})
+    CREATE (p3at2:Attribute { uuid: "p1at2", type: "Str", name: "lastname", branch_support: "aware"})
     CREATE (p3)-[:HAS_ATTRIBUTE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m120}]->(p3at1)
     CREATE (p3)-[:HAS_ATTRIBUTE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m120}]->(p3at2)
 


### PR DESCRIPTION
Due to some historic reason, we are currently using two node labels in the Graph for each attribute : `Attribute` & `AttributeLocal`.
This PR removes `AttributeLocal` which isn't used and doesn't add anything