### PR TITLE
Bugfix: Python SDK - Invalid schema error handling fix

### DIFF
--- a/python_sdk/infrahub_sdk/ctl/schema.py
+++ b/python_sdk/infrahub_sdk/ctl/schema.py
@@ -95,6 +95,7 @@ def display_schema_load_errors(console: Console, response: Dict[str, Any], schem
         if not valid_error_path(loc_path=loc_path):
             continue
 
+        loc_type = loc_path[-2]
         schema_index = int(loc_path[2])
         node_index = int(loc_path[4])
         node = get_node(schemas_data=schemas_data, schema_index=schema_index, node_index=node_index)
@@ -103,13 +104,11 @@ def display_schema_load_errors(console: Console, response: Dict[str, Any], schem
             console.print("Node data not found.")
             continue
 
-        input_label = loc_path[-1]
-        element_label = loc_path[-3][0:-1].title()
-
+        input_label = node[loc_type][loc_path[-1]].get("name", None)
         input_str = error.get("input", None)
-        error_message = f"{element_label} {input_label}: {input_str} | {error['msg']} ({error['type']})"
+        error_message = f"{loc_type[:-1].title()}: {input_label} ({input_str}) | {error['msg']} ({error['type']})"
 
-        console.print(f"  Node: {node.get('namespace', None)}.{node.get('name', None)} | {error_message}")
+        console.print(f"  Node: {node.get('namespace', None)}{node.get('name', None)} | {error_message}")
 
 
 def handle_non_detail_errors(console: Console, response: Dict[str, Any]) -> None:

--- a/python_sdk/tests/unit/sdk/test_schema.py
+++ b/python_sdk/tests/unit/sdk/test_schema.py
@@ -27,7 +27,7 @@ client_types = ["standard", "sync"]
 
 @pytest.fixture
 async def console_output():
-    return Console(file=StringIO())
+    return Console(file=StringIO(), width=1000)
 
 
 async def test_method_sanity():


### PR DESCRIPTION
- Updated error message to comply with Pydanticv2 format

My concern here with these changes is this may break with pydantic v1. I'm not sure if we'll encounter this as it appears to be handled automatically with Infrahub loading the schemas? If we're worried about it, I can add a variable within the `try/except` when importing from Pydantic to account for v1/v2 error message differences and update the logic.