### PR TITLE
BREAKING: Change env prefix from INFRAHUB_SDK_ -> INFRAHUB_

### DIFF
--- a/.devcontainer/demo-container/devcontainer.json
+++ b/.devcontainer/demo-container/devcontainer.json
@@ -26,7 +26,7 @@
   },
   "remoteUser": "vscode",
   "remoteEnv": {
-      "INFRAHUB_SDK_API_TOKEN": "06438eb2-8019-4776-878c-0941b1f1d1ec",
+      "INFRAHUB_API_TOKEN": "06438eb2-8019-4776-878c-0941b1f1d1ec",
       "INFRAHUB_DB_TYPE": "memgraph",
       "INFRAHUB_IMAGE_VER": "local"
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,7 @@
     },
     "remoteUser": "vscode",
     "remoteEnv": {
-        "INFRAHUB_SDK_API_TOKEN": "06438eb2-8019-4776-878c-0941b1f1d1ec",
+        "INFRAHUB_API_TOKEN": "06438eb2-8019-4776-878c-0941b1f1d1ec",
         "INFRAHUB_DB_TYPE": "memgraph",
         "INFRAHUB_IMAGE_VER": "local"
     },

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -135,8 +135,8 @@ services:
       INFRAHUB_ADDRESS: http://infrahub-server:8000
       INFRAHUB_PRODUCTION: false
       INFRAHUB_LOG_LEVEL: DEBUG
-      INFRAHUB_SDK_API_TOKEN: 06438eb2-8019-4776-878c-0941b1f1d1ec
-      INFRAHUB_SDK_TIMEOUT: 20
+      INFRAHUB_API_TOKEN: 06438eb2-8019-4776-878c-0941b1f1d1ec
+      INFRAHUB_TIMEOUT: 20
     volumes:
       - "git_data:/opt/infrahub/git"
       - "git_remote_data:/remote"

--- a/docs/docs/development/backend.mdx
+++ b/docs/docs/development/backend.mdx
@@ -26,9 +26,9 @@ Most of Infrahub and tools around it rely on some settings. These settings are i
 ```bash
 export INFRAHUB_PRODUCTION=false
 export INFRAHUB_SECURITY_SECRET_KEY=super-secret
-export INFRAHUB_SDK_USERNAME=admin
-export INFRAHUB_SDK_PASSWORD=infrahub
-export INFRAHUB_SDK_TIMEOUT=20
+export INFRAHUB_USERNAME=admin
+export INFRAHUB_PASSWORD=infrahub
+export INFRAHUB_TIMEOUT=20
 export INFRAHUB_METRICS_PORT=8001
 export INFRAHUB_DB_TYPE=memgraph # Accepts neo4j or memgraph
 export INFRAHUB_SECURITY_INITIAL_ADMIN_TOKEN="${ADMIN_TOKEN}" # Random string which can be generated using: openssl rand -hex 16

--- a/docs/docs/python-sdk/guides/client.mdx
+++ b/docs/docs/python-sdk/guides/client.mdx
@@ -30,7 +30,7 @@ client = InfrahubClientSync.init(address="http://localhost:8000")
 
 ## Authentication
 
-The SDK is using a token-based authentication method to authenticate with the API and GraphQL. The token can be provided using a Config object or you can define it as the `INFRAHUB_SDK_API_TOKEN` environment variable.
+The SDK is using a token-based authentication method to authenticate with the API and GraphQL. The token can be provided using a Config object or you can define it as the `INFRAHUB_API_TOKEN` environment variable.
 
 <Tabs groupId="async-sync">
   <TabItem value="Async" default>
@@ -38,7 +38,7 @@ The SDK is using a token-based authentication method to authenticate with the AP
   ```python
   from infrahub_sdk import InfrahubClient
   client = await InfrahubClient.init(config=Config(api_token="token"))
-  client = await InfrahubClient.init() # token is read from the INFRAHUB_SDK_API_TOKEN environment variable
+  client = await InfrahubClient.init() # token is read from the INFRAHUB_API_TOKEN environment variable
   ```
 
   </TabItem>
@@ -47,7 +47,7 @@ The SDK is using a token-based authentication method to authenticate with the AP
   ```python
   from infrahub_sdk import InfrahubClientSync
   client = InfrahubClientSync.init(config=Config(api_token="token"))
-  client = InfrahubClientSync.init() # token is read from the INFRAHUB_SDK_API_TOKEN environment variable
+  client = InfrahubClientSync.init() # token is read from the INFRAHUB_API_TOKEN environment variable
   ```
 
   </TabItem>

--- a/docs/docs/python-sdk/reference/config.mdx
+++ b/docs/docs/python-sdk/reference/config.mdx
@@ -31,14 +31,14 @@ The following settings can be defined in the Config class
 **Description**: The URL to use when connecting to Infrahub.<br />
 **Type**: `string`<br />
 **Default value**: http://localhost:8000<br />
-**Environment variable**: `INFRAHUB_SDK_ADDRESS`<br />
+**Environment variable**: `INFRAHUB_ADDRESS`<br />
 
 ## api_token
 
 **Property**: api_token<br />
 **Description**: API token for authentication against Infrahub.<br />
 **Type**: `string`<br />
-**Environment variable**: `INFRAHUB_SDK_API_TOKEN`<br />
+**Environment variable**: `INFRAHUB_API_TOKEN`<br />
 
 ## echo_graphql_queries
 
@@ -46,21 +46,21 @@ The following settings can be defined in the Config class
 **Description**: If set the GraphQL query and variables will be echoed to the screen<br />
 **Type**: `boolean`<br />
 **Default value**: False<br />
-**Environment variable**: `INFRAHUB_SDK_ECHO_GRAPHQL_QUERIES`<br />
+**Environment variable**: `INFRAHUB_ECHO_GRAPHQL_QUERIES`<br />
 
 ## username
 
 **Property**: username<br />
 **Description**: Username for accessing Infrahub<br />
 **Type**: `string`<br />
-**Environment variable**: `INFRAHUB_SDK_USERNAME`<br />
+**Environment variable**: `INFRAHUB_USERNAME`<br />
 
 ## password
 
 **Property**: password<br />
 **Description**: Password for accessing Infrahub<br />
 **Type**: `string`<br />
-**Environment variable**: `INFRAHUB_SDK_PASSWORD`<br />
+**Environment variable**: `INFRAHUB_PASSWORD`<br />
 
 ## default_branch
 
@@ -68,7 +68,7 @@ The following settings can be defined in the Config class
 **Description**: Default branch to target if not specified for each request.<br />
 **Type**: `string`<br />
 **Default value**: main<br />
-**Environment variable**: `INFRAHUB_SDK_DEFAULT_BRANCH`<br />
+**Environment variable**: `INFRAHUB_DEFAULT_BRANCH`<br />
 
 ## default_branch_from_git
 
@@ -76,14 +76,14 @@ The following settings can be defined in the Config class
 **Description**: Indicates if the default Infrahub branch to target should come from the active branch in the local Git repository.<br />
 **Type**: `boolean`<br />
 **Default value**: False<br />
-**Environment variable**: `INFRAHUB_SDK_DEFAULT_BRANCH_FROM_GIT`<br />
+**Environment variable**: `INFRAHUB_DEFAULT_BRANCH_FROM_GIT`<br />
 
 ## identifier
 
 **Property**: identifier<br />
 **Description**: Tracker identifier<br />
 **Type**: `string`<br />
-**Environment variable**: `INFRAHUB_SDK_IDENTIFIER`<br />
+**Environment variable**: `INFRAHUB_IDENTIFIER`<br />
 
 ## insert_tracker
 
@@ -91,7 +91,7 @@ The following settings can be defined in the Config class
 **Description**: Insert a tracker on queries to the server<br />
 **Type**: `boolean`<br />
 **Default value**: False<br />
-**Environment variable**: `INFRAHUB_SDK_INSERT_TRACKER`<br />
+**Environment variable**: `INFRAHUB_INSERT_TRACKER`<br />
 
 ## max_concurrent_execution
 
@@ -99,7 +99,7 @@ The following settings can be defined in the Config class
 **Description**: Max concurrent execution in batch mode<br />
 **Type**: `integer`<br />
 **Default value**: 5<br />
-**Environment variable**: `INFRAHUB_SDK_MAX_CONCURRENT_EXECUTION`<br />
+**Environment variable**: `INFRAHUB_MAX_CONCURRENT_EXECUTION`<br />
 
 ## mode
 
@@ -108,7 +108,7 @@ The following settings can be defined in the Config class
 **Type**: `string`<br />
 **Default value**: default<br />
 **Choices**: default, tracking<br />
-**Environment variable**: `INFRAHUB_SDK_MODE`<br />
+**Environment variable**: `INFRAHUB_MODE`<br />
 
 ## pagination_size
 
@@ -116,7 +116,7 @@ The following settings can be defined in the Config class
 **Description**: Page size for queries to the server<br />
 **Type**: `integer`<br />
 **Default value**: 50<br />
-**Environment variable**: `INFRAHUB_SDK_PAGINATION_SIZE`<br />
+**Environment variable**: `INFRAHUB_PAGINATION_SIZE`<br />
 
 ## retry_delay
 
@@ -124,7 +124,7 @@ The following settings can be defined in the Config class
 **Description**: Number of seconds to wait until attempting a retry.<br />
 **Type**: `integer`<br />
 **Default value**: 5<br />
-**Environment variable**: `INFRAHUB_SDK_RETRY_DELAY`<br />
+**Environment variable**: `INFRAHUB_RETRY_DELAY`<br />
 
 ## retry_on_failure
 
@@ -132,7 +132,7 @@ The following settings can be defined in the Config class
 **Description**: Retry operation in case of failure<br />
 **Type**: `boolean`<br />
 **Default value**: False<br />
-**Environment variable**: `INFRAHUB_SDK_RETRY_ON_FAILURE`<br />
+**Environment variable**: `INFRAHUB_RETRY_ON_FAILURE`<br />
 
 ## timeout
 
@@ -140,7 +140,7 @@ The following settings can be defined in the Config class
 **Description**: Default connection timeout in seconds<br />
 **Type**: `integer`<br />
 **Default value**: 10<br />
-**Environment variable**: `INFRAHUB_SDK_TIMEOUT`<br />
+**Environment variable**: `INFRAHUB_TIMEOUT`<br />
 
 ## transport
 
@@ -149,21 +149,21 @@ The following settings can be defined in the Config class
 **Type**: `string`<br />
 **Default value**: httpx<br />
 **Choices**: httpx, json<br />
-**Environment variable**: `INFRAHUB_SDK_TRANSPORT`<br />
+**Environment variable**: `INFRAHUB_TRANSPORT`<br />
 
 ## proxy
 
 **Property**: proxy<br />
 **Description**: Proxy address<br />
 **Type**: `string`<br />
-**Environment variable**: `INFRAHUB_SDK_PROXY`<br />
+**Environment variable**: `INFRAHUB_PROXY`<br />
 
 ## proxy_mounts
 
 **Property**: proxy_mounts<br />
 **Description**: Proxy mounts configuration<br />
 **Type**: `object`<br />
-**Environment variable**: `INFRAHUB_SDK_PROXY_MOUNTS`<br />
+**Environment variable**: `INFRAHUB_PROXY_MOUNTS`<br />
 
 ## update_group_context
 
@@ -171,7 +171,7 @@ The following settings can be defined in the Config class
 **Description**: Update GraphQL query groups<br />
 **Type**: `boolean`<br />
 **Default value**: False<br />
-**Environment variable**: `INFRAHUB_SDK_UPDATE_GROUP_CONTEXT`<br />
+**Environment variable**: `INFRAHUB_UPDATE_GROUP_CONTEXT`<br />
 
 ## recorder
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -71,8 +71,8 @@ infrahubGit:
       INFRAHUB_DB_TYPE: neo4j
       INFRAHUB_LOG_LEVEL: DEBUG
       INFRAHUB_PRODUCTION: "false"
-      INFRAHUB_SDK_API_TOKEN: 06438eb2-8019-4776-878c-0941b1f1d1ec
-      INFRAHUB_SDK_TIMEOUT: "20"
+      INFRAHUB_API_TOKEN: 06438eb2-8019-4776-878c-0941b1f1d1ec
+      INFRAHUB_TIMEOUT: "20"
     imagePullPolicy: Always
   waitForInfrahubServer:
     image:

--- a/python_sdk/infrahub_sdk/config.py
+++ b/python_sdk/infrahub_sdk/config.py
@@ -14,10 +14,10 @@ from infrahub_sdk.utils import get_branch, is_valid_url
 
 class ProxyMountsConfig(pydantic.BaseSettings):
     http: str = pydantic.Field(
-        default=None, description="Proxy for HTTP requests", alias="http://", env="INFRAHUB_SDK_PROXY_MOUNTS_HTTP"
+        default=None, description="Proxy for HTTP requests", alias="http://", env="INFRAHUB_PROXY_MOUNTS_HTTP"
     )
     https: str = pydantic.Field(
-        default=None, description="Proxy for HTTPS requests", alias="https://", env="INFRAHUB_SDK_PROXY_MOUNTS_HTTPS"
+        default=None, description="Proxy for HTTPS requests", alias="https://", env="INFRAHUB_PROXY_MOUNTS_HTTPS"
     )
 
     class Config:
@@ -61,7 +61,7 @@ class ConfigBase(pydantic.BaseSettings):
     update_group_context: bool = pydantic.Field(default=False, description="Update GraphQL query groups")
 
     class Config:
-        env_prefix = "INFRAHUB_SDK_"
+        env_prefix = "INFRAHUB_"
         case_sensitive = False
         validate_assignment = True
 

--- a/python_sdk/infrahub_sdk/playback.py
+++ b/python_sdk/infrahub_sdk/playback.py
@@ -60,5 +60,5 @@ class JSONPlayback(pydantic.BaseSettings):
         return response
 
     class Config:
-        env_prefix = "INFRAHUB_SDK_PLAYBACK_"
+        env_prefix = "INFRAHUB_PLAYBACK_"
         case_sensitive = False

--- a/python_sdk/infrahub_sdk/recorder.py
+++ b/python_sdk/infrahub_sdk/recorder.py
@@ -72,5 +72,5 @@ class JSONRecorder(pydantic.BaseSettings):
         response.request.url = httpx.URL(url=modified)
 
     class Config:
-        env_prefix = "INFRAHUB_SDK_JSON_RECORDER_"
+        env_prefix = "INFRAHUB_JSON_RECORDER_"
         case_sensitive = False


### PR DESCRIPTION
Makes the environment prefix for the SDK and infrahubctl shorter.