### PR TITLE
IFC-575 new logic to recalculating a diff and maintaining conflicts

### DIFF
--- a/backend/infrahub/core/diff/combiner.py
+++ b/backend/infrahub/core/diff/combiner.py
@@ -109,8 +109,9 @@ class DiffCombiner:
         }
         return actions_map[(earlier, later)]
 
-    def _combine_conflicts(
-        self, earlier: EnrichedDiffConflict | None, later: EnrichedDiffConflict | None
+    @staticmethod
+    def combine_conflicts(
+        earlier: EnrichedDiffConflict | None, later: EnrichedDiffConflict | None
     ) -> EnrichedDiffConflict | None:
         if later is None:
             return None
@@ -143,9 +144,7 @@ class DiffCombiner:
             later_property = later_props_by_type[earlier_property.property_type]
             if not self._should_include(earlier=earlier_property.action, later=later_property.action):
                 continue
-            combined_conflict = self._combine_conflicts(
-                earlier=earlier_property.conflict, later=later_property.conflict
-            )
+            combined_conflict = self.combine_conflicts(earlier=earlier_property.conflict, later=later_property.conflict)
             combined_properties.add(
                 replace(
                     later_property,
@@ -225,7 +224,7 @@ class DiffCombiner:
             peer_label=peer_label,
             path_identifier=final_element.path_identifier,
             properties=combined_properties,
-            conflict=self._combine_conflicts(earlier=ordered_elements[0].conflict, later=final_element.conflict),
+            conflict=self.combine_conflicts(earlier=ordered_elements[0].conflict, later=final_element.conflict),
         )
 
     def _combined_cardinality_many_relationship_elements(
@@ -342,9 +341,7 @@ class DiffCombiner:
                     path_identifier=node_pair.later.path_identifier,
                     attributes=combined_attributes,
                     relationships=combined_relationships,
-                    conflict=self._combine_conflicts(
-                        earlier=node_pair.earlier.conflict, later=node_pair.later.conflict
-                    ),
+                    conflict=self.combine_conflicts(earlier=node_pair.earlier.conflict, later=node_pair.later.conflict),
                 )
             )
         return combined_nodes

--- a/backend/infrahub/core/diff/conflict_transferer.py
+++ b/backend/infrahub/core/diff/conflict_transferer.py
@@ -1,0 +1,75 @@
+from .combiner import DiffCombiner
+from .model.path import (
+    EnrichedDiffAttribute,
+    EnrichedDiffNode,
+    EnrichedDiffRelationship,
+    EnrichedDiffRoot,
+    EnrichedDiffSingleRelationship,
+)
+
+
+class DiffConflictTransferer:
+    def __init__(self, diff_combiner: DiffCombiner):
+        self.diff_combiner = diff_combiner
+
+    async def transfer(self, earlier: EnrichedDiffRoot, later: EnrichedDiffRoot) -> None:
+        earlier_node_map = {n.uuid: n for n in earlier.nodes}
+        later_node_map = {n.uuid: n for n in later.nodes}
+        common_node_uuids = set(earlier_node_map.keys()) & set(later_node_map.keys())
+        for node_uuid in common_node_uuids:
+            earlier_node = earlier_node_map[node_uuid]
+            later_node = later_node_map[node_uuid]
+            self._transfer_node_conflicts(earlier=earlier_node, later=later_node)
+
+    def _transfer_node_conflicts(self, earlier: EnrichedDiffNode, later: EnrichedDiffNode) -> None:
+        if earlier.action is later.action:
+            later.conflict = self.diff_combiner.combine_conflicts(earlier=earlier.conflict, later=later.conflict)
+
+        earlier_attribute_map = {a.name: a for a in earlier.attributes}
+        later_attribute_map = {a.name: a for a in later.attributes}
+        common_attribute_names = set(earlier_attribute_map.keys()) & set(later_attribute_map.keys())
+        for attr_name in common_attribute_names:
+            earlier_attribute = earlier_attribute_map[attr_name]
+            later_attribute = later_attribute_map[attr_name]
+            self._transfer_property_conflicts(earlier=earlier_attribute, later=later_attribute)
+        earlier_relationship_map = {r.name: r for r in earlier.relationships}
+        later_relationship_map = {r.name: r for r in later.relationships}
+        common_relationship_names = set(earlier_relationship_map.keys()) & set(later_relationship_map.keys())
+        for relationship_name in common_relationship_names:
+            earlier_relationship = earlier_relationship_map[relationship_name]
+            later_relationship = later_relationship_map[relationship_name]
+            self._transfer_relationship_conflicts(
+                earlier=earlier_relationship,
+                later=later_relationship,
+            )
+
+    def _transfer_property_conflicts(
+        self,
+        earlier: EnrichedDiffAttribute | EnrichedDiffSingleRelationship,
+        later: EnrichedDiffAttribute | EnrichedDiffSingleRelationship,
+    ) -> None:
+        earlier_property_map = {p.property_type: p for p in earlier.properties}
+        later_property_map = {p.property_type: p for p in later.properties}
+        common_property_types = set(earlier_property_map.keys()) & set(later_property_map.keys())
+        for property_type in common_property_types:
+            earlier_property = earlier_property_map[property_type]
+            later_property = later_property_map[property_type]
+            later_property.conflict = self.diff_combiner.combine_conflicts(
+                earlier=earlier_property.conflict, later=later_property.conflict
+            )
+
+    def _transfer_relationship_conflicts(
+        self,
+        earlier: EnrichedDiffRelationship,
+        later: EnrichedDiffRelationship,
+    ) -> None:
+        earlier_elements_by_peer_id = {element.peer_id: element for element in earlier.relationships}
+        later_elements_by_peer_id = {element.peer_id: element for element in later.relationships}
+        common_peer_ids = set(earlier_elements_by_peer_id.keys()) & set(later_elements_by_peer_id.keys())
+        for peer_id in common_peer_ids:
+            earlier_element = earlier_elements_by_peer_id[peer_id]
+            later_element = later_elements_by_peer_id[peer_id]
+            later_element.conflict = self.diff_combiner.combine_conflicts(
+                earlier=earlier_element.conflict, later=later_element.conflict
+            )
+            self._transfer_property_conflicts(earlier=earlier_element, later=later_element)

--- a/backend/infrahub/core/diff/conflicts_enricher.py
+++ b/backend/infrahub/core/diff/conflicts_enricher.py
@@ -1,6 +1,6 @@
 from uuid import uuid4
 
-from infrahub.core.constants import RelationshipCardinality
+from infrahub.core.constants import DiffAction, RelationshipCardinality
 from infrahub.core.constants.database import DatabaseEdgeType
 from infrahub.database import InfrahubDatabase
 
@@ -151,7 +151,10 @@ class ConflictsEnricher:
         for property_type in common_property_types:
             base_property = base_properties_by_type[property_type]
             branch_property = branch_properties_by_type[property_type]
-            same_value = base_property.new_value == branch_property.new_value
+            same_value = base_property.new_value == branch_property.new_value or (
+                base_property.action is DiffAction.UNCHANGED
+                and base_property.previous_value == branch_property.previous_value
+            )
             # special handling for cardinality-one peer ID conflict
             if branch_property.property_type is DatabaseEdgeType.IS_RELATED and is_cardinality_one:
                 if same_value:

--- a/backend/infrahub/core/diff/model/path.py
+++ b/backend/infrahub/core/diff/model/path.py
@@ -66,6 +66,15 @@ class NameTrackingId(TrackingId):
     prefix = "name"
 
 
+def deserialize_tracking_id(tracking_id_str: str) -> TrackingId:
+    for tracking_id_class in (BranchTrackingId, NameTrackingId):
+        try:
+            return tracking_id_class.deserialize(id_string=tracking_id_str)
+        except ValueError:
+            ...
+    raise ValueError(f"{tracking_id_str} is not a valid TrackingId")
+
+
 @dataclass
 class BaseSummary:
     num_added: int = field(default=0, kw_only=True)

--- a/backend/infrahub/core/diff/query/diff_get.py
+++ b/backend/infrahub/core/diff/query/diff_get.py
@@ -15,6 +15,7 @@ QUERY_MATCH_NODES = """
     AND diff_root.from_time >= $from_time
     AND diff_root.to_time <= $to_time
     AND ($tracking_id IS NULL OR diff_root.tracking_id = $tracking_id)
+    AND ($diff_id IS NULL OR diff_root.uuid = $diff_id)
     WITH diff_root
     ORDER BY diff_root.base_branch, diff_root.diff_branch, diff_root.from_time, diff_root.to_time
     WITH diff_root.base_branch AS bb, diff_root.diff_branch AS db, collect(diff_root) AS same_branch_diff_roots
@@ -49,6 +50,7 @@ class EnrichedDiffGetQuery(Query):
         from_time: Timestamp | None = None,
         to_time: Timestamp | None = None,
         tracking_id: TrackingId | None = None,
+        diff_id: str | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -58,6 +60,7 @@ class EnrichedDiffGetQuery(Query):
         self.to_time: Timestamp = to_time or Timestamp()
         self.max_depth = max_depth
         self.tracking_id = tracking_id
+        self.diff_id = diff_id
         self.filters = filters or EnrichedDiffQueryFilters()
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:
@@ -67,6 +70,7 @@ class EnrichedDiffGetQuery(Query):
             "from_time": self.from_time.to_string(),
             "to_time": self.to_time.to_string(),
             "tracking_id": self.tracking_id.serialize() if self.tracking_id else None,
+            "diff_id": self.diff_id,
             "limit": self.limit,
             "offset": self.offset,
         }

--- a/backend/infrahub/core/diff/query/diff_summary.py
+++ b/backend/infrahub/core/diff/query/diff_summary.py
@@ -68,6 +68,7 @@ class DiffSummaryQuery(Query):
             "from_time": self.from_time.to_string(),
             "to_time": self.to_time.to_string(),
             "tracking_id": self.tracking_id.serialize() if self.tracking_id else None,
+            "diff_id": None,
         }
 
         # ruff: noqa: E501

--- a/backend/infrahub/core/diff/query/empty_roots.py
+++ b/backend/infrahub/core/diff/query/empty_roots.py
@@ -1,0 +1,22 @@
+from typing import Any, Generator
+
+from neo4j.graph import Node as Neo4jNode
+
+from infrahub.core.query import Query, QueryType
+from infrahub.database import InfrahubDatabase
+
+
+class EnrichedDiffEmptyRootsQuery(Query):
+    name = "enriched_diff_empty_roots"
+    type = QueryType.READ
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:
+        query = """
+        MATCH (diff_root:DiffRoot)
+        """
+        self.return_labels = ["diff_root"]
+        self.add_to_query(query=query)
+
+    def get_empty_root_nodes(self) -> Generator[Neo4jNode, None, None]:
+        for result in self.get_results():
+            yield result.get_node("diff_root")

--- a/backend/infrahub/core/diff/query/empty_roots.py
+++ b/backend/infrahub/core/diff/query/empty_roots.py
@@ -10,9 +10,20 @@ class EnrichedDiffEmptyRootsQuery(Query):
     name = "enriched_diff_empty_roots"
     type = QueryType.READ
 
+    def __init__(
+        self, diff_branch_names: list[str] | None = None, base_branch_names: list[str] | None = None, **kwargs: Any
+    ) -> None:
+        super().__init__(**kwargs)
+        self.diff_branch_names = diff_branch_names
+        self.base_branch_names = base_branch_names
+
     async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:
+        self.params = {"diff_branch_names": self.diff_branch_names, "base_branch_names": self.base_branch_names}
+
         query = """
         MATCH (diff_root:DiffRoot)
+        WHERE ($diff_branch_names IS NULL OR diff_root.diff_branch IN $diff_branch_names)
+        AND ($base_branch_names IS NULL OR diff_root.base_branch IN $base_branch_names)
         """
         self.return_labels = ["diff_root"]
         self.add_to_query(query=query)

--- a/backend/infrahub/core/diff/repository/repository.py
+++ b/backend/infrahub/core/diff/repository/repository.py
@@ -8,6 +8,7 @@ from ..model.path import ConflictSelection, EnrichedDiffConflict, EnrichedDiffRo
 from ..query.delete_query import EnrichedDiffDeleteQuery
 from ..query.diff_get import EnrichedDiffGetQuery
 from ..query.diff_summary import DiffSummaryCounters, DiffSummaryQuery
+from ..query.empty_roots import EnrichedDiffEmptyRootsQuery
 from ..query.filters import EnrichedDiffQueryFilters
 from ..query.get_conflict_query import EnrichedDiffConflictQuery
 from ..query.save_query import EnrichedDiffSaveQuery
@@ -119,6 +120,14 @@ class DiffRepository:
         )
         await query.execute(db=self.db)
         return await query.get_time_ranges()
+
+    async def get_empty_roots(self) -> list[EnrichedDiffRoot]:
+        query = await EnrichedDiffEmptyRootsQuery.init(db=self.db)
+        await query.execute(db=self.db)
+        diff_roots = []
+        for neo4j_node in query.get_empty_root_nodes():
+            diff_roots.append(self.deserializer.build_diff_root(root_node=neo4j_node))
+        return diff_roots
 
     async def get_conflict_by_id(self, conflict_id: str) -> EnrichedDiffConflict:
         query = await EnrichedDiffConflictQuery.init(db=self.db, conflict_id=conflict_id)

--- a/backend/infrahub/dependencies/builder/diff/conflict_transferer.py
+++ b/backend/infrahub/dependencies/builder/diff/conflict_transferer.py
@@ -1,0 +1,10 @@
+from infrahub.core.diff.conflict_transferer import DiffConflictTransferer
+from infrahub.dependencies.interface import DependencyBuilder, DependencyBuilderContext
+
+from .combiner import DiffCombinerDependency
+
+
+class DiffConflictTransfererDependency(DependencyBuilder[DiffConflictTransferer]):
+    @classmethod
+    def build(cls, context: DependencyBuilderContext) -> DiffConflictTransferer:
+        return DiffConflictTransferer(diff_combiner=DiffCombinerDependency.build(context=context))

--- a/backend/infrahub/dependencies/builder/diff/coordinator.py
+++ b/backend/infrahub/dependencies/builder/diff/coordinator.py
@@ -3,6 +3,7 @@ from infrahub.dependencies.interface import DependencyBuilder, DependencyBuilder
 
 from .calculator import DiffCalculatorDependency
 from .combiner import DiffCombinerDependency
+from .conflict_transferer import DiffConflictTransfererDependency
 from .conflicts_enricher import DiffConflictsEnricherDependency
 from .data_check_synchronizer import DiffDataCheckSynchronizerDependency
 from .enricher.aggregated import DiffAggregatedEnricherDependency
@@ -23,4 +24,5 @@ class DiffCoordinatorDependency(DependencyBuilder[DiffCoordinator]):
             labels_enricher=DiffLabelsEnricherDependency.build(context=context),
             summary_counts_enricher=DiffSummaryCountsEnricherDependency.build(context=context),
             data_check_synchronizer=DiffDataCheckSynchronizerDependency.build(context=context),
+            conflict_transferer=DiffConflictTransfererDependency.build(context=context),
         )

--- a/backend/infrahub/graphql/mutations/branch.py
+++ b/backend/infrahub/graphql/mutations/branch.py
@@ -244,23 +244,22 @@ class BranchRebase(Mutation):
 
             ok = True
 
-            if context.service:
-                log_data = get_log_data()
-                request_id = log_data.get("request_id", "")
-                differ = await merger.get_graph_diff()
-                diff_parser = IpamDiffParser(
-                    db=context.db,
-                    differ=differ,
-                    source_branch_name=obj.name,
-                    target_branch_name=registry.default_branch,
-                )
-                ipam_node_details = await diff_parser.get_changed_ipam_node_details()
-                message = messages.EventBranchRebased(
-                    branch=obj.name,
-                    ipam_node_details=ipam_node_details,
-                    meta=Meta(initiator_id=WORKER_IDENTITY, request_id=request_id),
-                )
-                await context.service.send(message=message)
+            log_data = get_log_data()
+            request_id = log_data.get("request_id", "")
+            differ = await merger.get_graph_diff()
+            diff_parser = IpamDiffParser(
+                db=context.db,
+                differ=differ,
+                source_branch_name=obj.name,
+                target_branch_name=registry.default_branch,
+            )
+            ipam_node_details = await diff_parser.get_changed_ipam_node_details()
+            message = messages.EventBranchRebased(
+                branch=obj.name,
+                ipam_node_details=ipam_node_details,
+                meta=Meta(initiator_id=WORKER_IDENTITY, request_id=request_id),
+            )
+            await context.service.send(message=message)
 
             return cls(object=await obj.to_graphql(fields=fields.get("object", {})), ok=ok)
 

--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -370,6 +370,7 @@ class DiffTreeResolver:
         root: dict,
         info: GraphQLResolveInfo,
         branch: str | None = None,
+        name: str | None = None,
         from_time: datetime | None = None,
         to_time: datetime | None = None,
         filters: dict | None = None,
@@ -409,6 +410,7 @@ class DiffTreeResolver:
             include_parents=include_parents,
             limit=limit,
             offset=offset,
+            tracking_id=NameTrackingId(name) if name else None,
             include_empty=True,
         )
         if not enriched_diffs:

--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -415,7 +415,15 @@ class DiffTreeResolver:
         )
         if not enriched_diffs:
             return None
-        enriched_diff = enriched_diffs[0]
+        if len(enriched_diffs) > 0:
+            # take the one with the longest duration that covers multiple branches
+            enriched_diff = sorted(
+                enriched_diffs,
+                key=lambda d: (d.base_branch_name != d.diff_branch_name, d.to_time.obj - d.from_time.obj),
+                reverse=True,
+            )[0]
+        else:
+            enriched_diff = enriched_diffs[0]
 
         full_fields = await extract_fields(info.field_nodes[0].selection_set)
         diff_tree = await self.to_diff_tree(enriched_diff_root=enriched_diff, context=context)

--- a/backend/infrahub/message_bus/messages/__init__.py
+++ b/backend/infrahub/message_bus/messages/__init__.py
@@ -34,6 +34,7 @@ from .refresh_webhook_configuration import RefreshWebhookConfiguration
 from .request_artifact_generate import RequestArtifactGenerate
 from .request_artifactdefinition_check import RequestArtifactDefinitionCheck
 from .request_artifactdefinition_generate import RequestArtifactDefinitionGenerate
+from .request_diff_refresh import RequestDiffRefresh
 from .request_diff_update import RequestDiffUpdate
 from .request_generator_run import RequestGeneratorRun
 from .request_generatordefinition_check import RequestGeneratorDefinitionCheck
@@ -90,6 +91,7 @@ MESSAGE_MAP: dict[str, type[InfrahubMessage]] = {
     "request.artifact_definition.check": RequestArtifactDefinitionCheck,
     "request.artifact_definition.generate": RequestArtifactDefinitionGenerate,
     "request.diff.update": RequestDiffUpdate,
+    "request.diff.refresh": RequestDiffRefresh,
     "request.generator.run": RequestGeneratorRun,
     "request.generator_definition.check": RequestGeneratorDefinitionCheck,
     "request.generator_definition.run": RequestGeneratorDefinitionRun,

--- a/backend/infrahub/message_bus/messages/request_diff_refresh.py
+++ b/backend/infrahub/message_bus/messages/request_diff_refresh.py
@@ -7,4 +7,4 @@ class RequestDiffRefresh(InfrahubMessage):
     """Request diff be recalculated from scratch."""
 
     branch_name: str = Field(..., description="The branch associated with the diff")
-    tracking_id_str: str = Field(..., description="The serialized tracking_id for this diff")
+    diff_id: str = Field(..., description="The id for this diff")

--- a/backend/infrahub/message_bus/messages/request_diff_refresh.py
+++ b/backend/infrahub/message_bus/messages/request_diff_refresh.py
@@ -1,0 +1,10 @@
+from pydantic import Field
+
+from infrahub.message_bus import InfrahubMessage
+
+
+class RequestDiffRefresh(InfrahubMessage):
+    """Request diff be recalculated from scratch."""
+
+    branch_name: str = Field(..., description="The branch associated with the diff")
+    tracking_id_str: str = Field(..., description="The serialized tracking_id for this diff")

--- a/backend/infrahub/message_bus/operations/__init__.py
+++ b/backend/infrahub/message_bus/operations/__init__.py
@@ -45,6 +45,7 @@ COMMAND_MAP = {
     "refresh.registry.branches": refresh.registry.branches,
     "refresh.registry.rebased_branch": refresh.registry.rebased_branch,
     "refresh.webhook.configuration": refresh.webhook.configuration,
+    "request.diff.refresh": requests.diff.refresh,
     "request.diff.update": requests.diff.update,
     "request.generator.run": requests.generator.run,
     "request.generator_definition.check": requests.generator_definition.check,

--- a/backend/infrahub/message_bus/operations/event/branch.py
+++ b/backend/infrahub/message_bus/operations/event/branch.py
@@ -1,5 +1,9 @@
 from typing import List
 
+from infrahub.core import registry
+from infrahub.core.diff.model.path import EnrichedDiffRoot, NameTrackingId
+from infrahub.core.diff.repository.repository import DiffRepository
+from infrahub.dependencies.registry import get_component_registry
 from infrahub.log import get_logger
 from infrahub.message_bus import InfrahubMessage, messages
 from infrahub.services import InfrahubServices
@@ -41,6 +45,14 @@ async def merge(message: messages.EventBranchMerge, service: InfrahubServices) -
         messages.TriggerArtifactDefinitionGenerate(branch=message.target_branch),
         messages.TriggerGeneratorDefinitionRun(branch=message.target_branch),
     ]
+    open_branch_diffs = await get_diff_roots_for_open_branches(service=service)
+    for diff in open_branch_diffs:
+        if diff.tracking_id:
+            if isinstance(diff.tracking_id, NameTrackingId):
+                name = diff.tracking_id.name
+            else:
+                name = None
+            events.append(messages.RequestDiffUpdate(branch_name=diff.diff_branch_name, name=name))
 
     for event in events:
         event.assign_meta(parent=message)
@@ -58,6 +70,28 @@ async def rebased(message: messages.EventBranchRebased, service: InfrahubService
             messages.TriggerIpamReconciliation(branch=message.branch, ipam_node_details=message.ipam_node_details),
         )
 
+    open_branch_diffs = await get_diff_roots_for_open_branches(service=service)
+    for diff in open_branch_diffs:
+        if diff.tracking_id:
+            events.append(
+                messages.RequestDiffRefresh(
+                    branch_name=diff.diff_branch_name, tracking_id_str=diff.tracking_id.serialize()
+                )
+            )
+
     for event in events:
         event.assign_meta(parent=message)
         await service.send(message=event)
+
+
+async def get_diff_roots_for_open_branches(service: InfrahubServices) -> list[EnrichedDiffRoot]:
+    component_registry = get_component_registry()
+    default_branch = registry.get_branch_from_registry()
+    diff_repository = await component_registry.get_component(DiffRepository, db=service.database, branch=default_branch)
+    all_diff_roots = await diff_repository.get_empty_roots()
+    open_branch_names = set()
+    for branch_name in registry.branch:
+        branch = registry.get_branch_from_registry(branch=branch_name)
+        if branch.status == "OPEN":
+            open_branch_names.add(branch.name)
+    return [dr for dr in all_diff_roots if dr.diff_branch_name in open_branch_names]

--- a/backend/infrahub/message_bus/operations/event/branch.py
+++ b/backend/infrahub/message_bus/operations/event/branch.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from infrahub.core import registry
-from infrahub.core.diff.model.path import EnrichedDiffRoot, NameTrackingId
+from infrahub.core.diff.model.path import BranchTrackingId
 from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.log import get_logger
@@ -45,14 +45,19 @@ async def merge(message: messages.EventBranchMerge, service: InfrahubServices) -
         messages.TriggerArtifactDefinitionGenerate(branch=message.target_branch),
         messages.TriggerGeneratorDefinitionRun(branch=message.target_branch),
     ]
-    open_branch_diffs = await get_diff_roots_for_open_branches(service=service)
-    for diff in open_branch_diffs:
-        if diff.tracking_id:
-            if isinstance(diff.tracking_id, NameTrackingId):
-                name = diff.tracking_id.name
-            else:
-                name = None
-            events.append(messages.RequestDiffUpdate(branch_name=diff.diff_branch_name, name=name))
+    component_registry = get_component_registry()
+    default_branch = registry.get_branch_from_registry()
+    diff_repository = await component_registry.get_component(DiffRepository, db=service.database, branch=default_branch)
+    # send diff update requests for every branch-tracking diff
+    branch_diff_roots = await diff_repository.get_empty_roots(base_branch_names=[message.target_branch])
+
+    for diff_root in branch_diff_roots:
+        if (
+            diff_root.base_branch_name != diff_root.diff_branch_name
+            and diff_root.tracking_id
+            and isinstance(diff_root.tracking_id, BranchTrackingId)
+        ):
+            events.append(messages.RequestDiffUpdate(branch_name=diff_root.diff_branch_name))
 
     for event in events:
         event.assign_meta(parent=message)
@@ -70,28 +75,16 @@ async def rebased(message: messages.EventBranchRebased, service: InfrahubService
             messages.TriggerIpamReconciliation(branch=message.branch, ipam_node_details=message.ipam_node_details),
         )
 
-    open_branch_diffs = await get_diff_roots_for_open_branches(service=service)
-    for diff in open_branch_diffs:
-        if diff.tracking_id:
-            events.append(
-                messages.RequestDiffRefresh(
-                    branch_name=diff.diff_branch_name, tracking_id_str=diff.tracking_id.serialize()
-                )
-            )
+    # for every diff that touches the rebased branch, recalculate it
+    component_registry = get_component_registry()
+    default_branch = registry.get_branch_from_registry()
+    diff_repository = await component_registry.get_component(DiffRepository, db=service.database, branch=default_branch)
+    diff_roots_to_refresh = await diff_repository.get_empty_roots(diff_branch_names=[message.branch])
+
+    for diff_root in diff_roots_to_refresh:
+        if diff_root.base_branch_name != diff_root.diff_branch_name:
+            events.append(messages.RequestDiffRefresh(branch_name=diff_root.diff_branch_name, diff_id=diff_root.uuid))
 
     for event in events:
         event.assign_meta(parent=message)
         await service.send(message=event)
-
-
-async def get_diff_roots_for_open_branches(service: InfrahubServices) -> list[EnrichedDiffRoot]:
-    component_registry = get_component_registry()
-    default_branch = registry.get_branch_from_registry()
-    diff_repository = await component_registry.get_component(DiffRepository, db=service.database, branch=default_branch)
-    all_diff_roots = await diff_repository.get_empty_roots()
-    open_branch_names = set()
-    for branch_name in registry.branch:
-        branch = registry.get_branch_from_registry(branch=branch_name)
-        if branch.status == "OPEN":
-            open_branch_names.add(branch.name)
-    return [dr for dr in all_diff_roots if dr.diff_branch_name in open_branch_names]

--- a/backend/infrahub/message_bus/operations/requests/diff.py
+++ b/backend/infrahub/message_bus/operations/requests/diff.py
@@ -1,5 +1,6 @@
 from infrahub.core import registry
 from infrahub.core.diff.coordinator import DiffCoordinator
+from infrahub.core.diff.model.path import deserialize_tracking_id
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.log import get_logger
 from infrahub.message_bus import messages
@@ -20,4 +21,16 @@ async def update(message: messages.RequestDiffUpdate, service: InfrahubServices)
         from_time=message.from_time,
         to_time=message.to_time,
         name=message.name,
+    )
+
+
+async def refresh(message: messages.RequestDiffRefresh, service: InfrahubServices) -> None:
+    component_registry = get_component_registry()
+    base_branch = await registry.get_branch(db=service.database, branch=registry.default_branch)
+    diff_branch = await registry.get_branch(db=service.database, branch=message.branch_name)
+    tracking_id = deserialize_tracking_id(tracking_id_str=message.tracking_id_str)
+
+    diff_coordinator = await component_registry.get_component(DiffCoordinator, db=service.database, branch=diff_branch)
+    await diff_coordinator.recalculate_for_tracked_diff(
+        base_branch=base_branch, diff_branch=diff_branch, tracking_id=tracking_id
     )

--- a/backend/infrahub/message_bus/operations/requests/diff.py
+++ b/backend/infrahub/message_bus/operations/requests/diff.py
@@ -1,6 +1,5 @@
 from infrahub.core import registry
 from infrahub.core.diff.coordinator import DiffCoordinator
-from infrahub.core.diff.model.path import deserialize_tracking_id
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.log import get_logger
 from infrahub.message_bus import messages
@@ -15,6 +14,7 @@ async def update(message: messages.RequestDiffUpdate, service: InfrahubServices)
     diff_branch = await registry.get_branch(db=service.database, branch=message.branch_name)
 
     diff_coordinator = await component_registry.get_component(DiffCoordinator, db=service.database, branch=diff_branch)
+
     await diff_coordinator.run_update(
         base_branch=base_branch,
         diff_branch=diff_branch,
@@ -28,9 +28,6 @@ async def refresh(message: messages.RequestDiffRefresh, service: InfrahubService
     component_registry = get_component_registry()
     base_branch = await registry.get_branch(db=service.database, branch=registry.default_branch)
     diff_branch = await registry.get_branch(db=service.database, branch=message.branch_name)
-    tracking_id = deserialize_tracking_id(tracking_id_str=message.tracking_id_str)
 
     diff_coordinator = await component_registry.get_component(DiffCoordinator, db=service.database, branch=diff_branch)
-    await diff_coordinator.recalculate_for_tracked_diff(
-        base_branch=base_branch, diff_branch=diff_branch, tracking_id=tracking_id
-    )
+    await diff_coordinator.recalculate(base_branch=base_branch, diff_branch=diff_branch, diff_id=message.diff_id)

--- a/backend/tests/integration/diff/test_diff_rebase.py
+++ b/backend/tests/integration/diff/test_diff_rebase.py
@@ -1,0 +1,215 @@
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from infrahub import config, lock
+from infrahub.core.diff.coordinator import DiffCoordinator
+import pytest
+from infrahub_sdk.exceptions import GraphQLError
+
+from infrahub.core import registry
+from infrahub.core.constants import BranchConflictKeep, DiffAction, InfrahubKind, ProposedChangeState
+from infrahub.core.constants.database import DatabaseEdgeType
+from infrahub.core.diff.model.path import BranchTrackingId, ConflictSelection, EnrichedDiffProperty, EnrichedDiffRoot
+from infrahub.core.diff.repository.repository import DiffRepository
+from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
+from infrahub.core.timestamp import Timestamp
+from infrahub.dependencies.registry import get_component_registry
+from infrahub.services.adapters.cache.redis import RedisCache
+from tests.constants import TestKind
+from tests.helpers.schema import CAR_SCHEMA, load_schema
+from tests.helpers.test_app import TestInfrahubApp
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClient
+
+    from infrahub.core.branch import Branch
+    from infrahub.database import InfrahubDatabase
+    from tests.adapters.message_bus import BusSimulator
+
+
+DIFF_UPDATE_QUERY = """
+mutation DiffUpdate($branch_name: String!, $wait_for_completion: Boolean) {
+    DiffUpdate(data: { branch: $branch_name, wait_for_completion: $wait_for_completion }) {
+        ok
+    }
+}
+"""
+
+BRANCH_MERGE = """
+mutation($branch: String!) {
+    BranchMerge(data: { name: $branch }) {
+        ok
+    }
+}
+"""
+
+
+
+class TestDiffRebase(TestInfrahubApp):
+    @pytest.fixture(scope="class", autouse=True)
+    def configure_settings(self):
+        config.SETTINGS.broker.enable = True
+        config.SETTINGS.cache.enable = False
+
+    @pytest.fixture(scope="class", autouse=True)
+    def initialize_lock(self):
+        lock.initialize_lock(local_only=True)
+
+    @pytest.fixture(scope="class")
+    async def initial_dataset(
+        self,
+        db: InfrahubDatabase,
+        default_branch,
+        client: InfrahubClient,
+        bus_simulator: BusSimulator,
+    ) -> dict[str, Node]:
+        await load_schema(db, schema=CAR_SCHEMA)
+        john = await Node.init(schema=TestKind.PERSON, db=db)
+        await john.new(db=db, name="John", height=175, description="The famous Joe Doe")
+        await john.save(db=db)
+        kara = await Node.init(schema=TestKind.PERSON, db=db)
+        await kara.new(db=db, name="Kara Thrace", height=165, description="Starbuck")
+        await kara.save(db=db)
+        murphy = await Node.init(schema=TestKind.PERSON, db=db)
+        await murphy.new(db=db, name="Alex Murphy", height=185, description="Robocop")
+        await murphy.save(db=db)
+        koenigsegg = await Node.init(schema=TestKind.MANUFACTURER, db=db)
+        await koenigsegg.new(db=db, name="Koenigsegg", customers=[john])
+        await koenigsegg.save(db=db)
+        omnicorp = await Node.init(schema=TestKind.MANUFACTURER, db=db)
+        await omnicorp.new(db=db, name="Omnicorp", customers=[murphy])
+        await omnicorp.save(db=db)
+        cyberdyne = await Node.init(schema=TestKind.MANUFACTURER, db=db)
+        await cyberdyne.new(db=db, name="Cyberdyne")
+        await cyberdyne.save(db=db)
+        people = await Node.init(schema=InfrahubKind.STANDARDGROUP, db=db)
+        await people.new(db=db, name="people", members=[john])
+        await people.save(db=db)
+
+        jesko = await Node.init(schema=TestKind.CAR, db=db)
+        await jesko.new(
+            db=db,
+            name="Jesko",
+            color="Red",
+            description="A limited production mid-engine sports car",
+            owner=john,
+            manufacturer=koenigsegg,
+        )
+        await jesko.save(db=db)
+        t_800 = await Node.init(schema=TestKind.CAR, db=db)
+        await t_800.new(
+            db=db,
+            name="Cyberdyne systems model 101",
+            color="Chrome",
+            description="killing machine with secret heart of gold",
+            owner=john,
+            manufacturer=cyberdyne,
+        )
+        await t_800.save(db=db)
+        ed_209 = await Node.init(schema=TestKind.CAR, db=db)
+        await ed_209.new(
+            db=db,
+            name="ED-209",
+            color="Chrome",
+            description="still working on doing stairs",
+            owner=john,
+            manufacturer=omnicorp,
+        )
+        await ed_209.save(db=db)
+
+        bus_simulator.service.cache = RedisCache()
+
+        return {
+            "john": john,
+            "kara": kara,
+            "murphy": murphy,
+            "koenigsegg": koenigsegg,
+            "omnicorp": omnicorp,
+            "cyberdyne": cyberdyne,
+            "people": people,
+            "jesko": jesko,
+            "t_800": t_800,
+            "ed_209": ed_209,
+        }
+
+    @pytest.fixture(scope="class")
+    async def branch_1(self, db: InfrahubDatabase) -> Branch:
+        return await create_branch(branch_name="branch_1", db=db)
+
+    @pytest.fixture(scope="class")
+    async def branch_2(self, db: InfrahubDatabase) -> Branch:
+        return await create_branch(branch_name="branch_2", db=db)
+
+    @pytest.fixture(scope="class")
+    def diff_coordinator(self, db: InfrahubDatabase) -> DiffCoordinator:
+        ...
+
+    @pytest.fixture(scope="class")
+    async def diff_repository(self, db: InfrahubDatabase, default_branch: Branch) -> DiffRepository:
+        component_registry = get_component_registry()
+        return await component_registry.get_component(DiffRepository, db=db, branch=default_branch)
+
+    @pytest.fixture(scope="class")
+    async def add_branches_and_diffs(self, db: InfrahubDatabase, client: InfrahubClient, default_branch: Branch, initial_dataset, branch_1: Branch, branch_2: Branch):
+        kara_id = initial_dataset["kara"].id
+        kara_branch_1 = await NodeManager.get_one(db=db, id=kara_id, branch=branch_1)
+        kara_branch_1.description.value = "branch-1-description"
+        await kara_branch_1.save(db=db)
+        kara_branch_2 = await NodeManager.get_one(db=db, id=kara_id, branch=branch_2)
+        kara_branch_2.description.value = "branch-2-description"
+        await kara_branch_2.save(db=db)
+
+        result = await client.execute_graphql(query=DIFF_UPDATE_QUERY, variables={"branch_name": branch_1.name})
+        assert result["DiffUpdate"]["ok"]
+        result = await client.execute_graphql(query=DIFF_UPDATE_QUERY, variables={"branch_name": branch_2.name})
+        assert result["DiffUpdate"]["ok"]
+
+    async def test_no_conflicts_before_merge(self, db: InfrahubDatabase, initial_dataset, add_branches_and_diffs, branch_1, branch_2, diff_repository: DiffRepository):
+        kara_id = initial_dataset["kara"].id
+        
+        branch_1_diff = await diff_repository.get_one(diff_branch_name=branch_1.name, tracking_id=BranchTrackingId(name=branch_1.name))
+        branch_2_diff = await diff_repository.get_one(diff_branch_name=branch_2.name, tracking_id=BranchTrackingId(name=branch_2.name))
+        for (new_value, branch_diff) in [("branch-1-description", branch_1_diff), ("branch-2-description", branch_2_diff)]:
+            assert len(branch_diff.nodes) == 1
+            kara_node = branch_diff.nodes.pop()
+            assert kara_node.uuid == kara_id
+            assert len(kara_node.attributes) == 1
+            description_attr = kara_node.attributes.pop()
+            assert description_attr.name == "description"
+            assert len(description_attr.properties) == 1
+            value_prop = description_attr.properties.pop()
+            assert value_prop.property_type is DatabaseEdgeType.HAS_VALUE
+            assert value_prop.previous_value == "Starbuck"
+            assert value_prop.new_value == new_value
+            assert value_prop.conflict is None
+
+    async def test_merge_causes_diff_update(self,db: InfrahubDatabase, client: InfrahubClient, initial_dataset, add_branches_and_diffs, branch_1, branch_2, diff_repository):
+        kara_id = initial_dataset["kara"].id
+        before_merge = Timestamp()
+        result = await client.execute_graphql(query=BRANCH_MERGE, variables={"branch": branch_1.name})
+        assert result["BranchMerge"]["ok"]
+
+        branch_2_diff = await diff_repository.get_one(diff_branch_name=branch_2.name, tracking_id=BranchTrackingId(name=branch_2.name))
+
+        assert len(branch_2_diff.nodes) == 1
+        assert branch_2_diff.to_time > before_merge
+        kara_node = branch_2_diff.nodes.pop()
+        assert kara_node.uuid == kara_id
+        assert len(kara_node.attributes) == 1
+        description_attr = kara_node.attributes.pop()
+        assert description_attr.name == "description"
+        assert len(description_attr.properties) == 1
+        value_prop = description_attr.properties.pop()
+        assert value_prop.property_type is DatabaseEdgeType.HAS_VALUE
+        assert value_prop.previous_value == "Starbuck"
+        assert value_prop.new_value == "branch-2-description"
+        assert value_prop.conflict
+        assert value_prop.conflict.base_branch_action is DiffAction.UPDATED
+        assert value_prop.conflict.base_branch_value == "branch-1-description"
+        assert value_prop.conflict.diff_branch_action is DiffAction.UPDATED
+        assert value_prop.conflict.diff_branch_value == "branch-2-description"

--- a/backend/tests/integration/diff/test_diff_rebase.py
+++ b/backend/tests/integration/diff/test_diff_rebase.py
@@ -1,18 +1,13 @@
-
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
+
+import pytest
 
 from infrahub import config, lock
-from infrahub.core.diff.coordinator import DiffCoordinator
-import pytest
-from infrahub_sdk.exceptions import GraphQLError
-
-from infrahub.core import registry
-from infrahub.core.constants import BranchConflictKeep, DiffAction, InfrahubKind, ProposedChangeState
+from infrahub.core.constants import DiffAction, InfrahubKind
 from infrahub.core.constants.database import DatabaseEdgeType
-from infrahub.core.diff.model.path import BranchTrackingId, ConflictSelection, EnrichedDiffProperty, EnrichedDiffRoot
+from infrahub.core.diff.model.path import BranchTrackingId, ConflictSelection
 from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
@@ -48,6 +43,21 @@ mutation($branch: String!) {
 }
 """
 
+CONFLICT_SELECTION_QUERY = """
+mutation ResolveDiffConflict($conflict_id: String!, $selected_branch: ConflictSelection!) {
+    ResolveDiffConflict(data: { conflict_id: $conflict_id, selected_branch: $selected_branch }) {
+        ok
+    }
+}
+"""
+
+BRANCH_REBASE = """
+mutation($branch: String!) {
+    BranchRebase(data: { name: $branch }) {
+        ok
+    }
+}
+"""
 
 
 class TestDiffRebase(TestInfrahubApp):
@@ -146,35 +156,56 @@ class TestDiffRebase(TestInfrahubApp):
         return await create_branch(branch_name="branch_2", db=db)
 
     @pytest.fixture(scope="class")
-    def diff_coordinator(self, db: InfrahubDatabase) -> DiffCoordinator:
-        ...
-
-    @pytest.fixture(scope="class")
     async def diff_repository(self, db: InfrahubDatabase, default_branch: Branch) -> DiffRepository:
         component_registry = get_component_registry()
         return await component_registry.get_component(DiffRepository, db=db, branch=default_branch)
 
     @pytest.fixture(scope="class")
-    async def add_branches_and_diffs(self, db: InfrahubDatabase, client: InfrahubClient, default_branch: Branch, initial_dataset, branch_1: Branch, branch_2: Branch):
+    async def add_branch_1_changes(
+        self, db: InfrahubDatabase, client: InfrahubClient, default_branch: Branch, initial_dataset, branch_1: Branch
+    ):
         kara_id = initial_dataset["kara"].id
         kara_branch_1 = await NodeManager.get_one(db=db, id=kara_id, branch=branch_1)
         kara_branch_1.description.value = "branch-1-description"
         await kara_branch_1.save(db=db)
+
+        result = await client.execute_graphql(query=DIFF_UPDATE_QUERY, variables={"branch_name": branch_1.name})
+        assert result["DiffUpdate"]["ok"]
+
+    @pytest.fixture(scope="class")
+    async def add_branch_2_changes(
+        self, db: InfrahubDatabase, client: InfrahubClient, default_branch: Branch, initial_dataset, branch_2: Branch
+    ):
+        kara_id = initial_dataset["kara"].id
         kara_branch_2 = await NodeManager.get_one(db=db, id=kara_id, branch=branch_2)
         kara_branch_2.description.value = "branch-2-description"
         await kara_branch_2.save(db=db)
 
-        result = await client.execute_graphql(query=DIFF_UPDATE_QUERY, variables={"branch_name": branch_1.name})
-        assert result["DiffUpdate"]["ok"]
         result = await client.execute_graphql(query=DIFF_UPDATE_QUERY, variables={"branch_name": branch_2.name})
         assert result["DiffUpdate"]["ok"]
 
-    async def test_no_conflicts_before_merge(self, db: InfrahubDatabase, initial_dataset, add_branches_and_diffs, branch_1, branch_2, diff_repository: DiffRepository):
+    async def test_no_conflicts_before_merge(
+        self,
+        db: InfrahubDatabase,
+        initial_dataset,
+        add_branch_1_changes,
+        add_branch_2_changes,
+        branch_1: Branch,
+        branch_2: Branch,
+        diff_repository: DiffRepository,
+    ):
         kara_id = initial_dataset["kara"].id
-        
-        branch_1_diff = await diff_repository.get_one(diff_branch_name=branch_1.name, tracking_id=BranchTrackingId(name=branch_1.name))
-        branch_2_diff = await diff_repository.get_one(diff_branch_name=branch_2.name, tracking_id=BranchTrackingId(name=branch_2.name))
-        for (new_value, branch_diff) in [("branch-1-description", branch_1_diff), ("branch-2-description", branch_2_diff)]:
+
+        branch_1_diff = await diff_repository.get_one(
+            diff_branch_name=branch_1.name, tracking_id=BranchTrackingId(name=branch_1.name)
+        )
+        branch_2_diff = await diff_repository.get_one(
+            diff_branch_name=branch_2.name, tracking_id=BranchTrackingId(name=branch_2.name)
+        )
+        for new_value, branch_diff in [
+            ("branch-1-description", branch_1_diff),
+            ("branch-2-description", branch_2_diff),
+        ]:
             assert len(branch_diff.nodes) == 1
             kara_node = branch_diff.nodes.pop()
             assert kara_node.uuid == kara_id
@@ -188,13 +219,24 @@ class TestDiffRebase(TestInfrahubApp):
             assert value_prop.new_value == new_value
             assert value_prop.conflict is None
 
-    async def test_merge_causes_diff_update(self,db: InfrahubDatabase, client: InfrahubClient, initial_dataset, add_branches_and_diffs, branch_1, branch_2, diff_repository):
+    async def test_merge_causes_diff_update(
+        self,
+        db: InfrahubDatabase,
+        client: InfrahubClient,
+        initial_dataset,
+        add_branch_1_changes,
+        branch_1: Branch,
+        branch_2: Branch,
+        diff_repository,
+    ):
         kara_id = initial_dataset["kara"].id
         before_merge = Timestamp()
         result = await client.execute_graphql(query=BRANCH_MERGE, variables={"branch": branch_1.name})
         assert result["BranchMerge"]["ok"]
 
-        branch_2_diff = await diff_repository.get_one(diff_branch_name=branch_2.name, tracking_id=BranchTrackingId(name=branch_2.name))
+        branch_2_diff = await diff_repository.get_one(
+            diff_branch_name=branch_2.name, tracking_id=BranchTrackingId(name=branch_2.name)
+        )
 
         assert len(branch_2_diff.nodes) == 1
         assert branch_2_diff.to_time > before_merge
@@ -213,3 +255,57 @@ class TestDiffRebase(TestInfrahubApp):
         assert value_prop.conflict.base_branch_value == "branch-1-description"
         assert value_prop.conflict.diff_branch_action is DiffAction.UPDATED
         assert value_prop.conflict.diff_branch_value == "branch-2-description"
+
+    async def test_resolve_conflict(self, client: InfrahubClient, branch_2: Branch, diff_repository: DiffRepository):
+        branch_2_diff = await diff_repository.get_one(
+            diff_branch_name=branch_2.name, tracking_id=BranchTrackingId(name=branch_2.name)
+        )
+        conflict = branch_2_diff.get_all_conflicts()[0]
+
+        result = await client.execute_graphql(
+            query=CONFLICT_SELECTION_QUERY,
+            variables={"conflict_id": conflict.uuid, "selected_branch": ConflictSelection.DIFF_BRANCH.name},
+        )
+        assert result["ResolveDiffConflict"]["ok"]
+
+        branch_2_diff = await diff_repository.get_one(
+            diff_branch_name=branch_2.name, tracking_id=BranchTrackingId(name=branch_2.name)
+        )
+        conflict = branch_2_diff.get_all_conflicts()[0]
+        assert conflict.selected_branch is ConflictSelection.DIFF_BRANCH
+
+    async def test_rebase_causes_diff_recalculation(
+        self,
+        db: InfrahubDatabase,
+        client: InfrahubClient,
+        initial_dataset,
+        branch_2: Branch,
+        diff_repository: DiffRepository,
+    ):
+        kara_id = initial_dataset["kara"].id
+        before_rebase = Timestamp()
+        result = await client.execute_graphql(query=BRANCH_REBASE, variables={"branch": branch_2.name})
+        assert result["BranchRebase"]["ok"]
+
+        branch_2_diff = await diff_repository.get_one(
+            diff_branch_name=branch_2.name, tracking_id=BranchTrackingId(name=branch_2.name)
+        )
+
+        assert len(branch_2_diff.nodes) == 1
+        assert branch_2_diff.to_time > before_rebase
+        kara_node = branch_2_diff.nodes.pop()
+        assert kara_node.uuid == kara_id
+        assert len(kara_node.attributes) == 1
+        description_attr = kara_node.attributes.pop()
+        assert description_attr.name == "description"
+        assert len(description_attr.properties) == 1
+        value_prop = description_attr.properties.pop()
+        assert value_prop.property_type is DatabaseEdgeType.HAS_VALUE
+        assert value_prop.previous_value == "Starbuck"
+        assert value_prop.new_value == "branch-2-description"
+        assert value_prop.conflict
+        assert value_prop.conflict.base_branch_action is DiffAction.UPDATED
+        assert value_prop.conflict.base_branch_value == "branch-1-description"
+        assert value_prop.conflict.diff_branch_action is DiffAction.UPDATED
+        assert value_prop.conflict.diff_branch_value == "branch-2-description"
+        assert value_prop.conflict.selected_branch is ConflictSelection.DIFF_BRANCH

--- a/backend/tests/unit/core/diff/test_conflict_transferer.py
+++ b/backend/tests/unit/core/diff/test_conflict_transferer.py
@@ -1,0 +1,161 @@
+from dataclasses import replace
+
+import pytest
+
+from infrahub.core.constants.database import DatabaseEdgeType
+from infrahub.core.diff.combiner import DiffCombiner
+from infrahub.core.diff.conflict_transferer import DiffConflictTransferer
+from infrahub.core.diff.model.path import ConflictSelection
+
+from .factories import (
+    EnrichedAttributeFactory,
+    EnrichedConflictFactory,
+    EnrichedNodeFactory,
+    EnrichedPropertyFactory,
+    EnrichedRelationshipElementFactory,
+    EnrichedRelationshipGroupFactory,
+    EnrichedRootFactory,
+)
+
+
+class TestDiffConflictsTransferer:
+    @pytest.fixture
+    async def conflict_transferer(self):
+        return DiffConflictTransferer(diff_combiner=DiffCombiner())
+
+    async def test_node_conflicts(self, conflict_transferer: DiffConflictTransferer):
+        conflict_early_only = EnrichedConflictFactory.build()
+        node_early_only_1 = EnrichedNodeFactory.build(conflict=conflict_early_only)
+        node_early_only_2 = EnrichedNodeFactory.build(
+            uuid=node_early_only_1.uuid, action=node_early_only_1.action, conflict=None
+        )
+        conflict_later_only = EnrichedConflictFactory.build()
+        node_later_only_1 = EnrichedNodeFactory.build(conflict=None)
+        node_later_only_2 = EnrichedNodeFactory.build(
+            uuid=node_later_only_1.uuid, action=node_later_only_1.action, conflict=conflict_later_only
+        )
+        conflict_transfer_1 = EnrichedConflictFactory.build(selected_branch=ConflictSelection.DIFF_BRANCH)
+        conflict_transfer_2 = replace(conflict_transfer_1, selected_branch=None)
+        node_transfer_1 = EnrichedNodeFactory.build(conflict=conflict_transfer_1)
+        node_transfer_2 = EnrichedNodeFactory.build(
+            uuid=node_transfer_1.uuid, action=node_transfer_1.action, conflict=conflict_transfer_2
+        )
+        node_later_only_1 = EnrichedNodeFactory.build(conflict=None)
+        node_later_only_2 = EnrichedNodeFactory.build(uuid=node_later_only_1.uuid, conflict=conflict_later_only)
+        diff_1 = EnrichedRootFactory.build(nodes={node_later_only_1, node_early_only_1, node_transfer_1})
+        diff_2 = EnrichedRootFactory.build(nodes={node_later_only_2, node_early_only_2, node_transfer_2})
+
+        await conflict_transferer.transfer(earlier=diff_1, later=diff_2)
+
+        assert node_early_only_2.conflict is None
+        assert node_later_only_2.conflict == conflict_later_only
+        assert node_transfer_2.conflict == conflict_transfer_1
+
+    async def test_attr_conflicts(self, conflict_transferer: DiffConflictTransferer):
+        conflict_early_only = EnrichedConflictFactory.build()
+        prop_early_only_1 = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.IS_RELATED, conflict=conflict_early_only
+        )
+        prop_early_only_2 = EnrichedPropertyFactory.build(property_type=DatabaseEdgeType.IS_RELATED, conflict=None)
+        conflict_later_only = EnrichedConflictFactory.build()
+        prop_later_only_1 = EnrichedPropertyFactory.build(property_type=DatabaseEdgeType.IS_PROTECTED, conflict=None)
+        prop_later_only_2 = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.IS_PROTECTED, conflict=conflict_later_only
+        )
+        conflict_transfer_1 = EnrichedConflictFactory.build(selected_branch=ConflictSelection.DIFF_BRANCH)
+        conflict_transfer_2 = replace(conflict_transfer_1, selected_branch=None)
+        prop_transfer_1 = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.IS_VISIBLE, conflict=conflict_transfer_1
+        )
+        prop_transfer_2 = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.IS_VISIBLE, conflict=conflict_transfer_2
+        )
+
+        attr_early = EnrichedAttributeFactory.build(properties={prop_early_only_1, prop_later_only_1, prop_transfer_1})
+        attr_later = EnrichedAttributeFactory.build(
+            name=attr_early.name, properties={prop_early_only_2, prop_later_only_2, prop_transfer_2}
+        )
+        node_early = EnrichedNodeFactory.build(attributes={attr_early})
+        node_later = EnrichedNodeFactory.build(uuid=node_early.uuid, attributes={attr_later})
+        diff_1 = EnrichedRootFactory.build(nodes={node_early})
+        diff_2 = EnrichedRootFactory.build(nodes={node_later})
+
+        await conflict_transferer.transfer(earlier=diff_1, later=diff_2)
+
+        assert prop_early_only_2.conflict is None
+        assert prop_later_only_2.conflict == conflict_later_only
+        assert prop_transfer_2.conflict == conflict_transfer_1
+
+    async def test_rel_conflicts(self, conflict_transferer: DiffConflictTransferer):
+        conflict_early_only = EnrichedConflictFactory.build()
+        element_early_only_1 = EnrichedRelationshipElementFactory.build(conflict=conflict_early_only)
+        element_early_only_2 = EnrichedRelationshipElementFactory.build(
+            peer_id=element_early_only_1.peer_id, conflict=None
+        )
+        conflict_later_only = EnrichedConflictFactory.build()
+        element_later_only_1 = EnrichedRelationshipElementFactory.build(conflict=None)
+        element_later_only_2 = EnrichedRelationshipElementFactory.build(
+            peer_id=element_later_only_1.peer_id, conflict=conflict_later_only
+        )
+        conflict_transfer_1 = EnrichedConflictFactory.build(selected_branch=ConflictSelection.DIFF_BRANCH)
+        conflict_transfer_2 = replace(conflict_transfer_1, selected_branch=None)
+        element_transfer_1 = EnrichedRelationshipElementFactory.build(conflict=conflict_transfer_1)
+        element_transfer_2 = EnrichedRelationshipElementFactory.build(
+            peer_id=element_transfer_1.peer_id, conflict=conflict_transfer_2
+        )
+
+        rel_early = EnrichedRelationshipGroupFactory.build(
+            relationships={element_early_only_1, element_later_only_1, element_transfer_1}
+        )
+        rel_later = EnrichedRelationshipGroupFactory.build(
+            name=rel_early.name, relationships={element_early_only_2, element_later_only_2, element_transfer_2}
+        )
+        node_early = EnrichedNodeFactory.build(relationships={rel_early})
+        node_later = EnrichedNodeFactory.build(uuid=node_early.uuid, relationships={rel_later})
+        diff_1 = EnrichedRootFactory.build(nodes={node_early})
+        diff_2 = EnrichedRootFactory.build(nodes={node_later})
+
+        await conflict_transferer.transfer(earlier=diff_1, later=diff_2)
+
+        assert element_early_only_2.conflict is None
+        assert element_later_only_2.conflict == conflict_later_only
+        assert element_transfer_2.conflict == conflict_transfer_1
+
+    async def test_rel_prop_conflicts(self, conflict_transferer: DiffConflictTransferer):
+        conflict_early_only = EnrichedConflictFactory.build()
+        prop_early_only_1 = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.IS_RELATED, conflict=conflict_early_only
+        )
+        prop_early_only_2 = EnrichedPropertyFactory.build(property_type=DatabaseEdgeType.IS_RELATED, conflict=None)
+        conflict_later_only = EnrichedConflictFactory.build()
+        prop_later_only_1 = EnrichedPropertyFactory.build(property_type=DatabaseEdgeType.IS_PROTECTED, conflict=None)
+        prop_later_only_2 = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.IS_PROTECTED, conflict=conflict_later_only
+        )
+        conflict_transfer_1 = EnrichedConflictFactory.build(selected_branch=ConflictSelection.DIFF_BRANCH)
+        conflict_transfer_2 = replace(conflict_transfer_1, selected_branch=None)
+        prop_transfer_1 = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.IS_VISIBLE, conflict=conflict_transfer_1
+        )
+        prop_transfer_2 = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.IS_VISIBLE, conflict=conflict_transfer_2
+        )
+
+        element_early = EnrichedRelationshipElementFactory.build(
+            properties={prop_early_only_1, prop_later_only_1, prop_transfer_1}
+        )
+        element_later = EnrichedRelationshipElementFactory.build(
+            peer_id=element_early.peer_id, properties={prop_early_only_2, prop_later_only_2, prop_transfer_2}
+        )
+        rel_early = EnrichedRelationshipGroupFactory.build(relationships={element_early})
+        rel_later = EnrichedRelationshipGroupFactory.build(name=rel_early.name, relationships={element_later})
+        node_early = EnrichedNodeFactory.build(relationships={rel_early})
+        node_later = EnrichedNodeFactory.build(uuid=node_early.uuid, relationships={rel_later})
+        diff_1 = EnrichedRootFactory.build(nodes={node_early})
+        diff_2 = EnrichedRootFactory.build(nodes={node_later})
+
+        await conflict_transferer.transfer(earlier=diff_1, later=diff_2)
+
+        assert prop_early_only_2.conflict is None
+        assert prop_later_only_2.conflict == conflict_later_only
+        assert prop_transfer_2.conflict == conflict_transfer_1

--- a/backend/tests/unit/core/diff/test_coordinator_lock.py
+++ b/backend/tests/unit/core/diff/test_coordinator_lock.py
@@ -10,13 +10,14 @@ from infrahub.core.diff.coordinator import DiffCoordinator
 from infrahub.core.diff.data_check_synchronizer import DiffDataCheckSynchronizer
 from infrahub.core.initialization import create_branch
 from infrahub.core.node import Node
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.dependencies.registry import get_component_registry
 
 
 class TestDiffCoordinatorLocks:
     @pytest.fixture
-    async def branch_data(self, db: InfrahubDatabase, default_branch: Branch, car_person_schema):
+    async def branch_with_data(self, db: InfrahubDatabase, default_branch: Branch, car_person_schema) -> Branch:
         lock.initialize_lock(local_only=True)
         branch_1 = await create_branch(branch_name="branch_1", db=db)
         for _ in range(10):
@@ -41,8 +42,10 @@ class TestDiffCoordinatorLocks:
         diff_coordinator.diff_calculator = wrapped_calculator
         return diff_coordinator
 
-    async def test_incremental_locks_do_not_queue_up(self, db: InfrahubDatabase, default_branch: Branch, branch_data):
-        diff_branch = branch_data
+    async def test_incremental_diff_locks_do_not_queue_up(
+        self, db: InfrahubDatabase, default_branch: Branch, branch_with_data: Branch
+    ):
+        diff_branch = branch_with_data
         diff_coordinator = await self.get_diff_coordinator(db=db, diff_branch=diff_branch)
 
         results = await asyncio.gather(
@@ -55,3 +58,90 @@ class TestDiffCoordinatorLocks:
         assert len(diff_coordinator.diff_calculator.calculate_diff.call_args_list) == 2
         # called instead of calculating the diff again
         diff_coordinator.diff_repo.get_one.assert_awaited_once()
+
+    async def test_arbitrary_diff_locks_queue_up(
+        self, db: InfrahubDatabase, default_branch: Branch, branch_with_data: Branch
+    ):
+        diff_branch = branch_with_data
+        diff_coordinator = await self.get_diff_coordinator(db=db, diff_branch=diff_branch)
+
+        results = await asyncio.gather(
+            diff_coordinator.create_or_update_arbitrary_timeframe_diff(
+                base_branch=default_branch,
+                diff_branch=diff_branch,
+                from_time=Timestamp(branch_with_data.created_at),
+                to_time=Timestamp(),
+            ),
+            diff_coordinator.create_or_update_arbitrary_timeframe_diff(
+                base_branch=default_branch,
+                diff_branch=diff_branch,
+                from_time=Timestamp(branch_with_data.created_at),
+                to_time=Timestamp(),
+            ),
+        )
+        assert len(results) == 2
+        assert results[0].to_time != results[1].to_time
+        assert results[0].uuid != results[1].uuid
+        results[0].to_time = results[1].to_time
+        results[0].uuid = results[1].uuid
+        assert results[0] == results[1]
+        # called once to calculate diff on main and once to calculate diff on the branch for each request
+        assert len(diff_coordinator.diff_calculator.calculate_diff.call_args_list) == 4
+        # not called because diffs are calculated both times
+        diff_coordinator.diff_repo.get_one.assert_not_awaited()
+
+    async def test_arbitrary_diff_blocks_incremental_diff(
+        self, db: InfrahubDatabase, default_branch: Branch, branch_with_data: Branch
+    ):
+        diff_branch = branch_with_data
+        diff_coordinator = await self.get_diff_coordinator(db=db, diff_branch=diff_branch)
+
+        results = await asyncio.gather(
+            diff_coordinator.create_or_update_arbitrary_timeframe_diff(
+                base_branch=default_branch,
+                diff_branch=diff_branch,
+                from_time=Timestamp(branch_with_data.created_at),
+                to_time=Timestamp(),
+            ),
+            diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=diff_branch),
+        )
+        assert len(results) == 2
+        assert results[0].to_time != results[1].to_time
+        assert results[0].uuid != results[1].uuid
+        assert results[0].tracking_id != results[1].tracking_id
+        results[0].to_time = results[1].to_time
+        results[0].uuid = results[1].uuid
+        results[0].tracking_id = results[1].tracking_id
+        assert results[0] == results[1]
+        # called once to calculate diff on main and once to calculate diff on the branch for each request
+        assert len(diff_coordinator.diff_calculator.calculate_diff.call_args_list) == 4
+        # not called because diffs are calculated both times
+        diff_coordinator.diff_repo.get_one.assert_not_awaited()
+
+    async def test_incremental_diff_blocks_arbitrary_diff(
+        self, db: InfrahubDatabase, default_branch: Branch, branch_with_data: Branch
+    ):
+        diff_branch = branch_with_data
+        diff_coordinator = await self.get_diff_coordinator(db=db, diff_branch=diff_branch)
+
+        results = await asyncio.gather(
+            diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=diff_branch),
+            diff_coordinator.create_or_update_arbitrary_timeframe_diff(
+                base_branch=default_branch,
+                diff_branch=diff_branch,
+                from_time=Timestamp(branch_with_data.created_at),
+                to_time=Timestamp(),
+            ),
+        )
+        assert len(results) == 2
+        assert results[0].to_time != results[1].to_time
+        assert results[0].uuid != results[1].uuid
+        assert results[0].tracking_id != results[1].tracking_id
+        results[0].to_time = results[1].to_time
+        results[0].uuid = results[1].uuid
+        results[0].tracking_id = results[1].tracking_id
+        assert results[0] == results[1]
+        # called once to calculate diff on main and once to calculate diff on the branch for each request
+        assert len(diff_coordinator.diff_calculator.calculate_diff.call_args_list) == 4
+        # not called because diffs are calculated both times
+        diff_coordinator.diff_repo.get_one.assert_not_awaited()

--- a/backend/tests/unit/message_bus/operations/event/test_branch.py
+++ b/backend/tests/unit/message_bus/operations/event/test_branch.py
@@ -73,7 +73,7 @@ async def test_merged(default_branch: Branch):
         await merge(message=message, service=service)
 
     mock_component_registry.get_component.assert_awaited_once_with(DiffRepository, db=database, branch=default_branch)
-    diff_repo.get_empty_roots.assert_awaited_once_with(diff_branch_names=[target_branch_name])
+    diff_repo.get_empty_roots.assert_awaited_once_with(base_branch_names=[target_branch_name])
     assert len(recorder.messages) == 6
     assert recorder.messages[0] == messages.RefreshRegistryBranches()
     assert recorder.messages[1] == messages.TriggerIpamReconciliation(branch=target_branch_name, ipam_node_details=[])

--- a/backend/tests/unit/message_bus/operations/event/test_branch.py
+++ b/backend/tests/unit/message_bus/operations/event/test_branch.py
@@ -1,5 +1,13 @@
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from uuid import uuid4
+
+from infrahub.core.branch import Branch
+from infrahub.core.diff.model.path import BranchTrackingId, EnrichedDiffRoot
+from infrahub.core.diff.repository.repository import DiffRepository
+from infrahub.core.timestamp import Timestamp
+from infrahub.dependencies.component.registry import ComponentDependencyRegistry
 from infrahub.message_bus import messages
-from infrahub.message_bus.operations.event.branch import delete, rebased
+from infrahub.message_bus.operations.event.branch import delete, merge, rebased
 from infrahub.services import InfrahubServices
 from tests.adapters.message_bus import BusRecorder
 
@@ -23,17 +31,91 @@ async def test_delete():
     assert trigger_cancel.branch == "cr1234"
 
 
-async def test_rebased():
-    """Validate that a rebased branch triggers a registry refresh and cancels open proposed changes"""
-
-    message = messages.EventBranchRebased(branch="cr1234")
+async def test_merged(default_branch: Branch):
+    source_branch_name = "cr1234"
+    target_branch_name = "main"
+    right_now = Timestamp()
+    message = messages.EventBranchMerge(
+        source_branch=source_branch_name, target_branch=target_branch_name, ipam_node_details=[]
+    )
 
     recorder = BusRecorder()
-    service = InfrahubServices(message_bus=recorder)
+    database = MagicMock()
+    service = InfrahubServices(message_bus=recorder, database=database)
+    tracked_diff_roots = [
+        EnrichedDiffRoot(
+            base_branch_name=target_branch_name,
+            diff_branch_name=str(uuid4()),
+            from_time=right_now,
+            to_time=right_now,
+            uuid=str(uuid4()),
+            tracking_id=BranchTrackingId(name=str(uuid4())),
+        )
+        for _ in range(2)
+    ]
+    untracked_diff_roots = [
+        EnrichedDiffRoot(
+            base_branch_name=target_branch_name,
+            diff_branch_name=str(uuid4()),
+            from_time=right_now,
+            to_time=right_now,
+            uuid=str(uuid4()),
+        )
+        for _ in range(2)
+    ]
+    diff_repo = AsyncMock(spec=DiffRepository)
+    diff_repo.get_empty_roots.return_value = untracked_diff_roots + tracked_diff_roots
+    mock_component_registry = Mock(spec=ComponentDependencyRegistry)
+    mock_get_component_registry = MagicMock(return_value=mock_component_registry)
+    mock_component_registry.get_component.return_value = diff_repo
 
-    await rebased(message=message, service=service)
+    with patch("infrahub.message_bus.operations.event.branch.get_component_registry", new=mock_get_component_registry):
+        await merge(message=message, service=service)
 
-    assert len(recorder.messages) == 1
+    mock_component_registry.get_component.assert_awaited_once_with(DiffRepository, db=database, branch=default_branch)
+    diff_repo.get_empty_roots.assert_awaited_once_with(diff_branch_names=[target_branch_name])
+    assert len(recorder.messages) == 6
+    assert recorder.messages[0] == messages.RefreshRegistryBranches()
+    assert recorder.messages[1] == messages.TriggerIpamReconciliation(branch=target_branch_name, ipam_node_details=[])
+    assert recorder.messages[2] == messages.TriggerArtifactDefinitionGenerate(branch=target_branch_name)
+    assert recorder.messages[3] == messages.TriggerGeneratorDefinitionRun(branch=target_branch_name)
+    assert recorder.messages[4] == messages.RequestDiffUpdate(branch_name=tracked_diff_roots[0].diff_branch_name)
+    assert recorder.messages[5] == messages.RequestDiffUpdate(branch_name=tracked_diff_roots[1].diff_branch_name)
+
+
+async def test_rebased(default_branch: Branch):
+    """Validate that a rebased branch triggers a registry refresh and cancels open proposed changes"""
+    branch_name = "cr1234"
+    right_now = Timestamp()
+    message = messages.EventBranchRebased(branch=branch_name)
+
+    recorder = BusRecorder()
+    database = MagicMock()
+    service = InfrahubServices(message_bus=recorder, database=database)
+    diff_roots = [
+        EnrichedDiffRoot(
+            base_branch_name="main",
+            diff_branch_name=branch_name,
+            from_time=right_now,
+            to_time=right_now,
+            uuid=str(uuid4()),
+        )
+        for _ in range(2)
+    ]
+    diff_repo = AsyncMock(spec=DiffRepository)
+    diff_repo.get_empty_roots.return_value = diff_roots
+    mock_component_registry = Mock(spec=ComponentDependencyRegistry)
+    mock_get_component_registry = MagicMock(return_value=mock_component_registry)
+    mock_component_registry.get_component.return_value = diff_repo
+
+    with patch("infrahub.message_bus.operations.event.branch.get_component_registry", new=mock_get_component_registry):
+        await rebased(message=message, service=service)
+
+    mock_component_registry.get_component.assert_awaited_once_with(DiffRepository, db=database, branch=default_branch)
+    diff_repo.get_empty_roots.assert_awaited_once_with(diff_branch_names=[branch_name])
+    assert len(recorder.messages) == 3
     assert isinstance(recorder.messages[0], messages.RefreshRegistryRebasedBranch)
     refresh_message: messages.RefreshRegistryRebasedBranch = recorder.messages[0]
     assert refresh_message.branch == "cr1234"
+    assert recorder.messages[1] == messages.RequestDiffRefresh(branch_name=branch_name, diff_id=diff_roots[0].uuid)
+    assert recorder.messages[2] == messages.RequestDiffRefresh(branch_name=branch_name, diff_id=diff_roots[1].uuid)

--- a/docs/docs/reference/message-bus-events.mdx
+++ b/docs/docs/reference/message-bus-events.mdx
@@ -684,6 +684,21 @@ For more detailed explanations on how to use these events within Infrahub, see t
 | **from_time** | N/A | N/A | None |
 | **to_time** | N/A | N/A | None |
 <!-- vale on -->
+<!-- vale off -->
+#### Event request.diff.refresh
+<!-- vale on -->
+
+**Description**: Request diff be recalculated from scratch.
+
+**Priority**: 3
+
+<!-- vale off -->
+| Key | Description | Type | Default Value |
+|-----|-------------|------|---------------|
+| **meta** | Meta properties for the message | N/A | None |
+| **branch_name** | The branch associated with the diff | string | None |
+| **diff_id** | The id for this diff | string | None |
+<!-- vale on -->
 
 <!-- vale off -->
 ### Request Generator
@@ -1911,6 +1926,22 @@ For more detailed explanations on how to use these events within Infrahub, see t
 | **name** | N/A | N/A | None |
 | **from_time** | N/A | N/A | None |
 | **to_time** | N/A | N/A | None |
+<!-- vale on -->
+<!-- vale off -->
+#### Event request.diff.refresh
+<!-- vale on -->
+
+**Description**: Request diff be recalculated from scratch.
+
+**Priority**: 3
+
+
+<!-- vale off -->
+| Key | Description | Type | Default Value |
+|-----|-------------|------|---------------|
+| **meta** | Meta properties for the message | N/A | None |
+| **branch_name** | The branch associated with the diff | string | None |
+| **diff_id** | The id for this diff | string | None |
 <!-- vale on -->
 
 <!-- vale off -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "infrahub"
-version = "0.16.0-dev"
+version = "0.16.0"
 description = "Infrahub is taking a new approach to Infrastructure Management by providing a new generation of datastore to organize and control all the data that defines how an infrastructure should run."
 authors = ["OpsMill <info@opsmill.com>"]
 readme = "README.md"


### PR DESCRIPTION
IFC-575

- when a branch is rebased, we need to recalculate all of the cached diffs associated with that branch, because the history could have been rewritten
- when a branch is merged into the default branch, we should update the diffs for all cached diffs that are tracking open branches

I linked this logic into the existing `EventBranchMerge` and `EventBranchRebase` message logic

and bumps the version to `0.16.0`