### PR TITLE
fix(ci): use input ref for concurrency group

### DIFF
--- a/.github/workflows/ci-docker-image.yml
+++ b/.github/workflows/ci-docker-image.yml
@@ -30,6 +30,11 @@ on:
         type: string
         required: true
         description: The labels for the docker image
+      platforms:
+        type: string
+        required: false
+        description: Comma separated platform list to build the image for
+        default: "linux/amd64,linux/arm64"
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.ref }}
@@ -37,7 +42,6 @@ concurrency:
 
 env:
   DOCKERFILE: "development/Dockerfile"
-  PLATFORMS: "linux/amd64,linux/arm64"
 
 jobs:
   build:
@@ -72,7 +76,7 @@ jobs:
           provenance: false   # To avoid cross platform "unknown"
           push: ${{ inputs.publish }}
           target: "backend"
-          platforms: ${{ env.PLATFORMS }}
+          platforms: ${{ inputs.platforms }}
           tags: ${{ inputs.tags }}
           labels: ${{ inputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/publish-dev-docker-image.yml
+++ b/.github/workflows/publish-dev-docker-image.yml
@@ -15,6 +15,10 @@ on:
         description: commit sha or branch name
         default: ''
         required: false
+      platforms:
+        type: string
+        description: Comma separated platform list to build the image for
+        default: "linux/amd64,linux/arm64"
       tag:
         type: string
         description: additional image tag
@@ -63,3 +67,4 @@ jobs:
       ref: ${{ needs.meta_data.outputs.ref }}
       tags: ${{needs.meta_data.outputs.tags}}
       labels: ${{needs.meta_data.outputs.labels}}
+      platforms: ${{ inputs.platforms }}


### PR DESCRIPTION
The input ref is not the same as the github ref (the scheduled workflow always run on stable whereas we want to build develop using the stable workflow).

Also use input parameter for docker image platforms so that we can opt-out either amd64 or arm64 (amd64 builds are faster).