### PR TITLE
fix(core): improve get schema performance

### DIFF
--- a/backend/infrahub/api/schema.py
+++ b/backend/infrahub/api/schema.py
@@ -35,8 +35,10 @@ router = APIRouter(prefix="/schema")
 class APISchemaMixin:
     @classmethod
     def from_schema(cls, schema: Union[NodeSchema, GenericSchema]) -> Self:
-        schema_instance = schema.with_public_relationships()
-        data = schema_instance.model_dump()
+        data = schema.model_dump()
+        data["relationships"] = [
+            relationship.model_dump() for relationship in schema.relationships if not relationship.internal_peer
+        ]
         data["hash"] = schema.get_hash()
         return cls(**data)
 

--- a/backend/infrahub/core/schema/__init__.py
+++ b/backend/infrahub/core/schema/__init__.py
@@ -285,13 +285,6 @@ class BaseNodeSchema(HashableModel):  # pylint: disable=too-many-public-methods
 
         return node_diff
 
-    def with_public_relationships(self) -> Self:
-        duplicate = self.duplicate()
-        duplicate.relationships = [
-            relationship for relationship in self.relationships if not relationship.internal_peer
-        ]
-        return duplicate
-
     def get_field(self, name: str, raise_on_error: bool = True) -> Optional[Union[AttributeSchema, RelationshipSchema]]:
         if field := self.get_attribute(name, raise_on_error=False):
             return field

--- a/backend/infrahub/core/schema_manager.py
+++ b/backend/infrahub/core/schema_manager.py
@@ -293,7 +293,7 @@ class SchemaBranch:
         }
 
     def get_namespaces(self, include_internal: bool = False) -> List[SchemaNamespace]:
-        all_schemas = self.get_all(include_internal=include_internal)
+        all_schemas = self.get_all(include_internal=include_internal, duplicate=False)
         namespaces: Dict[str, SchemaNamespace] = {}
         for schema in all_schemas.values():
             if schema.namespace in namespaces:
@@ -308,7 +308,7 @@ class SchemaBranch:
         self, namespaces: Optional[List[str]] = None, include_internal: bool = False
     ) -> List[Union[NodeSchema, GenericSchema]]:
         """Retrive everything in a single dictionary."""
-        all_schemas = self.get_all(include_internal=include_internal)
+        all_schemas = self.get_all(include_internal=include_internal, duplicate=False)
         if namespaces:
             return [schema for schema in all_schemas.values() if schema.namespace in namespaces]
         return list(all_schemas.values())


### PR DESCRIPTION
Some low hanging fruit to get around 3x speedup by avoiding duplicating data.
This should speed up page loads when refreshing on the browser.
On our preview cluster it translates to a drop from 1.2 seconds to 400 ms.

There's still a bottleneck remaining at https://github.com/opsmill/infrahub/blob/develop/backend/infrahub/core/models.py#L285 when processing BaseNodeSchema filters.

Before:
![Screenshot_2024-03-06_10-54-12](https://github.com/opsmill/infrahub/assets/15028881/7816c7db-5810-4790-aff1-3e05eb567959)

After:
![Screenshot_2024-03-06_11-11-33](https://github.com/opsmill/infrahub/assets/15028881/820e5cb4-e7db-4ebd-882f-7e79696d4169)