### PR TITLE
Fix error rendering in infrahubctl schema load

### DIFF
--- a/backend/tests/helpers/cli.py
+++ b/backend/tests/helpers/cli.py
@@ -1,5 +1,6 @@
 import re
 
+
 def remove_ansi_color(text: str) -> str:
-    ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
-    return ansi_escape.sub('', text)
+    ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+    return ansi_escape.sub("", text)

--- a/backend/tests/helpers/cli.py
+++ b/backend/tests/helpers/cli.py
@@ -1,0 +1,5 @@
+import re
+
+def remove_ansi_color(text: str) -> str:
+    ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+    return ansi_escape.sub('', text)

--- a/python_sdk/infrahub_sdk/ctl/schema.py
+++ b/python_sdk/infrahub_sdk/ctl/schema.py
@@ -113,8 +113,8 @@ def display_schema_load_errors(response: dict[str, Any], schemas_data: list[dict
             console.print(f"  Node: {node.get('namespace', None)}{node.get('name', None)} | {error_message}")
 
         elif len(loc_path) > 6:
-            loc_type = loc_path[-3]
-            input_label = node[loc_type][loc_path[-2]].get("name", None)
+            loc_type = loc_path[5]
+            input_label = node[loc_type][loc_path[6]].get("name", None)
             input_str = error.get("input", None)
             error_message = f"{loc_type[:-1].title()}: {input_label} ({input_str}) | {error['msg']} ({error['type']})"
             console.print(f"  Node: {node.get('namespace', None)}{node.get('name', None)} | {error_message}")

--- a/python_sdk/infrahub_sdk/ctl/schema.py
+++ b/python_sdk/infrahub_sdk/ctl/schema.py
@@ -96,7 +96,8 @@ def display_schema_load_errors(response: dict[str, Any], schemas_data: list[dict
         if not valid_error_path(loc_path=loc_path):
             continue
 
-        loc_type = loc_path[-2]
+        # if the len of the path is equal to 6, the error is at the root of the object
+        # if the len of the path is higher than 6, the error is in an attribute or a relationships
         schema_index = int(loc_path[2])
         node_index = int(loc_path[4])
         node = get_node(schemas_data=schemas_data, schema_index=schema_index, node_index=node_index)
@@ -105,11 +106,18 @@ def display_schema_load_errors(response: dict[str, Any], schemas_data: list[dict
             console.print("Node data not found.")
             continue
 
-        input_label = node[loc_type][loc_path[-1]].get("name", None)
-        input_str = error.get("input", None)
-        error_message = f"{loc_type[:-1].title()}: {input_label} ({input_str}) | {error['msg']} ({error['type']})"
+        if len(loc_path) == 6:
+            loc_type = loc_path[-1]
+            input_str = error.get("input", None)
+            error_message = f"{loc_type} ({input_str}) | {error['msg']} ({error['type']})"
+            console.print(f"  Node: {node.get('namespace', None)}{node.get('name', None)} | {error_message}")
 
-        console.print(f"  Node: {node.get('namespace', None)}{node.get('name', None)} | {error_message}")
+        elif len(loc_path) > 6:
+            loc_type = loc_path[-3]
+            input_label = node[loc_type][loc_path[-2]].get("name", None)
+            input_str = error.get("input", None)
+            error_message = f"{loc_type[:-1].title()}: {input_label} ({input_str}) | {error['msg']} ({error['type']})"
+            console.print(f"  Node: {node.get('namespace', None)}{node.get('name', None)} | {error_message}")
 
 
 def handle_non_detail_errors(response: dict[str, Any]) -> None:

--- a/python_sdk/tests/fixtures/models/non_valid_namespace.json
+++ b/python_sdk/tests/fixtures/models/non_valid_namespace.json
@@ -1,0 +1,26 @@
+{   "version": "1.0",
+    "nodes": [
+        {
+            "name": "Device",
+            "namespace": "OuT",
+            "default_filter": "name__value",
+            "branch": "aware",
+            "attributes": [
+                {
+                    "name": "name",
+                    "kind": "Text",
+                    "unique": true
+                },
+                {
+                    "name": "description",
+                    "kind": "Text",
+                    "optional": true
+                },
+                {
+                    "name": "type",
+                    "kind": "Text"
+                }
+            ]
+        }
+    ]
+}

--- a/python_sdk/tests/unit/ctl/test_branch_app.py
+++ b/python_sdk/tests/unit/ctl/test_branch_app.py
@@ -28,5 +28,6 @@ def test_branch_create_no_auth(httpx_mock: HTTPXMock, authentication_error_paylo
 
 def test_branch_create_wrong_name(mock_branch_create_error):
     result = runner.invoke(app=app, args=["create", "branch2"])
+
     assert result.exit_code == 5
-    assert 'invalid field name: string does not match regex "^[a-z][a-z0-9' in result.stdout.replace("\n", "")
+    assert "invalid field name: string does not match regex" in result.stdout.replace("\n", "")

--- a/python_sdk/tests/unit/ctl/test_schema_app.py
+++ b/python_sdk/tests/unit/ctl/test_schema_app.py
@@ -48,7 +48,6 @@ def test_schema_load_one_valid(httpx_mock: HTTPXMock):
     assert content_json == {"schemas": [fixture_file_content]}
 
 
-# @pytest.mark.xfail(reason="FIXME: work locally but not in CI")
 def test_schema_load_multiple(httpx_mock: HTTPXMock):
     fixture_file1 = get_fixtures_dir() / "models" / "valid_schemas" / "contract.yml"
     fixture_file2 = get_fixtures_dir() / "models" / "valid_schemas" / "rack.yml"

--- a/python_sdk/tests/unit/ctl/test_schema_app.py
+++ b/python_sdk/tests/unit/ctl/test_schema_app.py
@@ -101,8 +101,12 @@ def test_schema_load_notvalid_namespace(httpx_mock: HTTPXMock):
 
     expected_result = (
         "\x1b[31mUnable to load the schema:\x1b[0m\n "
-        " Node: OuTDevice | namespace \x1b[1m(\x1b[0mOuT\x1b[1m)\x1b[0m | String should match pattern \x1b[32m'^\x1b[0m\x1b[32m[\x1b[0m\x1b[32mA-Z\x1b[0m\x1b[32m]\x1b[0m\x1b[32m+$'\x1b[0m \x1b[1m(\x1b[0mstring_pattern_mismatch\x1b[1m)\x1b[0m\n "
-        " Node: OuTDevice | Attribute: name \x1b[1m(\x1b[0mNotValid\x1b[1m)\x1b[0m | Value error, Only valid Attribute Kind are : \x1b[1m[\x1b[0m\x1b[32m'ID'\x1b[0m, \x1b[32m'Dropdown'\x1b[0m\x1b[1m]\x1b[0m  \x1b[1m(\x1b[0mvalue_error\x1b[1m)\x1b[0m\n\x1b[1;31m1\x1b[0m\n"
+        " Node: OuTDevice | namespace \x1b[1m(\x1b[0mOuT\x1b[1m)\x1b[0m | "
+        "String should match pattern \x1b[32m'^\x1b[0m\x1b[32m[\x1b[0m\x1b[32mA-Z\x1b[0m\x1b[32m]\x1b[0m\x1b[32m+$'\x1b[0m "
+        "\x1b[1m(\x1b[0mstring_pattern_mismatch\x1b[1m)\x1b[0m\n "
+        " Node: OuTDevice | Attribute: name \x1b[1m(\x1b[0mNotValid\x1b[1m)\x1b[0m | "
+        "Value error, Only valid Attribute Kind are : \x1b[1m[\x1b[0m\x1b[32m'ID'\x1b[0m, \x1b[32m'Dropdown'\x1b[0m\x1b[1m]\x1b[0m "
+        " \x1b[1m(\x1b[0mvalue_error\x1b[1m)\x1b[0m\n\x1b[1;31m1\x1b[0m\n"
     )
     assert expected_result == result.stdout
 

--- a/python_sdk/tests/unit/ctl/test_schema_app.py
+++ b/python_sdk/tests/unit/ctl/test_schema_app.py
@@ -1,10 +1,10 @@
-import pytest
 import yaml
 from pytest_httpx import HTTPXMock
 from typer.testing import CliRunner
 
 from infrahub_sdk.ctl.schema import app
 from infrahub_sdk.ctl.utils import get_fixtures_dir
+from tests.helpers.cli import remove_ansi_color
 
 runner = CliRunner()
 
@@ -38,7 +38,7 @@ def test_schema_load_one_valid(httpx_mock: HTTPXMock):
     result = runner.invoke(app=app, args=["load", str(fixture_file)])
 
     assert result.exit_code == 0
-    assert f"schema '{fixture_file}' loaded successfully" in result.stdout.replace("\n", "")
+    assert f"schema '{fixture_file}' loaded successfully" in remove_ansi_color(result.stdout.replace("\n", ""))
 
     content = httpx_mock.get_requests()[0].content.decode("utf8")
     content_json = yaml.safe_load(content)
@@ -48,17 +48,32 @@ def test_schema_load_one_valid(httpx_mock: HTTPXMock):
     assert content_json == {"schemas": [fixture_file_content]}
 
 
-@pytest.mark.xfail(reason="FIXME: work locally but not in CI")
+# @pytest.mark.xfail(reason="FIXME: work locally but not in CI")
 def test_schema_load_multiple(httpx_mock: HTTPXMock):
     fixture_file1 = get_fixtures_dir() / "models" / "valid_schemas" / "contract.yml"
     fixture_file2 = get_fixtures_dir() / "models" / "valid_schemas" / "rack.yml"
 
-    httpx_mock.add_response(method="POST", url="http://mock/api/schema/load?branch=main", status_code=202)
+    httpx_mock.add_response(
+        method="POST",
+        url="http://mock/api/schema/load?branch=main",
+        status_code=200,
+        json={
+            "hash": "497c17fbe915062c8c5a698be62130e4",
+            "previous_hash": "d3f7f4e7161f0ae6538a01d5a42dc661",
+            "diff": {
+                "added": {"InfraDevice": {"added": {}, "changed": {}, "removed": {}}},
+                "changed": {},
+                "removed": {},
+            },
+            "schema_updated": True,
+        },
+    )
     result = runner.invoke(app=app, args=["load", str(fixture_file1), str(fixture_file2)])
 
     assert result.exit_code == 0
-    assert f"schema '{fixture_file1}' loaded successfully" in result.stdout.replace("\n", "")
-    assert f"schema '{fixture_file2}' loaded successfully" in result.stdout.replace("\n", "")
+    clean_output = remove_ansi_color(result.stdout.replace("\n", ""))
+    assert f"schema '{fixture_file1}' loaded successfully" in clean_output
+    assert f"schema '{fixture_file2}' loaded successfully" in clean_output
 
     content = httpx_mock.get_requests()[0].content.decode("utf8")
     content_json = yaml.safe_load(content)
@@ -99,16 +114,14 @@ def test_schema_load_notvalid_namespace(httpx_mock: HTTPXMock):
 
     assert result.exit_code == 1
 
+    clean_output = remove_ansi_color(result.stdout.replace("\n", ""))
     expected_result = (
-        "\x1b[31mUnable to load the schema:\x1b[0m\n "
-        " Node: OuTDevice | namespace \x1b[1m(\x1b[0mOuT\x1b[1m)\x1b[0m | "
-        "String should match pattern \x1b[32m'^\x1b[0m\x1b[32m[\x1b[0m\x1b[32mA-Z\x1b[0m\x1b[32m]\x1b[0m\x1b[32m+$'\x1b[0m "
-        "\x1b[1m(\x1b[0mstring_pattern_mismatch\x1b[1m)\x1b[0m\n "
-        " Node: OuTDevice | Attribute: name \x1b[1m(\x1b[0mNotValid\x1b[1m)\x1b[0m | "
-        "Value error, Only valid Attribute Kind are : \x1b[1m[\x1b[0m\x1b[32m'ID'\x1b[0m, \x1b[32m'Dropdown'\x1b[0m\x1b[1m]\x1b[0m "
-        " \x1b[1m(\x1b[0mvalue_error\x1b[1m)\x1b[0m\n\x1b[1;31m1\x1b[0m\n"
+        "Unable to load the schema:  Node: OuTDevice | "
+        "namespace (OuT) | String should match pattern '^[A-Z]+$' (string_pattern_mismatch) "
+        " Node: OuTDevice | Attribute: name (NotValid) | Value error, Only valid Attribute Kind "
+        "are : ['ID', 'Dropdown']  (value_error)1"
     )
-    assert expected_result == result.stdout
+    assert expected_result == clean_output
 
     content = httpx_mock.get_requests()[0].content.decode("utf8")
     content_json = yaml.safe_load(content)


### PR DESCRIPTION
Fixes #3859

I think the issue has been introduced when we switched to Pydantic2, I would bet the format of the error messages changed which caused this issue.
I added a unit test to ensure we'll catch it in the future if the format changes again

I'll open another issue but I think ideally this logic should be done in the backend directly to improve the error messages for everyone but this is mostlikely a bigger effort