### PR TITLE
Run IPAM reconcilement after assignment from pool

### DIFF
--- a/backend/infrahub/core/node/resource_manager/ip_address_pool.py
+++ b/backend/infrahub/core/node/resource_manager/ip_address_pool.py
@@ -4,6 +4,7 @@ import ipaddress
 from typing import TYPE_CHECKING, Any, Optional
 
 from infrahub.core import registry
+from infrahub.core.ipam.reconciler import IpamReconciler
 from infrahub.core.query.ipam import get_ip_addresses
 from infrahub.core.query.resource_manager import (
     IPAddressPoolGetReserved,
@@ -65,6 +66,8 @@ class CoreIPAddressPool(Node):
         node = await Node.init(db=db, schema=target_schema, branch=branch)
         await node.new(db=db, address=str(next_prefix), ip_namespace=ip_namespace, **data)
         await node.save(db=db)
+        reconciler = IpamReconciler(db=db, branch=branch)
+        await reconciler.reconcile(ip_value=next_prefix, namespace=ip_namespace.id, node_uuid=node.get_id())
 
         if identifier:
             query_set = await IPAddressPoolSetReserved.init(

--- a/backend/infrahub/core/node/resource_manager/ip_prefix_pool.py
+++ b/backend/infrahub/core/node/resource_manager/ip_prefix_pool.py
@@ -4,6 +4,7 @@ import ipaddress
 from typing import TYPE_CHECKING, Any, Optional
 
 from infrahub.core import registry
+from infrahub.core.ipam.reconciler import IpamReconciler
 from infrahub.core.query.ipam import get_subnets
 from infrahub.core.query.resource_manager import (
     PrefixPoolGetReserved,
@@ -69,6 +70,8 @@ class CorePrefixPool(Node):
         node = await Node.init(db=db, schema=target_schema, branch=branch)
         await node.new(db=db, prefix=str(next_prefix), member_type=member_type, ip_namespace=ip_namespace, **data)
         await node.save(db=db)
+        reconciler = IpamReconciler(db=db, branch=branch)
+        await reconciler.reconcile(ip_value=next_prefix, namespace=ip_namespace.id, node_uuid=node.get_id())
 
         if identifier:
             query_set = await PrefixPoolSetReserved.init(


### PR DESCRIPTION
Runs the IPAM reconcilement process when assigning an IP address or prefix from a pool. Without this utilization or hierarchy isn't recalculated.