### PR TITLE
Fix GraphQL parameters for allocation mutations

### DIFF
--- a/python_sdk/infrahub_sdk/client.py
+++ b/python_sdk/infrahub_sdk/client.py
@@ -216,12 +216,18 @@ class BaseClient:
         return url
 
     def _build_ip_address_allocation_query(
-        self, resource_pool_id: str, identifier: Optional[str] = None, data: Optional[Dict[str, Any]] = None
+        self,
+        resource_pool_id: str,
+        identifier: Optional[str] = None,
+        address_type: Optional[str] = None,
+        data: Optional[Dict[str, Any]] = None,
     ) -> str:
         mutation_definition = "mutation AllocateIPAddress"
         mutation_parameters = f'id: "{resource_pool_id}"'
         if identifier:
             mutation_parameters += f', identifier: "{identifier}"'
+        if address_type:
+            mutation_parameters += f', address_type: "{address_type}"'
         if data:
             mutation_definition += "($data: GenericScalar)"
             mutation_parameters += ", data: $data"
@@ -246,18 +252,21 @@ class BaseClient:
         self,
         resource_pool_id: str,
         identifier: Optional[str] = None,
-        prefix_length: Optional[int] = None,
+        size: Optional[int] = None,
         member_type: Optional[str] = None,
+        prefix_type: Optional[str] = None,
         data: Optional[Dict[str, Any]] = None,
     ) -> str:
         mutation_definition = "mutation AllocateIPPrefix"
         mutation_parameters = f'id: "{resource_pool_id}"'
         if identifier:
             mutation_parameters += f', identifier: "{identifier}"'
-        if prefix_length:
-            mutation_parameters += f", prefix_length: {prefix_length}"
+        if size:
+            mutation_parameters += f", size: {size}"
         if member_type:
             mutation_parameters += f', member_type: "{member_type}"'
+        if prefix_type:
+            mutation_parameters += f', prefix_type: "{prefix_type}"'
         if data:
             mutation_definition += "($data: GenericScalar)"
             mutation_parameters += ", data: $data"
@@ -870,6 +879,7 @@ class InfrahubClient(BaseClient):
         self,
         resource_pool: InfrahubNode,
         identifier: Optional[str] = None,
+        address_type: Optional[str] = None,
         data: Optional[Dict[str, Any]] = None,
         branch: Optional[str] = None,
         timeout: Optional[int] = None,
@@ -881,6 +891,7 @@ class InfrahubClient(BaseClient):
         Args:
             resource_pool (InfrahubNode): Node corresponding to the pool to allocate resources from.
             identifier (str, optional): Value to perform idempotent allocation, the same resource will be returned for a given identifier.
+            address_type (str, optional): Kind of the address to allocate.
             data (dict, optional): A key/value map to use to set attributes values on the allocated address.
             branch (str, optional): Name of the branch to allocate from. Defaults to default_branch.
             timeout (int, optional): Flag to indicate whether to populate the store with the retrieved nodes.
@@ -896,7 +907,7 @@ class InfrahubClient(BaseClient):
         mutation_name = "IPAddressPoolGetResource"
 
         query = self._build_ip_address_allocation_query(
-            resource_pool_id=resource_pool.id, identifier=identifier, data=data
+            resource_pool_id=resource_pool.id, identifier=identifier, address_type=address_type, data=data
         )
         response = await self.execute_graphql(
             query=query,
@@ -916,8 +927,9 @@ class InfrahubClient(BaseClient):
         self,
         resource_pool: InfrahubNode,
         identifier: Optional[str] = None,
-        prefix_length: Optional[int] = None,
+        size: Optional[int] = None,
         member_type: Optional[str] = None,
+        prefix_type: Optional[str] = None,
         data: Optional[Dict[str, Any]] = None,
         branch: Optional[str] = None,
         timeout: Optional[int] = None,
@@ -929,8 +941,9 @@ class InfrahubClient(BaseClient):
         Args:
             resource_pool (InfrahubNode): Node corresponding to the pool to allocate resources from.
             identifier (str, optional): Value to perform idempotent allocation, the same resource will be returned for a given identifier.
-            prefix_length (int, optional): Length of the prefix to allocate.
+            size (int, optional): Length of the prefix to allocate.
             member_type (str, optional): Member type of the prefix to allocate.
+            prefix_type (str, optional): Kind of the prefix to allocate.
             data (dict, optional): A key/value map to use to set attributes values on the allocated prefix.
             branch (str, optional): Name of the branch to allocate from. Defaults to default_branch.
             timeout (int, optional): Flag to indicate whether to populate the store with the retrieved nodes.
@@ -948,8 +961,9 @@ class InfrahubClient(BaseClient):
         query = self._build_ip_prefix_allocation_query(
             resource_pool_id=resource_pool.id,
             identifier=identifier,
-            prefix_length=prefix_length,
+            size=size,
             member_type=member_type,
+            prefix_type=prefix_type,
             data=data,
         )
         response = await self.execute_graphql(
@@ -1485,6 +1499,7 @@ class InfrahubClientSync(BaseClient):
         self,
         resource_pool: InfrahubNodeSync,
         identifier: Optional[str] = None,
+        address_type: Optional[str] = None,
         data: Optional[Dict[str, Any]] = None,
         branch: Optional[str] = None,
         timeout: Optional[int] = None,
@@ -1496,6 +1511,7 @@ class InfrahubClientSync(BaseClient):
         Args:
             resource_pool (InfrahubNodeSync): Node corresponding to the pool to allocate resources from.
             identifier (str, optional): Value to perform idempotent allocation, the same resource will be returned for a given identifier.
+            address_type (str, optional): Kind of the address to allocate.
             data (dict, optional): A key/value map to use to set attributes values on the allocated address.
             branch (str, optional): Name of the branch to allocate from. Defaults to default_branch.
             timeout (int, optional): Flag to indicate whether to populate the store with the retrieved nodes.
@@ -1511,7 +1527,7 @@ class InfrahubClientSync(BaseClient):
         mutation_name = "IPAddressPoolGetResource"
 
         query = self._build_ip_address_allocation_query(
-            resource_pool_id=resource_pool.id, identifier=identifier, data=data
+            resource_pool_id=resource_pool.id, identifier=identifier, address_type=address_type, data=data
         )
         response = self.execute_graphql(
             query=query,
@@ -1531,8 +1547,9 @@ class InfrahubClientSync(BaseClient):
         self,
         resource_pool: InfrahubNodeSync,
         identifier: Optional[str] = None,
-        prefix_length: Optional[int] = None,
+        size: Optional[int] = None,
         member_type: Optional[str] = None,
+        prefix_type: Optional[str] = None,
         data: Optional[Dict[str, Any]] = None,
         branch: Optional[str] = None,
         timeout: Optional[int] = None,
@@ -1544,8 +1561,9 @@ class InfrahubClientSync(BaseClient):
         Args:
             resource_pool (InfrahubNodeSync): Node corresponding to the pool to allocate resources from.
             identifier (str, optional): Value to perform idempotent allocation, the same resource will be returned for a given identifier.
-            prefix_length (int, optional): Length of the prefix to allocate.
+            size (int, optional): Length of the prefix to allocate.
             member_type (str, optional): Member type of the prefix to allocate.
+            prefix_type (str, optional): Kind of the prefix to allocate.
             data (dict, optional): A key/value map to use to set attributes values on the allocated prefix.
             branch (str, optional): Name of the branch to allocate from. Defaults to default_branch.
             timeout (int, optional): Flag to indicate whether to populate the store with the retrieved nodes.
@@ -1563,8 +1581,9 @@ class InfrahubClientSync(BaseClient):
         query = self._build_ip_prefix_allocation_query(
             resource_pool_id=resource_pool.id,
             identifier=identifier,
-            prefix_length=prefix_length,
+            size=size,
             member_type=member_type,
+            prefix_type=prefix_type,
             data=data,
         )
         response = self.execute_graphql(


### PR DESCRIPTION
Fixes https://github.com/opsmill/infrahub/issues/3617

In this PR, we also add the capability to pass an `address_type` or a `prefix_type` to the respective functions.