### PR TITLE
Add relationship name to generated identifier

### DIFF
--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -397,7 +397,8 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin):
             del data_from_pool["id"]
 
             if "identifier" not in data_from_pool and self._node:
-                data_from_pool["identifier"] = await self._node.get_hfid_as_string(db=db, include_kind=True)
+                hfid_str = await self._node.get_hfid_as_string(db=db, include_kind=True)
+                data_from_pool["identifier"] = f"hfid={hfid_str} rel={self.name}"
 
             assigned_peer: Node = await pool.get_resource(db=db, branch=self.branch, **data_from_pool)  # type: ignore[attr-defined]
             await self.set_peer(value=assigned_peer)


### PR DESCRIPTION
This PR adds the name of the relationship in the identifier generated for the resource pool when we are allocating a resource from a pool as part of a relationship.
Without the relationship name it would not be possible to assign 2 resources from the same pool to the same object.

I think the bigger question is : how should we structure the identifier internally, right now it's a string but I think we are quickly reaching the limit of that.