### PR TITLE
Behaviour update for boolean attributes

### DIFF
--- a/frontend/src/utils/formStructureForCreateEdit.ts
+++ b/frontend/src/utils/formStructureForCreateEdit.ts
@@ -41,6 +41,11 @@ const validate = (value: any, attribute: any = {}, optional?: boolean) => {
     return true;
   }
 
+  // If the attribute is of kind boolean, then it should
+  if (attribute.kind === "Boolean") {
+    return true;
+  }
+
   // If the attribute is a date, check if the date is valid
   if (attribute.kind === "DateTime") {
     if (!value) {

--- a/frontend/src/utils/getSchemaObjectColumns.ts
+++ b/frontend/src/utils/getSchemaObjectColumns.ts
@@ -212,6 +212,10 @@ const getValue = (row: any, attribute: any, profile: any) => {
     return profile[attribute.name]?.value;
   }
 
+  if (attribute.kind === "Boolean") {
+    return attribute.default_value ?? false;
+  }
+
   return attribute.default_value;
 };
 

--- a/frontend/tests/integrations/screens/object-fields.cy.tsx
+++ b/frontend/tests/integrations/screens/object-fields.cy.tsx
@@ -240,7 +240,7 @@ describe("Object list", () => {
     cy.get("[data-cy='field-error-message']").should("not.exist");
   });
 
-  it("should open the add panel, submit without checking the checkbox and display a required message", function () {
+  it("should open the add panel, submit without checking the checkbox and do not display a required message", function () {
     cy.viewport(1920, 1080);
 
     cy.intercept("POST", "/graphql/main ", this.mutation).as("mutate");
@@ -277,7 +277,7 @@ describe("Object list", () => {
     cy.get(".bg-custom-blue-700").click();
 
     // The required message should appear
-    cy.get("[data-cy='field-error-message']").should("have.text", "Required");
+    cy.get("[data-cy='field-error-message']").should("not.exist");
   });
 
   it("should open the add panel, submit without checking the checkbox and should not display a required message (default value is defined)", function () {


### PR DESCRIPTION
Issue: https://github.com/opsmill/infrahub/issues/3646

* Fixes validation behaviour for boolean attributes, to use false as default value
* Required field won't need the checkbox to be toggled to submit the data, `false` will be sent
