### PR TITLE
infrastructure_edge: Readability and performance improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -606,7 +606,6 @@ max-complexity = 33
 # like this so that we can reactivate them one by one. Alternatively ignored after further       #
 # investigation if they are deemed to not make sense.                                            #
 ##################################################################################################
-    "C901", # `run` is too complex
     "E501", # Line too long
 ]
 


### PR DESCRIPTION
In this iteration I've started to move out code from the global run() method and provide a way to batch tasks that doesn't depend on each other in a simpler way.

I also changed the randomness of the script with regards to how many IPv6 addresses were created. In the previous version we had for networks where we created a random number of hosts between 1 and 255, this make it harder to measure the time it took for the script to complete as it was completely random each time.

There are also some improvements with regards to how the profiles are assigned to the interfaces (here's an example where I don't think the current ".fetch()" approach works that great.

There's still a lot to do to improve both the speed and readability of the script but I don't want to change too much in one go.

Related to #3733.