### PR TITLE
Rewrite SDK client allocation functions

### DIFF
--- a/python_sdk/infrahub_sdk/client.py
+++ b/python_sdk/infrahub_sdk/client.py
@@ -890,7 +890,6 @@ class InfrahubClient(BaseClient):
             timeout=timeout,
             tracker=tracker,
             raise_for_error=raise_for_error,
-            variables={"identifier": identifier, "data": data},
         )
 
         if response[mutation_name]["ok"]:
@@ -939,17 +938,7 @@ class InfrahubClient(BaseClient):
             data=data,
         )
         response = await self.execute_graphql(
-            query=query.render(),
-            branch_name=branch,
-            timeout=timeout,
-            tracker=tracker,
-            raise_for_error=raise_for_error,
-            variables={
-                "identifier": identifier,
-                "prefix_length": prefix_length,
-                "member_type": member_type,
-                "data": data,
-            },
+            query=query.render(), branch_name=branch, timeout=timeout, tracker=tracker, raise_for_error=raise_for_error
         )
 
         if response[mutation_name]["ok"]:
@@ -1510,12 +1499,7 @@ class InfrahubClientSync(BaseClient):
             resource_pool_id=resource_pool.id, identifier=identifier, data=data
         )
         response = self.execute_graphql(
-            query=query.render(),
-            branch_name=branch,
-            timeout=timeout,
-            tracker=tracker,
-            raise_for_error=raise_for_error,
-            variables={"identifier": identifier, "data": data},
+            query=query.render(), branch_name=branch, timeout=timeout, tracker=tracker, raise_for_error=raise_for_error
         )
 
         if response[mutation_name]["ok"]:
@@ -1564,17 +1548,7 @@ class InfrahubClientSync(BaseClient):
             data=data,
         )
         response = self.execute_graphql(
-            query=query.render(),
-            branch_name=branch,
-            timeout=timeout,
-            tracker=tracker,
-            raise_for_error=raise_for_error,
-            variables={
-                "identifier": identifier,
-                "prefix_length": prefix_length,
-                "member_type": member_type,
-                "data": data,
-            },
+            query=query.render(), branch_name=branch, timeout=timeout, tracker=tracker, raise_for_error=raise_for_error
         )
 
         if response[mutation_name]["ok"]:

--- a/python_sdk/infrahub_sdk/client.py
+++ b/python_sdk/infrahub_sdk/client.py
@@ -30,7 +30,7 @@ from infrahub_sdk.exceptions import (
     ServerNotReachableError,
     ServerNotResponsiveError,
 )
-from infrahub_sdk.graphql import Query
+from infrahub_sdk.graphql import Mutation, Query
 from infrahub_sdk.node import (
     InfrahubNode,
     InfrahubNodeSync,
@@ -218,30 +218,20 @@ class BaseClient:
 
     def _build_ip_address_allocation_query(
         self, resource_pool_id: str, identifier: Optional[str] = None, data: Optional[Dict[str, Any]] = None
-    ) -> str:
-        mutation_definition = "mutation AllocateIPAddress"
-        mutation_parameters = f'id: "{resource_pool_id}"'
-        if identifier:
-            mutation_parameters += f', identifier: "{identifier}"'
-        if data:
-            mutation_definition += "($data: GenericScalar)"
-            mutation_parameters += ", data: $data"
+    ) -> Mutation:
+        input_data = {"id": resource_pool_id}
 
-        return """
-            %s {
-                IPAddressPoolGetResource(data: {
-                    %s
-                }) {
-                    ok
-                    node {
-                        id
-                        kind
-                        identifier
-                        display_label
-                    }
-                }
-            }
-        """ % (mutation_definition, mutation_parameters)
+        if identifier:
+            input_data["identifier"] = identifier
+        if data:
+            input_data["data"] = data
+
+        return Mutation(
+            name="AllocateIPAddress",
+            mutation="IPAddressPoolGetResource",
+            query={"ok": None, "node": {"id": None, "kind": None, "identifier": None, "display_label": None}},
+            input_data={"data": input_data},
+        )
 
     def _build_ip_prefix_allocation_query(
         self,
@@ -250,34 +240,24 @@ class BaseClient:
         prefix_length: Optional[int] = None,
         member_type: Optional[str] = None,
         data: Optional[Dict[str, Any]] = None,
-    ) -> str:
-        mutation_definition = "mutation AllocateIPPrefix"
-        mutation_parameters = f'id: "{resource_pool_id}"'
-        if identifier:
-            mutation_parameters += f', identifier: "{identifier}"'
-        if prefix_length:
-            mutation_parameters += f", prefix_length: {prefix_length}"
-        if member_type:
-            mutation_parameters += f', member_type: "{member_type}"'
-        if data:
-            mutation_definition += "($data: GenericScalar)"
-            mutation_parameters += ", data: $data"
+    ) -> Mutation:
+        input_data = {"id": resource_pool_id}
 
-        return """
-            %s {
-                IPPrefixPoolGetResource(data: {
-                    %s
-                }) {
-                    ok
-                    node {
-                        id
-                        kind
-                        identifier
-                        display_label
-                    }
-                }
-            }
-        """ % (mutation_definition, mutation_parameters)
+        if identifier:
+            input_data["identifier"] = identifier
+        if prefix_length:
+            input_data["prefix_length"] = prefix_length
+        if member_type:
+            input_data["member_type"] = member_type
+        if data:
+            input_data["data"] = data
+
+        return Mutation(
+            name="AllocateIPPrefix",
+            mutation="IPPrefixPoolGetResource",
+            query={"ok": None, "node": {"id": None, "kind": None, "identifier": None, "display_label": None}},
+            input_data={"data": input_data},
+        )
 
 
 class InfrahubClient(BaseClient):
@@ -905,12 +885,12 @@ class InfrahubClient(BaseClient):
             resource_pool_id=resource_pool.id, identifier=identifier, data=data
         )
         response = await self.execute_graphql(
-            query=query,
+            query=query.render(),
             branch_name=branch,
             timeout=timeout,
             tracker=tracker,
             raise_for_error=raise_for_error,
-            variables={"data": data},
+            variables={"identifier": identifier, "data": data},
         )
 
         if response[mutation_name]["ok"]:
@@ -959,12 +939,17 @@ class InfrahubClient(BaseClient):
             data=data,
         )
         response = await self.execute_graphql(
-            query=query,
+            query=query.render(),
             branch_name=branch,
             timeout=timeout,
             tracker=tracker,
             raise_for_error=raise_for_error,
-            variables={"data": data},
+            variables={
+                "identifier": identifier,
+                "prefix_length": prefix_length,
+                "member_type": member_type,
+                "data": data,
+            },
         )
 
         if response[mutation_name]["ok"]:
@@ -1525,12 +1510,12 @@ class InfrahubClientSync(BaseClient):
             resource_pool_id=resource_pool.id, identifier=identifier, data=data
         )
         response = self.execute_graphql(
-            query=query,
+            query=query.render(),
             branch_name=branch,
             timeout=timeout,
             tracker=tracker,
             raise_for_error=raise_for_error,
-            variables={"data": data},
+            variables={"identifier": identifier, "data": data},
         )
 
         if response[mutation_name]["ok"]:
@@ -1579,12 +1564,17 @@ class InfrahubClientSync(BaseClient):
             data=data,
         )
         response = self.execute_graphql(
-            query=query,
+            query=query.render(),
             branch_name=branch,
             timeout=timeout,
             tracker=tracker,
             raise_for_error=raise_for_error,
-            variables={"data": data},
+            variables={
+                "identifier": identifier,
+                "prefix_length": prefix_length,
+                "member_type": member_type,
+                "data": data,
+            },
         )
 
         if response[mutation_name]["ok"]:

--- a/python_sdk/infrahub_sdk/client.py
+++ b/python_sdk/infrahub_sdk/client.py
@@ -219,7 +219,7 @@ class BaseClient:
     def _build_ip_address_allocation_query(
         self, resource_pool_id: str, identifier: Optional[str] = None, data: Optional[Dict[str, Any]] = None
     ) -> Mutation:
-        input_data = {"id": resource_pool_id}
+        input_data: dict[str, Any] = {"id": resource_pool_id}
 
         if identifier:
             input_data["identifier"] = identifier
@@ -241,7 +241,7 @@ class BaseClient:
         member_type: Optional[str] = None,
         data: Optional[Dict[str, Any]] = None,
     ) -> Mutation:
-        input_data = {"id": resource_pool_id}
+        input_data: dict[str, Any] = {"id": resource_pool_id}
 
         if identifier:
             input_data["identifier"] = identifier


### PR DESCRIPTION
They now use the proper `Mutation` class to build the actual GraphQL mutation strings.