### PR TITLE
fix(docs): fixes interface name in graphql mutation used in the getting started tutorial 

### DIFF
--- a/docs/docs/tutorials/getting-started/graphql-mutation.mdx
+++ b/docs/docs/tutorials/getting-started/graphql-mutation.mdx
@@ -46,9 +46,9 @@ mutation {
       enabled: { value: true }
       description: { value: "new interface in branch" }
       device: { id: "ord1-edge1" }
-      status: { id: "active" }
+      status: { value: "active" }
       speed: { value: 10000 }
-      role: { id: "spare" }
+      role: { value: "spare" }
     }
   ) {
     ok


### PR DESCRIPTION
fixes #2806 