### PR TITLE
Remove getattr from extract_field

### DIFF
--- a/python_sdk/infrahub_sdk/utils.py
+++ b/python_sdk/infrahub_sdk/utils.py
@@ -10,7 +10,7 @@ from uuid import UUID, uuid4
 import httpx
 import ujson
 from git.repo import Repo
-from graphql import (  # pylint: disable=no-name-in-module
+from graphql import (
     FieldNode,
     InlineFragmentNode,
     SelectionSetNode,
@@ -285,7 +285,7 @@ async def extract_fields(selection_set: Optional[SelectionSetNode]) -> Optional[
         return None
 
     fields = {}
-    for node in getattr(selection_set, "selections", []):
+    for node in selection_set.selections:
         sub_selection_set = getattr(node, "selection_set", None)
         if isinstance(node, FieldNode):
             value = await extract_fields(sub_selection_set)


### PR DESCRIPTION
I this this as a test while working on a modified version of this function. I find this a bit cleaner, not sure why we were using getattr previously as `selection_set.selections` should not be `None`.

Seems to pass all the tests. Does anyone know why it looked this way?