### PR TITLE
Add test for repository connectivity action

### DIFF
--- a/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
@@ -33,7 +33,7 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
         git_repos_source_dir_module_scope: Path,
         client: InfrahubClient,
         bus_simulator: BusSimulator,
-    ) -> None:
+    ) -> str:
         await load_schema(db, schema=CAR_SCHEMA)
         john = await Node.init(schema=TestKind.PERSON, db=db)
         await john.new(db=db, name="John", height=175, description="The famous Joe Doe")
@@ -63,6 +63,7 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
             data={"name": "car-dealership", "location": f"{git_repos_source_dir_module_scope}/car-dealership"},
         )
         await client_repository.save()
+        return client_repository.id
 
     @pytest.fixture(scope="class")
     async def happy_dataset(self, db: InfrahubDatabase, initial_dataset: None, client: InfrahubClient) -> None:
@@ -164,3 +165,17 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
         # The value of the description should match that of the source branch that was selected
         # as the branch to keep in the data conflict
         assert john.description.value == "Oh boy"  # type: ignore[attr-defined]
+
+    async def test_connectivity(self, db: InfrahubDatabase, initial_dataset: str, client: InfrahubClient) -> None:
+        """Validate that the request to check connectivity to the remote repository is successful"""
+        query = """
+        mutation InfrahubRepositoryConnectivity($id: String!) {
+            InfrahubRepositoryConnectivity(data: {id: $id}) {
+                ok
+                message
+            }
+        }
+        """
+        result = await client.execute_graphql(query=query, variables={"id": initial_dataset})
+        assert result["InfrahubRepositoryConnectivity"]["ok"]
+        assert result["InfrahubRepositoryConnectivity"]["message"] == "Successfully accessed repository"


### PR DESCRIPTION
Note here I'm piggybacking on another of the integration test classes. The main reason for this is that the setup time of these tests are fairly long and the test itself is very quick. I didn't want to add half a minute to the CI just because of this test. 

It could be that we should later go back and rename this folder and test to have it better reflect the current state.