### PR TITLE
Use coverage instead of pytest-cov for SDK unittests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,10 +208,13 @@ jobs:
       - name: "Mypy Tests"
         run: "poetry run mypy --show-error-codes infrahub_sdk/"
       - name: "Unit Tests"
-        run: "poetry --directory python_sdk run pytest -v --cov=infrahub_sdk python_sdk/tests/unit/"
+        run: "poetry --directory python_sdk run coverage run --source=infrahub_sdk -m pytest python_sdk/tests/unit/"
         working-directory: ./
         env:
           BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_SDK_UNIT }}
+      - name: "Create coverage file"
+        run: "poetry --directory python_sdk run coverage xml"
+        working-directory: ./
       - name: "Coveralls : Unit Tests"
         uses: coverallsapp/github-action@v2
         env:


### PR DESCRIPTION
Using pytest-cov seems quite broken for our SDK at the moment. If we run pytest in the repo root a lot of lines are excluded. Probably as they are already loaded before pytest-cov kicks in so those lines are never read. If we run pytest from the python-sdk directory the coverage report instead confuses coveralls.io so that we end up with problems for modules under the sdk, i.e. ctl and the pytest plugin.

In this PR I moved away from pytest-cov specifically for the unittests in order to have these auto-imported lines correctly reported.