### PR TITLE
IFC-582 synchronize uniqueness_constraints and unique attributes

### DIFF
--- a/backend/infrahub/core/schema/basenode_schema.py
+++ b/backend/infrahub/core/schema/basenode_schema.py
@@ -458,12 +458,11 @@ class BaseNodeSchema(GeneratedBaseNodeSchema):  # pylint: disable=too-many-publi
             return constraint_paths_groups
 
         for uniqueness_path_group in self.uniqueness_constraints:
-            constraint_paths_groups.append(
-                [
-                    self.parse_schema_path(path=uniqueness_path_part, schema=schema_branch)
-                    for uniqueness_path_part in uniqueness_path_group
-                ]
-            )
+            constraint_paths_group = []
+            for uniqueness_path_part in uniqueness_path_group:
+                constraint_paths_group.append(self.parse_schema_path(path=uniqueness_path_part, schema=schema_branch))
+            if constraint_paths_group not in constraint_paths_groups:
+                constraint_paths_groups.append(constraint_paths_group)
         return constraint_paths_groups
 
 

--- a/backend/infrahub/core/schema/definitions/core.py
+++ b/backend/infrahub/core/schema/definitions/core.py
@@ -34,6 +34,7 @@ core_profile_schema_definition: dict[str, Any] = {
     "label": "Profile",
     "display_labels": ["profile_name__value"],
     "default_filter": "profile_name__value",
+    "uniqueness_constraints": [["profile_name__value"]],
     "attributes": [
         {
             "name": "profile_name",
@@ -156,6 +157,7 @@ core_models: dict[str, Any] = {
             "icon": "mdi:group",
             "hierarchical": True,
             "branch": BranchSupportType.AWARE.value,
+            "uniqueness_constraints": [["name__value"]],
             "attributes": [
                 {"name": "name", "kind": "Text", "unique": True},
                 {"name": "label", "kind": "Text", "optional": True},
@@ -291,6 +293,7 @@ core_models: dict[str, Any] = {
             "display_labels": ["label__value"],
             "branch": BranchSupportType.AWARE.value,
             "documentation": "/topics/proposed-change",
+            "uniqueness_constraints": [["name__value"]],
             "attributes": [
                 {"name": "name", "kind": "Text", "unique": True},
                 {"name": "label", "kind": "Text", "optional": True},
@@ -357,6 +360,7 @@ core_models: dict[str, Any] = {
             "display_labels": ["name__value"],
             "include_in_menu": False,
             "branch": BranchSupportType.AGNOSTIC.value,
+            "uniqueness_constraints": [["name__value"]],
             "attributes": [
                 {"name": "name", "kind": "Text", "unique": True, "order_weight": 1000},
                 {"name": "description", "kind": "Text", "optional": True, "order_weight": 2000},
@@ -381,6 +385,7 @@ core_models: dict[str, Any] = {
             "display_labels": ["name__value"],
             "icon": "mdi:source-repository",
             "branch": BranchSupportType.AGNOSTIC.value,
+            "uniqueness_constraints": [["name__value"], ["location__value"]],
             "documentation": "/topics/repository",
             "attributes": [
                 {
@@ -575,6 +580,7 @@ core_models: dict[str, Any] = {
             "display_labels": ["name__value"],
             "icon": "mdi:format-list-group",
             "branch": BranchSupportType.AWARE.value,
+            "uniqueness_constraints": [["name__value"]],
             "generate_profile": False,
             "attributes": [
                 {
@@ -802,6 +808,7 @@ core_models: dict[str, Any] = {
             "human_friendly_id": ["name__value"],
             "icon": "mdi:view-grid-outline",
             "branch": BranchSupportType.AGNOSTIC.value,
+            "uniqueness_constraints": [["name__value"]],
             "generate_profile": False,
             "attributes": [
                 {
@@ -831,6 +838,7 @@ core_models: dict[str, Any] = {
             "human_friendly_id": ["name__value"],
             "branch": BranchSupportType.AGNOSTIC.value,
             "documentation": "/topics/auth",
+            "uniqueness_constraints": [["name__value"]],
             "attributes": [
                 {"name": "name", "kind": "Text", "unique": True},
                 {"name": "password", "kind": "HashedPassword", "unique": False},
@@ -884,6 +892,7 @@ core_models: dict[str, Any] = {
             "icon": "mdi:key-variant",
             "human_friendly_id": ["name__value"],
             "branch": BranchSupportType.AGNOSTIC.value,
+            "uniqueness_constraints": [["name__value"]],
             "documentation": "/topics/auth",
             "attributes": [
                 {"name": "name", "kind": "Text", "unique": True, "order_weight": 1000},
@@ -958,6 +967,7 @@ core_models: dict[str, Any] = {
             "order_by": ["name__value"],
             "display_labels": ["name__value"],
             "branch": BranchSupportType.AWARE.value,
+            "uniqueness_constraints": [["name__value"]],
             "attributes": [
                 {"name": "name", "kind": "Text", "unique": True},
                 {"name": "description", "kind": "Text", "optional": True},
@@ -987,6 +997,7 @@ core_models: dict[str, Any] = {
             "display_labels": ["token__value"],
             "generate_profile": False,
             "branch": BranchSupportType.AGNOSTIC.value,
+            "uniqueness_constraints": [["token__value"]],
             "documentation": "/topics/auth",
             "attributes": [
                 {"name": "name", "kind": "Text", "optional": True},
@@ -1541,6 +1552,7 @@ core_models: dict[str, Any] = {
             "order_by": ["name__value"],
             "display_labels": ["name__value"],
             "branch": BranchSupportType.AWARE.value,
+            "uniqueness_constraints": [["name__value"]],
             "generate_profile": False,
             "inherit_from": [InfrahubKind.TASKTARGET],
             "attributes": [
@@ -1615,6 +1627,7 @@ core_models: dict[str, Any] = {
             "display_labels": ["name__value"],
             "generate_profile": False,
             "branch": BranchSupportType.AWARE.value,
+            "uniqueness_constraints": [["name__value"]],
             "documentation": "/topics/graphql",
             "attributes": [
                 {"name": "name", "kind": "Text", "unique": True},
@@ -1742,6 +1755,7 @@ core_models: dict[str, Any] = {
             "display_labels": ["name__value"],
             "branch": BranchSupportType.AWARE.value,
             "generate_profile": False,
+            "uniqueness_constraints": [["name__value"]],
             "inherit_from": [InfrahubKind.TASKTARGET],
             "documentation": "/topics/artifact",
             "attributes": [
@@ -1784,6 +1798,7 @@ core_models: dict[str, Any] = {
             "order_by": ["name__value"],
             "display_labels": ["name__value"],
             "branch": BranchSupportType.AWARE.value,
+            "uniqueness_constraints": [["name__value"]],
             "generate_profile": False,
             "inherit_from": [InfrahubKind.TASKTARGET],
             "attributes": [

--- a/backend/infrahub/core/schema_manager.py
+++ b/backend/infrahub/core/schema_manager.py
@@ -624,7 +624,7 @@ class SchemaBranch:
         return schema_attribute_path
 
     def sync_uniqueness_constraints_and_unique_attributes(self) -> None:
-        for name in self.all_names:
+        for name in self.generic_names + self.node_names:
             node_schema = self.get(name=name, duplicate=False)
 
             if not node_schema.unique_attributes and not node_schema.uniqueness_constraints:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -232,6 +232,7 @@ async def car_person_schema_unregistered(db: InfrahubDatabase, node_group_schema
                 "namespace": "Test",
                 "default_filter": "name__value",
                 "display_labels": ["name__value", "color__value"],
+                "uniqueness_constraints": [["name__value"]],
                 "branch": BranchSupportType.AWARE.value,
                 "attributes": [
                     {"name": "name", "kind": "Text", "unique": True},
@@ -263,6 +264,7 @@ async def car_person_schema_unregistered(db: InfrahubDatabase, node_group_schema
                 "default_filter": "name__value",
                 "display_labels": ["name__value"],
                 "branch": BranchSupportType.AWARE.value,
+                "uniqueness_constraints": [["name__value"]],
                 "attributes": [
                     {"name": "name", "kind": "Text", "unique": True},
                     {"name": "height", "kind": "Number", "optional": True},
@@ -396,6 +398,7 @@ async def node_group_schema(db: InfrahubDatabase, default_branch: Branch, data_s
                 "default_filter": "name__value",
                 "order_by": ["name__value"],
                 "display_labels": ["label__value"],
+                "uniqueness_constraints": [["name__value"]],
                 "branch": BranchSupportType.AWARE.value,
                 "attributes": [
                     {"name": "name", "kind": "Text", "unique": True},

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_main.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_main.py
@@ -388,6 +388,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
                     },
                 },
                 "human_friendly_id": None,
+                "uniqueness_constraints": None,
             },
         }
 

--- a/backend/tests/unit/core/constraint_validators/test_determiner.py
+++ b/backend/tests/unit/core/constraint_validators/test_determiner.py
@@ -170,11 +170,13 @@ class TestConstraintDeterminer:
 
         constraints = await determiner.get_constraints(node_diffs=[node_diff])
 
-        non_generate_profile_constraints = [
-            c for c in constraints if c.constraint_name != "node.generate_profile.update"
+        relevant_constraints = [
+            c
+            for c in constraints
+            if c.constraint_name not in ["node.generate_profile.update", "node.uniqueness_constraints.update"]
         ]
-        assert len(non_generate_profile_constraints) == len(constraint_info_set)
-        assert set(non_generate_profile_constraints) == constraint_info_set
+        assert len(relevant_constraints) == len(constraint_info_set)
+        assert set(relevant_constraints) == constraint_info_set
 
     async def test_many_relationship_update(self, car_person_schema, default_branch, person_cars_node_diff):
         schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
@@ -217,8 +219,10 @@ class TestConstraintDeterminer:
 
         constraints = await determiner.get_constraints(node_diffs=[node_diff])
 
-        non_generate_profile_constraints = [
-            c for c in constraints if c.constraint_name != "node.generate_profile.update"
+        relevant_constraints = [
+            c
+            for c in constraints
+            if c.constraint_name != "node.generate_profile.update" and c.path.schema_kind in {"TestCar", "TestPerson"}
         ]
-        assert len(non_generate_profile_constraints) == len(constraint_info_set)
-        assert set(non_generate_profile_constraints) == constraint_info_set
+        assert len(relevant_constraints) == len(constraint_info_set)
+        assert set(relevant_constraints) == constraint_info_set

--- a/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
+++ b/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
@@ -128,8 +128,8 @@ async def test_get_proposed_change_schema_integrity_constraints(
     )
     non_generate_profile_constraints = [c for c in constraints if c.constraint_name != "node.generate_profile.update"]
     # should be updated/removed when ConstraintValidatorDeterminer is updated (#2592)
-    assert len(constraints) == 127
-    assert len(non_generate_profile_constraints) == 62
+    assert len(constraints) == 159
+    assert len(non_generate_profile_constraints) == 94
     dumped_constraints = [c.model_dump() for c in non_generate_profile_constraints]
     assert {
         "constraint_name": "relationship.optional.update",

--- a/changelog/4182.fixed.md
+++ b/changelog/4182.fixed.md
@@ -1,0 +1,1 @@
+Synchronize uniqueness_constraints and unique attributes during schema processing


### PR DESCRIPTION
fixes #4182 
IFC-582

adds a new step to schema processing that synchronizes uniqueness_constraints and unique attributes such that 
- all attributes set to `unique=True` will be added to the uniqueness_constraints for the schema
- all uniqueness_constraints that are a single attribute value will cause `unique` to be set True for that attribute

for example
```
TestDog
  - uniqueness_constraints = [["name__value"]]
  - attributes
    - name
      - unique:  False
    - breed
      - unique: True
```

would become the following after processing
```
TestDog
  - uniqueness_constraints = [["name__value"], ["breed__value"]]
  - attributes
    - name
      - unique:  True
    - breed
      - unique: True
```
