### PR TITLE
Change return type for Node.init

### DIFF
--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -190,7 +190,7 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
         db: InfrahubDatabase,
         branch: Optional[Union[Branch, str]] = None,
         at: Optional[Union[Timestamp, str]] = None,
-    ) -> Any:
+    ) -> Self | SchemaProtocol:
         attrs: dict[str, Any] = {}
 
         branch = await registry.get_branch(branch=branch, db=db)


### PR DESCRIPTION
I realised that we we were probably doing these return statements wrong as there are parts of the code where we actually assume that `Any` is returned and as such mypy can look the other way as any type of property could exist on an `Any` response.

Changing this on Node.init doesn't show any difference in the rest of the code, but if we change NodeManager.query to return a union of all overload options instead of `Any` a few problems surface.

I think the correct approach here is to ensure that we return a union of all valid return types. Which for NodeManager.query would be `list[Node] | list[SchemaProtocol]`.

As an example if I do this change:
```diff
diff --git a/backend/infrahub/api/query.py b/backend/infrahub/api/query.py
index f96810b75..97a22e5f5 100644
--- a/backend/infrahub/api/query.py
+++ b/backend/infrahub/api/query.py
@@ -51,7 +51,7 @@ async def execute_query(

     gql_params = prepare_graphql_params(db=db, branch=branch_params.branch, at=branch_params.at)
     analyzed_query = InfrahubGraphQLQueryAnalyzer(
-        query=gql_query.query.value,  # type: ignore[attr-defined]
+        query=gql_query.query.value,
         schema=gql_params.schema,
         branch=branch_params.branch,
     )
```

After this `mypy` still succeeds and I think it's because we changed the default response from `Node` to `Any`. I think we want to be in a position where we can remove all of the `# type: ignore[attr-defined]` and have mypy fail if we aren't using a `SchemaProtocol` assuming we're accessing attributes directly.

Any thoughts on this @dgarros?