### PR TITLE
Activate poetry env to make sure pydantic-settings is present

### DIFF
--- a/.github/workflows/update-compose-file.yml
+++ b/.github/workflows/update-compose-file.yml
@@ -29,27 +29,21 @@ jobs:
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
-      - name: Set up Python 3.12
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
-
-      - name: Install Poetry
+          python-version: 3.12
+      - name: "Setup environment"
         run: |
-          curl -sSL https://install.python-poetry.org | python - -y
+          pipx install poetry
+          poetry config virtualenvs.prefer-active-python true
+      - name: "Install Package"
+        run: "poetry install --all-extras"
 
-      - name: Update PATH
-        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-      - name: Update Poetry configuration
-        run: poetry config virtualenvs.create false
-
-      - name: Install dependencies
-        run: poetry install --no-ansi --no-interaction
-      - name: "Update Docker Env & Infrahub Version in docker-compose.yml file"
-        run: |
-            invoke dev.gen-config-env -u
-            invoke dev.update-docker-compose
+      - name: "Update Docker Env variable in docker-compose.yml file"
+        run: "poetry run invoke dev.gen-config-env -u"
+      - name: "Update Infrahub Image Version in docker-compose.yml file"
+        run: "poetry run invoke dev.update-docker-compose"
       - name: Commit docker-compose.yml
         uses: github-actions-x/commit@v2.9
         with:

--- a/.github/workflows/update-compose-file.yml
+++ b/.github/workflows/update-compose-file.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           pipx install poetry
           poetry config virtualenvs.prefer-active-python true
-          pip install invoke toml
+
       - name: "Install Package"
         run: "poetry install --all-extras"
 

--- a/.github/workflows/update-compose-file.yml
+++ b/.github/workflows/update-compose-file.yml
@@ -41,10 +41,11 @@ jobs:
       - name: "Install Package"
         run: "poetry install --all-extras"
 
-      - name: "Update Docker Env variable in docker-compose.yml file"
-        run: "invoke dev.gen-config-env -u"
-      - name: "Update Infrahub Image Version in docker-compose.yml file"
-        run: "invoke dev.update-docker-compose"
+      - name: "Update Docker Env & Infrahub Version in docker-compose.yml file"
+        run: |
+            source $(poetry env info --path)/bin/activate
+            invoke dev.gen-config-env -u
+            invoke dev.update-docker-compose
 
       - name: Commit docker-compose.yml
         uses: github-actions-x/commit@v2.9

--- a/.github/workflows/update-compose-file.yml
+++ b/.github/workflows/update-compose-file.yml
@@ -29,24 +29,27 @@ jobs:
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
-      - name: Set up Python
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
-      - name: "Setup environment"
+          python-version: "3.12"
+
+      - name: Install Poetry
         run: |
-          pipx install poetry
-          poetry config virtualenvs.prefer-active-python true
+          curl -sSL https://install.python-poetry.org | python - -y
 
-      - name: "Install Package"
-        run: "poetry install --all-extras"
+      - name: Update PATH
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
 
+      - name: Update Poetry configuration
+        run: poetry config virtualenvs.create false
+
+      - name: Install dependencies
+        run: poetry install --no-ansi --no-interaction
       - name: "Update Docker Env & Infrahub Version in docker-compose.yml file"
         run: |
-            source $(poetry env info --path)/bin/activate
             invoke dev.gen-config-env -u
             invoke dev.update-docker-compose
-
       - name: Commit docker-compose.yml
         uses: github-actions-x/commit@v2.9
         with:


### PR DESCRIPTION
Fixing issue where pydantic-settings is not found during the invoke even if it's installed in poetry just before

Logs from a failed CICD job
```
Run poetry install --all-extras
Creating virtualenv infrahub-1pwcNQ10-py3.12 in /home/runner/.cache/pypoetry/virtualenvs
Installing dependencies from lock file

Package operations: 159 installs, 0 updates, 0 removals

  - Installing six (1.16.0)
  - Installing wrapt (1.16.0)
  - Installing zipp (3.18.1)
  - Installing deprecated (1.2.14)
  - Installing importlib-metadata (6.[11](https://github.com/opsmill/infrahub/actions/runs/10008909570/job/27666588027#step:6:12).0)
  - Installing jmespath (1.0.1)
  - Installing python-dateutil (2.9.0.post0)
  - Installing typing-extensions (4.10.0)
  - Installing urllib3 (2.2.2)
  - Installing annotated-types (0.6.0)
  - Installing botocore (1.34.[12](https://github.com/opsmill/infrahub/actions/runs/10008909570/job/27666588027#step:6:13)9)
  - Installing certifi (2024.7.4)
  - Installing h11 (0.14.0)
  - Installing mdurl (0.1.2)
  - Installing multidict (6.0.5)
  - Installing idna (3.7)
  - Installing opentelemetry-api (1.24.0)
  - Installing protobuf (4.25.3)
  - Installing pydantic-core (2.18.3)
  - Installing setuptools (69.2.0)
  - Installing smmap (5.0.1)
  - Installing sniffio (1.3.1)
  - Installing anyio (4.3.0)
  - Installing asgiref (3.8.1)
  - Installing asttokens (2.4.1)
  - Installing charset-normalizer (3.3.2)
  - Installing click (8.1.7)
  - Installing distlib (0.3.8)
  - Installing executing (2.0.1)
  - Installing filelock (3.[13](https://github.com/opsmill/infrahub/actions/runs/10008909570/job/27666588027#step:6:14).3)
  - Installing gitdb (4.0.11)
  - Installing graphql-core (3.2.3)
  - Installing httpcore (1.0.4)
  - Installing iniconfig (2.0.0)
  - Installing markdown-it-py (3.0.0)
  - Installing markupsafe (2.1.5)
  - Installing numpy (1.26.4)
  - Installing opentelemetry-instrumentation (0.45b0)
  - Installing opentelemetry-proto (1.24.0)
  - Installing opentelemetry-semantic-conventions (0.45b0)
  - Installing opentelemetry-util-http (0.45b0)
  - Installing packaging (24.0)
  - Installing pamqp (3.3.0)
  - Installing parso (0.8.3)
  - Installing platformdirs (4.2.0)
  - Installing pluggy (1.4.0)
  - Installing ptyprocess (0.7.0)
  - Installing pure-eval (0.2.2)
  - Installing pycparser (2.21)
  - Installing pydantic (2.7.2)
  - Installing pygments (2.17.2)
  - Installing python-dotenv (1.0.1)
  - Installing pytz (2024.1)
  - Installing s3transfer (0.10.1)
  - Installing traitlets (5.[14](https://github.com/opsmill/infrahub/actions/runs/10008909570/job/27666588027#step:6:15).2)
  - Installing tzdata (2024.1)
  - Installing wcwidth (0.2.13)
  - Installing yarl (1.9.4)
  - Installing aiormq (6.8.0)
  - Installing aniso8601 (9.0.1)
  - Installing astroid (3.1.0)
  - Installing backcall (0.2.0)
  - Installing boto3 (1.34.129)
  - Installing cffi (1.16.0)
  - Installing cfgv (3.4.0)
  - Installing colorama (0.4.6)
  - Installing coverage (7.4.4)
  - Installing decorator (5.1.1)
  - Installing dill (0.3.8)
  - Installing dnspython (2.6.1)
  - Installing execnet (2.0.2)
  - Installing gitpython (3.1.42)
  - Installing googleapis-common-protos (1.63.0)
  - Installing graphql-relay (3.2.0)
  - Installing grpcio (1.62.1)
  - Installing hiredis (2.3.2)
  - Installing httptools (0.6.1)
  - Installing httpx (0.27.0)
  - Installing identify (2.5.35)
  - Installing isort (5.13.2)
  - Installing jedi (0.19.1)
  - Installing jinja2 (3.1.4)
  - Installing matplotlib-inline (0.1.6)
  - Installing mccabe (0.7.0)
  - Installing mypy-extensions (1.0.0)
  - Installing neo4j (5.20.0)
  - Installing nodeenv (1.8.0)
  - Installing opentelemetry-exporter-otlp-proto-common (1.24.0)
  - Installing opentelemetry-instrumentation-asgi (0.45b0)
  - Installing opentelemetry-sdk (1.24.0)
  - Installing ordered-set (4.1.0)
  - Installing pathspec (0.12.1)
  - Installing pendulum (3.0.0)
  - Installing pexpect (4.9.0)
  - Installing pickleshare (0.7.5)
  - Installing pprintpp (0.4.0)
  - Installing prometheus-client (0.20.0)
  - Installing prompt-toolkit (3.0.43)
  - Installing py-cpuinfo (9.0.0)
  - Installing pyarrow (14.0.2)
  - Installing pydantic-settings (2.2.1)
  - Installing pytest (7.4.4)
  - Installing pyyaml (6.0.1)
  - Installing requests (2.32.3)
  - Installing rich (13.7.1)
  - Installing shellingham (1.4.0)
  - Installing stack-data (0.6.3)
  - Installing starlette (0.36.3)
  - Installing toml (0.10.2)
  - Installing tomlkit (0.12.4)
  - Installing typer (0.7.0)
  - Installing ujson (5.9.0)
  - Installing uvloop (0.19.0)
  - Installing virtualenv (20.25.1)
  - Installing watchfiles (0.21.0)
  - Installing websockets (12.0)
  - Installing aio-pika (9.4.1)
  - Installing asgi-correlation-id (4.2.0)
  - Installing bcrypt (4.1.2)
  - Installing deepdiff (6.7.1)
  - Installing email-validator (2.1.1)
  - Installing fastapi (0.110.0)
  - Installing fastapi-storages (0.3.0)
  - Installing graphene (3.3)
  - Installing gunicorn (22.0.0)
  - Installing invoke (2.2.0)
  - Installing ipython (8.12.3)
  - Installing lunr (0.7.0.post1)
  - Installing mypy (1.10.0)
  - Installing nats-py (2.7.2)
  - Installing neo4j-rust-ext (5.20.0.0)
  - Installing netaddr (1.3.0)
  - Installing opentelemetry-exporter-otlp-proto-grpc (1.24.0)
  - Installing opentelemetry-exporter-otlp-proto-http (1.24.0)
  - Installing opentelemetry-instrumentation-aio-pika (0.45b0)
  - Installing opentelemetry-instrumentation-fastapi (0.45b0)
  - Installing pre-commit (2.21.0)
  - Installing pyjwt (2.8.0)
  - Installing pylint (3.1.0)
  - Installing pytest-asyncio (0.21.1)
  - Installing pytest-benchmark (4.0.0)
  - Installing pytest-clarity (1.0.1)
  - Installing pytest-codspeed (2.2.1)
  - Installing pytest-cov (4.1.0)
  - Installing pytest-httpx (0.30.0)
  - Installing pytest-xdist (3.4.0)
  - Installing python-multipart (0.0.9)
  - Installing redis (5.0.3)
  - Installing ruff (0.4.6)
  - Installing starlette-exporter (0.21.0)
  - Installing structlog (24.1.0)
  - Installing typer-cli (0.0.13)
  - Installing types-python-slugify (8.0.2.20240310)
  - Installing types-pyyaml (6.0.12.20240311)
  - Installing types-toml (0.10.8.20240310)
  - Installing types-ujson (5.9.0.0)
  - Installing uvicorn (0.27.1)
  - Installing yamllint (1.35.1)
  - Installing infrahub-sdk (0.12.0 /home/runner/work/infrahub/infrahub/python_sdk)

Installing the current project: infrahub (0.[15](https://github.com/opsmill/infrahub/actions/runs/10008909570/job/27666588027#step:6:16).0)
0s
Run invoke dev.gen-config-env -u
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.12.4/x64/bin/invoke", line 8, in <module>
    sys.exit(program.run())
             ^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.4/x64/lib/python3.12/site-packages/invoke/program.py", line 398, in run
    self.execute()
  File "/opt/hostedtoolcache/Python/3.12.4/x64/lib/python3.12/site-packages/invoke/program.py", line 583, in execute
    executor.execute(*self.tasks)
  File "/opt/hostedtoolcache/Python/3.12.4/x64/lib/python3.12/site-packages/invoke/executor.py", line 140, in execute
    result = call.task(*args, **call.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.4/x64/lib/python3.12/site-packages/invoke/tasks.py", line 138, in __call__
    result = self.body(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/infrahub/infrahub/tasks/dev.py", line [31](https://github.com/opsmill/infrahub/actions/runs/10008909570/job/27666588027#step:6:32)3, in gen_config_env
    from pydantic_settings import BaseSettings
ModuleNotFoundError: No module named 'pydantic_settings'
Error: Process completed with exit code 1.
```