### PR TITLE
Add merging of proposed change to happy test and fix value bug

### DIFF
--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -123,7 +123,7 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
                     validator_kind = validation.get_kind()
                     if (
                         validator_kind != InfrahubKind.DATAVALIDATOR
-                        and validation.conclusion.value != ValidatorConclusion.SUCCESS.value
+                        and validation.conclusion.value.value != ValidatorConclusion.SUCCESS.value
                     ):
                         # Ignoring Data integrity checks as they are handled again later
                         raise ValidationError("Unable to merge proposed change containing failing checks")

--- a/backend/tests/integration/proposed_change/test_proposed_change.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change.py
@@ -116,6 +116,9 @@ class TestProposedChangePipeline(TestInfrahubApp):
         ][0]
         assert repository_merge_conflict.conclusion.value.value == ValidatorConclusion.SUCCESS.value
 
+        proposed_change_create.state.value = "merged"  # type: ignore[attr-defined]
+        await proposed_change_create.save()
+
     async def test_conflict_pipeline(
         self, db: InfrahubDatabase, conflict_dataset: None, client: InfrahubClient
     ) -> None:


### PR DESCRIPTION
A bug was introduced in a recent PR adding an additional .value under an existing value but it wasn't caught as we didn't have a test that covered that path. The result is that currently merging a proposed change is broken. This PR adds a test to avoid regressions in the future.