### PR TITLE
Add Mutation to validate connectivity / credentials against Git repos

### DIFF
--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -700,6 +700,13 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
 
         return path
 
+    def check_connectivity(self, url: str) -> None:
+        repo = self.get_git_repo_main()
+        try:
+            repo.git.ls_remote([url, "HEAD"])
+        except GitCommandError as exc:
+            self._raise_enriched_error(error=exc)
+
     def _raise_enriched_error(self, error: GitCommandError, branch_name: str | None = None) -> NoReturn:
         if "Repository not found" in error.stderr or "does not appear to be a git" in error.stderr:
             raise RepositoryError(

--- a/backend/infrahub/graphql/mutations/__init__.py
+++ b/backend/infrahub/graphql/mutations/__init__.py
@@ -35,7 +35,7 @@ from .proposed_change import (
     ProposedChangeRequestRunCheck,
 )
 from .relationship import RelationshipAdd, RelationshipRemove
-from .repository import InfrahubRepositoryMutation, ProcessRepository
+from .repository import InfrahubRepositoryMutation, ProcessRepository, ValidateRepositoryConnectivity
 from .resource_manager import InfrahubNumberPoolMutation, IPAddressPoolGetResource, IPPrefixPoolGetResource
 from .schema import SchemaDropdownAdd, SchemaDropdownRemove, SchemaEnumAdd, SchemaEnumRemove
 from .task import TaskCreate, TaskUpdate
@@ -90,4 +90,5 @@ __all__ = [
     "SchemaEnumRemove",
     "TaskCreate",
     "TaskUpdate",
+    "ValidateRepositoryConnectivity",
 ]

--- a/backend/infrahub/graphql/schema.py
+++ b/backend/infrahub/graphql/schema.py
@@ -31,6 +31,7 @@ from .mutations import (
     SchemaEnumRemove,
     TaskCreate,
     TaskUpdate,
+    ValidateRepositoryConnectivity,
 )
 from .parser import extract_selection
 from .queries import (
@@ -120,6 +121,7 @@ class InfrahubBaseMutation(ObjectType):
     BranchUpdate = BranchUpdate.Field()
     BranchValidate = BranchValidate.Field()
     InfrahubRepositoryProcess = ProcessRepository.Field()
+    InfrahubRepositoryConnectivity = ValidateRepositoryConnectivity.Field()
     InfrahubTaskCreate = TaskCreate.Field()
     InfrahubTaskUpdate = TaskUpdate.Field()
 

--- a/backend/infrahub/message_bus/messages/__init__.py
+++ b/backend/infrahub/message_bus/messages/__init__.py
@@ -17,6 +17,7 @@ from .git_branch_create import GitBranchCreate
 from .git_diff_namesonly import GitDiffNamesOnly, GitDiffNamesOnlyResponse
 from .git_file_get import GitFileGet, GitFileGetResponse
 from .git_repository_add import GitRepositoryAdd
+from .git_repository_connectivity import GitRepositoryConnectivity
 from .git_repository_importobjects import GitRepositoryImportObjects
 from .git_repository_merge import GitRepositoryMerge
 from .git_repository_read_only_add import GitRepositoryAddReadOnly
@@ -74,6 +75,7 @@ MESSAGE_MAP: dict[str, type[InfrahubMessage]] = {
     "git.diff.names_only": GitDiffNamesOnly,
     "git.file.get": GitFileGet,
     "git.repository.add": GitRepositoryAdd,
+    "git.repository.connectivity": GitRepositoryConnectivity,
     "git.repository.merge": GitRepositoryMerge,
     "git.repository.add_read_only": GitRepositoryAddReadOnly,
     "git.repository.import_objects": GitRepositoryImportObjects,

--- a/backend/infrahub/message_bus/messages/git_repository_connectivity.py
+++ b/backend/infrahub/message_bus/messages/git_repository_connectivity.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pydantic import Field
+
+from infrahub.message_bus import InfrahubMessage, InfrahubResponse, InfrahubResponseData
+
+ROUTING_KEY = "git.repository.connectivity"
+
+
+class GitRepositoryConnectivity(InfrahubMessage):
+    """Validate connectivity and credentials to remote repository"""
+
+    repository_id: str = Field(..., description="The unique ID of the Repository")
+    repository_name: str = Field(..., description="The name of the repository")
+    repository_kind: str = Field(..., description="The type of repository")
+    repository_location: str = Field(..., description="The location of repository")
+
+
+class GitRepositoryConnectivityResponseData(InfrahubResponseData):
+    message: str = Field(..., description="The status message")
+    success: bool = Field(...)
+
+
+class GitRepositoryConnectivityResponse(InfrahubResponse):
+    routing_key: str = ROUTING_KEY
+    data: GitRepositoryConnectivityResponseData = Field(default=...)

--- a/backend/infrahub/message_bus/operations/__init__.py
+++ b/backend/infrahub/message_bus/operations/__init__.py
@@ -38,6 +38,7 @@ COMMAND_MAP = {
     "git.file.get": git.file.get,
     "git.repository.add": git.repository.add,
     "git.repository.add_read_only": git.repository.add_read_only,
+    "git.repository.connectivity": git.repository.connectivity,
     "git.repository.import_objects": git.repository.import_objects,
     "git.repository.pull_read_only": git.repository.pull_read_only,
     "git.repository.merge": git.repository.merge,

--- a/docs/docs/reference/message-bus-events.mdx
+++ b/docs/docs/reference/message-bus-events.mdx
@@ -399,6 +399,23 @@ For more detailed explanations on how to use these events within Infrahub, see t
 | **default_branch_name** | Default branch for this repository | N/A | None |
 <!-- vale on -->
 <!-- vale off -->
+#### Event git.repository.connectivity
+<!-- vale on -->
+
+**Description**: Validate connectivity and credentials to remote repository
+
+**Priority**: 3
+
+<!-- vale off -->
+| Key | Description | Type | Default Value |
+|-----|-------------|------|---------------|
+| **meta** | Meta properties for the message | N/A | None |
+| **repository_id** | The unique ID of the Repository | string | None |
+| **repository_name** | The name of the repository | string | None |
+| **repository_kind** | The type of repository | string | None |
+| **repository_location** | The location of repository | string | None |
+<!-- vale on -->
+<!-- vale off -->
 #### Event git.repository.merge
 <!-- vale on -->
 
@@ -1564,6 +1581,24 @@ For more detailed explanations on how to use these events within Infrahub, see t
 | **repository_name** | The name of the repository | string | None |
 | **created_by** | The user ID of the user that created the repository | N/A | None |
 | **default_branch_name** | Default branch for this repository | N/A | None |
+<!-- vale on -->
+<!-- vale off -->
+#### Event git.repository.connectivity
+<!-- vale on -->
+
+**Description**: Validate connectivity and credentials to remote repository
+
+**Priority**: 3
+
+
+<!-- vale off -->
+| Key | Description | Type | Default Value |
+|-----|-------------|------|---------------|
+| **meta** | Meta properties for the message | N/A | None |
+| **repository_id** | The unique ID of the Repository | string | None |
+| **repository_name** | The name of the repository | string | None |
+| **repository_kind** | The type of repository | string | None |
+| **repository_location** | The location of repository | string | None |
 <!-- vale on -->
 <!-- vale off -->
 #### Event git.repository.merge


### PR DESCRIPTION
This PR adds a mutation that validates the connectivity to a Git repository by issuing a `git ls-remote` command.

The mutation can be used like this:

```graphql
mutation InfrahubRepositoryConnectivity {
  InfrahubRepositoryConnectivity(
    data: {id: "17e12f32-af20-0670-58d7-1746b52b14c4"}
  ) {
    message
    ok
  }
}
```

A successful response:

```json
{
  "data": {
    "InfrahubRepositoryConnectivity": {
      "message": "Successfully accessed repository",
      "ok": true
    }
  }
}
```

A failed response:

```json
{
  "data": {
    "InfrahubRepositoryConnectivity": {
      "message": "Authentication failed for blue, please validate the credentials.",
      "ok": false
    }
  }
}
```

A small caveat with this is that git by default caches credentials for 15 minutes. Mostly this means that you can't change the password to something that doesn't work. We'd need to set the cache to a lower value in: https://github.com/opsmill/infrahub/blob/develop/development/Dockerfile#L70-L74

Will try to fix a test for this tomorrow, but the code is quite simple and might not be a blocker in terms of making this new mutation available for testing.