### PR TITLE
Add repository to pipeline tests with additional verifications

### DIFF
--- a/backend/infrahub/core/initialization.py
+++ b/backend/infrahub/core/initialization.py
@@ -178,6 +178,7 @@ async def create_branch(
         hierarchy_level=2,
         description=description,
         is_default=False,
+        sync_with_git=False,
         created_at=at,
         branched_from=at,
         is_isolated=isolated,

--- a/backend/tests/fixtures/repos/car-dealership/initial__main/.infrahub.yml
+++ b/backend/tests/fixtures/repos/car-dealership/initial__main/.infrahub.yml
@@ -4,3 +4,18 @@ check_definitions:
   - name: "car_description_check"
     file_path: "checks/car_overview.py"
     class_name: "CarDescription"
+
+jinja2_transforms:
+  - name: person_with_cars
+    description: "Template to a report card showing a person and the cars they own"
+    query: "person_with_cars"
+    template_path: "templates/person_with_cars.j2"
+
+artifact_definitions:
+  - name: "Ownership report"
+    artifact_name: "car-owner"
+    parameters:
+      name: "name__value"
+    content_type: "text/plain"
+    targets: "people"
+    transformation: "person_with_cars"

--- a/backend/tests/fixtures/repos/car-dealership/initial__main/checks/car_overview.py
+++ b/backend/tests/fixtures/repos/car-dealership/initial__main/checks/car_overview.py
@@ -6,7 +6,7 @@ class CarDescription(InfrahubCheck):
 
     def validate(self, data: dict) -> None:
         for car in data["TestingCar"]["edges"]:
-            name = car["node"]["status"]["value"]
-            description = car["node"]["status"]["value"]
+            name = car["node"]["name"]["value"]
+            description = car["node"]["description"]["value"]
             if not description:
                 self.log_error(message=f"The {name} car doesn't have a description, how will we sell it?")

--- a/backend/tests/fixtures/repos/car-dealership/initial__main/templates/person_with_cars.gql
+++ b/backend/tests/fixtures/repos/car-dealership/initial__main/templates/person_with_cars.gql
@@ -1,0 +1,23 @@
+query PersonWithTheirCars($name: String!) {
+  TestingPerson(name__value: $name) {
+    edges {
+      node {
+        name {
+          value
+        }
+        age {
+          value
+        }
+        cars {
+          edges {
+            node {
+              name {
+                value
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/backend/tests/fixtures/repos/car-dealership/initial__main/templates/person_with_cars.j2
+++ b/backend/tests/fixtures/repos/car-dealership/initial__main/templates/person_with_cars.j2
@@ -1,0 +1,1 @@
+Name: {{ data.TestingPerson.edges[0].node.name.value }}

--- a/backend/tests/helpers/schema/car.py
+++ b/backend/tests/helpers/schema/car.py
@@ -7,6 +7,7 @@ CAR = NodeSchema(
     namespace="Testing",
     include_in_menu=True,
     label="Car",
+    default_filter="name__value",
     attributes=[
         AttributeSchema(name="name", kind="Text"),
         AttributeSchema(name="description", kind="Text", optional=True),

--- a/backend/tests/helpers/schema/manufacturer.py
+++ b/backend/tests/helpers/schema/manufacturer.py
@@ -7,6 +7,7 @@ MANUFACTURER = NodeSchema(
     namespace="Testing",
     include_in_menu=True,
     label="Manufacturer",
+    default_filter="name__value",
     attributes=[
         AttributeSchema(name="name", kind="Text"),
         AttributeSchema(name="description", kind="Text", optional=True),

--- a/backend/tests/helpers/schema/person.py
+++ b/backend/tests/helpers/schema/person.py
@@ -12,7 +12,9 @@ PERSON = NodeSchema(
         AttributeSchema(name="name", kind="Text"),
         AttributeSchema(name="description", kind="Text", optional=True),
         AttributeSchema(name="height", kind="Number", optional=True),
+        AttributeSchema(name="age", kind="Number", optional=True),
     ],
+    inherit_from=["LineageOwner", "LineageSource"],
     relationships=[
         RelationshipSchema(
             name="cars",

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -84,7 +84,7 @@ class TestInfrahubApp:
         await app_initialization(app)
         return InfrahubTestClient(app=app)
 
-    @pytest.fixture
+    @pytest.fixture(scope="class")
     async def client(
         self, test_client: InfrahubTestClient, api_token: str, bus_simulator: BusSimulator
     ) -> InfrahubClient:

--- a/backend/tests/integration/git/test_repository.py
+++ b/backend/tests/integration/git/test_repository.py
@@ -6,6 +6,8 @@ import pytest
 
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
+from tests.constants import TestKind
 from tests.helpers.file_repo import FileRepo
 from tests.helpers.schema import CAR_SCHEMA, load_schema
 from tests.helpers.test_app import TestInfrahubApp
@@ -27,6 +29,12 @@ class TestCreateRepository(TestInfrahubApp):
     ) -> None:
         await load_schema(db, schema=CAR_SCHEMA)
         FileRepo(name="car-dealership", sources_directory=git_repos_source_dir_module_scope)
+        john = await Node.init(schema=TestKind.PERSON, db=db)
+        await john.new(db=db, name="John", height=175, age=25)
+        await john.save(db=db)
+        people = await Node.init(schema=InfrahubKind.STANDARDGROUP, db=db)
+        await people.new(db=db, name="people", members=[john])
+        await people.save(db=db)
 
     async def test_create_repository(
         self,

--- a/backend/tests/integration/proposed_change/test_proposed_change.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change.py
@@ -8,7 +8,9 @@ from infrahub.core.constants import InfrahubKind, ValidatorConclusion
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
+from infrahub.services.adapters.cache.redis import RedisCache
 from tests.constants import TestKind
+from tests.helpers.file_repo import FileRepo
 from tests.helpers.schema import CAR_SCHEMA, load_schema
 from tests.helpers.test_app import TestInfrahubApp
 
@@ -16,15 +18,48 @@ if TYPE_CHECKING:
     from infrahub_sdk import InfrahubClient
 
     from infrahub.database import InfrahubDatabase
+    from tests.adapters.message_bus import BusSimulator
 
 
 class TestProposedChangePipeline(TestInfrahubApp):
     @pytest.fixture(scope="class")
-    async def initial_dataset(self, db: InfrahubDatabase, initialize_registry: None) -> None:
+    async def initial_dataset(
+        self,
+        db: InfrahubDatabase,
+        initialize_registry: None,
+        git_repos_source_dir_module_scope: str,
+        client: InfrahubClient,
+        bus_simulator: BusSimulator,
+    ) -> None:
         await load_schema(db, schema=CAR_SCHEMA)
         john = await Node.init(schema=TestKind.PERSON, db=db)
         await john.new(db=db, name="John", height=175, description="The famous Joe Doe")
         await john.save(db=db)
+        koenigsegg = await Node.init(schema=TestKind.MANUFACTURER, db=db)
+        await koenigsegg.new(db=db, name="Koenigsegg")
+        await koenigsegg.save(db=db)
+        people = await Node.init(schema=InfrahubKind.STANDARDGROUP, db=db)
+        await people.new(db=db, name="people", members=[john])
+        await people.save(db=db)
+
+        jesko = await Node.init(schema=TestKind.CAR, db=db)
+        await jesko.new(
+            db=db,
+            name="Jesko",
+            color="Red",
+            description="A limited production mid-engine sports car",
+            owner=john,
+            manufacturer=koenigsegg,
+        )
+        await jesko.save(db=db)
+
+        bus_simulator.service.cache = RedisCache()
+        FileRepo(name="car-dealership", sources_directory=git_repos_source_dir_module_scope)
+        client_repository = await client.create(
+            kind=InfrahubKind.REPOSITORY,
+            data={"name": "car-dealership", "location": f"{git_repos_source_dir_module_scope}/car-dealership"},
+        )
+        await client_repository.save()
 
     @pytest.fixture(scope="class")
     async def happy_dataset(self, db: InfrahubDatabase, initial_dataset: None) -> None:
@@ -32,6 +67,12 @@ class TestProposedChangePipeline(TestInfrahubApp):
         richard = await Node.init(schema=TestKind.PERSON, db=db, branch=branch1)
         await richard.new(db=db, name="Richard", height=180, description="The less famous Richard Doe")
         await richard.save(db=db)
+
+        john = await NodeManager.get_one_by_id_or_default_filter(
+            db=db, id="John", schema_name=TestKind.PERSON, branch=branch1
+        )
+        john.age.value = 26  # type: ignore[attr-defined]
+        await john.save(db=db)
 
     @pytest.fixture(scope="class")
     async def conflict_dataset(self, db: InfrahubDatabase, initial_dataset: None) -> None:
@@ -60,6 +101,14 @@ class TestProposedChangePipeline(TestInfrahubApp):
         assert peers
         data_integrity = [validator for validator in peers.values() if validator.label.value == "Data Integrity"][0]
         assert data_integrity.conclusion.value == ValidatorConclusion.SUCCESS.value
+        ownership_artifacts = [
+            validator for validator in peers.values() if validator.label.value == "Artifact Validator: Ownership report"
+        ][0]
+        assert ownership_artifacts.conclusion.value == ValidatorConclusion.SUCCESS.value
+        description_check = [
+            validator for validator in peers.values() if validator.label.value == "Check: car_description_check"
+        ][0]
+        assert description_check.conclusion.value == ValidatorConclusion.SUCCESS.value
 
     async def test_conflict_pipeline(
         self, db: InfrahubDatabase, conflict_dataset: None, client: InfrahubClient


### PR DESCRIPTION
For the most part I'm just adding tests here, there are two changes of note.

1. In infrahub.core.initialization I change the default behaviour when creating branches. This change should only revert to the behaviour we had previously. An issue here is that we switched the default boolean option when changing is_data_only to sync_with_git. In another PR I think we should remove this function from Infrahub core, I think it's only used within the tests and could instead be defined under tests/helpers
2. I changed the scope of the client fixture as I wanted to use it within another fixture.