### PR TITLE
fix(docs): add more information on base directory in installation guide

### DIFF
--- a/docs/docs/guides/installation.mdx
+++ b/docs/docs/guides/installation.mdx
@@ -46,7 +46,6 @@ mkdir -p ~/source/infrahub/
 cd ~/source/infrahub/
 ```
 
-
 Next, clone the `stable` branch of the Infrahub GitHub repository into the current directory. (This branch always holds the current stable release)
 
 ```bash


### PR DESCRIPTION
We suggest `/opt/infrahub` as the base directory for the Infrahub directory. This directory does not make a lot of sense in all scenarios (development, demo, ...)

Also, depending on your system configuration, you might need to change the permissions on the `/opt/infrahub` directory before users can write into it.