### PR TITLE
IFC-618 fix diff relationship bug when conflicting changes with main changes after branch changes

### DIFF
--- a/backend/infrahub/core/diff/enricher/cardinality_one.py
+++ b/backend/infrahub/core/diff/enricher/cardinality_one.py
@@ -33,26 +33,14 @@ class DiffCardinalityOneEnricher(DiffEnricherInterface):
         self._node_schema_map: dict[str, MainSchemaTypes] = {}
 
     async def enrich(self, enriched_diff_root: EnrichedDiffRoot, calculated_diffs: CalculatedDiffs) -> None:
+        self._node_schema_map = {}
         for diff_node in enriched_diff_root.nodes:
             for relationship_group in diff_node.relationships:
                 if (
-                    self.is_cardinality_one(
-                        node_kind=diff_node.kind,
-                        relationship_name=relationship_group.name,
-                        diff_branch_name=enriched_diff_root.diff_branch_name,
-                    )
+                    relationship_group.cardinality is RelationshipCardinality.ONE
                     and len(relationship_group.relationships) > 0
                 ):
                     self.consolidate_cardinality_one_diff_elements(diff_relationship=relationship_group)
-
-    def is_cardinality_one(self, node_kind: str, relationship_name: str, diff_branch_name: str) -> bool:
-        if node_kind not in self._node_schema_map:
-            self._node_schema_map[node_kind] = self.db.schema.get(
-                name=node_kind, branch=diff_branch_name, duplicate=False
-            )
-        node_schema = self._node_schema_map[node_kind]
-        relationship_schema = node_schema.get_relationship(name=relationship_name)
-        return relationship_schema.cardinality == RelationshipCardinality.ONE
 
     def _determine_action(self, previous_value: Any, new_value: Any) -> DiffAction:
         if previous_value == new_value:

--- a/backend/tests/unit/core/diff/test_cardinality_one_enricher.py
+++ b/backend/tests/unit/core/diff/test_cardinality_one_enricher.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 from uuid import uuid4
 
-from infrahub.core.constants import DiffAction
+from infrahub.core.constants import DiffAction, RelationshipCardinality
 from infrahub.core.constants.database import DatabaseEdgeType
 from infrahub.core.diff.enricher.cardinality_one import DiffCardinalityOneEnricher
 from infrahub.core.diff.model.path import EnrichedDiffProperty
@@ -23,7 +23,10 @@ class TestDiffCardinalityOneEnricher:
         branch = await create_branch(db=db, branch_name="branch")
         enricher = DiffCardinalityOneEnricher(db=db)
         diff_relationship = EnrichedRelationshipGroupFactory.build(
-            name="cars", nodes=set(), relationships={EnrichedRelationshipElementFactory.build() for _ in range(3)}
+            name="cars",
+            nodes=set(),
+            cardinality=RelationshipCardinality.MANY,
+            relationships={EnrichedRelationshipElementFactory.build() for _ in range(3)},
         )
         diff_node = EnrichedNodeFactory.build(kind="TestPerson", relationships={diff_relationship})
         diff_root = EnrichedRootFactory.build(diff_branch_name=branch.name, nodes={diff_node})
@@ -69,7 +72,10 @@ class TestDiffCardinalityOneEnricher:
         )
 
         diff_relationship = EnrichedRelationshipGroupFactory.build(
-            name="owner", nodes=set(), relationships={diff_rel_element_1, diff_rel_element_2}
+            name="owner",
+            nodes=set(),
+            cardinality=RelationshipCardinality.ONE,
+            relationships={diff_rel_element_1, diff_rel_element_2},
         )
         diff_node = EnrichedNodeFactory.build(kind="TestCar", relationships={diff_relationship})
         diff_root = EnrichedRootFactory.build(diff_branch_name=branch.name, nodes={diff_node})
@@ -157,7 +163,10 @@ class TestDiffCardinalityOneEnricher:
         )
 
         diff_relationship = EnrichedRelationshipGroupFactory.build(
-            name="owner", nodes=set(), relationships={diff_rel_element_1, diff_rel_element_2}
+            name="owner",
+            nodes=set(),
+            cardinality=RelationshipCardinality.ONE,
+            relationships={diff_rel_element_1, diff_rel_element_2},
         )
         diff_node = EnrichedNodeFactory.build(kind="TestCar", relationships={diff_relationship})
         diff_root = EnrichedRootFactory.build(diff_branch_name=branch.name, nodes={diff_node})
@@ -235,7 +244,10 @@ class TestDiffCardinalityOneEnricher:
         )
 
         diff_relationship = EnrichedRelationshipGroupFactory.build(
-            name="owner", nodes=set(), relationships={diff_rel_element_1, diff_rel_element_2}
+            name="owner",
+            nodes=set(),
+            cardinality=RelationshipCardinality.ONE,
+            relationships={diff_rel_element_1, diff_rel_element_2},
         )
         diff_node = EnrichedNodeFactory.build(kind="TestCar", relationships={diff_relationship})
         diff_root = EnrichedRootFactory.build(diff_branch_name=branch.name, nodes={diff_node})


### PR DESCRIPTION
IFC-618

fix a bug in diff calculation that affected relationships of cardinality=one when a conflicting change was made on the base branch AFTER the change on the diff branch