### PR TITLE
Define GraphQL queries in .infrahub.yml files

### DIFF
--- a/backend/tests/fixtures/repos/car-dealership/initial__main/.infrahub.yml
+++ b/backend/tests/fixtures/repos/car-dealership/initial__main/.infrahub.yml
@@ -40,3 +40,13 @@ generator_definitions:
     convert_query_response: true
     parameters:
       name: "name__value"
+
+queries:
+  - name: car_overview
+    file_path: "checks/car_overview.gql"
+  - name: car_owner_age
+    file_path: "checks/car_owner_age.gql"
+  - name: cartags
+    file_path: "generators/cartags.gql"
+  - name: person_with_cars
+    file_path: "templates/person_with_cars.gql"

--- a/backend/tests/fixtures/repos/infrahub-demo-edge/initial__main/.infrahub.yml
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge/initial__main/.infrahub.yml
@@ -42,3 +42,15 @@ python_transforms:
   - name: oc_interfaces
     class_name: OCInterfaces
     file_path: "transforms/openconfig.py"
+
+queries:
+  - name: check_backbone_link_redundancy
+    file_path: "checks/check_backbone_link_redundancy.gql"
+  - name: device_startup_info
+    file_path: "templates/device_startup_info.gql"
+  - name: topology_info
+    file_path: "topology/topology_info.gql"
+  - name: oc_bgp_neighbors
+    file_path: "transforms/oc_bgp_neighbors.gql"
+  - name: oc_interfaces
+    file_path: "transforms/oc_interfaces.gql"

--- a/backend/tests/unit/git/test_git_repository.py
+++ b/backend/tests/unit/git/test_git_repository.py
@@ -24,7 +24,6 @@ from infrahub.git.constants import BRANCHES_DIRECTORY_NAME, COMMITS_DIRECTORY_NA
 from infrahub.git.integrator import (
     ArtifactGenerateResult,
     CheckDefinitionInformation,
-    GraphQLQueryInformation,
 )
 from infrahub.git.worktree import Worktree
 from infrahub.utils import find_first_file_in_directory
@@ -703,16 +702,6 @@ async def test_find_files_by_commit(git_repo_jinja: InfrahubRepository):
 
     yaml_files = await repo.find_files(extension=["yml", "j2"], branch_name=commit)
     assert len(yaml_files) == 4
-
-
-async def test_find_graphql_queries(git_repo_10: InfrahubRepository):
-    repo = git_repo_10
-
-    commit = repo.get_commit_value(branch_name="main")
-
-    queries = await repo.find_graphql_queries(commit=commit)
-    assert len(queries) == 5
-    assert isinstance(queries[0], GraphQLQueryInformation)
 
 
 async def test_calculate_diff_between_commits(

--- a/docs/docs/reference/dotinfrahub.mdx
+++ b/docs/docs/reference/dotinfrahub.mdx
@@ -114,3 +114,17 @@ To help with the development process of a repository configuration file, you can
 | targets | string | The group to target when running this generator | True |
 | class_name | string | The name of the generator class to run. | False |
 | convert_query_response | boolean | Decide if the generator should convert the result of the GraphQL query to SDK InfrahubNode objects. | False |
+
+<!-- vale off -->
+## Queries
+<!-- vale on -->
+
+**Description**: GraphQL Queries<br/>
+**Key**: queries<br/>
+**Type**: array<br/>
+**Item type**: InfrahubRepositoryGraphQLConfig<br/>
+
+| Property | Type | Description | Mandatory |
+| -------- | ---- | ----------- | --------- |
+| name | string | The name of the GraphQL Query | True |
+| file_path | string | The file within the repository with the query code. | True |

--- a/python_sdk/infrahub_sdk/ctl/generator.py
+++ b/python_sdk/infrahub_sdk/ctl/generator.py
@@ -46,7 +46,11 @@ async def run(
     client = await initialize_client()
     if variables_dict:
         data = execute_graphql_query(
-            query=generator_config.query, variables_dict=variables_dict, branch=branch, debug=False
+            query=generator_config.query,
+            variables_dict=variables_dict,
+            branch=branch,
+            debug=False,
+            repository_config=repository_config,
         )
         generator = generator_class(
             query=generator_config.query,
@@ -80,7 +84,11 @@ async def run(
                 infrahub_node=InfrahubNode,
             )
             data = execute_graphql_query(
-                query=generator_config.query, variables_dict=check_parameter, branch=branch, debug=False
+                query=generator_config.query,
+                variables_dict=check_parameter,
+                branch=branch,
+                debug=False,
+                repository_config=repository_config,
             )
             await generator._init_client.schema.all(branch=generator.branch_name)
             await generator.run(identifier=generator_config.name, data=data)

--- a/python_sdk/infrahub_sdk/ctl/utils.py
+++ b/python_sdk/infrahub_sdk/ctl/utils.py
@@ -20,6 +20,7 @@ from infrahub_sdk.exceptions import (
     ServerNotReachableError,
     ServerNotResponsiveError,
 )
+from infrahub_sdk.schema import InfrahubRepositoryConfig
 
 from .client import initialize_client_sync
 
@@ -101,10 +102,15 @@ def catch_exception(  # noqa: C901
 
 
 def execute_graphql_query(
-    query: str, variables_dict: dict[str, Any], branch: Optional[str] = None, debug: bool = False
+    query: str,
+    variables_dict: dict[str, Any],
+    repository_config: InfrahubRepositoryConfig,
+    branch: Optional[str] = None,
+    debug: bool = False,
 ) -> dict:
     console = Console()
-    query_str = find_graphql_query(query)
+    query_object = repository_config.get_query(name=query)
+    query_str = query_object.load_query()
 
     client = initialize_client_sync()
     response = client.execute_graphql(


### PR DESCRIPTION
Changes the Git import to require GraphQL queries to be defined within a .infrahub.yml file for consistency. This also required some changes within infrahubctl to find query files from .infrahub.yml instead of globbing through the repository.

This PR goes hand in hand with https://github.com/opsmill/infrahub-demo-edge-develop/pull/31.

Fixes #4068.