### PR TITLE
fix(tests, scale): do not fetch db stats in CI

### DIFF
--- a/backend/tests/scale/common/events.py
+++ b/backend/tests/scale/common/events.py
@@ -61,25 +61,26 @@ def setup_iteration_limit(environment: Environment, **kwargs):
 def request_event_handler(
     request_type, name, response_time, response_length, response, context, exception, start_time, **kwargs
 ):
-    graphdb_stats = get_graphdb_stats()
     result = {
         "name": name,
         "start_time": f"{start_time:.2f}",
         "response_time": f"{response_time:.2f}ms",
-        "db_size": f"{graphdb_stats.db_size}B",
-        "db_node_count": graphdb_stats.node_count,
-        "db_rel_count": graphdb_stats.rel_count,
         "failed": True if exception else False,
     }
 
     if os.getenv("CI") is None:
         server_container_stats = get_container_resource_usage(config.server_container)
         db_container_stats = get_container_resource_usage(config.db_container)
+        graphdb_stats = get_graphdb_stats()
 
         result["server_cpu"] = f"{server_container_stats.cpu_usage:.2f}%"
         result["server_memory"] = f"{server_container_stats.memory_usage}B"
         result["db_cpu"] = f"{db_container_stats.cpu_usage:.2f}%"
         result["db_memory"] = f"{db_container_stats.memory_usage}B"
+
+        result["db_size"] =  f"{graphdb_stats.db_size}B",
+        result["db_node_count"] = graphdb_stats.node_count,
+        result["db_rel_count"] = graphdb_stats.rel_count,
 
     output = []
     output = [f"{k}={v}" for k, v in result.items()]


### PR DESCRIPTION
Fetching takes an eternity and slows down all operations... 1000x times faster now.