### PR TITLE
Populate permissions in query results

### DIFF
--- a/backend/infrahub/core/account.py
+++ b/backend/infrahub/core/account.py
@@ -186,8 +186,6 @@ class AccountObjectPermissionQuery(Query):
 
 
 async def fetch_permissions(account_id: str, db: InfrahubDatabase, branch: Branch) -> AssignedPermissions:
-    branch = await registry.get_branch(db=db, branch=branch)
-
     query1 = await AccountGlobalPermissionQuery.init(db=db, branch=branch, account_id=account_id, branch_agnostic=True)
     await query1.execute(db=db)
     global_permissions = query1.get_permissions()

--- a/backend/infrahub/graphql/__init__.py
+++ b/backend/infrahub/graphql/__init__.py
@@ -7,6 +7,7 @@ from starlette.background import BackgroundTasks
 
 from infrahub.core import registry
 from infrahub.core.timestamp import Timestamp
+from infrahub.exceptions import InitializationError
 
 from .manager import GraphQLSchemaManager
 
@@ -37,6 +38,16 @@ class GraphqlContext:
     account_session: Optional[AccountSession] = None
     background: Optional[BackgroundTasks] = None
     request: Optional[HTTPConnection] = None
+
+    @property
+    def active_account_session(self) -> AccountSession:
+        """Return an account session or raise an error
+
+        Eventualy this property should be removed, that can be done after self.account_session is no longer optional
+        """
+        if self.account_session:
+            return self.account_session
+        raise InitializationError("GraphQLContext doesn't contain an account_session")
 
 
 def prepare_graphql_params(

--- a/backend/infrahub/permissions/report.py
+++ b/backend/infrahub/permissions/report.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from infrahub.core.account import fetch_permissions
+from infrahub.core.constants import GlobalPermissions, PermissionDecision
+from infrahub.core.registry import registry
+from infrahub.permissions.local_backend import LocalPermissionBackend
+
+if TYPE_CHECKING:
+    from infrahub.auth import AccountSession
+    from infrahub.core.branch import Branch
+    from infrahub.core.schema import MainSchemaTypes
+    from infrahub.database import InfrahubDatabase
+    from infrahub.permissions.types import KindPermissions
+
+
+async def report_schema_permissions(
+    db: InfrahubDatabase, schemas: list[MainSchemaTypes], account_session: AccountSession, branch: Branch
+) -> list[KindPermissions]:
+    permissions = await fetch_permissions(account_id=account_session.account_id, db=db, branch=branch)
+
+    restrict_changes = False
+    if branch.name == registry.default_branch:
+        restrict_changes = True
+        for global_permission in permissions["global_permissions"]:
+            if global_permission.action == GlobalPermissions.EDIT_DEFAULT_BRANCH.value:
+                restrict_changes = False
+
+    checker = LocalPermissionBackend()
+
+    permission_objects: list[KindPermissions] = []
+
+    for node in schemas:
+        permission_base = f"object:{branch.name}:{node.namespace}:{node.name}"
+
+        has_create = checker.resolve_object_permission(
+            permissions=permissions["object_permissions"], permission_to_check=f"{permission_base}:create:allow"
+        )
+        has_delete = checker.resolve_object_permission(
+            permissions=permissions["object_permissions"], permission_to_check=f"{permission_base}:delete:allow"
+        )
+        has_update = checker.resolve_object_permission(
+            permissions=permissions["object_permissions"], permission_to_check=f"{permission_base}:update:allow"
+        )
+        has_view = checker.resolve_object_permission(
+            permissions=permissions["object_permissions"], permission_to_check=f"{permission_base}:view:allow"
+        )
+
+        permission_objects.append(
+            {
+                "kind": node.kind,
+                "create": PermissionDecision.ALLOW if has_create and not restrict_changes else PermissionDecision.DENY,
+                "delete": PermissionDecision.ALLOW if has_delete and not restrict_changes else PermissionDecision.DENY,
+                "update": PermissionDecision.ALLOW if has_update and not restrict_changes else PermissionDecision.DENY,
+                "view": PermissionDecision.ALLOW if has_view else PermissionDecision.DENY,
+            }
+        )
+
+    return permission_objects

--- a/backend/infrahub/permissions/types.py
+++ b/backend/infrahub/permissions/types.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypedDict
+
+if TYPE_CHECKING:
+    from infrahub.core.constants import PermissionDecision
+
+
+class KindPermissions(TypedDict):
+    kind: str
+    create: PermissionDecision
+    delete: PermissionDecision
+    update: PermissionDecision
+    view: PermissionDecision

--- a/backend/tests/unit/graphql/queries/test_list_permissions.py
+++ b/backend/tests/unit/graphql/queries/test_list_permissions.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from graphql import graphql
+
+from infrahub.auth import AccountSession, AuthType
+from infrahub.core.account import ObjectPermission
+from infrahub.core.constants import (
+    InfrahubKind,
+    PermissionAction,
+    PermissionDecision,
+)
+from infrahub.core.initialization import create_branch
+from infrahub.core.node import Node
+from infrahub.core.registry import registry
+from infrahub.graphql import prepare_graphql_params
+from infrahub.permissions.local_backend import LocalPermissionBackend
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.core.protocols import CoreAccount
+    from infrahub.database import InfrahubDatabase
+
+
+QUERY_TAGS = """
+query {
+  BuiltinTag {
+    permissions {
+        count
+        edges {
+            node {
+                kind
+                create
+                update
+                delete
+                view
+            }
+        }
+    }
+  }
+}
+"""
+
+REPOSITORY_QUERY = """
+query {
+  CoreGenericRepository {
+    permissions {
+        count
+        edges {
+            node {
+                kind
+                create
+                update
+                delete
+                view
+            }
+        }
+    }
+  }
+}
+"""
+
+
+class PermissionsHelper:
+    def __init__(self) -> None:
+        self._first: None | CoreAccount = None
+        self._default_branch: None | Branch = None
+
+    @property
+    def default_branch(self) -> Branch:
+        if self._default_branch:
+            return self._default_branch
+
+        raise NotImplementedError()
+
+    @property
+    def first(self) -> CoreAccount:
+        if self._first:
+            return self._first
+
+        raise NotImplementedError()
+
+
+permission_helper = PermissionsHelper()
+
+
+class TestObjectPermissions:
+    async def test_setup(
+        self,
+        db: InfrahubDatabase,
+        register_core_models_schema: None,
+        default_branch: Branch,
+        first_account: CoreAccount,
+    ):
+        permission_helper._first = first_account
+        permission_helper._default_branch = default_branch
+        registry.permission_backends = [LocalPermissionBackend()]
+
+        permissions = []
+        for object_permission in [
+            ObjectPermission(
+                id="",
+                branch="*",
+                namespace="Builtin",
+                name="*",
+                action=PermissionAction.VIEW.value,
+                decision=PermissionDecision.ALLOW.value,
+            ),
+            ObjectPermission(
+                id="",
+                branch="*",
+                namespace="Builtin",
+                name="*",
+                action=PermissionAction.ADD.value,
+                decision=PermissionDecision.ALLOW.value,
+            ),
+            ObjectPermission(
+                id="",
+                branch="*",
+                namespace="Builtin",
+                name="*",
+                action=PermissionAction.DELETE.value,
+                decision=PermissionDecision.ALLOW.value,
+            ),
+            ObjectPermission(
+                id="",
+                branch="*",
+                namespace="Core",
+                name="*",
+                action=PermissionAction.ANY.value,
+                decision=PermissionDecision.ALLOW.value,
+            ),
+        ]:
+            obj = await Node.init(db=db, schema=InfrahubKind.OBJECTPERMISSION)
+            await obj.new(
+                db=db,
+                branch=object_permission.branch,
+                namespace=object_permission.namespace,
+                name=object_permission.name,
+                action=object_permission.action,
+                decision=object_permission.decision,
+            )
+            await obj.save(db=db)
+            permissions.append(obj)
+
+        role = await Node.init(db=db, schema=InfrahubKind.ACCOUNTROLE)
+        await role.new(db=db, name="admin", permissions=permissions)
+        await role.save(db=db)
+
+        group = await Node.init(db=db, schema=InfrahubKind.ACCOUNTGROUP)
+        await group.new(db=db, name="admin", roles=[role])
+        await group.save(db=db)
+
+        await group.members.add(db=db, data={"id": first_account.id})
+        await group.members.save(db=db)
+
+    async def test_first_account_tags_main_branch(self, db: InfrahubDatabase) -> None:
+        """In the main branch the first account doesn't have the permission to make changes"""
+        session = AccountSession(
+            authenticated=True,
+            account_id=permission_helper.first.id,
+            session_id=str(uuid4()),
+            auth_type=AuthType.JWT,
+        )
+        gql_params = prepare_graphql_params(
+            db=db, include_mutation=True, branch=permission_helper.default_branch, account_session=session
+        )
+
+        result = await graphql(
+            schema=gql_params.schema,
+            source=QUERY_TAGS,
+            context_value=gql_params.context,
+        )
+
+        assert not result.errors
+        assert result.data
+        assert result.data["BuiltinTag"]["permissions"]["count"] == 1
+        assert result.data["BuiltinTag"]["permissions"]["edges"][0] == {
+            "node": {"kind": "BuiltinTag", "create": "DENY", "update": "DENY", "delete": "DENY", "view": "ALLOW"}
+        }
+
+    async def test_first_account_tags_non_main_branch(self, db: InfrahubDatabase) -> None:
+        """In other branches the permissions for the first account is less restrictive"""
+        branch2 = await create_branch(branch_name="pr-12345", db=db)
+        session = AccountSession(
+            authenticated=True,
+            account_id=permission_helper.first.id,
+            session_id=str(uuid4()),
+            auth_type=AuthType.JWT,
+        )
+        gql_params = prepare_graphql_params(db=db, include_mutation=True, branch=branch2, account_session=session)
+
+        result = await graphql(
+            schema=gql_params.schema,
+            source=QUERY_TAGS,
+            context_value=gql_params.context,
+        )
+
+        assert not result.errors
+        assert result.data
+        assert result.data["BuiltinTag"]["permissions"]["count"] == 1
+        assert result.data["BuiltinTag"]["permissions"]["edges"][0] == {
+            "node": {"kind": "BuiltinTag", "create": "ALLOW", "update": "DENY", "delete": "ALLOW", "view": "ALLOW"}
+        }
+
+    async def test_first_account_list_permissions_for_generics(self, db: InfrahubDatabase) -> None:
+        """In the main branch the first account doesn't have the permission to make changes"""
+        session = AccountSession(
+            authenticated=True,
+            account_id=permission_helper.first.id,
+            session_id=str(uuid4()),
+            auth_type=AuthType.JWT,
+        )
+        gql_params = prepare_graphql_params(
+            db=db, include_mutation=True, branch=permission_helper.default_branch, account_session=session
+        )
+
+        result = await graphql(
+            schema=gql_params.schema,
+            source=REPOSITORY_QUERY,
+            context_value=gql_params.context,
+        )
+
+        assert not result.errors
+        assert result.data
+        assert result.data["CoreGenericRepository"]["permissions"]["count"] == 3
+        assert {
+            "node": {
+                "kind": "CoreGenericRepository",
+                "create": "DENY",
+                "update": "DENY",
+                "delete": "DENY",
+                "view": "ALLOW",
+            }
+        } in result.data["CoreGenericRepository"]["permissions"]["edges"]
+        assert {
+            "node": {
+                "kind": "CoreRepository",
+                "create": "DENY",
+                "update": "DENY",
+                "delete": "DENY",
+                "view": "ALLOW",
+            }
+        } in result.data["CoreGenericRepository"]["permissions"]["edges"]
+        assert {
+            "node": {
+                "kind": "CoreReadOnlyRepository",
+                "create": "DENY",
+                "update": "DENY",
+                "delete": "DENY",
+                "view": "ALLOW",
+            }
+        } in result.data["CoreGenericRepository"]["permissions"]["edges"]


### PR DESCRIPTION
This PR changes the "permissions" queries under each list object so that we can use the object permissions to see what is allowed for the current node kind (or kinds if it's a generic query).

For now I've added support to also a check to see if the current user has the global permission to make changes to the default branch. This will need to change as more permissions are added for instance with branch agnostic objects such as proposed changes and repositories. At that point we'll look at combining it with the other checkers in a different way, however as it is now the checks would work quite differently as the checkers only validates if something is allowed or not they don't produce a report.

The goal right now is to allow for the permissions are they are now to be visible when the frontend is querying for them.