### PR TITLE
chore(docs): add infrahubctl installation instructions

### DIFF
--- a/docs/docs/infrahubctl.mdx
+++ b/docs/docs/infrahubctl.mdx
@@ -18,7 +18,7 @@ It's meant to run on any laptop or server and it communicates with a remote Infr
 
 ## Installation
 
-The `infrahubctl` command line utility is installed as a part of the [Infrahub SDK for Python](python-sdk/readme#installation).
+The `infrahubctl` command line utility is installed as a part of the [Infrahub SDK for Python](/python-sdk/#installation).
 
 ## Configuration
 


### PR DESCRIPTION
Add reference to Python SDK installation instructions for the installation instructions of infrahubctl