### PR TITLE
chore: upgrade to neo4j 5.20

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,7 +126,7 @@ services:
       retries: 3
 
   database:
-    image: ${NEO4J_DOCKER_IMAGE:-neo4j:5.19.0-community}
+    image: ${NEO4J_DOCKER_IMAGE:-neo4j:5.20.0-community}
     restart: unless-stopped
     environment:
       NEO4J_AUTH: neo4j/${INFRAHUB_DB_PASSWORD:-admin}

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.1
+version: 2.6.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -23,7 +23,7 @@ appVersion: "0.15.2"
 
 dependencies:
   - name: neo4j
-    version: "5.19.0"
+    version: "5.20.0"
     repository: "https://helm.neo4j.com/neo4j/"
     condition: neo4j.enabled
   - name: redis

--- a/tasks/shared.py
+++ b/tasks/shared.py
@@ -28,7 +28,7 @@ DATABASE_DOCKER_IMAGE = os.getenv("DATABASE_DOCKER_IMAGE", None)
 MEMGRAPH_DOCKER_IMAGE = os.getenv(
     "MEMGRAPH_DOCKER_IMAGE", "memgraph/memgraph-platform:2.14.0-memgraph2.14.0-lab2.11.1-mage1.14"
 )
-NEO4J_DOCKER_IMAGE = os.getenv("NEO4J_DOCKER_IMAGE", "neo4j:5.19.0-enterprise")
+NEO4J_DOCKER_IMAGE = os.getenv("NEO4J_DOCKER_IMAGE", "neo4j:5.20.0-enterprise")
 MESSAGE_QUEUE_DOCKER_IMAGE = os.getenv(
     "MESSAGE_QUEUE_DOCKER_IMAGE", "rabbitmq:3.13.1-management" if not INFRAHUB_USE_NATS else "nats:2.10.14-alpine"
 )


### PR DESCRIPTION
The following feature is handy for production deployments:

> https://neo4j.com/release-notes/database/neo4j-5/
> https://github.com/neo4j/neo4j/wiki/Neo4j-5-changelog#5200
> 
> Full Neo4j backups created by Enterprise Edition can now be loaded using  neo4j-admin database load, including into Community Edition. For details, refer to [Restore a database dump – Operations manual](https://neo4j.com/docs/operations-manual/current/backup-restore/restore-dump/).