### PR TITLE
bugfix: demo data - Add identifiers to site relationships

### DIFF
--- a/models/base/location.yml
+++ b/models/base/location.yml
@@ -73,14 +73,17 @@ nodes:
         optional: true
     relationships:
       - name: devices
+        identifier: "site__devices"
         cardinality: many
         peer: InfraDevice
         kind: Component
       - name: vlans
+        identifier: "site__vlans"
         cardinality: many
         kind: Component
         peer: InfraVLAN
       - name: circuit_endpoints
+        identifier: "site__circuit_endpoints"
         cardinality: many
         kind: Component
         peer: InfraCircuitEndpoint


### PR DESCRIPTION
When looking at the site detail of a site such as `atl1` in the demo data, the following tabs were showing 0: devices, vlans, and circuit endpoints. The demo data does indeed have devices in the `atl1` site as depicted below.

<img width="789" alt="image" src="https://github.com/opsmill/infrahub/assets/29315002/ade0f1b8-fefe-48a7-b7b5-1787ef0f6cbe">

<img width="727" alt="image" src="https://github.com/opsmill/infrahub/assets/29315002/5765e68a-1651-411c-b933-fb63f71e7203">

With the identifiers updated in the demo data, they're now properly showing.

<img width="802" alt="image" src="https://github.com/opsmill/infrahub/assets/29315002/69e1cc01-5acc-4a95-9f41-1d1c570768d0">
