### PR TITLE
feat(backend): enable gzip middleware

### DIFF
--- a/backend/infrahub/server.py
+++ b/backend/infrahub/server.py
@@ -9,6 +9,7 @@ from asgi_correlation_id import CorrelationIdMiddleware
 from asgi_correlation_id.context import correlation_id
 from fastapi import FastAPI, Request, Response
 from fastapi.logger import logger
+from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -156,6 +157,7 @@ app.add_middleware(
     skip_paths=["/health"],
 )
 app.add_middleware(InfrahubCORSMiddleware)
+app.add_middleware(GZipMiddleware, minimum_size=100_000)
 
 app.add_exception_handler(Error, generic_api_exception_handler)
 app.add_exception_handler(TimestampFormatError, partial(generic_api_exception_handler, http_code=400))


### PR DESCRIPTION
This will enable compression of response bodies bigger than 100 kB. It should help downloading the js app and schemas such as the demo schema which is 1 MB.

Before:
![image](https://github.com/opsmill/infrahub/assets/15028881/a8455ce2-f959-4785-8732-0956e43e5cf6)

After:
![image](https://github.com/opsmill/infrahub/assets/15028881/b0512b18-6508-4939-8f6f-63fcf2884618)
