### PR TITLE
Fix inconsistency issues with infrahubctl check

### DIFF
--- a/docs/docs/infrahubctl/infrahubctl-check.mdx
+++ b/docs/docs/infrahubctl/infrahubctl-check.mdx
@@ -5,38 +5,22 @@ Execute user-defined checks.
 **Usage**:
 
 ```console
-$ infrahubctl check [OPTIONS] COMMAND [ARGS]...
-```
-
-**Options**:
-
-* `--install-completion`: Install completion for the current shell.
-* `--show-completion`: Show completion for the current shell, to copy it or customize the installation.
-* `--help`: Show this message and exit.
-
-**Commands**:
-
-* `run`: Locate and execute all checks under the...
-
-## `infrahubctl check run`
-
-Locate and execute all checks under the defined path.
-
-**Usage**:
-
-```console
-$ infrahubctl check run [OPTIONS] [PATH]
+$ infrahubctl check [OPTIONS] [CHECK_NAME] [VARIABLES]...
 ```
 
 **Arguments**:
 
-* `[PATH]`: [default: .]
+* `[CHECK_NAME]`: Name of the Python check
+* `[VARIABLES]...`: Variables to pass along with the query. Format key=value key=value.
 
 **Options**:
 
 * `--branch TEXT`
+* `--path TEXT`: Root directory  [default: .]
 * `--debug / --no-debug`: [default: no-debug]
 * `--format-json / --no-format-json`: [default: no-format-json]
 * `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]
-* `--name TEXT`
+* `--list`: Show available Python checks
+* `--install-completion`: Install completion for the current shell.
+* `--show-completion`: Show completion for the current shell, to copy it or customize the installation.
 * `--help`: Show this message and exit.

--- a/docs/docs/infrahubctl/infrahubctl-transform.mdx
+++ b/docs/docs/infrahubctl/infrahubctl-transform.mdx
@@ -10,7 +10,7 @@ $ infrahubctl transform [OPTIONS] [TRANSFORM_NAME] [VARIABLES]...
 
 **Arguments**:
 
-* `[TRANSFORM_NAME]`: [default: Name of the Python transformation class]
+* `[TRANSFORM_NAME]`: Name of the Python transformation
 * `[VARIABLES]...`: Variables to pass along with the query. Format key=value key=value.
 
 **Options**:

--- a/python_sdk/infrahub_sdk/ctl/utils.py
+++ b/python_sdk/infrahub_sdk/ctl/utils.py
@@ -58,7 +58,7 @@ def print_graphql_errors(console: Console, errors: List) -> None:
             console.print(f"[red]{escape(str(error))}")
 
 
-def parse_cli_vars(variables: Optional[List[str]]) -> dict:
+def parse_cli_vars(variables: Optional[List[str]]) -> Dict[str, str]:
     if not variables:
         return {}
 


### PR DESCRIPTION
* Added a --list argument to list all checks
* Made it possible to define the GraphQL parameters for non global checks using --param key=value pairs
* Rephrased "path" argument so that it's only an optional param instead of part of the command
* The --name parameter doesn't work exactly as with the transforms, this is to enable running all checks at once. If --name is specified it will only target one check

Fixes  #2330

It seemed that we'd already fixed the issue of not requiring the GraphQL queries to be stored in Infrahub. Though I'm pretty sure that was a while ago.

TODO:

- [ ] Remove the `infrahubctl check run` keyword. This will be done after #2290 is merged to avoid merge conflicts