### PR TITLE
Fixes for pipeline with generators converting to SDK objects

### DIFF
--- a/backend/infrahub/core/schema/definitions/core.py
+++ b/backend/infrahub/core/schema/definitions/core.py
@@ -1501,6 +1501,7 @@ core_models: dict[str, Any] = {
                 {"name": "parameters", "kind": "JSON"},
                 {"name": "file_path", "kind": "Text"},
                 {"name": "class_name", "kind": "Text"},
+                {"name": "convert_query_response", "kind": "Boolean", "optional": True, "default_value": False},
             ],
             "relationships": [
                 {

--- a/backend/infrahub/git/repository.py
+++ b/backend/infrahub/git/repository.py
@@ -1467,11 +1467,12 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
         if targets:
             generator.targets = targets[0].id
 
-        if (
+        if (  # pylint: disable=too-many-boolean-expressions
             existing_generator.query.id != generator.query
             or existing_generator.file_path.value != str(generator.file_path)
             or existing_generator.class_name.value != generator.class_name
             or existing_generator.parameters.value != generator.parameters
+            or existing_generator.convert_query_response.value != generator.convert_query_response
             or existing_generator.targets.id != generator.targets
         ):
             return True
@@ -1665,6 +1666,9 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
 
         if existing_generator.file_path.value != str(generator.file_path):
             existing_generator.file_path.value = str(generator.file_path)
+
+        if existing_generator.convert_query_response.value != generator.convert_query_response:
+            existing_generator.convert_query_response.value = generator.convert_query_response
 
         if existing_generator.parameters.value != generator.parameters:
             existing_generator.parameters.value = generator.parameters

--- a/backend/infrahub/message_bus/operations/check/generator.py
+++ b/backend/infrahub/message_bus/operations/check/generator.py
@@ -31,6 +31,7 @@ async def run(message: messages.CheckGeneratorRun, service: InfrahubServices):
         file_path=message.generator_definition.file_path,
         query=message.generator_definition.query_name,
         targets=message.generator_definition.group_id,
+        convert_query_response=message.generator_definition.convert_query_response,
     )
 
     commit_worktree = repository.get_commit_worktree(commit=message.commit)

--- a/backend/infrahub/message_bus/operations/requests/generator.py
+++ b/backend/infrahub/message_bus/operations/requests/generator.py
@@ -25,6 +25,7 @@ async def run(message: messages.RequestGeneratorRun, service: InfrahubServices):
         file_path=message.generator_definition.file_path,
         query=message.generator_definition.query_name,
         targets=message.generator_definition.group_id,
+        convert_query_response=message.generator_definition.convert_query_response,
     )
 
     commit_worktree = repository.get_commit_worktree(commit=message.commit)

--- a/backend/infrahub/message_bus/operations/requests/proposed_change.py
+++ b/backend/infrahub/message_bus/operations/requests/proposed_change.py
@@ -402,6 +402,7 @@ async def run_generators(message: messages.RequestProposedChangeRunGenerators, s
                 repository_id=generator.repository.peer.id,
                 parameters=generator.parameters.value,
                 group_id=generator.targets.peer.id,
+                convert_query_response=generator.convert_query_response.value,
             )
             for generator in generators
         ]

--- a/backend/infrahub/message_bus/operations/trigger/generator_definition.py
+++ b/backend/infrahub/message_bus/operations/trigger/generator_definition.py
@@ -20,6 +20,7 @@ async def run(message: messages.TriggerGeneratorDefinitionRun, service: Infrahub
             repository_id=generator.repository.peer.id,
             parameters=generator.parameters.value,
             group_id=generator.targets.peer.id,
+            convert_query_response=generator.convert_query_response.value,
         )
         for generator in generators
     ]

--- a/backend/infrahub/message_bus/types.py
+++ b/backend/infrahub/message_bus/types.py
@@ -90,6 +90,7 @@ class ProposedChangeGeneratorDefinition(BaseModel):
     definition_id: str
     definition_name: str
     query_name: str
+    convert_query_response: bool
     query_models: list[str]
     repository_id: str
     class_name: str

--- a/backend/tests/fixtures/repos/car-dealership/initial__main/.infrahub.yml
+++ b/backend/tests/fixtures/repos/car-dealership/initial__main/.infrahub.yml
@@ -33,3 +33,10 @@ generator_definitions:
     query: cartags
     parameters:
       name: "name__value"
+  - name: cartags_convert_response
+    file_path: "generators/cartags_convert_response.py"
+    targets: people
+    query: cartags
+    convert_query_response: true
+    parameters:
+      name: "name__value"

--- a/backend/tests/fixtures/repos/car-dealership/initial__main/generators/cartags.gql
+++ b/backend/tests/fixtures/repos/car-dealership/initial__main/generators/cartags.gql
@@ -1,18 +1,17 @@
 query CarOwner($name: String!) {
   TestingPerson(name__value: $name) {
     edges {
-      node {
+      node @expand {
         cars {
           edges {
             node {
+              __typename
+              id
               name {
                 value
               }
             }
           }
-        }
-        name {
-          value
         }
       }
     }

--- a/backend/tests/fixtures/repos/car-dealership/initial__main/generators/cartags_convert_response.py
+++ b/backend/tests/fixtures/repos/car-dealership/initial__main/generators/cartags_convert_response.py
@@ -1,0 +1,14 @@
+from infrahub_sdk.generator import InfrahubGenerator
+
+
+class Generator(InfrahubGenerator):
+    async def generate(self, data: dict) -> None:
+        owner = self.nodes[0]
+        for node in owner.cars.peers:
+            car = node.peer
+            payload = {
+                "name": f"InfrahubNode-{owner.name.value.lower()}-{car.name.value.lower()}",
+                "description": "Tag",
+            }
+            obj = await self.client.create(kind="BuiltinTag", data=payload)
+            await obj.save(allow_upsert=True)

--- a/backend/tests/integration/proposed_change/test_proposed_change.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change.py
@@ -121,6 +121,7 @@ class TestProposedChangePipeline(TestInfrahubApp):
         tags = await client.all(kind="BuiltinTag", branch="conflict_free")
         # The Generator defined in the repository is expected to have created this tag during the pipeline
         assert "john-jesko" in [tag.name.value for tag in tags]  # type: ignore[attr-defined]
+        assert "InfrahubNode-john-jesko" in [tag.name.value for tag in tags]  # type: ignore[attr-defined]
 
         proposed_change_create.state.value = "merged"  # type: ignore[attr-defined]
         await proposed_change_create.save()

--- a/python_sdk/infrahub_sdk/generator.py
+++ b/python_sdk/infrahub_sdk/generator.py
@@ -97,7 +97,8 @@ class InfrahubGenerator:
             update_group=True,
             subscribers=self.subscribers,
         )
-        await self.process_nodes(data=data)
+        unpacked = data.get("data") or data
+        await self.process_nodes(data=unpacked)
         return data
 
     async def run(self, identifier: str, data: Optional[dict] = None) -> None:
@@ -115,6 +116,9 @@ class InfrahubGenerator:
     async def process_nodes(self, data: dict) -> None:
         if not self.convert_query_response:
             return
+
+        await self._init_client.schema.all(branch=self.branch_name)
+
         for kind in data:
             if kind in self._init_client.schema.cache[self.branch_name]:
                 for result in data[kind].get("edges", []):


### PR DESCRIPTION
When testing further I realized that I added the "convert_query_response" option after fully testing the pipeline and we need to have this as an attribute within the database too. 

Also adds a testcase that uses a generator with SDK objects.