### PR TITLE
Fix construct path for path that already contains qsp

### DIFF
--- a/frontend/app/src/utils/fetch.ts
+++ b/frontend/app/src/utils/fetch.ts
@@ -83,6 +83,10 @@ export const constructPath = (
   // Prevent having a trailing '?'
   if (!newURLSearchParams.toString()) return path;
 
+  if (path.includes("?")) {
+    return `${path}&${newURLSearchParams.toString()}`;
+  }
+
   return `${path}?${newURLSearchParams.toString()}`;
 };
 


### PR DESCRIPTION
Issue: https://github.com/opsmill/infrahub/issues/3745

Fixes the construct path function to handle path that already contains QSP