### PR TITLE
fix(ci): move cypress e2e tests to our own runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -534,7 +534,8 @@ jobs:
       always() && !cancelled() &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
-    runs-on: "runner-ubuntu-8-32"
+    runs-on:
+      group: huge-runners
     timeout-minutes: 40
     env:
       INFRAHUB_DB_TYPE: memgraph


### PR DESCRIPTION
Billed 264 USD last month...

![image](https://github.com/opsmill/infrahub/assets/15028881/7d92e537-cec4-4a7f-9d3f-eadddeaadebe)
