### PR TITLE
Convert attribute variables on CoreGraphQLQuery to read-only

### DIFF
--- a/backend/infrahub/core/schema/definitions/core.py
+++ b/backend/infrahub/core/schema/definitions/core.py
@@ -1370,7 +1370,13 @@ core_models: dict[str, Any] = {
                 {"name": "name", "kind": "Text", "unique": True},
                 {"name": "description", "kind": "Text", "optional": True},
                 {"name": "query", "kind": "TextArea"},
-                {"name": "variables", "kind": "JSON", "description": "variables in use in the query", "optional": True},
+                {
+                    "name": "variables",
+                    "kind": "JSON",
+                    "description": "variables in use in the query",
+                    "optional": True,
+                    "read_only": True,
+                },
                 {
                     "name": "operations",
                     "kind": "List",


### PR DESCRIPTION
the variables are automatically extracted from the query itself and shouldn't be set by the user directly