### PR TITLE
Add exception in schema_manager for  ip_namespace

### DIFF
--- a/backend/infrahub/core/schema_manager.py
+++ b/backend/infrahub/core/schema_manager.py
@@ -631,8 +631,12 @@ class SchemaBranch:
                         allowed_path_types=SchemaElementPathType.ATTR | SchemaElementPathType.REL_ONE_NO_ATTR,
                         element_name="uniqueness_constraints",
                     )
-                    if schema_path.is_type_relationship:
-                        if schema_path.relationship_schema.optional:
+                    if schema_path.is_type_relationship and schema_path.relationship_schema:
+                        if schema_path.relationship_schema.optional and not (
+                            schema_path.relationship_schema.name == "ip_namespace"
+                            and isinstance(node_schema, NodeSchema)
+                            and (node_schema.is_ip_address() or node_schema.is_ip_prefix)
+                        ):
                             raise ValueError(
                                 f"Only mandatory relation of cardinality one can be used in uniqueness_constraints,"
                                 f" {schema_path.relationship_schema.name} is not mandatory. ({constraint_path})"
@@ -711,8 +715,12 @@ class SchemaBranch:
                 if schema_path.attribute_schema.unique:
                     has_unique_item = True
 
-                if schema_path.is_type_relationship:
-                    if schema_path.relationship_schema.optional:
+                if schema_path.is_type_relationship and schema_path.relationship_schema:
+                    if schema_path.relationship_schema.optional and not (
+                        schema_path.relationship_schema.name == "ip_namespace"
+                        and isinstance(node_schema, NodeSchema)
+                        and (node_schema.is_ip_address() or node_schema.is_ip_prefix)
+                    ):
                         raise ValueError(
                             f"Only mandatory relationship of cardinality one can be used in human_friendly_id, "
                             f"{schema_path.relationship_schema.name} is not mandatory on {schema_path.relationship_schema.kind} for "


### PR DESCRIPTION
Currently it would not be possible to create a schema that would enforce the uniqueness of an IP address or an IP Prefix because the relationship to `IP Namespace` is set as optional in the schema for both.

Technically the relationship is always gonna be present because we are automatically adding the default ip_namespace if it's not provided by the user. 
As a workaround, this PR adds an exception in the schema manager to allow a user to use the relationship `ip_namespace` on an IP Address or an IP Prefix as part of a uniqueness_constraints or as part of a HFID

The right solution would be properly support mandatory relationships with a default value in the schema, I'll open an issue to track that