### PR TITLE
IFC-42 example new diff query

### DIFF
--- a/backend/infrahub/core/diff/calculator.py
+++ b/backend/infrahub/core/diff/calculator.py
@@ -1,5 +1,3 @@
-from dataclasses import dataclass
-
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.diff.query_parser import DiffQueryParser
@@ -7,15 +5,7 @@ from infrahub.core.query.diff import DiffAllPathsQuery
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 
-from .model.path import DiffRoot
-
-
-@dataclass
-class CalculatedDiffs:
-    base_branch_name: str
-    diff_branch_name: str
-    base_branch_diff: DiffRoot
-    diff_branch_diff: DiffRoot
+from .model.path import CalculatedDiffs
 
 
 class DiffCalculator:

--- a/backend/infrahub/core/diff/combiner.py
+++ b/backend/infrahub/core/diff/combiner.py
@@ -1,6 +1,6 @@
-from .model.path import DiffRoot
+from .model.path import EnrichedDiffRoot
 
 
 class DiffCombiner:
-    def combine(self, earlier_diff: DiffRoot, later_diff: DiffRoot) -> DiffRoot:  # pylint: disable=unused-argument
+    def combine(self, earlier_diff: EnrichedDiffRoot, later_diff: EnrichedDiffRoot) -> EnrichedDiffRoot:  # pylint: disable=unused-argument
         return earlier_diff

--- a/backend/infrahub/core/diff/enricher.py
+++ b/backend/infrahub/core/diff/enricher.py
@@ -1,0 +1,10 @@
+from .model.path import CalculatedDiffs, EnrichedDiffRoot
+
+
+class DiffEnricher:
+    def __init__(self) -> None:
+        self.conflicts_enricher = None
+        self.parent_nodes_enricher = None
+
+    async def enrich(self, calculated_diffs: CalculatedDiffs) -> EnrichedDiffRoot:
+        raise NotImplementedError()

--- a/backend/infrahub/core/diff/model/path.py
+++ b/backend/infrahub/core/diff/model/path.py
@@ -15,6 +15,89 @@ if TYPE_CHECKING:
 
 
 @dataclass
+class ConflictBranchChoice:
+    BASE = "base"
+    DIFF = "diff"
+
+
+@dataclass
+class EnrichedDiffPropertyConflict:
+    uuid: str
+    base_branch_action: DiffAction
+    base_branch_value: Any
+    base_branch_changed_at: Timestamp
+    diff_branch_action: DiffAction
+    diff_branch_value: Any
+    diff_branch_changed_at: Timestamp
+    selected_branch: Optional[ConflictBranchChoice]
+
+
+@dataclass
+class EnrichedDiffProperty:
+    property_type: str
+    changed_at: Timestamp
+    previous_value: Any
+    new_value: Any
+    action: DiffAction
+    conflict: Optional[EnrichedDiffPropertyConflict]
+
+
+@dataclass
+class EnrichedDiffAttribute:
+    name: str
+    changed_at: Timestamp
+    action: DiffAction
+    properties: list[DiffProperty] = field(default_factory=list)
+
+
+@dataclass
+class EnrichedDiffSingleRelationship:
+    changed_at: Timestamp
+    action: DiffAction
+    peer_id: str
+    conflict: Optional[EnrichedDiffPropertyConflict]
+    properties: list[DiffProperty] = field(default_factory=list)
+
+
+@dataclass
+class EnrichedDiffRelationship:
+    name: str
+    changed_at: Timestamp
+    action: DiffAction
+    relationships: list[EnrichedDiffSingleRelationship] = field(default_factory=list)
+    nodes: list[EnrichedDiffNode] = field(default_factory=list)
+
+
+@dataclass
+class EnrichedDiffNode:
+    uuid: str
+    kind: str
+    label: str
+    changed_at: Timestamp
+    action: DiffAction
+    attributes: list[EnrichedDiffAttribute] = field(default_factory=list)
+    relationships: list[EnrichedDiffRelationship] = field(default_factory=list)
+
+
+@dataclass
+class EnrichedDiffRoot:
+    base_branch_name: str
+    diff_branch_name: str
+    from_time: Timestamp
+    to_time: Timestamp
+    uuid: str
+    nodes: list[EnrichedDiffNode] = field(default_factory=list)
+
+
+@dataclass
+class CalculatedDiffs:
+    base_branch_name: str
+    diff_branch_name: str
+    base_branch_diff: DiffRoot
+    diff_branch_diff: DiffRoot
+
+
+@dataclass
 class DiffProperty:
     property_type: str
     changed_at: Timestamp

--- a/backend/infrahub/core/diff/model/path.py
+++ b/backend/infrahub/core/diff/model/path.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import TYPE_CHECKING, Any, Optional
 
 from infrahub.core.constants import DiffAction, RelationshipStatus
@@ -14,8 +15,7 @@ if TYPE_CHECKING:
     from neo4j.graph import Relationship as Neo4jRelationship
 
 
-@dataclass
-class ConflictBranchChoice:
+class ConflictBranchChoice(Enum):
     BASE = "base"
     DIFF = "diff"
 
@@ -47,7 +47,7 @@ class EnrichedDiffAttribute:
     name: str
     changed_at: Timestamp
     action: DiffAction
-    properties: list[DiffProperty] = field(default_factory=list)
+    properties: list[EnrichedDiffProperty] = field(default_factory=list)
 
 
 @dataclass
@@ -56,7 +56,7 @@ class EnrichedDiffSingleRelationship:
     action: DiffAction
     peer_id: str
     conflict: Optional[EnrichedDiffPropertyConflict]
-    properties: list[DiffProperty] = field(default_factory=list)
+    properties: list[EnrichedDiffProperty] = field(default_factory=list)
 
 
 @dataclass

--- a/backend/infrahub/core/diff/repository.py
+++ b/backend/infrahub/core/diff/repository.py
@@ -1,14 +1,27 @@
 from infrahub.core.branch import Branch
 from infrahub.core.timestamp import Timestamp
 
-from .model.path import DiffRoot
+from .model.path import EnrichedDiffRoot
 
 
 class DiffRepository:
-    async def get_calculated_diffs(
+    async def get(
         self, base_branch: Branch, diff_branch: Branch, from_time: Timestamp, to_time: Timestamp
-    ) -> list[DiffRoot]:
+    ) -> list[EnrichedDiffRoot]:
         """Get all diffs for the given branch that touch the given timeframe in chronological order"""
         raise NotImplementedError()
 
-    async def save_diff_root(self, diff_root: DiffRoot) -> None: ...  # pylint: disable=unused-argument
+    async def save(self, enriched_diff: EnrichedDiffRoot) -> None:  # pylint: disable=unused-argument
+        """
+        Cached Diff Graph Format
+        (DiffRoot)-[DIFF_HAS_NODE]->(DiffNode)
+            (DiffNode)-[DIFF_HAS_ATTRIBUTE]->(DiffAttribute)
+                (DiffAttribute)-[DIFF_HAS_PROPERTY]->(DiffProperty)
+                    (DiffProperty)-[DIFF_HAS_CONFLICT]->(DiffConflict)
+
+            (DiffNode)-[DIFF_HAS_RELATIONSHIP]->(DiffRelationship)
+                (DiffRelationship)-[DIFF_HAS_NODE]->(DiffNode)
+                (DiffRelationship)-[DIFF_HAS_ELEMENT]->(DiffRelationshipElement)
+                    (DiffRelationshipElement)-[DIFF_HAS_PROPERTY]->(DiffProperty)
+                        (DiffProperty)-[DIFF_HAS_CONFLICT]->(DiffConflict)
+        """

--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -38,20 +38,6 @@ query DiffTree
 - when merging, we need to lock main, calculate the small interval of the diff to make it current, then merge if no conflicts
 """
 
-"""
-Cached Diff Graph Format
-(DiffRoot)-[DIFF_HAS_NODE]->(DiffNode)
-    (DiffNode)-[DIFF_HAS_ATTRIBUTE]->(DiffAttribute)
-        (DiffAttribute)-[DIFF_HAS_PROPERTY]->(DiffProperty)
-            (DiffProperty)-[DIFF_HAS_CONFLICT]->(DiffConflict)
-
-    (DiffNode)-[DIFF_HAS_RELATIONSHIP]->(DiffRelationship)
-        (DiffRelationship)-[DIFF_HAS_NODE]->(DiffNode)
-        (DiffRelationship)-[DIFF_HAS_ELEMENT]->(DiffRelationshipElement)
-            (DiffRelationshipElement)-[DIFF_HAS_PROPERTY]->(DiffProperty)
-                (DiffProperty)-[DIFF_HAS_CONFLICT]->(DiffConflict)
-"""
-
 
 class ConflictSelection(GrapheneEnum):
     BASE_BRANCH = "base"
@@ -62,8 +48,10 @@ class ConflictDetails(ObjectType):
     uuid = String(required=True)
     base_branch_action = Field(GrapheneDiffActionEnum, required=True)
     base_branch_value = String()
+    base_branch_changed_at = DateTime(required=True)
     diff_branch_action = Field(GrapheneDiffActionEnum, required=True)
     diff_branch_value = String()
+    diff_branch_changed_at = DateTime(required=True)
     selected_branch = Field(ConflictSelection)
 
 
@@ -96,6 +84,7 @@ class DiffSingleRelationship(DiffSummaryCounts):
     status = Field(GrapheneDiffActionEnum, required=True)
     peer_id = String(required=True)
     contains_conflict = Boolean(required=True)
+    conflict = Field(ConflictDetails, required=False)
     properties = List(DiffProperty)
 
 
@@ -268,8 +257,10 @@ class DiffTreeResolver:
                                             uuid="0a7a5898-e8a0-4baf-b7ae-1fac1fcdf468",
                                             base_branch_action=DiffAction.REMOVED,
                                             base_branch_value=None,
+                                            base_branch_changed_at=the_time,
                                             diff_branch_action=DiffAction.UPDATED,
                                             diff_branch_value="c411c56f-d88b-402d-8753-0a35defaab1f",
+                                            diff_branch_changed_at=the_time,
                                             selected_branch=None,
                                         ),
                                     ),
@@ -283,8 +274,10 @@ class DiffTreeResolver:
                                             uuid="60b2456b-0dcd-47c9-a9f1-590b30a597de",
                                             base_branch_action=DiffAction.REMOVED,
                                             base_branch_value=None,
+                                            base_branch_changed_at=the_time,
                                             diff_branch_action=DiffAction.UPDATED,
                                             diff_branch_value=True,
+                                            diff_branch_changed_at=the_time,
                                             selected_branch=ConflictSelection.DIFF_BRANCH,
                                         ),
                                     ),

--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -25,10 +25,7 @@ query DiffTree
         depth: Number
         limit: Number
         offset: Number
-"""
 
-
-"""
 - query to get all diffs for a list of branches that returns summary counts
 - some way to track conflicts that have been addressed
 - some way (a new mutation?) to allow discarding ANY change for an UPDATE
@@ -317,9 +314,9 @@ class DiffTreeResolver:
             return response_list
         return response_list[0]
 
-    async def resolve(
+    async def resolve(  # pylint: disable=unused-argument
         self,
-        root: dict,  # pylint: disable=unused-argument
+        root: dict,
         info: GraphQLResolveInfo,
         **kwargs: Any,
     ) -> Optional[Union[list[dict[str, Any]], dict[str, Any]]]:

--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, Optional, Union
+
+from graphene import Boolean, DateTime, Field, Int, List, ObjectType, String
+from graphene import Enum as GrapheneEnum
+from graphene import Union as GrapheneUnion
+from infrahub_sdk.utils import extract_fields
+
+from infrahub.core.constants import DiffAction
+
+if TYPE_CHECKING:
+    from graphql import GraphQLResolveInfo
+
+GrapheneDiffActionEnum = GrapheneEnum.from_enum(DiffAction)
+
+
+"""
+query DiffTree
+    filters:
+        branches: [Text]!
+        from_time: Timestamp
+        to_time: Timestamp
+        root_node_uuid: Text
+        depth: Number
+        limit: Number
+        offset: Number
+"""
+
+
+class ConflictDetails(ObjectType):
+    base_branch_action = Field(GrapheneDiffActionEnum, required=True)
+    base_branch_value = String()
+    diff_branch_action = Field(GrapheneDiffActionEnum, required=True)
+    diff_branch_value = String()
+
+
+class DiffSummaryCounts(ObjectType):
+    num_added = Int(required=False)
+    num_updated = Int(required=False)
+    num_removed = Int(required=False)
+    num_conflicts = Int(required=False)
+
+
+class DiffProperty(ObjectType):
+    property_type = String(required=True)
+    last_changed_at = DateTime(required=True)
+    previous_value = String(required=False)
+    new_value = String(required=False)
+    status = Field(GrapheneDiffActionEnum, required=True)
+    conflict = Field(ConflictDetails, required=False)
+
+
+class DiffAttribute(DiffSummaryCounts):
+    name = String(required=True)
+    last_changed_at = DateTime(required=True)
+    status = Field(GrapheneDiffActionEnum, required=True)
+    properties = List(DiffProperty)
+    contains_conflict = Boolean(required=True)
+
+
+class DiffSingleRelationship(DiffSummaryCounts):
+    last_changed_at = DateTime(required=False)
+    status = Field(GrapheneDiffActionEnum, required=True)
+    peer_id = String(required=True)
+    contains_conflict = Boolean(required=True)
+    properties = List(DiffProperty)
+
+    @classmethod
+    def is_type_of(cls, result: dict[str, Any], info: GraphQLResolveInfo) -> bool:
+        return bool(result.get("properties"))
+
+
+class DiffNode(DiffSummaryCounts):
+    uuid = String(required=True)
+    kind = String(required=True)
+    label = String(required=True)
+    status = Field(GrapheneDiffActionEnum, required=True)
+    contains_conflict = Boolean(required=True)
+    last_changed_at = DateTime(required=False)
+    attributes = List(DiffAttribute, required=True)
+    relationships = List(of_type=lambda: DiffRelationship, required=True)
+
+    @classmethod
+    def is_type_of(cls, result: dict[str, Any], info: GraphQLResolveInfo) -> bool:
+        return bool(result.get("uuid"))
+
+
+class DiffRelationshipElement(GrapheneUnion):
+    class Meta:
+        types = (DiffNode, DiffSingleRelationship)
+
+
+class DiffRelationship(DiffSummaryCounts):
+    name = String(required=True)
+    last_changed_at = DateTime(required=False)
+    status = Field(GrapheneDiffActionEnum, required=True)
+    elements = List(DiffRelationshipElement)
+    contains_conflict = Boolean(required=True)
+
+
+class DiffTree(DiffSummaryCounts):
+    base_branch = String(required=True)
+    diff_branch = String(required=True)
+    from_time = DateTime(required=True)
+    to_time = DateTime(required=True)
+    nodes = List(DiffNode)
+
+
+class DiffTreeResolver:
+    the_time = datetime(year=2024, month=2, day=3, hour=4, minute=5, second=6, tzinfo=UTC)
+    EXAMPLE_DIFF = DiffTree(
+        base_branch="main",
+        diff_branch="branch",
+        from_time=the_time,
+        to_time=the_time,
+        num_added=1,
+        num_updated=0,
+        num_removed=0,
+        num_conflicts=0,
+        nodes=[
+            DiffNode(
+                uuid="cdea5cb3-36eb-4b26-87aa-0a1123dd7960",
+                kind="SomethingKind",
+                num_added=1,
+                num_updated=0,
+                num_removed=0,
+                num_conflicts=0,
+                last_changed_at=the_time,
+                label="SomethingLabel",
+                status=DiffAction.ADDED,
+                contains_conflict=False,
+                relationships=[],
+                attributes=[
+                    DiffAttribute(
+                        name="SomethingAttribute",
+                        last_changed_at=the_time,
+                        status=DiffAction.ADDED,
+                        num_added=1,
+                        num_updated=0,
+                        num_removed=0,
+                        num_conflicts=0,
+                        contains_conflict=False,
+                        properties=[
+                            DiffProperty(
+                                property_type="value",
+                                last_changed_at=the_time,
+                                previous_value=None,
+                                new_value=42,
+                                status=DiffAction.ADDED,
+                            )
+                        ],
+                    )
+                ],
+            ),
+            DiffNode(
+                uuid="2beecc03-8d17-4360-b331-f242c9fb4997",
+                kind="ParentKind",
+                num_added=0,
+                num_updated=0,
+                num_removed=0,
+                num_conflicts=0,
+                last_changed_at=the_time,
+                label="ParentLabel",
+                status=DiffAction.UNCHANGED,
+                contains_conflict=False,
+                attributes=[],
+                relationships=[
+                    DiffRelationship(
+                        name="child_relationship",
+                        last_changed_at=the_time,
+                        status=DiffAction.UPDATED,
+                        contains_conflict=False,
+                        elements=[
+                            DiffNode(
+                                uuid="990e1eda-687b-454d-a6c3-dc6039f125dd",
+                                kind="ChildKind",
+                                num_added=0,
+                                num_updated=1,
+                                num_removed=0,
+                                num_conflicts=0,
+                                last_changed_at=the_time,
+                                label="ChildLabel",
+                                status=DiffAction.UPDATED,
+                                contains_conflict=False,
+                                attributes=[
+                                    DiffAttribute(
+                                        name="ChildAttribute",
+                                        last_changed_at=the_time,
+                                        status=DiffAction.UPDATED,
+                                        num_added=0,
+                                        num_updated=1,
+                                        num_removed=0,
+                                        num_conflicts=0,
+                                        contains_conflict=False,
+                                        properties=[
+                                            DiffProperty(
+                                                property_type="owner",
+                                                last_changed_at=the_time,
+                                                previous_value="herbert",
+                                                new_value="willy",
+                                                status=DiffAction.UPDATED,
+                                            )
+                                        ],
+                                    )
+                                ],
+                            )
+                        ],
+                    )
+                ],
+            ),
+            DiffNode(
+                uuid="a1b2f0c8-eda7-47e3-b3a2-5a055974c19c",
+                kind="RelationshipConflictKind",
+                num_added=0,
+                num_updated=1,
+                num_removed=0,
+                num_conflicts=1,
+                last_changed_at=the_time,
+                label="RelationshipConflictLabel",
+                status=DiffAction.UPDATED,
+                contains_conflict=True,
+                attributes=[],
+                relationships=[
+                    DiffRelationship(
+                        name="conflict_relationship",
+                        last_changed_at=the_time,
+                        status=DiffAction.UPDATED,
+                        contains_conflict=True,
+                        elements=[
+                            DiffSingleRelationship(
+                                last_changed_at=the_time,
+                                status=DiffAction.UPDATED,
+                                peer_id="7f0d1a04-1543-4d7e-b348-8fb1d19f7a8c",
+                                contains_conflict=True,
+                                properties=[
+                                    DiffProperty(
+                                        property_type="peer_id",
+                                        last_changed_at=the_time,
+                                        previous_value="87a4e7f8-5d7d-4b22-ab92-92b4d8890e75",
+                                        new_value="c411c56f-d88b-402d-8753-0a35defaab1f",
+                                        status=DiffAction.UPDATED,
+                                        conflict=ConflictDetails(
+                                            base_branch_action=DiffAction.REMOVED,
+                                            base_branch_value=None,
+                                            diff_branch_action=DiffAction.UPDATED,
+                                            diff_branch_value="c411c56f-d88b-402d-8753-0a35defaab1f",
+                                        ),
+                                    ),
+                                    DiffProperty(
+                                        property_type="is_visible",
+                                        last_changed_at=the_time,
+                                        previous_value=False,
+                                        new_value=True,
+                                        status=DiffAction.UPDATED,
+                                        conflict=ConflictDetails(
+                                            base_branch_action=DiffAction.REMOVED,
+                                            base_branch_value=None,
+                                            diff_branch_action=DiffAction.UPDATED,
+                                            diff_branch_value=True,
+                                        ),
+                                    ),
+                                ],
+                            )
+                        ],
+                    )
+                ],
+            ),
+        ],
+    )
+
+    def to_graphql(
+        self, fields: dict[str, dict], diff_object: Optional[Any]
+    ) -> Optional[Union[list[dict[str, Any]], dict[str, Any]]]:
+        if diff_object is None:
+            return None
+        if isinstance(diff_object, list):
+            list_response = True
+            diff_elements = diff_object
+        else:
+            list_response = False
+            diff_elements = [diff_object]
+
+        response_list = []
+        for diff_object_element in diff_elements:
+            element_response = {}
+            for field_name, sub_fields in fields.items():
+                if sub_fields is None:
+                    element_response[field_name] = getattr(diff_object_element, field_name, None)
+                elif hasattr(diff_object_element, field_name):
+                    element_response[field_name] = self.to_graphql(sub_fields, getattr(diff_object_element, field_name))
+                else:
+                    continue
+            response_list.append(element_response)
+        if list_response:
+            return response_list
+        return response_list[0]
+
+    async def resolve(
+        self,
+        root: dict,  # pylint: disable=unused-argument
+        info: GraphQLResolveInfo,
+        **kwargs: Any,
+    ) -> Optional[Union[list[dict[str, Any]], dict[str, Any]]]:
+        full_fields = await extract_fields(info.field_nodes[0].selection_set)
+        return self.to_graphql(fields=full_fields, diff_object=self.EXAMPLE_DIFF)
+
+
+DiffTreeQuery = Field(
+    DiffTree,
+    name=String(),
+    resolver=DiffTreeResolver().resolve,
+)

--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -21,7 +21,7 @@ query DiffTree
         branches: [Text]!
         from_time: Timestamp
         to_time: Timestamp
-        root_node_uuid: Text
+        root_node_uuids: [Text!]
         depth: Number
         limit: Number
         offset: Number

--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -15,27 +15,6 @@ if TYPE_CHECKING:
 GrapheneDiffActionEnum = GrapheneEnum.from_enum(DiffAction)
 
 
-"""
-query DiffTree
-    filters:
-        branches: [Text]!
-        from_time: Timestamp
-        to_time: Timestamp
-        root_node_uuids: [Text!]
-        depth: Number
-        limit: Number
-        offset: Number
-
-- query to get all diffs for a list of branches that returns summary counts
-- some way to track conflicts that have been addressed
-- some way (a new mutation?) to allow discarding ANY change for an UPDATE
-  - add a comment on the proposed change automatically
-- track number of changes on main as part of cached diff for a given branch
-- rebasing will require recalculating the diff and invalidating the cached diffs for this branch
-- when merging, we need to lock main, calculate the small interval of the diff to make it current, then merge if no conflicts
-"""
-
-
 class ConflictSelection(GrapheneEnum):
     BASE_BRANCH = "base"
     DIFF_BRANCH = "diff"
@@ -328,4 +307,11 @@ DiffTreeQuery = Field(
     DiffTree,
     name=String(),
     resolver=DiffTreeResolver().resolve,
+    branches=List(String),
+    from_time=DateTime(),
+    to_time=DateTime(),
+    root_node_uuids=List(String),
+    max_depth=Int(),
+    limit=Int(),
+    offset=Int(),
 )

--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -57,6 +57,7 @@ class ConflictSelection(GrapheneEnum):
     BASE_BRANCH = "base"
     DIFF_BRANCH = "diff"
 
+
 class ConflictDetails(ObjectType):
     uuid = String(required=True)
     base_branch_action = Field(GrapheneDiffActionEnum, required=True)
@@ -284,7 +285,7 @@ class DiffTreeResolver:
                                             base_branch_value=None,
                                             diff_branch_action=DiffAction.UPDATED,
                                             diff_branch_value=True,
-                                            selected_branch=ConflictSelection.DIFF_BRANCH
+                                            selected_branch=ConflictSelection.DIFF_BRANCH,
                                         ),
                                     ),
                                 ],

--- a/backend/infrahub/graphql/schema.py
+++ b/backend/infrahub/graphql/schema.py
@@ -49,6 +49,7 @@ from .queries import (
     Relationship,
     Task,
 )
+from .queries.diff.tree import DiffTreeQuery
 
 if TYPE_CHECKING:
     from graphql import GraphQLResolveInfo
@@ -87,6 +88,7 @@ class InfrahubBaseQuery(ObjectType):
     Branch = BranchQueryList
     CoreAccountToken = AccountToken
 
+    DiffTree = DiffTreeQuery
     DiffSummary = DiffSummary
     DiffSummaryOld = DiffSummaryOld
 

--- a/backend/tests/unit/graphql/test_graphql_query.py
+++ b/backend/tests/unit/graphql/test_graphql_query.py
@@ -15,6 +15,285 @@ from infrahub.database import InfrahubDatabase
 from infrahub.graphql import prepare_graphql_params
 
 
+async def test_diff_tree(db: InfrahubDatabase, default_branch: Branch, data_schema):
+    query = """
+    query {
+        DiffTree {
+            base_branch
+            diff_branch
+            from_time
+            to_time
+            num_added
+            num_removed
+            num_updated
+            num_conflicts
+            nodes {
+                uuid
+                kind
+                label
+                last_changed_at
+                status
+                contains_conflict
+                num_added
+                num_removed
+                num_updated
+                num_conflicts
+                attributes {
+                    name
+                    last_changed_at
+                    status
+                    num_added
+                    num_removed
+                    num_updated
+                    num_conflicts
+                    contains_conflict
+                    properties {
+                        property_type
+                        last_changed_at
+                        previous_value
+                        new_value
+                        status
+                    }
+                }
+                relationships {
+                    name
+                    last_changed_at
+                    status
+                    contains_conflict
+                    elements {
+                        ... on DiffNode {
+                            uuid
+                            kind
+                            label
+                            status
+                            last_changed_at
+                            contains_conflict
+                            num_added
+                            num_removed
+                            num_updated
+                            num_conflicts
+                            attributes {
+                                name
+                                last_changed_at
+                                status
+                                num_added
+                                num_removed
+                                num_updated
+                                num_conflicts
+                                contains_conflict
+                                properties {
+                                    property_type
+                                    last_changed_at
+                                    previous_value
+                                    new_value
+                                    status
+                                    conflict {
+                                        base_branch_action
+                                        base_branch_value
+                                        diff_branch_action
+                                        diff_branch_value
+                                    }
+                                }
+                            }
+                        }
+                        ... on DiffSingleRelationship {
+                            status
+                            peer_id
+                            last_changed_at
+                            contains_conflict
+                            properties {
+                                property_type
+                                last_changed_at
+                                previous_value
+                                new_value
+                                status
+                                conflict {
+                                    base_branch_action
+                                    base_branch_value
+                                    diff_branch_action
+                                    diff_branch_value
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+
+    params = prepare_graphql_params(db=db, include_mutation=False, include_subscription=False, branch=default_branch)
+    result = await graphql(
+        schema=params.schema,
+        source=query,
+        context_value=params.context,
+        root_value=None,
+        variable_values={},
+    )
+
+    assert result.errors is None
+    assert result.data["DiffTree"] == {
+        "base_branch": "main",
+        "diff_branch": "branch",
+        "from_time": "2024-02-03T04:05:06+00:00",
+        "to_time": "2024-02-03T04:05:06+00:00",
+        "num_added": 1,
+        "num_removed": 0,
+        "num_updated": 0,
+        "num_conflicts": 0,
+        "nodes": [
+            {
+                "uuid": "cdea5cb3-36eb-4b26-87aa-0a1123dd7960",
+                "kind": "SomethingKind",
+                "label": "SomethingLabel",
+                "last_changed_at": "2024-02-03T04:05:06+00:00",
+                "num_added": 1,
+                "num_removed": 0,
+                "num_updated": 0,
+                "num_conflicts": 0,
+                "status": "ADDED",
+                "contains_conflict": False,
+                "relationships": [],
+                "attributes": [
+                    {
+                        "name": "SomethingAttribute",
+                        "last_changed_at": "2024-02-03T04:05:06+00:00",
+                        "num_added": 1,
+                        "num_removed": 0,
+                        "num_updated": 0,
+                        "num_conflicts": 0,
+                        "status": "ADDED",
+                        "contains_conflict": False,
+                        "properties": [
+                            {
+                                "property_type": "value",
+                                "last_changed_at": "2024-02-03T04:05:06+00:00",
+                                "previous_value": None,
+                                "new_value": "42",
+                                "status": "ADDED",
+                            }
+                        ],
+                    }
+                ],
+            },
+            {
+                "uuid": "2beecc03-8d17-4360-b331-f242c9fb4997",
+                "kind": "ParentKind",
+                "num_added": 0,
+                "num_updated": 0,
+                "num_removed": 0,
+                "num_conflicts": 0,
+                "last_changed_at": "2024-02-03T04:05:06+00:00",
+                "label": "ParentLabel",
+                "status": "UNCHANGED",
+                "contains_conflict": False,
+                "attributes": [],
+                "relationships": [
+                    {
+                        "name": "child_relationship",
+                        "last_changed_at": "2024-02-03T04:05:06+00:00",
+                        "status": "UPDATED",
+                        "contains_conflict": False,
+                        "elements": [
+                            {
+                                "uuid": "990e1eda-687b-454d-a6c3-dc6039f125dd",
+                                "kind": "ChildKind",
+                                "label": "ChildLabel",
+                                "last_changed_at": "2024-02-03T04:05:06+00:00",
+                                "status": "UPDATED",
+                                "contains_conflict": False,
+                                "num_added": 0,
+                                "num_removed": 0,
+                                "num_updated": 1,
+                                "num_conflicts": 0,
+                                "attributes": [
+                                    {
+                                        "name": "ChildAttribute",
+                                        "last_changed_at": "2024-02-03T04:05:06+00:00",
+                                        "num_added": 0,
+                                        "num_removed": 0,
+                                        "num_updated": 1,
+                                        "num_conflicts": 0,
+                                        "status": "UPDATED",
+                                        "contains_conflict": False,
+                                        "properties": [
+                                            {
+                                                "conflict": None,
+                                                "property_type": "owner",
+                                                "last_changed_at": "2024-02-03T04:05:06+00:00",
+                                                "previous_value": "herbert",
+                                                "new_value": "willy",
+                                                "status": "UPDATED",
+                                            }
+                                        ],
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+            {
+                "uuid": "a1b2f0c8-eda7-47e3-b3a2-5a055974c19c",
+                "kind": "RelationshipConflictKind",
+                "num_added": 0,
+                "num_updated": 1,
+                "num_removed": 0,
+                "num_conflicts": 1,
+                "last_changed_at": "2024-02-03T04:05:06+00:00",
+                "label": "RelationshipConflictLabel",
+                "status": "UPDATED",
+                "contains_conflict": True,
+                "attributes": [],
+                "relationships": [
+                    {
+                        "name": "conflict_relationship",
+                        "last_changed_at": "2024-02-03T04:05:06+00:00",
+                        "status": "UPDATED",
+                        "contains_conflict": True,
+                        "elements": [
+                            {
+                                "last_changed_at": "2024-02-03T04:05:06+00:00",
+                                "status": "UPDATED",
+                                "peer_id": "7f0d1a04-1543-4d7e-b348-8fb1d19f7a8c",
+                                "contains_conflict": True,
+                                "properties": [
+                                    {
+                                        "property_type": "peer_id",
+                                        "last_changed_at": "2024-02-03T04:05:06+00:00",
+                                        "previous_value": "87a4e7f8-5d7d-4b22-ab92-92b4d8890e75",
+                                        "new_value": "c411c56f-d88b-402d-8753-0a35defaab1f",
+                                        "status": "UPDATED",
+                                        "conflict": {
+                                            "base_branch_action": "REMOVED",
+                                            "base_branch_value": None,
+                                            "diff_branch_action": "UPDATED",
+                                            "diff_branch_value": "c411c56f-d88b-402d-8753-0a35defaab1f",
+                                        },
+                                    },
+                                    {
+                                        "property_type": "is_visible",
+                                        "last_changed_at": "2024-02-03T04:05:06+00:00",
+                                        "previous_value": "false",
+                                        "new_value": "true",
+                                        "status": "UPDATED",
+                                        "conflict": {
+                                            "base_branch_action": "REMOVED",
+                                            "base_branch_value": None,
+                                            "diff_branch_action": "UPDATED",
+                                            "diff_branch_value": "true",
+                                        },
+                                    },
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+        ],
+    }
+
+
 async def test_info_query(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
     query = """
     query {

--- a/backend/tests/unit/graphql/test_graphql_query.py
+++ b/backend/tests/unit/graphql/test_graphql_query.py
@@ -53,6 +53,12 @@ async def test_diff_tree(db: InfrahubDatabase, default_branch: Branch, data_sche
                         previous_value
                         new_value
                         status
+                        conflict {
+                            base_branch_action
+                            base_branch_value
+                            diff_branch_action
+                            diff_branch_value
+                        }
                     }
                 }
                 relationships {
@@ -60,59 +66,23 @@ async def test_diff_tree(db: InfrahubDatabase, default_branch: Branch, data_sche
                     last_changed_at
                     status
                     contains_conflict
+                    node_uuids
                     elements {
-                        ... on DiffNode {
-                            uuid
-                            kind
-                            label
-                            status
+                        status
+                        peer_id
+                        last_changed_at
+                        contains_conflict
+                        properties {
+                            property_type
                             last_changed_at
-                            contains_conflict
-                            num_added
-                            num_removed
-                            num_updated
-                            num_conflicts
-                            attributes {
-                                name
-                                last_changed_at
-                                status
-                                num_added
-                                num_removed
-                                num_updated
-                                num_conflicts
-                                contains_conflict
-                                properties {
-                                    property_type
-                                    last_changed_at
-                                    previous_value
-                                    new_value
-                                    status
-                                    conflict {
-                                        base_branch_action
-                                        base_branch_value
-                                        diff_branch_action
-                                        diff_branch_value
-                                    }
-                                }
-                            }
-                        }
-                        ... on DiffSingleRelationship {
+                            previous_value
+                            new_value
                             status
-                            peer_id
-                            last_changed_at
-                            contains_conflict
-                            properties {
-                                property_type
-                                last_changed_at
-                                previous_value
-                                new_value
-                                status
-                                conflict {
-                                    base_branch_action
-                                    base_branch_value
-                                    diff_branch_action
-                                    diff_branch_value
-                                }
+                            conflict {
+                                base_branch_action
+                                base_branch_value
+                                diff_branch_action
+                                diff_branch_value
                             }
                         }
                     }
@@ -171,6 +141,42 @@ async def test_diff_tree(db: InfrahubDatabase, default_branch: Branch, data_sche
                                 "previous_value": None,
                                 "new_value": "42",
                                 "status": "ADDED",
+                                "conflict": None,
+                            }
+                        ],
+                    }
+                ],
+            },
+            {
+                "uuid": "990e1eda-687b-454d-a6c3-dc6039f125dd",
+                "kind": "ChildKind",
+                "label": "ChildLabel",
+                "last_changed_at": "2024-02-03T04:05:06+00:00",
+                "status": "UPDATED",
+                "contains_conflict": False,
+                "num_added": 0,
+                "num_removed": 0,
+                "num_updated": 1,
+                "num_conflicts": 0,
+                "relationships": [],
+                "attributes": [
+                    {
+                        "name": "ChildAttribute",
+                        "last_changed_at": "2024-02-03T04:05:06+00:00",
+                        "num_added": 0,
+                        "num_removed": 0,
+                        "num_updated": 1,
+                        "num_conflicts": 0,
+                        "status": "UPDATED",
+                        "contains_conflict": False,
+                        "properties": [
+                            {
+                                "property_type": "owner",
+                                "last_changed_at": "2024-02-03T04:05:06+00:00",
+                                "previous_value": "herbert",
+                                "new_value": "willy",
+                                "status": "UPDATED",
+                                "conflict": None,
                             }
                         ],
                     }
@@ -194,42 +200,8 @@ async def test_diff_tree(db: InfrahubDatabase, default_branch: Branch, data_sche
                         "last_changed_at": "2024-02-03T04:05:06+00:00",
                         "status": "UPDATED",
                         "contains_conflict": False,
-                        "elements": [
-                            {
-                                "uuid": "990e1eda-687b-454d-a6c3-dc6039f125dd",
-                                "kind": "ChildKind",
-                                "label": "ChildLabel",
-                                "last_changed_at": "2024-02-03T04:05:06+00:00",
-                                "status": "UPDATED",
-                                "contains_conflict": False,
-                                "num_added": 0,
-                                "num_removed": 0,
-                                "num_updated": 1,
-                                "num_conflicts": 0,
-                                "attributes": [
-                                    {
-                                        "name": "ChildAttribute",
-                                        "last_changed_at": "2024-02-03T04:05:06+00:00",
-                                        "num_added": 0,
-                                        "num_removed": 0,
-                                        "num_updated": 1,
-                                        "num_conflicts": 0,
-                                        "status": "UPDATED",
-                                        "contains_conflict": False,
-                                        "properties": [
-                                            {
-                                                "conflict": None,
-                                                "property_type": "owner",
-                                                "last_changed_at": "2024-02-03T04:05:06+00:00",
-                                                "previous_value": "herbert",
-                                                "new_value": "willy",
-                                                "status": "UPDATED",
-                                            }
-                                        ],
-                                    }
-                                ],
-                            }
-                        ],
+                        "elements": [],
+                        "node_uuids": ["990e1eda-687b-454d-a6c3-dc6039f125dd"],
                     }
                 ],
             },
@@ -251,6 +223,7 @@ async def test_diff_tree(db: InfrahubDatabase, default_branch: Branch, data_sche
                         "last_changed_at": "2024-02-03T04:05:06+00:00",
                         "status": "UPDATED",
                         "contains_conflict": True,
+                        "node_uuids": [],
                         "elements": [
                             {
                                 "last_changed_at": "2024-02-03T04:05:06+00:00",

--- a/backend/tests/unit/graphql/test_graphql_query.py
+++ b/backend/tests/unit/graphql/test_graphql_query.py
@@ -54,10 +54,12 @@ async def test_diff_tree(db: InfrahubDatabase, default_branch: Branch, data_sche
                         new_value
                         status
                         conflict {
+                            uuid
                             base_branch_action
                             base_branch_value
                             diff_branch_action
                             diff_branch_value
+                            selected_branch
                         }
                     }
                 }
@@ -79,10 +81,12 @@ async def test_diff_tree(db: InfrahubDatabase, default_branch: Branch, data_sche
                             new_value
                             status
                             conflict {
+                                uuid
                                 base_branch_action
                                 base_branch_value
                                 diff_branch_action
                                 diff_branch_value
+                                selected_branch
                             }
                         }
                     }
@@ -238,10 +242,12 @@ async def test_diff_tree(db: InfrahubDatabase, default_branch: Branch, data_sche
                                         "new_value": "c411c56f-d88b-402d-8753-0a35defaab1f",
                                         "status": "UPDATED",
                                         "conflict": {
+                                            "uuid": "0a7a5898-e8a0-4baf-b7ae-1fac1fcdf468",
                                             "base_branch_action": "REMOVED",
                                             "base_branch_value": None,
                                             "diff_branch_action": "UPDATED",
                                             "diff_branch_value": "c411c56f-d88b-402d-8753-0a35defaab1f",
+                                            "selected_branch": None,
                                         },
                                     },
                                     {
@@ -251,10 +257,12 @@ async def test_diff_tree(db: InfrahubDatabase, default_branch: Branch, data_sche
                                         "new_value": "true",
                                         "status": "UPDATED",
                                         "conflict": {
+                                            "uuid": "60b2456b-0dcd-47c9-a9f1-590b30a597de",
                                             "base_branch_action": "REMOVED",
                                             "base_branch_value": None,
                                             "diff_branch_action": "UPDATED",
                                             "diff_branch_value": "true",
+                                            "selected_branch": "DIFF_BRANCH",
                                         },
                                     },
                                 ],

--- a/backend/tests/unit/graphql/test_graphql_query.py
+++ b/backend/tests/unit/graphql/test_graphql_query.py
@@ -18,7 +18,7 @@ from infrahub.graphql import prepare_graphql_params
 async def test_diff_tree(db: InfrahubDatabase, default_branch: Branch, data_schema):
     query = """
     query {
-        DiffTree {
+        DiffTree (branches: ["diff"]) {
             base_branch
             diff_branch
             from_time

--- a/backend/tests/unit/graphql/test_graphql_query.py
+++ b/backend/tests/unit/graphql/test_graphql_query.py
@@ -57,8 +57,10 @@ async def test_diff_tree(db: InfrahubDatabase, default_branch: Branch, data_sche
                             uuid
                             base_branch_action
                             base_branch_value
+                            base_branch_changed_at
                             diff_branch_action
                             diff_branch_value
+                            diff_branch_changed_at
                             selected_branch
                         }
                     }
@@ -74,6 +76,16 @@ async def test_diff_tree(db: InfrahubDatabase, default_branch: Branch, data_sche
                         peer_id
                         last_changed_at
                         contains_conflict
+                        conflict {
+                            uuid
+                            base_branch_action
+                            base_branch_changed_at
+                            base_branch_value
+                            diff_branch_action
+                            diff_branch_value
+                            diff_branch_changed_at
+                            selected_branch
+                        }
                         properties {
                             property_type
                             last_changed_at
@@ -84,8 +96,10 @@ async def test_diff_tree(db: InfrahubDatabase, default_branch: Branch, data_sche
                                 uuid
                                 base_branch_action
                                 base_branch_value
+                                base_branch_changed_at
                                 diff_branch_action
                                 diff_branch_value
+                                diff_branch_changed_at
                                 selected_branch
                             }
                         }
@@ -234,6 +248,7 @@ async def test_diff_tree(db: InfrahubDatabase, default_branch: Branch, data_sche
                                 "status": "UPDATED",
                                 "peer_id": "7f0d1a04-1543-4d7e-b348-8fb1d19f7a8c",
                                 "contains_conflict": True,
+                                "conflict": None,
                                 "properties": [
                                     {
                                         "property_type": "peer_id",
@@ -245,8 +260,10 @@ async def test_diff_tree(db: InfrahubDatabase, default_branch: Branch, data_sche
                                             "uuid": "0a7a5898-e8a0-4baf-b7ae-1fac1fcdf468",
                                             "base_branch_action": "REMOVED",
                                             "base_branch_value": None,
+                                            "base_branch_changed_at": "2024-02-03T04:05:06+00:00",
                                             "diff_branch_action": "UPDATED",
                                             "diff_branch_value": "c411c56f-d88b-402d-8753-0a35defaab1f",
+                                            "diff_branch_changed_at": "2024-02-03T04:05:06+00:00",
                                             "selected_branch": None,
                                         },
                                     },
@@ -260,8 +277,10 @@ async def test_diff_tree(db: InfrahubDatabase, default_branch: Branch, data_sche
                                             "uuid": "60b2456b-0dcd-47c9-a9f1-590b30a597de",
                                             "base_branch_action": "REMOVED",
                                             "base_branch_value": None,
+                                            "base_branch_changed_at": "2024-02-03T04:05:06+00:00",
                                             "diff_branch_action": "UPDATED",
                                             "diff_branch_value": "true",
+                                            "diff_branch_changed_at": "2024-02-03T04:05:06+00:00",
                                             "selected_branch": "DIFF_BRANCH",
                                         },
                                     },


### PR DESCRIPTION
proposed format of the new diff query required for the new tree view as well as a unit test with an example
the new GraphQL query (`DiffTree`) will return correctly formatted dummy data. see `DiffTreeResolver` for the actual data. filters are ignored, but the available should be correct

also, some more of the skeleton/stub classes for the actual logic