### PR TITLE
IFC-605 fix delete constraint to handle relationships on generics

### DIFF
--- a/backend/tests/unit/graphql/test_mutation_delete.py
+++ b/backend/tests/unit/graphql/test_mutation_delete.py
@@ -74,3 +74,81 @@ async def test_delete_prevented(
     assert result.data["TestPersonDelete"] is None
 
     assert await NodeManager.get_one(db=db, id=person_jane_main.id) is not None
+
+
+async def test_delete_allowed_when_peer_rel_optional_on_generic(
+    db: InfrahubDatabase, default_branch, animal_person_schema
+):
+    person_schema = animal_person_schema.get(name="TestPerson")
+    dog_schema = animal_person_schema.get(name="TestDog")
+
+    person1 = await Node.init(db=db, schema=person_schema, branch=default_branch)
+    await person1.new(db=db, name="Jack")
+    await person1.save(db=db)
+    person2 = await Node.init(db=db, schema=person_schema, branch=default_branch)
+    await person2.new(db=db, name="Jill")
+    await person2.save(db=db)
+
+    dog1 = await Node.init(db=db, schema=dog_schema, branch=default_branch)
+    await dog1.new(db=db, name="Rocky", breed="Labrador", owner=person2, best_friend=person1)
+    await dog1.save(db=db)
+
+    query = """
+    mutation DeletePerson($person_id: String!){
+        TestPersonDelete(data: {id: $person_id}) {
+            ok
+        }
+    }
+    """
+    gql_params = prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"person_id": person1.id},
+    )
+
+    assert result.errors is None
+    assert result.data["TestPersonDelete"]["ok"] is True
+
+    updated_dog1 = await NodeManager.get_one(db=db, id=dog1.id)
+    updated_best_friend = await updated_dog1.best_friend.get_peer(db=db)
+    assert updated_best_friend is None
+
+
+async def test_delete_prevented_when_peer_rel_required_on_generic(
+    db: InfrahubDatabase, default_branch, animal_person_schema
+):
+    person_schema = animal_person_schema.get(name="TestPerson")
+    dog_schema = animal_person_schema.get(name="TestDog")
+
+    person1 = await Node.init(db=db, schema=person_schema, branch=default_branch)
+    await person1.new(db=db, name="Jack")
+    await person1.save(db=db)
+
+    dog1 = await Node.init(db=db, schema=dog_schema, branch=default_branch)
+    await dog1.new(db=db, name="Rocky", breed="Labrador", owner=person1)
+    await dog1.save(db=db)
+
+    query = """
+    mutation DeletePerson($person_id: String!){
+        TestPersonDelete(data: {id: $person_id}) {
+            ok
+        }
+    }
+    """
+    gql_params = prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"person_id": person1.id},
+    )
+
+    expected_error_message = f"Cannot delete TestPerson '{person1.id}'."
+    expected_error_message += f" It is linked to mandatory relationship owner on node TestDog '{dog1.id}'"
+    assert result.errors
+    assert len(result.errors) == 1
+    assert expected_error_message in result.errors[0].message

--- a/changelog/4207.fixed.md
+++ b/changelog/4207.fixed.md
@@ -1,0 +1,1 @@
+Deleting a node that is linked to a mandatory relationship on a generic schema will now fail with an error message


### PR DESCRIPTION
fixes #4207 
IFC-605

updates the node delete constraint logic to correctly handle mandatory relationships defined on a generic schema