### PR TITLE
Minor tutorial docs fixes related to `Integration with Git`

### DIFF
--- a/docs/docs/tutorials/getting-started/git-integration.mdx
+++ b/docs/docs/tutorials/getting-started/git-integration.mdx
@@ -8,6 +8,8 @@ One of the three pillars Infrahub is built on is the idea of having unified stor
 
 When integrating a Git repository with Infrahub, the Git agent will ensure that both systems stay in sync at any time. Changes to branches or files in a Git repository will be synced to Infrahub automatically.
 
+Please refer to [Repository](/topics/repository) to learn more about it.
+
 ## Fork & Clone the repository for the demo
 
 Create a fork of the repository:
@@ -49,10 +51,10 @@ Refer to [Adding a repository guide](/guides/repository).
 
 After adding the `infrahub-demo-edge` repository you will be able to see several new [Transformations](/topics/transformation) and related objects:
 
-- 3 Jinja Rendered File under [Jinja2 Transformation](http://localhost:8000/objects/CoreTransformJinja2/)
-- 4 Python Transformation under [Python Transformation](http://localhost:8000/objects/CoreTransformPython)
-- 4 [Artifact Definition](http://localhost:8000/objects/CoreArtifactDefinition)
-- 7 GraphQL [Queries](/topics/graphql) under [Objects / GraphQL Query](http://localhost:8000/objects/GraphQLQuery/)
+- 2 Jinja Rendered File under [Jinja2 Transformation](http://localhost:8000/objects/CoreTransformJinja2/)
+- 2 Python Transformation under [Python Transformation](http://localhost:8000/objects/CoreTransformPython)
+- 2 [Artifact Definition](http://localhost:8000/objects/CoreArtifactDefinition)
+- 9 GraphQL [Queries](/topics/graphql) under [Objects / GraphQL Query](http://localhost:8000/objects/CoreGraphQLQuery/)
 
 :::note Troubleshooting
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -96,6 +96,7 @@ const sidebars: SidebarsConfig = {
         'topics/local-demo-environment',
         'topics/generator',
         'topics/graphql',
+        'topics/metadata',
         'topics/object-storage',
         'topics/version-control',
         'topics/proposed-change',


### PR DESCRIPTION
- While reading `Integration with Git` tutorial, adding a reference to [Repository](https://docs.infrahub.app/topics/repository) helps as this page contains information about what synchronization between a git repository and infrahub really is (`.gql` files + .`infrahub.yml` file).
- Fixed number of synced transformations/queries from `infrahub-demo-edge`.
- Add reference to metadata topics page, currently it seems we can only access is through links from other pages such as [Data lineage and metadata](https://docs.infrahub.app/tutorials/getting-started/lineage-information).

Note that running `invoke docs.lint` at the root of `infrahub` folder outputs `✖ 18976 errors, 7179 warnings and 0 suggestions in 1865 files.`. I would have expected it to returns 0 errors or potential ones this PR could have introduced, is there another way to use this command?

Also, I am not sure what is the purpose of `invoke docs.validate`, should I commit some generated files in this PR?