### PR TITLE
Avoid star-arg unpacking after keyword arguments

### DIFF
--- a/backend/infrahub/core/query/__init__.py
+++ b/backend/infrahub/core/query/__init__.py
@@ -351,10 +351,10 @@ class Query(ABC):
         at: Optional[Union[Timestamp, str]] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-        *args,
+        *args,  # pylint: disable=unused-argument
         **kwargs,
     ) -> Self:
-        query = cls(branch=branch, at=at, limit=limit, offset=offset, *args, **kwargs)
+        query = cls(branch=branch, at=at, limit=limit, offset=offset, **kwargs)
 
         await query.query_init(db=db, **kwargs)
 

--- a/backend/infrahub/core/query/diff.py
+++ b/backend/infrahub/core/query/diff.py
@@ -309,7 +309,7 @@ class DiffNodePropertiesByIDSRangeQuery(Query):
         diff_from: str,
         diff_to: str,
         account=None,
-        *args,
+        *args,  # pylint: disable=unused-argument
         **kwargs,
     ):
         self.account = account
@@ -317,7 +317,7 @@ class DiffNodePropertiesByIDSRangeQuery(Query):
         self.time_from = Timestamp(diff_from)
         self.time_to = Timestamp(diff_to)
 
-        super().__init__(order_by=["a.name"], *args, **kwargs)
+        super().__init__(order_by=["a.name"], **kwargs)
 
     async def query_init(self, db: InfrahubDatabase, *args, **kwargs):
         self.params["ids"] = self.ids

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -410,7 +410,7 @@ class NodeListGetAttributeQuery(Query):
         include_source: bool = False,
         include_owner: bool = False,
         account=None,
-        *args,
+        *args,  # pylint: disable=unused-argument
         **kwargs,
     ):
         self.account = account
@@ -419,7 +419,7 @@ class NodeListGetAttributeQuery(Query):
         self.include_source = include_source
         self.include_owner = include_owner
 
-        super().__init__(order_by=["n.uuid", "a.name"], *args, **kwargs)
+        super().__init__(order_by=["n.uuid", "a.name"], **kwargs)
 
     async def query_init(self, db: InfrahubDatabase, *args, **kwargs):
         self.params["ids"] = self.ids

--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -205,7 +205,7 @@ class RelationshipCreateQuery(RelationshipQuery):
         if not destination and not destination_id:
             raise ValueError("Either destination or destination_id must be provided.")
 
-        super().__init__(destination=destination, destination_id=destination_id, *args, **kwargs)
+        super().__init__(destination=destination, destination_id=destination_id, **kwargs)
 
     async def query_init(self, db: InfrahubDatabase, *args, **kwargs):
         self.params["source_id"] = self.source_id

--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -66,12 +66,12 @@ class InfrahubMutationMixin:
 
         if "Create" in cls.__name__:
             obj, mutation = await cls.mutate_create(
-                root=root, info=info, branch=context.branch, at=context.at, *args, **kwargs
+                root=root, info=info, branch=context.branch, at=context.at, **kwargs
             )
             action = MutationAction.ADDED
         elif "Update" in cls.__name__:
             obj, mutation = await cls.mutate_update(
-                root=root, info=info, branch=context.branch, at=context.at, *args, **kwargs
+                root=root, info=info, branch=context.branch, at=context.at, **kwargs
             )
             action = MutationAction.UPDATED
         elif "Upsert" in cls.__name__:
@@ -82,7 +82,7 @@ class InfrahubMutationMixin:
                 MutationNodeGetterByDefaultFilter(db=context.db, node_manager=node_manager),
             ]
             obj, mutation, created = await cls.mutate_upsert(
-                root=root, info=info, branch=context.branch, at=context.at, node_getters=node_getters, *args, **kwargs
+                root=root, info=info, branch=context.branch, at=context.at, node_getters=node_getters, **kwargs
             )
             if created:
                 action = MutationAction.ADDED
@@ -90,7 +90,7 @@ class InfrahubMutationMixin:
                 action = MutationAction.UPDATED
         elif "Delete" in cls.__name__:
             obj, mutation = await cls.mutate_delete(
-                root=root, info=info, branch=context.branch, at=context.at, *args, **kwargs
+                root=root, info=info, branch=context.branch, at=context.at, **kwargs
             )
             action = MutationAction.REMOVED
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -465,7 +465,6 @@ ignore = [
     "B008",     # Do not perform function call `Depends` in argument defaults;
     "B009",     # [*] Do not call `getattr` with a constant attribute value. It is not any safer than normal property access.
     "B010",     # [*] Do not call `setattr` with a constant attribute value. It is not any safer than normal property access.
-    "B026",     # Star-arg unpacking after a keyword argument is strongly discouraged
     "B904",     # Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
     "C403",     # Unnecessary `list` comprehension (rewrite as a `set` comprehension)
     "C409",     # Unnecessary `list` literal passed to `tuple()` (rewrite as a `tuple` literal)


### PR DESCRIPTION
Fixes Ruff rule B026: Star-arg unpacking after a keyword argument is strongly discouraged