### PR TITLE
run site generation for `infrastructure_edge` outside of batch

### DIFF
--- a/models/infrastructure_edge.py
+++ b/models/infrastructure_edge.py
@@ -271,7 +271,7 @@ VLANS = (
 store = NodeStore()
 
 
-async def generate_site(client: InfrahubClient, log: logging.Logger, branch: str, site: Dict[str, str]):
+async def generate_site(client: InfrahubClient, log: logging.Logger, branch: str, site: Dict[str, str]) -> str:
     group_eng = store.get("Engineering Team")
     group_ops = store.get("Operation Team")
     account_pop = store.get("pop-builder")
@@ -1155,11 +1155,8 @@ async def run(client: InfrahubClient, log: logging.Logger, branch: str):
     # ------------------------------------------
     log.info("Creating Site and associated objects (Device, Circuit, BGP Sessions)")
     sites = site_generator(nbr_site=5)
-    batch = await client.create_batch()
     for site in sites:
-        batch.add(task=generate_site, site=site, client=client, branch=branch, log=log)
-
-    async for _, response in batch.execute():
+        response = await generate_site(client=client, log=log, branch=branch, site=site)
         log.debug(f"{response} - Creation Completed")
 
     # ------------------------------------------


### PR DESCRIPTION
fixes #3187

the root cause of the linked issue is that the `generate_site` function in `infrastructure_edge.py` is run inside of a batch _and_ includes updates to the `many` relationships `CoreStandardGroup.members`. This is a problem b/c each of the 5 batches sends its own update `mutation` for each batch. These mutations are run inside of database transactions and if they are handled at the same time, then it is possible for duplicate relationships to be created such that we have multiple _almost_ identical relationships linking pairs of nodes. These duplicate relationships cause the differing count numbers and inconsistent `limit` behavior described in the bug.

there is probably a cleaner way to make this update and still use batches, but I could not get it to work and we don't have time to rewrite `generate_site` before the release

Some ideas for longer term solutions
- some sort of lock to prevent this type of simultaneous update race condition issue (although this might be hard to implement b/c a full solution would require locking both sides of a relationships for an update)
-  we could consider consolidating the logic we use to show counts of group members and paginate members of many relationships, so that duplicate relationships could be ignored, but then we would need to make sure we correctly handle duplicate relationships during deletes/updates or it would just become a problem in a different place