### PR TITLE
Remove .login() call in pytest plugin

### DIFF
--- a/python_sdk/infrahub_sdk/pytest_plugin/plugin.py
+++ b/python_sdk/infrahub_sdk/pytest_plugin/plugin.py
@@ -82,7 +82,6 @@ def pytest_sessionstart(session: Session) -> None:
         }
 
     infrahub_client = InfrahubClientSync(config=client_config)
-    infrahub_client.login()
     session.infrahub_client = infrahub_client  # type: ignore[attr-defined]
 
 


### PR DESCRIPTION
Removes the call to .login() from the pytest plugin.

In most cases where it's required to login this should happen automatically from within the ._post() call in the client.

The current setup is a bit problematic when testing locally and you have environment variables for username and password set:

```bash
export INFRAHUB_SDK_USERNAME=admin
export INFRAHUB_SDK_PASSWORD=infrahub
```

With this in place running a test like this:

```bash
❯ pytest backend/tests/unit/graphql/test_graphql_utils.py::test_schema_models_generics
```

Would fail with:

```python
INTERNALERROR> httpx.ConnectError: [Errno 61] Connection refused
INTERNALERROR>
INTERNALERROR> The above exception was the direct cause of the following exception:
INTERNALERROR>
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/Users/patrick/.virtualenvs/infrahub/lib/python3.12/site-packages/_pytest/main.py", line 269, in wrap_session
INTERNALERROR>     config.hook.pytest_sessionstart(session=session)
INTERNALERROR>   File "/Users/patrick/.virtualenvs/infrahub/lib/python3.12/site-packages/pluggy/_hooks.py", line 501, in __call__
INTERNALERROR>     return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/patrick/.virtualenvs/infrahub/lib/python3.12/site-packages/pluggy/_manager.py", line 119, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/patrick/.virtualenvs/infrahub/lib/python3.12/site-packages/pluggy/_callers.py", line 181, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/patrick/.virtualenvs/infrahub/lib/python3.12/site-packages/pluggy/_result.py", line 99, in get_result
INTERNALERROR>     raise exc.with_traceback(exc.__traceback__)
INTERNALERROR>   File "/Users/patrick/.virtualenvs/infrahub/lib/python3.12/site-packages/pluggy/_callers.py", line 102, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>           ^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/patrick/Code/opsmill/infrahub/python_sdk/infrahub_sdk/pytest_plugin/plugin.py", line 85, in pytest_sessionstart
INTERNALERROR>     infrahub_client.login()
INTERNALERROR>   File "/Users/patrick/Code/opsmill/infrahub/python_sdk/infrahub_sdk/client.py", line 1362, in login
INTERNALERROR>     response = self._request(
INTERNALERROR>                ^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/patrick/Code/opsmill/infrahub/python_sdk/infrahub_sdk/client.py", line 1313, in _request
INTERNALERROR>     response = self._request_method(url=url, method=method, headers=headers, timeout=timeout, payload=payload)
INTERNALERROR>                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/patrick/Code/opsmill/infrahub/python_sdk/infrahub_sdk/client.py", line 1348, in _default_request_method
INTERNALERROR>     raise ServerNotReachableError(address=self.address) from exc
INTERNALERROR> infrahub_sdk.exceptions.ServerNotReachableError: Unable to connect to 'http://localhost:8000'.
```

It seems like the plugin tries to login to a system even though we don't use the plugin for the test. Removing the call to login avoids this and also ensures that the plugin doesn't try to access a system during initialization.