### PR TITLE
chore: remove infrahub-server restart from load-infra-schema invoke command

### DIFF
--- a/tasks/demo.py
+++ b/tasks/demo.py
@@ -177,9 +177,6 @@ def load_infra_schema(context: Context, database: str = INFRAHUB_DATABASE):
         command = f"{base_cmd} run infrahub-git infrahubctl schema load models/infrastructure_base.yml"
         execute_command(context=context, command=command)
 
-        command = f"{base_cmd} restart infrahub-server"
-        execute_command(context=context, command=command)
-
 
 @task(optional=["database"])
 def load_infra_data(context: Context, database: str = INFRAHUB_DATABASE):


### PR DESCRIPTION
This steps seems to be confusing customers, thinking it is required to do a restart when loading a schema into Infrhaub.
It is not required anymore to do a restart after loading a schema.