### PR TITLE
Configure yamllint to ignore .git folder

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -2,6 +2,7 @@
 extends: default
 
 ignore: |
+  /.git
   /.venv
   /examples
   /repositories


### PR DESCRIPTION
This is to avoid having yamllint go looking in the .git folder.

```bash
❯ yamllint -s .
./.git/logs/refs/remotes/origin/pog-define-graphql-infrahub.yml
  1:121     error    line too long (153 > 120 characters)  (line-length)
  2:121     error    line too long (153 > 120 characters)  (line-length)
  3:121     error    line too long (153 > 120 characters)  (line-length)
  4:121     error    line too long (153 > 120 characters)  (line-length)
  1:139     error    syntax error: found character '\t' that cannot start any token (syntax)

./.git/refs/remotes/origin/pog-define-graphql-infrahub.yml
  1:1       warning  missing document start "---"  (document-start)

```