### PR TITLE
FIlters update removes pagination offset

### DIFF
--- a/frontend/app/src/components/filters/filters.tsx
+++ b/frontend/app/src/components/filters/filters.tsx
@@ -8,6 +8,7 @@ import { Icon } from "@iconify-icon/react";
 import { useAtomValue } from "jotai";
 import { useState } from "react";
 import ObjectForm from "@/components/form/object-form";
+import usePagination from "@/hooks/usePagination";
 
 type tFilters = {
   schema: any;
@@ -45,10 +46,16 @@ export const Filters = (props: tFilters) => {
 
   const branch = useAtomValue(currentBranchAtom);
   const [filters, setFilters] = useFilters();
+  const [pagination, setPagination] = usePagination();
   const [showFilters, setShowFilters] = useState(false);
 
   const removeFilters = () => {
     const newFilters = filters.filter((filter) => SEARCH_FILTERS.includes(filter.name));
+
+    setPagination({
+      ...pagination,
+      offset: 0,
+    });
 
     setFilters(newFilters);
   };
@@ -57,6 +64,11 @@ export const Filters = (props: tFilters) => {
 
   const handleSubmit = (data: any) => {
     const newFilters = constructNewFilters(data) as Filter[];
+
+    setPagination({
+      ...pagination,
+      offset: 0,
+    });
 
     setFilters([...filters, ...newFilters]);
 

--- a/frontend/app/src/components/filters/filters.tsx
+++ b/frontend/app/src/components/filters/filters.tsx
@@ -77,6 +77,25 @@ export const Filters = (props: tFilters) => {
 
   const currentFilters = filters.filter((filter) => !SEARCH_FILTERS.includes(filter.name));
 
+  const currentFiltersObject = filters
+    .map((filter) => {
+      // Get filer key name
+      const key = filter.name.split("__")[0];
+
+      return {
+        [key]: {
+          value: filter.value,
+        },
+      };
+    })
+    .reduce(
+      (acc, filter) => ({
+        ...acc,
+        ...filter,
+      }),
+      {}
+    );
+
   return (
     <div className="flex flex-1">
       <div className="flex flex-1 items-center">
@@ -135,6 +154,7 @@ export const Filters = (props: tFilters) => {
           kind={schema?.kind}
           isFilterForm
           submitLabel="Apply filters"
+          currentObject={currentFiltersObject}
         />
       </SlideOver>
     </div>

--- a/frontend/app/src/components/filters/filters.tsx
+++ b/frontend/app/src/components/filters/filters.tsx
@@ -82,6 +82,14 @@ export const Filters = (props: tFilters) => {
       // Get filer key name
       const key = filter.name.split("__")[0];
 
+      if (Array.isArray(filter.value)) {
+        return {
+          [key]: {
+            edges: filter.value.map((value) => ({ node: value })),
+          },
+        };
+      }
+
       return {
         [key]: {
           value: filter.value,

--- a/frontend/app/src/components/form/object-form.tsx
+++ b/frontend/app/src/components/form/object-form.tsx
@@ -27,6 +27,7 @@ import DynamicForm, { DynamicFormProps } from "@/components/form/dynamic-form";
 import { AttributeType } from "@/utils/getObjectItemDisplayValue";
 import { useAuth } from "@/hooks/useAuth";
 import { useObjectItems } from "@/hooks/useObjectItems";
+import useFilters from "@/hooks/useFilters";
 
 interface ObjectFormProps extends Omit<DynamicFormProps, "fields"> {
   kind: string;
@@ -174,6 +175,7 @@ const NodeForm = ({
 }: NodeFormProps) => {
   const branch = useAtomValue(currentBranchAtom);
   const date = useAtomValue(datetimeAtom);
+  const [filters] = useFilters();
   const { data, permissions } = useAuth();
 
   const fields = getFormFieldsFromSchema({
@@ -182,6 +184,7 @@ const NodeForm = ({
     initialObject: currentObject,
     user: { ...data, permissions },
     isFilterForm,
+    filters,
   });
 
   async function onSubmit(data: any) {

--- a/frontend/app/src/components/form/utils.ts
+++ b/frontend/app/src/components/form/utils.ts
@@ -50,9 +50,12 @@ export const getFormFieldsFromSchema = ({
     const basicFomFieldProps = {
       name: attribute.name,
       label: attribute.label ?? undefined,
-      defaultValue: isFilterForm
-        ? null
-        : getObjectDefaultValue({ fieldSchema: attribute, initialObject, profile }),
+      defaultValue: getObjectDefaultValue({
+        fieldSchema: attribute,
+        initialObject,
+        profile,
+        isFilterForm,
+      }),
       description: attribute.description ?? undefined,
       disabled,
       type: attribute.kind as Exclude<SchemaAttributeType, "Dropdown">,
@@ -133,16 +136,22 @@ export type GetObjectDefaultValue = {
   fieldSchema: GetObjectDefaultValueFromSchema;
   initialObject?: Record<string, AttributeType>;
   profile?: Record<string, AttributeType>;
+  isFilterForm?: boolean;
 };
 
 export const getObjectDefaultValue = ({
   fieldSchema,
   initialObject,
   profile,
+  isFilterForm,
 }: GetObjectDefaultValue) => {
   const currentFieldValue = initialObject?.[fieldSchema.name]?.value;
   const defaultValueFromProfile = profile?.[fieldSchema.name]?.value;
   const defaultValueFromSchema = getDefaultValueFromSchema(fieldSchema);
+
+  if (isFilterForm) {
+    return currentFieldValue ?? null;
+  }
 
   return currentFieldValue ?? defaultValueFromProfile ?? defaultValueFromSchema ?? null;
 };

--- a/frontend/app/src/components/form/utils.ts
+++ b/frontend/app/src/components/form/utils.ts
@@ -21,6 +21,7 @@ type GetFormFieldsFromSchema = {
   initialObject?: Record<string, AttributeType>;
   user?: any;
   isFilterForm?: boolean;
+  filters?: Array<any>;
 };
 
 export const getFormFieldsFromSchema = ({
@@ -29,6 +30,7 @@ export const getFormFieldsFromSchema = ({
   initialObject,
   user,
   isFilterForm,
+  filters,
 }: GetFormFieldsFromSchema): Array<DynamicFieldProps> => {
   const unorderedFields = [
     ...(schema.attributes ?? []),
@@ -114,12 +116,15 @@ export const getFormFieldsFromSchema = ({
 
   // Allow kind filter for generic
   if (isFilterForm && schema.used_by?.length) {
+    const kindFilter = filters?.find((filter) => filter.name == "kind__value");
+
     return [
       {
         name: "kind",
         label: "Kind",
         description: "Select a kind to filter nodes",
         type: "Dropdown",
+        defaultValue: kindFilter?.value,
         items: schema.used_by.map((kind) => ({
           id: kind,
           name: kind,

--- a/frontend/app/src/pages/objects/object-items.tsx
+++ b/frontend/app/src/pages/objects/object-items.tsx
@@ -5,21 +5,15 @@ import ErrorScreen from "@/screens/errors/error-screen";
 import ObjectItems from "@/screens/object-items/object-items-paginated";
 import { genericsState, profilesAtom, schemaState } from "@/state/atoms/schema.atom";
 import Content from "@/screens/layout/content";
-import useFilters from "@/hooks/useFilters";
 
 export function ObjectItemsPage() {
   const { objectKind } = useParams();
-  const [filters] = useFilters();
-
-  const kindFilter = filters?.find((filter) => filter.name == "kind__value");
 
   const nodes = useAtomValue(schemaState);
   const generics = useAtomValue(genericsState);
   const profiles = useAtomValue(profilesAtom);
 
-  const requestedKind = kindFilter?.value ?? objectKind;
-
-  const schema = [...nodes, ...generics, ...profiles].find(({ kind }) => kind === requestedKind);
+  const schema = [...nodes, ...generics, ...profiles].find(({ kind }) => kind === objectKind);
 
   if (!schema) return <ErrorScreen message={`Object ${objectKind} not found.`} />;
 

--- a/frontend/app/src/screens/object-items/object-items-paginated.tsx
+++ b/frontend/app/src/screens/object-items/object-items-paginated.tsx
@@ -61,6 +61,8 @@ export default function ObjectItems({
   const [deleteModal, setDeleteModal] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
+  const kindFilter = filters?.find((filter) => filter.name == "kind__value");
+
   if (schema && MENU_EXCLUDELIST.includes(schema.kind as string) && !preventBlock) {
     return <Navigate to="/" />;
   }
@@ -70,7 +72,7 @@ export default function ObjectItems({
 
   const { loading, error, data = {} } = useObjectItems(schema, filters);
 
-  const result = data && schema?.kind ? data[schema?.kind] ?? {} : {};
+  const result = data && schema?.kind ? data[kindFilter?.value || schema?.kind] ?? {} : {};
 
   const { count = "...", edges } = result;
 

--- a/frontend/app/src/screens/objects/object-header.tsx
+++ b/frontend/app/src/screens/objects/object-header.tsx
@@ -28,8 +28,9 @@ const ObjectHeader = ({ schema, objectId }: ObjectHeaderProps) => {
 const ObjectItemsHeader = ({ schema }: ObjectHeaderProps) => {
   const [filters] = useFilters();
   const { data, loading, error } = useObjectItems(schema, filters);
+  const kindFilter = filters?.find((filter) => filter.name == "kind__value");
 
-  const schemaKind = schema.kind as string;
+  const schemaKind = kindFilter?.value || (schema.kind as string);
   const isProfile = schema.namespace === "Profile" || schemaKind === PROFILE_KIND;
   const breadcrumbModelLabel = isProfile ? "All Profiles" : schema.label || schema.name;
 
@@ -59,6 +60,7 @@ const ObjectItemsHeader = ({ schema }: ObjectHeaderProps) => {
     </Content.Title>
   );
 };
+
 const ObjectDetailsHeader = ({ schema, objectId }: ObjectHeaderProps & { objectId: string }) => {
   const { data, loading, error } = useObjectDetails(schema, objectId);
 

--- a/frontend/app/tests/e2e/objects/object-filters.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-filters.spec.ts
@@ -17,26 +17,45 @@ test.describe("Object filters", () => {
     });
 
     await test.step("start filtering objects", async () => {
-      await page.getByTestId("apply-filters").click();
-      await page
-        .getByTestId("side-panel-container")
-        .getByText("Status")
-        .locator("../..")
-        .getByTestId("select-open-option-button")
-        .click();
-      await page.getByRole("option", { name: "Provisioning In the process" }).click();
+      await test.step("select filters", async () => {
+        await page.getByTestId("apply-filters").click();
+        await page
+          .getByTestId("side-panel-container")
+          .getByText("Status")
+          .locator("../..")
+          .getByTestId("select-open-option-button")
+          .click();
+        await page.getByRole("option", { name: "Provisioning In the process" }).click();
 
-      const tagsMultiSelectOpenButton = page
-        .getByTestId("side-panel-container")
-        .getByText("Tags")
-        .locator("../..")
-        .getByTestId("select-open-option-button");
-      await tagsMultiSelectOpenButton.click();
+        const tagsMultiSelectOpenButton = page
+          .getByTestId("side-panel-container")
+          .getByText("Tags")
+          .locator("../..")
+          .getByTestId("select-open-option-button");
+        await tagsMultiSelectOpenButton.click();
 
-      await page.getByTestId("side-panel-container").getByText("red").click();
+        await page.getByTestId("side-panel-container").getByText("red").click();
 
-      // Closes the multiselect
-      await tagsMultiSelectOpenButton.click();
+        // Closes the multiselect
+        await tagsMultiSelectOpenButton.click();
+
+        await page.getByRole("button", { name: "Apply filters" }).scrollIntoViewIfNeeded();
+        await page.getByRole("button", { name: "Apply filters" }).click();
+      });
+
+      await test.step("verify filter initial value", async () => {
+        await page.getByTestId("apply-filters").click();
+
+        await expect(
+          page
+            .getByTestId("side-panel-container")
+            .getByText("Tags")
+            .locator("../..")
+            .getByTestId("select-input")
+        ).toHaveValue("Provisioning In the process");
+      });
+
+      await expect(page.locator("form")).toContainText("red");
 
       await page.getByRole("button", { name: "Apply filters" }).scrollIntoViewIfNeeded();
       await page.getByRole("button", { name: "Apply filters" }).click();
@@ -95,11 +114,19 @@ test.describe("Object filters", () => {
     const kindSelector = page
       .getByTestId("side-panel-container")
       .getByText("Kind")
-      .locator("../..")
-      .getByTestId("select-open-option-button");
-    await kindSelector.click();
-    await page.getByRole("option", { name: "InfraInterfaceL2", exact: true }).click();
-    await page.getByRole("button", { name: "Apply filters" }).click();
-    await expect(page.getByRole("main")).toContainText("Showing 1 to 10 of 510 results");
+      .locator("../..");
+
+    await test.step("filter objects", async () => {
+      await kindSelector.getByTestId("select-open-option-button").click();
+      await page.getByRole("option", { name: "InfraInterfaceL2", exact: true }).click();
+      await page.getByRole("button", { name: "Apply filters" }).click();
+      await expect(page.getByRole("main")).toContainText("Showing 1 to 10 of 510 results");
+    });
+
+    await test.step("verify filter initial value", async () => {
+      await page.getByTestId("apply-filters").click();
+      await kindSelector.getByTestId("select-input");
+      await expect(kindSelector.getByTestId("select-input")).toHaveValue("InfraInterfaceL2");
+    });
   });
 });

--- a/frontend/app/tests/e2e/objects/object-filters.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-filters.spec.ts
@@ -49,10 +49,10 @@ test.describe("Object filters", () => {
         await expect(
           page
             .getByTestId("side-panel-container")
-            .getByText("Tags")
+            .getByText("Status")
             .locator("../..")
             .getByTestId("select-input")
-        ).toHaveValue("Provisioning In the process");
+        ).toHaveValue("Provisioning");
       });
 
       await expect(page.locator("form")).toContainText("red");


### PR DESCRIPTION
Issue: https://github.com/opsmill/infrahub/issues/3726

When updating filters, the pagination offset is set to 0 so we can go back on the first page (since the pagination won't be the same after the filters update)

It also fixes initial values in filters and updates tests