### PR TITLE
Improve error message on repo config read failure

### DIFF
--- a/python_sdk/infrahub_sdk/ctl/exceptions.py
+++ b/python_sdk/infrahub_sdk/ctl/exceptions.py
@@ -10,5 +10,5 @@ class QueryNotFoundError(Error):
 
 class FileNotValidError(Error):
     def __init__(self, name: str, message: str = ""):
-        self.message = message or f"Unable to access the file '{name}'."
+        self.message = message or f"Cannot parse '{name}' content."
         super().__init__(self.message)

--- a/python_sdk/infrahub_sdk/ctl/repository.py
+++ b/python_sdk/infrahub_sdk/ctl/repository.py
@@ -14,10 +14,10 @@ def get_repository_config(repo_config_file: Path) -> InfrahubRepositoryConfig:
     try:
         config_file_data = load_repository_config_file(repo_config_file)
     except FileNotFoundError as exc:
-        console.print(f"[red]{exc}")
+        console.print(f"[red]File not found {exc}")
         raise typer.Exit(1) from exc
     except FileNotValidError as exc:
-        console.print(f"[red]{exc}")
+        console.print(f"[red]{exc.message}")
         raise typer.Exit(1) from exc
 
     try:


### PR DESCRIPTION
When the repository config file was not found, the displayed error was just the name of the file without any context. This was very confusing for users.

With this small fixes we are now providing a more user focused error message.