### PR TITLE
Remove "contact opsmill" from swagger docs

### DIFF
--- a/backend/infrahub/server.py
+++ b/backend/infrahub/server.py
@@ -93,10 +93,6 @@ app = FastAPI(
     title="Infrahub",
     version=__version__,
     lifespan=lifespan,
-    contact={
-        "name": "OpsMill",
-        "email": "info@opsmill.com",
-    },
     openapi_url="/api/openapi.json",
     docs_url="/api/docs",
     redoc_url="/api/redoc",


### PR DESCRIPTION
There's a "Contact OpsMill" at the top of the /api/docs page that serves no purpose in swagger docs.