### PR TITLE
Raise user-friendly error and exit if git-agent is unable to reach Infrahub

### DIFF
--- a/backend/infrahub/cli/git_agent.py
+++ b/backend/infrahub/cli/git_agent.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 import typer
 from infrahub_sdk import Config, InfrahubClient
 from infrahub_sdk.async_typer import AsyncTyper
+from infrahub_sdk.exceptions import Error as SdkError
 from prometheus_client import start_http_server
 from rich.logging import RichHandler
 
@@ -91,7 +92,11 @@ async def start(
     client = InfrahubClient(
         config=Config(address=config.SETTINGS.main.internal_address, retry_on_failure=True, log=log)
     )
-    await client.branch.all()
+    try:
+        await client.branch.all()
+    except SdkError as exc:
+        log.error(f"Error in communication with Infrahub: {exc.message}")
+        raise typer.Exit(1)
 
     # Initialize trace
     if config.SETTINGS.trace.enable:

--- a/python_sdk/infrahub_sdk/exceptions.py
+++ b/python_sdk/infrahub_sdk/exceptions.py
@@ -9,7 +9,7 @@ class Error(Exception):
         super().__init__(self.message)
 
 
-class JsonDecodeError(Exception):
+class JsonDecodeError(Error):
     def __init__(self, message: Optional[str] = None, content: Optional[str] = None, url: Optional[str] = None):
         self.message = message
         self.content = content


### PR DESCRIPTION
This PR catches the initial request to Infrahub during git-agent startup and raises a user friendly error if there's a problem then exits the program.

```bash
❯ infrahub git-agent start
2024-05-24T05:59:53.593892Z [error    ] Error in communication with Infrahub: Unable to decode response as JSON data from http://localhost:8000/api/auth/login [infrahub]
```

Fixes #3407