### PR TITLE
feat(utilities): add benchmark tool

### DIFF
--- a/.github/workflows/push-bench-image.yml
+++ b/.github/workflows/push-bench-image.yml
@@ -1,0 +1,58 @@
+---
+# yamllint disable rule:truthy
+name: Build And Push Bench image
+
+on:
+  workflow_dispatch:
+
+env:
+  DOCKERFILE: "utilities/benchmark/Dockerfile"
+
+jobs:
+  build:
+    runs-on:
+      group: huge-runners
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        id: login
+        with:
+          registry: ${{ vars.HARBOR_HOST }}
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_PASSWORD }}
+
+      - name: Set docker image meta data
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ vars.HARBOR_HOST }}/opsmill/bench
+          tags: |
+            type=raw,value=latest
+          labels: |
+            org.opencontainers.image.source=opsmill/bench
+          flavor: |
+            latest=true
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        id: push
+        with:
+          context: utilities/benchmark
+          file: ${{ env.DOCKERFILE }}
+          provenance: false   # To avoid cross platform "unknown"
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/utilities/benchmark/Dockerfile
+++ b/utilities/benchmark/Dockerfile
@@ -1,0 +1,18 @@
+FROM debian:bookworm-slim
+ARG TARGETPLATFORM
+
+RUN apt-get update && \
+    apt-get install -y curl libncurses5 unzip yq jq fio
+
+COPY entrypoint.sh /entrypoint.sh
+
+RUN bash -c 'curl -o pt_linux.zip https://www.passmark.com/downloads/pt_linux_$([ "$TARGETPLATFORM" == "linux/amd64" ] && echo "x64" || echo "arm64").zip' && \
+    unzip pt_linux.zip && \
+    mv PerformanceTest/pt_linux_* /usr/local/bin/pt_linux && \
+    rm -rf PerformanceTest pt_linux.zip && \
+    chmod +x /entrypoint.sh && \
+    apt-get autoremove -y && \
+    apt-get clean all && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD /entrypoint.sh

--- a/utilities/benchmark/entrypoint.sh
+++ b/utilities/benchmark/entrypoint.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+READ_IOPS_LIMIT=5000 # neo4j requirements
+WRITE_IOPS_LIMIT=5000
+RAM_LIMIT=7000 # 8 GB
+SINGLETHREAD_PERF_LIMIT=2000 # around 4000 on M2 Pro and CI runners https://www.cpubenchmark.net/singleThread.html
+
+echo "Running Disk IOPS benchmark... hold on"
+
+fio --randrepeat=1 --ioengine=libaio --direct=1 --gtod_reduce=1 --name=test --filename=randomrw.fio --bs=4k --iodepth=64 --size=128M --readwrite=randrw --rwmixread=75 --output=fio_results.json --output-format=json
+
+READ_IOPS=$(printf "%.0f" $(jq '.jobs[0].read.iops' fio_results.json))
+WRITE_IOPS=$(printf "%.0f" $(jq '.jobs[0].write.iops' fio_results.json))
+
+echo "Running CPU/Memory benchmark... hold on"
+
+TERM=dumb pt_linux -d 1 -r 1 -i 1 >/dev/null 2>/dev/null
+
+TOTAL_RAM=$(yq .SystemInformation.Memory results_cpu.yml)
+SINGLETHREAD_PERF=$(printf "%.0f" $(yq .Results.CPU_SINGLETHREAD results_cpu.yml))
+
+NC='\033[0m'
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+
+echo ""
+echo "Benchmark results:"
+echo ""
+
+[ $TOTAL_RAM -lt $RAM_LIMIT ] && echo -n $RED || echo -n $GREEN
+echo -n "Memory: ${TOTAL_RAM} MB - Required: ${RAM_LIMIT} MB "
+[ $TOTAL_RAM -lt $RAM_LIMIT ] && echo ": KO" || echo ": OK"
+
+[ $SINGLETHREAD_PERF -lt $SINGLETHREAD_PERF_LIMIT ] && echo -n $RED || echo -n $GREEN
+echo -n "CPU Perf: ${SINGLETHREAD_PERF} - Required: ${SINGLETHREAD_PERF_LIMIT} "
+[ $SINGLETHREAD_PERF -lt $SINGLETHREAD_PERF_LIMIT ] && echo ": KO" || echo ": OK"
+
+[ $READ_IOPS -lt $READ_IOPS_LIMIT ] && echo -n $RED || echo -n $GREEN
+echo -n "Disk Read IOPS: ${READ_IOPS} - Required: ${READ_IOPS_LIMIT} "
+[ $READ_IOPS -lt $READ_IOPS_LIMIT ] && echo ": KO" || echo ": OK"
+
+[ $WRITE_IOPS -lt $WRITE_IOPS_LIMIT ] && echo -n $RED || echo -n $GREEN
+echo -n "Disk Write IOPS: ${WRITE_IOPS} - Required: ${WRITE_IOPS_LIMIT} "
+[ $WRITE_IOPS -lt $WRITE_IOPS_LIMIT ] && echo ": KO" || echo ": OK"
+
+echo $NC
+echo "Benchmark completed..."


### PR DESCRIPTION
```bash
root@b3-16-gra11:~# docker run --pull always registry.opsmill.io/opsmill/bench
latest: Pulling from opsmill/bench
09f376ebb190: Already exists 
6008598ecd4d: Already exists 
b70c7f4d3f19: Pull complete 
84e80b988953: Pull complete 
Digest: sha256:6f0031a0f61823cca7d319033087f80524eadffa87b1981b2e82d841ada12895
Status: Downloaded newer image for registry.opsmill.io/opsmill/bench:latest
Running Disk IOPS benchmark... hold on
Running CPU/Memory benchmark... hold on

Benchmark results:

Memory: 15611 MB - Required: 8000 MB : OK
CPU Perf: 2337 - Required: 1500 : OK
Disk Read IOPS: 47742 - Required: 5000 : OK
Disk Write IOPS: 15885 - Required: 5000 : OK

Benchmark completed...
```

What's interesting with passmark is that almost all CPUs are referenced here: https://www.cpubenchmark.net/singleThread.html