### PR TITLE
fixes git clone command in installation guide

### DIFF
--- a/docs/docs/guides/installation.mdx
+++ b/docs/docs/guides/installation.mdx
@@ -63,7 +63,7 @@ cd ~/source/infrahub/
 Next, clone the `stable` branch of the Infrahub GitHub repository into the current directory. (This branch always holds the current stable release)
 
 ```bash
-git clone -b stable --depth 1 git@github.com:opsmill/infrahub.git .
+git clone -b stable --depth 1 https://github.com/opsmill/infrahub.git
 ```
 
 :::note


### PR DESCRIPTION
Updates the `git clone` command in the installation guide to use HTTPS.
Users that don't have their SSH client configured properly will run into a failure when using git over ssh.

Also removed the "." at the end of the command. It implies you have created a directory yourself that is empty, if not git will refuse to clone the repository. This is confusing to people who are not that familiar wit git.