### PR TITLE
Add ability to construct HFIDs from payload for upsert mutations

### DIFF
--- a/backend/infrahub/graphql/mutations/node_getter/by_hfid.py
+++ b/backend/infrahub/graphql/mutations/node_getter/by_hfid.py
@@ -5,6 +5,7 @@ from graphene import InputObjectType
 from infrahub.core.branch import Branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
+from infrahub.core.registry import registry
 from infrahub.core.schema import MainSchemaTypes
 from infrahub.database import InfrahubDatabase
 
@@ -23,14 +24,61 @@ class MutationNodeGetterByHfid(MutationNodeGetterInterface):
         branch: Branch,
         at: str,
     ) -> Optional[Node]:
-        node = None
-        if not node_schema.human_friendly_id or "hfid" not in data:
-            return node
+        if not node_schema.human_friendly_id:
+            return None
 
-        return await self.node_manager.get_one_by_hfid(
-            db=self.db,
-            hfid=data["hfid"],
-            kind=node_schema.kind,
-            branch=branch,
-            at=at,
-        )
+        if "hfid" in data:
+            return await self.node_manager.get_one_by_hfid(
+                db=self.db,
+                hfid=data["hfid"],
+                kind=node_schema.kind,
+                branch=branch,
+                at=at,
+            )
+
+        for component in node_schema.human_friendly_id:
+            name = component.split("__")[0]
+            if name not in data.keys():
+                # The update neither includes "hfid" or all components to form an hfid:
+                return None
+
+        schema_branch = registry.schema.get_schema_branch(name=branch.name)
+        hfid: list[str] = []
+        for component in node_schema.human_friendly_id:
+            attribute_path = node_schema.parse_schema_path(path=component, schema=schema_branch)
+
+            if attribute_path.is_type_attribute and attribute_path.attribute_schema:
+                hfid_component = data[attribute_path.attribute_schema.name].get(attribute_path.attribute_property_name)
+                if hfid_component is not None:
+                    hfid.append(hfid_component)
+            if (
+                attribute_path.relationship_schema
+                and attribute_path.related_schema
+                and attribute_path.attribute_property_name
+                and attribute_path.attribute_schema
+            ):
+                related_node = await self.node_manager.find_object(
+                    db=self.db,
+                    kind=attribute_path.relationship_schema.peer,
+                    branch=branch,
+                    at=at,
+                    id=data[attribute_path.relationship_schema.name].get("id"),
+                    hfid=data[attribute_path.relationship_schema.name].get("hfid"),
+                )
+                relationship_attribute = getattr(related_node, attribute_path.attribute_schema.name)
+                relationship_attribute_value = getattr(relationship_attribute, attribute_path.attribute_property_name)
+                if relationship_attribute_value is None:
+                    return None
+
+                hfid.append(str(relationship_attribute_value))
+
+        if len(hfid) == len(node_schema.human_friendly_id):
+            return await self.node_manager.get_one_by_hfid(
+                db=self.db,
+                hfid=hfid,
+                kind=node_schema.kind,
+                branch=branch,
+                at=at,
+            )
+
+        return None

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -345,6 +345,7 @@ async def animal_person_schema_unregistered(db: InfrahubDatabase, node_group_sch
                 "name": "Person",
                 "namespace": "Test",
                 "display_labels": ["name__value"],
+                "default_filter": "name__value",
                 "human_friendly_id": ["name__value"],
                 "attributes": [
                     {"name": "name", "kind": "Text", "unique": True},

--- a/changelog/4167.added.md
+++ b/changelog/4167.added.md
@@ -1,0 +1,1 @@
+Add ability to construct HFIDs from payload for upsert mutations

--- a/python_sdk/infrahub_sdk/node.py
+++ b/python_sdk/infrahub_sdk/node.py
@@ -725,12 +725,11 @@ class InfrahubNodeBase:
         if not self._schema.human_friendly_id:
             return None
 
-        # If all components of an HFID are null, we cannot identify a single node
+        # If an HFID component is missing we assume that it is invalid and not usable for this node
         hfid_components = [self.get_path_value(path=item) for item in self._schema.human_friendly_id]
-        if all(c is None for c in hfid_components):
+        if None in hfid_components:
             return None
-
-        return [str(c) for c in hfid_components]
+        return [str(hfid) for hfid in hfid_components]
 
     def get_human_friendly_id_as_string(self, include_kind: bool = False) -> Optional[str]:
         hfid = self.get_human_friendly_id()


### PR DESCRIPTION
This adds to the `MutationNodeGetterByHfid` class so that it attempts to construct an HFID based on the payload of the mutation. This is done by looking at how the HFID for the object should be constructed and then see if we have enough information within the payload to create an HFID.

I've not looked too closely at the HFIDs before the implementation here is done with the assumption that there are two kinds of HFID components

* attributes: based on the name of the attribute and the property to look at i.e. `name__value`
* relationships: as attributes but prefixed by the name of the relationship i.e. `device__name__value`

I've also changed the SDK so that it doesn't attempt to send in hfid if any of the fields are missing. The current behaviour was to convert the `None` value into the string "None". I don't know if there is a scenario where we actually want part of the htid to be the string "None", but that part seems wrong.

Fixes opsmill/infrahub-sdk-python#45