### PR TITLE
update getting-started/branches

### DIFF
--- a/docs/docs/tutorials/getting-started/branches.mdx
+++ b/docs/docs/tutorials/getting-started/branches.mdx
@@ -45,7 +45,7 @@ Branch names are fairly permissive, but must conform to [git ref format](https:/
   ```graphql
   # Endpoint : http://127.0.0.1:8000/graphql/main
   mutation {
-    BranchCreate(data: { name: "cr1234", sync_with_git: true}) {
+    BranchCreate(data: { name: "cr1234" }) {
       ok
       object {
         id


### PR DESCRIPTION
fixes https://github.com/opsmill/infrahub/issues/4013

Agreed the Getting Started tutorial shouldn't include the "sync with git" option to keep the focus of the tutorial on the basics.