### PR TITLE
Exclude CoreAccount from being dumped by default

### DIFF
--- a/docs/docs/infrahubctl/infrahubctl-dump.mdx
+++ b/docs/docs/infrahubctl/infrahubctl-dump.mdx
@@ -11,7 +11,7 @@ $ infrahubctl dump [OPTIONS]
 **Options**:
 
 * `--namespace TEXT`: Namespace(s) to export
-* `--directory PATH`: Directory path to store export.  [default: (dynamic)]
+* `--directory PATH`: Directory path to store export  [default: (dynamic)]
 * `--quiet / --no-quiet`: No console output  [default: no-quiet]
 * `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]
 * `--branch TEXT`: Branch from which to export  [default: main]

--- a/docs/docs/infrahubctl/infrahubctl-load.mdx
+++ b/docs/docs/infrahubctl/infrahubctl-load.mdx
@@ -5,15 +5,12 @@ Import nodes and their relationships into the database.
 **Usage**:
 
 ```console
-$ infrahubctl load [OPTIONS] [DIRECTORY]
+$ infrahubctl load [OPTIONS]
 ```
-
-**Arguments**:
-
-* `[DIRECTORY]`: Directory path of exported data.
 
 **Options**:
 
+* `--directory PATH`: Directory path of exported data  [default: (dynamic)]
 * `--continue-on-error / --no-continue-on-error`: Allow exceptions during loading and display them when complete  [default: no-continue-on-error]
 * `--quiet / --no-quiet`: No console output  [default: no-quiet]
 * `--config-file TEXT`: [env var: INFRAHUBCTL_CONFIG; default: infrahubctl.toml]

--- a/python_sdk/infrahub_sdk/ctl/exporter.py
+++ b/python_sdk/infrahub_sdk/ctl/exporter.py
@@ -20,7 +20,7 @@ def directory_name_with_timestamp():
 
 def dump(
     namespace: List[str] = typer.Option([], help="Namespace(s) to export"),
-    directory: Path = typer.Option(directory_name_with_timestamp, help="Directory path to store export."),
+    directory: Path = typer.Option(directory_name_with_timestamp, help="Directory path to store export"),
     quiet: bool = typer.Option(False, help="No console output"),
     config_file: str = typer.Option("infrahubctl.toml", envvar="INFRAHUBCTL_CONFIG"),
     branch: str = typer.Option("main", help="Branch from which to export"),

--- a/python_sdk/infrahub_sdk/ctl/importer.py
+++ b/python_sdk/infrahub_sdk/ctl/importer.py
@@ -11,8 +11,13 @@ from infrahub_sdk.transfer.importer.json import LineDelimitedJSONImporter
 from infrahub_sdk.transfer.schema_sorter import InfrahubSchemaTopologicalSorter
 
 
+def local_directory():
+    # We use a function here to avoid failure when generating the documentation due to directory name
+    return Path(".").absolute()
+
+
 def load(
-    directory: Path = typer.Argument(default=None, help="Directory path of exported data."),
+    directory: Path = typer.Option(local_directory, help="Directory path of exported data"),
     continue_on_error: bool = typer.Option(
         False, help="Allow exceptions during loading and display them when complete"
     ),


### PR DESCRIPTION
Until we have a proper way to restore accounts (with or without their passwords)

See https://github.com/opsmill/infrahub/issues/2606

Also make the directory option an non-required argument when trying to load data, the default will try to read data from the current directory.