### PR TITLE
update diff labels enricher to include peer display labels

### DIFF
--- a/backend/infrahub/core/diff/combiner.py
+++ b/backend/infrahub/core/diff/combiner.py
@@ -198,6 +198,7 @@ class DiffCombiner:
                 changed_at=later_element.changed_at,
                 action=self._combine_actions(earlier=earlier_element.action, later=later_element.action),
                 peer_id=later_element.peer_id,
+                peer_label=later_element.peer_label,
                 properties=self._combine_properties(
                     earlier_properties=earlier_element.properties, later_properties=later_element.properties
                 ),

--- a/backend/infrahub/core/diff/model/path.py
+++ b/backend/infrahub/core/diff/model/path.py
@@ -107,6 +107,7 @@ class EnrichedDiffSingleRelationship(BaseSummary):
     changed_at: Timestamp
     action: DiffAction
     peer_id: str
+    peer_label: str | None = field(default=None, kw_only=True)
     conflict: EnrichedDiffConflict | None = field(default=None)
     properties: set[EnrichedDiffProperty] = field(default_factory=set)
 

--- a/backend/infrahub/core/diff/repository/get_query.py
+++ b/backend/infrahub/core/diff/repository/get_query.py
@@ -396,10 +396,12 @@ class EnrichedDiffDeserializer:
         if rel_element_key in self._diff_node_rel_element_map:
             return self._diff_node_rel_element_map[rel_element_key]
 
+        peer_label = self._get_str_or_none_property_value(node=relationship_element_node, property_name="peer_label")
         enriched_rel_element = EnrichedDiffSingleRelationship(
             changed_at=Timestamp(str(relationship_element_node.get("changed_at"))),
             action=DiffAction(str(relationship_element_node.get("action"))),
             peer_id=diff_element_peer_id,
+            peer_label=peer_label,
             num_added=int(relationship_element_node.get("num_added")),
             num_updated=int(relationship_element_node.get("num_updated")),
             num_removed=int(relationship_element_node.get("num_removed")),

--- a/backend/infrahub/core/diff/repository/save_query.py
+++ b/backend/infrahub/core/diff/repository/save_query.py
@@ -169,6 +169,7 @@ class EnrichedDiffSaveQuery(Query):
                 "changed_at": enriched_single_relationship.changed_at.to_string(),
                 "action": enriched_single_relationship.action,
                 "peer_id": enriched_single_relationship.peer_id,
+                "peer_label": enriched_single_relationship.peer_label,
                 "num_added": enriched_single_relationship.num_added,
                 "num_updated": enriched_single_relationship.num_updated,
                 "num_removed": enriched_single_relationship.num_removed,

--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -76,6 +76,7 @@ class DiffSingleRelationship(DiffSummaryCounts):
     last_changed_at = DateTime(required=False)
     status = Field(GrapheneDiffActionEnum, required=True)
     peer_id = String(required=True)
+    peer_label = String(required=False)
     contains_conflict = Boolean(required=True)
     conflict = Field(ConflictDetails, required=False)
     properties = List(DiffProperty)
@@ -189,6 +190,7 @@ class DiffTreeResolver:
             last_changed_at=enriched_element.changed_at.obj,
             status=enriched_element.action,
             peer_id=enriched_element.peer_id,
+            peer_label=enriched_element.peer_label,
             conflict=conflict,
             properties=diff_properties,
             contains_conflict=enriched_element.contains_conflict,

--- a/backend/tests/unit/core/diff/test_diff_combiner.py
+++ b/backend/tests/unit/core/diff/test_diff_combiner.py
@@ -496,18 +496,21 @@ class TestDiffCombiner:
             changed_at=removed_element_2.changed_at,
             action=DiffAction.REMOVED,
             peer_id=removed_element_peer_id,
+            peer_label=removed_element_2.peer_label,
             properties=expected_removed_props,
         )
         expected_added_element = EnrichedDiffSingleRelationship(
             changed_at=added_element_2.changed_at,
             action=DiffAction.ADDED,
             peer_id=added_element_peer_id,
+            peer_label=added_element_2.peer_label,
             properties=expected_added_props,
         )
         expected_updated_element = EnrichedDiffSingleRelationship(
             changed_at=updated_element_2.changed_at,
             action=DiffAction.UPDATED,
             peer_id=updated_element_peer_id,
+            peer_label=updated_element_2.peer_label,
             properties={
                 EnrichedDiffProperty(
                     property_type=DatabaseEdgeType.HAS_OWNER,

--- a/backend/tests/unit/core/diff/test_diff_labels_enricher.py
+++ b/backend/tests/unit/core/diff/test_diff_labels_enricher.py
@@ -2,12 +2,18 @@ from infrahub.core.diff.enricher.labels import DiffLabelsEnricher
 from infrahub.core.initialization import create_branch
 from infrahub.database import InfrahubDatabase
 
-from .factories import EnrichedNodeFactory, EnrichedRelationshipGroupFactory, EnrichedRootFactory
+from .factories import (
+    EnrichedNodeFactory,
+    EnrichedRelationshipElementFactory,
+    EnrichedRelationshipGroupFactory,
+    EnrichedRootFactory,
+)
 
 
-async def test_labels_added(db: InfrahubDatabase, default_branch, car_yaris_main):
+async def test_labels_added(db: InfrahubDatabase, default_branch, car_yaris_main, person_jane_main):
     branch = await create_branch(db=db, branch_name="branch")
-    diff_rel = EnrichedRelationshipGroupFactory.build(name="owner", nodes=set())
+    diff_rel_element = EnrichedRelationshipElementFactory.build(peer_id=person_jane_main.id)
+    diff_rel = EnrichedRelationshipGroupFactory.build(name="owner", nodes=set(), relationships={diff_rel_element})
     diff_node = EnrichedNodeFactory.build(
         uuid=car_yaris_main.get_id(), kind=car_yaris_main.get_kind(), relationships={diff_rel}
     )
@@ -22,11 +28,16 @@ async def test_labels_added(db: InfrahubDatabase, default_branch, car_yaris_main
     assert updated_node.label == "yaris #444444"
     updated_rel = updated_node.relationships.pop()
     assert updated_rel.label == "Commander of Car"
+    updated_element = updated_rel.relationships.pop()
+    assert updated_element.peer_label == "Jane"
 
 
 async def test_labels_skipped(db: InfrahubDatabase, default_branch, car_person_schema):
     branch = await create_branch(db=db, branch_name="branch")
-    diff_rel = EnrichedRelationshipGroupFactory.build(name="cars", nodes=set(), label="")
+    diff_rel_element = EnrichedRelationshipElementFactory.build(peer_id="not-a-real-one", peer_label=None)
+    diff_rel = EnrichedRelationshipGroupFactory.build(
+        name="cars", nodes=set(), label="", relationships={diff_rel_element}
+    )
     diff_node = EnrichedNodeFactory.build(relationships={diff_rel}, kind="TestPerson", label="")
     diff_root = EnrichedRootFactory.build(
         base_branch_name=default_branch.name, diff_branch_name=branch.name, nodes={diff_node}
@@ -39,3 +50,5 @@ async def test_labels_skipped(db: InfrahubDatabase, default_branch, car_person_s
     assert not updated_node.label
     updated_rel = updated_node.relationships.pop()
     assert updated_rel.label == "Cars"
+    updated_element = updated_rel.relationships.pop()
+    assert updated_element.peer_label is None


### PR DESCRIPTION
- add a new `peer_label` property to the relationship element in an enriched diff
- update the labels enricher to get and set the display label associated with each peer ID, if it can be found