### PR TITLE
Empty option in select correctly sends null in the mutation

### DIFF
--- a/frontend/src/components/inputs/select.tsx
+++ b/frontend/src/components/inputs/select.tsx
@@ -204,7 +204,7 @@ export const Select = (props: SelectProps) => {
 
     if (newValue.id === emptyOption.id) {
       setSelectedOption(emptyOption);
-      onChange(newValue);
+      onChange(null);
       return;
     }
 

--- a/frontend/tests/e2e/objects/object-update.spec.ts
+++ b/frontend/tests/e2e/objects/object-update.spec.ts
@@ -118,4 +118,70 @@ test.describe("Object update", () => {
       await expect(tabInput).toBeVisible();
     });
   });
+
+  test("should correctly remove values from selector", async ({ page }) => {
+    await test.step("access the object", async () => {
+      await page.goto("/objects/InfraDevice/");
+      await page.getByRole("link", { name: "atl1-leaf1" }).click();
+    });
+
+    await test.step("assert initial object values", async () => {
+      await expect(page.getByText("Active")).toBeVisible();
+      await expect(page.getByText("Leaf Switch")).toBeVisible();
+      await expect(page.getByRole("link", { name: "AS64496" })).toBeVisible();
+    });
+
+    await test.step("edit object values", async () => {
+      await page.getByRole("button", { name: "Edit" }).click();
+
+      await page
+        .getByTestId("side-panel-container")
+        .getByText("Status")
+        .locator("../..")
+        .getByTestId("select-open-option-button")
+        .click();
+      await page.getByText("Empty").click();
+
+      await page
+        .getByTestId("side-panel-container")
+        .getByText("Role")
+        .locator("../..")
+        .getByTestId("select-open-option-button")
+        .click();
+      await page.getByText("Empty").click();
+
+      await page
+        .getByTestId("side-panel-container")
+        .getByText("Asn")
+        .locator("../..")
+        .getByTestId("select-open-option-button")
+        .click();
+      await page.getByText("Empty").click();
+
+      await page.getByRole("button", { name: "Save" }).click();
+    });
+
+    await test.step("assert new empty values", async () => {
+      await expect(
+        page
+          .locator("div")
+          .filter({ hasText: /^Status-$/ })
+          .getByRole("definition")
+      ).toBeVisible();
+
+      await expect(
+        page
+          .locator("div")
+          .filter({ hasText: /^Role-$/ })
+          .getByRole("definition")
+      ).toBeVisible();
+
+      await expect(
+        page
+          .locator("div")
+          .filter({ hasText: /^Asn-$/ })
+          .getByRole("definition")
+      ).toBeVisible();
+    });
+  });
 });


### PR DESCRIPTION
* When selecting the empty option, it will correctly remove the relationship using `null`
* E2E test updated for this behaviour