### PR TITLE
Cypher relationship delete bugs

### DIFF
--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -416,7 +416,7 @@ class RelationshipDataDeleteQuery(RelationshipQuery):
 
         for prop_name, prop in self.data.properties.items():
             self.add_to_query(
-                "CREATE (prop_%s)-[rel_prop_%s:%s $rel_prop ]->(rl)" % (prop_name, prop_name, prop_name.upper()),
+                "CREATE (prop_%s)<-[rel_prop_%s:%s $rel_prop ]-(rl)" % (prop_name, prop_name, prop_name.upper()),
             )
             self.return_labels.append(f"rel_prop_{prop_name}")
 

--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -423,6 +423,7 @@ class RelationshipDataDeleteQuery(RelationshipQuery):
 
 class RelationshipDeleteQuery(RelationshipQuery):
     name = "relationship_delete"
+    insert_return = False
 
     type: QueryType = QueryType.WRITE
 
@@ -451,6 +452,27 @@ class RelationshipDeleteQuery(RelationshipQuery):
         MATCH (s:Node { uuid: $source_id })-[]-(rl:Relationship {uuid: $rel_id})-[]-(d:Node { uuid: $destination_id })
         CREATE (s)%s(rl)
         CREATE (rl)%s(d)
+        WITH rl
+        CALL {
+            WITH rl
+            MATCH (rl)-[edge:IS_VISIBLE]->(visible)
+            CREATE (rl)-[deleted_edge:IS_VISIBLE $rel_prop]->(visible)
+        }
+        CALL {
+            WITH rl
+            MATCH (rl)-[edge:IS_PROTECTED]->(protected)
+            CREATE (rl)-[deleted_edge:IS_PROTECTED $rel_prop]->(protected)
+        }
+        CALL {
+            WITH rl
+            MATCH (rl)-[edge:HAS_OWNER]->(owner_node)
+            CREATE (rl)-[deleted_edge:HAS_OWNER $rel_prop]->(owner_node)
+        }
+        CALL {
+            WITH rl
+            MATCH (rl)-[edge:HAS_SOURCE]->(source_node)
+            CREATE (rl)-[deleted_edge:HAS_SOURCE $rel_prop]->(source_node)
+        }
         """ % (
             r1,
             r2,
@@ -459,7 +481,6 @@ class RelationshipDeleteQuery(RelationshipQuery):
         self.params["at"] = self.at.to_string()
 
         self.add_to_query(query)
-        self.return_labels = ["s", "d", "rl", "r1", "r2"]
 
 
 class RelationshipGetPeerQuery(Query):

--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -423,7 +423,6 @@ class RelationshipDataDeleteQuery(RelationshipQuery):
 
 class RelationshipDeleteQuery(RelationshipQuery):
     name = "relationship_delete"
-    insert_return = False
 
     type: QueryType = QueryType.WRITE
 
@@ -479,6 +478,7 @@ class RelationshipDeleteQuery(RelationshipQuery):
         )
 
         self.params["at"] = self.at.to_string()
+        self.return_labels = ["rl"]
 
         self.add_to_query(query)
 

--- a/backend/tests/unit/core/test_relationship_query.py
+++ b/backend/tests/unit/core/test_relationship_query.py
@@ -337,7 +337,10 @@ async def test_relationship_delete_peer(db: InfrahubDatabase, default_branch, ta
         elif database_rel.status == "deleted":
             assert create_after < database_rel.changed_at < update_after
 
-async def test_relationship_update_with_delete_peer(db: InfrahubDatabase, default_branch, tag_blue_main: Node, tag_red_main: Node):
+
+async def test_relationship_update_with_delete_peer(
+    db: InfrahubDatabase, default_branch, tag_blue_main: Node, tag_red_main: Node
+):
     person = await Node.init(db=db, branch=default_branch, schema="TestPerson")
     await person.new(db=db, firstname="Kara", lastname="Thrace", tags=[tag_blue_main])
     create_before = Timestamp()

--- a/backend/tests/unit/graphql/test_mutation_relationship.py
+++ b/backend/tests/unit/graphql/test_mutation_relationship.py
@@ -540,7 +540,7 @@ async def test_relationship_groups_add_remove(db: InfrahubDatabase, default_bran
     assert result.errors is None
 
     nbr_rels_after = await count_relationships(db=db)
-    assert nbr_rels_after - nbr_rels_before == 4
+    assert nbr_rels_after - nbr_rels_before == 8
 
     group1 = await NodeManager.get_one(db=db, id=g1.id, branch=default_branch)
     members = await group1.members.get(db=db)
@@ -613,7 +613,7 @@ async def test_relationship_groups_add_remove(db: InfrahubDatabase, default_bran
 
     assert result.errors is None
     nbr_rels_after = await count_relationships(db=db)
-    assert nbr_rels_after - nbr_rels_before == 4
+    assert nbr_rels_after - nbr_rels_before == 8
 
     group1 = await NodeManager.get_one(db=db, id=g1.id, branch=default_branch)
     members = await group1.members.get(db=db)


### PR DESCRIPTION
fixes #3689 
fixes #3690 

pretty small updates and tests to fix the above bugs

- we weren't adding `status=deleted` edges for the `IS_VISIBLE` or `IS_PROTECTED` properties when deleting a relationship
- we were adding _backwards_ relationships when deleting relationships in some cases