### PR TITLE
Remove incorrect consumer timeout

### DIFF
--- a/backend/infrahub/services/adapters/message_bus/rabbitmq.py
+++ b/backend/infrahub/services/adapters/message_bus/rabbitmq.py
@@ -142,7 +142,7 @@ class RabbitMQMessageBus(InfrahubMessageBus):
         queue = await self.channel.declare_queue(
             f"{self.settings.namespace}.rpcs",
             durable=True,
-            arguments={"x-max-priority": 5, "x-consumer-timeout": self.DELIVER_TIMEOUT * 1000},
+            arguments={"x-max-priority": 5},
         )
 
         self.delayed_exchange = await self.channel.declare_exchange(

--- a/backend/tests/integration/services/adapters/message_bus/test_rabbitmq.py
+++ b/backend/tests/integration/services/adapters/message_bus/test_rabbitmq.py
@@ -218,7 +218,7 @@ async def test_rabbitmq_initial_setup(rabbitmq_api: RabbitMQManager) -> None:
     assert (
         Queue(
             name="infrahub.rpcs",
-            arguments={"x-max-priority": 5, "x-consumer-timeout": 30000},
+            arguments={"x-max-priority": 5},
             durable=True,
             exclusive=False,
             queue_type="classic",

--- a/changelog/4308.fixed.md
+++ b/changelog/4308.fixed.md
@@ -1,0 +1,11 @@
+Fixed incorrect consumer timeout for RabbitMQ queue infrahub.rpcs
+
+If you are upgrading from a previous version of Infrahub and using the provided Docker Compose files you don't have to take any additional action. However if you are using your own setup for RabbitMQ you will need to manually delete the queue yourself.
+
+Swap the container name and credentials to RabbitMQ if they are different in your setup: 
+
+```bash
+docker exec -it infrahub-message-queue-1 rabbitmqadmin --username infrahub --password infrahub delete queue name=infrahub.rpcs
+```
+
+After this step Infrahub and the Git agents need to be restarted, when doing so the correct queue will be recreated.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,7 +103,7 @@ x-infrahub-config: &infrahub_config
 
 services:
   message-queue:
-    image: ${MESSAGE_QUEUE_DOCKER_IMAGE:-rabbitmq:3.13.1-management}
+    image: ${MESSAGE_QUEUE_DOCKER_IMAGE:-rabbitmq:3.13.7-management}
     restart: unless-stopped
     environment:
       RABBITMQ_DEFAULT_USER: *broker_username

--- a/tasks/shared.py
+++ b/tasks/shared.py
@@ -30,7 +30,7 @@ MEMGRAPH_DOCKER_IMAGE = os.getenv(
 )
 NEO4J_DOCKER_IMAGE = os.getenv("NEO4J_DOCKER_IMAGE", "neo4j:5.19.0-enterprise")
 MESSAGE_QUEUE_DOCKER_IMAGE = os.getenv(
-    "MESSAGE_QUEUE_DOCKER_IMAGE", "rabbitmq:3.13.1-management" if not INFRAHUB_USE_NATS else "nats:2.10.14-alpine"
+    "MESSAGE_QUEUE_DOCKER_IMAGE", "rabbitmq:3.13.7-management" if not INFRAHUB_USE_NATS else "nats:2.10.14-alpine"
 )
 CACHE_DOCKER_IMAGE = os.getenv("CACHE_DOCKER_IMAGE", "redis:7.2.4" if not INFRAHUB_USE_NATS else "nats:2.10.14-alpine")
 


### PR DESCRIPTION
Removes the `x-consumer-timeout` property on the queue, it was supposed to be set to 30 minutes (which is also the default) and was set to 30 seconds which caused problems for any task on the Git agent that took longer than 30 seconds to complete.

Also upgrades RabbitMQ to the latest patch version on the 3.13 version. This is mainly to ensure that the container is swapped out during the upgrade so that end users don't need to care about changing anything themselves.

Fixes #4308