### PR TITLE
Migrate exception handler to pydantic v2

### DIFF
--- a/backend/infrahub/api/exception_handlers.py
+++ b/backend/infrahub/api/exception_handlers.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from fastapi.responses import JSONResponse
-from pydantic.v1 import ValidationError
+from pydantic import ValidationError
 
 from infrahub.exceptions import Error
 


### PR DESCRIPTION
Pydantic v2 seems to work different compared to v1 with regards to how errors are raised. Since the test was using a made up field with a custom error I instead opted to create a new field which I think would be a closer match to what we see in production regardless.

Also made some minor changes to clean up typing in the tests.

Part of #2813.