### PR TITLE
Validate attribute kind are the same when inheriting attributes

### DIFF
--- a/backend/infrahub/core/schema/node_schema.py
+++ b/backend/infrahub/core/schema/node_schema.py
@@ -42,9 +42,11 @@ class NodeSchema(GeneratedNodeSchema):
                         f"{self.kind}'s attribute {attribute.name} inherited from {interface.kind} cannot be overriden"
                     )
                 # Check existing inherited attribute kind is the same as the incoming inherited attribute
-                if attribute.kind != interface.get_attribute(attribute.name).kind:
+                interface_attr_kind = interface.get_attribute(attribute.name).kind
+                if attribute.kind != interface_attr_kind:
                     raise ValueError(
-                        f"{self.kind}'s attribute {attribute.name} inherited from {interface.kind} must have the same kind"
+                        f"{self.kind}.{attribute.name} inherited from {interface.namespace}{interface.name} must be the same kind "
+                        f'["{interface_attr_kind}", "{attribute.kind}"]'
                     )
 
         for relationship in self.relationships:

--- a/backend/infrahub/core/schema/node_schema.py
+++ b/backend/infrahub/core/schema/node_schema.py
@@ -26,16 +26,26 @@ class NodeSchema(GeneratedNodeSchema):
         return False
 
     def validate_inheritance(self, interface: GenericSchema) -> None:
-        """Check that protected attributes and relationships are not overriden before inheriting them from interface."""
+        """Perform checks specific to inheritance from Generics.
+
+        Checks:
+            - Check that protected attributes and relationships are not overridden before inheriting them from interface.
+            - Check that the attribute types to be inherited are same kind.
+        """
         for attribute in self.attributes:
-            if (
-                attribute.name in interface.attribute_names
-                and not attribute.inherited
-                and interface.get_attribute(attribute.name).allow_override == AllowOverrideType.NONE
-            ):
-                raise ValueError(
-                    f"{self.kind}'s attribute {attribute.name} inherited from {interface.kind} cannot be overriden"
-                )
+            if attribute.name in interface.attribute_names:
+                if (
+                    not attribute.inherited
+                    and interface.get_attribute(attribute.name).allow_override == AllowOverrideType.NONE
+                ):
+                    raise ValueError(
+                        f"{self.kind}'s attribute {attribute.name} inherited from {interface.kind} cannot be overriden"
+                    )
+                # Check existing inherited attribute kind is the same as the incoming inherited attribute
+                if attribute.kind != interface.get_attribute(attribute.name).kind:
+                    raise ValueError(
+                        f"{self.kind}'s attribute {attribute.name} inherited from {interface.kind} must have the same kind"
+                    )
 
         for relationship in self.relationships:
             if (

--- a/backend/infrahub/core/schema_manager.py
+++ b/backend/infrahub/core/schema_manager.py
@@ -1075,7 +1075,7 @@ class SchemaBranch:
                 if generic_kind_schema.hierarchical:
                     generic_with_hierarchical_support.append(generic_kind)
 
-                # Check if a node redefine protected generic attributes or relationships
+                # Perform checks to validate that the node is not breaking inheritance rules
                 node.validate_inheritance(interface=generic_kind_schema)
 
                 # Store the list of node referencing a specific generics

--- a/backend/tests/unit/core/schema_manager/conftest.py
+++ b/backend/tests/unit/core/schema_manager/conftest.py
@@ -348,3 +348,39 @@ def schema_parent_component() -> dict:
         ],
     }
     return FULL_SCHEMA
+
+
+@pytest.fixture
+def schema_diff_attr_inheritance_types():
+    """Two generics with the same attribute but different types and a single node implementation."""
+    FULL_SCHEMA = {
+        "generics": [
+            {
+                "name": "Adapter",
+                "namespace": "Test",
+                "display_labels": ["name__value"],
+                "order_by": ["name__value"],
+                "attributes": [{"name": "name", "kind": "Text"}, {"name": "choice", "kind": "Text", "optional": True}],
+            },
+            {
+                "name": "Status",
+                "namespace": "Test",
+                "display_labels": ["label__value"],
+                "order_by": ["label__value"],
+                "attributes": [
+                    {"name": "label", "kind": "Text"},
+                    {"name": "choice", "kind": "Number", "optional": True},
+                ],
+            },
+        ],
+        "nodes": [
+            {
+                "name": "Widget",
+                "namespace": "Test",
+                "description": "A Circuit endpoint is attached to each end of a circuit",
+                "attributes": [{"name": "widget", "kind": "Text"}],
+                "inherit_from": ["TestAdapter", "TestStatus"],
+            }
+        ],
+    }
+    return FULL_SCHEMA

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -121,7 +121,7 @@ async def test_schema_process_inheritance_different_generic_attribute_types(sche
     with pytest.raises(ValueError) as exc:
         schema.process_inheritance()
 
-    assert exc.value.args[0] == "TestWidget's attribute choice inherited from TestStatus must have the same kind"
+    assert exc.value.args[0] == 'TestWidget.choice inherited from TestStatus must be the same kind ["Number", "Text"]'
 
 
 async def test_schema_process_inheritance_different_generic_attribute_types_on_node(schema_diff_attr_inheritance_types):
@@ -136,7 +136,7 @@ async def test_schema_process_inheritance_different_generic_attribute_types_on_n
     with pytest.raises(ValueError) as exc:
         schema.process_inheritance()
 
-    assert exc.value.args[0] == "TestWidget's attribute choice inherited from TestAdapter must have the same kind"
+    assert exc.value.args[0] == 'TestWidget.choice inherited from TestAdapter must be the same kind ["Text", "List"]'
 
 
 async def test_schema_branch_process_inheritance_node_level(animal_person_schema_dict):

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -113,6 +113,32 @@ async def test_schema_branch_process_inheritance(schema_all_in_one):
     }
 
 
+async def test_schema_process_inheritance_different_generic_attribute_types(schema_diff_attr_inheritance_types):
+    """Test that we raise an exception if a node is inheriting from two generics with different attribute types for a specific attribute."""
+    schema = SchemaBranch(cache={}, name="test")
+    schema.load_schema(schema=SchemaRoot(**schema_diff_attr_inheritance_types))
+
+    with pytest.raises(ValueError) as exc:
+        schema.process_inheritance()
+
+    assert exc.value.args[0] == "TestWidget's attribute choice inherited from TestStatus must have the same kind"
+
+
+async def test_schema_process_inheritance_different_generic_attribute_types_on_node(schema_diff_attr_inheritance_types):
+    """Test that we raise an exception if a node is inheriting an attribute with different attribute type that already exists on node."""
+    schema = SchemaBranch(cache={}, name="test")
+    schema_new = copy.deepcopy(schema_diff_attr_inheritance_types)
+    schema_new["generics"].pop()
+    schema_new["nodes"][0]["inherit_from"].pop()
+    schema_new["nodes"][0]["attributes"].append({"name": "choice", "kind": "List"})
+    schema.load_schema(schema=SchemaRoot(**schema_new))
+
+    with pytest.raises(ValueError) as exc:
+        schema.process_inheritance()
+
+    assert exc.value.args[0] == "TestWidget's attribute choice inherited from TestAdapter must have the same kind"
+
+
 async def test_schema_branch_process_inheritance_node_level(animal_person_schema_dict):
     schema = SchemaBranch(cache={}, name="test")
     schema.load_schema(schema=SchemaRoot(**animal_person_schema_dict))


### PR DESCRIPTION
Fixes #1563 

- Add check to validate an attribute being inherited is of the same kind of the current attribute on the node (inherited or not)

A few questions:
- Is inheriting attributes from a generic supported if the attribute is defined on the node itself? I have a test for that situation, but not sure how it should be handled.
    - If not, it may make more sense for this logic to be in `node.inherit_from_interface`. We may also want to add logic to fail if this scenario is encountered.