### PR TITLE
fix(docker): use curl for healthcheck

### DIFF
--- a/development/docker-compose-test-scale.yml
+++ b/development/docker-compose-test-scale.yml
@@ -34,7 +34,7 @@ services:
       com.github.run_id: "${GITHUB_RUN_ID:-unknown}"
       com.github.job: "${JOB_NAME:-unknown}"
     healthcheck:
-      test: wget -O /dev/null http://localhost:8000/api/schema/summary || exit 1
+      test: curl -s -f -o /dev/null http://localhost:8000/api/schema/summary || exit 1
       interval: 5s
       timeout: 5s
       retries: 20

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       com.github.run_id: "${GITHUB_RUN_ID:-unknown}"
       com.github.job: "${JOB_NAME:-unknown}"
     healthcheck:
-      test: wget -O /dev/null http://localhost:8000/api/schema/summary || exit 1
+      test: curl -s -f -o /dev/null http://localhost:8000/api/schema/summary || exit 1
       interval: 5s
       timeout: 5s
       retries: 20

--- a/helm/templates/infrahub-server.yaml
+++ b/helm/templates/infrahub-server.yaml
@@ -37,7 +37,7 @@ spec:
               command:
                 - sh
                 - -c
-                - wget -O /dev/null http://localhost:{{ (index .Values.infrahubServer.ports 0).port }}/api/schema || exit 1
+                - curl -s -f -o /dev/null http://localhost:{{ (index .Values.infrahubServer.ports 0).port }}/api/schema/summary || exit 1
             failureThreshold: 20
             initialDelaySeconds: 10
             periodSeconds: 5


### PR DESCRIPTION
Python slim variant doesn't include wget, so switch to curl.

Fixes #2910 