### PR TITLE
Add support for using default_branch in git other than main

### DIFF
--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -195,7 +195,7 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
     @property
     def directory_default(self) -> str:
         """Return the path to the directory of the main branch."""
-        return os.path.join(self.directory_root, registry.default_branch)
+        return os.path.join(self.directory_root, "main")
 
     @property
     def directory_branches(self) -> str:
@@ -352,7 +352,6 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
         """Access a specific worktree by its identifier."""
 
         worktrees = self.get_worktrees()
-
         for worktree in worktrees:
             if worktree.identifier == identifier:
                 return worktree
@@ -463,11 +462,12 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
             False if they already had the same value
         """
 
+        infrahub_branch = self._get_mapped_target_branch(branch_name=branch_name)
         log.debug(
-            f"Updating commit value to {commit} for branch {branch_name}", repository=self.name, branch=branch_name
+            f"Updating commit value to {commit} for branch {branch_name}", repository=self.name, branch=infrahub_branch
         )
         await self.sdk.repository_update_commit(
-            branch_name=branch_name, repository_id=self.id, commit=commit, is_read_only=self.is_read_only
+            branch_name=infrahub_branch, repository_id=self.id, commit=commit, is_read_only=self.is_read_only
         )
 
         return True
@@ -601,13 +601,19 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
 
         return sorted(list(new_branches)), sorted(updated_branches)
 
-    async def validate_remote_branch(self, branch_name: str) -> bool:  # pylint: disable=unused-argument
+    async def validate_remote_branch(self, branch_name: str) -> bool:
         """Validate a branch present on the remote repository.
         To check a branch we need to first create a worktree in the temporary folder then apply some checks:
         - xxx
 
         At the end, we need to delete the worktree in the temporary folder.
         """
+        if branch_name == registry.default_branch and branch_name != self.default_branch:
+            # If the default branch of Infrahub and the git repository differs we map the repository
+            # default branch to that of Infrahub. In that scenario we can't import a branch from the
+            # repository if it matches the default branch of Infrahub
+            log.warning("Ignoring import of mismatched default branch", branch=branch_name, repository=self.name)
+            return False
         try:
             # Check if the branch can be created in the database
             Branch(name=branch_name)
@@ -628,8 +634,11 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
 
         if not self.has_origin:
             return False
+        identifier = branch_name
+        if branch_name == self.default_branch and branch_name != registry.default_branch:
+            identifier = "main"
 
-        repo = self.get_git_repo_worktree(identifier=branch_name)
+        repo = self.get_git_repo_worktree(identifier=identifier)
         if not repo:
             raise ValueError(f"Unable to identify the worktree for the branch : {branch_name}")
 
@@ -645,7 +654,8 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
             return True
 
         self.create_commit_worktree(commit=commit_after)
-        await self.update_commit_value(branch_name=branch_name, commit=commit_after)
+        infrahub_branch = self._get_mapped_target_branch(branch_name=branch_name)
+        await self.update_commit_value(branch_name=infrahub_branch, commit=commit_after)
 
         return commit_after
 
@@ -767,3 +777,15 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
             ) from error
 
         raise RepositoryError(identifier=name, message=error.stderr) from error
+
+    def _get_mapped_remote_branch(self, branch_name: str) -> str:
+        """Returns the remote branch for Git Repositories."""
+        if branch_name != self.default_branch and branch_name == registry.default_branch:
+            return self.default_branch
+        return branch_name
+
+    def _get_mapped_target_branch(self, branch_name: str) -> str:
+        """Returns the target branch within Infrahub."""
+        if branch_name == self.default_branch and branch_name != registry.default_branch:
+            return registry.default_branch
+        return branch_name

--- a/backend/infrahub/git/repository.py
+++ b/backend/infrahub/git/repository.py
@@ -113,29 +113,32 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
                 if not is_valid:
                     continue
 
+                infrahub_branch = self._get_mapped_target_branch(branch_name=branch_name)
                 try:
-                    branch = await self.create_branch_in_graph(branch_name=branch_name)
+                    branch = await self.create_branch_in_graph(branch_name=infrahub_branch)
                 except GraphQLError as exc:
                     if "already exist" not in exc.errors[0]["message"]:
                         raise
-                    branch = await self.sdk.branch.get(branch_name=branch_name)
+                    branch = await self.sdk.branch.get(branch_name=infrahub_branch)
 
                 await self.create_branch_in_git(branch_name=branch.name, branch_id=branch.id)
 
                 commit = self.get_commit_value(branch_name=branch_name, remote=False)
                 self.create_commit_worktree(commit=commit)
-                await self.update_commit_value(branch_name=branch_name, commit=commit)
+                await self.update_commit_value(branch_name=infrahub_branch, commit=commit)
 
-                await self.import_objects_from_files(infrahub_branch_name=branch_name, commit=commit)
+                await self.import_objects_from_files(infrahub_branch_name=infrahub_branch, commit=commit)
 
             for branch_name in updated_branches:
                 is_valid = await self.validate_remote_branch(branch_name=branch_name)
                 if not is_valid:
                     continue
 
+                infrahub_branch = self._get_mapped_target_branch(branch_name=branch_name)
+
                 commit_after = await self.pull(branch_name=branch_name)
                 if isinstance(commit_after, str):
-                    await self.import_objects_from_files(infrahub_branch_name=branch_name, commit=commit_after)
+                    await self.import_objects_from_files(infrahub_branch_name=infrahub_branch, commit=commit_after)
 
                 elif commit_after is True:
                     log.warning(
@@ -177,7 +180,8 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
 
         # TODO Catch potential exceptions coming from origin.push
         repo = self.get_git_repo_worktree(identifier=branch_name)
-        repo.remotes.origin.push(branch_name)
+        remote_branch = self._get_mapped_remote_branch(branch_name=branch_name)
+        repo.remotes.origin.push(remote_branch)
 
         return True
 
@@ -206,7 +210,6 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
 
         self.create_commit_worktree(commit_after)
         await self.update_commit_value(branch_name=dest_branch, commit=commit_after)
-
         if self.has_origin and push_remote:
             await self.push(branch_name=dest_branch)
 

--- a/backend/infrahub/message_bus/messages/git_repository_merge.py
+++ b/backend/infrahub/message_bus/messages/git_repository_merge.py
@@ -11,3 +11,4 @@ class GitRepositoryMerge(InfrahubMessage):
     admin_status: str = Field(..., description="Administrative status of the repository")
     source_branch: str = Field(..., description="The source branch")
     destination_branch: str = Field(..., description="The source branch")
+    default_branch: str = Field(..., description="The default branch in Git")

--- a/backend/infrahub/message_bus/operations/git/repository.py
+++ b/backend/infrahub/message_bus/operations/git/repository.py
@@ -34,6 +34,7 @@ async def add(message: messages.GitRepositoryAdd, service: InfrahubServices) -> 
                 task_report=git_report,
                 infrahub_branch_name=message.infrahub_branch_name,
                 admin_status=message.admin_status,
+                default_branch_name=message.default_branch_name,
             )
             await repo.import_objects_from_files(
                 infrahub_branch_name=message.infrahub_branch_name, git_branch_name=message.default_branch_name
@@ -156,7 +157,12 @@ async def merge(message: messages.GitRepositoryMerge, service: InfrahubServices)
         destination_branch=message.destination_branch,
     )
 
-    repo = await InfrahubRepository.init(id=message.repository_id, name=message.repository_name, client=service.client)
+    repo = await InfrahubRepository.init(
+        id=message.repository_id,
+        name=message.repository_name,
+        client=service.client,
+        default_branch_name=message.default_branch,
+    )
 
     if message.admin_status == RepositoryAdminStatus.STAGING.value:
         repo_source = await service.client.get(

--- a/backend/tests/unit/git/test_git_rpc.py
+++ b/backend/tests/unit/git/test_git_rpc.py
@@ -90,6 +90,7 @@ class TestAddRepository:
             task_report=self.git_report,
             infrahub_branch_name=self.default_branch_name,
             admin_status="active",
+            default_branch_name=self.default_branch_name,
         )
         self.mock_repo.import_objects_from_files.assert_awaited_once_with(
             infrahub_branch_name=self.default_branch_name, git_branch_name=self.default_branch_name
@@ -116,6 +117,7 @@ async def test_git_rpc_merge(
         source_branch="branch01",
         destination_branch="main",
         admin_status=RepositoryAdminStatus.ACTIVE.value,
+        default_branch="main",
     )
 
     client_config = Config(requester=dummy_async_request)

--- a/docs/docs/reference/message-bus-events.mdx
+++ b/docs/docs/reference/message-bus-events.mdx
@@ -432,6 +432,7 @@ For more detailed explanations on how to use these events within Infrahub, see t
 | **admin_status** | Administrative status of the repository | string | None |
 | **source_branch** | The source branch | string | None |
 | **destination_branch** | The source branch | string | None |
+| **default_branch** | The default branch in Git | string | None |
 <!-- vale on -->
 <!-- vale off -->
 #### Event git.repository.add_read_only
@@ -1647,6 +1648,7 @@ For more detailed explanations on how to use these events within Infrahub, see t
 | **admin_status** | Administrative status of the repository | string | None |
 | **source_branch** | The source branch | string | None |
 | **destination_branch** | The source branch | string | None |
+| **default_branch** | The default branch in Git | string | None |
 <!-- vale on -->
 <!-- vale off -->
 #### Event git.repository.add_read_only


### PR DESCRIPTION
What this PR does is to change map the default branch within Infrahub to the default_branch configured for a given repository. Under normal circumstances it's expected that `main` will be used for both. If the default branch differs on a repository this PR will swap out the name of the default branch when populating Infrahub. In the other direction we will swap out the name of the branch when pushing to the remote Git origin (i.e. instead of pushing to `main` we'd push to the name indicated by the default_branch setting).

A consequence of this is that if someone is using a non-default branch for a Git repository but then adds a branch to the Git repository that matches the Infrahub default branch (i.e. main), then that branch will be ignored by the importer. This is to avoid pushing changes from both of these branches into the main Infrahub branch.

Fixes #3435