### PR TITLE
Adds backbone service model to demo schema

### DIFF
--- a/models/base/service.yml
+++ b/models/base/service.yml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://schema.infrahub.app/infrahub/schema/latest.json
+---
+version: "1.0"
+nodes:
+  - name: BackBoneService
+    namespace: Infra
+    description: "Backbone Service"
+    label: "Backbone Service"
+    icon: ""
+    default_filter: name__value
+    uniqueness_constraints:
+      - ["circuit_id__value", "internal_circuit_id__value"]
+    order_by:
+      - name__value
+    display_labels:
+      - name__value
+    attributes:
+      - name: name
+        kind: Text
+        label: Name
+        optional: false
+      - name: circuit_id
+        kind: Text
+        label: Circuit ID
+        optional: false
+      - name: internal_circuit_id
+        kind: Text
+        label: Internal Circuit ID
+        optional: false
+    relationships:
+      - name: provider
+        cardinality: one
+        peer: OrganizationProvider
+        optional: false
+      - name: site_a
+        label: Site A
+        cardinality: one
+        peer: LocationSite
+        optional: false
+        identifier: infrabackboneservice__location_site_a
+      - name: site_b
+        label: Site B
+        cardinality: one
+        peer: LocationSite
+        optional: false
+        identifier: infrabackboneservice__location_site_b

--- a/models/infrastructure_edge.py
+++ b/models/infrastructure_edge.py
@@ -279,6 +279,7 @@ GROUPS = (
     ("backbone_interfaces", "Backbone Interfaces"),
     ("maintenance_circuits", "Circuits in Maintenance"),
     ("provisioning_circuits", "Circuits in Provisioning"),
+    ("backbone_services", "Backbone Services"),
 )
 
 BGP_PEER_GROUPS = (


### PR DESCRIPTION
- add a backbone service model to the demo schema
- add a backbone_services group to the demo data

both of these well be used for a generator that will be defined in the `infrahub-demo-edge` repository