### PR TITLE
Fix GraphQL queries and Jinja2 templates lookup in tests

### DIFF
--- a/python_sdk/infrahub_sdk/pytest_plugin/items/graphql_query.py
+++ b/python_sdk/infrahub_sdk/pytest_plugin/items/graphql_query.py
@@ -45,7 +45,7 @@ class InfrahubGraphQLQueryItem(InfrahubItem):
 
 class InfrahubGraphQLQuerySmokeItem(InfrahubGraphQLQueryItem):
     def runtest(self) -> None:
-        query = self.test.spec.path.read_text()  # type: ignore[attr-defined,union-attr]
+        query = (self.session.infrahub_config_path.parent / self.test.spec.path).read_text()  # type: ignore[attr-defined,union-attr]
         GraphQLQueryAnalyzer(query)
 
 

--- a/python_sdk/infrahub_sdk/pytest_plugin/items/jinja2_transform.py
+++ b/python_sdk/infrahub_sdk/pytest_plugin/items/jinja2_transform.py
@@ -86,7 +86,7 @@ class InfrahubJinja2Item(InfrahubItem):
 
 class InfrahubJinja2TransformSmokeItem(InfrahubJinja2Item):
     def runtest(self) -> None:
-        file_path: Path = self.resource_config.template_path  # type: ignore[attr-defined]
+        file_path: Path = self.session.infrahub_config_path.parent / self.resource_config.template_path  # type: ignore[attr-defined]
         self.get_jinja2_environment().parse(file_path.read_text(), filename=file_path.name)
 
 


### PR DESCRIPTION
Perform the lookup by appending the root of the repository next to the relative path in order to be able to run tests outside of the repo.