### PR TITLE
[FIX] Regression on proposed changes form (create and update)

### DIFF
--- a/frontend/app/src/components/form/type.ts
+++ b/frontend/app/src/components/form/type.ts
@@ -91,7 +91,7 @@ export type DynamicDropdownFieldProps = FormFieldProps & {
 
 export type DynamicEnumFieldProps = FormFieldProps & {
   type: "enum";
-  items: Array<string>;
+  items: Array<SelectOption>;
   field?:
     | components["schemas"]["AttributeSchema-Output"]
     | components["schemas"]["RelationshipSchema-Output"];

--- a/frontend/app/src/screens/proposed-changes/proposed-changes-create-form.tsx
+++ b/frontend/app/src/screens/proposed-changes/proposed-changes-create-form.tsx
@@ -24,6 +24,7 @@ import { Icon } from "@iconify-icon/react";
 import { useAtomValue } from "jotai";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
+import { ACCOUNT_OBJECT } from "@/config/constants";
 
 export const ProposedChangeCreateForm = () => {
   const { user } = useAuth();
@@ -149,7 +150,7 @@ export const ProposedChangeCreateForm = () => {
               <Select
                 multiple
                 options={
-                  getAllAccountsData?.CoreAccount?.edges.map((edge: any) => ({
+                  getAllAccountsData?.[ACCOUNT_OBJECT]?.edges.map((edge: any) => ({
                     id: edge?.node.id,
                     name: edge?.node?.display_label,
                   })) ?? []

--- a/frontend/app/src/utils/getSchemaObjectColumns.ts
+++ b/frontend/app/src/utils/getSchemaObjectColumns.ts
@@ -10,6 +10,7 @@ import { store } from "@/state";
 import { iGenericSchema, iNodeSchema, profilesAtom } from "@/state/atoms/schema.atom";
 import * as R from "ramda";
 import { isGeneric, sortByOrderWeight } from "./common";
+import { SelectOption } from "@/components/inputs/select";
 
 type tgetObjectAttributes = {
   schema: iNodeSchema | iGenericSchema | undefined;
@@ -204,7 +205,7 @@ export const getRelationshipOptions = (row: any, field: any, schemas: any[], gen
   return [option];
 };
 
-export const getOptionsFromAttribute = (attribute: any, value: any) => {
+export const getOptionsFromAttribute = (attribute: any, value: any): Array<SelectOption> => {
   if (attribute.kind === "List") {
     return (value || [])?.map((option: any) => ({
       name: option,

--- a/frontend/app/tests/e2e/proposed-changes/proposed-changes.spec.ts
+++ b/frontend/app/tests/e2e/proposed-changes/proposed-changes.spec.ts
@@ -1,4 +1,4 @@
-import { expect, Page, test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import { ACCOUNT_STATE_PATH } from "../../constants";
 import { createBranch, deleteBranch } from "../../utils";
 
@@ -44,32 +44,44 @@ test.describe("/proposed-changes", () => {
     test.describe("Create, edit and merge proposed change", async () => {
       test.describe.configure({ mode: "serial" });
 
-      let page: Page;
       const pcName = "pc-e2e";
       const pcBranchName = "main-copy-for-pc-e2e";
 
       test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
+        const page = await browser.newPage();
         await page.goto("/proposed-changes");
         await createBranch(page, pcBranchName);
+        await page.close();
       });
 
-      test.afterAll(async () => {
+      test.afterAll(async ({ browser }) => {
+        const page = await browser.newPage();
+        await page.goto("/proposed-changes");
         await deleteBranch(page, pcBranchName);
+        await page.close();
       });
 
       test("create new proposed change", async ({ page }) => {
         await page.goto("/proposed-changes/new");
         await expect(page.getByText("Create a proposed Change")).toBeVisible();
+
         await page.getByLabel("Source Branch *").click();
         await page.getByRole("option", { name: pcBranchName }).click();
-
         await page.getByLabel("Name *").fill(pcName);
-        await page.getByRole("button", { name: "Create" }).click();
+        await page.getByTestId("codemirror-editor").getByRole("textbox").fill("My description");
+        await page.getByTestId("select-open-option-button").click();
+        await page.getByRole("option", { name: "Architecture Team" }).click();
+        await page.getByRole("option", { name: "Crm Synchronization" }).click();
+        await page.getByTestId("select-open-option-button").click();
+
+        await page.getByRole("button", { name: "Create proposed change" }).click();
         await expect(page.getByText("Proposed change created")).toBeVisible();
       });
 
-      test.fixme("display and edit proposed change", async () => {
+      test("display and edit proposed change", async ({ page }) => {
+        await page.goto("/proposed-changes");
+        await page.getByText(pcName, { exact: true }).first().click();
+
         await test.step("display created proposed change details", async () => {
           await expect(page.getByText("Name" + pcName)).toBeVisible();
           await expect(page.getByText("Source branch" + pcBranchName)).toBeVisible();
@@ -77,22 +89,31 @@ test.describe("/proposed-changes", () => {
         });
 
         await test.step("edit proposed change reviewers", async () => {
-          await page.getByTestId("edit-button").click();
+          await page.getByRole("button", { name: "Edit" }).click();
+          await page.getByLabel("Name").fill(pcName + "edit");
           await page
-            .getByText("Empty list")
-            .locator("..")
-            .getByTestId("select-open-option-button")
-            .click();
-          await page.getByRole("option", { name: "Architecture Team" }).click();
-          await page.getByText("CoreThread").click(); // Hack to close Reviewers select option list
+            .getByTestId("side-panel-container")
+            .getByTestId("codemirror-editor")
+            .getByRole("textbox")
+            .fill("My description edit");
+          await page.getByTestId("multi-select-input").getByText("Crm Synchronization").click();
+          await page.getByLabel("Reviewers").click(); // Hack to close Reviewers select option list
           await page.getByRole("button", { name: "Save" }).click();
           await expect(page.getByText("ProposedChange updated")).toBeVisible();
 
-          await expect(page.getByText("ReviewersArchitecture Team", { exact: true })).toBeVisible();
+          await expect(page.getByText("Name" + pcName + "edit")).toBeVisible();
+          await page.getByText("DescriptionMy description edit").click();
+          await expect(page.getByText("ReviewersAT")).toBeVisible();
         });
       });
 
-      test.fixme("merged proposed change", async () => {
+      test("merged proposed change", async ({ page }) => {
+        await page.goto("/proposed-changes");
+        await page
+          .getByText(pcName + "edit", { exact: true })
+          .first()
+          .click();
+
         await test.step("merge proposed change and update UI", async () => {
           await page.getByRole("button", { name: "Merge" }).click();
           await expect(page.getByText("Proposed changes merged successfully!")).toBeVisible();
@@ -101,7 +122,7 @@ test.describe("/proposed-changes", () => {
 
         await test.step("not able to edit proposed change", async () => {
           await expect(page.getByRole("button", { name: "Merge" })).toBeDisabled();
-          await expect(page.getByTestId("edit-button")).toBeDisabled();
+          await expect(page.getByRole("button", { name: "Edit" })).toBeDisabled();
         });
       });
 

--- a/frontend/app/tests/e2e/proposed-changes/proposed-changes.spec.ts
+++ b/frontend/app/tests/e2e/proposed-changes/proposed-changes.spec.ts
@@ -107,7 +107,7 @@ test.describe("/proposed-changes", () => {
         });
       });
 
-      test("merged proposed change", async ({ page }) => {
+      test.fixme("merged proposed change", async ({ page }) => {
         await page.goto("/proposed-changes");
         await page
           .getByText(pcName + "edit", { exact: true })


### PR DESCRIPTION
Create:
- fixed a bug where reviewers options where empty.

Update:
- Fixing default value and submit.

These bugs were introduced when account kind changed + input context where added. The tests for theses cases where disabled. probably due to some flakiness in the past.

I'm adding test to prevent it from happening again.