### PR TITLE
Set "get:schema/" API endpoint as deprecated

### DIFF
--- a/backend/infrahub/api/schema.py
+++ b/backend/infrahub/api/schema.py
@@ -135,7 +135,6 @@ def evaluate_candidate_schemas(
 
 
 @router.get("")
-@router.get("/")
 async def get_schema(
     branch: Branch = Depends(get_branch_dep), namespaces: Union[list[str], None] = Query(default=None)
 ) -> SchemaReadAPI:

--- a/backend/infrahub/api/schema.py
+++ b/backend/infrahub/api/schema.py
@@ -135,6 +135,7 @@ def evaluate_candidate_schemas(
 
 
 @router.get("")
+@router.get("/", include_in_schema=False, deprecated=True)
 async def get_schema(
     branch: Branch = Depends(get_branch_dep), namespaces: Union[list[str], None] = Query(default=None)
 ) -> SchemaReadAPI:


### PR DESCRIPTION
I set the get "schema/" API endpoint as deprecated and flagged it so it's not included in the schema anymore. Also, it appears that this endpoint is consumed at various places in the SDK (This will be addressed in a separated PR).

#1363 