### PR TITLE
Add description to resource pool default_prefix_length attribute

### DIFF
--- a/backend/infrahub/core/schema/definitions/core.py
+++ b/backend/infrahub/core/schema/definitions/core.py
@@ -1681,6 +1681,7 @@ core_models: dict[str, Any] = {
                 {
                     "name": "default_prefix_length",
                     "kind": "Number",
+                    "description": "The default prefix length as an integer for prefixes allocated from this pool.",
                     "optional": True,
                     "order_weight": 5000,
                 },
@@ -1741,6 +1742,7 @@ core_models: dict[str, Any] = {
                 {
                     "name": "default_prefix_length",
                     "kind": "Number",
+                    "description": "The default prefix length as an integer for addresses allocated from this pool.",
                     "optional": True,
                     "order_weight": 4000,
                 },

--- a/docs/docs/reference/infrahub-cli/infrahub-db.mdx
+++ b/docs/docs/reference/infrahub-cli/infrahub-db.mdx
@@ -35,7 +35,7 @@ $ infrahub db constraint [OPTIONS] [ACTION]:[show|add|drop] [CONFIG_FILE]
 
 **Arguments**:
 
-* `[ACTION]:[show|add|drop]`: [default: show]
+* `[ACTION]:[show|add|drop]`: [default: ConstraintAction.SHOW]
 * `[CONFIG_FILE]`: [env var: INFRAHUB_CONFIG;default: infrahub.toml]
 
 **Options**:
@@ -54,7 +54,7 @@ $ infrahub db index [OPTIONS] [ACTION]:[show|add|drop] [CONFIG_FILE]
 
 **Arguments**:
 
-* `[ACTION]:[show|add|drop]`: [default: show]
+* `[ACTION]:[show|add|drop]`: [default: IndexAction.SHOW]
 * `[CONFIG_FILE]`: [env var: INFRAHUB_CONFIG;default: infrahub.toml]
 
 **Options**:


### PR DESCRIPTION
Fixes #3490

![Screenshot 2024-05-29 at 15 35 54](https://github.com/opsmill/infrahub/assets/6694669/822bac1c-602c-45ba-ba0c-f4125afeb115)

Example view after #3528 was merged.

Are you good with this @BRBCoffeeDebuff or did you have anything else in mind?