### PR TITLE
Update version to 0.12.0-dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "infrahub"
-version = "0.11.2"
+version = "0.12.0-dev"
 description = ""
 authors = ["OpsMill <info@opsmill.com>"]
 


### PR DESCRIPTION
I think we need to get better at defining development versions in both the stable and the develop branch to avoid the confusion with the actual releases.
All development versions should finish with `-dev`: 
- for `develop` it should be `0.12.0-dev`
- for `stable` it should be the next minor release `0.11.3-dev`

> It will generate some small merge conflicts when we need to pull stable into develop etc .. but I don't think there is a better way around that