### PR TITLE
fix(ci): enable benchmarks back

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -780,11 +780,11 @@ jobs:
       - files-changed
       - yaml-lint
       - python-lint
-    if: false  # |
-      # always() && !cancelled() &&
-      # !contains(needs.*.result, 'failure') &&
-      # !contains(needs.*.result, 'cancelled') &&
-      # needs.files-changed.outputs.backend == 'true'
+    if: |
+      always() && !cancelled() &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled') &&
+      needs.files-changed.outputs.backend == 'true'
     runs-on:
       group: huge-runners
     env:


### PR DESCRIPTION
It seems to have been mistakenly disabled during the merge of candidate into develop...