### PR TITLE
prevent console error when displaying a toast message

### DIFF
--- a/frontend/app/src/components/account-menu.tsx
+++ b/frontend/app/src/components/account-menu.tsx
@@ -51,7 +51,7 @@ export const AccountMenu = () => {
   const profile = data?.AccountProfile;
 
   if (error) {
-    toast(<Alert type={ALERT_TYPES.ERROR} message="Error while loading profile data" />, {
+    toast(() => <Alert type={ALERT_TYPES.ERROR} message="Error while loading profile data" />, {
       toastId: customId,
     });
 

--- a/frontend/app/src/components/buttons/clipboard.tsx
+++ b/frontend/app/src/components/buttons/clipboard.tsx
@@ -22,7 +22,7 @@ export const Clipboard = (props: tClipboard) => {
 
     await navigator.clipboard.writeText(value);
 
-    toast(<Alert message={alert} type={ALERT_TYPES.INFO} />);
+    toast(() => <Alert message={alert} type={ALERT_TYPES.INFO} />);
 
     setTimeout(() => {
       setIsCopied(false);

--- a/frontend/app/src/components/conversations/thread.tsx
+++ b/frontend/app/src/components/conversations/thread.tsx
@@ -150,7 +150,7 @@ export const Thread = (props: tThread) => {
       setDisplayAddComment(false);
     }
 
-    toast(<Alert type={ALERT_TYPES.SUCCESS} message={"Thread resolved"} />);
+    toast(() => <Alert type={ALERT_TYPES.SUCCESS} message={"Thread resolved"} />);
   };
 
   const comments = thread?.comments?.edges?.map((comment: any) => comment.node) ?? [];

--- a/frontend/app/src/components/editor/code-editor.tsx
+++ b/frontend/app/src/components/editor/code-editor.tsx
@@ -22,7 +22,7 @@ export const CodeEditor = (props: any) => {
 
     await navigator.clipboard.writeText(value);
 
-    toast(<Alert message="Content copied" type={ALERT_TYPES.INFO} />);
+    toast(() => <Alert message="Content copied" type={ALERT_TYPES.INFO} />);
 
     setTimeout(() => {
       setIsCopied(false);

--- a/frontend/app/src/components/file.tsx
+++ b/frontend/app/src/components/file.tsx
@@ -28,7 +28,7 @@ export const File = (props: tFile) => {
       setFileContent(fileResult);
     } catch (err) {
       console.error("err: ", err);
-      toast(<Alert type={ALERT_TYPES.ERROR} message="Error while loading file content" />);
+      toast(() => <Alert type={ALERT_TYPES.ERROR} message="Error while loading file content" />);
     }
 
     setIsLoading(false);

--- a/frontend/app/src/components/list.tsx
+++ b/frontend/app/src/components/list.tsx
@@ -40,7 +40,7 @@ const List = forwardRef<HTMLInputElement, OpsListProps>((props, ref) => {
       sertInputValue("");
 
       if (newArray.length === value.length) {
-        toast(<Alert message="Item already in the list" type={ALERT_TYPES.INFO} />);
+        toast(() => <Alert message="Item already in the list" type={ALERT_TYPES.INFO} />);
       }
     }
   };

--- a/frontend/app/src/decorators/withSchemaContext.tsx
+++ b/frontend/app/src/decorators/withSchemaContext.tsx
@@ -87,9 +87,9 @@ export const withSchemaContext = (AppComponent: any) => (props: any) => {
       setNamespaces(namespaces);
       setProfiles(profiles);
     } catch (error) {
-      toast(
+      toast(() => (
         <Alert type={ALERT_TYPES.ERROR} message="Something went wrong when fetching the schema" />
-      );
+      ));
 
       console.error("Error while fetching the schema: ", error);
     }

--- a/frontend/app/src/graphql/graphqlClientApollo.tsx
+++ b/frontend/app/src/graphql/graphqlClientApollo.tsx
@@ -126,7 +126,7 @@ export const errorLink = onError(({ graphQLErrors, operation, forward }) => {
         }
         default:
           if (graphQLError.message) {
-            toast(<Alert type={ALERT_TYPES.ERROR} message={graphQLError.message} />, {
+            toast(() => <Alert type={ALERT_TYPES.ERROR} message={graphQLError.message} />, {
               toastId: "alert-error",
             });
           }

--- a/frontend/app/src/hooks/useAuth.tsx
+++ b/frontend/app/src/hooks/useAuth.tsx
@@ -108,7 +108,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setIsLoading(false);
 
     if (!result?.access_token) {
-      toast(<Alert type={ALERT_TYPES.ERROR} message="Invalid username and password" />, {
+      toast(() => <Alert type={ALERT_TYPES.ERROR} message="Invalid username and password" />, {
         toastId: "alert-error-sign-in",
       });
 

--- a/frontend/app/src/index.tsx
+++ b/frontend/app/src/index.tsx
@@ -27,9 +27,9 @@ export const Infrahub = () => {
     try {
       return fetchUrl(CONFIG.CONFIG_URL);
     } catch (err) {
-      toast(
+      toast(() => (
         <Alert type={ALERT_TYPES.ERROR} message="Something went wrong when fetching the config" />
-      );
+      ));
       console.error("Error while fetching the config: ", err);
       return undefined;
     }
@@ -48,9 +48,9 @@ export const Infrahub = () => {
         return;
       }
 
-      toast(
+      toast(() => (
         <Alert type={ALERT_TYPES.ERROR} message="Something went wrong when fetching the config" />
-      );
+      ));
       console.error("Error while fetching the config: ", error);
     }
   };

--- a/frontend/app/src/screens/artifacts/generate.tsx
+++ b/frontend/app/src/screens/artifacts/generate.tsx
@@ -50,9 +50,9 @@ export const Generate = (props: tGenerateProps) => {
       });
 
       if (artifactid) {
-        toast(<Alert message="Artifact re-generated" type={ALERT_TYPES.SUCCESS} />);
+        toast(() => <Alert message="Artifact re-generated" type={ALERT_TYPES.SUCCESS} />);
       } else {
-        toast(<Alert message="Artifacts generated" type={ALERT_TYPES.SUCCESS} />);
+        toast(() => <Alert message="Artifacts generated" type={ALERT_TYPES.SUCCESS} />);
       }
 
       setIsLoading(false);

--- a/frontend/app/src/screens/branches/branch-details.tsx
+++ b/frontend/app/src/screens/branches/branch-details.tsx
@@ -77,7 +77,7 @@ export const BranchDetails = () => {
       console.log("error: ", error);
       setDetailsContent(error);
 
-      toast(<Alert type={ALERT_TYPES.SUCCESS} message={errorMessage} />);
+      toast(() => <Alert type={ALERT_TYPES.SUCCESS} message={errorMessage} />);
     }
 
     setIsLoadingRequest(false);

--- a/frontend/app/src/screens/diff/artifact-diff/artifact-content-diff.tsx
+++ b/frontend/app/src/screens/diff/artifact-diff/artifact-content-diff.tsx
@@ -141,7 +141,7 @@ export const ArtifactContentDiff = (props: any) => {
       setState(fileResult || "");
     } catch (err) {
       console.error("Error while loading files diff: ", err);
-      toast(<Alert type={ALERT_TYPES.ERROR} message="Error while loading files diff" />);
+      toast(() => <Alert type={ALERT_TYPES.ERROR} message="Error while loading files diff" />);
     }
 
     setIsLoading(false);
@@ -244,7 +244,7 @@ export const ArtifactContentDiff = (props: any) => {
         },
       });
 
-      toast(<Alert type={ALERT_TYPES.SUCCESS} message={"Comment added"} />);
+      toast(() => <Alert type={ALERT_TYPES.SUCCESS} message={"Comment added"} />);
 
       if (refetch) {
         refetch();
@@ -275,13 +275,13 @@ export const ArtifactContentDiff = (props: any) => {
 
       console.error("An error occurred while creating the comment: ", error);
 
-      toast(
+      toast(() => (
         <Alert
           type={ALERT_TYPES.ERROR}
           message={"An error occurred while creating the comment"}
           details={error.message}
         />
-      );
+      ));
 
       setIsLoading(false);
     }

--- a/frontend/app/src/screens/diff/artifact-diff/artifacts-diff.tsx
+++ b/frontend/app/src/screens/diff/artifact-diff/artifacts-diff.tsx
@@ -45,7 +45,7 @@ export const ArtifactsDiff = forwardRef((props, ref) => {
       setArtifactsDiff(filesResult);
     } catch (err) {
       console.error("Error while loading artifacts diff: ", err);
-      toast(<Alert type={ALERT_TYPES.ERROR} message="Error while loading artifacts diff" />);
+      toast(() => <Alert type={ALERT_TYPES.ERROR} message="Error while loading artifacts diff" />);
     }
 
     setIsLoading(false);

--- a/frontend/app/src/screens/diff/checks/checks-summary.tsx
+++ b/frontend/app/src/screens/diff/checks/checks-summary.tsx
@@ -64,7 +64,7 @@ export const ChecksSummary = (props: tChecksSummaryProps) => {
     refetch();
 
     if (result?.data?.CoreProposedChangeRunCheck?.ok) {
-      toast(<Alert type={ALERT_TYPES.SUCCESS} message="Checks are running" />);
+      toast(() => <Alert type={ALERT_TYPES.SUCCESS} message="Checks are running" />);
     }
   };
 

--- a/frontend/app/src/screens/diff/checks/conflict.tsx
+++ b/frontend/app/src/screens/diff/checks/conflict.tsx
@@ -92,7 +92,7 @@ export const Conflict = (props: any) => {
         },
       });
 
-      toast(<Alert type={ALERT_TYPES.SUCCESS} message="Conflict marked as resovled" />);
+      toast(() => <Alert type={ALERT_TYPES.SUCCESS} message="Conflict marked as resovled" />);
 
       setIsLoading(false);
 

--- a/frontend/app/src/screens/diff/data-diff.tsx
+++ b/frontend/app/src/screens/diff/data-diff.tsx
@@ -135,7 +135,7 @@ export const DataDiff = forwardRef((props, ref) => {
     } catch (err) {
       console.error("Error when fethcing branches: ", err);
 
-      toast(<Alert type={ALERT_TYPES.ERROR} message="Error while loading branch diff" />);
+      toast(() => <Alert type={ALERT_TYPES.ERROR} message="Error while loading branch diff" />);
     }
 
     setIsLoading(false);

--- a/frontend/app/src/screens/diff/diff-comments.tsx
+++ b/frontend/app/src/screens/diff/diff-comments.tsx
@@ -153,7 +153,7 @@ export const DataDiffComments = (props: tDataDiffComments) => {
         },
       });
 
-      toast(<Alert type={ALERT_TYPES.SUCCESS} message={"Comment added"} />);
+      toast(() => <Alert type={ALERT_TYPES.SUCCESS} message={"Comment added"} />);
 
       handleRefetch();
     } catch (error: any) {

--- a/frontend/app/src/screens/diff/file-diff/file-content-diff.tsx
+++ b/frontend/app/src/screens/diff/file-diff/file-content-diff.tsx
@@ -160,7 +160,7 @@ export const FileContentDiff = (props: any) => {
       setState(fileResult);
     } catch (err) {
       console.error("Error while loading files diff: ", err);
-      toast(<Alert type={ALERT_TYPES.ERROR} message="Error while loading files diff" />);
+      toast(() => <Alert type={ALERT_TYPES.ERROR} message="Error while loading files diff" />);
     }
 
     setIsLoading(false);
@@ -274,7 +274,7 @@ export const FileContentDiff = (props: any) => {
         },
       });
 
-      toast(<Alert type={ALERT_TYPES.SUCCESS} message={"Comment added"} />);
+      toast(() => <Alert type={ALERT_TYPES.SUCCESS} message={"Comment added"} />);
 
       if (refetch) {
         refetch();
@@ -305,13 +305,13 @@ export const FileContentDiff = (props: any) => {
 
       console.error("An error occurred while creating the comment: ", error);
 
-      toast(
+      toast(() => (
         <Alert
           type={ALERT_TYPES.ERROR}
           message={"An error occurred while creating the comment"}
           details={error.message}
         />
-      );
+      ));
 
       setIsLoading(false);
     }

--- a/frontend/app/src/screens/diff/schema-diff.tsx
+++ b/frontend/app/src/screens/diff/schema-diff.tsx
@@ -45,7 +45,7 @@ export const SchemaDiff = forwardRef((props, ref) => {
       setDiff(diffDetails?.diffs ?? []);
     } catch (err) {
       console.error("Error when loading branch diff: ", err);
-      toast(<Alert type={ALERT_TYPES.ERROR} message="Error while loading branch diff" />);
+      toast(() => <Alert type={ALERT_TYPES.ERROR} message="Error while loading branch diff" />);
     }
 
     setIsLoading(false);

--- a/frontend/app/src/screens/groups/add-object-to-group.tsx
+++ b/frontend/app/src/screens/groups/add-object-to-group.tsx
@@ -135,7 +135,7 @@ export default function AddObjectToGroup(props: Props) {
         });
       }
 
-      toast(<Alert type={ALERT_TYPES.SUCCESS} message={`${schemaData?.name} updated`} />);
+      toast(() => <Alert type={ALERT_TYPES.SUCCESS} message={`${schemaData?.name} updated`} />);
 
       closeDrawer();
 

--- a/frontend/app/src/screens/layout/sidebar/desktop-menu.tsx
+++ b/frontend/app/src/screens/layout/sidebar/desktop-menu.tsx
@@ -43,7 +43,7 @@ export function DesktopMenu({ className = "" }: MenuProps) {
       setIsLoading(false);
     } catch (error) {
       console.error("error: ", error);
-      toast(<Alert type={ALERT_TYPES.ERROR} message="Error while fetching the menu" />);
+      toast(() => <Alert type={ALERT_TYPES.ERROR} message="Error while fetching the menu" />);
       setIsLoading(false);
     }
   };

--- a/frontend/app/src/screens/object-item-details/relationship-details-paginated.tsx
+++ b/frontend/app/src/screens/object-item-details/relationship-details-paginated.tsx
@@ -153,12 +153,12 @@ export default function RelationshipDetails(props: iRelationDetailsProps) {
       refetch();
     }
 
-    toast(
+    toast(() => (
       <Alert
         type={ALERT_TYPES.SUCCESS}
         message={`Association with ${relationshipSchema.peer} removed`}
       />
-    );
+    ));
   };
 
   const handleSubmit = async (data: any) => {
@@ -189,12 +189,12 @@ export default function RelationshipDetails(props: iRelationDetailsProps) {
         refetch();
       }
 
-      toast(
+      toast(() => (
         <Alert
           type={ALERT_TYPES.SUCCESS}
           message={`Association with ${relationshipSchema.peer} added`}
         />
-      );
+      ));
 
       setShowAddDrawer(false);
     }

--- a/frontend/app/src/screens/object-item-details/relationships-details-paginated.tsx
+++ b/frontend/app/src/screens/object-item-details/relationships-details-paginated.tsx
@@ -117,7 +117,7 @@ export const RelationshipsDetails = forwardRef((props: RelationshipsDetailsProps
 
     updatePageData();
 
-    toast(<Alert type={ALERT_TYPES.SUCCESS} message={"Item removed from the group"} />);
+    toast(() => <Alert type={ALERT_TYPES.SUCCESS} message={"Item removed from the group"} />);
   };
 
   // const count = data[schemaData?.kind].count;

--- a/frontend/app/src/screens/object-item-edit/object-item-edit-paginated.tsx
+++ b/frontend/app/src/screens/object-item-edit/object-item-edit-paginated.tsx
@@ -135,7 +135,7 @@ export default function ObjectItemEditComponent(props: Props) {
           context: { branch: branch?.name, date },
         });
 
-        toast(<Alert type={ALERT_TYPES.SUCCESS} message={`${schema?.name} updated`} />, {
+        toast(() => <Alert type={ALERT_TYPES.SUCCESS} message={`${schema?.name} updated`} />, {
           toastId: "alert-success-updated",
         });
 

--- a/frontend/app/src/screens/object-items/object-items-paginated.tsx
+++ b/frontend/app/src/screens/object-items/object-items-paginated.tsx
@@ -186,12 +186,12 @@ export default function ObjectItems({
 
       setRowToDelete(undefined);
 
-      toast(
+      toast(() => (
         <Alert
           type={ALERT_TYPES.SUCCESS}
           message={`Object ${rowToDelete?.display_label} deleted`}
         />
-      );
+      ));
     } catch (error) {
       console.error("Error while deleting object: ", error);
     }

--- a/frontend/app/src/screens/proposed-changes/conversations.tsx
+++ b/frontend/app/src/screens/proposed-changes/conversations.tsx
@@ -174,7 +174,7 @@ export const Conversations = forwardRef((props: tConversations, ref) => {
         },
       });
 
-      toast(<Alert type={ALERT_TYPES.SUCCESS} message={"Comment added"} />);
+      toast(() => <Alert type={ALERT_TYPES.SUCCESS} message={"Comment added"} />);
 
       await refetch();
     } catch (error: any) {
@@ -234,7 +234,7 @@ export const Conversations = forwardRef((props: tConversations, ref) => {
         context: { branch: branch?.name, date },
       });
 
-      toast(<Alert type={ALERT_TYPES.SUCCESS} message="Proposed change approved" />);
+      toast(() => <Alert type={ALERT_TYPES.SUCCESS} message="Proposed change approved" />);
 
       if (detailsRefetch) {
         await detailsRefetch();
@@ -283,16 +283,18 @@ export const Conversations = forwardRef((props: tConversations, ref) => {
         detailsRefetch();
       }
 
-      toast(<Alert type={ALERT_TYPES.SUCCESS} message={"Proposed changes merged successfully!"} />);
+      toast(() => (
+        <Alert type={ALERT_TYPES.SUCCESS} message={"Proposed changes merged successfully!"} />
+      ));
     } catch (error: any) {
       console.log("error: ", error);
 
-      toast(
+      toast(() => (
         <Alert
           type={ALERT_TYPES.SUCCESS}
           message={"An error occurred while merging the proposed changes"}
         />
-      );
+      ));
     }
 
     setIsLoadingMerge(false);
@@ -327,12 +329,12 @@ export const Conversations = forwardRef((props: tConversations, ref) => {
         context: { branch: branch?.name, date },
       });
 
-      toast(
+      toast(() => (
         <Alert
           type={ALERT_TYPES.SUCCESS}
           message={`Proposed change ${state === "closed" ? "opened" : "closed"}`}
         />
-      );
+      ));
 
       if (detailsRefetch) {
         detailsRefetch();

--- a/frontend/app/src/screens/proposed-changes/proposed-changes-item.tsx
+++ b/frontend/app/src/screens/proposed-changes/proposed-changes-item.tsx
@@ -66,7 +66,7 @@ export const ProposedChange = (props: any) => {
 
     setIsLoading(false);
 
-    toast(<Alert type={ALERT_TYPES.SUCCESS} message={"Proposed changes deleted"} />);
+    toast(() => <Alert type={ALERT_TYPES.SUCCESS} message={"Proposed changes deleted"} />);
   };
 
   return (

--- a/frontend/app/tests/e2e/tutorial/tutorial-1_object-create-update-diff-and-merge.spec.ts
+++ b/frontend/app/tests/e2e/tutorial/tutorial-1_object-create-update-diff-and-merge.spec.ts
@@ -140,7 +140,9 @@ test.describe("Getting started with Infrahub - Object and branch creation, updat
     await test.step("Row my-first-tenant is not visible when date prior to its creation is selected", async () => {
       await page.getByTestId("timeframe-selector").click();
       await saveScreenshotForDocs(page, "tutorial_2_historical");
-      await page.getByRole("option", { name: format(dateBeforeTest, "h:mm aa") }).click();
+      await page
+        .getByRole("option", { name: format(dateBeforeTest, "h:mm aa"), exact: true })
+        .click();
       await expect(page.locator("tbody")).not.toContainText("my-first-tenant");
     });
 


### PR DESCRIPTION
prevent error on console:
```
Warning: React does not recognize the `toastProps` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `toastprops` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    at div
    at Alert (http://localhost:8080/src/components/ui/alert.tsx:35:11)
    at div
    at div
    at div
    at http://localhost:8080/node_modules/.vite/deps/react-toastify.js?v=70720234:51:21
    at N (http://localhost:8080/node_modules/.vite/deps/react-toastify.js?v=70720234:243:89)
    at div
    at div
    at http://localhost:8080/node_modules/.vite/deps/react-toastify.js?v=70720234:255:73
    at ApolloProvider (http://localhost:8080/node_modules/.vite/deps/@apollo_client.js?v=c378b5d2:6212:19)
    at QueryParamProviderInner (http://localhost:8080/node_modules/.vite/deps/use-query-params.js?v=39e5681e:740:3)
    at ReactRouter6Adapter (http://localhost:8080/node_modules/.vite/deps/use-query-params_adapters_react-router-6.js?v=26aaf94c:18:3)
    at QueryParamProvider (http://localhost:8080/node_modules/.vite/deps/use-query-params.js?v=39e5681e:759:3)
    at Router (http://localhost:8080/node_modules/.vite/deps/chunk-3PGGYOGI.js?v=0deee5a7:3938:15)
    at BrowserRouter (http://localhost:8080/node_modules/.vite/deps/chunk-3PGGYOGI.js?v=0deee5a7:4678:5)
    at Infrahub (http://localhost:8080/src/index.tsx:38:21)
    at ErrorBoundary (http://localhost:8080/node_modules/.vite/deps/react-error-boundary.js?v=77bb04e2:18:5)
    at Provider (http://localhost:8080/node_modules/.vite/deps/chunk-F65DJ7I5.js?v=0deee5a7:625:3)
    ```