### PR TITLE
Add protocols for attributes for Python SDK and split Sync and Async

### DIFF
--- a/backend/infrahub/message_bus/messages/schema_validator_path.py
+++ b/backend/infrahub/message_bus/messages/schema_validator_path.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import Field
 
 from infrahub.core.branch import Branch  # noqa: TCH001
@@ -22,8 +20,8 @@ class SchemaValidatorPath(InfrahubMessage):
 
 class SchemaValidatorPathResponseData(InfrahubResponseData):
     violations: list[SchemaViolation] = Field(default_factory=list)
-    constraint_name: Optional[str] = None
-    schema_path: Optional[SchemaPath] = None
+    constraint_name: str
+    schema_path: SchemaPath
 
 
 class SchemaValidatorPathResponse(InfrahubResponse):

--- a/backend/infrahub/message_bus/operations/requests/proposed_change.py
+++ b/backend/infrahub/message_bus/operations/requests/proposed_change.py
@@ -32,6 +32,7 @@ from infrahub.pytest_plugin import InfrahubBackendPlugin
 
 if TYPE_CHECKING:
     from infrahub_sdk.node import InfrahubNode
+    from infrahub_sdk.protocols import CoreGeneratorDefinition, CoreProposedChange
 
     from infrahub.core.models import SchemaUpdateConstraintInfo
     from infrahub.core.schema_manager import SchemaBranch
@@ -47,7 +48,7 @@ class DefinitionSelect(IntFlag):
     FILE_CHANGES = 2
 
     @staticmethod
-    def add_flag(current: DefinitionSelect, flag: DefinitionSelect, condition: bool):
+    def add_flag(current: DefinitionSelect, flag: DefinitionSelect, condition: bool) -> DefinitionSelect:
         if condition:
             return current | flag
         return current
@@ -74,7 +75,9 @@ async def cancel(message: messages.RequestProposedChangeCancel, service: Infrahu
         title="Canceling proposed change",
     ) as task_report:
         await task_report.info("Canceling proposed change as the source branch was deleted", id=message.proposed_change)
-        proposed_change = await service.client.get(kind=InfrahubKind.PROPOSEDCHANGE, id=message.proposed_change)
+        proposed_change: CoreProposedChange = await service.client.get(
+            kind=InfrahubKind.PROPOSEDCHANGE, id=message.proposed_change
+        )
         proposed_change.state.value = ProposedChangeState.CANCELED.value
         await proposed_change.save()
 
@@ -98,7 +101,9 @@ async def data_integrity(message: messages.RequestProposedChangeDataIntegrity, s
                 validator_label="Data Integrity",
                 check_schema_kind=InfrahubKind.DATACHECK,
             )
-            await object_conflict_validator_recorder.record_conflicts(message.proposed_change, conflicts)
+            await object_conflict_validator_recorder.record_conflicts(
+                proposed_change_id=message.proposed_change, conflicts=conflicts
+            )
 
 
 async def pipeline(message: messages.RequestProposedChangePipeline, service: InfrahubServices) -> None:
@@ -254,7 +259,7 @@ async def schema_integrity(
         # ----------------------------------------------------------
         source_branch = registry.get_branch_from_registry(branch=message.source_branch)
         _, responses = await schema_validators_checker(
-            branch=source_branch, schema=candidate_schema, constraints=constraints, service=service
+            branch=source_branch, schema=candidate_schema, constraints=list(constraints), service=service
         )
 
         # TODO we need to report a failure if an error happened during the execution of a validator
@@ -396,8 +401,8 @@ async def run_generators(message: messages.RequestProposedChangeRunGenerators, s
         related_node=message.proposed_change,
         title="Evaluating Generators",
     ) as task_report:
-        generators = await service.client.filters(
-            kind="CoreGeneratorDefinition",
+        generators: list[CoreGeneratorDefinition] = await service.client.filters(
+            kind=InfrahubKind.GENERATORDEFINITION,
             prefetch_relationships=True,
             populate_store=True,
             branch=message.source_branch,

--- a/backend/templates/generate_protocols_sdk.j2
+++ b/backend/templates/generate_protocols_sdk.j2
@@ -4,38 +4,36 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, Protocol, Union, runtime_checkable
 
+from .protocols_base import CoreNode, CoreNodeSync
+
 if TYPE_CHECKING:
     from datetime import datetime
     from infrahub_sdk.node import RelatedNodeSync, RelationshipManagerSync, RelatedNode, RelationshipManager
+    from .protocols_base import String, StringOptional, Integer, IntegerOptional, Boolean, BooleanOptional, URL, URLOptional, Dropdown, DropdownOptional, Enum, EnumOptional, DateTime, DateTimeOptional, IPHost, IPHostOptional, IPNetwork, IPNetworkOptional, HashedPassword, HashedPasswordOptional, JSONAttribute, JSONAttributeOptional, ListAttribute, ListAttributeOptional
 
+# pylint: disable=too-many-ancestors
 
-@runtime_checkable
-class CoreNode(Protocol):
-    id: str
-    display_label: Optional[str]
-    hfid: Optional[list[str]]
-    hfid_str: Optional[str]
-
-    def get_kind(self) -> str: ...
-
+# ---------------------------------------------
+# ASYNC
+# ---------------------------------------------
 {% for generic in generics %}
 class {{ generic.namespace }}{{ generic.name }}(CoreNode):
     {%- if not generic.attributes|default([]) and not generic.relationships|default([]) %}
     pass
     {%- endif %}
     {%- for attribute in generic.attributes|default([]) %}
-    {{ attribute | render_attribute(use_python_primitive=True) }}
+    {{ attribute | render_attribute(use_python_primitive=False) }}
     {%- endfor %}
     {%- for relationship in generic.relationships|default([]) %}
     {%- if relationship.cardinality == "many" %}
-    {{ relationship.name }}: Union[RelationshipManager, RelationshipManagerSync]
+    {{ relationship.name }}: RelationshipManager
     {%- else %}
-    {{ relationship.name }}: Union[RelatedNode, RelatedNodeSync]
+    {{ relationship.name }}: RelatedNode
     {%- endif %}
     {%- endfor %}
     {%- if generic.hierarchical | default(false) %}
-    parent: Union[RelatedNode, RelatedNodeSync]
-    children: Union[RelationshipManager, RelationshipManagerSync]
+    parent: RelatedNode
+    children: RelationshipManager
     {%- endif %}
 {% endfor %}
 
@@ -45,17 +43,62 @@ class {{ model.namespace }}{{ model.name }}({{ model | inheritance }}):
     pass
     {%- endif %}
     {%- for attribute in model.attributes|default([]) %}
-    {{ attribute | render_attribute(use_python_primitive=True) }}
+    {{ attribute | render_attribute(use_python_primitive=False) }}
     {%- endfor %}
     {%- for relationship in model.relationships|default([]) %}
     {%- if relationship.cardinality == "many" %}
-    {{ relationship.name }}: Union[RelationshipManager, RelationshipManagerSync]
+    {{ relationship.name }}: RelationshipManager
     {%- else %}
-    {{ relationship.name }}: Union[RelatedNode, RelatedNodeSync]
+    {{ relationship.name }}: RelatedNode
     {%- endif %}
     {%- endfor %}
     {%- if model.hierarchical | default(false) %}
-    parent: Union[RelatedNode, RelatedNodeSync]
-    children: Union[RelationshipManager, RelationshipManagerSync]
+    parent: RelatedNode
+    children: RelationshipManager
+    {%- endif %}
+{% endfor %}
+
+# ---------------------------------------------
+# SYNC 
+# ---------------------------------------------
+{% for generic in generics %}
+class {{ generic.namespace }}{{ generic.name }}Sync(CoreNodeSync):
+    {%- if not generic.attributes|default([]) and not generic.relationships|default([]) %}
+    pass
+    {%- endif %}
+    {%- for attribute in generic.attributes|default([]) %}
+    {{ attribute | render_attribute(use_python_primitive=False) }}
+    {%- endfor %}
+    {%- for relationship in generic.relationships|default([]) %}
+    {%- if relationship.cardinality == "many" %}
+    {{ relationship.name }}: RelationshipManagerSync
+    {%- else %}
+    {{ relationship.name }}: RelatedNodeSync
+    {%- endif %}
+    {%- endfor %}
+    {%- if generic.hierarchical | default(false) %}
+    parent: RelatedNodeSync
+    children: RelationshipManagerSync
+    {%- endif %}
+{% endfor %}
+
+{% for model in models %}
+class {{ model.namespace }}{{ model.name }}Sync({{ model | inheritance(sync=True) }}):
+    {%- if not model.attributes|default([]) and not model.relationships|default([]) %}
+    pass
+    {%- endif %}
+    {%- for attribute in model.attributes|default([]) %}
+    {{ attribute | render_attribute(use_python_primitive=False) }}
+    {%- endfor %}
+    {%- for relationship in model.relationships|default([]) %}
+    {%- if relationship.cardinality == "many" %}
+    {{ relationship.name }}: RelationshipManagerSync
+    {%- else %}
+    {{ relationship.name }}: RelatedNodeSync
+    {%- endif %}
+    {%- endfor %}
+    {%- if model.hierarchical | default(false) %}
+    parent: RelatedNodeSync
+    children: RelationshipManagerSync
     {%- endif %}
 {% endfor %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -374,21 +374,12 @@ ignore_errors = true
 module = "infrahub.message_bus.operations.refresh.webhook"
 ignore_errors = true
 
-
 [[tool.mypy.overrides]]
 module = "infrahub.message_bus.operations.requests.artifact"
 ignore_errors = true
 
 [[tool.mypy.overrides]]
-module = "infrahub.message_bus.operations.requests.generator"
-ignore_errors = true
-
-[[tool.mypy.overrides]]
 module = "infrahub.message_bus.operations.requests.graphql_query_group"
-ignore_errors = true
-
-[[tool.mypy.overrides]]
-module = "infrahub.message_bus.operations.requests.proposed_change"
 ignore_errors = true
 
 [[tool.mypy.overrides]]

--- a/python_sdk/infrahub_sdk/protocols.py
+++ b/python_sdk/infrahub_sdk/protocols.py
@@ -2,121 +2,137 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Protocol, Union, runtime_checkable
+from typing import TYPE_CHECKING
+
+from .protocols_base import CoreNode, CoreNodeSync
 
 if TYPE_CHECKING:
-    from datetime import datetime
-
     from infrahub_sdk.node import RelatedNode, RelatedNodeSync, RelationshipManager, RelationshipManagerSync
 
+    from .protocols_base import (
+        URL,
+        Boolean,
+        BooleanOptional,
+        DateTime,
+        DateTimeOptional,
+        Dropdown,
+        Enum,
+        HashedPassword,
+        Integer,
+        IntegerOptional,
+        IPHost,
+        IPNetwork,
+        JSONAttribute,
+        JSONAttributeOptional,
+        ListAttributeOptional,
+        String,
+        StringOptional,
+    )
 
-@runtime_checkable
-class CoreNode(Protocol):
-    id: str
-    display_label: Optional[str]
-    hfid: Optional[list[str]]
-    hfid_str: Optional[str]
+# pylint: disable=too-many-ancestors
 
-    def get_kind(self) -> str: ...
+# ---------------------------------------------
+# ASYNC
+# ---------------------------------------------
 
 
 class BuiltinIPAddress(CoreNode):
-    address: str
-    description: Optional[str]
-    ip_namespace: Union[RelatedNode, RelatedNodeSync]
-    ip_prefix: Union[RelatedNode, RelatedNodeSync]
+    address: IPHost
+    description: StringOptional
+    ip_namespace: RelatedNode
+    ip_prefix: RelatedNode
 
 
 class BuiltinIPNamespace(CoreNode):
-    name: str
-    description: Optional[str]
-    ip_prefixes: Union[RelationshipManager, RelationshipManagerSync]
-    ip_addresses: Union[RelationshipManager, RelationshipManagerSync]
+    name: String
+    description: StringOptional
+    ip_prefixes: RelationshipManager
+    ip_addresses: RelationshipManager
 
 
 class BuiltinIPPrefix(CoreNode):
-    prefix: str
-    description: Optional[str]
-    member_type: str
-    is_pool: bool
-    is_top_level: Optional[bool]
-    utilization: Optional[int]
-    netmask: Optional[str]
-    hostmask: Optional[str]
-    network_address: Optional[str]
-    broadcast_address: Optional[str]
-    ip_namespace: Union[RelatedNode, RelatedNodeSync]
-    ip_addresses: Union[RelationshipManager, RelationshipManagerSync]
-    resource_pool: Union[RelationshipManager, RelationshipManagerSync]
-    parent: Union[RelatedNode, RelatedNodeSync]
-    children: Union[RelationshipManager, RelationshipManagerSync]
+    prefix: IPNetwork
+    description: StringOptional
+    member_type: Dropdown
+    is_pool: Boolean
+    is_top_level: BooleanOptional
+    utilization: IntegerOptional
+    netmask: StringOptional
+    hostmask: StringOptional
+    network_address: StringOptional
+    broadcast_address: StringOptional
+    ip_namespace: RelatedNode
+    ip_addresses: RelationshipManager
+    resource_pool: RelationshipManager
+    parent: RelatedNode
+    children: RelationshipManager
 
 
 class CoreArtifactTarget(CoreNode):
-    artifacts: Union[RelationshipManager, RelationshipManagerSync]
+    artifacts: RelationshipManager
 
 
 class CoreCheck(CoreNode):
-    name: Optional[str]
-    label: Optional[str]
-    origin: str
-    kind: str
-    message: Optional[str]
-    conclusion: Optional[str]
-    severity: Optional[str]
-    created_at: Optional[datetime]
-    validator: Union[RelatedNode, RelatedNodeSync]
+    name: StringOptional
+    label: StringOptional
+    origin: String
+    kind: String
+    message: StringOptional
+    conclusion: Enum
+    severity: Enum
+    created_at: DateTimeOptional
+    validator: RelatedNode
 
 
 class CoreComment(CoreNode):
-    text: str
-    created_at: Optional[datetime]
-    created_by: Union[RelatedNode, RelatedNodeSync]
+    text: String
+    created_at: DateTimeOptional
+    created_by: RelatedNode
 
 
 class CoreGenericAccount(CoreNode):
-    name: str
-    password: str
-    label: Optional[str]
-    description: Optional[str]
-    account_type: str
-    role: str
-    tokens: Union[RelationshipManager, RelationshipManagerSync]
+    name: String
+    password: HashedPassword
+    label: StringOptional
+    description: StringOptional
+    account_type: Enum
+    role: Enum
+    tokens: RelationshipManager
 
 
 class CoreGenericRepository(CoreNode):
-    name: str
-    description: Optional[str]
-    location: str
-    username: Optional[str]
-    password: Optional[str]
-    admin_status: str
-    tags: Union[RelationshipManager, RelationshipManagerSync]
-    transformations: Union[RelationshipManager, RelationshipManagerSync]
-    queries: Union[RelationshipManager, RelationshipManagerSync]
-    checks: Union[RelationshipManager, RelationshipManagerSync]
-    generators: Union[RelationshipManager, RelationshipManagerSync]
+    name: String
+    description: StringOptional
+    location: String
+    username: StringOptional
+    password: StringOptional
+    admin_status: Dropdown
+    tags: RelationshipManager
+    transformations: RelationshipManager
+    queries: RelationshipManager
+    checks: RelationshipManager
+    generators: RelationshipManager
 
 
 class CoreGroup(CoreNode):
-    name: str
-    label: Optional[str]
-    description: Optional[str]
-    group_type: str
-    members: Union[RelationshipManager, RelationshipManagerSync]
-    subscribers: Union[RelationshipManager, RelationshipManagerSync]
-    parent: Union[RelatedNode, RelatedNodeSync]
-    children: Union[RelationshipManager, RelationshipManagerSync]
+    name: String
+    label: StringOptional
+    description: StringOptional
+    group_type: Enum
+    members: RelationshipManager
+    subscribers: RelationshipManager
+    parent: RelatedNode
+    children: RelationshipManager
 
 
 class CoreProfile(CoreNode):
-    profile_name: str
-    profile_priority: Optional[int]
+    profile_name: String
+    profile_priority: IntegerOptional
 
 
 class CoreResourcePool(CoreNode):
-    name: str
-    description: Optional[str]
+    name: String
+    description: StringOptional
 
 
 class CoreTaskTarget(CoreNode):
@@ -124,39 +140,39 @@ class CoreTaskTarget(CoreNode):
 
 
 class CoreThread(CoreNode):
-    label: Optional[str]
-    resolved: bool
-    created_at: Optional[datetime]
-    change: Union[RelatedNode, RelatedNodeSync]
-    comments: Union[RelationshipManager, RelationshipManagerSync]
-    created_by: Union[RelatedNode, RelatedNodeSync]
+    label: StringOptional
+    resolved: Boolean
+    created_at: DateTimeOptional
+    change: RelatedNode
+    comments: RelationshipManager
+    created_by: RelatedNode
 
 
 class CoreTransformation(CoreNode):
-    name: str
-    label: Optional[str]
-    description: Optional[str]
-    timeout: int
-    query: Union[RelatedNode, RelatedNodeSync]
-    repository: Union[RelatedNode, RelatedNodeSync]
-    tags: Union[RelationshipManager, RelationshipManagerSync]
+    name: String
+    label: StringOptional
+    description: StringOptional
+    timeout: Integer
+    query: RelatedNode
+    repository: RelatedNode
+    tags: RelationshipManager
 
 
 class CoreValidator(CoreNode):
-    label: Optional[str]
-    state: str
-    conclusion: str
-    completed_at: Optional[datetime]
-    started_at: Optional[datetime]
-    proposed_change: Union[RelatedNode, RelatedNodeSync]
-    checks: Union[RelationshipManager, RelationshipManagerSync]
+    label: StringOptional
+    state: Enum
+    conclusion: Enum
+    completed_at: DateTimeOptional
+    started_at: DateTimeOptional
+    proposed_change: RelatedNode
+    checks: RelationshipManager
 
 
 class CoreWebhook(CoreNode):
-    name: str
-    description: Optional[str]
-    url: str
-    validate_certificates: Optional[bool]
+    name: String
+    description: StringOptional
+    url: URL
+    validate_certificates: BooleanOptional
 
 
 class LineageOwner(CoreNode):
@@ -168,8 +184,8 @@ class LineageSource(CoreNode):
 
 
 class BuiltinTag(CoreNode):
-    name: str
-    description: Optional[str]
+    name: String
+    description: StringOptional
 
 
 class CoreAccount(LineageOwner, LineageSource, CoreGenericAccount):
@@ -177,46 +193,46 @@ class CoreAccount(LineageOwner, LineageSource, CoreGenericAccount):
 
 
 class CoreArtifact(CoreTaskTarget):
-    name: str
-    status: str
-    content_type: str
-    checksum: Optional[str]
-    storage_id: Optional[str]
-    parameters: Optional[dict]
-    object: Union[RelatedNode, RelatedNodeSync]
-    definition: Union[RelatedNode, RelatedNodeSync]
+    name: String
+    status: Enum
+    content_type: Enum
+    checksum: StringOptional
+    storage_id: StringOptional
+    parameters: JSONAttributeOptional
+    object: RelatedNode
+    definition: RelatedNode
 
 
 class CoreArtifactCheck(CoreCheck):
-    changed: Optional[bool]
-    checksum: Optional[str]
-    artifact_id: Optional[str]
-    storage_id: Optional[str]
-    line_number: Optional[int]
+    changed: BooleanOptional
+    checksum: StringOptional
+    artifact_id: StringOptional
+    storage_id: StringOptional
+    line_number: IntegerOptional
 
 
 class CoreArtifactDefinition(CoreTaskTarget):
-    name: str
-    artifact_name: str
-    description: Optional[str]
-    parameters: dict
-    content_type: str
-    targets: Union[RelatedNode, RelatedNodeSync]
-    transformation: Union[RelatedNode, RelatedNodeSync]
+    name: String
+    artifact_name: String
+    description: StringOptional
+    parameters: JSONAttribute
+    content_type: Enum
+    targets: RelatedNode
+    transformation: RelatedNode
 
 
 class CoreArtifactThread(CoreThread):
-    artifact_id: Optional[str]
-    storage_id: Optional[str]
-    line_number: Optional[int]
+    artifact_id: StringOptional
+    storage_id: StringOptional
+    line_number: IntegerOptional
 
 
 class CoreArtifactValidator(CoreValidator):
-    definition: Union[RelatedNode, RelatedNodeSync]
+    definition: RelatedNode
 
 
 class CoreChangeComment(CoreComment):
-    change: Union[RelatedNode, RelatedNodeSync]
+    change: RelatedNode
 
 
 class CoreChangeThread(CoreThread):
@@ -224,25 +240,25 @@ class CoreChangeThread(CoreThread):
 
 
 class CoreCheckDefinition(CoreTaskTarget):
-    name: str
-    description: Optional[str]
-    file_path: str
-    class_name: str
-    timeout: int
-    parameters: Optional[dict]
-    repository: Union[RelatedNode, RelatedNodeSync]
-    query: Union[RelatedNode, RelatedNodeSync]
-    targets: Union[RelatedNode, RelatedNodeSync]
-    tags: Union[RelationshipManager, RelationshipManagerSync]
+    name: String
+    description: StringOptional
+    file_path: String
+    class_name: String
+    timeout: Integer
+    parameters: JSONAttributeOptional
+    repository: RelatedNode
+    query: RelatedNode
+    targets: RelatedNode
+    tags: RelationshipManager
 
 
 class CoreCustomWebhook(CoreWebhook, CoreTaskTarget):
-    transformation: Union[RelatedNode, RelatedNodeSync]
+    transformation: RelatedNode
 
 
 class CoreDataCheck(CoreCheck):
-    conflicts: dict
-    keep_branch: Optional[str]
+    conflicts: JSONAttribute
+    keep_branch: Enum
 
 
 class CoreDataValidator(CoreValidator):
@@ -250,31 +266,31 @@ class CoreDataValidator(CoreValidator):
 
 
 class CoreFileCheck(CoreCheck):
-    files: Optional[list]
-    commit: Optional[str]
+    files: ListAttributeOptional
+    commit: StringOptional
 
 
 class CoreFileThread(CoreThread):
-    file: Optional[str]
-    commit: Optional[str]
-    line_number: Optional[int]
-    repository: Union[RelatedNode, RelatedNodeSync]
+    file: StringOptional
+    commit: StringOptional
+    line_number: IntegerOptional
+    repository: RelatedNode
 
 
 class CoreGeneratorCheck(CoreCheck):
-    instance: str
+    instance: String
 
 
 class CoreGeneratorDefinition(CoreTaskTarget):
-    name: str
-    description: Optional[str]
-    parameters: dict
-    file_path: str
-    class_name: str
-    convert_query_response: Optional[bool]
-    query: Union[RelatedNode, RelatedNodeSync]
-    repository: Union[RelatedNode, RelatedNodeSync]
-    targets: Union[RelatedNode, RelatedNodeSync]
+    name: String
+    description: StringOptional
+    parameters: JSONAttribute
+    file_path: String
+    class_name: String
+    convert_query_response: BooleanOptional
+    query: RelatedNode
+    repository: RelatedNode
+    targets: RelatedNode
 
 
 class CoreGeneratorGroup(CoreGroup):
@@ -282,90 +298,90 @@ class CoreGeneratorGroup(CoreGroup):
 
 
 class CoreGeneratorInstance(CoreTaskTarget):
-    name: str
-    status: str
-    object: Union[RelatedNode, RelatedNodeSync]
-    definition: Union[RelatedNode, RelatedNodeSync]
+    name: String
+    status: Enum
+    object: RelatedNode
+    definition: RelatedNode
 
 
 class CoreGeneratorValidator(CoreValidator):
-    definition: Union[RelatedNode, RelatedNodeSync]
+    definition: RelatedNode
 
 
 class CoreGraphQLQuery(CoreNode):
-    name: str
-    description: Optional[str]
-    query: str
-    variables: Optional[dict]
-    operations: Optional[list]
-    models: Optional[list]
-    depth: Optional[int]
-    height: Optional[int]
-    repository: Union[RelatedNode, RelatedNodeSync]
-    tags: Union[RelationshipManager, RelationshipManagerSync]
+    name: String
+    description: StringOptional
+    query: String
+    variables: JSONAttributeOptional
+    operations: ListAttributeOptional
+    models: ListAttributeOptional
+    depth: IntegerOptional
+    height: IntegerOptional
+    repository: RelatedNode
+    tags: RelationshipManager
 
 
 class CoreGraphQLQueryGroup(CoreGroup):
-    parameters: Optional[dict]
-    query: Union[RelatedNode, RelatedNodeSync]
+    parameters: JSONAttributeOptional
+    query: RelatedNode
 
 
 class CoreIPAddressPool(CoreResourcePool, LineageSource):
-    default_address_type: str
-    default_prefix_length: Optional[int]
-    resources: Union[RelationshipManager, RelationshipManagerSync]
-    ip_namespace: Union[RelatedNode, RelatedNodeSync]
+    default_address_type: String
+    default_prefix_length: IntegerOptional
+    resources: RelationshipManager
+    ip_namespace: RelatedNode
 
 
 class CoreIPPrefixPool(CoreResourcePool, LineageSource):
-    default_prefix_length: Optional[int]
-    default_member_type: Optional[str]
-    default_prefix_type: Optional[str]
-    resources: Union[RelationshipManager, RelationshipManagerSync]
-    ip_namespace: Union[RelatedNode, RelatedNodeSync]
+    default_prefix_length: IntegerOptional
+    default_member_type: Enum
+    default_prefix_type: StringOptional
+    resources: RelationshipManager
+    ip_namespace: RelatedNode
 
 
 class CoreNumberPool(CoreResourcePool, LineageSource):
-    node: str
-    node_attribute: str
-    start_range: int
-    end_range: int
+    node: String
+    node_attribute: String
+    start_range: Integer
+    end_range: Integer
 
 
 class CoreObjectThread(CoreThread):
-    object_path: str
+    object_path: String
 
 
 class CoreProposedChange(CoreTaskTarget):
-    name: str
-    description: Optional[str]
-    source_branch: str
-    destination_branch: str
-    state: Optional[str]
-    approved_by: Union[RelationshipManager, RelationshipManagerSync]
-    reviewers: Union[RelationshipManager, RelationshipManagerSync]
-    created_by: Union[RelatedNode, RelatedNodeSync]
-    comments: Union[RelationshipManager, RelationshipManagerSync]
-    threads: Union[RelationshipManager, RelationshipManagerSync]
-    validations: Union[RelationshipManager, RelationshipManagerSync]
+    name: String
+    description: StringOptional
+    source_branch: String
+    destination_branch: String
+    state: Enum
+    approved_by: RelationshipManager
+    reviewers: RelationshipManager
+    created_by: RelatedNode
+    comments: RelationshipManager
+    threads: RelationshipManager
+    validations: RelationshipManager
 
 
 class CoreReadOnlyRepository(LineageOwner, LineageSource, CoreGenericRepository, CoreTaskTarget):
-    ref: str
-    commit: Optional[str]
+    ref: String
+    commit: StringOptional
 
 
 class CoreRepository(LineageOwner, LineageSource, CoreGenericRepository, CoreTaskTarget):
-    default_branch: str
-    commit: Optional[str]
+    default_branch: String
+    commit: StringOptional
 
 
 class CoreRepositoryValidator(CoreValidator):
-    repository: Union[RelatedNode, RelatedNodeSync]
+    repository: RelatedNode
 
 
 class CoreSchemaCheck(CoreCheck):
-    conflicts: dict
+    conflicts: JSONAttribute
 
 
 class CoreSchemaValidator(CoreValidator):
@@ -381,38 +397,441 @@ class CoreStandardGroup(CoreGroup):
 
 
 class CoreStandardWebhook(CoreWebhook, CoreTaskTarget):
-    shared_key: str
+    shared_key: String
 
 
 class CoreThreadComment(CoreComment):
-    thread: Union[RelatedNode, RelatedNodeSync]
+    thread: RelatedNode
 
 
 class CoreTransformJinja2(CoreTransformation):
-    template_path: str
+    template_path: String
 
 
 class CoreTransformPython(CoreTransformation):
-    file_path: str
-    class_name: str
+    file_path: String
+    class_name: String
 
 
 class CoreUserValidator(CoreValidator):
-    check_definition: Union[RelatedNode, RelatedNodeSync]
-    repository: Union[RelatedNode, RelatedNodeSync]
+    check_definition: RelatedNode
+    repository: RelatedNode
 
 
 class InternalAccountToken(CoreNode):
-    name: Optional[str]
-    token: str
-    expiration: Optional[datetime]
-    account: Union[RelatedNode, RelatedNodeSync]
+    name: StringOptional
+    token: String
+    expiration: DateTimeOptional
+    account: RelatedNode
 
 
 class InternalRefreshToken(CoreNode):
-    expiration: datetime
-    account: Union[RelatedNode, RelatedNodeSync]
+    expiration: DateTime
+    account: RelatedNode
 
 
 class IpamNamespace(BuiltinIPNamespace):
-    default: Optional[bool]
+    default: BooleanOptional
+
+
+# ---------------------------------------------
+# SYNC
+# ---------------------------------------------
+
+
+class BuiltinIPAddressSync(CoreNodeSync):
+    address: IPHost
+    description: StringOptional
+    ip_namespace: RelatedNodeSync
+    ip_prefix: RelatedNodeSync
+
+
+class BuiltinIPNamespaceSync(CoreNodeSync):
+    name: String
+    description: StringOptional
+    ip_prefixes: RelationshipManagerSync
+    ip_addresses: RelationshipManagerSync
+
+
+class BuiltinIPPrefixSync(CoreNodeSync):
+    prefix: IPNetwork
+    description: StringOptional
+    member_type: Dropdown
+    is_pool: Boolean
+    is_top_level: BooleanOptional
+    utilization: IntegerOptional
+    netmask: StringOptional
+    hostmask: StringOptional
+    network_address: StringOptional
+    broadcast_address: StringOptional
+    ip_namespace: RelatedNodeSync
+    ip_addresses: RelationshipManagerSync
+    resource_pool: RelationshipManagerSync
+    parent: RelatedNodeSync
+    children: RelationshipManagerSync
+
+
+class CoreArtifactTargetSync(CoreNodeSync):
+    artifacts: RelationshipManagerSync
+
+
+class CoreCheckSync(CoreNodeSync):
+    name: StringOptional
+    label: StringOptional
+    origin: String
+    kind: String
+    message: StringOptional
+    conclusion: Enum
+    severity: Enum
+    created_at: DateTimeOptional
+    validator: RelatedNodeSync
+
+
+class CoreCommentSync(CoreNodeSync):
+    text: String
+    created_at: DateTimeOptional
+    created_by: RelatedNodeSync
+
+
+class CoreGenericAccountSync(CoreNodeSync):
+    name: String
+    password: HashedPassword
+    label: StringOptional
+    description: StringOptional
+    account_type: Enum
+    role: Enum
+    tokens: RelationshipManagerSync
+
+
+class CoreGenericRepositorySync(CoreNodeSync):
+    name: String
+    description: StringOptional
+    location: String
+    username: StringOptional
+    password: StringOptional
+    admin_status: Dropdown
+    tags: RelationshipManagerSync
+    transformations: RelationshipManagerSync
+    queries: RelationshipManagerSync
+    checks: RelationshipManagerSync
+    generators: RelationshipManagerSync
+
+
+class CoreGroupSync(CoreNodeSync):
+    name: String
+    label: StringOptional
+    description: StringOptional
+    group_type: Enum
+    members: RelationshipManagerSync
+    subscribers: RelationshipManagerSync
+    parent: RelatedNodeSync
+    children: RelationshipManagerSync
+
+
+class CoreProfileSync(CoreNodeSync):
+    profile_name: String
+    profile_priority: IntegerOptional
+
+
+class CoreResourcePoolSync(CoreNodeSync):
+    name: String
+    description: StringOptional
+
+
+class CoreTaskTargetSync(CoreNodeSync):
+    pass
+
+
+class CoreThreadSync(CoreNodeSync):
+    label: StringOptional
+    resolved: Boolean
+    created_at: DateTimeOptional
+    change: RelatedNodeSync
+    comments: RelationshipManagerSync
+    created_by: RelatedNodeSync
+
+
+class CoreTransformationSync(CoreNodeSync):
+    name: String
+    label: StringOptional
+    description: StringOptional
+    timeout: Integer
+    query: RelatedNodeSync
+    repository: RelatedNodeSync
+    tags: RelationshipManagerSync
+
+
+class CoreValidatorSync(CoreNodeSync):
+    label: StringOptional
+    state: Enum
+    conclusion: Enum
+    completed_at: DateTimeOptional
+    started_at: DateTimeOptional
+    proposed_change: RelatedNodeSync
+    checks: RelationshipManagerSync
+
+
+class CoreWebhookSync(CoreNodeSync):
+    name: String
+    description: StringOptional
+    url: URL
+    validate_certificates: BooleanOptional
+
+
+class LineageOwnerSync(CoreNodeSync):
+    pass
+
+
+class LineageSourceSync(CoreNodeSync):
+    pass
+
+
+class BuiltinTagSync(CoreNodeSync):
+    name: String
+    description: StringOptional
+
+
+class CoreAccountSync(LineageOwnerSync, LineageSourceSync, CoreGenericAccountSync):
+    pass
+
+
+class CoreArtifactSync(CoreTaskTargetSync):
+    name: String
+    status: Enum
+    content_type: Enum
+    checksum: StringOptional
+    storage_id: StringOptional
+    parameters: JSONAttributeOptional
+    object: RelatedNodeSync
+    definition: RelatedNodeSync
+
+
+class CoreArtifactCheckSync(CoreCheckSync):
+    changed: BooleanOptional
+    checksum: StringOptional
+    artifact_id: StringOptional
+    storage_id: StringOptional
+    line_number: IntegerOptional
+
+
+class CoreArtifactDefinitionSync(CoreTaskTargetSync):
+    name: String
+    artifact_name: String
+    description: StringOptional
+    parameters: JSONAttribute
+    content_type: Enum
+    targets: RelatedNodeSync
+    transformation: RelatedNodeSync
+
+
+class CoreArtifactThreadSync(CoreThreadSync):
+    artifact_id: StringOptional
+    storage_id: StringOptional
+    line_number: IntegerOptional
+
+
+class CoreArtifactValidatorSync(CoreValidatorSync):
+    definition: RelatedNodeSync
+
+
+class CoreChangeCommentSync(CoreCommentSync):
+    change: RelatedNodeSync
+
+
+class CoreChangeThreadSync(CoreThreadSync):
+    pass
+
+
+class CoreCheckDefinitionSync(CoreTaskTargetSync):
+    name: String
+    description: StringOptional
+    file_path: String
+    class_name: String
+    timeout: Integer
+    parameters: JSONAttributeOptional
+    repository: RelatedNodeSync
+    query: RelatedNodeSync
+    targets: RelatedNodeSync
+    tags: RelationshipManagerSync
+
+
+class CoreCustomWebhookSync(CoreWebhookSync, CoreTaskTargetSync):
+    transformation: RelatedNodeSync
+
+
+class CoreDataCheckSync(CoreCheckSync):
+    conflicts: JSONAttribute
+    keep_branch: Enum
+
+
+class CoreDataValidatorSync(CoreValidatorSync):
+    pass
+
+
+class CoreFileCheckSync(CoreCheckSync):
+    files: ListAttributeOptional
+    commit: StringOptional
+
+
+class CoreFileThreadSync(CoreThreadSync):
+    file: StringOptional
+    commit: StringOptional
+    line_number: IntegerOptional
+    repository: RelatedNodeSync
+
+
+class CoreGeneratorCheckSync(CoreCheckSync):
+    instance: String
+
+
+class CoreGeneratorDefinitionSync(CoreTaskTargetSync):
+    name: String
+    description: StringOptional
+    parameters: JSONAttribute
+    file_path: String
+    class_name: String
+    convert_query_response: BooleanOptional
+    query: RelatedNodeSync
+    repository: RelatedNodeSync
+    targets: RelatedNodeSync
+
+
+class CoreGeneratorGroupSync(CoreGroupSync):
+    pass
+
+
+class CoreGeneratorInstanceSync(CoreTaskTargetSync):
+    name: String
+    status: Enum
+    object: RelatedNodeSync
+    definition: RelatedNodeSync
+
+
+class CoreGeneratorValidatorSync(CoreValidatorSync):
+    definition: RelatedNodeSync
+
+
+class CoreGraphQLQuerySync(CoreNodeSync):
+    name: String
+    description: StringOptional
+    query: String
+    variables: JSONAttributeOptional
+    operations: ListAttributeOptional
+    models: ListAttributeOptional
+    depth: IntegerOptional
+    height: IntegerOptional
+    repository: RelatedNodeSync
+    tags: RelationshipManagerSync
+
+
+class CoreGraphQLQueryGroupSync(CoreGroupSync):
+    parameters: JSONAttributeOptional
+    query: RelatedNodeSync
+
+
+class CoreIPAddressPoolSync(CoreResourcePoolSync, LineageSourceSync):
+    default_address_type: String
+    default_prefix_length: IntegerOptional
+    resources: RelationshipManagerSync
+    ip_namespace: RelatedNodeSync
+
+
+class CoreIPPrefixPoolSync(CoreResourcePoolSync, LineageSourceSync):
+    default_prefix_length: IntegerOptional
+    default_member_type: Enum
+    default_prefix_type: StringOptional
+    resources: RelationshipManagerSync
+    ip_namespace: RelatedNodeSync
+
+
+class CoreNumberPoolSync(CoreResourcePoolSync, LineageSourceSync):
+    node: String
+    node_attribute: String
+    start_range: Integer
+    end_range: Integer
+
+
+class CoreObjectThreadSync(CoreThreadSync):
+    object_path: String
+
+
+class CoreProposedChangeSync(CoreTaskTargetSync):
+    name: String
+    description: StringOptional
+    source_branch: String
+    destination_branch: String
+    state: Enum
+    approved_by: RelationshipManagerSync
+    reviewers: RelationshipManagerSync
+    created_by: RelatedNodeSync
+    comments: RelationshipManagerSync
+    threads: RelationshipManagerSync
+    validations: RelationshipManagerSync
+
+
+class CoreReadOnlyRepositorySync(LineageOwnerSync, LineageSourceSync, CoreGenericRepositorySync, CoreTaskTargetSync):
+    ref: String
+    commit: StringOptional
+
+
+class CoreRepositorySync(LineageOwnerSync, LineageSourceSync, CoreGenericRepositorySync, CoreTaskTargetSync):
+    default_branch: String
+    commit: StringOptional
+
+
+class CoreRepositoryValidatorSync(CoreValidatorSync):
+    repository: RelatedNodeSync
+
+
+class CoreSchemaCheckSync(CoreCheckSync):
+    conflicts: JSONAttribute
+
+
+class CoreSchemaValidatorSync(CoreValidatorSync):
+    pass
+
+
+class CoreStandardCheckSync(CoreCheckSync):
+    pass
+
+
+class CoreStandardGroupSync(CoreGroupSync):
+    pass
+
+
+class CoreStandardWebhookSync(CoreWebhookSync, CoreTaskTargetSync):
+    shared_key: String
+
+
+class CoreThreadCommentSync(CoreCommentSync):
+    thread: RelatedNodeSync
+
+
+class CoreTransformJinja2Sync(CoreTransformationSync):
+    template_path: String
+
+
+class CoreTransformPythonSync(CoreTransformationSync):
+    file_path: String
+    class_name: String
+
+
+class CoreUserValidatorSync(CoreValidatorSync):
+    check_definition: RelatedNodeSync
+    repository: RelatedNodeSync
+
+
+class InternalAccountTokenSync(CoreNodeSync):
+    name: StringOptional
+    token: String
+    expiration: DateTimeOptional
+    account: RelatedNodeSync
+
+
+class InternalRefreshTokenSync(CoreNodeSync):
+    expiration: DateTime
+    account: RelatedNodeSync
+
+
+class IpamNamespaceSync(BuiltinIPNamespaceSync):
+    default: BooleanOptional

--- a/python_sdk/infrahub_sdk/protocols_base.py
+++ b/python_sdk/infrahub_sdk/protocols_base.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from typing import Any, Optional, Protocol, runtime_checkable
+
+
+class RelatedNode(Protocol): ...
+
+
+class RelatedNodeSync(Protocol): ...
+
+
+@runtime_checkable
+class Attribute(Protocol):
+    name: str
+    id: Optional[str]
+
+    is_default: Optional[bool]
+    is_from_profile: Optional[bool]
+    is_inherited: Optional[bool]
+    updated_at: Optional[str]
+    is_visible: Optional[bool]
+    is_protected: Optional[bool]
+
+
+class String(Attribute):
+    value: str
+
+
+class StringOptional(Attribute):
+    value: Optional[str]
+
+
+class Integer(Attribute):
+    value: int
+
+
+class IntegerOptional(Attribute):
+    value: Optional[int]
+
+
+class Boolean(Attribute):
+    value: bool
+
+
+class BooleanOptional(Attribute):
+    value: Optional[bool]
+
+
+class DateTime(Attribute):
+    value: str
+
+
+class DateTimeOptional(Attribute):
+    value: Optional[str]
+
+
+class Enum(Attribute):
+    value: str
+
+
+class EnumOptional(Attribute):
+    value: Optional[str]
+
+
+class URL(Attribute):
+    value: str
+
+
+class URLOptional(Attribute):
+    value: Optional[str]
+
+
+class Dropdown(Attribute):
+    value: str
+
+
+class DropdownOptional(Attribute):
+    value: Optional[str]
+
+
+class IPNetwork(Attribute):
+    value: str
+
+
+class IPNetworkOptional(Attribute):
+    value: Optional[str]
+
+
+class IPHost(Attribute):
+    value: str
+
+
+class IPHostOptional(Attribute):
+    value: Optional[str]
+
+
+class HashedPassword(Attribute):
+    value: str
+
+
+class HashedPasswordOptional(Attribute):
+    value: Any
+
+
+class JSONAttribute(Attribute):
+    value: Any
+
+
+class JSONAttributeOptional(Attribute):
+    value: Optional[Any]
+
+
+class ListAttribute(Attribute):
+    value: list[Any]
+
+
+class ListAttributeOptional(Attribute):
+    value: Optional[list[Any]]
+
+
+class CoreNodeBase(Protocol):
+    id: str
+    display_label: Optional[str]
+    hfid: Optional[list[str]]
+    hfid_str: Optional[str]
+
+
+class CoreNode(CoreNodeBase, Protocol):
+    def get_kind(self) -> str: ...
+
+    async def save(self) -> None: ...
+
+    async def update(self, do_full_update: bool) -> None: ...
+
+
+class CoreNodeSync(CoreNodeBase, Protocol):
+    id: str
+    display_label: Optional[str]
+    hfid: Optional[list[str]]
+    hfid_str: Optional[str]
+
+    def get_kind(self) -> str: ...
+
+    def save(self) -> None: ...
+
+    def update(self, do_full_update: bool) -> None: ...

--- a/tasks/backend.py
+++ b/tasks/backend.py
@@ -273,12 +273,14 @@ def _generate_schemas(context: Context):
     execute_command(context=context, command=f"ruff check --fix {generated}")
 
 
-def _jinja2_filter_inheritance(value: dict[str, Any]) -> str:
+def _jinja2_filter_inheritance(value: dict[str, Any], sync: bool = False) -> str:
     inherit_from: list[str] = value.get("inherit_from", [])
 
+    suffix = "Sync" if sync else ""
+
     if not inherit_from:
-        return "CoreNode"
-    return ", ".join(inherit_from)
+        return f"CoreNode{suffix}"
+    return ", ".join([f"{item}{suffix}" for item in inherit_from])
 
 
 def _jinja2_filter_render_attribute(value: dict[str, Any], use_python_primitive: bool = False) -> str:


### PR DESCRIPTION
Cont working on the protocols, similar to #3881 but this time for the Python SDK

The main changes are 
- Generate separate protocols for Sync and Async
- Added protocols for mandatory and optional attributes

The signatures of the protocols aren't complete yet but it's getting us closer.