### PR TITLE
Add new DateTime Infrahub type. Add validate_content.

### DIFF
--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -610,7 +610,7 @@ class DateTime(BaseAttribute):
 
         # If DateTime attribute is an empty string and is not required do not complete any further validation of format.
         # This was added due to infrahub.core.integrity.object_conflict.conflict_recorder.py initialize_validator sets completed_at to a blank string
-        if not value and not schema.optional:
+        if not value and schema.optional:
             return
 
         try:

--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -600,7 +600,6 @@ class Boolean(BaseAttribute):
     type = bool
 
 
-# TODO: Add properties for different datetime format outputs to mimic IP property types for GraphQL
 class DateTime(BaseAttribute):
     type = str
 

--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -608,8 +608,6 @@ class DateTime(BaseAttribute):
     def validate_format(cls, value: Any, name: str, schema: AttributeSchema) -> None:
         super().validate_format(value=value, name=name, schema=schema)
 
-        # If DateTime attribute is an empty string and is not required do not complete any further validation of format.
-        # This was added due to infrahub.core.integrity.object_conflict.conflict_recorder.py initialize_validator sets completed_at to a blank string
         if not value and schema.optional:
             return
 

--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -5,9 +5,9 @@ import re
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 
-import pendulum
 import ujson
 from infrahub_sdk import UUIDT
+from infrahub_sdk.timestamp import TimestampFormatError
 from infrahub_sdk.utils import is_valid_url
 from pydantic.v1 import BaseModel, Field
 
@@ -611,12 +611,9 @@ class DateTime(BaseAttribute):
             return
 
         try:
-            time = pendulum.parse(value, exact=True)
-        except pendulum.exceptions.ParserError as exc:
+            Timestamp(value)
+        except TimestampFormatError as exc:
             raise ValidationError({name: f"{value} is not a valid {schema.kind}"}) from exc
-
-        if not isinstance(time, pendulum.DateTime):
-            raise ValidationError({name: f"{value} is not a valid {schema.kind}"})
 
 
 class Dropdown(BaseAttribute):

--- a/backend/infrahub/core/protocols.py
+++ b/backend/infrahub/core/protocols.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     from infrahub.core.attribute import (
         URL,
         Boolean,
+        DateTime,
         Dropdown,
         HashedPassword,
         Integer,
@@ -74,13 +75,13 @@ class CoreCheck(CoreNode):
     message: String
     conclusion: Enum
     severity: Enum
-    created_at: String
+    created_at: DateTime
     validator: RelationshipManager
 
 
 class CoreComment(CoreNode):
     text: String
-    created_at: String
+    created_at: DateTime
     created_by: RelationshipManager
 
 
@@ -124,7 +125,7 @@ class CoreTaskTarget(CoreNode):
 class CoreThread(CoreNode):
     label: String
     resolved: Boolean
-    created_at: String
+    created_at: DateTime
     change: RelationshipManager
     comments: RelationshipManager
     created_by: RelationshipManager
@@ -144,8 +145,8 @@ class CoreValidator(CoreNode):
     label: String
     state: Enum
     conclusion: Enum
-    completed_at: String
-    started_at: String
+    completed_at: DateTime
+    started_at: DateTime
     proposed_change: RelationshipManager
     checks: RelationshipManager
 
@@ -402,12 +403,12 @@ class CoreUserValidator(CoreValidator):
 class InternalAccountToken(CoreNode):
     name: String
     token: String
-    expiration: String
+    expiration: DateTime
     account: RelationshipManager
 
 
 class InternalRefreshToken(CoreNode):
-    expiration: String
+    expiration: DateTime
     account: RelationshipManager
 
 

--- a/backend/infrahub/types.py
+++ b/backend/infrahub/types.py
@@ -138,7 +138,7 @@ class DateTime(InfrahubDataType):
     graphql_create = "TextAttributeCreate"
     graphql_update = "TextAttributeUpdate"
     graphql_filter = graphene.String
-    infrahub = "String"
+    infrahub = "DateTime"
 
 
 class Email(InfrahubDataType):

--- a/backend/infrahub/types.py
+++ b/backend/infrahub/types.py
@@ -133,11 +133,11 @@ class TextArea(Text):
 
 class DateTime(InfrahubDataType):
     label: str = "DateTime"
-    graphql = graphene.String
+    graphql = graphene.DateTime
     graphql_query = "TextAttributeType"
     graphql_create = "TextAttributeCreate"
     graphql_update = "TextAttributeUpdate"
-    graphql_filter = graphene.String
+    graphql_filter = graphene.DateTime
     infrahub = "DateTime"
 
 

--- a/backend/templates/generate_protocols.j2
+++ b/backend/templates/generate_protocols.j2
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from enum import Enum
-    from infrahub.core.attribute import Boolean, Dropdown, HashedPassword, Integer, IPHost, IPNetwork, JSONAttribute, ListAttribute, String, URL
+    from infrahub.core.attribute import Boolean, DateTime, Dropdown, HashedPassword, Integer, IPHost, IPNetwork, JSONAttribute, ListAttribute, String, URL
     from infrahub.core.relationship import RelationshipManager
 
 

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -1708,6 +1708,7 @@ async def criticality_schema(db: InfrahubDatabase, default_branch: Branch, group
             {"name": "json_no_default", "kind": "JSON", "optional": True},
             {"name": "json_default", "kind": "JSON", "default_value": {"value": "bob"}},
             {"name": "description", "kind": "Text", "optional": True},
+            {"name": "time", "kind": "DateTime", "optional": True},
             {
                 "name": "status",
                 "kind": "Dropdown",

--- a/backend/tests/unit/core/test_attribute.py
+++ b/backend/tests/unit/core/test_attribute.py
@@ -117,11 +117,10 @@ async def test_validate_format_datetime_invalid(
 ):
     schema = criticality_schema.get_attribute("time")
 
-    with pytest.raises(ValidationError) as error:
+    with pytest.raises(ValidationError, match=r"invalid-datetime is not a valid DateTime"):
         DateTime(name="test", schema=schema, branch=default_branch, at=Timestamp(), node=None, data="invalid-datetime")
-    assert error.value.args[0] == "invalid-datetime is not a valid DateTime"
 
-    with pytest.raises(ValidationError) as error:
+    with pytest.raises(ValidationError, match=r"10:10:10 is not a valid DateTime"):
         DateTime(
             name="test",
             schema=schema,
@@ -130,7 +129,6 @@ async def test_validate_format_datetime_invalid(
             node=None,
             data="10:10:10",
         )
-    assert error.value.args[0] == "10:10:10 is not a valid DateTime"
 
 
 async def test_validate_iphost_returns(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema):

--- a/backend/tests/unit/core/test_attribute.py
+++ b/backend/tests/unit/core/test_attribute.py
@@ -120,14 +120,14 @@ async def test_validate_format_datetime_invalid(
     with pytest.raises(ValidationError, match=r"invalid-datetime is not a valid DateTime"):
         DateTime(name="test", schema=schema, branch=default_branch, at=Timestamp(), node=None, data="invalid-datetime")
 
-    with pytest.raises(ValidationError, match=r"10:10:10 is not a valid DateTime"):
+    with pytest.raises(ValidationError, match=r"10:1010 is not a valid DateTime"):
         DateTime(
             name="test",
             schema=schema,
             branch=default_branch,
             at=Timestamp(),
             node=None,
-            data="10:10:10",
+            data="10:1010",
         )
 
 

--- a/backend/tests/unit/graphql/test_manager.py
+++ b/backend/tests/unit/graphql/test_manager.py
@@ -48,6 +48,7 @@ async def test_generate_graphql_object(db: InfrahubDatabase, default_branch: Bra
         "mylist",
         "name",
         "status",
+        "time",
     ]
 
 

--- a/backend/tests/unit/graphql/test_mutation_create.py
+++ b/backend/tests/unit/graphql/test_mutation_create.py
@@ -1116,7 +1116,7 @@ async def test_create_valid_datetime_success(db: InfrahubDatabase, default_branc
     )
     assert result.errors is None
     assert result.data["TestCriticalityCreate"]["ok"] is True
-    crit = await NodeManager.get_one(db=db, id=result.data["TestCriticalityCreate"]["id"])
+    crit = await NodeManager.get_one(db=db, id=result.data["TestCriticalityCreate"]["object"]["id"])
     assert crit.time.value == "2021-01-01T00:00:00Z"
     assert crit.time.is_default is False
     assert crit.name.value == "HIGH"

--- a/backend/tests/unit/graphql/test_mutation_create.py
+++ b/backend/tests/unit/graphql/test_mutation_create.py
@@ -1100,6 +1100,9 @@ async def test_create_valid_datetime_success(db: InfrahubDatabase, default_branc
     mutation {
         TestCriticalityCreate(data: {name: { value: "HIGH"}, level: {value: 1}, time: {value: "2021-01-01T00:00:00Z"}}) {
             ok
+            object {
+                id
+            }
         }
     }
     """
@@ -1113,6 +1116,11 @@ async def test_create_valid_datetime_success(db: InfrahubDatabase, default_branc
     )
     assert result.errors is None
     assert result.data["TestCriticalityCreate"]["ok"] is True
+    crit = await NodeManager.get_one(db=db, id=result.data["TestCriticalityCreate"]["id"])
+    assert crit.time.value == "2021-01-01T00:00:00Z"
+    assert crit.time.is_default is False
+    assert crit.name.value == "HIGH"
+    assert crit.level.value == 1
 
 
 async def test_create_valid_datetime_failure(db: InfrahubDatabase, default_branch, criticality_schema):

--- a/backend/tests/unit/graphql/test_mutation_create.py
+++ b/backend/tests/unit/graphql/test_mutation_create.py
@@ -1093,3 +1093,43 @@ async def test_incorrect_peer_type_prevented(db: InfrahubDatabase, default_branc
         result.errors[0].message
         == f"""TestDog - {dog2.id} cannot be added to relationship, must be of type: ['TestPerson'] at owner"""
     )
+
+
+async def test_create_valid_datetime_success(db: InfrahubDatabase, default_branch, criticality_schema):
+    query = """
+    mutation {
+        TestCriticalityCreate(data: {name: { value: "HIGH"}, level: {value: 1}, time: {value: "2021-01-01T00:00:00Z"}}) {
+            ok
+        }
+    }
+    """
+    gql_params = prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
+    assert result.errors is None
+    assert result.data["TestCriticalityCreate"]["ok"] is True
+
+
+async def test_create_valid_datetime_failure(db: InfrahubDatabase, default_branch, criticality_schema):
+    query = """
+    mutation {
+        TestCriticalityCreate(data: {name: { value: "HIGH"}, level: {value: 1}, time: {value: "10:10:10"}}) {
+            ok
+        }
+    }
+    """
+    gql_params = prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
+    assert result.errors[0].args[0] == "10:10:10 is not a valid DateTime at time"
+    assert result.data["TestCriticalityCreate"] is None

--- a/backend/tests/unit/graphql/test_mutation_create.py
+++ b/backend/tests/unit/graphql/test_mutation_create.py
@@ -1126,7 +1126,7 @@ async def test_create_valid_datetime_success(db: InfrahubDatabase, default_branc
 async def test_create_valid_datetime_failure(db: InfrahubDatabase, default_branch, criticality_schema):
     query = """
     mutation {
-        TestCriticalityCreate(data: {name: { value: "HIGH"}, level: {value: 1}, time: {value: "10:10:10"}}) {
+        TestCriticalityCreate(data: {name: { value: "HIGH"}, level: {value: 1}, time: {value: "10:1010"}}) {
             ok
         }
     }
@@ -1139,5 +1139,5 @@ async def test_create_valid_datetime_failure(db: InfrahubDatabase, default_branc
         root_value=None,
         variable_values={},
     )
-    assert result.errors[0].args[0] == "10:10:10 is not a valid DateTime at time"
+    assert result.errors[0].args[0] == "10:1010 is not a valid DateTime at time"
     assert result.data["TestCriticalityCreate"] is None

--- a/backend/tests/unit/graphql/test_parser.py
+++ b/backend/tests/unit/graphql/test_parser.py
@@ -63,6 +63,7 @@ async def test_simple_directive(db: InfrahubDatabase, default_branch: Branch, cr
             "json_no_default": {"value": None, "is_default": True, "is_from_profile": False},
             "json_default": {"value": {"value": "bob"}, "is_default": True, "is_from_profile": False},
             "description": {"value": None, "is_default": True, "is_from_profile": False},
+            "time": {"value": None, "is_default": True, "is_from_profile": False},
             "status": {"value": None, "is_default": True, "is_from_profile": False},
         }
     } in result.data["TestCriticality"]["edges"]
@@ -117,6 +118,7 @@ async def test_directive_exclude(db: InfrahubDatabase, default_branch: Branch, c
             "json_no_default": {"value": None, "is_default": True, "is_from_profile": False},
             "json_default": {"value": {"value": "bob"}, "is_default": True, "is_from_profile": False},
             "description": {"value": None, "is_default": True, "is_from_profile": False},
+            "time": {"value": None, "is_default": True, "is_from_profile": False},
             "status": {"value": None, "is_default": True, "is_from_profile": False},
         }
     } in result.data["TestCriticality"]["edges"]


### PR DESCRIPTION
Fixes #3551 

- Add new `DateTime` attribute and added `validate_format` to assert the input is `pendulum.DateTime` object
- Update `DateTime` Infrahub type with new `DateTime` attribute
- Update `DateTime` infrahub type `graphql` and `graphql_filter` to use `graphene.DateTime`