### PR TITLE
Remove rebase property from ProposedChangeArtifactDefinition

### DIFF
--- a/backend/infrahub/message_bus/types.py
+++ b/backend/infrahub/message_bus/types.py
@@ -75,7 +75,6 @@ class ProposedChangeArtifactDefinition(BaseModel):
     content_type: str
     file_path: str = Field(default="")
     timeout: int
-    rebase: bool
 
     @property
     def transform_location(self) -> str:


### PR DESCRIPTION
We missed this rebase property when changing the default branch behaviour, this PR fixes an issue where we try to create an object where the "rebase" param had been removed.

```python

│ /Users/patrick/Code/opsmill/infrahub/backend/infrahub/message_bus/operations/requests/proposed_c │
│ hange.py:630 in _parse_artifact_definitions                                                      │
│                                                                                                  │
│   627 │                                                                                          │
│   628 │   parsed = []                                                                            │
│   629 │   for definition in definitions:                                                         │
│ ❱ 630 │   │   artifact_definition = ProposedChangeArtifactDefinition(                            │
│   631 │   │   │   definition_id=definition["node"]["id"],                                        │
│   632 │   │   │   definition_name=definition["node"]["name"]["value"],                           │
│   633 │   │   │   content_type=definition["node"]["content_type"]["value"],                      │
│                                                                               

ValidationError: 1 validation error for ProposedChangeArtifactDefinition
rebase
  Field required [type=missing, input_value={'definition_id': '17ba29...: 'CoreTransformPython'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.6/v/missing


```