### PR TITLE
Kind select fix when there is no objects to select

### DIFF
--- a/frontend/app/src/components/form/fields/relationship.field.tsx
+++ b/frontend/app/src/components/form/fields/relationship.field.tsx
@@ -162,6 +162,7 @@ const RelationshipField = ({
                     <RelationshipInput
                       {...field}
                       {...props}
+                      options={[]}
                       peer={selectedKind?.id}
                       parent={{ name: parentRelationship?.name, value: selectedParent?.id }}
                       disabled={props.disabled || !selectedKind?.id}

--- a/frontend/app/src/components/form/object-form.tsx
+++ b/frontend/app/src/components/form/object-form.tsx
@@ -100,8 +100,6 @@ const NodeWithProfileForm = ({ kind, currentProfile, ...props }: ObjectFormProps
     return <NoDataFound message={`${kind} schema not found. Try to reload the page.`} />;
   }
 
-  console.log("nodeSchema: ", nodeSchema);
-  console.log("nodeSchema.generate_profile: ", nodeSchema.generate_profile);
   return (
     <>
       {nodeSchema.generate_profile && (

--- a/frontend/app/tests/e2e/form/select-2-steps.spec.ts
+++ b/frontend/app/tests/e2e/form/select-2-steps.spec.ts
@@ -80,4 +80,18 @@ test.describe("Verifies the object creation", () => {
       );
     });
   });
+
+  test("verifies empty values after kind select", async ({ page }) => {
+    await page.goto("/objects/CoreGraphQLQuery");
+    await page.getByTestId("create-object-button").click();
+    await page.getByLabel("Kind").click();
+    await page
+      .getByTestId("side-panel-container")
+      .getByLabel("", { exact: true })
+      .getByText("Repository", { exact: true })
+      .click();
+    await page.getByLabel("Repository").click();
+    await expect(page.getByText("Empty", { exact: true })).toBeVisible();
+    await expect(page.getByText("Read-Only Repository", { exact: true })).not.toBeVisible();
+  });
 });


### PR DESCRIPTION
For the kind selector on relationships of cardinality one, when there was no objects to choose after having selecting a kind, the options from the parent were used (the list of the kinds) because of the props destructuring

To fix that, the options props is manually defined as empty array, it's populated with the async load

Before:
<img width="383" alt="image" src="https://github.com/opsmill/infrahub/assets/16644715/ea575512-7a1e-49e4-95e8-5792dd9aacec">


After:
<img width="394" alt="image" src="https://github.com/opsmill/infrahub/assets/16644715/4b294103-c332-461d-bea5-38730c3df837">
