### PR TITLE
move profile attributes to generic, set CoreProfile.used_by

### DIFF
--- a/backend/infrahub/core/schema/definitions/core.py
+++ b/backend/infrahub/core/schema/definitions/core.py
@@ -21,6 +21,33 @@ from infrahub.core.constants import (
 
 # pylint: disable=too-many-lines
 
+core_profile_schema_definition = {
+    "name": "Profile",
+    "namespace": "Core",
+    "include_in_menu": False,
+    "description": "Base Profile in Infrahub.",
+    "label": "Profile",
+    "display_labels": ["profile_name__value"],
+    "default_filter": "profile_name__value",
+    "attributes": [
+        {
+            "name": "profile_name",
+            "kind": "Text",
+            "min_length": 3,
+            "max_length": 32,
+            "optional": False,
+            "unique": True,
+        },
+        {
+            "name": "profile_priority",
+            "kind": "Number",
+            "default_value": 1000,
+            "optional": True,
+        },
+    ],
+}
+
+
 core_models: dict[str, Any] = {
     "generics": [
         {
@@ -31,31 +58,6 @@ core_models: dict[str, Any] = {
             "label": "Node",
         },
         {
-            "name": "Profile",
-            "namespace": "Core",
-            "include_in_menu": False,
-            "description": "Base Profile in Infrahub.",
-            "label": "Profile",
-            "display_labels": ["profile_name__value"],
-            "default_filter": "profile_name__value",
-            "attributes": [
-                {
-                    "name": "profile_name",
-                    "kind": "Text",
-                    "min_length": 3,
-                    "max_length": 32,
-                    "optional": False,
-                    "unique": True,
-                },
-                {
-                    "name": "profile_priority",
-                    "kind": "Number",
-                    "default_value": 1000,
-                    "optional": True,
-                },
-            ],
-        },
-        {
             "name": "Owner",
             "namespace": "Lineage",
             "description": "Any Entities that is responsible for some data.",
@@ -63,6 +65,7 @@ core_models: dict[str, Any] = {
             "include_in_menu": False,
             "documentation": "/topics/metadata",
         },
+        core_profile_schema_definition,
         {
             "name": "Source",
             "namespace": "Lineage",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -26,6 +26,7 @@ from infrahub.core.schema import (
     core_models,
     internal_schema,
 )
+from infrahub.core.schema.definitions.core import core_profile_schema_definition
 from infrahub.core.schema_manager import SchemaBranch, SchemaManager
 from infrahub.core.utils import delete_all_nodes
 from infrahub.database import InfrahubDatabase, get_db
@@ -174,14 +175,9 @@ async def data_schema(db: InfrahubDatabase, default_branch: Branch) -> None:
                 "description": "Any Entities that stores or produces data.",
                 "namespace": "Lineage",
             },
+            core_profile_schema_definition,
         ]
     }
-    for generic in core_models["generics"]:
-        if generic["name"] == "Profile" and generic["namespace"] == "Core":
-            core_profile = generic
-            break
-    if core_profile:
-        SCHEMA["generics"].append(core_profile)
 
     schema = SchemaRoot(**SCHEMA)
     registry.schema.register_schema(schema=schema, branch=default_branch.name)

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -293,6 +293,14 @@ async def test_schema_branch_add_profile_schema(schema_all_in_one):
     assert profile.get_attribute("profile_name").branch == BranchSupportType.AGNOSTIC.value
     assert profile.get_attribute("profile_priority").branch == BranchSupportType.AGNOSTIC.value
     assert set(profile.attribute_names) == {"profile_name", "profile_priority", "name", "level", "color", "description"}
+    core_profile_schema = schema.get("CoreProfile")
+    assert set(core_profile_schema.used_by) == {
+        "ProfileBuiltinCriticality",
+        "ProfileBuiltinTag",
+        "ProfileBuiltinStatus",
+        "ProfileBuiltinBadge",
+        "ProfileCoreStandardGroup",
+    }
 
 
 async def test_schema_branch_generate_identifiers(schema_all_in_one):
@@ -2183,7 +2191,8 @@ async def test_load_schema_from_db(
     schema2 = await registry.schema.load_schema_from_db(db=db, branch=default_branch.name)
 
     assert len(schema2.nodes) == 6
-    assert len(schema2.generics) == 1
+    assert set(schema2.generics.keys()) == {"CoreProfile", "TestGenericInterface"}
+    assert set(schema2.profiles.keys()) == {"ProfileBuiltinTag", "ProfileTestCriticality"}
 
     assert schema11.get(name="TestCriticality").get_hash() == schema2.get(name="TestCriticality").get_hash()
     assert schema11.get(name=InfrahubKind.TAG).get_hash() == schema2.get(name="BuiltinTag").get_hash()
@@ -2256,7 +2265,8 @@ async def test_load_schema(
     schema2 = await registry.schema.load_schema(db=db, branch=default_branch.name)
 
     assert len(schema2.nodes) == 6
-    assert len(schema2.generics) == 1
+    assert set(schema2.generics.keys()) == {"CoreProfile", "TestGenericInterface"}
+    assert set(schema2.profiles.keys()) == {"ProfileBuiltinTag", "ProfileTestCriticality"}
 
     assert schema11.get(name="TestCriticality").get_hash() == schema2.get(name="TestCriticality").get_hash()
     assert schema11.get(name=InfrahubKind.TAG).get_hash() == schema2.get(name=InfrahubKind.TAG).get_hash()


### PR DESCRIPTION
fixes #3030 

- moves `profile_name` and `profile_priority` to `CoreProfile`
    - had to include some new logic to handle setting `branch` correctly on `profile_name` and `profile_priority` b/c they are supposed to inherit `branch` from the NodeSchema that they are profiling
- correctly set `CoreProfile.used_by`   
- prevent saving `CoreProfile` to the database, b/c the only thing it is really used for is the `used_by` attribute that tracks all the Profiles which inherit from it