### PR TITLE
Hierarchical dropdowns for relationships

### DIFF
--- a/frontend/app/package-lock.json
+++ b/frontend/app/package-lock.json
@@ -102,6 +102,7 @@
         "openapi-typescript": "^6.7.3",
         "postcss": "^8.4.23",
         "prettier": "2.8.8",
+        "prettier-eslint": "^16.3.0",
         "pretty-quick": "^3.1.3",
         "react-test-renderer": "^18.2.0",
         "tailwindcss": "^3.4.3",
@@ -10374,19 +10375,7 @@
         "node": ">=4.0.0"
       }
     },
-    "node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/eslint-scope": {
+    "node_modules/eslint-scope": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
       "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
@@ -10395,6 +10384,18 @@
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -11374,6 +11375,27 @@
       },
       "optionalDependencies": {
         "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-ansi/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/has-bigints": {
@@ -13395,6 +13417,93 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.1.tgz",
+      "integrity": "sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
+    "node_modules/loglevel-colored-level-prefix": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/loglevel-colored-level-prefix/-/loglevel-colored-level-prefix-1.0.0.tgz",
+      "integrity": "sha512-u45Wcxxc+SdAlh4yeF/uKlC1SPUPCy0gullSNKXod5I4bmifzk+Q4lSLExNEVn19tGaJipbZ4V4jbFn79/6mVA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^1.1.3",
+        "loglevel": "^1.4.1"
+      }
+    },
+    "node_modules/loglevel-colored-level-prefix/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/loglevel-colored-level-prefix/node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/loglevel-colored-level-prefix/node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/loglevel-colored-level-prefix/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/loglevel-colored-level-prefix/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/loglevel-colored-level-prefix/node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/longest-streak": {
@@ -15526,6 +15635,227 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prettier-eslint": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-16.3.0.tgz",
+      "integrity": "sha512-Lh102TIFCr11PJKUMQ2kwNmxGhTsv/KzUg9QYF2Gkw259g/kPgndZDWavk7/ycbRvj2oz4BPZ1gCU8bhfZH/Xg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/parser": "^6.7.5",
+        "common-tags": "^1.4.0",
+        "dlv": "^1.1.0",
+        "eslint": "^8.7.0",
+        "indent-string": "^4.0.0",
+        "lodash.merge": "^4.6.0",
+        "loglevel-colored-level-prefix": "^1.0.0",
+        "prettier": "^3.0.1",
+        "pretty-format": "^29.7.0",
+        "require-relative": "^0.8.7",
+        "typescript": "^5.2.2",
+        "vue-eslint-parser": "^9.1.0"
+      },
+      "engines": {
+        "node": ">=16.10.0"
+      },
+      "peerDependencies": {
+        "prettier-plugin-svelte": "^3.0.0",
+        "svelte-eslint-parser": "*"
+      },
+      "peerDependenciesMeta": {
+        "prettier-plugin-svelte": {
+          "optional": true
+        },
+        "svelte-eslint-parser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/prettier-eslint/node_modules/@typescript-eslint/parser": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/prettier-eslint/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/prettier-eslint/node_modules/@typescript-eslint/types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/prettier-eslint/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/prettier-eslint/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/prettier-eslint/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prettier-eslint/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/prettier-eslint/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/prettier-eslint/node_modules/prettier": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
+      "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-eslint/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/prettier-eslint/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true
+    },
+    "node_modules/prettier-eslint/node_modules/semver": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
@@ -16498,6 +16828,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
+    "node_modules/require-relative": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
+      "integrity": "sha512-AKGr4qvHiryxRb19m3PsLRGuKVAbJLUD7E6eOaHkfKhwc+vSgVOCY5xNvm9EkolBKTOf0GrQAZKLimOCz81Khg==",
       "dev": true
     },
     "node_modules/requires-port": {
@@ -18910,6 +19246,42 @@
       "version": "3.17.5",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
       "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
+    },
+    "node_modules/vue-eslint-parser": {
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.4.3.tgz",
+      "integrity": "sha512-2rYRLWlIpaiN8xbPiDyXZXRgLGOtWxERV7ND5fFAv5qo1D2N9Fu9MNajBNc6o13lZ+24DAWCkQCvj4klgmcITg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "eslint-scope": "^7.1.1",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.3.1",
+        "esquery": "^1.4.0",
+        "lodash": "^4.17.21",
+        "semver": "^7.3.6"
+      },
+      "engines": {
+        "node": "^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/vue-eslint-parser/node_modules/semver": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
@@ -26133,16 +26505,6 @@
         "text-table": "^0.2.0"
       },
       "dependencies": {
-        "eslint-scope": {
-          "version": "7.2.2",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-          "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.3.0",
-            "estraverse": "^5.2.0"
-          }
-        },
         "glob-parent": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -26464,6 +26826,16 @@
       "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
       "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
       "dev": true
+    },
+    "eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "3.4.3",
@@ -27166,6 +27538,23 @@
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+          "dev": true
+        }
       }
     },
     "has-bigints": {
@@ -28552,6 +28941,70 @@
             "astral-regex": "^2.0.0",
             "is-fullwidth-code-point": "^3.0.0"
           }
+        }
+      }
+    },
+    "loglevel": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.1.tgz",
+      "integrity": "sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg==",
+      "dev": true
+    },
+    "loglevel-colored-level-prefix": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/loglevel-colored-level-prefix/-/loglevel-colored-level-prefix-1.0.0.tgz",
+      "integrity": "sha512-u45Wcxxc+SdAlh4yeF/uKlC1SPUPCy0gullSNKXod5I4bmifzk+Q4lSLExNEVn19tGaJipbZ4V4jbFn79/6mVA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "loglevel": "^1.4.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+          "dev": true
         }
       }
     },
@@ -30002,6 +30455,136 @@
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true
     },
+    "prettier-eslint": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-16.3.0.tgz",
+      "integrity": "sha512-Lh102TIFCr11PJKUMQ2kwNmxGhTsv/KzUg9QYF2Gkw259g/kPgndZDWavk7/ycbRvj2oz4BPZ1gCU8bhfZH/Xg==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/parser": "^6.7.5",
+        "common-tags": "^1.4.0",
+        "dlv": "^1.1.0",
+        "eslint": "^8.7.0",
+        "indent-string": "^4.0.0",
+        "lodash.merge": "^4.6.0",
+        "loglevel-colored-level-prefix": "^1.0.0",
+        "prettier": "^3.0.1",
+        "pretty-format": "^29.7.0",
+        "require-relative": "^0.8.7",
+        "typescript": "^5.2.2",
+        "vue-eslint-parser": "^9.1.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/parser": {
+          "version": "6.21.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+          "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/scope-manager": "6.21.0",
+            "@typescript-eslint/types": "6.21.0",
+            "@typescript-eslint/typescript-estree": "6.21.0",
+            "@typescript-eslint/visitor-keys": "6.21.0",
+            "debug": "^4.3.4"
+          }
+        },
+        "@typescript-eslint/scope-manager": {
+          "version": "6.21.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+          "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "6.21.0",
+            "@typescript-eslint/visitor-keys": "6.21.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "6.21.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+          "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "6.21.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+          "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "6.21.0",
+            "@typescript-eslint/visitor-keys": "6.21.0",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "minimatch": "9.0.3",
+            "semver": "^7.5.4",
+            "ts-api-utils": "^1.0.1"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "6.21.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+          "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "6.21.0",
+            "eslint-visitor-keys": "^3.4.1"
+          }
+        },
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+          "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "prettier": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
+          "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+          "dev": true,
+          "requires": {
+            "@jest/schemas": "^29.6.3",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^18.0.0"
+          }
+        },
+        "react-is": {
+          "version": "18.3.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+          "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+          "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+          "dev": true
+        }
+      }
+    },
     "pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
@@ -30691,6 +31274,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
+    "require-relative": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
+      "integrity": "sha512-AKGr4qvHiryxRb19m3PsLRGuKVAbJLUD7E6eOaHkfKhwc+vSgVOCY5xNvm9EkolBKTOf0GrQAZKLimOCz81Khg==",
       "dev": true
     },
     "requires-port": {
@@ -32348,6 +32937,29 @@
       "version": "3.17.5",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
       "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
+    },
+    "vue-eslint-parser": {
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.4.3.tgz",
+      "integrity": "sha512-2rYRLWlIpaiN8xbPiDyXZXRgLGOtWxERV7ND5fFAv5qo1D2N9Fu9MNajBNc6o13lZ+24DAWCkQCvj4klgmcITg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.3.4",
+        "eslint-scope": "^7.1.1",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.3.1",
+        "esquery": "^1.4.0",
+        "lodash": "^4.17.21",
+        "semver": "^7.3.6"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+          "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+          "dev": true
+        }
+      }
     },
     "w3c-keyname": {
       "version": "2.2.8",

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -124,6 +124,7 @@
     "openapi-typescript": "^6.7.3",
     "postcss": "^8.4.23",
     "prettier": "2.8.8",
+    "prettier-eslint": "^16.3.0",
     "pretty-quick": "^3.1.3",
     "react-test-renderer": "^18.2.0",
     "tailwindcss": "^3.4.3",

--- a/frontend/app/src/components/form/fields/checkbox.field.tsx
+++ b/frontend/app/src/components/form/fields/checkbox.field.tsx
@@ -36,11 +36,11 @@ const CheckboxField = ({
           <div className="relative flex flex-col">
             <div className="flex items-center">
               <FormInput>
-                <Checkbox {...fieldMethodsWithoutValue} {...props} checked={!!value} />
+                <Checkbox {...fieldMethodsWithoutValue} {...props} checked={!!value} cl />
               </FormInput>
 
               <LabelFormField
-                className="m-0"
+                className="m-0 ml-2"
                 label={label}
                 unique={unique}
                 required={!!rules?.required}

--- a/frontend/app/src/components/form/fields/common.tsx
+++ b/frontend/app/src/components/form/fields/common.tsx
@@ -12,6 +12,7 @@ type LabelFormFieldProps = {
   required?: boolean;
   unique?: boolean;
   description?: string;
+  variant?: string;
 };
 
 export const LabelFormField = ({
@@ -20,10 +21,11 @@ export const LabelFormField = ({
   required,
   unique,
   description,
+  variant,
 }: LabelFormFieldProps) => {
   return (
-    <div className={classNames("px-1 mb-1 flex items-center gap-1", className)}>
-      <FormLabel>
+    <div className={classNames("mb-1 flex items-center gap-1", className)}>
+      <FormLabel variant={variant}>
         {label} {required && "*"}
       </FormLabel>
       {unique && <InputUniqueTips />}

--- a/frontend/app/src/components/form/fields/common.tsx
+++ b/frontend/app/src/components/form/fields/common.tsx
@@ -1,19 +1,20 @@
 import { FormLabel } from "@/components/ui/form";
 import { QuestionMark } from "@/components/display/question-mark";
 import { classNames } from "@/utils/common";
+import { LabelProps } from "@headlessui/react/dist/components/label/label";
 
 export const InputUniqueTips = () => (
   <span className="text-xs text-gray-600 italic self-end mb-px">must be unique</span>
 );
 
-type LabelFormFieldProps = {
+interface LabelFormFieldProps extends LabelProps {
   className?: string;
   label?: string;
   required?: boolean;
   unique?: boolean;
   description?: string;
   variant?: string;
-};
+}
 
 export const LabelFormField = ({
   className,

--- a/frontend/app/src/components/form/fields/relationship.field.tsx
+++ b/frontend/app/src/components/form/fields/relationship.field.tsx
@@ -75,9 +75,9 @@ const RelationshipField = ({
               <div className="relative flex flex-col">
                 <LabelFormField
                   label={"Kind"}
+                  description="Kind of node to use as relationship"
                   unique={unique}
                   required={!!rules?.required}
-                  description={description}
                   variant="small"
                 />
 
@@ -106,9 +106,9 @@ const RelationshipField = ({
               <div className="relative flex flex-col mt-1">
                 <LabelFormField
                   label={"Parent"}
+                  description="Parent to filter the available nodes"
                   unique={unique}
                   required={!!rules?.required}
-                  description={description}
                   variant="small"
                 />
 
@@ -137,7 +137,7 @@ const RelationshipField = ({
             return (
               <div className="relative flex flex-col mt-1">
                 <LabelFormField
-                  label={"Object"}
+                  label={"Node"}
                   unique={unique}
                   required={!!rules?.required}
                   description={description}
@@ -187,10 +187,10 @@ const RelationshipField = ({
             return (
               <div className="relative flex flex-col">
                 <LabelFormField
-                  label={"Parent"}
+                  label="Parent"
+                  description="Parent to filter the available nodes"
                   unique={unique}
                   required={!!rules?.required}
-                  description={description}
                   variant="small"
                 />
 

--- a/frontend/app/src/components/form/fields/relationship.field.tsx
+++ b/frontend/app/src/components/form/fields/relationship.field.tsx
@@ -1,16 +1,16 @@
-import { ElementRef, forwardRef } from "react";
+import { ElementRef, forwardRef, useState } from "react";
 import { useAtomValue } from "jotai";
 import { components } from "@/infraops";
 import { store } from "@/state";
 import { genericsState, IModelSchema, profilesAtom, schemaState } from "@/state/atoms/schema.atom";
 import { FormField, FormInput, FormMessage } from "@/components/ui/form";
 import { Select } from "@/components/inputs/select";
-import { OpsSelect2Step } from "@/components/form/select-2-step";
 import { DynamicRelationshipFieldProps, FormFieldProps } from "@/components/form/type";
 import { LabelFormField } from "@/components/form/fields/common";
 
 export interface RelationshipFieldProps extends DynamicRelationshipFieldProps {}
 
+// Select kind (select 2 steps) if needed
 const RelationshipField = ({
   defaultValue,
   description,
@@ -20,30 +20,136 @@ const RelationshipField = ({
   unique,
   ...props
 }: RelationshipFieldProps) => {
-  return (
-    <FormField
-      key={name}
-      name={name}
-      rules={rules}
-      defaultValue={defaultValue}
-      render={({ field }) => {
-        return (
-          <div className="relative flex flex-col">
-            <LabelFormField
-              label={label}
-              unique={unique}
-              required={!!rules?.required}
-              description={description}
-            />
+  const { options, parent, relationship } = props;
 
-            <FormInput>
-              <RelationshipInput {...field} {...props} />
-            </FormInput>
-            <FormMessage />
-          </div>
-        );
-      }}
-    />
+  const [selectedLeft, setSelectedLeft] = useState(
+    parent ? options?.find((option) => option.id === parent) : null
+  );
+
+  const generics = useAtomValue(genericsState);
+  const generic = generics.find((generic) => generic.kind === relationship.peer);
+
+  if (generic) {
+    const nodes = store.get(schemaState);
+    const profiles = store.get(profilesAtom);
+    const options = (generic.used_by || []).map((name: string) => {
+      const relatedSchema = [...nodes, ...profiles].find((s: any) => s.kind === name);
+
+      if (relatedSchema) {
+        return {
+          id: name,
+          name: relatedSchema.name,
+        };
+      }
+    });
+
+    const selectOptions = Array.isArray(options)
+      ? options.map((o) => ({
+          name: o.name,
+          id: o.id,
+        }))
+      : [];
+
+    return (
+      <div>
+        <LabelFormField
+          label={label}
+          unique={unique}
+          required={!!rules?.required}
+          description={description}
+        />
+
+        <FormField
+          key={`${name}_1`}
+          name={name}
+          rules={rules}
+          defaultValue={defaultValue}
+          render={({ field }) => {
+            return (
+              <div className="relative flex flex-col">
+                <LabelFormField
+                  label={"Kind"}
+                  unique={unique}
+                  required={!!rules?.required}
+                  description={description}
+                  variant="small"
+                />
+
+                <FormInput>
+                  <RelationshipInput
+                    {...field}
+                    {...props}
+                    options={selectOptions}
+                    onChange={setSelectedLeft}
+                    value={selectedLeft?.id}
+                  />
+                </FormInput>
+                <FormMessage />
+              </div>
+            );
+          }}
+        />
+
+        <FormField
+          key={`${name}_2`}
+          name={name}
+          rules={rules}
+          defaultValue={defaultValue}
+          render={({ field }) => {
+            return (
+              <div className="relative flex flex-col mt-2">
+                <LabelFormField
+                  label={"Object"}
+                  unique={unique}
+                  required={!!rules?.required}
+                  description={description}
+                  variant="small"
+                />
+
+                <FormInput>
+                  <RelationshipInput
+                    {...field}
+                    {...props}
+                    peer={selectedLeft?.id}
+                    disabled={props.disabled || !selectedLeft?.id}
+                    className="mt-1"
+                  />
+                </FormInput>
+                <FormMessage />
+              </div>
+            );
+          }}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <FormField
+        key={name}
+        name={name}
+        rules={rules}
+        defaultValue={defaultValue}
+        render={({ field }) => {
+          return (
+            <div className="relative flex flex-col">
+              <LabelFormField
+                label={label}
+                unique={unique}
+                required={!!rules?.required}
+                description={description}
+              />
+
+              <FormInput>
+                <RelationshipInput {...field} {...props} peer={relationship?.peer} />
+              </FormInput>
+              <FormMessage />
+            </div>
+          );
+        }}
+      />
+    </div>
   );
 };
 
@@ -52,80 +158,21 @@ interface RelationshipInputProps extends FormFieldProps, RelationshipFieldProps 
   schema: IModelSchema;
   onChange: (value: any) => void;
   value?: string;
+  className?: string;
 }
 
+// Select parent if needed
 const RelationshipInput = forwardRef<ElementRef<typeof Select>, RelationshipInputProps>(
-  ({ schema, value, options, parent, relationship, ...props }, ref) => {
-    const generics = useAtomValue(genericsState);
-    if (relationship.cardinality === "many") {
-      return (
-        <Select
-          ref={ref}
-          {...props}
-          multiple
-          options={options ?? []}
-          peer={relationship.peer}
-          field={relationship}
-          schema={schema}
-          value={value}
-          className="w-full"
-        />
-      );
-    }
-
-    const generic = generics.find((generic) => generic.kind === relationship.peer);
-    if (generic || relationship.inherited) {
-      if (generic) {
-        const nodes = store.get(schemaState);
-        const profiles = store.get(profilesAtom);
-        const options = (generic.used_by || []).map((name: string) => {
-          const relatedSchema = [...nodes, ...profiles].find((s: any) => s.kind === name);
-
-          if (relatedSchema) {
-            return {
-              id: name,
-              name: relatedSchema.name,
-            };
-          }
-        });
-
-        const selectOptions = Array.isArray(options)
-          ? options.map((o) => ({
-              name: o.name,
-              id: o.id,
-            }))
-          : [];
-
-        return (
-          <OpsSelect2Step
-            {...props}
-            isOptional
-            isProtected={props.disabled}
-            options={selectOptions}
-            value={{
-              parent: parent ?? null,
-              child: value?.id ?? value ?? null,
-            }}
-            peer={relationship.peer}
-            field={relationship}
-            schema={schema}
-            onChange={(newOption) => {
-              props.onChange(newOption);
-            }}
-          />
-        );
-      }
-    }
-
+  ({ schema, value, options, relationship, ...props }, ref) => {
     return (
       <Select
         ref={ref}
         {...props}
         value={value}
         options={options ?? []}
-        peer={relationship.peer}
         field={relationship}
         schema={schema}
+        multiple={relationship.cardinality === "many"}
         className="w-full"
       />
     );

--- a/frontend/app/src/components/form/fields/relationship.field.tsx
+++ b/frontend/app/src/components/form/fields/relationship.field.tsx
@@ -163,7 +163,7 @@ const RelationshipField = ({
     );
   }
 
-  const schemaData = schemaList.find((schema) => schema.kind === selectedKind?.id);
+  const schemaData = schemaList.find((schema) => schema.kind === relationship?.peer);
   const parentRelationship = schemaData?.relationships?.find((rel) => rel.kind === "Parent");
 
   return (
@@ -239,7 +239,12 @@ const RelationshipField = ({
               )}
 
               <FormInput>
-                <RelationshipInput {...field} {...props} peer={relationship?.peer} />
+                <RelationshipInput
+                  {...field}
+                  {...props}
+                  peer={relationship?.peer}
+                  parent={{ name: parentRelationship?.name, value: selectedParent?.id }}
+                />
               </FormInput>
               <FormMessage />
             </div>

--- a/frontend/app/src/components/form/fields/relationship.field.tsx
+++ b/frontend/app/src/components/form/fields/relationship.field.tsx
@@ -21,6 +21,7 @@ const RelationshipField = ({
   ...props
 }: RelationshipFieldProps) => {
   const { options, parent, relationship } = props;
+  console.log("parent: ", parent);
 
   const generics = useAtomValue(genericsState);
   const schemaList = useAtomValue(schemaState);
@@ -32,7 +33,7 @@ const RelationshipField = ({
 
   const generic = generics.find((generic) => generic.kind === relationship.peer);
 
-  if (generic) {
+  if (generic && relationship.cardinality === "one") {
     const nodes = store.get(schemaState);
     const profiles = store.get(profilesAtom);
     const schemaData = schemaList.find((schema) => schema.kind === selectedKind?.id);

--- a/frontend/app/src/components/form/fields/relationship.field.tsx
+++ b/frontend/app/src/components/form/fields/relationship.field.tsx
@@ -50,11 +50,15 @@ const RelationshipField = ({
     });
 
     const kindOptions = Array.isArray(genericOptions)
-      ? genericOptions.map((o) => ({
-          name: o.name,
-          id: o.id,
+      ? genericOptions.map((option) => ({
+          name: option?.name,
+          id: option?.id,
         }))
       : [];
+
+    if (kindOptions?.length === 1 && !selectedKind) {
+      setSelectedKind(kindOptions[0]);
+    }
 
     return (
       <div>

--- a/frontend/app/src/components/form/fields/relationship.field.tsx
+++ b/frontend/app/src/components/form/fields/relationship.field.tsx
@@ -56,8 +56,14 @@ const RelationshipField = ({
         }))
       : [];
 
+    // Select the first option if the only available
     if (kindOptions?.length === 1 && !selectedKind) {
       setSelectedKind(kindOptions[0]);
+    }
+
+    // Select the kind after building the options from generics
+    if (parent && !selectedKind && kindOptions?.length) {
+      setSelectedKind(kindOptions?.find((option) => option.id === parent));
     }
 
     return (

--- a/frontend/app/src/components/form/fields/relationship.field.tsx
+++ b/frontend/app/src/components/form/fields/relationship.field.tsx
@@ -37,7 +37,6 @@ const RelationshipField = ({
     const profiles = store.get(profilesAtom);
     const schemaData = schemaList.find((schema) => schema.kind === selectedKind?.id);
     const parentRelationship = schemaData?.relationships?.find((rel) => rel.kind === "Parent");
-    console.log("parentRelationship: ", parentRelationship);
 
     const genericOptions = (generic.used_by || []).map((name: string) => {
       const relatedSchema = [...nodes, ...profiles].find((s: any) => s.kind === name);
@@ -152,6 +151,7 @@ const RelationshipField = ({
                     peer={selectedKind?.id}
                     parent={{ name: parentRelationship?.name, value: selectedParent?.id }}
                     disabled={props.disabled || !selectedKind?.id}
+                    multiple={relationship.cardinality === "many"}
                     className="mt-1"
                   />
                 </FormInput>
@@ -245,6 +245,7 @@ const RelationshipField = ({
                   {...props}
                   peer={relationship?.peer}
                   parent={{ name: parentRelationship?.name, value: selectedParent?.id }}
+                  multiple={relationship.cardinality === "many"}
                 />
               </FormInput>
               <FormMessage />
@@ -261,6 +262,7 @@ interface RelationshipInputProps extends FormFieldProps, RelationshipFieldProps 
   schema: IModelSchema;
   onChange: (value: any) => void;
   value?: string;
+  multiple?: boolean;
   className?: string;
 }
 
@@ -275,7 +277,6 @@ const RelationshipInput = forwardRef<ElementRef<typeof Select>, RelationshipInpu
         options={options ?? []}
         field={relationship}
         schema={schema}
-        multiple={relationship.cardinality === "many"}
         className="w-full"
       />
     );

--- a/frontend/app/src/components/form/fields/relationship.field.tsx
+++ b/frontend/app/src/components/form/fields/relationship.field.tsx
@@ -21,7 +21,6 @@ const RelationshipField = ({
   ...props
 }: RelationshipFieldProps) => {
   const { options, parent, relationship } = props;
-  console.log("---");
 
   const generics = useAtomValue(genericsState);
   const schemaList = useAtomValue(schemaState);
@@ -104,7 +103,7 @@ const RelationshipField = ({
           defaultValue={defaultValue}
           render={({ field }) => {
             return (
-              <div className="relative flex flex-col mt-2">
+              <div className="relative flex flex-col mt-1">
                 <LabelFormField
                   label={"Parent"}
                   unique={unique}
@@ -136,7 +135,7 @@ const RelationshipField = ({
           defaultValue={defaultValue}
           render={({ field }) => {
             return (
-              <div className="relative flex flex-col mt-2">
+              <div className="relative flex flex-col mt-1">
                 <LabelFormField
                   label={"Object"}
                   unique={unique}
@@ -164,8 +163,54 @@ const RelationshipField = ({
     );
   }
 
+  const schemaData = schemaList.find((schema) => schema.kind === selectedKind?.id);
+  const parentRelationship = schemaData?.relationships?.find((rel) => rel.kind === "Parent");
+
   return (
     <div>
+      {parentRelationship && (
+        <LabelFormField
+          label={label}
+          unique={unique}
+          required={!!rules?.required}
+          description={description}
+        />
+      )}
+
+      {parentRelationship && (
+        <FormField
+          key={`${name}_parent`}
+          name={name}
+          rules={rules}
+          defaultValue={defaultValue}
+          render={({ field }) => {
+            return (
+              <div className="relative flex flex-col">
+                <LabelFormField
+                  label={"Parent"}
+                  unique={unique}
+                  required={!!rules?.required}
+                  description={description}
+                  variant="small"
+                />
+
+                <FormInput>
+                  <RelationshipInput
+                    {...field}
+                    {...props}
+                    peer={parentRelationship?.peer}
+                    disabled={props.disabled}
+                    onChange={setSelectedParent}
+                    className="mt-1"
+                  />
+                </FormInput>
+                <FormMessage />
+              </div>
+            );
+          }}
+        />
+      )}
+
       <FormField
         key={name}
         name={name}
@@ -173,13 +218,25 @@ const RelationshipField = ({
         defaultValue={defaultValue}
         render={({ field }) => {
           return (
-            <div className="relative flex flex-col">
-              <LabelFormField
-                label={label}
-                unique={unique}
-                required={!!rules?.required}
-                description={description}
-              />
+            <div className="relative flex flex-col mt-1">
+              {parentRelationship && (
+                <LabelFormField
+                  label={"Object"}
+                  unique={unique}
+                  required={!!rules?.required}
+                  description={description}
+                  variant="small"
+                />
+              )}
+
+              {!parentRelationship && (
+                <LabelFormField
+                  label={label}
+                  unique={unique}
+                  required={!!rules?.required}
+                  description={description}
+                />
+              )}
 
               <FormInput>
                 <RelationshipInput {...field} {...props} peer={relationship?.peer} />

--- a/frontend/app/src/components/form/fields/relationship.field.tsx
+++ b/frontend/app/src/components/form/fields/relationship.field.tsx
@@ -37,6 +37,7 @@ const RelationshipField = ({
     const profiles = store.get(profilesAtom);
     const schemaData = schemaList.find((schema) => schema.kind === selectedKind?.id);
     const parentRelationship = schemaData?.relationships?.find((rel) => rel.kind === "Parent");
+    console.log("parentRelationship: ", parentRelationship);
 
     const genericOptions = (generic.used_by || []).map((name: string) => {
       const relatedSchema = [...nodes, ...profiles].find((s: any) => s.kind === name);
@@ -117,7 +118,7 @@ const RelationshipField = ({
                     {...field}
                     {...props}
                     peer={parentRelationship?.peer}
-                    disabled={props.disabled || !selectedKind?.id}
+                    disabled={props.disabled || !parentRelationship || !selectedKind?.id}
                     onChange={setSelectedParent}
                     className="mt-1"
                   />

--- a/frontend/app/src/components/form/fields/relationship.field.tsx
+++ b/frontend/app/src/components/form/fields/relationship.field.tsx
@@ -21,7 +21,6 @@ const RelationshipField = ({
   ...props
 }: RelationshipFieldProps) => {
   const { options, parent, relationship } = props;
-  console.log("parent: ", parent);
 
   const generics = useAtomValue(genericsState);
   const schemaList = useAtomValue(schemaState);

--- a/frontend/app/src/components/form/type.ts
+++ b/frontend/app/src/components/form/type.ts
@@ -1,7 +1,7 @@
 import { FormField } from "@/components/ui/form";
 import { SchemaAttributeType } from "@/screens/edit-form-hook/dynamic-control-types";
 import { ComponentProps } from "react";
-import { SelectOption } from "@/components/inputs/select";
+import { Parent, SelectOption } from "@/components/inputs/select";
 import { components } from "@/infraops";
 import { IModelSchema } from "@/state/atoms/schema.atom";
 
@@ -32,7 +32,8 @@ export type DynamicEnumFieldProps = FormFieldProps & {
 
 export type DynamicRelationshipFieldProps = FormFieldProps & {
   type: "relationship";
-  parent?: string;
+  peer?: string;
+  parent?: Parent;
   options?: SelectOption[];
   relationship: components["schemas"]["RelationshipSchema-Output"];
   schema: IModelSchema;

--- a/frontend/app/src/components/inputs/checkbox.tsx
+++ b/frontend/app/src/components/inputs/checkbox.tsx
@@ -21,7 +21,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>((props, ref)
       className={classNames(
         "focus:ring-0 focus:ring-offset-0",
         focusStyle,
-        "w-4 h-4 mr-2 text-custom-blue-800 disabled:text-gray-300 bg-gray-100 border-gray-300 rounded cursor-pointer disabled:cursor-not-allowed"
+        "w-4 h-4 text-custom-blue-800 disabled:text-gray-300 bg-gray-100 border-gray-300 rounded cursor-pointer disabled:cursor-not-allowed"
       )}
       data-cy="checkbox"
       {...propsToPass}

--- a/frontend/app/src/components/inputs/checkbox.tsx
+++ b/frontend/app/src/components/inputs/checkbox.tsx
@@ -21,7 +21,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>((props, ref)
       className={classNames(
         "focus:ring-0 focus:ring-offset-0",
         focusStyle,
-        "w-4 h-4 text-custom-blue-800 disabled:text-gray-300 bg-gray-100 border-gray-300 rounded cursor-pointer disabled:cursor-not-allowed"
+        "w-4 h-4 mr-2 text-custom-blue-800 disabled:text-gray-300 bg-gray-100 border-gray-300 rounded cursor-pointer disabled:cursor-not-allowed"
       )}
       data-cy="checkbox"
       {...propsToPass}

--- a/frontend/app/src/components/inputs/select.tsx
+++ b/frontend/app/src/components/inputs/select.tsx
@@ -38,6 +38,11 @@ import { comparedOptions } from "@/utils/array";
 import { getOptionsFromRelationship } from "@/utils/getSchemaObjectColumns";
 import DynamicForm from "@/components/form/dynamic-form";
 
+export type Parent = {
+  name: string;
+  value: string;
+};
+
 export type SelectOption = {
   id: string | number;
   name: string;
@@ -56,6 +61,7 @@ export type SelectProps = {
   kind?: string;
   name?: string;
   peer?: string;
+  parent?: Parent;
   options: SelectOption[];
   onChange?: (value: any) => void;
   disabled?: boolean;
@@ -85,6 +91,7 @@ export const Select = forwardRef<HTMLDivElement, SelectProps>((props, ref) => {
     error,
     direction,
     peer,
+    parent,
     preventObjectsCreation,
     multiple,
     dropdown,
@@ -135,9 +142,13 @@ export const Select = forwardRef<HTMLDivElement, SelectProps>((props, ref) => {
     ?.filter(Boolean)?.length;
   const poolPeer = canRequestPools && POOLS_DICTIONNARY[peer];
 
+  const parentFilter = parent?.value ? `${parent.name}__ids: ["${parent.value}"]` : "";
+
   // Query to fetch options only if a peer is defined
   // TODO: Find another solution for queries while loading schema
-  const optionsQueryString = peer ? getDropdownOptions({ kind: peer }) : "query { ok }";
+  const optionsQueryString = peer
+    ? getDropdownOptions({ kind: peer, parentFilter })
+    : "query { ok }";
   const poolsQueryString = poolPeer ? getDropdownOptions({ kind: poolPeer }) : "query { ok }";
 
   const optionsQuery = gql`

--- a/frontend/app/src/components/inputs/select.tsx
+++ b/frontend/app/src/components/inputs/select.tsx
@@ -39,8 +39,8 @@ import { getOptionsFromRelationship } from "@/utils/getSchemaObjectColumns";
 import DynamicForm from "@/components/form/dynamic-form";
 
 export type Parent = {
-  name: string;
-  value: string;
+  name?: string;
+  value?: string;
 };
 
 export type SelectOption = {

--- a/frontend/app/src/components/ui/label.tsx
+++ b/frontend/app/src/components/ui/label.tsx
@@ -8,12 +8,27 @@ export interface LabelProps
     VariantProps<typeof labelVariants> {}
 
 const labelVariants = cva(
-  "text-sm font-medium text-gray-900 cursor-pointer peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+  "cursor-pointer peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+  {
+    variants: {
+      variant: {
+        noramal: "text-sm font-medium text-gray-900",
+        small: "text-xs font-normal",
+      },
+    },
+    defaultVariants: {
+      variant: "noramal",
+    },
+  }
 );
 
 const Label = React.forwardRef<React.ElementRef<typeof LabelPrimitive.Root>, LabelProps>(
-  ({ className, ...props }, ref) => (
-    <LabelPrimitive.Root ref={ref} className={classNames(labelVariants(), className)} {...props} />
+  ({ className, variant, ...props }, ref) => (
+    <LabelPrimitive.Root
+      ref={ref}
+      className={classNames(labelVariants({ variant }), className)}
+      {...props}
+    />
   )
 );
 

--- a/frontend/app/src/components/ui/label.tsx
+++ b/frontend/app/src/components/ui/label.tsx
@@ -12,12 +12,12 @@ const labelVariants = cva(
   {
     variants: {
       variant: {
-        noramal: "text-sm font-medium text-gray-900",
+        default: "text-sm font-medium text-gray-900",
         small: "text-xs font-normal",
       },
     },
     defaultVariants: {
-      variant: "noramal",
+      variant: "default",
     },
   }
 );

--- a/frontend/app/src/graphql/queries/objects/dropdownOptions.ts
+++ b/frontend/app/src/graphql/queries/objects/dropdownOptions.ts
@@ -1,7 +1,7 @@
 import Handlebars from "handlebars";
 
 export const getDropdownOptions = Handlebars.compile(`query DropdownOptions {
-  {{kind}} {
+  {{kind}}{{#if parentFilter}}({{{parentFilter}}}){{/if}}  {
     count
     edges {
       node {

--- a/frontend/app/tests/e2e/ipam/ip-namespace.spec.ts
+++ b/frontend/app/tests/e2e/ipam/ip-namespace.spec.ts
@@ -100,9 +100,7 @@ test.describe("/ipam - IP Namespace", () => {
     await test.step("create a prefix at top level", async () => {
       await page.getByTestId("create-object-button").click();
       await page.getByLabel("Prefix *").fill("11.0.0.0/8");
-      await page.getByTestId("select2step-1").getByTestId("select-open-option-button").click();
-      await page.getByRole("option", { name: "Namespace" }).click();
-      await page.getByTestId("select2step-2").getByTestId("select-open-option-button").click();
+      await page.getByText("IP Namespace Kind ?Parent ?Node").getByLabel("Node").click();
       await page.getByRole("option", { name: "test-namespace" }).click();
       await page.getByRole("button", { name: "Save" }).click();
       await expect(page.getByText("IPPrefix created")).toBeVisible();
@@ -116,9 +114,7 @@ test.describe("/ipam - IP Namespace", () => {
     await test.step("create a children prefix", async () => {
       await page.getByTestId("create-object-button").click();
       await page.getByLabel("Prefix *").fill("11.0.0.0/16");
-      await page.getByTestId("select2step-1").getByTestId("select-open-option-button").click();
-      await page.getByRole("option", { name: "Namespace" }).click();
-      await page.getByTestId("select2step-2").getByTestId("select-open-option-button").click();
+      await page.getByText("IP Namespace Kind ?Parent ?Node").getByLabel("Node").click();
       await page.getByRole("option", { name: "test-namespace" }).click();
       await page.getByRole("button", { name: "Save" }).click();
       await expect(page.getByText("IPPrefix created")).toBeVisible();
@@ -137,9 +133,7 @@ test.describe("/ipam - IP Namespace", () => {
     await test.step("create a prefix between a parent and its children", async () => {
       await page.getByTestId("create-object-button").click();
       await page.getByLabel("Prefix *").fill("11.0.0.0/10");
-      await page.getByTestId("select2step-1").getByTestId("select-open-option-button").click();
-      await page.getByRole("option", { name: "Namespace" }).click();
-      await page.getByTestId("select2step-2").getByTestId("select-open-option-button").click();
+      await page.getByText("IP Namespace Kind ?Parent ?Node").getByLabel("Node").click();
       await page.getByRole("option", { name: "test-namespace" }).click();
       await page.getByRole("button", { name: "Save" }).click();
       await expect(page.getByText("IPPrefix created")).toBeVisible();

--- a/frontend/app/tests/e2e/objects/object-details.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-details.spec.ts
@@ -63,13 +63,20 @@ test.describe("/objects/:objectname/:objectid", () => {
       await page.getByText("Interfaces15").click();
       await page.getByRole("link", { name: "Backbone: Connected to jfk1-" }).click();
       await page.getByRole("button", { name: "Edit" }).click();
-      await page.getByTestId("select2step-1").scrollIntoViewIfNeeded();
-      await expect(page.getByTestId("select2step-1").getByTestId("select-input")).toHaveValue(
-        "CircuitEndpoint"
-      );
-      await expect(page.getByTestId("select2step-2").locator("input")).toHaveValue(
-        /InfraCircuitEndpoint/g
-      );
+
+      const kindSelector = page
+        .getByTestId("side-panel-container")
+        .getByText("Kind")
+        .locator("../..")
+        .getByTestId("select-input");
+      await expect(kindSelector).toHaveValue("CircuitEndpoint");
+
+      const nodeSelector = page
+        .getByTestId("side-panel-container")
+        .getByText("Node")
+        .locator("../..")
+        .getByTestId("select-input");
+      await expect(nodeSelector).toHaveValue(/InfraCircuitEndpoint/g);
     });
   });
 });

--- a/frontend/app/tests/e2e/objects/object-filters.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-filters.spec.ts
@@ -79,7 +79,13 @@ test.describe("Object filters", () => {
     await page.goto("/objects/CoreArtifact");
     await page.getByTestId("apply-filters").click();
     await expect(page.getByTestId("side-panel-container").getByText("Object")).toBeVisible();
-    await page.getByTestId("select2step-1").getByTestId("select-open-option-button").click();
+
+    const kindSelector = page
+      .getByTestId("side-panel-container")
+      .getByText("Kind")
+      .locator("../..")
+      .getByTestId("select-open-option-button");
+    await kindSelector.click();
     await expect(page.getByRole("option", { name: "Tag", exact: true })).toBeVisible();
   });
 });

--- a/frontend/app/tests/e2e/objects/object-metadata.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-metadata.spec.ts
@@ -29,7 +29,7 @@ test.describe("Object metadata", () => {
 
     // Owner should be empty
     await expect(
-      page.getByTestId("select-container").nth(0).getByTestId("select-input")
+      page.getByText("Kind").first().locator("../..").getByTestId("select-input")
     ).toHaveValue("");
 
     // Is visible should be checked
@@ -42,9 +42,9 @@ test.describe("Object metadata", () => {
     await page.getByLabel("is protected *").check();
 
     // Select Architecture team
-    await page.getByText("Owner Kind ?Parent ?Node").getByLabel("Kind").click();
+    await page.getByLabel("Kind").first().click();
     await page.getByRole("option", { name: "Account" }).click();
-    await page.getByText("Owner Kind ?Parent ?Node").getByLabel("Node").click();
+    await page.getByLabel("Node").first().click();
     await page.getByRole("option", { name: "Architecture Team" }).click();
 
     // Save
@@ -70,10 +70,10 @@ test.describe("Object metadata", () => {
 
     // Source should be Account + Pop-Builder
     await expect(
-      page.getByTestId("select-container").nth(0).getByTestId("select-input")
+      page.getByText("Kind").first().locator("../..").getByTestId("select-input")
     ).toHaveValue("Account");
     await expect(
-      page.getByTestId("select-container").nth(1).getByTestId("select-input")
+      page.getByText("Node").first().locator("../..").getByTestId("select-input")
     ).toHaveValue("Architecture Team");
 
     // Is protected should be checked

--- a/frontend/app/tests/e2e/objects/object-metadata.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-metadata.spec.ts
@@ -29,7 +29,18 @@ test.describe("Object metadata", () => {
 
     // Owner should be empty
     await expect(
-      page.getByText("Kind").first().locator("../..").getByTestId("select-input")
+      page
+        .getByText("Owner Kind ?Parent ?Node")
+        .getByLabel("Kind")
+        .locator("../..")
+        .getByTestId("select-input")
+    ).toHaveValue("");
+    await expect(
+      page
+        .getByText("Owner Kind ?Parent ?Node")
+        .getByLabel("Node")
+        .locator("../..")
+        .getByTestId("select-input")
     ).toHaveValue("");
 
     // Is visible should be checked
@@ -42,9 +53,9 @@ test.describe("Object metadata", () => {
     await page.getByLabel("is protected *").check();
 
     // Select Architecture team
-    await page.getByLabel("Kind").first().click();
+    await page.getByText("Owner Kind ?Parent ?Node").getByLabel("Kind").first().click();
     await page.getByRole("option", { name: "Account" }).click();
-    await page.getByLabel("Node").first().click();
+    await page.getByText("Owner Kind ?Parent ?Node").getByLabel("Node").click();
     await page.getByRole("option", { name: "Architecture Team" }).click();
 
     // Save
@@ -70,10 +81,18 @@ test.describe("Object metadata", () => {
 
     // Source should be Account + Pop-Builder
     await expect(
-      page.getByText("Kind").first().locator("../..").getByTestId("select-input")
+      page
+        .getByText("Owner Kind ?Parent ?Node")
+        .getByLabel("Kind")
+        .locator("../..")
+        .getByTestId("select-input")
     ).toHaveValue("Account");
     await expect(
-      page.getByText("Node").first().locator("../..").getByTestId("select-input")
+      page
+        .getByText("Owner Kind ?Parent ?Node")
+        .getByLabel("Node")
+        .locator("../..")
+        .getByTestId("select-input")
     ).toHaveValue("Architecture Team");
 
     // Is protected should be checked

--- a/frontend/app/tests/e2e/objects/object-metadata.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-metadata.spec.ts
@@ -28,20 +28,8 @@ test.describe("Object metadata", () => {
     await metadataTooltip.getByTestId("edit-metadata-button").click();
 
     // Owner should be empty
-    await expect(
-      page
-        .getByText("Owner Kind ?Parent ?Node")
-        .getByLabel("Kind")
-        .locator("../..")
-        .getByTestId("select-input")
-    ).toHaveValue("");
-    await expect(
-      page
-        .getByText("Owner Kind ?Parent ?Node")
-        .getByLabel("Node")
-        .locator("../..")
-        .getByTestId("select-input")
-    ).toHaveValue("");
+    await expect(page.getByTestId("select-input").nth(0)).toHaveValue("");
+    await expect(page.getByTestId("select-input").nth(2)).toHaveValue("");
 
     // Is visible should be checked
     await expect(page.getByLabel("is visible *")).toBeChecked();
@@ -80,20 +68,8 @@ test.describe("Object metadata", () => {
     await metadataTooltipUpdated.getByTestId("edit-metadata-button").click();
 
     // Source should be Account + Pop-Builder
-    await expect(
-      page
-        .getByText("Owner Kind ?Parent ?Node")
-        .getByLabel("Kind")
-        .locator("../..")
-        .getByTestId("select-input")
-    ).toHaveValue("Account");
-    await expect(
-      page
-        .getByText("Owner Kind ?Parent ?Node")
-        .getByLabel("Node")
-        .locator("../..")
-        .getByTestId("select-input")
-    ).toHaveValue("Architecture Team");
+    await expect(page.getByTestId("select-input").nth(0)).toHaveValue("Account");
+    await expect(page.getByTestId("select-input").nth(2)).toHaveValue("Architecture Team");
 
     // Is protected should be checked
     await expect(page.getByLabel("is protected *")).toBeChecked();

--- a/frontend/app/tests/e2e/objects/object-metadata.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-metadata.spec.ts
@@ -42,9 +42,9 @@ test.describe("Object metadata", () => {
     await page.getByLabel("is protected *").check();
 
     // Select Architecture team
-    await page.getByLabel("Owner").click();
+    await page.getByText("Owner Kind ?Parent ?Node").getByLabel("Kind").click();
     await page.getByRole("option", { name: "Account" }).click();
-    await page.getByTestId("select2step-2").getByTestId("select-open-option-button").nth(0).click();
+    await page.getByText("Owner Kind ?Parent ?Node").getByLabel("Node").click();
     await page.getByRole("option", { name: "Architecture Team" }).click();
 
     // Save

--- a/frontend/app/tests/e2e/resource-manager/resource-pool.spec.ts
+++ b/frontend/app/tests/e2e/resource-manager/resource-pool.spec.ts
@@ -37,9 +37,8 @@ test.describe("/resource-manager - Resource Manager", () => {
     await page.getByRole("option", { name: "10.0.0.0/16" }).click();
     await page.getByRole("option", { name: "10.1.0.0/16" }).click();
     await page.getByLabel("Resources *").click();
-    await page.getByTestId("select2step-1").getByTestId("select-open-option-button").click();
-    await page.getByRole("option", { name: "Namespace" }).click();
-    await page.getByTestId("select2step-2").getByTestId("select-open-option-button").click();
+
+    await page.getByLabel("Node").click();
     await page.getByRole("option", { name: "default" }).click();
     await page.getByRole("button", { name: "Save" }).click();
 

--- a/frontend/app/tests/e2e/tutorial/tutorial-2_data-lineage-and-metadata.spec.ts
+++ b/frontend/app/tests/e2e/tutorial/tutorial-2_data-lineage-and-metadata.spec.ts
@@ -27,9 +27,9 @@ test.describe("Getting started with Infrahub - Data lineage and metadata", () =>
 
     await test.step("Update Description attribute to make it protected", async () => {
       await page.getByTestId("edit-metadata-button").click();
-      await page.getByTestId("select2step-1").first().getByRole("button").click();
+      await page.getByLabel("Kind").first().click();
       await page.getByRole("option", { name: "Account" }).click();
-      await page.getByTestId("select2step-2").first().getByRole("button").click();
+      await page.getByLabel("Node").first().click();
       await page.getByRole("option", { name: "Admin" }).click();
       await page.getByLabel("is protected *").check();
       await saveScreenshotForDocs(page, "tutorial_4_metadata_edit");


### PR DESCRIPTION
Issue:
* https://github.com/opsmill/infrahub/issues/2050
* https://github.com/opsmill/infrahub/issues/3576
* https://github.com/opsmill/infrahub/issues/3584

Notes:
* Upgrades relationship fields and removes the select 2 steps usage
* If possible, a parent dropdown will allow users to filter nodes from a specific parent
  * for a regular relationship, if the kind is Parent
  * for a generic, if the kind selected has a relationship of kind Parent
    * if the kind selected doesn't allow a parent filter, the select will be disabled
* Adds tooltips for hierarchical dropdowns tips
* Adds prettier-eslint in dev dependencies for formatting purpose
* Aligns labels in forms

<img width="399" alt="Capture d’écran 2024-06-17 à 18 30 32" src="https://github.com/opsmill/infrahub/assets/16644715/680b3fb3-6f82-4f12-8b41-568cbf5b264d">
<img width="506" alt="Capture d’écran 2024-06-17 à 18 30 49" src="https://github.com/opsmill/infrahub/assets/16644715/83f1cbef-859c-4abf-8176-978fdf4df2a7">
<img width="504" alt="Capture d’écran 2024-06-17 à 18 31 02" src="https://github.com/opsmill/infrahub/assets/16644715/1b4105e1-40a1-447c-b635-32ff82632163">
