### PR TITLE
Fix API schema validator call

### DIFF
--- a/backend/infrahub/api/schema.py
+++ b/backend/infrahub/api/schema.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
 
 from fastapi import APIRouter, BackgroundTasks, Depends, Query, Request
-from pydantic import BaseModel, Field, computed_field
+from pydantic import BaseModel, Field, computed_field, model_validator
 from starlette.responses import JSONResponse
 
 from infrahub import config, lock
@@ -42,6 +42,13 @@ class APISchemaMixin:
         ]
         data["hash"] = schema.get_hash()
         return cls(**data)
+
+    @model_validator(mode="before")
+    @classmethod
+    def set_kind(cls, values: Any) -> Any:
+        if isinstance(values, dict):
+            values["kind"] = f'{values["namespace"]}{values["name"]}'
+        return values
 
 
 class APINodeSchema(NodeSchema, APISchemaMixin):

--- a/backend/infrahub/core/schema/basenode_schema.py
+++ b/backend/infrahub/core/schema/basenode_schema.py
@@ -6,7 +6,7 @@ from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Literal, Optional, Type, Union, overload
 
 from infrahub_sdk.utils import compare_lists, intersection
-from pydantic import computed_field, field_validator
+from pydantic import field_validator
 
 from infrahub.core.models import HashableModelDiff
 
@@ -32,7 +32,6 @@ class BaseNodeSchema(GeneratedBaseNodeSchema):  # pylint: disable=too-many-publi
     _exclude_from_hash: List[str] = ["attributes", "relationships", "filters"]
     _sort_by: List[str] = ["namespace", "name"]
 
-    @computed_field
     @property
     def kind(self) -> str:
         if self.namespace == "Attribute":


### PR DESCRIPTION
The Pydantic model validator can have as value to its parameter any arbitrary object, so we have to ensure its type before doing anything with it.