### PR TITLE
diff calculation bug where owner is also the peer on a related node

### DIFF
--- a/backend/infrahub/core/diff/query_parser.py
+++ b/backend/infrahub/core/diff/query_parser.py
@@ -275,7 +275,11 @@ class DiffRelationshipIntermediate:
     _single_relationship_list: list[DiffSingleRelationshipIntermediate] = field(default_factory=list)
 
     def add_path(self, database_path: DatabasePath) -> None:
-        if database_path.property_type == DatabaseEdgeType.IS_RELATED:
+        if database_path.property_type in [
+            DatabaseEdgeType.IS_RELATED,
+            DatabaseEdgeType.HAS_OWNER,
+            DatabaseEdgeType.HAS_SOURCE,
+        ]:
             value = database_path.peer_id
         else:
             value = database_path.property_value
@@ -553,7 +557,7 @@ class DiffQueryParser:
             for relationship_diff in node_diff.relationships_by_name.values():
                 for diff_relationship_property_list in relationship_diff.properties_by_db_id.values():
                     for diff_relationship_property in diff_relationship_property_list:
-                        if diff_relationship_property.changed_at <= self.from_time:
+                        if diff_relationship_property.changed_at >= self.from_time:
                             return
         del self._diff_root_by_branch[self.base_branch_name]
 

--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -289,14 +289,21 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin):
     def compare_properties_with_data(self, data: RelationshipPeerData) -> list[str]:
         different_properties = []
 
-        for prop_name, prop in data.properties.items():
-            if hasattr(self, "_flag_properties") and prop_name in self._flag_properties:
-                if prop.value != getattr(self, prop_name):
-                    different_properties.append(prop_name)
+        if hasattr(self, "_flag_properties"):
+            for property_name in self._flag_properties:
+                memory_value = getattr(self, property_name, None)
+                database_prop = data.properties.get(property_name)
+                database_value = database_prop.value if database_prop else None
+                if memory_value != database_value:
+                    different_properties.append(property_name)
 
-            elif hasattr(self, "_node_properties") and prop_name in self._node_properties:
-                if prop.value != getattr(self, f"{prop_name}_id"):
-                    different_properties.append(prop_name)
+        if hasattr(self, "_node_properties"):
+            for property_name in self._node_properties:
+                memory_value = getattr(self, f"{property_name}_id", None)
+                database_prop = data.properties.get(property_name)
+                database_value = database_prop.value if database_prop else None
+                if memory_value != database_value:
+                    different_properties.append(property_name)
 
         return different_properties
 


### PR DESCRIPTION
fixes two bugs:
1. the logic for updating a relationship prevented adding a new owner/source to a given relationship when you were not updating the peer
2. the diff calculation logic could not handle the case where a relationship's owner/source is ALSO the peer of the relationship. this was not a path shape that I considered when building that query, but we support it now