### PR TITLE
Add query skeleton for InfrahubResourcePoolAllocated

### DIFF
--- a/backend/infrahub/graphql/queries/__init__.py
+++ b/backend/infrahub/graphql/queries/__init__.py
@@ -5,7 +5,7 @@ from .diff.old import DiffSummaryOld
 from .internal import InfrahubInfo
 from .ipam import InfrahubIPAddressGetNextAvailable, InfrahubIPPrefixGetNextAvailable
 from .relationship import Relationship
-from .resource_manager import InfrahubResourcePoolUtilization
+from .resource_manager import InfrahubResourcePoolAllocated, InfrahubResourcePoolUtilization
 from .status import InfrahubStatus
 from .task import Task
 
@@ -18,6 +18,7 @@ __all__ = [
     "InfrahubStatus",
     "InfrahubIPAddressGetNextAvailable",
     "InfrahubIPPrefixGetNextAvailable",
+    "InfrahubResourcePoolAllocated",
     "InfrahubResourcePoolUtilization",
     "Relationship",
     "Task",

--- a/backend/infrahub/graphql/schema.py
+++ b/backend/infrahub/graphql/schema.py
@@ -38,6 +38,7 @@ from .queries import (
     InfrahubInfo,
     InfrahubIPAddressGetNextAvailable,
     InfrahubIPPrefixGetNextAvailable,
+    InfrahubResourcePoolAllocated,
     InfrahubResourcePoolUtilization,
     InfrahubStatus,
     Relationship,
@@ -93,6 +94,7 @@ class InfrahubBaseQuery(ObjectType):
 
     IPAddressGetNextAvailable = InfrahubIPAddressGetNextAvailable
     IPPrefixGetNextAvailable = InfrahubIPPrefixGetNextAvailable
+    InfrahubResourcePoolAllocated = InfrahubResourcePoolAllocated
     InfrahubResourcePoolUtilization = InfrahubResourcePoolUtilization
 
 


### PR DESCRIPTION
Will be used to query for resources used within a pool in the resource manager.

Example query:
```graphql
query MyQuery {
  InfrahubResourcePoolAllocated(pool_id: "d2ec0efb-055e-411a-99a1-4a961ac1f804") {
    count
    edges {
      node {
        branch
        display_label
        id
        identifier
        kind
      }
    }
  }
}
```

Static response:
```json
{
  "data": {
    "InfrahubResourcePoolAllocated": {
      "count": 2,
      "edges": [
        {
          "node": {
            "branch": "main",
            "display_label": "10.24.16.0/18",
            "id": "imaginary-id-1",
            "identifier": "device1__dhcpA",
            "kind": "IpamIPPrefix"
          }
        },
        {
          "node": {
            "branch": "branch1",
            "display_label": "10.28.0.0/16",
            "id": "imaginary-id-2",
            "identifier": null,
            "kind": "IpamIPPrefix"
          }
        }
      ]
    }
  }
}
```