### PR TITLE
Generate uniqueness_constraints for schema node if hfid exists

### DIFF
--- a/backend/infrahub/core/schema_manager.py
+++ b/backend/infrahub/core/schema_manager.py
@@ -778,7 +778,6 @@ class SchemaBranch:
             if not node_schema.human_friendly_id:
                 continue
 
-            has_unique_item = False
             allowed_types = SchemaElementPathType.ATTR | SchemaElementPathType.REL_ONE_ATTR
             for item in node_schema.human_friendly_id:
                 schema_path = self.validate_schema_path(
@@ -787,9 +786,6 @@ class SchemaBranch:
                     allowed_path_types=allowed_types,
                     element_name="human_friendly_id",
                 )
-
-                if schema_path.attribute_schema.unique:
-                    has_unique_item = True
 
                 if schema_path.is_type_attribute:
                     required_properties = tuple(schema_path.attribute_schema.get_class().get_allowed_property_in_path())
@@ -811,11 +807,6 @@ class SchemaBranch:
                             f"{schema_path.relationship_schema.name} is not mandatory on {schema_path.relationship_schema.kind} for "
                             f"{node_schema.kind}. ({item})"
                         )
-
-            if not has_unique_item:
-                raise ValueError(
-                    f"At least one attribute must be unique in the human_friendly_id for {node_schema.kind}."
-                )
 
     def validate_required_relationships(self) -> None:
         reverse_dependency_map: dict[str, set[str]] = {}
@@ -1100,7 +1091,7 @@ class SchemaBranch:
                         self.set(name=node.kind, schema=node)
                         break
 
-            if node.human_friendly_id and not node.unique_attributes and not node.uniqueness_constraints:
+            if node.human_friendly_id and not node.uniqueness_constraints:
                 uniqueness_constraints: list[str] = []
                 for item in node.human_friendly_id:
                     schema_attribute_path = node.parse_schema_path(path=item, schema=self)

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -193,6 +193,7 @@ async def test_schema_branch_process_inheritance_update_inherited_elements(anima
         (None, ["breed"], ["name__value"]),
         ([["name__value", "breed__value"]], ["breed"], ["name__value"]),
         (None, ["name"], ["name__value"]),
+        (None, [], ["name__value", "breed__value"]),
     ],
 )
 async def test_validate_human_friendly_id_assign_uniquess_constraints(

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -192,19 +192,21 @@ async def test_schema_branch_process_inheritance_update_inherited_elements(anima
         ([["breed__value"]], [], ["name__value"]),
         (None, ["breed"], ["name__value"]),
         ([["name__value", "breed__value"]], ["breed"], ["name__value"]),
+        (None, ["name"], ["name__value"]),
     ],
 )
-async def test_validate_human_friendly_id_uniqueness_failure(
+async def test_validate_human_friendly_id_assign_uniquess_constraints(
     uniqueness_constraints: list[list[str]] | None,
     unique_attributes: list[str],
     human_friendly_id: list[str] | None,
     animal_person_schema_dict,
 ):
     schema = SchemaBranch(cache={}, name="test")
-    for node_schema in animal_person_schema_dict["nodes"]:
+    for node_schema in animal_person_schema_dict["generics"]:
         if node_schema["name"] == "Animal" and node_schema["namespace"] == "Test":
             node_schema["uniqueness_constraints"] = None
             node_schema["human_friendly_id"] = None
+    for node_schema in animal_person_schema_dict["nodes"]:
         if node_schema["name"] == "Dog" and node_schema["namespace"] == "Test":
             node_schema["uniqueness_constraints"] = uniqueness_constraints
             node_schema["human_friendly_id"] = human_friendly_id
@@ -213,9 +215,12 @@ async def test_validate_human_friendly_id_uniqueness_failure(
     schema.load_schema(schema=SchemaRoot(**animal_person_schema_dict))
 
     schema.process_inheritance()
-    schema.sync_uniqueness_constraints_and_unique_attributes()
-    with pytest.raises(ValueError, match=r"At least one attribute must be unique in the human_friendly_id"):
-        schema.validate_human_friendly_id()
+    schema.validate_human_friendly_id()
+    schema.process_human_friendly_id()
+
+    dog_node = schema.get("TestDog")
+    expected_uniqueness_constraints = uniqueness_constraints or [human_friendly_id]
+    assert dog_node.uniqueness_constraints == expected_uniqueness_constraints
 
 
 @pytest.mark.parametrize(

--- a/changelog/4186.fixed.md
+++ b/changelog/4186.fixed.md
@@ -1,0 +1,1 @@
+Ensure schema uniqueness_constraint are created if they are missing and human_friendly_id has been specified for the node


### PR DESCRIPTION
This looks like a regression as we already had code to generate uniqueness_constraints if non existed and hfid was provided.

Fixes #4186
