### PR TITLE
Fix for IP namespace test in E2E tests

### DIFF
--- a/frontend/tests/e2e/ipam/ip-namespace.spec.ts
+++ b/frontend/tests/e2e/ipam/ip-namespace.spec.ts
@@ -8,7 +8,7 @@ test.describe("/ipam - IP Namespace", () => {
   test("create ip namespace", async ({ page }) => {
     await page.goto("/objects/BuiltinIPNamespace");
 
-    await expect(page.getByRole("link", { name: "default" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "default", exact: true })).toBeVisible();
 
     await page.getByTestId("create-object-button").click();
     await page.getByTestId("side-panel-container").getByTestId("select-open-option-button").click();


### PR DESCRIPTION
Fixes #3355 

I tried to add a check to ensure that the list of existing namespace has finished to load before creating a new one ... 
