### PR TITLE
cardinality=one enricher for diffs to clean up one-member relationships

### DIFF
--- a/backend/infrahub/core/diff/enricher/cardinality_one.py
+++ b/backend/infrahub/core/diff/enricher/cardinality_one.py
@@ -1,5 +1,20 @@
-from ..model.path import CalculatedDiffs, EnrichedDiffRoot
+from typing import TYPE_CHECKING, Any
+
+from infrahub.core.constants import DiffAction, RelationshipCardinality
+from infrahub.core.constants.database import DatabaseEdgeType
+from infrahub.database import InfrahubDatabase
+
+from ..model.path import (
+    CalculatedDiffs,
+    EnrichedDiffProperty,
+    EnrichedDiffRelationship,
+    EnrichedDiffRoot,
+    EnrichedDiffSingleRelationship,
+)
 from .interface import DiffEnricherInterface
+
+if TYPE_CHECKING:
+    from infrahub.core.schema import MainSchemaTypes
 
 
 class DiffCardinalityOneEnricher(DiffEnricherInterface):
@@ -10,9 +25,120 @@ class DiffCardinalityOneEnricher(DiffEnricherInterface):
      - the peer_id property of the element will be the latest non-null peer ID for this element
      - the element MUST have an EnrichedDiffProperty of property_type=IS_RELATED that correctly records
         the previous and new values of the peer ID for this element
-
-    changes to properties (IS_VISIBLE, etc) of a cardinality=one relationship with an updated peer ID will
-    probably need to be cleaned up as well
+     - changes to properties (IS_VISIBLE, etc) of a cardinality=one relationship are consolidated as well
     """
 
-    async def enrich(self, enriched_diff_root: EnrichedDiffRoot, calculated_diffs: CalculatedDiffs) -> None: ...
+    def __init__(self, db: InfrahubDatabase):
+        self.db = db
+        self._node_schema_map: dict[str, MainSchemaTypes] = {}
+
+    async def enrich(self, enriched_diff_root: EnrichedDiffRoot, calculated_diffs: CalculatedDiffs) -> None:
+        for diff_node in enriched_diff_root.nodes:
+            for relationship_group in diff_node.relationships:
+                if (
+                    self.is_cardinality_one(
+                        node_kind=diff_node.kind,
+                        relationship_name=relationship_group.name,
+                        diff_branch_name=enriched_diff_root.diff_branch_name,
+                    )
+                    and len(relationship_group.relationships) > 0
+                ):
+                    self.consolidate_cardinality_one_diff_elements(diff_relationship=relationship_group)
+
+    def is_cardinality_one(self, node_kind: str, relationship_name: str, diff_branch_name: str) -> bool:
+        if node_kind not in self._node_schema_map:
+            self._node_schema_map[node_kind] = self.db.schema.get(
+                name=node_kind, branch=diff_branch_name, duplicate=False
+            )
+        node_schema = self._node_schema_map[node_kind]
+        relationship_schema = node_schema.get_relationship(name=relationship_name)
+        return relationship_schema.cardinality == RelationshipCardinality.ONE
+
+    def _determine_action(self, previous_value: Any, new_value: Any) -> DiffAction:
+        if previous_value == new_value:
+            return DiffAction.UNCHANGED
+        if previous_value in (None, "NULL"):
+            return DiffAction.ADDED
+        if new_value in (None, "NULL"):
+            return DiffAction.ADDED
+        return DiffAction.UPDATED
+
+    def _build_property_maps(
+        self, diff_relationship: EnrichedDiffRelationship
+    ) -> tuple[dict[DatabaseEdgeType, EnrichedDiffProperty], dict[DatabaseEdgeType, EnrichedDiffProperty]]:
+        earliest_property_map: dict[DatabaseEdgeType, EnrichedDiffProperty] = {}
+        latest_property_map: dict[DatabaseEdgeType, EnrichedDiffProperty] = {}
+        for diff_rel_element in diff_relationship.relationships:
+            for diff_property in diff_rel_element.properties:
+                prop_type = diff_property.property_type
+                current_earliest = earliest_property_map.get(prop_type)
+                if not current_earliest:
+                    earliest_property_map[prop_type] = diff_property
+                elif diff_property.changed_at < current_earliest.changed_at:
+                    earliest_property_map[prop_type] = diff_property
+                # special handling for a REMOVE and ADD with the same timestamp to treat them as an update
+                elif diff_property.changed_at == current_earliest.changed_at:
+                    if diff_property.action is DiffAction.REMOVED and current_earliest.action is DiffAction.ADDED:
+                        earliest_property_map[prop_type] = diff_property
+
+                current_latest = latest_property_map.get(prop_type)
+                if not current_latest:
+                    latest_property_map[prop_type] = diff_property
+                elif diff_property.changed_at > current_latest.changed_at:
+                    latest_property_map[prop_type] = diff_property
+                # special handling for a REMOVE and ADD with the same timestamp to treat them as an update
+                elif diff_property.changed_at == current_latest.changed_at:
+                    if diff_property.action is DiffAction.ADDED and current_latest.action is DiffAction.REMOVED:
+                        latest_property_map[prop_type] = diff_property
+        return (earliest_property_map, latest_property_map)
+
+    def consolidate_cardinality_one_diff_elements(self, diff_relationship: EnrichedDiffRelationship) -> None:
+        earliest_property_map, latest_property_map = self._build_property_maps(diff_relationship=diff_relationship)
+        consolidated_properties = set()
+        for prop_type, earliest_prop in earliest_property_map.items():
+            latest_prop = latest_property_map[prop_type]
+            # this means there was only one property of this type, so we keep it
+            if earliest_prop is latest_prop:
+                consolidated_properties.add(latest_prop)
+                continue
+            prop_action = self._determine_action(
+                previous_value=earliest_prop.previous_value, new_value=latest_prop.new_value
+            )
+            if prop_action is DiffAction.UNCHANGED:
+                continue
+            consolidated_properties.add(
+                EnrichedDiffProperty(
+                    property_type=prop_type,
+                    changed_at=latest_prop.changed_at,
+                    previous_value=earliest_prop.previous_value,
+                    new_value=latest_prop.new_value,
+                    action=prop_action,
+                    conflict=None,
+                )
+            )
+        if consolidated_properties:
+            element_timestamps = {element.changed_at for element in diff_relationship.relationships}
+            element_actions = {element.action for element in diff_relationship.relationships}
+            # check if this is a simultaneous update
+            if (
+                len(diff_relationship.relationships) > 1
+                and len(element_timestamps) == 1
+                and {DiffAction.REMOVED, DiffAction.ADDED} <= element_actions
+            ):
+                latest_element = [
+                    element for element in diff_relationship.relationships if element.action is DiffAction.ADDED
+                ][0]
+                consolidated_element_action = DiffAction.UPDATED
+            else:
+                latest_element = max(diff_relationship.relationships, key=lambda elem: elem.changed_at)
+                consolidated_element_action = latest_element.action
+            diff_relationship.relationships = {
+                EnrichedDiffSingleRelationship(
+                    changed_at=latest_element.changed_at,
+                    action=consolidated_element_action,
+                    peer_id=latest_element.peer_id,
+                    peer_label=latest_element.peer_label,
+                    conflict=None,
+                    properties=consolidated_properties,
+                )
+            }

--- a/backend/infrahub/dependencies/builder/diff/enricher/cardinality_one.py
+++ b/backend/infrahub/dependencies/builder/diff/enricher/cardinality_one.py
@@ -5,4 +5,4 @@ from infrahub.dependencies.interface import DependencyBuilder, DependencyBuilder
 class DiffCardinalityOneEnricherDependency(DependencyBuilder[DiffCardinalityOneEnricher]):
     @classmethod
     def build(cls, context: DependencyBuilderContext) -> DiffCardinalityOneEnricher:
-        return DiffCardinalityOneEnricher()
+        return DiffCardinalityOneEnricher(db=context.db)

--- a/backend/tests/unit/core/diff/test_cardinality_one_enricher.py
+++ b/backend/tests/unit/core/diff/test_cardinality_one_enricher.py
@@ -1,0 +1,259 @@
+from copy import deepcopy
+from uuid import uuid4
+
+from infrahub.core.constants import DiffAction
+from infrahub.core.constants.database import DatabaseEdgeType
+from infrahub.core.diff.enricher.cardinality_one import DiffCardinalityOneEnricher
+from infrahub.core.diff.model.path import EnrichedDiffProperty
+from infrahub.core.initialization import create_branch
+from infrahub.core.timestamp import Timestamp
+from infrahub.database import InfrahubDatabase
+
+from .factories import (
+    EnrichedNodeFactory,
+    EnrichedPropertyFactory,
+    EnrichedRelationshipElementFactory,
+    EnrichedRelationshipGroupFactory,
+    EnrichedRootFactory,
+)
+
+
+class TestDiffCardinalityOneEnricher:
+    async def test_no_cardinality_one_relationships(self, db: InfrahubDatabase, car_person_schema):
+        branch = await create_branch(db=db, branch_name="branch")
+        enricher = DiffCardinalityOneEnricher(db=db)
+        diff_relationship = EnrichedRelationshipGroupFactory.build(
+            name="cars", nodes=set(), relationships={EnrichedRelationshipElementFactory.build() for _ in range(3)}
+        )
+        diff_node = EnrichedNodeFactory.build(kind="TestPerson", relationships={diff_relationship})
+        diff_root = EnrichedRootFactory.build(diff_branch_name=branch.name, nodes={diff_node})
+        diff_root_copy = deepcopy(diff_root)
+
+        await enricher.enrich(enriched_diff_root=diff_root, calculated_diffs=None)
+
+        assert diff_root == diff_root_copy
+
+    async def test_cardinality_one_relationship_update(self, db: InfrahubDatabase, car_person_schema):
+        branch = await create_branch(db=db, branch_name="branch")
+        enricher = DiffCardinalityOneEnricher(db=db)
+        peer_id_1 = str(uuid4())
+        peer_id_2 = str(uuid4())
+        has_owner_prop_1 = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.HAS_OWNER, action=DiffAction.REMOVED, conflict=None
+        )
+        is_related_prop_1 = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.IS_RELATED,
+            action=DiffAction.REMOVED,
+            conflict=None,
+            previous_value=peer_id_1,
+            new_value=None,
+        )
+        diff_rel_element_1 = EnrichedRelationshipElementFactory.build(
+            properties={has_owner_prop_1, is_related_prop_1}, peer_id=peer_id_1
+        )
+        has_source_prop_2 = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.HAS_SOURCE, action=DiffAction.REMOVED, conflict=None
+        )
+        is_related_prop_2 = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.IS_RELATED,
+            action=DiffAction.ADDED,
+            conflict=None,
+            previous_value=None,
+            new_value=peer_id_2,
+            changed_at=is_related_prop_1.changed_at.add_delta(minutes=2),
+        )
+        diff_rel_element_2 = EnrichedRelationshipElementFactory.build(
+            properties={has_source_prop_2, is_related_prop_2},
+            peer_id=peer_id_2,
+            changed_at=diff_rel_element_1.changed_at.add_delta(minutes=2),
+        )
+
+        diff_relationship = EnrichedRelationshipGroupFactory.build(
+            name="owner", nodes=set(), relationships={diff_rel_element_1, diff_rel_element_2}
+        )
+        diff_node = EnrichedNodeFactory.build(kind="TestCar", relationships={diff_relationship})
+        diff_root = EnrichedRootFactory.build(diff_branch_name=branch.name, nodes={diff_node})
+
+        await enricher.enrich(enriched_diff_root=diff_root, calculated_diffs=None)
+
+        assert len(diff_root.nodes) == 1
+        diff_node = diff_root.nodes.pop()
+        assert len(diff_node.relationships) == 1
+        diff_rel = diff_node.relationships.pop()
+        assert len(diff_rel.relationships) == 1
+        diff_rel_element = diff_rel.relationships.pop()
+        assert diff_rel_element.changed_at == diff_rel_element_2.changed_at
+        assert diff_rel_element.action == diff_rel_element_2.action
+        assert diff_rel_element.peer_id == peer_id_2
+        assert diff_rel_element.peer_label == diff_rel_element_2.peer_label
+        assert diff_rel_element.conflict is None
+        diff_properties = diff_rel_element.properties
+        assert len(diff_properties) == 3
+        assert has_owner_prop_1 in diff_properties
+        assert has_source_prop_2 in diff_properties
+        assert (
+            EnrichedDiffProperty(
+                property_type=DatabaseEdgeType.IS_RELATED,
+                changed_at=is_related_prop_2.changed_at,
+                previous_value=peer_id_1,
+                new_value=peer_id_2,
+                action=DiffAction.UPDATED,
+                conflict=None,
+            )
+            in diff_properties
+        )
+
+    async def test_cardinality_one_relationship_simulataneous_update(self, db: InfrahubDatabase, car_person_schema):
+        branch = await create_branch(db=db, branch_name="branch")
+        enricher = DiffCardinalityOneEnricher(db=db)
+        peer_id_1 = str(uuid4())
+        peer_id_2 = str(uuid4())
+        owner_1 = str(uuid4())
+        owner_2 = str(uuid4())
+        timestamp = Timestamp()
+        has_owner_prop_1 = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.HAS_OWNER,
+            action=DiffAction.REMOVED,
+            previous_value=owner_1,
+            new_value=None,
+            conflict=None,
+            changed_at=timestamp,
+        )
+        is_related_prop_1 = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.IS_RELATED,
+            action=DiffAction.REMOVED,
+            conflict=None,
+            previous_value=peer_id_1,
+            new_value=None,
+            changed_at=timestamp,
+        )
+        diff_rel_element_1 = EnrichedRelationshipElementFactory.build(
+            properties={has_owner_prop_1, is_related_prop_1},
+            peer_id=peer_id_1,
+            action=DiffAction.REMOVED,
+            changed_at=timestamp,
+        )
+        has_owner_prop_2 = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.HAS_OWNER,
+            action=DiffAction.ADDED,
+            conflict=None,
+            previous_value=None,
+            new_value=owner_2,
+            changed_at=timestamp,
+        )
+        is_related_prop_2 = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.IS_RELATED,
+            action=DiffAction.ADDED,
+            conflict=None,
+            previous_value=None,
+            new_value=peer_id_2,
+            changed_at=timestamp,
+        )
+        diff_rel_element_2 = EnrichedRelationshipElementFactory.build(
+            properties={has_owner_prop_2, is_related_prop_2},
+            peer_id=peer_id_2,
+            action=DiffAction.ADDED,
+            changed_at=timestamp,
+        )
+
+        diff_relationship = EnrichedRelationshipGroupFactory.build(
+            name="owner", nodes=set(), relationships={diff_rel_element_1, diff_rel_element_2}
+        )
+        diff_node = EnrichedNodeFactory.build(kind="TestCar", relationships={diff_relationship})
+        diff_root = EnrichedRootFactory.build(diff_branch_name=branch.name, nodes={diff_node})
+
+        await enricher.enrich(enriched_diff_root=diff_root, calculated_diffs=None)
+
+        assert len(diff_root.nodes) == 1
+        diff_node = diff_root.nodes.pop()
+        assert len(diff_node.relationships) == 1
+        diff_rel = diff_node.relationships.pop()
+        assert len(diff_rel.relationships) == 1
+        diff_rel_element = diff_rel.relationships.pop()
+        assert diff_rel_element.changed_at == diff_rel_element_2.changed_at
+        assert diff_rel_element.action == DiffAction.UPDATED
+        assert diff_rel_element.peer_id == peer_id_2
+        assert diff_rel_element.peer_label == diff_rel_element_2.peer_label
+        assert diff_rel_element.conflict is None
+        diff_properties = diff_rel_element.properties
+        assert len(diff_properties) == 2
+        assert (
+            EnrichedDiffProperty(
+                property_type=DatabaseEdgeType.HAS_OWNER,
+                changed_at=timestamp,
+                previous_value=owner_1,
+                new_value=owner_2,
+                action=DiffAction.UPDATED,
+                conflict=None,
+            )
+            in diff_properties
+        )
+        assert (
+            EnrichedDiffProperty(
+                property_type=DatabaseEdgeType.IS_RELATED,
+                changed_at=timestamp,
+                previous_value=peer_id_1,
+                new_value=peer_id_2,
+                action=DiffAction.UPDATED,
+                conflict=None,
+            )
+            in diff_properties
+        )
+
+    async def test_cardinality_one_relationship_reverted_update(self, db: InfrahubDatabase, car_person_schema):
+        branch = await create_branch(db=db, branch_name="branch")
+        enricher = DiffCardinalityOneEnricher(db=db)
+        peer_id = str(uuid4())
+        has_owner_prop_1 = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.HAS_OWNER, action=DiffAction.REMOVED, conflict=None
+        )
+        is_related_prop_1 = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.IS_RELATED,
+            action=DiffAction.REMOVED,
+            conflict=None,
+            previous_value=peer_id,
+            new_value=None,
+        )
+        diff_rel_element_1 = EnrichedRelationshipElementFactory.build(
+            properties={has_owner_prop_1, is_related_prop_1}, peer_id=peer_id
+        )
+        has_source_prop_2 = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.HAS_SOURCE, action=DiffAction.REMOVED, conflict=None
+        )
+        is_related_prop_2 = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.IS_RELATED,
+            action=DiffAction.ADDED,
+            conflict=None,
+            previous_value=None,
+            new_value=peer_id,
+            changed_at=is_related_prop_1.changed_at.add_delta(minutes=2),
+        )
+        diff_rel_element_2 = EnrichedRelationshipElementFactory.build(
+            properties={has_source_prop_2, is_related_prop_2},
+            peer_id=peer_id,
+            changed_at=diff_rel_element_1.changed_at.add_delta(minutes=2),
+        )
+
+        diff_relationship = EnrichedRelationshipGroupFactory.build(
+            name="owner", nodes=set(), relationships={diff_rel_element_1, diff_rel_element_2}
+        )
+        diff_node = EnrichedNodeFactory.build(kind="TestCar", relationships={diff_relationship})
+        diff_root = EnrichedRootFactory.build(diff_branch_name=branch.name, nodes={diff_node})
+
+        await enricher.enrich(enriched_diff_root=diff_root, calculated_diffs=None)
+
+        assert len(diff_root.nodes) == 1
+        diff_node = diff_root.nodes.pop()
+        assert len(diff_node.relationships) == 1
+        diff_rel = diff_node.relationships.pop()
+        assert len(diff_rel.relationships) == 1
+        diff_rel_element = diff_rel.relationships.pop()
+        assert diff_rel_element.changed_at == diff_rel_element_2.changed_at
+        assert diff_rel_element.action == diff_rel_element_2.action
+        assert diff_rel_element.peer_id == peer_id
+        assert diff_rel_element.peer_label == diff_rel_element_2.peer_label
+        assert diff_rel_element.conflict is None
+        diff_properties = diff_rel_element.properties
+        assert len(diff_properties) == 2
+        assert has_owner_prop_1 in diff_properties
+        assert has_source_prop_2 in diff_properties


### PR DESCRIPTION
should follow #4110 

cardinality=one relationships require special handling to massage them into a format that is easier to understand for people and the easier to digest in the front-end

the format without this enricher is something like the following
```
"relationships": [
{
  "name": "device",
  "last_changed_at": "2024-08-14T23:37:00.629349+00:00",
  "status": "UPDATED",
  "contains_conflict": false,
  "node_uuids": [],
  "elements": [
    {
      "status": "REMOVED",
      "peer_id": "17ebbbb7-110a-0af1-2de2-c5105a09aff0",
      "peer_label": "atl1-leaf1",
      "last_changed_at": "2024-08-14T23:37:00.629349+00:00",
      "contains_conflict": false,
      "conflict": null,
      "properties": [
        {
          "property_type": "IS_PROTECTED",
          "last_changed_at": "2024-08-14T23:37:00.629349+00:00",
          "previous_value": "True",
          "new_value": null,
          "status": "REMOVED",
          "conflict": null
        },
        {
          "property_type": "IS_RELATED",
          "last_changed_at": "2024-08-14T23:37:00.629349+00:00",
          "previous_value": "17ebbbb7-110a-0af1-2de2-c5105a09aff0",
          "new_value": null,
          "status": "REMOVED",
          "conflict": null
        },
      ]
    },
    {
      "status": "ADDED",
      "peer_id": "17ebbbbc-3c4c-34b3-2de2-c512f25e6a9a",
      "peer_label": "atl1-leaf2",
      "last_changed_at": "2024-08-14T23:37:00.629349+00:00",
      "contains_conflict": false,
      "conflict": null,
      "properties": [
        {
          "property_type": "IS_PROTECTED",
          "last_changed_at": "2024-08-14T23:37:00.629349+00:00",
          "previous_value": null,
          "new_value": "False",
          "status": "ADDED",
          "conflict": null
        },
        {
          "property_type": "IS_RELATED",
          "last_changed_at": "2024-08-14T23:37:00.629349+00:00",
          "previous_value": null,
          "new_value": "17ebbbbc-3c4c-34b3-2de2-c512f25e6a9a",
          "status": "ADDED",
          "conflict": null
        },
      ]
    }
  ]
}

```

with this enricher, the elements of the relationship are combined into a single element with the latest peer ID and peer display label, which is a more accurate and easier-to-consumer representation of a cardinality=one relationship