### PR TITLE
Fix typehints on registry tasks

### DIFF
--- a/backend/infrahub/core/definitions.py
+++ b/backend/infrahub/core/definitions.py
@@ -1,21 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
-
-if TYPE_CHECKING:
-    from infrahub.core.branch import Branch
-    from infrahub.database import InfrahubDatabase
-
-
-@runtime_checkable
-class Brancher(Protocol):
-    @classmethod
-    async def get_by_name(cls, name: str, db: InfrahubDatabase) -> Branch:
-        raise NotImplementedError()
-
-    @classmethod
-    def isinstance(cls, obj: Any) -> bool:
-        return isinstance(obj, cls)
+from typing import Protocol, runtime_checkable
 
 
 @runtime_checkable

--- a/backend/tests/integration/proposed_change/test_proposed_change.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change.py
@@ -69,7 +69,7 @@ class TestProposedChangePipeline(TestInfrahubApp):
         await richard.save(db=db)
 
         john = await NodeManager.get_one_by_id_or_default_filter(
-            db=db, id="John", schema_name=TestKind.PERSON, branch=branch1
+            db=db, id="John", schema_name=TestKind.PERSON, branch=branch1.name
         )
         john.age.value = 26  # type: ignore[attr-defined]
         await john.save(db=db)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -381,10 +381,6 @@ module = "infrahub.message_bus.operations.*"
 ignore_errors = true
 
 [[tool.mypy.overrides]]
-module = "infrahub.tasks.registry"
-ignore_errors = true
-
-[[tool.mypy.overrides]]
 module = "infrahub.test_data.*"
 ignore_errors = true
 


### PR DESCRIPTION
Also removes the Brancher protocol and some cleanup for the registry get_branch methods. The logic in the get_branch methods looked a bit weird as they were (I think I wrote or converted parts of them.), looking at them they seemed a bit overly complex and unless I'm just missing something now it didn't seem like they actually did much.