### PR TITLE
Modify tests to use branch that is synced-with-git

### DIFF
--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -88,7 +88,9 @@ class TestInfrahubApp:
     async def client(
         self, test_client: InfrahubTestClient, api_token: str, bus_simulator: BusSimulator
     ) -> InfrahubClient:
-        config = Config(api_token=api_token, requester=test_client.async_request)
+        config = Config(
+            api_token=api_token, requester=test_client.async_request, sync_requester=test_client.sync_request
+        )
 
         sdk_client = await InfrahubClient.init(config=config)
 

--- a/backend/tests/helpers/test_client.py
+++ b/backend/tests/helpers/test_client.py
@@ -1,11 +1,17 @@
+import asyncio
 import json
 from typing import Any, Dict, Optional
 
 import httpx
+from fastapi import FastAPI
 from infrahub_sdk.types import HTTPMethod
 
 
 class InfrahubTestClient(httpx.AsyncClient):
+    def __init__(self, app: FastAPI, base_url: str = ""):
+        self.loop = asyncio.get_event_loop()
+        super().__init__(app=app, base_url=base_url)
+
     async def _request(
         self, url: str, method: HTTPMethod, headers: Dict[str, Any], timeout: int, payload: Optional[Dict] = None
     ) -> httpx.Response:
@@ -18,3 +24,11 @@ class InfrahubTestClient(httpx.AsyncClient):
         self, url: str, method: HTTPMethod, headers: Dict[str, Any], timeout: int, payload: Optional[Dict] = None
     ) -> httpx.Response:
         return await self._request(url=url, method=method, headers=headers, timeout=timeout, payload=payload)
+
+    def sync_request(
+        self, url: str, method: HTTPMethod, headers: Dict[str, Any], timeout: int, payload: Optional[Dict] = None
+    ) -> httpx.Response:
+        future = asyncio.run_coroutine_threadsafe(
+            self._request(url=url, method=method, headers=headers, timeout=timeout, payload=payload), self.loop
+        )
+        return future.result()

--- a/backend/tests/integration/proposed_change/test_proposed_change.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change.py
@@ -62,9 +62,9 @@ class TestProposedChangePipeline(TestInfrahubApp):
         await client_repository.save()
 
     @pytest.fixture(scope="class")
-    async def happy_dataset(self, db: InfrahubDatabase, initial_dataset: None) -> None:
-        branch1 = await create_branch(db=db, branch_name="conflict_free")
-        richard = await Node.init(schema=TestKind.PERSON, db=db, branch=branch1)
+    async def happy_dataset(self, db: InfrahubDatabase, initial_dataset: None, client: InfrahubClient) -> None:
+        branch1 = await client.branch.create(branch_name="conflict_free")
+        richard = await Node.init(schema=TestKind.PERSON, db=db, branch=branch1.name)
         await richard.new(db=db, name="Richard", height=180, description="The less famous Richard Doe")
         await richard.save(db=db)
 


### PR DESCRIPTION
This PR changes the branch that gets creates is synced-with-git and is created by the SDK client and in turn the GraphQL mutation gets used. Due to this change additional operations within the message_bus system gets triggered.

It also includes a change to the InfrahubTestClient so that we trigger the pytest test framework to run with a sync client.

For now there are no additional asserts, this is only to enable us to write these type of tests.