### PR TITLE
Add SchemaProtocol overloads to Node.init

### DIFF
--- a/backend/infrahub/core/protocols_base.py
+++ b/backend/infrahub/core/protocols_base.py
@@ -7,11 +7,9 @@ from typing_extensions import Self
 if TYPE_CHECKING:
     from neo4j import AsyncResult, AsyncSession, AsyncTransaction, Record
 
+    from infrahub.core.schema_manager import SchemaBranch
+
 # pylint: disable=redefined-builtin
-
-
-@runtime_checkable
-class SchemaBranch(Protocol): ...
 
 
 @runtime_checkable

--- a/backend/infrahub/test_data/dataset01.py
+++ b/backend/infrahub/test_data/dataset01.py
@@ -1,5 +1,5 @@
-from infrahub.core.constants import InfrahubKind
 from infrahub.core.node import Node
+from infrahub.core.protocols import CoreGroup
 from infrahub.database import InfrahubDatabase
 from infrahub.log import get_logger
 
@@ -74,7 +74,7 @@ INTERFACE_ROLES = {
 log = get_logger()
 
 
-async def load_data(db: InfrahubDatabase, nbr_devices: int = None):
+async def load_data(db: InfrahubDatabase, nbr_devices: int = 0) -> None:
     # ------------------------------------------
     # Create User Accounts and Groups
     # ------------------------------------------
@@ -82,7 +82,7 @@ async def load_data(db: InfrahubDatabase, nbr_devices: int = None):
     # tags_dict = {}
 
     for group in GROUPS:
-        obj = await Node.init(db=db, schema=InfrahubKind.GENERICGROUP)
+        obj = await Node.init(db=db, schema=CoreGroup)
         await obj.new(db=db, description=group[0], name=group[1])
         await obj.save(db=db)
         groups_dict[group[1]] = obj
@@ -112,10 +112,10 @@ async def load_data(db: InfrahubDatabase, nbr_devices: int = None):
         role = None
         if device[4]:
             role = device[4]
-        obj = await Node.init(db=db, schema="InfraDevice")
-        await obj.new(db=db, name=device[0], status=status, type=device[2], role=role, site=site_hq)
+        device_obj = await Node.init(db=db, schema="InfraDevice")
+        await device_obj.new(db=db, name=device[0], status=status, type=device[2], role=role, site=site_hq)
 
-        await obj.save(db=db)
+        await device_obj.save(db=db)
         log.info(f"- Created Device: {device[0]}")
 
         # Add a special interface for spine1
@@ -152,7 +152,7 @@ async def load_data(db: InfrahubDatabase, nbr_devices: int = None):
             intf = await Node.init(db=db, schema="InfraInterfaceL3")
             await intf.new(
                 db=db,
-                device=obj,
+                device=device_obj,
                 name=intf_name,
                 speed=10000,
                 enabled=enabled,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -397,10 +397,6 @@ module = "infrahub.message_bus.operations.trigger.ipam"
 ignore_errors = true
 
 [[tool.mypy.overrides]]
-module = "infrahub.test_data.dataset01"
-ignore_errors = true
-
-[[tool.mypy.overrides]]
 module = "infrahub.test_data.dataset03"
 ignore_errors = true
 


### PR DESCRIPTION
This PR adds SchemaProtocol overloads for the Node.init() method. This was something that came up with #4185 even though it wasn't related to that PR.

I also changed one of the dataset files, this was just as a reference to show that we could remove it from the excluded list for mypy (previously mypy complained that we were using the name attribute (`log.info(f"Group Created: {obj.name.value}")`). Some other minor changes were also done in the dataset file.

In order to get it to work I also had to delete the protocol definition for SchemaBranch and import the real object. I don't know if the protocol was created for a specific reason that I can't think of now or if it was just created on the fly.