### PR TITLE
fix(sdk): use https submodule instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "python_sdk"]
 	path = python_sdk
-	url = git@github.com:opsmill/infrahub-sdk-python.git
+	url = https://github.com/opsmill/infrahub-sdk-python.git


### PR DESCRIPTION
This would break cloning with unauthenticated users.