### PR TITLE
Fixes SDK error on save after include

### DIFF
--- a/python_sdk/infrahub_sdk/node.py
+++ b/python_sdk/infrahub_sdk/node.py
@@ -479,7 +479,7 @@ class RelationshipManager(RelationshipManagerBase):
         super().__init__(name=name, schema=schema, branch=branch)
 
         self.initialized = data is not None
-        self._has_update = data is not None
+        self._has_update = False
 
         if data is None:
             return
@@ -574,7 +574,7 @@ class RelationshipManagerSync(RelationshipManagerBase):
         super().__init__(name=name, schema=schema, branch=branch)
 
         self.initialized = data is not None
-        self._has_update = data is not None
+        self._has_update = False
 
         if data is None:
             return

--- a/python_sdk/tests/unit/sdk/test_node.py
+++ b/python_sdk/tests/unit/sdk/test_node.py
@@ -1073,7 +1073,9 @@ async def test_create_input_data_with_relationships_03(clients, rfile_schema, cl
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_create_input_data_with_relationships_03_for_update_include_unmodified(clients, rfile_schema, client_type):
+async def test_create_input_data_with_relationships_03_for_update_include_unmodified(
+    clients, rfile_schema, client_type
+):
     data = {
         "name": {"value": "rfile01", "is_protected": True, "source": "ffffffff"},
         "template_path": {"value": "mytemplate.j2"},
@@ -1090,6 +1092,11 @@ async def test_create_input_data_with_relationships_03_for_update_include_unmodi
     node.template_path.value = "my-changed-template.j2"
     assert node._generate_input_data(exclude_unmodified=False)["data"] == {
         "data": {
+            "name": {
+                "is_protected": True,
+                "source": "ffffffff",
+                "value": "rfile01",
+            },
             "query": {
                 "id": "qqqqqqqq",
                 "_relation__is_protected": True,
@@ -1104,7 +1111,9 @@ async def test_create_input_data_with_relationships_03_for_update_include_unmodi
 
 
 @pytest.mark.parametrize("client_type", client_types)
-async def test_create_input_data_with_relationships_03_for_update_exclude_unmodified(clients, rfile_schema, client_type):
+async def test_create_input_data_with_relationships_03_for_update_exclude_unmodified(
+    clients, rfile_schema, client_type
+):
     data = {
         "name": {"value": "rfile01", "is_protected": True, "source": "ffffffff"},
         "template_path": {"value": "mytemplate.j2"},
@@ -1456,7 +1465,7 @@ async def test_relationships_excluded_input_data(client, location_schema, client
     else:
         node = InfrahubNodeSync(client=client, schema=location_schema, data=data)
 
-    assert node.tags.has_update is True
+    assert node.tags.has_update is False
 
 
 @pytest.mark.parametrize("client_type", client_types)


### PR DESCRIPTION
Fixes #4116

I don't think we should indicate the RelationshipManager as `_has_update` when we init it with data. It's being initialized and we track that in another variable.

There is still an issue on the backend side regarding the bidirectional relationship (which we found with 4116), I will open another issue for it