### PR TITLE
Add workflow_db volume in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -245,3 +245,4 @@ volumes:
   git_data:
   git_remote_data:
   storage_data:
+  workflow_db:


### PR DESCRIPTION
During a deployment I faced an issue with docker-compose:

`service "task-manager-db" refers to undefined volume workflow_db: invalid compose project"`

Is it needed to explicitly define that volume in the volume section of the docker-compose? (Adding the volume actually solved my issue)