### PR TITLE
Set yamllint to strict mode and fix violations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       - name: "Setup environment"
         run: "pip install yamllint==1.35.1"
       - name: "Linting: yamllint"
-        run: "yamllint ."
+        run: "yamllint -s ."
 
   javascript-lint:
     if: needs.files-changed.outputs.javascript == 'true'

--- a/models/examples/nautobot/nautobot-v1.yml
+++ b/models/examples/nautobot/nautobot-v1.yml
@@ -991,7 +991,7 @@ nodes:
         optional: true
         cardinality: one
         kind: Generic
-  - name: Generic # Status
+  - name: Generic  # Status
     namespace: Status
     label: Status
     description: 'Represent the status of an object: active, maintenance'
@@ -1009,7 +1009,7 @@ nodes:
       - kind: Text
         name: description
         optional: true
-  - name: Generic # Role
+  - name: Generic  # Role
     namespace: Role
     label: Role
     description: Represent the role of an object
@@ -1028,7 +1028,7 @@ nodes:
       - kind: Text
         name: description
         optional: true
-  - name: Generic # Location
+  - name: Generic  # Location
     namespace: Location
     label: Location
     description: 'A location represent a physical element: a building, a site, a city'

--- a/models/examples/nautobot/nautobot-v2.yml
+++ b/models/examples/nautobot/nautobot-v2.yml
@@ -995,7 +995,7 @@ nodes:
         optional: true
         cardinality: many
         kind: Attribute
-  - name: Generic # Organization
+  - name: Generic  # Organization
     namespace: Organization
     label: Organization
     description: An organization represent a legal entity, a company.
@@ -1029,7 +1029,7 @@ nodes:
         optional: true
         cardinality: one
         kind: Generic
-  - name: Generic # Status
+  - name: Generic  # Status
     namespace: Status
     label: Status
     description: 'Represent the status of an object: active, maintenance'
@@ -1047,7 +1047,7 @@ nodes:
       - kind: Text
         name: description
         optional: true
-  - name: Generic # Role
+  - name: Generic  # Role
     namespace: Role
     label: Role
     description: Represent the role of an object
@@ -1066,7 +1066,7 @@ nodes:
       - kind: Text
         name: description
         optional: true
-  - name: Generic # Location
+  - name: Generic  # Location
     namespace: Location
     label: Location
     description: 'A location represent a physical element: a building, a site, a city'

--- a/models/examples/netbox/netbox.yml
+++ b/models/examples/netbox/netbox.yml
@@ -929,7 +929,7 @@ nodes:
         optional: true
         cardinality: many
         kind: Attribute
-  - name: Generic # Organization
+  - name: Generic  # Organization
     namespace: Organization
     label: Organization
     description: An organization represent a legal entity, a company.
@@ -963,7 +963,7 @@ nodes:
         optional: true
         cardinality: one
         kind: Generic
-  - name: Generic # Status
+  - name: Generic  # Status
     namespace: Status
     label: Status
     description: 'Represent the status of an object: active, maintenance'
@@ -981,7 +981,7 @@ nodes:
       - kind: Text
         name: description
         optional: true
-  - name: Generic # Role
+  - name: Generic  # Role
     namespace: Role
     label: Role
     description: Represent the role of an object
@@ -1000,7 +1000,7 @@ nodes:
       - kind: Text
         name: description
         optional: true
-  - name: Generic # Location
+  - name: Generic  # Location
     namespace: Location
     label: Location
     description: 'A location represent a physical element: a building, a site, a city'

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -20,7 +20,7 @@ ns.add_collection(sync)
 def yamllint(context: Context):
     """This will run yamllint to validate formatting of all yaml files."""
 
-    exec_cmd = "yamllint ."
+    exec_cmd = "yamllint -s ."
     context.run(exec_cmd, pty=True)
 
 


### PR DESCRIPTION
Github's own yaml linter inserts warnings on all PRs that are unrelated to the actual PR. This change will set yamllint to strict mode so that we can fix the code before it is committed to the repo in the first place.