### PR TITLE
Add task reports to Python checks

### DIFF
--- a/backend/infrahub/message_bus/messages/check_repository_checkdefinition.py
+++ b/backend/infrahub/message_bus/messages/check_repository_checkdefinition.py
@@ -1,10 +1,13 @@
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 from infrahub.message_bus import InfrahubMessage
+from infrahub.message_bus.types import ProposedChangeBranchDiff
 
 
 class CheckRepositoryCheckDefinition(InfrahubMessage):
     """Triggers user defined checks to run based on a Check Definition."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     check_definition_id: str = Field(..., description="The unique ID of the check definition")
     commit: str = Field(..., description="The commit to target")
@@ -14,3 +17,4 @@ class CheckRepositoryCheckDefinition(InfrahubMessage):
     file_path: str = Field(..., description="The path and filename of the check")
     class_name: str = Field(..., description="The name of the class containing the check")
     proposed_change: str = Field(..., description="The unique ID of the Proposed Change")
+    branch_diff: ProposedChangeBranchDiff = Field(..., description="The calculated diff between the two branches")

--- a/backend/infrahub/message_bus/messages/check_repository_usercheck.py
+++ b/backend/infrahub/message_bus/messages/check_repository_usercheck.py
@@ -1,10 +1,13 @@
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 from infrahub.message_bus import InfrahubMessage
+from infrahub.message_bus.types import ProposedChangeBranchDiff
 
 
 class CheckRepositoryUserCheck(InfrahubMessage):
     """Runs a check as defined within a CoreCheckDefinition within a repository."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     validator_id: str = Field(..., description="The id of the validator associated with this check")
     validator_execution_id: str = Field(..., description="The id of current execution of the associated validator")
@@ -19,3 +22,4 @@ class CheckRepositoryUserCheck(InfrahubMessage):
     proposed_change: str = Field(..., description="The unique ID of the Proposed Change")
     variables: dict = Field(default_factory=dict, description="Input variables when running the check")
     name: str = Field(..., description="The name of the check")
+    branch_diff: ProposedChangeBranchDiff = Field(..., description="The calculated diff between the two branches")

--- a/backend/infrahub/message_bus/messages/request_repository_userchecks.py
+++ b/backend/infrahub/message_bus/messages/request_repository_userchecks.py
@@ -1,12 +1,17 @@
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 from infrahub.message_bus import InfrahubMessage
+from infrahub.message_bus.types import ProposedChangeBranchDiff
 
 
 class RequestRepositoryUserChecks(InfrahubMessage):
     """Sent to trigger the user defined checks on a repository."""
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     proposed_change: str = Field(..., description="The unique ID of the Proposed Change")
     repository: str = Field(..., description="The unique ID of the Repository")
     source_branch: str = Field(..., description="The source branch")
+    source_branch_data_only: bool = Field(..., description="Indicates if the source branch is a data only branch")
     target_branch: str = Field(..., description="The target branch")
+    branch_diff: ProposedChangeBranchDiff = Field(..., description="The calculated diff between the two branches")

--- a/backend/infrahub/message_bus/operations/requests/proposed_change.py
+++ b/backend/infrahub/message_bus/operations/requests/proposed_change.py
@@ -300,7 +300,9 @@ async def repository_checks(message: messages.RequestProposedChangeRepositoryChe
                     proposed_change=message.proposed_change,
                     repository=repository.repository_id,
                     source_branch=message.source_branch,
+                    source_branch_data_only=message.source_branch_data_only,
                     target_branch=message.destination_branch,
+                    branch_diff=message.branch_diff,
                 )
             )
             await task_report.info(f"{repository.repository_name}: Requesting user checks")

--- a/python_sdk/infrahub_sdk/checks.py
+++ b/python_sdk/infrahub_sdk/checks.py
@@ -136,7 +136,7 @@ class InfrahubCheck:
     async def collect_data(self) -> Dict:
         """Query the result of the GraphQL Query defined in self.query and return the result"""
 
-        return await self.client.query_gql_query(name=self.query, branch_name=self.branch_name, params=self.params)
+        return await self.client.query_gql_query(name=self.query, branch_name=self.branch_name, variables=self.params)
 
     async def run(self, data: Optional[dict] = None) -> bool:
         """Execute the check after collecting the data from the GraphQL query.


### PR DESCRIPTION
* Adds task logs to user defined Python checks to indicate what checks are discovered and will be executed.

I'm thinking that with this we can close #1927 and continue with additional improvements as feature requests when people have started to look at the logs and have some feedback.