### PR TITLE
Switch to list since List is a Graphene import

### DIFF
--- a/backend/infrahub/graphql/queries/relationship.py
+++ b/backend/infrahub/graphql/queries/relationship.py
@@ -22,10 +22,10 @@ class Relationships(ObjectType):
     async def resolve(
         root: dict,  # pylint: disable=unused-argument
         info: GraphQLResolveInfo,
-        ids: List[str],
+        ids: list[str],
         limit: int = 10,
         offset: int = 0,
-        excluded_namespaces: Optional[List[str]] = None,
+        excluded_namespaces: Optional[list[str]] = None,
     ) -> Dict[str, Any]:
         context: GraphqlContext = info.context
 


### PR DESCRIPTION
The typehints were incorrect here as we were using graphene.List as if it was a typing.List.