### PR TITLE
Set generate_profile to false for pools

### DIFF
--- a/backend/infrahub/core/schema/definitions/core.py
+++ b/backend/infrahub/core/schema/definitions/core.py
@@ -680,6 +680,7 @@ core_models: dict[str, Any] = {
             "human_friendly_id": ["name__value"],
             "icon": "mdi:view-grid-outline",
             "branch": BranchSupportType.AGNOSTIC.value,
+            "generate_profile": False,
             "attributes": [
                 {
                     "name": "name",
@@ -1723,6 +1724,7 @@ core_models: dict[str, Any] = {
             "label": "IP Prefix Pool",
             "include_in_menu": False,
             "branch": BranchSupportType.AGNOSTIC.value,
+            "generate_profile": False,
             "inherit_from": [InfrahubKind.RESOURCEPOOL, InfrahubKind.LINEAGESOURCE],
             "attributes": [
                 {
@@ -1777,6 +1779,7 @@ core_models: dict[str, Any] = {
             "label": "IP Address Pool",
             "include_in_menu": False,
             "branch": BranchSupportType.AGNOSTIC.value,
+            "generate_profile": False,
             "inherit_from": [InfrahubKind.RESOURCEPOOL, InfrahubKind.LINEAGESOURCE],
             "attributes": [
                 {
@@ -1824,6 +1827,7 @@ core_models: dict[str, Any] = {
             "label": "Number Pool",
             "include_in_menu": False,
             "branch": BranchSupportType.AGNOSTIC.value,
+            "generate_profile": False,
             "inherit_from": [InfrahubKind.RESOURCEPOOL, InfrahubKind.LINEAGESOURCE],
             "attributes": [
                 {


### PR DESCRIPTION
Due to how the profiles are generated without changing these attributes it's not possible to load the pools within the frontend.

Replaces #3762.