### PR TITLE
fix pytest plugin integration tests

### DIFF
--- a/python_sdk/infrahub_sdk/pytest_plugin/plugin.py
+++ b/python_sdk/infrahub_sdk/pytest_plugin/plugin.py
@@ -76,12 +76,11 @@ def pytest_sessionstart(session: Session) -> None:
         "default_branch": session.config.option.infrahub_branch,
     }
     if hasattr(session.config.option, "infrahub_key"):
-        client_config = {"api_token": session.config.option.infrahub_key}
+        client_config["api_token"] = session.config.option.infrahub_key
     elif hasattr(session.config.option, "infrahub_username") and hasattr(session.config.option, "infrahub_password"):
-        client_config = {
-            "username": session.config.option.infrahub_username,
-            "password": session.config.option.infrahub_password,
-        }
+        client_config.pop("api_token")
+        client_config["username"] = session.config.option.infrahub_username
+        client_config["password"] = session.config.option.infrahub_password
 
     infrahub_client = InfrahubClientSync(config=client_config)
     session.infrahub_client = infrahub_client  # type: ignore[attr-defined]

--- a/python_sdk/infrahub_sdk/pytest_plugin/plugin.py
+++ b/python_sdk/infrahub_sdk/pytest_plugin/plugin.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import Optional, Union
 
@@ -34,6 +35,7 @@ def pytest_addoption(parser: Parser) -> None:
         action="store",
         dest="infrahub_key",
         metavar="INFRAHUB_TESTS_API_KEY",
+        default=os.getenv("INFRAHUB_API_TOKEN"),
         help="Key to use when querying the Infrahub instance for live testing",
     )
     group.addoption(


### PR DESCRIPTION
Fixes an issue when using the resource testing framework integration tests in Infrahub.
Integration tests were unable to run because we were not properly setting the `api_token` configuration setting for the SDK.

Fixes  another potential issue where some provided configuration settings could be ignored, when a specific set of configuration options were being set together.