### PR TITLE
Configure Neo4j Notification system

### DIFF
--- a/backend/infrahub/database/__init__.py
+++ b/backend/infrahub/database/__init__.py
@@ -12,6 +12,8 @@ from neo4j import (
     AsyncResult,
     AsyncSession,
     AsyncTransaction,
+    NotificationDisabledCategory,
+    NotificationMinimumSeverity,
     Query,
     Record,
     TrustAll,
@@ -384,6 +386,8 @@ async def get_db(retry: int = 0) -> AsyncDriver:
         auth=(config.SETTINGS.database.username, config.SETTINGS.database.password),
         encrypted=config.SETTINGS.database.tls_enabled,
         trusted_certificates=trusted_certificates,
+        notifications_disabled_categories=[NotificationDisabledCategory.UNRECOGNIZED],
+        warn_notification_severity=NotificationMinimumSeverity.INFORMATION,
     )
 
     if config.SETTINGS.database.database_name not in validated_database:

--- a/backend/infrahub/database/__init__.py
+++ b/backend/infrahub/database/__init__.py
@@ -387,7 +387,7 @@ async def get_db(retry: int = 0) -> AsyncDriver:
         encrypted=config.SETTINGS.database.tls_enabled,
         trusted_certificates=trusted_certificates,
         notifications_disabled_categories=[NotificationDisabledCategory.UNRECOGNIZED],
-        warn_notification_severity=NotificationMinimumSeverity.INFORMATION,
+        notifications_min_severity=NotificationMinimumSeverity.WARNING,
     )
 
     if config.SETTINGS.database.database_name not in validated_database:


### PR DESCRIPTION
As a part of #4147 I noticed that Neo4j is generating a lot of notifications related to unrecognized patterns when we are running unit tests.

The notifications in Neo4j have been introduced recently
https://github.com/neo4j/neo4j-python-driver/discussions/1064

```
10:19:02.762 | WARNING | neo4j.notifications - Received notification from DBMS server: {severity: WARNING} {code: Neo.ClientNotification.Statement.UnknownPropertyKeyWarning} {category: UNRECOGNIZED} {title: The provided property key is not in the database} {description: One of the property names in your query is not available in the database
```