### PR TITLE
IFC-31 Permission backends

### DIFF
--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -77,6 +77,10 @@ class MainSettings(BaseSettings):
     telemetry_interval: int = Field(
         default=3600 * 24, ge=60, description="Time (in seconds) between telemetry usage push"
     )
+    permission_backends: list[str] = Field(
+        default=["infrahub.permissions.LocalPermissionBackend"],
+        description="List of modules to handle permissions, they will be run in the given order",
+    )
 
 
 class FileSystemStorageSettings(BaseSettings):

--- a/backend/infrahub/core/registry.py
+++ b/backend/infrahub/core/registry.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from infrahub.database import InfrahubDatabase
     from infrahub.graphql.mutations.attribute import BaseAttributeCreate, BaseAttributeUpdate
     from infrahub.graphql.types import InfrahubObject
+    from infrahub.permissions import PermissionBackend
     from infrahub.storage import InfrahubObjectStorage
     from infrahub.types import InfrahubDataType
 
@@ -45,6 +46,7 @@ class Registry:
     _branch_object: Optional[type[Branch]] = None
     _manager: Optional[type[NodeManager]] = None
     _storage: Optional[InfrahubObjectStorage] = None
+    permission_backends: Optional[list[PermissionBackend]] = None
 
     @property
     def branch_object(self) -> type[Branch]:

--- a/backend/infrahub/graphql/queries/account.py
+++ b/backend/infrahub/graphql/queries/account.py
@@ -102,7 +102,9 @@ async def resolve_account_permissions(
     if registry.permission_backends:
         for permission_backend in registry.permission_backends:
             permissions.update(
-                await permission_backend.load_permissions(db=context.db, account_id=context.account_session.account_id)
+                await permission_backend.load_permissions(
+                    db=context.db, account_id=context.account_session.account_id, branch=context.branch
+                )
             )
 
     response: dict[str, Any] = {}

--- a/backend/infrahub/permissions/__init__.py
+++ b/backend/infrahub/permissions/__init__.py
@@ -1,0 +1,4 @@
+from .backend import PermissionBackend
+from .local_backend import LocalPermissionBackend
+
+__all__ = ["PermissionBackend", "LocalPermissionBackend"]

--- a/backend/infrahub/permissions/backend.py
+++ b/backend/infrahub/permissions/backend.py
@@ -1,12 +1,17 @@
 from abc import ABC, abstractmethod
 
 from infrahub.core.account import GlobalPermission
+from infrahub.core.branch import Branch
 from infrahub.database import InfrahubDatabase
 
 
 class PermissionBackend(ABC):
     @abstractmethod
-    async def load_permissions(self, db: InfrahubDatabase, account_id: str) -> dict[str, list[GlobalPermission]]: ...
+    async def load_permissions(
+        self, db: InfrahubDatabase, account_id: str, branch: Branch | str | None = None
+    ) -> dict[str, list[GlobalPermission]]: ...
 
     @abstractmethod
-    async def has_permission(self, db: InfrahubDatabase, account_id: str, permission: str) -> bool: ...
+    async def has_permission(
+        self, db: InfrahubDatabase, account_id: str, permission: str, branch: Branch | str | None = None
+    ) -> bool: ...

--- a/backend/infrahub/permissions/backend.py
+++ b/backend/infrahub/permissions/backend.py
@@ -1,0 +1,12 @@
+from abc import ABC, abstractmethod
+
+from infrahub.core.account import GlobalPermission
+from infrahub.database import InfrahubDatabase
+
+
+class PermissionBackend(ABC):
+    @abstractmethod
+    async def load_permissions(self, db: InfrahubDatabase, account_id: str) -> dict[str, list[GlobalPermission]]: ...
+
+    @abstractmethod
+    async def has_permission(self, db: InfrahubDatabase, account_id: str, permission: str) -> bool: ...

--- a/backend/infrahub/permissions/local_backend.py
+++ b/backend/infrahub/permissions/local_backend.py
@@ -1,0 +1,16 @@
+from infrahub.core.account import GlobalPermission, fetch_permissions
+from infrahub.database import InfrahubDatabase
+
+from .backend import PermissionBackend
+
+
+class LocalPermissionBackend(PermissionBackend):
+    async def load_permissions(self, db: InfrahubDatabase, account_id: str) -> dict[str, list[GlobalPermission]]:
+        all_permissions = await fetch_permissions(db=db, account_id=account_id)
+        return {"global_permissions": all_permissions.get("global_permissions", [])}
+
+    async def has_permission(self, db: InfrahubDatabase, account_id: str, permission: str) -> bool:
+        granted_permissions = await self.load_permissions(db=db, account_id=account_id)
+        return permission.startswith("global:") and permission in [
+            str(p) for p in granted_permissions["global_permissions"]
+        ]

--- a/backend/infrahub/permissions/local_backend.py
+++ b/backend/infrahub/permissions/local_backend.py
@@ -1,16 +1,21 @@
 from infrahub.core.account import GlobalPermission, fetch_permissions
+from infrahub.core.branch import Branch
 from infrahub.database import InfrahubDatabase
 
 from .backend import PermissionBackend
 
 
 class LocalPermissionBackend(PermissionBackend):
-    async def load_permissions(self, db: InfrahubDatabase, account_id: str) -> dict[str, list[GlobalPermission]]:
-        all_permissions = await fetch_permissions(db=db, account_id=account_id)
+    async def load_permissions(
+        self, db: InfrahubDatabase, account_id: str, branch: Branch | str | None = None
+    ) -> dict[str, list[GlobalPermission]]:
+        all_permissions = await fetch_permissions(db=db, account_id=account_id, branch=branch)
         return {"global_permissions": all_permissions.get("global_permissions", [])}
 
-    async def has_permission(self, db: InfrahubDatabase, account_id: str, permission: str) -> bool:
-        granted_permissions = await self.load_permissions(db=db, account_id=account_id)
+    async def has_permission(
+        self, db: InfrahubDatabase, account_id: str, permission: str, branch: Branch | str | None = None
+    ) -> bool:
+        granted_permissions = await self.load_permissions(db=db, account_id=account_id, branch=branch)
         return permission.startswith("global:") and permission in [
             str(p) for p in granted_permissions["global_permissions"]
         ]

--- a/backend/tests/unit/permissions/test_backends.py
+++ b/backend/tests/unit/permissions/test_backends.py
@@ -1,24 +1,29 @@
 from infrahub.core.account import GlobalPermission
+from infrahub.core.branch import Branch
 from infrahub.core.constants import GlobalPermissions
 from infrahub.database import InfrahubDatabase
 from infrahub.permissions import LocalPermissionBackend
 
 
-async def test_load_permissions(db: InfrahubDatabase, create_test_admin, first_account):
+async def test_load_permissions(db: InfrahubDatabase, branch: Branch, create_test_admin, first_account):
     backend = LocalPermissionBackend()
 
-    permissions = await backend.load_permissions(db=db, account_id=create_test_admin.id)
+    permissions = await backend.load_permissions(db=db, account_id=create_test_admin.id, branch=branch)
     assert "global_permissions" in permissions
     assert permissions["global_permissions"][0].action == GlobalPermissions.EDIT_DEFAULT_BRANCH.value
 
-    permissions = await backend.load_permissions(db=db, account_id=first_account.id)
+    permissions = await backend.load_permissions(db=db, account_id=first_account.id, branch=branch)
     assert "global_permissions" in permissions
     assert not permissions["global_permissions"]
 
 
-async def test_has_permissions(db: InfrahubDatabase, create_test_admin, first_account):
+async def test_has_permissions(db: InfrahubDatabase, branch: Branch, create_test_admin, first_account):
     backend = LocalPermissionBackend()
     permission = GlobalPermission(id="", action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value, name="Edit default branch")
 
-    assert await backend.has_permission(db=db, account_id=create_test_admin.id, permission=str(permission))
-    assert not await backend.has_permission(db=db, account_id=first_account.id, permission=str(permission))
+    assert await backend.has_permission(
+        db=db, account_id=create_test_admin.id, permission=str(permission), branch=branch
+    )
+    assert not await backend.has_permission(
+        db=db, account_id=first_account.id, permission=str(permission), branch=branch
+    )

--- a/backend/tests/unit/permissions/test_backends.py
+++ b/backend/tests/unit/permissions/test_backends.py
@@ -1,0 +1,24 @@
+from infrahub.core.account import GlobalPermission
+from infrahub.core.constants import GlobalPermissions
+from infrahub.database import InfrahubDatabase
+from infrahub.permissions import LocalPermissionBackend
+
+
+async def test_load_permissions(db: InfrahubDatabase, create_test_admin, first_account):
+    backend = LocalPermissionBackend()
+
+    permissions = await backend.load_permissions(db=db, account_id=create_test_admin.id)
+    assert "global_permissions" in permissions
+    assert permissions["global_permissions"][0].action == GlobalPermissions.EDIT_DEFAULT_BRANCH.value
+
+    permissions = await backend.load_permissions(db=db, account_id=first_account.id)
+    assert "global_permissions" in permissions
+    assert not permissions["global_permissions"]
+
+
+async def test_has_permissions(db: InfrahubDatabase, create_test_admin, first_account):
+    backend = LocalPermissionBackend()
+    permission = GlobalPermission(id="", action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value, name="Edit default branch")
+
+    assert await backend.has_permission(db=db, account_id=create_test_admin.id, permission=str(permission))
+    assert not await backend.has_permission(db=db, account_id=first_account.id, permission=str(permission))


### PR DESCRIPTION
Permission backends are an attempt at making permission interfaces generic. The goal is to provide a standard way to interact with permissions without having to worry about the way the permissions are stored.

This PR depends on #4185.