### PR TITLE
Add a clone option for the SDK

### DIFF
--- a/python_sdk/infrahub_sdk/client.py
+++ b/python_sdk/infrahub_sdk/client.py
@@ -426,6 +426,10 @@ class InfrahubClient(BaseClient):  # pylint: disable=too-many-public-methods
 
         return nodes
 
+    def clone(self) -> InfrahubClient:
+        """Return a cloned version of the client using the same configuration"""
+        return InfrahubClient(config=self.config)
+
     async def execute_graphql(  # pylint: disable=too-many-branches
         self,
         query: str,
@@ -842,6 +846,10 @@ class InfrahubClientSync(BaseClient):  # pylint: disable=too-many-public-methods
 
     def create_batch(self, return_exceptions: bool = False) -> InfrahubBatch:
         raise NotImplementedError("This method hasn't been implemented in the sync client yet.")
+
+    def clone(self) -> InfrahubClientSync:
+        """Return a cloned version of the client using the same configuration"""
+        return InfrahubClientSync(config=self.config)
 
     def execute_graphql(  # pylint: disable=too-many-branches
         self,

--- a/python_sdk/infrahub_sdk/generator.py
+++ b/python_sdk/infrahub_sdk/generator.py
@@ -30,8 +30,7 @@ class InfrahubGenerator:
         self.params = params or {}
         self.root_directory = root_directory or os.getcwd()
         self.generator_instance = generator_instance
-        # self._init_client = deepcopy(client)
-        self._init_client = client
+        self._init_client = client.clone()
         self._init_client.config.default_branch = self._init_client.default_branch = self.branch_name
         self._client: Optional[InfrahubClient] = None
 

--- a/python_sdk/tests/unit/sdk/test_client.py
+++ b/python_sdk/tests/unit/sdk/test_client.py
@@ -412,3 +412,15 @@ async def test_query_echo(httpx_mock: HTTPXMock, echo_clients, client_type):  # 
 
     assert response == {"BuiltinTag": {"edges": []}}
     assert echo_clients.stdout.getvalue().splitlines() == EXPECTED_ECHO.splitlines()
+
+
+@pytest.mark.parametrize("client_type", client_types)
+async def test_clone(clients, client_type):
+    if client_type == "standard":
+        clone = clients.standard.clone()
+        assert clone.config == clients.standard.config
+        assert isinstance(clone, InfrahubClient)
+    else:
+        clone = clients.sync.clone()
+        assert clone.config == clients.sync.config
+        assert isinstance(clone, InfrahubClientSync)


### PR DESCRIPTION
The clone options returns a new client using the same config, i.e. it will be a fresh store and default setting for tracking etc.

The PR also modifies the generator to use this new clone method.