### PR TITLE
IFC-623 diff locking enhancements

### DIFF
--- a/backend/infrahub/core/diff/coordinator.py
+++ b/backend/infrahub/core/diff/coordinator.py
@@ -35,6 +35,8 @@ class EnrichedDiffRequest:
 
 
 class DiffCoordinator:
+    lock_namespace = "diff-update"
+
     def __init__(
         self,
         diff_repo: DiffRepository,
@@ -54,6 +56,7 @@ class DiffCoordinator:
         self.labels_enricher = labels_enricher
         self.summary_counts_enricher = summary_counts_enricher
         self.data_check_synchronizer = data_check_synchronizer
+        self.lock_registry = lock.registry
         self._enriched_diff_cache: dict[EnrichedDiffRequest, EnrichedDiffRoot] = {}
 
     async def run_update(
@@ -84,17 +87,41 @@ class DiffCoordinator:
             name=name,
         )
 
+    def _get_lock_name(self, base_branch_name: str, diff_branch_name: str, is_incremental: bool) -> str:
+        lock_name = f"{base_branch_name}__{diff_branch_name}"
+        if is_incremental:
+            lock_name += "__incremental"
+        return lock_name
+
     async def update_branch_diff(self, base_branch: Branch, diff_branch: Branch) -> EnrichedDiffRoot:
+        incremental_lock_name = self._get_lock_name(
+            base_branch_name=base_branch.name, diff_branch_name=diff_branch.name, is_incremental=True
+        )
+        existing_incremental_lock = self.lock_registry.get_existing(
+            name=incremental_lock_name, namespace=self.lock_namespace
+        )
+        if existing_incremental_lock and await existing_incremental_lock.locked():
+            async with self.lock_registry.get(name=incremental_lock_name, namespace=self.lock_namespace):
+                return await self.diff_repo.get_one(
+                    tracking_id=BranchTrackingId(name=diff_branch.name), diff_branch_name=diff_branch.name
+                )
+        general_lock_name = self._get_lock_name(
+            base_branch_name=base_branch.name, diff_branch_name=diff_branch.name, is_incremental=False
+        )
         from_time = Timestamp(diff_branch.get_created_at())
         to_time = Timestamp()
         tracking_id = BranchTrackingId(name=diff_branch.name)
-        return await self._update_diffs(
-            base_branch=base_branch,
-            diff_branch=diff_branch,
-            from_time=from_time,
-            to_time=to_time,
-            tracking_id=tracking_id,
-        )
+        async with (
+            self.lock_registry.get(name=general_lock_name, namespace=self.lock_namespace),
+            self.lock_registry.get(name=incremental_lock_name, namespace=self.lock_namespace),
+        ):
+            return await self._update_diffs(
+                base_branch=base_branch,
+                diff_branch=diff_branch,
+                from_time=from_time,
+                to_time=to_time,
+                tracking_id=tracking_id,
+            )
 
     async def create_or_update_arbitrary_timeframe_diff(
         self,
@@ -107,13 +134,17 @@ class DiffCoordinator:
         tracking_id = None
         if name:
             tracking_id = NameTrackingId(name=name)
-        return await self._update_diffs(
-            base_branch=base_branch,
-            diff_branch=diff_branch,
-            from_time=from_time,
-            to_time=to_time,
-            tracking_id=tracking_id,
+        general_lock_name = self._get_lock_name(
+            base_branch_name=base_branch.name, diff_branch_name=diff_branch.name, is_incremental=False
         )
+        async with self.lock_registry.get(name=general_lock_name, namespace=self.lock_namespace):
+            return await self._update_diffs(
+                base_branch=base_branch,
+                diff_branch=diff_branch,
+                from_time=from_time,
+                to_time=to_time,
+                tracking_id=tracking_id,
+            )
 
     async def _update_diffs(
         self,
@@ -123,67 +154,66 @@ class DiffCoordinator:
         to_time: Timestamp,
         tracking_id: TrackingId | None = None,
     ) -> EnrichedDiffRoot:
-        async with lock.registry.get(name=f"{base_branch.name}__{diff_branch.name}", namespace="branch-diff"):
-            requested_diff_branches = {base_branch.name: base_branch, diff_branch.name: diff_branch}
-            aggregated_diffs_by_branch_name: dict[str, EnrichedDiffRoot] = {}
-            diff_uuids_to_delete = []
-            for branch in requested_diff_branches.values():
-                retrieved_enriched_diffs = await self.diff_repo.get(
-                    base_branch_name=base_branch.name,
-                    diff_branch_names=[branch.name],
-                    from_time=from_time,
-                    to_time=to_time,
-                    tracking_id=tracking_id,
-                    include_empty=True,
-                )
-                if tracking_id:
-                    diff_uuids_to_delete += [
-                        diff.uuid for diff in retrieved_enriched_diffs if diff.tracking_id == tracking_id
-                    ]
-                covered_time_ranges = [
-                    TimeRange(from_time=enriched_diff.from_time, to_time=enriched_diff.to_time)
-                    for enriched_diff in retrieved_enriched_diffs
-                ]
-                missing_time_ranges = self._get_missing_time_ranges(
-                    time_ranges=covered_time_ranges, from_time=from_time, to_time=to_time
-                )
-                all_enriched_diffs = list(retrieved_enriched_diffs)
-                for missing_time_range in missing_time_ranges:
-                    diff_request = EnrichedDiffRequest(
-                        base_branch=base_branch,
-                        diff_branch=branch,
-                        from_time=missing_time_range.from_time,
-                        to_time=missing_time_range.to_time,
-                    )
-                    enriched_diff = await self._get_enriched_diff(diff_request=diff_request)
-                    all_enriched_diffs.append(enriched_diff)
-                all_enriched_diffs.sort(key=lambda e_diff: e_diff.from_time)
-                combined_diff = all_enriched_diffs[0]
-                for next_diff in all_enriched_diffs[1:]:
-                    combined_diff = await self.diff_combiner.combine(earlier_diff=combined_diff, later_diff=next_diff)
-                aggregated_diffs_by_branch_name[branch.name] = combined_diff
-
-            if len(aggregated_diffs_by_branch_name) > 1:
-                await self.conflicts_enricher.add_conflicts_to_branch_diff(
-                    base_diff_root=aggregated_diffs_by_branch_name[base_branch.name],
-                    branch_diff_root=aggregated_diffs_by_branch_name[diff_branch.name],
-                )
-                await self.labels_enricher.enrich(
-                    enriched_diff_root=aggregated_diffs_by_branch_name[diff_branch.name], conflicts_only=True
-                )
-
+        requested_diff_branches = {base_branch.name: base_branch, diff_branch.name: diff_branch}
+        aggregated_diffs_by_branch_name: dict[str, EnrichedDiffRoot] = {}
+        diff_uuids_to_delete = []
+        for branch in requested_diff_branches.values():
+            retrieved_enriched_diffs = await self.diff_repo.get(
+                base_branch_name=base_branch.name,
+                diff_branch_names=[branch.name],
+                from_time=from_time,
+                to_time=to_time,
+                tracking_id=tracking_id,
+                include_empty=True,
+            )
             if tracking_id:
-                for enriched_diff in aggregated_diffs_by_branch_name.values():
-                    enriched_diff.tracking_id = tracking_id
-                if diff_uuids_to_delete:
-                    await self.diff_repo.delete_diff_roots(diff_root_uuids=diff_uuids_to_delete)
+                diff_uuids_to_delete += [
+                    diff.uuid for diff in retrieved_enriched_diffs if diff.tracking_id == tracking_id
+                ]
+            covered_time_ranges = [
+                TimeRange(from_time=enriched_diff.from_time, to_time=enriched_diff.to_time)
+                for enriched_diff in retrieved_enriched_diffs
+            ]
+            missing_time_ranges = self._get_missing_time_ranges(
+                time_ranges=covered_time_ranges, from_time=from_time, to_time=to_time
+            )
+            all_enriched_diffs = list(retrieved_enriched_diffs)
+            for missing_time_range in missing_time_ranges:
+                diff_request = EnrichedDiffRequest(
+                    base_branch=base_branch,
+                    diff_branch=branch,
+                    from_time=missing_time_range.from_time,
+                    to_time=missing_time_range.to_time,
+                )
+                enriched_diff = await self._get_enriched_diff(diff_request=diff_request)
+                all_enriched_diffs.append(enriched_diff)
+            all_enriched_diffs.sort(key=lambda e_diff: e_diff.from_time)
+            combined_diff = all_enriched_diffs[0]
+            for next_diff in all_enriched_diffs[1:]:
+                combined_diff = await self.diff_combiner.combine(earlier_diff=combined_diff, later_diff=next_diff)
+            aggregated_diffs_by_branch_name[branch.name] = combined_diff
 
+        if len(aggregated_diffs_by_branch_name) > 1:
+            await self.conflicts_enricher.add_conflicts_to_branch_diff(
+                base_diff_root=aggregated_diffs_by_branch_name[base_branch.name],
+                branch_diff_root=aggregated_diffs_by_branch_name[diff_branch.name],
+            )
+            await self.labels_enricher.enrich(
+                enriched_diff_root=aggregated_diffs_by_branch_name[diff_branch.name], conflicts_only=True
+            )
+
+        if tracking_id:
             for enriched_diff in aggregated_diffs_by_branch_name.values():
-                await self.summary_counts_enricher.enrich(enriched_diff_root=enriched_diff)
-                await self.diff_repo.save(enriched_diff=enriched_diff)
-            branch_enriched_diff = aggregated_diffs_by_branch_name[diff_branch.name]
-            await self._update_core_data_checks(enriched_diff=enriched_diff)
-            return branch_enriched_diff
+                enriched_diff.tracking_id = tracking_id
+            if diff_uuids_to_delete:
+                await self.diff_repo.delete_diff_roots(diff_root_uuids=diff_uuids_to_delete)
+
+        for enriched_diff in aggregated_diffs_by_branch_name.values():
+            await self.summary_counts_enricher.enrich(enriched_diff_root=enriched_diff)
+            await self.diff_repo.save(enriched_diff=enriched_diff)
+        branch_enriched_diff = aggregated_diffs_by_branch_name[diff_branch.name]
+        await self._update_core_data_checks(enriched_diff=enriched_diff)
+        return branch_enriched_diff
 
     async def _update_core_data_checks(self, enriched_diff: EnrichedDiffRoot) -> list[Node]:
         return await self.data_check_synchronizer.synchronize(enriched_diff=enriched_diff)

--- a/backend/infrahub/core/integrity/object_conflict/conflict_recorder.py
+++ b/backend/infrahub/core/integrity/object_conflict/conflict_recorder.py
@@ -18,7 +18,7 @@ class ObjectConflictValidatorRecorder:
         self.validator_label = validator_label
         self.check_schema_kind = check_schema_kind
 
-    async def record_conflicts(self, proposed_change_id: str, conflicts: Sequence[ObjectConflict]) -> list[Node]:
+    async def record_conflicts(self, proposed_change_id: str, conflicts: Sequence[ObjectConflict]) -> list[Node]:  # pylint: disable=too-many-branches
         try:
             proposed_change = await NodeManager.get_one_by_id_or_default_filter(
                 id=proposed_change_id, kind=InfrahubKind.PROPOSEDCHANGE, db=self.db

--- a/backend/infrahub/core/integrity/object_conflict/conflict_recorder.py
+++ b/backend/infrahub/core/integrity/object_conflict/conflict_recorder.py
@@ -8,6 +8,7 @@ from infrahub.core.node import Node
 from infrahub.core.protocols import CoreProposedChange
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
+from infrahub.exceptions import NodeNotFoundError
 
 
 class ObjectConflictValidatorRecorder:
@@ -18,9 +19,12 @@ class ObjectConflictValidatorRecorder:
         self.check_schema_kind = check_schema_kind
 
     async def record_conflicts(self, proposed_change_id: str, conflicts: Sequence[ObjectConflict]) -> list[Node]:
-        proposed_change = await NodeManager.get_one_by_id_or_default_filter(
-            id=proposed_change_id, kind=InfrahubKind.PROPOSEDCHANGE, db=self.db
-        )
+        try:
+            proposed_change = await NodeManager.get_one_by_id_or_default_filter(
+                id=proposed_change_id, kind=InfrahubKind.PROPOSEDCHANGE, db=self.db
+            )
+        except NodeNotFoundError:
+            return []
         proposed_change = cast(CoreProposedChange, proposed_change)
         validator = await self.get_or_create_validator(proposed_change)
         await self.initialize_validator(validator)

--- a/backend/infrahub/lock.py
+++ b/backend/infrahub/lock.py
@@ -102,6 +102,9 @@ class NATSLock:
     async def release(self) -> None:
         await self.service.cache.delete(key=self.name)
 
+    async def locked(self) -> bool:
+        return await self.service.cache.get(key=self.name) is not None
+
 
 class InfrahubLock:
     """InfrahubLock object to provide a unified interface for both Local and Distributed locks.

--- a/backend/infrahub/lock.py
+++ b/backend/infrahub/lock.py
@@ -209,6 +209,17 @@ class InfrahubLockRegistry:
 
         return new_name
 
+    def get_existing(
+        self,
+        name: str,
+        namespace: str | None,
+        local: Optional[bool] = None,
+    ) -> InfrahubLock | None:
+        lock_name = self._generate_name(name=name, namespace=namespace, local=local)
+        if lock_name not in self.locks:
+            return None
+        return self.locks[lock_name]
+
     def get(
         self, name: str, namespace: Optional[str] = None, local: Optional[bool] = None, in_multi: bool = False
     ) -> InfrahubLock:

--- a/backend/tests/unit/core/diff/test_coordinator_lock.py
+++ b/backend/tests/unit/core/diff/test_coordinator_lock.py
@@ -1,0 +1,57 @@
+import asyncio
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from infrahub import lock
+from infrahub.core.branch import Branch
+from infrahub.core.diff.coordinator import DiffCoordinator
+from infrahub.core.diff.data_check_synchronizer import DiffDataCheckSynchronizer
+from infrahub.core.initialization import create_branch
+from infrahub.core.node import Node
+from infrahub.database import InfrahubDatabase
+from infrahub.dependencies.registry import get_component_registry
+
+
+class TestDiffCoordinatorLocks:
+    @pytest.fixture
+    async def branch_data(self, db: InfrahubDatabase, default_branch: Branch, car_person_schema):
+        lock.initialize_lock(local_only=True)
+        branch_1 = await create_branch(branch_name="branch_1", db=db)
+        for _ in range(10):
+            person = await Node.init(db=db, schema="TestPerson", branch=default_branch)
+            await person.new(db=db, name=str(uuid4), height=180)
+            await person.save(db=db)
+        for _ in range(10):
+            person = await Node.init(db=db, schema="TestPerson", branch=branch_1)
+            await person.new(db=db, name=str(uuid4), height=180)
+            await person.save(db=db)
+
+        return branch_1
+
+    async def get_diff_coordinator(self, db: InfrahubDatabase, diff_branch: Branch) -> DiffCoordinator:
+        component_registry = get_component_registry()
+        diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=diff_branch)
+        mock_synchronizer = AsyncMock(spec=DiffDataCheckSynchronizer)
+        diff_coordinator.data_check_synchronizer = mock_synchronizer
+        wrapped_repo = AsyncMock(wraps=diff_coordinator.diff_repo)
+        diff_coordinator.diff_repo = wrapped_repo
+        wrapped_calculator = AsyncMock(wraps=diff_coordinator.diff_calculator)
+        diff_coordinator.diff_calculator = wrapped_calculator
+        return diff_coordinator
+
+    async def test_incremental_locks_do_not_queue_up(self, db: InfrahubDatabase, default_branch: Branch, branch_data):
+        diff_branch = branch_data
+        diff_coordinator = await self.get_diff_coordinator(db=db, diff_branch=diff_branch)
+
+        results = await asyncio.gather(
+            diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=diff_branch),
+            diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=diff_branch),
+        )
+        assert len(results) == 2
+        assert results[0] == results[1]
+        # called once to calculate diff on main and once to calculate diff on the branch
+        assert len(diff_coordinator.diff_calculator.calculate_diff.call_args_list) == 2
+        # called instead of calculating the diff again
+        diff_coordinator.diff_repo.get_one.assert_awaited_once()


### PR DESCRIPTION
IFC-623

update how we handle locking when updating a diff. the old version was to always wait until the lock was acquired, and then run the diff update. if the frontend sends two requests for almost the same diff (same branches, 10 seconds apart), then we would end up calculating the whole diff two (or more) times, which is slow. 
the new approach is to add some special handling for when we get multiple requests to update the diff for the whole lifetime a given branch. in this case, we will check for an existing lock. if we find one, then we wait for it to be released and we return. otherwise, we run the diff update calculation as normal.

- had to make some updates to the lock code to get this to work
- added some debug logging that might be helpful with some problems we are seeing in the E2E tests
- also added some exception handling for if a proposed change is not found when trying to update the CoreDataChecks for a given diff. it seems like this is happening in the E2E tests somehow, but I'm not totally certain