### PR TITLE
Fix schema inconsistency issue by reverting 3792 

### DIFF
--- a/backend/infrahub/core/schema_manager.py
+++ b/backend/infrahub/core/schema_manager.py
@@ -1492,26 +1492,24 @@ class SchemaBranch:
             if node.namespace in RESTRICTED_NAMESPACES:
                 continue
 
-            profiles_rel_settings = dict(
-                name="profiles",
-                identifier="node__profile",
-                peer=InfrahubKind.PROFILE,
-                kind=RelationshipKind.PROFILE,
-                cardinality=RelationshipCardinality.MANY,
-                branch=BranchSupportType.AWARE,
-            )
+            profiles_rel_settings: dict[str, Any] = {
+                "name": "profiles",
+                "identifier": "node__profile",
+                "peer": InfrahubKind.PROFILE,
+                "kind": RelationshipKind.PROFILE,
+                "cardinality": RelationshipCardinality.MANY,
+                "branch": BranchSupportType.AWARE,
+            }
 
             # Add relationship between node and profile
             if "profiles" not in node.relationship_names:
                 node_schema = self.get(name=node_name, duplicate=True)
 
-                node_schema.relationships.append(
-                    RelationshipSchema( **profiles_rel_settings )
-                )
+                node_schema.relationships.append(RelationshipSchema(**profiles_rel_settings))
                 self.set(name=node_name, schema=node_schema)
             else:
                 has_changes: bool = False
-                rel_profiles = node_schema.get_relationship(name="profiles")
+                rel_profiles = node.get_relationship(name="profiles")
                 for name, value in profiles_rel_settings.items():
                     if getattr(rel_profiles, name) != value:
                         has_changes = True
@@ -1526,7 +1524,6 @@ class SchemaBranch:
                         setattr(rel_profiles, name, value)
 
                 self.set(name=node_name, schema=node_schema)
-
 
     def _get_profile_kind(self, node_kind: str) -> str:
         return f"Profile{node_kind}"

--- a/backend/infrahub/core/schema_manager.py
+++ b/backend/infrahub/core/schema_manager.py
@@ -477,7 +477,7 @@ class SchemaBranch:
         self.process_hierarchy()
         self.process_branch_support()
         self.manage_profile_schemas()
-        self.add_profile_relationships()
+        self.manage_profile_relationships()
 
     def process_validate(self) -> None:
         self.validate_names()
@@ -1485,28 +1485,48 @@ class SchemaBranch:
                 core_node_schema.used_by = sorted(list(updated_used_by_node))
                 self.set(name=InfrahubKind.NODE, schema=core_node_schema)
 
-    def add_profile_relationships(self) -> None:
+    def manage_profile_relationships(self) -> None:
         for node_name in self.node_names + self.generic_names:
             node = self.get(name=node_name, duplicate=False)
-            needs_profile_relationship = "profiles" not in node.relationship_names
-            if node.namespace in RESTRICTED_NAMESPACES:
-                needs_profile_relationship = False
 
-            if needs_profile_relationship:
+            if node.namespace in RESTRICTED_NAMESPACES:
+                continue
+
+            profiles_rel_settings = dict(
+                name="profiles",
+                identifier="node__profile",
+                peer=InfrahubKind.PROFILE,
+                kind=RelationshipKind.PROFILE,
+                cardinality=RelationshipCardinality.MANY,
+                branch=BranchSupportType.AWARE,
+            )
+
+            # Add relationship between node and profile
+            if "profiles" not in node.relationship_names:
                 node_schema = self.get(name=node_name, duplicate=True)
-                # Add relationship between node and profile
+
                 node_schema.relationships.append(
-                    RelationshipSchema(
-                        name="profiles",
-                        identifier="node__profile",
-                        peer=InfrahubKind.PROFILE,
-                        kind=RelationshipKind.PROFILE,
-                        cardinality=RelationshipCardinality.MANY,
-                        branch=BranchSupportType.AWARE,
-                    )
+                    RelationshipSchema( **profiles_rel_settings )
                 )
                 self.set(name=node_name, schema=node_schema)
-                # Add relationship between group and profile
+            else:
+                has_changes: bool = False
+                rel_profiles = node_schema.get_relationship(name="profiles")
+                for name, value in profiles_rel_settings.items():
+                    if getattr(rel_profiles, name) != value:
+                        has_changes = True
+
+                if not has_changes:
+                    continue
+
+                node_schema = self.get(name=node_name, duplicate=True)
+                rel_profiles = node_schema.get_relationship(name="profiles")
+                for name, value in profiles_rel_settings.items():
+                    if getattr(rel_profiles, name) != value:
+                        setattr(rel_profiles, name, value)
+
+                self.set(name=node_name, schema=node_schema)
+
 
     def _get_profile_kind(self, node_kind: str) -> str:
         return f"Profile{node_kind}"
@@ -1865,9 +1885,6 @@ class SchemaManager(NodeManager):
                 new_node.attributes.append(new_attr)
 
             for item in node.relationships:
-                if item.name == "profiles":
-                    new_node.relationships.append(item)
-                    continue
                 new_rel = await self.create_relationship_in_db(
                     schema=relationship_schema, item=item, parent=obj, branch=branch, db=db
                 )
@@ -1933,10 +1950,6 @@ class SchemaManager(NodeManager):
             if item.id and item.id in items:
                 await self.update_relationship_in_db(item=item, rel=items[item.id], db=db)
             elif not item.id:
-                if item.name == "profiles":
-                    if "profiles" not in new_node.relationship_names:
-                        new_node.relationships.append(item)
-                    continue
                 new_rel = await self.create_relationship_in_db(
                     schema=relationship_schema, item=item, branch=branch, db=db, parent=obj
                 )

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -2314,6 +2314,7 @@ async def test_load_schema_to_db_core_models(
     assert len(results) > 1
     assert all(r for r in results if r.namespace.value != "Profile")
 
+
 async def test_clean_diff_after_reload_from_db(
     db: InfrahubDatabase, default_branch: Branch, register_internal_models_schema
 ):
@@ -2328,6 +2329,7 @@ async def test_clean_diff_after_reload_from_db(
     await registry.schema.load_schema_from_db(db=db, branch=default_branch, schema=schema_branch)
 
     assert not schema_pre.diff(other=schema_branch).all
+
 
 async def test_load_schema_to_db_simple_01(
     db: InfrahubDatabase,


### PR DESCRIPTION
Fixes #3892 and #3994

This PR fixes an issue with the schema that would get out of sync between the different workers and that would report some diff even after no changes have been applied.

The issue was related to #3792 when we stop storing the relationship `profiles` in the database to ensure it will always be accurate. As a result the attribute order_weight would constantly get recalculated and if the relationship was not the last one the first time the value will change, resulting in a different hash.

To fix the issue, I've reverted the change introduced in #3792 and I've updated the function `manage_profile_relationships` to manually update the value of the relationship if its definition changes in the code.