### PR TITLE
Fix 4120: Repository name cannot contain '/' character anymore

### DIFF
--- a/backend/infrahub/core/schema/definitions/core.py
+++ b/backend/infrahub/core/schema/definitions/core.py
@@ -370,6 +370,7 @@ core_models: dict[str, Any] = {
             "attributes": [
                 {
                     "name": "name",
+                    "regex": "^[^/]*$",
                     "kind": "Text",
                     "unique": True,
                     "branch": BranchSupportType.AGNOSTIC.value,


### PR DESCRIPTION
Fix https://github.com/opsmill/infrahub/issues/4120.

Note the current error message displayed to the user might not be very friendly. I am not sure whether we are fine with this or if we want to display a clearer one.
![image](https://github.com/user-attachments/assets/3526085d-f59a-46bb-b55f-3b81d276d070)

Also note that as discussed with @ogenstad the long term fix for this issue might be to store a repository using its `id` instead of `name` attribute so `/` characters could not be considered as file path separators.

This PR currently targets `stable` but we might want to re-target it to `0.16.1` branch once created.