### PR TITLE
fix off-by-one type error in ip address parent identification

### DIFF
--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -349,11 +349,12 @@ class IPPrefixReconcileQuery(Query):
         self.params["ip_version"] = self.ip_value.version
         # possible prefix: highest possible prefix length for a match
         possible_prefix_map: dict[str, int] = {}
-        for max_prefix_len in range(prefixlen - 1, 0, -1):
+        start_prefixlen = prefixlen if is_address else prefixlen - 1
+        for max_prefix_len in range(start_prefixlen, 0, -1):
             tmp_prefix = prefix_bin_host[:max_prefix_len]
             possible_prefix = tmp_prefix.ljust(self.ip_value.max_prefixlen, "0")
             if possible_prefix not in possible_prefix_map:
-                possible_prefix_map[possible_prefix] = max_prefix_len + 1 if is_address else max_prefix_len
+                possible_prefix_map[possible_prefix] = max_prefix_len
         self.params["possible_prefix_and_length_list"] = [
             [possible_prefix, max_length] for possible_prefix, max_length in possible_prefix_map.items()
         ]


### PR DESCRIPTION
Guillaume identified this issue in slack

![image](https://github.com/opsmill/infrahub/assets/19253956/7eda45f7-1210-40f9-bc95-28005fa4a34c)
`(only the first 2 address should appear, not the last 2)`

this is a fix for that issue with some unit tests

feel free to merge if approved and tests are passing