### PR TITLE
Remove "at" param from create and update methods on Node

### DIFF
--- a/backend/infrahub/pytest_plugin.py
+++ b/backend/infrahub/pytest_plugin.py
@@ -141,7 +141,7 @@ class InfrahubBackendPlugin:
         check.severity.value = OUTCOME_TO_SEVERITY_MAP[report.outcome]
         check.conclusion.value = OUTCOME_TO_CONCLUSION_MAP[report.outcome]
         # Workaround for https://github.com/opsmill/infrahub/issues/2184
-        check.update(at=Timestamp(), do_full_update=True)
+        check.update(do_full_update=True)
 
     def pytest_sessionfinish(self, session: Session) -> None:  # pylint: disable=unused-argument
         """Set the final RepositoryValidator details after completing the test session."""

--- a/python_sdk/tests/unit/sdk/conftest.py
+++ b/python_sdk/tests/unit/sdk/conftest.py
@@ -1647,25 +1647,25 @@ async def mock_rest_api_artifact_generate(httpx_mock: HTTPXMock) -> HTTPXMock:
 
 
 @pytest.fixture
-async def mock_query_mutation_schema_dropdown_add(httpx_mock: HTTPXMock) -> HTTPXMock:
+async def mock_query_mutation_schema_dropdown_add(httpx_mock: HTTPXMock) -> None:
     response = {"data": {"SchemaDropdownAdd": {"ok": True}}}
     httpx_mock.add_response(method="POST", url="http://mock/graphql", json=response)
 
 
 @pytest.fixture
-async def mock_query_mutation_schema_dropdown_remove(httpx_mock: HTTPXMock) -> HTTPXMock:
+async def mock_query_mutation_schema_dropdown_remove(httpx_mock: HTTPXMock) -> None:
     response = {"data": {"SchemaDropdownRemove": {"ok": True}}}
     httpx_mock.add_response(method="POST", url="http://mock/graphql", json=response)
 
 
 @pytest.fixture
-async def mock_query_mutation_schema_enum_add(httpx_mock: HTTPXMock) -> HTTPXMock:
+async def mock_query_mutation_schema_enum_add(httpx_mock: HTTPXMock) -> None:
     response = {"data": {"SchemaEnumAdd": {"ok": True}}}
     httpx_mock.add_response(method="POST", url="http://mock/graphql", json=response)
 
 
 @pytest.fixture
-async def mock_query_mutation_schema_enum_remove(httpx_mock: HTTPXMock) -> HTTPXMock:
+async def mock_query_mutation_schema_enum_remove(httpx_mock: HTTPXMock) -> None:
     response = {"data": {"SchemaEnumRemove": {"ok": True}}}
     httpx_mock.add_response(method="POST", url="http://mock/graphql", json=response)
 
@@ -1685,9 +1685,7 @@ async def mock_query_mutation_location_create_failed(httpx_mock: HTTPXMock) -> H
             }
         ],
     }
-    url_regex = re.compile(
-        r"http://mock/graphql/main\?at=[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}Z"
-    )
+    url_regex = re.compile(r"http://mock/graphql/main")
     httpx_mock.add_response(method="POST", url=url_regex, json=response1)
     httpx_mock.add_response(method="POST", url=url_regex, json=response2)
     return httpx_mock


### PR DESCRIPTION
We don't allow items to be created or updated in the past or future.

For now raise a deprecation warning if the parameters are used.

Fixes #2201