### PR TITLE
Remove deprecated at call in update_group()

### DIFF
--- a/python_sdk/infrahub_sdk/query_groups.py
+++ b/python_sdk/infrahub_sdk/query_groups.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Dict, List, Optional
 
 from infrahub_sdk.constants import InfrahubClientMode
 from infrahub_sdk.exceptions import NodeNotFoundError
-from infrahub_sdk.timestamp import Timestamp
 from infrahub_sdk.utils import dict_hash
 
 if TYPE_CHECKING:
@@ -167,7 +166,7 @@ class InfrahubGroupContext(InfrahubGroupContextBase):
             members=members,
             children=children,
         )
-        await group.save(at=Timestamp(), allow_upsert=True, update_group_context=False)
+        await group.save(allow_upsert=True, update_group_context=False)
 
         if not existing_group:
             return
@@ -273,7 +272,7 @@ class InfrahubGroupContextSync(InfrahubGroupContextBase):
             members=members,
             children=children,
         )
-        group.save(at=Timestamp(), allow_upsert=True, update_group_context=False)
+        group.save(allow_upsert=True, update_group_context=False)
 
         if not existing_group:
             return


### PR DESCRIPTION
We were still using a deprecated "at" parameter when saving the group.

This caused some extra noise when running SDK integration tests:

```python
tests/integration/test_infrahub_client.py::TestInfrahubClient::test_tracking_mode
tests/integration/test_infrahub_client.py::TestInfrahubClient::test_tracking_mode
tests/integration/test_infrahub_client.py::TestInfrahubClient::test_tracking_mode
  /Users/patrick/Code/opsmill/infrahub/python_sdk/infrahub_sdk/query_groups.py:170: DeprecationWarning: at has been deprecated and will be removed completely in a future version
    await group.save(at=Timestamp(), allow_upsert=True, update_group_context=False)

tests/integration/test_infrahub_client_sync.py::TestInfrahubClientSync::test_tracking_mode
tests/integration/test_infrahub_client_sync.py::TestInfrahubClientSync::test_tracking_mode
tests/integration/test_infrahub_client_sync.py::TestInfrahubClientSync::test_tracking_mode
  /Users/patrick/Code/opsmill/infrahub/python_sdk/infrahub_sdk/query_groups.py:276: DeprecationWarning: at has been deprecated and will be removed completely in a future version
    group.save(at=Timestamp(), allow_upsert=True, update_group_context=False)
```

