### PR TITLE
Fix type hints in infrahub.core.schema

### DIFF
--- a/backend/infrahub/core/schema/__init__.py
+++ b/backend/infrahub/core/schema/__init__.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-import enum
 from typing import Any, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from infrahub.core.constants import RESTRICTED_NAMESPACES
 from infrahub.core.models import HashableModel
-from infrahub.core.relationship import Relationship
-from infrahub.types import ATTRIBUTE_KIND_LABELS
 
 from .attribute_schema import AttributeSchema
 from .basenode_schema import AttributePathParsingError, BaseNodeSchema, SchemaAttributePath
@@ -19,14 +16,6 @@ from .filter import FilterSchema
 from .generic_schema import GenericSchema
 from .node_schema import NodeSchema
 from .relationship_schema import RelationshipSchema
-
-# pylint: disable=redefined-builtin
-
-# Generate an Enum for Pydantic based on a List of String
-attribute_dict = {attr.upper(): attr for attr in ATTRIBUTE_KIND_LABELS}
-AttributeKind = enum.Enum("AttributeKind", dict(attribute_dict))
-
-RELATIONSHIPS_MAPPING = {"Relationship": Relationship}
 
 
 # -----------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,10 +258,6 @@ module = "infrahub.core.query.subquery"
 ignore_errors = true
 
 [[tool.mypy.overrides]]
-module = "infrahub.core.schema"
-ignore_errors = true
-
-[[tool.mypy.overrides]]
 module = "infrahub.core.schema.attribute_schema"
 ignore_errors = true
 


### PR DESCRIPTION
The problem was the code generation for an enum that wasn't used so I deleted it.