### PR TITLE
Fix ruff command to produce correct exit code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
       - name: "Setup environment"
         run: "pip install ruff==0.4.6"
       - name: "Linting: ruff check"
-        run: "ruff check --diff ."
+        run: "ruff check ."
       - name: "Linting: ruff format"
         run: "ruff format --check --diff ."
 

--- a/python_sdk/tests/unit/sdk/test_schema.py
+++ b/python_sdk/tests/unit/sdk/test_schema.py
@@ -278,5 +278,5 @@ async def test_display_schema_load_errors_details(mock_get_node, console_output)
     output = console_output.file.getvalue()
     expected_console = """Unable to load the schema:
   Node: CloudInstance | Attribute: status ({'name': 'status', 'kind': 'Dropdown'}) | Value error, The property 'choices' is required for kind=Dropdown (value_error)
-"""
+"""  # noqa: E501
     assert output == expected_console

--- a/sync/infrahub-sync/infrahub_sync/adapters/ipfabricsync.py
+++ b/sync/infrahub-sync/infrahub_sync/adapters/ipfabricsync.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any
 
 try:
     from ipfabric import IPFClient
@@ -80,7 +80,7 @@ class IpfabricsyncAdapter(DiffSyncMixin, Adapter):
                 self.update_or_add_model_instance(item)
 
     def ipfabric_dict_to_diffsync(self, obj: dict, mapping: SchemaMappingModel, model: IpfabricsyncModel) -> dict:  # pylint: disable=too-many-branches
-        data: Dict[str, Any] = {"local_id": str(obj["id"])}
+        data: dict[str, Any] = {"local_id": str(obj["id"])}
 
         for field in mapping.fields:  # pylint: disable=too-many-nested-blocks
             field_is_list = model.is_list(name=field.name)


### PR DESCRIPTION
Also fixes two violations that wasn't handled before due to the error codes being returned for these warnings.