### PR TITLE
Fix available URLs after running infrahub server in backend guide

### DIFF
--- a/docs/docs/development/backend.mdx
+++ b/docs/docs/development/backend.mdx
@@ -103,10 +103,7 @@ infrahub server start --debug
 
 The `debug` flag allows the server to be reloaded when a change is detected in the source code.
 
-Note that this will only make the backend service usable, the frontend will not be available. Only the following URLs should work:
-
-* http://localhost:8000/api/docs/
-* http://localhost:8000/graphql/
+Note that this will only make the backend service usable, the frontend will not be available. Only http://localhost:8000/api/docs should work.
 
 For running the frontend, please refer to its [dedicated documentation section](./frontend).
 

--- a/docs/docs/development/backend.mdx
+++ b/docs/docs/development/backend.mdx
@@ -103,7 +103,8 @@ infrahub server start --debug
 
 The `debug` flag allows the server to be reloaded when a change is detected in the source code.
 
-Note that this will only make the backend service usable, the frontend will not be available. Only http://localhost:8000/api/docs should work.
+Note that this will only make the backend service usable, the frontend will not be available. Only Swagger documentation should be available at http://localhost:8000/api/docs.
+GraphQL sandbox is available through the frontend.
 
 For running the frontend, please refer to its [dedicated documentation section](./frontend).
 


### PR DESCRIPTION
- http://localhost:8000/api/docs/ was broken due to extra `/` at the end.
- http://localhost:8000/graphql/ is not relevant anymore as graphql sandbox is now handled on frontend side as discussed with @bilalabbad.