### PR TITLE
Apply a lock to DiffCoordinator._update_diffs()

### DIFF
--- a/backend/infrahub/core/diff/coordinator.py
+++ b/backend/infrahub/core/diff/coordinator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING
 
+from infrahub import lock
 from infrahub.core.timestamp import Timestamp
 
 from .model.path import BranchTrackingId, EnrichedDiffRoot, NameTrackingId, TimeRange, TrackingId
@@ -122,66 +123,67 @@ class DiffCoordinator:
         to_time: Timestamp,
         tracking_id: TrackingId | None = None,
     ) -> EnrichedDiffRoot:
-        requested_diff_branches = {base_branch.name: base_branch, diff_branch.name: diff_branch}
-        aggregated_diffs_by_branch_name: dict[str, EnrichedDiffRoot] = {}
-        diff_uuids_to_delete = []
-        for branch in requested_diff_branches.values():
-            retrieved_enriched_diffs = await self.diff_repo.get(
-                base_branch_name=base_branch.name,
-                diff_branch_names=[branch.name],
-                from_time=from_time,
-                to_time=to_time,
-                tracking_id=tracking_id,
-                include_empty=True,
-            )
-            if tracking_id:
-                diff_uuids_to_delete += [
-                    diff.uuid for diff in retrieved_enriched_diffs if diff.tracking_id == tracking_id
-                ]
-            covered_time_ranges = [
-                TimeRange(from_time=enriched_diff.from_time, to_time=enriched_diff.to_time)
-                for enriched_diff in retrieved_enriched_diffs
-            ]
-            missing_time_ranges = self._get_missing_time_ranges(
-                time_ranges=covered_time_ranges, from_time=from_time, to_time=to_time
-            )
-            all_enriched_diffs = list(retrieved_enriched_diffs)
-            for missing_time_range in missing_time_ranges:
-                diff_request = EnrichedDiffRequest(
-                    base_branch=base_branch,
-                    diff_branch=branch,
-                    from_time=missing_time_range.from_time,
-                    to_time=missing_time_range.to_time,
+        async with lock.registry.get(name=f"{base_branch.name}__{diff_branch.name}", namespace="branch-diff"):
+            requested_diff_branches = {base_branch.name: base_branch, diff_branch.name: diff_branch}
+            aggregated_diffs_by_branch_name: dict[str, EnrichedDiffRoot] = {}
+            diff_uuids_to_delete = []
+            for branch in requested_diff_branches.values():
+                retrieved_enriched_diffs = await self.diff_repo.get(
+                    base_branch_name=base_branch.name,
+                    diff_branch_names=[branch.name],
+                    from_time=from_time,
+                    to_time=to_time,
+                    tracking_id=tracking_id,
+                    include_empty=True,
                 )
-                enriched_diff = await self._get_enriched_diff(diff_request=diff_request)
-                all_enriched_diffs.append(enriched_diff)
-            all_enriched_diffs.sort(key=lambda e_diff: e_diff.from_time)
-            combined_diff = all_enriched_diffs[0]
-            for next_diff in all_enriched_diffs[1:]:
-                combined_diff = await self.diff_combiner.combine(earlier_diff=combined_diff, later_diff=next_diff)
-            aggregated_diffs_by_branch_name[branch.name] = combined_diff
+                if tracking_id:
+                    diff_uuids_to_delete += [
+                        diff.uuid for diff in retrieved_enriched_diffs if diff.tracking_id == tracking_id
+                    ]
+                covered_time_ranges = [
+                    TimeRange(from_time=enriched_diff.from_time, to_time=enriched_diff.to_time)
+                    for enriched_diff in retrieved_enriched_diffs
+                ]
+                missing_time_ranges = self._get_missing_time_ranges(
+                    time_ranges=covered_time_ranges, from_time=from_time, to_time=to_time
+                )
+                all_enriched_diffs = list(retrieved_enriched_diffs)
+                for missing_time_range in missing_time_ranges:
+                    diff_request = EnrichedDiffRequest(
+                        base_branch=base_branch,
+                        diff_branch=branch,
+                        from_time=missing_time_range.from_time,
+                        to_time=missing_time_range.to_time,
+                    )
+                    enriched_diff = await self._get_enriched_diff(diff_request=diff_request)
+                    all_enriched_diffs.append(enriched_diff)
+                all_enriched_diffs.sort(key=lambda e_diff: e_diff.from_time)
+                combined_diff = all_enriched_diffs[0]
+                for next_diff in all_enriched_diffs[1:]:
+                    combined_diff = await self.diff_combiner.combine(earlier_diff=combined_diff, later_diff=next_diff)
+                aggregated_diffs_by_branch_name[branch.name] = combined_diff
 
-        if len(aggregated_diffs_by_branch_name) > 1:
-            await self.conflicts_enricher.add_conflicts_to_branch_diff(
-                base_diff_root=aggregated_diffs_by_branch_name[base_branch.name],
-                branch_diff_root=aggregated_diffs_by_branch_name[diff_branch.name],
-            )
-            await self.labels_enricher.enrich(
-                enriched_diff_root=aggregated_diffs_by_branch_name[diff_branch.name], conflicts_only=True
-            )
+            if len(aggregated_diffs_by_branch_name) > 1:
+                await self.conflicts_enricher.add_conflicts_to_branch_diff(
+                    base_diff_root=aggregated_diffs_by_branch_name[base_branch.name],
+                    branch_diff_root=aggregated_diffs_by_branch_name[diff_branch.name],
+                )
+                await self.labels_enricher.enrich(
+                    enriched_diff_root=aggregated_diffs_by_branch_name[diff_branch.name], conflicts_only=True
+                )
 
-        if tracking_id:
+            if tracking_id:
+                for enriched_diff in aggregated_diffs_by_branch_name.values():
+                    enriched_diff.tracking_id = tracking_id
+                if diff_uuids_to_delete:
+                    await self.diff_repo.delete_diff_roots(diff_root_uuids=diff_uuids_to_delete)
+
             for enriched_diff in aggregated_diffs_by_branch_name.values():
-                enriched_diff.tracking_id = tracking_id
-            if diff_uuids_to_delete:
-                await self.diff_repo.delete_diff_roots(diff_root_uuids=diff_uuids_to_delete)
-
-        for enriched_diff in aggregated_diffs_by_branch_name.values():
-            await self.summary_counts_enricher.enrich(enriched_diff_root=enriched_diff)
-            await self.diff_repo.save(enriched_diff=enriched_diff)
-        branch_enriched_diff = aggregated_diffs_by_branch_name[diff_branch.name]
-        await self._update_core_data_checks(enriched_diff=enriched_diff)
-        return branch_enriched_diff
+                await self.summary_counts_enricher.enrich(enriched_diff_root=enriched_diff)
+                await self.diff_repo.save(enriched_diff=enriched_diff)
+            branch_enriched_diff = aggregated_diffs_by_branch_name[diff_branch.name]
+            await self._update_core_data_checks(enriched_diff=enriched_diff)
+            return branch_enriched_diff
 
     async def _update_core_data_checks(self, enriched_diff: EnrichedDiffRoot) -> list[Node]:
         return await self.data_check_synchronizer.synchronize(enriched_diff=enriched_diff)


### PR DESCRIPTION
This PR adds a lock to DiffCoordinator._update_diffs() using the base and diff branch names as keys.

This iteration is based on a simplistic approach where we wait for the previous _update_diffs to completed before running it again. I.e., no consideration is given depending on if we call the update method from `.create_or_update_arbitrary_timeframe_diff()` or from `.update_branch_diff()`. 

Depending on how long it takes to run this method I think this approach would make most sense as changes could have been made to the branch after the initial lock was created and the second update request was made.

One thing to note is that applying the lock in this way hangs the request frontend. I.e. until the previous request is completed and the lock is released and until the following request is completed the frontend request is going to hang here and wait for a response.
![Screenshot 2024-09-03 at 13 23 23](https://github.com/user-attachments/assets/091d7aca-8115-4c64-8f42-bee6f8a7da86)

I don't know if browsers typically has a request timeout in these situations or if we should rethink this logic in the future.

Also I don't like the way we manage the lock like this with regards to it being a global object, I'd like to move it into the services object so that we can initialize the lock the same way as with the service adapters within the CI.
