### PR TITLE
ignore pkg_resources is deprecated as an API message in pytest config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,7 @@ testpaths = ["tests"]
 filterwarnings = [
     "ignore:Module already imported so cannot be rewritten",
     "ignore:Deprecated call to",
+    "ignore:pkg_resources is deprecated as an API",
 ]
 addopts = "-vs --cov-report term-missing --cov-report xml --dist loadscope --junitxml=pytest-junit.xml"
 junit_duration_report = "call"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,7 +160,7 @@ testpaths = ["tests"]
 filterwarnings = [
     "ignore:Module already imported so cannot be rewritten",
     "ignore:Deprecated call to",
-    "ignore:pkg_resources is deprecated as an API",
+    "ignore:pkg_resources is deprecated as an API",  # Remove on https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2181 has been fixed
 ]
 addopts = "-vs --cov-report term-missing --cov-report xml --dist loadscope --junitxml=pytest-junit.xml"
 junit_duration_report = "call"


### PR DESCRIPTION
Update pytest config to ignore the warning below until it gets fixed in `opentelemetry`

The issue is being worked on but it's not clear when it will be included in a release
 https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2181

```
backend/tests/unit/api/test_12_file.py::test_get_file
  /Users/damien/Library/Caches/pypoetry/virtualenvs/infrahub-zK4H253C-py3.11/lib/python3.11/site-packages/opentelemetry/instrumentation/dependencies.py:4: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    from pkg_resources import (

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```