### PR TITLE
Add start_period and raise retry counter

### DIFF
--- a/development/docker-compose-deps.yml
+++ b/development/docker-compose-deps.yml
@@ -9,7 +9,8 @@ services:
       test: rabbitmq-diagnostics -q check_port_connectivity
       interval: 5s
       timeout: 30s
-      retries: 3
+      retries: 5
+      start_period: 3s
   cache:
     image: "${CACHE_DOCKER_IMAGE:-redis:latest}"
     healthcheck:


### PR DESCRIPTION
Hopefully this is enough to fix the flaky startups of the RabbitMQ containers in the pipeline