### PR TITLE
Allow generators and artifacts to run on node without name attribute

### DIFF
--- a/backend/infrahub/message_bus/operations/requests/artifact_definition.py
+++ b/backend/infrahub/message_bus/operations/requests/artifact_definition.py
@@ -107,7 +107,7 @@ async def check(message: messages.RequestArtifactDefinitionCheck, service: Infra
                         query=message.artifact_definition.query_name,
                         variables=member.extract(params=artifact_definition.parameters.value),
                         target_id=member.id,
-                        target_name=member.name.value,
+                        target_name=member.display_label,
                         timeout=message.artifact_definition.timeout,
                         validator_id=validator.id,
                         meta=Meta(validator_execution_id=validator_execution_id, check_execution_id=check_execution_id),
@@ -203,7 +203,7 @@ async def generate(message: messages.RequestArtifactDefinitionGenerate, service:
                 query=query.name.value,
                 variables=member.extract(params=artifact_definition.parameters.value),
                 target_id=member.id,
-                target_name=member.name.value,
+                target_name=member.display_label,
                 timeout=transform.timeout.value,
             )
         )

--- a/backend/infrahub/message_bus/operations/requests/generator_definition.py
+++ b/backend/infrahub/message_bus/operations/requests/generator_definition.py
@@ -101,7 +101,7 @@ async def check(message: messages.RequestGeneratorDefinitionCheck, service: Infr
                         query=message.generator_definition.query_name,
                         variables=member.extract(params=message.generator_definition.parameters),
                         target_id=member.id,
-                        target_name=member.name.value,
+                        target_name=member.display_label,
                         validator_id=validator.id,
                         meta=Meta(validator_execution_id=validator_execution_id, check_execution_id=check_execution_id),
                     )
@@ -177,7 +177,7 @@ async def run(message: messages.RequestGeneratorDefinitionRun, service: Infrahub
                     query=message.generator_definition.query_name,
                     variables=member.extract(params=message.generator_definition.parameters),
                     target_id=member.id,
-                    target_name=member.name.value,
+                    target_name=member.display_label,
                 )
             )
 

--- a/changelog/4062.fixed.md
+++ b/changelog/4062.fixed.md
@@ -1,0 +1,1 @@
+Allow users to run artifacts and generators on nodes without name attribute


### PR DESCRIPTION
- Used "display_name" attribute when dispatching message

fixes #4062