### PR TITLE
Set default_value even for 'falsy' values

### DIFF
--- a/backend/infrahub/core/migrations/query/attribute_add.py
+++ b/backend/infrahub/core/migrations/query/attribute_add.py
@@ -38,7 +38,7 @@ class AttributeAddQuery(Query):
         self.params["attr_type"] = self.attribute_kind
         self.params["branch_support"] = self.branch_support
 
-        if self.default_value:
+        if self.default_value is not None:
             self.params["attr_value"] = self.default_value
         else:
             self.params["attr_value"] = NULL_VALUE


### PR DESCRIPTION
This change would allow the default value to be assigned even if it was falsy i.e. 0 or similar.

FYI @dgarros, I left a comment around this on your PR. I think this is what you wanted to do.