### PR TITLE
Mark InfrahubClient(/Sync).init as deprecated

### DIFF
--- a/backend/infrahub/git_credential/askpass.py
+++ b/backend/infrahub/git_credential/askpass.py
@@ -37,7 +37,7 @@ def askpass(
     if not request_type:
         raise typer.Exit(f"Unable to identify the request type in '{text}'")
 
-    client = InfrahubClientSync.init(config=Config(address=config.SETTINGS.main.internal_address, insert_tracker=True))
+    client = InfrahubClientSync(config=Config(address=config.SETTINGS.main.internal_address, insert_tracker=True))
     repo = client.get(kind=InfrahubKind.GENERICREPOSITORY, location__value=location)
 
     attr = getattr(repo, request_type)

--- a/backend/infrahub/git_credential/helper.py
+++ b/backend/infrahub/git_credential/helper.py
@@ -50,7 +50,7 @@ def get(
 
     # FIXME currently we are only querying the repo in the main branch,
     # this will not work if a new repository is added in a branch first.
-    client = InfrahubClientSync.init(config=Config(address=config.SETTINGS.main.internal_address, insert_tracker=True))
+    client = InfrahubClientSync(config=Config(address=config.SETTINGS.main.internal_address, insert_tracker=True))
     repo = client.get(kind=InfrahubKind.GENERICREPOSITORY, location__value=location)
 
     if not repo:

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -92,7 +92,7 @@ class TestInfrahubApp:
             api_token=api_token, requester=test_client.async_request, sync_requester=test_client.sync_request
         )
 
-        sdk_client = await InfrahubClient.init(config=config)
+        sdk_client = InfrahubClient(config=config)
 
         bus_simulator.service._client = sdk_client
 

--- a/backend/tests/integration/git/test_git_repository.py
+++ b/backend/tests/integration/git/test_git_repository.py
@@ -62,7 +62,7 @@ class TestInfrahubClient:
         admin_token = await integration_helper.create_token()
         config = Config(api_token=admin_token, requester=test_client.async_request)
 
-        return await InfrahubClient.init(config=config)
+        return InfrahubClient(config=config)
 
     @pytest.fixture(scope="class")
     async def query_99(self, db: InfrahubDatabase, test_client):

--- a/backend/tests/unit/git/conftest.py
+++ b/backend/tests/unit/git/conftest.py
@@ -21,8 +21,8 @@ from infrahub.utils import find_first_file_in_directory, get_fixtures_dir
 
 
 @pytest.fixture
-async def client() -> InfrahubClient:
-    return await InfrahubClient.init(config=Config(address="http://mock", insert_tracker=True))
+def client() -> InfrahubClient:
+    return InfrahubClient(config=Config(address="http://mock", insert_tracker=True))
 
 
 @pytest.fixture

--- a/docs/_templates/sdk_config.j2
+++ b/docs/_templates/sdk_config.j2
@@ -11,14 +11,14 @@ The Python SDK (Async or Sync) client can be configured using an instance of the
   ```python
   from infrahub_sdk import Config, InfrahubClient
   config = Config(address="http://infrahub:8080", api_token="123-xyz-invalid-token")
-  client = await InfrahubClient.init(config=config)
+  client = InfrahubClient(config=config)
   ```
   </TabItem>
   <TabItem value="Sync">
   ```python
   from infrahub_sdk import Config, InfrahubClientSync
   config = Config(address="http://infrahub:8080", api_token="123-xyz-invalid-token")
-  client = InfrahubClientSync.init(config=config)
+  client = InfrahubClientSync(config=config)
   ```
   </TabItem>
 </Tabs>

--- a/docs/docs/python-sdk/guides/batch.mdx
+++ b/docs/docs/python-sdk/guides/batch.mdx
@@ -25,7 +25,7 @@ from infrahub_sdk import InfrahubClient
 
 
 async def main():
-    client = await InfrahubClient.init()
+    client = InfrahubClient()
     batch = await client.create_batch()
 
     for tag in ["red", "green", "blue", "yellow", "orange"]:
@@ -50,7 +50,7 @@ from infrahub_sdk import Config, InfrahubClient
 
 
 async def main():
-    client = await InfrahubClient.init(Config(max_concurrent_execution=10))
+    client = InfrahubClient(Config(max_concurrent_execution=10))
     batch = await client.create_batch()
 
     for tag in ["red", "green", "blue", "yellow", "orange"]:
@@ -76,7 +76,7 @@ async def will_raise(swallowed: bool):
     raise Exception()
 
 async def main():
-    client = await InfrahubClient.init()
+    client = InfrahubClient()
     batch = await client.create_batch()
 
     batch.add(task=client.get, kind="BuiltinTag", name__value="red")
@@ -101,7 +101,7 @@ async def will_raise(swallowed: bool):
     raise Exception()
 
 async def main():
-    client = await InfrahubClient.init()
+    client = InfrahubClient()
     batch = await client.create_batch()
 
     batch.add(task=client.get, kind="BuiltinTag", name__value="red")
@@ -130,7 +130,7 @@ from infrahub_sdk import InfrahubClient
 
 
 async def main():
-    client = await InfrahubClient.init()
+    client = InfrahubClient()
     batch = await client.create_batch()
 
     for idx in range(100):

--- a/docs/docs/python-sdk/guides/branches.mdx
+++ b/docs/docs/python-sdk/guides/branches.mdx
@@ -24,7 +24,7 @@ The Python SDK provides multiple methods to manage the branches in an Infrahub i
 
   ```python
   from infrahub_sdk import InfrahubClient
-  client = await InfrahubClient.init()
+  client = InfrahubClient()
   branch = await client.branch.get(branch_name="main")
   ```
 
@@ -33,7 +33,7 @@ The Python SDK provides multiple methods to manage the branches in an Infrahub i
 
   ```python
   from infrahub_sdk import InfrahubClientSync
-  client = InfrahubClientSync.init()
+  client = InfrahubClientSync()
   branch = client.branch.get(branch_name="main")
   ```
 
@@ -91,7 +91,7 @@ The Python SDK provides multiple methods to manage the branches in an Infrahub i
 
   ```python
   from infrahub_sdk import InfrahubClient
-  client = await InfrahubClient.init()
+  client = InfrahubClient()
   await client.branch.delete(branch_name="new-branch")
   ```
 
@@ -100,7 +100,7 @@ The Python SDK provides multiple methods to manage the branches in an Infrahub i
 
   ```python
   from infrahub_sdk import InfrahubClientSync
-  client = InfrahubClientSync.init()
+  client = InfrahubClientSync()
   client.branch.delete(branch_name="new-branch")
   ```
 
@@ -114,7 +114,7 @@ The Python SDK provides multiple methods to manage the branches in an Infrahub i
 
   ```python
   from infrahub_sdk import InfrahubClient
-  client = await InfrahubClient.init()
+  client = await InfrahubClient()
   diff = await client.branch.diff_data(branch_name="new-branch")
   ```
 
@@ -123,7 +123,7 @@ The Python SDK provides multiple methods to manage the branches in an Infrahub i
 
   ```python
   from infrahub_sdk import InfrahubClientSync
-  client = InfrahubClientSync.init()
+  client = InfrahubClientSync()
   diff = client.branch.diff_data(branch_name="new-branch")
   ```
 

--- a/docs/docs/python-sdk/guides/client.mdx
+++ b/docs/docs/python-sdk/guides/client.mdx
@@ -16,7 +16,7 @@ The default client class `InfrahubClient` provides the asynchronous version.
 
 ```python
 from infrahub_sdk import InfrahubClient
-client = await InfrahubClient.init(address="http://localhost:8000")
+client = InfrahubClient(address="http://localhost:8000")
 ```
 
 ## Synchronous Python
@@ -25,7 +25,7 @@ The `InfrahubClientSync` class provides the synchronous version.
 
 ```python
 from infrahub_sdk import InfrahubClientSync
-client = InfrahubClientSync.init(address="http://localhost:8000")
+client = InfrahubClientSync(address="http://localhost:8000")
 ```
 
 ## Authentication
@@ -37,8 +37,8 @@ The SDK is using a token-based authentication method to authenticate with the AP
 
   ```python
   from infrahub_sdk import InfrahubClient
-  client = await InfrahubClient.init(config=Config(api_token="token"))
-  client = await InfrahubClient.init() # token is read from the INFRAHUB_API_TOKEN environment variable
+  client = await InfrahubClient(config=Config(api_token="token"))
+  client = await InfrahubClient() # token is read from the INFRAHUB_API_TOKEN environment variable
   ```
 
   </TabItem>
@@ -46,8 +46,8 @@ The SDK is using a token-based authentication method to authenticate with the AP
 
   ```python
   from infrahub_sdk import InfrahubClientSync
-  client = InfrahubClientSync.init(config=Config(api_token="token"))
-  client = InfrahubClientSync.init() # token is read from the INFRAHUB_API_TOKEN environment variable
+  client = InfrahubClientSync(config=Config(api_token="token"))
+  client = InfrahubClientSync() # token is read from the INFRAHUB_API_TOKEN environment variable
   ```
 
   </TabItem>
@@ -63,7 +63,7 @@ The client object can be configured by providing a Config object. Here we will s
   ```python
   from infrahub_sdk import InfrahubClient, Config
   config = Config(echo_graphql_queries=True)
-  client = await InfrahubClient.init(config=config)
+  client = await InfrahubClient(config=config)
   ```
 
   </TabItem>
@@ -72,7 +72,7 @@ The client object can be configured by providing a Config object. Here we will s
   ```python
   from infrahub_sdk import InfrahubClientSync, Config
   config = Config(echo_graphql_queries=True)
-  client = InfrahubClientSync.init(config=config)
+  client = InfrahubClientSync(config=config)
   ```
 
   </TabItem>
@@ -90,7 +90,7 @@ The client object can be configured to use a specific branch in Infrahub. By def
   ```python
   from infrahub_sdk import InfrahubClient, Config
   config = Config(default_branch="other-branch")
-  client_other_branch = await InfrahubClient.init(config=config)
+  client_other_branch = InfrahubClient(config=config)
 
   tag_other_branch = await client_other_branch.get(kind="BuiltinTag", name__value="RED")
   tag_main_branch = await client_other_branch.get(kind="BuiltinTag", name__value="RED", branch="main")
@@ -102,7 +102,7 @@ The client object can be configured to use a specific branch in Infrahub. By def
   ```python
   from infrahub_sdk import InfrahubClientSync, Config
   config = Config(default_branch="other-branch")
-  client_other_branch = InfrahubClientSync.init(config=config)
+  client_other_branch = InfrahubClientSync(config=config)
 
   tag_other_branch = client_other_branch.get(kind="BuiltinTag", name__value="RED")
   tag_main_branch = client_other_branch.get(kind="BuiltinTag", name__value="RED", branch="main")

--- a/docs/docs/python-sdk/guides/object-storage.mdx
+++ b/docs/docs/python-sdk/guides/object-storage.mdx
@@ -14,7 +14,7 @@ import json
 from infrahub_sdk import InfrahubClientSync
 
 
-client = InfrahubClientSync.init()
+client = InfrahubClientSync()
 
 data = {
     "key": "value",
@@ -39,7 +39,7 @@ import json
 from infrahub_sdk import InfrahubClientSync
 
 
-client = InfrahubClientSync.init()
+client = InfrahubClientSync()
 identifier = "17d19a20-70f6-3e44-3341-c5124065cda9"
 
 response = client.object_store.get(identifier="17d19a20-70f6-3e44-3341-c5124065cda9")
@@ -68,7 +68,7 @@ data = {
 json_file = Path("/tmp/file.json")
 json_file.write_text(json.dumps(data))
 
-client = InfrahubClientSync.init()
+client = InfrahubClientSync()
 identifier = "17d19a20-70f6-3e44-3341-c5124065cda9"
 
 response = client.object_store.upload(content=json_file.read_text())

--- a/docs/docs/python-sdk/guides/tracking.mdx
+++ b/docs/docs/python-sdk/guides/tracking.mdx
@@ -79,7 +79,7 @@ This behavior ensures that the tracking group specifically reflects changes made
   ```python
   from infrahub_sdk.client import InfrahubClient
 
-  client = await InfrahubClient.init(address="http://localhost:8000")
+  client = InfrahubClient(address="http://localhost:8000")
 
   await client.start_tracking(identifier="my_tracking_session")
   node = await client.create(kind="MyNodeKind", data={"name": "Example"})
@@ -92,7 +92,7 @@ This behavior ensures that the tracking group specifically reflects changes made
   ```python
   from infrahub_sdk.client_sync import InfrahubClientSync
 
-  client = InfrahubClientSync.init(address="http://localhost:8000")
+  client = InfrahubClientSync(address="http://localhost:8000")
 
   client.start_tracking(identifier="my_tracking_session")
   node = client.create(kind="MyNodeKind", data={"name": "Example"})
@@ -165,7 +165,7 @@ This step involves creating or updating (using upsert) the `CoreStandardGroup` u
   ```python
   from infrahub_sdk.client import InfrahubClient
 
-  client = await InfrahubClient.init(address="http://localhost:8000")
+  client = InfrahubClient(address="http://localhost:8000")
 
   await client.start_tracking(identifier="my_tracking_session")
   node = await client.create(kind="MyNodeKind", data={"name": "Example"})
@@ -181,7 +181,7 @@ This step involves creating or updating (using upsert) the `CoreStandardGroup` u
   ```python
   from infrahub_sdk.client_sync import InfrahubClientSync
 
-  client = InfrahubClientSync.init(address="http://localhost:8000")
+  client = InfrahubClientSync(address="http://localhost:8000")
 
   client.start_tracking(identifier="my_tracking_session")
   node = client.create(kind="MyNodeKind", data={"name": "Example"})

--- a/docs/docs/python-sdk/reference/config.mdx
+++ b/docs/docs/python-sdk/reference/config.mdx
@@ -11,14 +11,14 @@ The Python SDK (Async or Sync) client can be configured using an instance of the
   ```python
   from infrahub_sdk import Config, InfrahubClient
   config = Config(address="http://infrahub:8080", api_token="123-xyz-invalid-token")
-  client = await InfrahubClient.init(config=config)
+  client = InfrahubClient(config=config)
   ```
   </TabItem>
   <TabItem value="Sync">
   ```python
   from infrahub_sdk import Config, InfrahubClientSync
   config = Config(address="http://infrahub:8080", api_token="123-xyz-invalid-token")
-  client = InfrahubClientSync.init(config=config)
+  client = InfrahubClientSync(config=config)
   ```
   </TabItem>
 </Tabs>

--- a/python_sdk/examples/branch_create.py
+++ b/python_sdk/examples/branch_create.py
@@ -4,7 +4,7 @@ from infrahub_sdk import InfrahubClient
 
 
 async def main():
-    client = await InfrahubClient.init(address="http://localhost:8000")
+    client = InfrahubClient(address="http://localhost:8000")
     await client.branch.create(branch_name="new-branch", description="description", sync_with_git=False)
     print("New branch created")
 

--- a/python_sdk/examples/branch_create_sync.py
+++ b/python_sdk/examples/branch_create_sync.py
@@ -2,7 +2,7 @@ from infrahub_sdk import InfrahubClientSync
 
 
 def main():
-    client = InfrahubClientSync.init(address="http://localhost:8000")
+    client = InfrahubClientSync(address="http://localhost:8000")
     client.branch.create(branch_name="new-branch2", description="description", sync_with_git=False)
     print("New branch created")
 

--- a/python_sdk/examples/branch_list.py
+++ b/python_sdk/examples/branch_list.py
@@ -6,7 +6,7 @@ from infrahub_sdk import InfrahubClient
 
 
 async def main():
-    client = await InfrahubClient.init(address="http://localhost:8000")
+    client = InfrahubClient(address="http://localhost:8000")
     branches = await client.branch.all()
     rprint(branches)
 

--- a/python_sdk/examples/branch_list_sync.py
+++ b/python_sdk/examples/branch_list_sync.py
@@ -4,7 +4,7 @@ from infrahub_sdk import InfrahubClientSync
 
 
 def main():
-    client = InfrahubClientSync.init(address="http://localhost:8000")
+    client = InfrahubClientSync(address="http://localhost:8000")
     branches = client.branch.all()
     rprint(branches)
 

--- a/python_sdk/examples/branch_merge.py
+++ b/python_sdk/examples/branch_merge.py
@@ -4,7 +4,7 @@ from infrahub_sdk import InfrahubClient
 
 
 async def main():
-    client = await InfrahubClient.init(address="http://localhost:8000")
+    client = InfrahubClient(address="http://localhost:8000")
     await client.branch.merge(branch_name="new-branch")
 
 

--- a/python_sdk/examples/branch_merge_sync.py
+++ b/python_sdk/examples/branch_merge_sync.py
@@ -2,7 +2,7 @@ from infrahub_sdk import InfrahubClientSync
 
 
 def main():
-    client = InfrahubClientSync.init(address="http://localhost:8000")
+    client = InfrahubClientSync(address="http://localhost:8000")
     client.branch.merge(branch_name="new-branch")
 
 

--- a/python_sdk/examples/branch_rebase.py
+++ b/python_sdk/examples/branch_rebase.py
@@ -4,7 +4,7 @@ from infrahub_sdk import InfrahubClient
 
 
 async def main():
-    client = await InfrahubClient.init(address="http://localhost:8000")
+    client = InfrahubClient(address="http://localhost:8000")
     await client.branch.rebase(branch_name="new-branch")
 
 

--- a/python_sdk/examples/branch_rebase_sync.py
+++ b/python_sdk/examples/branch_rebase_sync.py
@@ -2,7 +2,7 @@ from infrahub_sdk import InfrahubClientSync
 
 
 def main():
-    client = InfrahubClientSync.init(address="http://localhost:8000")
+    client = InfrahubClientSync(address="http://localhost:8000")
     client.branch.rebase(branch_name="new-branch")
 
 

--- a/python_sdk/examples/example_create_sync.py
+++ b/python_sdk/examples/example_create_sync.py
@@ -2,7 +2,7 @@ from infrahub_sdk import InfrahubClientSync
 
 
 def main():
-    client = InfrahubClientSync.init(address="http://localhost:8000")
+    client = InfrahubClientSync(address="http://localhost:8000")
     data = {
         "name": "janedoe",
         "label": "Jane Doe",

--- a/python_sdk/examples/example_delete.py
+++ b/python_sdk/examples/example_delete.py
@@ -4,7 +4,7 @@ from infrahub_sdk import InfrahubClient
 
 
 async def main():
-    client = await InfrahubClient.init(address="http://localhost:8000")
+    client = InfrahubClient(address="http://localhost:8000")
     obj = await client.get(kind="CoreAccount", name__value="johndoe")
     await obj.delete()
 

--- a/python_sdk/examples/example_update.py
+++ b/python_sdk/examples/example_update.py
@@ -4,7 +4,7 @@ from infrahub_sdk import InfrahubClient
 
 
 async def main():
-    client = await InfrahubClient.init(address="http://localhost:8000")
+    client = InfrahubClient(address="http://localhost:8000")
     obj = await client.get(kind="CoreAccount", name__value="admin")
     obj.label.value = "Administrator"
     await obj.save()

--- a/python_sdk/examples/node_create_data.py
+++ b/python_sdk/examples/node_create_data.py
@@ -4,7 +4,7 @@ from infrahub_sdk import InfrahubClient
 
 
 async def main():
-    client = await InfrahubClient.init(address="http://localhost:8000")
+    client = InfrahubClient(address="http://localhost:8000")
     data = {
         "name": "johndoe",
         "label": "John Doe",

--- a/python_sdk/examples/node_create_inline.py
+++ b/python_sdk/examples/node_create_inline.py
@@ -4,7 +4,7 @@ from infrahub_sdk import InfrahubClient
 
 
 async def main():
-    client = await InfrahubClient.init(address="http://localhost:8000")
+    client = InfrahubClient(address="http://localhost:8000")
     obj = await client.create(
         kind="CoreAccount",
         name="janedoe",

--- a/python_sdk/examples/query_all.py
+++ b/python_sdk/examples/query_all.py
@@ -6,7 +6,7 @@ from infrahub_sdk import InfrahubClient
 
 
 async def main():
-    client = await InfrahubClient.init(address="http://localhost:8000")
+    client = InfrahubClient(address="http://localhost:8000")
     accounts = await client.all(kind="CoreAccount")
     rprint(accounts)
 

--- a/python_sdk/examples/query_filters.py
+++ b/python_sdk/examples/query_filters.py
@@ -6,7 +6,7 @@ from infrahub_sdk import InfrahubClient
 
 
 async def main():
-    client = await InfrahubClient.init(address="http://localhost:8000")
+    client = InfrahubClient(address="http://localhost:8000")
     accounts = await client.filters(kind="CoreAccount")
     rprint(accounts)
 

--- a/python_sdk/infrahub_sdk/client.py
+++ b/python_sdk/infrahub_sdk/client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import copy
 import logging
+import warnings
 from functools import wraps
 from time import sleep
 from typing import TYPE_CHECKING, Any, Callable, Coroutine, Dict, List, MutableMapping, Optional, Type, TypedDict, Union
@@ -299,6 +300,11 @@ class InfrahubClient(BaseClient):
         address: str = "",
         config: Optional[Union[Config, Dict[str, Any]]] = None,
     ) -> InfrahubClient:
+        warnings.warn(
+            "InfrahubClient.init has been deprecated and will be removed in Infrahub SDK 0.14.0 or the next major version",
+            DeprecationWarning,
+            stacklevel=1,
+        )
         return cls(address=address, config=config)
 
     async def create(
@@ -1051,6 +1057,11 @@ class InfrahubClientSync(BaseClient):
         address: str = "",
         config: Optional[Union[Config, Dict[str, Any]]] = None,
     ) -> InfrahubClientSync:
+        warnings.warn(
+            "InfrahubClientSync.init has been deprecated and will be removed in Infrahub SDK 0.14.0 or the next major version",
+            DeprecationWarning,
+            stacklevel=1,
+        )
         return cls(address=address, config=config)
 
     def create(

--- a/python_sdk/infrahub_sdk/transforms.py
+++ b/python_sdk/infrahub_sdk/transforms.py
@@ -50,7 +50,7 @@ class InfrahubTransform:
         if client:
             item.client = client
         else:
-            item.client = await InfrahubClient.init(address=item.server_url)
+            item.client = InfrahubClient(address=item.server_url)
 
         return item
 

--- a/python_sdk/tests/integration/test_infrahub_client.py
+++ b/python_sdk/tests/integration/test_infrahub_client.py
@@ -35,14 +35,14 @@ class TestInfrahubClient:
         return InfrahubTestClient(app)
 
     @pytest.fixture
-    async def client(self, test_client: InfrahubTestClient) -> InfrahubClient:
+    def client(self, test_client: InfrahubTestClient) -> InfrahubClient:
         config = Config(username="admin", password="infrahub", requester=test_client.async_request)
-        return await InfrahubClient.init(config=config)
+        return InfrahubClient(config=config)
 
     @pytest.fixture(scope="class")
     async def base_dataset(self, db: InfrahubDatabase, test_client: InfrahubTestClient, builtin_org_schema):
         config = Config(username="admin", password="infrahub", requester=test_client.async_request)
-        client = await InfrahubClient.init(config=config)
+        client = InfrahubClient(config=config)
         response = await client.schema.load(schemas=[builtin_org_schema])
         assert not response.errors
 

--- a/python_sdk/tests/integration/test_infrahub_client_sync.py
+++ b/python_sdk/tests/integration/test_infrahub_client_sync.py
@@ -38,12 +38,12 @@ class TestInfrahubClientSync:
             password="infrahub",
             sync_requester=test_client.sync_request,
         )
-        return InfrahubClientSync.init(config=config)
+        return InfrahubClientSync(config=config)
 
     @pytest.fixture(scope="class")
     async def base_dataset(self, db: InfrahubDatabase, test_client: InfrahubTestClient, builtin_org_schema):
         config = Config(username="admin", password="infrahub", sync_requester=test_client.sync_request)
-        client = InfrahubClientSync.init(config=config)
+        client = InfrahubClientSync(config=config)
         response = client.schema.load(schemas=[builtin_org_schema])
         assert not response.errors
 

--- a/python_sdk/tests/integration/test_node.py
+++ b/python_sdk/tests/integration/test_node.py
@@ -21,19 +21,19 @@ class TestInfrahubNode:
     @pytest.fixture
     async def client(self, test_client):
         config = Config(username="admin", password="infrahub", requester=test_client.async_request)
-        return await InfrahubClient.init(config=config)
+        return InfrahubClient(config=config)
 
     @pytest.fixture(scope="class")
     async def load_builtin_schema(self, db: InfrahubDatabase, test_client: InfrahubTestClient, builtin_org_schema):
         config = Config(username="admin", password="infrahub", requester=test_client.async_request)
-        client = await InfrahubClient.init(config=config)
+        client = InfrahubClient(config=config)
         response = await client.schema.load(schemas=[builtin_org_schema])
         assert not response.errors
 
     @pytest.fixture(scope="class")
     async def load_ipam_schema(self, db: InfrahubDatabase, test_client: InfrahubTestClient, ipam_schema) -> None:
         config = Config(username="admin", password="infrahub", requester=test_client.async_request)
-        client = await InfrahubClient.init(config=config)
+        client = InfrahubClient(config=config)
         response = await client.schema.load(schemas=[ipam_schema])
         assert not response.errors
 

--- a/python_sdk/tests/integration/test_schema.py
+++ b/python_sdk/tests/integration/test_schema.py
@@ -17,7 +17,7 @@ class TestInfrahubSchema:
 
     async def test_schema_all(self, client, init_db_base):
         config = Config(requester=client.async_request)
-        ifc = await InfrahubClient.init(config=config)
+        ifc = InfrahubClient(config=config)
         schema_nodes = await ifc.schema.all()
 
         nodes = [node for node in core_models["nodes"] if node["namespace"] != "Internal"]
@@ -32,7 +32,7 @@ class TestInfrahubSchema:
 
     async def test_schema_get(self, client, init_db_base):
         config = Config(username="admin", password="infrahub", requester=client.async_request)
-        ifc = await InfrahubClient.init(config=config)
+        ifc = InfrahubClient(config=config)
         schema_node = await ifc.schema.get(kind="BuiltinTag")
 
         assert isinstance(schema_node, NodeSchema)
@@ -47,7 +47,7 @@ class TestInfrahubSchema:
 
     async def test_schema_load_many(self, client, init_db_base, schema_extension_01, schema_extension_02):
         config = Config(username="admin", password="infrahub", requester=client.async_request)
-        ifc = await InfrahubClient.init(config=config)
+        ifc = InfrahubClient(config=config)
         response = await ifc.schema.load(schemas=[schema_extension_01, schema_extension_02])
 
         assert response.schema_updated

--- a/python_sdk/tests/unit/sdk/checks/conftest.py
+++ b/python_sdk/tests/unit/sdk/checks/conftest.py
@@ -6,7 +6,7 @@ from infrahub_sdk import Config, InfrahubClient
 
 @pytest.fixture
 async def client() -> InfrahubClient:
-    return await InfrahubClient.init(config=Config(address="http://mock", insert_tracker=True))
+    return InfrahubClient(config=Config(address="http://mock", insert_tracker=True))
 
 
 @pytest.fixture

--- a/python_sdk/tests/unit/sdk/conftest.py
+++ b/python_sdk/tests/unit/sdk/conftest.py
@@ -25,16 +25,14 @@ class BothClients:
 
 @pytest.fixture
 async def client() -> InfrahubClient:
-    return await InfrahubClient.init(config=Config(address="http://mock", insert_tracker=True, pagination_size=3))
+    return InfrahubClient(config=Config(address="http://mock", insert_tracker=True, pagination_size=3))
 
 
 @pytest.fixture
 async def clients() -> BothClients:
     both = BothClients(
-        standard=await InfrahubClient.init(
-            config=Config(address="http://mock", insert_tracker=True, pagination_size=3)
-        ),
-        sync=InfrahubClientSync.init(config=Config(address="http://mock", insert_tracker=True, pagination_size=3)),
+        standard=InfrahubClient(config=Config(address="http://mock", insert_tracker=True, pagination_size=3)),
+        sync=InfrahubClientSync(config=Config(address="http://mock", insert_tracker=True, pagination_size=3)),
     )
     return both
 

--- a/python_sdk/tests/unit/sdk/test_client.py
+++ b/python_sdk/tests/unit/sdk/test_client.py
@@ -42,21 +42,9 @@ async def test_validate_method_signature(
     assert replace_async_return_annotation(async_sig.return_annotation) == sync_sig.return_annotation
 
 
-async def test_init_client():
-    await InfrahubClient.init()
-
-    assert True
-
-
-async def test_init_client_sync():
-    InfrahubClientSync.init()
-
-    assert True
-
-
-async def test_init_with_invalid_address():
+def test_init_with_invalid_address():
     with pytest.raises(ValueError) as exc:
-        await InfrahubClient.init(address="missing-schema")
+        InfrahubClient(address="missing-schema")
 
     assert "The configured address is not a valid url" in str(exc.value)
 

--- a/python_sdk/tests/unit/sdk/test_schema.py
+++ b/python_sdk/tests/unit/sdk/test_schema.py
@@ -40,10 +40,10 @@ async def test_validate_method_signature(method):
 @pytest.mark.parametrize("client_type", client_types)
 async def test_fetch_schema(mock_schema_query_01, client_type):  # pylint: disable=unused-argument
     if client_type == "standard":
-        client = await InfrahubClient.init(config=Config(address="http://mock", insert_tracker=True))
+        client = InfrahubClient(config=Config(address="http://mock", insert_tracker=True))
         nodes = await client.schema.fetch(branch="main")
     else:
-        client = InfrahubClientSync.init(config=Config(address="http://mock", insert_tracker=True))
+        client = InfrahubClientSync(config=Config(address="http://mock", insert_tracker=True))
         nodes = client.schema.fetch(branch="main")
 
     assert len(nodes) == 4
@@ -59,9 +59,9 @@ async def test_fetch_schema(mock_schema_query_01, client_type):  # pylint: disab
 @pytest.mark.parametrize("client_type", client_types)
 async def test_schema_data_validation(rfile_schema, client_type):
     if client_type == "standard":
-        client = await InfrahubClient.init(config=Config(address="http://mock", insert_tracker=True))
+        client = InfrahubClient(config=Config(address="http://mock", insert_tracker=True))
     else:
-        client = InfrahubClientSync.init(config=Config(address="http://mock", insert_tracker=True))
+        client = InfrahubClientSync(config=Config(address="http://mock", insert_tracker=True))
 
     client.schema.validate_data_against_schema(
         schema=rfile_schema,


### PR DESCRIPTION
Removes the `.init()` wrapper that currently only adds an extra layer.

Set Infrahub SDK version 0.14.0 as the version where the methods will be removed completely. After this is merged I'll also create the 0.13 and 0.14 milestones and add an issue to track this for removal in 0.14.0 of the SDK.