### PR TITLE
DiffTree: Add flag to include or exclude parents from response

### DIFF
--- a/backend/infrahub/core/diff/repository/repository.py
+++ b/backend/infrahub/core/diff/repository/repository.py
@@ -21,6 +21,7 @@ class DiffRepository:
         from_time: Timestamp,
         to_time: Timestamp,
         filters: dict | None = None,
+        include_parents: bool = True,
         limit: int | None = None,
         offset: int | None = None,
     ) -> list[EnrichedDiffRoot]:
@@ -38,7 +39,7 @@ class DiffRepository:
             offset=offset,
         )
         await query.execute(db=self.db)
-        diff_roots = await query.get_enriched_diff_roots()
+        diff_roots = await query.get_enriched_diff_roots(include_parents=include_parents)
         diff_roots = [dr for dr in diff_roots if len(dr.nodes) > 0]
         return diff_roots
 

--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -289,6 +289,7 @@ class DiffTreeResolver:
         from_time: datetime | None = None,
         to_time: datetime | None = None,
         filters: dict | None = None,
+        include_parents: bool = True,
         root_node_uuids: list[str] | None = None,
         limit: int | None = None,
         offset: int | None = None,
@@ -328,6 +329,7 @@ class DiffTreeResolver:
             from_time=from_timestamp,
             to_time=to_timestamp,
             filters=filters_dict,
+            include_parents=include_parents,
             limit=limit,
             offset=offset,
         )
@@ -415,6 +417,7 @@ DiffTreeQuery = Field(
     from_time=DateTime(),
     to_time=DateTime(),
     root_node_uuids=Argument(List(String), deprecation_reason="replaced by filters"),
+    include_parents=Boolean(),
     filters=DiffTreeQueryFilters(),
     limit=Int(),
     offset=Int(),

--- a/backend/tests/unit/core/diff/query/test_read.py
+++ b/backend/tests/unit/core/diff/query/test_read.py
@@ -5,6 +5,7 @@ import pytest
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.diff.coordinator import DiffCoordinator
+from infrahub.core.diff.query.diff_get import EnrichedDiffGetQuery
 from infrahub.core.diff.query.diff_summary import DiffSummaryCounters, DiffSummaryQuery, EnrichedDiffQueryFilters
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
@@ -222,3 +223,29 @@ class TestDiffReadQuery(TestInfrahub):
 
         summary = query.get_summary()
         assert summary == counters
+
+    async def test_get_without_parent(self, db: InfrahubDatabase, default_branch: Branch, load_data):
+        query = await EnrichedDiffGetQuery.init(
+            db=db,
+            base_branch_name=default_branch.name,
+            diff_branch_names=[load_data["diff_branch"].name],
+            from_time=load_data["from_time"],
+            to_time=load_data["to_time"],
+            filters=EnrichedDiffQueryFilters(status={"includes": ["updated"]}),
+            max_depth=10,
+            limit=1000,
+            offset=0,
+        )
+        await query.execute(db=db)
+
+        diffs_without = await query.get_enriched_diff_roots(include_parents=False)
+        diffs_with = await query.get_enriched_diff_roots(include_parents=True)
+
+        assert set([node.label for node in diffs_without[0].nodes]) == {"paris-r1", "paris rack2", "THING1"}
+        assert set([node.label for node in diffs_with[0].nodes]) == {
+            "paris",
+            "THING1",
+            "paris-r1",
+            "paris rack2",
+            "europe",
+        }


### PR DESCRIPTION

Add a new `include_parents` flag on the DIffTree query to include or exclude parents (include by default)