### PR TITLE
Allow update of relationship identifier

### DIFF
--- a/backend/infrahub/core/schema/definitions/internal.py
+++ b/backend/infrahub/core/schema/definitions/internal.py
@@ -631,7 +631,7 @@ relationship_schema = SchemaNode(
             regex=str(NAME_REGEX),
             max_length=DEFAULT_REL_IDENTIFIER_LENGTH,
             optional=True,
-            extra={"update": UpdateSupport.MIGRATION_REQUIRED},
+            extra={"update": UpdateSupport.ALLOWED},
         ),
         SchemaAttribute(
             name="cardinality",

--- a/backend/infrahub/core/schema/generated/relationship_schema.py
+++ b/backend/infrahub/core/schema/generated/relationship_schema.py
@@ -58,7 +58,7 @@ class GeneratedRelationshipSchema(HashableModel):
         description="Unique identifier of the relationship within a model, identifiers must match to traverse a relationship on both direction.",
         pattern=r"^[a-z0-9\_]+$",
         max_length=128,
-        json_schema_extra={"update": "migration_required"},
+        json_schema_extra={"update": "allowed"},
     )
     cardinality: RelationshipCardinality = Field(
         default=RelationshipCardinality.MANY,


### PR DESCRIPTION
Related to #2472

After more consideration, a migration isn't required in most cases when we update the identifier of a relationship because the existing relationships could be used by another part of the schema.
Only when we are changing an identifier that isn't referenced anywhere else is the schema a migration would make sense .

For now the proposal is to allow the identifier to be updated without a migration.