### PR TITLE
fix(backend): various perf optimizations

### DIFF
--- a/backend/infrahub/core/schema/attribute_schema.py
+++ b/backend/infrahub/core/schema/attribute_schema.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
 class AttributeSchema(GeneratedAttributeSchema):
     _sort_by: list[str] = ["name"]
+    _enum_class: Optional[type[enum.Enum]] = None
 
     @property
     def is_attribute(self) -> bool:
@@ -65,7 +66,9 @@ class AttributeSchema(GeneratedAttributeSchema):
     def get_enum_class(self) -> type[enum.Enum]:
         if not self.enum:
             raise ValueError(f"{self.name} is not an Enum")
-        return generate_python_enum(name=f"{self.name.title()}Enum", options=self.enum)
+        if not self._enum_class:
+            self._enum_class = generate_python_enum(name=f"{self.name.title()}Enum", options=self.enum)
+        return self._enum_class
 
     def convert_value_to_enum(self, value: Any) -> Optional[enum.Enum]:
         if isinstance(value, enum.Enum) or value is None:

--- a/python_sdk/infrahub_sdk/uuidt.py
+++ b/python_sdk/infrahub_sdk/uuidt.py
@@ -12,6 +12,8 @@ from infrahub_sdk.utils import base16encode
 BASE = 16
 DIVISOR = BASE - 1
 CHARACTERS = list("0123456789abcdefghijklmnopqrstuvwxyz")[:BASE]
+HOSTNAME = socket.gethostname()
+DEFAULT_NAMESPACE = str(Path(__file__).parent.resolve())
 
 # Code inspired from https://github.com/isaacharrisholt/uuidt
 
@@ -39,9 +41,9 @@ class UUIDT:
         hostname: Optional[str] = None,
         random_chars: Optional[str] = None,
     ):
-        self.namespace = namespace or str(Path(__file__).parent.resolve())
+        self.namespace = namespace or DEFAULT_NAMESPACE
         self.timestamp = timestamp or time.time_ns()
-        self.hostname = hostname or socket.gethostname()
+        self.hostname = hostname or HOSTNAME
         self.random_chars = random_chars or "".join(random.choices(CHARACTERS, k=8))
 
     def __str__(self) -> str:


### PR DESCRIPTION
This should improve read paths when using the following query against the demo data
We should actually run this kind of query during the CI benchmark step but that requires loading the demo data...

```
query {
  InfraDevice {
    edges {
      node {
        name {
          value
        }
        interfaces {
          edges {
            node {
              name {
                value
              }
            }
          }
        }
      }
    }
  }
}
```