### PR TITLE
Add skeleton for IPPrefix pool utilization query

### DIFF
--- a/backend/infrahub/graphql/queries/__init__.py
+++ b/backend/infrahub/graphql/queries/__init__.py
@@ -4,6 +4,7 @@ from .diff.old import DiffSummaryOld
 from .internal import InfrahubInfo
 from .ipam import InfrahubIPAddressGetNextAvailable, InfrahubIPPrefixGetNextAvailable
 from .relationship import Relationship
+from .resource_manager import InfrahubResourcePoolUtilization
 from .status import InfrahubStatus
 from .task import Task
 
@@ -15,6 +16,7 @@ __all__ = [
     "InfrahubStatus",
     "InfrahubIPAddressGetNextAvailable",
     "InfrahubIPPrefixGetNextAvailable",
+    "InfrahubResourcePoolUtilization",
     "Relationship",
     "Task",
 ]

--- a/backend/infrahub/graphql/queries/resource_manager.py
+++ b/backend/infrahub/graphql/queries/resource_manager.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from graphene import Field, Float, Int, List, ObjectType, String
+
+if TYPE_CHECKING:
+    from graphql import GraphQLResolveInfo
+
+
+class IPPoolUtilizationResource(ObjectType):
+    id = Field(String, required=True, description="The ID of the current resource")
+    display_label = Field(String, required=True, description="The common name of the resource")
+    kind = Field(String, required=True, description="The resource kind")
+    weight = Field(Int, required=True, description="The relative weight of this resource.")
+    utilization = Field(Float, required=True, description="The overall utilization of the resource.")
+    utilization_branches = Field(
+        Float,
+        required=True,
+        description="The utilization of the resource across all branches aside from the default one.",
+    )
+    utilization_default_branch = Field(
+        Float, required=True, description="The overall utilization of the resource isolated to the default branch."
+    )
+
+
+class IPPrefixUtilizationEdge(ObjectType):
+    node = Field(IPPoolUtilizationResource, required=True)
+
+
+class IPPrefixPoolUtilization(ObjectType):
+    count = Field(Int, required=True, description="The number of resources within the selected pool.")
+    utilization = Field(Float, required=True, description="The overall utilization of the pool.")
+    utilization_branches = Field(
+        Float, required=True, description="The utilization of the pool across all branches aside from the default one."
+    )
+    utilization_default_branch = Field(
+        Float, required=True, description="The overall utilization of the pool isolated to the default branch."
+    )
+    edges = Field(List(of_type=IPPrefixUtilizationEdge, required=True), required=True)
+
+    @staticmethod
+    async def resolve(  # pylint: disable=unused-argument
+        root: dict,
+        info: GraphQLResolveInfo,
+        pool_id: str,
+    ) -> dict:
+        return {
+            "count": 2,
+            "utilization": 46,
+            "utilization_branches": 12,
+            "utilization_default_branch": 34,
+            "edges": [
+                {
+                    "node": {
+                        "id": "imaginary-id-1",
+                        "kind": "IpamIPPrefix",
+                        "display_label": "10.24.16.0/18",
+                        "weight": 18,
+                        "utilization": 50,
+                        "utilization_branches": 26,
+                        "utilization_default_branch": 76,
+                    }
+                },
+                {
+                    "node": {
+                        "id": "imaginary-id-2",
+                        "kind": "IpamIPPrefix",
+                        "display_label": "10.28.0.0/16",
+                        "weight": 16,
+                        "utilization": 20,
+                        "utilization_branches": 0,
+                        "utilization_default_branch": 20,
+                    }
+                },
+            ],
+        }
+
+
+InfrahubResourcePoolUtilization = Field(
+    IPPrefixPoolUtilization,
+    pool_id=String(required=True),
+    resolver=IPPrefixPoolUtilization.resolve,
+)

--- a/backend/infrahub/graphql/schema.py
+++ b/backend/infrahub/graphql/schema.py
@@ -36,6 +36,7 @@ from .queries import (
     InfrahubInfo,
     InfrahubIPAddressGetNextAvailable,
     InfrahubIPPrefixGetNextAvailable,
+    InfrahubResourcePoolUtilization,
     InfrahubStatus,
     Relationship,
     Task,
@@ -89,6 +90,7 @@ class InfrahubBaseQuery(ObjectType):
 
     IPAddressGetNextAvailable = InfrahubIPAddressGetNextAvailable
     IPPrefixGetNextAvailable = InfrahubIPPrefixGetNextAvailable
+    InfrahubResourcePoolUtilization = InfrahubResourcePoolUtilization
 
 
 class InfrahubBaseMutation(ObjectType):


### PR DESCRIPTION
Updated after discussion about format, for now this is only to allow the frontend to have something to test.

Example query:

```graphql
query MyQuery {
  InfrahubResourcePoolUtilization(pool_id: "17cfebfe-028f-e6b0-58d3-1746886288ef") {
    count
    utilization
    utilization_branches
    utilization_default_branch
    edges {
      node {
        display_label
        id
        kind
        utilization
        utilization_branches
        utilization_default_branch
        weight
      }
    }
  }
}
```

Static response:
```json
{
  "data": {
    "InfrahubResourcePoolUtilization": {
      "count": 2,
      "utilization": 46,
      "utilization_branches": 12,
      "utilization_default_branch": 34,
      "edges": [
        {
          "node": {
            "display_label": "10.24.16.0/18",
            "id": "imaginary-id-1",
            "kind": "IpamIPPrefix",
            "utilization": 50,
            "utilization_branches": 26,
            "utilization_default_branch": 76,
            "weight": 18
          }
        },
        {
          "node": {
            "display_label": "10.28.0.0/16",
            "id": "imaginary-id-2",
            "kind": "IpamIPPrefix",
            "utilization": 20,
            "utilization_branches": 0,
            "utilization_default_branch": 20,
            "weight": 16
          }
        }
      ]
    }
  }
}
```