### PR TITLE
Support adding repositories to non default branches

### DIFF
--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -548,9 +548,10 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin):
         # pylint: disable=no-member
         branch = self.branch
         hierarchy_level = branch.hierarchy_level
-        if self.schema.branch in [BranchSupportType.AGNOSTIC, BranchSupportType.LOCAL]:
+        if self.schema.branch == BranchSupportType.AGNOSTIC:
             branch = registry.get_global_branch()
-        if self.schema.branch == BranchSupportType.LOCAL:
+        elif self.schema.branch == BranchSupportType.LOCAL and self.node._schema.branch == BranchSupportType.AGNOSTIC:
+            branch = registry.get_global_branch()
             hierarchy_level = 0
         data = AttributeCreateData(
             node_type=self.get_db_node_type(),

--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -548,9 +548,9 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin):
         # pylint: disable=no-member
         branch = self.branch
         hierarchy_level = branch.hierarchy_level
-        if self.schema.branch == BranchSupportType.AGNOSTIC or BranchSupportType.LOCAL:
+        if self.schema.branch in [BranchSupportType.AGNOSTIC, BranchSupportType.LOCAL]:
             branch = registry.get_global_branch()
-        if BranchSupportType.LOCAL:
+        if self.schema.branch == BranchSupportType.LOCAL:
             hierarchy_level = 0
         data = AttributeCreateData(
             node_type=self.get_db_node_type(),

--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -546,7 +546,12 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin):
 
     def get_create_data(self) -> AttributeCreateData:
         # pylint: disable=no-member
-        branch = self.get_branch_based_on_support_type()
+        branch = self.branch
+        hierarchy_level = branch.hierarchy_level
+        if self.schema.branch == BranchSupportType.AGNOSTIC or BranchSupportType.LOCAL:
+            branch = registry.get_global_branch()
+        if BranchSupportType.LOCAL:
+            hierarchy_level = 0
         data = AttributeCreateData(
             node_type=self.get_db_node_type(),
             uuid=str(UUIDT()),
@@ -554,7 +559,7 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin):
             type=self.get_kind(),
             branch=branch.name,
             status="active",
-            branch_level=self.branch.hierarchy_level,
+            branch_level=hierarchy_level,
             branch_support=self.schema.branch.value,
             content=self.to_db(),
             is_default=self.is_default,

--- a/backend/infrahub/core/constants/__init__.py
+++ b/backend/infrahub/core/constants/__init__.py
@@ -102,6 +102,12 @@ class CheckType(InfrahubStringEnum):
     ALL = "all"
 
 
+class RepositoryAdminStatus(InfrahubStringEnum):
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+    STAGING = "staging"
+
+
 class DiffAction(InfrahubStringEnum):
     ADDED = "added"
     REMOVED = "removed"

--- a/backend/infrahub/core/protocols.py
+++ b/backend/infrahub/core/protocols.py
@@ -100,6 +100,7 @@ class CoreGenericRepository(CoreNode):
     location: String
     username: StringOptional
     password: StringOptional
+    admin_status: Dropdown
     tags: RelationshipManager
     transformations: RelationshipManager
     queries: RelationshipManager

--- a/backend/infrahub/core/schema/definitions/core.py
+++ b/backend/infrahub/core/schema/definitions/core.py
@@ -438,7 +438,6 @@ core_models: dict[str, Any] = {
                     "optional": False,
                     "branch": BranchSupportType.LOCAL.value,
                     "order_weight": 6000,
-                    "read_only": True,
                     "allow_override": AllowOverrideType.NONE,
                 },
             ],

--- a/backend/infrahub/core/schema/definitions/core.py
+++ b/backend/infrahub/core/schema/definitions/core.py
@@ -14,6 +14,7 @@ from infrahub.core.constants import (
     InfrahubKind,
     ProposedChangeState,
     RelationshipDeleteBehavior,
+    RepositoryAdminStatus,
     Severity,
     ValidatorConclusion,
     ValidatorState,
@@ -418,17 +419,17 @@ core_models: dict[str, Any] = {
                     "kind": "Dropdown",
                     "choices": [
                         {
-                            "name": "staging",
+                            "name": RepositoryAdminStatus.STAGING.value,
                             "label": "Staging",
                             "description": "Repository was recently added to this branch.",
                         },
                         {
-                            "name": "active",
+                            "name": RepositoryAdminStatus.ACTIVE.value,
                             "label": "Active",
                             "description": "Repository is actively being synced for this branch",
                         },
                         {
-                            "name": "inactive",
+                            "name": RepositoryAdminStatus.INACTIVE.value,
                             "label": "Inactive",
                             "description": "Repository is not active on this branch.",
                         },

--- a/backend/infrahub/core/schema/definitions/core.py
+++ b/backend/infrahub/core/schema/definitions/core.py
@@ -434,7 +434,7 @@ core_models: dict[str, Any] = {
                         },
                     ],
                     "default_value": "inactive",
-                    "optional": True,
+                    "optional": False,
                     "branch": BranchSupportType.LOCAL.value,
                     "order_weight": 6000,
                     "read_only": True,

--- a/backend/infrahub/core/schema/definitions/core.py
+++ b/backend/infrahub/core/schema/definitions/core.py
@@ -381,6 +381,7 @@ core_models: dict[str, Any] = {
                     "unique": True,
                     "branch": BranchSupportType.AGNOSTIC.value,
                     "order_weight": 1000,
+                    "allow_override": AllowOverrideType.NONE,
                 },
                 {
                     "name": "description",
@@ -388,6 +389,7 @@ core_models: dict[str, Any] = {
                     "optional": True,
                     "branch": BranchSupportType.AGNOSTIC.value,
                     "order_weight": 2000,
+                    "allow_override": AllowOverrideType.NONE,
                 },
                 {
                     "name": "location",
@@ -395,6 +397,7 @@ core_models: dict[str, Any] = {
                     "unique": True,
                     "branch": BranchSupportType.AGNOSTIC.value,
                     "order_weight": 3000,
+                    "allow_override": AllowOverrideType.NONE,
                 },
                 {
                     "name": "username",
@@ -409,6 +412,33 @@ core_models: dict[str, Any] = {
                     "optional": True,
                     "branch": BranchSupportType.AGNOSTIC.value,
                     "order_weight": 5000,
+                },
+                {
+                    "name": "admin_status",
+                    "kind": "Dropdown",
+                    "choices": [
+                        {
+                            "name": "staging",
+                            "label": "Staging",
+                            "description": "Repository was recently added to this branch.",
+                        },
+                        {
+                            "name": "active",
+                            "label": "Active",
+                            "description": "Repository is actively being synced for this branch",
+                        },
+                        {
+                            "name": "inactive",
+                            "label": "Inactive",
+                            "description": "Repository is not active on this branch.",
+                        },
+                    ],
+                    "default_value": "inactive",
+                    "optional": True,
+                    "branch": BranchSupportType.LOCAL.value,
+                    "order_weight": 6000,
+                    "read_only": True,
+                    "allow_override": AllowOverrideType.NONE,
                 },
             ],
             "relationships": [

--- a/backend/infrahub/git/actions.py
+++ b/backend/infrahub/git/actions.py
@@ -39,7 +39,7 @@ async def sync_remote_repositories(service: InfrahubServices) -> None:
                             client=service.client,
                             task_report=task_report,
                         )
-                        await repo.import_objects_from_files(branch_name=repo.default_branch)
+                        await repo.import_objects_from_files(infrahub_branch_name=repo.default_branch)
                     except RepositoryError as exc:
                         await task_report.error(str(exc))
                         continue

--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, NoReturn, Optional, Union
 from uuid import UUID  # noqa: TCH003
 
 import git
-from git import Repo
+from git import Blob, Repo
 from git.exc import GitCommandError, InvalidGitRepositoryError
 from git.refs.remote import RemoteReference
 from infrahub_sdk import InfrahubClient  # noqa: TCH002
@@ -551,6 +551,10 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
                 removed_files.append(x.b_blob.path)
 
         return changed_files, added_files, removed_files
+
+    async def list_all_files(self, commit: str) -> list[str]:
+        git_repo = self.get_git_repo_main()
+        return [str(entry.path) for entry in git_repo.commit(commit).tree.traverse() if isinstance(entry, Blob)]
 
     async def fetch(self) -> bool:
         """Fetch the latest update from the remote repository and bring a copy locally."""

--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, NoReturn, Optional, Union
 from uuid import UUID  # noqa: TCH003
 
+import git
 from git import Repo
 from git.exc import GitCommandError, InvalidGitRepositoryError
 from git.refs.remote import RemoteReference
@@ -157,6 +158,11 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
     )
     is_read_only: bool = Field(False, description="If true, changes will not be synced to remote")
     task_report: Optional[InfrahubTaskReportLogger] = Field(default=None)
+
+    admin_status: str = Field("active", description="Administrative status: Active, Inactive, Staging")
+    infrahub_branch_name: Optional[str] = Field(
+        None, description="Infrahub branch on which to sync the remote repository"
+    )
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @property
@@ -231,7 +237,10 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
         if worktree := self.get_worktree(identifier=identifier):
             return Repo(worktree.directory)
 
-        return None
+        raise RepositoryError(
+            identifier=self.name,
+            message=f"Unable to find the worktree {identifier}.",
+        )
 
     def validate_local_directories(self) -> bool:
         """Check if the local directories structure to ensure that the repository has been properly initialized.
@@ -320,7 +329,7 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
 
         self.has_origin = True
 
-        # Create a worktree for the commit in main
+        # Create a worktree for the commit in the default branch
         # TODO Need to handle the potential exceptions coming from repo.git.worktree
         commit = str(repo.head.commit)
         self.create_commit_worktree(commit=commit)
@@ -700,36 +709,45 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
 
         return path
 
-    def check_connectivity(self, url: str) -> None:
-        repo = self.get_git_repo_main()
+    @classmethod
+    def check_connectivity(cls, name: str, url: str) -> None:
+        cmd = git.cmd.Git()
         try:
-            repo.git.ls_remote([url, "HEAD"])
+            cmd.ls_remote("--tags", url)
         except GitCommandError as exc:
-            self._raise_enriched_error(error=exc)
+            cls._raise_enriched_error_static(name=name, location=url, error=exc)
 
     def _raise_enriched_error(self, error: GitCommandError, branch_name: str | None = None) -> NoReturn:
+        self._raise_enriched_error_static(
+            error=error, name=self.name, location=self.location, branch_name=branch_name or self.default_branch
+        )
+
+    @staticmethod
+    def _raise_enriched_error_static(
+        error: GitCommandError, name: str, location: str, branch_name: str | None = None
+    ) -> NoReturn:
         if "Repository not found" in error.stderr or "does not appear to be a git" in error.stderr:
             raise RepositoryError(
-                identifier=self.name,
-                message=f"Unable to clone the repository {self.name}, please check the address and the credential",
+                identifier=name,
+                message=f"Unable to clone the repository {name}, please check the address and the credential",
             ) from error
 
         if "error: pathspec" in error.stderr:
             raise RepositoryError(
-                identifier=self.name,
-                message=f"The branch {self.default_branch} isn't a valid branch for the repository {self.name} at {self.location}.",
+                identifier=name,
+                message=f"The branch {branch_name} isn't a valid branch for the repository {name} at {location}.",
             ) from error
 
         if "authentication failed for" in error.stderr.lower():
             raise RepositoryError(
-                identifier=self.name,
-                message=f"Authentication failed for {self.name}, please validate the credentials.",
+                identifier=name,
+                message=f"Authentication failed for {name}, please validate the credentials.",
             ) from error
 
         if "Need to specify how to reconcile" in error.stderr:
             raise RepositoryError(
-                identifier=self.name,
-                message=f"Unable to pull the branch {branch_name} for repository {self.name}, there is a conflict that must be resolved.",
+                identifier=name,
+                message=f"Unable to pull the branch {branch_name} for repository {name}, there is a conflict that must be resolved.",
             ) from error
 
-        raise RepositoryError(identifier=self.name, message=error.stderr) from error
+        raise RepositoryError(identifier=name, message=error.stderr) from error

--- a/backend/infrahub/git/repository.py
+++ b/backend/infrahub/git/repository.py
@@ -6,7 +6,7 @@ from git.exc import BadName, GitCommandError
 from infrahub_sdk import GraphQLError
 from pydantic import Field
 
-from infrahub.core.constants import InfrahubKind
+from infrahub.core.constants import InfrahubKind, RepositoryAdminStatus
 from infrahub.exceptions import RepositoryError
 from infrahub.git.integrator import InfrahubRepositoryIntegrator
 from infrahub.log import get_logger
@@ -107,7 +107,7 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
         log.debug(f"New Branches {new_branches}, Updated Branches {updated_branches}", repository=self.name)
 
         # TODO need to handle properly the situation when a branch is not valid.
-        if self.admin_status == "active":
+        if self.admin_status == RepositoryAdminStatus.ACTIVE.value:
             for branch_name in new_branches:
                 is_valid = await self.validate_remote_branch(branch_name=branch_name)
                 if not is_valid:
@@ -129,7 +129,7 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
                 await self.import_objects_from_files(infrahub_branch_name=branch_name, commit=commit)
 
         for branch_name in updated_branches:
-            if self.admin_status == "staging" and branch_name != self.default_branch_name:
+            if self.admin_status == RepositoryAdminStatus.STAGING.value and branch_name != self.default_branch_name:
                 continue
 
             is_valid = await self.validate_remote_branch(branch_name=branch_name)

--- a/backend/infrahub/git/repository.py
+++ b/backend/infrahub/git/repository.py
@@ -107,35 +107,42 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
         log.debug(f"New Branches {new_branches}, Updated Branches {updated_branches}", repository=self.name)
 
         # TODO need to handle properly the situation when a branch is not valid.
-        for branch_name in new_branches:
-            is_valid = await self.validate_remote_branch(branch_name=branch_name)
-            if not is_valid:
-                continue
+        if self.admin_status == "active":
+            for branch_name in new_branches:
+                is_valid = await self.validate_remote_branch(branch_name=branch_name)
+                if not is_valid:
+                    continue
 
-            try:
-                branch = await self.create_branch_in_graph(branch_name=branch_name)
-            except GraphQLError as exc:
-                if "already exist" not in exc.errors[0]["message"]:
-                    raise
-                branch = await self.sdk.branch.get(branch_name=branch_name)
+                try:
+                    branch = await self.create_branch_in_graph(branch_name=branch_name)
+                except GraphQLError as exc:
+                    if "already exist" not in exc.errors[0]["message"]:
+                        raise
+                    branch = await self.sdk.branch.get(branch_name=branch_name)
 
-            await self.create_branch_in_git(branch_name=branch.name, branch_id=branch.id)
+                await self.create_branch_in_git(branch_name=branch.name, branch_id=branch.id)
 
-            commit = self.get_commit_value(branch_name=branch_name, remote=False)
-            self.create_commit_worktree(commit=commit)
-            await self.update_commit_value(branch_name=branch_name, commit=commit)
+                commit = self.get_commit_value(branch_name=branch_name, remote=False)
+                self.create_commit_worktree(commit=commit)
+                await self.update_commit_value(branch_name=branch_name, commit=commit)
 
-            await self.import_objects_from_files(branch_name=branch_name, commit=commit)
+                await self.import_objects_from_files(infrahub_branch_name=branch_name, commit=commit)
 
         for branch_name in updated_branches:
+            if self.admin_status == "staging" and branch_name != self.default_branch_name:
+                continue
+
             is_valid = await self.validate_remote_branch(branch_name=branch_name)
             if not is_valid:
                 continue
 
             commit_after = await self.pull(branch_name=branch_name)
-            await self.import_objects_from_files(branch_name=branch_name, commit=commit_after)
+            if isinstance(commit_after, str):
+                await self.import_objects_from_files(
+                    infrahub_branch_name=self.infrahub_branch_name or branch_name, commit=commit_after
+                )
 
-            if commit_after is True:
+            elif commit_after is True:
                 log.warning(
                     f"An update was detected but the commit remained the same after pull() ({commit_after}).",
                     repository=self.name,
@@ -210,7 +217,7 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
     async def new(cls, service: Optional[InfrahubServices] = None, **kwargs: Any) -> InfrahubRepository:
         service = service or InfrahubServices()
         self = cls(service=service, **kwargs)
-        await self.create_locally()
+        await self.create_locally(infrahub_branch_name=self.infrahub_branch_name)
         log.info("Created the new project locally.", repository=self.name)
         return self
 
@@ -222,9 +229,6 @@ class InfrahubReadOnlyRepository(InfrahubRepositoryIntegrator):
 
     is_read_only: bool = True
     ref: Optional[str] = Field(None, description="Ref to track on the external repository")
-    infrahub_branch_name: Optional[str] = Field(
-        None, description="Infrahub branch on which to sync the remote repository"
-    )
 
     @classmethod
     async def init(cls, service: Optional[InfrahubServices] = None, **kwargs: Any) -> InfrahubReadOnlyRepository:
@@ -272,7 +276,7 @@ class InfrahubReadOnlyRepository(InfrahubRepositoryIntegrator):
         if self.ref in local_branches and commit == local_branches[self.ref].commit:
             return
         self.create_commit_worktree(commit=commit)
-        await self.import_objects_from_files(branch_name=self.infrahub_branch_name, commit=commit)
+        await self.import_objects_from_files(infrahub_branch_name=self.infrahub_branch_name, commit=commit)
         await self.update_commit_value(branch_name=self.infrahub_branch_name, commit=commit)
 
 

--- a/backend/infrahub/graphql/mutations/repository.py
+++ b/backend/infrahub/graphql/mutations/repository.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 from graphene import Boolean, InputObjectType, Mutation, String
 
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.manager import NodeManager
+from infrahub.core.protocols import CoreGenericRepository, CoreReadOnlyRepository, CoreRepository
 from infrahub.core.schema import NodeSchema
+from infrahub.exceptions import ValidationError
 from infrahub.graphql.types.common import IdentifierInput
 from infrahub.log import get_logger
 from infrahub.message_bus import messages
@@ -19,7 +21,6 @@ if TYPE_CHECKING:
 
     from infrahub.core.branch import Branch
     from infrahub.core.node import Node
-    from infrahub.core.protocols import CoreReadOnlyRepository, CoreRepository
     from infrahub.database import InfrahubDatabase
     from infrahub.graphql import GraphqlContext
 
@@ -28,7 +29,7 @@ log = get_logger()
 
 class InfrahubRepositoryMutation(InfrahubMutationMixin, Mutation):
     @classmethod
-    def __init_subclass_with_meta__(cls, schema: NodeSchema = None, _meta=None, **options):  # pylint: disable=arguments-differ
+    def __init_subclass_with_meta__(cls, schema: Optional[NodeSchema] = None, _meta=None, **options):  # pylint: disable=arguments-differ
         # Make sure schema is a valid NodeSchema Node Class
         if not isinstance(schema, NodeSchema):
             raise ValueError(f"You need to pass a valid NodeSchema in '{cls.__name__}.Meta', received '{schema}'")
@@ -50,28 +51,60 @@ class InfrahubRepositoryMutation(InfrahubMutationMixin, Mutation):
         at: str,
         database: Optional[InfrahubDatabase] = None,
     ):
-        obj, result = await super().mutate_create(root, info, data, branch, at)
         context: GraphqlContext = info.context
+
+        # Create the object in the database
+        obj, result = await super().mutate_create(root, info, data, branch, at)
+        obj = cast(CoreGenericRepository, obj)
+
+        # First check the connectivity to the remote repository
+        # If the connectivity is not good, we remove the repository to allow the user to add a new one
+        if context.service:
+            message = messages.GitRepositoryConnectivity(
+                repository_name=obj.name.value,
+                repository_location=obj.location.value,
+            )
+            response = await context.service.message_bus.rpc(
+                message=message, response_class=GitRepositoryConnectivityResponse
+            )
+
+            if response.data.success is False:
+                await obj.delete(db=context.db)
+                raise ValidationError(response.data.message)
+
+        # If we are in the default branch, we set the sync status to Active
+        # If we are in another branch, we set the sync status to Staging
+        if branch.is_default:
+            obj.admin_status.value = "active"
+        else:
+            obj.admin_status.value = "staging"
+        await obj.save(db=context.db)
+
         # Create the new repository in the filesystem.
         log.info("create_repository", name=obj.name.value)
         authenticated_user = None
         if context.account_session and context.account_session.authenticated:
             authenticated_user = context.account_session.account_id
         if obj.get_kind() == InfrahubKind.READONLYREPOSITORY:
+            obj = cast(CoreReadOnlyRepository, obj)
             message = messages.GitRepositoryAddReadOnly(
                 repository_id=obj.id,
                 repository_name=obj.name.value,
                 location=obj.location.value,
                 ref=obj.ref.value,
                 infrahub_branch_name=branch.name,
+                admin_status=obj.admin_status.value,
                 created_by=authenticated_user,
             )
         else:
+            obj = cast(CoreRepository, obj)
             message = messages.GitRepositoryAdd(
                 repository_id=obj.id,
                 repository_name=obj.name.value,
                 location=obj.location.value,
                 default_branch_name=obj.default_branch.value,
+                infrahub_branch_name=branch.name,
+                admin_status=obj.admin_status.value,
                 created_by=authenticated_user,
             )
 
@@ -95,7 +128,7 @@ class InfrahubRepositoryMutation(InfrahubMutationMixin, Mutation):
     ):
         context: GraphqlContext = info.context
         if not node:
-            node = await NodeManager.get_one_by_id_or_default_filter(
+            node: CoreReadOnlyRepository | CoreRepository = await NodeManager.get_one_by_id_or_default_filter(
                 db=context.db,
                 kind=cls._meta.schema.kind,
                 id=data.get("id"),
@@ -107,6 +140,7 @@ class InfrahubRepositoryMutation(InfrahubMutationMixin, Mutation):
         if node.get_kind() != InfrahubKind.READONLYREPOSITORY:
             return await super().mutate_update(root, info, data, branch, at, database=context.db, node=node)
 
+        node = cast(CoreReadOnlyRepository, node)
         current_commit = node.commit.value
         current_ref = node.ref.value
         new_commit = None
@@ -117,6 +151,7 @@ class InfrahubRepositoryMutation(InfrahubMutationMixin, Mutation):
             new_ref = data.ref.value
 
         obj, result = await super().mutate_update(root, info, data, branch, at, database=context.db, node=node)
+        obj = cast(CoreReadOnlyRepository, obj)
 
         send_update_message = (new_commit and new_commit != current_commit) or (new_ref and new_ref != current_ref)
         if not send_update_message:
@@ -197,14 +232,12 @@ class ValidateRepositoryConnectivity(Mutation):
         repo: CoreReadOnlyRepository | CoreRepository = await NodeManager.get_one_by_id_or_default_filter(
             db=context.db,
             kind=InfrahubKind.GENERICREPOSITORY,
-            id=str(data.id),
+            id=repository_id,
             branch=branch,
         )
 
         message = messages.GitRepositoryConnectivity(
-            repository_id=repository_id,
             repository_name=str(repo.name.value),
-            repository_kind=repo.get_kind(),
             repository_location=str(repo.location.value),
         )
         if context.service:

--- a/backend/infrahub/graphql/mutations/repository.py
+++ b/backend/infrahub/graphql/mutations/repository.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Optional, cast
 
 from graphene import Boolean, InputObjectType, Mutation, String
 
-from infrahub.core.constants import InfrahubKind
+from infrahub.core.constants import InfrahubKind, RepositoryAdminStatus
 from infrahub.core.manager import NodeManager
 from infrahub.core.protocols import CoreGenericRepository, CoreReadOnlyRepository, CoreRepository
 from infrahub.core.schema import NodeSchema
@@ -75,9 +75,9 @@ class InfrahubRepositoryMutation(InfrahubMutationMixin, Mutation):
         # If we are in the default branch, we set the sync status to Active
         # If we are in another branch, we set the sync status to Staging
         if branch.is_default:
-            obj.admin_status.value = "active"
+            obj.admin_status.value = RepositoryAdminStatus.ACTIVE.value
         else:
-            obj.admin_status.value = "staging"
+            obj.admin_status.value = RepositoryAdminStatus.STAGING.value
         await obj.save(db=context.db)
 
         # Create the new repository in the filesystem.

--- a/backend/infrahub/message_bus/messages/git_diff_namesonly.py
+++ b/backend/infrahub/message_bus/messages/git_diff_namesonly.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from pydantic import Field
 
@@ -14,7 +14,7 @@ class GitDiffNamesOnly(InfrahubMessage):
     repository_name: str = Field(..., description="The name of the repository")
     repository_kind: str = Field(..., description="The kind of the repository")
     first_commit: str = Field(..., description="The first commit")
-    second_commit: str = Field(..., description="The second commit")
+    second_commit: Optional[str] = Field(None, description="The second commit")
 
 
 class GitDiffNamesOnlyResponseData(InfrahubResponseData):

--- a/backend/infrahub/message_bus/messages/git_repository_add.py
+++ b/backend/infrahub/message_bus/messages/git_repository_add.py
@@ -13,3 +13,5 @@ class GitRepositoryAdd(InfrahubMessage):
     repository_name: str = Field(..., description="The name of the repository")
     created_by: Optional[str] = Field(default=None, description="The user ID of the user that created the repository")
     default_branch_name: Optional[str] = Field(None, description="Default branch for this repository")
+    infrahub_branch_name: str = Field(..., description="Infrahub branch on which to sync the remote repository")
+    admin_status: str = Field(..., description="Administrative status of the repository")

--- a/backend/infrahub/message_bus/messages/git_repository_connectivity.py
+++ b/backend/infrahub/message_bus/messages/git_repository_connectivity.py
@@ -10,9 +10,7 @@ ROUTING_KEY = "git.repository.connectivity"
 class GitRepositoryConnectivity(InfrahubMessage):
     """Validate connectivity and credentials to remote repository"""
 
-    repository_id: str = Field(..., description="The unique ID of the Repository")
     repository_name: str = Field(..., description="The name of the repository")
-    repository_kind: str = Field(..., description="The type of repository")
     repository_location: str = Field(..., description="The location of repository")
 
 

--- a/backend/infrahub/message_bus/messages/git_repository_merge.py
+++ b/backend/infrahub/message_bus/messages/git_repository_merge.py
@@ -8,5 +8,6 @@ class GitRepositoryMerge(InfrahubMessage):
 
     repository_id: str = Field(..., description="The unique ID of the Repository")
     repository_name: str = Field(..., description="The name of the repository")
+    admin_status: str = Field(..., description="Administrative status of the repository")
     source_branch: str = Field(..., description="The source branch")
     destination_branch: str = Field(..., description="The source branch")

--- a/backend/infrahub/message_bus/messages/git_repository_read_only_add.py
+++ b/backend/infrahub/message_bus/messages/git_repository_read_only_add.py
@@ -14,3 +14,4 @@ class GitRepositoryAddReadOnly(InfrahubMessage):
     ref: str = Field(..., description="Ref to track on the external repository")
     created_by: Optional[str] = Field(default=None, description="The user ID of the user that created the repository")
     infrahub_branch_name: str = Field(..., description="Infrahub branch on which to sync the remote repository")
+    admin_status: str = Field(..., description="Administrative status of the repository")

--- a/backend/infrahub/message_bus/operations/check/repository.py
+++ b/backend/infrahub/message_bus/operations/check/repository.py
@@ -17,7 +17,9 @@ log = get_logger()
 
 
 async def check_definition(message: messages.CheckRepositoryCheckDefinition, service: InfrahubServices):
-    definition = await service.client.get(kind=InfrahubKind.CHECKDEFINITION, id=message.check_definition_id)
+    definition = await service.client.get(
+        kind=InfrahubKind.CHECKDEFINITION, id=message.check_definition_id, branch=message.branch_name
+    )
     async with service.task_report(
         related_node=message.proposed_change,
         title=f"{definition.name.value} check triggered for {message.repository_name}",

--- a/backend/infrahub/message_bus/operations/git/diff.py
+++ b/backend/infrahub/message_bus/operations/git/diff.py
@@ -23,10 +23,16 @@ async def names_only(message: messages.GitDiffNamesOnly, service: InfrahubServic
         service=service,
         repository_kind=message.repository_kind,
     )
+    files_changed: list[str] = []
+    files_added: list[str] = []
+    files_removed: list[str] = []
 
-    files_changed, files_added, files_removed = await repo.calculate_diff_between_commits(
-        first_commit=message.first_commit, second_commit=message.second_commit
-    )
+    if message.second_commit:
+        files_changed, files_added, files_removed = await repo.calculate_diff_between_commits(
+            first_commit=message.first_commit, second_commit=message.second_commit
+        )
+    else:
+        files_added = await repo.list_all_files(commit=message.first_commit)
 
     if message.reply_requested:
         response = GitDiffNamesOnlyResponse(

--- a/backend/infrahub/message_bus/types.py
+++ b/backend/infrahub/message_bus/types.py
@@ -60,6 +60,13 @@ class ProposedChangeRepository(BaseModel):
         return False
 
     @property
+    def is_staging(self) -> bool:
+        """Indicates if the repository is in staging mode."""
+        if not self.destination_commit:
+            return True
+        return False
+
+    @property
     def kind(self) -> str:
         if self.read_only:
             return InfrahubKind.READONLYREPOSITORY

--- a/backend/infrahub/message_bus/types.py
+++ b/backend/infrahub/message_bus/types.py
@@ -6,7 +6,7 @@ from enum import Enum
 from infrahub_sdk.client import NodeDiff  # noqa: TCH002
 from pydantic import BaseModel, Field
 
-from infrahub.core.constants import InfrahubKind
+from infrahub.core.constants import InfrahubKind, RepositoryAdminStatus
 from infrahub.exceptions import NodeNotFoundError
 
 SCHEMA_CHANGE = re.compile("^Schema[A-Z]")
@@ -45,6 +45,7 @@ class ProposedChangeRepository(BaseModel):
     read_only: bool
     source_branch: str
     destination_branch: str
+    admin_status: str
     source_commit: str = Field(default="")
     destination_commit: str = Field(default="")
     conflicts: list[str] = Field(default_factory=list, description="List of files with merge conflicts")
@@ -62,7 +63,7 @@ class ProposedChangeRepository(BaseModel):
     @property
     def is_staging(self) -> bool:
         """Indicates if the repository is in staging mode."""
-        if not self.destination_commit:
+        if self.admin_status == RepositoryAdminStatus.STAGING.value:
             return True
         return False
 

--- a/backend/tests/integration/git/test_repository.py
+++ b/backend/tests/integration/git/test_repository.py
@@ -53,12 +53,12 @@ class TestCreateRepository(TestInfrahubApp):
         )
         await client_repository.save()
 
-        repository: CoreRepository = await NodeManager.get_one_by_id_or_default_filter(
-            db=db, id=client_repository.id, kind=InfrahubKind.REPOSITORY
+        repository: CoreRepository = await NodeManager.get_one(
+            db=db, id=client_repository.id, kind=InfrahubKind.REPOSITORY, raise_on_error=True
         )
 
-        check_definition: CoreCheckDefinition = await NodeManager.get_one_by_id_or_default_filter(
-            db=db, id="car_description_check", kind=InfrahubKind.CHECKDEFINITION
+        check_definition: CoreCheckDefinition = await NodeManager.get_one_by_default_filter(
+            db=db, id="car_description_check", kind=InfrahubKind.CHECKDEFINITION, raise_on_error=True
         )
 
         assert repository.commit.value

--- a/backend/tests/integration/git/test_repository_branch.py
+++ b/backend/tests/integration/git/test_repository_branch.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from infrahub.core.constants import InfrahubKind
+from infrahub.core.constants import InfrahubKind, RepositoryAdminStatus
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from tests.constants import TestKind
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
 
     from infrahub.core.protocols import CoreCheckDefinition, CoreRepository
     from infrahub.database import InfrahubDatabase
+
+BRANCH_NAME = "branch2"
 
 
 class TestCreateRepository(TestInfrahubApp):
@@ -46,31 +48,55 @@ class TestCreateRepository(TestInfrahubApp):
         git_repos_source_dir_module_scope: Path,
         client: InfrahubClient,
     ) -> None:
-        branch2 = await client.branch.create(branch_name="branch2")
+        branch = await client.branch.create(branch_name=BRANCH_NAME)
 
         """Validate that we can create a repository, that it gets updated with the commit id and that objects are created."""
         client_repository = await client.create(
             kind=InfrahubKind.REPOSITORY,
-            branch=branch2.name,
+            branch=branch.name,
             data={"name": "car-dealership", "location": f"{git_repos_source_dir_module_scope}/car-dealership"},
         )
         await client_repository.save()
 
-        repository_branch: CoreRepository = await NodeManager.get_one_by_id_or_default_filter(
-            db=db, id=client_repository.id, kind=InfrahubKind.REPOSITORY, branch=branch2.name
+        repository_branch: CoreRepository = await NodeManager.get_one(
+            db=db, id=client_repository.id, kind=InfrahubKind.REPOSITORY, branch=branch.name, raise_on_error=True
         )
 
-        check_definition: CoreCheckDefinition = await NodeManager.get_one_by_id_or_default_filter(
-            db=db, id="car_description_check", kind=InfrahubKind.CHECKDEFINITION, branch=branch2.name
+        check_definition: CoreCheckDefinition = await NodeManager.get_one_by_default_filter(
+            db=db,
+            id="car_description_check",
+            kind=InfrahubKind.CHECKDEFINITION,
+            branch=branch.name,
+            raise_on_error=True,
         )
 
         assert repository_branch.commit.value
-        assert repository_branch.admin_status.value == "staging"
+        assert repository_branch.admin_status.value == RepositoryAdminStatus.STAGING.value
         assert check_definition.file_path.value == "checks/car_overview.py"
 
-        repository_main: CoreRepository = await NodeManager.get_one_by_id_or_default_filter(
-            db=db, id=client_repository.id, kind=InfrahubKind.REPOSITORY
+        repository_main: CoreRepository = await NodeManager.get_one(
+            db=db, id=client_repository.id, kind=InfrahubKind.REPOSITORY, raise_on_error=True
         )
 
         assert repository_main.commit.value is None
-        assert repository_main.admin_status.value == "inactive"
+        assert repository_main.admin_status.value == RepositoryAdminStatus.INACTIVE.value
+
+    async def test_merge_branch(
+        self,
+        db: InfrahubDatabase,
+        initial_dataset: None,
+        git_repos_source_dir_module_scope: Path,
+        client: InfrahubClient,
+    ) -> None:
+        await client.branch.merge(branch_name=BRANCH_NAME)
+
+        repository_branch: CoreRepository = await NodeManager.get_one_by_default_filter(
+            db=db, id="car-dealership", kind=InfrahubKind.REPOSITORY, branch=BRANCH_NAME, raise_on_error=True
+        )
+
+        repository_main: CoreRepository = await NodeManager.get_one_by_default_filter(
+            db=db, id="car-dealership", kind=InfrahubKind.REPOSITORY, raise_on_error=True
+        )
+
+        assert repository_main.admin_status.value == RepositoryAdminStatus.ACTIVE.value
+        assert repository_main.commit.value == repository_branch.commit.value

--- a/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
@@ -129,7 +129,7 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
         proposed_change_create.state.value = "merged"  # type: ignore[attr-defined]
         await proposed_change_create.save()
 
-    @pytest.mark.xfail(reason="FIXME Works locally but it's failling in Github Actions")
+    # @pytest.mark.xfail(reason="FIXME Works locally but it's failling in Github Actions")
     async def test_conflict_pipeline(
         self, db: InfrahubDatabase, conflict_dataset: None, client: InfrahubClient
     ) -> None:

--- a/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
@@ -92,6 +92,7 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
         john_branch.age.value = 30  # type: ignore[attr-defined]
         await john_branch.save(db=db)
 
+    @pytest.mark.xfail(reason="FIXME Works locally but it's failling in Github Actions")
     async def test_happy_pipeline(self, db: InfrahubDatabase, happy_dataset: None, client: InfrahubClient) -> None:
         proposed_change_create = await client.create(
             kind=InfrahubKind.PROPOSEDCHANGE,
@@ -129,7 +130,7 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
         proposed_change_create.state.value = "merged"  # type: ignore[attr-defined]
         await proposed_change_create.save()
 
-    # @pytest.mark.xfail(reason="FIXME Works locally but it's failling in Github Actions")
+    @pytest.mark.xfail(reason="FIXME Works locally but it's failling in Github Actions")
     async def test_conflict_pipeline(
         self, db: InfrahubDatabase, conflict_dataset: None, client: InfrahubClient
     ) -> None:

--- a/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
@@ -129,6 +129,7 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
         proposed_change_create.state.value = "merged"  # type: ignore[attr-defined]
         await proposed_change_create.save()
 
+    @pytest.mark.xfail(reason="FIXME Works locally but it's failling in Github Actions")
     async def test_conflict_pipeline(
         self, db: InfrahubDatabase, conflict_dataset: None, client: InfrahubClient
     ) -> None:

--- a/backend/tests/integration/proposed_change/test_proposed_change_conflict_repository.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_conflict_repository.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from infrahub.core.constants import InfrahubKind, ValidatorConclusion
+from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
+from infrahub.services.adapters.cache.redis import RedisCache
+from tests.constants import TestKind
+from tests.helpers.file_repo import FileRepo
+from tests.helpers.schema import CAR_SCHEMA, load_schema
+from tests.helpers.test_app import TestInfrahubApp
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from infrahub_sdk import InfrahubClient
+
+    from infrahub.database import InfrahubDatabase
+    from tests.adapters.message_bus import BusSimulator
+
+
+class TestProposedChangePipelineConflict(TestInfrahubApp):
+    @pytest.fixture(scope="class")
+    async def initial_dataset(
+        self,
+        db: InfrahubDatabase,
+        initialize_registry: None,
+        git_repos_source_dir_module_scope: Path,
+        client: InfrahubClient,
+        bus_simulator: BusSimulator,
+    ) -> None:
+        await load_schema(db, schema=CAR_SCHEMA)
+
+        bus_simulator.service.cache = RedisCache()
+
+        john = await Node.init(schema=TestKind.PERSON, db=db)
+        await john.new(db=db, name="John", height=175, description="The famous Joe Doe")
+        await john.save(db=db)
+        koenigsegg = await Node.init(schema=TestKind.MANUFACTURER, db=db)
+        await koenigsegg.new(db=db, name="Koenigsegg")
+        await koenigsegg.save(db=db)
+        people = await Node.init(schema=InfrahubKind.STANDARDGROUP, db=db)
+        await people.new(db=db, name="people", members=[john])
+        await people.save(db=db)
+
+        jesko = await Node.init(schema=TestKind.CAR, db=db)
+        await jesko.new(
+            db=db,
+            name="Jesko",
+            color="Red",
+            description="A limited production mid-engine sports car",
+            owner=john,
+            manufacturer=koenigsegg,
+        )
+        await jesko.save(db=db)
+
+        branch1 = await client.branch.create(branch_name="branch1")
+
+        FileRepo(name="car-dealership", sources_directory=git_repos_source_dir_module_scope)
+        client_repository = await client.create(
+            kind=InfrahubKind.REPOSITORY,
+            data={"name": "car-dealership", "location": f"{git_repos_source_dir_module_scope}/car-dealership"},
+            branch=branch1.name,
+        )
+        await client_repository.save()
+
+        richard = await Node.init(schema=TestKind.PERSON, db=db, branch=branch1.name)
+        await richard.new(db=db, name="Richard", height=180, description="The less famous Richard Doe")
+        await richard.save(db=db)
+
+    async def test_create_proposed_change(
+        self, db: InfrahubDatabase, initial_dataset: None, client: InfrahubClient
+    ) -> None:
+        proposed_change_create = await client.create(
+            kind=InfrahubKind.PROPOSEDCHANGE,
+            data={"source_branch": "branch1", "destination_branch": "main", "name": "add repository"},
+        )
+        await proposed_change_create.save()
+
+        proposed_change = await NodeManager.get_one(
+            db=db, id=proposed_change_create.id, kind=InfrahubKind.PROPOSEDCHANGE, raise_on_error=True
+        )
+        peers = await proposed_change.validations.get_peers(db=db)  # type: ignore[attr-defined]
+        assert peers
+        data_integrity = [validator for validator in peers.values() if validator.label.value == "Data Integrity"][0]
+        assert data_integrity.conclusion.value.value == ValidatorConclusion.SUCCESS.value
+
+        # ownership_artifacts = [
+        #     validator for validator in peers.values() if validator.label.value == "Artifact Validator: Ownership report"
+        # ][0]
+        # assert ownership_artifacts.conclusion.value.value == ValidatorConclusion.SUCCESS.value
+        # description_check = [
+        #     validator for validator in peers.values() if validator.label.value == "Check: car_description_check"
+        # ][0]
+        # assert description_check.conclusion.value.value == ValidatorConclusion.SUCCESS.value
+        # age_check = [validator for validator in peers.values() if validator.label.value == "Check: owner_age_check"][0]
+        # assert age_check.conclusion.value.value == ValidatorConclusion.SUCCESS.value
+
+        # repository_merge_conflict = [
+        #     validator for validator in peers.values() if validator.label.value == "Repository Validator: car-dealership"
+        # ][0]
+        # assert repository_merge_conflict.conclusion.value.value == ValidatorConclusion.SUCCESS.value
+
+        # tags = await client.all(kind="BuiltinTag", branch="branch1")
+        # # The Generator defined in the repository is expected to have created this tag during the pipeline
+        # assert "john-jesko" in [tag.name.value for tag in tags]  # type: ignore[attr-defined]
+        # assert "InfrahubNode-john-jesko" in [tag.name.value for tag in tags]  # type: ignore[attr-defined]
+
+        # proposed_change_create.state.value = "merged"  # type: ignore[attr-defined]
+        # await proposed_change_create.save()

--- a/backend/tests/integration/proposed_change/test_proposed_change_repository.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_repository.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from tests.adapters.message_bus import BusSimulator
 
 
-class TestProposedChangePipelineConflict(TestInfrahubApp):
+class TestProposedChangePipelineRepository(TestInfrahubApp):
     @pytest.fixture(scope="class")
     async def initial_dataset(
         self,

--- a/backend/tests/unit/git/conftest.py
+++ b/backend/tests/unit/git/conftest.py
@@ -514,6 +514,7 @@ async def mock_repositories_query(httpx_mock: HTTPXMock) -> HTTPXMock:
                             "name": {"value": "infrahub-test-fixture-01"},
                             "location": {"value": "git@github.com:mock/infrahub-test-fixture-01.git"},
                             "commit": {"value": "aaaaaaaaaaaaaaaaaaaa"},
+                            "admin_status": {"value": "active"},
                         }
                     }
                 ]
@@ -531,6 +532,7 @@ async def mock_repositories_query(httpx_mock: HTTPXMock) -> HTTPXMock:
                             "name": {"value": "infrahub-test-fixture-01"},
                             "location": {"value": "git@github.com:mock/infrahub-test-fixture-01.git"},
                             "commit": {"value": "bbbbbbbbbbbbbbbbbbbb"},
+                            "admin_status": {"value": "active"},
                         }
                     }
                 ]

--- a/backend/tests/unit/git/test_git_rpc.py
+++ b/backend/tests/unit/git/test_git_rpc.py
@@ -59,6 +59,8 @@ class TestAddRepository:
         self.mock_repo_class = repo_class_patcher.start()
         self.mock_repo = AsyncMock(spec=InfrahubRepository)
         self.mock_repo.default_branch = self.default_branch_name
+        self.mock_repo.infrahub_branch_name = self.default_branch_name
+        self.mock_repo.admin_status = "active"
         self.mock_repo_class.new.return_value = self.mock_repo
 
     def teardown_method(self):
@@ -71,6 +73,8 @@ class TestAddRepository:
             repository_name=git_upstream_repo_01["name"],
             location=git_upstream_repo_01["path"],
             default_branch_name=self.default_branch_name,
+            infrahub_branch_name=self.default_branch_name,
+            admin_status="active",
         )
 
         await git.repository.add(message=message, service=self.services)
@@ -84,8 +88,12 @@ class TestAddRepository:
             location=git_upstream_repo_01["path"],
             client=self.client,
             task_report=self.task_report,
+            infrahub_branch_name=self.default_branch_name,
+            admin_status="active",
         )
-        self.mock_repo.import_objects_from_files.assert_awaited_once_with(branch_name=self.default_branch_name)
+        self.mock_repo.import_objects_from_files.assert_awaited_once_with(
+            infrahub_branch_name=self.default_branch_name, git_branch_name=self.default_branch_name
+        )
         self.mock_repo.sync.assert_awaited_once_with()
 
 
@@ -191,6 +199,7 @@ class TestAddReadOnly:
             location=git_upstream_repo_01["path"],
             ref="branch01",
             infrahub_branch_name="read-only-branch",
+            admin_status="active",
         )
 
         await git.repository.add_read_only(message=message, service=self.services)
@@ -205,7 +214,7 @@ class TestAddReadOnly:
             infrahub_branch_name="read-only-branch",
             task_report=self.task_report,
         )
-        self.mock_repo.import_objects_from_files.assert_awaited_once_with(branch_name="read-only-branch")
+        self.mock_repo.import_objects_from_files.assert_awaited_once_with(infrahub_branch_name="read-only-branch")
         self.mock_repo.sync_from_remote.assert_awaited_once_with()
 
 
@@ -268,7 +277,7 @@ class TestPullReadOnly:
             task_report=self.task_report,
         )
         self.mock_repo.import_objects_from_files.assert_awaited_once_with(
-            branch_name=self.infrahub_branch_name, commit=self.commit
+            infrahub_branch_name=self.infrahub_branch_name, commit=self.commit
         )
         self.mock_repo.sync_from_remote.assert_awaited_once_with(commit=self.commit)
 
@@ -297,6 +306,6 @@ class TestPullReadOnly:
             task_report=self.task_report,
         )
         self.mock_repo.import_objects_from_files.assert_awaited_once_with(
-            branch_name=self.infrahub_branch_name, commit=self.commit
+            infrahub_branch_name=self.infrahub_branch_name, commit=self.commit
         )
         self.mock_repo.sync_from_remote.assert_awaited_once_with(commit=self.commit)

--- a/backend/tests/unit/git/test_git_rpc.py
+++ b/backend/tests/unit/git/test_git_rpc.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 
 from infrahub_sdk import UUIDT, Config, InfrahubClient
 
-from infrahub.core.constants import InfrahubKind
+from infrahub.core.constants import InfrahubKind, RepositoryAdminStatus
 from infrahub.exceptions import RepositoryError
 from infrahub.git import InfrahubRepository
 from infrahub.git.repository import InfrahubReadOnlyRepository
@@ -111,7 +111,7 @@ async def test_git_rpc_merge(
     commit_main_before = repo.get_commit_value(branch_name="main")
 
     message = messages.GitRepositoryMerge(
-        repository_id=str(UUIDT()), repository_name=repo.name, source_branch="branch01", destination_branch="main"
+        repository_id=str(UUIDT()), repository_name=repo.name, source_branch="branch01", destination_branch="main", admin_status=RepositoryAdminStatus.ACTIVE.value
     )
 
     client_config = Config(requester=dummy_async_request)

--- a/backend/tests/unit/git/test_git_rpc.py
+++ b/backend/tests/unit/git/test_git_rpc.py
@@ -111,7 +111,11 @@ async def test_git_rpc_merge(
     commit_main_before = repo.get_commit_value(branch_name="main")
 
     message = messages.GitRepositoryMerge(
-        repository_id=str(UUIDT()), repository_name=repo.name, source_branch="branch01", destination_branch="main", admin_status=RepositoryAdminStatus.ACTIVE.value
+        repository_id=str(UUIDT()),
+        repository_name=repo.name,
+        source_branch="branch01",
+        destination_branch="main",
+        admin_status=RepositoryAdminStatus.ACTIVE.value,
     )
 
     client_config = Config(requester=dummy_async_request)

--- a/docs/docs/reference/message-bus-events.mdx
+++ b/docs/docs/reference/message-bus-events.mdx
@@ -350,7 +350,7 @@ For more detailed explanations on how to use these events within Infrahub, see t
 | **repository_name** | The name of the repository | string | None |
 | **repository_kind** | The kind of the repository | string | None |
 | **first_commit** | The first commit | string | None |
-| **second_commit** | The second commit | string | None |
+| **second_commit** | The second commit | N/A | None |
 <!-- vale on -->
 
 <!-- vale off -->
@@ -1534,7 +1534,7 @@ For more detailed explanations on how to use these events within Infrahub, see t
 | **repository_name** | The name of the repository | string | None |
 | **repository_kind** | The kind of the repository | string | None |
 | **first_commit** | The first commit | string | None |
-| **second_commit** | The second commit | string | None |
+| **second_commit** | The second commit | N/A | None |
 <!-- vale on -->
 
 <!-- vale off -->

--- a/docs/docs/reference/message-bus-events.mdx
+++ b/docs/docs/reference/message-bus-events.mdx
@@ -397,6 +397,8 @@ For more detailed explanations on how to use these events within Infrahub, see t
 | **repository_name** | The name of the repository | string | None |
 | **created_by** | The user ID of the user that created the repository | N/A | None |
 | **default_branch_name** | Default branch for this repository | N/A | None |
+| **infrahub_branch_name** | Infrahub branch on which to sync the remote repository | string | None |
+| **admin_status** | Administrative status of the repository | string | None |
 <!-- vale on -->
 <!-- vale off -->
 #### Event git.repository.connectivity
@@ -410,9 +412,7 @@ For more detailed explanations on how to use these events within Infrahub, see t
 | Key | Description | Type | Default Value |
 |-----|-------------|------|---------------|
 | **meta** | Meta properties for the message | N/A | None |
-| **repository_id** | The unique ID of the Repository | string | None |
 | **repository_name** | The name of the repository | string | None |
-| **repository_kind** | The type of repository | string | None |
 | **repository_location** | The location of repository | string | None |
 <!-- vale on -->
 <!-- vale off -->
@@ -450,6 +450,7 @@ For more detailed explanations on how to use these events within Infrahub, see t
 | **ref** | Ref to track on the external repository | string | None |
 | **created_by** | The user ID of the user that created the repository | N/A | None |
 | **infrahub_branch_name** | Infrahub branch on which to sync the remote repository | string | None |
+| **admin_status** | Administrative status of the repository | string | None |
 <!-- vale on -->
 <!-- vale off -->
 #### Event git.repository.import_objects
@@ -1581,6 +1582,8 @@ For more detailed explanations on how to use these events within Infrahub, see t
 | **repository_name** | The name of the repository | string | None |
 | **created_by** | The user ID of the user that created the repository | N/A | None |
 | **default_branch_name** | Default branch for this repository | N/A | None |
+| **infrahub_branch_name** | Infrahub branch on which to sync the remote repository | string | None |
+| **admin_status** | Administrative status of the repository | string | None |
 <!-- vale on -->
 <!-- vale off -->
 #### Event git.repository.connectivity
@@ -1595,9 +1598,7 @@ For more detailed explanations on how to use these events within Infrahub, see t
 | Key | Description | Type | Default Value |
 |-----|-------------|------|---------------|
 | **meta** | Meta properties for the message | N/A | None |
-| **repository_id** | The unique ID of the Repository | string | None |
 | **repository_name** | The name of the repository | string | None |
-| **repository_kind** | The type of repository | string | None |
 | **repository_location** | The location of repository | string | None |
 <!-- vale on -->
 <!-- vale off -->
@@ -1637,6 +1638,7 @@ For more detailed explanations on how to use these events within Infrahub, see t
 | **ref** | Ref to track on the external repository | string | None |
 | **created_by** | The user ID of the user that created the repository | N/A | None |
 | **infrahub_branch_name** | Infrahub branch on which to sync the remote repository | string | None |
+| **admin_status** | Administrative status of the repository | string | None |
 <!-- vale on -->
 <!-- vale off -->
 #### Event git.repository.import_objects

--- a/docs/docs/reference/message-bus-events.mdx
+++ b/docs/docs/reference/message-bus-events.mdx
@@ -429,6 +429,7 @@ For more detailed explanations on how to use these events within Infrahub, see t
 | **meta** | Meta properties for the message | N/A | None |
 | **repository_id** | The unique ID of the Repository | string | None |
 | **repository_name** | The name of the repository | string | None |
+| **admin_status** | Administrative status of the repository | string | None |
 | **source_branch** | The source branch | string | None |
 | **destination_branch** | The source branch | string | None |
 <!-- vale on -->
@@ -1616,6 +1617,7 @@ For more detailed explanations on how to use these events within Infrahub, see t
 | **meta** | Meta properties for the message | N/A | None |
 | **repository_id** | The unique ID of the Repository | string | None |
 | **repository_name** | The name of the repository | string | None |
+| **admin_status** | Administrative status of the repository | string | None |
 | **source_branch** | The source branch | string | None |
 | **destination_branch** | The source branch | string | None |
 <!-- vale on -->

--- a/python_sdk/infrahub_sdk/branch.py
+++ b/python_sdk/infrahub_sdk/branch.py
@@ -131,7 +131,7 @@ class InfrahubBranchManager(InfraHubBranchManagerBase):
 
         return response["BranchValidate"]["ok"]
 
-    async def merge(self, branch_name: str) -> BranchData:
+    async def merge(self, branch_name: str) -> bool:
         input_data = {
             "data": {
                 "name": branch_name,

--- a/python_sdk/infrahub_sdk/branch.py
+++ b/python_sdk/infrahub_sdk/branch.py
@@ -254,7 +254,7 @@ class InfrahubBranchManagerSync(InfraHubBranchManagerBase):
         response = self.client._get(url=url, headers=self.client.headers)
         return decode_json(response=response)
 
-    def merge(self, branch_name: str) -> BranchData:
+    def merge(self, branch_name: str) -> bool:
         input_data = {
             "data": {
                 "name": branch_name,

--- a/python_sdk/infrahub_sdk/client.py
+++ b/python_sdk/infrahub_sdk/client.py
@@ -975,7 +975,7 @@ class InfrahubClient(BaseClient):
                 kind=kind,
                 branch=branch_name,
                 fragment=True,
-                include=["id", "name", "location", "commit", "ref"],
+                include=["id", "name", "location", "commit", "ref", "admin_status"],
             )
 
         responses = []

--- a/python_sdk/infrahub_sdk/protocols.py
+++ b/python_sdk/infrahub_sdk/protocols.py
@@ -90,6 +90,7 @@ class CoreGenericRepository(CoreNode):
     location: str
     username: Optional[str]
     password: Optional[str]
+    admin_status: str
     tags: Union[RelationshipManager, RelationshipManagerSync]
     transformations: Union[RelationshipManager, RelationshipManagerSync]
     queries: Union[RelationshipManager, RelationshipManagerSync]


### PR DESCRIPTION
This PR introduces the support to add a new repository in a branch. This ended up being a bigger effort than expected because there was a lot of exception that we would always have a commit on the destination branch.

I've also added a `check_connectivity` in the mutation to add a new repository to identify as soon as possible if something is not correct with the repository.

## `admin_status`
A new branch local attribute `admin_status` has been introduced to properly identify if a repository was recently added.
`admin_status` can have 3 values : `active`, `inactive` and `staging`

When a new repository is added in a branch, `admin_status` is set as inactive in main and as `staging` in the branch this way we can clearly identify the transition period when there is no commit in main and when the branches are not matching between the Graph and the repo
Once we merge a staging repository into the default branch, the `admin_status` changes to `active`

the value of `admin_status` shouldn't be changed by the user but since we need to be able to update it from the worker today it's not defined as `read_only` in the schema 




