### PR TITLE
Add Core to restricted namespaces

### DIFF
--- a/backend/infrahub/core/constants/__init__.py
+++ b/backend/infrahub/core/constants/__init__.py
@@ -276,7 +276,7 @@ RESTRICTED_NAMESPACES: list[str] = [
     "Account",
     "Branch",
     # "Builtin",
-    # "Core",
+    "Core",
     "Deprecated",
     "Diff",
     "Infrahub",

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -381,7 +381,6 @@ async def test_schema_branch_add_profile_schema(schema_all_in_one):
         "ProfileBuiltinTag",
         "ProfileBuiltinStatus",
         "ProfileBuiltinBadge",
-        "ProfileCoreStandardGroup",
         "ProfileInfraTinySchema",
     }
 
@@ -396,7 +395,6 @@ async def test_schema_branch_add_profile_schema(schema_all_in_one):
         "ProfileBuiltinTag",
         "ProfileBuiltinStatus",
         "ProfileBuiltinBadge",
-        "ProfileCoreStandardGroup",
         "ProfileInfraTinySchema",
     }
 

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -419,7 +419,6 @@ async def test_schema_branch_add_profile_schema_respects_flag(schema_all_in_one)
         "ProfileBuiltinCriticality",
         "ProfileBuiltinStatus",
         "ProfileBuiltinBadge",
-        "ProfileCoreStandardGroup",
         "ProfileInfraTinySchema",
     }
 

--- a/frontend/app/tests/e2e/resource-manager/resource-pool.spec.ts
+++ b/frontend/app/tests/e2e/resource-manager/resource-pool.spec.ts
@@ -20,16 +20,7 @@ test.describe("/resource-manager - Resource Manager", () => {
 
     await page.getByLabel("Select an object type").click();
 
-    await Promise.all([
-      page.waitForResponse((response) => {
-        const reqData = response.request().postDataJSON();
-        const status = response.status();
-
-        return reqData?.operationName === "ProfileCoreIPPrefixPool" && status === 200;
-      }),
-
-      page.getByRole("option", { name: "CoreIPPrefixPool" }).click(),
-    ]);
+    await page.getByRole("option", { name: "CoreIPPrefixPool" }).click();
 
     await page.getByLabel("Name *").fill("test prefix pool");
     await page.getByLabel("Resources *").click();

--- a/python_sdk/tests/fixtures/models/valid_schemas/contract.yml
+++ b/python_sdk/tests/fixtures/models/valid_schemas/contract.yml
@@ -19,14 +19,14 @@ nodes:
         optional: true
     relationships:
       - name: Organization
-        peer: CoreOrganization
+        peer: TestOrganization
         optional: false
         cardinality: one
         kind: Attribute
 
 extensions:
   nodes:
-    - kind: CoreOrganization
+    - kind: TestOrganization
       relationships:
         - name: contract
           peer: ProcurementContract

--- a/python_sdk/tests/integration/conftest.py
+++ b/python_sdk/tests/integration/conftest.py
@@ -118,7 +118,7 @@ async def builtin_org_schema() -> SchemaRoot:
         "nodes": [
             {
                 "name": "Organization",
-                "namespace": "Core",
+                "namespace": "Test",
                 "description": "An organization represent a legal entity, a company.",
                 "include_in_menu": True,
                 "label": "Organization",

--- a/python_sdk/tests/integration/test_infrahub_client.py
+++ b/python_sdk/tests/integration/test_infrahub_client.py
@@ -191,7 +191,7 @@ class TestInfrahubClient:
                 await obj.save(allow_upsert=True)
                 tags.append(obj)
 
-            org = await clt.create(kind="CoreOrganization", name=orgname, tags=tags)
+            org = await clt.create(kind="TestOrganization", name=orgname, tags=tags)
             await org.save(allow_upsert=True)
 
         # First execution, we create one org with 3 tags

--- a/python_sdk/tests/integration/test_infrahub_client_sync.py
+++ b/python_sdk/tests/integration/test_infrahub_client_sync.py
@@ -193,7 +193,7 @@ class TestInfrahubClientSync:
                 obj.save(allow_upsert=True)
                 tags.append(obj)
 
-            org = clt.create(kind="CoreOrganization", name=orgname, tags=tags)
+            org = clt.create(kind="TestOrganization", name=orgname, tags=tags)
             org.save(allow_upsert=True)
 
         # First execution, we create one org with 3 tags

--- a/python_sdk/tests/integration/test_node.py
+++ b/python_sdk/tests/integration/test_node.py
@@ -292,7 +292,7 @@ class TestInfrahubNode:
         assert node.name.value == "cdg01"  # type: ignore[attr-defined]
 
     async def test_relationship_manager_errors_without_fetch(self, client: InfrahubClient, load_builtin_schema):
-        organization = await client.create("CoreOrganization", name="organization-1")
+        organization = await client.create("TestOrganization", name="organization-1")
         await organization.save()
         tag = await client.create("BuiltinTag", name="blurple")
         await tag.save()
@@ -304,7 +304,7 @@ class TestInfrahubNode:
         organization.tags.add(tag)
         await organization.save()
 
-        organization = await client.get("CoreOrganization", name__value="organization-1")
+        organization = await client.get("TestOrganization", name__value="organization-1")
         assert [t.id for t in organization.tags.peers] == [tag.id]
 
     async def test_relationships_not_overwritten(


### PR DESCRIPTION
Fixes #996.

(As discussed later in the comments this also removes the profile for Core models)