### PR TITLE
fix the /api/diff/schema endpoint returning non-Schema diffs

### DIFF
--- a/backend/infrahub/api/diff/diff.py
+++ b/backend/infrahub/api/diff/diff.py
@@ -78,7 +78,7 @@ async def get_diff_schema(
         branch_only=query.branch_only,
         kinds_include=INTERNAL_SCHEMA_NODE_KINDS,
     )
-    diff_payload_builder = DiffPayloadBuilder(db=db, diff=diff)
+    diff_payload_builder = DiffPayloadBuilder(db=db, diff=diff, kinds_to_include=INTERNAL_SCHEMA_NODE_KINDS)
     return await diff_payload_builder.get_branch_diff()
 
 


### PR DESCRIPTION
the `/api/diff/schema` endpoint can return non-Schema diffs under certain circumstances. I am not sure exactly what they are, but I managed to reproduce it and this very small change fixes the issue.

I don't know exactly how non-Schema diffs are getting added to `BranchDiffer` on the line above my change, but it is happening somehow.