### PR TITLE
Update image version and accept NEO4J licence in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,13 +105,12 @@ services:
       retries: 3
 
   database:
-    image: ${NEO4J_DOCKER_IMAGE:-neo4j:5.19.0-enterprise}
+    image: ${NEO4J_DOCKER_IMAGE:-neo4j:5.19.0-community}
     restart: unless-stopped
     environment:
       - "NEO4J_AUTH=neo4j/admin"
       - "NEO4J_dbms_security_procedures_unrestricted=apoc.*"
       - "NEO4J_dbms_security_auth__minimum__password__length=4"
-      - "NEO4J_ACCEPT_LICENSE_AGREEMENT=yes"
     volumes:
       - "database_data:/data"
       - "database_logs:/logs"
@@ -157,7 +156,7 @@ services:
     deploy:
       mode: replicated
       replicas: 2
-    image: "registry.opsmill.io/opsmill/infrahub:${VERSION:-0.12.1}"
+    image: "registry.opsmill.io/opsmill/infrahub:${VERSION:-0.13.0}"
     command: infrahub git-agent start --debug
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
The `docker-compose.yml` file at the root of the repository is still referencing the enterprise version of NEO4J, so we need to accept the license agreement.

The workflow to update the Infrahub image version in this compose file doesn't seem to have been triggered, hence manually updating it for now.