### PR TITLE
fix(ci): add docker labels to containers

### DIFF
--- a/development/docker-compose-database-memgraph.yml
+++ b/development/docker-compose-database-memgraph.yml
@@ -21,6 +21,8 @@ services:
       start_period: 3s
     labels:
       infrahub_role: "database"
+      com.github.run_id: "${GITHUB_RUN_ID:-unknown}"
+      com.github.job: "${GITHUB_JOB:-unknown}"
 
 
 volumes:

--- a/development/docker-compose-database-neo4j.yml
+++ b/development/docker-compose-database-neo4j.yml
@@ -24,6 +24,8 @@ services:
       start_period: 3s
     labels:
       infrahub_role: "database"
+      com.github.run_id: "${GITHUB_RUN_ID:-unknown}"
+      com.github.job: "${GITHUB_JOB:-unknown}"
     ports:
       - "${INFRAHUB_DB_BACKUP_PORT:-6362}:6362"
 

--- a/development/docker-compose-test-metrics.yml
+++ b/development/docker-compose-test-metrics.yml
@@ -16,7 +16,7 @@ services:
       - ./vmagent.yml:/etc/prometheus/prometheus.yml:ro
     command:
       - "--promscrape.config=/etc/prometheus/prometheus.yml"
-      - "--remoteWrite.sendTimeout=0s" # https://github.com/golang/go/issues/59017
+      - "--remoteWrite.sendTimeout=0s"  # https://github.com/golang/go/issues/59017
       - "--remoteWrite.url=${METRICS_ENDPOINT:-http://127.0.0.1:8424}"
       - "--remoteWrite.label=job=${GITHUB_JOB}"
       - "--remoteWrite.label=run_id=${GITHUB_RUN_ID}"

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -30,6 +30,9 @@ services:
     volumes:
       - "storage_data:/opt/infrahub/storage"
     tty: true
+    labels:
+      com.github.run_id: "${GITHUB_RUN_ID:-unknown}"
+      com.github.job: "${GITHUB_JOB:-unknown}"
     healthcheck:
       test: wget -O /dev/null http://localhost:8000/api/schema/summary || exit 1
       interval: 5s
@@ -62,6 +65,9 @@ services:
       - "git_data:/opt/infrahub/git"
       - "git_remote_data:/remote"
     tty: true
+    labels:
+      com.github.run_id: "${GITHUB_RUN_ID:-unknown}"
+      com.github.job: "${GITHUB_JOB:-unknown}"
 
 volumes:
   git_data:


### PR DESCRIPTION
This will be useful to identify containers running on our CI runners as the labels are exported through cAdvisor.