### PR TITLE
Replace deprecated API call "get:schema/" from SDK

### DIFF
--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -2562,7 +2562,7 @@ async def read_only_repos_in_main(db: InfrahubDatabase, register_core_models_sch
 @pytest.fixture
 async def mock_core_schema_01(helper, httpx_mock: HTTPXMock) -> HTTPXMock:
     response_text = helper.schema_file(file_name="core_schema_01.json")
-    httpx_mock.add_response(method="GET", url="http://mock/api/schema/?branch=main", json=response_text)
+    httpx_mock.add_response(method="GET", url="http://mock/api/schema?branch=main", json=response_text)
     return httpx_mock
 
 

--- a/backend/tests/unit/git/conftest.py
+++ b/backend/tests/unit/git/conftest.py
@@ -639,7 +639,7 @@ async def mock_schema_query_01(helper, httpx_mock: HTTPXMock) -> HTTPXMock:
         encoding="UTF-8"
     )
 
-    httpx_mock.add_response(method="GET", url="http://mock/api/schema/?branch=main", json=ujson.loads(response_text))
+    httpx_mock.add_response(method="GET", url="http://mock/api/schema?branch=main", json=ujson.loads(response_text))
     return httpx_mock
 
 
@@ -649,7 +649,7 @@ async def mock_schema_query_02(helper, httpx_mock: HTTPXMock) -> HTTPXMock:
         encoding="UTF-8"
     )
 
-    httpx_mock.add_response(method="GET", url="http://mock/api/schema/?branch=main", json=ujson.loads(response_text))
+    httpx_mock.add_response(method="GET", url="http://mock/api/schema?branch=main", json=ujson.loads(response_text))
     return httpx_mock
 
 

--- a/backend/tests/unit/message_bus/operations/requests/test_graphql_query_group.py
+++ b/backend/tests/unit/message_bus/operations/requests/test_graphql_query_group.py
@@ -19,7 +19,7 @@ async def mock_schema_query_02(helper, httpx_mock: HTTPXMock) -> HTTPXMock:
         encoding="UTF-8"
     )
 
-    httpx_mock.add_response(method="GET", url="http://mock/api/schema/?branch=main", json=ujson.loads(response_text))
+    httpx_mock.add_response(method="GET", url="http://mock/api/schema?branch=main", json=ujson.loads(response_text))
     return httpx_mock
 
 

--- a/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
+++ b/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
@@ -40,7 +40,7 @@ async def mock_schema_query_02(helper, httpx_mock: HTTPXMock) -> HTTPXMock:
         encoding="UTF-8"
     )
 
-    httpx_mock.add_response(method="GET", url="http://mock/api/schema/?branch=main", json=ujson.loads(response_text))
+    httpx_mock.add_response(method="GET", url="http://mock/api/schema?branch=main", json=ujson.loads(response_text))
     return httpx_mock
 
 

--- a/python_sdk/infrahub_sdk/schema.py
+++ b/python_sdk/infrahub_sdk/schema.py
@@ -687,7 +687,7 @@ class InfrahubSchema(InfrahubSchemaBase):
         if namespaces:
             url_parts.extend([("namespaces", ns) for ns in namespaces])
         query_params = urlencode(url_parts)
-        url = f"{self.client.address}/api/schema/?{query_params}"
+        url = f"{self.client.address}/api/schema?{query_params}"
 
         response = await self.client._get(url=url)
         response.raise_for_status()
@@ -880,7 +880,7 @@ class InfrahubSchemaSync(InfrahubSchemaBase):
         if namespaces:
             url_parts.extend([("namespaces", ns) for ns in namespaces])
         query_params = urlencode(url_parts)
-        url = f"{self.client.address}/api/schema/?{query_params}"
+        url = f"{self.client.address}/api/schema?{query_params}"
 
         response = self.client._get(url=url)
         response.raise_for_status()

--- a/python_sdk/tests/unit/sdk/conftest.py
+++ b/python_sdk/tests/unit/sdk/conftest.py
@@ -1650,7 +1650,7 @@ async def mock_schema_query_01(httpx_mock: HTTPXMock) -> HTTPXMock:
 
     httpx_mock.add_response(
         method="GET",
-        url="http://mock/api/schema/?branch=main",
+        url="http://mock/api/schema?branch=main",
         json=ujson.loads(response_text),
     )
     return httpx_mock
@@ -1662,7 +1662,7 @@ async def mock_schema_query_02(httpx_mock: HTTPXMock) -> HTTPXMock:
 
     httpx_mock.add_response(
         method="GET",
-        url="http://mock/api/schema/?branch=main",
+        url="http://mock/api/schema?branch=main",
         json=ujson.loads(response_text),
     )
     return httpx_mock
@@ -1680,7 +1680,7 @@ async def mock_rest_api_artifact_fetch(httpx_mock: HTTPXMock) -> HTTPXMock:
 
     httpx_mock.add_response(
         method="GET",
-        url="http://mock/api/schema/?branch=main",
+        url="http://mock/api/schema?branch=main",
         json=ujson.loads(schema_response),
     )
 
@@ -1772,7 +1772,7 @@ async def mock_rest_api_artifact_generate(httpx_mock: HTTPXMock) -> HTTPXMock:
 
     httpx_mock.add_response(
         method="GET",
-        url="http://mock/api/schema/?branch=main",
+        url="http://mock/api/schema?branch=main",
         json=ujson.loads(schema_response),
     )
 
@@ -2330,5 +2330,5 @@ def query_introspection() -> str:
 async def mock_schema_query_ipam(httpx_mock: HTTPXMock) -> HTTPXMock:
     response_text = (get_fixtures_dir() / "schema_ipam.json").read_text(encoding="UTF-8")
 
-    httpx_mock.add_response(method="GET", url="http://mock/api/schema/?branch=main", json=ujson.loads(response_text))
+    httpx_mock.add_response(method="GET", url="http://mock/api/schema?branch=main", json=ujson.loads(response_text))
     return httpx_mock


### PR DESCRIPTION
Following https://github.com/opsmill/infrahub/pull/3813 API endpoint "get:schema/" is now deprecated. I adjusted Python SDK so it's not using this endpoint anymore but rather "get:schema".

#3820