### PR TITLE
Display prefix value instead of id in ip address breadcrumb

### DIFF
--- a/frontend/src/screens/ipam/ip-addresses/ipam-ip-address-list.tsx
+++ b/frontend/src/screens/ipam/ip-addresses/ipam-ip-address-list.tsx
@@ -22,7 +22,14 @@ import ErrorScreen from "../../error-screen/error-screen";
 import LoadingScreen from "../../loading-screen/loading-screen";
 import ObjectItemEditComponent from "../../object-item-edit/object-item-edit-paginated";
 import { constructPathForIpam } from "../common/utils";
-import { IPAM_QSP, IPAM_ROUTE, IPAM_TABS, IP_ADDRESS_GENERIC } from "../constants";
+import {
+  IPAM_QSP,
+  IPAM_ROUTE,
+  IPAM_TABS,
+  IP_ADDRESS_GENERIC,
+  IP_PREFIX_GENERIC,
+} from "../constants";
+import { GET_PREFIX_KIND } from "../../../graphql/queries/ipam/prefixes";
 
 const IpamIPAddressesList = forwardRef((props, ref) => {
   const { prefix } = useParams();
@@ -43,6 +50,13 @@ const IpamIPAddressesList = forwardRef((props, ref) => {
   const { loading, error, data, refetch } = useQuery(GET_IP_ADDRESSES, {
     variables: { prefixIds: prefix ? [prefix] : null },
   });
+
+  const { data: getPrefixKindData } = useQuery(GET_PREFIX_KIND, {
+    variables: { ids: [prefix] },
+    skip: !prefix,
+  });
+
+  const prefixData = getPrefixKindData?.[IP_PREFIX_GENERIC]?.edges?.[0]?.node;
 
   // Provide refetch function to parent
   useImperativeHandle(ref, () => ({ refetch }));
@@ -124,15 +138,18 @@ const IpamIPAddressesList = forwardRef((props, ref) => {
 
   return (
     <div>
-      {prefix && (
+      {prefixData && (
         <div className="flex items-center mb-2">
-          <span className="mr-2">Prefix:</span>
           <Link
-            to={constructPathForIpam(`${IPAM_ROUTE.PREFIXES}/${prefix}`, [
+            to={constructPathForIpam(`${IPAM_ROUTE.PREFIXES}/${prefixData.id}`, [
               { name: IPAM_QSP, value: IPAM_TABS.PREFIX_DETAILS },
             ])}>
-            {prefix}
+            {prefixData.display_label}
           </Link>
+
+          <Icon icon="mdi:chevron-right" />
+
+          <span>IP Addresses</span>
         </div>
       )}
 

--- a/frontend/tests/e2e/ipam/ip-address-list.spec.ts
+++ b/frontend/tests/e2e/ipam/ip-address-list.spec.ts
@@ -31,7 +31,7 @@ test.describe("/ipam/addresses - IP Address list", () => {
 
     await test.step("select a prefix to view all ip addresses", async () => {
       await page.getByRole("treeitem", { name: "172.20.20.0/27" }).click();
-      await expect(page.getByText("Prefix:")).toBeVisible();
+      await expect(page.getByText("172.20.20.0/27IP Addresses")).toBeVisible();
       await expect(page.getByText("Showing 1 to ")).toBeVisible();
     });
 


### PR DESCRIPTION
<img width="1365" alt="image" src="https://github.com/opsmill/infrahub/assets/15261980/4805e1e4-b304-4113-8a4a-59978bcc76ad">
