### PR TITLE
Avoid running attribute uniqueness check on schema attributes

### DIFF
--- a/backend/infrahub/core/validators/attribute/unique.py
+++ b/backend/infrahub/core/validators/attribute/unique.py
@@ -106,6 +106,10 @@ class AttributeUniquenessChecker(ConstraintCheckerInterface):
         grouped_data_paths_list = []
         if not request.schema_path.field_name:
             raise ValueError("field_name is not defined")
+        if request.node_schema.namespace == "Schema":
+            # We don't need to run uniqueness constraints for attributes within the Schema nodes
+            return []
+
         attribute_schema = request.node_schema.get_attribute(name=request.schema_path.field_name)
         if attribute_schema.unique is False:
             return []


### PR DESCRIPTION
Currenly we treat SchemaNode objects in the same way as any other, this causes problems if multiple schema objects has the same constraints i.e. two of them has an attribute called "name" and that attribute is marked as being unique for that particular model.

Fixes #3986