### PR TITLE
Allow users to add a new generic to an existing node

### DIFF
--- a/backend/infrahub/core/schema/definitions/internal.py
+++ b/backend/infrahub/core/schema/definitions/internal.py
@@ -393,7 +393,7 @@ node_schema = SchemaNode(
             default_factory="list",
             description="List of Generic Kind that this node is inheriting from",
             optional=True,
-            extra={"update": UpdateSupport.NOT_SUPPORTED},
+            extra={"update": UpdateSupport.VALIDATE_CONSTRAINT},
         ),
         SchemaAttribute(
             name="generate_profile",

--- a/backend/infrahub/core/schema/generated/node_schema.py
+++ b/backend/infrahub/core/schema/generated/node_schema.py
@@ -13,7 +13,7 @@ class GeneratedNodeSchema(BaseNodeSchema):
     inherit_from: list[str] = Field(
         default_factory=list,
         description="List of Generic Kind that this node is inheriting from",
-        json_schema_extra={"update": "not_supported"},
+        json_schema_extra={"update": "validate_constraint"},
     )
     generate_profile: bool = Field(
         default=True,

--- a/backend/infrahub/core/validators/__init__.py
+++ b/backend/infrahub/core/validators/__init__.py
@@ -10,6 +10,7 @@ from .attribute.unique import AttributeUniquenessChecker
 from .interface import ConstraintCheckerInterface
 from .node.generate_profile import NodeGenerateProfileChecker
 from .node.hierarchy import NodeHierarchyChecker
+from .node.inherit_from import NodeInheritFromChecker
 from .relationship.count import RelationshipCountChecker
 from .relationship.optional import RelationshipOptionalChecker
 from .relationship.peer import RelationshipPeerChecker
@@ -29,6 +30,7 @@ CONSTRAINT_VALIDATOR_MAP: dict[str, Optional[type[ConstraintCheckerInterface]]] 
     "relationship.optional.update": RelationshipOptionalChecker,
     "relationship.min_count.update": RelationshipCountChecker,
     "relationship.max_count.update": RelationshipCountChecker,
+    "node.inherit_from.update": NodeInheritFromChecker,
     "node.uniqueness_constraints.update": UniquenessChecker,
     "node.parent.update": NodeHierarchyChecker,
     "node.children.update": NodeHierarchyChecker,

--- a/backend/infrahub/core/validators/node/inherit_from.py
+++ b/backend/infrahub/core/validators/node/inherit_from.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+from infrahub_sdk.utils import compare_lists
+
+from infrahub.core.constants import PathType
+from infrahub.core.path import DataPath, GroupedDataPaths
+from infrahub.core.schema import NodeSchema
+
+from ..interface import ConstraintCheckerInterface
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.database import InfrahubDatabase
+
+    from ..model import SchemaConstraintValidatorRequest
+
+
+class NodeInheritFromChecker(ConstraintCheckerInterface):
+    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch]):
+        self.db = db
+        self.branch = branch
+
+    @property
+    def name(self) -> str:
+        return "node.inherit_from.update"
+
+    def supports(self, request: SchemaConstraintValidatorRequest) -> bool:
+        return request.constraint_name == self.name
+
+    async def check(self, request: SchemaConstraintValidatorRequest) -> list[GroupedDataPaths]:
+        grouped_data_paths_list: list[GroupedDataPaths] = []
+        group_data_path = GroupedDataPaths()
+
+        current_schema = self.db.schema.get_node_schema(
+            name=request.node_schema.kind, branch=request.branch, duplicate=False
+        )
+
+        if not isinstance(request.node_schema, NodeSchema):
+            return grouped_data_paths_list
+
+        _, removed, _ = compare_lists(list1=current_schema.inherit_from, list2=request.node_schema.inherit_from)
+
+        if removed:
+            group_data_path.add_data_path(
+                DataPath(
+                    branch=str(request.branch.name),
+                    path_type=PathType.NODE,
+                    node_id=str(request.node_schema.id),
+                    field_name="inherit_from",
+                    kind="SchemaNode",
+                    value=removed,
+                )
+            )
+
+            grouped_data_paths_list.append(group_data_path)
+
+        return grouped_data_paths_list

--- a/backend/infrahub/dependencies/builder/constraint/schema/aggregated.py
+++ b/backend/infrahub/dependencies/builder/constraint/schema/aggregated.py
@@ -8,6 +8,7 @@ from .attribute_optional import SchemaAttributeOptionalConstraintDependency
 from .attribute_regex import SchemaAttributeRegexConstraintDependency
 from .attribute_uniqueness import SchemaAttributeUniqueConstraintDependency
 from .generate_profile import SchemaGenerateProfileConstraintDependency
+from .inherit_from import SchemaInheritFromConstraintDependency
 from .relationship_count import SchemaRelationshipCountConstraintDependency
 from .relationship_optional import SchemaRelationshipOptionalConstraintDependency
 from .uniqueness import SchemaUniquenessConstraintDependency
@@ -20,6 +21,7 @@ class AggregatedSchemaConstraintsDependency(DependencyBuilder[AggregatedConstrai
             constraints=[
                 SchemaUniquenessConstraintDependency.build(context=context),
                 SchemaGenerateProfileConstraintDependency.build(context=context),
+                SchemaInheritFromConstraintDependency.build(context=context),
                 SchemaRelationshipOptionalConstraintDependency.build(context=context),
                 SchemaRelationshipCountConstraintDependency.build(context=context),
                 SchemaAttributeRegexConstraintDependency.build(context=context),

--- a/backend/infrahub/dependencies/builder/constraint/schema/inherit_from.py
+++ b/backend/infrahub/dependencies/builder/constraint/schema/inherit_from.py
@@ -1,0 +1,8 @@
+from infrahub.core.validators.node.inherit_from import NodeInheritFromChecker
+from infrahub.dependencies.interface import DependencyBuilder, DependencyBuilderContext
+
+
+class SchemaInheritFromConstraintDependency(DependencyBuilder[NodeInheritFromChecker]):
+    @classmethod
+    def build(cls, context: DependencyBuilderContext) -> NodeInheritFromChecker:
+        return NodeInheritFromChecker(db=context.db, branch=context.branch)

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_inherit_from.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_inherit_from.py
@@ -1,0 +1,207 @@
+from typing import Any, Dict
+
+import pytest
+from infrahub_sdk import InfrahubClient
+
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.initialization import create_branch
+from infrahub.core.node import Node
+from infrahub.database import InfrahubDatabase
+
+from ..shared import load_schema
+from .shared import (
+    TestSchemaLifecycleBase,
+)
+
+PERSON_KIND = "TestingPerson"
+CYLON_KIND = "TestingCylon"
+CAR_KIND = "TestingCar"
+
+# pylint: disable=unused-argument
+
+
+class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
+    @pytest.fixture(scope="class")
+    def schema_car_base(self) -> Dict[str, Any]:
+        return {
+            "name": "Car",
+            "namespace": "Testing",
+            "include_in_menu": True,
+            "default_filter": "name__value",
+            "label": "Car",
+            "attributes": [
+                {"name": "name", "kind": "Text"},
+                {"name": "description", "kind": "Text", "optional": True},
+                {"name": "color", "kind": "Text"},
+            ],
+            "relationships": [
+                {
+                    "name": "owner",
+                    "kind": "Attribute",
+                    "optional": False,
+                    "peer": "TestingHumanoid",
+                    "cardinality": "one",
+                },
+            ],
+        }
+
+    @pytest.fixture(scope="class")
+    def schema_humanoid_base(self) -> Dict[str, Any]:
+        return {
+            "name": "Humanoid",
+            "namespace": "Testing",
+            "include_in_menu": True,
+            "label": "Humanoid",
+            "attributes": [
+                {"name": "name", "kind": "Text"},
+                {"name": "description", "kind": "Text", "optional": True},
+                {"name": "height", "kind": "Number", "optional": True},
+                {"name": "favorite_color", "kind": "Text", "optional": True},
+            ],
+            "relationships": [
+                {"name": "cars", "kind": "Generic", "optional": True, "peer": "TestingCar", "cardinality": "many"}
+            ],
+        }
+
+    @pytest.fixture(scope="class")
+    def schema_person_base(self) -> Dict[str, Any]:
+        return {
+            "name": "Person",
+            "namespace": "Testing",
+            "include_in_menu": True,
+            "label": "Person",
+            "inherit_from": ["TestingHumanoid"],
+            "attributes": [
+                {"name": "homeworld", "kind": "Text", "optional": False},
+            ],
+        }
+
+    @pytest.fixture(scope="class")
+    def schema_cylon_base(self) -> Dict[str, Any]:
+        return {
+            "name": "Cylon",
+            "namespace": "Testing",
+            "include_in_menu": True,
+            "label": "Cylon",
+            "inherit_from": ["TestingHumanoid"],
+            "attributes": [
+                {"name": "model_number", "kind": "Number", "optional": False},
+            ],
+        }
+
+    @pytest.fixture(scope="class")
+    def schema_robot_base(self) -> Dict[str, Any]:
+        return {
+            "name": "Robot",
+            "namespace": "Testing",
+            "include_in_menu": True,
+            "label": "Robot",
+        }
+
+    @pytest.fixture(scope="class")
+    async def branch_2(self, db: InfrahubDatabase) -> Branch:
+        return await create_branch(db=db, branch_name="branch_2")
+
+    @pytest.fixture(scope="class")
+    async def initial_dataset(self, db: InfrahubDatabase, initialize_registry, schema_step_01):
+        await load_schema(db=db, schema=schema_step_01)
+
+        starbuck = await Node.init(schema=PERSON_KIND, db=db)
+        await starbuck.new(db=db, name="Kara", height=175, description="Starbuck", homeworld="Caprica")
+        await starbuck.save(db=db)
+
+        gaius = await Node.init(schema=PERSON_KIND, db=db)
+        await gaius.new(db=db, name="Gaius", height=155, description="'Scientist'", homeworld="Aerilon")
+        await gaius.save(db=db)
+
+        boomer = await Node.init(schema=CYLON_KIND, db=db)
+        await boomer.new(db=db, name="Sharon", height=165, model_number=8, description="8 (Boomer)")
+        await boomer.save(db=db)
+
+        caprica = await Node.init(schema=CYLON_KIND, db=db)
+        await caprica.new(db=db, name="Caprica", height=185, model_number=6, description="6 (Caprica)")
+        await caprica.save(db=db)
+
+        megane = await Node.init(schema=CAR_KIND, db=db)
+        await megane.new(db=db, name="Megane", description="Renault Megane", color="#c93420", owner=starbuck)
+        await megane.save(db=db)
+
+        objs = {
+            "starbuck": starbuck.id,
+            "gaius": gaius.id,
+            "boomer": boomer.id,
+            "caprica": caprica.id,
+            "megane": megane.id,
+        }
+
+        return objs
+
+    @pytest.fixture(scope="class")
+    def schema_01_cylon_robot(self, schema_cylon_base) -> Dict[str, Any]:
+        schema_cylon_base["inherit_from"] = ["TestingHumanoid", "TestingRobot"]
+        return schema_cylon_base
+
+    @pytest.fixture(scope="class")
+    def schema_03_cylon_robot(self, schema_cylon_base) -> Dict[str, Any]:
+        schema_cylon_base["inherit_from"] = []
+        return schema_cylon_base
+
+    @pytest.fixture(scope="class")
+    def schema_step_01(
+        self,
+        schema_humanoid_base,
+        schema_car_base,
+        schema_person_base,
+        schema_cylon_base,
+    ) -> Dict[str, Any]:
+        return {
+            "version": "1.0",
+            "generics": [schema_humanoid_base],
+            "nodes": [schema_car_base, schema_person_base, schema_cylon_base],
+        }
+
+    @pytest.fixture(scope="class")
+    def schema_step_02_add_generic(
+        self, schema_humanoid_base, schema_car_base, schema_person_base, schema_01_cylon_robot, schema_robot_base
+    ) -> Dict[str, Any]:
+        return {
+            "version": "1.0",
+            "generics": [schema_humanoid_base, schema_robot_base],
+            "nodes": [schema_car_base, schema_person_base, schema_01_cylon_robot],
+        }
+
+    @pytest.fixture(scope="class")
+    def schema_step_03_remove_generic(
+        self, schema_humanoid_base, schema_car_base, schema_person_base, schema_03_cylon_robot, schema_robot_base
+    ) -> Dict[str, Any]:
+        return {
+            "version": "1.0",
+            "generics": [schema_humanoid_base, schema_robot_base],
+            "nodes": [schema_car_base, schema_person_base, schema_03_cylon_robot],
+        }
+
+    async def test_baseline_backend(self, db: InfrahubDatabase, initial_dataset):
+        persons = await registry.manager.query(db=db, schema=PERSON_KIND)
+        cylons = await registry.manager.query(db=db, schema=CYLON_KIND)
+        cars = await registry.manager.query(db=db, schema=CAR_KIND)
+        assert len(persons) == 2
+        assert len(cylons) == 2
+        assert len(cars) == 1
+
+    async def test_step_02_add_generic(self, client: InfrahubClient, initial_dataset, schema_step_02_add_generic):
+        success, _ = await client.schema.check(schemas=[schema_step_02_add_generic])
+        assert success is True
+
+    async def test_step_03_remove_generic(
+        self,
+        client: InfrahubClient,
+        db: InfrahubDatabase,
+        initial_dataset,
+        schema_step_03_remove_generic,
+    ):
+        success, response = await client.schema.check(schemas=[schema_step_03_remove_generic])
+        assert success is False
+        assert len(response["errors"]) == 1
+        error = response["errors"][0]
+        assert "is not compatible with the constraint 'node.inherit_from.update'" in error["message"]

--- a/backend/tests/unit/core/constraint_validators/test_determiner.py
+++ b/backend/tests/unit/core/constraint_validators/test_determiner.py
@@ -59,6 +59,24 @@ def person_name_node_diff(
                 property_name="unique",
             ),
         ),
+        SchemaUpdateConstraintInfo(
+            constraint_name="node.inherit_from.update",
+            path=SchemaPath(
+                path_type=SchemaPathType.NODE,
+                schema_kind="TestPerson",
+                field_name="inherit_from",
+                property_name="inherit_from",
+            ),
+        ),
+        SchemaUpdateConstraintInfo(
+            constraint_name="node.inherit_from.update",
+            path=SchemaPath(
+                path_type=SchemaPathType.NODE,
+                schema_kind="TestCar",
+                field_name="inherit_from",
+                property_name="inherit_from",
+            ),
+        ),
     }
     return node_diff, schema_updated_constraint_infos
 

--- a/backend/tests/unit/core/constraint_validators/test_node_inherit_from_update.py
+++ b/backend/tests/unit/core/constraint_validators/test_node_inherit_from_update.py
@@ -18,7 +18,7 @@ async def test_add_generic_success(db: InfrahubDatabase, default_branch: Branch,
     dog_schema.inherit_from.append("TestXXX")
     request = SchemaConstraintValidatorRequest(
         branch=branch,
-        constraint_name="node.generate_profile.update",
+        constraint_name="node.inherit_from.update",
         node_schema=dog_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestDog"),
     )
@@ -38,7 +38,7 @@ async def test_remove_generic_fail(db: InfrahubDatabase, default_branch: Branch,
     dog_schema.inherit_from = []
     request = SchemaConstraintValidatorRequest(
         branch=branch,
-        constraint_name="node.generate_profile.update",
+        constraint_name="node.inherit_from.update",
         node_schema=dog_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestDog"),
     )

--- a/backend/tests/unit/core/constraint_validators/test_node_inherit_from_update.py
+++ b/backend/tests/unit/core/constraint_validators/test_node_inherit_from_update.py
@@ -1,0 +1,60 @@
+import uuid
+from itertools import chain
+
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.constants import PathType, SchemaPathType
+from infrahub.core.initialization import create_branch
+from infrahub.core.path import DataPath, SchemaPath
+from infrahub.core.validators.model import SchemaConstraintValidatorRequest
+from infrahub.core.validators.node.inherit_from import NodeInheritFromChecker
+from infrahub.database import InfrahubDatabase
+
+
+async def test_add_generic_success(db: InfrahubDatabase, default_branch: Branch, animal_person_schema):
+    branch = await create_branch(branch_name="branch", db=db)
+
+    dog_schema = registry.schema.get_node_schema(name="TestDog")
+    dog_schema.inherit_from.append("TestXXX")
+    request = SchemaConstraintValidatorRequest(
+        branch=branch,
+        constraint_name="node.generate_profile.update",
+        node_schema=dog_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestDog"),
+    )
+
+    checker = NodeInheritFromChecker(db=db, branch=branch)
+
+    grouped_data_paths = await checker.check(request=request)
+    all_data_paths = list(chain(*[gdp.get_all_data_paths() for gdp in grouped_data_paths]))
+    assert len(all_data_paths) == 0
+
+
+async def test_remove_generic_fail(db: InfrahubDatabase, default_branch: Branch, animal_person_schema):
+    branch = await create_branch(branch_name="branch", db=db)
+
+    dog_schema = registry.schema.get_node_schema(name="TestDog")
+    dog_schema.id = str(uuid.uuid4())
+    dog_schema.inherit_from = []
+    request = SchemaConstraintValidatorRequest(
+        branch=branch,
+        constraint_name="node.generate_profile.update",
+        node_schema=dog_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestDog"),
+    )
+
+    checker = NodeInheritFromChecker(db=db, branch=branch)
+
+    grouped_data_paths = await checker.check(request=request)
+    all_data_paths = list(chain(*[gdp.get_all_data_paths() for gdp in grouped_data_paths]))
+    assert (
+        DataPath(
+            branch=branch.name,
+            path_type=PathType.NODE,
+            node_id=dog_schema.id,
+            kind="SchemaNode",
+            field_name="inherit_from",
+            value=["TestAnimal"],
+        )
+        in all_data_paths
+    )

--- a/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
+++ b/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
@@ -128,8 +128,8 @@ async def test_get_proposed_change_schema_integrity_constraints(
     )
     non_generate_profile_constraints = [c for c in constraints if c.constraint_name != "node.generate_profile.update"]
     # should be updated/removed when ConstraintValidatorDeterminer is updated (#2592)
-    assert len(constraints) == 82
-    assert len(non_generate_profile_constraints) == 17
+    assert len(constraints) == 127
+    assert len(non_generate_profile_constraints) == 62
     dumped_constraints = [c.model_dump() for c in non_generate_profile_constraints]
     assert {
         "constraint_name": "relationship.optional.update",

--- a/changelog/4051.fixed.md
+++ b/changelog/4051.fixed.md
@@ -1,0 +1,1 @@
+Allow users to add a new generic to an existing node

--- a/docs/docs/reference/schema/validator-migration.mdx
+++ b/docs/docs/reference/schema/validator-migration.mdx
@@ -40,7 +40,7 @@ In this context, an element represent either a Node, a Generic, an Attribute or 
 | **order_by** | allowed |
 | **uniqueness_constraints** | validate_constraint |
 | **documentation** | allowed |
-| **inherit_from** | not_supported |
+| **inherit_from** | validate_constraint |
 | **generate_profile** | validate_constraint |
 | **hierarchy** | validate_constraint |
 | **parent** | validate_constraint |


### PR DESCRIPTION
Fixes #4051 

This PR changed the constraint on the field `inherit_from` in the schema. Previously it was not possible to update it, now it's possible to add new value to it but it's still not possible to remove item from the list.

Removing a Generic from a node can have a significant impact and we need more work to fully support that, I've opened https://github.com/opsmill/infrahub/issues/4155 to track that

The error message isn't very explicit right now, I'm planning to fix that in a separate PR because it requires some changes to the validators framework