### PR TITLE
Add job to validate generation of GraphQL schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,6 +439,53 @@ jobs:
       - name: "Run validator"
         run: "poetry run invoke backend.validate-generated"
 
+  graphql-schema:
+    if: |
+      always() && !cancelled() &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled') &&
+      needs.files-changed.outputs.backend == 'true'
+    needs: ["files-changed", "yaml-lint", "python-lint"]
+    runs-on:
+      group: huge-runners
+    env:
+      INFRAHUB_DB_TYPE: memgraph
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - name: "Setup environment"
+        run: |
+          pipx install poetry
+          poetry config virtualenvs.prefer-active-python true
+          pip install invoke toml
+      - name: Set Version of Pydantic
+        run: poetry add pydantic@^2
+      - name: "Install Package"
+        run: "poetry install"
+
+      - name: Select infrahub db port
+        run: echo "INFRAHUB_DB_PORT=$(shuf -n 1 -i 10000-60000)" >> $GITHUB_ENV
+
+      - name: "Set environment variables"
+        run: echo INFRAHUB_BUILD_NAME=infrahub-${{ runner.name }} >> $GITHUB_ENV
+      - name: "Set environment variables"
+        run: echo INFRAHUB_IMAGE_VER=local-${{ runner.name }}-${{ github.sha }} >> $GITHUB_ENV
+      - name: "Clear docker environment"
+        run: docker compose -p $INFRAHUB_BUILD_NAME down -v --remove-orphans --rmi local
+
+      - name: Create docker compose override
+        run: mv development/docker-compose.dev-override-benchmark.yml development/docker-compose.dev-override.yml
+
+      - name: Start dependencies
+        run: invoke demo.dev-start
+
+      - name: Run validation
+        run: poetry run invoke schema.validate-graphqlschema
+
   frontend-tests:
     if: |
       always() && !cancelled() &&

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,0 +1,3 @@
+# Infrahub GraphQL core schema
+
+This directory contains the latest version of the Infrahub core schema, i.e. the schema without any custom objects loaded. It can be used to generate GraphQL bindings for the core product.

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -1,0 +1,4425 @@
+"""Attribute of type Text"""
+type TextAttribute implements AttributeInterface {
+  is_inherited: Boolean
+  is_protected: Boolean
+  is_visible: Boolean
+  updated_at: DateTime
+  id: String
+  value: String
+  source: LineageSource
+  owner: LineageOwner
+}
+
+interface AttributeInterface {
+  is_inherited: Boolean
+  is_protected: Boolean
+  is_visible: Boolean
+  updated_at: DateTime
+}
+
+"""
+The `DateTime` scalar type represents a DateTime
+value as specified by
+[iso8601](https://en.wikipedia.org/wiki/ISO_8601).
+"""
+scalar DateTime
+
+"""Attribute of type Dropdown"""
+type Dropdown implements AttributeInterface {
+  is_inherited: Boolean
+  is_protected: Boolean
+  is_visible: Boolean
+  updated_at: DateTime
+  value: String
+  label: String
+  color: String
+  description: String
+  id: String
+  source: LineageSource
+  owner: LineageOwner
+}
+
+"""Attribute of type Number"""
+type NumberAttribute implements AttributeInterface {
+  is_inherited: Boolean
+  is_protected: Boolean
+  is_visible: Boolean
+  updated_at: DateTime
+  id: String
+  value: Int
+  source: LineageSource
+  owner: LineageOwner
+}
+
+"""Attribute of type Text"""
+type IPHost implements AttributeInterface {
+  is_inherited: Boolean
+  is_protected: Boolean
+  is_visible: Boolean
+  updated_at: DateTime
+  id: String
+  value: String
+  ip: String
+  hostmask: String
+  netmask: String
+  prefixlen: String
+  version: Int
+  with_hostmask: String
+  with_netmask: String
+  source: LineageSource
+  owner: LineageOwner
+}
+
+"""Attribute of type Text"""
+type IPNetwork implements AttributeInterface {
+  is_inherited: Boolean
+  is_protected: Boolean
+  is_visible: Boolean
+  updated_at: DateTime
+  id: String
+  value: String
+  broadcast_address: String
+  hostmask: String
+  netmask: String
+  prefixlen: String
+  num_addresses: Int
+  version: Int
+  with_hostmask: String
+  with_netmask: String
+  source: LineageSource
+  owner: LineageOwner
+}
+
+"""Attribute of type Checkbox"""
+type CheckboxAttribute implements AttributeInterface {
+  is_inherited: Boolean
+  is_protected: Boolean
+  is_visible: Boolean
+  updated_at: DateTime
+  id: String
+  value: Boolean
+  source: LineageSource
+  owner: LineageOwner
+}
+
+"""Attribute of type List"""
+type ListAttribute implements AttributeInterface {
+  is_inherited: Boolean
+  is_protected: Boolean
+  is_visible: Boolean
+  updated_at: DateTime
+  id: String
+  value: GenericScalar
+  source: LineageSource
+  owner: LineageOwner
+}
+
+"""
+The `GenericScalar` scalar type represents a generic
+GraphQL scalar value that could be:
+String, Boolean, Int, Float, List or Object.
+"""
+scalar GenericScalar
+
+"""Attribute of type JSON"""
+type JSONAttribute implements AttributeInterface {
+  is_inherited: Boolean
+  is_protected: Boolean
+  is_visible: Boolean
+  updated_at: DateTime
+  id: String
+  value: GenericScalar
+  source: LineageSource
+  owner: LineageOwner
+}
+
+"""Attribute of type GenericScalar"""
+type AnyAttribute implements AttributeInterface {
+  is_inherited: Boolean
+  is_protected: Boolean
+  is_visible: Boolean
+  updated_at: DateTime
+  id: String
+  value: GenericScalar
+  source: LineageSource
+  owner: LineageOwner
+}
+
+"""Base Node in Infrahub."""
+interface CoreNode {
+  display_label: String
+
+  """Unique identifier"""
+  id: String
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""Base Node in Infrahub."""
+type EdgedCoreNode {
+  node: CoreNode
+}
+
+"""Base Node in Infrahub."""
+type PaginatedCoreNode {
+  count: Int
+  edges: [EdgedCoreNode]
+}
+
+"""Any Entities that is responsible for some data."""
+interface LineageOwner {
+  display_label: String
+  name: TextAttribute!
+  description: TextAttribute
+
+  """Unique identifier"""
+  id: String
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""Any Entities that is responsible for some data."""
+type EdgedLineageOwner {
+  node: LineageOwner
+}
+
+"""Any Entities that is responsible for some data."""
+type PaginatedLineageOwner {
+  count: Int
+  edges: [EdgedLineageOwner]
+}
+
+"""Any Entities that stores or produces data."""
+interface LineageSource {
+  display_label: String
+  name: TextAttribute!
+  description: TextAttribute
+
+  """Unique identifier"""
+  id: String
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""Any Entities that stores or produces data."""
+type EdgedLineageSource {
+  node: LineageSource
+}
+
+"""Any Entities that stores or produces data."""
+type PaginatedLineageSource {
+  count: Int
+  edges: [EdgedLineageSource]
+}
+
+"""A comment on a Proposed Change"""
+interface CoreComment {
+  display_label: String
+  text: TextAttribute!
+  created_at: TextAttribute
+
+  """Unique identifier"""
+  id: String
+  created_by: NestedEdgedCoreAccount
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""A comment on a Proposed Change"""
+type EdgedCoreComment {
+  node: CoreComment
+}
+
+"""A comment on a Proposed Change"""
+type PaginatedCoreComment {
+  count: Int
+  edges: [EdgedCoreComment]
+}
+
+"""A thread on a Proposed Change"""
+interface CoreThread {
+  display_label: String
+  label: TextAttribute
+  resolved: CheckboxAttribute
+  created_at: TextAttribute
+
+  """Unique identifier"""
+  id: String
+  change: NestedEdgedCoreProposedChange
+  comments(offset: Int, limit: Int, ids: [ID], text__value: String, text__values: [String], text__source__id: ID, text__owner__id: ID, text__is_visible: Boolean, text__is_protected: Boolean, created_at__value: String, created_at__values: [String], created_at__source__id: ID, created_at__owner__id: ID, created_at__is_visible: Boolean, created_at__is_protected: Boolean): NestedPaginatedCoreThreadComment
+  created_by: NestedEdgedCoreAccount
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""A thread on a Proposed Change"""
+type EdgedCoreThread {
+  node: CoreThread
+}
+
+"""A thread on a Proposed Change"""
+type PaginatedCoreThread {
+  count: Int
+  edges: [EdgedCoreThread]
+}
+
+"""Generic Group Object."""
+interface CoreGroup {
+  display_label: String
+  name: TextAttribute!
+  label: TextAttribute
+  description: TextAttribute
+
+  """Unique identifier"""
+  id: String
+  members(offset: Int, limit: Int, ids: [ID], include_descendants: Boolean): NestedPaginatedCoreNode
+  subscribers(offset: Int, limit: Int, ids: [ID], include_descendants: Boolean): NestedPaginatedCoreNode
+}
+
+"""Generic Group Object."""
+type EdgedCoreGroup {
+  node: CoreGroup
+}
+
+"""Generic Group Object."""
+type PaginatedCoreGroup {
+  count: Int
+  edges: [EdgedCoreGroup]
+}
+
+interface CoreValidator {
+  display_label: String
+  label: TextAttribute
+  state: TextAttribute
+  conclusion: TextAttribute
+  completed_at: TextAttribute
+  started_at: TextAttribute
+
+  """Unique identifier"""
+  id: String
+  proposed_change: NestedEdgedCoreProposedChange
+  checks(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, origin__value: String, origin__values: [String], origin__source__id: ID, origin__owner__id: ID, origin__is_visible: Boolean, origin__is_protected: Boolean, kind__value: String, kind__values: [String], kind__source__id: ID, kind__owner__id: ID, kind__is_visible: Boolean, kind__is_protected: Boolean, message__value: String, message__values: [String], message__source__id: ID, message__owner__id: ID, message__is_visible: Boolean, message__is_protected: Boolean, conclusion__value: String, conclusion__values: [String], conclusion__source__id: ID, conclusion__owner__id: ID, conclusion__is_visible: Boolean, conclusion__is_protected: Boolean, severity__value: String, severity__values: [String], severity__source__id: ID, severity__owner__id: ID, severity__is_visible: Boolean, severity__is_protected: Boolean, created_at__value: String, created_at__values: [String], created_at__source__id: ID, created_at__owner__id: ID, created_at__is_visible: Boolean, created_at__is_protected: Boolean): NestedPaginatedCoreCheck
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+type EdgedCoreValidator {
+  node: CoreValidator
+}
+
+type PaginatedCoreValidator {
+  count: Int
+  edges: [EdgedCoreValidator]
+}
+
+interface CoreCheck {
+  display_label: String
+  name: TextAttribute
+  label: TextAttribute
+  origin: TextAttribute!
+  kind: TextAttribute!
+  message: TextAttribute
+  conclusion: TextAttribute
+  severity: TextAttribute
+  created_at: TextAttribute
+
+  """Unique identifier"""
+  id: String
+  validator: NestedEdgedCoreValidator
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+type EdgedCoreCheck {
+  node: CoreCheck
+}
+
+type PaginatedCoreCheck {
+  count: Int
+  edges: [EdgedCoreCheck]
+}
+
+"""Generic Transformation Object."""
+interface CoreTransformation {
+  display_label: String
+  name: TextAttribute!
+  label: TextAttribute
+  description: TextAttribute
+  timeout: NumberAttribute
+
+  """Unique identifier"""
+  id: String
+  query: NestedEdgedCoreGraphQLQuery
+  repository: NestedEdgedCoreGenericRepository
+  tags(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedBuiltinTag
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""Generic Transformation Object."""
+type EdgedCoreTransformation {
+  node: CoreTransformation
+}
+
+"""Generic Transformation Object."""
+type PaginatedCoreTransformation {
+  count: Int
+  edges: [EdgedCoreTransformation]
+}
+
+"""Extend a node to be associated with artifacts"""
+interface CoreArtifactTarget {
+  display_label: String
+
+  """Unique identifier"""
+  id: String
+  artifacts(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, status__value: String, status__values: [String], status__source__id: ID, status__owner__id: ID, status__is_visible: Boolean, status__is_protected: Boolean, content_type__value: String, content_type__values: [String], content_type__source__id: ID, content_type__owner__id: ID, content_type__is_visible: Boolean, content_type__is_protected: Boolean, checksum__value: String, checksum__values: [String], checksum__source__id: ID, checksum__owner__id: ID, checksum__is_visible: Boolean, checksum__is_protected: Boolean, storage_id__value: String, storage_id__values: [String], storage_id__source__id: ID, storage_id__owner__id: ID, storage_id__is_visible: Boolean, storage_id__is_protected: Boolean, parameters__value: GenericScalar, parameters__values: [GenericScalar], parameters__source__id: ID, parameters__owner__id: ID, parameters__is_visible: Boolean, parameters__is_protected: Boolean): NestedPaginatedCoreArtifact
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""Extend a node to be associated with artifacts"""
+type EdgedCoreArtifactTarget {
+  node: CoreArtifactTarget
+}
+
+"""Extend a node to be associated with artifacts"""
+type PaginatedCoreArtifactTarget {
+  count: Int
+  edges: [EdgedCoreArtifactTarget]
+}
+
+"""Extend a node to be associated with tasks"""
+interface CoreTaskTarget {
+  display_label: String
+
+  """Unique identifier"""
+  id: String
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""Extend a node to be associated with tasks"""
+type EdgedCoreTaskTarget {
+  node: CoreTaskTarget
+}
+
+"""Extend a node to be associated with tasks"""
+type PaginatedCoreTaskTarget {
+  count: Int
+  edges: [EdgedCoreTaskTarget]
+}
+
+"""A webhook that connects to an external integration"""
+interface CoreWebhook {
+  display_label: String
+  name: TextAttribute!
+  description: TextAttribute
+  url: TextAttribute!
+  validate_certificates: CheckboxAttribute
+
+  """Unique identifier"""
+  id: String
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""A webhook that connects to an external integration"""
+type EdgedCoreWebhook {
+  node: CoreWebhook
+}
+
+"""A webhook that connects to an external integration"""
+type PaginatedCoreWebhook {
+  count: Int
+  edges: [EdgedCoreWebhook]
+}
+
+"""A Git Repository integrated with Infrahub"""
+interface CoreGenericRepository {
+  display_label: String
+  name: TextAttribute!
+  description: TextAttribute
+  location: TextAttribute!
+  username: TextAttribute
+  password: TextAttribute
+
+  """Unique identifier"""
+  id: String
+  tags(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedBuiltinTag
+  transformations(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, timeout__value: Int, timeout__values: [Int], timeout__source__id: ID, timeout__owner__id: ID, timeout__is_visible: Boolean, timeout__is_protected: Boolean): NestedPaginatedCoreTransformation
+  queries(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, query__value: String, query__values: [String], query__source__id: ID, query__owner__id: ID, query__is_visible: Boolean, query__is_protected: Boolean, variables__value: GenericScalar, variables__values: [GenericScalar], variables__source__id: ID, variables__owner__id: ID, variables__is_visible: Boolean, variables__is_protected: Boolean, operations__value: GenericScalar, operations__values: [GenericScalar], operations__source__id: ID, operations__owner__id: ID, operations__is_visible: Boolean, operations__is_protected: Boolean, models__value: GenericScalar, models__values: [GenericScalar], models__source__id: ID, models__owner__id: ID, models__is_visible: Boolean, models__is_protected: Boolean, depth__value: Int, depth__values: [Int], depth__source__id: ID, depth__owner__id: ID, depth__is_visible: Boolean, depth__is_protected: Boolean, height__value: Int, height__values: [Int], height__source__id: ID, height__owner__id: ID, height__is_visible: Boolean, height__is_protected: Boolean): NestedPaginatedCoreGraphQLQuery
+  checks(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, file_path__value: String, file_path__values: [String], file_path__source__id: ID, file_path__owner__id: ID, file_path__is_visible: Boolean, file_path__is_protected: Boolean, class_name__value: String, class_name__values: [String], class_name__source__id: ID, class_name__owner__id: ID, class_name__is_visible: Boolean, class_name__is_protected: Boolean, timeout__value: Int, timeout__values: [Int], timeout__source__id: ID, timeout__owner__id: ID, timeout__is_visible: Boolean, timeout__is_protected: Boolean, parameters__value: GenericScalar, parameters__values: [GenericScalar], parameters__source__id: ID, parameters__owner__id: ID, parameters__is_visible: Boolean, parameters__is_protected: Boolean): NestedPaginatedCoreCheckDefinition
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""A Git Repository integrated with Infrahub"""
+type EdgedCoreGenericRepository {
+  node: CoreGenericRepository
+}
+
+"""A Git Repository integrated with Infrahub"""
+type PaginatedCoreGenericRepository {
+  count: Int
+  edges: [EdgedCoreGenericRepository]
+}
+
+"""Defines properties for relationships"""
+type RelationshipProperty {
+  is_visible: Boolean
+  is_protected: Boolean
+  updated_at: DateTime
+  source: LineageSource
+  owner: LineageOwner
+}
+
+"""Base Node in Infrahub."""
+type NestedPaginatedCoreNode {
+  count: Int
+  edges: [NestedEdgedCoreNode]
+}
+
+"""Base Node in Infrahub."""
+type NestedEdgedCoreNode {
+  node: CoreNode
+  _updated_at: DateTime
+  properties: RelationshipProperty
+}
+
+"""Any Entities that is responsible for some data."""
+type NestedPaginatedLineageOwner {
+  count: Int
+  edges: [NestedEdgedLineageOwner]
+}
+
+"""Any Entities that is responsible for some data."""
+type NestedEdgedLineageOwner {
+  node: LineageOwner
+  _updated_at: DateTime
+  properties: RelationshipProperty
+}
+
+"""Any Entities that stores or produces data."""
+type NestedPaginatedLineageSource {
+  count: Int
+  edges: [NestedEdgedLineageSource]
+}
+
+"""Any Entities that stores or produces data."""
+type NestedEdgedLineageSource {
+  node: LineageSource
+  _updated_at: DateTime
+  properties: RelationshipProperty
+}
+
+"""A comment on a Proposed Change"""
+type NestedPaginatedCoreComment {
+  count: Int
+  edges: [NestedEdgedCoreComment]
+}
+
+"""A comment on a Proposed Change"""
+type NestedEdgedCoreComment {
+  node: CoreComment
+  _updated_at: DateTime
+  properties: RelationshipProperty
+}
+
+"""A thread on a Proposed Change"""
+type NestedPaginatedCoreThread {
+  count: Int
+  edges: [NestedEdgedCoreThread]
+}
+
+"""A thread on a Proposed Change"""
+type NestedEdgedCoreThread {
+  node: CoreThread
+  _updated_at: DateTime
+  properties: RelationshipProperty
+}
+
+"""Generic Group Object."""
+type NestedPaginatedCoreGroup {
+  count: Int
+  edges: [NestedEdgedCoreGroup]
+}
+
+"""Generic Group Object."""
+type NestedEdgedCoreGroup {
+  node: CoreGroup
+  _updated_at: DateTime
+  properties: RelationshipProperty
+}
+
+type NestedPaginatedCoreValidator {
+  count: Int
+  edges: [NestedEdgedCoreValidator]
+}
+
+type NestedEdgedCoreValidator {
+  node: CoreValidator
+  _updated_at: DateTime
+  properties: RelationshipProperty
+}
+
+type NestedPaginatedCoreCheck {
+  count: Int
+  edges: [NestedEdgedCoreCheck]
+}
+
+type NestedEdgedCoreCheck {
+  node: CoreCheck
+  _updated_at: DateTime
+  properties: RelationshipProperty
+}
+
+"""Generic Transformation Object."""
+type NestedPaginatedCoreTransformation {
+  count: Int
+  edges: [NestedEdgedCoreTransformation]
+}
+
+"""Generic Transformation Object."""
+type NestedEdgedCoreTransformation {
+  node: CoreTransformation
+  _updated_at: DateTime
+  properties: RelationshipProperty
+}
+
+"""Extend a node to be associated with artifacts"""
+type NestedPaginatedCoreArtifactTarget {
+  count: Int
+  edges: [NestedEdgedCoreArtifactTarget]
+}
+
+"""Extend a node to be associated with artifacts"""
+type NestedEdgedCoreArtifactTarget {
+  node: CoreArtifactTarget
+  _updated_at: DateTime
+  properties: RelationshipProperty
+}
+
+"""Extend a node to be associated with tasks"""
+type NestedPaginatedCoreTaskTarget {
+  count: Int
+  edges: [NestedEdgedCoreTaskTarget]
+}
+
+"""Extend a node to be associated with tasks"""
+type NestedEdgedCoreTaskTarget {
+  node: CoreTaskTarget
+  _updated_at: DateTime
+  properties: RelationshipProperty
+}
+
+"""A webhook that connects to an external integration"""
+type NestedPaginatedCoreWebhook {
+  count: Int
+  edges: [NestedEdgedCoreWebhook]
+}
+
+"""A webhook that connects to an external integration"""
+type NestedEdgedCoreWebhook {
+  node: CoreWebhook
+  _updated_at: DateTime
+  properties: RelationshipProperty
+}
+
+"""A Git Repository integrated with Infrahub"""
+type NestedPaginatedCoreGenericRepository {
+  count: Int
+  edges: [NestedEdgedCoreGenericRepository]
+}
+
+"""A Git Repository integrated with Infrahub"""
+type NestedEdgedCoreGenericRepository {
+  node: CoreGenericRepository
+  _updated_at: DateTime
+  properties: RelationshipProperty
+}
+
+"""Group of nodes of any kind."""
+type CoreStandardGroup implements CoreGroup {
+  display_label: String
+  name: TextAttribute!
+  label: TextAttribute
+  description: TextAttribute
+  id: String!
+  _updated_at: DateTime
+  members(offset: Int, limit: Int, ids: [ID], include_descendants: Boolean): NestedPaginatedCoreNode
+  subscribers(offset: Int, limit: Int, ids: [ID], include_descendants: Boolean): NestedPaginatedCoreNode
+  parent: NestedEdgedCoreGroup
+  children(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, include_descendants: Boolean): NestedPaginatedCoreGroup
+  ancestors(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  descendants(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""Group of nodes of any kind."""
+type EdgedCoreStandardGroup {
+  node: CoreStandardGroup
+}
+
+"""Group of nodes of any kind."""
+type NestedEdgedCoreStandardGroup {
+  node: CoreStandardGroup
+  properties: RelationshipProperty
+}
+
+"""Group of nodes of any kind."""
+type PaginatedCoreStandardGroup {
+  count: Int
+  edges: [EdgedCoreStandardGroup]
+}
+
+"""Group of nodes of any kind."""
+type NestedPaginatedCoreStandardGroup {
+  count: Int
+  edges: [NestedEdgedCoreStandardGroup]
+}
+
+"""Group of nodes associated with a given GraphQLQuery."""
+type CoreGraphQLQueryGroup implements CoreGroup {
+  display_label: String
+  name: TextAttribute!
+  label: TextAttribute
+  description: TextAttribute
+  id: String!
+  _updated_at: DateTime
+  parameters: JSONAttribute
+  query: NestedEdgedCoreGraphQLQuery
+  members(offset: Int, limit: Int, ids: [ID], include_descendants: Boolean): NestedPaginatedCoreNode
+  subscribers(offset: Int, limit: Int, ids: [ID], include_descendants: Boolean): NestedPaginatedCoreNode
+  parent: NestedEdgedCoreGroup
+  children(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, include_descendants: Boolean): NestedPaginatedCoreGroup
+  ancestors(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  descendants(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""Group of nodes associated with a given GraphQLQuery."""
+type EdgedCoreGraphQLQueryGroup {
+  node: CoreGraphQLQueryGroup
+}
+
+"""Group of nodes associated with a given GraphQLQuery."""
+type NestedEdgedCoreGraphQLQueryGroup {
+  node: CoreGraphQLQueryGroup
+  properties: RelationshipProperty
+}
+
+"""Group of nodes associated with a given GraphQLQuery."""
+type PaginatedCoreGraphQLQueryGroup {
+  count: Int
+  edges: [EdgedCoreGraphQLQueryGroup]
+}
+
+"""Group of nodes associated with a given GraphQLQuery."""
+type NestedPaginatedCoreGraphQLQueryGroup {
+  count: Int
+  edges: [NestedEdgedCoreGraphQLQueryGroup]
+}
+
+"""
+Standard Tag object to attached to other objects to provide some context.
+"""
+type BuiltinTag implements CoreNode {
+  display_label: String
+  id: String!
+  _updated_at: DateTime
+  name: TextAttribute!
+  description: TextAttribute
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""
+Standard Tag object to attached to other objects to provide some context.
+"""
+type EdgedBuiltinTag {
+  node: BuiltinTag
+}
+
+"""
+Standard Tag object to attached to other objects to provide some context.
+"""
+type NestedEdgedBuiltinTag {
+  node: BuiltinTag
+  properties: RelationshipProperty
+}
+
+"""
+Standard Tag object to attached to other objects to provide some context.
+"""
+type PaginatedBuiltinTag {
+  count: Int
+  edges: [EdgedBuiltinTag]
+}
+
+"""
+Standard Tag object to attached to other objects to provide some context.
+"""
+type NestedPaginatedBuiltinTag {
+  count: Int
+  edges: [NestedEdgedBuiltinTag]
+}
+
+"""User Account for Infrahub"""
+type CoreAccount implements LineageSource & CoreNode & LineageOwner {
+  display_label: String
+  name: TextAttribute!
+  description: TextAttribute
+  id: String!
+  _updated_at: DateTime
+  password: TextAttribute!
+  label: TextAttribute
+  type: TextAttribute
+  role: TextAttribute
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""User Account for Infrahub"""
+type EdgedCoreAccount {
+  node: CoreAccount
+}
+
+"""User Account for Infrahub"""
+type NestedEdgedCoreAccount {
+  node: CoreAccount
+  properties: RelationshipProperty
+}
+
+"""User Account for Infrahub"""
+type PaginatedCoreAccount {
+  count: Int
+  edges: [EdgedCoreAccount]
+}
+
+"""User Account for Infrahub"""
+type NestedPaginatedCoreAccount {
+  count: Int
+  edges: [NestedEdgedCoreAccount]
+}
+
+"""Token for User Account"""
+type InternalAccountToken implements CoreNode {
+  display_label: String
+  id: String!
+  _updated_at: DateTime
+  name: TextAttribute
+  token: TextAttribute!
+  expiration: TextAttribute
+  account: NestedEdgedCoreAccount
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""Token for User Account"""
+type EdgedInternalAccountToken {
+  node: InternalAccountToken
+}
+
+"""Token for User Account"""
+type NestedEdgedInternalAccountToken {
+  node: InternalAccountToken
+  properties: RelationshipProperty
+}
+
+"""Token for User Account"""
+type PaginatedInternalAccountToken {
+  count: Int
+  edges: [EdgedInternalAccountToken]
+}
+
+"""Token for User Account"""
+type NestedPaginatedInternalAccountToken {
+  count: Int
+  edges: [NestedEdgedInternalAccountToken]
+}
+
+"""Refresh Token"""
+type InternalRefreshToken implements CoreNode {
+  display_label: String
+  id: String!
+  _updated_at: DateTime
+  expiration: TextAttribute!
+  account: NestedEdgedCoreAccount
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""Refresh Token"""
+type EdgedInternalRefreshToken {
+  node: InternalRefreshToken
+}
+
+"""Refresh Token"""
+type NestedEdgedInternalRefreshToken {
+  node: InternalRefreshToken
+  properties: RelationshipProperty
+}
+
+"""Refresh Token"""
+type PaginatedInternalRefreshToken {
+  count: Int
+  edges: [EdgedInternalRefreshToken]
+}
+
+"""Refresh Token"""
+type NestedPaginatedInternalRefreshToken {
+  count: Int
+  edges: [NestedEdgedInternalRefreshToken]
+}
+
+"""Metadata related to a proposed change"""
+type CoreProposedChange implements CoreTaskTarget & CoreNode {
+  display_label: String
+  id: String!
+  _updated_at: DateTime
+  name: TextAttribute!
+  description: TextAttribute
+  source_branch: TextAttribute!
+  destination_branch: TextAttribute!
+  state: TextAttribute
+  approved_by(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, password__value: String, password__values: [String], password__source__id: ID, password__owner__id: ID, password__is_visible: Boolean, password__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, type__value: String, type__values: [String], type__source__id: ID, type__owner__id: ID, type__is_visible: Boolean, type__is_protected: Boolean, role__value: String, role__values: [String], role__source__id: ID, role__owner__id: ID, role__is_visible: Boolean, role__is_protected: Boolean): NestedPaginatedCoreAccount
+  reviewers(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, password__value: String, password__values: [String], password__source__id: ID, password__owner__id: ID, password__is_visible: Boolean, password__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, type__value: String, type__values: [String], type__source__id: ID, type__owner__id: ID, type__is_visible: Boolean, type__is_protected: Boolean, role__value: String, role__values: [String], role__source__id: ID, role__owner__id: ID, role__is_visible: Boolean, role__is_protected: Boolean): NestedPaginatedCoreAccount
+  created_by: NestedEdgedCoreAccount
+  comments(offset: Int, limit: Int, ids: [ID], text__value: String, text__values: [String], text__source__id: ID, text__owner__id: ID, text__is_visible: Boolean, text__is_protected: Boolean, created_at__value: String, created_at__values: [String], created_at__source__id: ID, created_at__owner__id: ID, created_at__is_visible: Boolean, created_at__is_protected: Boolean): NestedPaginatedCoreChangeComment
+  threads(offset: Int, limit: Int, ids: [ID], label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, resolved__value: Boolean, resolved__values: [Boolean], resolved__source__id: ID, resolved__owner__id: ID, resolved__is_visible: Boolean, resolved__is_protected: Boolean, created_at__value: String, created_at__values: [String], created_at__source__id: ID, created_at__owner__id: ID, created_at__is_visible: Boolean, created_at__is_protected: Boolean): NestedPaginatedCoreThread
+  validations(offset: Int, limit: Int, ids: [ID], label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, state__value: String, state__values: [String], state__source__id: ID, state__owner__id: ID, state__is_visible: Boolean, state__is_protected: Boolean, conclusion__value: String, conclusion__values: [String], conclusion__source__id: ID, conclusion__owner__id: ID, conclusion__is_visible: Boolean, conclusion__is_protected: Boolean, completed_at__value: String, completed_at__values: [String], completed_at__source__id: ID, completed_at__owner__id: ID, completed_at__is_visible: Boolean, completed_at__is_protected: Boolean, started_at__value: String, started_at__values: [String], started_at__source__id: ID, started_at__owner__id: ID, started_at__is_visible: Boolean, started_at__is_protected: Boolean): NestedPaginatedCoreValidator
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""Metadata related to a proposed change"""
+type EdgedCoreProposedChange {
+  node: CoreProposedChange
+}
+
+"""Metadata related to a proposed change"""
+type NestedEdgedCoreProposedChange {
+  node: CoreProposedChange
+  properties: RelationshipProperty
+}
+
+"""Metadata related to a proposed change"""
+type PaginatedCoreProposedChange {
+  count: Int
+  edges: [EdgedCoreProposedChange]
+}
+
+"""Metadata related to a proposed change"""
+type NestedPaginatedCoreProposedChange {
+  count: Int
+  edges: [NestedEdgedCoreProposedChange]
+}
+
+"""A thread on proposed change"""
+type CoreChangeThread implements CoreThread & CoreNode {
+  display_label: String
+  label: TextAttribute
+  resolved: CheckboxAttribute
+  created_at: TextAttribute
+  id: String!
+  _updated_at: DateTime
+  change: NestedEdgedCoreProposedChange
+  comments(offset: Int, limit: Int, ids: [ID], text__value: String, text__values: [String], text__source__id: ID, text__owner__id: ID, text__is_visible: Boolean, text__is_protected: Boolean, created_at__value: String, created_at__values: [String], created_at__source__id: ID, created_at__owner__id: ID, created_at__is_visible: Boolean, created_at__is_protected: Boolean): NestedPaginatedCoreThreadComment
+  created_by: NestedEdgedCoreAccount
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""A thread on proposed change"""
+type EdgedCoreChangeThread {
+  node: CoreChangeThread
+}
+
+"""A thread on proposed change"""
+type NestedEdgedCoreChangeThread {
+  node: CoreChangeThread
+  properties: RelationshipProperty
+}
+
+"""A thread on proposed change"""
+type PaginatedCoreChangeThread {
+  count: Int
+  edges: [EdgedCoreChangeThread]
+}
+
+"""A thread on proposed change"""
+type NestedPaginatedCoreChangeThread {
+  count: Int
+  edges: [NestedEdgedCoreChangeThread]
+}
+
+"""A thread related to a file on a proposed change"""
+type CoreFileThread implements CoreThread & CoreNode {
+  display_label: String
+  label: TextAttribute
+  resolved: CheckboxAttribute
+  created_at: TextAttribute
+  id: String!
+  _updated_at: DateTime
+  file: TextAttribute
+  commit: TextAttribute
+  line_number: NumberAttribute
+  repository: NestedEdgedCoreRepository
+  change: NestedEdgedCoreProposedChange
+  comments(offset: Int, limit: Int, ids: [ID], text__value: String, text__values: [String], text__source__id: ID, text__owner__id: ID, text__is_visible: Boolean, text__is_protected: Boolean, created_at__value: String, created_at__values: [String], created_at__source__id: ID, created_at__owner__id: ID, created_at__is_visible: Boolean, created_at__is_protected: Boolean): NestedPaginatedCoreThreadComment
+  created_by: NestedEdgedCoreAccount
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""A thread related to a file on a proposed change"""
+type EdgedCoreFileThread {
+  node: CoreFileThread
+}
+
+"""A thread related to a file on a proposed change"""
+type NestedEdgedCoreFileThread {
+  node: CoreFileThread
+  properties: RelationshipProperty
+}
+
+"""A thread related to a file on a proposed change"""
+type PaginatedCoreFileThread {
+  count: Int
+  edges: [EdgedCoreFileThread]
+}
+
+"""A thread related to a file on a proposed change"""
+type NestedPaginatedCoreFileThread {
+  count: Int
+  edges: [NestedEdgedCoreFileThread]
+}
+
+"""A thread related to an artifact on a proposed change"""
+type CoreArtifactThread implements CoreThread & CoreNode {
+  display_label: String
+  label: TextAttribute
+  resolved: CheckboxAttribute
+  created_at: TextAttribute
+  id: String!
+  _updated_at: DateTime
+  artifact_id: TextAttribute
+  storage_id: TextAttribute
+  line_number: NumberAttribute
+  change: NestedEdgedCoreProposedChange
+  comments(offset: Int, limit: Int, ids: [ID], text__value: String, text__values: [String], text__source__id: ID, text__owner__id: ID, text__is_visible: Boolean, text__is_protected: Boolean, created_at__value: String, created_at__values: [String], created_at__source__id: ID, created_at__owner__id: ID, created_at__is_visible: Boolean, created_at__is_protected: Boolean): NestedPaginatedCoreThreadComment
+  created_by: NestedEdgedCoreAccount
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""A thread related to an artifact on a proposed change"""
+type EdgedCoreArtifactThread {
+  node: CoreArtifactThread
+}
+
+"""A thread related to an artifact on a proposed change"""
+type NestedEdgedCoreArtifactThread {
+  node: CoreArtifactThread
+  properties: RelationshipProperty
+}
+
+"""A thread related to an artifact on a proposed change"""
+type PaginatedCoreArtifactThread {
+  count: Int
+  edges: [EdgedCoreArtifactThread]
+}
+
+"""A thread related to an artifact on a proposed change"""
+type NestedPaginatedCoreArtifactThread {
+  count: Int
+  edges: [NestedEdgedCoreArtifactThread]
+}
+
+"""A thread related to an object on a proposed change"""
+type CoreObjectThread implements CoreThread & CoreNode {
+  display_label: String
+  label: TextAttribute
+  resolved: CheckboxAttribute
+  created_at: TextAttribute
+  id: String!
+  _updated_at: DateTime
+  object_path: TextAttribute!
+  change: NestedEdgedCoreProposedChange
+  comments(offset: Int, limit: Int, ids: [ID], text__value: String, text__values: [String], text__source__id: ID, text__owner__id: ID, text__is_visible: Boolean, text__is_protected: Boolean, created_at__value: String, created_at__values: [String], created_at__source__id: ID, created_at__owner__id: ID, created_at__is_visible: Boolean, created_at__is_protected: Boolean): NestedPaginatedCoreThreadComment
+  created_by: NestedEdgedCoreAccount
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""A thread related to an object on a proposed change"""
+type EdgedCoreObjectThread {
+  node: CoreObjectThread
+}
+
+"""A thread related to an object on a proposed change"""
+type NestedEdgedCoreObjectThread {
+  node: CoreObjectThread
+  properties: RelationshipProperty
+}
+
+"""A thread related to an object on a proposed change"""
+type PaginatedCoreObjectThread {
+  count: Int
+  edges: [EdgedCoreObjectThread]
+}
+
+"""A thread related to an object on a proposed change"""
+type NestedPaginatedCoreObjectThread {
+  count: Int
+  edges: [NestedEdgedCoreObjectThread]
+}
+
+"""A comment on proposed change"""
+type CoreChangeComment implements CoreNode & CoreComment {
+  display_label: String
+  id: String!
+  text: TextAttribute!
+  created_at: TextAttribute
+  _updated_at: DateTime
+  change: NestedEdgedCoreProposedChange
+  created_by: NestedEdgedCoreAccount
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""A comment on proposed change"""
+type EdgedCoreChangeComment {
+  node: CoreChangeComment
+}
+
+"""A comment on proposed change"""
+type NestedEdgedCoreChangeComment {
+  node: CoreChangeComment
+  properties: RelationshipProperty
+}
+
+"""A comment on proposed change"""
+type PaginatedCoreChangeComment {
+  count: Int
+  edges: [EdgedCoreChangeComment]
+}
+
+"""A comment on proposed change"""
+type NestedPaginatedCoreChangeComment {
+  count: Int
+  edges: [NestedEdgedCoreChangeComment]
+}
+
+"""A comment on thread within a Proposed Change"""
+type CoreThreadComment implements CoreNode & CoreComment {
+  display_label: String
+  id: String!
+  text: TextAttribute!
+  created_at: TextAttribute
+  _updated_at: DateTime
+  thread: NestedEdgedCoreThread
+  created_by: NestedEdgedCoreAccount
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""A comment on thread within a Proposed Change"""
+type EdgedCoreThreadComment {
+  node: CoreThreadComment
+}
+
+"""A comment on thread within a Proposed Change"""
+type NestedEdgedCoreThreadComment {
+  node: CoreThreadComment
+  properties: RelationshipProperty
+}
+
+"""A comment on thread within a Proposed Change"""
+type PaginatedCoreThreadComment {
+  count: Int
+  edges: [EdgedCoreThreadComment]
+}
+
+"""A comment on thread within a Proposed Change"""
+type NestedPaginatedCoreThreadComment {
+  count: Int
+  edges: [NestedEdgedCoreThreadComment]
+}
+
+"""A Git Repository integrated with Infrahub"""
+type CoreRepository implements CoreGenericRepository & CoreNode & LineageSource & LineageOwner & CoreTaskTarget {
+  display_label: String
+  name: TextAttribute!
+  description: TextAttribute
+  location: TextAttribute!
+  username: TextAttribute
+  password: TextAttribute
+  id: String!
+  _updated_at: DateTime
+  default_branch: TextAttribute
+  commit: TextAttribute
+  tags(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedBuiltinTag
+  transformations(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, timeout__value: Int, timeout__values: [Int], timeout__source__id: ID, timeout__owner__id: ID, timeout__is_visible: Boolean, timeout__is_protected: Boolean): NestedPaginatedCoreTransformation
+  queries(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, query__value: String, query__values: [String], query__source__id: ID, query__owner__id: ID, query__is_visible: Boolean, query__is_protected: Boolean, variables__value: GenericScalar, variables__values: [GenericScalar], variables__source__id: ID, variables__owner__id: ID, variables__is_visible: Boolean, variables__is_protected: Boolean, operations__value: GenericScalar, operations__values: [GenericScalar], operations__source__id: ID, operations__owner__id: ID, operations__is_visible: Boolean, operations__is_protected: Boolean, models__value: GenericScalar, models__values: [GenericScalar], models__source__id: ID, models__owner__id: ID, models__is_visible: Boolean, models__is_protected: Boolean, depth__value: Int, depth__values: [Int], depth__source__id: ID, depth__owner__id: ID, depth__is_visible: Boolean, depth__is_protected: Boolean, height__value: Int, height__values: [Int], height__source__id: ID, height__owner__id: ID, height__is_visible: Boolean, height__is_protected: Boolean): NestedPaginatedCoreGraphQLQuery
+  checks(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, file_path__value: String, file_path__values: [String], file_path__source__id: ID, file_path__owner__id: ID, file_path__is_visible: Boolean, file_path__is_protected: Boolean, class_name__value: String, class_name__values: [String], class_name__source__id: ID, class_name__owner__id: ID, class_name__is_visible: Boolean, class_name__is_protected: Boolean, timeout__value: Int, timeout__values: [Int], timeout__source__id: ID, timeout__owner__id: ID, timeout__is_visible: Boolean, timeout__is_protected: Boolean, parameters__value: GenericScalar, parameters__values: [GenericScalar], parameters__source__id: ID, parameters__owner__id: ID, parameters__is_visible: Boolean, parameters__is_protected: Boolean): NestedPaginatedCoreCheckDefinition
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""A Git Repository integrated with Infrahub"""
+type EdgedCoreRepository {
+  node: CoreRepository
+}
+
+"""A Git Repository integrated with Infrahub"""
+type NestedEdgedCoreRepository {
+  node: CoreRepository
+  properties: RelationshipProperty
+}
+
+"""A Git Repository integrated with Infrahub"""
+type PaginatedCoreRepository {
+  count: Int
+  edges: [EdgedCoreRepository]
+}
+
+"""A Git Repository integrated with Infrahub"""
+type NestedPaginatedCoreRepository {
+  count: Int
+  edges: [NestedEdgedCoreRepository]
+}
+
+"""
+A Git Repository integrated with Infrahub, Git-side will not be updated
+"""
+type CoreReadOnlyRepository implements CoreGenericRepository & CoreNode & LineageSource & LineageOwner & CoreTaskTarget {
+  display_label: String
+  name: TextAttribute!
+  description: TextAttribute
+  location: TextAttribute!
+  username: TextAttribute
+  password: TextAttribute
+  id: String!
+  _updated_at: DateTime
+  ref: TextAttribute
+  commit: TextAttribute
+  tags(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedBuiltinTag
+  transformations(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, timeout__value: Int, timeout__values: [Int], timeout__source__id: ID, timeout__owner__id: ID, timeout__is_visible: Boolean, timeout__is_protected: Boolean): NestedPaginatedCoreTransformation
+  queries(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, query__value: String, query__values: [String], query__source__id: ID, query__owner__id: ID, query__is_visible: Boolean, query__is_protected: Boolean, variables__value: GenericScalar, variables__values: [GenericScalar], variables__source__id: ID, variables__owner__id: ID, variables__is_visible: Boolean, variables__is_protected: Boolean, operations__value: GenericScalar, operations__values: [GenericScalar], operations__source__id: ID, operations__owner__id: ID, operations__is_visible: Boolean, operations__is_protected: Boolean, models__value: GenericScalar, models__values: [GenericScalar], models__source__id: ID, models__owner__id: ID, models__is_visible: Boolean, models__is_protected: Boolean, depth__value: Int, depth__values: [Int], depth__source__id: ID, depth__owner__id: ID, depth__is_visible: Boolean, depth__is_protected: Boolean, height__value: Int, height__values: [Int], height__source__id: ID, height__owner__id: ID, height__is_visible: Boolean, height__is_protected: Boolean): NestedPaginatedCoreGraphQLQuery
+  checks(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, file_path__value: String, file_path__values: [String], file_path__source__id: ID, file_path__owner__id: ID, file_path__is_visible: Boolean, file_path__is_protected: Boolean, class_name__value: String, class_name__values: [String], class_name__source__id: ID, class_name__owner__id: ID, class_name__is_visible: Boolean, class_name__is_protected: Boolean, timeout__value: Int, timeout__values: [Int], timeout__source__id: ID, timeout__owner__id: ID, timeout__is_visible: Boolean, timeout__is_protected: Boolean, parameters__value: GenericScalar, parameters__values: [GenericScalar], parameters__source__id: ID, parameters__owner__id: ID, parameters__is_visible: Boolean, parameters__is_protected: Boolean): NestedPaginatedCoreCheckDefinition
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""
+A Git Repository integrated with Infrahub, Git-side will not be updated
+"""
+type EdgedCoreReadOnlyRepository {
+  node: CoreReadOnlyRepository
+}
+
+"""
+A Git Repository integrated with Infrahub, Git-side will not be updated
+"""
+type NestedEdgedCoreReadOnlyRepository {
+  node: CoreReadOnlyRepository
+  properties: RelationshipProperty
+}
+
+"""
+A Git Repository integrated with Infrahub, Git-side will not be updated
+"""
+type PaginatedCoreReadOnlyRepository {
+  count: Int
+  edges: [EdgedCoreReadOnlyRepository]
+}
+
+"""
+A Git Repository integrated with Infrahub, Git-side will not be updated
+"""
+type NestedPaginatedCoreReadOnlyRepository {
+  count: Int
+  edges: [NestedEdgedCoreReadOnlyRepository]
+}
+
+"""A file rendered from a Jinja2 template"""
+type CoreTransformJinja2 implements CoreTransformation & CoreNode {
+  display_label: String
+  name: TextAttribute!
+  label: TextAttribute
+  description: TextAttribute
+  timeout: NumberAttribute
+  id: String!
+  _updated_at: DateTime
+  template_path: TextAttribute!
+  query: NestedEdgedCoreGraphQLQuery
+  repository: NestedEdgedCoreGenericRepository
+  tags(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedBuiltinTag
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""A file rendered from a Jinja2 template"""
+type EdgedCoreTransformJinja2 {
+  node: CoreTransformJinja2
+}
+
+"""A file rendered from a Jinja2 template"""
+type NestedEdgedCoreTransformJinja2 {
+  node: CoreTransformJinja2
+  properties: RelationshipProperty
+}
+
+"""A file rendered from a Jinja2 template"""
+type PaginatedCoreTransformJinja2 {
+  count: Int
+  edges: [EdgedCoreTransformJinja2]
+}
+
+"""A file rendered from a Jinja2 template"""
+type NestedPaginatedCoreTransformJinja2 {
+  count: Int
+  edges: [NestedEdgedCoreTransformJinja2]
+}
+
+"""A check related to some Data"""
+type CoreDataCheck implements CoreCheck & CoreNode {
+  display_label: String
+  name: TextAttribute
+  label: TextAttribute
+  origin: TextAttribute!
+  kind: TextAttribute!
+  message: TextAttribute
+  conclusion: TextAttribute
+  severity: TextAttribute
+  created_at: TextAttribute
+  id: String!
+  _updated_at: DateTime
+  conflicts: JSONAttribute!
+  keep_branch: TextAttribute
+  validator: NestedEdgedCoreValidator
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""A check related to some Data"""
+type EdgedCoreDataCheck {
+  node: CoreDataCheck
+}
+
+"""A check related to some Data"""
+type NestedEdgedCoreDataCheck {
+  node: CoreDataCheck
+  properties: RelationshipProperty
+}
+
+"""A check related to some Data"""
+type PaginatedCoreDataCheck {
+  count: Int
+  edges: [EdgedCoreDataCheck]
+}
+
+"""A check related to some Data"""
+type NestedPaginatedCoreDataCheck {
+  count: Int
+  edges: [NestedEdgedCoreDataCheck]
+}
+
+"""A standard check"""
+type CoreStandardCheck implements CoreCheck & CoreNode {
+  display_label: String
+  name: TextAttribute
+  label: TextAttribute
+  origin: TextAttribute!
+  kind: TextAttribute!
+  message: TextAttribute
+  conclusion: TextAttribute
+  severity: TextAttribute
+  created_at: TextAttribute
+  id: String!
+  _updated_at: DateTime
+  validator: NestedEdgedCoreValidator
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""A standard check"""
+type EdgedCoreStandardCheck {
+  node: CoreStandardCheck
+}
+
+"""A standard check"""
+type NestedEdgedCoreStandardCheck {
+  node: CoreStandardCheck
+  properties: RelationshipProperty
+}
+
+"""A standard check"""
+type PaginatedCoreStandardCheck {
+  count: Int
+  edges: [EdgedCoreStandardCheck]
+}
+
+"""A standard check"""
+type NestedPaginatedCoreStandardCheck {
+  count: Int
+  edges: [NestedEdgedCoreStandardCheck]
+}
+
+"""A check related to the schema"""
+type CoreSchemaCheck implements CoreCheck & CoreNode {
+  display_label: String
+  name: TextAttribute
+  label: TextAttribute
+  origin: TextAttribute!
+  kind: TextAttribute!
+  message: TextAttribute
+  conclusion: TextAttribute
+  severity: TextAttribute
+  created_at: TextAttribute
+  id: String!
+  _updated_at: DateTime
+  conflicts: JSONAttribute!
+  validator: NestedEdgedCoreValidator
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""A check related to the schema"""
+type EdgedCoreSchemaCheck {
+  node: CoreSchemaCheck
+}
+
+"""A check related to the schema"""
+type NestedEdgedCoreSchemaCheck {
+  node: CoreSchemaCheck
+  properties: RelationshipProperty
+}
+
+"""A check related to the schema"""
+type PaginatedCoreSchemaCheck {
+  count: Int
+  edges: [EdgedCoreSchemaCheck]
+}
+
+"""A check related to the schema"""
+type NestedPaginatedCoreSchemaCheck {
+  count: Int
+  edges: [NestedEdgedCoreSchemaCheck]
+}
+
+"""A check related to a file in a Git Repository"""
+type CoreFileCheck implements CoreCheck & CoreNode {
+  display_label: String
+  name: TextAttribute
+  label: TextAttribute
+  origin: TextAttribute!
+  kind: TextAttribute!
+  message: TextAttribute
+  conclusion: TextAttribute
+  severity: TextAttribute
+  created_at: TextAttribute
+  id: String!
+  _updated_at: DateTime
+  files: ListAttribute
+  commit: TextAttribute
+  validator: NestedEdgedCoreValidator
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""A check related to a file in a Git Repository"""
+type EdgedCoreFileCheck {
+  node: CoreFileCheck
+}
+
+"""A check related to a file in a Git Repository"""
+type NestedEdgedCoreFileCheck {
+  node: CoreFileCheck
+  properties: RelationshipProperty
+}
+
+"""A check related to a file in a Git Repository"""
+type PaginatedCoreFileCheck {
+  count: Int
+  edges: [EdgedCoreFileCheck]
+}
+
+"""A check related to a file in a Git Repository"""
+type NestedPaginatedCoreFileCheck {
+  count: Int
+  edges: [NestedEdgedCoreFileCheck]
+}
+
+"""A check related to an artifact"""
+type CoreArtifactCheck implements CoreCheck & CoreNode {
+  display_label: String
+  name: TextAttribute
+  label: TextAttribute
+  origin: TextAttribute!
+  kind: TextAttribute!
+  message: TextAttribute
+  conclusion: TextAttribute
+  severity: TextAttribute
+  created_at: TextAttribute
+  id: String!
+  _updated_at: DateTime
+  changed: CheckboxAttribute
+  checksum: TextAttribute
+  artifact_id: TextAttribute
+  storage_id: TextAttribute
+  line_number: NumberAttribute
+  validator: NestedEdgedCoreValidator
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""A check related to an artifact"""
+type EdgedCoreArtifactCheck {
+  node: CoreArtifactCheck
+}
+
+"""A check related to an artifact"""
+type NestedEdgedCoreArtifactCheck {
+  node: CoreArtifactCheck
+  properties: RelationshipProperty
+}
+
+"""A check related to an artifact"""
+type PaginatedCoreArtifactCheck {
+  count: Int
+  edges: [EdgedCoreArtifactCheck]
+}
+
+"""A check related to an artifact"""
+type NestedPaginatedCoreArtifactCheck {
+  count: Int
+  edges: [NestedEdgedCoreArtifactCheck]
+}
+
+"""A check to validate the data integrity between two branches"""
+type CoreDataValidator implements CoreValidator & CoreNode {
+  display_label: String
+  label: TextAttribute
+  state: TextAttribute
+  conclusion: TextAttribute
+  completed_at: TextAttribute
+  started_at: TextAttribute
+  id: String!
+  _updated_at: DateTime
+  proposed_change: NestedEdgedCoreProposedChange
+  checks(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, origin__value: String, origin__values: [String], origin__source__id: ID, origin__owner__id: ID, origin__is_visible: Boolean, origin__is_protected: Boolean, kind__value: String, kind__values: [String], kind__source__id: ID, kind__owner__id: ID, kind__is_visible: Boolean, kind__is_protected: Boolean, message__value: String, message__values: [String], message__source__id: ID, message__owner__id: ID, message__is_visible: Boolean, message__is_protected: Boolean, conclusion__value: String, conclusion__values: [String], conclusion__source__id: ID, conclusion__owner__id: ID, conclusion__is_visible: Boolean, conclusion__is_protected: Boolean, severity__value: String, severity__values: [String], severity__source__id: ID, severity__owner__id: ID, severity__is_visible: Boolean, severity__is_protected: Boolean, created_at__value: String, created_at__values: [String], created_at__source__id: ID, created_at__owner__id: ID, created_at__is_visible: Boolean, created_at__is_protected: Boolean): NestedPaginatedCoreCheck
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""A check to validate the data integrity between two branches"""
+type EdgedCoreDataValidator {
+  node: CoreDataValidator
+}
+
+"""A check to validate the data integrity between two branches"""
+type NestedEdgedCoreDataValidator {
+  node: CoreDataValidator
+  properties: RelationshipProperty
+}
+
+"""A check to validate the data integrity between two branches"""
+type PaginatedCoreDataValidator {
+  count: Int
+  edges: [EdgedCoreDataValidator]
+}
+
+"""A check to validate the data integrity between two branches"""
+type NestedPaginatedCoreDataValidator {
+  count: Int
+  edges: [NestedEdgedCoreDataValidator]
+}
+
+"""A Validator related to a specific repository"""
+type CoreRepositoryValidator implements CoreValidator & CoreNode {
+  display_label: String
+  label: TextAttribute
+  state: TextAttribute
+  conclusion: TextAttribute
+  completed_at: TextAttribute
+  started_at: TextAttribute
+  id: String!
+  _updated_at: DateTime
+  repository: NestedEdgedCoreGenericRepository
+  proposed_change: NestedEdgedCoreProposedChange
+  checks(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, origin__value: String, origin__values: [String], origin__source__id: ID, origin__owner__id: ID, origin__is_visible: Boolean, origin__is_protected: Boolean, kind__value: String, kind__values: [String], kind__source__id: ID, kind__owner__id: ID, kind__is_visible: Boolean, kind__is_protected: Boolean, message__value: String, message__values: [String], message__source__id: ID, message__owner__id: ID, message__is_visible: Boolean, message__is_protected: Boolean, conclusion__value: String, conclusion__values: [String], conclusion__source__id: ID, conclusion__owner__id: ID, conclusion__is_visible: Boolean, conclusion__is_protected: Boolean, severity__value: String, severity__values: [String], severity__source__id: ID, severity__owner__id: ID, severity__is_visible: Boolean, severity__is_protected: Boolean, created_at__value: String, created_at__values: [String], created_at__source__id: ID, created_at__owner__id: ID, created_at__is_visible: Boolean, created_at__is_protected: Boolean): NestedPaginatedCoreCheck
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""A Validator related to a specific repository"""
+type EdgedCoreRepositoryValidator {
+  node: CoreRepositoryValidator
+}
+
+"""A Validator related to a specific repository"""
+type NestedEdgedCoreRepositoryValidator {
+  node: CoreRepositoryValidator
+  properties: RelationshipProperty
+}
+
+"""A Validator related to a specific repository"""
+type PaginatedCoreRepositoryValidator {
+  count: Int
+  edges: [EdgedCoreRepositoryValidator]
+}
+
+"""A Validator related to a specific repository"""
+type NestedPaginatedCoreRepositoryValidator {
+  count: Int
+  edges: [NestedEdgedCoreRepositoryValidator]
+}
+
+"""A Validator related to a user defined checks in a repository"""
+type CoreUserValidator implements CoreValidator & CoreNode {
+  display_label: String
+  label: TextAttribute
+  state: TextAttribute
+  conclusion: TextAttribute
+  completed_at: TextAttribute
+  started_at: TextAttribute
+  id: String!
+  _updated_at: DateTime
+  check_definition: NestedEdgedCoreCheckDefinition
+  repository: NestedEdgedCoreGenericRepository
+  proposed_change: NestedEdgedCoreProposedChange
+  checks(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, origin__value: String, origin__values: [String], origin__source__id: ID, origin__owner__id: ID, origin__is_visible: Boolean, origin__is_protected: Boolean, kind__value: String, kind__values: [String], kind__source__id: ID, kind__owner__id: ID, kind__is_visible: Boolean, kind__is_protected: Boolean, message__value: String, message__values: [String], message__source__id: ID, message__owner__id: ID, message__is_visible: Boolean, message__is_protected: Boolean, conclusion__value: String, conclusion__values: [String], conclusion__source__id: ID, conclusion__owner__id: ID, conclusion__is_visible: Boolean, conclusion__is_protected: Boolean, severity__value: String, severity__values: [String], severity__source__id: ID, severity__owner__id: ID, severity__is_visible: Boolean, severity__is_protected: Boolean, created_at__value: String, created_at__values: [String], created_at__source__id: ID, created_at__owner__id: ID, created_at__is_visible: Boolean, created_at__is_protected: Boolean): NestedPaginatedCoreCheck
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""A Validator related to a user defined checks in a repository"""
+type EdgedCoreUserValidator {
+  node: CoreUserValidator
+}
+
+"""A Validator related to a user defined checks in a repository"""
+type NestedEdgedCoreUserValidator {
+  node: CoreUserValidator
+  properties: RelationshipProperty
+}
+
+"""A Validator related to a user defined checks in a repository"""
+type PaginatedCoreUserValidator {
+  count: Int
+  edges: [EdgedCoreUserValidator]
+}
+
+"""A Validator related to a user defined checks in a repository"""
+type NestedPaginatedCoreUserValidator {
+  count: Int
+  edges: [NestedEdgedCoreUserValidator]
+}
+
+"""A validator related to the schema"""
+type CoreSchemaValidator implements CoreValidator & CoreNode {
+  display_label: String
+  label: TextAttribute
+  state: TextAttribute
+  conclusion: TextAttribute
+  completed_at: TextAttribute
+  started_at: TextAttribute
+  id: String!
+  _updated_at: DateTime
+  proposed_change: NestedEdgedCoreProposedChange
+  checks(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, origin__value: String, origin__values: [String], origin__source__id: ID, origin__owner__id: ID, origin__is_visible: Boolean, origin__is_protected: Boolean, kind__value: String, kind__values: [String], kind__source__id: ID, kind__owner__id: ID, kind__is_visible: Boolean, kind__is_protected: Boolean, message__value: String, message__values: [String], message__source__id: ID, message__owner__id: ID, message__is_visible: Boolean, message__is_protected: Boolean, conclusion__value: String, conclusion__values: [String], conclusion__source__id: ID, conclusion__owner__id: ID, conclusion__is_visible: Boolean, conclusion__is_protected: Boolean, severity__value: String, severity__values: [String], severity__source__id: ID, severity__owner__id: ID, severity__is_visible: Boolean, severity__is_protected: Boolean, created_at__value: String, created_at__values: [String], created_at__source__id: ID, created_at__owner__id: ID, created_at__is_visible: Boolean, created_at__is_protected: Boolean): NestedPaginatedCoreCheck
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""A validator related to the schema"""
+type EdgedCoreSchemaValidator {
+  node: CoreSchemaValidator
+}
+
+"""A validator related to the schema"""
+type NestedEdgedCoreSchemaValidator {
+  node: CoreSchemaValidator
+  properties: RelationshipProperty
+}
+
+"""A validator related to the schema"""
+type PaginatedCoreSchemaValidator {
+  count: Int
+  edges: [EdgedCoreSchemaValidator]
+}
+
+"""A validator related to the schema"""
+type NestedPaginatedCoreSchemaValidator {
+  count: Int
+  edges: [NestedEdgedCoreSchemaValidator]
+}
+
+"""A validator related to the artifacts"""
+type CoreArtifactValidator implements CoreValidator & CoreNode {
+  display_label: String
+  label: TextAttribute
+  state: TextAttribute
+  conclusion: TextAttribute
+  completed_at: TextAttribute
+  started_at: TextAttribute
+  id: String!
+  _updated_at: DateTime
+  definition: NestedEdgedCoreArtifactDefinition
+  proposed_change: NestedEdgedCoreProposedChange
+  checks(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, origin__value: String, origin__values: [String], origin__source__id: ID, origin__owner__id: ID, origin__is_visible: Boolean, origin__is_protected: Boolean, kind__value: String, kind__values: [String], kind__source__id: ID, kind__owner__id: ID, kind__is_visible: Boolean, kind__is_protected: Boolean, message__value: String, message__values: [String], message__source__id: ID, message__owner__id: ID, message__is_visible: Boolean, message__is_protected: Boolean, conclusion__value: String, conclusion__values: [String], conclusion__source__id: ID, conclusion__owner__id: ID, conclusion__is_visible: Boolean, conclusion__is_protected: Boolean, severity__value: String, severity__values: [String], severity__source__id: ID, severity__owner__id: ID, severity__is_visible: Boolean, severity__is_protected: Boolean, created_at__value: String, created_at__values: [String], created_at__source__id: ID, created_at__owner__id: ID, created_at__is_visible: Boolean, created_at__is_protected: Boolean): NestedPaginatedCoreCheck
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""A validator related to the artifacts"""
+type EdgedCoreArtifactValidator {
+  node: CoreArtifactValidator
+}
+
+"""A validator related to the artifacts"""
+type NestedEdgedCoreArtifactValidator {
+  node: CoreArtifactValidator
+  properties: RelationshipProperty
+}
+
+"""A validator related to the artifacts"""
+type PaginatedCoreArtifactValidator {
+  count: Int
+  edges: [EdgedCoreArtifactValidator]
+}
+
+"""A validator related to the artifacts"""
+type NestedPaginatedCoreArtifactValidator {
+  count: Int
+  edges: [NestedEdgedCoreArtifactValidator]
+}
+
+type CoreCheckDefinition implements CoreTaskTarget & CoreNode {
+  display_label: String
+  id: String!
+  _updated_at: DateTime
+  name: TextAttribute!
+  description: TextAttribute
+  file_path: TextAttribute!
+  class_name: TextAttribute!
+  timeout: NumberAttribute
+  parameters: JSONAttribute
+  repository: NestedEdgedCoreGenericRepository
+  query: NestedEdgedCoreGraphQLQuery
+  targets: NestedEdgedCoreGroup
+  tags(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedBuiltinTag
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+type EdgedCoreCheckDefinition {
+  node: CoreCheckDefinition
+}
+
+type NestedEdgedCoreCheckDefinition {
+  node: CoreCheckDefinition
+  properties: RelationshipProperty
+}
+
+type PaginatedCoreCheckDefinition {
+  count: Int
+  edges: [EdgedCoreCheckDefinition]
+}
+
+type NestedPaginatedCoreCheckDefinition {
+  count: Int
+  edges: [NestedEdgedCoreCheckDefinition]
+}
+
+"""A transform function written in Python"""
+type CoreTransformPython implements CoreTransformation & CoreNode {
+  display_label: String
+  name: TextAttribute!
+  label: TextAttribute
+  description: TextAttribute
+  timeout: NumberAttribute
+  id: String!
+  _updated_at: DateTime
+  file_path: TextAttribute!
+  class_name: TextAttribute!
+  query: NestedEdgedCoreGraphQLQuery
+  repository: NestedEdgedCoreGenericRepository
+  tags(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedBuiltinTag
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""A transform function written in Python"""
+type EdgedCoreTransformPython {
+  node: CoreTransformPython
+}
+
+"""A transform function written in Python"""
+type NestedEdgedCoreTransformPython {
+  node: CoreTransformPython
+  properties: RelationshipProperty
+}
+
+"""A transform function written in Python"""
+type PaginatedCoreTransformPython {
+  count: Int
+  edges: [EdgedCoreTransformPython]
+}
+
+"""A transform function written in Python"""
+type NestedPaginatedCoreTransformPython {
+  count: Int
+  edges: [NestedEdgedCoreTransformPython]
+}
+
+"""A pre-defined GraphQL Query"""
+type CoreGraphQLQuery implements CoreNode {
+  display_label: String
+  id: String!
+  _updated_at: DateTime
+  name: TextAttribute!
+  description: TextAttribute
+  query: TextAttribute!
+
+  """variables in use in the query"""
+  variables: JSONAttribute
+
+  """
+  Operations in use in the query, valid operations: 'query', 'mutation' or 'subscription'
+  """
+  operations: ListAttribute
+
+  """List of models associated with this query"""
+  models: ListAttribute
+
+  """number of nested levels in the query"""
+  depth: NumberAttribute
+
+  """total number of fields requested in the query"""
+  height: NumberAttribute
+  repository: NestedEdgedCoreGenericRepository
+  tags(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedBuiltinTag
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""A pre-defined GraphQL Query"""
+type EdgedCoreGraphQLQuery {
+  node: CoreGraphQLQuery
+}
+
+"""A pre-defined GraphQL Query"""
+type NestedEdgedCoreGraphQLQuery {
+  node: CoreGraphQLQuery
+  properties: RelationshipProperty
+}
+
+"""A pre-defined GraphQL Query"""
+type PaginatedCoreGraphQLQuery {
+  count: Int
+  edges: [EdgedCoreGraphQLQuery]
+}
+
+"""A pre-defined GraphQL Query"""
+type NestedPaginatedCoreGraphQLQuery {
+  count: Int
+  edges: [NestedEdgedCoreGraphQLQuery]
+}
+
+type CoreArtifact implements CoreTaskTarget & CoreNode {
+  display_label: String
+  id: String!
+  _updated_at: DateTime
+  name: TextAttribute!
+  status: TextAttribute!
+  content_type: TextAttribute!
+  checksum: TextAttribute
+
+  """ID of the file in the object store"""
+  storage_id: TextAttribute
+  parameters: JSONAttribute
+  object: NestedEdgedCoreNode
+  definition: NestedEdgedCoreArtifactDefinition
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+type EdgedCoreArtifact {
+  node: CoreArtifact
+}
+
+type NestedEdgedCoreArtifact {
+  node: CoreArtifact
+  properties: RelationshipProperty
+}
+
+type PaginatedCoreArtifact {
+  count: Int
+  edges: [EdgedCoreArtifact]
+}
+
+type NestedPaginatedCoreArtifact {
+  count: Int
+  edges: [NestedEdgedCoreArtifact]
+}
+
+type CoreArtifactDefinition implements CoreTaskTarget & CoreNode {
+  display_label: String
+  id: String!
+  _updated_at: DateTime
+  name: TextAttribute!
+  artifact_name: TextAttribute!
+  description: TextAttribute
+  parameters: JSONAttribute!
+  content_type: TextAttribute!
+  targets: NestedEdgedCoreGroup
+  transformation: NestedEdgedCoreTransformation
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+type EdgedCoreArtifactDefinition {
+  node: CoreArtifactDefinition
+}
+
+type NestedEdgedCoreArtifactDefinition {
+  node: CoreArtifactDefinition
+  properties: RelationshipProperty
+}
+
+type PaginatedCoreArtifactDefinition {
+  count: Int
+  edges: [EdgedCoreArtifactDefinition]
+}
+
+type NestedPaginatedCoreArtifactDefinition {
+  count: Int
+  edges: [NestedEdgedCoreArtifactDefinition]
+}
+
+"""A webhook that connects to an external integration"""
+type CoreStandardWebhook implements CoreWebhook & CoreTaskTarget & CoreNode {
+  display_label: String
+  name: TextAttribute!
+  description: TextAttribute
+  url: TextAttribute!
+  validate_certificates: CheckboxAttribute
+  id: String!
+  _updated_at: DateTime
+  shared_key: TextAttribute!
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""A webhook that connects to an external integration"""
+type EdgedCoreStandardWebhook {
+  node: CoreStandardWebhook
+}
+
+"""A webhook that connects to an external integration"""
+type NestedEdgedCoreStandardWebhook {
+  node: CoreStandardWebhook
+  properties: RelationshipProperty
+}
+
+"""A webhook that connects to an external integration"""
+type PaginatedCoreStandardWebhook {
+  count: Int
+  edges: [EdgedCoreStandardWebhook]
+}
+
+"""A webhook that connects to an external integration"""
+type NestedPaginatedCoreStandardWebhook {
+  count: Int
+  edges: [NestedEdgedCoreStandardWebhook]
+}
+
+"""A webhook that connects to an external integration"""
+type CoreCustomWebhook implements CoreWebhook & CoreTaskTarget & CoreNode {
+  display_label: String
+  name: TextAttribute!
+  description: TextAttribute
+  url: TextAttribute!
+  validate_certificates: CheckboxAttribute
+  id: String!
+  _updated_at: DateTime
+  transformation: NestedEdgedCoreTransformPython
+  member_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+  subscriber_of_groups(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean): NestedPaginatedCoreGroup
+}
+
+"""A webhook that connects to an external integration"""
+type EdgedCoreCustomWebhook {
+  node: CoreCustomWebhook
+}
+
+"""A webhook that connects to an external integration"""
+type NestedEdgedCoreCustomWebhook {
+  node: CoreCustomWebhook
+  properties: RelationshipProperty
+}
+
+"""A webhook that connects to an external integration"""
+type PaginatedCoreCustomWebhook {
+  count: Int
+  edges: [EdgedCoreCustomWebhook]
+}
+
+"""A webhook that connects to an external integration"""
+type NestedPaginatedCoreCustomWebhook {
+  count: Int
+  edges: [NestedEdgedCoreCustomWebhook]
+}
+
+type DiffSummaryElementAttribute implements DiffSummaryElementInterface {
+  element_type: DiffElementType!
+  name: String!
+  action: DiffAction!
+  summary: DiffSummaryCount!
+}
+
+interface DiffSummaryElementInterface {
+  element_type: DiffElementType!
+  name: String!
+  action: DiffAction!
+  summary: DiffSummaryCount!
+}
+
+"""An enumeration."""
+enum DiffElementType {
+  ATTRIBUTE
+  RELATIONSHIP_ONE
+  RELATIONSHIP_MANY
+}
+
+"""An enumeration."""
+enum DiffAction {
+  ADDED
+  REMOVED
+  UPDATED
+  UNCHANGED
+}
+
+type DiffSummaryCount {
+  added: Int
+  updated: Int
+  removed: Int
+}
+
+type DiffSummaryElementRelationshipOne implements DiffSummaryElementInterface {
+  element_type: DiffElementType!
+  name: String!
+  action: DiffAction!
+  summary: DiffSummaryCount!
+}
+
+type DiffSummaryElementRelationshipMany implements DiffSummaryElementInterface {
+  element_type: DiffElementType!
+  name: String!
+  action: DiffAction!
+  summary: DiffSummaryCount!
+  peers: [DiffActionSummary]
+}
+
+type DiffActionSummary {
+  action: DiffAction!
+  summary: DiffSummaryCount
+}
+
+type Query {
+  CoreStandardGroup(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, members__ids: [ID], subscribers__ids: [ID], parent__ids: [ID], parent__name__value: String, parent__name__values: [String], parent__name__source__id: ID, parent__name__owner__id: ID, parent__name__is_visible: Boolean, parent__name__is_protected: Boolean, parent__label__value: String, parent__label__values: [String], parent__label__source__id: ID, parent__label__owner__id: ID, parent__label__is_visible: Boolean, parent__label__is_protected: Boolean, parent__description__value: String, parent__description__values: [String], parent__description__source__id: ID, parent__description__owner__id: ID, parent__description__is_visible: Boolean, parent__description__is_protected: Boolean, children__ids: [ID], children__name__value: String, children__name__values: [String], children__name__source__id: ID, children__name__owner__id: ID, children__name__is_visible: Boolean, children__name__is_protected: Boolean, children__label__value: String, children__label__values: [String], children__label__source__id: ID, children__label__owner__id: ID, children__label__is_visible: Boolean, children__label__is_protected: Boolean, children__description__value: String, children__description__values: [String], children__description__source__id: ID, children__description__owner__id: ID, children__description__is_visible: Boolean, children__description__is_protected: Boolean): PaginatedCoreStandardGroup
+  CoreGraphQLQueryGroup(offset: Int, limit: Int, ids: [ID], parameters__value: GenericScalar, parameters__values: [GenericScalar], parameters__source__id: ID, parameters__owner__id: ID, parameters__is_visible: Boolean, parameters__is_protected: Boolean, name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, query__ids: [ID], query__name__value: String, query__name__values: [String], query__name__source__id: ID, query__name__owner__id: ID, query__name__is_visible: Boolean, query__name__is_protected: Boolean, query__description__value: String, query__description__values: [String], query__description__source__id: ID, query__description__owner__id: ID, query__description__is_visible: Boolean, query__description__is_protected: Boolean, query__query__value: String, query__query__values: [String], query__query__source__id: ID, query__query__owner__id: ID, query__query__is_visible: Boolean, query__query__is_protected: Boolean, query__variables__value: GenericScalar, query__variables__values: [GenericScalar], query__variables__source__id: ID, query__variables__owner__id: ID, query__variables__is_visible: Boolean, query__variables__is_protected: Boolean, query__operations__value: GenericScalar, query__operations__values: [GenericScalar], query__operations__source__id: ID, query__operations__owner__id: ID, query__operations__is_visible: Boolean, query__operations__is_protected: Boolean, query__models__value: GenericScalar, query__models__values: [GenericScalar], query__models__source__id: ID, query__models__owner__id: ID, query__models__is_visible: Boolean, query__models__is_protected: Boolean, query__depth__value: Int, query__depth__values: [Int], query__depth__source__id: ID, query__depth__owner__id: ID, query__depth__is_visible: Boolean, query__depth__is_protected: Boolean, query__height__value: Int, query__height__values: [Int], query__height__source__id: ID, query__height__owner__id: ID, query__height__is_visible: Boolean, query__height__is_protected: Boolean, members__ids: [ID], subscribers__ids: [ID], parent__ids: [ID], parent__name__value: String, parent__name__values: [String], parent__name__source__id: ID, parent__name__owner__id: ID, parent__name__is_visible: Boolean, parent__name__is_protected: Boolean, parent__label__value: String, parent__label__values: [String], parent__label__source__id: ID, parent__label__owner__id: ID, parent__label__is_visible: Boolean, parent__label__is_protected: Boolean, parent__description__value: String, parent__description__values: [String], parent__description__source__id: ID, parent__description__owner__id: ID, parent__description__is_visible: Boolean, parent__description__is_protected: Boolean, children__ids: [ID], children__name__value: String, children__name__values: [String], children__name__source__id: ID, children__name__owner__id: ID, children__name__is_visible: Boolean, children__name__is_protected: Boolean, children__label__value: String, children__label__values: [String], children__label__source__id: ID, children__label__owner__id: ID, children__label__is_visible: Boolean, children__label__is_protected: Boolean, children__description__value: String, children__description__values: [String], children__description__source__id: ID, children__description__owner__id: ID, children__description__is_visible: Boolean, children__description__is_protected: Boolean): PaginatedCoreGraphQLQueryGroup
+  BuiltinTag(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedBuiltinTag
+  CoreAccount(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, password__value: String, password__values: [String], password__source__id: ID, password__owner__id: ID, password__is_visible: Boolean, password__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, type__value: String, type__values: [String], type__source__id: ID, type__owner__id: ID, type__is_visible: Boolean, type__is_protected: Boolean, role__value: String, role__values: [String], role__source__id: ID, role__owner__id: ID, role__is_visible: Boolean, role__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreAccount
+  AccountProfile: CoreAccount
+  CoreProposedChange(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, source_branch__value: String, source_branch__values: [String], source_branch__source__id: ID, source_branch__owner__id: ID, source_branch__is_visible: Boolean, source_branch__is_protected: Boolean, destination_branch__value: String, destination_branch__values: [String], destination_branch__source__id: ID, destination_branch__owner__id: ID, destination_branch__is_visible: Boolean, destination_branch__is_protected: Boolean, state__value: String, state__values: [String], state__source__id: ID, state__owner__id: ID, state__is_visible: Boolean, state__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, approved_by__ids: [ID], approved_by__name__value: String, approved_by__name__values: [String], approved_by__name__source__id: ID, approved_by__name__owner__id: ID, approved_by__name__is_visible: Boolean, approved_by__name__is_protected: Boolean, approved_by__password__value: String, approved_by__password__values: [String], approved_by__password__source__id: ID, approved_by__password__owner__id: ID, approved_by__password__is_visible: Boolean, approved_by__password__is_protected: Boolean, approved_by__label__value: String, approved_by__label__values: [String], approved_by__label__source__id: ID, approved_by__label__owner__id: ID, approved_by__label__is_visible: Boolean, approved_by__label__is_protected: Boolean, approved_by__description__value: String, approved_by__description__values: [String], approved_by__description__source__id: ID, approved_by__description__owner__id: ID, approved_by__description__is_visible: Boolean, approved_by__description__is_protected: Boolean, approved_by__type__value: String, approved_by__type__values: [String], approved_by__type__source__id: ID, approved_by__type__owner__id: ID, approved_by__type__is_visible: Boolean, approved_by__type__is_protected: Boolean, approved_by__role__value: String, approved_by__role__values: [String], approved_by__role__source__id: ID, approved_by__role__owner__id: ID, approved_by__role__is_visible: Boolean, approved_by__role__is_protected: Boolean, reviewers__ids: [ID], reviewers__name__value: String, reviewers__name__values: [String], reviewers__name__source__id: ID, reviewers__name__owner__id: ID, reviewers__name__is_visible: Boolean, reviewers__name__is_protected: Boolean, reviewers__password__value: String, reviewers__password__values: [String], reviewers__password__source__id: ID, reviewers__password__owner__id: ID, reviewers__password__is_visible: Boolean, reviewers__password__is_protected: Boolean, reviewers__label__value: String, reviewers__label__values: [String], reviewers__label__source__id: ID, reviewers__label__owner__id: ID, reviewers__label__is_visible: Boolean, reviewers__label__is_protected: Boolean, reviewers__description__value: String, reviewers__description__values: [String], reviewers__description__source__id: ID, reviewers__description__owner__id: ID, reviewers__description__is_visible: Boolean, reviewers__description__is_protected: Boolean, reviewers__type__value: String, reviewers__type__values: [String], reviewers__type__source__id: ID, reviewers__type__owner__id: ID, reviewers__type__is_visible: Boolean, reviewers__type__is_protected: Boolean, reviewers__role__value: String, reviewers__role__values: [String], reviewers__role__source__id: ID, reviewers__role__owner__id: ID, reviewers__role__is_visible: Boolean, reviewers__role__is_protected: Boolean, created_by__ids: [ID], created_by__name__value: String, created_by__name__values: [String], created_by__name__source__id: ID, created_by__name__owner__id: ID, created_by__name__is_visible: Boolean, created_by__name__is_protected: Boolean, created_by__password__value: String, created_by__password__values: [String], created_by__password__source__id: ID, created_by__password__owner__id: ID, created_by__password__is_visible: Boolean, created_by__password__is_protected: Boolean, created_by__label__value: String, created_by__label__values: [String], created_by__label__source__id: ID, created_by__label__owner__id: ID, created_by__label__is_visible: Boolean, created_by__label__is_protected: Boolean, created_by__description__value: String, created_by__description__values: [String], created_by__description__source__id: ID, created_by__description__owner__id: ID, created_by__description__is_visible: Boolean, created_by__description__is_protected: Boolean, created_by__type__value: String, created_by__type__values: [String], created_by__type__source__id: ID, created_by__type__owner__id: ID, created_by__type__is_visible: Boolean, created_by__type__is_protected: Boolean, created_by__role__value: String, created_by__role__values: [String], created_by__role__source__id: ID, created_by__role__owner__id: ID, created_by__role__is_visible: Boolean, created_by__role__is_protected: Boolean, comments__ids: [ID], comments__text__value: String, comments__text__values: [String], comments__text__source__id: ID, comments__text__owner__id: ID, comments__text__is_visible: Boolean, comments__text__is_protected: Boolean, comments__created_at__value: String, comments__created_at__values: [String], comments__created_at__source__id: ID, comments__created_at__owner__id: ID, comments__created_at__is_visible: Boolean, comments__created_at__is_protected: Boolean, threads__ids: [ID], threads__label__value: String, threads__label__values: [String], threads__label__source__id: ID, threads__label__owner__id: ID, threads__label__is_visible: Boolean, threads__label__is_protected: Boolean, threads__resolved__value: Boolean, threads__resolved__values: [Boolean], threads__resolved__source__id: ID, threads__resolved__owner__id: ID, threads__resolved__is_visible: Boolean, threads__resolved__is_protected: Boolean, threads__created_at__value: String, threads__created_at__values: [String], threads__created_at__source__id: ID, threads__created_at__owner__id: ID, threads__created_at__is_visible: Boolean, threads__created_at__is_protected: Boolean, validations__ids: [ID], validations__label__value: String, validations__label__values: [String], validations__label__source__id: ID, validations__label__owner__id: ID, validations__label__is_visible: Boolean, validations__label__is_protected: Boolean, validations__state__value: String, validations__state__values: [String], validations__state__source__id: ID, validations__state__owner__id: ID, validations__state__is_visible: Boolean, validations__state__is_protected: Boolean, validations__conclusion__value: String, validations__conclusion__values: [String], validations__conclusion__source__id: ID, validations__conclusion__owner__id: ID, validations__conclusion__is_visible: Boolean, validations__conclusion__is_protected: Boolean, validations__completed_at__value: String, validations__completed_at__values: [String], validations__completed_at__source__id: ID, validations__completed_at__owner__id: ID, validations__completed_at__is_visible: Boolean, validations__completed_at__is_protected: Boolean, validations__started_at__value: String, validations__started_at__values: [String], validations__started_at__source__id: ID, validations__started_at__owner__id: ID, validations__started_at__is_visible: Boolean, validations__started_at__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreProposedChange
+  CoreChangeThread(offset: Int, limit: Int, ids: [ID], label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, resolved__value: Boolean, resolved__values: [Boolean], resolved__source__id: ID, resolved__owner__id: ID, resolved__is_visible: Boolean, resolved__is_protected: Boolean, created_at__value: String, created_at__values: [String], created_at__source__id: ID, created_at__owner__id: ID, created_at__is_visible: Boolean, created_at__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, change__ids: [ID], change__name__value: String, change__name__values: [String], change__name__source__id: ID, change__name__owner__id: ID, change__name__is_visible: Boolean, change__name__is_protected: Boolean, change__description__value: String, change__description__values: [String], change__description__source__id: ID, change__description__owner__id: ID, change__description__is_visible: Boolean, change__description__is_protected: Boolean, change__source_branch__value: String, change__source_branch__values: [String], change__source_branch__source__id: ID, change__source_branch__owner__id: ID, change__source_branch__is_visible: Boolean, change__source_branch__is_protected: Boolean, change__destination_branch__value: String, change__destination_branch__values: [String], change__destination_branch__source__id: ID, change__destination_branch__owner__id: ID, change__destination_branch__is_visible: Boolean, change__destination_branch__is_protected: Boolean, change__state__value: String, change__state__values: [String], change__state__source__id: ID, change__state__owner__id: ID, change__state__is_visible: Boolean, change__state__is_protected: Boolean, comments__ids: [ID], comments__text__value: String, comments__text__values: [String], comments__text__source__id: ID, comments__text__owner__id: ID, comments__text__is_visible: Boolean, comments__text__is_protected: Boolean, comments__created_at__value: String, comments__created_at__values: [String], comments__created_at__source__id: ID, comments__created_at__owner__id: ID, comments__created_at__is_visible: Boolean, comments__created_at__is_protected: Boolean, created_by__ids: [ID], created_by__name__value: String, created_by__name__values: [String], created_by__name__source__id: ID, created_by__name__owner__id: ID, created_by__name__is_visible: Boolean, created_by__name__is_protected: Boolean, created_by__password__value: String, created_by__password__values: [String], created_by__password__source__id: ID, created_by__password__owner__id: ID, created_by__password__is_visible: Boolean, created_by__password__is_protected: Boolean, created_by__label__value: String, created_by__label__values: [String], created_by__label__source__id: ID, created_by__label__owner__id: ID, created_by__label__is_visible: Boolean, created_by__label__is_protected: Boolean, created_by__description__value: String, created_by__description__values: [String], created_by__description__source__id: ID, created_by__description__owner__id: ID, created_by__description__is_visible: Boolean, created_by__description__is_protected: Boolean, created_by__type__value: String, created_by__type__values: [String], created_by__type__source__id: ID, created_by__type__owner__id: ID, created_by__type__is_visible: Boolean, created_by__type__is_protected: Boolean, created_by__role__value: String, created_by__role__values: [String], created_by__role__source__id: ID, created_by__role__owner__id: ID, created_by__role__is_visible: Boolean, created_by__role__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreChangeThread
+  CoreFileThread(offset: Int, limit: Int, ids: [ID], file__value: String, file__values: [String], file__source__id: ID, file__owner__id: ID, file__is_visible: Boolean, file__is_protected: Boolean, commit__value: String, commit__values: [String], commit__source__id: ID, commit__owner__id: ID, commit__is_visible: Boolean, commit__is_protected: Boolean, line_number__value: Int, line_number__values: [Int], line_number__source__id: ID, line_number__owner__id: ID, line_number__is_visible: Boolean, line_number__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, resolved__value: Boolean, resolved__values: [Boolean], resolved__source__id: ID, resolved__owner__id: ID, resolved__is_visible: Boolean, resolved__is_protected: Boolean, created_at__value: String, created_at__values: [String], created_at__source__id: ID, created_at__owner__id: ID, created_at__is_visible: Boolean, created_at__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, repository__ids: [ID], repository__default_branch__value: String, repository__default_branch__values: [String], repository__default_branch__source__id: ID, repository__default_branch__owner__id: ID, repository__default_branch__is_visible: Boolean, repository__default_branch__is_protected: Boolean, repository__commit__value: String, repository__commit__values: [String], repository__commit__source__id: ID, repository__commit__owner__id: ID, repository__commit__is_visible: Boolean, repository__commit__is_protected: Boolean, repository__name__value: String, repository__name__values: [String], repository__name__source__id: ID, repository__name__owner__id: ID, repository__name__is_visible: Boolean, repository__name__is_protected: Boolean, repository__description__value: String, repository__description__values: [String], repository__description__source__id: ID, repository__description__owner__id: ID, repository__description__is_visible: Boolean, repository__description__is_protected: Boolean, repository__location__value: String, repository__location__values: [String], repository__location__source__id: ID, repository__location__owner__id: ID, repository__location__is_visible: Boolean, repository__location__is_protected: Boolean, repository__username__value: String, repository__username__values: [String], repository__username__source__id: ID, repository__username__owner__id: ID, repository__username__is_visible: Boolean, repository__username__is_protected: Boolean, repository__password__value: String, repository__password__values: [String], repository__password__source__id: ID, repository__password__owner__id: ID, repository__password__is_visible: Boolean, repository__password__is_protected: Boolean, change__ids: [ID], change__name__value: String, change__name__values: [String], change__name__source__id: ID, change__name__owner__id: ID, change__name__is_visible: Boolean, change__name__is_protected: Boolean, change__description__value: String, change__description__values: [String], change__description__source__id: ID, change__description__owner__id: ID, change__description__is_visible: Boolean, change__description__is_protected: Boolean, change__source_branch__value: String, change__source_branch__values: [String], change__source_branch__source__id: ID, change__source_branch__owner__id: ID, change__source_branch__is_visible: Boolean, change__source_branch__is_protected: Boolean, change__destination_branch__value: String, change__destination_branch__values: [String], change__destination_branch__source__id: ID, change__destination_branch__owner__id: ID, change__destination_branch__is_visible: Boolean, change__destination_branch__is_protected: Boolean, change__state__value: String, change__state__values: [String], change__state__source__id: ID, change__state__owner__id: ID, change__state__is_visible: Boolean, change__state__is_protected: Boolean, comments__ids: [ID], comments__text__value: String, comments__text__values: [String], comments__text__source__id: ID, comments__text__owner__id: ID, comments__text__is_visible: Boolean, comments__text__is_protected: Boolean, comments__created_at__value: String, comments__created_at__values: [String], comments__created_at__source__id: ID, comments__created_at__owner__id: ID, comments__created_at__is_visible: Boolean, comments__created_at__is_protected: Boolean, created_by__ids: [ID], created_by__name__value: String, created_by__name__values: [String], created_by__name__source__id: ID, created_by__name__owner__id: ID, created_by__name__is_visible: Boolean, created_by__name__is_protected: Boolean, created_by__password__value: String, created_by__password__values: [String], created_by__password__source__id: ID, created_by__password__owner__id: ID, created_by__password__is_visible: Boolean, created_by__password__is_protected: Boolean, created_by__label__value: String, created_by__label__values: [String], created_by__label__source__id: ID, created_by__label__owner__id: ID, created_by__label__is_visible: Boolean, created_by__label__is_protected: Boolean, created_by__description__value: String, created_by__description__values: [String], created_by__description__source__id: ID, created_by__description__owner__id: ID, created_by__description__is_visible: Boolean, created_by__description__is_protected: Boolean, created_by__type__value: String, created_by__type__values: [String], created_by__type__source__id: ID, created_by__type__owner__id: ID, created_by__type__is_visible: Boolean, created_by__type__is_protected: Boolean, created_by__role__value: String, created_by__role__values: [String], created_by__role__source__id: ID, created_by__role__owner__id: ID, created_by__role__is_visible: Boolean, created_by__role__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreFileThread
+  CoreArtifactThread(offset: Int, limit: Int, ids: [ID], artifact_id__value: String, artifact_id__values: [String], artifact_id__source__id: ID, artifact_id__owner__id: ID, artifact_id__is_visible: Boolean, artifact_id__is_protected: Boolean, storage_id__value: String, storage_id__values: [String], storage_id__source__id: ID, storage_id__owner__id: ID, storage_id__is_visible: Boolean, storage_id__is_protected: Boolean, line_number__value: Int, line_number__values: [Int], line_number__source__id: ID, line_number__owner__id: ID, line_number__is_visible: Boolean, line_number__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, resolved__value: Boolean, resolved__values: [Boolean], resolved__source__id: ID, resolved__owner__id: ID, resolved__is_visible: Boolean, resolved__is_protected: Boolean, created_at__value: String, created_at__values: [String], created_at__source__id: ID, created_at__owner__id: ID, created_at__is_visible: Boolean, created_at__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, change__ids: [ID], change__name__value: String, change__name__values: [String], change__name__source__id: ID, change__name__owner__id: ID, change__name__is_visible: Boolean, change__name__is_protected: Boolean, change__description__value: String, change__description__values: [String], change__description__source__id: ID, change__description__owner__id: ID, change__description__is_visible: Boolean, change__description__is_protected: Boolean, change__source_branch__value: String, change__source_branch__values: [String], change__source_branch__source__id: ID, change__source_branch__owner__id: ID, change__source_branch__is_visible: Boolean, change__source_branch__is_protected: Boolean, change__destination_branch__value: String, change__destination_branch__values: [String], change__destination_branch__source__id: ID, change__destination_branch__owner__id: ID, change__destination_branch__is_visible: Boolean, change__destination_branch__is_protected: Boolean, change__state__value: String, change__state__values: [String], change__state__source__id: ID, change__state__owner__id: ID, change__state__is_visible: Boolean, change__state__is_protected: Boolean, comments__ids: [ID], comments__text__value: String, comments__text__values: [String], comments__text__source__id: ID, comments__text__owner__id: ID, comments__text__is_visible: Boolean, comments__text__is_protected: Boolean, comments__created_at__value: String, comments__created_at__values: [String], comments__created_at__source__id: ID, comments__created_at__owner__id: ID, comments__created_at__is_visible: Boolean, comments__created_at__is_protected: Boolean, created_by__ids: [ID], created_by__name__value: String, created_by__name__values: [String], created_by__name__source__id: ID, created_by__name__owner__id: ID, created_by__name__is_visible: Boolean, created_by__name__is_protected: Boolean, created_by__password__value: String, created_by__password__values: [String], created_by__password__source__id: ID, created_by__password__owner__id: ID, created_by__password__is_visible: Boolean, created_by__password__is_protected: Boolean, created_by__label__value: String, created_by__label__values: [String], created_by__label__source__id: ID, created_by__label__owner__id: ID, created_by__label__is_visible: Boolean, created_by__label__is_protected: Boolean, created_by__description__value: String, created_by__description__values: [String], created_by__description__source__id: ID, created_by__description__owner__id: ID, created_by__description__is_visible: Boolean, created_by__description__is_protected: Boolean, created_by__type__value: String, created_by__type__values: [String], created_by__type__source__id: ID, created_by__type__owner__id: ID, created_by__type__is_visible: Boolean, created_by__type__is_protected: Boolean, created_by__role__value: String, created_by__role__values: [String], created_by__role__source__id: ID, created_by__role__owner__id: ID, created_by__role__is_visible: Boolean, created_by__role__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreArtifactThread
+  CoreObjectThread(offset: Int, limit: Int, ids: [ID], object_path__value: String, object_path__values: [String], object_path__source__id: ID, object_path__owner__id: ID, object_path__is_visible: Boolean, object_path__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, resolved__value: Boolean, resolved__values: [Boolean], resolved__source__id: ID, resolved__owner__id: ID, resolved__is_visible: Boolean, resolved__is_protected: Boolean, created_at__value: String, created_at__values: [String], created_at__source__id: ID, created_at__owner__id: ID, created_at__is_visible: Boolean, created_at__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, change__ids: [ID], change__name__value: String, change__name__values: [String], change__name__source__id: ID, change__name__owner__id: ID, change__name__is_visible: Boolean, change__name__is_protected: Boolean, change__description__value: String, change__description__values: [String], change__description__source__id: ID, change__description__owner__id: ID, change__description__is_visible: Boolean, change__description__is_protected: Boolean, change__source_branch__value: String, change__source_branch__values: [String], change__source_branch__source__id: ID, change__source_branch__owner__id: ID, change__source_branch__is_visible: Boolean, change__source_branch__is_protected: Boolean, change__destination_branch__value: String, change__destination_branch__values: [String], change__destination_branch__source__id: ID, change__destination_branch__owner__id: ID, change__destination_branch__is_visible: Boolean, change__destination_branch__is_protected: Boolean, change__state__value: String, change__state__values: [String], change__state__source__id: ID, change__state__owner__id: ID, change__state__is_visible: Boolean, change__state__is_protected: Boolean, comments__ids: [ID], comments__text__value: String, comments__text__values: [String], comments__text__source__id: ID, comments__text__owner__id: ID, comments__text__is_visible: Boolean, comments__text__is_protected: Boolean, comments__created_at__value: String, comments__created_at__values: [String], comments__created_at__source__id: ID, comments__created_at__owner__id: ID, comments__created_at__is_visible: Boolean, comments__created_at__is_protected: Boolean, created_by__ids: [ID], created_by__name__value: String, created_by__name__values: [String], created_by__name__source__id: ID, created_by__name__owner__id: ID, created_by__name__is_visible: Boolean, created_by__name__is_protected: Boolean, created_by__password__value: String, created_by__password__values: [String], created_by__password__source__id: ID, created_by__password__owner__id: ID, created_by__password__is_visible: Boolean, created_by__password__is_protected: Boolean, created_by__label__value: String, created_by__label__values: [String], created_by__label__source__id: ID, created_by__label__owner__id: ID, created_by__label__is_visible: Boolean, created_by__label__is_protected: Boolean, created_by__description__value: String, created_by__description__values: [String], created_by__description__source__id: ID, created_by__description__owner__id: ID, created_by__description__is_visible: Boolean, created_by__description__is_protected: Boolean, created_by__type__value: String, created_by__type__values: [String], created_by__type__source__id: ID, created_by__type__owner__id: ID, created_by__type__is_visible: Boolean, created_by__type__is_protected: Boolean, created_by__role__value: String, created_by__role__values: [String], created_by__role__source__id: ID, created_by__role__owner__id: ID, created_by__role__is_visible: Boolean, created_by__role__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreObjectThread
+  CoreChangeComment(offset: Int, limit: Int, ids: [ID], text__value: String, text__values: [String], text__source__id: ID, text__owner__id: ID, text__is_visible: Boolean, text__is_protected: Boolean, created_at__value: String, created_at__values: [String], created_at__source__id: ID, created_at__owner__id: ID, created_at__is_visible: Boolean, created_at__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, change__ids: [ID], change__name__value: String, change__name__values: [String], change__name__source__id: ID, change__name__owner__id: ID, change__name__is_visible: Boolean, change__name__is_protected: Boolean, change__description__value: String, change__description__values: [String], change__description__source__id: ID, change__description__owner__id: ID, change__description__is_visible: Boolean, change__description__is_protected: Boolean, change__source_branch__value: String, change__source_branch__values: [String], change__source_branch__source__id: ID, change__source_branch__owner__id: ID, change__source_branch__is_visible: Boolean, change__source_branch__is_protected: Boolean, change__destination_branch__value: String, change__destination_branch__values: [String], change__destination_branch__source__id: ID, change__destination_branch__owner__id: ID, change__destination_branch__is_visible: Boolean, change__destination_branch__is_protected: Boolean, change__state__value: String, change__state__values: [String], change__state__source__id: ID, change__state__owner__id: ID, change__state__is_visible: Boolean, change__state__is_protected: Boolean, created_by__ids: [ID], created_by__name__value: String, created_by__name__values: [String], created_by__name__source__id: ID, created_by__name__owner__id: ID, created_by__name__is_visible: Boolean, created_by__name__is_protected: Boolean, created_by__password__value: String, created_by__password__values: [String], created_by__password__source__id: ID, created_by__password__owner__id: ID, created_by__password__is_visible: Boolean, created_by__password__is_protected: Boolean, created_by__label__value: String, created_by__label__values: [String], created_by__label__source__id: ID, created_by__label__owner__id: ID, created_by__label__is_visible: Boolean, created_by__label__is_protected: Boolean, created_by__description__value: String, created_by__description__values: [String], created_by__description__source__id: ID, created_by__description__owner__id: ID, created_by__description__is_visible: Boolean, created_by__description__is_protected: Boolean, created_by__type__value: String, created_by__type__values: [String], created_by__type__source__id: ID, created_by__type__owner__id: ID, created_by__type__is_visible: Boolean, created_by__type__is_protected: Boolean, created_by__role__value: String, created_by__role__values: [String], created_by__role__source__id: ID, created_by__role__owner__id: ID, created_by__role__is_visible: Boolean, created_by__role__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreChangeComment
+  CoreThreadComment(offset: Int, limit: Int, ids: [ID], text__value: String, text__values: [String], text__source__id: ID, text__owner__id: ID, text__is_visible: Boolean, text__is_protected: Boolean, created_at__value: String, created_at__values: [String], created_at__source__id: ID, created_at__owner__id: ID, created_at__is_visible: Boolean, created_at__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, thread__ids: [ID], thread__label__value: String, thread__label__values: [String], thread__label__source__id: ID, thread__label__owner__id: ID, thread__label__is_visible: Boolean, thread__label__is_protected: Boolean, thread__resolved__value: Boolean, thread__resolved__values: [Boolean], thread__resolved__source__id: ID, thread__resolved__owner__id: ID, thread__resolved__is_visible: Boolean, thread__resolved__is_protected: Boolean, thread__created_at__value: String, thread__created_at__values: [String], thread__created_at__source__id: ID, thread__created_at__owner__id: ID, thread__created_at__is_visible: Boolean, thread__created_at__is_protected: Boolean, created_by__ids: [ID], created_by__name__value: String, created_by__name__values: [String], created_by__name__source__id: ID, created_by__name__owner__id: ID, created_by__name__is_visible: Boolean, created_by__name__is_protected: Boolean, created_by__password__value: String, created_by__password__values: [String], created_by__password__source__id: ID, created_by__password__owner__id: ID, created_by__password__is_visible: Boolean, created_by__password__is_protected: Boolean, created_by__label__value: String, created_by__label__values: [String], created_by__label__source__id: ID, created_by__label__owner__id: ID, created_by__label__is_visible: Boolean, created_by__label__is_protected: Boolean, created_by__description__value: String, created_by__description__values: [String], created_by__description__source__id: ID, created_by__description__owner__id: ID, created_by__description__is_visible: Boolean, created_by__description__is_protected: Boolean, created_by__type__value: String, created_by__type__values: [String], created_by__type__source__id: ID, created_by__type__owner__id: ID, created_by__type__is_visible: Boolean, created_by__type__is_protected: Boolean, created_by__role__value: String, created_by__role__values: [String], created_by__role__source__id: ID, created_by__role__owner__id: ID, created_by__role__is_visible: Boolean, created_by__role__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreThreadComment
+  CoreRepository(offset: Int, limit: Int, ids: [ID], default_branch__value: String, default_branch__values: [String], default_branch__source__id: ID, default_branch__owner__id: ID, default_branch__is_visible: Boolean, default_branch__is_protected: Boolean, commit__value: String, commit__values: [String], commit__source__id: ID, commit__owner__id: ID, commit__is_visible: Boolean, commit__is_protected: Boolean, name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, location__value: String, location__values: [String], location__source__id: ID, location__owner__id: ID, location__is_visible: Boolean, location__is_protected: Boolean, username__value: String, username__values: [String], username__source__id: ID, username__owner__id: ID, username__is_visible: Boolean, username__is_protected: Boolean, password__value: String, password__values: [String], password__source__id: ID, password__owner__id: ID, password__is_visible: Boolean, password__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, tags__ids: [ID], tags__name__value: String, tags__name__values: [String], tags__name__source__id: ID, tags__name__owner__id: ID, tags__name__is_visible: Boolean, tags__name__is_protected: Boolean, tags__description__value: String, tags__description__values: [String], tags__description__source__id: ID, tags__description__owner__id: ID, tags__description__is_visible: Boolean, tags__description__is_protected: Boolean, transformations__ids: [ID], transformations__name__value: String, transformations__name__values: [String], transformations__name__source__id: ID, transformations__name__owner__id: ID, transformations__name__is_visible: Boolean, transformations__name__is_protected: Boolean, transformations__label__value: String, transformations__label__values: [String], transformations__label__source__id: ID, transformations__label__owner__id: ID, transformations__label__is_visible: Boolean, transformations__label__is_protected: Boolean, transformations__description__value: String, transformations__description__values: [String], transformations__description__source__id: ID, transformations__description__owner__id: ID, transformations__description__is_visible: Boolean, transformations__description__is_protected: Boolean, transformations__timeout__value: Int, transformations__timeout__values: [Int], transformations__timeout__source__id: ID, transformations__timeout__owner__id: ID, transformations__timeout__is_visible: Boolean, transformations__timeout__is_protected: Boolean, queries__ids: [ID], queries__name__value: String, queries__name__values: [String], queries__name__source__id: ID, queries__name__owner__id: ID, queries__name__is_visible: Boolean, queries__name__is_protected: Boolean, queries__description__value: String, queries__description__values: [String], queries__description__source__id: ID, queries__description__owner__id: ID, queries__description__is_visible: Boolean, queries__description__is_protected: Boolean, queries__query__value: String, queries__query__values: [String], queries__query__source__id: ID, queries__query__owner__id: ID, queries__query__is_visible: Boolean, queries__query__is_protected: Boolean, queries__variables__value: GenericScalar, queries__variables__values: [GenericScalar], queries__variables__source__id: ID, queries__variables__owner__id: ID, queries__variables__is_visible: Boolean, queries__variables__is_protected: Boolean, queries__operations__value: GenericScalar, queries__operations__values: [GenericScalar], queries__operations__source__id: ID, queries__operations__owner__id: ID, queries__operations__is_visible: Boolean, queries__operations__is_protected: Boolean, queries__models__value: GenericScalar, queries__models__values: [GenericScalar], queries__models__source__id: ID, queries__models__owner__id: ID, queries__models__is_visible: Boolean, queries__models__is_protected: Boolean, queries__depth__value: Int, queries__depth__values: [Int], queries__depth__source__id: ID, queries__depth__owner__id: ID, queries__depth__is_visible: Boolean, queries__depth__is_protected: Boolean, queries__height__value: Int, queries__height__values: [Int], queries__height__source__id: ID, queries__height__owner__id: ID, queries__height__is_visible: Boolean, queries__height__is_protected: Boolean, checks__ids: [ID], checks__name__value: String, checks__name__values: [String], checks__name__source__id: ID, checks__name__owner__id: ID, checks__name__is_visible: Boolean, checks__name__is_protected: Boolean, checks__description__value: String, checks__description__values: [String], checks__description__source__id: ID, checks__description__owner__id: ID, checks__description__is_visible: Boolean, checks__description__is_protected: Boolean, checks__file_path__value: String, checks__file_path__values: [String], checks__file_path__source__id: ID, checks__file_path__owner__id: ID, checks__file_path__is_visible: Boolean, checks__file_path__is_protected: Boolean, checks__class_name__value: String, checks__class_name__values: [String], checks__class_name__source__id: ID, checks__class_name__owner__id: ID, checks__class_name__is_visible: Boolean, checks__class_name__is_protected: Boolean, checks__timeout__value: Int, checks__timeout__values: [Int], checks__timeout__source__id: ID, checks__timeout__owner__id: ID, checks__timeout__is_visible: Boolean, checks__timeout__is_protected: Boolean, checks__parameters__value: GenericScalar, checks__parameters__values: [GenericScalar], checks__parameters__source__id: ID, checks__parameters__owner__id: ID, checks__parameters__is_visible: Boolean, checks__parameters__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreRepository
+  CoreReadOnlyRepository(offset: Int, limit: Int, ids: [ID], ref__value: String, ref__values: [String], ref__source__id: ID, ref__owner__id: ID, ref__is_visible: Boolean, ref__is_protected: Boolean, commit__value: String, commit__values: [String], commit__source__id: ID, commit__owner__id: ID, commit__is_visible: Boolean, commit__is_protected: Boolean, name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, location__value: String, location__values: [String], location__source__id: ID, location__owner__id: ID, location__is_visible: Boolean, location__is_protected: Boolean, username__value: String, username__values: [String], username__source__id: ID, username__owner__id: ID, username__is_visible: Boolean, username__is_protected: Boolean, password__value: String, password__values: [String], password__source__id: ID, password__owner__id: ID, password__is_visible: Boolean, password__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, tags__ids: [ID], tags__name__value: String, tags__name__values: [String], tags__name__source__id: ID, tags__name__owner__id: ID, tags__name__is_visible: Boolean, tags__name__is_protected: Boolean, tags__description__value: String, tags__description__values: [String], tags__description__source__id: ID, tags__description__owner__id: ID, tags__description__is_visible: Boolean, tags__description__is_protected: Boolean, transformations__ids: [ID], transformations__name__value: String, transformations__name__values: [String], transformations__name__source__id: ID, transformations__name__owner__id: ID, transformations__name__is_visible: Boolean, transformations__name__is_protected: Boolean, transformations__label__value: String, transformations__label__values: [String], transformations__label__source__id: ID, transformations__label__owner__id: ID, transformations__label__is_visible: Boolean, transformations__label__is_protected: Boolean, transformations__description__value: String, transformations__description__values: [String], transformations__description__source__id: ID, transformations__description__owner__id: ID, transformations__description__is_visible: Boolean, transformations__description__is_protected: Boolean, transformations__timeout__value: Int, transformations__timeout__values: [Int], transformations__timeout__source__id: ID, transformations__timeout__owner__id: ID, transformations__timeout__is_visible: Boolean, transformations__timeout__is_protected: Boolean, queries__ids: [ID], queries__name__value: String, queries__name__values: [String], queries__name__source__id: ID, queries__name__owner__id: ID, queries__name__is_visible: Boolean, queries__name__is_protected: Boolean, queries__description__value: String, queries__description__values: [String], queries__description__source__id: ID, queries__description__owner__id: ID, queries__description__is_visible: Boolean, queries__description__is_protected: Boolean, queries__query__value: String, queries__query__values: [String], queries__query__source__id: ID, queries__query__owner__id: ID, queries__query__is_visible: Boolean, queries__query__is_protected: Boolean, queries__variables__value: GenericScalar, queries__variables__values: [GenericScalar], queries__variables__source__id: ID, queries__variables__owner__id: ID, queries__variables__is_visible: Boolean, queries__variables__is_protected: Boolean, queries__operations__value: GenericScalar, queries__operations__values: [GenericScalar], queries__operations__source__id: ID, queries__operations__owner__id: ID, queries__operations__is_visible: Boolean, queries__operations__is_protected: Boolean, queries__models__value: GenericScalar, queries__models__values: [GenericScalar], queries__models__source__id: ID, queries__models__owner__id: ID, queries__models__is_visible: Boolean, queries__models__is_protected: Boolean, queries__depth__value: Int, queries__depth__values: [Int], queries__depth__source__id: ID, queries__depth__owner__id: ID, queries__depth__is_visible: Boolean, queries__depth__is_protected: Boolean, queries__height__value: Int, queries__height__values: [Int], queries__height__source__id: ID, queries__height__owner__id: ID, queries__height__is_visible: Boolean, queries__height__is_protected: Boolean, checks__ids: [ID], checks__name__value: String, checks__name__values: [String], checks__name__source__id: ID, checks__name__owner__id: ID, checks__name__is_visible: Boolean, checks__name__is_protected: Boolean, checks__description__value: String, checks__description__values: [String], checks__description__source__id: ID, checks__description__owner__id: ID, checks__description__is_visible: Boolean, checks__description__is_protected: Boolean, checks__file_path__value: String, checks__file_path__values: [String], checks__file_path__source__id: ID, checks__file_path__owner__id: ID, checks__file_path__is_visible: Boolean, checks__file_path__is_protected: Boolean, checks__class_name__value: String, checks__class_name__values: [String], checks__class_name__source__id: ID, checks__class_name__owner__id: ID, checks__class_name__is_visible: Boolean, checks__class_name__is_protected: Boolean, checks__timeout__value: Int, checks__timeout__values: [Int], checks__timeout__source__id: ID, checks__timeout__owner__id: ID, checks__timeout__is_visible: Boolean, checks__timeout__is_protected: Boolean, checks__parameters__value: GenericScalar, checks__parameters__values: [GenericScalar], checks__parameters__source__id: ID, checks__parameters__owner__id: ID, checks__parameters__is_visible: Boolean, checks__parameters__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreReadOnlyRepository
+  CoreTransformJinja2(offset: Int, limit: Int, ids: [ID], template_path__value: String, template_path__values: [String], template_path__source__id: ID, template_path__owner__id: ID, template_path__is_visible: Boolean, template_path__is_protected: Boolean, name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, timeout__value: Int, timeout__values: [Int], timeout__source__id: ID, timeout__owner__id: ID, timeout__is_visible: Boolean, timeout__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, query__ids: [ID], query__name__value: String, query__name__values: [String], query__name__source__id: ID, query__name__owner__id: ID, query__name__is_visible: Boolean, query__name__is_protected: Boolean, query__description__value: String, query__description__values: [String], query__description__source__id: ID, query__description__owner__id: ID, query__description__is_visible: Boolean, query__description__is_protected: Boolean, query__query__value: String, query__query__values: [String], query__query__source__id: ID, query__query__owner__id: ID, query__query__is_visible: Boolean, query__query__is_protected: Boolean, query__variables__value: GenericScalar, query__variables__values: [GenericScalar], query__variables__source__id: ID, query__variables__owner__id: ID, query__variables__is_visible: Boolean, query__variables__is_protected: Boolean, query__operations__value: GenericScalar, query__operations__values: [GenericScalar], query__operations__source__id: ID, query__operations__owner__id: ID, query__operations__is_visible: Boolean, query__operations__is_protected: Boolean, query__models__value: GenericScalar, query__models__values: [GenericScalar], query__models__source__id: ID, query__models__owner__id: ID, query__models__is_visible: Boolean, query__models__is_protected: Boolean, query__depth__value: Int, query__depth__values: [Int], query__depth__source__id: ID, query__depth__owner__id: ID, query__depth__is_visible: Boolean, query__depth__is_protected: Boolean, query__height__value: Int, query__height__values: [Int], query__height__source__id: ID, query__height__owner__id: ID, query__height__is_visible: Boolean, query__height__is_protected: Boolean, repository__ids: [ID], repository__name__value: String, repository__name__values: [String], repository__name__source__id: ID, repository__name__owner__id: ID, repository__name__is_visible: Boolean, repository__name__is_protected: Boolean, repository__description__value: String, repository__description__values: [String], repository__description__source__id: ID, repository__description__owner__id: ID, repository__description__is_visible: Boolean, repository__description__is_protected: Boolean, repository__location__value: String, repository__location__values: [String], repository__location__source__id: ID, repository__location__owner__id: ID, repository__location__is_visible: Boolean, repository__location__is_protected: Boolean, repository__username__value: String, repository__username__values: [String], repository__username__source__id: ID, repository__username__owner__id: ID, repository__username__is_visible: Boolean, repository__username__is_protected: Boolean, repository__password__value: String, repository__password__values: [String], repository__password__source__id: ID, repository__password__owner__id: ID, repository__password__is_visible: Boolean, repository__password__is_protected: Boolean, tags__ids: [ID], tags__name__value: String, tags__name__values: [String], tags__name__source__id: ID, tags__name__owner__id: ID, tags__name__is_visible: Boolean, tags__name__is_protected: Boolean, tags__description__value: String, tags__description__values: [String], tags__description__source__id: ID, tags__description__owner__id: ID, tags__description__is_visible: Boolean, tags__description__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreTransformJinja2
+  CoreDataCheck(offset: Int, limit: Int, ids: [ID], conflicts__value: GenericScalar, conflicts__values: [GenericScalar], conflicts__source__id: ID, conflicts__owner__id: ID, conflicts__is_visible: Boolean, conflicts__is_protected: Boolean, keep_branch__value: String, keep_branch__values: [String], keep_branch__source__id: ID, keep_branch__owner__id: ID, keep_branch__is_visible: Boolean, keep_branch__is_protected: Boolean, name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, origin__value: String, origin__values: [String], origin__source__id: ID, origin__owner__id: ID, origin__is_visible: Boolean, origin__is_protected: Boolean, kind__value: String, kind__values: [String], kind__source__id: ID, kind__owner__id: ID, kind__is_visible: Boolean, kind__is_protected: Boolean, message__value: String, message__values: [String], message__source__id: ID, message__owner__id: ID, message__is_visible: Boolean, message__is_protected: Boolean, conclusion__value: String, conclusion__values: [String], conclusion__source__id: ID, conclusion__owner__id: ID, conclusion__is_visible: Boolean, conclusion__is_protected: Boolean, severity__value: String, severity__values: [String], severity__source__id: ID, severity__owner__id: ID, severity__is_visible: Boolean, severity__is_protected: Boolean, created_at__value: String, created_at__values: [String], created_at__source__id: ID, created_at__owner__id: ID, created_at__is_visible: Boolean, created_at__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, validator__ids: [ID], validator__label__value: String, validator__label__values: [String], validator__label__source__id: ID, validator__label__owner__id: ID, validator__label__is_visible: Boolean, validator__label__is_protected: Boolean, validator__state__value: String, validator__state__values: [String], validator__state__source__id: ID, validator__state__owner__id: ID, validator__state__is_visible: Boolean, validator__state__is_protected: Boolean, validator__conclusion__value: String, validator__conclusion__values: [String], validator__conclusion__source__id: ID, validator__conclusion__owner__id: ID, validator__conclusion__is_visible: Boolean, validator__conclusion__is_protected: Boolean, validator__completed_at__value: String, validator__completed_at__values: [String], validator__completed_at__source__id: ID, validator__completed_at__owner__id: ID, validator__completed_at__is_visible: Boolean, validator__completed_at__is_protected: Boolean, validator__started_at__value: String, validator__started_at__values: [String], validator__started_at__source__id: ID, validator__started_at__owner__id: ID, validator__started_at__is_visible: Boolean, validator__started_at__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreDataCheck
+  CoreStandardCheck(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, origin__value: String, origin__values: [String], origin__source__id: ID, origin__owner__id: ID, origin__is_visible: Boolean, origin__is_protected: Boolean, kind__value: String, kind__values: [String], kind__source__id: ID, kind__owner__id: ID, kind__is_visible: Boolean, kind__is_protected: Boolean, message__value: String, message__values: [String], message__source__id: ID, message__owner__id: ID, message__is_visible: Boolean, message__is_protected: Boolean, conclusion__value: String, conclusion__values: [String], conclusion__source__id: ID, conclusion__owner__id: ID, conclusion__is_visible: Boolean, conclusion__is_protected: Boolean, severity__value: String, severity__values: [String], severity__source__id: ID, severity__owner__id: ID, severity__is_visible: Boolean, severity__is_protected: Boolean, created_at__value: String, created_at__values: [String], created_at__source__id: ID, created_at__owner__id: ID, created_at__is_visible: Boolean, created_at__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, validator__ids: [ID], validator__label__value: String, validator__label__values: [String], validator__label__source__id: ID, validator__label__owner__id: ID, validator__label__is_visible: Boolean, validator__label__is_protected: Boolean, validator__state__value: String, validator__state__values: [String], validator__state__source__id: ID, validator__state__owner__id: ID, validator__state__is_visible: Boolean, validator__state__is_protected: Boolean, validator__conclusion__value: String, validator__conclusion__values: [String], validator__conclusion__source__id: ID, validator__conclusion__owner__id: ID, validator__conclusion__is_visible: Boolean, validator__conclusion__is_protected: Boolean, validator__completed_at__value: String, validator__completed_at__values: [String], validator__completed_at__source__id: ID, validator__completed_at__owner__id: ID, validator__completed_at__is_visible: Boolean, validator__completed_at__is_protected: Boolean, validator__started_at__value: String, validator__started_at__values: [String], validator__started_at__source__id: ID, validator__started_at__owner__id: ID, validator__started_at__is_visible: Boolean, validator__started_at__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreStandardCheck
+  CoreSchemaCheck(offset: Int, limit: Int, ids: [ID], conflicts__value: GenericScalar, conflicts__values: [GenericScalar], conflicts__source__id: ID, conflicts__owner__id: ID, conflicts__is_visible: Boolean, conflicts__is_protected: Boolean, name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, origin__value: String, origin__values: [String], origin__source__id: ID, origin__owner__id: ID, origin__is_visible: Boolean, origin__is_protected: Boolean, kind__value: String, kind__values: [String], kind__source__id: ID, kind__owner__id: ID, kind__is_visible: Boolean, kind__is_protected: Boolean, message__value: String, message__values: [String], message__source__id: ID, message__owner__id: ID, message__is_visible: Boolean, message__is_protected: Boolean, conclusion__value: String, conclusion__values: [String], conclusion__source__id: ID, conclusion__owner__id: ID, conclusion__is_visible: Boolean, conclusion__is_protected: Boolean, severity__value: String, severity__values: [String], severity__source__id: ID, severity__owner__id: ID, severity__is_visible: Boolean, severity__is_protected: Boolean, created_at__value: String, created_at__values: [String], created_at__source__id: ID, created_at__owner__id: ID, created_at__is_visible: Boolean, created_at__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, validator__ids: [ID], validator__label__value: String, validator__label__values: [String], validator__label__source__id: ID, validator__label__owner__id: ID, validator__label__is_visible: Boolean, validator__label__is_protected: Boolean, validator__state__value: String, validator__state__values: [String], validator__state__source__id: ID, validator__state__owner__id: ID, validator__state__is_visible: Boolean, validator__state__is_protected: Boolean, validator__conclusion__value: String, validator__conclusion__values: [String], validator__conclusion__source__id: ID, validator__conclusion__owner__id: ID, validator__conclusion__is_visible: Boolean, validator__conclusion__is_protected: Boolean, validator__completed_at__value: String, validator__completed_at__values: [String], validator__completed_at__source__id: ID, validator__completed_at__owner__id: ID, validator__completed_at__is_visible: Boolean, validator__completed_at__is_protected: Boolean, validator__started_at__value: String, validator__started_at__values: [String], validator__started_at__source__id: ID, validator__started_at__owner__id: ID, validator__started_at__is_visible: Boolean, validator__started_at__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreSchemaCheck
+  CoreFileCheck(offset: Int, limit: Int, ids: [ID], files__value: GenericScalar, files__values: [GenericScalar], files__source__id: ID, files__owner__id: ID, files__is_visible: Boolean, files__is_protected: Boolean, commit__value: String, commit__values: [String], commit__source__id: ID, commit__owner__id: ID, commit__is_visible: Boolean, commit__is_protected: Boolean, name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, origin__value: String, origin__values: [String], origin__source__id: ID, origin__owner__id: ID, origin__is_visible: Boolean, origin__is_protected: Boolean, kind__value: String, kind__values: [String], kind__source__id: ID, kind__owner__id: ID, kind__is_visible: Boolean, kind__is_protected: Boolean, message__value: String, message__values: [String], message__source__id: ID, message__owner__id: ID, message__is_visible: Boolean, message__is_protected: Boolean, conclusion__value: String, conclusion__values: [String], conclusion__source__id: ID, conclusion__owner__id: ID, conclusion__is_visible: Boolean, conclusion__is_protected: Boolean, severity__value: String, severity__values: [String], severity__source__id: ID, severity__owner__id: ID, severity__is_visible: Boolean, severity__is_protected: Boolean, created_at__value: String, created_at__values: [String], created_at__source__id: ID, created_at__owner__id: ID, created_at__is_visible: Boolean, created_at__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, validator__ids: [ID], validator__label__value: String, validator__label__values: [String], validator__label__source__id: ID, validator__label__owner__id: ID, validator__label__is_visible: Boolean, validator__label__is_protected: Boolean, validator__state__value: String, validator__state__values: [String], validator__state__source__id: ID, validator__state__owner__id: ID, validator__state__is_visible: Boolean, validator__state__is_protected: Boolean, validator__conclusion__value: String, validator__conclusion__values: [String], validator__conclusion__source__id: ID, validator__conclusion__owner__id: ID, validator__conclusion__is_visible: Boolean, validator__conclusion__is_protected: Boolean, validator__completed_at__value: String, validator__completed_at__values: [String], validator__completed_at__source__id: ID, validator__completed_at__owner__id: ID, validator__completed_at__is_visible: Boolean, validator__completed_at__is_protected: Boolean, validator__started_at__value: String, validator__started_at__values: [String], validator__started_at__source__id: ID, validator__started_at__owner__id: ID, validator__started_at__is_visible: Boolean, validator__started_at__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreFileCheck
+  CoreArtifactCheck(offset: Int, limit: Int, ids: [ID], changed__value: Boolean, changed__values: [Boolean], changed__source__id: ID, changed__owner__id: ID, changed__is_visible: Boolean, changed__is_protected: Boolean, checksum__value: String, checksum__values: [String], checksum__source__id: ID, checksum__owner__id: ID, checksum__is_visible: Boolean, checksum__is_protected: Boolean, artifact_id__value: String, artifact_id__values: [String], artifact_id__source__id: ID, artifact_id__owner__id: ID, artifact_id__is_visible: Boolean, artifact_id__is_protected: Boolean, storage_id__value: String, storage_id__values: [String], storage_id__source__id: ID, storage_id__owner__id: ID, storage_id__is_visible: Boolean, storage_id__is_protected: Boolean, line_number__value: Int, line_number__values: [Int], line_number__source__id: ID, line_number__owner__id: ID, line_number__is_visible: Boolean, line_number__is_protected: Boolean, name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, origin__value: String, origin__values: [String], origin__source__id: ID, origin__owner__id: ID, origin__is_visible: Boolean, origin__is_protected: Boolean, kind__value: String, kind__values: [String], kind__source__id: ID, kind__owner__id: ID, kind__is_visible: Boolean, kind__is_protected: Boolean, message__value: String, message__values: [String], message__source__id: ID, message__owner__id: ID, message__is_visible: Boolean, message__is_protected: Boolean, conclusion__value: String, conclusion__values: [String], conclusion__source__id: ID, conclusion__owner__id: ID, conclusion__is_visible: Boolean, conclusion__is_protected: Boolean, severity__value: String, severity__values: [String], severity__source__id: ID, severity__owner__id: ID, severity__is_visible: Boolean, severity__is_protected: Boolean, created_at__value: String, created_at__values: [String], created_at__source__id: ID, created_at__owner__id: ID, created_at__is_visible: Boolean, created_at__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, validator__ids: [ID], validator__label__value: String, validator__label__values: [String], validator__label__source__id: ID, validator__label__owner__id: ID, validator__label__is_visible: Boolean, validator__label__is_protected: Boolean, validator__state__value: String, validator__state__values: [String], validator__state__source__id: ID, validator__state__owner__id: ID, validator__state__is_visible: Boolean, validator__state__is_protected: Boolean, validator__conclusion__value: String, validator__conclusion__values: [String], validator__conclusion__source__id: ID, validator__conclusion__owner__id: ID, validator__conclusion__is_visible: Boolean, validator__conclusion__is_protected: Boolean, validator__completed_at__value: String, validator__completed_at__values: [String], validator__completed_at__source__id: ID, validator__completed_at__owner__id: ID, validator__completed_at__is_visible: Boolean, validator__completed_at__is_protected: Boolean, validator__started_at__value: String, validator__started_at__values: [String], validator__started_at__source__id: ID, validator__started_at__owner__id: ID, validator__started_at__is_visible: Boolean, validator__started_at__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreArtifactCheck
+  CoreDataValidator(offset: Int, limit: Int, ids: [ID], label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, state__value: String, state__values: [String], state__source__id: ID, state__owner__id: ID, state__is_visible: Boolean, state__is_protected: Boolean, conclusion__value: String, conclusion__values: [String], conclusion__source__id: ID, conclusion__owner__id: ID, conclusion__is_visible: Boolean, conclusion__is_protected: Boolean, completed_at__value: String, completed_at__values: [String], completed_at__source__id: ID, completed_at__owner__id: ID, completed_at__is_visible: Boolean, completed_at__is_protected: Boolean, started_at__value: String, started_at__values: [String], started_at__source__id: ID, started_at__owner__id: ID, started_at__is_visible: Boolean, started_at__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, proposed_change__ids: [ID], proposed_change__name__value: String, proposed_change__name__values: [String], proposed_change__name__source__id: ID, proposed_change__name__owner__id: ID, proposed_change__name__is_visible: Boolean, proposed_change__name__is_protected: Boolean, proposed_change__description__value: String, proposed_change__description__values: [String], proposed_change__description__source__id: ID, proposed_change__description__owner__id: ID, proposed_change__description__is_visible: Boolean, proposed_change__description__is_protected: Boolean, proposed_change__source_branch__value: String, proposed_change__source_branch__values: [String], proposed_change__source_branch__source__id: ID, proposed_change__source_branch__owner__id: ID, proposed_change__source_branch__is_visible: Boolean, proposed_change__source_branch__is_protected: Boolean, proposed_change__destination_branch__value: String, proposed_change__destination_branch__values: [String], proposed_change__destination_branch__source__id: ID, proposed_change__destination_branch__owner__id: ID, proposed_change__destination_branch__is_visible: Boolean, proposed_change__destination_branch__is_protected: Boolean, proposed_change__state__value: String, proposed_change__state__values: [String], proposed_change__state__source__id: ID, proposed_change__state__owner__id: ID, proposed_change__state__is_visible: Boolean, proposed_change__state__is_protected: Boolean, checks__ids: [ID], checks__name__value: String, checks__name__values: [String], checks__name__source__id: ID, checks__name__owner__id: ID, checks__name__is_visible: Boolean, checks__name__is_protected: Boolean, checks__label__value: String, checks__label__values: [String], checks__label__source__id: ID, checks__label__owner__id: ID, checks__label__is_visible: Boolean, checks__label__is_protected: Boolean, checks__origin__value: String, checks__origin__values: [String], checks__origin__source__id: ID, checks__origin__owner__id: ID, checks__origin__is_visible: Boolean, checks__origin__is_protected: Boolean, checks__kind__value: String, checks__kind__values: [String], checks__kind__source__id: ID, checks__kind__owner__id: ID, checks__kind__is_visible: Boolean, checks__kind__is_protected: Boolean, checks__message__value: String, checks__message__values: [String], checks__message__source__id: ID, checks__message__owner__id: ID, checks__message__is_visible: Boolean, checks__message__is_protected: Boolean, checks__conclusion__value: String, checks__conclusion__values: [String], checks__conclusion__source__id: ID, checks__conclusion__owner__id: ID, checks__conclusion__is_visible: Boolean, checks__conclusion__is_protected: Boolean, checks__severity__value: String, checks__severity__values: [String], checks__severity__source__id: ID, checks__severity__owner__id: ID, checks__severity__is_visible: Boolean, checks__severity__is_protected: Boolean, checks__created_at__value: String, checks__created_at__values: [String], checks__created_at__source__id: ID, checks__created_at__owner__id: ID, checks__created_at__is_visible: Boolean, checks__created_at__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreDataValidator
+  CoreRepositoryValidator(offset: Int, limit: Int, ids: [ID], label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, state__value: String, state__values: [String], state__source__id: ID, state__owner__id: ID, state__is_visible: Boolean, state__is_protected: Boolean, conclusion__value: String, conclusion__values: [String], conclusion__source__id: ID, conclusion__owner__id: ID, conclusion__is_visible: Boolean, conclusion__is_protected: Boolean, completed_at__value: String, completed_at__values: [String], completed_at__source__id: ID, completed_at__owner__id: ID, completed_at__is_visible: Boolean, completed_at__is_protected: Boolean, started_at__value: String, started_at__values: [String], started_at__source__id: ID, started_at__owner__id: ID, started_at__is_visible: Boolean, started_at__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, repository__ids: [ID], repository__name__value: String, repository__name__values: [String], repository__name__source__id: ID, repository__name__owner__id: ID, repository__name__is_visible: Boolean, repository__name__is_protected: Boolean, repository__description__value: String, repository__description__values: [String], repository__description__source__id: ID, repository__description__owner__id: ID, repository__description__is_visible: Boolean, repository__description__is_protected: Boolean, repository__location__value: String, repository__location__values: [String], repository__location__source__id: ID, repository__location__owner__id: ID, repository__location__is_visible: Boolean, repository__location__is_protected: Boolean, repository__username__value: String, repository__username__values: [String], repository__username__source__id: ID, repository__username__owner__id: ID, repository__username__is_visible: Boolean, repository__username__is_protected: Boolean, repository__password__value: String, repository__password__values: [String], repository__password__source__id: ID, repository__password__owner__id: ID, repository__password__is_visible: Boolean, repository__password__is_protected: Boolean, proposed_change__ids: [ID], proposed_change__name__value: String, proposed_change__name__values: [String], proposed_change__name__source__id: ID, proposed_change__name__owner__id: ID, proposed_change__name__is_visible: Boolean, proposed_change__name__is_protected: Boolean, proposed_change__description__value: String, proposed_change__description__values: [String], proposed_change__description__source__id: ID, proposed_change__description__owner__id: ID, proposed_change__description__is_visible: Boolean, proposed_change__description__is_protected: Boolean, proposed_change__source_branch__value: String, proposed_change__source_branch__values: [String], proposed_change__source_branch__source__id: ID, proposed_change__source_branch__owner__id: ID, proposed_change__source_branch__is_visible: Boolean, proposed_change__source_branch__is_protected: Boolean, proposed_change__destination_branch__value: String, proposed_change__destination_branch__values: [String], proposed_change__destination_branch__source__id: ID, proposed_change__destination_branch__owner__id: ID, proposed_change__destination_branch__is_visible: Boolean, proposed_change__destination_branch__is_protected: Boolean, proposed_change__state__value: String, proposed_change__state__values: [String], proposed_change__state__source__id: ID, proposed_change__state__owner__id: ID, proposed_change__state__is_visible: Boolean, proposed_change__state__is_protected: Boolean, checks__ids: [ID], checks__name__value: String, checks__name__values: [String], checks__name__source__id: ID, checks__name__owner__id: ID, checks__name__is_visible: Boolean, checks__name__is_protected: Boolean, checks__label__value: String, checks__label__values: [String], checks__label__source__id: ID, checks__label__owner__id: ID, checks__label__is_visible: Boolean, checks__label__is_protected: Boolean, checks__origin__value: String, checks__origin__values: [String], checks__origin__source__id: ID, checks__origin__owner__id: ID, checks__origin__is_visible: Boolean, checks__origin__is_protected: Boolean, checks__kind__value: String, checks__kind__values: [String], checks__kind__source__id: ID, checks__kind__owner__id: ID, checks__kind__is_visible: Boolean, checks__kind__is_protected: Boolean, checks__message__value: String, checks__message__values: [String], checks__message__source__id: ID, checks__message__owner__id: ID, checks__message__is_visible: Boolean, checks__message__is_protected: Boolean, checks__conclusion__value: String, checks__conclusion__values: [String], checks__conclusion__source__id: ID, checks__conclusion__owner__id: ID, checks__conclusion__is_visible: Boolean, checks__conclusion__is_protected: Boolean, checks__severity__value: String, checks__severity__values: [String], checks__severity__source__id: ID, checks__severity__owner__id: ID, checks__severity__is_visible: Boolean, checks__severity__is_protected: Boolean, checks__created_at__value: String, checks__created_at__values: [String], checks__created_at__source__id: ID, checks__created_at__owner__id: ID, checks__created_at__is_visible: Boolean, checks__created_at__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreRepositoryValidator
+  CoreUserValidator(offset: Int, limit: Int, ids: [ID], label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, state__value: String, state__values: [String], state__source__id: ID, state__owner__id: ID, state__is_visible: Boolean, state__is_protected: Boolean, conclusion__value: String, conclusion__values: [String], conclusion__source__id: ID, conclusion__owner__id: ID, conclusion__is_visible: Boolean, conclusion__is_protected: Boolean, completed_at__value: String, completed_at__values: [String], completed_at__source__id: ID, completed_at__owner__id: ID, completed_at__is_visible: Boolean, completed_at__is_protected: Boolean, started_at__value: String, started_at__values: [String], started_at__source__id: ID, started_at__owner__id: ID, started_at__is_visible: Boolean, started_at__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, check_definition__ids: [ID], check_definition__name__value: String, check_definition__name__values: [String], check_definition__name__source__id: ID, check_definition__name__owner__id: ID, check_definition__name__is_visible: Boolean, check_definition__name__is_protected: Boolean, check_definition__description__value: String, check_definition__description__values: [String], check_definition__description__source__id: ID, check_definition__description__owner__id: ID, check_definition__description__is_visible: Boolean, check_definition__description__is_protected: Boolean, check_definition__file_path__value: String, check_definition__file_path__values: [String], check_definition__file_path__source__id: ID, check_definition__file_path__owner__id: ID, check_definition__file_path__is_visible: Boolean, check_definition__file_path__is_protected: Boolean, check_definition__class_name__value: String, check_definition__class_name__values: [String], check_definition__class_name__source__id: ID, check_definition__class_name__owner__id: ID, check_definition__class_name__is_visible: Boolean, check_definition__class_name__is_protected: Boolean, check_definition__timeout__value: Int, check_definition__timeout__values: [Int], check_definition__timeout__source__id: ID, check_definition__timeout__owner__id: ID, check_definition__timeout__is_visible: Boolean, check_definition__timeout__is_protected: Boolean, check_definition__parameters__value: GenericScalar, check_definition__parameters__values: [GenericScalar], check_definition__parameters__source__id: ID, check_definition__parameters__owner__id: ID, check_definition__parameters__is_visible: Boolean, check_definition__parameters__is_protected: Boolean, repository__ids: [ID], repository__name__value: String, repository__name__values: [String], repository__name__source__id: ID, repository__name__owner__id: ID, repository__name__is_visible: Boolean, repository__name__is_protected: Boolean, repository__description__value: String, repository__description__values: [String], repository__description__source__id: ID, repository__description__owner__id: ID, repository__description__is_visible: Boolean, repository__description__is_protected: Boolean, repository__location__value: String, repository__location__values: [String], repository__location__source__id: ID, repository__location__owner__id: ID, repository__location__is_visible: Boolean, repository__location__is_protected: Boolean, repository__username__value: String, repository__username__values: [String], repository__username__source__id: ID, repository__username__owner__id: ID, repository__username__is_visible: Boolean, repository__username__is_protected: Boolean, repository__password__value: String, repository__password__values: [String], repository__password__source__id: ID, repository__password__owner__id: ID, repository__password__is_visible: Boolean, repository__password__is_protected: Boolean, proposed_change__ids: [ID], proposed_change__name__value: String, proposed_change__name__values: [String], proposed_change__name__source__id: ID, proposed_change__name__owner__id: ID, proposed_change__name__is_visible: Boolean, proposed_change__name__is_protected: Boolean, proposed_change__description__value: String, proposed_change__description__values: [String], proposed_change__description__source__id: ID, proposed_change__description__owner__id: ID, proposed_change__description__is_visible: Boolean, proposed_change__description__is_protected: Boolean, proposed_change__source_branch__value: String, proposed_change__source_branch__values: [String], proposed_change__source_branch__source__id: ID, proposed_change__source_branch__owner__id: ID, proposed_change__source_branch__is_visible: Boolean, proposed_change__source_branch__is_protected: Boolean, proposed_change__destination_branch__value: String, proposed_change__destination_branch__values: [String], proposed_change__destination_branch__source__id: ID, proposed_change__destination_branch__owner__id: ID, proposed_change__destination_branch__is_visible: Boolean, proposed_change__destination_branch__is_protected: Boolean, proposed_change__state__value: String, proposed_change__state__values: [String], proposed_change__state__source__id: ID, proposed_change__state__owner__id: ID, proposed_change__state__is_visible: Boolean, proposed_change__state__is_protected: Boolean, checks__ids: [ID], checks__name__value: String, checks__name__values: [String], checks__name__source__id: ID, checks__name__owner__id: ID, checks__name__is_visible: Boolean, checks__name__is_protected: Boolean, checks__label__value: String, checks__label__values: [String], checks__label__source__id: ID, checks__label__owner__id: ID, checks__label__is_visible: Boolean, checks__label__is_protected: Boolean, checks__origin__value: String, checks__origin__values: [String], checks__origin__source__id: ID, checks__origin__owner__id: ID, checks__origin__is_visible: Boolean, checks__origin__is_protected: Boolean, checks__kind__value: String, checks__kind__values: [String], checks__kind__source__id: ID, checks__kind__owner__id: ID, checks__kind__is_visible: Boolean, checks__kind__is_protected: Boolean, checks__message__value: String, checks__message__values: [String], checks__message__source__id: ID, checks__message__owner__id: ID, checks__message__is_visible: Boolean, checks__message__is_protected: Boolean, checks__conclusion__value: String, checks__conclusion__values: [String], checks__conclusion__source__id: ID, checks__conclusion__owner__id: ID, checks__conclusion__is_visible: Boolean, checks__conclusion__is_protected: Boolean, checks__severity__value: String, checks__severity__values: [String], checks__severity__source__id: ID, checks__severity__owner__id: ID, checks__severity__is_visible: Boolean, checks__severity__is_protected: Boolean, checks__created_at__value: String, checks__created_at__values: [String], checks__created_at__source__id: ID, checks__created_at__owner__id: ID, checks__created_at__is_visible: Boolean, checks__created_at__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreUserValidator
+  CoreSchemaValidator(offset: Int, limit: Int, ids: [ID], label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, state__value: String, state__values: [String], state__source__id: ID, state__owner__id: ID, state__is_visible: Boolean, state__is_protected: Boolean, conclusion__value: String, conclusion__values: [String], conclusion__source__id: ID, conclusion__owner__id: ID, conclusion__is_visible: Boolean, conclusion__is_protected: Boolean, completed_at__value: String, completed_at__values: [String], completed_at__source__id: ID, completed_at__owner__id: ID, completed_at__is_visible: Boolean, completed_at__is_protected: Boolean, started_at__value: String, started_at__values: [String], started_at__source__id: ID, started_at__owner__id: ID, started_at__is_visible: Boolean, started_at__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, proposed_change__ids: [ID], proposed_change__name__value: String, proposed_change__name__values: [String], proposed_change__name__source__id: ID, proposed_change__name__owner__id: ID, proposed_change__name__is_visible: Boolean, proposed_change__name__is_protected: Boolean, proposed_change__description__value: String, proposed_change__description__values: [String], proposed_change__description__source__id: ID, proposed_change__description__owner__id: ID, proposed_change__description__is_visible: Boolean, proposed_change__description__is_protected: Boolean, proposed_change__source_branch__value: String, proposed_change__source_branch__values: [String], proposed_change__source_branch__source__id: ID, proposed_change__source_branch__owner__id: ID, proposed_change__source_branch__is_visible: Boolean, proposed_change__source_branch__is_protected: Boolean, proposed_change__destination_branch__value: String, proposed_change__destination_branch__values: [String], proposed_change__destination_branch__source__id: ID, proposed_change__destination_branch__owner__id: ID, proposed_change__destination_branch__is_visible: Boolean, proposed_change__destination_branch__is_protected: Boolean, proposed_change__state__value: String, proposed_change__state__values: [String], proposed_change__state__source__id: ID, proposed_change__state__owner__id: ID, proposed_change__state__is_visible: Boolean, proposed_change__state__is_protected: Boolean, checks__ids: [ID], checks__name__value: String, checks__name__values: [String], checks__name__source__id: ID, checks__name__owner__id: ID, checks__name__is_visible: Boolean, checks__name__is_protected: Boolean, checks__label__value: String, checks__label__values: [String], checks__label__source__id: ID, checks__label__owner__id: ID, checks__label__is_visible: Boolean, checks__label__is_protected: Boolean, checks__origin__value: String, checks__origin__values: [String], checks__origin__source__id: ID, checks__origin__owner__id: ID, checks__origin__is_visible: Boolean, checks__origin__is_protected: Boolean, checks__kind__value: String, checks__kind__values: [String], checks__kind__source__id: ID, checks__kind__owner__id: ID, checks__kind__is_visible: Boolean, checks__kind__is_protected: Boolean, checks__message__value: String, checks__message__values: [String], checks__message__source__id: ID, checks__message__owner__id: ID, checks__message__is_visible: Boolean, checks__message__is_protected: Boolean, checks__conclusion__value: String, checks__conclusion__values: [String], checks__conclusion__source__id: ID, checks__conclusion__owner__id: ID, checks__conclusion__is_visible: Boolean, checks__conclusion__is_protected: Boolean, checks__severity__value: String, checks__severity__values: [String], checks__severity__source__id: ID, checks__severity__owner__id: ID, checks__severity__is_visible: Boolean, checks__severity__is_protected: Boolean, checks__created_at__value: String, checks__created_at__values: [String], checks__created_at__source__id: ID, checks__created_at__owner__id: ID, checks__created_at__is_visible: Boolean, checks__created_at__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreSchemaValidator
+  CoreArtifactValidator(offset: Int, limit: Int, ids: [ID], label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, state__value: String, state__values: [String], state__source__id: ID, state__owner__id: ID, state__is_visible: Boolean, state__is_protected: Boolean, conclusion__value: String, conclusion__values: [String], conclusion__source__id: ID, conclusion__owner__id: ID, conclusion__is_visible: Boolean, conclusion__is_protected: Boolean, completed_at__value: String, completed_at__values: [String], completed_at__source__id: ID, completed_at__owner__id: ID, completed_at__is_visible: Boolean, completed_at__is_protected: Boolean, started_at__value: String, started_at__values: [String], started_at__source__id: ID, started_at__owner__id: ID, started_at__is_visible: Boolean, started_at__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, definition__ids: [ID], definition__name__value: String, definition__name__values: [String], definition__name__source__id: ID, definition__name__owner__id: ID, definition__name__is_visible: Boolean, definition__name__is_protected: Boolean, definition__artifact_name__value: String, definition__artifact_name__values: [String], definition__artifact_name__source__id: ID, definition__artifact_name__owner__id: ID, definition__artifact_name__is_visible: Boolean, definition__artifact_name__is_protected: Boolean, definition__description__value: String, definition__description__values: [String], definition__description__source__id: ID, definition__description__owner__id: ID, definition__description__is_visible: Boolean, definition__description__is_protected: Boolean, definition__parameters__value: GenericScalar, definition__parameters__values: [GenericScalar], definition__parameters__source__id: ID, definition__parameters__owner__id: ID, definition__parameters__is_visible: Boolean, definition__parameters__is_protected: Boolean, definition__content_type__value: String, definition__content_type__values: [String], definition__content_type__source__id: ID, definition__content_type__owner__id: ID, definition__content_type__is_visible: Boolean, definition__content_type__is_protected: Boolean, proposed_change__ids: [ID], proposed_change__name__value: String, proposed_change__name__values: [String], proposed_change__name__source__id: ID, proposed_change__name__owner__id: ID, proposed_change__name__is_visible: Boolean, proposed_change__name__is_protected: Boolean, proposed_change__description__value: String, proposed_change__description__values: [String], proposed_change__description__source__id: ID, proposed_change__description__owner__id: ID, proposed_change__description__is_visible: Boolean, proposed_change__description__is_protected: Boolean, proposed_change__source_branch__value: String, proposed_change__source_branch__values: [String], proposed_change__source_branch__source__id: ID, proposed_change__source_branch__owner__id: ID, proposed_change__source_branch__is_visible: Boolean, proposed_change__source_branch__is_protected: Boolean, proposed_change__destination_branch__value: String, proposed_change__destination_branch__values: [String], proposed_change__destination_branch__source__id: ID, proposed_change__destination_branch__owner__id: ID, proposed_change__destination_branch__is_visible: Boolean, proposed_change__destination_branch__is_protected: Boolean, proposed_change__state__value: String, proposed_change__state__values: [String], proposed_change__state__source__id: ID, proposed_change__state__owner__id: ID, proposed_change__state__is_visible: Boolean, proposed_change__state__is_protected: Boolean, checks__ids: [ID], checks__name__value: String, checks__name__values: [String], checks__name__source__id: ID, checks__name__owner__id: ID, checks__name__is_visible: Boolean, checks__name__is_protected: Boolean, checks__label__value: String, checks__label__values: [String], checks__label__source__id: ID, checks__label__owner__id: ID, checks__label__is_visible: Boolean, checks__label__is_protected: Boolean, checks__origin__value: String, checks__origin__values: [String], checks__origin__source__id: ID, checks__origin__owner__id: ID, checks__origin__is_visible: Boolean, checks__origin__is_protected: Boolean, checks__kind__value: String, checks__kind__values: [String], checks__kind__source__id: ID, checks__kind__owner__id: ID, checks__kind__is_visible: Boolean, checks__kind__is_protected: Boolean, checks__message__value: String, checks__message__values: [String], checks__message__source__id: ID, checks__message__owner__id: ID, checks__message__is_visible: Boolean, checks__message__is_protected: Boolean, checks__conclusion__value: String, checks__conclusion__values: [String], checks__conclusion__source__id: ID, checks__conclusion__owner__id: ID, checks__conclusion__is_visible: Boolean, checks__conclusion__is_protected: Boolean, checks__severity__value: String, checks__severity__values: [String], checks__severity__source__id: ID, checks__severity__owner__id: ID, checks__severity__is_visible: Boolean, checks__severity__is_protected: Boolean, checks__created_at__value: String, checks__created_at__values: [String], checks__created_at__source__id: ID, checks__created_at__owner__id: ID, checks__created_at__is_visible: Boolean, checks__created_at__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreArtifactValidator
+  CoreCheckDefinition(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, file_path__value: String, file_path__values: [String], file_path__source__id: ID, file_path__owner__id: ID, file_path__is_visible: Boolean, file_path__is_protected: Boolean, class_name__value: String, class_name__values: [String], class_name__source__id: ID, class_name__owner__id: ID, class_name__is_visible: Boolean, class_name__is_protected: Boolean, timeout__value: Int, timeout__values: [Int], timeout__source__id: ID, timeout__owner__id: ID, timeout__is_visible: Boolean, timeout__is_protected: Boolean, parameters__value: GenericScalar, parameters__values: [GenericScalar], parameters__source__id: ID, parameters__owner__id: ID, parameters__is_visible: Boolean, parameters__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, repository__ids: [ID], repository__name__value: String, repository__name__values: [String], repository__name__source__id: ID, repository__name__owner__id: ID, repository__name__is_visible: Boolean, repository__name__is_protected: Boolean, repository__description__value: String, repository__description__values: [String], repository__description__source__id: ID, repository__description__owner__id: ID, repository__description__is_visible: Boolean, repository__description__is_protected: Boolean, repository__location__value: String, repository__location__values: [String], repository__location__source__id: ID, repository__location__owner__id: ID, repository__location__is_visible: Boolean, repository__location__is_protected: Boolean, repository__username__value: String, repository__username__values: [String], repository__username__source__id: ID, repository__username__owner__id: ID, repository__username__is_visible: Boolean, repository__username__is_protected: Boolean, repository__password__value: String, repository__password__values: [String], repository__password__source__id: ID, repository__password__owner__id: ID, repository__password__is_visible: Boolean, repository__password__is_protected: Boolean, query__ids: [ID], query__name__value: String, query__name__values: [String], query__name__source__id: ID, query__name__owner__id: ID, query__name__is_visible: Boolean, query__name__is_protected: Boolean, query__description__value: String, query__description__values: [String], query__description__source__id: ID, query__description__owner__id: ID, query__description__is_visible: Boolean, query__description__is_protected: Boolean, query__query__value: String, query__query__values: [String], query__query__source__id: ID, query__query__owner__id: ID, query__query__is_visible: Boolean, query__query__is_protected: Boolean, query__variables__value: GenericScalar, query__variables__values: [GenericScalar], query__variables__source__id: ID, query__variables__owner__id: ID, query__variables__is_visible: Boolean, query__variables__is_protected: Boolean, query__operations__value: GenericScalar, query__operations__values: [GenericScalar], query__operations__source__id: ID, query__operations__owner__id: ID, query__operations__is_visible: Boolean, query__operations__is_protected: Boolean, query__models__value: GenericScalar, query__models__values: [GenericScalar], query__models__source__id: ID, query__models__owner__id: ID, query__models__is_visible: Boolean, query__models__is_protected: Boolean, query__depth__value: Int, query__depth__values: [Int], query__depth__source__id: ID, query__depth__owner__id: ID, query__depth__is_visible: Boolean, query__depth__is_protected: Boolean, query__height__value: Int, query__height__values: [Int], query__height__source__id: ID, query__height__owner__id: ID, query__height__is_visible: Boolean, query__height__is_protected: Boolean, targets__ids: [ID], targets__name__value: String, targets__name__values: [String], targets__name__source__id: ID, targets__name__owner__id: ID, targets__name__is_visible: Boolean, targets__name__is_protected: Boolean, targets__label__value: String, targets__label__values: [String], targets__label__source__id: ID, targets__label__owner__id: ID, targets__label__is_visible: Boolean, targets__label__is_protected: Boolean, targets__description__value: String, targets__description__values: [String], targets__description__source__id: ID, targets__description__owner__id: ID, targets__description__is_visible: Boolean, targets__description__is_protected: Boolean, tags__ids: [ID], tags__name__value: String, tags__name__values: [String], tags__name__source__id: ID, tags__name__owner__id: ID, tags__name__is_visible: Boolean, tags__name__is_protected: Boolean, tags__description__value: String, tags__description__values: [String], tags__description__source__id: ID, tags__description__owner__id: ID, tags__description__is_visible: Boolean, tags__description__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreCheckDefinition
+  CoreTransformPython(offset: Int, limit: Int, ids: [ID], file_path__value: String, file_path__values: [String], file_path__source__id: ID, file_path__owner__id: ID, file_path__is_visible: Boolean, file_path__is_protected: Boolean, class_name__value: String, class_name__values: [String], class_name__source__id: ID, class_name__owner__id: ID, class_name__is_visible: Boolean, class_name__is_protected: Boolean, name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, timeout__value: Int, timeout__values: [Int], timeout__source__id: ID, timeout__owner__id: ID, timeout__is_visible: Boolean, timeout__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, query__ids: [ID], query__name__value: String, query__name__values: [String], query__name__source__id: ID, query__name__owner__id: ID, query__name__is_visible: Boolean, query__name__is_protected: Boolean, query__description__value: String, query__description__values: [String], query__description__source__id: ID, query__description__owner__id: ID, query__description__is_visible: Boolean, query__description__is_protected: Boolean, query__query__value: String, query__query__values: [String], query__query__source__id: ID, query__query__owner__id: ID, query__query__is_visible: Boolean, query__query__is_protected: Boolean, query__variables__value: GenericScalar, query__variables__values: [GenericScalar], query__variables__source__id: ID, query__variables__owner__id: ID, query__variables__is_visible: Boolean, query__variables__is_protected: Boolean, query__operations__value: GenericScalar, query__operations__values: [GenericScalar], query__operations__source__id: ID, query__operations__owner__id: ID, query__operations__is_visible: Boolean, query__operations__is_protected: Boolean, query__models__value: GenericScalar, query__models__values: [GenericScalar], query__models__source__id: ID, query__models__owner__id: ID, query__models__is_visible: Boolean, query__models__is_protected: Boolean, query__depth__value: Int, query__depth__values: [Int], query__depth__source__id: ID, query__depth__owner__id: ID, query__depth__is_visible: Boolean, query__depth__is_protected: Boolean, query__height__value: Int, query__height__values: [Int], query__height__source__id: ID, query__height__owner__id: ID, query__height__is_visible: Boolean, query__height__is_protected: Boolean, repository__ids: [ID], repository__name__value: String, repository__name__values: [String], repository__name__source__id: ID, repository__name__owner__id: ID, repository__name__is_visible: Boolean, repository__name__is_protected: Boolean, repository__description__value: String, repository__description__values: [String], repository__description__source__id: ID, repository__description__owner__id: ID, repository__description__is_visible: Boolean, repository__description__is_protected: Boolean, repository__location__value: String, repository__location__values: [String], repository__location__source__id: ID, repository__location__owner__id: ID, repository__location__is_visible: Boolean, repository__location__is_protected: Boolean, repository__username__value: String, repository__username__values: [String], repository__username__source__id: ID, repository__username__owner__id: ID, repository__username__is_visible: Boolean, repository__username__is_protected: Boolean, repository__password__value: String, repository__password__values: [String], repository__password__source__id: ID, repository__password__owner__id: ID, repository__password__is_visible: Boolean, repository__password__is_protected: Boolean, tags__ids: [ID], tags__name__value: String, tags__name__values: [String], tags__name__source__id: ID, tags__name__owner__id: ID, tags__name__is_visible: Boolean, tags__name__is_protected: Boolean, tags__description__value: String, tags__description__values: [String], tags__description__source__id: ID, tags__description__owner__id: ID, tags__description__is_visible: Boolean, tags__description__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreTransformPython
+  CoreGraphQLQuery(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, query__value: String, query__values: [String], query__source__id: ID, query__owner__id: ID, query__is_visible: Boolean, query__is_protected: Boolean, variables__value: GenericScalar, variables__values: [GenericScalar], variables__source__id: ID, variables__owner__id: ID, variables__is_visible: Boolean, variables__is_protected: Boolean, operations__value: GenericScalar, operations__values: [GenericScalar], operations__source__id: ID, operations__owner__id: ID, operations__is_visible: Boolean, operations__is_protected: Boolean, models__value: GenericScalar, models__values: [GenericScalar], models__source__id: ID, models__owner__id: ID, models__is_visible: Boolean, models__is_protected: Boolean, depth__value: Int, depth__values: [Int], depth__source__id: ID, depth__owner__id: ID, depth__is_visible: Boolean, depth__is_protected: Boolean, height__value: Int, height__values: [Int], height__source__id: ID, height__owner__id: ID, height__is_visible: Boolean, height__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, repository__ids: [ID], repository__name__value: String, repository__name__values: [String], repository__name__source__id: ID, repository__name__owner__id: ID, repository__name__is_visible: Boolean, repository__name__is_protected: Boolean, repository__description__value: String, repository__description__values: [String], repository__description__source__id: ID, repository__description__owner__id: ID, repository__description__is_visible: Boolean, repository__description__is_protected: Boolean, repository__location__value: String, repository__location__values: [String], repository__location__source__id: ID, repository__location__owner__id: ID, repository__location__is_visible: Boolean, repository__location__is_protected: Boolean, repository__username__value: String, repository__username__values: [String], repository__username__source__id: ID, repository__username__owner__id: ID, repository__username__is_visible: Boolean, repository__username__is_protected: Boolean, repository__password__value: String, repository__password__values: [String], repository__password__source__id: ID, repository__password__owner__id: ID, repository__password__is_visible: Boolean, repository__password__is_protected: Boolean, tags__ids: [ID], tags__name__value: String, tags__name__values: [String], tags__name__source__id: ID, tags__name__owner__id: ID, tags__name__is_visible: Boolean, tags__name__is_protected: Boolean, tags__description__value: String, tags__description__values: [String], tags__description__source__id: ID, tags__description__owner__id: ID, tags__description__is_visible: Boolean, tags__description__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreGraphQLQuery
+  CoreArtifact(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, status__value: String, status__values: [String], status__source__id: ID, status__owner__id: ID, status__is_visible: Boolean, status__is_protected: Boolean, content_type__value: String, content_type__values: [String], content_type__source__id: ID, content_type__owner__id: ID, content_type__is_visible: Boolean, content_type__is_protected: Boolean, checksum__value: String, checksum__values: [String], checksum__source__id: ID, checksum__owner__id: ID, checksum__is_visible: Boolean, checksum__is_protected: Boolean, storage_id__value: String, storage_id__values: [String], storage_id__source__id: ID, storage_id__owner__id: ID, storage_id__is_visible: Boolean, storage_id__is_protected: Boolean, parameters__value: GenericScalar, parameters__values: [GenericScalar], parameters__source__id: ID, parameters__owner__id: ID, parameters__is_visible: Boolean, parameters__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, object__ids: [ID], definition__ids: [ID], definition__name__value: String, definition__name__values: [String], definition__name__source__id: ID, definition__name__owner__id: ID, definition__name__is_visible: Boolean, definition__name__is_protected: Boolean, definition__artifact_name__value: String, definition__artifact_name__values: [String], definition__artifact_name__source__id: ID, definition__artifact_name__owner__id: ID, definition__artifact_name__is_visible: Boolean, definition__artifact_name__is_protected: Boolean, definition__description__value: String, definition__description__values: [String], definition__description__source__id: ID, definition__description__owner__id: ID, definition__description__is_visible: Boolean, definition__description__is_protected: Boolean, definition__parameters__value: GenericScalar, definition__parameters__values: [GenericScalar], definition__parameters__source__id: ID, definition__parameters__owner__id: ID, definition__parameters__is_visible: Boolean, definition__parameters__is_protected: Boolean, definition__content_type__value: String, definition__content_type__values: [String], definition__content_type__source__id: ID, definition__content_type__owner__id: ID, definition__content_type__is_visible: Boolean, definition__content_type__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreArtifact
+  CoreArtifactDefinition(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, artifact_name__value: String, artifact_name__values: [String], artifact_name__source__id: ID, artifact_name__owner__id: ID, artifact_name__is_visible: Boolean, artifact_name__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, parameters__value: GenericScalar, parameters__values: [GenericScalar], parameters__source__id: ID, parameters__owner__id: ID, parameters__is_visible: Boolean, parameters__is_protected: Boolean, content_type__value: String, content_type__values: [String], content_type__source__id: ID, content_type__owner__id: ID, content_type__is_visible: Boolean, content_type__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, targets__ids: [ID], targets__name__value: String, targets__name__values: [String], targets__name__source__id: ID, targets__name__owner__id: ID, targets__name__is_visible: Boolean, targets__name__is_protected: Boolean, targets__label__value: String, targets__label__values: [String], targets__label__source__id: ID, targets__label__owner__id: ID, targets__label__is_visible: Boolean, targets__label__is_protected: Boolean, targets__description__value: String, targets__description__values: [String], targets__description__source__id: ID, targets__description__owner__id: ID, targets__description__is_visible: Boolean, targets__description__is_protected: Boolean, transformation__ids: [ID], transformation__name__value: String, transformation__name__values: [String], transformation__name__source__id: ID, transformation__name__owner__id: ID, transformation__name__is_visible: Boolean, transformation__name__is_protected: Boolean, transformation__label__value: String, transformation__label__values: [String], transformation__label__source__id: ID, transformation__label__owner__id: ID, transformation__label__is_visible: Boolean, transformation__label__is_protected: Boolean, transformation__description__value: String, transformation__description__values: [String], transformation__description__source__id: ID, transformation__description__owner__id: ID, transformation__description__is_visible: Boolean, transformation__description__is_protected: Boolean, transformation__timeout__value: Int, transformation__timeout__values: [Int], transformation__timeout__source__id: ID, transformation__timeout__owner__id: ID, transformation__timeout__is_visible: Boolean, transformation__timeout__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreArtifactDefinition
+  CoreStandardWebhook(offset: Int, limit: Int, ids: [ID], shared_key__value: String, shared_key__values: [String], shared_key__source__id: ID, shared_key__owner__id: ID, shared_key__is_visible: Boolean, shared_key__is_protected: Boolean, name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, url__value: String, url__values: [String], url__source__id: ID, url__owner__id: ID, url__is_visible: Boolean, url__is_protected: Boolean, validate_certificates__value: Boolean, validate_certificates__values: [Boolean], validate_certificates__source__id: ID, validate_certificates__owner__id: ID, validate_certificates__is_visible: Boolean, validate_certificates__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreStandardWebhook
+  CoreCustomWebhook(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, url__value: String, url__values: [String], url__source__id: ID, url__owner__id: ID, url__is_visible: Boolean, url__is_protected: Boolean, validate_certificates__value: Boolean, validate_certificates__values: [Boolean], validate_certificates__source__id: ID, validate_certificates__owner__id: ID, validate_certificates__is_visible: Boolean, validate_certificates__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, transformation__ids: [ID], transformation__file_path__value: String, transformation__file_path__values: [String], transformation__file_path__source__id: ID, transformation__file_path__owner__id: ID, transformation__file_path__is_visible: Boolean, transformation__file_path__is_protected: Boolean, transformation__class_name__value: String, transformation__class_name__values: [String], transformation__class_name__source__id: ID, transformation__class_name__owner__id: ID, transformation__class_name__is_visible: Boolean, transformation__class_name__is_protected: Boolean, transformation__name__value: String, transformation__name__values: [String], transformation__name__source__id: ID, transformation__name__owner__id: ID, transformation__name__is_visible: Boolean, transformation__name__is_protected: Boolean, transformation__label__value: String, transformation__label__values: [String], transformation__label__source__id: ID, transformation__label__owner__id: ID, transformation__label__is_visible: Boolean, transformation__label__is_protected: Boolean, transformation__description__value: String, transformation__description__values: [String], transformation__description__source__id: ID, transformation__description__owner__id: ID, transformation__description__is_visible: Boolean, transformation__description__is_protected: Boolean, transformation__timeout__value: Int, transformation__timeout__values: [Int], transformation__timeout__source__id: ID, transformation__timeout__owner__id: ID, transformation__timeout__is_visible: Boolean, transformation__timeout__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreCustomWebhook
+  CoreNode(offset: Int, limit: Int, ids: [ID], any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreNode
+  LineageOwner(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedLineageOwner
+  LineageSource(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedLineageSource
+  CoreComment(offset: Int, limit: Int, ids: [ID], text__value: String, text__values: [String], text__source__id: ID, text__owner__id: ID, text__is_visible: Boolean, text__is_protected: Boolean, created_at__value: String, created_at__values: [String], created_at__source__id: ID, created_at__owner__id: ID, created_at__is_visible: Boolean, created_at__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, created_by__ids: [ID], created_by__name__value: String, created_by__name__values: [String], created_by__name__source__id: ID, created_by__name__owner__id: ID, created_by__name__is_visible: Boolean, created_by__name__is_protected: Boolean, created_by__password__value: String, created_by__password__values: [String], created_by__password__source__id: ID, created_by__password__owner__id: ID, created_by__password__is_visible: Boolean, created_by__password__is_protected: Boolean, created_by__label__value: String, created_by__label__values: [String], created_by__label__source__id: ID, created_by__label__owner__id: ID, created_by__label__is_visible: Boolean, created_by__label__is_protected: Boolean, created_by__description__value: String, created_by__description__values: [String], created_by__description__source__id: ID, created_by__description__owner__id: ID, created_by__description__is_visible: Boolean, created_by__description__is_protected: Boolean, created_by__type__value: String, created_by__type__values: [String], created_by__type__source__id: ID, created_by__type__owner__id: ID, created_by__type__is_visible: Boolean, created_by__type__is_protected: Boolean, created_by__role__value: String, created_by__role__values: [String], created_by__role__source__id: ID, created_by__role__owner__id: ID, created_by__role__is_visible: Boolean, created_by__role__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreComment
+  CoreThread(offset: Int, limit: Int, ids: [ID], label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, resolved__value: Boolean, resolved__values: [Boolean], resolved__source__id: ID, resolved__owner__id: ID, resolved__is_visible: Boolean, resolved__is_protected: Boolean, created_at__value: String, created_at__values: [String], created_at__source__id: ID, created_at__owner__id: ID, created_at__is_visible: Boolean, created_at__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, change__ids: [ID], change__name__value: String, change__name__values: [String], change__name__source__id: ID, change__name__owner__id: ID, change__name__is_visible: Boolean, change__name__is_protected: Boolean, change__description__value: String, change__description__values: [String], change__description__source__id: ID, change__description__owner__id: ID, change__description__is_visible: Boolean, change__description__is_protected: Boolean, change__source_branch__value: String, change__source_branch__values: [String], change__source_branch__source__id: ID, change__source_branch__owner__id: ID, change__source_branch__is_visible: Boolean, change__source_branch__is_protected: Boolean, change__destination_branch__value: String, change__destination_branch__values: [String], change__destination_branch__source__id: ID, change__destination_branch__owner__id: ID, change__destination_branch__is_visible: Boolean, change__destination_branch__is_protected: Boolean, change__state__value: String, change__state__values: [String], change__state__source__id: ID, change__state__owner__id: ID, change__state__is_visible: Boolean, change__state__is_protected: Boolean, comments__ids: [ID], comments__text__value: String, comments__text__values: [String], comments__text__source__id: ID, comments__text__owner__id: ID, comments__text__is_visible: Boolean, comments__text__is_protected: Boolean, comments__created_at__value: String, comments__created_at__values: [String], comments__created_at__source__id: ID, comments__created_at__owner__id: ID, comments__created_at__is_visible: Boolean, comments__created_at__is_protected: Boolean, created_by__ids: [ID], created_by__name__value: String, created_by__name__values: [String], created_by__name__source__id: ID, created_by__name__owner__id: ID, created_by__name__is_visible: Boolean, created_by__name__is_protected: Boolean, created_by__password__value: String, created_by__password__values: [String], created_by__password__source__id: ID, created_by__password__owner__id: ID, created_by__password__is_visible: Boolean, created_by__password__is_protected: Boolean, created_by__label__value: String, created_by__label__values: [String], created_by__label__source__id: ID, created_by__label__owner__id: ID, created_by__label__is_visible: Boolean, created_by__label__is_protected: Boolean, created_by__description__value: String, created_by__description__values: [String], created_by__description__source__id: ID, created_by__description__owner__id: ID, created_by__description__is_visible: Boolean, created_by__description__is_protected: Boolean, created_by__type__value: String, created_by__type__values: [String], created_by__type__source__id: ID, created_by__type__owner__id: ID, created_by__type__is_visible: Boolean, created_by__type__is_protected: Boolean, created_by__role__value: String, created_by__role__values: [String], created_by__role__source__id: ID, created_by__role__owner__id: ID, created_by__role__is_visible: Boolean, created_by__role__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreThread
+  CoreGroup(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, members__ids: [ID], subscribers__ids: [ID]): PaginatedCoreGroup
+  CoreValidator(offset: Int, limit: Int, ids: [ID], label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, state__value: String, state__values: [String], state__source__id: ID, state__owner__id: ID, state__is_visible: Boolean, state__is_protected: Boolean, conclusion__value: String, conclusion__values: [String], conclusion__source__id: ID, conclusion__owner__id: ID, conclusion__is_visible: Boolean, conclusion__is_protected: Boolean, completed_at__value: String, completed_at__values: [String], completed_at__source__id: ID, completed_at__owner__id: ID, completed_at__is_visible: Boolean, completed_at__is_protected: Boolean, started_at__value: String, started_at__values: [String], started_at__source__id: ID, started_at__owner__id: ID, started_at__is_visible: Boolean, started_at__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, proposed_change__ids: [ID], proposed_change__name__value: String, proposed_change__name__values: [String], proposed_change__name__source__id: ID, proposed_change__name__owner__id: ID, proposed_change__name__is_visible: Boolean, proposed_change__name__is_protected: Boolean, proposed_change__description__value: String, proposed_change__description__values: [String], proposed_change__description__source__id: ID, proposed_change__description__owner__id: ID, proposed_change__description__is_visible: Boolean, proposed_change__description__is_protected: Boolean, proposed_change__source_branch__value: String, proposed_change__source_branch__values: [String], proposed_change__source_branch__source__id: ID, proposed_change__source_branch__owner__id: ID, proposed_change__source_branch__is_visible: Boolean, proposed_change__source_branch__is_protected: Boolean, proposed_change__destination_branch__value: String, proposed_change__destination_branch__values: [String], proposed_change__destination_branch__source__id: ID, proposed_change__destination_branch__owner__id: ID, proposed_change__destination_branch__is_visible: Boolean, proposed_change__destination_branch__is_protected: Boolean, proposed_change__state__value: String, proposed_change__state__values: [String], proposed_change__state__source__id: ID, proposed_change__state__owner__id: ID, proposed_change__state__is_visible: Boolean, proposed_change__state__is_protected: Boolean, checks__ids: [ID], checks__name__value: String, checks__name__values: [String], checks__name__source__id: ID, checks__name__owner__id: ID, checks__name__is_visible: Boolean, checks__name__is_protected: Boolean, checks__label__value: String, checks__label__values: [String], checks__label__source__id: ID, checks__label__owner__id: ID, checks__label__is_visible: Boolean, checks__label__is_protected: Boolean, checks__origin__value: String, checks__origin__values: [String], checks__origin__source__id: ID, checks__origin__owner__id: ID, checks__origin__is_visible: Boolean, checks__origin__is_protected: Boolean, checks__kind__value: String, checks__kind__values: [String], checks__kind__source__id: ID, checks__kind__owner__id: ID, checks__kind__is_visible: Boolean, checks__kind__is_protected: Boolean, checks__message__value: String, checks__message__values: [String], checks__message__source__id: ID, checks__message__owner__id: ID, checks__message__is_visible: Boolean, checks__message__is_protected: Boolean, checks__conclusion__value: String, checks__conclusion__values: [String], checks__conclusion__source__id: ID, checks__conclusion__owner__id: ID, checks__conclusion__is_visible: Boolean, checks__conclusion__is_protected: Boolean, checks__severity__value: String, checks__severity__values: [String], checks__severity__source__id: ID, checks__severity__owner__id: ID, checks__severity__is_visible: Boolean, checks__severity__is_protected: Boolean, checks__created_at__value: String, checks__created_at__values: [String], checks__created_at__source__id: ID, checks__created_at__owner__id: ID, checks__created_at__is_visible: Boolean, checks__created_at__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreValidator
+  CoreCheck(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, origin__value: String, origin__values: [String], origin__source__id: ID, origin__owner__id: ID, origin__is_visible: Boolean, origin__is_protected: Boolean, kind__value: String, kind__values: [String], kind__source__id: ID, kind__owner__id: ID, kind__is_visible: Boolean, kind__is_protected: Boolean, message__value: String, message__values: [String], message__source__id: ID, message__owner__id: ID, message__is_visible: Boolean, message__is_protected: Boolean, conclusion__value: String, conclusion__values: [String], conclusion__source__id: ID, conclusion__owner__id: ID, conclusion__is_visible: Boolean, conclusion__is_protected: Boolean, severity__value: String, severity__values: [String], severity__source__id: ID, severity__owner__id: ID, severity__is_visible: Boolean, severity__is_protected: Boolean, created_at__value: String, created_at__values: [String], created_at__source__id: ID, created_at__owner__id: ID, created_at__is_visible: Boolean, created_at__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, validator__ids: [ID], validator__label__value: String, validator__label__values: [String], validator__label__source__id: ID, validator__label__owner__id: ID, validator__label__is_visible: Boolean, validator__label__is_protected: Boolean, validator__state__value: String, validator__state__values: [String], validator__state__source__id: ID, validator__state__owner__id: ID, validator__state__is_visible: Boolean, validator__state__is_protected: Boolean, validator__conclusion__value: String, validator__conclusion__values: [String], validator__conclusion__source__id: ID, validator__conclusion__owner__id: ID, validator__conclusion__is_visible: Boolean, validator__conclusion__is_protected: Boolean, validator__completed_at__value: String, validator__completed_at__values: [String], validator__completed_at__source__id: ID, validator__completed_at__owner__id: ID, validator__completed_at__is_visible: Boolean, validator__completed_at__is_protected: Boolean, validator__started_at__value: String, validator__started_at__values: [String], validator__started_at__source__id: ID, validator__started_at__owner__id: ID, validator__started_at__is_visible: Boolean, validator__started_at__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreCheck
+  CoreTransformation(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, label__value: String, label__values: [String], label__source__id: ID, label__owner__id: ID, label__is_visible: Boolean, label__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, timeout__value: Int, timeout__values: [Int], timeout__source__id: ID, timeout__owner__id: ID, timeout__is_visible: Boolean, timeout__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, query__ids: [ID], query__name__value: String, query__name__values: [String], query__name__source__id: ID, query__name__owner__id: ID, query__name__is_visible: Boolean, query__name__is_protected: Boolean, query__description__value: String, query__description__values: [String], query__description__source__id: ID, query__description__owner__id: ID, query__description__is_visible: Boolean, query__description__is_protected: Boolean, query__query__value: String, query__query__values: [String], query__query__source__id: ID, query__query__owner__id: ID, query__query__is_visible: Boolean, query__query__is_protected: Boolean, query__variables__value: GenericScalar, query__variables__values: [GenericScalar], query__variables__source__id: ID, query__variables__owner__id: ID, query__variables__is_visible: Boolean, query__variables__is_protected: Boolean, query__operations__value: GenericScalar, query__operations__values: [GenericScalar], query__operations__source__id: ID, query__operations__owner__id: ID, query__operations__is_visible: Boolean, query__operations__is_protected: Boolean, query__models__value: GenericScalar, query__models__values: [GenericScalar], query__models__source__id: ID, query__models__owner__id: ID, query__models__is_visible: Boolean, query__models__is_protected: Boolean, query__depth__value: Int, query__depth__values: [Int], query__depth__source__id: ID, query__depth__owner__id: ID, query__depth__is_visible: Boolean, query__depth__is_protected: Boolean, query__height__value: Int, query__height__values: [Int], query__height__source__id: ID, query__height__owner__id: ID, query__height__is_visible: Boolean, query__height__is_protected: Boolean, repository__ids: [ID], repository__name__value: String, repository__name__values: [String], repository__name__source__id: ID, repository__name__owner__id: ID, repository__name__is_visible: Boolean, repository__name__is_protected: Boolean, repository__description__value: String, repository__description__values: [String], repository__description__source__id: ID, repository__description__owner__id: ID, repository__description__is_visible: Boolean, repository__description__is_protected: Boolean, repository__location__value: String, repository__location__values: [String], repository__location__source__id: ID, repository__location__owner__id: ID, repository__location__is_visible: Boolean, repository__location__is_protected: Boolean, repository__username__value: String, repository__username__values: [String], repository__username__source__id: ID, repository__username__owner__id: ID, repository__username__is_visible: Boolean, repository__username__is_protected: Boolean, repository__password__value: String, repository__password__values: [String], repository__password__source__id: ID, repository__password__owner__id: ID, repository__password__is_visible: Boolean, repository__password__is_protected: Boolean, tags__ids: [ID], tags__name__value: String, tags__name__values: [String], tags__name__source__id: ID, tags__name__owner__id: ID, tags__name__is_visible: Boolean, tags__name__is_protected: Boolean, tags__description__value: String, tags__description__values: [String], tags__description__source__id: ID, tags__description__owner__id: ID, tags__description__is_visible: Boolean, tags__description__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreTransformation
+  CoreArtifactTarget(offset: Int, limit: Int, ids: [ID], any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, artifacts__ids: [ID], artifacts__name__value: String, artifacts__name__values: [String], artifacts__name__source__id: ID, artifacts__name__owner__id: ID, artifacts__name__is_visible: Boolean, artifacts__name__is_protected: Boolean, artifacts__status__value: String, artifacts__status__values: [String], artifacts__status__source__id: ID, artifacts__status__owner__id: ID, artifacts__status__is_visible: Boolean, artifacts__status__is_protected: Boolean, artifacts__content_type__value: String, artifacts__content_type__values: [String], artifacts__content_type__source__id: ID, artifacts__content_type__owner__id: ID, artifacts__content_type__is_visible: Boolean, artifacts__content_type__is_protected: Boolean, artifacts__checksum__value: String, artifacts__checksum__values: [String], artifacts__checksum__source__id: ID, artifacts__checksum__owner__id: ID, artifacts__checksum__is_visible: Boolean, artifacts__checksum__is_protected: Boolean, artifacts__storage_id__value: String, artifacts__storage_id__values: [String], artifacts__storage_id__source__id: ID, artifacts__storage_id__owner__id: ID, artifacts__storage_id__is_visible: Boolean, artifacts__storage_id__is_protected: Boolean, artifacts__parameters__value: GenericScalar, artifacts__parameters__values: [GenericScalar], artifacts__parameters__source__id: ID, artifacts__parameters__owner__id: ID, artifacts__parameters__is_visible: Boolean, artifacts__parameters__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreArtifactTarget
+  CoreTaskTarget(offset: Int, limit: Int, ids: [ID], any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreTaskTarget
+  CoreWebhook(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, url__value: String, url__values: [String], url__source__id: ID, url__owner__id: ID, url__is_visible: Boolean, url__is_protected: Boolean, validate_certificates__value: Boolean, validate_certificates__values: [Boolean], validate_certificates__source__id: ID, validate_certificates__owner__id: ID, validate_certificates__is_visible: Boolean, validate_certificates__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreWebhook
+  CoreGenericRepository(offset: Int, limit: Int, ids: [ID], name__value: String, name__values: [String], name__source__id: ID, name__owner__id: ID, name__is_visible: Boolean, name__is_protected: Boolean, description__value: String, description__values: [String], description__source__id: ID, description__owner__id: ID, description__is_visible: Boolean, description__is_protected: Boolean, location__value: String, location__values: [String], location__source__id: ID, location__owner__id: ID, location__is_visible: Boolean, location__is_protected: Boolean, username__value: String, username__values: [String], username__source__id: ID, username__owner__id: ID, username__is_visible: Boolean, username__is_protected: Boolean, password__value: String, password__values: [String], password__source__id: ID, password__owner__id: ID, password__is_visible: Boolean, password__is_protected: Boolean, any__value: String, any__values: [String], any__source__id: ID, any__owner__id: ID, any__is_visible: Boolean, any__is_protected: Boolean, partial_match: Boolean, tags__ids: [ID], tags__name__value: String, tags__name__values: [String], tags__name__source__id: ID, tags__name__owner__id: ID, tags__name__is_visible: Boolean, tags__name__is_protected: Boolean, tags__description__value: String, tags__description__values: [String], tags__description__source__id: ID, tags__description__owner__id: ID, tags__description__is_visible: Boolean, tags__description__is_protected: Boolean, transformations__ids: [ID], transformations__name__value: String, transformations__name__values: [String], transformations__name__source__id: ID, transformations__name__owner__id: ID, transformations__name__is_visible: Boolean, transformations__name__is_protected: Boolean, transformations__label__value: String, transformations__label__values: [String], transformations__label__source__id: ID, transformations__label__owner__id: ID, transformations__label__is_visible: Boolean, transformations__label__is_protected: Boolean, transformations__description__value: String, transformations__description__values: [String], transformations__description__source__id: ID, transformations__description__owner__id: ID, transformations__description__is_visible: Boolean, transformations__description__is_protected: Boolean, transformations__timeout__value: Int, transformations__timeout__values: [Int], transformations__timeout__source__id: ID, transformations__timeout__owner__id: ID, transformations__timeout__is_visible: Boolean, transformations__timeout__is_protected: Boolean, queries__ids: [ID], queries__name__value: String, queries__name__values: [String], queries__name__source__id: ID, queries__name__owner__id: ID, queries__name__is_visible: Boolean, queries__name__is_protected: Boolean, queries__description__value: String, queries__description__values: [String], queries__description__source__id: ID, queries__description__owner__id: ID, queries__description__is_visible: Boolean, queries__description__is_protected: Boolean, queries__query__value: String, queries__query__values: [String], queries__query__source__id: ID, queries__query__owner__id: ID, queries__query__is_visible: Boolean, queries__query__is_protected: Boolean, queries__variables__value: GenericScalar, queries__variables__values: [GenericScalar], queries__variables__source__id: ID, queries__variables__owner__id: ID, queries__variables__is_visible: Boolean, queries__variables__is_protected: Boolean, queries__operations__value: GenericScalar, queries__operations__values: [GenericScalar], queries__operations__source__id: ID, queries__operations__owner__id: ID, queries__operations__is_visible: Boolean, queries__operations__is_protected: Boolean, queries__models__value: GenericScalar, queries__models__values: [GenericScalar], queries__models__source__id: ID, queries__models__owner__id: ID, queries__models__is_visible: Boolean, queries__models__is_protected: Boolean, queries__depth__value: Int, queries__depth__values: [Int], queries__depth__source__id: ID, queries__depth__owner__id: ID, queries__depth__is_visible: Boolean, queries__depth__is_protected: Boolean, queries__height__value: Int, queries__height__values: [Int], queries__height__source__id: ID, queries__height__owner__id: ID, queries__height__is_visible: Boolean, queries__height__is_protected: Boolean, checks__ids: [ID], checks__name__value: String, checks__name__values: [String], checks__name__source__id: ID, checks__name__owner__id: ID, checks__name__is_visible: Boolean, checks__name__is_protected: Boolean, checks__description__value: String, checks__description__values: [String], checks__description__source__id: ID, checks__description__owner__id: ID, checks__description__is_visible: Boolean, checks__description__is_protected: Boolean, checks__file_path__value: String, checks__file_path__values: [String], checks__file_path__source__id: ID, checks__file_path__owner__id: ID, checks__file_path__is_visible: Boolean, checks__file_path__is_protected: Boolean, checks__class_name__value: String, checks__class_name__values: [String], checks__class_name__source__id: ID, checks__class_name__owner__id: ID, checks__class_name__is_visible: Boolean, checks__class_name__is_protected: Boolean, checks__timeout__value: Int, checks__timeout__values: [Int], checks__timeout__source__id: ID, checks__timeout__owner__id: ID, checks__timeout__is_visible: Boolean, checks__timeout__is_protected: Boolean, checks__parameters__value: GenericScalar, checks__parameters__values: [GenericScalar], checks__parameters__source__id: ID, checks__parameters__owner__id: ID, checks__parameters__is_visible: Boolean, checks__parameters__is_protected: Boolean, member_of_groups__ids: [ID], member_of_groups__name__value: String, member_of_groups__name__values: [String], member_of_groups__label__value: String, member_of_groups__label__values: [String], member_of_groups__description__value: String, member_of_groups__description__values: [String], subscriber_of_groups__ids: [ID], subscriber_of_groups__name__value: String, subscriber_of_groups__name__values: [String], subscriber_of_groups__label__value: String, subscriber_of_groups__label__values: [String], subscriber_of_groups__description__value: String, subscriber_of_groups__description__values: [String]): PaginatedCoreGenericRepository
+  Branch(ids: [ID], name: String): [Branch]
+  DiffSummary(time_from: String, time_to: String, branch_only: Boolean = false): [DiffSummaryEntry]
+  DiffSummaryOld(time_from: String, time_to: String, branch_only: Boolean = false): [DiffSummaryEntryOld]
+  InfrahubInfo: Info
+  Relationship(limit: Int, offset: Int, ids: [String!]!, excluded_namespaces: [String]): Relationships
+  InfrahubTask(limit: Int, offset: Int, related_node__ids: [String], ids: [String]): Tasks
+}
+
+"""Branch"""
+type Branch {
+  id: String!
+  name: String!
+  description: String
+  origin_branch: String
+  branched_from: String
+  created_at: String
+  sync_with_git: Boolean
+  is_default: Boolean
+  is_isolated: Boolean
+  has_schema_changes: Boolean
+}
+
+type DiffSummaryEntry {
+  branch: String!
+  id: String!
+  kind: String!
+  action: DiffAction
+  display_label: String
+  elements: [DiffSummaryElementInterface]
+}
+
+type DiffSummaryEntryOld {
+  branch: String!
+  node: String!
+  kind: String!
+  actions: [String]!
+}
+
+type Info {
+  deployment_id: String!
+  version: String!
+}
+
+type Relationships {
+  edges: [RelationshipNode]
+  count: Int
+}
+
+type RelationshipNode {
+  node: Relationship
+}
+
+type Relationship {
+  id: String
+  identifier: String
+  peers: [RelationshipPeer]
+}
+
+type RelationshipPeer {
+  id: String
+  kind: String
+}
+
+type Tasks {
+  edges: [TaskNodes]
+  count: Int
+}
+
+type TaskNodes {
+  node: TaskNode
+}
+
+type TaskNode {
+  id: String!
+  title: String!
+  conclusion: String!
+  created_at: String!
+  updated_at: String!
+  related_node: String!
+  related_node_kind: String!
+  logs: TaskLogEdge
+}
+
+type TaskLogEdge {
+  edges: [TaskLogNodes]
+}
+
+type TaskLogNodes {
+  node: TaskLog
+}
+
+type TaskLog {
+  message: String!
+  severity: String!
+  task_id: String!
+  timestamp: String!
+  id: String
+}
+
+type Mutation {
+  """Group of nodes of any kind."""
+  CoreStandardGroupCreate(data: CoreStandardGroupCreateInput!): CoreStandardGroupCreate
+
+  """Group of nodes of any kind."""
+  CoreStandardGroupUpdate(data: CoreStandardGroupUpdateInput!): CoreStandardGroupUpdate
+
+  """Group of nodes of any kind."""
+  CoreStandardGroupUpsert(data: CoreStandardGroupCreateInput!): CoreStandardGroupUpsert
+
+  """Group of nodes of any kind."""
+  CoreStandardGroupDelete(data: DeleteInput!): CoreStandardGroupDelete
+
+  """Group of nodes associated with a given GraphQLQuery."""
+  CoreGraphQLQueryGroupCreate(data: CoreGraphQLQueryGroupCreateInput!): CoreGraphQLQueryGroupCreate
+
+  """Group of nodes associated with a given GraphQLQuery."""
+  CoreGraphQLQueryGroupUpdate(data: CoreGraphQLQueryGroupUpdateInput!): CoreGraphQLQueryGroupUpdate
+
+  """Group of nodes associated with a given GraphQLQuery."""
+  CoreGraphQLQueryGroupUpsert(data: CoreGraphQLQueryGroupCreateInput!): CoreGraphQLQueryGroupUpsert
+
+  """Group of nodes associated with a given GraphQLQuery."""
+  CoreGraphQLQueryGroupDelete(data: DeleteInput!): CoreGraphQLQueryGroupDelete
+
+  """
+  Standard Tag object to attached to other objects to provide some context.
+  """
+  BuiltinTagCreate(data: BuiltinTagCreateInput!): BuiltinTagCreate
+
+  """
+  Standard Tag object to attached to other objects to provide some context.
+  """
+  BuiltinTagUpdate(data: BuiltinTagUpdateInput!): BuiltinTagUpdate
+
+  """
+  Standard Tag object to attached to other objects to provide some context.
+  """
+  BuiltinTagUpsert(data: BuiltinTagCreateInput!): BuiltinTagUpsert
+
+  """
+  Standard Tag object to attached to other objects to provide some context.
+  """
+  BuiltinTagDelete(data: DeleteInput!): BuiltinTagDelete
+
+  """User Account for Infrahub"""
+  CoreAccountCreate(data: CoreAccountCreateInput!): CoreAccountCreate
+
+  """User Account for Infrahub"""
+  CoreAccountUpdate(data: CoreAccountUpdateInput!): CoreAccountUpdate
+
+  """User Account for Infrahub"""
+  CoreAccountUpsert(data: CoreAccountCreateInput!): CoreAccountUpsert
+
+  """User Account for Infrahub"""
+  CoreAccountDelete(data: DeleteInput!): CoreAccountDelete
+
+  """Metadata related to a proposed change"""
+  CoreProposedChangeCreate(data: CoreProposedChangeCreateInput!): CoreProposedChangeCreate
+
+  """Metadata related to a proposed change"""
+  CoreProposedChangeUpdate(data: CoreProposedChangeUpdateInput!): CoreProposedChangeUpdate
+
+  """Metadata related to a proposed change"""
+  CoreProposedChangeUpsert(data: CoreProposedChangeCreateInput!): CoreProposedChangeUpsert
+
+  """Metadata related to a proposed change"""
+  CoreProposedChangeDelete(data: DeleteInput!): CoreProposedChangeDelete
+
+  """A thread on proposed change"""
+  CoreChangeThreadCreate(data: CoreChangeThreadCreateInput!): CoreChangeThreadCreate
+
+  """A thread on proposed change"""
+  CoreChangeThreadUpdate(data: CoreChangeThreadUpdateInput!): CoreChangeThreadUpdate
+
+  """A thread on proposed change"""
+  CoreChangeThreadUpsert(data: CoreChangeThreadCreateInput!): CoreChangeThreadUpsert
+
+  """A thread on proposed change"""
+  CoreChangeThreadDelete(data: DeleteInput!): CoreChangeThreadDelete
+
+  """A thread related to a file on a proposed change"""
+  CoreFileThreadCreate(data: CoreFileThreadCreateInput!): CoreFileThreadCreate
+
+  """A thread related to a file on a proposed change"""
+  CoreFileThreadUpdate(data: CoreFileThreadUpdateInput!): CoreFileThreadUpdate
+
+  """A thread related to a file on a proposed change"""
+  CoreFileThreadUpsert(data: CoreFileThreadCreateInput!): CoreFileThreadUpsert
+
+  """A thread related to a file on a proposed change"""
+  CoreFileThreadDelete(data: DeleteInput!): CoreFileThreadDelete
+
+  """A thread related to an artifact on a proposed change"""
+  CoreArtifactThreadCreate(data: CoreArtifactThreadCreateInput!): CoreArtifactThreadCreate
+
+  """A thread related to an artifact on a proposed change"""
+  CoreArtifactThreadUpdate(data: CoreArtifactThreadUpdateInput!): CoreArtifactThreadUpdate
+
+  """A thread related to an artifact on a proposed change"""
+  CoreArtifactThreadUpsert(data: CoreArtifactThreadCreateInput!): CoreArtifactThreadUpsert
+
+  """A thread related to an artifact on a proposed change"""
+  CoreArtifactThreadDelete(data: DeleteInput!): CoreArtifactThreadDelete
+
+  """A thread related to an object on a proposed change"""
+  CoreObjectThreadCreate(data: CoreObjectThreadCreateInput!): CoreObjectThreadCreate
+
+  """A thread related to an object on a proposed change"""
+  CoreObjectThreadUpdate(data: CoreObjectThreadUpdateInput!): CoreObjectThreadUpdate
+
+  """A thread related to an object on a proposed change"""
+  CoreObjectThreadUpsert(data: CoreObjectThreadCreateInput!): CoreObjectThreadUpsert
+
+  """A thread related to an object on a proposed change"""
+  CoreObjectThreadDelete(data: DeleteInput!): CoreObjectThreadDelete
+
+  """A comment on proposed change"""
+  CoreChangeCommentCreate(data: CoreChangeCommentCreateInput!): CoreChangeCommentCreate
+
+  """A comment on proposed change"""
+  CoreChangeCommentUpdate(data: CoreChangeCommentUpdateInput!): CoreChangeCommentUpdate
+
+  """A comment on proposed change"""
+  CoreChangeCommentUpsert(data: CoreChangeCommentCreateInput!): CoreChangeCommentUpsert
+
+  """A comment on proposed change"""
+  CoreChangeCommentDelete(data: DeleteInput!): CoreChangeCommentDelete
+
+  """A comment on thread within a Proposed Change"""
+  CoreThreadCommentCreate(data: CoreThreadCommentCreateInput!): CoreThreadCommentCreate
+
+  """A comment on thread within a Proposed Change"""
+  CoreThreadCommentUpdate(data: CoreThreadCommentUpdateInput!): CoreThreadCommentUpdate
+
+  """A comment on thread within a Proposed Change"""
+  CoreThreadCommentUpsert(data: CoreThreadCommentCreateInput!): CoreThreadCommentUpsert
+
+  """A comment on thread within a Proposed Change"""
+  CoreThreadCommentDelete(data: DeleteInput!): CoreThreadCommentDelete
+
+  """A Git Repository integrated with Infrahub"""
+  CoreRepositoryCreate(data: CoreRepositoryCreateInput!): CoreRepositoryCreate
+
+  """A Git Repository integrated with Infrahub"""
+  CoreRepositoryUpdate(data: CoreRepositoryUpdateInput!): CoreRepositoryUpdate
+
+  """A Git Repository integrated with Infrahub"""
+  CoreRepositoryUpsert(data: CoreRepositoryCreateInput!): CoreRepositoryUpsert
+
+  """A Git Repository integrated with Infrahub"""
+  CoreRepositoryDelete(data: DeleteInput!): CoreRepositoryDelete
+
+  """
+  A Git Repository integrated with Infrahub, Git-side will not be updated
+  """
+  CoreReadOnlyRepositoryCreate(data: CoreReadOnlyRepositoryCreateInput!): CoreReadOnlyRepositoryCreate
+
+  """
+  A Git Repository integrated with Infrahub, Git-side will not be updated
+  """
+  CoreReadOnlyRepositoryUpdate(data: CoreReadOnlyRepositoryUpdateInput!): CoreReadOnlyRepositoryUpdate
+
+  """
+  A Git Repository integrated with Infrahub, Git-side will not be updated
+  """
+  CoreReadOnlyRepositoryUpsert(data: CoreReadOnlyRepositoryCreateInput!): CoreReadOnlyRepositoryUpsert
+
+  """
+  A Git Repository integrated with Infrahub, Git-side will not be updated
+  """
+  CoreReadOnlyRepositoryDelete(data: DeleteInput!): CoreReadOnlyRepositoryDelete
+
+  """A file rendered from a Jinja2 template"""
+  CoreTransformJinja2Create(data: CoreTransformJinja2CreateInput!): CoreTransformJinja2Create
+
+  """A file rendered from a Jinja2 template"""
+  CoreTransformJinja2Update(data: CoreTransformJinja2UpdateInput!): CoreTransformJinja2Update
+
+  """A file rendered from a Jinja2 template"""
+  CoreTransformJinja2Upsert(data: CoreTransformJinja2CreateInput!): CoreTransformJinja2Upsert
+
+  """A file rendered from a Jinja2 template"""
+  CoreTransformJinja2Delete(data: DeleteInput!): CoreTransformJinja2Delete
+
+  """A check related to some Data"""
+  CoreDataCheckCreate(data: CoreDataCheckCreateInput!): CoreDataCheckCreate
+
+  """A check related to some Data"""
+  CoreDataCheckUpdate(data: CoreDataCheckUpdateInput!): CoreDataCheckUpdate
+
+  """A check related to some Data"""
+  CoreDataCheckUpsert(data: CoreDataCheckCreateInput!): CoreDataCheckUpsert
+
+  """A check related to some Data"""
+  CoreDataCheckDelete(data: DeleteInput!): CoreDataCheckDelete
+
+  """A standard check"""
+  CoreStandardCheckCreate(data: CoreStandardCheckCreateInput!): CoreStandardCheckCreate
+
+  """A standard check"""
+  CoreStandardCheckUpdate(data: CoreStandardCheckUpdateInput!): CoreStandardCheckUpdate
+
+  """A standard check"""
+  CoreStandardCheckUpsert(data: CoreStandardCheckCreateInput!): CoreStandardCheckUpsert
+
+  """A standard check"""
+  CoreStandardCheckDelete(data: DeleteInput!): CoreStandardCheckDelete
+
+  """A check related to the schema"""
+  CoreSchemaCheckCreate(data: CoreSchemaCheckCreateInput!): CoreSchemaCheckCreate
+
+  """A check related to the schema"""
+  CoreSchemaCheckUpdate(data: CoreSchemaCheckUpdateInput!): CoreSchemaCheckUpdate
+
+  """A check related to the schema"""
+  CoreSchemaCheckUpsert(data: CoreSchemaCheckCreateInput!): CoreSchemaCheckUpsert
+
+  """A check related to the schema"""
+  CoreSchemaCheckDelete(data: DeleteInput!): CoreSchemaCheckDelete
+
+  """A check related to a file in a Git Repository"""
+  CoreFileCheckCreate(data: CoreFileCheckCreateInput!): CoreFileCheckCreate
+
+  """A check related to a file in a Git Repository"""
+  CoreFileCheckUpdate(data: CoreFileCheckUpdateInput!): CoreFileCheckUpdate
+
+  """A check related to a file in a Git Repository"""
+  CoreFileCheckUpsert(data: CoreFileCheckCreateInput!): CoreFileCheckUpsert
+
+  """A check related to a file in a Git Repository"""
+  CoreFileCheckDelete(data: DeleteInput!): CoreFileCheckDelete
+
+  """A check related to an artifact"""
+  CoreArtifactCheckCreate(data: CoreArtifactCheckCreateInput!): CoreArtifactCheckCreate
+
+  """A check related to an artifact"""
+  CoreArtifactCheckUpdate(data: CoreArtifactCheckUpdateInput!): CoreArtifactCheckUpdate
+
+  """A check related to an artifact"""
+  CoreArtifactCheckUpsert(data: CoreArtifactCheckCreateInput!): CoreArtifactCheckUpsert
+
+  """A check related to an artifact"""
+  CoreArtifactCheckDelete(data: DeleteInput!): CoreArtifactCheckDelete
+
+  """A check to validate the data integrity between two branches"""
+  CoreDataValidatorCreate(data: CoreDataValidatorCreateInput!): CoreDataValidatorCreate
+
+  """A check to validate the data integrity between two branches"""
+  CoreDataValidatorUpdate(data: CoreDataValidatorUpdateInput!): CoreDataValidatorUpdate
+
+  """A check to validate the data integrity between two branches"""
+  CoreDataValidatorUpsert(data: CoreDataValidatorCreateInput!): CoreDataValidatorUpsert
+
+  """A check to validate the data integrity between two branches"""
+  CoreDataValidatorDelete(data: DeleteInput!): CoreDataValidatorDelete
+
+  """A Validator related to a specific repository"""
+  CoreRepositoryValidatorCreate(data: CoreRepositoryValidatorCreateInput!): CoreRepositoryValidatorCreate
+
+  """A Validator related to a specific repository"""
+  CoreRepositoryValidatorUpdate(data: CoreRepositoryValidatorUpdateInput!): CoreRepositoryValidatorUpdate
+
+  """A Validator related to a specific repository"""
+  CoreRepositoryValidatorUpsert(data: CoreRepositoryValidatorCreateInput!): CoreRepositoryValidatorUpsert
+
+  """A Validator related to a specific repository"""
+  CoreRepositoryValidatorDelete(data: DeleteInput!): CoreRepositoryValidatorDelete
+
+  """A Validator related to a user defined checks in a repository"""
+  CoreUserValidatorCreate(data: CoreUserValidatorCreateInput!): CoreUserValidatorCreate
+
+  """A Validator related to a user defined checks in a repository"""
+  CoreUserValidatorUpdate(data: CoreUserValidatorUpdateInput!): CoreUserValidatorUpdate
+
+  """A Validator related to a user defined checks in a repository"""
+  CoreUserValidatorUpsert(data: CoreUserValidatorCreateInput!): CoreUserValidatorUpsert
+
+  """A Validator related to a user defined checks in a repository"""
+  CoreUserValidatorDelete(data: DeleteInput!): CoreUserValidatorDelete
+
+  """A validator related to the schema"""
+  CoreSchemaValidatorCreate(data: CoreSchemaValidatorCreateInput!): CoreSchemaValidatorCreate
+
+  """A validator related to the schema"""
+  CoreSchemaValidatorUpdate(data: CoreSchemaValidatorUpdateInput!): CoreSchemaValidatorUpdate
+
+  """A validator related to the schema"""
+  CoreSchemaValidatorUpsert(data: CoreSchemaValidatorCreateInput!): CoreSchemaValidatorUpsert
+
+  """A validator related to the schema"""
+  CoreSchemaValidatorDelete(data: DeleteInput!): CoreSchemaValidatorDelete
+
+  """A validator related to the artifacts"""
+  CoreArtifactValidatorCreate(data: CoreArtifactValidatorCreateInput!): CoreArtifactValidatorCreate
+
+  """A validator related to the artifacts"""
+  CoreArtifactValidatorUpdate(data: CoreArtifactValidatorUpdateInput!): CoreArtifactValidatorUpdate
+
+  """A validator related to the artifacts"""
+  CoreArtifactValidatorUpsert(data: CoreArtifactValidatorCreateInput!): CoreArtifactValidatorUpsert
+
+  """A validator related to the artifacts"""
+  CoreArtifactValidatorDelete(data: DeleteInput!): CoreArtifactValidatorDelete
+  CoreCheckDefinitionCreate(data: CoreCheckDefinitionCreateInput!): CoreCheckDefinitionCreate
+  CoreCheckDefinitionUpdate(data: CoreCheckDefinitionUpdateInput!): CoreCheckDefinitionUpdate
+  CoreCheckDefinitionUpsert(data: CoreCheckDefinitionCreateInput!): CoreCheckDefinitionUpsert
+  CoreCheckDefinitionDelete(data: DeleteInput!): CoreCheckDefinitionDelete
+
+  """A transform function written in Python"""
+  CoreTransformPythonCreate(data: CoreTransformPythonCreateInput!): CoreTransformPythonCreate
+
+  """A transform function written in Python"""
+  CoreTransformPythonUpdate(data: CoreTransformPythonUpdateInput!): CoreTransformPythonUpdate
+
+  """A transform function written in Python"""
+  CoreTransformPythonUpsert(data: CoreTransformPythonCreateInput!): CoreTransformPythonUpsert
+
+  """A transform function written in Python"""
+  CoreTransformPythonDelete(data: DeleteInput!): CoreTransformPythonDelete
+
+  """A pre-defined GraphQL Query"""
+  CoreGraphQLQueryCreate(data: CoreGraphQLQueryCreateInput!): CoreGraphQLQueryCreate
+
+  """A pre-defined GraphQL Query"""
+  CoreGraphQLQueryUpdate(data: CoreGraphQLQueryUpdateInput!): CoreGraphQLQueryUpdate
+
+  """A pre-defined GraphQL Query"""
+  CoreGraphQLQueryUpsert(data: CoreGraphQLQueryCreateInput!): CoreGraphQLQueryUpsert
+
+  """A pre-defined GraphQL Query"""
+  CoreGraphQLQueryDelete(data: DeleteInput!): CoreGraphQLQueryDelete
+  CoreArtifactCreate(data: CoreArtifactCreateInput!): CoreArtifactCreate
+  CoreArtifactUpdate(data: CoreArtifactUpdateInput!): CoreArtifactUpdate
+  CoreArtifactUpsert(data: CoreArtifactCreateInput!): CoreArtifactUpsert
+  CoreArtifactDelete(data: DeleteInput!): CoreArtifactDelete
+  CoreArtifactDefinitionCreate(data: CoreArtifactDefinitionCreateInput!): CoreArtifactDefinitionCreate
+  CoreArtifactDefinitionUpdate(data: CoreArtifactDefinitionUpdateInput!): CoreArtifactDefinitionUpdate
+  CoreArtifactDefinitionUpsert(data: CoreArtifactDefinitionCreateInput!): CoreArtifactDefinitionUpsert
+  CoreArtifactDefinitionDelete(data: DeleteInput!): CoreArtifactDefinitionDelete
+
+  """A webhook that connects to an external integration"""
+  CoreStandardWebhookCreate(data: CoreStandardWebhookCreateInput!): CoreStandardWebhookCreate
+
+  """A webhook that connects to an external integration"""
+  CoreStandardWebhookUpdate(data: CoreStandardWebhookUpdateInput!): CoreStandardWebhookUpdate
+
+  """A webhook that connects to an external integration"""
+  CoreStandardWebhookUpsert(data: CoreStandardWebhookCreateInput!): CoreStandardWebhookUpsert
+
+  """A webhook that connects to an external integration"""
+  CoreStandardWebhookDelete(data: DeleteInput!): CoreStandardWebhookDelete
+
+  """A webhook that connects to an external integration"""
+  CoreCustomWebhookCreate(data: CoreCustomWebhookCreateInput!): CoreCustomWebhookCreate
+
+  """A webhook that connects to an external integration"""
+  CoreCustomWebhookUpdate(data: CoreCustomWebhookUpdateInput!): CoreCustomWebhookUpdate
+
+  """A webhook that connects to an external integration"""
+  CoreCustomWebhookUpsert(data: CoreCustomWebhookCreateInput!): CoreCustomWebhookUpsert
+
+  """A webhook that connects to an external integration"""
+  CoreCustomWebhookDelete(data: DeleteInput!): CoreCustomWebhookDelete
+  CoreAccountTokenCreate(data: CoreAccountTokenCreateInput!): CoreAccountTokenCreate
+  CoreAccountSelfUpdate(data: CoreAccountUpdateSelfInput!): CoreAccountSelfUpdate
+  CoreProposedChangeRunCheck(data: ProposedChangeRequestRunCheckInput!): ProposedChangeRequestRunCheck
+  BranchCreate(background_execution: Boolean, data: BranchCreateInput!): BranchCreate
+  BranchDelete(data: BranchNameInput!): BranchDelete
+  BranchRebase(data: BranchNameInput!): BranchRebase
+  BranchMerge(data: BranchNameInput!): BranchMerge
+  BranchUpdate(data: BranchUpdateInput!): BranchUpdate
+  BranchValidate(data: BranchNameInput!): BranchValidate
+  InfrahubTaskCreate(data: TaskCreateInput!): TaskCreate
+  InfrahubTaskUpdate(data: TaskUpdateInput!): TaskUpdate
+  RelationshipAdd(data: RelationshipNodesInput!): RelationshipAdd
+  RelationshipRemove(data: RelationshipNodesInput!): RelationshipRemove
+  SchemaDropdownAdd(data: SchemaDropdownAddInput!): SchemaDropdownAdd
+  SchemaDropdownRemove(data: SchemaDropdownRemoveInput!): SchemaDropdownRemove
+  SchemaEnumAdd(data: SchemaEnumInput!): SchemaEnumAdd
+  SchemaEnumRemove(data: SchemaEnumInput!): SchemaEnumRemove
+}
+
+"""Group of nodes of any kind."""
+type CoreStandardGroupCreate {
+  ok: Boolean
+  object: CoreStandardGroup
+}
+
+input CoreStandardGroupCreateInput {
+  id: String
+  name: TextAttributeInput!
+  label: TextAttributeInput
+  description: TextAttributeInput
+  members: [RelatedNodeInput]
+  subscribers: [RelatedNodeInput]
+  parent: RelatedNodeInput
+  children: [RelatedNodeInput]
+}
+
+input TextAttributeInput {
+  is_visible: Boolean
+  is_protected: Boolean
+  source: String
+  owner: String
+  value: String
+}
+
+input RelatedNodeInput {
+  id: String!
+  _relation__is_visible: Boolean
+  _relation__is_protected: Boolean
+  _relation__owner: String
+  _relation__source: String
+}
+
+"""Group of nodes of any kind."""
+type CoreStandardGroupUpdate {
+  ok: Boolean
+  object: CoreStandardGroup
+}
+
+input CoreStandardGroupUpdateInput {
+  id: String!
+  name: TextAttributeInput
+  label: TextAttributeInput
+  description: TextAttributeInput
+  members: [RelatedNodeInput]
+  subscribers: [RelatedNodeInput]
+  parent: RelatedNodeInput
+  children: [RelatedNodeInput]
+}
+
+"""Group of nodes of any kind."""
+type CoreStandardGroupUpsert {
+  ok: Boolean
+  object: CoreStandardGroup
+}
+
+"""Group of nodes of any kind."""
+type CoreStandardGroupDelete {
+  ok: Boolean
+}
+
+input DeleteInput {
+  id: String!
+}
+
+"""Group of nodes associated with a given GraphQLQuery."""
+type CoreGraphQLQueryGroupCreate {
+  ok: Boolean
+  object: CoreGraphQLQueryGroup
+}
+
+input CoreGraphQLQueryGroupCreateInput {
+  id: String
+  parameters: JSONAttributeInput
+  name: TextAttributeInput!
+  label: TextAttributeInput
+  description: TextAttributeInput
+  query: RelatedNodeInput!
+  members: [RelatedNodeInput]
+  subscribers: [RelatedNodeInput]
+  parent: RelatedNodeInput
+  children: [RelatedNodeInput]
+}
+
+input JSONAttributeInput {
+  is_visible: Boolean
+  is_protected: Boolean
+  source: String
+  owner: String
+  value: GenericScalar
+}
+
+"""Group of nodes associated with a given GraphQLQuery."""
+type CoreGraphQLQueryGroupUpdate {
+  ok: Boolean
+  object: CoreGraphQLQueryGroup
+}
+
+input CoreGraphQLQueryGroupUpdateInput {
+  id: String!
+  parameters: JSONAttributeInput
+  name: TextAttributeInput
+  label: TextAttributeInput
+  description: TextAttributeInput
+  query: RelatedNodeInput
+  members: [RelatedNodeInput]
+  subscribers: [RelatedNodeInput]
+  parent: RelatedNodeInput
+  children: [RelatedNodeInput]
+}
+
+"""Group of nodes associated with a given GraphQLQuery."""
+type CoreGraphQLQueryGroupUpsert {
+  ok: Boolean
+  object: CoreGraphQLQueryGroup
+}
+
+"""Group of nodes associated with a given GraphQLQuery."""
+type CoreGraphQLQueryGroupDelete {
+  ok: Boolean
+}
+
+"""
+Standard Tag object to attached to other objects to provide some context.
+"""
+type BuiltinTagCreate {
+  ok: Boolean
+  object: BuiltinTag
+}
+
+input BuiltinTagCreateInput {
+  id: String
+  name: TextAttributeInput!
+  description: TextAttributeInput
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""
+Standard Tag object to attached to other objects to provide some context.
+"""
+type BuiltinTagUpdate {
+  ok: Boolean
+  object: BuiltinTag
+}
+
+input BuiltinTagUpdateInput {
+  id: String!
+  name: TextAttributeInput
+  description: TextAttributeInput
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""
+Standard Tag object to attached to other objects to provide some context.
+"""
+type BuiltinTagUpsert {
+  ok: Boolean
+  object: BuiltinTag
+}
+
+"""
+Standard Tag object to attached to other objects to provide some context.
+"""
+type BuiltinTagDelete {
+  ok: Boolean
+}
+
+"""User Account for Infrahub"""
+type CoreAccountCreate {
+  ok: Boolean
+  object: CoreAccount
+}
+
+input CoreAccountCreateInput {
+  id: String
+  name: TextAttributeInput!
+  password: TextAttributeInput!
+  label: TextAttributeInput
+  description: TextAttributeInput
+  type: TextAttributeInput
+  role: TextAttributeInput
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""User Account for Infrahub"""
+type CoreAccountUpdate {
+  ok: Boolean
+  object: CoreAccount
+}
+
+input CoreAccountUpdateInput {
+  id: String!
+  name: TextAttributeInput
+  password: TextAttributeInput
+  label: TextAttributeInput
+  description: TextAttributeInput
+  type: TextAttributeInput
+  role: TextAttributeInput
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""User Account for Infrahub"""
+type CoreAccountUpsert {
+  ok: Boolean
+  object: CoreAccount
+}
+
+"""User Account for Infrahub"""
+type CoreAccountDelete {
+  ok: Boolean
+}
+
+"""Metadata related to a proposed change"""
+type CoreProposedChangeCreate {
+  ok: Boolean
+  object: CoreProposedChange
+}
+
+input CoreProposedChangeCreateInput {
+  id: String
+  name: TextAttributeInput!
+  description: TextAttributeInput
+  source_branch: TextAttributeInput!
+  destination_branch: TextAttributeInput!
+  state: TextAttributeInput
+  approved_by: [RelatedNodeInput]
+  reviewers: [RelatedNodeInput]
+  created_by: RelatedNodeInput
+  comments: [RelatedNodeInput]
+  threads: [RelatedNodeInput]
+  validations: [RelatedNodeInput]
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""Metadata related to a proposed change"""
+type CoreProposedChangeUpdate {
+  ok: Boolean
+  object: CoreProposedChange
+}
+
+input CoreProposedChangeUpdateInput {
+  id: String!
+  name: TextAttributeInput
+  description: TextAttributeInput
+  source_branch: TextAttributeInput
+  destination_branch: TextAttributeInput
+  state: TextAttributeInput
+  approved_by: [RelatedNodeInput]
+  reviewers: [RelatedNodeInput]
+  created_by: RelatedNodeInput
+  comments: [RelatedNodeInput]
+  threads: [RelatedNodeInput]
+  validations: [RelatedNodeInput]
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""Metadata related to a proposed change"""
+type CoreProposedChangeUpsert {
+  ok: Boolean
+  object: CoreProposedChange
+}
+
+"""Metadata related to a proposed change"""
+type CoreProposedChangeDelete {
+  ok: Boolean
+}
+
+"""A thread on proposed change"""
+type CoreChangeThreadCreate {
+  ok: Boolean
+  object: CoreChangeThread
+}
+
+input CoreChangeThreadCreateInput {
+  id: String
+  label: TextAttributeInput
+  resolved: CheckboxAttributeInput
+  created_at: TextAttributeInput
+  change: RelatedNodeInput!
+  comments: [RelatedNodeInput]
+  created_by: RelatedNodeInput
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+input CheckboxAttributeInput {
+  is_visible: Boolean
+  is_protected: Boolean
+  source: String
+  owner: String
+  value: Boolean
+}
+
+"""A thread on proposed change"""
+type CoreChangeThreadUpdate {
+  ok: Boolean
+  object: CoreChangeThread
+}
+
+input CoreChangeThreadUpdateInput {
+  id: String!
+  label: TextAttributeInput
+  resolved: CheckboxAttributeInput
+  created_at: TextAttributeInput
+  change: RelatedNodeInput
+  comments: [RelatedNodeInput]
+  created_by: RelatedNodeInput
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A thread on proposed change"""
+type CoreChangeThreadUpsert {
+  ok: Boolean
+  object: CoreChangeThread
+}
+
+"""A thread on proposed change"""
+type CoreChangeThreadDelete {
+  ok: Boolean
+}
+
+"""A thread related to a file on a proposed change"""
+type CoreFileThreadCreate {
+  ok: Boolean
+  object: CoreFileThread
+}
+
+input CoreFileThreadCreateInput {
+  id: String
+  file: TextAttributeInput
+  commit: TextAttributeInput
+  line_number: NumberAttributeInput
+  label: TextAttributeInput
+  resolved: CheckboxAttributeInput
+  created_at: TextAttributeInput
+  repository: RelatedNodeInput!
+  change: RelatedNodeInput!
+  comments: [RelatedNodeInput]
+  created_by: RelatedNodeInput
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+input NumberAttributeInput {
+  is_visible: Boolean
+  is_protected: Boolean
+  source: String
+  owner: String
+  value: Int
+}
+
+"""A thread related to a file on a proposed change"""
+type CoreFileThreadUpdate {
+  ok: Boolean
+  object: CoreFileThread
+}
+
+input CoreFileThreadUpdateInput {
+  id: String!
+  file: TextAttributeInput
+  commit: TextAttributeInput
+  line_number: NumberAttributeInput
+  label: TextAttributeInput
+  resolved: CheckboxAttributeInput
+  created_at: TextAttributeInput
+  repository: RelatedNodeInput
+  change: RelatedNodeInput
+  comments: [RelatedNodeInput]
+  created_by: RelatedNodeInput
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A thread related to a file on a proposed change"""
+type CoreFileThreadUpsert {
+  ok: Boolean
+  object: CoreFileThread
+}
+
+"""A thread related to a file on a proposed change"""
+type CoreFileThreadDelete {
+  ok: Boolean
+}
+
+"""A thread related to an artifact on a proposed change"""
+type CoreArtifactThreadCreate {
+  ok: Boolean
+  object: CoreArtifactThread
+}
+
+input CoreArtifactThreadCreateInput {
+  id: String
+  artifact_id: TextAttributeInput
+  storage_id: TextAttributeInput
+  line_number: NumberAttributeInput
+  label: TextAttributeInput
+  resolved: CheckboxAttributeInput
+  created_at: TextAttributeInput
+  change: RelatedNodeInput!
+  comments: [RelatedNodeInput]
+  created_by: RelatedNodeInput
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A thread related to an artifact on a proposed change"""
+type CoreArtifactThreadUpdate {
+  ok: Boolean
+  object: CoreArtifactThread
+}
+
+input CoreArtifactThreadUpdateInput {
+  id: String!
+  artifact_id: TextAttributeInput
+  storage_id: TextAttributeInput
+  line_number: NumberAttributeInput
+  label: TextAttributeInput
+  resolved: CheckboxAttributeInput
+  created_at: TextAttributeInput
+  change: RelatedNodeInput
+  comments: [RelatedNodeInput]
+  created_by: RelatedNodeInput
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A thread related to an artifact on a proposed change"""
+type CoreArtifactThreadUpsert {
+  ok: Boolean
+  object: CoreArtifactThread
+}
+
+"""A thread related to an artifact on a proposed change"""
+type CoreArtifactThreadDelete {
+  ok: Boolean
+}
+
+"""A thread related to an object on a proposed change"""
+type CoreObjectThreadCreate {
+  ok: Boolean
+  object: CoreObjectThread
+}
+
+input CoreObjectThreadCreateInput {
+  id: String
+  object_path: TextAttributeInput!
+  label: TextAttributeInput
+  resolved: CheckboxAttributeInput
+  created_at: TextAttributeInput
+  change: RelatedNodeInput!
+  comments: [RelatedNodeInput]
+  created_by: RelatedNodeInput
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A thread related to an object on a proposed change"""
+type CoreObjectThreadUpdate {
+  ok: Boolean
+  object: CoreObjectThread
+}
+
+input CoreObjectThreadUpdateInput {
+  id: String!
+  object_path: TextAttributeInput
+  label: TextAttributeInput
+  resolved: CheckboxAttributeInput
+  created_at: TextAttributeInput
+  change: RelatedNodeInput
+  comments: [RelatedNodeInput]
+  created_by: RelatedNodeInput
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A thread related to an object on a proposed change"""
+type CoreObjectThreadUpsert {
+  ok: Boolean
+  object: CoreObjectThread
+}
+
+"""A thread related to an object on a proposed change"""
+type CoreObjectThreadDelete {
+  ok: Boolean
+}
+
+"""A comment on proposed change"""
+type CoreChangeCommentCreate {
+  ok: Boolean
+  object: CoreChangeComment
+}
+
+input CoreChangeCommentCreateInput {
+  id: String
+  text: TextAttributeInput!
+  created_at: TextAttributeInput
+  change: RelatedNodeInput!
+  created_by: RelatedNodeInput
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A comment on proposed change"""
+type CoreChangeCommentUpdate {
+  ok: Boolean
+  object: CoreChangeComment
+}
+
+input CoreChangeCommentUpdateInput {
+  id: String!
+  text: TextAttributeInput
+  created_at: TextAttributeInput
+  change: RelatedNodeInput
+  created_by: RelatedNodeInput
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A comment on proposed change"""
+type CoreChangeCommentUpsert {
+  ok: Boolean
+  object: CoreChangeComment
+}
+
+"""A comment on proposed change"""
+type CoreChangeCommentDelete {
+  ok: Boolean
+}
+
+"""A comment on thread within a Proposed Change"""
+type CoreThreadCommentCreate {
+  ok: Boolean
+  object: CoreThreadComment
+}
+
+input CoreThreadCommentCreateInput {
+  id: String
+  text: TextAttributeInput!
+  created_at: TextAttributeInput
+  thread: RelatedNodeInput!
+  created_by: RelatedNodeInput
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A comment on thread within a Proposed Change"""
+type CoreThreadCommentUpdate {
+  ok: Boolean
+  object: CoreThreadComment
+}
+
+input CoreThreadCommentUpdateInput {
+  id: String!
+  text: TextAttributeInput
+  created_at: TextAttributeInput
+  thread: RelatedNodeInput
+  created_by: RelatedNodeInput
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A comment on thread within a Proposed Change"""
+type CoreThreadCommentUpsert {
+  ok: Boolean
+  object: CoreThreadComment
+}
+
+"""A comment on thread within a Proposed Change"""
+type CoreThreadCommentDelete {
+  ok: Boolean
+}
+
+"""A Git Repository integrated with Infrahub"""
+type CoreRepositoryCreate {
+  ok: Boolean
+  object: CoreRepository
+}
+
+input CoreRepositoryCreateInput {
+  id: String
+  default_branch: TextAttributeInput
+  commit: TextAttributeInput
+  name: TextAttributeInput!
+  description: TextAttributeInput
+  location: TextAttributeInput!
+  username: TextAttributeInput
+  password: TextAttributeInput
+  tags: [RelatedNodeInput]
+  transformations: [RelatedNodeInput]
+  queries: [RelatedNodeInput]
+  checks: [RelatedNodeInput]
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A Git Repository integrated with Infrahub"""
+type CoreRepositoryUpdate {
+  ok: Boolean
+  object: CoreRepository
+}
+
+input CoreRepositoryUpdateInput {
+  id: String!
+  default_branch: TextAttributeInput
+  commit: TextAttributeInput
+  name: TextAttributeInput
+  description: TextAttributeInput
+  location: TextAttributeInput
+  username: TextAttributeInput
+  password: TextAttributeInput
+  tags: [RelatedNodeInput]
+  transformations: [RelatedNodeInput]
+  queries: [RelatedNodeInput]
+  checks: [RelatedNodeInput]
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A Git Repository integrated with Infrahub"""
+type CoreRepositoryUpsert {
+  ok: Boolean
+  object: CoreRepository
+}
+
+"""A Git Repository integrated with Infrahub"""
+type CoreRepositoryDelete {
+  ok: Boolean
+}
+
+"""
+A Git Repository integrated with Infrahub, Git-side will not be updated
+"""
+type CoreReadOnlyRepositoryCreate {
+  ok: Boolean
+  object: CoreReadOnlyRepository
+}
+
+input CoreReadOnlyRepositoryCreateInput {
+  id: String
+  ref: TextAttributeInput
+  commit: TextAttributeInput
+  name: TextAttributeInput!
+  description: TextAttributeInput
+  location: TextAttributeInput!
+  username: TextAttributeInput
+  password: TextAttributeInput
+  tags: [RelatedNodeInput]
+  transformations: [RelatedNodeInput]
+  queries: [RelatedNodeInput]
+  checks: [RelatedNodeInput]
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""
+A Git Repository integrated with Infrahub, Git-side will not be updated
+"""
+type CoreReadOnlyRepositoryUpdate {
+  ok: Boolean
+  object: CoreReadOnlyRepository
+}
+
+input CoreReadOnlyRepositoryUpdateInput {
+  id: String!
+  ref: TextAttributeInput
+  commit: TextAttributeInput
+  name: TextAttributeInput
+  description: TextAttributeInput
+  location: TextAttributeInput
+  username: TextAttributeInput
+  password: TextAttributeInput
+  tags: [RelatedNodeInput]
+  transformations: [RelatedNodeInput]
+  queries: [RelatedNodeInput]
+  checks: [RelatedNodeInput]
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""
+A Git Repository integrated with Infrahub, Git-side will not be updated
+"""
+type CoreReadOnlyRepositoryUpsert {
+  ok: Boolean
+  object: CoreReadOnlyRepository
+}
+
+"""
+A Git Repository integrated with Infrahub, Git-side will not be updated
+"""
+type CoreReadOnlyRepositoryDelete {
+  ok: Boolean
+}
+
+"""A file rendered from a Jinja2 template"""
+type CoreTransformJinja2Create {
+  ok: Boolean
+  object: CoreTransformJinja2
+}
+
+input CoreTransformJinja2CreateInput {
+  id: String
+  template_path: TextAttributeInput!
+  name: TextAttributeInput!
+  label: TextAttributeInput
+  description: TextAttributeInput
+  timeout: NumberAttributeInput
+  query: RelatedNodeInput!
+  repository: RelatedNodeInput!
+  tags: [RelatedNodeInput]
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A file rendered from a Jinja2 template"""
+type CoreTransformJinja2Update {
+  ok: Boolean
+  object: CoreTransformJinja2
+}
+
+input CoreTransformJinja2UpdateInput {
+  id: String!
+  template_path: TextAttributeInput
+  name: TextAttributeInput
+  label: TextAttributeInput
+  description: TextAttributeInput
+  timeout: NumberAttributeInput
+  query: RelatedNodeInput
+  repository: RelatedNodeInput
+  tags: [RelatedNodeInput]
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A file rendered from a Jinja2 template"""
+type CoreTransformJinja2Upsert {
+  ok: Boolean
+  object: CoreTransformJinja2
+}
+
+"""A file rendered from a Jinja2 template"""
+type CoreTransformJinja2Delete {
+  ok: Boolean
+}
+
+"""A check related to some Data"""
+type CoreDataCheckCreate {
+  ok: Boolean
+  object: CoreDataCheck
+}
+
+input CoreDataCheckCreateInput {
+  id: String
+  conflicts: JSONAttributeInput!
+  keep_branch: TextAttributeInput
+  name: TextAttributeInput
+  label: TextAttributeInput
+  origin: TextAttributeInput!
+  kind: TextAttributeInput!
+  message: TextAttributeInput
+  conclusion: TextAttributeInput
+  severity: TextAttributeInput
+  created_at: TextAttributeInput
+  validator: RelatedNodeInput!
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A check related to some Data"""
+type CoreDataCheckUpdate {
+  ok: Boolean
+  object: CoreDataCheck
+}
+
+input CoreDataCheckUpdateInput {
+  id: String!
+  conflicts: JSONAttributeInput
+  keep_branch: TextAttributeInput
+  name: TextAttributeInput
+  label: TextAttributeInput
+  origin: TextAttributeInput
+  kind: TextAttributeInput
+  message: TextAttributeInput
+  conclusion: TextAttributeInput
+  severity: TextAttributeInput
+  created_at: TextAttributeInput
+  validator: RelatedNodeInput
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A check related to some Data"""
+type CoreDataCheckUpsert {
+  ok: Boolean
+  object: CoreDataCheck
+}
+
+"""A check related to some Data"""
+type CoreDataCheckDelete {
+  ok: Boolean
+}
+
+"""A standard check"""
+type CoreStandardCheckCreate {
+  ok: Boolean
+  object: CoreStandardCheck
+}
+
+input CoreStandardCheckCreateInput {
+  id: String
+  name: TextAttributeInput
+  label: TextAttributeInput
+  origin: TextAttributeInput!
+  kind: TextAttributeInput!
+  message: TextAttributeInput
+  conclusion: TextAttributeInput
+  severity: TextAttributeInput
+  created_at: TextAttributeInput
+  validator: RelatedNodeInput!
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A standard check"""
+type CoreStandardCheckUpdate {
+  ok: Boolean
+  object: CoreStandardCheck
+}
+
+input CoreStandardCheckUpdateInput {
+  id: String!
+  name: TextAttributeInput
+  label: TextAttributeInput
+  origin: TextAttributeInput
+  kind: TextAttributeInput
+  message: TextAttributeInput
+  conclusion: TextAttributeInput
+  severity: TextAttributeInput
+  created_at: TextAttributeInput
+  validator: RelatedNodeInput
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A standard check"""
+type CoreStandardCheckUpsert {
+  ok: Boolean
+  object: CoreStandardCheck
+}
+
+"""A standard check"""
+type CoreStandardCheckDelete {
+  ok: Boolean
+}
+
+"""A check related to the schema"""
+type CoreSchemaCheckCreate {
+  ok: Boolean
+  object: CoreSchemaCheck
+}
+
+input CoreSchemaCheckCreateInput {
+  id: String
+  conflicts: JSONAttributeInput!
+  name: TextAttributeInput
+  label: TextAttributeInput
+  origin: TextAttributeInput!
+  kind: TextAttributeInput!
+  message: TextAttributeInput
+  conclusion: TextAttributeInput
+  severity: TextAttributeInput
+  created_at: TextAttributeInput
+  validator: RelatedNodeInput!
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A check related to the schema"""
+type CoreSchemaCheckUpdate {
+  ok: Boolean
+  object: CoreSchemaCheck
+}
+
+input CoreSchemaCheckUpdateInput {
+  id: String!
+  conflicts: JSONAttributeInput
+  name: TextAttributeInput
+  label: TextAttributeInput
+  origin: TextAttributeInput
+  kind: TextAttributeInput
+  message: TextAttributeInput
+  conclusion: TextAttributeInput
+  severity: TextAttributeInput
+  created_at: TextAttributeInput
+  validator: RelatedNodeInput
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A check related to the schema"""
+type CoreSchemaCheckUpsert {
+  ok: Boolean
+  object: CoreSchemaCheck
+}
+
+"""A check related to the schema"""
+type CoreSchemaCheckDelete {
+  ok: Boolean
+}
+
+"""A check related to a file in a Git Repository"""
+type CoreFileCheckCreate {
+  ok: Boolean
+  object: CoreFileCheck
+}
+
+input CoreFileCheckCreateInput {
+  id: String
+  files: ListAttributeInput
+  commit: TextAttributeInput
+  name: TextAttributeInput
+  label: TextAttributeInput
+  origin: TextAttributeInput!
+  kind: TextAttributeInput!
+  message: TextAttributeInput
+  conclusion: TextAttributeInput
+  severity: TextAttributeInput
+  created_at: TextAttributeInput
+  validator: RelatedNodeInput!
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+input ListAttributeInput {
+  is_visible: Boolean
+  is_protected: Boolean
+  source: String
+  owner: String
+  value: GenericScalar
+}
+
+"""A check related to a file in a Git Repository"""
+type CoreFileCheckUpdate {
+  ok: Boolean
+  object: CoreFileCheck
+}
+
+input CoreFileCheckUpdateInput {
+  id: String!
+  files: ListAttributeInput
+  commit: TextAttributeInput
+  name: TextAttributeInput
+  label: TextAttributeInput
+  origin: TextAttributeInput
+  kind: TextAttributeInput
+  message: TextAttributeInput
+  conclusion: TextAttributeInput
+  severity: TextAttributeInput
+  created_at: TextAttributeInput
+  validator: RelatedNodeInput
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A check related to a file in a Git Repository"""
+type CoreFileCheckUpsert {
+  ok: Boolean
+  object: CoreFileCheck
+}
+
+"""A check related to a file in a Git Repository"""
+type CoreFileCheckDelete {
+  ok: Boolean
+}
+
+"""A check related to an artifact"""
+type CoreArtifactCheckCreate {
+  ok: Boolean
+  object: CoreArtifactCheck
+}
+
+input CoreArtifactCheckCreateInput {
+  id: String
+  changed: CheckboxAttributeInput
+  checksum: TextAttributeInput
+  artifact_id: TextAttributeInput
+  storage_id: TextAttributeInput
+  line_number: NumberAttributeInput
+  name: TextAttributeInput
+  label: TextAttributeInput
+  origin: TextAttributeInput!
+  kind: TextAttributeInput!
+  message: TextAttributeInput
+  conclusion: TextAttributeInput
+  severity: TextAttributeInput
+  created_at: TextAttributeInput
+  validator: RelatedNodeInput!
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A check related to an artifact"""
+type CoreArtifactCheckUpdate {
+  ok: Boolean
+  object: CoreArtifactCheck
+}
+
+input CoreArtifactCheckUpdateInput {
+  id: String!
+  changed: CheckboxAttributeInput
+  checksum: TextAttributeInput
+  artifact_id: TextAttributeInput
+  storage_id: TextAttributeInput
+  line_number: NumberAttributeInput
+  name: TextAttributeInput
+  label: TextAttributeInput
+  origin: TextAttributeInput
+  kind: TextAttributeInput
+  message: TextAttributeInput
+  conclusion: TextAttributeInput
+  severity: TextAttributeInput
+  created_at: TextAttributeInput
+  validator: RelatedNodeInput
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A check related to an artifact"""
+type CoreArtifactCheckUpsert {
+  ok: Boolean
+  object: CoreArtifactCheck
+}
+
+"""A check related to an artifact"""
+type CoreArtifactCheckDelete {
+  ok: Boolean
+}
+
+"""A check to validate the data integrity between two branches"""
+type CoreDataValidatorCreate {
+  ok: Boolean
+  object: CoreDataValidator
+}
+
+input CoreDataValidatorCreateInput {
+  id: String
+  label: TextAttributeInput
+  state: TextAttributeInput
+  conclusion: TextAttributeInput
+  completed_at: TextAttributeInput
+  started_at: TextAttributeInput
+  proposed_change: RelatedNodeInput!
+  checks: [RelatedNodeInput]
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A check to validate the data integrity between two branches"""
+type CoreDataValidatorUpdate {
+  ok: Boolean
+  object: CoreDataValidator
+}
+
+input CoreDataValidatorUpdateInput {
+  id: String!
+  label: TextAttributeInput
+  state: TextAttributeInput
+  conclusion: TextAttributeInput
+  completed_at: TextAttributeInput
+  started_at: TextAttributeInput
+  proposed_change: RelatedNodeInput
+  checks: [RelatedNodeInput]
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A check to validate the data integrity between two branches"""
+type CoreDataValidatorUpsert {
+  ok: Boolean
+  object: CoreDataValidator
+}
+
+"""A check to validate the data integrity between two branches"""
+type CoreDataValidatorDelete {
+  ok: Boolean
+}
+
+"""A Validator related to a specific repository"""
+type CoreRepositoryValidatorCreate {
+  ok: Boolean
+  object: CoreRepositoryValidator
+}
+
+input CoreRepositoryValidatorCreateInput {
+  id: String
+  label: TextAttributeInput
+  state: TextAttributeInput
+  conclusion: TextAttributeInput
+  completed_at: TextAttributeInput
+  started_at: TextAttributeInput
+  repository: RelatedNodeInput!
+  proposed_change: RelatedNodeInput!
+  checks: [RelatedNodeInput]
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A Validator related to a specific repository"""
+type CoreRepositoryValidatorUpdate {
+  ok: Boolean
+  object: CoreRepositoryValidator
+}
+
+input CoreRepositoryValidatorUpdateInput {
+  id: String!
+  label: TextAttributeInput
+  state: TextAttributeInput
+  conclusion: TextAttributeInput
+  completed_at: TextAttributeInput
+  started_at: TextAttributeInput
+  repository: RelatedNodeInput
+  proposed_change: RelatedNodeInput
+  checks: [RelatedNodeInput]
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A Validator related to a specific repository"""
+type CoreRepositoryValidatorUpsert {
+  ok: Boolean
+  object: CoreRepositoryValidator
+}
+
+"""A Validator related to a specific repository"""
+type CoreRepositoryValidatorDelete {
+  ok: Boolean
+}
+
+"""A Validator related to a user defined checks in a repository"""
+type CoreUserValidatorCreate {
+  ok: Boolean
+  object: CoreUserValidator
+}
+
+input CoreUserValidatorCreateInput {
+  id: String
+  label: TextAttributeInput
+  state: TextAttributeInput
+  conclusion: TextAttributeInput
+  completed_at: TextAttributeInput
+  started_at: TextAttributeInput
+  check_definition: RelatedNodeInput!
+  repository: RelatedNodeInput!
+  proposed_change: RelatedNodeInput!
+  checks: [RelatedNodeInput]
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A Validator related to a user defined checks in a repository"""
+type CoreUserValidatorUpdate {
+  ok: Boolean
+  object: CoreUserValidator
+}
+
+input CoreUserValidatorUpdateInput {
+  id: String!
+  label: TextAttributeInput
+  state: TextAttributeInput
+  conclusion: TextAttributeInput
+  completed_at: TextAttributeInput
+  started_at: TextAttributeInput
+  check_definition: RelatedNodeInput
+  repository: RelatedNodeInput
+  proposed_change: RelatedNodeInput
+  checks: [RelatedNodeInput]
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A Validator related to a user defined checks in a repository"""
+type CoreUserValidatorUpsert {
+  ok: Boolean
+  object: CoreUserValidator
+}
+
+"""A Validator related to a user defined checks in a repository"""
+type CoreUserValidatorDelete {
+  ok: Boolean
+}
+
+"""A validator related to the schema"""
+type CoreSchemaValidatorCreate {
+  ok: Boolean
+  object: CoreSchemaValidator
+}
+
+input CoreSchemaValidatorCreateInput {
+  id: String
+  label: TextAttributeInput
+  state: TextAttributeInput
+  conclusion: TextAttributeInput
+  completed_at: TextAttributeInput
+  started_at: TextAttributeInput
+  proposed_change: RelatedNodeInput!
+  checks: [RelatedNodeInput]
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A validator related to the schema"""
+type CoreSchemaValidatorUpdate {
+  ok: Boolean
+  object: CoreSchemaValidator
+}
+
+input CoreSchemaValidatorUpdateInput {
+  id: String!
+  label: TextAttributeInput
+  state: TextAttributeInput
+  conclusion: TextAttributeInput
+  completed_at: TextAttributeInput
+  started_at: TextAttributeInput
+  proposed_change: RelatedNodeInput
+  checks: [RelatedNodeInput]
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A validator related to the schema"""
+type CoreSchemaValidatorUpsert {
+  ok: Boolean
+  object: CoreSchemaValidator
+}
+
+"""A validator related to the schema"""
+type CoreSchemaValidatorDelete {
+  ok: Boolean
+}
+
+"""A validator related to the artifacts"""
+type CoreArtifactValidatorCreate {
+  ok: Boolean
+  object: CoreArtifactValidator
+}
+
+input CoreArtifactValidatorCreateInput {
+  id: String
+  label: TextAttributeInput
+  state: TextAttributeInput
+  conclusion: TextAttributeInput
+  completed_at: TextAttributeInput
+  started_at: TextAttributeInput
+  definition: RelatedNodeInput!
+  proposed_change: RelatedNodeInput!
+  checks: [RelatedNodeInput]
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A validator related to the artifacts"""
+type CoreArtifactValidatorUpdate {
+  ok: Boolean
+  object: CoreArtifactValidator
+}
+
+input CoreArtifactValidatorUpdateInput {
+  id: String!
+  label: TextAttributeInput
+  state: TextAttributeInput
+  conclusion: TextAttributeInput
+  completed_at: TextAttributeInput
+  started_at: TextAttributeInput
+  definition: RelatedNodeInput
+  proposed_change: RelatedNodeInput
+  checks: [RelatedNodeInput]
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A validator related to the artifacts"""
+type CoreArtifactValidatorUpsert {
+  ok: Boolean
+  object: CoreArtifactValidator
+}
+
+"""A validator related to the artifacts"""
+type CoreArtifactValidatorDelete {
+  ok: Boolean
+}
+
+type CoreCheckDefinitionCreate {
+  ok: Boolean
+  object: CoreCheckDefinition
+}
+
+input CoreCheckDefinitionCreateInput {
+  id: String
+  name: TextAttributeInput!
+  description: TextAttributeInput
+  file_path: TextAttributeInput!
+  class_name: TextAttributeInput!
+  timeout: NumberAttributeInput
+  parameters: JSONAttributeInput
+  repository: RelatedNodeInput!
+  query: RelatedNodeInput
+  targets: RelatedNodeInput
+  tags: [RelatedNodeInput]
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+type CoreCheckDefinitionUpdate {
+  ok: Boolean
+  object: CoreCheckDefinition
+}
+
+input CoreCheckDefinitionUpdateInput {
+  id: String!
+  name: TextAttributeInput
+  description: TextAttributeInput
+  file_path: TextAttributeInput
+  class_name: TextAttributeInput
+  timeout: NumberAttributeInput
+  parameters: JSONAttributeInput
+  repository: RelatedNodeInput
+  query: RelatedNodeInput
+  targets: RelatedNodeInput
+  tags: [RelatedNodeInput]
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+type CoreCheckDefinitionUpsert {
+  ok: Boolean
+  object: CoreCheckDefinition
+}
+
+type CoreCheckDefinitionDelete {
+  ok: Boolean
+}
+
+"""A transform function written in Python"""
+type CoreTransformPythonCreate {
+  ok: Boolean
+  object: CoreTransformPython
+}
+
+input CoreTransformPythonCreateInput {
+  id: String
+  file_path: TextAttributeInput!
+  class_name: TextAttributeInput!
+  name: TextAttributeInput!
+  label: TextAttributeInput
+  description: TextAttributeInput
+  timeout: NumberAttributeInput
+  query: RelatedNodeInput!
+  repository: RelatedNodeInput!
+  tags: [RelatedNodeInput]
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A transform function written in Python"""
+type CoreTransformPythonUpdate {
+  ok: Boolean
+  object: CoreTransformPython
+}
+
+input CoreTransformPythonUpdateInput {
+  id: String!
+  file_path: TextAttributeInput
+  class_name: TextAttributeInput
+  name: TextAttributeInput
+  label: TextAttributeInput
+  description: TextAttributeInput
+  timeout: NumberAttributeInput
+  query: RelatedNodeInput
+  repository: RelatedNodeInput
+  tags: [RelatedNodeInput]
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A transform function written in Python"""
+type CoreTransformPythonUpsert {
+  ok: Boolean
+  object: CoreTransformPython
+}
+
+"""A transform function written in Python"""
+type CoreTransformPythonDelete {
+  ok: Boolean
+}
+
+"""A pre-defined GraphQL Query"""
+type CoreGraphQLQueryCreate {
+  ok: Boolean
+  object: CoreGraphQLQuery
+}
+
+input CoreGraphQLQueryCreateInput {
+  id: String
+  name: TextAttributeInput!
+  description: TextAttributeInput
+  query: TextAttributeInput!
+
+  """variables in use in the query"""
+  variables: JSONAttributeInput
+  repository: RelatedNodeInput
+  tags: [RelatedNodeInput]
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A pre-defined GraphQL Query"""
+type CoreGraphQLQueryUpdate {
+  ok: Boolean
+  object: CoreGraphQLQuery
+}
+
+input CoreGraphQLQueryUpdateInput {
+  id: String!
+  name: TextAttributeInput
+  description: TextAttributeInput
+  query: TextAttributeInput
+
+  """variables in use in the query"""
+  variables: JSONAttributeInput
+  repository: RelatedNodeInput
+  tags: [RelatedNodeInput]
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A pre-defined GraphQL Query"""
+type CoreGraphQLQueryUpsert {
+  ok: Boolean
+  object: CoreGraphQLQuery
+}
+
+"""A pre-defined GraphQL Query"""
+type CoreGraphQLQueryDelete {
+  ok: Boolean
+}
+
+type CoreArtifactCreate {
+  ok: Boolean
+  object: CoreArtifact
+}
+
+input CoreArtifactCreateInput {
+  id: String
+  name: TextAttributeInput!
+  status: TextAttributeInput!
+  content_type: TextAttributeInput!
+  checksum: TextAttributeInput
+
+  """ID of the file in the object store"""
+  storage_id: TextAttributeInput
+  parameters: JSONAttributeInput
+  object: RelatedNodeInput!
+  definition: RelatedNodeInput!
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+type CoreArtifactUpdate {
+  ok: Boolean
+  object: CoreArtifact
+}
+
+input CoreArtifactUpdateInput {
+  id: String!
+  name: TextAttributeInput
+  status: TextAttributeInput
+  content_type: TextAttributeInput
+  checksum: TextAttributeInput
+
+  """ID of the file in the object store"""
+  storage_id: TextAttributeInput
+  parameters: JSONAttributeInput
+  object: RelatedNodeInput
+  definition: RelatedNodeInput
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+type CoreArtifactUpsert {
+  ok: Boolean
+  object: CoreArtifact
+}
+
+type CoreArtifactDelete {
+  ok: Boolean
+}
+
+type CoreArtifactDefinitionCreate {
+  ok: Boolean
+  object: CoreArtifactDefinition
+}
+
+input CoreArtifactDefinitionCreateInput {
+  id: String
+  name: TextAttributeInput!
+  artifact_name: TextAttributeInput!
+  description: TextAttributeInput
+  parameters: JSONAttributeInput!
+  content_type: TextAttributeInput!
+  targets: RelatedNodeInput!
+  transformation: RelatedNodeInput!
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+type CoreArtifactDefinitionUpdate {
+  ok: Boolean
+  object: CoreArtifactDefinition
+}
+
+input CoreArtifactDefinitionUpdateInput {
+  id: String!
+  name: TextAttributeInput
+  artifact_name: TextAttributeInput
+  description: TextAttributeInput
+  parameters: JSONAttributeInput
+  content_type: TextAttributeInput
+  targets: RelatedNodeInput
+  transformation: RelatedNodeInput
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+type CoreArtifactDefinitionUpsert {
+  ok: Boolean
+  object: CoreArtifactDefinition
+}
+
+type CoreArtifactDefinitionDelete {
+  ok: Boolean
+}
+
+"""A webhook that connects to an external integration"""
+type CoreStandardWebhookCreate {
+  ok: Boolean
+  object: CoreStandardWebhook
+}
+
+input CoreStandardWebhookCreateInput {
+  id: String
+  shared_key: TextAttributeInput!
+  name: TextAttributeInput!
+  description: TextAttributeInput
+  url: TextAttributeInput!
+  validate_certificates: CheckboxAttributeInput
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A webhook that connects to an external integration"""
+type CoreStandardWebhookUpdate {
+  ok: Boolean
+  object: CoreStandardWebhook
+}
+
+input CoreStandardWebhookUpdateInput {
+  id: String!
+  shared_key: TextAttributeInput
+  name: TextAttributeInput
+  description: TextAttributeInput
+  url: TextAttributeInput
+  validate_certificates: CheckboxAttributeInput
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A webhook that connects to an external integration"""
+type CoreStandardWebhookUpsert {
+  ok: Boolean
+  object: CoreStandardWebhook
+}
+
+"""A webhook that connects to an external integration"""
+type CoreStandardWebhookDelete {
+  ok: Boolean
+}
+
+"""A webhook that connects to an external integration"""
+type CoreCustomWebhookCreate {
+  ok: Boolean
+  object: CoreCustomWebhook
+}
+
+input CoreCustomWebhookCreateInput {
+  id: String
+  name: TextAttributeInput!
+  description: TextAttributeInput
+  url: TextAttributeInput!
+  validate_certificates: CheckboxAttributeInput
+  transformation: RelatedNodeInput
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A webhook that connects to an external integration"""
+type CoreCustomWebhookUpdate {
+  ok: Boolean
+  object: CoreCustomWebhook
+}
+
+input CoreCustomWebhookUpdateInput {
+  id: String!
+  name: TextAttributeInput
+  description: TextAttributeInput
+  url: TextAttributeInput
+  validate_certificates: CheckboxAttributeInput
+  transformation: RelatedNodeInput
+  member_of_groups: [RelatedNodeInput]
+  subscriber_of_groups: [RelatedNodeInput]
+}
+
+"""A webhook that connects to an external integration"""
+type CoreCustomWebhookUpsert {
+  ok: Boolean
+  object: CoreCustomWebhook
+}
+
+"""A webhook that connects to an external integration"""
+type CoreCustomWebhookDelete {
+  ok: Boolean
+}
+
+type CoreAccountTokenCreate {
+  ok: Boolean
+  object: CoreAccountTokenType
+}
+
+type CoreAccountTokenType {
+  token: ValueType
+}
+
+type ValueType {
+  value: String!
+}
+
+input CoreAccountTokenCreateInput {
+  """The name of the token"""
+  name: String
+
+  """Timestamp when the token expires"""
+  expiration: String
+}
+
+type CoreAccountSelfUpdate {
+  ok: Boolean
+}
+
+input CoreAccountUpdateSelfInput {
+  """The new password"""
+  password: String
+
+  """The new description"""
+  description: String
+}
+
+type ProposedChangeRequestRunCheck {
+  ok: Boolean
+}
+
+input ProposedChangeRequestRunCheckInput {
+  id: String!
+  check_type: CheckType
+}
+
+"""An enumeration."""
+enum CheckType {
+  ARTIFACT
+  DATA
+  REPOSITORY
+  SCHEMA
+  TEST
+  USER
+  ALL
+}
+
+type BranchCreate {
+  ok: Boolean
+  object: Branch
+}
+
+input BranchCreateInput {
+  id: String
+  name: String!
+  description: String
+  origin_branch: String
+  branched_from: String
+  sync_with_git: Boolean
+  is_isolated: Boolean
+}
+
+type BranchDelete {
+  ok: Boolean
+}
+
+input BranchNameInput {
+  name: String
+}
+
+type BranchRebase {
+  ok: Boolean
+  object: Branch
+}
+
+type BranchMerge {
+  ok: Boolean
+  object: Branch
+}
+
+type BranchUpdate {
+  ok: Boolean
+}
+
+input BranchUpdateInput {
+  name: String!
+  description: String
+  is_isolated: Boolean
+}
+
+type BranchValidate {
+  ok: Boolean
+  messages: [String]
+  object: Branch
+}
+
+type TaskCreate {
+  ok: Boolean
+  object: TaskFields
+}
+
+type TaskFields {
+  id: String
+  title: String
+  conclusion: TaskConclusion
+}
+
+"""An enumeration."""
+enum TaskConclusion {
+  UNKNOWN
+  FAILURE
+  SUCCESS
+}
+
+input TaskCreateInput {
+  id: UUID
+  title: String!
+  created_by: String
+  conclusion: TaskConclusion!
+  related_node: String
+  logs: [RelatedTaskLogCreateInput]
+}
+
+"""
+Leverages the internal Python implementation of UUID (uuid.UUID) to provide native UUID objects
+in fields, resolvers and input.
+"""
+scalar UUID
+
+input RelatedTaskLogCreateInput {
+  message: String!
+  severity: Severity!
+}
+
+"""An enumeration."""
+enum Severity {
+  SUCCESS
+  INFO
+  WARNING
+  ERROR
+  CRITICAL
+}
+
+type TaskUpdate {
+  ok: Boolean
+  object: TaskFields
+}
+
+input TaskUpdateInput {
+  id: UUID!
+  title: String
+  conclusion: TaskConclusion
+  logs: [RelatedTaskLogCreateInput]
+}
+
+type RelationshipAdd {
+  ok: Boolean
+}
+
+input RelationshipNodesInput {
+  """ID of the node at the source of the relationship"""
+  id: String
+
+  """Name of the relationship to add or remove nodes"""
+  name: String
+
+  """List of nodes to add or remove to the relationships"""
+  nodes: [RelatedNodeInput]
+}
+
+type RelationshipRemove {
+  ok: Boolean
+}
+
+type SchemaDropdownAdd {
+  ok: Boolean
+  object: DropdownFields
+}
+
+type DropdownFields {
+  value: String
+  label: String
+  color: String
+  description: String
+}
+
+input SchemaDropdownAddInput {
+  kind: String!
+  attribute: String!
+  dropdown: String!
+  color: String
+  description: String
+  label: String
+}
+
+type SchemaDropdownRemove {
+  ok: Boolean
+}
+
+input SchemaDropdownRemoveInput {
+  kind: String!
+  attribute: String!
+  dropdown: String!
+}
+
+type SchemaEnumAdd {
+  ok: Boolean
+}
+
+input SchemaEnumInput {
+  kind: String!
+  attribute: String!
+  enum: String!
+}
+
+type SchemaEnumRemove {
+  ok: Boolean
+}
+
+type Subscription {
+  query(name: String, params: GenericScalar, interval: Int): GenericScalar
+}


### PR DESCRIPTION
Currently this is failing due unpredictable sorting of fields within the schema.. Need to figure out how to enforce how everything is sorted..