### PR TITLE
Fix bug related to choice of data conflict resolutions

### DIFF
--- a/backend/infrahub/core/merge.py
+++ b/backend/infrahub/core/merge.py
@@ -262,7 +262,8 @@ class BranchMerger:
         # TODO need to find a way to properly communicate back to the user any issue that could come up during the merge
         # From the Graph or From the repositories
         await self.merge_graph(at=at, conflict_resolution=conflict_resolution)
-        await self.merge_repositories()
+        if self.source_branch.sync_with_git:
+            await self.merge_repositories()
 
     async def merge_graph(  # pylint: disable=too-many-branches,too-many-statements
         self,

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -135,7 +135,7 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
                                     "Data conflicts found on branch and missing decisions about what branch to keep"
                                 )
                             if check.conflicts.value:
-                                keep_source_value = check.keep_branch.value == "source"
+                                keep_source_value = check.keep_branch.value.value == "source"
                                 conflict_resolution[check.conflicts.value[0]["path"]] = keep_source_value
 
                 async with lock.registry.global_graph_lock():


### PR DESCRIPTION
Selecting the source branch as the branch to keep when resolving a data conflict within a proposed change previously didn't work. This PR fixes that behaviour and adds a test to validate that it works.

Note though the exceptions in the tests due to Memgraph. There are two things here that we need to ignore during the tests because they don't work with Memgraph (or how we interact with Memgraph). With this in mind it could be that we should consider swapping out Memgraph for Neo4j in the integration tests.

Also added another fix where we tried to merge git repositories for the source branch of all connected repositories even though the source branch wasn't setup to sync to git (i.e. previously is-data-only) This caused the merge operation within the message bus to fail since the source branch couldn't be found as it doesn't exist in git.

Fixes #2984
