### PR TITLE
Add towncrier newsfragments for resolved issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,9 @@ jobs:
         uses: DavidAnson/markdownlint-cli2-action@v16
         with:
           config: .markdownlint.yaml
-          globs: '**/*.{md,mdx}'
+          globs: |
+            **/*.{md,mdx}
+            !changelog/*.md
 
   action-lint:
     if: needs.files-changed.outputs.github_workflows == 'true'

--- a/changelog/3986.fixed.md
+++ b/changelog/3986.fixed.md
@@ -1,0 +1,1 @@
+Fix attribute uniquness check that was incorrectly running against schema nodes

--- a/changelog/3994.fixed.md
+++ b/changelog/3994.fixed.md
@@ -1,0 +1,1 @@
+Fix schema sync issue between worker nodes


### PR DESCRIPTION
* Add towncrier newsfragments
* Modify markdownlint rules to not scan the towncrier folder (as most fragments will violate our rules, we can potentially revisit this later to run the linter against these files with a limited set of rules)