### PR TITLE
IFC-587 track conflicts with an attribute instead of by ID

### DIFF
--- a/backend/infrahub/core/diff/data_check_synchronizer.py
+++ b/backend/infrahub/core/diff/data_check_synchronizer.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from typing import TYPE_CHECKING
 
 from infrahub.core.constants import BranchConflictKeep, InfrahubKind, ProposedChangeState
 from infrahub.core.integrity.object_conflict.conflict_recorder import ObjectConflictValidatorRecorder
@@ -9,9 +8,6 @@ from infrahub.database import InfrahubDatabase
 
 from .conflicts_extractor import DiffConflictsExtractor
 from .model.path import ConflictSelection, EnrichedDiffConflict, EnrichedDiffRoot
-
-if TYPE_CHECKING:
-    from infrahub.core.protocols import CoreProposedChange
 
 
 class DiffDataCheckSynchronizer:
@@ -33,26 +29,28 @@ class DiffDataCheckSynchronizer:
         )
         if not proposed_changes:
             return []
-        proposed_change: CoreProposedChange = proposed_changes[0]
         enriched_conflicts = enriched_diff.get_all_conflicts()
         data_conflicts = await self.conflicts_extractor.get_data_conflicts(enriched_diff_root=enriched_diff)
-        core_data_checks = await self.conflict_recorder.record_conflicts(
-            proposed_change_id=proposed_change.get_id(), conflicts=data_conflicts
-        )
-        core_data_checks_by_id = {cdc.get_id(): cdc for cdc in core_data_checks}
-        enriched_conflicts_by_id = {ec.uuid: ec for ec in enriched_conflicts}
-        for conflict_id, core_data_check in core_data_checks_by_id.items():
-            enriched_conflict = enriched_conflicts_by_id.get(conflict_id)
-            if not enriched_conflict:
-                continue
-            expected_keep_branch = self._get_keep_branch_for_enriched_conflict(enriched_conflict=enriched_conflict)
-            expected_keep_branch_value = (
-                expected_keep_branch.value if isinstance(expected_keep_branch, Enum) else expected_keep_branch
+        all_data_checks = []
+        for pc in proposed_changes:
+            core_data_checks = await self.conflict_recorder.record_conflicts(
+                proposed_change_id=pc.get_id(), conflicts=data_conflicts
             )
-            if core_data_check.keep_branch.value != expected_keep_branch_value:  # type: ignore[attr-defined]
-                core_data_check.keep_branch.value = expected_keep_branch_value  # type: ignore[attr-defined]
-                await core_data_check.save(db=self.db)
-        return core_data_checks
+            all_data_checks.extend(core_data_checks)
+            core_data_checks_by_id = {cdc.enriched_conflict_id.value: cdc for cdc in core_data_checks}   # type: ignore[attr-defined]
+            enriched_conflicts_by_id = {ec.uuid: ec for ec in enriched_conflicts}
+            for conflict_id, core_data_check in core_data_checks_by_id.items():
+                enriched_conflict = enriched_conflicts_by_id.get(conflict_id)
+                if not enriched_conflict:
+                    continue
+                expected_keep_branch = self._get_keep_branch_for_enriched_conflict(enriched_conflict=enriched_conflict)
+                expected_keep_branch_value = (
+                    expected_keep_branch.value if isinstance(expected_keep_branch, Enum) else expected_keep_branch
+                )
+                if core_data_check.keep_branch.value != expected_keep_branch_value:  # type: ignore[attr-defined]
+                    core_data_check.keep_branch.value = expected_keep_branch_value  # type: ignore[attr-defined]
+                    await core_data_check.save(db=self.db)
+        return all_data_checks
 
     def _get_keep_branch_for_enriched_conflict(
         self, enriched_conflict: EnrichedDiffConflict

--- a/backend/infrahub/core/diff/data_check_synchronizer.py
+++ b/backend/infrahub/core/diff/data_check_synchronizer.py
@@ -37,7 +37,7 @@ class DiffDataCheckSynchronizer:
                 proposed_change_id=pc.get_id(), conflicts=data_conflicts
             )
             all_data_checks.extend(core_data_checks)
-            core_data_checks_by_id = {cdc.enriched_conflict_id.value: cdc for cdc in core_data_checks}   # type: ignore[attr-defined]
+            core_data_checks_by_id = {cdc.enriched_conflict_id.value: cdc for cdc in core_data_checks}  # type: ignore[attr-defined]
             enriched_conflicts_by_id = {ec.uuid: ec for ec in enriched_conflicts}
             for conflict_id, core_data_check in core_data_checks_by_id.items():
                 enriched_conflict = enriched_conflicts_by_id.get(conflict_id)

--- a/backend/infrahub/core/protocols.py
+++ b/backend/infrahub/core/protocols.py
@@ -261,6 +261,7 @@ class CoreCustomWebhook(CoreWebhook, CoreTaskTarget):
 class CoreDataCheck(CoreCheck):
     conflicts: JSONAttribute
     keep_branch: Enum
+    enriched_conflict_id: StringOptional
 
 
 class CoreDataValidator(CoreValidator):

--- a/backend/infrahub/core/protocols.py
+++ b/backend/infrahub/core/protocols.py
@@ -390,6 +390,7 @@ class CoreRepositoryValidator(CoreValidator):
 
 class CoreSchemaCheck(CoreCheck):
     conflicts: JSONAttribute
+    enriched_conflict_id: StringOptional
 
 
 class CoreSchemaValidator(CoreValidator):

--- a/backend/infrahub/core/schema/definitions/core.py
+++ b/backend/infrahub/core/schema/definitions/core.py
@@ -1343,6 +1343,7 @@ core_models: dict[str, Any] = {
             "branch": BranchSupportType.AGNOSTIC.value,
             "attributes": [
                 {"name": "conflicts", "kind": "JSON"},
+                {"name": "enriched_conflict_id", "kind": "Text", "optional": True},
             ],
         },
         {

--- a/backend/infrahub/core/schema/definitions/core.py
+++ b/backend/infrahub/core/schema/definitions/core.py
@@ -1317,6 +1317,7 @@ core_models: dict[str, Any] = {
             "attributes": [
                 {"name": "conflicts", "kind": "JSON"},
                 {"name": "keep_branch", "enum": BranchConflictKeep.available_types(), "kind": "Text", "optional": True},
+                {"name": "enriched_conflict_id", "kind": "Text", "optional": True},
             ],
         },
         {

--- a/python_sdk/infrahub_sdk/protocols.py
+++ b/python_sdk/infrahub_sdk/protocols.py
@@ -267,6 +267,7 @@ class CoreCustomWebhook(CoreWebhook, CoreTaskTarget):
 class CoreDataCheck(CoreCheck):
     conflicts: JSONAttribute
     keep_branch: Enum
+    enriched_conflict_id: StringOptional
 
 
 class CoreDataValidator(CoreValidator):
@@ -683,6 +684,7 @@ class CoreCustomWebhookSync(CoreWebhookSync, CoreTaskTargetSync):
 class CoreDataCheckSync(CoreCheckSync):
     conflicts: JSONAttribute
     keep_branch: Enum
+    enriched_conflict_id: StringOptional
 
 
 class CoreDataValidatorSync(CoreValidatorSync):

--- a/python_sdk/infrahub_sdk/protocols.py
+++ b/python_sdk/infrahub_sdk/protocols.py
@@ -396,6 +396,7 @@ class CoreRepositoryValidator(CoreValidator):
 
 class CoreSchemaCheck(CoreCheck):
     conflicts: JSONAttribute
+    enriched_conflict_id: StringOptional
 
 
 class CoreSchemaValidator(CoreValidator):
@@ -813,6 +814,7 @@ class CoreRepositoryValidatorSync(CoreValidatorSync):
 
 class CoreSchemaCheckSync(CoreCheckSync):
     conflicts: JSONAttribute
+    enriched_conflict_id: StringOptional
 
 
 class CoreSchemaValidatorSync(CoreValidatorSync):


### PR DESCRIPTION
IFC-587

add an `enriched_conflict_id` attribute to the `CoreDataCheck` that we can use to link a `CoreDataCheck` to an `EnrichedDiffConflict` in the new cached diff format.
previously, we were linking these two entities using the UUID of the `CoreDataCheck`, but that would cause a duplicate UUID error on the database if multiple proposed changes were created for a single branch.