### PR TITLE
Number attributes now support large integers

### DIFF
--- a/backend/infrahub/graphql/mutations/attribute.py
+++ b/backend/infrahub/graphql/mutations/attribute.py
@@ -1,4 +1,4 @@
-from graphene import Boolean, Field, InputObjectType, Int, String
+from graphene import BigInt, Boolean, Field, InputObjectType, Int, String
 from graphene.types.generic import GenericScalar
 
 from infrahub.core import registry
@@ -47,12 +47,12 @@ class StringAttributeUpdate(BaseAttributeUpdate):
 
 
 class NumberAttributeCreate(BaseAttributeCreate):
-    value = Int(required=False)
+    value = BigInt(required=False)
     from_pool = Field(GenericPoolInput, required=False)
 
 
 class NumberAttributeUpdate(BaseAttributeUpdate):
-    value = Int(required=False)
+    value = BigInt(required=False)
     from_pool = Field(GenericPoolInput, required=False)
 
 

--- a/backend/infrahub/graphql/types/attribute.py
+++ b/backend/infrahub/graphql/types/attribute.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from graphene import Boolean, DateTime, Field, InputObjectType, Int, List, ObjectType, String
+from graphene import BigInt, Boolean, DateTime, Field, InputObjectType, Int, List, ObjectType, String
 from graphene.types.generic import GenericScalar
 
 from infrahub.core import registry
@@ -151,7 +151,7 @@ class MacAddressType(BaseAttribute):
 
 
 class NumberAttributeType(BaseAttribute):
-    value = Field(Int)
+    value = Field(BigInt)
 
     class Meta:
         description = "Attribute of type Number"

--- a/backend/infrahub/types.py
+++ b/backend/infrahub/types.py
@@ -227,11 +227,11 @@ class Dropdown(InfrahubDataType):
 
 class Number(InfrahubDataType):
     label: str = "Number"
-    graphql = graphene.Int
+    graphql = graphene.BigInt
     graphql_query = "NumberAttributeType"
     graphql_create = "NumberAttributeCreate"
     graphql_update = "NumberAttributeUpdate"
-    graphql_filter = graphene.Int
+    graphql_filter = graphene.BigInt
     infrahub = "Integer"
 
 

--- a/backend/tests/integration/user_workflows/test_user_worflow.py
+++ b/backend/tests/integration/user_workflows/test_user_worflow.py
@@ -111,7 +111,7 @@ INTERFACE_UPDATE = """
 """
 
 INTERFACE_CREATE = """
-    mutation($device: String!, $intf_name: String!, $description: String!, $speed: Int!, $role: String!, $status: String!) {
+    mutation($device: String!, $intf_name: String!, $description: String!, $speed: BigInt!, $role: String!, $status: String!) {
         InfraInterfaceL3Create(data: {
             device: { id: $device },
             name: { value: $intf_name },

--- a/backend/tests/unit/graphql/mutations/test_number_supports_large_integers.py
+++ b/backend/tests/unit/graphql/mutations/test_number_supports_large_integers.py
@@ -1,0 +1,58 @@
+from infrahub.core.branch import Branch
+from infrahub.database import InfrahubDatabase
+from tests.helpers.graphql import graphql_mutation, graphql_query
+
+
+async def test_number_supports_large_integers(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_person_schema,
+    register_core_models_schema,
+    session_admin,
+    person_john_main,
+):
+    query = """
+    mutation {
+        TestCarCreate(data: {
+                name: { value: "JetTricycle"},
+                nbr_seats: { value: 9999999999999 },
+                is_electric: { value: false },
+                owner: { id: "John" }
+            }) {
+            ok
+            object {
+                id
+                nbr_seats { value }
+            }
+        }
+    }
+    """
+
+    result = await graphql_mutation(query=query, db=db, branch=default_branch, account_session=session_admin)
+
+    assert result.errors is None
+    assert result.data
+    assert result.data["TestCarCreate"]["ok"] is True
+    assert result.data["TestCarCreate"]["object"]["nbr_seats"]["value"] == 9999999999999
+
+    id_test_car = result.data["TestCarCreate"]["object"]["id"]
+
+    query = """
+    query (
+        $ids_test_cars: [ID]!
+    ) {
+      TestCar (ids : $ids_test_cars) {
+        edges {
+          node {
+            id
+            nbr_seats { value }
+          }
+        }
+      }
+    }
+    """
+
+    result = await graphql_query(query=query, db=db, branch=default_branch, variables={"ids_test_cars": [id_test_car]})
+    assert result.errors is None
+    assert result.data
+    assert result.data["TestCar"]["edges"][0]["node"]["nbr_seats"]["value"] == 9999999999999

--- a/backend/tests/unit/graphql/mutations/test_resource_manager.py
+++ b/backend/tests/unit/graphql/mutations/test_resource_manager.py
@@ -614,8 +614,8 @@ mutation CreateNumberPool(
     $name: String!,
     $node: String!,
     $node_attribute: String!,
-    $start_range: Int!,
-    $end_range: Int!
+    $start_range: BigInt!,
+    $end_range: BigInt!
   ) {
   CoreNumberPoolCreate(
     data: {
@@ -640,8 +640,8 @@ mutation UpdateNumberPool(
     $name: String,
     $node: String,
     $node_attribute: String,
-    $start_range: Int,
-    $end_range: Int
+    $start_range: BigInt,
+    $end_range: BigInt
   ) {
   CoreNumberPoolUpdate(
     data: {

--- a/backend/tests/unit/graphql/queries/test_resource_pool.py
+++ b/backend/tests/unit/graphql/queries/test_resource_pool.py
@@ -672,8 +672,8 @@ mutation CreateNumberPool(
     $name: String!,
     $node: String!,
     $node_attribute: String!,
-    $start_range: Int!,
-    $end_range: Int!
+    $start_range: BigInt!,
+    $end_range: BigInt!
   ) {
   CoreNumberPoolCreate(
     data: {

--- a/backend/tests/unit/graphql/test_mutation_create.py
+++ b/backend/tests/unit/graphql/test_mutation_create.py
@@ -909,7 +909,7 @@ async def test_create_person_not_valid(db: InfrahubDatabase, default_branch, car
     )
 
     assert len(result.errors) == 1
-    assert "Int cannot represent non-integer value" in result.errors[0].message
+    assert result.errors[0].message == "Expected value of type 'BigInt', found \"182\"."
 
 
 async def test_create_with_attribute_not_valid(db: InfrahubDatabase, default_branch, car_person_schema):

--- a/changelog/4179.added.md
+++ b/changelog/4179.added.md
@@ -1,0 +1,1 @@
+Add support for numbers bigger or smaller than signed integers


### PR DESCRIPTION
Implements #4179 

Field type is defined at 5 different places, why is it needed to have separated/duplicated definitions in `BaseAttribute`, `BaseAttributeCreate` and `BaseAttributeUpdate` subclasses instead of defining field type only once in `InfrahubDataType` subclass for instance?