### PR TITLE
Fix sidebar to generate an index page for all tutorials

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -24,7 +24,13 @@ const sidebars: SidebarsConfig = {
       ],
     },
     {
-      'Tutorials': [
+      type: 'category',
+      label: 'Tutorials',
+      link: {
+        type: 'generated-index',
+        slug: 'tutorials'
+      },
+      items: [
         {
           type: 'category',
           label: 'Getting started',
@@ -36,7 +42,7 @@ const sidebars: SidebarsConfig = {
             'tutorials/getting-started/branches',
             'tutorials/getting-started/historical-data',
             'tutorials/getting-started/lineage-information',
-	    'tutorials/getting-started/resource-manager',
+            'tutorials/getting-started/resource-manager',
             'tutorials/getting-started/git-integration',
             'tutorials/getting-started/jinja2-integration',
             'tutorials/getting-started/custom-api-endpoint',


### PR DESCRIPTION
In #3674 it was identified that we had a dead link on the Infrahub frontpage. That PR was merged into `develop` to fix the link. This PR changes the generation of the tutorial part to instead generate an index page as we will probably have multiple tutorials in the future it's better if a link to /tutorial would show an index instead of a 404 page. It also fixes the issue for current users who try to follow the broken link.