### PR TITLE
Add ability to set group type when using tracker

### DIFF
--- a/python_sdk/infrahub_sdk/query_groups.py
+++ b/python_sdk/infrahub_sdk/query_groups.py
@@ -29,7 +29,11 @@ class InfrahubGroupContextBase:
         self.group_type: str = "CoreStandardGroup"
 
     def set_properties(
-        self, identifier: str, params: Optional[Dict[str, str]] = None, delete_unused_nodes: bool = False
+        self,
+        identifier: str,
+        params: Optional[Dict[str, str]] = None,
+        delete_unused_nodes: bool = False,
+        group_type: Optional[str] = None,
     ) -> None:
         """Setter method to set the values of identifier and params.
 
@@ -40,6 +44,7 @@ class InfrahubGroupContextBase:
         self.identifier = identifier
         self.params = params or {}
         self.delete_unused_nodes = delete_unused_nodes
+        self.group_type = group_type or self.group_type
 
     def _get_params_as_str(self) -> str:
         """Convert the params in dict format, into a string"""


### PR DESCRIPTION
Needed to be able to override the type of group used by the tracker. Will be used in the generators to be used with a new group type defined in #2753 (PR #2770)

Also rearranges the set_context_properties() method to avoid having to define the method three times.