### PR TITLE
Revert the deletion of Poetry during container build

### DIFF
--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -99,5 +99,4 @@ RUN poetry install --no-interaction --no-ansi --no-root --no-directory && \
 # Copy in the rest of the source code and install the project
 # --------------------------------------------
 COPY . ./
-RUN poetry install --no-interaction --no-ansi && \
-    rm -rf /root/.local
+RUN poetry install --no-interaction --no-ansi


### PR DESCRIPTION
This PR reverts a change that deleted poetry after installing packages.

Unfortunately this caused other PRs to break in the pipeline: https://github.com/opsmill/infrahub/actions/runs/8689276993/job/23828892762?pr=2918

It wasn't spotted earlier as we have jobs that aren't triggered when we change the Dockerfile. We should change this so that we run all jobs if this file is modified.

Deleting poetry here doesn't actually save any space either as it's already installed earlier (It could be that the install writes some small amount of files to /root/.local but the image since was 1.6 GB both before and after removing this.

At some point we will want a production image that doesn't have poetry or anything else we need during dev. At that point we should also ensure to only install production dependencies for Infrahub and also avoid installing curl etc.