### PR TITLE
Add managing api tokens guide to the documentation

### DIFF
--- a/docs/docs/guides/managing-api-tokens.mdx
+++ b/docs/docs/guides/managing-api-tokens.mdx
@@ -1,0 +1,60 @@
+---
+title: Managing API tokens
+---
+
+# Managing API tokens
+
+API tokens can be used as an authentication mechanism for Infrahub's REST- and GraphQL API, the Python SDK and infrahubctl.
+
+Managing API tokens for users is, at this moment, only possible through the GraphQL API. In the future we will be adding support for managing tokens through the web interface.
+
+## Generating an API token for a user
+
+1. Login to Infrahub's web interface as the user for which the token should be generated
+2. In the GraphQL sandbox, execute the following mutation, replace the name of the token in the mutation with a value that is appropriate for your use case
+
+```graphql
+mutation {
+  CoreAccountTokenCreate(data: {name: "token name"}) {
+    object {
+      token {
+        value
+      }
+    }
+  }
+}
+```
+
+3. The result of the query will show you the value of the token that was generated for the token. Store the token in a secure location, as there will be no way to retrieve the token from Infrahub at a later stage.
+
+## Listing existing API tokens for a user
+
+1. Login to Infrahub's web interface as the user for which you want to list the tokens
+2. In the GraphQL sandbox, execute the following query
+
+```graphql
+query {
+  CoreAccountToken {
+    edges {
+      node {
+        name
+        expiration
+        id
+      }
+    }
+  }
+}
+```
+
+## Deleting an API token for a user
+
+1. Login to Infrahub's web interface as the user for which the token should be generated
+2. In the GraphQL sandbox, execute the following mutation, replace the id of the token in the mutation with the id of the token that you want to delete
+
+```graphql
+mutation {
+  CoreAccountTokenDelete(data: {id: "17d8cde3-d36b-a0a3-370e-c51707234f19"}) {
+    ok
+  }
+}
+```

--- a/docs/docs/topics/auth.mdx
+++ b/docs/docs/topics/auth.mdx
@@ -21,8 +21,6 @@ Infrahub supports two authentication methods
 - JWT token: Short life tokens generated on demand from the API.
 - API Token: Long life tokens generated ahead of time.
 
-> API tokens can be generated via the user profile page or via the GraphQL interface.
-
 |                    | JWT  | TOKEN |
 | ------------------ | ---- | ----- |
 | API / GraphQL      | Yes  | Yes   |
@@ -30,6 +28,8 @@ Infrahub supports two authentication methods
 | Python SDK         | Soon | Yes   |
 | infrahubctl        | Soon | Yes   |
 | GraphQL Playground | No   | Yes   |
+
+More information on managing API token can be found in the [managing API tokens guide](/guides/managing-api-tokens).
 
 :::info
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -66,6 +66,7 @@ const sidebars: SidebarsConfig = {
         'guides/object-storage',
 	'guides/check',
 	'guides/resource-manager',
+	'guides/managing-api-tokens',
       ],
     },
     {


### PR DESCRIPTION
Add guide on managing API tokens and fix documentation page that states that we can manage them in the web frontend. 