### PR TITLE
Fix idempotency for number pools

### DIFF
--- a/backend/infrahub/core/initialization.py
+++ b/backend/infrahub/core/initialization.py
@@ -10,6 +10,7 @@ from infrahub.core.node import Node
 from infrahub.core.node.ipam import BuiltinIPPrefix
 from infrahub.core.node.resource_manager.ip_address_pool import CoreIPAddressPool
 from infrahub.core.node.resource_manager.ip_prefix_pool import CoreIPPrefixPool
+from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
 from infrahub.core.root import Root
 from infrahub.core.schema import SchemaRoot, core_models, internal_schema
 from infrahub.core.schema_manager import SchemaManager
@@ -79,6 +80,7 @@ async def initialize_registry(db: InfrahubDatabase, initialize: bool = False) ->
     registry.node[InfrahubKind.IPPREFIX] = BuiltinIPPrefix
     registry.node[InfrahubKind.IPADDRESSPOOL] = CoreIPAddressPool
     registry.node[InfrahubKind.IPPREFIXPOOL] = CoreIPPrefixPool
+    registry.node[InfrahubKind.NUMBERPOOL] = CoreNumberPool
 
 
 async def initialization(db: InfrahubDatabase) -> None:

--- a/backend/infrahub/core/node/resource_manager/number_pool.py
+++ b/backend/infrahub/core/node/resource_manager/number_pool.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+from infrahub.core.query.resource_manager import NumberPoolGetReserved, NumberPoolGetUsed, NumberPoolSetReserved
+from infrahub.exceptions import PoolExhaustedError
+
+from .. import Node
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.database import InfrahubDatabase
+
+
+class CoreNumberPool(Node):
+    async def get_resource(
+        self,
+        db: InfrahubDatabase,
+        branch: Branch,
+        node: Node,
+        identifier: Optional[str] = None,
+    ) -> int:
+        identifier = identifier or node.get_id()
+        # Check if there is already a resource allocated with this identifier
+        # if not, pull all existing prefixes and allocated the next available
+        # TODO add support for branch, if the node is reserved with this id in another branch we should return an error
+        query_get = await NumberPoolGetReserved.init(db=db, pool_id=self.id, identifier=identifier)
+        await query_get.execute(db=db)
+        result = query_get.get_result()
+        if result:
+            value = result.get_as_optional_type("reservation.value", return_type=int)
+            if value is not None:
+                return value
+
+        # If we have not returned a value we need to find one if avaiable
+        number = await self.get_next(db=db, branch=branch)
+
+        query_set = await NumberPoolSetReserved.init(
+            db=db, pool_id=self.get_id(), identifier=identifier, reserved=number
+        )
+        await query_set.execute(db=db)
+
+        return number
+
+    async def get_next(self, db: InfrahubDatabase, branch: Branch) -> int:
+        query = await NumberPoolGetUsed.init(db=db, branch=branch, pool=self, branch_agnostic=True)
+
+        await query.execute(db=db)
+        taken = [result.get_as_optional_type("av.value", return_type=int) for result in query.results]
+        next_number = find_next_free(
+            start=self.start_range.value,  # type: ignore[attr-defined]
+            end=self.end_range.value,  # type: ignore[attr-defined]
+            taken=taken,
+        )
+        if next_number is None:
+            raise PoolExhaustedError("There are no more addresses available in this pool.")
+
+        return next_number
+
+
+def find_next_free(start: int, end: int, taken: list[int | None]) -> Optional[int]:
+    used_numbers = [number for number in taken if number is not None]
+    used_set = set(used_numbers)
+
+    for num in range(start, end + 1):
+        if num not in used_set:
+            return num
+
+    return None

--- a/backend/infrahub/core/node/resource_manager/number_pool.py
+++ b/backend/infrahub/core/node/resource_manager/number_pool.py
@@ -24,7 +24,7 @@ class CoreNumberPool(Node):
         # Check if there is already a resource allocated with this identifier
         # if not, pull all existing prefixes and allocated the next available
         # TODO add support for branch, if the node is reserved with this id in another branch we should return an error
-        query_get = await NumberPoolGetReserved.init(db=db, pool_id=self.id, identifier=identifier)
+        query_get = await NumberPoolGetReserved.init(db=db, branch=branch, pool_id=self.id, identifier=identifier)
         await query_get.execute(db=db)
         result = query_get.get_result()
         if result:

--- a/backend/infrahub/core/node/resource_manager/number_pool.py
+++ b/backend/infrahub/core/node/resource_manager/number_pool.py
@@ -26,11 +26,9 @@ class CoreNumberPool(Node):
         # TODO add support for branch, if the node is reserved with this id in another branch we should return an error
         query_get = await NumberPoolGetReserved.init(db=db, branch=branch, pool_id=self.id, identifier=identifier)
         await query_get.execute(db=db)
-        result = query_get.get_result()
-        if result:
-            value = result.get_as_optional_type("reservation.value", return_type=int)
-            if value is not None:
-                return value
+        reservation = query_get.get_reservation()
+        if reservation is not None:
+            return reservation
 
         # If we have not returned a value we need to find one if avaiable
         number = await self.get_next(db=db, branch=branch)

--- a/backend/infrahub/core/query/__init__.py
+++ b/backend/infrahub/core/query/__init__.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Generator, Iterator, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Generator, Iterator, Optional, TypeVar, Union
 
 import ujson
 from neo4j.graph import Node as Neo4jNode
@@ -23,6 +23,8 @@ if TYPE_CHECKING:
 
     from infrahub.core.branch import Branch
     from infrahub.database import InfrahubDatabase
+
+RETURN_TYPE = TypeVar("RETURN_TYPE")
 
 
 def sort_results_by_time(results: list[QueryResult], rel_label: str) -> list[QueryResult]:
@@ -224,6 +226,27 @@ class QueryResult:
         if item:
             return str(item)
         return None
+
+    def get_as_optional_type(self, label: str, return_type: Callable[..., RETURN_TYPE]) -> Optional[RETURN_TYPE]:
+        """Return a label as a given type.
+
+        For example if an integer is needed the caller would use:
+        .get_as_optional_type(label="name_of_label", return_type=int)
+        """
+        item = self._get(label=label)
+        if item is not None:
+            return return_type(item)
+        return None
+
+    def get_as_type(self, label: str, return_type: Callable[..., RETURN_TYPE]) -> RETURN_TYPE:
+        """Return a label as a given type.
+
+        For example if an integer is needed the caller would use:
+        .get_as_type(label="name_of_label", return_type=int)
+        """
+        item = self._get(label=label)
+
+        return return_type(item)
 
     def get_node_collection(self, label: str) -> list[Neo4jNode]:
         entry = self._get(label=label)

--- a/backend/infrahub/core/query/resource_manager.py
+++ b/backend/infrahub/core/query/resource_manager.py
@@ -178,6 +178,12 @@ class NumberPoolGetReserved(Query):
         self.add_to_query(query)
         self.return_labels = ["reservation.value"]
 
+    def get_reservation(self) -> int | None:
+        result = self.get_result()
+        if result:
+            return result.get_as_optional_type("reservation.value", return_type=int)
+        return None
+
 
 class NumberPoolGetUsed(Query):
     name: str = "number_pool_get_used"

--- a/backend/infrahub/core/query/resource_manager.py
+++ b/backend/infrahub/core/query/resource_manager.py
@@ -162,10 +162,19 @@ class NumberPoolGetReserved(Query):
         self.params["pool_id"] = self.pool_id
         self.params["identifier"] = self.identifier
 
+        branch_filter, branch_params = self.branch.get_query_filter_path(
+            at=self.at.to_string(), branch_agnostic=self.branch_agnostic
+        )
+
+        self.params.update(branch_params)
+
         query = """
-        MATCH (pool:%(number_pool)s { uuid: $pool_id })-[rel:IS_RESERVED]->(reservation:AttributeValue)
-        WHERE rel.identifier = $identifier
-        """ % {"number_pool": InfrahubKind.NUMBERPOOL}
+        MATCH (pool:%(number_pool)s { uuid: $pool_id })-[r:IS_RESERVED]->(reservation:AttributeValue)
+        WHERE
+            r.identifier = $identifier
+            AND
+            %(branch_filter)s
+        """ % {"branch_filter": branch_filter, "number_pool": InfrahubKind.NUMBERPOOL}
         self.add_to_query(query)
         self.return_labels = ["reservation.value"]
 

--- a/backend/infrahub/pools/number.py
+++ b/backend/infrahub/pools/number.py
@@ -1,10 +1,16 @@
-from dataclasses import dataclass
-from typing import Optional, Union
+from __future__ import annotations
 
-from infrahub.core.protocols import CoreNode
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional, Union
+
+from infrahub.core.query.resource_manager import NumberPoolGetAllocated
 from infrahub.core.registry import registry
-from infrahub.core.timestamp import Timestamp
-from infrahub.database import InfrahubDatabase
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.core.protocols import CoreNode
+    from infrahub.core.timestamp import Timestamp
+    from infrahub.database import InfrahubDatabase
 
 
 @dataclass
@@ -14,10 +20,13 @@ class UsedNumber:
 
 
 class NumberUtilizationGetter:
-    def __init__(self, db: InfrahubDatabase, pool: CoreNode, at: Optional[Union[Timestamp, str]] = None) -> None:
+    def __init__(
+        self, db: InfrahubDatabase, pool: CoreNode, branch: Branch, at: Optional[Union[Timestamp, str]] = None
+    ) -> None:
         self.db = db
         self.at = at
         self.pool = pool
+        self.branch = branch
         self.start_range = int(pool.start_range.value)  # type: ignore[attr-defined]
         self.end_range = int(pool.end_range.value)  # type: ignore[attr-defined]
         self.used: list[UsedNumber] = []
@@ -25,26 +34,20 @@ class NumberUtilizationGetter:
         self.used_branches: set[int] = set()
 
     async def load_data(self) -> None:
-        existing_nodes = await registry.manager.query(
-            db=self.db,
-            schema=self.pool.node.value,  # type: ignore[attr-defined]
-            at=self.at,
-            branch_agnostic=True,
-        )
+        query = await NumberPoolGetAllocated.init(db=self.db, pool=self.pool, branch=self.branch, branch_agnostic=True)
+        await query.execute(db=self.db)
+
         self.used = [
-            UsedNumber(number=getattr(node, self.pool.node_attribute.value).value, branch=node._branch.name)  # type: ignore[attr-defined]
-            for node in existing_nodes
+            UsedNumber(
+                number=result.get_as_type(label="value", return_type=int),
+                branch=result.get_as_type(label="branch", return_type=str),
+            )
+            for result in query.results
+            if result.get_as_optional_type(label="value", return_type=int) is not None
         ]
-        self.used_default_branch = {
-            entry.number
-            for entry in self.used
-            if self.start_range <= entry.number <= self.end_range and entry.branch == registry.default_branch
-        }
-        used_branches = {
-            entry.number
-            for entry in self.used
-            if self.start_range <= entry.number <= self.end_range and entry.branch != registry.default_branch
-        }
+
+        self.used_default_branch = {entry.number for entry in self.used if entry.branch == registry.default_branch}
+        used_branches = {entry.number for entry in self.used if entry.branch != registry.default_branch}
         self.used_branches = used_branches - self.used_default_branch
 
     @property

--- a/backend/infrahub/utils.py
+++ b/backend/infrahub/utils.py
@@ -33,16 +33,6 @@ def format_label(slug: str) -> str:
     return " ".join([word.title() for word in slug.split("_")])
 
 
-def find_next_free(start: int, end: int, used_numbers: list[int]) -> Optional[int]:
-    used_set = set(used_numbers)
-
-    for num in range(start, end + 1):
-        if num not in used_set:
-            return num
-
-    return None
-
-
 class MetaEnum(EnumMeta):
     def __contains__(cls, item: Any) -> bool:
         try:

--- a/backend/tests/unit/graphql/queries/test_resource_pool.py
+++ b/backend/tests/unit/graphql/queries/test_resource_pool.py
@@ -4,7 +4,7 @@ from graphql import graphql
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind
-from infrahub.core.initialization import create_branch
+from infrahub.core.initialization import create_branch, initialization
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.node.resource_manager.ip_address_pool import CoreIPAddressPool
@@ -573,7 +573,7 @@ async def test_read_resources_in_pool_with_branch_with_mutations(
 async def test_number_pool_utilization(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema):
     await load_schema(db=db, schema=SchemaRoot(nodes=[TICKET]))
     gql_params = prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
-
+    await initialization(db=db)
     create_ok = await graphql(
         schema=gql_params.schema,
         source=CREATE_NUMBER_POOL,


### PR DESCRIPTION
* Fix idempotency issues to ensure that mutations using an id or an hfid will return the same value as previously allocated
* Fix issue where numbers outside of the number pool range were seen when looking at allocations from that pool
* Adds CoreNumberPool as a custom Node in the registry
* Swaps check within the Node class so that ID is assigned before processing fields, this is because we require a node ID to create a reserveration. Due to this change I also had to change the checks for `if not self.id` to `if not self._existing`
* Rewrite logic to manage reservations and assignments
* Rewrite logic to report utilization and allocations
* Adds QueryResult.get_as_type() and QueryResult.get_as_optional_type() to be able to specify the expected return data from a query result. (this could be useful in other locations where I noticed that we were calling .get_as_str() only to wrap the data back into a call to `int()`

After a discussion yesterday around the use of identifiers for the reservations I didn't want to persue that path as the expectation would be that the hfid of a node wouldn't change which doesn't have to be true. I think we need to reconsider how that actually works within the IP pools and figure out when and why to use it. I'd argue that the reservations should always be used with an ID that doesn't change (or if there's a static identifier chosen by the end user).

I also think that some additional though should be spent on how the reservations work with regards to merging of branches as the metadata doesn't currently get updated.

Note: In this iteration I haven't changed the from_pool part when it comes to requiring an id. I think it might be easier to add that part in a follow up PR if we want to be able to assign from the pool based on the hfid of the pool as opposed to using an id.