### PR TITLE
Fix Guide Create Schema, set attribute to unique

### DIFF
--- a/docs/docs/guides/create-schema.mdx
+++ b/docs/docs/guides/create-schema.mdx
@@ -355,6 +355,7 @@ nodes:
       - name: hostname
         kind: Text
         label: Hostname
+        unique: true
       - name: device_type
         label: Device Type
         kind: Text


### PR DESCRIPTION
One of the schema in the Guide `Create schema` is missing the property `unique: True` on the attribute `hostname`

Without it Infrahub will not accept the schema with this message
```
Unable to load the schema:
  At least one attribute must be unique in the human_friendly_id for NetworkDevice.
```

The problem is being tracked in https://github.com/opsmill/infrahub/issues/4186