### PR TITLE
Add `is_top_level` read-only field to IP prefix

### DIFF
--- a/backend/infrahub/core/node/ipam.py
+++ b/backend/infrahub/core/node/ipam.py
@@ -27,9 +27,6 @@ class BuiltinIPPrefix(Node):
                 if read_only_attr in fields:
                     response[read_only_attr] = {"value": getattr(self.prefix, read_only_attr)}  # type: ignore[attr-defined]
 
-            if "is_top_level" in fields:
-                response["is_top_level"] = {"value": await self.parent.get_peer(db=db) is None}  # type: ignore[attr-defined]
-
             if "utilization" in fields:
                 utilization = await get_utilization(self, db, branch=self._branch)
                 response["utilization"] = {"value": int(utilization)}

--- a/backend/infrahub/graphql/mutations/ipam.py
+++ b/backend/infrahub/graphql/mutations/ipam.py
@@ -201,6 +201,9 @@ class InfrahubIPPrefixMutation(InfrahubMutationMixin, Mutation):
         super_network = await get_container(db=db, branch=branch, at=at, ip_prefix=ip_network, namespace=namespace_id)
         if super_network:
             data["parent"] = {"id": super_network.id}
+            data["is_top_level"] = False
+        else:
+            data["is_top_level"] = True
 
         # Set subnets if found
         sub_networks = await get_subnets(db=db, branch=branch, at=at, ip_prefix=ip_network, namespace=namespace_id)


### PR DESCRIPTION
This field is used as a workaround. It tells if a prefix has a known parent. A prefix without parent is considered a top-level prefix.

This should ideally be removed by allowing to match on prefix with parent being `NULL` with a GraphQL query filter.

~~Funny thing is: using filters based on this field won't work either...~~