### PR TITLE
Clean up git command error handling, remove startup sync

### DIFF
--- a/backend/infrahub/cli/git_agent.py
+++ b/backend/infrahub/cli/git_agent.py
@@ -15,7 +15,6 @@ from infrahub.components import ComponentType
 from infrahub.core.initialization import initialization
 from infrahub.dependencies.registry import build_component_registry
 from infrahub.git import initialize_repositories_directory
-from infrahub.git.actions import sync_remote_repositories
 from infrahub.lock import initialize_lock
 from infrahub.log import get_logger
 from infrahub.services import InfrahubServices
@@ -49,11 +48,8 @@ def callback() -> None:
 
 
 async def initialize_git_agent(service: InfrahubServices) -> None:
-    log.info("Initializing Git Agent ...")
+    service.log.info("Initializing Git Agent ...")
     initialize_repositories_directory()
-
-    # TODO Validate access to the GraphQL API with the proper credentials
-    await sync_remote_repositories(service=service)
 
 
 @app.command()

--- a/backend/tests/unit/git/test_git_repository.py
+++ b/backend/tests/unit/git/test_git_repository.py
@@ -100,7 +100,7 @@ async def test_new_wrong_location(git_upstream_repo_01, git_repos_dir, tmp_path)
     with pytest.raises(RepositoryError) as exc:
         await InfrahubRepository.new(id=UUIDT.new(), name=git_upstream_repo_01["name"], location=str(tmp_path))
 
-    assert "An error occurred with GitRepository" in str(exc.value)
+    assert f"fatal: repository '{tmp_path}' does not exist" in str(exc.value)
 
 
 async def test_new_wrong_branch(git_upstream_repo_01, git_repos_dir, tmp_path):


### PR DESCRIPTION
This PR removes the startup sync of repositories which could cause a crash at startup. Syncs will get done once every 10 seconds regardless, and that will happen in an environment that has better error handling.

Also adds a try/except clause around the `git fetch` command

Finally adds a _raise_enriched_error() method to avoid having to redefine similar errors in multiple places.