### PR TITLE
Move git-agent init below db init

### DIFF
--- a/backend/infrahub/cli/git_agent.py
+++ b/backend/infrahub/cli/git_agent.py
@@ -79,10 +79,12 @@ async def _start(debug: bool, port: int) -> None:
         component_type=ComponentType.GIT_AGENT,
     )
     await service.initialize()
-    await initialize_git_agent(service=service)
 
     async with service.database.start_session() as db:
         await initialization(db=db)
+
+    await initialize_git_agent(service=service)
+
     build_component_registry()
 
     await service.message_bus.subscribe()


### PR DESCRIPTION
This PR fixes a problem when the loading of the database took too much time so the registry wasn't properly populated before requesting the default branch. This came up after moving the default branch to the database instead of the config but wasn't spotted from the start as it doesn't show up when you run it against a small database with only one branch and the default schema.

Before this change after loading the infrastructure schema and data and you try to start a new git-agent:

```python
❯ infrahub git-agent start
2024-03-11T08:41:22.254926Z [info     ] Initializing Git Agent ...     [infrahub]
Traceback (most recent call last):
  File "/Users/patrick/.virtualenvs/infrahub/bin/infrahub", line 6, in <module>
    sys.exit(app())
             ^^^^^
  File "/Users/patrick/.virtualenvs/infrahub/lib/python3.12/site-packages/typer/main.py", line 328, in __call__
    raise e
  File "/Users/patrick/.virtualenvs/infrahub/lib/python3.12/site-packages/typer/main.py", line 311, in __call__
    return get_command(self)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/.virtualenvs/infrahub/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/.virtualenvs/infrahub/lib/python3.12/site-packages/typer/core.py", line 778, in main
    return _main(
           ^^^^^^
  File "/Users/patrick/.virtualenvs/infrahub/lib/python3.12/site-packages/typer/core.py", line 216, in _main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/patrick/.virtualenvs/infrahub/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/.virtualenvs/infrahub/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/.virtualenvs/infrahub/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/.virtualenvs/infrahub/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/.virtualenvs/infrahub/lib/python3.12/site-packages/typer/main.py", line 683, in wrapper
    return callback(**use_params)  # type: ignore
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/Code/opsmill/infrahub/backend/infrahub/cli/git_agent.py", line 111, in start
    aiorun(_start(debug=debug, port=port))
  File "/Users/patrick/.nix-profile/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/Users/patrick/.nix-profile/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/.nix-profile/lib/python3.12/asyncio/base_events.py", line 684, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/patrick/Code/opsmill/infrahub/backend/infrahub/cli/git_agent.py", line 82, in _start
    await initialize_git_agent(service=service)
  File "/Users/patrick/Code/opsmill/infrahub/backend/infrahub/cli/git_agent.py", line 50, in initialize_git_agent
    await sync_remote_repositories(service=service)
  File "/Users/patrick/Code/opsmill/infrahub/backend/infrahub/git/actions.py", line 19, in sync_remote_repositories
    repo = await InfrahubRepository.init(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/Code/opsmill/infrahub/backend/infrahub/git/repository.py", line 525, in init
    self.validate_local_directories()
  File "/Users/patrick/Code/opsmill/infrahub/backend/infrahub/git/repository.py", line 418, in validate_local_directories
    self.directory_default,
    ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/Code/opsmill/infrahub/backend/infrahub/git/repository.py", line 362, in directory_default
    return os.path.join(self.directory_root, registry.default_branch)
                                             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/Code/opsmill/infrahub/backend/infrahub/core/registry.py", line 57, in default_branch
    raise InitializationError()
infrahub.exceptions.InitializationError
```