### PR TITLE
IFC-31 Enforce default branch edition permission

### DIFF
--- a/backend/infrahub/graphql/analyzer.py
+++ b/backend/infrahub/graphql/analyzer.py
@@ -1,9 +1,6 @@
 from typing import Any, Optional
 
-from graphql import (
-    GraphQLSchema,
-    OperationType,
-)
+from graphql import GraphQLSchema, OperationType
 from infrahub_sdk.analyzer import GraphQLQueryAnalyzer
 from infrahub_sdk.utils import extract_fields
 
@@ -12,8 +9,17 @@ from infrahub.graphql.utils import extract_schema_models
 
 
 class InfrahubGraphQLQueryAnalyzer(GraphQLQueryAnalyzer):
-    def __init__(self, query: str, schema: Optional[GraphQLSchema] = None, branch: Optional[Branch] = None):
+    def __init__(
+        self,
+        query: str,
+        query_variables: Optional[dict[str, Any]] = None,
+        schema: Optional[GraphQLSchema] = None,
+        operation_name: Optional[str] = None,
+        branch: Optional[Branch] = None,
+    ):
         self.branch: Optional[Branch] = branch
+        self.operation_name: Optional[str] = operation_name
+        self.query_variables: dict[str, Any] = query_variables or {}
         super().__init__(query=query, schema=schema)
 
     async def get_models_in_use(self, types: dict[str, Any]) -> set[str]:

--- a/backend/infrahub/graphql/api/dependencies.py
+++ b/backend/infrahub/graphql/api/dependencies.py
@@ -5,6 +5,7 @@ from infrahub import config
 from ..app import InfrahubGraphQLApp
 from ..auth.query_permission_checker.anonymous_checker import AnonymousGraphQLPermissionChecker
 from ..auth.query_permission_checker.checker import GraphQLQueryPermissionChecker
+from ..auth.query_permission_checker.default_branch_checker import DefaultBranchPermissionChecker
 from ..auth.query_permission_checker.default_checker import DefaultGraphQLPermissionChecker
 from ..auth.query_permission_checker.read_only_checker import ReadOnlyGraphQLPermissionChecker
 from ..auth.query_permission_checker.read_write_checker import ReadWriteGraphQLPermissionChecker
@@ -17,6 +18,7 @@ def get_anonymous_access_setting() -> bool:
 def build_graphql_query_permission_checker() -> GraphQLQueryPermissionChecker:
     return GraphQLQueryPermissionChecker(
         [
+            DefaultBranchPermissionChecker(),
             ReadWriteGraphQLPermissionChecker(),
             ReadOnlyGraphQLPermissionChecker(),
             AnonymousGraphQLPermissionChecker(get_anonymous_access_setting),

--- a/backend/infrahub/graphql/app.py
+++ b/backend/infrahub/graphql/app.py
@@ -47,7 +47,7 @@ from infrahub.auth import AccountSession, authentication_token
 from infrahub.core.registry import registry
 from infrahub.core.timestamp import Timestamp
 from infrahub.exceptions import BranchNotFoundError, Error
-from infrahub.graphql import prepare_graphql_params
+from infrahub.graphql import GraphqlParams, prepare_graphql_params
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 from infrahub.log import get_logger
 
@@ -197,16 +197,23 @@ class InfrahubGraphQLApp:
 
         operation = operations
         query = operation["query"]
+        variable_values = operation.get("variables")
+        operation_name = operation.get("operationName")
 
         at = request.query_params.get("at", None)
         graphql_params = prepare_graphql_params(
             db=db, branch=branch, at=at, account_session=account_session, request=request
         )
-        analyzed_query = InfrahubGraphQLQueryAnalyzer(query=query, schema=graphql_params.schema, branch=branch)
-        await self.permission_checker.check(account_session=account_session, analyzed_query=analyzed_query)
-
-        variable_values = operation.get("variables")
-        operation_name = operation.get("operationName")
+        analyzed_query = InfrahubGraphQLQueryAnalyzer(
+            query=query,
+            query_variables=variable_values,
+            schema=graphql_params.schema,
+            operation_name=operation_name,
+            branch=branch,
+        )
+        await self._evaluate_permissions(
+            request=request, query=analyzed_query, query_parameters=graphql_params, account_session=account_session
+        )
 
         # if the query contains some mutation, it's not currently supported to set AT manually
         if analyzed_query.contains_mutation:
@@ -221,13 +228,7 @@ class InfrahubGraphQLApp:
                 "Processing IntrospectionQuery .. ", branch=branch.name, nbr_object_in_schema=nbr_object_in_schema
             )
 
-        labels = {
-            "type": "mutation" if analyzed_query.contains_mutation else "query",
-            "branch": branch.name,
-            "operation": operation_name if operation_name is not None else "",
-            "name": analyzed_query.operations[0].name,
-            "query_id": "",
-        }
+        labels = self._set_labels(request=request, branch=branch, query=analyzed_query)
 
         with trace.get_tracer(__name__).start_as_current_span("execute_graphql") as span:
             span.set_attributes(labels)
@@ -272,23 +273,37 @@ class InfrahubGraphQLApp:
 
         return json_response
 
+    def _set_labels(self, request: Request, branch: Branch, query: InfrahubGraphQLQueryAnalyzer) -> dict[str, Any]:
+        return {
+            "type": "mutation" if query.contains_mutation else "query",
+            "branch": branch.name,
+            "operation": query.operation_name if query.operation_name is not None else "",
+            "name": query.operations[0].name,
+            "query_id": "",
+        }
+
+    async def _evaluate_permissions(
+        self,
+        request: Request,
+        query: InfrahubGraphQLQueryAnalyzer,
+        query_parameters: GraphqlParams,
+        account_session: AccountSession,
+    ) -> None:
+        await self.permission_checker.check(
+            account_session=account_session, analyzed_query=query, query_parameters=query_parameters
+        )
+
     def _log_error(self, error: Exception) -> None:
         if isinstance(error, Error):
             if 500 <= error.HTTP_CODE <= 500:
-                self.logger.error(
-                    "An exception occurred in resolvers",
-                    exc_info=error,
-                )
+                self.logger.error("An exception occurred in resolvers", exc_info=error)
             elif error.HTTP_CODE == 401:
                 self.logger.info("Permission denied within resolver", message=error.message)
             else:
                 self.logger.debug("An exception occurred in resolvers", exc_info=error)
 
         else:
-            self.logger.critical(
-                "Unhandled exception occurred in resolvers",
-                exc_info=error,
-            )
+            self.logger.critical("Unhandled exception occurred in resolvers", exc_info=error)
 
     async def _run_websocket_server(self, db: InfrahubDatabase, branch: Branch, websocket: WebSocket) -> None:
         subscriptions: dict[str, AsyncGenerator[Any, None]] = {}

--- a/backend/infrahub/graphql/app.py
+++ b/backend/infrahub/graphql/app.py
@@ -212,7 +212,12 @@ class InfrahubGraphQLApp:
             branch=branch,
         )
         await self._evaluate_permissions(
-            request=request, query=analyzed_query, query_parameters=graphql_params, account_session=account_session
+            db=db,
+            request=request,
+            query=analyzed_query,
+            query_parameters=graphql_params,
+            account_session=account_session,
+            branch=branch,
         )
 
         # if the query contains some mutation, it's not currently supported to set AT manually
@@ -285,12 +290,18 @@ class InfrahubGraphQLApp:
     async def _evaluate_permissions(
         self,
         request: Request,
+        db: InfrahubDatabase,
         query: InfrahubGraphQLQueryAnalyzer,
         query_parameters: GraphqlParams,
         account_session: AccountSession,
+        branch: Branch | str | None = None,
     ) -> None:
         await self.permission_checker.check(
-            account_session=account_session, analyzed_query=query, query_parameters=query_parameters
+            db=db,
+            account_session=account_session,
+            analyzed_query=query,
+            query_parameters=query_parameters,
+            branch=branch,
         )
 
     def _log_error(self, error: Exception) -> None:

--- a/backend/infrahub/graphql/auth/query_permission_checker/anonymous_checker.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/anonymous_checker.py
@@ -2,9 +2,10 @@ from typing import Callable
 
 from infrahub.auth import AccountSession
 from infrahub.exceptions import AuthorizationError
+from infrahub.graphql import GraphqlParams
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 
-from .interface import GraphQLQueryPermissionCheckerInterface
+from .interface import CheckerResolution, GraphQLQueryPermissionCheckerInterface
 
 
 class AnonymousGraphQLPermissionChecker(GraphQLQueryPermissionCheckerInterface):
@@ -14,7 +15,9 @@ class AnonymousGraphQLPermissionChecker(GraphQLQueryPermissionCheckerInterface):
     async def supports(self, account_session: AccountSession) -> bool:
         return not account_session.authenticated
 
-    async def check(self, analyzed_query: InfrahubGraphQLQueryAnalyzer) -> None:
+    async def check(
+        self, analyzed_query: InfrahubGraphQLQueryAnalyzer, query_parameters: GraphqlParams
+    ) -> CheckerResolution:
         if self.anonymous_access_allowed_func() and not analyzed_query.contains_mutation:
-            return
+            return CheckerResolution.TERMINATE
         raise AuthorizationError("Authentication is required to perform this operation")

--- a/backend/infrahub/graphql/auth/query_permission_checker/anonymous_checker.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/anonymous_checker.py
@@ -1,6 +1,8 @@
 from typing import Callable
 
 from infrahub.auth import AccountSession
+from infrahub.core.branch import Branch
+from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import AuthorizationError
 from infrahub.graphql import GraphqlParams
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
@@ -12,11 +14,17 @@ class AnonymousGraphQLPermissionChecker(GraphQLQueryPermissionCheckerInterface):
     def __init__(self, anonymous_access_allowed_func: Callable[[], bool]):
         self.anonymous_access_allowed_func = anonymous_access_allowed_func
 
-    async def supports(self, account_session: AccountSession) -> bool:
+    async def supports(
+        self, db: InfrahubDatabase, account_session: AccountSession, branch: Branch | str | None = None
+    ) -> bool:
         return not account_session.authenticated
 
     async def check(
-        self, analyzed_query: InfrahubGraphQLQueryAnalyzer, query_parameters: GraphqlParams
+        self,
+        db: InfrahubDatabase,
+        analyzed_query: InfrahubGraphQLQueryAnalyzer,
+        query_parameters: GraphqlParams,
+        branch: Branch | str | None = None,
     ) -> CheckerResolution:
         if self.anonymous_access_allowed_func() and not analyzed_query.contains_mutation:
             return CheckerResolution.TERMINATE

--- a/backend/infrahub/graphql/auth/query_permission_checker/checker.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/checker.py
@@ -1,19 +1,24 @@
-from typing import List
-
 from infrahub.auth import AccountSession
 from infrahub.exceptions import PermissionDeniedError
+from infrahub.graphql import GraphqlParams
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 
-from .interface import GraphQLQueryPermissionCheckerInterface
+from .interface import CheckerResolution, GraphQLQueryPermissionCheckerInterface
 
 
 class GraphQLQueryPermissionChecker:
-    def __init__(self, sub_checkers: List[GraphQLQueryPermissionCheckerInterface]):
+    def __init__(self, sub_checkers: list[GraphQLQueryPermissionCheckerInterface]):
         self.sub_checkers = sub_checkers
 
-    async def check(self, account_session: AccountSession, analyzed_query: InfrahubGraphQLQueryAnalyzer) -> None:
+    async def check(
+        self,
+        account_session: AccountSession,
+        analyzed_query: InfrahubGraphQLQueryAnalyzer,
+        query_parameters: GraphqlParams,
+    ) -> None:
         for sub_checker in self.sub_checkers:
             if await sub_checker.supports(account_session):
-                await sub_checker.check(analyzed_query)
-                return
+                resolution = await sub_checker.check(analyzed_query=analyzed_query, query_parameters=query_parameters)
+                if resolution == CheckerResolution.TERMINATE:
+                    return
         raise PermissionDeniedError("The current account is not authorized to perform this operation")

--- a/backend/infrahub/graphql/auth/query_permission_checker/checker.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/checker.py
@@ -1,4 +1,6 @@
 from infrahub.auth import AccountSession
+from infrahub.core.branch import Branch
+from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import PermissionDeniedError
 from infrahub.graphql import GraphqlParams
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
@@ -12,13 +14,17 @@ class GraphQLQueryPermissionChecker:
 
     async def check(
         self,
+        db: InfrahubDatabase,
         account_session: AccountSession,
         analyzed_query: InfrahubGraphQLQueryAnalyzer,
         query_parameters: GraphqlParams,
+        branch: Branch | str | None = None,
     ) -> None:
         for sub_checker in self.sub_checkers:
-            if await sub_checker.supports(account_session):
-                resolution = await sub_checker.check(analyzed_query=analyzed_query, query_parameters=query_parameters)
+            if await sub_checker.supports(db=db, account_session=account_session, branch=branch):
+                resolution = await sub_checker.check(
+                    db=db, analyzed_query=analyzed_query, query_parameters=query_parameters, branch=branch
+                )
                 if resolution == CheckerResolution.TERMINATE:
                     return
         raise PermissionDeniedError("The current account is not authorized to perform this operation")

--- a/backend/infrahub/graphql/auth/query_permission_checker/default_branch_checker.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/default_branch_checker.py
@@ -1,0 +1,62 @@
+from infrahub import config
+from infrahub.auth import AccountSession
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.constants import GLOBAL_BRANCH_NAME
+from infrahub.database import InfrahubDatabase
+from infrahub.exceptions import PermissionDeniedError
+from infrahub.graphql import GraphqlParams
+from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
+
+from .interface import CheckerResolution, GraphQLQueryPermissionCheckerInterface
+
+
+class DefaultBranchPermissionChecker(GraphQLQueryPermissionCheckerInterface):
+    permission_required = "global:edit_default_branch:allow"
+    exempt_operations = ["BranchCreate"]
+
+    def __init__(self) -> None:
+        self.can_edit_default_branch: bool = False
+
+    async def supports(
+        self, db: InfrahubDatabase, account_session: AccountSession, branch: Branch | str | None = None
+    ) -> bool:
+        self.can_edit_default_branch = False
+
+        if registry.permission_backends and account_session.authenticated:
+            for permission_backend in registry.permission_backends:
+                self.can_edit_default_branch = await permission_backend.has_permission(
+                    db=db, account_id=account_session.account_id, permission=self.permission_required, branch=branch
+                )
+                if self.can_edit_default_branch:
+                    break
+
+        return account_session.authenticated
+
+    async def check(
+        self,
+        db: InfrahubDatabase,
+        analyzed_query: InfrahubGraphQLQueryAnalyzer,
+        query_parameters: GraphqlParams,
+        branch: Branch | str | None = None,
+    ) -> CheckerResolution:
+        operates_on_default_branch = analyzed_query.branch is None or analyzed_query.branch.name in (
+            GLOBAL_BRANCH_NAME,
+            config.SETTINGS.initial.default_branch,
+        )
+        is_exempt_operation = analyzed_query.operation_name is not None and (
+            analyzed_query.operation_name in self.exempt_operations
+            or analyzed_query.operation_name.startswith("InfrahubAccount")  # Allow user to manage self
+        )
+
+        if (
+            not self.can_edit_default_branch
+            and operates_on_default_branch
+            and analyzed_query.contains_mutation
+            and not is_exempt_operation
+        ):
+            raise PermissionDeniedError(
+                f"You are not allowed to change data in the default branch '{config.SETTINGS.initial.default_branch}'"
+            )
+
+        return CheckerResolution.NEXT_CHECKER

--- a/backend/infrahub/graphql/auth/query_permission_checker/default_checker.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/default_checker.py
@@ -1,4 +1,6 @@
 from infrahub.auth import AccountSession
+from infrahub.core.branch import Branch
+from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import AuthorizationError
 from infrahub.graphql import GraphqlParams
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
@@ -7,10 +9,16 @@ from .interface import CheckerResolution, GraphQLQueryPermissionCheckerInterface
 
 
 class DefaultGraphQLPermissionChecker(GraphQLQueryPermissionCheckerInterface):
-    async def supports(self, account_session: AccountSession) -> bool:
+    async def supports(
+        self, db: InfrahubDatabase, account_session: AccountSession, branch: Branch | str | None = None
+    ) -> bool:
         return True
 
     async def check(
-        self, analyzed_query: InfrahubGraphQLQueryAnalyzer, query_parameters: GraphqlParams
+        self,
+        db: InfrahubDatabase,
+        analyzed_query: InfrahubGraphQLQueryAnalyzer,
+        query_parameters: GraphqlParams,
+        branch: Branch | str | None = None,
     ) -> CheckerResolution:
         raise AuthorizationError("Authentication is required to perform this operation")

--- a/backend/infrahub/graphql/auth/query_permission_checker/default_checker.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/default_checker.py
@@ -1,13 +1,16 @@
 from infrahub.auth import AccountSession
 from infrahub.exceptions import AuthorizationError
+from infrahub.graphql import GraphqlParams
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 
-from .interface import GraphQLQueryPermissionCheckerInterface
+from .interface import CheckerResolution, GraphQLQueryPermissionCheckerInterface
 
 
 class DefaultGraphQLPermissionChecker(GraphQLQueryPermissionCheckerInterface):
     async def supports(self, account_session: AccountSession) -> bool:
         return True
 
-    async def check(self, analyzed_query: InfrahubGraphQLQueryAnalyzer) -> None:
+    async def check(
+        self, analyzed_query: InfrahubGraphQLQueryAnalyzer, query_parameters: GraphqlParams
+    ) -> CheckerResolution:
         raise AuthorizationError("Authentication is required to perform this operation")

--- a/backend/infrahub/graphql/auth/query_permission_checker/interface.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/interface.py
@@ -2,6 +2,8 @@ from abc import ABC, abstractmethod
 from enum import Enum
 
 from infrahub.auth import AccountSession
+from infrahub.core.branch import Branch
+from infrahub.database import InfrahubDatabase
 from infrahub.graphql import GraphqlParams
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 
@@ -13,9 +15,15 @@ class CheckerResolution(Enum):
 
 class GraphQLQueryPermissionCheckerInterface(ABC):
     @abstractmethod
-    async def supports(self, account_session: AccountSession) -> bool: ...
+    async def supports(
+        self, db: InfrahubDatabase, account_session: AccountSession, branch: Branch | str | None = None
+    ) -> bool: ...
 
     @abstractmethod
     async def check(
-        self, analyzed_query: InfrahubGraphQLQueryAnalyzer, query_parameters: GraphqlParams
+        self,
+        db: InfrahubDatabase,
+        analyzed_query: InfrahubGraphQLQueryAnalyzer,
+        query_parameters: GraphqlParams,
+        branch: Branch | str | None = None,
     ) -> CheckerResolution: ...

--- a/backend/infrahub/graphql/auth/query_permission_checker/interface.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/interface.py
@@ -1,7 +1,14 @@
 from abc import ABC, abstractmethod
+from enum import Enum
 
 from infrahub.auth import AccountSession
+from infrahub.graphql import GraphqlParams
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
+
+
+class CheckerResolution(Enum):
+    TERMINATE = 0
+    NEXT_CHECKER = 1
 
 
 class GraphQLQueryPermissionCheckerInterface(ABC):
@@ -9,4 +16,6 @@ class GraphQLQueryPermissionCheckerInterface(ABC):
     async def supports(self, account_session: AccountSession) -> bool: ...
 
     @abstractmethod
-    async def check(self, analyzed_query: InfrahubGraphQLQueryAnalyzer) -> None: ...
+    async def check(
+        self, analyzed_query: InfrahubGraphQLQueryAnalyzer, query_parameters: GraphqlParams
+    ) -> CheckerResolution: ...

--- a/backend/infrahub/graphql/auth/query_permission_checker/read_only_checker.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/read_only_checker.py
@@ -1,6 +1,8 @@
 from graphql import OperationType
 
 from infrahub.auth import AccountSession
+from infrahub.core.branch import Branch
+from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import PermissionDeniedError
 from infrahub.graphql import GraphqlParams
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
@@ -11,11 +13,17 @@ from .interface import CheckerResolution, GraphQLQueryPermissionCheckerInterface
 class ReadOnlyGraphQLPermissionChecker(GraphQLQueryPermissionCheckerInterface):
     allowed_readonly_mutations = ["InfrahubAccountSelfUpdate"]
 
-    async def supports(self, account_session: AccountSession) -> bool:
+    async def supports(
+        self, db: InfrahubDatabase, account_session: AccountSession, branch: Branch | str | None = None
+    ) -> bool:
         return account_session.authenticated and account_session.read_only
 
     async def check(
-        self, analyzed_query: InfrahubGraphQLQueryAnalyzer, query_parameters: GraphqlParams
+        self,
+        db: InfrahubDatabase,
+        analyzed_query: InfrahubGraphQLQueryAnalyzer,
+        query_parameters: GraphqlParams,
+        branch: Branch | str | None = None,
     ) -> CheckerResolution:
         for operation in analyzed_query.operations:
             if (

--- a/backend/infrahub/graphql/auth/query_permission_checker/read_only_checker.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/read_only_checker.py
@@ -2,9 +2,10 @@ from graphql import OperationType
 
 from infrahub.auth import AccountSession
 from infrahub.exceptions import PermissionDeniedError
+from infrahub.graphql import GraphqlParams
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 
-from .interface import GraphQLQueryPermissionCheckerInterface
+from .interface import CheckerResolution, GraphQLQueryPermissionCheckerInterface
 
 
 class ReadOnlyGraphQLPermissionChecker(GraphQLQueryPermissionCheckerInterface):
@@ -13,10 +14,14 @@ class ReadOnlyGraphQLPermissionChecker(GraphQLQueryPermissionCheckerInterface):
     async def supports(self, account_session: AccountSession) -> bool:
         return account_session.authenticated and account_session.read_only
 
-    async def check(self, analyzed_query: InfrahubGraphQLQueryAnalyzer) -> None:
+    async def check(
+        self, analyzed_query: InfrahubGraphQLQueryAnalyzer, query_parameters: GraphqlParams
+    ) -> CheckerResolution:
         for operation in analyzed_query.operations:
             if (
                 operation.operation_type == OperationType.MUTATION
                 and operation.name not in self.allowed_readonly_mutations
             ):
                 raise PermissionDeniedError("The current account is not authorized to perform this operation")
+
+        return CheckerResolution.TERMINATE

--- a/backend/infrahub/graphql/auth/query_permission_checker/read_write_checker.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/read_write_checker.py
@@ -1,12 +1,15 @@
 from infrahub.auth import AccountSession
+from infrahub.graphql import GraphqlParams
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 
-from .interface import GraphQLQueryPermissionCheckerInterface
+from .interface import CheckerResolution, GraphQLQueryPermissionCheckerInterface
 
 
 class ReadWriteGraphQLPermissionChecker(GraphQLQueryPermissionCheckerInterface):
     async def supports(self, account_session: AccountSession) -> bool:
         return account_session.authenticated and not account_session.read_only
 
-    async def check(self, analyzed_query: InfrahubGraphQLQueryAnalyzer) -> None:
-        return
+    async def check(
+        self, analyzed_query: InfrahubGraphQLQueryAnalyzer, query_parameters: GraphqlParams
+    ) -> CheckerResolution:
+        return CheckerResolution.TERMINATE

--- a/backend/infrahub/graphql/auth/query_permission_checker/read_write_checker.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/read_write_checker.py
@@ -1,4 +1,6 @@
 from infrahub.auth import AccountSession
+from infrahub.core.branch import Branch
+from infrahub.database import InfrahubDatabase
 from infrahub.graphql import GraphqlParams
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 
@@ -6,10 +8,16 @@ from .interface import CheckerResolution, GraphQLQueryPermissionCheckerInterface
 
 
 class ReadWriteGraphQLPermissionChecker(GraphQLQueryPermissionCheckerInterface):
-    async def supports(self, account_session: AccountSession) -> bool:
+    async def supports(
+        self, db: InfrahubDatabase, account_session: AccountSession, branch: Branch | str | None = None
+    ) -> bool:
         return account_session.authenticated and not account_session.read_only
 
     async def check(
-        self, analyzed_query: InfrahubGraphQLQueryAnalyzer, query_parameters: GraphqlParams
+        self,
+        db: InfrahubDatabase,
+        analyzed_query: InfrahubGraphQLQueryAnalyzer,
+        query_parameters: GraphqlParams,
+        branch: Branch | str | None = None,
     ) -> CheckerResolution:
         return CheckerResolution.TERMINATE

--- a/backend/tests/unit/graphql/auth/test_anonymous_checker.py
+++ b/backend/tests/unit/graphql/auth/test_anonymous_checker.py
@@ -3,6 +3,8 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from infrahub.auth import AccountSession, AuthType
+from infrahub.core.branch import Branch
+from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import AuthorizationError
 from infrahub.graphql import GraphqlParams
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
@@ -18,23 +20,31 @@ class TestAnonymousAuthChecker:
         self.checker = AnonymousGraphQLPermissionChecker(self.mock_anonymous_setting_get)
 
     @pytest.mark.parametrize("is_authenticated,is_supported", [(True, False), (False, True)])
-    async def test_supports_unauthenticated_accounts(self, is_authenticated, is_supported):
+    async def test_supports_unauthenticated_accounts(
+        self, db: InfrahubDatabase, branch: Branch, is_authenticated, is_supported
+    ):
         self.account_session.authenticated = is_authenticated
 
-        has_support = await self.checker.supports(self.account_session)
+        has_support = await self.checker.supports(db=db, account_session=self.account_session, branch=branch)
 
         assert is_supported is has_support
 
     @pytest.mark.parametrize("anonymous_setting,query_has_mutations", [(False, False), (False, True), (True, True)])
-    async def test_failures_raise_error(self, anonymous_setting, query_has_mutations):
+    async def test_failures_raise_error(
+        self, db: InfrahubDatabase, branch: Branch, anonymous_setting, query_has_mutations
+    ):
         self.mock_anonymous_setting_get.return_value = anonymous_setting
         self.graphql_query.contains_mutation = query_has_mutations
 
         with pytest.raises(AuthorizationError):
-            await self.checker.check(self.graphql_query, query_parameters=self.query_parameters)
+            await self.checker.check(
+                db=db, analyzed_query=self.graphql_query, query_parameters=self.query_parameters, branch=branch
+            )
 
-    async def test_check_passes(self):
+    async def test_check_passes(self, db: InfrahubDatabase, branch: Branch):
         self.mock_anonymous_setting_get.return_value = True
         self.graphql_query.contains_mutation = False
 
-        await self.checker.check(analyzed_query=self.graphql_query, query_parameters=self.query_parameters)
+        await self.checker.check(
+            db=db, analyzed_query=self.graphql_query, query_parameters=self.query_parameters, branch=branch
+        )

--- a/backend/tests/unit/graphql/auth/test_anonymous_checker.py
+++ b/backend/tests/unit/graphql/auth/test_anonymous_checker.py
@@ -4,6 +4,7 @@ import pytest
 
 from infrahub.auth import AccountSession, AuthType
 from infrahub.exceptions import AuthorizationError
+from infrahub.graphql import GraphqlParams
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 from infrahub.graphql.auth.query_permission_checker.anonymous_checker import AnonymousGraphQLPermissionChecker
 
@@ -12,6 +13,7 @@ class TestAnonymousAuthChecker:
     def setup_method(self):
         self.account_session = AccountSession(account_id="abc", auth_type=AuthType.JWT)
         self.graphql_query = AsyncMock(spec=InfrahubGraphQLQueryAnalyzer)
+        self.query_parameters = MagicMock(spec=GraphqlParams)
         self.mock_anonymous_setting_get = MagicMock(return_value=True)
         self.checker = AnonymousGraphQLPermissionChecker(self.mock_anonymous_setting_get)
 
@@ -29,10 +31,10 @@ class TestAnonymousAuthChecker:
         self.graphql_query.contains_mutation = query_has_mutations
 
         with pytest.raises(AuthorizationError):
-            await self.checker.check(self.graphql_query)
+            await self.checker.check(self.graphql_query, query_parameters=self.query_parameters)
 
     async def test_check_passes(self):
         self.mock_anonymous_setting_get.return_value = True
         self.graphql_query.contains_mutation = False
 
-        await self.checker.check(self.graphql_query)
+        await self.checker.check(analyzed_query=self.graphql_query, query_parameters=self.query_parameters)

--- a/backend/tests/unit/graphql/auth/test_default_branch_checker.py
+++ b/backend/tests/unit/graphql/auth/test_default_branch_checker.py
@@ -1,0 +1,70 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from infrahub import config
+from infrahub.auth import AccountSession, AuthType
+from infrahub.core.branch import Branch
+from infrahub.core.constants import AccountRole, GlobalPermissions
+from infrahub.database import InfrahubDatabase
+from infrahub.exceptions import PermissionDeniedError
+from infrahub.graphql import GraphqlParams
+from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
+from infrahub.graphql.auth.query_permission_checker.default_branch_checker import DefaultBranchPermissionChecker
+
+
+class TestDefaultBranchPermissionChecker:
+    def setup_method(self):
+        self.account_session = AccountSession(account_id="abc", auth_type=AuthType.JWT, role=AccountRole.ADMIN)
+        self.graphql_query = AsyncMock(spec=InfrahubGraphQLQueryAnalyzer)
+        self.checker = DefaultBranchPermissionChecker()
+
+    @pytest.mark.parametrize(
+        "user",
+        [
+            AccountSession(
+                account_id="123",
+                auth_type=AuthType.JWT,
+                role=AccountRole.ADMIN,
+                permissions={"global_permissions": [GlobalPermissions.EDIT_DEFAULT_BRANCH.value]},
+            ),
+            AccountSession(account_id="abc", auth_type=AuthType.JWT, role=AccountRole.ADMIN),
+            AccountSession(authenticated=False, account_id="anonymous", auth_type=AuthType.NONE),
+        ],
+    )
+    async def test_supports_default_branch_permission_accounts(self, user, db: InfrahubDatabase, branch: Branch):
+        is_supported = await self.checker.supports(db=db, account_session=user, branch=branch)
+        assert is_supported == user.authenticated
+
+    @pytest.mark.parametrize(
+        "can_edit_default_branch,contains_mutations,branch_name",
+        [
+            (True, True, "main"),
+            (True, False, "main"),
+            (False, True, "main"),
+            (False, False, "main"),
+            (True, True, "not_default_branch"),
+            (True, False, "not_default_branch"),
+            (False, True, "not_default_branch"),
+            (False, False, "not_default_branch"),
+        ],
+    )
+    async def test_raise_if_not_permission(
+        self, can_edit_default_branch, contains_mutations, branch_name, db: InfrahubDatabase, branch: Branch
+    ):
+        self.checker.can_edit_default_branch = can_edit_default_branch
+        self.graphql_query.contains_mutations = contains_mutations
+        self.graphql_query.operation_name = "CreateTags"
+        self.graphql_query.branch = MagicMock()
+        self.graphql_query.branch.name = branch_name
+
+        if contains_mutations and not can_edit_default_branch and branch_name == config.SETTINGS.initial.default_branch:
+            with pytest.raises(
+                PermissionDeniedError, match=r"You are not allowed to change data in the default branch"
+            ):
+                await self.checker.check(
+                    db=db,
+                    analyzed_query=self.graphql_query,
+                    query_parameters=MagicMock(spec=GraphqlParams),
+                    branch=branch,
+                )

--- a/backend/tests/unit/graphql/auth/test_default_checker.py
+++ b/backend/tests/unit/graphql/auth/test_default_checker.py
@@ -1,10 +1,11 @@
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from infrahub.auth import AccountSession, AuthType
 from infrahub.core.constants import AccountRole
 from infrahub.exceptions import AuthorizationError
+from infrahub.graphql import GraphqlParams
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 from infrahub.graphql.auth.query_permission_checker.default_checker import DefaultGraphQLPermissionChecker
 
@@ -25,4 +26,4 @@ class TestDefaultAuthChecker:
 
     async def test_always_raises_error(self):
         with pytest.raises(AuthorizationError):
-            await self.checker.check(self.graphql_query)
+            await self.checker.check(analyzed_query=self.graphql_query, query_parameters=MagicMock(spec=GraphqlParams))

--- a/backend/tests/unit/graphql/auth/test_parent_checker.py
+++ b/backend/tests/unit/graphql/auth/test_parent_checker.py
@@ -1,27 +1,40 @@
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from infrahub.auth import AccountSession, AuthType
 from infrahub.core.constants import AccountRole
 from infrahub.exceptions import PermissionDeniedError
+from infrahub.graphql import GraphqlParams
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 from infrahub.graphql.auth.query_permission_checker.checker import GraphQLQueryPermissionChecker
-from infrahub.graphql.auth.query_permission_checker.interface import GraphQLQueryPermissionCheckerInterface
+from infrahub.graphql.auth.query_permission_checker.interface import (
+    CheckerResolution,
+    GraphQLQueryPermissionCheckerInterface,
+)
 
 
 class TestParentAuthChecker:
     def setup_method(self):
         self.account_session = AccountSession(account_id="abc", auth_type=AuthType.JWT, role=AccountRole.ADMIN)
         self.graphql_query = AsyncMock(spec=InfrahubGraphQLQueryAnalyzer)
+        self.query_parameters = MagicMock(spec=GraphqlParams)
         self.sub_auth_checker_one = AsyncMock(spec=GraphQLQueryPermissionCheckerInterface)
         self.sub_auth_checker_two = AsyncMock(spec=GraphQLQueryPermissionCheckerInterface)
         self.sub_auth_checker_one.supports.return_value = False
         self.sub_auth_checker_two.supports.return_value = True
+        self.sub_auth_checker_one.check = AsyncMock()
+        self.sub_auth_checker_one.check.return_value = CheckerResolution.TERMINATE
+        self.sub_auth_checker_two.check = AsyncMock()
+        self.sub_auth_checker_two.check.return_value = CheckerResolution.TERMINATE
         self.parent_checker = GraphQLQueryPermissionChecker([self.sub_auth_checker_one, self.sub_auth_checker_two])
 
     async def __call_system_under_test(self):
-        await self.parent_checker.check(self.account_session, self.graphql_query)
+        await self.parent_checker.check(
+            account_session=self.account_session,
+            analyzed_query=self.graphql_query,
+            query_parameters=self.query_parameters,
+        )
 
     async def test_only_checks_one(self):
         await self.__call_system_under_test()
@@ -29,7 +42,9 @@ class TestParentAuthChecker:
         self.sub_auth_checker_one.supports.assert_awaited_once_with(self.account_session)
         self.sub_auth_checker_two.supports.assert_awaited_once_with(self.account_session)
         self.sub_auth_checker_one.check.assert_not_awaited()
-        self.sub_auth_checker_two.check.assert_awaited_once_with(self.graphql_query)
+        self.sub_auth_checker_two.check.assert_awaited_once_with(
+            analyzed_query=self.graphql_query, query_parameters=self.query_parameters
+        )
 
     async def test_error_if_no_support(self):
         self.sub_auth_checker_two.supports.return_value = False

--- a/backend/tests/unit/graphql/auth/test_read_only_checker.py
+++ b/backend/tests/unit/graphql/auth/test_read_only_checker.py
@@ -5,7 +5,9 @@ from graphql import OperationType
 from infrahub_sdk.analyzer import GraphQLOperation
 
 from infrahub.auth import AccountSession, AuthType
+from infrahub.core.branch import Branch
 from infrahub.core.constants import AccountRole
+from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import PermissionDeniedError
 from infrahub.graphql import GraphqlParams
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
@@ -20,38 +22,44 @@ class TestReadOnlyAuthChecker:
         self.checker = ReadOnlyGraphQLPermissionChecker()
 
     @pytest.mark.parametrize("role", [AccountRole.ADMIN, AccountRole.READ_WRITE])
-    async def test_doesnt_supports_other_accounts(self, role):
+    async def test_doesnt_supports_other_accounts(self, db: InfrahubDatabase, branch: Branch, role):
         self.account_session.role = role
 
-        is_supported = await self.checker.supports(self.account_session)
+        is_supported = await self.checker.supports(db=db, account_session=self.account_session, branch=branch)
 
         assert is_supported is False
 
-    async def test_supports_read_only_accounts(self):
+    async def test_supports_read_only_accounts(self, db: InfrahubDatabase, branch: Branch):
         self.account_session.role = AccountRole.READ_ONLY
 
-        is_supported = await self.checker.supports(self.account_session)
+        is_supported = await self.checker.supports(db=db, account_session=self.account_session, branch=branch)
 
         assert is_supported is True
 
-    async def test_illegal_mutation_raises_error(self):
+    async def test_illegal_mutation_raises_error(self, db: InfrahubDatabase, branch: Branch):
         self.graphql_query.contains_mutation = True
         self.graphql_query.operations = [
             GraphQLOperation(name="ThisIsNotAllowed", operation_type=OperationType.MUTATION)
         ]
 
         with pytest.raises(PermissionDeniedError):
-            await self.checker.check(analyzed_query=self.graphql_query, query_parameters=self.query_parameters)
+            await self.checker.check(
+                db=db, analyzed_query=self.graphql_query, query_parameters=self.query_parameters, branch=branch
+            )
 
-    async def test_legal_mutation_is_okay(self):
+    async def test_legal_mutation_is_okay(self, db: InfrahubDatabase, branch: Branch):
         self.checker.allowed_readonly_mutations = ["ThisIsAllowed"]
         self.graphql_query.contains_mutation = True
         self.graphql_query.operations = [GraphQLOperation(name="ThisIsAllowed", operation_type=OperationType.MUTATION)]
 
-        await self.checker.check(analyzed_query=self.graphql_query, query_parameters=self.query_parameters)
+        await self.checker.check(
+            db=db, analyzed_query=self.graphql_query, query_parameters=self.query_parameters, branch=branch
+        )
 
-    async def test_query_is_okay(self):
+    async def test_query_is_okay(self, db: InfrahubDatabase, branch: Branch):
         self.graphql_query.contains_mutation = False
         self.graphql_query.operations = [GraphQLOperation(name="ThisIsAQuery", operation_type=OperationType.QUERY)]
 
-        await self.checker.check(analyzed_query=self.graphql_query, query_parameters=self.query_parameters)
+        await self.checker.check(
+            db=db, analyzed_query=self.graphql_query, query_parameters=self.query_parameters, branch=branch
+        )

--- a/backend/tests/unit/graphql/auth/test_read_only_checker.py
+++ b/backend/tests/unit/graphql/auth/test_read_only_checker.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from graphql import OperationType
@@ -7,6 +7,7 @@ from infrahub_sdk.analyzer import GraphQLOperation
 from infrahub.auth import AccountSession, AuthType
 from infrahub.core.constants import AccountRole
 from infrahub.exceptions import PermissionDeniedError
+from infrahub.graphql import GraphqlParams
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 from infrahub.graphql.auth.query_permission_checker.read_only_checker import ReadOnlyGraphQLPermissionChecker
 
@@ -15,6 +16,7 @@ class TestReadOnlyAuthChecker:
     def setup_method(self):
         self.account_session = AccountSession(account_id="abc", auth_type=AuthType.JWT, role=AccountRole.READ_ONLY)
         self.graphql_query = AsyncMock(spec=InfrahubGraphQLQueryAnalyzer)
+        self.query_parameters = MagicMock(spec=GraphqlParams)
         self.checker = ReadOnlyGraphQLPermissionChecker()
 
     @pytest.mark.parametrize("role", [AccountRole.ADMIN, AccountRole.READ_WRITE])
@@ -39,17 +41,17 @@ class TestReadOnlyAuthChecker:
         ]
 
         with pytest.raises(PermissionDeniedError):
-            await self.checker.check(self.graphql_query)
+            await self.checker.check(analyzed_query=self.graphql_query, query_parameters=self.query_parameters)
 
     async def test_legal_mutation_is_okay(self):
         self.checker.allowed_readonly_mutations = ["ThisIsAllowed"]
         self.graphql_query.contains_mutation = True
         self.graphql_query.operations = [GraphQLOperation(name="ThisIsAllowed", operation_type=OperationType.MUTATION)]
 
-        await self.checker.check(self.graphql_query)
+        await self.checker.check(analyzed_query=self.graphql_query, query_parameters=self.query_parameters)
 
     async def test_query_is_okay(self):
         self.graphql_query.contains_mutation = False
         self.graphql_query.operations = [GraphQLOperation(name="ThisIsAQuery", operation_type=OperationType.QUERY)]
 
-        await self.checker.check(self.graphql_query)
+        await self.checker.check(analyzed_query=self.graphql_query, query_parameters=self.query_parameters)

--- a/backend/tests/unit/graphql/auth/test_read_write_checker.py
+++ b/backend/tests/unit/graphql/auth/test_read_write_checker.py
@@ -3,7 +3,9 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from infrahub.auth import AccountSession, AuthType
+from infrahub.core.branch import Branch
 from infrahub.core.constants import AccountRole
+from infrahub.database import InfrahubDatabase
 from infrahub.graphql import GraphqlParams
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 from infrahub.graphql.auth.query_permission_checker.read_write_checker import ReadWriteGraphQLPermissionChecker
@@ -16,22 +18,24 @@ class TestReadWriteAuthChecker:
         self.checker = ReadWriteGraphQLPermissionChecker()
 
     @pytest.mark.parametrize("role", [AccountRole.ADMIN, AccountRole.READ_WRITE])
-    async def test_supports_readwrite_accounts(self, role):
+    async def test_supports_readwrite_accounts(self, db: InfrahubDatabase, branch: Branch, role):
         self.account_session.role = role
 
-        is_supported = await self.checker.supports(self.account_session)
+        is_supported = await self.checker.supports(db=db, account_session=self.account_session, branch=branch)
 
         assert is_supported is True
 
-    async def test_doesnt_support_readonly_accounts(self):
+    async def test_doesnt_support_readonly_accounts(self, db: InfrahubDatabase, branch: Branch):
         self.account_session.role = AccountRole.READ_ONLY
 
-        is_supported = await self.checker.supports(self.account_session)
+        is_supported = await self.checker.supports(db=db, account_session=self.account_session, branch=branch)
 
         assert is_supported is False
 
     @pytest.mark.parametrize("contains_mutations", [True, False])
-    async def test_never_raises_error(self, contains_mutations):
+    async def test_never_raises_error(self, db: InfrahubDatabase, branch: Branch, contains_mutations):
         self.graphql_query.contains_mutations = contains_mutations
 
-        await self.checker.check(analyzed_query=self.graphql_query, query_parameters=MagicMock(spec=GraphqlParams))
+        await self.checker.check(
+            db=db, analyzed_query=self.graphql_query, query_parameters=MagicMock(spec=GraphqlParams), branch=branch
+        )

--- a/backend/tests/unit/graphql/auth/test_read_write_checker.py
+++ b/backend/tests/unit/graphql/auth/test_read_write_checker.py
@@ -1,9 +1,10 @@
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from infrahub.auth import AccountSession, AuthType
 from infrahub.core.constants import AccountRole
+from infrahub.graphql import GraphqlParams
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 from infrahub.graphql.auth.query_permission_checker.read_write_checker import ReadWriteGraphQLPermissionChecker
 
@@ -33,4 +34,4 @@ class TestReadWriteAuthChecker:
     async def test_never_raises_error(self, contains_mutations):
         self.graphql_query.contains_mutations = contains_mutations
 
-        await self.checker.check(self.graphql_query)
+        await self.checker.check(analyzed_query=self.graphql_query, query_parameters=MagicMock(spec=GraphqlParams))

--- a/models/infrastructure_edge.py
+++ b/models/infrastructure_edge.py
@@ -1514,10 +1514,10 @@ async def generate_continents_countries(client: InfrahubClient, log: logging.Log
 
 
 async def prepare_accounts(client: InfrahubClient, log: logging.Logger, branch: str, batch: InfrahubBatch) -> None:
-    for account in ACCOUNTS:
-        groups = await client.filters(branch=branch, kind="CoreUserGroup", name__value="Administrators")
-        store.set(key=groups[0].name, node=groups[0])
+    groups = await client.filters(branch=branch, kind="CoreUserGroup", name__value="Administrators")
+    store.set(key=groups[0].name, node=groups[0])
 
+    for account in ACCOUNTS:
         data = account.model_dump()
         data["member_of_groups"] = groups
 

--- a/models/infrastructure_edge.py
+++ b/models/infrastructure_edge.py
@@ -1515,11 +1515,13 @@ async def generate_continents_countries(client: InfrahubClient, log: logging.Log
 
 async def prepare_accounts(client: InfrahubClient, log: logging.Logger, branch: str, batch: InfrahubBatch) -> None:
     for account in ACCOUNTS:
-        obj = await client.create(
-            branch=branch,
-            kind="CoreAccount",
-            data=account.model_dump(),
-        )
+        groups = await client.filters(branch=branch, kind="CoreUserGroup", name__value="Administrators")
+        store.set(key=groups[0].name, node=groups[0])
+
+        data = account.model_dump()
+        data["member_of_groups"] = groups
+
+        obj = await client.create(branch=branch, kind="CoreAccount", data=data)
         batch.add(task=obj.save, node=obj)
         store.set(key=account.name, node=obj)
 


### PR DESCRIPTION
Add default branch checker which makes sure that a user executing a GraphQL mutation has the permission to do so by verifying the "edit default branch" global permission.

This PR depends on https://github.com/opsmill/infrahub/pull/4260.