### PR TITLE
Readding restart after schema load to avoid causing CI failures

### DIFF
--- a/tasks/dev.py
+++ b/tasks/dev.py
@@ -151,7 +151,8 @@ def load_infra_data(context: Context, database: str = INFRAHUB_DATABASE):
 @task(optional=["database"])
 def load_infra_schema(context: Context, database: str = INFRAHUB_DATABASE):
     """Load the base schema for infrastructure."""
-    load_infrastructure_schema(context=context, database=database, namespace=NAMESPACE)
+    load_infrastructure_schema(context=context, database=database, namespace=NAMESPACE, add_wait=False)
+    restart_services(context=context, database=database, namespace=NAMESPACE)
 
 
 @task(optional=["database"])


### PR DESCRIPTION
We need to troubelshoot why the GraphQL schema starts to behave incorrectly before we can remove this again.