### PR TITLE
Raise the length limit for peers

### DIFF
--- a/backend/infrahub/core/schema/definitions/internal.py
+++ b/backend/infrahub/core/schema/definitions/internal.py
@@ -635,8 +635,6 @@ relationship_schema = SchemaNode(
             kind="Text",
             description="Type (kind) of objects supported on the other end of the relationship.",
             regex=str(NODE_KIND_REGEX),
-            min_length=DEFAULT_KIND_MIN_LENGTH,
-            max_length=DEFAULT_KIND_MAX_LENGTH,
             extra={"update": UpdateSupport.VALIDATE_CONSTRAINT},
         ),
         SchemaAttribute(

--- a/backend/infrahub/core/schema/generated/relationship_schema.py
+++ b/backend/infrahub/core/schema/generated/relationship_schema.py
@@ -37,8 +37,6 @@ class GeneratedRelationshipSchema(HashableModel):
         ...,
         description="Type (kind) of objects supported on the other end of the relationship.",
         pattern="^[A-Z][a-zA-Z0-9]+$",
-        min_length=3,
-        max_length=32,
         json_schema_extra={"update": "validate_constraint"},
     )
     kind: RelationshipKind = Field(

--- a/docs/docs/reference/schema/relationship.mdx
+++ b/docs/docs/reference/schema/relationship.mdx
@@ -227,7 +227,7 @@ Below is the list of all available options to define a Relationship in the schem
 | **Description** | Type (kind) of objects supported on the other end of the relationship. |
 | **Optional** | False |
 | **Default Value** |  |
-| **Constraints** |  Regex: `^[A-Z][a-zA-Z0-9]+$`<br /> Length: min 3, max 32 |
+| **Constraints** |  Regex: `^[A-Z][a-zA-Z0-9]+$` |
 
 ### read_only
 


### PR DESCRIPTION
This limit needs to match the length of "profile" + the name of the namespace and the name of the node itself. Today this would be 7 + 32 + 32.