### PR TITLE
Change init fixture to make it simpler to run tests locally

### DIFF
--- a/python_sdk/tests/integration/conftest.py
+++ b/python_sdk/tests/integration/conftest.py
@@ -96,7 +96,7 @@ def execute_before_any_test(worker_id, tmpdir_factory):
         config.SETTINGS.storage.local = config.FileSystemStorageSettings(path="/opt/infrahub/storage")
     else:
         storage_dir = tmpdir_factory.mktemp("storage")
-        config.SETTINGS.storage.local = config.FileSystemStorageSettings(path=str(storage_dir))
+        config.SETTINGS.storage.local.path_ = str(storage_dir)
 
     config.SETTINGS.broker.enable = False
     config.SETTINGS.cache.enable = True


### PR DESCRIPTION
Currently if you have the `INFRAHUB_STORAGE_LOCAL_PATH` variable set locally the tests fail to run.

```python
../../../.virtualenvs/infrahub/lib/python3.12/site-packages/pydantic_settings/main.py:84: ValidationError
___________________________________________________________________________________________________________ ERROR at setup of TestInfrahubSchema.test_schema_load_many ___________________________________________________________________________________________________________

worker_id = 'master'
tmpdir_factory = TempdirFactory(_tmppath_factory=TempPathFactory(_given_basetemp=None, _trace=<pluggy._tracing.TagTracerSub object at 0...folders/zv/vq9k9v817zd_81_r7rdn648c0000gn/T/pytest-of-patrick/pytest-9'), _retention_count=3, _retention_policy='all'))

    @pytest.fixture(scope="module", autouse=True)
    def execute_before_any_test(worker_id, tmpdir_factory):
        config.load_and_exit()

        config.SETTINGS.storage.driver = config.StorageDriver.FileSystemStorage

        if TEST_IN_DOCKER:
            try:
                db_id = int(worker_id[2]) + 1
            except (ValueError, IndexError):
                db_id = 1
            config.SETTINGS.cache.address = f"{BUILD_NAME}-cache-1"
            config.SETTINGS.database.address = f"{BUILD_NAME}-database-{db_id}"
            config.SETTINGS.storage.local = config.FileSystemStorageSettings(path="/opt/infrahub/storage")
        else:
            storage_dir = tmpdir_factory.mktemp("storage")
>           config.SETTINGS.storage.local = config.FileSystemStorageSettings(path=str(storage_dir))

python_sdk/tests/integration/conftest.py:99:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

__pydantic_self__ = FileSystemStorageSettings(), _case_sensitive = None, _env_prefix = None, _env_file = PosixPath('.'), _env_file_encoding = None, _env_ignore_empty = None, _env_nested_delimiter = None, _env_parse_none_str = None, _secrets_dir = None
values = {'path': '/private/var/folders/zv/vq9k9v817zd_81_r7rdn648c0000gn/T/pytest-of-patrick/pytest-9/storage5'}

    def __init__(
        __pydantic_self__,
        _case_sensitive: bool | None = None,
        _env_prefix: str | None = None,
        _env_file: DotenvType | None = ENV_FILE_SENTINEL,
        _env_file_encoding: str | None = None,
        _env_ignore_empty: bool | None = None,
        _env_nested_delimiter: str | None = None,
        _env_parse_none_str: str | None = None,
        _secrets_dir: str | Path | None = None,
        **values: Any,
    ) -> None:
        # Uses something other than `self` the first arg to allow "self" as a settable attribute
>       super().__init__(
            **__pydantic_self__._settings_build_values(
                values,
                _case_sensitive=_case_sensitive,
                _env_prefix=_env_prefix,
                _env_file=_env_file,
                _env_file_encoding=_env_file_encoding,
                _env_ignore_empty=_env_ignore_empty,
                _env_nested_delimiter=_env_nested_delimiter,
                _env_parse_none_str=_env_parse_none_str,
                _secrets_dir=_secrets_dir,
            )
        )
E       pydantic_core._pydantic_core.ValidationError: 1 validation error for FileSystemStorageSettings
E       path
E         Extra inputs are not permitted [type=extra_forbidden, input_value='/private/var/folders/zv/...trick/pytest-9/storage5', input_type=str]
E           For further information visit https://errors.pydantic.dev/2.6/v/extra_forbidden

../../../.virtualenvs/infrahub/lib/python3.12/site-packages/pydantic_settings/main.py:84: ValidationError


```