### PR TITLE
Small update for the demo environment in the doc

### DIFF
--- a/docs/docs/topics/local-demo-environment.mdx
+++ b/docs/docs/topics/local-demo-environment.mdx
@@ -29,7 +29,6 @@ It's designed to be controlled by `invoke` using a list of predefined commands.
 | **cache**           | redis:7.2                                              | Cache based on Redis, mainly used for distributed lock |
 | **infrahub-server** | Dockerfile                                             | Instance of the API server, running GraphQL            |
 | **infrahub-git**    | Dockerfile                                             | Instance of the Git agent, managing the Git Repository |
-| **frontend**        | Dockerfile                                             | Instance of the Frontend                               |
 
 <ReferenceLink title="Check the architecture diagram to have more information about each component" url="/topics/architecture" />
 
@@ -51,12 +50,6 @@ On a Laptop, both Docker & Docker Compose can be installed by installing [Docker
 :::
 
 ### First utilization
-
-Before the first utilization you need to build the images for Infrahub with the command:
-
-```bash
-invoke demo.build
-```
 
 Initialize the database and start the application
 
@@ -114,6 +107,6 @@ export INVOKE_PTY=0 to disable it completely
 It's recommended to check if all containers are still running using `invoke demo.status`. The 5 containers should be running and be present.
 
 - If one is not running, you can try to restart it with `invoke demo.start`.
-- If the container is still not coming up, you can watch the logs with `docker logs <container name>` (the container name will include the name of the project and a number, i.e., `infrahub-dev-infrahub-git-1` ).
+- If the container is still not coming up, you can watch the logs with `docker logs <container name>` (the container name will include the name of the project and a number, i.e., `infrahub-infrahub-git-1` ).
 
 If some containers are still not coming up, it's recommended to start from a fresh install with `invoke demo.destroy`.


### PR DESCRIPTION
Removed the reference to the `frontend` container that has been removed a long time ago
Removed the instruction to `build` the demo environment since we are now pulling the images from the registry