### PR TITLE
Clean up mapped methods within the registry

### DIFF
--- a/backend/infrahub/api/dependencies.py
+++ b/backend/infrahub/api/dependencies.py
@@ -8,8 +8,8 @@ from pydantic.v1 import BaseModel
 
 from infrahub import config
 from infrahub.auth import AccountSession, authentication_token, validate_jwt_access_token, validate_jwt_refresh_token
-from infrahub.core import get_branch
 from infrahub.core.branch import Branch  # noqa: TCH001
+from infrahub.core.registry import registry
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase  # noqa: TCH001
 from infrahub.exceptions import AuthorizationError, PermissionDeniedError
@@ -84,7 +84,7 @@ async def get_branch_params(
     branch_name: Optional[str] = Query(None, alias="branch", description="Name of the branch to use for the query"),
     at: Optional[str] = Query(None, description="Time to use for the query, in absolute or relative format"),
 ) -> BranchParams:
-    branch = await get_branch(db=db, branch=branch_name)
+    branch = await registry.get_branch(db=db, branch=branch_name)
     at = Timestamp(at)
 
     return BranchParams(branch=branch, at=at)
@@ -94,7 +94,7 @@ async def get_branch_dep(
     db: InfrahubDatabase = Depends(get_db),
     branch_name: Optional[str] = Query(None, alias="branch", description="Name of the branch to use for the query"),
 ) -> Branch:
-    return await get_branch(db=db, branch=branch_name)
+    return await registry.get_branch(db=db, branch=branch_name)
 
 
 async def get_current_user(

--- a/backend/infrahub/auth.py
+++ b/backend/infrahub/auth.py
@@ -10,11 +10,11 @@ import jwt
 from pydantic.v1 import BaseModel
 
 from infrahub import config, models
-from infrahub.core import get_branch
 from infrahub.core.account import validate_token
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
+from infrahub.core.registry import registry
 from infrahub.exceptions import AuthorizationError, NodeNotFoundError
 
 if TYPE_CHECKING:
@@ -44,7 +44,7 @@ class AccountSession(BaseModel):
 async def authenticate_with_password(
     db: InfrahubDatabase, credentials: models.PasswordCredential, branch: Optional[str] = None
 ) -> models.UserToken:
-    selected_branch = await get_branch(db=db, branch=branch)
+    selected_branch = await registry.get_branch(db=db, branch=branch)
     response = await NodeManager.query(
         schema=InfrahubKind.ACCOUNT,
         db=db,
@@ -88,7 +88,7 @@ async def create_db_refresh_token(db: InfrahubDatabase, account_id: str, expirat
 async def create_fresh_access_token(
     db: InfrahubDatabase, refresh_data: models.RefreshTokenData
 ) -> models.AccessTokenResponse:
-    selected_branch = await get_branch(db=db)
+    selected_branch = await registry.get_branch(db=db)
 
     refresh_token = await NodeManager.get_one(
         id=str(refresh_data.session_id),

--- a/backend/infrahub/core/__init__.py
+++ b/backend/infrahub/core/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-from infrahub.core.registry import get_branch, get_branch_from_registry, registry
+from infrahub.core.registry import registry
 
-__all__ = ["get_branch_from_registry", "get_branch", "registry"]
+__all__ = ["registry"]

--- a/backend/infrahub/core/account.py
+++ b/backend/infrahub/core/account.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, Tuple, Union
 
-from infrahub.core import get_branch, registry
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.manager import NodeManager
 from infrahub.core.query import Query
+from infrahub.core.registry import registry
 
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
@@ -77,7 +77,7 @@ class AccountTokenValidateQuery(Query):
 async def validate_token(
     token, db: InfrahubDatabase, branch: Optional[Union[Branch, str]] = None, at=None
 ) -> Tuple[Optional[str], str]:
-    branch = await get_branch(db=db, branch=branch)
+    branch = await registry.get_branch(db=db, branch=branch)
     query = await AccountTokenValidateQuery.init(db=db, branch=branch, token=token, at=at)
     await query.execute(db=db)
     return query.get_account_id(), query.get_account_role()

--- a/backend/infrahub/core/branch.py
+++ b/backend/infrahub/core/branch.py
@@ -17,7 +17,7 @@ from infrahub.core.query.branch import (
     RebaseBranchDeleteRelationshipQuery,
     RebaseBranchUpdateRelationshipQuery,
 )
-from infrahub.core.registry import get_branch_from_registry, registry
+from infrahub.core.registry import registry
 from infrahub.core.timestamp import Timestamp
 from infrahub.exceptions import BranchNotFoundError, InitializationError, ValidationError
 
@@ -146,7 +146,7 @@ class Branch(StandardNode):  # pylint: disable=too-many-public-methods
         if not self.origin_branch or self.origin_branch == self.name:
             return None
 
-        return get_branch_from_registry(branch=self.origin_branch)
+        return registry.get_branch_from_registry(branch=self.origin_branch)
 
     def get_branches_in_scope(self) -> List[str]:
         """Return the list of all the branches that are constituing this branch.

--- a/backend/infrahub/core/diff/payload_builder.py
+++ b/backend/infrahub/core/diff/payload_builder.py
@@ -4,9 +4,9 @@ import copy
 from collections import defaultdict
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
-from infrahub.core import get_branch, registry
 from infrahub.core.constants import DiffAction, RelationshipCardinality
 from infrahub.core.manager import NodeManager
+from infrahub.core.registry import registry
 from infrahub.log import get_logger
 
 from .model import (
@@ -45,7 +45,7 @@ async def get_display_labels_per_kind(
     kind: str, ids: List[str], branch_name: str, db: InfrahubDatabase
 ) -> Dict[str, str]:
     """Return the display_labels of a list of nodes of a specific kind."""
-    branch = await get_branch(branch=branch_name, db=db)
+    branch = await registry.get_branch(branch=branch_name, db=db)
     schema = registry.schema.get(name=kind, branch=branch)
     fields = schema.generate_fields_for_display_label()
     nodes = await NodeManager.get_many(ids=ids, fields=fields, db=db, branch=branch)

--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Type, Union
 
 from infrahub_sdk.utils import deep_merge_dict
 
-from infrahub.core import get_branch, registry
 from infrahub.core.node import Node
 from infrahub.core.query.node import (
     NodeGetHierarchyQuery,
@@ -15,6 +14,7 @@ from infrahub.core.query.node import (
     NodeToProcess,
 )
 from infrahub.core.query.relationship import RelationshipGetPeerQuery
+from infrahub.core.registry import registry
 from infrahub.core.relationship import Relationship
 from infrahub.core.schema import GenericSchema, NodeSchema, RelationshipSchema
 from infrahub.core.timestamp import Timestamp
@@ -79,7 +79,7 @@ class NodeManager:
             List[Node]: List of Node object
         """
 
-        branch = await get_branch(branch=branch, db=db)
+        branch = await registry.get_branch(branch=branch, db=db)
         at = Timestamp(at)
 
         if isinstance(schema, str):
@@ -143,7 +143,7 @@ class NodeManager:
             int: The number of responses found
         """
 
-        branch = await get_branch(branch=branch, db=db)
+        branch = await registry.get_branch(branch=branch, db=db)
         at = Timestamp(at)
 
         query = await NodeGetListQuery.init(
@@ -162,7 +162,7 @@ class NodeManager:
         at: Optional[Union[Timestamp, str]] = None,
         branch: Optional[Union[Branch, str]] = None,
     ) -> int:
-        branch = await get_branch(branch=branch, db=db)
+        branch = await registry.get_branch(branch=branch, db=db)
         at = Timestamp(at)
 
         rel = Relationship(schema=schema, branch=branch, node_id="PLACEHOLDER")
@@ -186,7 +186,7 @@ class NodeManager:
         at: Union[Timestamp, str] = None,
         branch: Union[Branch, str] = None,
     ) -> List[Relationship]:
-        branch = await get_branch(branch=branch, db=db)
+        branch = await registry.get_branch(branch=branch, db=db)
         at = Timestamp(at)
 
         rel = Relationship(schema=schema, branch=branch, node_id="PLACEHOLDER")
@@ -237,7 +237,7 @@ class NodeManager:
         at: Optional[Union[Timestamp, str]] = None,
         branch: Optional[Union[Branch, str]] = None,
     ) -> int:
-        branch = await get_branch(branch=branch, db=db)
+        branch = await registry.get_branch(branch=branch, db=db)
         at = Timestamp(at)
 
         query = await NodeGetHierarchyQuery.init(
@@ -266,7 +266,7 @@ class NodeManager:
         at: Union[Timestamp, str] = None,
         branch: Union[Branch, str] = None,
     ) -> Dict[str, Node]:
-        branch = await get_branch(branch=branch, db=db)
+        branch = await registry.get_branch(branch=branch, db=db)
         at = Timestamp(at)
 
         query = await NodeGetHierarchyQuery.init(
@@ -313,7 +313,7 @@ class NodeManager:
         prefetch_relationships: bool = False,
         account=None,
     ) -> Node:
-        branch = await get_branch(branch=branch, db=db)
+        branch = await registry.get_branch(branch=branch, db=db)
         at = Timestamp(at)
 
         node_schema = registry.schema.get(name=schema_name, branch=branch)
@@ -358,7 +358,7 @@ class NodeManager:
         prefetch_relationships: bool = False,
         account=None,
     ) -> Node:
-        branch = await get_branch(branch=branch, db=db)
+        branch = await registry.get_branch(branch=branch, db=db)
         at = Timestamp(at)
 
         node = await cls.get_one(
@@ -448,7 +448,7 @@ class NodeManager:
     ) -> Dict[str, Node]:
         """Return a list of nodes based on their IDs."""
 
-        branch = await get_branch(branch=branch, db=db)
+        branch = await registry.get_branch(branch=branch, db=db)
         at = Timestamp(at)
 
         # Query all nodes

--- a/backend/infrahub/core/registry.py
+++ b/backend/infrahub/core/registry.py
@@ -220,6 +220,3 @@ class Registry:
 
 
 registry = Registry()
-
-get_branch_from_registry = registry.get_branch_from_registry
-get_branch = registry.get_branch

--- a/backend/infrahub/core/schema_manager.py
+++ b/backend/infrahub/core/schema_manager.py
@@ -9,7 +9,6 @@ from infrahub_sdk.utils import compare_lists, duplicates, intersection
 from pydantic import BaseModel
 
 from infrahub import lock
-from infrahub.core import get_branch, get_branch_from_registry
 from infrahub.core.constants import (
     RESERVED_ATTR_GEN_NAMES,
     RESERVED_ATTR_REL_NAMES,
@@ -1193,7 +1192,7 @@ class SchemaManager(NodeManager):
         self, name: str, branch: Optional[Union[Branch, str]] = None, duplicate: bool = True
     ) -> Union[NodeSchema, GenericSchema]:
         # For now we assume that all branches are present, will see how we need to pull new branches later.
-        branch = get_branch_from_registry(branch=branch)
+        branch = registry.get_branch_from_registry(branch=branch)
 
         if branch.name in self._branches:
             try:
@@ -1216,7 +1215,7 @@ class SchemaManager(NodeManager):
     def get_full(
         self, branch: Optional[Union[Branch, str]] = None, duplicate: bool = True
     ) -> Dict[str, Union[NodeSchema, GenericSchema]]:
-        branch = get_branch_from_registry(branch=branch)
+        branch = registry.get_branch_from_registry(branch=branch)
 
         branch_name = None
         if branch.name in self._branches:
@@ -1257,7 +1256,7 @@ class SchemaManager(NodeManager):
         limit: Optional[List[str]] = None,
         update_db: bool = True,
     ):
-        branch = await get_branch(branch=branch, db=db)
+        branch = await registry.get_branch(branch=branch, db=db)
 
         updated_schema = None
         if update_db:
@@ -1299,7 +1298,7 @@ class SchemaManager(NodeManager):
     ) -> SchemaBranchDiff:
         """Load all nodes, generics and groups from a SchemaRoot object into the database."""
 
-        branch = await get_branch(branch=branch, db=db)
+        branch = await registry.get_branch(branch=branch, db=db)
 
         item_kinds = []
         for item_kind, item_diff in diff.added.items():
@@ -1337,7 +1336,7 @@ class SchemaManager(NodeManager):
     ) -> None:
         """Load all nodes, generics and groups from a SchemaRoot object into the database."""
 
-        branch = await get_branch(branch=branch, db=db)
+        branch = await registry.get_branch(branch=branch, db=db)
 
         for item_kind in schema.all_names:
             if limit and item_kind not in limit:
@@ -1357,7 +1356,7 @@ class SchemaManager(NodeManager):
         branch: Optional[Union[str, Branch]] = None,
     ) -> Union[NodeSchema, GenericSchema]:
         """Load a Node with its attributes and its relationships to the database."""
-        branch = await get_branch(branch=branch, db=db)
+        branch = await registry.get_branch(branch=branch, db=db)
 
         node_type = "SchemaNode"
         if isinstance(node, GenericSchema):
@@ -1405,7 +1404,7 @@ class SchemaManager(NodeManager):
         branch: Optional[Union[str, Branch]] = None,
     ) -> Union[NodeSchema, GenericSchema]:
         """Update a Node with its attributes and its relationships in the database."""
-        branch = await get_branch(branch=branch, db=db)
+        branch = await registry.get_branch(branch=branch, db=db)
 
         obj = await self.get_one(id=node.get_id(), branch=branch, db=db)
         if not obj:
@@ -1469,7 +1468,7 @@ class SchemaManager(NodeManager):
         branch: Optional[Union[str, Branch]] = None,
     ) -> Union[NodeSchema, GenericSchema]:
         """Update a Node with its attributes and its relationships in the database based on a HashableModelDiff."""
-        branch = await get_branch(branch=branch, db=db)
+        branch = await registry.get_branch(branch=branch, db=db)
 
         obj = await self.get_one(id=node.get_id(), branch=branch, db=db)
         if not obj:
@@ -1579,7 +1578,7 @@ class SchemaManager(NodeManager):
         branch: Optional[Union[str, Branch]] = None,
     ) -> None:
         """Delete the node with its attributes and relationships."""
-        branch = await get_branch(branch=branch, db=db)
+        branch = await registry.get_branch(branch=branch, db=db)
 
         obj = await self.get_one(id=node.get_id(), branch=branch, db=db)
         if not obj:
@@ -1645,10 +1644,10 @@ class SchemaManager(NodeManager):
         branch: Optional[Union[str, Branch]] = None,
     ) -> SchemaBranch:
         """Load the schema either from the cache or from the database"""
-        branch = await get_branch(branch=branch, db=db)
+        branch = await registry.get_branch(branch=branch, db=db)
 
         if not branch.is_default and branch.origin_branch:
-            origin_branch: Branch = await get_branch(branch=branch.origin_branch, db=db)
+            origin_branch: Branch = await registry.get_branch(branch=branch.origin_branch, db=db)
 
             if origin_branch.schema_hash.main == branch.schema_hash.main:
                 origin_schema = self.get_schema_branch(name=origin_branch.name)
@@ -1686,7 +1685,7 @@ class SchemaManager(NodeManager):
             SchemaBranch
         """
 
-        branch = await get_branch(branch=branch, db=db)
+        branch = await registry.get_branch(branch=branch, db=db)
         schema = schema or SchemaBranch(cache=self._cache, name=branch.name)
 
         # If schema_diff has been provided, we need to build the proper filters for the queries based on the namespace and the name of the object.

--- a/backend/infrahub/graphql/app.py
+++ b/backend/infrahub/graphql/app.py
@@ -45,7 +45,6 @@ from starlette.websockets import WebSocket, WebSocketDisconnect, WebSocketState
 
 from infrahub.api.dependencies import api_key_scheme, cookie_auth_scheme, jwt_scheme
 from infrahub.auth import AccountSession, authentication_token
-from infrahub.core import get_branch
 from infrahub.core.registry import registry
 from infrahub.core.timestamp import Timestamp
 from infrahub.exceptions import BranchNotFoundError, Error
@@ -137,7 +136,7 @@ class InfrahubGraphQLApp:
                 # Retrieve the branch name from the request and validate that it exist in the database
                 try:
                     branch_name = request.path_params.get("branch_name", registry.default_branch)
-                    branch = await get_branch(db=db, branch=branch_name)
+                    branch = await registry.get_branch(db=db, branch=branch_name)
                 except BranchNotFoundError as exc:
                     response = JSONResponse({"errors": [exc.message]}, status_code=404)
 
@@ -162,7 +161,7 @@ class InfrahubGraphQLApp:
 
             async with db.start_session() as db:
                 branch_name = websocket.path_params.get("branch_name", registry.default_branch)
-                branch = await get_branch(db=db, branch=branch_name)
+                branch = await registry.get_branch(db=db, branch=branch_name)
 
                 await self._run_websocket_server(db=db, branch=branch, websocket=websocket)
 

--- a/backend/infrahub/graphql/query.py
+++ b/backend/infrahub/graphql/query.py
@@ -4,10 +4,10 @@ from typing import TYPE_CHECKING, Optional, Union
 
 from graphql import graphql
 
-from infrahub.core import get_branch
 from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.manager import NodeManager
+from infrahub.core.registry import registry
 from infrahub.core.timestamp import Timestamp
 from infrahub.graphql import prepare_graphql_params
 
@@ -27,7 +27,7 @@ async def execute_query(
     """Helper function to Execute a GraphQL Query."""
 
     if not isinstance(branch, Branch):
-        branch = await get_branch(db=db, branch=branch)
+        branch = await registry.get_branch(db=db, branch=branch)
     at = Timestamp(at)
 
     graphql_query = await NodeManager.get_one_by_default_filter(

--- a/backend/tests/unit/core/test_branch.py
+++ b/backend/tests/unit/core/test_branch.py
@@ -1,12 +1,12 @@
 import pytest
 from pydantic import ValidationError as PydanticValidationError
 
-from infrahub.core import get_branch
 from infrahub.core.branch import Branch
 from infrahub.core.constants import GLOBAL_BRANCH_NAME
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
+from infrahub.core.registry import registry
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import BranchNotFoundError, ValidationError
@@ -116,7 +116,7 @@ async def test_branch_branched_form_format_validator(db: InfrahubDatabase):
 
 
 async def test_get_query_filter_relationships_main(db: InfrahubDatabase, base_dataset_02):
-    default_branch = await get_branch(branch="main", db=db)
+    default_branch = await registry.get_branch(branch="main", db=db)
 
     filters, params = default_branch.get_query_filter_relationships(
         rel_labels=["r1", "r2"], at=Timestamp().to_string(), include_outside_parentheses=False
@@ -135,7 +135,7 @@ async def test_get_query_filter_relationships_main(db: InfrahubDatabase, base_da
 
 
 async def test_get_query_filter_relationships_branch1(db: InfrahubDatabase, base_dataset_02):
-    branch1 = await get_branch(branch="branch1", db=db)
+    branch1 = await registry.get_branch(branch="branch1", db=db)
 
     filters, params = branch1.get_query_filter_relationships(
         rel_labels=["r1", "r2"], at=Timestamp().to_string(), include_outside_parentheses=False
@@ -150,7 +150,7 @@ async def test_get_query_filter_relationships_branch1(db: InfrahubDatabase, base
 async def test_get_branches_and_times_to_query_main(db: InfrahubDatabase, base_dataset_02):
     now = Timestamp("1s")
 
-    main_branch = await get_branch(branch="main", db=db)
+    main_branch = await registry.get_branch(branch="main", db=db)
 
     results = main_branch.get_branches_and_times_to_query(at=Timestamp())
     assert Timestamp(results[frozenset(["main"])]) > now
@@ -163,7 +163,7 @@ async def test_get_branches_and_times_to_query_main(db: InfrahubDatabase, base_d
 async def test_get_branches_and_times_to_query_branch1(db: InfrahubDatabase, base_dataset_02):
     now = Timestamp("1s")
 
-    branch1 = await get_branch(branch="branch1", db=db)
+    branch1 = await registry.get_branch(branch="branch1", db=db)
 
     t0 = Timestamp()
     results = branch1.get_branches_and_times_to_query(at=t0)
@@ -184,7 +184,7 @@ async def test_get_branches_and_times_to_query_branch1(db: InfrahubDatabase, bas
 async def test_get_branches_and_times_to_query_global_main(db: InfrahubDatabase, base_dataset_02):
     now = Timestamp("1s")
 
-    main_branch = await get_branch(branch="main", db=db)
+    main_branch = await registry.get_branch(branch="main", db=db)
 
     results = main_branch.get_branches_and_times_to_query_global(at=Timestamp())
     assert Timestamp(results[frozenset((GLOBAL_BRANCH_NAME, "main"))]) > now
@@ -197,7 +197,7 @@ async def test_get_branches_and_times_to_query_global_main(db: InfrahubDatabase,
 async def test_get_branches_and_times_to_query_global_branch1(db: InfrahubDatabase, base_dataset_02):
     now = Timestamp("1s")
 
-    branch1 = await get_branch(branch="branch1", db=db)
+    branch1 = await registry.get_branch(branch="branch1", db=db)
 
     t0 = Timestamp()
     results = branch1.get_branches_and_times_to_query_global(at=t0)
@@ -217,7 +217,7 @@ async def test_get_branches_and_times_to_query_global_branch1(db: InfrahubDataba
 
 async def test_get_branches_and_times_for_range_main(db: InfrahubDatabase, base_dataset_02):
     now = Timestamp()
-    main_branch = await get_branch(branch="main", db=db)
+    main_branch = await registry.get_branch(branch="main", db=db)
 
     start_times, end_times = main_branch.get_branches_and_times_for_range(start_time=Timestamp("1h"), end_time=now)
     assert list(start_times.keys()) == ["main"]
@@ -236,7 +236,7 @@ async def test_get_branches_and_times_for_range_main(db: InfrahubDatabase, base_
 
 async def test_get_branches_and_times_for_range_branch1(db: InfrahubDatabase, base_dataset_02):
     now = Timestamp()
-    branch1 = await get_branch(branch="branch1", db=db)
+    branch1 = await registry.get_branch(branch="branch1", db=db)
 
     start_times, end_times = branch1.get_branches_and_times_for_range(start_time=Timestamp("1h"), end_time=now)
     assert sorted(list(start_times.keys())) == ["branch1", "main"]
@@ -259,7 +259,7 @@ async def test_get_branches_and_times_for_range_branch1(db: InfrahubDatabase, ba
 
 async def test_get_branches_and_times_for_range_branch2(db: InfrahubDatabase, base_dataset_03):
     now = Timestamp()
-    branch2 = await get_branch(branch="branch2", db=db)
+    branch2 = await registry.get_branch(branch="branch2", db=db)
 
     start_times, end_times = branch2.get_branches_and_times_for_range(start_time=Timestamp("1h"), end_time=now)
     assert sorted(list(start_times.keys())) == ["branch2", "main"]

--- a/backend/tests/unit/core/test_branch_diff.py
+++ b/backend/tests/unit/core/test_branch_diff.py
@@ -5,7 +5,6 @@ import pytest
 from deepdiff import DeepDiff
 from pydantic.v1 import Field
 
-from infrahub.core import get_branch, registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import DiffAction, InfrahubKind
 from infrahub.core.diff.branch_differ import BranchDiffer
@@ -13,6 +12,7 @@ from infrahub.core.diff.model import BaseDiffElement
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
+from infrahub.core.registry import registry
 from infrahub.core.schema import AttributeSchema
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
@@ -880,7 +880,7 @@ async def test_diff_relationship_one_conflict(db: InfrahubDatabase, default_bran
 
 
 async def test_diff_relationship_many(db: InfrahubDatabase, default_branch: Branch, base_dataset_04):
-    branch1 = await get_branch(branch="branch1", db=db)
+    branch1 = await registry.get_branch(branch="branch1", db=db)
 
     diff = await BranchDiffer.init(branch=branch1, db=db)
     rels = await diff.get_relationships()

--- a/backend/tests/unit/core/test_manager_node.py
+++ b/backend/tests/unit/core/test_manager_node.py
@@ -1,12 +1,12 @@
 import pytest
 from infrahub_sdk import UUIDT
 
-from infrahub.core import get_branch, registry
 from infrahub.core.branch import Branch
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager, identify_node_class
 from infrahub.core.node import Node
 from infrahub.core.query.node import NodeToProcess
+from infrahub.core.registry import registry
 from infrahub.core.schema import NodeSchema
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
@@ -427,7 +427,7 @@ async def test_get_one_local_attribute_with_branch(db: InfrahubDatabase, default
 
 
 async def test_get_one_global(db: InfrahubDatabase, default_branch: Branch, base_dataset_12):
-    branch1 = await get_branch(db=db, branch="branch1")
+    branch1 = await registry.get_branch(db=db, branch="branch1")
 
     obj1 = await NodeManager.get_one(db=db, id="p1", branch=branch1)
 
@@ -447,7 +447,7 @@ async def test_get_one_global(db: InfrahubDatabase, default_branch: Branch, base
 
 
 async def test_get_one_global_isolated(db: InfrahubDatabase, default_branch: Branch, base_dataset_12):
-    branch1 = await get_branch(db=db, branch="branch1")
+    branch1 = await registry.get_branch(db=db, branch="branch1")
     branch1.is_isolated = True
 
     obj1 = await NodeManager.get_one(db=db, id="p1", branch=branch1)

--- a/backend/tests/unit/core/test_node_query.py
+++ b/backend/tests/unit/core/test_node_query.py
@@ -1,7 +1,6 @@
 import time
 from typing import Dict
 
-from infrahub.core import get_branch, registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind, RelationshipHierarchyDirection
 from infrahub.core.manager import NodeManager
@@ -24,6 +23,7 @@ from infrahub.core.query.node import (
     NodeListGetInfoQuery,
     NodeListGetRelationshipsQuery,
 )
+from infrahub.core.registry import registry
 from infrahub.database import InfrahubDatabase
 
 
@@ -261,8 +261,8 @@ async def test_query_NodeListGetInfoQuery_renamed(
 
 
 async def test_query_NodeListGetAttributeQuery_all_fields(db: InfrahubDatabase, base_dataset_02):
-    default_branch = await get_branch(db=db, branch="main")
-    branch1 = await get_branch(db=db, branch="branch1")
+    default_branch = await registry.get_branch(db=db, branch="main")
+    branch1 = await registry.get_branch(db=db, branch="branch1")
 
     # Query all the nodes in main but only c1 and c2 present
     # Expect 4 attributes per node(x2) = 8 attributes
@@ -312,7 +312,7 @@ async def test_query_NodeListGetAttributeQuery_with_source(
     )
     await obj2.save(db=db)
 
-    default_branch = await get_branch(db=db, branch="main")
+    default_branch = await registry.get_branch(db=db, branch="main")
 
     query = await NodeListGetAttributeQuery.init(
         db=db, ids=[obj1.id, obj2.id], branch=default_branch, include_source=True
@@ -325,8 +325,8 @@ async def test_query_NodeListGetAttributeQuery_with_source(
 
 
 async def test_query_NodeListGetAttributeQuery(db: InfrahubDatabase, base_dataset_02):
-    default_branch = await get_branch(db=db, branch="main")
-    branch1 = await get_branch(db=db, branch="branch1")
+    default_branch = await registry.get_branch(db=db, branch="main")
+    branch1 = await registry.get_branch(db=db, branch="branch1")
 
     # Query all the nodes in main but only c1 and c2 present
     # Expect 2 attributes per node(x2) = 4 attributes
@@ -370,8 +370,8 @@ async def test_query_NodeListGetAttributeQuery(db: InfrahubDatabase, base_datase
 
 
 async def test_query_NodeListGetAttributeQuery_deleted(db: InfrahubDatabase, base_dataset_02):
-    default_branch = await get_branch(db=db, branch="main")
-    branch1 = await get_branch(db=db, branch="branch1")
+    default_branch = await registry.get_branch(db=db, branch="main")
+    branch1 = await registry.get_branch(db=db, branch="branch1")
 
     schema = registry.schema.get_schema_branch(name=branch1.name)
     car_schema = schema.get(name="TestCar")
@@ -417,7 +417,7 @@ async def test_query_NodeListGetAttributeQuery_deleted(db: InfrahubDatabase, bas
 
 
 async def test_query_NodeListGetRelationshipsQuery(db: InfrahubDatabase, default_branch: Branch, person_jack_tags_main):
-    default_branch = await get_branch(db=db, branch="main")
+    default_branch = await registry.get_branch(db=db, branch="main")
     query = await NodeListGetRelationshipsQuery.init(
         db=db,
         ids=[person_jack_tags_main.id],

--- a/backend/tests/unit/core/test_query_branch.py
+++ b/backend/tests/unit/core/test_query_branch.py
@@ -1,11 +1,11 @@
-from infrahub.core import get_branch
 from infrahub.core.branch import Branch
 from infrahub.core.query.branch import GetAllBranchInternalRelationshipQuery
+from infrahub.core.registry import registry
 from infrahub.database import InfrahubDatabase
 
 
 async def test_GetAllBranchInternalRelationshipQuery(db: InfrahubDatabase, default_branch: Branch, base_dataset_02):
-    branch1 = await get_branch(branch="branch1", db=db)
+    branch1 = await registry.get_branch(branch="branch1", db=db)
 
     query = await GetAllBranchInternalRelationshipQuery.init(db=db, branch=branch1)
     await query.execute(db=db)

--- a/backend/tests/unit/core/test_query_diff.py
+++ b/backend/tests/unit/core/test_query_diff.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 
-from infrahub.core import get_branch
 from infrahub.core.query.diff import (
     DiffAttributeQuery,
     DiffNodePropertiesByIDSRangeQuery,
@@ -9,6 +8,7 @@ from infrahub.core.query.diff import (
     DiffRelationshipPropertyQuery,
     DiffRelationshipQuery,
 )
+from infrahub.core.registry import registry
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 
@@ -22,7 +22,7 @@ def group_results_per_node(results):
 
 
 async def test_diff_node_query(db: InfrahubDatabase, default_branch, base_dataset_02):
-    branch1 = await get_branch(branch="branch1", db=db)
+    branch1 = await registry.get_branch(branch="branch1", db=db)
 
     # Query all nodes from the creation of the first nodes (m60) to now
     query = await DiffNodeQuery.init(
@@ -119,7 +119,7 @@ async def test_diff_node_query(db: InfrahubDatabase, default_branch, base_datase
 
 
 async def test_diff_attribute_query(db: InfrahubDatabase, default_branch, base_dataset_02):
-    branch1 = await get_branch(branch="branch1", db=db)
+    branch1 = await registry.get_branch(branch="branch1", db=db)
 
     # Query all attributes from the creation of the branch (m45) to now
     query = await DiffAttributeQuery.init(
@@ -213,7 +213,7 @@ async def test_diff_attribute_query(db: InfrahubDatabase, default_branch, base_d
 
 
 async def test_diff_attribute_query_rebased_branch(db: InfrahubDatabase, default_branch, base_dataset_03):
-    branch2 = await get_branch(branch="branch2", db=db)
+    branch2 = await registry.get_branch(branch="branch2", db=db)
 
     # Query all attributes from the creation of the branch (m45) to now
     query = await DiffAttributeQuery.init(
@@ -229,7 +229,7 @@ async def test_diff_attribute_query_rebased_branch(db: InfrahubDatabase, default
 
 
 async def test_diff_node_properties_ids_range_query(db: InfrahubDatabase, default_branch, base_dataset_02):
-    branch1 = await get_branch(branch="branch1", db=db)
+    branch1 = await registry.get_branch(branch="branch1", db=db)
 
     # Query all Nodes from the creation of the first nodes (m60) to now
     query = await DiffNodePropertiesByIDSRangeQuery.init(
@@ -274,7 +274,7 @@ async def test_diff_node_properties_ids_range_query(db: InfrahubDatabase, defaul
 
 
 async def test_diff_relationship_properties_ids_range_query(db: InfrahubDatabase, default_branch, base_dataset_02):
-    branch1 = await get_branch(branch="branch1", db=db)
+    branch1 = await registry.get_branch(branch="branch1", db=db)
 
     # Query all Rels from the creation of the first nodes (m60) to now
     query = await DiffRelationshipPropertiesByIDSRangeQuery.init(
@@ -318,7 +318,7 @@ async def test_diff_relationship_properties_ids_range_query(db: InfrahubDatabase
 
 
 async def test_DiffRelationshipQuery(db: InfrahubDatabase, base_dataset_02):
-    branch1 = await get_branch(branch="branch1", db=db)
+    branch1 = await registry.get_branch(branch="branch1", db=db)
 
     # Execute the query with default timestamp from the creation of the branch to now
     query = await DiffRelationshipQuery.init(db=db, branch=branch1)
@@ -375,7 +375,7 @@ async def test_DiffRelationshipQuery(db: InfrahubDatabase, base_dataset_02):
 
 
 async def test_DiffRelationshipPropertyQuery(db: InfrahubDatabase, base_dataset_02):
-    branch1 = await get_branch(branch="branch1", db=db)
+    branch1 = await registry.get_branch(branch="branch1", db=db)
 
     # Execute the query with default timestamp from the creation of the branch to now
     # 4 changes are expected
@@ -425,7 +425,7 @@ async def test_DiffRelationshipPropertyQuery(db: InfrahubDatabase, base_dataset_
 
 
 async def test_DiffRelationshipPropertyQuery_both_branches(db: InfrahubDatabase, base_dataset_04):
-    branch1 = await get_branch(branch="branch1", db=db)
+    branch1 = await registry.get_branch(branch="branch1", db=db)
 
     # Execute the query with default timestamp from the creation of the branch to now
     # 4 changes are expected

--- a/backend/tests/unit/core/test_registry.py
+++ b/backend/tests/unit/core/test_registry.py
@@ -1,15 +1,15 @@
-from infrahub.core import get_branch, get_branch_from_registry, registry
 from infrahub.core.branch import Branch
+from infrahub.core.registry import registry
 from infrahub.core.schema import SchemaRoot, internal_schema
 from infrahub.core.schema_manager import SchemaManager
 from infrahub.database import InfrahubDatabase
 
 
 async def test_get_branch_from_registry(db: InfrahubDatabase, default_branch: Branch):
-    br1 = get_branch_from_registry()
+    br1 = registry.get_branch_from_registry()
     assert br1.name == default_branch.name
 
-    br2 = get_branch_from_registry(default_branch.name)
+    br2 = registry.get_branch_from_registry(default_branch.name)
     assert br2.name == default_branch.name
 
 
@@ -24,5 +24,5 @@ async def test_get_branch_not_in_registry(db: InfrahubDatabase, default_branch: 
     branch1.update_schema_hash()
     await branch1.save(db=db)
 
-    br1 = await get_branch(branch=branch1.name, db=db)
+    br1 = await registry.get_branch(branch=branch1.name, db=db)
     assert br1.name == branch1.name


### PR DESCRIPTION
Ever since we cleared out the circular imports we've had these weird mappings where we create a function that's just mapped to a method within the registry.

I.e. 

```python
registry = Registry()

get_branch_from_registry = registry.get_branch_from_registry
get_branch = registry.get_branch
```

This PR removes that mapping and instead use the methods directly from the registry.