### PR TITLE
Add internal HTTP adapter to allow for generic access from Infrahub

### DIFF
--- a/backend/infrahub/services/__init__.py
+++ b/backend/infrahub/services/__init__.py
@@ -13,6 +13,8 @@ from infrahub.message_bus.messages import ROUTING_KEY_MAP
 from infrahub.message_bus.types import MessageTTL
 
 from .adapters.cache import InfrahubCache
+from .adapters.http import InfrahubHTTP
+from .adapters.http.httpx import HttpxAdapter
 from .adapters.message_bus import InfrahubMessageBus
 from .component import InfrahubComponent
 from .protocols import InfrahubLogger
@@ -26,6 +28,7 @@ class InfrahubServices:
         client: Optional[InfrahubClient] = None,
         database: Optional[InfrahubDatabase] = None,
         message_bus: Optional[InfrahubMessageBus] = None,
+        http: InfrahubHTTP | None = None,
         log: Optional[InfrahubLogger] = None,
         component_type: Optional[ComponentType] = None,
     ):
@@ -35,6 +38,7 @@ class InfrahubServices:
         self.message_bus = message_bus or InfrahubMessageBus()
         self.log = log or get_logger()
         self.component_type = component_type or ComponentType.NONE
+        self.http = http or HttpxAdapter()
         self.scheduler = InfrahubScheduler()
         self.component = InfrahubComponent()
 
@@ -91,6 +95,7 @@ class InfrahubServices:
     async def initialize(self) -> None:
         """Initialize the Services"""
         await self.component.initialize(service=self)
+        await self.http.initialize(service=self)
         await self.message_bus.initialize(service=self)
         await self.cache.initialize(service=self)
         await self.scheduler.initialize(service=self)

--- a/backend/infrahub/services/adapters/http/__init__.py
+++ b/backend/infrahub/services/adapters/http/__init__.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from infrahub.services import InfrahubServices
+
+
+class InfrahubHTTP:
+    async def initialize(self, service: InfrahubServices) -> None:
+        """Initialize the HTTP adapter"""
+
+    async def post(
+        self, url: str, json: Any | None = None, headers: dict[str, Any] | None = None, verify: bool | None = None
+    ) -> None:
+        raise NotImplementedError()

--- a/backend/infrahub/services/adapters/http/httpx.py
+++ b/backend/infrahub/services/adapters/http/httpx.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from infrahub.services.adapters.http import InfrahubHTTP
+
+
+class HttpxAdapter(InfrahubHTTP):
+    async def post(
+        self, url: str, json: Any | None = None, headers: dict[str, Any] | None = None, verify: bool | None = None
+    ) -> None:
+        # Later verify will be controlled by the base settings for the HTTP adapter instead of defaulting
+        # to True
+        verify = verify if verify is not None else True
+        headers = headers or {}
+        async with httpx.AsyncClient(verify=verify) as client:
+            await client.post(url=url, json=json, headers=headers)

--- a/backend/infrahub/webhook.py
+++ b/backend/infrahub/webhook.py
@@ -6,7 +6,6 @@ from math import floor
 from typing import Any, Optional, Union
 from uuid import uuid4
 
-import httpx
 from pydantic import BaseModel, ConfigDict, Field
 
 from infrahub.core.constants import InfrahubKind
@@ -37,8 +36,7 @@ class Webhook(BaseModel):
     async def send(self) -> None:
         await self._prepare_payload()
         self._assign_headers()
-        async with httpx.AsyncClient(verify=self.validate_certificates) as client:
-            await client.post(self.url, json=self._payload, headers=self._headers)
+        await self.service.http.post(url=self.url, json=self._payload, headers=self._headers)
 
 
 class CustomWebhook(Webhook):

--- a/changelog/3302.added.md
+++ b/changelog/3302.added.md
@@ -1,0 +1,1 @@
+Add internal HTTP adapter to allow for generic access from Infrahub


### PR DESCRIPTION
This PR adds a generic HTTP adapter to Infrahub. At the moment it's very minimalistic and doesn't provide extra features compared to what we had before.

For now I mainly want to have this in place if we need it for the authorization parts of Oauth. Then we can build upon this work and add additional options.

The purpose of this:
* Have one way to control generic HTTP access from Infrahub
* Currently I've replaced the HTTP code within the Webhook function to use this new adapter, as a future step we'd also change the telemetry collection to use this adapter.
* This allows us to then add HTTP configuration to the base Infrahub config when it comes to setting default timeouts, SSL verifications, Proxy configuration etc.
* It will also allow us to replace the HTTP adapter with test dummies throughout the test framework

Fixes #3302