### PR TITLE
Use correct attribute names for update errors

### DIFF
--- a/backend/infrahub/graphql/mutations/resource_manager.py
+++ b/backend/infrahub/graphql/mutations/resource_manager.py
@@ -224,7 +224,7 @@ class InfrahubNumberPoolMutation(InfrahubMutationMixin, Mutation):
             or (data.get("node_attribute") and data.get("node_attribute").value)
             or (data.get("unique_for") and data.get("unique_for").value)
         ):
-            raise ValidationError(input_value="The fields 'model', 'model_attribute' or 'unique_for' can't be changed.")
+            raise ValidationError(input_value="The fields 'node', 'node_attribute' or 'unique_for' can't be changed.")
         context: GraphqlContext = info.context
 
         async with context.db.start_transaction() as dbt:

--- a/backend/tests/unit/graphql/mutations/test_resource_manager.py
+++ b/backend/tests/unit/graphql/mutations/test_resource_manager.py
@@ -807,7 +807,7 @@ async def test_test_number_pool_update(db: InfrahubDatabase, default_branch: Bra
     )
 
     assert update_forbidden.errors
-    assert "The fields 'model', 'model_attribute' or 'unique_for' can't be changed." in str(update_forbidden.errors[0])
+    assert "The fields 'node', 'node_attribute' or 'unique_for' can't be changed." in str(update_forbidden.errors[0])
     assert update_invalid_range.errors
     assert "start_range can't be larger than end_range" in str(update_invalid_range.errors[0])
     assert update_ok.data


### PR DESCRIPTION
The model and model_attribute attributes on the number pools were renamed to node and node_attribute but this error message never changed. This PR fixes this mistake.