### PR TITLE
feat(ci): report tracing spans for unit and e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,6 +338,14 @@ jobs:
         with:
           flag-name: backend-unit
           parallel: true
+      - name: Generate tracing spans
+        uses: inception-health/otel-upload-test-artifact-action@v1
+        with:
+          jobName: "backend-tests-unit"
+          stepName: "Unit Tests"
+          path: "pytest-junit.xml"
+          type: "junit"
+          githubToken: ${{ secrets.GH_TRACING_REPO_TOKEN }}
 
   backend-tests-integration:
     if: |
@@ -717,6 +725,15 @@ jobs:
         run: npm run ci:test:e2e
         env:
           BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_E2E_PLAYWRIGHT }}
+
+      - name: Generate tracing spans
+        uses: inception-health/otel-upload-test-artifact-action@v1
+        with:
+          jobName: "E2E-testing-playwright"
+          stepName: "Run Playwright tests"
+          path: "frontend/playwright-junit.xml"
+          type: "junit"
+          githubToken: ${{ secrets.GH_TRACING_REPO_TOKEN }}
 
       - name: playwright-report
         if: always()

--- a/.github/workflows/otel-export-trace.yml
+++ b/.github/workflows/otel-export-trace.yml
@@ -1,0 +1,25 @@
+---
+# yamllint disable rule:truthy rule:truthy rule:line-length
+name: OpenTelemetry Export Trace
+
+on:
+  workflow_run:
+    workflows:
+      - "CI"
+    types:
+      - completed
+
+jobs:
+  otel-export-trace:
+    name: OpenTelemetry Export Trace
+    runs-on:
+      group: huge-runners
+    steps:
+      - name: Export Workflow Trace
+        uses: inception-health/otel-export-trace-action@v1
+        with:
+          otlpEndpoint: ${{ secrets.TRACING_ENDPOINT }}
+          otlpHeaders: ""
+          otelServiceName: CI
+          githubToken: ${{ secrets.GH_TRACING_REPO_TOKEN }}
+          runId: ${{ github.event.workflow_run.id }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .coverage
 coverage.xml
+*junit*
 *.pyc
 *.env
 script.py

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "cypress:run:spec": "ELECTRON_ENABLE_LOGGING=1 cypress run --spec",
     "codegen": "graphql-codegen --config graphql.config.ts",
     "codegen:openapi": "npx openapi-typescript http://localhost:8000/api/openapi.json --output src/infraops.d.ts",
-    "ci:test:e2e": "CI=1 npm run test:e2e",
+    "ci:test:e2e": "CI=1 PLAYWRIGHT_JUNIT_OUTPUT_NAME=playwright-junit.xml playwright test --reporter=junit",
     "test:e2e": "playwright test",
     "test:e2e:debug": "playwright test --debug",
     "test:e2e:headed": "playwright test --headed",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,8 +149,8 @@ filterwarnings = [
     "ignore:Module already imported so cannot be rewritten",
     "ignore:Deprecated call to",
 ]
-addopts = "-vs --cov-report term-missing --cov-report xml --dist loadscope"
-
+addopts = "-vs --cov-report term-missing --cov-report xml --dist loadscope --junitxml=pytest-junit.xml"
+junit_duration_report = "call"
 
 [tool.mypy]
 pretty = true


### PR DESCRIPTION
Poor man's Buildkite...

Traces are correctly pushed to tempo, I just need this merged in the default branch so that the "workflow_run" workflow works fine. I will need to tweak some grafana dashboard after that.