### PR TITLE
Change yamllint to ignore all node_modules

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -5,9 +5,8 @@ ignore: |
   /.venv
   /examples
   /repositories
-  /frontend/node_modules
   /frontend/playwright-report
-  /node_modules
+  **/node_modules
   # https://github.com/sbaudoin/yamllint/issues/16
   /helm/templates
 


### PR DESCRIPTION
The ones under /docs/node_modules were showing up locally