### PR TITLE
Add option to fetch peers nodes in query_peers

### DIFF
--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -276,6 +276,7 @@ class NodeManager:
         at: Optional[Union[Timestamp, str]] = None,
         branch: Optional[Union[Branch, str]] = None,
         branch_agnostic: bool = False,
+        fetch_peers: bool = False,
     ) -> list[Relationship]:
         branch = await registry.get_branch(branch=branch, db=db)
         at = Timestamp(at)
@@ -308,16 +309,26 @@ class NodeManager:
             if display_label_fields:
                 fields = deep_merge_dict(dicta=fields, dictb=display_label_fields)
 
-        return [
-            await Relationship(schema=schema, branch=branch, at=at, node_id=peer.source_id).load(
+        if fetch_peers:
+            peer_ids = [peer.peer_id for peer in peers_info]
+            peer_nodes = await cls.get_many(
+                db=db, ids=peer_ids, fields=fields, at=at, branch=branch, branch_agnostic=branch_agnostic
+            )
+
+        results = []
+        for peer in peers_info:
+            result = await Relationship(schema=schema, branch=branch, at=at, node_id=peer.source_id).load(
                 db=db,
                 id=peer.rel_node_id,
                 db_id=peer.rel_node_db_id,
                 updated_at=peer.updated_at,
                 data=peer,
             )
-            for peer in peers_info
-        ]
+            if fetch_peers:
+                await result.set_peer(value=peer_nodes[peer.peer_id])
+            results.append(result)
+
+        return results
 
     @classmethod
     async def count_hierarchy(

--- a/backend/infrahub/graphql/resolver.py
+++ b/backend/infrahub/graphql/resolver.py
@@ -79,6 +79,7 @@ async def default_resolver(*args, **kwargs):
             at=context.at,
             branch=context.branch,
             branch_agnostic=node_rel.branch is BranchSupportType.AGNOSTIC,
+            fetch_peers=True,
         )
 
         if node_rel.cardinality == "many":
@@ -134,6 +135,7 @@ async def single_relationship_resolver(parent: dict, info: GraphQLResolveInfo, *
             at=context.at,
             branch=context.branch,
             branch_agnostic=node_rel.branch is BranchSupportType.AGNOSTIC,
+            fetch_peers=True,
         )
 
         if not objs:
@@ -231,6 +233,7 @@ async def many_relationship_resolver(
             at=context.at,
             branch=context.branch,
             branch_agnostic=node_rel.branch is BranchSupportType.AGNOSTIC,
+            fetch_peers=True,
         )
 
         if not objs:


### PR DESCRIPTION
replaces #3857 targeting `stable` instead of `develop`

This PR improves the response time of GraphQL queries that are accessing relationships