### PR TITLE
Replace pytest.state with proper classes

### DIFF
--- a/backend/tests/integration/schema_lifecycle/test_migration_attribute_branch.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_attribute_branch.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import pytest
 from infrahub_sdk import InfrahubClient
@@ -10,6 +10,7 @@ from infrahub.core.initialization import (
 )
 from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
+from infrahub.exceptions import InitializationError
 
 from ..shared import load_schema
 from .shared import (
@@ -23,10 +24,28 @@ from .shared import (
 # pylint: disable=unused-argument
 
 
+class BranchState:
+    def __init__(self) -> None:
+        self._branch: Optional[Branch] = None
+
+    @property
+    def branch(self) -> Branch:
+        if self._branch:
+            return self._branch
+        raise InitializationError
+
+    @branch.setter
+    def branch(self, value: Branch) -> None:
+        self._branch = value
+
+
+state = BranchState()
+
+
 class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
     @property
     def branch1(self) -> Branch:
-        return pytest.state["branch1"]  # type: ignore[index]
+        return state.branch
 
     @pytest.fixture(scope="class")
     async def initial_dataset(self, db: InfrahubDatabase, initialize_registry, schema_step01):
@@ -61,7 +80,7 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
 
         # Create Branch1
         branch1 = await create_branch(db=db, branch_name="branch1")
-        pytest.state = {"branch1": branch1}
+        state.branch = branch1
 
         # Load data in BRANCH1
         richard = await Node.init(schema=PERSON_KIND, db=db, branch=branch1)

--- a/backend/tests/integration/schema_lifecycle/test_migration_relationship_branch.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_relationship_branch.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import pytest
 from infrahub_sdk import InfrahubClient
@@ -10,6 +10,7 @@ from infrahub.core.initialization import (
 )
 from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
+from infrahub.exceptions import InitializationError
 
 from ..shared import load_schema
 from .shared import (
@@ -23,10 +24,28 @@ from .shared import (
 # pylint: disable=unused-argument
 
 
+class BranchState:
+    def __init__(self) -> None:
+        self._branch: Optional[Branch] = None
+
+    @property
+    def branch(self) -> Branch:
+        if self._branch:
+            return self._branch
+        raise InitializationError
+
+    @branch.setter
+    def branch(self, value: Branch) -> None:
+        self._branch = value
+
+
+state = BranchState()
+
+
 class TestSchemaLifecycleRelationshipBranch(TestSchemaLifecycleBase):
     @property
     def branch1(self) -> Branch:
-        return pytest.state["branch1"]  # type: ignore[index]
+        return state.branch
 
     @pytest.fixture(scope="class")
     async def initial_dataset(self, db: InfrahubDatabase, initialize_registry, schema_step01):
@@ -61,7 +80,7 @@ class TestSchemaLifecycleRelationshipBranch(TestSchemaLifecycleBase):
 
         # Create Branch1
         branch1 = await create_branch(db=db, branch_name="branch1")
-        pytest.state = {"branch1": branch1}
+        state.branch = branch1
 
         # Load data in BRANCH1
         richard = await Node.init(schema=PERSON_KIND, db=db, branch=branch1)

--- a/backend/tests/integration/schema_lifecycle/test_schema_migration_branch.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_migration_branch.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import pytest
 from infrahub_sdk import InfrahubClient
 
@@ -8,6 +10,7 @@ from infrahub.core.initialization import (
 )
 from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
+from infrahub.exceptions import InitializationError
 
 from ..shared import load_schema
 from .shared import (
@@ -22,10 +25,28 @@ from .shared import (
 # pylint: disable=unused-argument
 
 
+class BranchState:
+    def __init__(self) -> None:
+        self._branch: Optional[Branch] = None
+
+    @property
+    def branch(self) -> Branch:
+        if self._branch:
+            return self._branch
+        raise InitializationError
+
+    @branch.setter
+    def branch(self, value: Branch) -> None:
+        self._branch = value
+
+
+state = BranchState()
+
+
 class TestSchemaLifecycleBranch(TestSchemaLifecycleBase):
     @property
     def branch1(self) -> Branch:
-        return pytest.state["branch1"]  # type: ignore[index]
+        return state.branch
 
     @pytest.fixture(scope="class")
     async def initial_dataset(self, db: InfrahubDatabase, initialize_registry, schema_step01):
@@ -60,7 +81,7 @@ class TestSchemaLifecycleBranch(TestSchemaLifecycleBase):
 
         # Create Branch1
         branch1 = await create_branch(db=db, branch_name="branch1")
-        pytest.state = {"branch1": branch1}
+        state.branch = branch1
 
         # Load data in BRANCH1
         richard = await Node.init(schema=PERSON_KIND, db=db, branch=branch1)


### PR DESCRIPTION
When testing to upgrade to Pytest 8 (#3572) mypy started to complain about the use of pytest.state (state doesn't exist within pytest) and now got marked as invalid as we add an attribute to the module that doesn't exist from the start. This PR replaces `pytest.state` with a regular class that would serve the same purpose.