### PR TITLE
Change uniqueness_constraint for Netbox example schema post 0.14.0

### DIFF
--- a/models/examples/netbox/netbox.yml
+++ b/models/examples/netbox/netbox.yml
@@ -11,9 +11,8 @@ generics:
     display_labels:
       - name__value
     order_by:
+      - device__name__value
       - name__value
-    uniqueness_constraints:
-      - ["device", "name__value"]
     attributes:
       - name: name
         kind: Text
@@ -336,19 +335,15 @@ nodes:
     description: "Generic Device object"
     label: "Device"
     icon: "mdi:router-network"
-    # default_filter: name__value
     inherit_from:
       - "CoreArtifactTarget"
     order_by:
       - name__value
     display_labels:
       - name__value
-    uniqueness_constraints:
-      - ["name__value", "rack", "location", "organization"]
     attributes:
       - name: name
         kind: Text
-        # unique: true
         optional: true
       - name: description
         kind: Text
@@ -357,12 +352,10 @@ nodes:
         label: Serial Number
         kind: Text
         optional: true
-        # unique: true
       - name: asset_tag
         label: Asset Tag
         kind: Text
         optional: true
-        # unique: true
     relationships:
       - name: location
         peer: LocationGeneric
@@ -469,6 +462,7 @@ nodes:
     display_labels:
       - name__value
     order_by:
+      - device__name__value
       - name__value
     inherit_from:
       - "InfraInterface"
@@ -510,6 +504,7 @@ nodes:
     display_labels:
       - name__value
     order_by:
+      - device__name__value
       - name__value
     inherit_from:
       - "InfraInterface"
@@ -529,6 +524,7 @@ nodes:
     display_labels:
       - name__value
     order_by:
+      - device__name__value
       - name__value
     inherit_from:
       - "InfraInterface"
@@ -558,21 +554,9 @@ nodes:
     namespace: Infra
     description: "IP Address"
     label: "IP Address"
-    icon: "mdi:ip-outline"
-    menu_placement: "InfraPrefix"
-    default_filter: address__value
-    order_by:
-      - "address__value"
-    display_labels:
-      - address__value
-    uniqueness_constraints:
-      - ["prefix", "address__value"]
-    attributes:
-      - name: address
-        kind: IPHost
-      - name: description
-        kind: Text
-        optional: true
+    include_in_menu: false
+    inherit_from:
+      - "BuiltinIPAddress"
     relationships:
       - name: organization
         peer: OrganizationGeneric
@@ -583,13 +567,8 @@ nodes:
         peer: InfraInterfaceL3
         optional: true
         cardinality: one
-      - name: prefix
-        peer: InfraPrefix
-        identifier: "prefix__address"
-        optional: true
-        cardinality: one
       - name: vrf
-        identifier: "vrf__prefix"
+        identifier: "vrf__ipaddress"
         peer: InfraVRF
         optional: true
         cardinality: one
@@ -676,22 +655,9 @@ nodes:
   - name: Prefix
     namespace: Infra
     description: "IPv4 or IPv6 network (with mask)"
-    icon: "mdi:ip-network"
-    label: "Prefix"
-    default_filter: prefix__value
-    order_by:
-      - vrf__name__value
-      - prefix__value
-    display_labels:
-      - prefix__value
-    uniqueness_constraints:
-      - ["vrf", "prefix__value"]
-    attributes:
-      - name: prefix
-        kind: IPNetwork
-      - name: description
-        kind: Text
-        optional: true
+    include_in_menu: false
+    inherit_from:
+      - "BuiltinIPPrefix"
     relationships:
       - name: organization
         peer: OrganizationGeneric
@@ -730,26 +696,17 @@ nodes:
         optional: true
         cardinality: one
         kind: Attribute
-      - name: ip_addresses
-        peer: InfraIPAddress
-        identifier: "prefix__address"
-        cardinality: many
-        kind: Component
   - name: Rack
     namespace: Infra
     description: "A Rack represents a physical two- or four-post equipment rack in which devices can be installed"
     label: "Rack"
     icon: "mdi:server"
     menu_placement: "LocationGeneric"
-    # default_filter: name__value
     display_labels:
       - name__value
-    uniqueness_constraints:
-      - ["name__value", "location"]
     attributes:
       - name: name
         kind: Text
-        # unique: true
       - name: description
         kind: Text
         optional: true
@@ -824,14 +781,11 @@ nodes:
     description: "A VLAN is isolated layer two domain"
     label: "VLAN"
     icon: "mdi:lan-pending"   # mdi:lan
-    default_filter: name__value
     order_by:
       - vlan_id__value
     display_labels:
       - name__value
       - vlan_id__value
-    uniqueness_constraints:
-      - ["location", "vlan_group", "vlan_id__value"]
     attributes:
       - name: name
         kind: Text

--- a/sync/examples/netbox_to_infrahub/config.yml
+++ b/sync/examples/netbox_to_infrahub/config.yml
@@ -198,8 +198,9 @@ schema_mapping:
         reference: OrganizationGeneric
   # -> The netbox constraint is `dcim_device_unique_name_site_tenant`
   # Reusing device_name + site + Organization as identifiers
+  # /!\ Seem like Netbox allowed device to have the same name if there is a virtual-chassis
   - name: InfraDevice
-    identifiers: ["name", "location", "rack", "organization"]
+    identifiers: ["location", "rack", "organization", "name"]
     mapping: dcim.devices
     fields:
       - name: name
@@ -231,9 +232,10 @@ schema_mapping:
       - name: tags
         mapping: tags
         reference: BuiltinTag
+
   # Interfaces (interfaces, rear port, front port)
   - name: InfraInterfaceL2L3
-    identifiers: ["name", "device"]
+    identifiers: ["device", "name"]
     mapping: dcim.interfaces
     fields:
       - name: name

--- a/sync/examples/netbox_to_infrahub/infrahub/sync_models.py
+++ b/sync/examples/netbox_to_infrahub/infrahub/sync_models.py
@@ -41,7 +41,7 @@ class InfraCircuit(InfrahubModel):
 
 class InfraDevice(InfrahubModel):
     _modelname = "InfraDevice"
-    _identifiers = ("name", "location", "rack", "organization")
+    _identifiers = ("location", "rack", "organization", "name")
     _attributes = ("model", "role", "tags", "description", "serial_number", "asset_tag")
     name: Optional[str] = None
     description: Optional[str] = None
@@ -69,7 +69,7 @@ class InfraIPAddress(InfrahubModel):
 
 class InfraInterfaceL2L3(InfrahubModel):
     _modelname = "InfraInterfaceL2L3"
-    _identifiers = ("name", "device")
+    _identifiers = ("device", "name")
     _attributes = ("tagged_vlan", "tags", "l2_mode", "description", "mgmt_only", "mac_address", "interface_type")
     l2_mode: Optional[str] = None
     name: str
@@ -114,7 +114,7 @@ class InfraRack(InfrahubModel):
     _identifiers = ("name", "location")
     _attributes = ("role", "tags", "height", "facility_id", "serial_number", "asset_tag")
     name: str
-    height: int
+    height: Optional[int] = None
     facility_id: Optional[str] = None
     serial_number: Optional[str] = None
     asset_tag: Optional[str] = None

--- a/sync/examples/netbox_to_infrahub/netbox/sync_models.py
+++ b/sync/examples/netbox_to_infrahub/netbox/sync_models.py
@@ -41,7 +41,7 @@ class InfraCircuit(NetboxModel):
 
 class InfraDevice(NetboxModel):
     _modelname = "InfraDevice"
-    _identifiers = ("name", "location", "rack", "organization")
+    _identifiers = ("location", "rack", "organization", "name")
     _attributes = ("model", "role", "tags", "description", "serial_number", "asset_tag")
     name: Optional[str] = None
     description: Optional[str] = None
@@ -69,7 +69,7 @@ class InfraIPAddress(NetboxModel):
 
 class InfraInterfaceL2L3(NetboxModel):
     _modelname = "InfraInterfaceL2L3"
-    _identifiers = ("name", "device")
+    _identifiers = ("device", "name")
     _attributes = ("tagged_vlan", "tags", "l2_mode", "description", "mgmt_only", "mac_address", "interface_type")
     l2_mode: Optional[str] = None
     name: str
@@ -114,7 +114,7 @@ class InfraRack(NetboxModel):
     _identifiers = ("name", "location")
     _attributes = ("role", "tags", "height", "facility_id", "serial_number", "asset_tag")
     name: str
-    height: int
+    height: Optional[int] = None
     facility_id: Optional[str] = None
     serial_number: Optional[str] = None
     asset_tag: Optional[str] = None


### PR DESCRIPTION
In 0.14 with SDK 0.11, the uniqueness_constraints can only be used on non-optional attributes and relationships.

For now, I remove them from the schema to enforce them only in the mapping.
Also : 
- change the identifier order to make me more "readable" during the sync
- Add IPAM Builtin IP and Prefix into Netbox schema

Replace #3563