### PR TITLE
IFC-111 set repository display label correctly in proposed change diff

### DIFF
--- a/backend/infrahub/api/diff/diff.py
+++ b/backend/infrahub/api/diff/diff.py
@@ -103,16 +103,18 @@ async def get_diff_files(
 
     for branch_name, items in diff_files.items():
         for item in items:
-            if item.repository not in response[branch_name]:
-                response[branch_name][item.repository] = BranchDiffRepository(
-                    id=item.repository,
-                    display_name=f"Repository ({item.repository})",
+            repository_id = item.repository.get_id()
+            display_label = await item.repository.render_display_label(db=db)
+            if repository_id not in response[branch_name]:
+                response[branch_name][repository_id] = BranchDiffRepository(
+                    id=repository_id,
+                    display_name=display_label or f"Repository ({repository_id})",
                     commit_from=item.commit_from,
                     commit_to=item.commit_to,
                     branch=branch_name,
                 )
 
-            response[branch_name][item.repository].files.append(BranchDiffFile(**item.to_graphql()))
+            response[branch_name][repository_id].files.append(BranchDiffFile(**item.to_graphql()))
 
     return response
 

--- a/backend/infrahub/core/diff/branch_differ.py
+++ b/backend/infrahub/core/diff/branch_differ.py
@@ -971,7 +971,7 @@ class BranchDiffer:
                     FileDiffElement(
                         branch=branch_name,
                         location=filename,
-                        repository=repository.id,
+                        repository=repository,
                         action=diff_action,
                         commit_to=commit_to,
                         commit_from=commit_from,

--- a/backend/infrahub/core/diff/model.py
+++ b/backend/infrahub/core/diff/model.py
@@ -6,6 +6,7 @@ from typing import Any, Optional, Union
 from pydantic import BaseModel, ConfigDict, Field, computed_field
 
 from infrahub.core.constants import DiffAction, PathType
+from infrahub.core.node import Node
 from infrahub.core.timestamp import Timestamp
 
 
@@ -36,6 +37,8 @@ class BaseDiffElement(BaseModel):
                 resp[key] = value.value
             elif isinstance(value, Timestamp):
                 resp[key] = value.to_string()
+            elif isinstance(value, Node):
+                resp[key] = value.get_id()
             else:
                 resp[key] = value
 
@@ -117,7 +120,7 @@ class RelationshipDiffElement(BaseDiffElement):
 class FileDiffElement(BaseDiffElement):
     branch: str
     location: str
-    repository: str
+    repository: Node
     action: DiffAction
     commit_from: str
     commit_to: str

--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -781,7 +781,7 @@ class NodeManager:
         prefetch_relationships: bool = False,
         account=None,
         branch_agnostic: bool = False,
-    ) -> dict[str, Any]:
+    ) -> dict[str, Node]:
         """Return a list of nodes based on their IDs."""
 
         branch = await registry.get_branch(branch=branch, db=db)


### PR DESCRIPTION
fixes #3816 

sets the `display_name` of the repository for a `FileDiffElement` using `render_display_label()` instead of setting it to `Repository (<UUID>)`

this required some small refactoring to attach the `CoreRepository` Node to the `FileDiffElement` so that we would not need to retrieve it from the database again just to get the display name