### PR TITLE
update discord url

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you'd like to learn more about Infrahub, please refer to the following resour
 
 ## Support and Community
 
-If you need help, support for the open-source Infrahub project is provided on [![Join our Discord server](https://img.shields.io/badge/Discord-7289DA?logo=discord&logoColor=white)](https://discord.gg/jXMRp9hXSX) or via [filing an issue on GitHub](https://github.com/opsmill/infrahub/issues).
+If you need help, support for the open-source Infrahub project is provided on [![Join our Discord server](https://img.shields.io/badge/Discord-7289DA?logo=discord&logoColor=white)](https://discord.gg/opsmill) or via [filing an issue on GitHub](https://github.com/opsmill/infrahub/issues).
 
 ## Contributing
 

--- a/docs/docs/faq/faq.mdx
+++ b/docs/docs/faq/faq.mdx
@@ -88,20 +88,20 @@ Upcoming features and improvements include:
 
 ### How much data can Infrahub handle right now?
 
-The current data handling capabilities of Infrahub are still being actively developed and tested. If you have specific requirements or want to assess Infrahub's performance and scalability in your environment, please reach out to the team at contact@opsmill.com or through the [Discord](https://discord.gg/jXMRp9hXSX) server.
+The current data handling capabilities of Infrahub are still being actively developed and tested. If you have specific requirements or want to assess Infrahub's performance and scalability in your environment, please reach out to the team at contact@opsmill.com or through the [Discord](https://discord.gg/opsmill) server.
 
 ### Can I deploy Infrahub in production?
 
 Yes, Infrahub can be deployed in production but keep in mind we are still in beta so please ensure to have the right backup and safeguard in place.
 
-If you are planning to deploy Infrahub in a critical environment we recommend reaching out to our customer success team via [Discord](https://discord.gg/jXMRp9hXSX) or contact@opsmill.com
+If you are planning to deploy Infrahub in a critical environment we recommend reaching out to our customer success team via [Discord](https://discord.gg/opsmill) or contact@opsmill.com
 
 ### How can I get involved?
 
 We develop Infrahub for customers and with the community. There are a few different ways to get involved with Infrahub:
 
 - As you use Infrahub, please submit bugs and feature requests.
-- Reach out to OpsMill on [Discord](https://discord.gg/jXMRp9hXSX) and set up a user feedback session to share your thoughts with us.
+- Reach out to OpsMill on [Discord](https://discord.gg/opsmill) and set up a user feedback session to share your thoughts with us.
 - If you are a developer, we are open to pull requests. Please first discuss your intentions via [GitHub Discussions](https://github.com/opsmill/infrahub/discussions) and send a pull request our way to fix it.
 
 Please see our [development docs](https://docs.infrahub.app/development/) for a guide to getting started developing for Infrahub.
@@ -112,7 +112,7 @@ We maintain a [list of issues that are appropriate to newcomers](https://github.
 
 If you need assistance with Infrahub, you can reach out to the community and the development team through the following channels:
 
-- Discord: Join the Infrahub [Discord](https://discord.gg/jXMRp9hXSX) server to ask questions, get support, and engage with other users.
+- Discord: Join the Infrahub [Discord](https://discord.gg/opsmill) server to ask questions, get support, and engage with other users.
 - GitHub Issues: Submit issues or questions on the Infrahub GitHub repository (https://github.com/opsmill/infrahub/issues).
 
 ### Will there be paid support or an Enterprise version of Infrahub?
@@ -171,4 +171,4 @@ Almost! You’ll definitely feel like a tech genius managing your infrastructure
 
 ### Made it this far? We'd love to hear from you
 
-If you've made it this far, please feel free to reach out on the [Discord](https://discord.gg/jXMRp9hXSX) server to share your thoughts or schedule a customer interview session. The Infrahub team is always eager to receive feedback and engage with the community.
+If you've made it this far, please feel free to reach out on the [Discord](https://discord.gg/opsmill) server to share your thoughts or schedule a customer interview session. The Infrahub team is always eager to receive feedback and engage with the community.

--- a/frontend/app/src/screens/errors/error-fallback.tsx
+++ b/frontend/app/src/screens/errors/error-fallback.tsx
@@ -86,7 +86,7 @@ function ErrorFallback({ error }: ErrorFallbackProps) {
           If this was unexpected, please reach out to us on{" "}
           <a
             className="underline"
-            href="https://discord.com/channels/1212332642801025064/1212669187198025759"
+            href="https://discord.gg/opsmill"
             target="_blank"
             rel="noreferrer">
             Discord


### PR DESCRIPTION
We now have a permanent URL for Discord. Updated docs and one frontend location to remove the previous URLs which are time-limited in their validity.