### PR TITLE
chore(ci): increase pytest worker count

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ env:
   INFRAHUB_LOG_LEVEL: CRITICAL
   INFRAHUB_IMAGE_NAME: "opsmill/infrahub"
   INFRAHUB_IMAGE_VER: "testing"
-  PYTEST_XDIST_WORKER_COUNT: 3
+  PYTEST_XDIST_WORKER_COUNT: 4
   INFRAHUB_TEST_IN_DOCKER: 1
   BUILDKITE_ANALYTICS_BRANCH: ${{ github.ref }}
   BUILDKITE_BRANCH: ${{ github.ref }}
@@ -227,7 +227,8 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     needs: ["python-sdk-unit-tests"]
-    runs-on: ubuntu-latest
+    runs-on:
+      group: huge-runners
     timeout-minutes: 30
     env:
       INFRAHUB_DB_TYPE: memgraph
@@ -236,6 +237,14 @@ jobs:
         uses: "actions/checkout@v4"
       - name: "Install Invoke"
         run: "pip install toml invoke"
+
+      - name: "Set environment variables"
+        run: echo INFRAHUB_BUILD_NAME=infrahub-${{ runner.name }} >> $GITHUB_ENV
+      - name: "Set environment variables"
+        run: echo INFRAHUB_IMAGE_VER=${{ runner.name }}-${{ github.sha }} >> $GITHUB_ENV
+      - name: "Clear docker environment"
+        run: docker compose -p $INFRAHUB_BUILD_NAME down -v --remove-orphans --rmi local
+
       - name: "Build Test Image"
         run: "invoke test.build"
       - name: "Pull External Docker Images"


### PR DESCRIPTION
Also make python sdk integration tests run on our runners (it was our longest running job now that backend unit tests are faster...) it should also help to fix https://github.com/opsmill/infrahub/issues/2504

I observe only 10% of improvement on backend unit tests when using 4 pytest workers...