### PR TITLE
Improve Python Protocols 

### DIFF
--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -572,35 +572,61 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin):
 
 class AnyAttribute(BaseAttribute):
     type = Any
+    value: Any
 
     @classmethod
     def validate_format(cls, value: Any, name: str, schema: AttributeSchema) -> None:
         pass
 
 
+class AnyAttributeOptional(AnyAttribute):
+    pass
+
+
 class String(BaseAttribute):
     type = str
+    value: str
+
+
+class StringOptional(String):
+    value: Optional[str]
 
 
 class HashedPassword(BaseAttribute):
     type = str
+    value: str
 
     def serialize_value(self) -> str:
         """Serialize the value before storing it in the database."""
         return hash_password(str(self.value))
 
 
+class HashedPasswordOptional(HashedPassword):
+    value: Optional[str]
+
+
 class Integer(BaseAttribute):
     type = int
+    value: int
     from_pool: Optional[str] = None
+
+
+class IntegerOptional(Integer):
+    value: Optional[int]
 
 
 class Boolean(BaseAttribute):
     type = bool
+    value: bool
+
+
+class BooleanOptional(Boolean):
+    value: Optional[bool]
 
 
 class DateTime(BaseAttribute):
     type = str
+    value: str
 
     @classmethod
     def validate_format(cls, value: Any, name: str, schema: AttributeSchema) -> None:
@@ -615,8 +641,13 @@ class DateTime(BaseAttribute):
             raise ValidationError({name: f"{value} is not a valid {schema.kind}"}) from exc
 
 
+class DateTimeOptional(DateTime):
+    value: Optional[str]
+
+
 class Dropdown(BaseAttribute):
     type = str
+    value: str
 
     @property
     def color(self) -> str:
@@ -657,8 +688,13 @@ class Dropdown(BaseAttribute):
             raise ValidationError({name: f"{value} must be one of {', '.join(sorted(values))!r}"})
 
 
+class DropdownOptional(Dropdown):
+    value: Optional[str]
+
+
 class URL(BaseAttribute):
     type = str
+    value: str
 
     @classmethod
     def validate_format(cls, value: Any, name: str, schema: AttributeSchema) -> None:
@@ -668,8 +704,13 @@ class URL(BaseAttribute):
             raise ValidationError({name: f"{value} is not a valid {schema.kind}"})
 
 
+class URLOptional(URL):
+    value: Optional[str]
+
+
 class IPNetwork(BaseAttribute):
     type = str
+    value: str
 
     @staticmethod
     def get_allowed_property_in_path() -> list[str]:
@@ -796,8 +837,13 @@ class IPNetwork(BaseAttribute):
         return data
 
 
+class IPNetworkOptional(IPNetwork):
+    value: Optional[str]
+
+
 class IPHost(BaseAttribute):
     type = str
+    value: str
 
     @staticmethod
     def get_allowed_property_in_path() -> list[str]:
@@ -916,8 +962,13 @@ class IPHost(BaseAttribute):
         return data
 
 
+class IPHostOptional(IPHost):
+    value: Optional[str]
+
+
 class MacAddress(BaseAttribute):
     type = str
+    value: str
 
     @property
     def obj(self) -> netaddr.EUI:
@@ -1017,8 +1068,13 @@ class MacAddress(BaseAttribute):
         return str(netaddr.EUI(addr=str(self.value)))
 
 
+class MacAddressOptional(MacAddress):
+    value: Optional[str]
+
+
 class ListAttribute(BaseAttribute):
     type = list
+    value: list[Any]
 
     def serialize_value(self) -> str:
         """Serialize the value before storing it in the database."""
@@ -1031,8 +1087,13 @@ class ListAttribute(BaseAttribute):
         return data.value
 
 
+class ListAttributeOptional(ListAttribute):
+    value: Optional[list[Any]]
+
+
 class JSONAttribute(BaseAttribute):
     type = (dict, list)
+    value: Union[dict, list]
 
     def serialize_value(self) -> str:
         """Serialize the value before storing it in the database."""
@@ -1043,3 +1104,7 @@ class JSONAttribute(BaseAttribute):
         if data.value and isinstance(data.value, (str, bytes)):
             return ujson.loads(data.value)
         return data.value
+
+
+class JSONAttributeOptional(JSONAttribute):
+    value: Optional[Union[dict, list]]

--- a/backend/infrahub/core/protocols.py
+++ b/backend/infrahub/core/protocols.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Protocol, runtime_checkable
+from typing import TYPE_CHECKING
 
-from typing_extensions import Self
+from .protocols_base import CoreNode
 
 if TYPE_CHECKING:
     from enum import Enum
-
-    from neo4j import AsyncResult, AsyncSession, AsyncTransaction, Record
 
     from infrahub.core.attribute import (
         URL,
@@ -30,52 +28,6 @@ if TYPE_CHECKING:
         StringOptional,
     )
     from infrahub.core.relationship import RelationshipManager
-
-
-@runtime_checkable
-class SchemaBranch(Protocol): ...
-
-
-@runtime_checkable
-class Timestamp(Protocol): ...
-
-
-@runtime_checkable
-class InfrahubDatabase(Protocol):
-    is_session: bool
-    is_transaction: bool
-
-    def add_schema(self, schema: SchemaBranch, name: Optional[str] = None) -> None: ...
-    def start_session(self, read_only: bool = False, schemas: Optional[list[SchemaBranch]] = None) -> Self: ...
-    def start_transaction(self, schemas: Optional[list[SchemaBranch]] = None) -> Self: ...
-    async def session(self) -> AsyncSession: ...
-    async def transaction(self, name: Optional[str]) -> AsyncTransaction: ...
-    async def close(self) -> None: ...
-
-    async def execute_query(
-        self, query: str, params: Optional[dict[str, Any]] = None, name: Optional[str] = "undefined"
-    ) -> list[Record]: ...
-
-    async def execute_query_with_metadata(
-        self, query: str, params: Optional[dict[str, Any]] = None, name: Optional[str] = "undefined"
-    ) -> tuple[list[Record], dict[str, Any]]: ...
-
-    async def run_query(
-        self, query: str, params: Optional[dict[str, Any]] = None, name: Optional[str] = "undefined"
-    ) -> AsyncResult: ...
-
-    def render_list_comprehension(self, items: str, item_name: str) -> str: ...
-    def render_list_comprehension_with_list(self, items: str, item_names: list[str]) -> str: ...
-    def render_uuid_generation(self, node_label: str, node_attr: str) -> str: ...
-
-
-@runtime_checkable
-class CoreNode(Protocol):
-    id: str
-
-    def get_id(self) -> str: ...
-    def get_kind(self) -> str: ...
-    async def save(self, db: InfrahubDatabase, at: Optional[Timestamp] = None) -> Self: ...
 
 
 class BuiltinIPAddress(CoreNode):

--- a/backend/infrahub/core/protocols.py
+++ b/backend/infrahub/core/protocols.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Optional, Protocol, runtime_checkable
+
+from typing_extensions import Self
 
 if TYPE_CHECKING:
     from enum import Enum
+
+    from neo4j import AsyncResult, AsyncSession, AsyncTransaction, Record
 
     from infrahub.core.attribute import (
         URL,
@@ -29,12 +33,49 @@ if TYPE_CHECKING:
 
 
 @runtime_checkable
+class SchemaBranch(Protocol): ...
+
+
+@runtime_checkable
+class Timestamp(Protocol): ...
+
+
+@runtime_checkable
+class InfrahubDatabase(Protocol):
+    is_session: bool
+    is_transaction: bool
+
+    def add_schema(self, schema: SchemaBranch, name: Optional[str] = None) -> None: ...
+    def start_session(self, read_only: bool = False, schemas: Optional[list[SchemaBranch]] = None) -> Self: ...
+    def start_transaction(self, schemas: Optional[list[SchemaBranch]] = None) -> Self: ...
+    async def session(self) -> AsyncSession: ...
+    async def transaction(self, name: Optional[str]) -> AsyncTransaction: ...
+    async def close(self) -> None: ...
+
+    async def execute_query(
+        self, query: str, params: Optional[dict[str, Any]] = None, name: Optional[str] = "undefined"
+    ) -> list[Record]: ...
+
+    async def execute_query_with_metadata(
+        self, query: str, params: Optional[dict[str, Any]] = None, name: Optional[str] = "undefined"
+    ) -> tuple[list[Record], dict[str, Any]]: ...
+
+    async def run_query(
+        self, query: str, params: Optional[dict[str, Any]] = None, name: Optional[str] = "undefined"
+    ) -> AsyncResult: ...
+
+    def render_list_comprehension(self, items: str, item_name: str) -> str: ...
+    def render_list_comprehension_with_list(self, items: str, item_names: list[str]) -> str: ...
+    def render_uuid_generation(self, node_label: str, node_attr: str) -> str: ...
+
+
+@runtime_checkable
 class CoreNode(Protocol):
     id: str
 
     def get_id(self) -> str: ...
     def get_kind(self) -> str: ...
-    async def save(self) -> None: ...
+    async def save(self, db: InfrahubDatabase, at: Optional[Timestamp] = None) -> Self: ...
 
 
 class BuiltinIPAddress(CoreNode):

--- a/backend/infrahub/core/protocols.py
+++ b/backend/infrahub/core/protocols.py
@@ -10,15 +10,20 @@ if TYPE_CHECKING:
     from infrahub.core.attribute import (
         URL,
         Boolean,
+        BooleanOptional,
         DateTime,
+        DateTimeOptional,
         Dropdown,
         HashedPassword,
         Integer,
+        IntegerOptional,
         IPHost,
         IPNetwork,
         JSONAttribute,
-        ListAttribute,
+        JSONAttributeOptional,
+        ListAttributeOptional,
         String,
+        StringOptional,
     )
     from infrahub.core.relationship import RelationshipManager
 
@@ -34,29 +39,29 @@ class CoreNode(Protocol):
 
 class BuiltinIPAddress(CoreNode):
     address: IPHost
-    description: String
+    description: StringOptional
     ip_namespace: RelationshipManager
     ip_prefix: RelationshipManager
 
 
 class BuiltinIPNamespace(CoreNode):
     name: String
-    description: String
+    description: StringOptional
     ip_prefixes: RelationshipManager
     ip_addresses: RelationshipManager
 
 
 class BuiltinIPPrefix(CoreNode):
     prefix: IPNetwork
-    description: String
+    description: StringOptional
     member_type: Dropdown
     is_pool: Boolean
-    is_top_level: Boolean
-    utilization: Integer
-    netmask: String
-    hostmask: String
-    network_address: String
-    broadcast_address: String
+    is_top_level: BooleanOptional
+    utilization: IntegerOptional
+    netmask: StringOptional
+    hostmask: StringOptional
+    network_address: StringOptional
+    broadcast_address: StringOptional
     ip_namespace: RelationshipManager
     ip_addresses: RelationshipManager
     resource_pool: RelationshipManager
@@ -69,29 +74,29 @@ class CoreArtifactTarget(CoreNode):
 
 
 class CoreCheck(CoreNode):
-    name: String
-    label: String
+    name: StringOptional
+    label: StringOptional
     origin: String
     kind: String
-    message: String
+    message: StringOptional
     conclusion: Enum
     severity: Enum
-    created_at: DateTime
+    created_at: DateTimeOptional
     validator: RelationshipManager
 
 
 class CoreComment(CoreNode):
     text: String
-    created_at: DateTime
+    created_at: DateTimeOptional
     created_by: RelationshipManager
 
 
 class CoreGenericRepository(CoreNode):
     name: String
-    description: String
+    description: StringOptional
     location: String
-    username: String
-    password: String
+    username: StringOptional
+    password: StringOptional
     tags: RelationshipManager
     transformations: RelationshipManager
     queries: RelationshipManager
@@ -101,8 +106,8 @@ class CoreGenericRepository(CoreNode):
 
 class CoreGroup(CoreNode):
     name: String
-    label: String
-    description: String
+    label: StringOptional
+    description: StringOptional
     members: RelationshipManager
     subscribers: RelationshipManager
     parent: RelationshipManager
@@ -111,12 +116,12 @@ class CoreGroup(CoreNode):
 
 class CoreProfile(CoreNode):
     profile_name: String
-    profile_priority: Integer
+    profile_priority: IntegerOptional
 
 
 class CoreResourcePool(CoreNode):
     name: String
-    description: String
+    description: StringOptional
 
 
 class CoreTaskTarget(CoreNode):
@@ -124,9 +129,9 @@ class CoreTaskTarget(CoreNode):
 
 
 class CoreThread(CoreNode):
-    label: String
+    label: StringOptional
     resolved: Boolean
-    created_at: DateTime
+    created_at: DateTimeOptional
     change: RelationshipManager
     comments: RelationshipManager
     created_by: RelationshipManager
@@ -134,8 +139,8 @@ class CoreThread(CoreNode):
 
 class CoreTransformation(CoreNode):
     name: String
-    label: String
-    description: String
+    label: StringOptional
+    description: StringOptional
     timeout: Integer
     query: RelationshipManager
     repository: RelationshipManager
@@ -143,20 +148,20 @@ class CoreTransformation(CoreNode):
 
 
 class CoreValidator(CoreNode):
-    label: String
+    label: StringOptional
     state: Enum
     conclusion: Enum
-    completed_at: DateTime
-    started_at: DateTime
+    completed_at: DateTimeOptional
+    started_at: DateTimeOptional
     proposed_change: RelationshipManager
     checks: RelationshipManager
 
 
 class CoreWebhook(CoreNode):
     name: String
-    description: String
+    description: StringOptional
     url: URL
-    validate_certificates: Boolean
+    validate_certificates: BooleanOptional
 
 
 class LineageOwner(CoreNode):
@@ -169,14 +174,14 @@ class LineageSource(CoreNode):
 
 class BuiltinTag(CoreNode):
     name: String
-    description: String
+    description: StringOptional
 
 
 class CoreAccount(LineageOwner, LineageSource):
     name: String
     password: HashedPassword
-    label: String
-    description: String
+    label: StringOptional
+    description: StringOptional
     type: Enum
     role: Enum
     tokens: RelationshipManager
@@ -186,25 +191,25 @@ class CoreArtifact(CoreTaskTarget):
     name: String
     status: Enum
     content_type: Enum
-    checksum: String
-    storage_id: String
-    parameters: JSONAttribute
+    checksum: StringOptional
+    storage_id: StringOptional
+    parameters: JSONAttributeOptional
     object: RelationshipManager
     definition: RelationshipManager
 
 
 class CoreArtifactCheck(CoreCheck):
-    changed: Boolean
-    checksum: String
-    artifact_id: String
-    storage_id: String
-    line_number: Integer
+    changed: BooleanOptional
+    checksum: StringOptional
+    artifact_id: StringOptional
+    storage_id: StringOptional
+    line_number: IntegerOptional
 
 
 class CoreArtifactDefinition(CoreTaskTarget):
     name: String
     artifact_name: String
-    description: String
+    description: StringOptional
     parameters: JSONAttribute
     content_type: Enum
     targets: RelationshipManager
@@ -212,9 +217,9 @@ class CoreArtifactDefinition(CoreTaskTarget):
 
 
 class CoreArtifactThread(CoreThread):
-    artifact_id: String
-    storage_id: String
-    line_number: Integer
+    artifact_id: StringOptional
+    storage_id: StringOptional
+    line_number: IntegerOptional
 
 
 class CoreArtifactValidator(CoreValidator):
@@ -231,11 +236,11 @@ class CoreChangeThread(CoreThread):
 
 class CoreCheckDefinition(CoreTaskTarget):
     name: String
-    description: String
+    description: StringOptional
     file_path: String
     class_name: String
     timeout: Integer
-    parameters: JSONAttribute
+    parameters: JSONAttributeOptional
     repository: RelationshipManager
     query: RelationshipManager
     targets: RelationshipManager
@@ -256,14 +261,14 @@ class CoreDataValidator(CoreValidator):
 
 
 class CoreFileCheck(CoreCheck):
-    files: ListAttribute
-    commit: String
+    files: ListAttributeOptional
+    commit: StringOptional
 
 
 class CoreFileThread(CoreThread):
-    file: String
-    commit: String
-    line_number: Integer
+    file: StringOptional
+    commit: StringOptional
+    line_number: IntegerOptional
     repository: RelationshipManager
 
 
@@ -273,11 +278,11 @@ class CoreGeneratorCheck(CoreCheck):
 
 class CoreGeneratorDefinition(CoreTaskTarget):
     name: String
-    description: String
+    description: StringOptional
     parameters: JSONAttribute
     file_path: String
     class_name: String
-    convert_query_response: Boolean
+    convert_query_response: BooleanOptional
     query: RelationshipManager
     repository: RelationshipManager
     targets: RelationshipManager
@@ -300,33 +305,33 @@ class CoreGeneratorValidator(CoreValidator):
 
 class CoreGraphQLQuery(CoreNode):
     name: String
-    description: String
+    description: StringOptional
     query: String
-    variables: JSONAttribute
-    operations: ListAttribute
-    models: ListAttribute
-    depth: Integer
-    height: Integer
+    variables: JSONAttributeOptional
+    operations: ListAttributeOptional
+    models: ListAttributeOptional
+    depth: IntegerOptional
+    height: IntegerOptional
     repository: RelationshipManager
     tags: RelationshipManager
 
 
 class CoreGraphQLQueryGroup(CoreGroup):
-    parameters: JSONAttribute
+    parameters: JSONAttributeOptional
     query: RelationshipManager
 
 
 class CoreIPAddressPool(CoreResourcePool, LineageSource):
     default_address_type: String
-    default_prefix_length: Integer
+    default_prefix_length: IntegerOptional
     resources: RelationshipManager
     ip_namespace: RelationshipManager
 
 
 class CoreIPPrefixPool(CoreResourcePool, LineageSource):
-    default_prefix_length: Integer
+    default_prefix_length: IntegerOptional
     default_member_type: Enum
-    default_prefix_type: String
+    default_prefix_type: StringOptional
     resources: RelationshipManager
     ip_namespace: RelationshipManager
 
@@ -344,7 +349,7 @@ class CoreObjectThread(CoreThread):
 
 class CoreProposedChange(CoreTaskTarget):
     name: String
-    description: String
+    description: StringOptional
     source_branch: String
     destination_branch: String
     state: Enum
@@ -358,12 +363,12 @@ class CoreProposedChange(CoreTaskTarget):
 
 class CoreReadOnlyRepository(LineageOwner, LineageSource, CoreGenericRepository, CoreTaskTarget):
     ref: String
-    commit: String
+    commit: StringOptional
 
 
 class CoreRepository(LineageOwner, LineageSource, CoreGenericRepository, CoreTaskTarget):
     default_branch: String
-    commit: String
+    commit: StringOptional
 
 
 class CoreRepositoryValidator(CoreValidator):
@@ -409,9 +414,9 @@ class CoreUserValidator(CoreValidator):
 
 
 class InternalAccountToken(CoreNode):
-    name: String
+    name: StringOptional
     token: String
-    expiration: DateTime
+    expiration: DateTimeOptional
     account: RelationshipManager
 
 
@@ -421,4 +426,4 @@ class InternalRefreshToken(CoreNode):
 
 
 class IpamNamespace(BuiltinIPNamespace):
-    default: Boolean
+    default: BooleanOptional

--- a/backend/infrahub/core/protocols_base.py
+++ b/backend/infrahub/core/protocols_base.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional, Protocol, Union, runtime_checkable
+
+from typing_extensions import Self
+
+if TYPE_CHECKING:
+    from neo4j import AsyncResult, AsyncSession, AsyncTransaction, Record
+
+# pylint: disable=redefined-builtin
+
+
+@runtime_checkable
+class SchemaBranch(Protocol): ...
+
+
+@runtime_checkable
+class Timestamp(Protocol): ...
+
+
+@runtime_checkable
+class NodeSchema(Protocol): ...
+
+
+@runtime_checkable
+class ProfileSchema(Protocol): ...
+
+
+@runtime_checkable
+class Branch(Protocol): ...
+
+
+@runtime_checkable
+class InfrahubDatabase(Protocol):
+    is_session: bool
+    is_transaction: bool
+
+    def add_schema(self, schema: SchemaBranch, name: Optional[str] = None) -> None: ...
+    def start_session(self, read_only: bool = False, schemas: Optional[list[SchemaBranch]] = None) -> Self: ...
+    def start_transaction(self, schemas: Optional[list[SchemaBranch]] = None) -> Self: ...
+    async def session(self) -> AsyncSession: ...
+    async def transaction(self, name: Optional[str]) -> AsyncTransaction: ...
+    async def close(self) -> None: ...
+
+    async def execute_query(
+        self, query: str, params: Optional[dict[str, Any]] = None, name: Optional[str] = "undefined"
+    ) -> list[Record]: ...
+
+    async def execute_query_with_metadata(
+        self, query: str, params: Optional[dict[str, Any]] = None, name: Optional[str] = "undefined"
+    ) -> tuple[list[Record], dict[str, Any]]: ...
+
+    async def run_query(
+        self, query: str, params: Optional[dict[str, Any]] = None, name: Optional[str] = "undefined"
+    ) -> AsyncResult: ...
+
+    def render_list_comprehension(self, items: str, item_name: str) -> str: ...
+    def render_list_comprehension_with_list(self, items: str, item_names: list[str]) -> str: ...
+    def render_uuid_generation(self, node_label: str, node_attr: str) -> str: ...
+
+
+@runtime_checkable
+class CoreNode(Protocol):
+    id: str
+
+    def get_id(self) -> str: ...
+    def get_kind(self) -> str: ...
+    @classmethod
+    async def init(
+        cls,
+        schema: Union[NodeSchema, ProfileSchema, str],
+        db: InfrahubDatabase,
+        branch: Optional[Union[Branch, str]] = None,
+        at: Optional[Union[Timestamp, str]] = None,
+    ) -> Self: ...
+    async def new(self, db: InfrahubDatabase, id: Optional[str] = None, **kwargs: Any) -> Self: ...
+    async def save(self, db: InfrahubDatabase, at: Optional[Timestamp] = None) -> Self: ...
+    async def delete(self, db: InfrahubDatabase, at: Optional[Timestamp] = None) -> None: ...
+    async def load(
+        self,
+        db: InfrahubDatabase,
+        id: Optional[str] = None,
+        db_id: Optional[str] = None,
+        updated_at: Optional[Union[Timestamp, str]] = None,
+        **kwargs: Any,
+    ) -> Self: ...
+    async def to_graphql(
+        self,
+        db: InfrahubDatabase,
+        fields: Optional[dict] = None,
+        related_node_ids: Optional[set] = None,
+        filter_sensitive: bool = False,
+    ) -> dict: ...
+    async def render_display_label(self, db: Optional[InfrahubDatabase] = None) -> str: ...
+    async def from_graphql(self, data: dict, db: InfrahubDatabase) -> bool: ...

--- a/backend/infrahub/database/__init__.py
+++ b/backend/infrahub/database/__init__.py
@@ -159,13 +159,13 @@ class InfrahubDatabase:
             self.manager = DatabaseManagerMemgraph(db=self)
 
     @property
-    def is_session(self):
+    def is_session(self) -> bool:
         if self._mode == InfrahubDatabaseMode.SESSION:
             return True
         return False
 
     @property
-    def is_transaction(self):
+    def is_transaction(self) -> bool:
         if self._mode == InfrahubDatabaseMode.TRANSACTION:
             return True
         return False
@@ -265,7 +265,7 @@ class InfrahubDatabase:
             if self._is_session_local:
                 await self._session.close()
 
-    async def close(self):
+    async def close(self) -> None:
         await self._driver.close()
 
     async def execute_query(

--- a/backend/templates/generate_protocols.j2
+++ b/backend/templates/generate_protocols.j2
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable, Optional
 
 if TYPE_CHECKING:
     from enum import Enum
-    from infrahub.core.attribute import Boolean, DateTime, Dropdown, HashedPassword, Integer, IPHost, IPNetwork, JSONAttribute, ListAttribute, String, URL
+    from infrahub.core.attribute import Boolean, DateTime, Dropdown, HashedPassword, Integer, IPHost, IPNetwork, JSONAttribute, ListAttribute, String, URL, BooleanOptional, DateTimeOptional, DropdownOptional, HashedPasswordOptional, IntegerOptional, IPHostOptional, IPNetworkOptional, JSONAttributeOptional, ListAttributeOptional, StringOptional, URLOptional
     from infrahub.core.relationship import RelationshipManager
 
 

--- a/backend/templates/generate_protocols.j2
+++ b/backend/templates/generate_protocols.j2
@@ -3,63 +3,14 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Protocol, runtime_checkable, Optional, Any
-from typing_extensions import Self
+
+from .protocols_base import CoreNode
 
 if TYPE_CHECKING:
     from enum import Enum
     from infrahub.core.attribute import Boolean, DateTime, Dropdown, HashedPassword, Integer, IPHost, IPNetwork, JSONAttribute, ListAttribute, String, URL, BooleanOptional, DateTimeOptional, DropdownOptional, HashedPasswordOptional, IntegerOptional, IPHostOptional, IPNetworkOptional, JSONAttributeOptional, ListAttributeOptional, StringOptional, URLOptional
     from infrahub.core.relationship import RelationshipManager
-    from neo4j import (
-        AsyncResult,
-        AsyncSession,
-        AsyncTransaction,
-        Record
-    )
 
-@runtime_checkable
-class SchemaBranch(Protocol):
-    ...
-
-@runtime_checkable
-class Timestamp(Protocol):
-    ...
-
-
-@runtime_checkable
-class InfrahubDatabase(Protocol):
-    is_session: bool
-    is_transaction: bool
-
-    def add_schema(self, schema: SchemaBranch, name: Optional[str] = None) -> None: ...
-    def start_session(self, read_only: bool = False, schemas: Optional[list[SchemaBranch]] = None) -> Self:  ...
-    def start_transaction(self, schemas: Optional[list[SchemaBranch]] = None) -> Self:  ...
-    async def session(self) -> AsyncSession: ...
-    async def transaction(self, name: Optional[str]) -> AsyncTransaction: ...
-    async def close(self) -> None: ...
-
-    async def execute_query(
-        self, query: str, params: Optional[dict[str, Any]] = None, name: Optional[str] = "undefined"
-    ) -> list[Record]: ...
-
-    async def execute_query_with_metadata(
-        self, query: str, params: Optional[dict[str, Any]] = None, name: Optional[str] = "undefined"
-    ) -> tuple[list[Record], dict[str, Any]]: ...
-
-    async def run_query(
-        self, query: str, params: Optional[dict[str, Any]] = None, name: Optional[str] = "undefined"
-    ) -> AsyncResult: ...
-
-    def render_list_comprehension(self, items: str, item_name: str) -> str: ...
-    def render_list_comprehension_with_list(self, items: str, item_names: list[str]) -> str: ...
-    def render_uuid_generation(self, node_label: str, node_attr: str) -> str: ...
-
-@runtime_checkable
-class CoreNode(Protocol):
-    id: str
-
-    def get_id(self) -> str: ...
-    def get_kind(self) -> str: ...
-    async def save(self, db: InfrahubDatabase, at: Optional[Timestamp] = None ) -> Self: ...
 
 {% for generic in generics %}
 class {{ generic.namespace }}{{ generic.name }}(CoreNode):

--- a/backend/templates/generate_protocols.j2
+++ b/backend/templates/generate_protocols.j2
@@ -2,13 +2,56 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol, runtime_checkable, Optional
+from typing import TYPE_CHECKING, Protocol, runtime_checkable, Optional, Any
+from typing_extensions import Self
 
 if TYPE_CHECKING:
     from enum import Enum
     from infrahub.core.attribute import Boolean, DateTime, Dropdown, HashedPassword, Integer, IPHost, IPNetwork, JSONAttribute, ListAttribute, String, URL, BooleanOptional, DateTimeOptional, DropdownOptional, HashedPasswordOptional, IntegerOptional, IPHostOptional, IPNetworkOptional, JSONAttributeOptional, ListAttributeOptional, StringOptional, URLOptional
     from infrahub.core.relationship import RelationshipManager
+    from neo4j import (
+        AsyncResult,
+        AsyncSession,
+        AsyncTransaction,
+        Record
+    )
 
+@runtime_checkable
+class SchemaBranch(Protocol):
+    ...
+
+@runtime_checkable
+class Timestamp(Protocol):
+    ...
+
+
+@runtime_checkable
+class InfrahubDatabase(Protocol):
+    is_session: bool
+    is_transaction: bool
+
+    def add_schema(self, schema: SchemaBranch, name: Optional[str] = None) -> None: ...
+    def start_session(self, read_only: bool = False, schemas: Optional[list[SchemaBranch]] = None) -> Self:  ...
+    def start_transaction(self, schemas: Optional[list[SchemaBranch]] = None) -> Self:  ...
+    async def session(self) -> AsyncSession: ...
+    async def transaction(self, name: Optional[str]) -> AsyncTransaction: ...
+    async def close(self) -> None: ...
+
+    async def execute_query(
+        self, query: str, params: Optional[dict[str, Any]] = None, name: Optional[str] = "undefined"
+    ) -> list[Record]: ...
+
+    async def execute_query_with_metadata(
+        self, query: str, params: Optional[dict[str, Any]] = None, name: Optional[str] = "undefined"
+    ) -> tuple[list[Record], dict[str, Any]]: ...
+
+    async def run_query(
+        self, query: str, params: Optional[dict[str, Any]] = None, name: Optional[str] = "undefined"
+    ) -> AsyncResult: ...
+
+    def render_list_comprehension(self, items: str, item_name: str) -> str: ...
+    def render_list_comprehension_with_list(self, items: str, item_names: list[str]) -> str: ...
+    def render_uuid_generation(self, node_label: str, node_attr: str) -> str: ...
 
 @runtime_checkable
 class CoreNode(Protocol):
@@ -16,7 +59,7 @@ class CoreNode(Protocol):
 
     def get_id(self) -> str: ...
     def get_kind(self) -> str: ...
-    async def save(self) -> None: ...
+    async def save(self, db: InfrahubDatabase, at: Optional[Timestamp] = None ) -> Self: ...
 
 {% for generic in generics %}
 class {{ generic.namespace }}{{ generic.name }}(CoreNode):

--- a/python_sdk/infrahub_sdk/protocols.py
+++ b/python_sdk/infrahub_sdk/protocols.py
@@ -22,29 +22,29 @@ class CoreNode(Protocol):
 
 class BuiltinIPAddress(CoreNode):
     address: str
-    description: str
+    description: Optional[str]
     ip_namespace: Union[RelatedNode, RelatedNodeSync]
     ip_prefix: Union[RelatedNode, RelatedNodeSync]
 
 
 class BuiltinIPNamespace(CoreNode):
     name: str
-    description: str
+    description: Optional[str]
     ip_prefixes: Union[RelationshipManager, RelationshipManagerSync]
     ip_addresses: Union[RelationshipManager, RelationshipManagerSync]
 
 
 class BuiltinIPPrefix(CoreNode):
     prefix: str
-    description: str
+    description: Optional[str]
     member_type: str
     is_pool: bool
-    is_top_level: bool
-    utilization: int
-    netmask: str
-    hostmask: str
-    network_address: str
-    broadcast_address: str
+    is_top_level: Optional[bool]
+    utilization: Optional[int]
+    netmask: Optional[str]
+    hostmask: Optional[str]
+    network_address: Optional[str]
+    broadcast_address: Optional[str]
     ip_namespace: Union[RelatedNode, RelatedNodeSync]
     ip_addresses: Union[RelationshipManager, RelationshipManagerSync]
     resource_pool: Union[RelationshipManager, RelationshipManagerSync]
@@ -57,29 +57,29 @@ class CoreArtifactTarget(CoreNode):
 
 
 class CoreCheck(CoreNode):
-    name: str
-    label: str
+    name: Optional[str]
+    label: Optional[str]
     origin: str
     kind: str
-    message: str
-    conclusion: str
-    severity: str
-    created_at: datetime
+    message: Optional[str]
+    conclusion: Optional[str]
+    severity: Optional[str]
+    created_at: Optional[datetime]
     validator: Union[RelatedNode, RelatedNodeSync]
 
 
 class CoreComment(CoreNode):
     text: str
-    created_at: datetime
+    created_at: Optional[datetime]
     created_by: Union[RelatedNode, RelatedNodeSync]
 
 
 class CoreGenericRepository(CoreNode):
     name: str
-    description: str
+    description: Optional[str]
     location: str
-    username: str
-    password: str
+    username: Optional[str]
+    password: Optional[str]
     tags: Union[RelationshipManager, RelationshipManagerSync]
     transformations: Union[RelationshipManager, RelationshipManagerSync]
     queries: Union[RelationshipManager, RelationshipManagerSync]
@@ -89,8 +89,8 @@ class CoreGenericRepository(CoreNode):
 
 class CoreGroup(CoreNode):
     name: str
-    label: str
-    description: str
+    label: Optional[str]
+    description: Optional[str]
     members: Union[RelationshipManager, RelationshipManagerSync]
     subscribers: Union[RelationshipManager, RelationshipManagerSync]
     parent: Union[RelatedNode, RelatedNodeSync]
@@ -99,12 +99,12 @@ class CoreGroup(CoreNode):
 
 class CoreProfile(CoreNode):
     profile_name: str
-    profile_priority: int
+    profile_priority: Optional[int]
 
 
 class CoreResourcePool(CoreNode):
     name: str
-    description: str
+    description: Optional[str]
 
 
 class CoreTaskTarget(CoreNode):
@@ -112,9 +112,9 @@ class CoreTaskTarget(CoreNode):
 
 
 class CoreThread(CoreNode):
-    label: str
+    label: Optional[str]
     resolved: bool
-    created_at: datetime
+    created_at: Optional[datetime]
     change: Union[RelatedNode, RelatedNodeSync]
     comments: Union[RelationshipManager, RelationshipManagerSync]
     created_by: Union[RelatedNode, RelatedNodeSync]
@@ -122,8 +122,8 @@ class CoreThread(CoreNode):
 
 class CoreTransformation(CoreNode):
     name: str
-    label: str
-    description: str
+    label: Optional[str]
+    description: Optional[str]
     timeout: int
     query: Union[RelatedNode, RelatedNodeSync]
     repository: Union[RelatedNode, RelatedNodeSync]
@@ -131,20 +131,20 @@ class CoreTransformation(CoreNode):
 
 
 class CoreValidator(CoreNode):
-    label: str
+    label: Optional[str]
     state: str
     conclusion: str
-    completed_at: datetime
-    started_at: datetime
+    completed_at: Optional[datetime]
+    started_at: Optional[datetime]
     proposed_change: Union[RelatedNode, RelatedNodeSync]
     checks: Union[RelationshipManager, RelationshipManagerSync]
 
 
 class CoreWebhook(CoreNode):
     name: str
-    description: str
+    description: Optional[str]
     url: str
-    validate_certificates: bool
+    validate_certificates: Optional[bool]
 
 
 class LineageOwner(CoreNode):
@@ -157,14 +157,14 @@ class LineageSource(CoreNode):
 
 class BuiltinTag(CoreNode):
     name: str
-    description: str
+    description: Optional[str]
 
 
 class CoreAccount(LineageOwner, LineageSource):
     name: str
     password: str
-    label: str
-    description: str
+    label: Optional[str]
+    description: Optional[str]
     type: str
     role: str
     tokens: Union[RelationshipManager, RelationshipManagerSync]
@@ -174,25 +174,25 @@ class CoreArtifact(CoreTaskTarget):
     name: str
     status: str
     content_type: str
-    checksum: str
-    storage_id: str
-    parameters: dict
+    checksum: Optional[str]
+    storage_id: Optional[str]
+    parameters: Optional[dict]
     object: Union[RelatedNode, RelatedNodeSync]
     definition: Union[RelatedNode, RelatedNodeSync]
 
 
 class CoreArtifactCheck(CoreCheck):
-    changed: bool
-    checksum: str
-    artifact_id: str
-    storage_id: str
-    line_number: int
+    changed: Optional[bool]
+    checksum: Optional[str]
+    artifact_id: Optional[str]
+    storage_id: Optional[str]
+    line_number: Optional[int]
 
 
 class CoreArtifactDefinition(CoreTaskTarget):
     name: str
     artifact_name: str
-    description: str
+    description: Optional[str]
     parameters: dict
     content_type: str
     targets: Union[RelatedNode, RelatedNodeSync]
@@ -200,9 +200,9 @@ class CoreArtifactDefinition(CoreTaskTarget):
 
 
 class CoreArtifactThread(CoreThread):
-    artifact_id: str
-    storage_id: str
-    line_number: int
+    artifact_id: Optional[str]
+    storage_id: Optional[str]
+    line_number: Optional[int]
 
 
 class CoreArtifactValidator(CoreValidator):
@@ -219,11 +219,11 @@ class CoreChangeThread(CoreThread):
 
 class CoreCheckDefinition(CoreTaskTarget):
     name: str
-    description: str
+    description: Optional[str]
     file_path: str
     class_name: str
     timeout: int
-    parameters: dict
+    parameters: Optional[dict]
     repository: Union[RelatedNode, RelatedNodeSync]
     query: Union[RelatedNode, RelatedNodeSync]
     targets: Union[RelatedNode, RelatedNodeSync]
@@ -236,7 +236,7 @@ class CoreCustomWebhook(CoreWebhook, CoreTaskTarget):
 
 class CoreDataCheck(CoreCheck):
     conflicts: dict
-    keep_branch: str
+    keep_branch: Optional[str]
 
 
 class CoreDataValidator(CoreValidator):
@@ -244,14 +244,14 @@ class CoreDataValidator(CoreValidator):
 
 
 class CoreFileCheck(CoreCheck):
-    files: list
-    commit: str
+    files: Optional[list]
+    commit: Optional[str]
 
 
 class CoreFileThread(CoreThread):
-    file: str
-    commit: str
-    line_number: int
+    file: Optional[str]
+    commit: Optional[str]
+    line_number: Optional[int]
     repository: Union[RelatedNode, RelatedNodeSync]
 
 
@@ -261,11 +261,11 @@ class CoreGeneratorCheck(CoreCheck):
 
 class CoreGeneratorDefinition(CoreTaskTarget):
     name: str
-    description: str
+    description: Optional[str]
     parameters: dict
     file_path: str
     class_name: str
-    convert_query_response: bool
+    convert_query_response: Optional[bool]
     query: Union[RelatedNode, RelatedNodeSync]
     repository: Union[RelatedNode, RelatedNodeSync]
     targets: Union[RelatedNode, RelatedNodeSync]
@@ -288,33 +288,33 @@ class CoreGeneratorValidator(CoreValidator):
 
 class CoreGraphQLQuery(CoreNode):
     name: str
-    description: str
+    description: Optional[str]
     query: str
-    variables: dict
-    operations: list
-    models: list
-    depth: int
-    height: int
+    variables: Optional[dict]
+    operations: Optional[list]
+    models: Optional[list]
+    depth: Optional[int]
+    height: Optional[int]
     repository: Union[RelatedNode, RelatedNodeSync]
     tags: Union[RelationshipManager, RelationshipManagerSync]
 
 
 class CoreGraphQLQueryGroup(CoreGroup):
-    parameters: dict
+    parameters: Optional[dict]
     query: Union[RelatedNode, RelatedNodeSync]
 
 
 class CoreIPAddressPool(CoreResourcePool, LineageSource):
     default_address_type: str
-    default_prefix_length: int
+    default_prefix_length: Optional[int]
     resources: Union[RelationshipManager, RelationshipManagerSync]
     ip_namespace: Union[RelatedNode, RelatedNodeSync]
 
 
 class CoreIPPrefixPool(CoreResourcePool, LineageSource):
-    default_prefix_length: int
-    default_member_type: str
-    default_prefix_type: str
+    default_prefix_length: Optional[int]
+    default_member_type: Optional[str]
+    default_prefix_type: Optional[str]
     resources: Union[RelationshipManager, RelationshipManagerSync]
     ip_namespace: Union[RelatedNode, RelatedNodeSync]
 
@@ -332,10 +332,10 @@ class CoreObjectThread(CoreThread):
 
 class CoreProposedChange(CoreTaskTarget):
     name: str
-    description: str
+    description: Optional[str]
     source_branch: str
     destination_branch: str
-    state: str
+    state: Optional[str]
     approved_by: Union[RelationshipManager, RelationshipManagerSync]
     reviewers: Union[RelationshipManager, RelationshipManagerSync]
     created_by: Union[RelatedNode, RelatedNodeSync]
@@ -346,12 +346,12 @@ class CoreProposedChange(CoreTaskTarget):
 
 class CoreReadOnlyRepository(LineageOwner, LineageSource, CoreGenericRepository, CoreTaskTarget):
     ref: str
-    commit: str
+    commit: Optional[str]
 
 
 class CoreRepository(LineageOwner, LineageSource, CoreGenericRepository, CoreTaskTarget):
     default_branch: str
-    commit: str
+    commit: Optional[str]
 
 
 class CoreRepositoryValidator(CoreValidator):
@@ -397,9 +397,9 @@ class CoreUserValidator(CoreValidator):
 
 
 class InternalAccountToken(CoreNode):
-    name: str
+    name: Optional[str]
     token: str
-    expiration: datetime
+    expiration: Optional[datetime]
     account: Union[RelatedNode, RelatedNodeSync]
 
 
@@ -409,4 +409,4 @@ class InternalRefreshToken(CoreNode):
 
 
 class IpamNamespace(BuiltinIPNamespace):
-    default: bool
+    default: Optional[bool]

--- a/tasks/backend.py
+++ b/tasks/backend.py
@@ -286,13 +286,21 @@ def _jinja2_filter_render_attribute(value: dict[str, Any], use_python_primitive:
 
     attr_name: str = value["name"]
     attr_kind: str = value["kind"]
+    optional: bool = value.get("optional", False)
 
     if "enum" in value and not use_python_primitive:
         return f"{attr_name}: Enum"
 
     if use_python_primitive:
-        return f"{attr_name}: {PYTHON_PRIMITIVE_MAP[attr_kind.lower()]}"
-    return f"{attr_name}: {ATTRIBUTE_TYPES[attr_kind].infrahub}"
+        value = PYTHON_PRIMITIVE_MAP[attr_kind.lower()]
+        if optional:
+            value = f"Optional[{value}]"
+        return f"{attr_name}: {value}"
+
+    value = ATTRIBUTE_TYPES[attr_kind].infrahub
+    if optional:
+        value = f"{value}Optional"
+    return f"{attr_name}: {value}"
 
 
 def _sort_and_filter_models(


### PR DESCRIPTION
This PR improves the Protocols for Python in a few different ways: 
- Improve the support for Attribute by 
  - Setting the type of `value` for each kind of attribute
  - Creating an `Optional` version of each attribute with the appropriate type (Optional[XX])
- Added Protocols for a few internal object like InfrahubDatabase
- Added more functions signature for CoreNode
- Moved base protocols into a dedicated file 

> It looks like some models in the core schema have optional attributes that shouldn't be optional .. something to investigate 