### PR TITLE
Add temporary fix for load_infra_schema in demo environment

### DIFF
--- a/tasks/demo.py
+++ b/tasks/demo.py
@@ -109,8 +109,11 @@ def status(context: Context, database: str = INFRAHUB_DATABASE):
 
 @task(optional=["database"])
 def load_infra_schema(context: Context, database: str = INFRAHUB_DATABASE):
-    """Load the base schema for infrastructure."""
-    load_infrastructure_schema(context=context, database=database, namespace=NAMESPACE)
+    """Load the base schema for infrastructure.
+    FIXME: This command needs to be updated to remove the restart before releasing 0.13.0
+    """
+    load_infrastructure_schema(context=context, database=database, namespace=NAMESPACE, add_wait=False)
+    restart_services(context=context, database=database, namespace=NAMESPACE)
 
 
 @task(optional=["database"])

--- a/tasks/infra_ops.py
+++ b/tasks/infra_ops.py
@@ -17,9 +17,11 @@ def load_infrastructure_data(context: Context, database: str, namespace: str) ->
         execute_command(context=context, command=command)
 
 
-def load_infrastructure_schema(context: Context, database: str, namespace: str) -> None:
+def load_infrastructure_schema(context: Context, database: str, namespace: str, add_wait: bool = True) -> None:
     with context.cd(ESCAPED_REPO_PATH):
         compose_files_cmd = build_compose_files_cmd(database=database)
         base_cmd = f"{get_env_vars(context, namespace=namespace)} docker compose {compose_files_cmd} -p {BUILD_NAME}"
-        command = f"{base_cmd} run infrahub-git infrahubctl schema load models/infrastructure_base.yml --wait 30"
+        command = f"{base_cmd} run infrahub-git infrahubctl schema load models/infrastructure_base.yml"
+        if add_wait:
+            command += " --wait 30"
         execute_command(context=context, command=command)


### PR DESCRIPTION
This is a fix for the command `invoke demo.load-infra-schema` that is not working currently because infrahubctl in the stable container doesn't support `--wait`

We'll need to revert this change before publishing the next release

```
Usage: infrahubctl schema load [OPTIONS] SCHEMAS...
Try 'infrahubctl schema load --help' for help.
╭─ Error ──────────────────────────────────────────────────────────╮
│ No such option: --wait                                                                                                                                                            │
╰────────────────────────────��────────────────────────────────────╯
```