### PR TITLE
Update NodeAttributeAddMigrationQuery01 to add is_default

### DIFF
--- a/backend/infrahub/core/migrations/schema/node_attribute_add.py
+++ b/backend/infrahub/core/migrations/schema/node_attribute_add.py
@@ -50,7 +50,7 @@ class NodeAttributeAddMigrationQuery01(AttributeMigrationQuery):
         }
         WITH n1 as n, r1 as rb
         WHERE rb.status = "active"
-        MERGE (av:AttributeValue { value: $attr_value })
+        MERGE (av:AttributeValue { value: $attr_value, is_default: true })
         MERGE (is_protected_value:Boolean { value: $is_protected_default })
         MERGE (is_visible_value:Boolean { value: $is_visible_default })
         WITH n, av, is_protected_value, is_visible_value


### PR DESCRIPTION
Related to #2908

While looking at NodeAttributeAddMigrationQuery01, I realized that we don't need to specifically support IPHost and IPNetwork because we don't create a new AttributeValue node in this query, only a new Attribute node.

Having said that the query needed to be updated to support the new is_default flag otherwise the result would be somewhat unpredictable. 