### PR TITLE
make diff responses consistent with NULL vs being empty

### DIFF
--- a/backend/infrahub/core/diff/query/diff_summary.py
+++ b/backend/infrahub/core/diff/query/diff_summary.py
@@ -92,10 +92,13 @@ class DiffSummaryQuery(Query):
             "SUM(diff_node.num_conflicts) as num_conflicts",
             "min(diff_root.from_time) as from_time",
             "max(diff_root.to_time) as to_time",
+            "count(diff_root) as num_roots",
         ]
 
-    def get_summary(self) -> DiffSummaryCounters:
+    def get_summary(self) -> DiffSummaryCounters | None:
         result = self.get_result()
         if not result:
-            return DiffSummaryCounters(from_time=self.from_time, to_time=self.to_time)
+            return None
+        if result.get("num_roots") == 0:
+            return None
         return DiffSummaryCounters.from_graph(result)

--- a/backend/infrahub/core/diff/repository/repository.py
+++ b/backend/infrahub/core/diff/repository/repository.py
@@ -87,7 +87,7 @@ class DiffRepository:
         from_time: Timestamp,
         to_time: Timestamp,
         filters: dict | None = None,
-    ) -> DiffSummaryCounters:
+    ) -> DiffSummaryCounters | None:
         query = await DiffSummaryQuery.init(
             db=self.db,
             base_branch_name=base_branch_name,

--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -401,6 +401,7 @@ class DiffTreeResolver:
             include_parents=include_parents,
             limit=limit,
             offset=offset,
+            include_empty=True,
         )
         if not enriched_diffs:
             return None
@@ -454,6 +455,8 @@ class DiffTreeResolver:
             to_time=to_timestamp,
             filters=filters_dict,
         )
+        if summary is None:
+            return None
 
         diff_tree_summary = DiffTreeSummary(
             base_branch=base_branch.name,


### PR DESCRIPTION
update the response of `DiffTree` and `DiffTreeSummary` so that they are different when there are no diffs for the selected parameters vs when there is an empty diff, which indicates no changes

a request for which no diff exists will get a `null` response
a request for which an empty diff exists will get a regular looking response, but `nodes` will be an empty array and all of the counters will be 0