### PR TITLE
ci: increase scale testing timeout

### DIFF
--- a/.github/workflows/scale-tests.yml
+++ b/.github/workflows/scale-tests.yml
@@ -133,7 +133,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on:
       group: huge-runners
-    timeout-minutes: 120
+    timeout-minutes: 300
     env:
       INFRAHUB_DB_TYPE: neo4j
       METRICS_ENDPOINT: ${{ secrets.METRICS_ENDPOINT }}


### PR DESCRIPTION
Allow the tests to run for 5 hours, this is required for the 100k nodes test.