### PR TITLE
ifc-73 update profile schema label to be more human friendly

### DIFF
--- a/backend/infrahub/core/schema_manager.py
+++ b/backend/infrahub/core/schema_manager.py
@@ -1507,7 +1507,7 @@ class SchemaBranch:
         profile = ProfileSchema(
             name=node.kind,
             namespace="Profile",
-            label=f"Profile{node.kind}",
+            label=f"Profile {node.label}",
             description=f"Profile for {node.kind}",
             branch=node.branch,
             include_in_menu=False,

--- a/frontend/app/tests/e2e/objects/profiles/multi-profiles.spec.ts
+++ b/frontend/app/tests/e2e/objects/profiles/multi-profiles.spec.ts
@@ -22,7 +22,7 @@ test.describe("/objects/CoreProfile - Profiles page", () => {
       // Generic profile
       await page.getByTestId("create-object-button").click();
       await page.getByLabel("Select an object type").click();
-      await page.getByRole("option", { name: "ProfileInfraInterface Profile" }).click();
+      await page.getByRole("option", { name: "Profile Interface Profile" }).click();
       await page.getByLabel("Profile Name *").fill("Generic profile");
       await page.getByLabel("Description").fill("Desc from generic profile");
       await page.getByRole("button", { name: "Save" }).click();
@@ -31,7 +31,7 @@ test.describe("/objects/CoreProfile - Profiles page", () => {
       // L2 profile v1
       await page.getByTestId("create-object-button").click();
       await page.getByLabel("Select an object type").click();
-      await page.getByRole("option", { name: "ProfileInfraInterfaceL2" }).click();
+      await page.getByRole("option", { name: "Profile Interface L2" }).click();
       await page.getByLabel("Profile Name *").fill("L2 profile v1");
       await page.getByLabel("Description").fill("Desc from L2 profile v1");
       await page.getByRole("button", { name: "Save" }).click();
@@ -40,7 +40,7 @@ test.describe("/objects/CoreProfile - Profiles page", () => {
       // L2 profile v2
       await page.getByTestId("create-object-button").click();
       await page.getByLabel("Select an object type").click();
-      await page.getByRole("option", { name: "ProfileInfraInterfaceL2" }).click();
+      await page.getByRole("option", { name: "Profile Interface L2" }).click();
       await page.getByLabel("Profile Name *").fill("L2 profile v2");
       await page.getByLabel("Description").fill("Desc from L2 profile v2");
       await page.getByLabel("Profile Priority").fill("10");

--- a/frontend/app/tests/e2e/objects/profiles/profiles.spec.ts
+++ b/frontend/app/tests/e2e/objects/profiles/profiles.spec.ts
@@ -34,7 +34,7 @@ test.describe("/objects/CoreProfile - Profiles page", () => {
     await test.step("Create a new profile", async () => {
       await page.getByTestId("create-object-button").click();
       await page.getByLabel("Select an object type").click();
-      await page.getByRole("option", { name: "ProfileBuiltinTag" }).click();
+      await page.getByRole("option", { name: "Profile Tag" }).click();
       await page.getByLabel("Profile Name *").fill("profile test tag");
       await page.getByLabel("Description").fill("A profile for E2E test");
       await page.getByRole("button", { name: "Save" }).click();
@@ -44,7 +44,7 @@ test.describe("/objects/CoreProfile - Profiles page", () => {
       await expect(
         page.locator("#alert-success-BuiltinTag-created").getByText("BuiltinTag created")
       ).toBeVisible();
-      await expect(page.getByRole("link", { name: "ProfileBuiltinTag" })).toBeVisible();
+      await expect(page.getByRole("link", { name: "Profile Tag" })).toBeVisible();
       await expect(page.getByRole("link", { name: "profile test tag" })).toBeVisible();
     });
   });
@@ -174,7 +174,7 @@ test.describe("/objects/CoreProfile - Profiles page", () => {
 
     await test.step("Delete the profile", async () => {
       await page
-        .getByRole("row", { name: "ProfileBuiltinTag profile" })
+        .getByRole("row", { name: "Profile Tag profile" })
         .getByTestId("delete-row-button")
         .click();
       await expect(page.getByTestId("modal-delete")).toContainText(
@@ -220,7 +220,7 @@ test.describe("/objects/CoreProfile - Profile for Interface L2 and fields verifi
         .filter({ hasText: /^Clear$/ })
         .getByRole("combobox")
         .fill("l2");
-      await page.getByRole("option", { name: "ProfileInfraInterfaceL2" }).click();
+      await page.getByRole("option", { name: "Profile Interface L2" }).click();
     });
 
     await test.step("verify Interface L2 optional attributes are all visible", async () => {
@@ -257,7 +257,7 @@ test.describe("/objects/CoreProfile - Profile for Interface L2 and fields verifi
       ]);
       await page.getByTestId("create-object-button").click();
       await page.getByLabel("Select an object type").click();
-      await page.getByRole("option", { name: "ProfileInfraInterfaceL2" }).click();
+      await page.getByRole("option", { name: "Profile Interface L2" }).click();
     });
 
     await test.step("fill and submit form", async () => {
@@ -294,9 +294,7 @@ test.describe("/objects/CoreProfile - Profile for Interface L2 and fields verifi
       ]);
       await page.getByTestId("create-object-button").click();
       await page.getByLabel("Select an object type").click();
-      await page
-        .getByRole("option", { name: "ProfileInfraInterface Profile", exact: true })
-        .click();
+      await page.getByRole("option", { name: "Profile Interface Profile", exact: true }).click();
     });
 
     await test.step("fill and submit form", async () => {

--- a/frontend/app/tests/e2e/objects/profiles/profiles.spec.ts
+++ b/frontend/app/tests/e2e/objects/profiles/profiles.spec.ts
@@ -44,7 +44,7 @@ test.describe("/objects/CoreProfile - Profiles page", () => {
       await expect(
         page.locator("#alert-success-BuiltinTag-created").getByText("BuiltinTag created")
       ).toBeVisible();
-      await expect(page.getByRole("link", { name: "Profile Tag" })).toBeVisible();
+      await expect(page.getByRole("link", { name: "ProfileBuiltinTag" })).toBeVisible();
       await expect(page.getByRole("link", { name: "profile test tag" })).toBeVisible();
     });
   });


### PR DESCRIPTION
fix #3794 

make the ProfileSchema `label` a little more human friendly. for example, `ProfileCoreReadOnlyRepository` is now `Profile Read-Only Repository