### PR TITLE
Disable Git interactive prompt on git-agents

### DIFF
--- a/backend/infrahub/cli/git_agent.py
+++ b/backend/infrahub/cli/git_agent.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 import signal
 from typing import TYPE_CHECKING, Any
 
@@ -70,6 +71,9 @@ async def start(
     logging.getLogger("git").setLevel(logging.ERROR)
 
     log.debug(f"Config file : {config_file}")
+    # Prevent git from interactively prompting the user for passwords if the credentials provided
+    # by the credential helper is failing.
+    os.environ["GIT_TERMINAL_PROMPT"] = "0"
 
     context: CliContext = ctx.obj
 


### PR DESCRIPTION
If the credentials to a git repository is incorrect the git binary (that GitPython uses under the hood) can prompt the user for a username and password. When running locally this shows up as a blocking prompt in the git-agent. However when running as a container it seems like the console of the git-agent can just hang.

In this PR I'm adding an environment variable for the current process within the Git agent that disables the prompting of users for credentials which should instead fail immediately if there is an error.
