### PR TITLE
Add update mutation for generic

### DIFF
--- a/backend/infrahub/graphql/manager.py
+++ b/backend/infrahub/graphql/manager.py
@@ -399,9 +399,6 @@ class GraphQLSchemaManager:  # pylint: disable=too-many-public-methods
         full_schema = self.schema.get_all(duplicate=False)
 
         for node_schema in full_schema.values():
-            if not isinstance(node_schema, (NodeSchema, ProfileSchema)):
-                continue
-
             if node_schema.namespace == "Internal":
                 continue
 
@@ -422,28 +419,35 @@ class GraphQLSchemaManager:  # pylint: disable=too-many-public-methods
             else:
                 base_class = mutation_map.get(node_schema.kind, InfrahubMutation)
 
-            mutations = self.generate_graphql_mutations(schema=node_schema, base_class=base_class)
+            if isinstance(node_schema, (NodeSchema, ProfileSchema)):
+                mutations = self.generate_graphql_mutations(schema=node_schema, base_class=base_class)
 
-            class_attrs[f"{node_schema.kind}Create"] = mutations.create.Field()
-            class_attrs[f"{node_schema.kind}Update"] = mutations.update.Field()
-            class_attrs[f"{node_schema.kind}Upsert"] = mutations.upsert.Field()
-            class_attrs[f"{node_schema.kind}Delete"] = mutations.delete.Field()
+                class_attrs[f"{node_schema.kind}Create"] = mutations.create.Field()
+                class_attrs[f"{node_schema.kind}Update"] = mutations.update.Field()
+                class_attrs[f"{node_schema.kind}Upsert"] = mutations.upsert.Field()
+                class_attrs[f"{node_schema.kind}Delete"] = mutations.delete.Field()
+
+            elif isinstance(node_schema, GenericSchema):
+                graphql_mutation_update_input = self.generate_graphql_mutation_update_input(node_schema)
+                update = self.generate_graphql_mutation_update(
+                    schema=node_schema, base_class=base_class, input_type=graphql_mutation_update_input
+                )
+                self.set_type(name=update._meta.name, graphql_type=update)
+                class_attrs[f"{node_schema.kind}Update"] = update.Field()
 
         return type("MutationMixin", (object,), class_attrs)
 
-    def generate_graphql_object(
-        self, schema: Union[NodeSchema, ProfileSchema], populate_cache: bool = False
-    ) -> type[InfrahubObject]:
+    def generate_graphql_object(self, schema: MainSchemaTypes, populate_cache: bool = False) -> type[InfrahubObject]:
         """Generate a GraphQL object Type from a Infrahub NodeSchema."""
 
         interfaces: set[type[InfrahubObject]] = set()
 
-        if schema.inherit_from:
+        if isinstance(schema, (NodeSchema, ProfileSchema)) and schema.inherit_from:
             for generic_name in schema.inherit_from:
                 generic = self.get_type(name=generic_name)
                 interfaces.add(generic)
 
-        if not isinstance(schema, ProfileSchema):
+        if isinstance(schema, NodeSchema):
             if not schema.inherit_from or InfrahubKind.GENERICGROUP not in schema.inherit_from:
                 node_interface = self.get_type(name=InfrahubKind.NODE)
                 interfaces.add(node_interface)
@@ -601,7 +605,7 @@ class GraphQLSchemaManager:  # pylint: disable=too-many-public-methods
 
     def generate_graphql_mutation_update_input(
         self,
-        schema: Union[NodeSchema, ProfileSchema],
+        schema: MainSchemaTypes,
     ) -> type[graphene.InputObjectType]:
         """Generate an InputObjectType Object from a Infrahub NodeSchema
 
@@ -715,7 +719,7 @@ class GraphQLSchemaManager:  # pylint: disable=too-many-public-methods
 
     def generate_graphql_mutation_update(
         self,
-        schema: Union[NodeSchema, ProfileSchema],
+        schema: MainSchemaTypes,
         input_type: type[graphene.InputObjectType],
         base_class: type[InfrahubMutation] = InfrahubMutation,
     ) -> type[InfrahubMutation]:

--- a/backend/infrahub/graphql/manager.py
+++ b/backend/infrahub/graphql/manager.py
@@ -427,7 +427,10 @@ class GraphQLSchemaManager:  # pylint: disable=too-many-public-methods
                 class_attrs[f"{node_schema.kind}Upsert"] = mutations.upsert.Field()
                 class_attrs[f"{node_schema.kind}Delete"] = mutations.delete.Field()
 
-            elif isinstance(node_schema, GenericSchema):
+            elif (
+                isinstance(node_schema, GenericSchema)
+                and (len(node_schema.attributes) + len(node_schema.relationships)) > 0
+            ):
                 graphql_mutation_update_input = self.generate_graphql_mutation_update_input(node_schema)
                 update = self.generate_graphql_mutation_update(
                     schema=node_schema, base_class=base_class, input_type=graphql_mutation_update_input

--- a/backend/tests/unit/graphql/mutations/test_update_generic.py
+++ b/backend/tests/unit/graphql/mutations/test_update_generic.py
@@ -1,0 +1,50 @@
+from graphql import graphql
+
+from infrahub.core.branch import Branch
+from infrahub.core.node import Node
+from infrahub.database import InfrahubDatabase
+from infrahub.graphql import prepare_graphql_params
+
+
+async def test_display_label_generic(db: InfrahubDatabase, animal_person_schema, branch: Branch):
+    person_schema = animal_person_schema.get(name="TestPerson")
+    dog_schema = animal_person_schema.get(name="TestDog")
+    cat_schema = animal_person_schema.get(name="TestCat")
+
+    person1 = await Node.init(db=db, schema=person_schema, branch=branch)
+    await person1.new(db=db, name="Jack")
+    await person1.save(db=db)
+
+    dog1 = await Node.init(db=db, schema=dog_schema, branch=branch)
+    await dog1.new(db=db, name="Rocky", breed="Labrador", owner=person1)
+    await dog1.save(db=db)
+
+    cat1 = await Node.init(db=db, schema=cat_schema, branch=branch)
+    await cat1.new(db=db, name="Kitty", breed="Persian", owner=person1)
+    await cat1.save(db=db)
+
+    query = """
+    mutation ($id: String!){
+        TestAnimalUpdate(data: {id: $id, weight: { value: 15 }}) {
+            ok
+            object {
+                id
+                weight {
+                    value
+                }
+            }
+        }
+    }
+    """
+    gql_params = prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"id": dog1.id},
+    )
+
+    assert result.errors is None
+    assert result.data["TestAnimalUpdate"]["ok"] is True
+    assert result.data["TestAnimalUpdate"]["object"]["weight"]["value"]


### PR DESCRIPTION
As we're using Generic more and more it feels like we are missing a mutation to update a field defined on a Generic without knowing the exact type of the object.

This PR adds a new Update mutation for all generics, as an example below, it's now possible to update the description of a repository without knowing if it's a `CoreRepository` or a `CoreReadOnlyRepository`

```graphql
  mutation ($id: String!){
      CoreGenericRepository(data: {
          id: $id, 
          description: { value: "New description" }
       }) {
          ok
          object {
              id
              description {
                  value
              }
          }
      }
  }
```

this is required for #3948 but I'm sure we'll see more and more use cases over time

