### PR TITLE
IFC-42 Initial implementation of DiffSummary and Filters

### DIFF
--- a/backend/infrahub/core/diff/combiner.py
+++ b/backend/infrahub/core/diff/combiner.py
@@ -247,7 +247,7 @@ class DiffCombiner:
             combined_relationship = EnrichedDiffRelationship(
                 name=later_relationship.name,
                 label=later_relationship.label,
-                changed_at=later_relationship.changed_at,
+                changed_at=later_relationship.changed_at or earlier_relationship.changed_at,
                 action=self._combine_actions(earlier=earlier_relationship.action, later=later_relationship.action),
                 path_identifier=later_relationship.path_identifier,
                 relationships=combined_relationship_elements,
@@ -295,7 +295,7 @@ class DiffCombiner:
                     uuid=node_pair.later.uuid,
                     kind=node_pair.later.kind,
                     label=node_pair.later.label,
-                    changed_at=node_pair.later.changed_at,
+                    changed_at=node_pair.later.changed_at or node_pair.earlier.changed_at,
                     action=combined_action,
                     path_identifier=node_pair.later.path_identifier,
                     attributes=combined_attributes,

--- a/backend/infrahub/core/diff/combiner.py
+++ b/backend/infrahub/core/diff/combiner.py
@@ -41,10 +41,10 @@ class DiffCombiner:
         self._common_node_uuids = set()
         # map the parent of each node (if it exists), preference to the later diff
         for diff_root in (earlier_diff, later_diff):
-            for node in diff_root.nodes:
-                for rel in node.relationships:
-                    for child_node in rel.nodes:
-                        self._child_parent_uuid_map[child_node.uuid] = (node.uuid, rel.name)
+            for child_node in diff_root.nodes:
+                for parent_rel in child_node.relationships:
+                    for parent_node in parent_rel.nodes:
+                        self._child_parent_uuid_map[child_node.uuid] = (parent_node.uuid, parent_rel.name)
         # UUIDs of all the parents, removing the stale parents from the earlier diff
         self._parent_node_uuids = {parent_tuple[0] for parent_tuple in self._child_parent_uuid_map.values()}
         self._earlier_nodes_by_uuid = {n.uuid: n for n in earlier_diff.nodes}
@@ -311,8 +311,8 @@ class DiffCombiner:
                 continue
             parent_uuid, parent_rel_name = self._child_parent_uuid_map[child_node.uuid]
             parent_node = nodes_by_uuid[parent_uuid]
-            parent_rel = parent_node.get_relationship(name=parent_rel_name)
-            parent_rel.nodes.add(child_node)
+            parent_rel = child_node.get_relationship(name=parent_rel_name)
+            parent_rel.nodes.add(parent_node)
 
     async def combine(self, earlier_diff: EnrichedDiffRoot, later_diff: EnrichedDiffRoot) -> EnrichedDiffRoot:
         self._initialize(earlier_diff=earlier_diff, later_diff=later_diff)

--- a/backend/infrahub/core/diff/enricher/hierarchy.py
+++ b/backend/infrahub/core/diff/enricher/hierarchy.py
@@ -82,7 +82,6 @@ class DiffHierarchyEnricher(DiffEnricherInterface):
                     continue
 
                 node = enriched_diff_root.get_node(node_uuid=node_id)
-
                 parent_rel = hierarchy_schema.get_relationship(name="parent")
 
                 current_node = node
@@ -91,6 +90,7 @@ class DiffHierarchyEnricher(DiffEnricherInterface):
                         node_id=current_node.uuid,
                         parent_id=str(ancestor.uuid),
                         parent_kind=ancestor.kind,
+                        parent_label="",
                         parent_rel_name=parent_rel.name,
                         parent_rel_label=parent_rel.label or "",
                     )
@@ -147,6 +147,7 @@ class DiffHierarchyEnricher(DiffEnricherInterface):
                 node_id=node.uuid,
                 parent_id=str(peer_parent.peer_id),
                 parent_kind=peer_parent.peer_kind,
+                parent_label="",
                 parent_rel_name=parent_rel.name,
                 parent_rel_label=parent_rel.label or "",
             )

--- a/backend/infrahub/core/diff/model/path.py
+++ b/backend/infrahub/core/diff/model/path.py
@@ -309,14 +309,20 @@ class EnrichedDiffRoot(BaseSummary):
         )
 
     def add_parent(
-        self, node_id: str, parent_id: str, parent_kind: str, parent_rel_name: str, parent_rel_label: str = ""
+        self,
+        node_id: str,
+        parent_id: str,
+        parent_kind: str,
+        parent_label: str,
+        parent_rel_name: str,
+        parent_rel_label: str = "",
     ) -> EnrichedDiffNode:
         node = self.get_node(node_uuid=node_id)
         if not self.has_node(node_uuid=parent_id):
             parent = EnrichedDiffNode(
                 uuid=parent_id,
                 kind=parent_kind,
-                label="",
+                label=parent_label,
                 action=DiffAction.UNCHANGED,
                 changed_at=Timestamp(),
             )

--- a/backend/infrahub/core/diff/model/path.py
+++ b/backend/infrahub/core/diff/model/path.py
@@ -175,7 +175,7 @@ class EnrichedDiffRelationship(BaseSummary):
             name=node.get("name"),
             label=node.get("label"),
             changed_at=Timestamp(node.get("changed_at")),
-            action=node.get("action"),
+            action=DiffAction(str(node.get("action"))),
             path_identifier=str(node.get("path_identifier")),
             num_added=int(node.get("num_added")),
             num_conflicts=int(node.get("num_conflicts")),

--- a/backend/infrahub/core/diff/query/diff_get.py
+++ b/backend/infrahub/core/diff/query/diff_get.py
@@ -329,11 +329,12 @@ class EnrichedDiffDeserializer:
         if node_key in self._diff_node_map:
             return self._diff_node_map[node_key]
 
+        timestamp_str = self._get_str_or_none_property_value(node=node_node, property_name="changed_at")
         enriched_node = EnrichedDiffNode(
             uuid=node_uuid,
             kind=str(node_node.get("kind")),
             label=str(node_node.get("label")),
-            changed_at=Timestamp(node_node.get("changed_at")),
+            changed_at=Timestamp(timestamp_str) if timestamp_str else None,
             action=DiffAction(str(node_node.get("action"))),
             path_identifier=str(node_node.get("path_identifier")),
             num_added=int(node_node.get("num_added")),
@@ -480,15 +481,21 @@ class EnrichedDiffDeserializer:
         diff_branch_value = self._get_str_or_none_property_value(
             node=diff_conflict_node, property_name="diff_branch_value"
         )
+        base_timestamp_str = self._get_str_or_none_property_value(
+            node=diff_conflict_node, property_name="base_branch_changed_at"
+        )
+        diff_timestamp_str = self._get_str_or_none_property_value(
+            node=diff_conflict_node, property_name="diff_branch_changed_at"
+        )
         selected_branch = self._get_str_or_none_property_value(node=diff_conflict_node, property_name="selected_branch")
         conflict = EnrichedDiffConflict(
             uuid=str(diff_conflict_node.get("uuid")),
             base_branch_action=DiffAction(str(diff_conflict_node.get("base_branch_action"))),
             base_branch_value=base_branch_value,
-            base_branch_changed_at=Timestamp(str(diff_conflict_node.get("base_branch_changed_at"))),
+            base_branch_changed_at=Timestamp(base_timestamp_str) if base_timestamp_str else None,
             diff_branch_action=DiffAction(str(diff_conflict_node.get("diff_branch_action"))),
             diff_branch_value=diff_branch_value,
-            diff_branch_changed_at=Timestamp(str(diff_conflict_node.get("diff_branch_changed_at"))),
+            diff_branch_changed_at=Timestamp(diff_timestamp_str) if diff_timestamp_str else None,
             selected_branch=ConflictSelection(selected_branch) if selected_branch else None,
         )
 

--- a/backend/infrahub/core/diff/query/diff_summary.py
+++ b/backend/infrahub/core/diff/query/diff_summary.py
@@ -1,0 +1,112 @@
+from typing import Any
+
+from pydantic import BaseModel
+from typing_extensions import Self
+
+from infrahub.core.query import Query, QueryResult, QueryType
+from infrahub.core.timestamp import Timestamp
+from infrahub.database import InfrahubDatabase
+
+from .filters import EnrichedDiffQueryFilters
+
+
+# type: ignore[call-overload]
+class DiffSummaryCounters(BaseModel):
+    num_added: int = 0
+    num_updated: int = 0
+    num_unchanged: int = 0
+    num_removed: int = 0
+    num_conflicts: int = 0
+
+    @classmethod
+    def from_graph(cls, result: QueryResult) -> Self:
+        return cls(
+            num_added=int(result.get_as_str("num_added") or 0),
+            num_updated=int(result.get_as_str("num_updated") or 0),
+            num_unchanged=int(result.get_as_str("num_unchanged") or 0),
+            num_removed=int(result.get_as_str("num_removed") or 0),
+            num_conflicts=int(result.get_as_str("num_conflicts") or 0),
+        )
+
+
+class DiffSummaryQuery(Query):
+    """Get a Summary of the diff"""
+
+    name = "enriched_diff_summary"
+    type = QueryType.READ
+    insert_limit = False
+
+    def __init__(
+        self,
+        base_branch_name: str,
+        diff_branch_names: list[str],
+        from_time: Timestamp,
+        to_time: Timestamp,
+        filters: EnrichedDiffQueryFilters,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.base_branch_name = base_branch_name
+        self.diff_branch_names = diff_branch_names
+        self.from_time = from_time
+        self.to_time = to_time
+        self.filters = filters or EnrichedDiffQueryFilters()
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:
+        self.params = {
+            "base_branch": self.base_branch_name,
+            "diff_branches": self.diff_branch_names,
+            "from_time": self.from_time.to_string(),
+            "to_time": self.to_time.to_string(),
+        }
+
+        # ruff: noqa: E501
+        query_1 = """
+        // get the roots of all diffs in the query
+        MATCH (diff_root:DiffRoot)
+        WHERE diff_root.base_branch = $base_branch
+        AND diff_root.diff_branch IN $diff_branches
+        AND diff_root.from_time >= $from_time
+        AND diff_root.to_time <= $to_time
+        WITH diff_root
+        ORDER BY diff_root.base_branch, diff_root.diff_branch, diff_root.from_time, diff_root.to_time
+        WITH diff_root.base_branch AS bb, diff_root.diff_branch AS db, collect(diff_root) AS same_branch_diff_roots
+        WITH reduce(
+            non_overlapping = [], dr in same_branch_diff_roots |
+            CASE
+                WHEN size(non_overlapping) = 0 THEN [dr]
+                WHEN dr.from_time >= (non_overlapping[-1]).from_time AND dr.to_time <= (non_overlapping[-1]).to_time THEN non_overlapping
+                WHEN (non_overlapping[-1]).from_time >= dr.from_time AND (non_overlapping[-1]).to_time <= dr.to_time THEN non_overlapping[..-1] + [dr]
+                ELSE non_overlapping + [dr]
+            END
+        ) AS non_overlapping_diff_roots
+        UNWIND non_overlapping_diff_roots AS diff_root
+        // get all the nodes attached to the diffs
+        OPTIONAL MATCH (diff_root)-[:DIFF_HAS_NODE]->(diff_node:DiffNode)
+        """
+        self.add_to_query(query=query_1)
+
+        if not self.filters.is_empty:
+            filters, filter_params = self.filters.generate()
+            self.params.update(filter_params)
+
+            query_filters = """
+            WHERE (
+                %(filters)s
+            )
+            """ % {"filters": filters}
+            self.add_to_query(query=query_filters)
+
+        self.return_labels = [
+            "SUM(diff_node.num_added) as num_added",
+            "SUM(diff_node.num_updated) as num_updated",
+            "SUM(diff_node.num_unchanged) as num_unchanged",
+            "SUM(diff_node.num_removed) as num_removed",
+            "SUM(diff_node.num_conflicts) as num_conflicts",
+        ]
+
+    def get_summary(self) -> DiffSummaryCounters:
+        result = self.get_result()
+        if not result:
+            return DiffSummaryCounters()
+        return DiffSummaryCounters.from_graph(result)

--- a/backend/infrahub/core/diff/query/filters.py
+++ b/backend/infrahub/core/diff/query/filters.py
@@ -1,0 +1,94 @@
+from pydantic import BaseModel, Field
+
+from infrahub.core.constants import DiffAction
+from infrahub.core.query.utils import filter_and, filter_or
+
+
+class IncExclFilterOptions(BaseModel):
+    includes: list[str] = Field(default_factory=list)
+    excludes: list[str] = Field(default_factory=list)
+
+    @property
+    def is_empty(self) -> bool:
+        if not self.includes and not self.excludes:
+            return True
+        return False
+
+
+class IncExclActionFilterOptions(BaseModel):
+    includes: set[DiffAction] = Field(default_factory=list)
+    excludes: set[DiffAction] = Field(default_factory=list)
+
+    @property
+    def is_empty(self) -> bool:
+        if not self.includes and not self.excludes:
+            return True
+        return False
+
+
+class EnrichedDiffQueryFilters(BaseModel):
+    ids: list[str] = Field(default_factory=list)
+    kind: IncExclFilterOptions = IncExclFilterOptions()
+    namespace: IncExclFilterOptions = IncExclFilterOptions()
+    status: IncExclActionFilterOptions = IncExclActionFilterOptions()
+
+    @property
+    def is_empty(self) -> bool:
+        if not self.ids and self.kind.is_empty and self.namespace.is_empty and self.status.is_empty:
+            return True
+        return False
+
+    def generate(self) -> tuple[str, dict]:
+        default_filter = ""
+
+        params = {}
+
+        if self.ids:
+            params["ids"] = self.ids
+            return "diff_node.uuid in $ids", params
+
+        filters_list = []
+
+        if self.is_empty:
+            return default_filter, params
+
+        # KIND, Pass the list directly
+        if not self.kind.is_empty:
+            filter_kind = []
+            if self.kind.includes:
+                filter_kind.append("diff_node.kind IN $filter_kind_includes")
+                params["filter_kind_includes"] = self.kind.includes
+
+            if self.kind.excludes:
+                filter_kind.append("NOT(diff_node.kind IN $filter_kind_excludes)")
+                params["filter_kind_excludes"] = self.kind.excludes
+
+            filters_list.append(filter_and(filter_kind))
+
+        # NAMESPACE, match on the start of the kind
+        if not self.namespace.is_empty:
+            filter_namespace = []
+            if self.namespace.includes:
+                filter_namespace.append(
+                    filter_or([f'diff_node.kind STARTS WITH "{ns}"' for ns in self.namespace.includes])
+                )
+            if self.namespace.excludes:
+                filter_namespace.append(
+                    filter_and([f'NOT(diff_node.kind STARTS WITH "{ns}")' for ns in self.namespace.excludes])
+                )
+            filters_list.append(filter_and(filter_namespace))
+
+        # STATUS, Pass the list directly
+        if not self.status.is_empty:
+            filter_action = []
+            if self.status.includes:
+                filter_action.append("diff_node.action IN $filter_status_includes")
+                params["filter_status_includes"] = [str(item.value).lower() for item in self.status.includes]
+
+            if self.status.excludes:
+                filter_action.append("NOT(diff_node.action IN $filter_status_excludes)")
+                params["filter_status_excludes"] = [str(item.value).lower() for item in self.status.excludes]
+
+            filters_list.append(filter_and(filter_action))
+
+        return filter_and(filters_list), params

--- a/backend/infrahub/core/diff/repository/repository.py
+++ b/backend/infrahub/core/diff/repository/repository.py
@@ -3,9 +3,9 @@ from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 
 from ..model.path import EnrichedDiffRoot, TimeRange
+from ..query.diff_get import EnrichedDiffGetQuery
 from ..query.diff_summary import DiffSummaryCounters, DiffSummaryQuery
 from ..query.filters import EnrichedDiffQueryFilters
-from .get_query import EnrichedDiffGetQuery
 from .save_query import EnrichedDiffSaveQuery
 from .time_range_query import EnrichedDiffTimeRangeQuery
 
@@ -20,7 +20,7 @@ class DiffRepository:
         diff_branch_names: list[str],
         from_time: Timestamp,
         to_time: Timestamp,
-        root_node_uuids: list[str] | None = None,
+        filters: dict | None = None,
         limit: int | None = None,
         offset: int | None = None,
     ) -> list[EnrichedDiffRoot]:
@@ -32,15 +32,14 @@ class DiffRepository:
             diff_branch_names=diff_branch_names,
             from_time=from_time,
             to_time=to_time,
-            root_node_uuids=root_node_uuids,
+            filters=EnrichedDiffQueryFilters(**dict(filters or {})),
             max_depth=final_max_depth,
             limit=final_limit,
             offset=offset,
         )
         await query.execute(db=self.db)
         diff_roots = await query.get_enriched_diff_roots()
-        if root_node_uuids:
-            diff_roots = [dr for dr in diff_roots if len(dr.nodes) > 0]
+        diff_roots = [dr for dr in diff_roots if len(dr.nodes) > 0]
         return diff_roots
 
     async def save(self, enriched_diff: EnrichedDiffRoot) -> None:

--- a/backend/infrahub/core/diff/repository/save_query.py
+++ b/backend/infrahub/core/diff/repository/save_query.py
@@ -115,10 +115,14 @@ class EnrichedDiffSaveQuery(Query):
             "uuid": enriched_conflict.uuid,
             "base_branch_action": enriched_conflict.base_branch_action.value,
             "base_branch_value": enriched_conflict.base_branch_value,
-            "base_branch_changed_at": enriched_conflict.base_branch_changed_at.to_string(),
+            "base_branch_changed_at": enriched_conflict.base_branch_changed_at.to_string()
+            if enriched_conflict.base_branch_changed_at
+            else None,
             "diff_branch_action": enriched_conflict.diff_branch_action.value,
             "diff_branch_value": enriched_conflict.diff_branch_value,
-            "diff_branch_changed_at": enriched_conflict.diff_branch_changed_at.to_string(),
+            "diff_branch_changed_at": enriched_conflict.diff_branch_changed_at.to_string()
+            if enriched_conflict.diff_branch_changed_at
+            else None,
             "selected_branch": enriched_conflict.selected_branch.value if enriched_conflict.selected_branch else None,
         }
 
@@ -192,7 +196,9 @@ class EnrichedDiffSaveQuery(Query):
             "node_properties": {
                 "name": enriched_relationship.name,
                 "label": enriched_relationship.label,
-                "changed_at": enriched_relationship.changed_at.to_string(),
+                "changed_at": enriched_relationship.changed_at.to_string()
+                if enriched_relationship.changed_at
+                else None,
                 "action": enriched_relationship.action,
                 "path_identifier": enriched_relationship.path_identifier,
                 "num_added": enriched_relationship.num_added,
@@ -219,7 +225,7 @@ class EnrichedDiffSaveQuery(Query):
                 "uuid": enriched_node.uuid,
                 "kind": enriched_node.kind,
                 "label": enriched_node.label,
-                "changed_at": enriched_node.changed_at.to_string(),
+                "changed_at": enriched_node.changed_at.to_string() if enriched_node.changed_at else None,
                 "action": enriched_node.action.value,
                 "path_identifier": enriched_node.path_identifier,
                 "num_added": enriched_node.num_added,

--- a/backend/infrahub/core/query/utils.py
+++ b/backend/infrahub/core/query/utils.py
@@ -21,3 +21,17 @@ def find_node_schema(
                 return schema
 
     return None
+
+
+def filter_and(items: list[str]) -> str:
+    filter_str = " AND ".join(items)
+    if len(items) > 1:
+        return f" ( {filter_str} ) "
+    return filter_str
+
+
+def filter_or(items: list[str]) -> str:
+    filter_str = " OR ".join(items)
+    if len(items) > 1:
+        return f" ( {filter_str} ) "
+    return filter_str

--- a/backend/infrahub/graphql/queries/diff/diff.py
+++ b/backend/infrahub/graphql/queries/diff/diff.py
@@ -141,4 +141,5 @@ DiffSummary = Field(
     time_to=String(required=False),
     branch_only=Boolean(required=False, default_value=False),
     resolver=DiffSummaryEntry.resolve,
+    deprecation_reason="Please use DiffTree instead",
 )

--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -158,7 +158,7 @@ class DiffTreeResolver:
             label=enriched_node.label,
             status=enriched_node.action,
             parent_node=parent_node.uuid if parent_node else None,
-            last_changed_at=enriched_node.changed_at.obj,
+            last_changed_at=enriched_node.changed_at.obj if enriched_node.changed_at else None,
             path_identifier=enriched_node.path_identifier,
             attributes=diff_attributes,
             relationships=diff_relationships,
@@ -190,7 +190,7 @@ class DiffTreeResolver:
         return DiffRelationship(
             name=enriched_relationship.name,
             label=enriched_relationship.label,
-            last_changed_at=enriched_relationship.changed_at.obj,
+            last_changed_at=enriched_relationship.changed_at.obj if enriched_relationship.changed_at else None,
             status=enriched_relationship.action,
             path_identifier=enriched_relationship.path_identifier,
             elements=diff_elements,
@@ -240,10 +240,14 @@ class DiffTreeResolver:
             uuid=enriched_conflict.uuid,
             base_branch_action=enriched_conflict.base_branch_action,
             base_branch_value=enriched_conflict.base_branch_value,
-            base_branch_changed_at=enriched_conflict.base_branch_changed_at.obj,
+            base_branch_changed_at=enriched_conflict.base_branch_changed_at.obj
+            if enriched_conflict.base_branch_changed_at
+            else None,
             diff_branch_action=enriched_conflict.diff_branch_action,
             diff_branch_value=enriched_conflict.diff_branch_value,
-            diff_branch_changed_at=enriched_conflict.diff_branch_changed_at.obj,
+            diff_branch_changed_at=enriched_conflict.diff_branch_changed_at.obj
+            if enriched_conflict.diff_branch_changed_at
+            else None,
             selected_branch=enriched_conflict.selected_branch,
         )
 

--- a/backend/infrahub/graphql/schema.py
+++ b/backend/infrahub/graphql/schema.py
@@ -48,7 +48,7 @@ from .queries import (
     Relationship,
     Task,
 )
-from .queries.diff.tree import DiffTreeQuery
+from .queries.diff.tree import DiffTreeQuery, DiffTreeSummaryQuery
 
 if TYPE_CHECKING:
     from graphql import GraphQLResolveInfo
@@ -88,6 +88,7 @@ class InfrahubBaseQuery(ObjectType):
     InfrahubAccountToken = AccountToken
 
     DiffTree = DiffTreeQuery
+    DiffTreeSummary = DiffTreeSummaryQuery
     DiffSummary = DiffSummary
 
     Relationship = Relationship

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -24,11 +24,7 @@ from tests.adapters.message_bus import BusSimulator
 from .test_client import InfrahubTestClient
 
 
-class TestInfrahubApp:
-    @pytest.fixture(scope="class")
-    def api_token(self) -> str:
-        return str(UUIDT())
-
+class TestInfrahub:
     @pytest.fixture(scope="class")
     def local_storage_dir(self, tmpdir_factory: pytest.TempdirFactory) -> str:
         storage_dir = os.path.join(str(tmpdir_factory.getbasetemp().strpath), "storage")
@@ -41,14 +37,6 @@ class TestInfrahubApp:
         return storage_dir
 
     @pytest.fixture(scope="class")
-    def bus_simulator(self, db: InfrahubDatabase) -> Generator[BusSimulator, None, None]:
-        bus = BusSimulator(database=db)
-        original = config.OVERRIDE.message_bus
-        config.OVERRIDE.message_bus = bus
-        yield bus
-        config.OVERRIDE.message_bus = original
-
-    @pytest.fixture(scope="class")
     async def default_branch(self, local_storage_dir: str, db: InfrahubDatabase) -> Branch:
         registry.delete_all()
         await delete_all_nodes(db=db)
@@ -57,6 +45,20 @@ class TestInfrahubApp:
         await create_global_branch(db=db)
         registry.schema = SchemaManager()
         return branch
+
+
+class TestInfrahubApp(TestInfrahub):
+    @pytest.fixture(scope="class")
+    def api_token(self) -> str:
+        return str(UUIDT())
+
+    @pytest.fixture(scope="class")
+    def bus_simulator(self, db: InfrahubDatabase) -> Generator[BusSimulator, None, None]:
+        bus = BusSimulator(database=db)
+        original = config.OVERRIDE.message_bus
+        config.OVERRIDE.message_bus = bus
+        yield bus
+        config.OVERRIDE.message_bus = original
 
     @pytest.fixture(scope="class")
     async def register_internal_schema(self, db: InfrahubDatabase, default_branch: Branch) -> SchemaBranch:

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -2018,6 +2018,7 @@ async def hierarchical_location_schema_simple(db: InfrahubDatabase, default_bran
                 "name": "Thing",
                 "namespace": "Test",
                 "default_filter": "name__value",
+                "display_labels": ["name__value"],
                 "attributes": [
                     {"name": "name", "kind": "Text", "unique": True},
                 ],

--- a/backend/tests/unit/core/diff/factories.py
+++ b/backend/tests/unit/core/diff/factories.py
@@ -20,19 +20,48 @@ from infrahub.core.diff.model.path import (
 class EnrichedPropertyFactory(DataclassFactory[EnrichedDiffProperty]): ...
 
 
-class EnrichedAttributeFactory(DataclassFactory[EnrichedDiffAttribute]): ...
+class EnrichedAttributeFactory(DataclassFactory[EnrichedDiffAttribute]):
+    __set_as_default_factory_for_type__ = True
+    num_added = 0
+    num_updated = 0
+    num_removed = 0
+    num_conflicts = 0
+    contains_conflict = False
 
 
-class EnrichedRelationshipGroupFactory(DataclassFactory[EnrichedDiffRelationship]): ...
+class EnrichedRelationshipGroupFactory(DataclassFactory[EnrichedDiffRelationship]):
+    __set_as_default_factory_for_type__ = True
+    num_added = 0
+    num_updated = 0
+    num_removed = 0
+    num_conflicts = 0
+    contains_conflict = False
 
 
-class EnrichedRelationshipElementFactory(DataclassFactory[EnrichedDiffSingleRelationship]): ...
+class EnrichedRelationshipElementFactory(DataclassFactory[EnrichedDiffSingleRelationship]):
+    __set_as_default_factory_for_type__ = True
+    num_added = 0
+    num_updated = 0
+    num_removed = 0
+    num_conflicts = 0
+    contains_conflict = False
 
 
-class EnrichedNodeFactory(DataclassFactory[EnrichedDiffNode]): ...
+class EnrichedNodeFactory(DataclassFactory[EnrichedDiffNode]):
+    __set_as_default_factory_for_type__ = True
+    num_added = 0
+    num_updated = 0
+    num_removed = 0
+    num_conflicts = 0
+    contains_conflict = False
 
 
-class EnrichedRootFactory(DataclassFactory[EnrichedDiffRoot]): ...
+class EnrichedRootFactory(DataclassFactory[EnrichedDiffRoot]):
+    num_added = 0
+    num_updated = 0
+    num_removed = 0
+    num_conflicts = 0
+    contains_conflict = False
 
 
 class CalculatedDiffsFactory(DataclassFactory[CalculatedDiffs]): ...

--- a/backend/tests/unit/core/diff/factories.py
+++ b/backend/tests/unit/core/diff/factories.py
@@ -35,6 +35,7 @@ class EnrichedRelationshipGroupFactory(DataclassFactory[EnrichedDiffRelationship
     num_updated = 0
     num_removed = 0
     num_conflicts = 0
+    nodes = set()
     contains_conflict = False
 
 

--- a/backend/tests/unit/core/diff/query/test_read.py
+++ b/backend/tests/unit/core/diff/query/test_read.py
@@ -18,13 +18,14 @@ from tests.helpers.test_app import TestInfrahub
 
 class TestDiffReadQuery(TestInfrahub):
     @pytest.fixture(scope="class")
-    async def hierarchical_location_schema(db: InfrahubDatabase, default_branch: Branch) -> None:
+    async def hierarchical_location_schema(self, db: InfrahubDatabase, default_branch: Branch) -> None:
         SCHEMA: dict[str, Any] = {
             "generics": [
                 {
                     "name": "Generic",
                     "namespace": "Location",
                     "default_filter": "name__value",
+                    "display_labels": ["name__value"],
                     "hierarchical": True,
                     "attributes": [
                         {"name": "name", "kind": "Text", "unique": True},
@@ -65,6 +66,7 @@ class TestDiffReadQuery(TestInfrahub):
                     "name": "Thing",
                     "namespace": "Test",
                     "default_filter": "name__value",
+                    "display_labels": ["name__value"],
                     "attributes": [
                         {"name": "name", "kind": "Text", "unique": True},
                     ],

--- a/backend/tests/unit/core/diff/query/test_read.py
+++ b/backend/tests/unit/core/diff/query/test_read.py
@@ -1,0 +1,222 @@
+from typing import Any
+
+import pytest
+
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.diff.coordinator import DiffCoordinator
+from infrahub.core.diff.query.diff_summary import DiffSummaryCounters, DiffSummaryQuery, EnrichedDiffQueryFilters
+from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
+from infrahub.core.schema import SchemaRoot
+from infrahub.core.timestamp import Timestamp
+from infrahub.database import InfrahubDatabase
+from infrahub.dependencies.registry import get_component_registry
+from tests.helpers.test_app import TestInfrahub
+
+
+class TestDiffReadQuery(TestInfrahub):
+    @pytest.fixture(scope="class")
+    async def hierarchical_location_schema(db: InfrahubDatabase, default_branch: Branch) -> None:
+        SCHEMA: dict[str, Any] = {
+            "generics": [
+                {
+                    "name": "Generic",
+                    "namespace": "Location",
+                    "default_filter": "name__value",
+                    "hierarchical": True,
+                    "attributes": [
+                        {"name": "name", "kind": "Text", "unique": True},
+                        {"name": "status", "kind": "Text", "enum": ["online", "offline"], "default_value": "online"},
+                    ],
+                    "relationships": [
+                        {"name": "things", "peer": "TestThing", "cardinality": "many", "optional": True},
+                    ],
+                }
+            ],
+            "nodes": [
+                {
+                    "name": "Region",
+                    "namespace": "Location",
+                    "default_filter": "name__value",
+                    "inherit_from": ["LocationGeneric"],
+                    "parent": "",
+                    "children": "LocationSite",
+                },
+                {
+                    "name": "Site",
+                    "namespace": "Location",
+                    "default_filter": "name__value",
+                    "inherit_from": ["LocationGeneric"],
+                    "parent": "LocationRegion",
+                    "children": "LocationRack",
+                },
+                {
+                    "name": "Rack",
+                    "namespace": "Location",
+                    "default_filter": "name__value",
+                    "order_by": ["name__value"],
+                    "inherit_from": ["LocationGeneric"],
+                    "parent": "LocationSite",
+                    "children": "",
+                },
+                {
+                    "name": "Thing",
+                    "namespace": "Test",
+                    "default_filter": "name__value",
+                    "attributes": [
+                        {"name": "name", "kind": "Text", "unique": True},
+                    ],
+                    "relationships": [
+                        {"name": "location", "peer": "LocationGeneric", "cardinality": "one", "optional": False},
+                    ],
+                },
+            ],
+        }
+
+        schema = SchemaRoot(**SCHEMA)
+        registry.schema.register_schema(schema=schema, branch=default_branch.name)
+
+    @pytest.fixture(scope="class")
+    async def hierarchical_data(self, db: InfrahubDatabase, default_branch: Branch, hierarchical_location_schema):
+        REGIONS = (
+            ("north-america",),
+            ("europe",),
+            ("asia",),
+        )
+
+        SITES = (
+            ("paris", "europe"),
+            ("london", "europe"),
+            ("chicago", "north-america"),
+            ("seattle", "north-america"),
+            ("beijing", "asia"),
+            ("singapore", "asia"),
+        )
+        NBR_RACKS_PER_SITE = 2
+
+        nodes = {}
+
+        for region in REGIONS:
+            obj = await Node.init(db=db, schema="LocationRegion")
+            await obj.new(db=db, name=region[0])
+            await obj.save(db=db)
+            nodes[obj.name.value] = obj
+
+        for site in SITES:
+            obj = await Node.init(db=db, schema="LocationSite")
+            await obj.new(db=db, name=site[0], parent=site[1])
+            await obj.save(db=db)
+            nodes[obj.name.value] = obj
+
+            for idx in range(1, NBR_RACKS_PER_SITE + 1):
+                rack_name = f"{site[0]}-r{idx}"
+                statuses = ["online", "offline"]
+                obj = await Node.init(db=db, schema="LocationRack")
+                await obj.new(db=db, name=rack_name, parent=site[0], status=statuses[idx - 1])
+                await obj.save(db=db)
+                nodes[obj.name.value] = obj
+
+        return nodes
+
+    @pytest.fixture(scope="class")
+    async def load_data(self, db: InfrahubDatabase, default_branch: Branch, hierarchical_data):
+        rack1_main = hierarchical_data["paris-r1"]
+        rack2_main = hierarchical_data["paris-r2"]
+
+        thing1_main = await Node.init(db=db, schema="TestThing")
+        await thing1_main.new(db=db, name="thing1", location=rack1_main)
+        await thing1_main.save(db=db)
+
+        thing2_main = await Node.init(db=db, schema="TestThing")
+        await thing2_main.new(db=db, name="thing2", location=rack2_main)
+        await thing2_main.save(db=db)
+
+        diff_branch = await create_branch(db=db, branch_name="diff")
+
+        thing3_branch = await Node.init(db=db, schema="TestThing", branch=diff_branch)
+        await thing3_branch.new(db=db, name="thing3", location=rack1_main)
+        await thing3_branch.save(db=db)
+
+        # rprint(hierarchical_location_data)
+        rack1_branch = await NodeManager.get_one(db=db, id=rack1_main.id, branch=diff_branch)
+        rack1_branch.status.value = "offline"
+        rack2_branch = await NodeManager.get_one(db=db, id=rack2_main.id, branch=diff_branch)
+        rack2_branch.name.value = "paris rack2"
+
+        await rack1_branch.save(db=db)
+        await rack2_branch.save(db=db)
+
+        thing1_branch = await NodeManager.get_one(db=db, id=thing1_main.id, branch=diff_branch)
+        thing1_branch.name.value = "THING1"
+        await thing1_branch.save(db=db)
+
+        component_registry = get_component_registry()
+        diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=diff_branch)
+        # diff_repo = await component_registry.get_component(DiffRepository, db=db, branch=diff_branch)
+
+        from_timestamp = Timestamp(diff_branch.get_created_at())
+        to_timestamp = Timestamp()
+
+        await diff_coordinator.update_diffs(
+            base_branch=default_branch,
+            diff_branch=diff_branch,
+            from_time=from_timestamp,
+            to_time=to_timestamp,
+        )
+
+        return {
+            "diff_branch": diff_branch,
+            "from_time": from_timestamp,
+            "to_time": to_timestamp,
+        }
+
+    @pytest.mark.parametrize(
+        "filters,counters",
+        [
+            pytest.param({}, DiffSummaryCounters(num_added=2, num_updated=4), id="no-filters"),
+            pytest.param(
+                {"kind": {"includes": ["TestThing"]}},
+                DiffSummaryCounters(num_added=2, num_updated=1),
+                id="kind-includes",
+            ),
+            pytest.param({"kind": {"excludes": ["TestThing"]}}, DiffSummaryCounters(num_updated=3), id="kind-excludes"),
+            pytest.param(
+                {"namespace": {"includes": ["Test"]}},
+                DiffSummaryCounters(num_added=2, num_updated=1),
+                id="namespace-includes",
+            ),
+            pytest.param(
+                {"namespace": {"excludes": ["Location"]}},
+                DiffSummaryCounters(num_added=2, num_updated=1),
+                id="namespace-excludes",
+            ),
+            pytest.param(
+                {"status": {"includes": ["updated"]}}, DiffSummaryCounters(num_updated=4), id="status-includes"
+            ),
+            pytest.param(
+                {"status": {"excludes": ["unchanged"]}},
+                DiffSummaryCounters(num_added=2, num_updated=4),
+                id="status-excludes",
+            ),
+            pytest.param(
+                {"kind": {"includes": ["TestThing"]}, "status": {"excludes": ["added"]}},
+                DiffSummaryCounters(num_updated=1),
+                id="kind-includes-status-excludes",
+            ),
+        ],
+    )
+    async def test_summary_no_filter(self, db: InfrahubDatabase, default_branch: Branch, load_data, filters, counters):
+        query = await DiffSummaryQuery.init(
+            db=db,
+            base_branch_name=default_branch.name,
+            diff_branch_names=[load_data["diff_branch"].name],
+            from_time=load_data["from_time"],
+            to_time=load_data["to_time"],
+            filters=EnrichedDiffQueryFilters(**filters),
+        )
+        await query.execute(db=db)
+
+        summary = query.get_summary()
+        assert summary == counters

--- a/backend/tests/unit/core/diff/test_diff_combiner.py
+++ b/backend/tests/unit/core/diff/test_diff_combiner.py
@@ -124,7 +124,12 @@ class TestDiffCombiner:
     async def test_node_action_addition(self, action_1, action_2, expected_action):
         diff_node_1 = EnrichedNodeFactory.build(action=action_1, attributes=set(), relationships=set())
         diff_node_2 = EnrichedNodeFactory.build(
-            uuid=diff_node_1.uuid, kind=diff_node_1.kind, action=action_2, attributes=set(), relationships=set()
+            uuid=diff_node_1.uuid,
+            kind=diff_node_1.kind,
+            action=action_2,
+            attributes=set(),
+            relationships=set(),
+            changed_at=Timestamp(),
         )
         self.diff_root_1.nodes = {diff_node_1}
         self.diff_root_2.nodes = {diff_node_2}
@@ -255,6 +260,7 @@ class TestDiffCombiner:
             action=DiffAction.UPDATED,
             attributes={updated_attribute_2},
             relationships=set(),
+            changed_at=Timestamp(),
         )
 
         self.diff_root_1.nodes = {earlier_node_1, earlier_node_2}
@@ -355,13 +361,21 @@ class TestDiffCombiner:
             name=relationship_name, action=DiffAction.ADDED, relationships={early_element}, nodes=set()
         )
         later_relationship = EnrichedRelationshipGroupFactory.build(
-            name=relationship_name, action=DiffAction.UPDATED, relationships={later_element}, nodes=set()
+            name=relationship_name,
+            action=DiffAction.UPDATED,
+            relationships={later_element},
+            nodes=set(),
+            changed_at=Timestamp(),
         )
         early_node = EnrichedNodeFactory.build(
             kind="TestCar", action=DiffAction.UPDATED, relationships={early_relationship}
         )
         later_node = EnrichedNodeFactory.build(
-            uuid=early_node.uuid, kind="TestCar", action=DiffAction.UPDATED, relationships={later_relationship}
+            uuid=early_node.uuid,
+            kind="TestCar",
+            action=DiffAction.UPDATED,
+            relationships={later_relationship},
+            changed_at=Timestamp(),
         )
         self.diff_root_1.nodes = {early_node}
         self.diff_root_2.nodes = {later_node}
@@ -495,13 +509,18 @@ class TestDiffCombiner:
             name=relationship_name,
             action=DiffAction.UPDATED,
             relationships={added_element_2, removed_element_2, updated_element_2, canceled_element_2},
+            changed_at=Timestamp(),
             nodes=set(),
         )
         node_1 = EnrichedNodeFactory.build(
             kind="TestPerson", action=DiffAction.UPDATED, relationships={relationship_group_1}
         )
         node_2 = EnrichedNodeFactory.build(
-            uuid=node_1.uuid, kind=node_1.kind, action=DiffAction.UPDATED, relationships={relationship_group_2}
+            uuid=node_1.uuid,
+            kind=node_1.kind,
+            action=DiffAction.UPDATED,
+            relationships={relationship_group_2},
+            changed_at=Timestamp(),
         )
         self.diff_root_1.nodes = {node_1}
         self.diff_root_2.nodes = {node_2}
@@ -572,7 +591,11 @@ class TestDiffCombiner:
             uuid=child_node_uuid, kind="ThisKind", action=DiffAction.UPDATED, relationships=set()
         )
         child_node_2 = EnrichedNodeFactory.build(
-            uuid=child_node_uuid, kind="ThisKind", action=DiffAction.UPDATED, relationships=set()
+            uuid=child_node_uuid,
+            kind="ThisKind",
+            action=DiffAction.UPDATED,
+            relationships=set(),
+            changed_at=Timestamp(),
         )
         parent_rel_1 = EnrichedRelationshipGroupFactory.build(
             name=relationship_name, relationships=set(), nodes={child_node_1}, action=DiffAction.UNCHANGED
@@ -584,7 +607,7 @@ class TestDiffCombiner:
             action=DiffAction.UNCHANGED, attributes=set(), relationships={parent_rel_1}
         )
         parent_node_2 = EnrichedNodeFactory.build(
-            action=DiffAction.UNCHANGED, attributes=set(), relationships={parent_rel_2}
+            action=DiffAction.UNCHANGED, attributes=set(), relationships={parent_rel_2}, changed_at=Timestamp()
         )
         self.diff_root_1.nodes = {parent_node_1, child_node_1}
         self.diff_root_2.nodes = {parent_node_2, child_node_2}
@@ -620,7 +643,9 @@ class TestDiffCombiner:
         child_node_uuid = str(uuid4())
         relationship_name = "related-things"
         child_node_1 = EnrichedNodeFactory.build(uuid=child_node_uuid, action=DiffAction.UPDATED, relationships=set())
-        child_node_2 = EnrichedNodeFactory.build(uuid=child_node_uuid, action=DiffAction.UPDATED, relationships=set())
+        child_node_2 = EnrichedNodeFactory.build(
+            uuid=child_node_uuid, action=DiffAction.UPDATED, relationships=set(), changed_at=Timestamp()
+        )
         parent_element_1 = EnrichedRelationshipElementFactory.build()
         parent_rel_1 = EnrichedRelationshipGroupFactory.build(
             name=relationship_name,
@@ -638,7 +663,7 @@ class TestDiffCombiner:
         )
         parent_node_1 = EnrichedNodeFactory.build(action=DiffAction.UPDATED, relationships={parent_rel_1})
         parent_node_2 = EnrichedNodeFactory.build(
-            action=DiffAction.UNCHANGED, attributes=set(), relationships={parent_rel_2}
+            action=DiffAction.UNCHANGED, attributes=set(), relationships={parent_rel_2}, changed_at=Timestamp()
         )
         self.diff_root_1.nodes = {parent_node_1, child_node_1}
         self.diff_root_2.nodes = {parent_node_2, child_node_2}

--- a/backend/tests/unit/core/diff/test_diff_repository.py
+++ b/backend/tests/unit/core/diff/test_diff_repository.py
@@ -132,7 +132,7 @@ class TestDiffRepositorySaveAndLoad:
                 from_time=Timestamp(self.diff_from_time),
                 to_time=Timestamp(self.diff_to_time),
                 uuid=root_uuid,
-                nodes=[],
+                nodes={EnrichedNodeFactory.build(relationships={})},
             )
             await diff_repository.save(enriched_diff=enriched_diff)
 
@@ -162,7 +162,7 @@ class TestDiffRepositorySaveAndLoad:
                     from_time=Timestamp(start_time),
                     to_time=Timestamp(end_time),
                     uuid=root_uuid,
-                    nodes=[],
+                    nodes={EnrichedNodeFactory.build(relationships={})},
                 )
                 await diff_repository.save(enriched_diff=enriched_diff)
 
@@ -196,7 +196,7 @@ class TestDiffRepositorySaveAndLoad:
             from_time=Timestamp(self.diff_from_time),
             to_time=Timestamp(self.diff_to_time),
             uuid=root_uuid,
-            nodes=set(),
+            nodes={EnrichedNodeFactory.build(relationships={})},
         )
         await diff_repository.save(enriched_diff=enriched_diff)
 

--- a/backend/tests/unit/core/diff/test_diff_repository.py
+++ b/backend/tests/unit/core/diff/test_diff_repository.py
@@ -1,4 +1,5 @@
 import random
+from dataclasses import replace
 from datetime import UTC
 from uuid import uuid4
 
@@ -6,6 +7,7 @@ import pytest
 from pendulum.datetime import DateTime
 
 from infrahub import config
+from infrahub.core.constants import DiffAction
 from infrahub.core.constants.database import DatabaseEdgeType
 from infrahub.core.diff.model.path import (
     EnrichedDiffNode,
@@ -264,59 +266,118 @@ class TestDiffRepositorySaveAndLoad:
             enriched_diffs.append(enriched_diff)
             await diff_repository.save(enriched_diff=enriched_diff)
 
-        one_diff = enriched_diffs[0]
-        nodes_without_parents = one_diff.get_nodes_without_parents()
-        nodes_without_children = set()
-        for node in one_diff.nodes:
-            if any(rel.nodes for rel in node.relationships):
-                continue
-            nodes_without_children.add(node)
-        nodes_with_parents_and_children = one_diff.nodes - nodes_without_parents - nodes_without_children
+        parent_node = EnrichedNodeFactory.build()
+        middle_parent_rel = EnrichedRelationshipGroupFactory.build(nodes={parent_node})
+        other_middle_rels = {EnrichedRelationshipGroupFactory.build() for _ in range(2)}
+        middle_node = EnrichedNodeFactory.build(relationships={middle_parent_rel} | other_middle_rels)
+        leaf_middle_rel = EnrichedRelationshipGroupFactory.build(nodes={middle_node})
+        other_leaf_rels = {EnrichedRelationshipGroupFactory.build() for _ in range(2)}
+        leaf_node = EnrichedNodeFactory.build(relationships={leaf_middle_rel} | other_leaf_rels)
+        other_nodes = {EnrichedNodeFactory.build() for _ in range(2)}
+        this_diff = EnrichedRootFactory.build(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name="diff",
+            from_time=Timestamp(self.diff_from_time),
+            to_time=Timestamp(self.diff_to_time),
+            nodes=other_nodes | {parent_node, middle_node, leaf_node},
+        )
+        await diff_repository.save(enriched_diff=this_diff)
+        diff_branch_names = [e.diff_branch_name for e in enriched_diffs] + ["diff"]
 
-        # just root nodes
+        # get parent node
         retrieved = await diff_repository.get(
             base_branch_name=self.base_branch_name,
-            diff_branch_names=[rd.diff_branch_name for rd in enriched_diffs],
+            diff_branch_names=diff_branch_names,
             from_time=Timestamp(self.diff_from_time),
             to_time=Timestamp(self.diff_to_time),
-            filters={"ids": [n.uuid for n in nodes_without_parents]},
+            filters={"ids": [parent_node.uuid]},
         )
         assert len(retrieved) == 1
-        assert retrieved[0] == one_diff
-        # just leaf nodes
+        assert retrieved[0] == replace(this_diff, nodes={parent_node})
+
+        # get middle node
+        thin_parent_node = replace(
+            parent_node,
+            conflict=None,
+            attributes=set(),
+            relationships=set(),
+            action=DiffAction.UNCHANGED,
+            changed_at=None,
+        )
+        expected_middle_parent_rel = replace(middle_parent_rel, nodes={thin_parent_node})
+        expected_middle_node = replace(middle_node, relationships=other_middle_rels | {expected_middle_parent_rel})
         retrieved = await diff_repository.get(
             base_branch_name=self.base_branch_name,
-            diff_branch_names=[rd.diff_branch_name for rd in enriched_diffs],
+            diff_branch_names=diff_branch_names,
             from_time=Timestamp(self.diff_from_time),
             to_time=Timestamp(self.diff_to_time),
-            filters={"ids": [n.uuid for n in nodes_without_children]},
+            filters={"ids": [middle_node.uuid]},
         )
         assert len(retrieved) == 1
-        assert retrieved[0].nodes == nodes_without_children
-        # just middle nodes
+        assert retrieved[0] == replace(this_diff, nodes={thin_parent_node, expected_middle_node})
+
+        # get leaf node
+        thin_middle_parent_rel = replace(
+            middle_parent_rel,
+            nodes={thin_parent_node},
+            relationships=set(),
+            changed_at=None,
+            action=DiffAction.UNCHANGED,
+        )
+        thin_middle_node = replace(
+            middle_node,
+            conflict=None,
+            attributes=set(),
+            relationships={thin_middle_parent_rel},
+            action=DiffAction.UNCHANGED,
+            changed_at=None,
+        )
+        expected_leaf_middle_rel = replace(leaf_middle_rel, nodes={thin_middle_node})
+        expected_leaf_node = replace(leaf_node, relationships=other_leaf_rels | {expected_leaf_middle_rel})
         retrieved = await diff_repository.get(
             base_branch_name=self.base_branch_name,
-            diff_branch_names=[rd.diff_branch_name for rd in enriched_diffs],
+            diff_branch_names=diff_branch_names,
             from_time=Timestamp(self.diff_from_time),
             to_time=Timestamp(self.diff_to_time),
-            filters={"ids": [n.uuid for n in nodes_with_parents_and_children]},
+            filters={"ids": [leaf_node.uuid]},
         )
         assert len(retrieved) == 1
-        assert retrieved[0].nodes == one_diff.nodes - nodes_without_parents
-        # one node from each diff
-        first_nodes_map = {diff.uuid: diff.nodes.pop() for diff in enriched_diffs}
+        assert retrieved[0] == replace(this_diff, nodes={thin_parent_node, thin_middle_node, expected_leaf_node})
+
+        # get middle and parent nodes
         retrieved = await diff_repository.get(
             base_branch_name=self.base_branch_name,
-            diff_branch_names=[rd.diff_branch_name for rd in enriched_diffs],
+            diff_branch_names=diff_branch_names,
             from_time=Timestamp(self.diff_from_time),
             to_time=Timestamp(self.diff_to_time),
-            filters={"ids": [n.uuid for n in first_nodes_map.values()]},
+            filters={"ids": [parent_node.uuid, middle_node.uuid]},
         )
-        assert len(retrieved) == 5
-        for retrieved_root in retrieved:
-            expected_first_node = first_nodes_map[retrieved_root.uuid]
-            node_with_children = expected_first_node.get_all_child_nodes() | {expected_first_node}
-            assert retrieved_root.nodes == node_with_children
+        assert len(retrieved) == 1
+        assert retrieved[0] == replace(this_diff, nodes={parent_node, middle_node})
+
+        # get leaf and parent nodes
+        thin_middle_parent_rel = replace(
+            middle_parent_rel, nodes={parent_node}, relationships=set(), changed_at=None, action=DiffAction.UNCHANGED
+        )
+        thin_middle_node = replace(
+            middle_node,
+            conflict=None,
+            attributes=set(),
+            relationships={thin_middle_parent_rel},
+            action=DiffAction.UNCHANGED,
+            changed_at=None,
+        )
+        expected_leaf_middle_rel = replace(leaf_middle_rel, nodes={thin_middle_node})
+        expected_leaf_node = replace(leaf_node, relationships=other_leaf_rels | {expected_leaf_middle_rel})
+        retrieved = await diff_repository.get(
+            base_branch_name=self.base_branch_name,
+            diff_branch_names=diff_branch_names,
+            from_time=Timestamp(self.diff_from_time),
+            to_time=Timestamp(self.diff_to_time),
+            filters={"ids": [parent_node.uuid, leaf_node.uuid]},
+        )
+        assert len(retrieved) == 1
+        assert retrieved[0] == replace(this_diff, nodes={parent_node, thin_middle_node, expected_leaf_node})
 
     # async def test_filter_limit_and_offset_flat(self, diff_repository: DiffRepository, reset_database):
     #     ordered_nodes = []

--- a/backend/tests/unit/core/diff/test_diff_repository.py
+++ b/backend/tests/unit/core/diff/test_diff_repository.py
@@ -303,6 +303,7 @@ class TestDiffRepositorySaveAndLoad:
             relationships=set(),
             action=DiffAction.UNCHANGED,
             changed_at=None,
+            path_identifier="",
         )
         expected_middle_parent_rel = replace(middle_parent_rel, nodes={thin_parent_node})
         expected_middle_node = replace(middle_node, relationships=other_middle_rels | {expected_middle_parent_rel})
@@ -323,6 +324,7 @@ class TestDiffRepositorySaveAndLoad:
             relationships=set(),
             changed_at=None,
             action=DiffAction.UNCHANGED,
+            path_identifier="",
         )
         thin_middle_node = replace(
             middle_node,
@@ -331,6 +333,7 @@ class TestDiffRepositorySaveAndLoad:
             relationships={thin_middle_parent_rel},
             action=DiffAction.UNCHANGED,
             changed_at=None,
+            path_identifier="",
         )
         expected_leaf_middle_rel = replace(leaf_middle_rel, nodes={thin_middle_node})
         expected_leaf_node = replace(leaf_node, relationships=other_leaf_rels | {expected_leaf_middle_rel})
@@ -357,7 +360,12 @@ class TestDiffRepositorySaveAndLoad:
 
         # get leaf and parent nodes
         thin_middle_parent_rel = replace(
-            middle_parent_rel, nodes={parent_node}, relationships=set(), changed_at=None, action=DiffAction.UNCHANGED
+            middle_parent_rel,
+            nodes={parent_node},
+            relationships=set(),
+            changed_at=None,
+            action=DiffAction.UNCHANGED,
+            path_identifier="",
         )
         thin_middle_node = replace(
             middle_node,
@@ -366,6 +374,7 @@ class TestDiffRepositorySaveAndLoad:
             relationships={thin_middle_parent_rel},
             action=DiffAction.UNCHANGED,
             changed_at=None,
+            path_identifier="",
         )
         expected_leaf_middle_rel = replace(leaf_middle_rel, nodes={thin_middle_node})
         expected_leaf_node = replace(leaf_node, relationships=other_leaf_rels | {expected_leaf_middle_rel})

--- a/backend/tests/unit/graphql/test_diff_tree_query.py
+++ b/backend/tests/unit/graphql/test_diff_tree_query.py
@@ -155,22 +155,9 @@ async def test_diff_tree_empty_diff(db: InfrahubDatabase, default_branch: Branch
         root_value=None,
         variable_values={"branch": diff_branch.name},
     )
-    from_time = datetime.fromisoformat(diff_branch.created_at)
-    to_time = datetime.fromisoformat(params.context.at.to_string())
 
     assert result.errors is None
-
-    assert result.data["DiffTree"] == {
-        "base_branch": "main",
-        "diff_branch": "diff",
-        "from_time": from_time.isoformat(),
-        "to_time": to_time.isoformat(),
-        "num_added": 0,
-        "num_removed": 0,
-        "num_updated": 0,
-        "num_conflicts": 0,
-        "nodes": [],
-    }
+    assert result.data["DiffTree"] is None
 
 
 async def test_diff_tree_no_branch(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema):


### PR DESCRIPTION
This PR implement new filters for `DiffTree` and adds a new `DiffTreeSummary` query to retrieve all the counters related to a diff faster

## Filters

The filters for the diff have been implemented in a structured way and allows to filter on : `ids`, `kind`, `namespace`, `status`
For `kind`, `namespace` and `action` it's possible to provide a list of value to include and/or to exclude

For now, the parent of any given node will be always included in the response, even if they don't match the filters. Any additional flag will be implemented to control that

```graphql
query ($branch: String, $filters: DiffTreeQueryFilters){
    DiffTree (branch: $branch, filters: $filters) {
        nodes {
            uuid
            kind
            label
            status
        }
    }
}
```
Examples of variables
```json
{  "filters": { "namespace": {"exclude": ["Schema", "Profile"] } } }
```
```json
{  "filters": { "ids": ["XXXX", "YYYY"] } }
```
> `root_node_uuids` is still available but it's recommended to use filters ` "filters": { "ids": [] }


## DiffTreeSummary

The new DiffTreeSummary query has a similar format as the main DiffTree query it doesn't return any nodes 
```graphql
query GetDiffTreeSummary($branch: String, $filters: DiffTreeQueryFilters){
    DiffTreeSummary (branch: $branch, filters: $filters) {
        base_branch
        diff_branch
        from_time
        to_time
        num_added
        num_removed
        num_updated
        num_conflicts
        num_unchanged
    }
}
```