### PR TITLE
Activate additional ruff rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -401,22 +401,28 @@ task-tags = [
 preview = true
 
 select = [
-    "C90",  # mccabe complexity
-    "DJ",   # flake8-django
-    "DTZ",  # flake8-datetimez
-    "E",    # pycodestyle errors
-    "EXE",  # flake8-executable
-    "F",    # pyflakes
-    "I",    # isort-like checks
-    "ICN",  # flake8-import-conventions
-    "PL",   # pylint
-    "PYI",  # flake8-pyi
-    "Q",    # flake8-quotes
-    "TCH",  # flake8-type-checking
-    "TRIO", # flake8-trio
-    "T10",  # flake8-debugger
-    "W",    # pycodestyle warnings
-    "YTT",  # flake8-2020
+    "ASYNC", # flake8-async
+    "B",     # flake8-bugbear
+    "C4",    # flake8-comprehensions
+    "C90",   # mccabe complexity
+    "DJ",    # flake8-django
+    "DTZ",   # flake8-datetimez
+    "E",     # pycodestyle errors
+    "EXE",   # flake8-executable
+    "F",     # pyflakes
+    "I",     # isort-like checks
+    "ICN",   # flake8-import-conventions
+    "INP",   # flake8-no-pep420
+    "PIE",   # flake8-pie
+    "PL",    # pylint
+    "PYI",   # flake8-pyi
+    "Q",     # flake8-quotes
+    "RET",   # flake8-return
+    "TCH",   # flake8-type-checking
+    "TRIO",  # flake8-trio
+    "T10",   # flake8-debugger
+    "W",     # pycodestyle warnings
+    "YTT",   # flake8-2020
 ]
 
 ignore = [
@@ -426,21 +432,44 @@ ignore = [
 # like this so that we can reactivate them one by one. Alternatively ignored after further       #
 # investigation if they are deemed to not make sense.                                            #
 ##################################################################################################
-    "PLC0415", # `import` should be at the top-level of a file
-    "PLR0904", # Too many public methods
-    "PLR0912", # Too many branches
-    "PLR0913", # Too many arguments in function definition
-    "PLR0915", # Too many statements
-    "PLR0916", # Too many Boolean expressions
-    "PLR0917", # Too many positional arguments
-    "PLR1706", # Consider using if-else expression
-    "PLR2004", # Magic value used in comparison this could possibly be fine in the tests folders
-    "PLR6201", # Use a `set` literal when testing for membership
-    "PLR6301", # Method could be a function, class method, or static method
-    "PLW0603", # Using the global statement to update `SETTINGS` is discouraged
-    "PLW1508", # Invalid type for environment variable default; expected `str` or `None`
-    "PLW2901", # `for` loop variable `path` overwritten by assignment target
-    "PLW3201", # Bad or misspelled dunder method name `__init_subclass_with_meta__`
+    "ASYNC101", # Async functions should not call `open`, `time.sleep`, or `subprocess` methods
+    "B006",     # Do not use mutable data structures for argument defaults
+    "B007",     # Loop control variable not used within loop body
+    "B008",     # Do not perform function call `Depends` in argument defaults;
+    "B009",     # [*] Do not call `getattr` with a constant attribute value. It is not any safer than normal property access.
+    "B010",     # [*] Do not call `setattr` with a constant attribute value. It is not any safer than normal property access.
+    "B015",     # Pointless comparison. Did you mean to assign a value? Otherwise, prepend `assert` or remove it
+    "B018",     # Found useless expression. Either assign it to a variable or remove it.
+    "B026",     # Star-arg unpacking after a keyword argument is strongly discouraged
+    "B904",     # Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
+    "C403",     # Unnecessary `list` comprehension (rewrite as a `set` comprehension)
+    "C408",     # Unnecessary `dict` call (rewrite as a literal)
+    "C409",     # Unnecessary `list` literal passed to `tuple()` (rewrite as a `tuple` literal)
+    "C414",     # Unnecessary `list` call within `sorted()`
+    "C419",     # Unnecessary list comprehension.
+    "INP001",   # File is part of an implicit namespace package. Add an `__init__.py`.
+    "PIE804",   # [*] Unnecessary `dict` kwargs
+    "PIE807",   # Prefer `dict` over useless lambda
+    "PIE808",   # [*] Unnecessary `start` argument in `range`
+    "PLC0415",  # `import` should be at the top-level of a file
+    "PLR0904",  # Too many public methods
+    "PLR0912",  # Too many branches
+    "PLR0913",  # Too many arguments in function definition
+    "PLR0915",  # Too many statements
+    "PLR0916",  # Too many Boolean expressions
+    "PLR0917",  # Too many positional arguments
+    "PLR1706",  # Consider using if-else expression
+    "PLR2004",  # Magic value used in comparison this could possibly be fine in the tests folders
+    "PLR6201",  # Use a `set` literal when testing for membership
+    "PLR6301",  # Method could be a function, class method, or static method
+    "PLW0603",  # Using the global statement to update `SETTINGS` is discouraged
+    "PLW1508",  # Invalid type for environment variable default; expected `str` or `None`
+    "PLW2901",  # `for` loop variable `path` overwritten by assignment target
+    "PLW3201",  # Bad or misspelled dunder method name `__init_subclass_with_meta__`
+    "RET502",   # [*] Do not implicitly `return None` in function able to return non-`None` value
+    "RET503",   # Missing explicit `return` at the end of function able to return non-`None` value
+    "RET504",   # Unnecessary assignment before `return` statement
+    "RET505",   # RET505 Unnecessary `else` after `return` statement
 ]
 
 #https://docs.astral.sh/ruff/formatter/black/

--- a/python_sdk/pyproject.toml
+++ b/python_sdk/pyproject.toml
@@ -177,22 +177,28 @@ task-tags = [
 preview = true
 
 select = [
-    "C90",  # mccabe complexity
-    "DJ",   # flake8-django
-    "DTZ",  # flake8-datetimez
-    "E",    # pycodestyle errors
-    "EXE",  # flake8-executable
-    "F",    # pyflakes
-    "I",    # isort-like checks
-    "ICN",  # flake8-import-conventions
-    "PL",   # pylint
-    "PYI",  # flake8-pyi
-    "Q",    # flake8-quotes
-    "TCH",  # flake8-type-checking
-    "TRIO", # flake8-trio
-    "T10",  # flake8-debugger
-    "W",    # pycodestyle warnings
-    "YTT",  # flake8-2020
+    "ASYNC", # flake8-async
+    "B",     # flake8-bugbear
+    "C4",    # flake8-comprehensions
+    "C90",   # mccabe complexity
+    "DJ",    # flake8-django
+    "DTZ",   # flake8-datetimez
+    "E",     # pycodestyle errors
+    "EXE",   # flake8-executable
+    "F",     # pyflakes
+    "I",     # isort-like checks
+    "ICN",   # flake8-import-conventions
+    "INP",   # flake8-no-pep420
+    "PIE",   # flake8-pie
+    "PL",    # pylint
+    "PYI",   # flake8-pyi
+    "Q",     # flake8-quotes
+    "RET",   # flake8-return
+    "TCH",   # flake8-type-checking
+    "TRIO",  # flake8-trio
+    "T10",   # flake8-debugger
+    "W",     # pycodestyle warnings
+    "YTT",   # flake8-2020
 ]
 
 ignore = [
@@ -202,6 +208,14 @@ ignore = [
 # like this so that we can reactivate them one by one. Alternatively ignored after further       #
 # investigation if they are deemed to not make sense.                                            #
 ##################################################################################################
+    "B007",    # Loop control variable `result` not used within loop body
+    "B008",    #  Do not perform function call `typer.Option` in argument defaults; instead, perform the call within the function, or read the default from a module-level singleton variable
+    "B904",    # Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
+    "B018",    # Found useless attribute access. Either assign it to a variable or remove it.
+    "C408",    # Unnecessary `dict` call (rewrite as a literal)
+    "C414",    # Unnecessary `list` call within `sorted()`
+    "INP001",  # File is part of an implicit namespace package. Add an `__init__.py`.
+    "PIE808",  # [*] Unnecessary `start` argument in `range`
     "PLR0912", # Too many branches
     "PLR0913", # Too many arguments in function definition
     "PLR0917", # Too many positional arguments
@@ -209,6 +223,7 @@ ignore = [
     "PLR6301", # Method could be a function, class method, or static method
     "PLW0603", # Using the global statement to update `SETTINGS` is discouraged
     "PLW1641", # Object does not implement `__hash__` method
+    "RET504",  # Unnecessary assignment to `data` before `return` statement
 ]
 
 

--- a/sync/pyproject.toml
+++ b/sync/pyproject.toml
@@ -149,22 +149,28 @@ task-tags = [
 preview = true
 
 select = [
-    "C90",  # mccabe complexity
-    "DJ",   # flake8-django
-    "DTZ",  # flake8-datetimez
-    "E",    # pycodestyle errors
-    "EXE",  # flake8-executable
-    "F",    # pyflakes
-    "I",    # isort-like checks
-    "ICN",  # flake8-import-conventions
-    "PL",   # pylint
-    "PYI",  # flake8-pyi
-    "Q",    # flake8-quotes
-    "TCH",  # flake8-type-checking
-    "TRIO", # flake8-trio
-    "T10",  # flake8-debugger
-    "W",    # pycodestyle warnings
-    "YTT",  # flake8-2020
+   "ASYNC", # flake8-async
+    "B",     # flake8-bugbear
+    "C4",    # flake8-comprehensions
+    "C90",   # mccabe complexity
+    "DJ",    # flake8-django
+    "DTZ",   # flake8-datetimez
+    "E",     # pycodestyle errors
+    "EXE",   # flake8-executable
+    "F",     # pyflakes
+    "I",     # isort-like checks
+    "ICN",   # flake8-import-conventions
+    "INP",   # flake8-no-pep420
+    "PIE",   # flake8-pie
+    "PL",    # pylint
+    "PYI",   # flake8-pyi
+    "Q",     # flake8-quotes
+    "RET",   # flake8-return
+    "TCH",   # flake8-type-checking
+    "TRIO",  # flake8-trio
+    "T10",   # flake8-debugger
+    "W",     # pycodestyle warnings
+    "YTT",   # flake8-2020
 ]
 
 ignore = [
@@ -174,10 +180,14 @@ ignore = [
 # like this so that we can reactivate them one by one. Alternatively ignored after further       #
 # investigation if they are deemed to not make sense.                                            #
 ##################################################################################################
+    "B904",    # Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
+    "C416",    # Unnecessary `list` comprehension (rewrite using `list()`)
+    "INP001",  # File is part of an implicit namespace package. Add an `__init__.py`.
     "PLR0912", # Too many branches
     "PLR0913", # Too many arguments in function definition
     "PLR0917", # Too many positional arguments
     "PLR6301", # Method could be a function, class method, or static method
+    "RET504",  # Unnecessary assignment to `ptd` before `return` statement
 ]
 
 #https://docs.astral.sh/ruff/formatter/black/


### PR DESCRIPTION
* ASYNC (#1255)
* PIE (#2196)
* INP (#2195)
* C4 (#2194)
* B (#2193)
* RET (#2192)

This PR only adds the rules but doesn't touch the violations those have been added to the ignore list so that we can review them one by one instead.

In order to keep everything neat the indentation of previous rules have been modified so it looks like there are more changes that there actually are in this PR.