### PR TITLE
Fix schema integrity check label to add indication of problem

### DIFF
--- a/backend/infrahub/core/integrity/object_conflict/conflict_recorder.py
+++ b/backend/infrahub/core/integrity/object_conflict/conflict_recorder.py
@@ -64,7 +64,7 @@ class ObjectConflictValidatorRecorder:
 
                 await conflict_obj.new(
                     db=self.db,
-                    label="Data Conflict",
+                    label=f"{conflict.name} ({conflict.id})",
                     origin="internal",
                     kind="DataIntegrity",
                     validator=validator.id,


### PR DESCRIPTION
While this is mostly a quickfix with this in place it's at least possible to identify why a schema integrity check is failing on a proposed change.

Fixes #2796