### PR TITLE
Remove conditional check if client exists

### DIFF
--- a/backend/infrahub/git/repository.py
+++ b/backend/infrahub/git/repository.py
@@ -650,13 +650,6 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
             False if they already had the same value
         """
 
-        if not self.client:
-            log.warning(
-                "Unable to update the value of the commit because a valid client hasn't been provided.",
-                repository=self.name,
-            )
-            return False
-
         log.debug(
             f"Updating commit value to {commit} for branch {branch_name}", repository=self.name, branch=branch_name
         )
@@ -862,13 +855,6 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
         return conflict_files
 
     async def import_objects_from_files(self, branch_name: str, commit: Optional[str] = None):
-        if not self.client:
-            log.warning(
-                "Unable to import the objects from the files because a valid client hasn't been provided.",
-                repository=self.name,
-            )
-            return
-
         if not commit:
             commit = self.get_commit_value(branch_name=branch_name)
 

--- a/backend/tests/helpers/test_client.py
+++ b/backend/tests/helpers/test_client.py
@@ -7,6 +7,13 @@ from fastapi import FastAPI
 from infrahub_sdk.types import HTTPMethod
 
 
+async def dummy_async_request(
+    url: str, method: HTTPMethod, headers: Dict[str, Any], timeout: int, payload: Optional[Dict] = None
+) -> httpx.Response:
+    """Return an empty response and to pretend that the git commit was updated successfully"""
+    return httpx.Response(status_code=200, json={"data": {}}, request=httpx.Request(method="POST", url="http://mock"))
+
+
 class InfrahubTestClient(httpx.AsyncClient):
     def __init__(self, app: FastAPI, base_url: str = ""):
         self.loop = asyncio.get_event_loop()

--- a/backend/tests/integration/git/test_git_repository.py
+++ b/backend/tests/integration/git/test_git_repository.py
@@ -95,9 +95,8 @@ class TestInfrahubClient:
             name=git_repo_infrahub_demo_edge.name,
             location=git_repo_infrahub_demo_edge.path,
             task_report=FakeTaskReportLogger(),
+            client=client,
         )
-
-        repo.client = client
 
         return repo
 

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 
 import pendulum
 import pytest
-from infrahub_sdk import UUIDT
+from infrahub_sdk import UUIDT, Config, InfrahubClient
 from neo4j._codec.hydration.v1 import HydrationHandler
 from pytest_httpx import HTTPXMock
 
@@ -39,6 +39,7 @@ from infrahub.dependencies.registry import build_component_registry
 from infrahub.git import InfrahubRepository
 from infrahub.test_data import dataset01 as ds01
 from tests.helpers.file_repo import FileRepo
+from tests.helpers.test_client import dummy_async_request
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -92,6 +93,7 @@ async def git_fixture_repo(git_sources_dir: Path, git_repos_dir: Path) -> Infrah
         id=UUIDT.new(),
         name="test_basename",
         location=f"{git_sources_dir}/test_base",
+        client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
 
     await repo.create_branch_in_git(branch_name="main", branch_id="8808dcea-f7b4-4f5a-b5e9-a0605d4c11ba")

--- a/backend/tests/unit/git/conftest.py
+++ b/backend/tests/unit/git/conftest.py
@@ -18,6 +18,7 @@ from infrahub.core.schema import SchemaRoot, core_models
 from infrahub.git import InfrahubRepository
 from infrahub.git.repository import InfrahubReadOnlyRepository
 from infrahub.utils import find_first_file_in_directory, get_fixtures_dir
+from tests.helpers.test_client import dummy_async_request
 
 
 @pytest.fixture
@@ -134,6 +135,7 @@ async def git_repo_01(client, git_upstream_repo_01, git_repos_dir) -> InfrahubRe
         id=UUIDT.new(),
         name=git_upstream_repo_01["name"],
         location=git_upstream_repo_01["path"],
+        client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
 
     return repo
@@ -149,6 +151,7 @@ async def git_repo_01_read_only(client, git_upstream_repo_01, git_repos_dir) -> 
         location=git_upstream_repo_01["path"],
         ref="branch01",
         infrahub_branch_name="main",
+        client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
 
     return repo
@@ -169,6 +172,7 @@ async def git_repo_02(git_upstream_repo_02, git_repos_dir) -> InfrahubRepository
         id=UUIDT.new(),
         name=git_upstream_repo_02["name"],
         location=git_upstream_repo_02["path"],
+        client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
 
     return repo
@@ -185,8 +189,12 @@ async def git_repo_02_w_client(git_repo_02, client) -> InfrahubRepository:
 @pytest.fixture
 async def git_repo_03(client, git_upstream_repo_03, git_repos_dir) -> InfrahubRepository:
     """Git Repository with git_upstream_repo_03 as remote"""
+
     repo = await InfrahubRepository.new(
-        id=UUIDT.new(), name=git_upstream_repo_03["name"], location=git_upstream_repo_03["path"]
+        id=UUIDT.new(),
+        name=git_upstream_repo_03["name"],
+        location=git_upstream_repo_03["path"],
+        client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
 
     return repo
@@ -212,6 +220,7 @@ async def git_repo_04(client, git_upstream_repo_03, git_repos_dir, branch01: Bra
         id=UUIDT.new(),
         name=git_upstream_repo_03["name"],
         location=git_upstream_repo_03["path"],
+        client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
     await repo.create_branch_in_git(branch_name=branch01.name, branch_id=branch01.id)
 
@@ -245,6 +254,7 @@ async def git_repo_05(client, git_upstream_repo_01, git_repos_dir) -> InfrahubRe
         id=UUIDT.new(),
         name=git_upstream_repo_01["name"],
         location=git_upstream_repo_01["path"],
+        client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
 
     # Update the first file at the top level and commit the change in the branch
@@ -272,6 +282,7 @@ async def git_repo_06(client, git_upstream_repo_01, git_repos_dir, branch01: Bra
         id=UUIDT.new(),
         name=git_upstream_repo_01["name"],
         location=git_upstream_repo_01["path"],
+        client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
     await repo.create_branch_in_git(branch_name=branch01.name, branch_id=branch01.id)
 
@@ -362,6 +373,7 @@ async def git_repo_jinja(client, git_upstream_repo_02, git_repos_dir, branch01: 
         id=UUIDT.new(),
         name=git_upstream_repo_02["name"],
         location=git_upstream_repo_02["path"],
+        client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
     await repo.create_branch_in_git(branch_name=branch01.name, branch_id=branch01.id)
 
@@ -399,6 +411,7 @@ async def git_repo_checks(client, git_upstream_repo_02, git_repos_dir) -> Infrah
         id=UUIDT.new(),
         name=git_upstream_repo_02["name"],
         location=git_upstream_repo_02["path"],
+        client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
     return repo
 
@@ -428,6 +441,7 @@ async def git_repo_transforms(client, git_upstream_repo_02, git_repos_dir) -> In
         id=UUIDT.new(),
         name=git_upstream_repo_02["name"],
         location=git_upstream_repo_02["path"],
+        client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
     return repo
 
@@ -446,6 +460,7 @@ async def git_repo_10(client, git_upstream_repo_10, git_repos_dir) -> InfrahubRe
         id=UUIDT.new(),
         name=git_upstream_repo_10["name"],
         location=git_upstream_repo_10["path"],
+        client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
 
     repo.client = client

--- a/backend/tests/unit/git/test_git_read_only_repository.py
+++ b/backend/tests/unit/git/test_git_read_only_repository.py
@@ -3,9 +3,10 @@ from typing import Dict
 from unittest.mock import AsyncMock
 
 from infrahub_sdk import UUIDT
-from infrahub_sdk.client import InfrahubClient
+from infrahub_sdk.client import Config, InfrahubClient
 
 from infrahub.git.repository import InfrahubReadOnlyRepository
+from tests.helpers.test_client import dummy_async_request
 
 
 async def test_new_empty_dir(git_upstream_repo_01: Dict[str, str], git_repos_dir: str):
@@ -15,6 +16,7 @@ async def test_new_empty_dir(git_upstream_repo_01: Dict[str, str], git_repos_dir
         location=git_upstream_repo_01["path"],
         ref="branch01",
         infrahub_branch_name="main",
+        client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
 
     assert os.path.isdir(repo.directory_root)

--- a/backend/tests/unit/git/test_git_repository.py
+++ b/backend/tests/unit/git/test_git_repository.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 from git import Repo
-from infrahub_sdk import UUIDT, InfrahubNode
+from infrahub_sdk import UUIDT, Config, InfrahubClient, InfrahubNode
 from infrahub_sdk.branch import BranchData
 
 from infrahub.core.constants import InfrahubKind
@@ -27,11 +27,15 @@ from infrahub.git import (
     extract_repo_file_information,
 )
 from infrahub.utils import find_first_file_in_directory
+from tests.helpers.test_client import dummy_async_request
 
 
 async def test_directories_props(git_upstream_repo_01, git_repos_dir):
     repo = await InfrahubRepository.new(
-        id=UUIDT.new(), name=git_upstream_repo_01["name"], location=git_upstream_repo_01["path"]
+        id=UUIDT.new(),
+        name=git_upstream_repo_01["name"],
+        location=git_upstream_repo_01["path"],
+        client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
 
     assert repo.directory_root == os.path.join(git_repos_dir, git_upstream_repo_01["name"])
@@ -42,7 +46,10 @@ async def test_directories_props(git_upstream_repo_01, git_repos_dir):
 
 async def test_new_empty_dir(git_upstream_repo_01, git_repos_dir):
     repo = await InfrahubRepository.new(
-        id=UUIDT.new(), name=git_upstream_repo_01["name"], location=git_upstream_repo_01["path"]
+        id=UUIDT.new(),
+        name=git_upstream_repo_01["name"],
+        location=git_upstream_repo_01["path"],
+        client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
 
     # Check if all the directories are present
@@ -58,7 +65,10 @@ async def test_new_existing_directory(git_upstream_repo_01, git_repos_dir):
     Path(os.path.join(git_repos_dir, git_upstream_repo_01["name"], "file1.txt")).touch()
 
     repo = await InfrahubRepository.new(
-        id=UUIDT.new(), name=git_upstream_repo_01["name"], location=git_upstream_repo_01["path"]
+        id=UUIDT.new(),
+        name=git_upstream_repo_01["name"],
+        location=git_upstream_repo_01["path"],
+        client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
 
     # Check if all the directories are present
@@ -73,7 +83,10 @@ async def test_new_existing_file(git_upstream_repo_01, git_repos_dir):
     Path(os.path.join(git_repos_dir, git_upstream_repo_01["name"])).touch()
 
     repo = await InfrahubRepository.new(
-        id=UUIDT.new(), name=git_upstream_repo_01["name"], location=git_upstream_repo_01["path"]
+        id=UUIDT.new(),
+        name=git_upstream_repo_01["name"],
+        location=git_upstream_repo_01["path"],
+        client=InfrahubClient(config=Config(requester=dummy_async_request)),
     )
 
     # Check if all the directories are present

--- a/backend/tests/unit/git/test_git_rpc.py
+++ b/backend/tests/unit/git/test_git_rpc.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Dict, Optional, Type
 from unittest.mock import AsyncMock, patch
 
-import httpx
 from infrahub_sdk import UUIDT, Config, InfrahubClient
 
 from infrahub.core.constants import InfrahubKind
@@ -14,6 +13,7 @@ from infrahub.lock import InfrahubLockRegistry
 from infrahub.message_bus import Meta, messages
 from infrahub.message_bus.operations import git
 from infrahub.services import InfrahubServices
+from tests.helpers.test_client import dummy_async_request
 
 # pylint: disable=redefined-outer-name
 
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
     from types import TracebackType
 
     from infrahub_sdk.branch import BranchData
-    from infrahub_sdk.types import HTTPMethod
 
     from tests.conftest import TestHelper
 
@@ -41,13 +40,6 @@ class AsyncContextManagerMock:
 
     def __call__(self, *args: Any, **kwargs: Any):
         return self
-
-
-async def dummy_async_request(
-    url: str, method: HTTPMethod, headers: Dict[str, Any], timeout: int, payload: Optional[Dict] = None
-) -> httpx.Response:
-    """Return an empty response and to pretend that the git commit was updated successfully"""
-    return httpx.Response(status_code=200, json={"data": {}}, request=httpx.Request(method="POST", url="http://mock"))
 
 
 class TestAddRepository:


### PR DESCRIPTION
The conditional if-statements in repository.py prevents us from raising an error as `self.client` is currently optional. We never want to have this in production and the if-statement was only used to simplify the tests in the past.

I've updated the tests impacted by this so that we instead use a dummy transport method for these calls.