### PR TITLE
set branch for Nodes returned by NodeListGetInfoQuery

### DIFF
--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -890,7 +890,8 @@ class NodeManager:
 
             new_node_data_with_profile_overrides = profile_index.apply_profiles(new_node_data)
             node_class = identify_node_class(node=node)
-            item = await node_class.init(schema=node.schema, branch=branch, at=at, db=db)
+            node_branch = await registry.get_branch(db=db, branch=node.branch)
+            item = await node_class.init(schema=node.schema, branch=node_branch, at=at, db=db)
             await item.load(**new_node_data_with_profile_overrides, db=db)
 
             nodes[node_id] = item

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -638,7 +638,7 @@ class NodeListGetInfoQuery(Query):
                 node_uuid=result.get_node("n").get("uuid"),
                 profile_uuids=[str(puuid) for puuid in result.get("profile_uuids")],
                 updated_at=result.get_rel("rb").get("from"),
-                branch=self.branch.name,
+                branch=result.get_rel("rb").get("branch"),
                 labels=list(result.get_node("n").labels),
             )
 

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -632,13 +632,16 @@ class NodeListGetInfoQuery(Query):
 
         for result in self.get_results_group_by(("n", "uuid")):
             schema = find_node_schema(db=db, node=result.get_node("n"), branch=self.branch, duplicate=duplicate)
+            node_branch = self.branch
+            if self.branch_agnostic:
+                node_branch = result.get_rel("rb").get("branch")
             yield NodeToProcess(
                 schema=schema,
                 node_id=result.get_node("n").element_id,
                 node_uuid=result.get_node("n").get("uuid"),
                 profile_uuids=[str(puuid) for puuid in result.get("profile_uuids")],
                 updated_at=result.get_rel("rb").get("from"),
-                branch=result.get_rel("rb").get("branch"),
+                branch=node_branch,
                 labels=list(result.get_node("n").labels),
             )
 

--- a/backend/tests/unit/core/test_manager_node.py
+++ b/backend/tests/unit/core/test_manager_node.py
@@ -332,8 +332,8 @@ async def test_get_many_branch_agnostic(
         db=db, branch=branch, ids=[criticality_low.id, criticality_medium.id, new_crit.id]
     )
     assert len(node_map) == 3
-    assert node_map[criticality_low.id].get_branch_based_on_support_type().name == default_branch.name
-    assert node_map[criticality_medium.id].get_branch_based_on_support_type().name == default_branch.name
+    assert node_map[criticality_low.id].get_branch_based_on_support_type().name == branch.name
+    assert node_map[criticality_medium.id].get_branch_based_on_support_type().name == branch.name
     assert node_map[new_crit.id].get_branch_based_on_support_type().name == branch.name
 
 


### PR DESCRIPTION
fixes #3719 

dynamically set `branch` for nodes returned by `NodeListGetInfoQuery` where `branch_agnostic=True` instead of assuming that every node returned is on the same `branch` as the query

the `branch` of a node is determined by the `branch` value of its `IS_PART_OF` edge to the Root node in the database