### PR TITLE
IFC-607 - Update from pool structure in mutation for number pool

### DIFF
--- a/frontend/app/src/components/form/type.ts
+++ b/frontend/app/src/components/form/type.ts
@@ -29,7 +29,7 @@ export type AttributeValueFormPool = {
     kind: string;
     id: string;
   };
-  value: { from_pool: string };
+  value: { from_pool: { id: string } };
 };
 
 export type AttributeValueForCheckbox = {

--- a/frontend/app/src/components/form/utils/updateFormFieldValue.ts
+++ b/frontend/app/src/components/form/utils/updateFormFieldValue.ts
@@ -35,7 +35,9 @@ export const updateAttributeFieldValue = (
         label: newValue.from_pool.name,
       },
       value: {
-        from_pool: newValue.from_pool.id,
+        from_pool: {
+          id: newValue.from_pool.id,
+        },
       },
     };
   }


### PR DESCRIPTION
After a backend update for consistency, the frontend needs also to fix the from_pool structure to use
```
from_pool: { id: "..." }
```
instead of
```
from_pool: "..."
```