### PR TITLE
Add a decode_json function that can fail instead of assuming success

### DIFF
--- a/python_sdk/infrahub_sdk/branch.py
+++ b/python_sdk/infrahub_sdk/branch.py
@@ -9,6 +9,7 @@ except ImportError:
 
 from infrahub_sdk.exceptions import BranchNotFoundError
 from infrahub_sdk.graphql import Mutation, Query
+from infrahub_sdk.utils import decode_json
 
 if TYPE_CHECKING:
     from infrahub_sdk.client import InfrahubClient, InfrahubClientSync
@@ -181,7 +182,7 @@ class InfrahubBranchManager(InfraHubBranchManagerBase):
             time_to=time_to,
         )
         response = await self.client._get(url=url, headers=self.client.headers)
-        return response.json()
+        return decode_json(response=response, url=url)
 
 
 class InfrahubBranchManagerSync(InfraHubBranchManagerBase):
@@ -254,7 +255,7 @@ class InfrahubBranchManagerSync(InfraHubBranchManagerBase):
             time_to=time_to,
         )
         response = self.client._get(url=url, headers=self.client.headers)
-        return response.json()
+        return decode_json(response=response, url=url)
 
     def merge(self, branch_name: str) -> BranchData:
         input_data = {

--- a/python_sdk/infrahub_sdk/exceptions.py
+++ b/python_sdk/infrahub_sdk/exceptions.py
@@ -9,6 +9,16 @@ class Error(Exception):
         super().__init__(self.message)
 
 
+class JsonDecodeError(Exception):
+    def __init__(self, message: Optional[str] = None, content: Optional[str] = None, url: Optional[str] = None):
+        self.message = message
+        self.content = content
+        self.url = url
+        if not self.message and self.url:
+            self.message = f"Unable to decode response as JSON data from {self.url}"
+        super().__init__(self.message)
+
+
 class ServerNotReachableError(Error):
     def __init__(self, address: str, message: Optional[str] = None):
         self.address = address

--- a/python_sdk/infrahub_sdk/utils.py
+++ b/python_sdk/infrahub_sdk/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import glob
 import hashlib
+import json
 from itertools import groupby
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
@@ -15,6 +16,8 @@ from graphql import (
     InlineFragmentNode,
     SelectionSetNode,
 )
+
+from infrahub_sdk.exceptions import JsonDecodeError
 
 if TYPE_CHECKING:
     from graphql import GraphQLResolveInfo
@@ -77,6 +80,13 @@ def is_valid_uuid(value: Any) -> bool:
         return True
     except ValueError:
         return False
+
+
+def decode_json(response: httpx.Response, url: Optional[str] = None) -> dict:
+    try:
+        return response.json()
+    except json.decoder.JSONDecodeError as exc:
+        raise JsonDecodeError(content=response.text, url=url) from exc
 
 
 def generate_uuid() -> str:


### PR DESCRIPTION
Throughout the SDK we are decoding the response from the server as JSON and have the expectation that it will work provided that we get an HTTP 200 request from various URLs. While this would make sense when using Infrahub it is not a sensible assumption to make in all cases.

One example is if we startup a Git agent locally with the default config without access to a running Infrahub:

```bash
> infrahub git-agent start
```

It fails with an error that isn't easy to decipher.

```python
  File "/Users/patrick/.nix-profile/lib/python3.12/asyncio/base_events.py", line 685, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/patrick/Code/opsmill/infrahub/backend/infrahub/cli/git_agent.py", line 94, in start
    await client.branch.all()
  File "/Users/patrick/Code/opsmill/infrahub/python_sdk/infrahub_sdk/branch.py", line 151, in all
    data = await self.client.execute_graphql(query=query.render(), tracker="query-branch-all")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/Code/opsmill/infrahub/python_sdk/infrahub_sdk/client.py", line 526, in execute_graphql
    resp = await self._post(url=url, payload=payload, headers=headers, timeout=timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/Code/opsmill/infrahub/python_sdk/infrahub_sdk/client.py", line 93, in wrapper
    response = await func(client, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/Code/opsmill/infrahub/python_sdk/infrahub_sdk/client.py", line 574, in _post
    await self.login()
  File "/Users/patrick/Code/opsmill/infrahub/python_sdk/infrahub_sdk/client.py", line 698, in login
    self.access_token = response.json()["access_token"]
                        ^^^^^^^^^^^^^^^
  File "/Users/patrick/.virtualenvs/infrahub/lib/python3.12/site-packages/httpx/_models.py", line 764, in json
    return jsonlib.loads(self.content, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/.nix-profile/lib/python3.12/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/.nix-profile/lib/python3.12/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/.nix-profile/lib/python3.12/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

The problem here is that the Git Agent is also starting a webserver on localhost at 8000 to host metrics that can be collected by a system like prometheus.

This PR changes the behaviour of the Git Agent so that we can at least have a somewhat better error:

```python
  File "/Users/patrick/Code/opsmill/infrahub/python_sdk/infrahub_sdk/branch.py", line 152, in all
    data = await self.client.execute_graphql(query=query.render(), tracker="query-branch-all")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/Code/opsmill/infrahub/python_sdk/infrahub_sdk/client.py", line 526, in execute_graphql
    resp = await self._post(url=url, payload=payload, headers=headers, timeout=timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/Code/opsmill/infrahub/python_sdk/infrahub_sdk/client.py", line 93, in wrapper
    response = await func(client, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/Code/opsmill/infrahub/python_sdk/infrahub_sdk/client.py", line 574, in _post
    await self.login()
  File "/Users/patrick/Code/opsmill/infrahub/python_sdk/infrahub_sdk/client.py", line 701, in login
    data = decode_json(response=response, url=url)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/Code/opsmill/infrahub/python_sdk/infrahub_sdk/utils.py", line 89, in decode_json
    raise JsonDecodeError(content=response.text, url=url) from exc
infrahub_sdk.exceptions.JsonDecodeError: Unable to decode response as JSON data from http://localhost:8000/api/auth/login
```

Related to #3407

Note there are still a few response.json() calls throughout the SDK that should be modified. Also the infrahub git-agent CLI tool should also provide a wrapper around errors such as this so that it's even easier to spot the error.