### PR TITLE
Add decorator to handle exceptions for commands

### DIFF
--- a/python_sdk/infrahub_sdk/client.py
+++ b/python_sdk/infrahub_sdk/client.py
@@ -622,11 +622,7 @@ class InfrahubClient(BaseClient):
 
     @handle_relogin
     async def _post(
-        self,
-        url: str,
-        payload: dict,
-        headers: Optional[dict] = None,
-        timeout: Optional[int] = None,
+        self, url: str, payload: dict, headers: Optional[dict] = None, timeout: Optional[int] = None
     ) -> httpx.Response:
         """Execute a HTTP POST with HTTPX.
 
@@ -1607,11 +1603,7 @@ class InfrahubClientSync(BaseClient):
 
     @handle_relogin_sync
     def _post(
-        self,
-        url: str,
-        payload: dict,
-        headers: Optional[dict] = None,
-        timeout: Optional[int] = None,
+        self, url: str, payload: dict, headers: Optional[dict] = None, timeout: Optional[int] = None
     ) -> httpx.Response:
         """Execute a HTTP POST with HTTPX.
 

--- a/python_sdk/infrahub_sdk/ctl/check.py
+++ b/python_sdk/infrahub_sdk/ctl/check.py
@@ -17,10 +17,11 @@ from infrahub_sdk.ctl import config
 from infrahub_sdk.ctl.client import initialize_client
 from infrahub_sdk.ctl.exceptions import QueryNotFoundError
 from infrahub_sdk.ctl.repository import get_repository_config
-from infrahub_sdk.ctl.utils import execute_graphql_query
+from infrahub_sdk.ctl.utils import catch_exception, execute_graphql_query
 from infrahub_sdk.schema import InfrahubCheckDefinitionConfig, InfrahubRepositoryConfig
 
 app = typer.Typer()
+console = Console()
 
 
 @dataclass
@@ -41,6 +42,7 @@ def callback() -> None:
 
 
 @app.command()
+@catch_exception(console=console)
 def run(
     *,
     path: str,
@@ -56,8 +58,6 @@ def run(
     log_level = "DEBUG" if debug else "INFO"
     FORMAT = "%(message)s"
     logging.basicConfig(level=log_level, format=FORMAT, datefmt="[%X]", handlers=[RichHandler()])
-
-    console = Console()
 
     repository_config = get_repository_config(Path(config.INFRAHUB_REPO_CONFIG_FILE))
 
@@ -231,7 +231,6 @@ def get_modules(check_definitions: list[InfrahubCheckDefinitionConfig]) -> list[
 
 
 def list_checks(repository_config: InfrahubRepositoryConfig) -> None:
-    console = Console()
     console.print(f"Python checks defined in repository: {len(repository_config.check_definitions)}")
 
     for check in repository_config.check_definitions:

--- a/python_sdk/infrahub_sdk/ctl/cli_commands.py
+++ b/python_sdk/infrahub_sdk/ctl/cli_commands.py
@@ -9,7 +9,6 @@ from typing import Any, Callable, Optional, Union
 import jinja2
 import typer
 import ujson
-from httpx import HTTPError
 from rich.console import Console
 from rich.logging import RichHandler
 from rich.traceback import Traceback
@@ -30,13 +29,7 @@ from infrahub_sdk.ctl.schema import app as schema
 from infrahub_sdk.ctl.transform import list_transforms
 from infrahub_sdk.ctl.utils import catch_exception, execute_graphql_query, parse_cli_vars
 from infrahub_sdk.ctl.validate import app as validate_app
-from infrahub_sdk.exceptions import (
-    AuthenticationError,
-    GraphQLError,
-    InfrahubTransformNotFoundError,
-    ServerNotReachableError,
-    ServerNotResponsiveError,
-)
+from infrahub_sdk.exceptions import GraphQLError, InfrahubTransformNotFoundError
 from infrahub_sdk.jinja2 import identify_faulty_jinja_code
 from infrahub_sdk.schema import AttributeSchema, GenericSchema, NodeSchema, RelationshipSchema
 from infrahub_sdk.transforms import get_transform_class_instance
@@ -58,6 +51,7 @@ console = Console()
 
 
 @app.command(name="check")
+@catch_exception(console=console)
 def check(
     check_name: str = typer.Argument(default="", help="Name of the Python check"),
     branch: Optional[str] = None,
@@ -85,6 +79,7 @@ def check(
 
 
 @app.command(name="generator")
+@catch_exception(console=console)
 async def generator(
     generator_name: str = typer.Argument(default="", help="Name of the Generator"),
     branch: Optional[str] = None,
@@ -108,6 +103,7 @@ async def generator(
 
 
 @app.command(name="run")
+@catch_exception(console=console)
 async def run(
     script: Path,
     method: str = "run",
@@ -215,6 +211,7 @@ def _run_transform(query: str, variables: dict[str, Any], transformer: Callable,
 
 
 @app.command(name="render")
+@catch_exception(console=console)
 def render(
     transform_name: str = typer.Argument(default="", help="Name of the Python transformation", show_default=False),
     variables: Optional[list[str]] = typer.Argument(
@@ -252,6 +249,7 @@ def render(
 
 
 @app.command(name="transform")
+@catch_exception(console=console)
 def transform(
     transform_name: str = typer.Argument(default="", help="Name of the Python transformation", show_default=False),
     variables: Optional[list[str]] = typer.Argument(
@@ -300,6 +298,7 @@ def transform(
 
 
 @app.command(name="protocols")
+@catch_exception(console=console)
 def protocols(  # noqa: PLR0915
     branch: str = typer.Option(None, help="Branch of schema to export Python protocols for."),
     _: str = CONFIG_PARAM,
@@ -412,7 +411,7 @@ def protocols(  # noqa: PLR0915
 
 
 @app.command(name="version")
-@catch_exception((AuthenticationError, HTTPError, ServerNotReachableError, ServerNotResponsiveError), console)
+@catch_exception(console=console)
 def version(_: str = CONFIG_PARAM):
     """Display the version of Infrahub and the version of the Python SDK in use."""
 

--- a/python_sdk/infrahub_sdk/ctl/parameters.py
+++ b/python_sdk/infrahub_sdk/ctl/parameters.py
@@ -10,8 +10,5 @@ def load_configuration(value: str) -> str:
 
 
 CONFIG_PARAM = typer.Option(
-    config.DEFAULT_CONFIG_FILE,
-    "--config-file",
-    envvar=config.ENVVAR_CONFIG_FILE,
-    callback=load_configuration,
+    config.DEFAULT_CONFIG_FILE, "--config-file", envvar=config.ENVVAR_CONFIG_FILE, callback=load_configuration
 )

--- a/python_sdk/infrahub_sdk/ctl/schema.py
+++ b/python_sdk/infrahub_sdk/ctl/schema.py
@@ -12,7 +12,7 @@ from infrahub_sdk import InfrahubClient
 from infrahub_sdk.async_typer import AsyncTyper
 from infrahub_sdk.ctl.client import initialize_client
 from infrahub_sdk.ctl.exceptions import FileNotValidError
-from infrahub_sdk.ctl.utils import init_logging
+from infrahub_sdk.ctl.utils import catch_exception, init_logging
 from infrahub_sdk.queries import SCHEMA_HASH_SYNC_STATUS
 from infrahub_sdk.utils import find_files
 from infrahub_sdk.yaml import SchemaFile
@@ -20,6 +20,7 @@ from infrahub_sdk.yaml import SchemaFile
 from .parameters import CONFIG_PARAM
 
 app = AsyncTyper()
+console = Console()
 
 
 @app.callback()
@@ -132,6 +133,7 @@ def get_node(schemas_data: list[dict], schema_index: int, node_index: int) -> Op
 
 
 @app.command()
+@catch_exception(console=console)
 async def load(
     schemas: list[Path],
     debug: bool = False,
@@ -142,8 +144,6 @@ async def load(
     """Load one or multiple schema files into Infrahub."""
 
     init_logging(debug=debug)
-
-    console = Console()
 
     schemas_data = load_schemas_from_disk_and_exit(console=console, schemas=schemas)
     schema_definition = "schema" if len(schemas_data) == 1 else "schemas"
@@ -184,6 +184,7 @@ async def load(
 
 
 @app.command()
+@catch_exception(console=console)
 async def check(
     schemas: list[Path],
     debug: bool = False,
@@ -193,8 +194,6 @@ async def check(
     """Check if schema files are valid and what would be the impact of loading them with Infrahub."""
 
     init_logging(debug=debug)
-
-    console = Console()
 
     schemas_data = load_schemas_from_disk_and_exit(console=console, schemas=schemas)
     client = await initialize_client()

--- a/python_sdk/infrahub_sdk/ctl/schema.py
+++ b/python_sdk/infrahub_sdk/ctl/schema.py
@@ -49,7 +49,7 @@ def load_schemas_from_disk(schemas: list[Path]) -> list[SchemaFile]:
     return schemas_data
 
 
-def load_schemas_from_disk_and_exit(schemas: list[Path], console: Console):
+def load_schemas_from_disk_and_exit(schemas: list[Path]):
     has_error = False
     try:
         schemas_data = load_schemas_from_disk(schemas=schemas)
@@ -69,7 +69,7 @@ def load_schemas_from_disk_and_exit(schemas: list[Path], console: Console):
     return schemas_data
 
 
-def validate_schema_content_and_exit(client: InfrahubClient, console: Console, schemas: list[SchemaFile]) -> None:
+def validate_schema_content_and_exit(client: InfrahubClient, schemas: list[SchemaFile]) -> None:
     has_error: bool = False
     for schema_file in schemas:
         try:
@@ -85,10 +85,10 @@ def validate_schema_content_and_exit(client: InfrahubClient, console: Console, s
         raise typer.Exit(2)
 
 
-def display_schema_load_errors(console: Console, response: dict[str, Any], schemas_data: list[dict]) -> None:
+def display_schema_load_errors(response: dict[str, Any], schemas_data: list[dict]) -> None:
     console.print("[red]Unable to load the schema:")
     if "detail" not in response:
-        handle_non_detail_errors(console=console, response=response)
+        handle_non_detail_errors(response=response)
         return
 
     for error in response["detail"]:
@@ -112,7 +112,7 @@ def display_schema_load_errors(console: Console, response: dict[str, Any], schem
         console.print(f"  Node: {node.get('namespace', None)}{node.get('name', None)} | {error_message}")
 
 
-def handle_non_detail_errors(console: Console, response: dict[str, Any]) -> None:
+def handle_non_detail_errors(response: dict[str, Any]) -> None:
     if "error" in response:
         console.print(f"  {response.get('error')}")
     elif "errors" in response:
@@ -145,17 +145,17 @@ async def load(
 
     init_logging(debug=debug)
 
-    schemas_data = load_schemas_from_disk_and_exit(console=console, schemas=schemas)
+    schemas_data = load_schemas_from_disk_and_exit(schemas=schemas)
     schema_definition = "schema" if len(schemas_data) == 1 else "schemas"
     client = await initialize_client()
-    validate_schema_content_and_exit(console=console, client=client, schemas=schemas_data)
+    validate_schema_content_and_exit(client=client, schemas=schemas_data)
 
     start_time = time.time()
     response = await client.schema.load(schemas=[item.content for item in schemas_data], branch=branch)
     loading_time = time.time() - start_time
 
     if response.errors:
-        display_schema_load_errors(console=console, response=response.errors, schemas_data=schemas_data)
+        display_schema_load_errors(response=response.errors, schemas_data=schemas_data)
         raise typer.Exit(1)
 
     if response.schema_updated:
@@ -195,14 +195,14 @@ async def check(
 
     init_logging(debug=debug)
 
-    schemas_data = load_schemas_from_disk_and_exit(console=console, schemas=schemas)
+    schemas_data = load_schemas_from_disk_and_exit(schemas=schemas)
     client = await initialize_client()
-    validate_schema_content_and_exit(console=console, client=client, schemas=schemas_data)
+    validate_schema_content_and_exit(client=client, schemas=schemas_data)
 
     success, response = await client.schema.check(schemas=[item.content for item in schemas_data], branch=branch)
 
     if not success:
-        display_schema_load_errors(console=console, response=response, schemas_data=schemas_data)
+        display_schema_load_errors(response=response, schemas_data=schemas_data)
     else:
         for schema_file in schemas_data:
             console.print(f"[green] schema '{schema_file.location}' is Valid!")

--- a/python_sdk/infrahub_sdk/ctl/utils.py
+++ b/python_sdk/infrahub_sdk/ctl/utils.py
@@ -46,7 +46,7 @@ def catch_exception(
         if asyncio.iscoroutinefunction(func):
 
             @wraps(func)
-            async def wrapper(*args: Any, **kwargs: Any):
+            async def async_wrapper(*args: Any, **kwargs: Any):
                 try:
                     return await func(*args, **kwargs)
                 except AuthenticationError as exc:
@@ -68,7 +68,7 @@ def catch_exception(
                     console.print(f"[red]{str(exc)}")
                     raise typer.Exit(code=exit_code)
 
-            return wrapper
+            return async_wrapper
 
         @wraps(func)
         def wrapper(*args: Any, **kwargs: Any):

--- a/python_sdk/infrahub_sdk/ctl/utils.py
+++ b/python_sdk/infrahub_sdk/ctl/utils.py
@@ -35,12 +35,14 @@ def init_logging(debug: bool = False) -> None:
     logging.getLogger("infrahubctl")
 
 
-def catch_exception(
+def catch_exception(  # noqa: C901
     which_exception: Union[type[Exception], Iterable[type[Exception]]] = Exception,
-    console: Console = None,
+    console: Optional[Console] = None,
     exit_code: int = 1,
 ):
     """Decorator to handle exception for commands."""
+    if not console:
+        console = Console()
 
     def decorator(func: Callable):
         if asyncio.iscoroutinefunction(func):

--- a/python_sdk/infrahub_sdk/ctl/validate.py
+++ b/python_sdk/infrahub_sdk/ctl/validate.py
@@ -12,13 +12,14 @@ from ujson import JSONDecodeError
 from infrahub_sdk.async_typer import AsyncTyper
 from infrahub_sdk.ctl.client import initialize_client, initialize_client_sync
 from infrahub_sdk.ctl.exceptions import QueryNotFoundError
-from infrahub_sdk.ctl.utils import find_graphql_query, parse_cli_vars
+from infrahub_sdk.ctl.utils import catch_exception, find_graphql_query, parse_cli_vars
 from infrahub_sdk.exceptions import GraphQLError
 from infrahub_sdk.utils import get_branch, write_to_file
 
 from .parameters import CONFIG_PARAM
 
 app = AsyncTyper()
+console = Console()
 
 
 @app.callback()
@@ -29,13 +30,9 @@ def callback() -> None:
 
 
 @app.command(name="schema")
-async def validate_schema(
-    schema: Path,
-    _: str = CONFIG_PARAM,
-) -> None:
+@catch_exception(console=console)
+async def validate_schema(schema: Path, _: str = CONFIG_PARAM) -> None:
     """Validate the format of a schema file either in JSON or YAML"""
-
-    console = Console()
 
     try:
         schema_data = yaml.safe_load(schema.read_text())
@@ -58,6 +55,7 @@ async def validate_schema(
 
 
 @app.command(name="graphql-query")
+@catch_exception(console=console)
 def validate_graphql(
     query: str,
     variables: Optional[list[str]] = typer.Argument(
@@ -69,8 +67,6 @@ def validate_graphql(
     out: str = typer.Option(None, help="Path to a file to save the result."),
 ) -> None:
     """Validate the format of a GraphQL Query stored locally by executing it on a remote GraphQL endpoint"""
-
-    console = Console()
 
     branch = get_branch(branch)
 

--- a/python_sdk/tests/unit/ctl/test_branch_app.py
+++ b/python_sdk/tests/unit/ctl/test_branch_app.py
@@ -22,11 +22,11 @@ def test_branch_create_no_auth(httpx_mock: HTTPXMock, authentication_error_paylo
         match_headers={"X-Infrahub-Tracker": "mutation-branch-create"},
     )
     result = runner.invoke(app=app, args=["create", "branch2"])
-    assert result.exit_code == 1
+    assert result.exit_code == 2
     assert "Authentication is required" in result.stdout
 
 
 def test_branch_create_wrong_name(mock_branch_create_error):
     result = runner.invoke(app=app, args=["create", "branch2"])
-    assert result.exit_code == 1
+    assert result.exit_code == 5
     assert 'invalid field name: string does not match regex "^[a-z][a-z0-9' in result.stdout.replace("\n", "")

--- a/python_sdk/tests/unit/ctl/test_schema_app.py
+++ b/python_sdk/tests/unit/ctl/test_schema_app.py
@@ -13,7 +13,7 @@ def test_schema_load_empty(httpx_mock: HTTPXMock):
     fixture_file = get_fixtures_dir() / "models" / "empty.json"
     result = runner.invoke(app=app, args=["load", str(fixture_file)])
 
-    assert result.exit_code == 2
+    assert result.exit_code == 1
     assert "Empty YAML/JSON file" in result.stdout
 
 

--- a/python_sdk/tests/unit/ctl/test_validate_app.py
+++ b/python_sdk/tests/unit/ctl/test_validate_app.py
@@ -26,7 +26,7 @@ def test_validate_schema_non_valid():
     fixture_file = get_fixtures_dir() / "models" / "non_valid_model_01.json"
 
     result = runner.invoke(app=app, args=["schema", str(fixture_file)])
-    assert result.exit_code == 2
+    assert result.exit_code == 1
     assert "Schema not valid" in result.stdout
 
 
@@ -35,5 +35,5 @@ def test_validate_schema_json_non_valid():
     fixture_file = get_fixtures_dir() / "models" / "non_valid_json_01.json"
 
     result = runner.invoke(app=app, args=["schema", str(fixture_file)])
-    assert result.exit_code == 2
+    assert result.exit_code == 1
     assert "Invalid JSON file" in result.stdout


### PR DESCRIPTION
Fixes https://github.com/opsmill/infrahub/issues/3506

Commands to use decorator with:

- [x] `infrahubctl branch`
- [x] `infrahubctl check`
- [x] `infrahubctl generator`
- [x] `infrahubctl render`
- [x] `infrahubctl run`
- [x] `infrahubctl schema`
- [x] `infrahubctl transform`
- [x] `infrahubctl version`

The decorator code is redundant due to having to handle both sync and async commands. Is it worth to have async commands since these have a pretty linear execution?