### PR TITLE
Fix toml example in docs

### DIFF
--- a/docs/docs/infrahubctl.mdx
+++ b/docs/docs/infrahubctl.mdx
@@ -37,6 +37,6 @@ The `infrahubctl` command line utility is installed as a part of the [Infrahub S
 ### `infrahubctl.toml` file
 
 ```toml title="infrahubctl.toml"
-server_address="http://localhost:8000"
-api_token="06438eb2-8019-4776-878c-0941b1f1d1ec"
+INFRAHUB_ADDRESS="http://localhost:8000"
+INFRAHUB_API_TOKEN="06438eb2-8019-4776-878c-0941b1f1d1ec"
 ```


### PR DESCRIPTION
The toml example in the docs was incorrect: https://docs.infrahub.app/infrahubctl#infrahubctltoml-file

It's been corrected. 

fixes #3944