### PR TITLE
Fix disabling fields when it is protected and owned by another user

### DIFF
--- a/frontend/app/src/components/form/object-form.tsx
+++ b/frontend/app/src/components/form/object-form.tsx
@@ -256,14 +256,14 @@ const NodeForm = ({
   const date = useAtomValue(datetimeAtom);
   const schemas = useAtomValue(schemaState);
   const [filters] = useFilters();
-  const { data, permissions } = useAuth();
+  const auth = useAuth();
 
   const fields = getFormFieldsFromSchema({
     schema,
     schemas,
     profile,
     initialObject: currentObject,
-    user: { ...data, permissions },
+    user: auth,
     isFilterForm,
     filters,
   });

--- a/frontend/app/src/components/form/utils.ts
+++ b/frontend/app/src/components/form/utils.ts
@@ -14,13 +14,14 @@ import { AttributeType } from "@/utils/getObjectItemDisplayValue";
 import { store } from "@/state";
 import { getIsDisabled } from "@/utils/formStructureForCreateEdit";
 import { components } from "@/infraops";
+import { AuthContextType } from "@/hooks/useAuth";
 
 type GetFormFieldsFromSchema = {
   schema: iNodeSchema | iGenericSchema;
   schemas?: iNodeSchema[] | iGenericSchema[];
   profile?: Object;
   initialObject?: Record<string, AttributeType>;
-  user?: any;
+  user?: AuthContextType;
   isFilterForm?: boolean;
   filters?: Array<any>;
 };

--- a/frontend/app/src/components/inputs/select.tsx
+++ b/frontend/app/src/components/inputs/select.tsx
@@ -862,7 +862,9 @@ export const Select = forwardRef<HTMLDivElement, SelectProps>((props, ref) => {
   }, [options?.length]);
 
   return (
-    <div className={classNames("relative", className)} data-testid="select-container">
+    <div
+      className={classNames("relative", dropdown && disabled && "opacity-60", className)}
+      data-testid="select-container">
       <Combobox
         as="div"
         value={multiple ? selectedOption ?? [] : selectedOption ?? ""}

--- a/frontend/app/src/hooks/useAuth.tsx
+++ b/frontend/app/src/hooks/useAuth.tsx
@@ -19,7 +19,7 @@ type User = {
   id: string;
 };
 
-type AuthContextType = {
+export type AuthContextType = {
   accessToken: string | null;
   data?: any;
   isAuthenticated: boolean;

--- a/frontend/app/src/utils/formStructureForCreateEdit.ts
+++ b/frontend/app/src/utils/formStructureForCreateEdit.ts
@@ -16,8 +16,16 @@ import {
   getRelationshipValue,
   getSelectParent,
 } from "./getSchemaObjectColumns";
+import { AuthContextType } from "@/hooks/useAuth";
 
-export const getIsDisabled = ({ owner, user, isProtected, isReadOnly }: any) => {
+type getIsDisabledParams = {
+  owner?: { id: string };
+  user?: AuthContextType;
+  isProtected?: boolean;
+  isReadOnly?: boolean;
+};
+
+export const getIsDisabled = ({ owner, user, isProtected, isReadOnly }: getIsDisabledParams) => {
   // Field is read only
   if (isReadOnly) return true;
 

--- a/frontend/app/tests/unit/utils/getFormFieldsFromSchema.test.ts
+++ b/frontend/app/tests/unit/utils/getFormFieldsFromSchema.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { getFormFieldsFromSchema } from "../../../src/components/form/utils";
 import { IModelSchema } from "../../../src/state/atoms/schema.atom";
+import { AuthContextType } from "@/hooks/useAuth";
+import { AttributeType } from "@/utils/getObjectItemDisplayValue";
 
 describe("getFormFieldsFromSchema", () => {
   it("returns no fields if schema has no attributes nor relationships", () => {
@@ -279,6 +281,162 @@ describe("getFormFieldsFromSchema", () => {
       field: schema.attributes?.[0],
       schema,
       unique: false,
+    });
+  });
+
+  it("should disable a protected field if the owner is not the current user", () => {
+    // GIVEN
+    const schema: Pick<IModelSchema, "attributes" | "relationships"> = {
+      attributes: [
+        {
+          id: "17d67b92-f0b9-cf97-3001-c51824a9c7dc",
+          state: "present",
+          name: "name",
+          kind: "Text",
+          enum: null,
+          choices: null,
+          regex: null,
+          max_length: null,
+          min_length: null,
+          label: "Name",
+          description: null,
+          read_only: false,
+          unique: true,
+          optional: false,
+          branch: "aware",
+          order_weight: 1000,
+          default_value: null,
+          inherited: false,
+          allow_override: "any",
+        },
+      ],
+    };
+
+    const initialObject: { name: AttributeType } = {
+      name: {
+        is_from_profile: false,
+        is_protected: true,
+        is_visible: true,
+        owner: {
+          id: "17dd42a7-d547-60af-3111-c51b4b2fc72e",
+          display_label: "Architecture Team",
+          __typename: "CoreAccount",
+        },
+        source: null,
+        updated_at: "2024-07-15T09:32:01.363787+00:00",
+        value: "test-value",
+        __typename: "TextAttribute",
+      },
+    };
+
+    const user: AuthContextType = {
+      accessToken: "abc",
+      isAuthenticated: true,
+      isLoading: false,
+      data: {
+        sub: "1",
+      },
+      signIn: async () => {},
+      signOut: () => {},
+      user: {
+        id: "1",
+      },
+    };
+
+    // WHEN
+    const fields = getFormFieldsFromSchema({ schema, initialObject, user });
+
+    // THEN
+    expect(fields.length).to.equal(1);
+    expect(fields[0]).to.deep.equal({
+      defaultValue: "test-value",
+      description: undefined,
+      disabled: true,
+      name: "name",
+      label: "Name",
+      type: "Text",
+      unique: true,
+      rules: {
+        required: true,
+      },
+    });
+  });
+
+  it("should enable a protected field if the owner is the current user", () => {
+    // GIVEN
+    const schema: Pick<IModelSchema, "attributes" | "relationships"> = {
+      attributes: [
+        {
+          id: "17d67b92-f0b9-cf97-3001-c51824a9c7dc",
+          state: "present",
+          name: "name",
+          kind: "Text",
+          enum: null,
+          choices: null,
+          regex: null,
+          max_length: null,
+          min_length: null,
+          label: "Name",
+          description: null,
+          read_only: false,
+          unique: true,
+          optional: false,
+          branch: "aware",
+          order_weight: 1000,
+          default_value: null,
+          inherited: false,
+          allow_override: "any",
+        },
+      ],
+    };
+
+    const initialObject: { name: AttributeType } = {
+      name: {
+        is_from_profile: false,
+        is_protected: true,
+        is_visible: true,
+        owner: {
+          id: "1",
+          display_label: "Architecture Team",
+          __typename: "CoreAccount",
+        },
+        source: null,
+        updated_at: "2024-07-15T09:32:01.363787+00:00",
+        value: "test-value",
+        __typename: "TextAttribute",
+      },
+    };
+
+    const user: AuthContextType = {
+      accessToken: "abc",
+      isAuthenticated: true,
+      isLoading: false,
+      data: {
+        sub: "1",
+      },
+      signIn: async () => {},
+      signOut: () => {},
+      user: {
+        id: "1",
+      },
+    };
+
+    // WHEN
+    const fields = getFormFieldsFromSchema({ schema, initialObject, user });
+
+    // THEN
+    expect(fields.length).to.equal(1);
+    expect(fields[0]).to.deep.equal({
+      defaultValue: "test-value",
+      description: undefined,
+      disabled: false,
+      name: "name",
+      label: "Name",
+      type: "Text",
+      unique: true,
+      rules: {
+        required: true,
+      },
     });
   });
 });


### PR DESCRIPTION
Issue:
- #3824 

Fix:
- dropdown disabled state is visible (opacity lowered)
- fixed check where owner id = user id to disable input