### PR TITLE
Remove setting for storage as it conflicts with env variables

### DIFF
--- a/development/infrahub.toml
+++ b/development/infrahub.toml
@@ -21,9 +21,3 @@ address = "cache"
 
 [storage]
 driver = "local"
-
-[storage.local]
-path = "/opt/infrahub/storage"
-
-# [experimental_features]
-# pull_request = true


### PR DESCRIPTION
Removing the setting for storage location as it's pointing to the default setting regardless. Also it gets in the way of using environment variables. Also removed the experimental section that isn't used at the moment and when if we add anything there again it will probably be using environment variables.