### PR TITLE
Set integer enum values to strings, otherwise keep the previous logic of _.join

### DIFF
--- a/backend/infrahub/core/enums.py
+++ b/backend/infrahub/core/enums.py
@@ -8,6 +8,10 @@ ENUM_NAME_REGEX = re.compile("[_a-zA-Z0-9]+")
 def generate_python_enum(name: str, options: List[Any]) -> Type[enum.Enum]:
     main_attrs = {}
     for option in options:
-        enum_name = "_".join(re.findall(ENUM_NAME_REGEX, option)).upper()
+        if isinstance(option, int):
+            enum_name = str(option)
+        else:
+            enum_name = "_".join(re.findall(ENUM_NAME_REGEX, option)).upper()
+
         main_attrs[enum_name] = option
     return enum.Enum(name, main_attrs)  # type: ignore[return-value]

--- a/backend/tests/unit/core/test_enums.py
+++ b/backend/tests/unit/core/test_enums.py
@@ -10,3 +10,13 @@ def test_generate_python_enum():
     enum_blue = enum_class("blue")
     assert isinstance(enum_blue, enum.Enum)
     assert {enum.name for enum in enum_class} == {"RED", "BLUE"}
+
+
+def test_generate_python_enum_with_integers():
+    enum_class = generate_python_enum(name="DHGroup", options=[2, 5, 14])
+    assert isinstance(enum_class, enum.EnumType)
+
+    enum_two = enum_class(2)
+    assert isinstance(enum_two, enum.Enum)
+    assert {enum.name for enum in enum_class} == {"2", "5", "14"}
+    assert {enum.value for enum in enum_class} == {2, 5, 14}


### PR DESCRIPTION
Fixes #3281

It looks like integers need to be handled due to the `kind: Number` when using `enum` on a node.

This simply stringifies the enum integer value when it's dynamically constructing the enum. If a mapping is passed into `enum.Enum`, the key appears like it should be a string or tuple for it to unpack, therefore, it seems like just stringifying an integer makes the most sense to keep with current strategy.

```
│ /usr/local/lib/python3.12/enum.py:898 in _create_                                                │
│                                                                                                  │
│    895 │   │   │   if isinstance(item, str):                                                     │
│    896 │   │   │   │   member_name, member_value = item, names[item]                             │
│    897 │   │   │   else:                                                                         │
│ ❱  898 │   │   │   │   member_name, member_value = item                                          │
│    899 │   │   │   classdict[member_name] = member_value 
```