### PR TITLE
Hierarchical dropdowns update to hide parent and node fields + use clear labels

### DIFF
--- a/frontend/app/src/components/display/question-mark.tsx
+++ b/frontend/app/src/components/display/question-mark.tsx
@@ -1,5 +1,4 @@
 import { Tooltip } from "@/components/ui/tooltip";
-import { Button } from "@/components/buttons/button-primitive";
 import { classNames } from "@/utils/common";
 
 type tQuestionMark = {
@@ -12,13 +11,14 @@ export const QuestionMark = ({ className, message }: tQuestionMark) => {
 
   return (
     <Tooltip content={message} enabled>
-      <Button
-        size="icon"
-        variant="outline"
-        className={classNames("h-4 w-4 p-2 text-[10px]", className)}
+      <div
+        className={classNames(
+          "rounded-full border bg-custom-white shadow-sm h-4 w-4 text-[10px] text-center cursor-help",
+          className
+        )}
         data-cy="question-mark">
         ?
-      </Button>
+      </div>
     </Tooltip>
   );
 };

--- a/frontend/app/src/components/display/question-mark.tsx
+++ b/frontend/app/src/components/display/question-mark.tsx
@@ -1,4 +1,5 @@
 import { Tooltip } from "@/components/ui/tooltip";
+import { Button } from "@/components/buttons/button-primitive";
 import { classNames } from "@/utils/common";
 
 type tQuestionMark = {
@@ -11,14 +12,13 @@ export const QuestionMark = ({ className, message }: tQuestionMark) => {
 
   return (
     <Tooltip content={message} enabled>
-      <div
-        className={classNames(
-          "rounded-full border bg-custom-white shadow-sm h-4 w-4 text-[10px] text-center cursor-help",
-          className
-        )}
+      <Button
+        size="icon"
+        variant="outline"
+        className={classNames("h-4 w-4 p-2 text-[10px]", className)}
         data-cy="question-mark">
         ?
-      </div>
+      </Button>
     </Tooltip>
   );
 };

--- a/frontend/app/src/components/form/fields/relationship.field.tsx
+++ b/frontend/app/src/components/form/fields/relationship.field.tsx
@@ -258,6 +258,7 @@ const RelationshipField = ({
                 <RelationshipInput
                   {...field}
                   {...props}
+                  peer={relationship?.peer}
                   parent={{ name: parentRelationship?.name, value: selectedParent?.id }}
                   multiple={relationship.cardinality === "many"}
                 />

--- a/frontend/app/src/components/form/fields/relationship.field.tsx
+++ b/frontend/app/src/components/form/fields/relationship.field.tsx
@@ -203,7 +203,7 @@ const RelationshipField = ({
             return (
               <div className="relative flex flex-col">
                 <LabelFormField
-                  label="Parent"
+                  label={parentRelationship?.label ?? "Parent"}
                   description="Parent to filter the available nodes"
                   unique={unique}
                   required={!!rules?.required}
@@ -237,7 +237,7 @@ const RelationshipField = ({
             <div className="relative flex flex-col mt-1">
               {parentRelationship && (
                 <LabelFormField
-                  label={"Object"}
+                  label={label}
                   unique={unique}
                   required={!!rules?.required}
                   description={description}
@@ -258,7 +258,6 @@ const RelationshipField = ({
                 <RelationshipInput
                   {...field}
                   {...props}
-                  peer={relationship?.peer}
                   parent={{ name: parentRelationship?.name, value: selectedParent?.id }}
                   multiple={relationship.cardinality === "many"}
                 />

--- a/frontend/app/src/components/form/fields/relationship.field.tsx
+++ b/frontend/app/src/components/form/fields/relationship.field.tsx
@@ -44,7 +44,7 @@ const RelationshipField = ({
       if (relatedSchema) {
         return {
           id: name,
-          name: relatedSchema.name,
+          name: relatedSchema.label || relatedSchema.name,
         };
       }
     });
@@ -55,6 +55,7 @@ const RelationshipField = ({
           id: option?.id,
         }))
       : [];
+    const selectedKindOption = kindOptions?.find((option) => option.id === selectedKind?.id);
 
     // Select the first option if the only available
     if (kindOptions?.length === 1 && !selectedKind) {
@@ -106,70 +107,74 @@ const RelationshipField = ({
           }}
         />
 
-        <FormField
-          key={`${name}_parent`}
-          name={name}
-          rules={rules}
-          defaultValue={defaultValue}
-          render={({ field }) => {
-            return (
-              <div className="relative flex flex-col mt-1">
-                <LabelFormField
-                  label={"Parent"}
-                  description="Parent to filter the available nodes"
-                  unique={unique}
-                  required={!!rules?.required}
-                  variant="small"
-                />
-
-                <FormInput>
-                  <RelationshipInput
-                    {...field}
-                    {...props}
-                    peer={parentRelationship?.peer}
-                    disabled={props.disabled || !parentRelationship || !selectedKind?.id}
-                    onChange={setSelectedParent}
-                    className="mt-1"
+        {selectedKind && (
+          <FormField
+            key={`${name}_parent`}
+            name={name}
+            rules={rules}
+            defaultValue={defaultValue}
+            render={({ field }) => {
+              return (
+                <div className="relative flex flex-col mt-1">
+                  <LabelFormField
+                    label={parentRelationship?.label ?? "Parent"}
+                    description={parentRelationship?.description}
+                    unique={unique}
+                    required={!!rules?.required}
+                    variant="small"
                   />
-                </FormInput>
-                <FormMessage />
-              </div>
-            );
-          }}
-        />
 
-        <FormField
-          key={`${name}_2`}
-          name={name}
-          rules={rules}
-          defaultValue={defaultValue}
-          render={({ field }) => {
-            return (
-              <div className="relative flex flex-col mt-1">
-                <LabelFormField
-                  label={"Node"}
-                  unique={unique}
-                  required={!!rules?.required}
-                  description={description}
-                  variant="small"
-                />
+                  <FormInput>
+                    <RelationshipInput
+                      {...field}
+                      {...props}
+                      peer={parentRelationship?.peer}
+                      disabled={props.disabled || !parentRelationship || !selectedKind?.id}
+                      onChange={setSelectedParent}
+                      className="mt-1"
+                    />
+                  </FormInput>
+                  <FormMessage />
+                </div>
+              );
+            }}
+          />
+        )}
 
-                <FormInput>
-                  <RelationshipInput
-                    {...field}
-                    {...props}
-                    peer={selectedKind?.id}
-                    parent={{ name: parentRelationship?.name, value: selectedParent?.id }}
-                    disabled={props.disabled || !selectedKind?.id}
-                    multiple={relationship.cardinality === "many"}
-                    className="mt-1"
+        {selectedKind && (
+          <FormField
+            key={`${name}_2`}
+            name={name}
+            rules={rules}
+            defaultValue={defaultValue}
+            render={({ field }) => {
+              return (
+                <div className="relative flex flex-col mt-1">
+                  <LabelFormField
+                    label={selectedKindOption?.name || "Node"}
+                    unique={unique}
+                    required={!!rules?.required}
+                    description={description}
+                    variant="small"
                   />
-                </FormInput>
-                <FormMessage />
-              </div>
-            );
-          }}
-        />
+
+                  <FormInput>
+                    <RelationshipInput
+                      {...field}
+                      {...props}
+                      peer={selectedKind?.id}
+                      parent={{ name: parentRelationship?.name, value: selectedParent?.id }}
+                      disabled={props.disabled || !selectedKind?.id}
+                      multiple={relationship.cardinality === "many"}
+                      className="mt-1"
+                    />
+                  </FormInput>
+                  <FormMessage />
+                </div>
+              );
+            }}
+          />
+        )}
       </div>
     );
   }

--- a/frontend/app/src/components/form/fields/relationship.field.tsx
+++ b/frontend/app/src/components/form/fields/relationship.field.tsx
@@ -131,7 +131,7 @@ const RelationshipField = ({
                       peer={parentRelationship?.peer}
                       disabled={props.disabled || !parentRelationship || !selectedKind?.id}
                       onChange={setSelectedParent}
-                      className="mt-1"
+                      className="mt-2"
                     />
                   </FormInput>
                   <FormMessage />
@@ -166,7 +166,7 @@ const RelationshipField = ({
                       parent={{ name: parentRelationship?.name, value: selectedParent?.id }}
                       disabled={props.disabled || !selectedKind?.id}
                       multiple={relationship.cardinality === "many"}
-                      className="mt-1"
+                      className="mt-2"
                     />
                   </FormInput>
                   <FormMessage />

--- a/frontend/app/tests/e2e/ipam/ip-namespace.spec.ts
+++ b/frontend/app/tests/e2e/ipam/ip-namespace.spec.ts
@@ -100,7 +100,7 @@ test.describe("/ipam - IP Namespace", () => {
     await test.step("create a prefix at top level", async () => {
       await page.getByTestId("create-object-button").click();
       await page.getByLabel("Prefix *").fill("11.0.0.0/8");
-      await page.getByText("IP Namespace Kind ?Parent ?Node").getByLabel("Node").click();
+      await page.getByText("IP Namespace Kind").getByLabel("IPAM Namespace").click();
       await page.getByRole("option", { name: "test-namespace" }).click();
       await page.getByRole("button", { name: "Save" }).click();
       await expect(page.getByText("IPPrefix created")).toBeVisible();
@@ -114,7 +114,7 @@ test.describe("/ipam - IP Namespace", () => {
     await test.step("create a children prefix", async () => {
       await page.getByTestId("create-object-button").click();
       await page.getByLabel("Prefix *").fill("11.0.0.0/16");
-      await page.getByText("IP Namespace Kind ?Parent ?Node").getByLabel("Node").click();
+      await page.getByText("IP Namespace Kind").getByLabel("IPAM Namespace").click();
       await page.getByRole("option", { name: "test-namespace" }).click();
       await page.getByRole("button", { name: "Save" }).click();
       await expect(page.getByText("IPPrefix created")).toBeVisible();
@@ -133,7 +133,7 @@ test.describe("/ipam - IP Namespace", () => {
     await test.step("create a prefix between a parent and its children", async () => {
       await page.getByTestId("create-object-button").click();
       await page.getByLabel("Prefix *").fill("11.0.0.0/10");
-      await page.getByText("IP Namespace Kind ?Parent ?Node").getByLabel("Node").click();
+      await page.getByText("IP Namespace Kind").getByLabel("IPAM Namespace").click();
       await page.getByRole("option", { name: "test-namespace" }).click();
       await page.getByRole("button", { name: "Save" }).click();
       await expect(page.getByText("IPPrefix created")).toBeVisible();

--- a/frontend/app/tests/e2e/objects/object-details.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-details.spec.ts
@@ -69,7 +69,7 @@ test.describe("/objects/:objectname/:objectid", () => {
         .getByText("Kind")
         .locator("../..")
         .getByTestId("select-input");
-      await expect(kindSelector).toHaveValue("CircuitEndpoint");
+      await expect(kindSelector).toHaveValue("Circuit Endpoint");
 
       const nodeSelector = page
         .getByTestId("side-panel-container")

--- a/frontend/app/tests/e2e/objects/object-details.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-details.spec.ts
@@ -73,7 +73,7 @@ test.describe("/objects/:objectname/:objectid", () => {
 
       const nodeSelector = page
         .getByTestId("side-panel-container")
-        .getByText("Node")
+        .getByText("Circuit Endpoint")
         .locator("../..")
         .getByTestId("select-input");
       await expect(nodeSelector).toHaveValue(/InfraCircuitEndpoint/g);

--- a/frontend/app/tests/e2e/objects/object-metadata.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-metadata.spec.ts
@@ -41,9 +41,9 @@ test.describe("Object metadata", () => {
     await page.getByLabel("is protected *").check();
 
     // Select Architecture team
-    await page.getByText("Owner Kind ?Parent ?Node").getByLabel("Kind").first().click();
+    await page.getByText("Owner Kind ?").getByLabel("Kind").first().click();
     await page.getByRole("option", { name: "Account" }).click();
-    await page.getByText("Owner Kind ?Parent ?Node").getByLabel("Node").click();
+    await page.getByText("Owner Kind ?").getByLabel("Node").click();
     await page.getByRole("option", { name: "Architecture Team" }).click();
 
     // Save

--- a/frontend/app/tests/e2e/objects/object-metadata.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-metadata.spec.ts
@@ -43,7 +43,7 @@ test.describe("Object metadata", () => {
     // Select Architecture team
     await page.getByText("Owner Kind ?").getByLabel("Kind").first().click();
     await page.getByRole("option", { name: "Account" }).click();
-    await page.getByText("Owner Kind ?").getByLabel("Node").click();
+    await page.getByText("Owner Kind ?").getByLabel("Account").click();
     await page.getByRole("option", { name: "Architecture Team" }).click();
 
     // Save

--- a/frontend/app/tests/e2e/resource-manager/resource-pool.spec.ts
+++ b/frontend/app/tests/e2e/resource-manager/resource-pool.spec.ts
@@ -38,7 +38,7 @@ test.describe("/resource-manager - Resource Manager", () => {
     await page.getByRole("option", { name: "10.1.0.0/16" }).click();
     await page.getByLabel("Resources *").click();
 
-    await page.getByLabel("Node").click();
+    await page.getByLabel("IPAM Namespace *").click();
     await page.getByRole("option", { name: "default" }).click();
     await page.getByRole("button", { name: "Save" }).click();
 

--- a/frontend/app/tests/e2e/tutorial/tutorial-2_data-lineage-and-metadata.spec.ts
+++ b/frontend/app/tests/e2e/tutorial/tutorial-2_data-lineage-and-metadata.spec.ts
@@ -29,7 +29,7 @@ test.describe("Getting started with Infrahub - Data lineage and metadata", () =>
       await page.getByTestId("edit-metadata-button").click();
       await page.getByLabel("Kind").first().click();
       await page.getByRole("option", { name: "Account" }).click();
-      await page.getByLabel("Node").first().click();
+      await page.getByLabel("Account").click();
       await page.getByRole("option", { name: "Admin" }).click();
       await page.getByLabel("is protected *").check();
       await saveScreenshotForDocs(page, "tutorial_4_metadata_edit");


### PR DESCRIPTION
* Labels are updated to define the parent filter and the peer name (for parent and node selects)
* Parent and node selects are now hidden by default
* For regular relationships, the labels are clear right away

<img width="1469" alt="Capture d’écran 2024-06-21 à 17 22 11" src="https://github.com/opsmill/infrahub/assets/16644715/1a1c2423-3153-4c15-ae8a-d9373b9ee616">
<img width="1469" alt="Capture d’écran 2024-06-21 à 17 22 17" src="https://github.com/opsmill/infrahub/assets/16644715/6b4b7446-6f42-4136-9c9b-53a84a607681">
<img width="1469" alt="Capture d’écran 2024-06-21 à 17 22 37" src="https://github.com/opsmill/infrahub/assets/16644715/394c3699-8c29-48eb-8746-b13602cb0e31">
