### PR TITLE
Set attribute source when assigning from number pools

### DIFF
--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -246,6 +246,7 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
 
                 if next_free:
                     attribute.value = next_free
+                    attribute.source = number_pool.id
                 else:
                     errors.append(
                         ValidationError(


### PR DESCRIPTION
This PR ensures that attributes assigned from number pools get the source of said number pool as a metadata property.