### PR TITLE
Migration of schema migrations and validations to prefect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ coverage.xml
 *.env
 script.py
 **/*.local.*
+local/*
 .vscode/settings.json
 node_modules/*
 development/docker-compose.override.yml

--- a/backend/infrahub/cli/db.py
+++ b/backend/infrahub/cli/db.py
@@ -1,10 +1,12 @@
 import importlib
 import logging
+import os
 from enum import Enum
 from typing import TYPE_CHECKING, Optional
 
 import typer
 from infrahub_sdk.async_typer import AsyncTyper
+from prefect.testing.utilities import prefect_test_harness
 from rich import print as rprint
 from rich.console import Console
 from rich.logging import RichHandler
@@ -18,16 +20,18 @@ from infrahub.core.graph.index import node_indexes, rel_indexes
 from infrahub.core.graph.schema import GRAPH_SCHEMA
 from infrahub.core.initialization import first_time_initialization, get_root_node, initialization, initialize_registry
 from infrahub.core.migrations.graph import get_graph_migrations
-from infrahub.core.migrations.schema.runner import schema_migrations_runner
+from infrahub.core.migrations.schema.models import SchemaApplyMigrationData
 from infrahub.core.schema import SchemaRoot, core_models, internal_schema
 from infrahub.core.schema.definitions.deprecated import deprecated_models
 from infrahub.core.schema_manager import SchemaManager
 from infrahub.core.utils import delete_all_nodes
-from infrahub.core.validators.checker import schema_validators_checker
+from infrahub.core.validators.models.validate_migration import SchemaValidateMigrationData
 from infrahub.database import DatabaseType
 from infrahub.log import get_logger
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.message_bus.local import BusSimulator
+from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
+from infrahub.workflows.catalogue import SCHEMA_APPLY_MIGRATION, SCHEMA_VALIDATE_MIGRATION
 
 if TYPE_CHECKING:
     from infrahub.cli.context import CliContext
@@ -177,6 +181,9 @@ async def update_core_schema(  # pylint: disable=too-many-statements
     """Check the current format of the internal graph and apply the necessary migrations"""
     logging.getLogger("infrahub").setLevel(logging.WARNING)
     logging.getLogger("neo4j").setLevel(logging.ERROR)
+    logging.getLogger("prefect").setLevel(logging.ERROR)
+    os.environ["PREFECT_SERVER_ANALYTICS_ENABLED"] = "false"
+
     config.load_and_exit(config_file_name=config_file)
 
     context: CliContext = ctx.obj
@@ -185,98 +192,109 @@ async def update_core_schema(  # pylint: disable=too-many-statements
     error_badge = "[bold red]ERROR[/bold red]"
 
     async with dbdriver.start_session() as db:
-        # ----------------------------------------------------------
-        # Initialize Schema and Registry
-        # ----------------------------------------------------------
-        service = InfrahubServices(database=db, message_bus=BusSimulator(database=db))
-        await initialize_registry(db=db)
-
-        default_branch = registry.get_branch_from_registry(branch=registry.default_branch)
-
-        registry.schema = SchemaManager()
-        schema = SchemaRoot(**internal_schema)
-        registry.schema.register_schema(schema=schema)
-
-        # ----------------------------------------------------------
-        # Load Current Schema from the database
-        # ----------------------------------------------------------
-        schema_default_branch = await registry.schema.load_schema_from_db(db=db, branch=default_branch)
-        registry.schema.set_schema_branch(name=default_branch.name, schema=schema_default_branch)
-        branch_schema = registry.schema.get_schema_branch(name=registry.default_branch)
-
-        candidate_schema = branch_schema.duplicate()
-        candidate_schema.load_schema(schema=SchemaRoot(**internal_schema))
-        candidate_schema.load_schema(schema=SchemaRoot(**core_models))
-        candidate_schema.load_schema(schema=SchemaRoot(**deprecated_models))
-        candidate_schema.process()
-
-        result = branch_schema.validate_update(other=candidate_schema, enforce_update_support=False)
-        if result.errors:
-            rprint(f"{error_badge} | Unable to update the schema, due to failed validations")
-            for error in result.errors:
-                rprint(error.to_string())
-            raise typer.Exit(1)
-
-        if not result.diff.all:
-            rprint("Core Schema Up to date, nothing to update")
-            raise typer.Exit(0)
-
-        rprint("Core Schema has diff, will need to be updated")
-        if debug:
-            result.diff.print()
-
-        # ----------------------------------------------------------
-        # Validate if the new schema is valid with the content of the database
-        # ----------------------------------------------------------
-        error_messages, _ = await schema_validators_checker(
-            branch=default_branch, schema=candidate_schema, constraints=result.constraints, service=service
-        )
-        if error_messages:
-            rprint(f"{error_badge} | Unable to update the schema, due to failed validations")
-            for message in error_messages:
-                rprint(message)
-            raise typer.Exit(1)
-
-        # ----------------------------------------------------------
-        # Update the schema
-        # ----------------------------------------------------------
-        origin_schema = branch_schema.duplicate()
-
-        # Update the internal schema
-        schema_default_branch.load_schema(schema=SchemaRoot(**internal_schema))
-        schema_default_branch.process()
-        registry.schema.set_schema_branch(name=default_branch.name, schema=schema_default_branch)
-
-        async with db.start_transaction() as dbt:
-            await registry.schema.update_schema_branch(
-                schema=candidate_schema,
-                db=dbt,
-                branch=default_branch.name,
-                diff=result.diff,
-                limit=result.diff.all,
-                update_db=True,
+        with prefect_test_harness():
+            # ----------------------------------------------------------
+            # Initialize Schema and Registry
+            # ----------------------------------------------------------
+            service = InfrahubServices(
+                database=db, message_bus=BusSimulator(database=db), workflow=WorkflowLocalExecution()
             )
-            default_branch.update_schema_hash()
-            rprint("The Core Schema has been updated")
-            if debug:
-                rprint(f"New schema hash: {default_branch.active_schema_hash.main}")
-            await default_branch.save(db=dbt)
+            await initialize_registry(db=db)
 
-        # ----------------------------------------------------------
-        # Run the migrations
-        # ----------------------------------------------------------
-        error_messages = await schema_migrations_runner(
-            branch=default_branch,
-            new_schema=candidate_schema,
-            previous_schema=origin_schema,
-            migrations=result.migrations,
-            service=service,
-        )
-        if error_messages:
-            rprint(f"{error_badge} | Some error(s) happened while running the schema migrations")
-            for message in error_messages:
-                rprint(message)
-            raise typer.Exit(1)
+            default_branch = registry.get_branch_from_registry(branch=registry.default_branch)
+
+            registry.schema = SchemaManager()
+            schema = SchemaRoot(**internal_schema)
+            registry.schema.register_schema(schema=schema)
+
+            # ----------------------------------------------------------
+            # Load Current Schema from the database
+            # ----------------------------------------------------------
+            schema_default_branch = await registry.schema.load_schema_from_db(db=db, branch=default_branch)
+            registry.schema.set_schema_branch(name=default_branch.name, schema=schema_default_branch)
+            branch_schema = registry.schema.get_schema_branch(name=registry.default_branch)
+
+            candidate_schema = branch_schema.duplicate()
+            candidate_schema.load_schema(schema=SchemaRoot(**internal_schema))
+            candidate_schema.load_schema(schema=SchemaRoot(**core_models))
+            candidate_schema.load_schema(schema=SchemaRoot(**deprecated_models))
+            candidate_schema.process()
+
+            result = branch_schema.validate_update(other=candidate_schema, enforce_update_support=False)
+            if result.errors:
+                rprint(f"{error_badge} | Unable to update the schema, due to failed validations")
+                for error in result.errors:
+                    rprint(error.to_string())
+                raise typer.Exit(1)
+
+            if not result.diff.all:
+                rprint("Core Schema Up to date, nothing to update")
+                raise typer.Exit(0)
+
+            rprint("Core Schema has diff, will need to be updated")
+            if debug:
+                result.diff.print()
+
+            # ----------------------------------------------------------
+            # Validate if the new schema is valid with the content of the database
+            # ----------------------------------------------------------
+            validate_migration_data = SchemaValidateMigrationData(
+                branch=default_branch,
+                schema_branch=candidate_schema,
+                constraints=result.constraints,
+            )
+            error_messages = await service.workflow.execute(  # type: ignore[var-annotated]
+                workflow=SCHEMA_VALIDATE_MIGRATION, message=validate_migration_data
+            )
+            if error_messages:
+                rprint(f"{error_badge} | Unable to update the schema, due to failed validations")
+                for message in error_messages:
+                    rprint(message)
+                raise typer.Exit(1)
+
+            # ----------------------------------------------------------
+            # Update the schema
+            # ----------------------------------------------------------
+            origin_schema = branch_schema.duplicate()
+
+            # Update the internal schema
+            schema_default_branch.load_schema(schema=SchemaRoot(**internal_schema))
+            schema_default_branch.process()
+            registry.schema.set_schema_branch(name=default_branch.name, schema=schema_default_branch)
+
+            async with db.start_transaction() as dbt:
+                await registry.schema.update_schema_branch(
+                    schema=candidate_schema,
+                    db=dbt,
+                    branch=default_branch.name,
+                    diff=result.diff,
+                    limit=result.diff.all,
+                    update_db=True,
+                )
+                default_branch.update_schema_hash()
+                rprint("The Core Schema has been updated")
+                if debug:
+                    rprint(f"New schema hash: {default_branch.active_schema_hash.main}")
+                await default_branch.save(db=dbt)
+
+            # ----------------------------------------------------------
+            # Run the migrations
+            # ----------------------------------------------------------
+            apply_migration_data = SchemaApplyMigrationData(
+                branch=default_branch,
+                new_schema=candidate_schema,
+                previous_schema=origin_schema,
+                migrations=result.migrations,
+            )
+            migration_error_msgs = await service.workflow.execute(  # type: ignore[var-annotated]
+                workflow=SCHEMA_APPLY_MIGRATION, message=apply_migration_data
+            )
+
+            if migration_error_msgs:
+                rprint(f"{error_badge} | Some error(s) happened while running the schema migrations")
+                for message in migration_error_msgs:
+                    rprint(message)
+                raise typer.Exit(1)
 
 
 @app.command()

--- a/backend/infrahub/core/migrations/schema/models.py
+++ b/backend/infrahub/core/migrations/schema/models.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel, ConfigDict
+
+from infrahub.core.branch import Branch
+from infrahub.core.models import SchemaUpdateMigrationInfo
+from infrahub.core.schema_manager import SchemaBranch
+
+
+class SchemaApplyMigrationData(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True, json_encoders={SchemaBranch: SchemaBranch.to_dict_schema_object}
+    )
+    branch: Branch
+    new_schema: SchemaBranch
+    previous_schema: SchemaBranch
+    migrations: list[SchemaUpdateMigrationInfo]

--- a/backend/infrahub/core/migrations/schema/runner.py
+++ b/backend/infrahub/core/migrations/schema/runner.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Optional
 
-from infrahub.message_bus.messages.schema_migration_path import SchemaMigrationPath, SchemaMigrationPathResponse
+from infrahub.message_bus.messages.schema_migration_path import (
+    SchemaMigrationPath,
+    SchemaMigrationPathResponse,
+)
 
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch

--- a/backend/infrahub/core/migrations/schema/tasks.py
+++ b/backend/infrahub/core/migrations/schema/tasks.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+from infrahub_sdk.batch import InfrahubBatch
+from prefect import flow
+
+from infrahub.message_bus.messages.schema_migration_path import (
+    SchemaMigrationPathData,
+)
+from infrahub.message_bus.operations.schema.migration import schema_path_migrate
+from infrahub.services import services
+
+from .models import SchemaApplyMigrationData  # noqa: TCH001
+
+if TYPE_CHECKING:
+    from infrahub.core.schema import MainSchemaTypes
+
+
+@flow
+async def schema_apply_migrations(message: SchemaApplyMigrationData) -> list[str]:
+    service = services.service
+
+    batch = InfrahubBatch()
+    error_messages: list[str] = []
+
+    if not message.migrations:
+        return error_messages
+
+    for migration in message.migrations:
+        service.log.info(
+            f"Preparing migration for {migration.migration_name!r} ({migration.routing_key})",
+            branch=message.branch.name,
+        )
+
+        new_node_schema: Optional[MainSchemaTypes] = None
+        previous_node_schema: Optional[MainSchemaTypes] = None
+
+        if message.new_schema.has(name=migration.path.schema_kind):
+            new_node_schema = message.new_schema.get(name=migration.path.schema_kind)
+
+        if new_node_schema and new_node_schema.id:
+            previous_node_schema = message.previous_schema.get_by_id(id=new_node_schema.id)
+        else:
+            previous_node_schema = message.previous_schema.get(name=migration.path.schema_kind)
+
+        if not previous_node_schema:
+            raise ValueError(
+                f"Unable to find the previous version of the schema for {migration.path.schema_kind}, in order to run the migration."
+            )
+
+        msg = SchemaMigrationPathData(
+            branch=message.branch,
+            migration_name=migration.migration_name,
+            new_node_schema=new_node_schema,
+            previous_node_schema=previous_node_schema,
+            schema_path=migration.path,
+        )
+
+        batch.add(task=schema_path_migrate, message=msg)
+
+    async for _, result in batch.execute():
+        error_messages.extend(result.errors)
+
+    return error_messages

--- a/backend/infrahub/core/validators/models/validate_migration.py
+++ b/backend/infrahub/core/validators/models/validate_migration.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel, ConfigDict
+
+from infrahub.core.branch import Branch
+from infrahub.core.models import SchemaUpdateConstraintInfo
+from infrahub.core.schema_manager import SchemaBranch
+
+
+class SchemaValidateMigrationData(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True, json_encoders={SchemaBranch: SchemaBranch.to_dict_schema_object}
+    )
+    branch: Branch
+    schema_branch: SchemaBranch
+    constraints: list[SchemaUpdateConstraintInfo]

--- a/backend/infrahub/core/validators/models/violation.py
+++ b/backend/infrahub/core/validators/models/violation.py
@@ -1,0 +1,22 @@
+from typing import Union
+
+from pydantic import BaseModel, Field
+
+from infrahub.core.branch import Branch
+from infrahub.core.path import SchemaPath
+from infrahub.core.schema import GenericSchema, NodeSchema
+
+
+class SchemaConstraintValidatorRequest(BaseModel):
+    branch: Branch = Field(..., description="The name of the branch to target")
+    constraint_name: str = Field(..., description="The name of the constraint to validate")
+    node_schema: Union[NodeSchema, GenericSchema] = Field(..., description="Schema of Node or Generic to validate")
+    schema_path: SchemaPath = Field(..., description="SchemaPath to the element of the schema to validate")
+
+
+class SchemaViolation(BaseModel):
+    node_id: str
+    node_kind: str
+    display_label: str
+    full_display_label: str
+    message: str = ""

--- a/backend/infrahub/core/validators/tasks.py
+++ b/backend/infrahub/core/validators/tasks.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from infrahub_sdk.batch import InfrahubBatch
+from prefect import flow
+
+from infrahub.message_bus.messages.schema_validator_path import (
+    SchemaValidatorPathData,
+)
+from infrahub.message_bus.operations.schema.validator import schema_path_validate
+from infrahub.services import services
+
+from .models.validate_migration import SchemaValidateMigrationData  # noqa: TCH001
+
+
+@flow
+async def schema_validate_migrations(message: SchemaValidateMigrationData) -> list[str]:
+    batch = InfrahubBatch(return_exceptions=True)
+    error_messages: list[str] = []
+    service = services.service
+
+    if not message.constraints:
+        return error_messages
+
+    for constraint in message.constraints:
+        service.log.info(
+            f"Preparing validator for constraint {constraint.constraint_name!r} ({constraint.routing_key})",
+            branch=message.branch.name,
+            constraint_name=constraint.constraint_name,
+            routing_key=constraint.routing_key,
+        )
+
+        msg = SchemaValidatorPathData(
+            branch=message.branch,
+            constraint_name=constraint.constraint_name,
+            node_schema=message.schema_branch.get(name=constraint.path.schema_kind),
+            schema_path=constraint.path,
+        )
+        batch.add(task=schema_path_validate, message=msg)
+
+    async for _, result in batch.execute():
+        for violation in result.violations:
+            error_messages.append(violation.message)
+
+    return error_messages

--- a/backend/infrahub/message_bus/messages/schema_migration_path.py
+++ b/backend/infrahub/message_bus/messages/schema_migration_path.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 from infrahub.core.branch import Branch  # noqa: TCH001
 from infrahub.core.path import SchemaPath  # noqa: TCH001
@@ -12,7 +12,7 @@ from infrahub.message_bus import InfrahubMessage, InfrahubResponse, InfrahubResp
 ROUTING_KEY = "schema.migration.path"
 
 
-class SchemaMigrationPath(InfrahubMessage):
+class SchemaMigrationPathData(BaseModel):
     branch: Branch = Field(..., description="The name of the branch to target")
     migration_name: str = Field(..., description="The name of the migration to run")
     new_node_schema: Optional[MainSchemaTypes] = Field(None, description="new Schema of Node or Generic to process")
@@ -20,6 +20,10 @@ class SchemaMigrationPath(InfrahubMessage):
         None, description="Previous Schema of Node or Generic to process"
     )
     schema_path: SchemaPath = Field(..., description="SchemaPath to the element of the schema to migrate")
+
+
+class SchemaMigrationPath(SchemaMigrationPathData, InfrahubMessage):
+    pass
 
 
 class SchemaMigrationPathResponseData(InfrahubResponseData):

--- a/backend/infrahub/message_bus/messages/schema_validator_path.py
+++ b/backend/infrahub/message_bus/messages/schema_validator_path.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 from infrahub.core.branch import Branch  # noqa: TCH001
 from infrahub.core.path import SchemaPath  # noqa: TCH001
@@ -11,11 +11,15 @@ from infrahub.message_bus import InfrahubMessage, InfrahubResponse, InfrahubResp
 ROUTING_KEY = "schema.validator.path"
 
 
-class SchemaValidatorPath(InfrahubMessage):
+class SchemaValidatorPathData(BaseModel):
     branch: Branch = Field(..., description="The name of the branch to target")
     constraint_name: str = Field(..., description="The name of the constraint to validate")
     node_schema: MainSchemaTypes = Field(..., description="Schema of Node or Generic to validate")
     schema_path: SchemaPath = Field(..., description="SchemaPath to the element of the schema to validate")
+
+
+class SchemaValidatorPath(SchemaValidatorPathData, InfrahubMessage):
+    pass
 
 
 class SchemaValidatorPathResponseData(InfrahubResponseData):

--- a/backend/infrahub/message_bus/operations/schema/migration.py
+++ b/backend/infrahub/message_bus/operations/schema/migration.py
@@ -1,11 +1,16 @@
+from prefect import task
+from prefect.logging import get_run_logger
+from prefect.runtime import task_run
+
 from infrahub.core.migrations import MIGRATION_MAP
 from infrahub.log import get_logger
 from infrahub.message_bus.messages.schema_migration_path import (
     SchemaMigrationPath,
+    SchemaMigrationPathData,
     SchemaMigrationPathResponse,
     SchemaMigrationPathResponseData,
 )
-from infrahub.services import InfrahubServices
+from infrahub.services import InfrahubServices, services
 
 log = get_logger()
 
@@ -52,3 +57,60 @@ async def path(message: SchemaMigrationPath, service: InfrahubServices) -> None:
                 )
             )
             await service.reply(message=response, initiator=message)
+
+
+def generate_task_name() -> str:
+    task_name = task_run.task_name
+    message: SchemaMigrationPathData = task_run.parameters["message"]
+    return f"{task_name}-{message.branch.name}-{message.migration_name}"
+
+
+@task(
+    task_run_name=generate_task_name,
+    description="Apply a given migration to the database",
+    retries=3,
+)
+async def schema_path_migrate(message: SchemaMigrationPathData) -> SchemaMigrationPathResponseData:
+    service = services.service
+    logger = get_run_logger()
+
+    async with service.database.start_session() as db:
+        node_kind = None
+        if message.new_node_schema:
+            node_kind = message.new_node_schema.kind
+        elif message.previous_node_schema:
+            node_kind = message.previous_node_schema.kind
+
+        service.log.info(
+            "schema.migration.path - received",
+            migration=message.migration_name,
+            node_kind=node_kind,
+            path=message.schema_path.get_path(),
+        )
+        migration_class = MIGRATION_MAP.get(message.migration_name)
+        if not migration_class:
+            raise ValueError(f"Unable to find the migration class for {message.migration_name}")
+
+        migration = migration_class(
+            new_node_schema=message.new_node_schema,
+            previous_node_schema=message.previous_node_schema,
+            schema_path=message.schema_path,
+        )
+        execution_result = await migration.execute(db=db, branch=message.branch)
+
+        logger.info(f"Migration completed for {message.migration_name}")
+
+        service.log.info(
+            "schema.migration.path - completed",
+            migration=message.migration_name,
+            node_kind=node_kind,
+            path=message.schema_path.get_path(),
+            result=execution_result,
+        )
+
+        return SchemaMigrationPathResponseData(
+            migration_name=message.migration_name,
+            schema_path=message.schema_path,
+            errors=execution_result.errors,
+            nbr_migrations_executed=execution_result.nbr_migrations_executed,
+        )

--- a/backend/infrahub/message_bus/operations/schema/validator.py
+++ b/backend/infrahub/message_bus/operations/schema/validator.py
@@ -1,13 +1,17 @@
+from prefect import task
+from prefect.runtime import task_run
+
 from infrahub.core.validators.aggregated_checker import AggregatedConstraintChecker
 from infrahub.core.validators.model import SchemaConstraintValidatorRequest
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.log import get_logger
 from infrahub.message_bus.messages.schema_validator_path import (
     SchemaValidatorPath,
+    SchemaValidatorPathData,
     SchemaValidatorPathResponse,
     SchemaValidatorPathResponseData,
 )
-from infrahub.services import InfrahubServices
+from infrahub.services import InfrahubServices, services
 
 log = get_logger()
 
@@ -41,3 +45,43 @@ async def path(message: SchemaValidatorPath, service: InfrahubServices) -> None:
                 )
             )
             await service.reply(message=response, initiator=message)
+
+
+def generate_task_name() -> str:
+    task_name = task_run.task_name
+    message: SchemaValidatorPathData = task_run.parameters["message"]
+    return f"{task_name}-{message.branch.name}-{message.constraint_name}"
+
+
+@task(
+    task_run_name=generate_task_name,
+    description="Validate if a given migration is compatible with the existing data",
+    retries=3,
+)
+async def schema_path_validate(message: SchemaValidatorPathData) -> SchemaValidatorPathResponseData:
+    service = services.service
+
+    async with service.database.start_session() as db:
+        log.info(
+            "schema.validator.path",
+            constraint=message.constraint_name,
+            node_kind=message.node_schema.kind,
+            path=message.schema_path.get_path(),
+        )
+
+        constraint_request = SchemaConstraintValidatorRequest(
+            branch=message.branch,
+            constraint_name=message.constraint_name,
+            node_schema=message.node_schema,
+            schema_path=message.schema_path,
+        )
+
+        component_registry = get_component_registry()
+        aggregated_constraint_checker = await component_registry.get_component(
+            AggregatedConstraintChecker, db=db, branch=message.branch
+        )
+        violations = await aggregated_constraint_checker.run_constraints(constraint_request)
+
+        return SchemaValidatorPathResponseData(
+            violations=violations, constraint_name=message.constraint_name, schema_path=message.schema_path
+        )

--- a/backend/infrahub/services/adapters/workflow/__init__.py
+++ b/backend/infrahub/services/adapters/workflow/__init__.py
@@ -20,6 +20,6 @@ class InfrahubWorkflow:
         self,
         workflow: WorkflowDefinition | None = None,
         function: Callable[..., Awaitable[Return]] | None = None,
-        **kwargs: dict[str, Any],
+        **kwargs: Any,
     ) -> Return:
         raise NotImplementedError()

--- a/backend/infrahub/services/adapters/workflow/local.py
+++ b/backend/infrahub/services/adapters/workflow/local.py
@@ -10,7 +10,7 @@ class WorkflowLocalExecution(InfrahubWorkflow):
         self,
         workflow: WorkflowDefinition | None = None,
         function: Callable[..., Awaitable[Return]] | None = None,
-        **kwargs: dict[str, Any],
+        **kwargs: Any,
     ) -> Return:
         if workflow:
             fn = workflow.get_function()

--- a/backend/infrahub/services/adapters/workflow/worker.py
+++ b/backend/infrahub/services/adapters/workflow/worker.py
@@ -50,7 +50,7 @@ class WorkflowWorkerExecution(InfrahubWorkflow):
             response: FlowRun = await run_deployment(name=workflow.full_name, parameters=kwargs or {})  # type: ignore[return-value, misc]
             if not response.state:
                 raise RuntimeError("Unable to read state from the response")
-            return await response.state.result(fetch=True, raise_on_failure=True)  # type: ignore[call-overload]
+            return response.state.result(raise_on_failure=True)
 
         if function:
             return await function(**kwargs)

--- a/backend/infrahub/workflows/catalogue.py
+++ b/backend/infrahub/workflows/catalogue.py
@@ -33,6 +33,27 @@ DUMMY_FLOW = WorkflowDefinition(
     function="dummy_flow",
 )
 
+SCHEMA_APPLY_MIGRATION = WorkflowDefinition(
+    name="schema_apply_migrations",
+    work_pool=WORKER_POOL,
+    module="infrahub.core.migrations.schema.tasks",
+    function="schema_apply_migrations",
+)
+
+SCHEMA_VALIDATE_MIGRATION = WorkflowDefinition(
+    name="schema_validate_migrations",
+    work_pool=WORKER_POOL,
+    module="infrahub.core.validators.tasks",
+    function="schema_validate_migrations",
+)
+
 worker_pools = [WORKER_POOL]
 
-workflows = [WEBHOOK_SEND, TRANSFORM_JINJA2_RENDER, ANONYMOUS_TELEMETRY_SEND, DUMMY_FLOW]
+workflows = [
+    WEBHOOK_SEND,
+    TRANSFORM_JINJA2_RENDER,
+    ANONYMOUS_TELEMETRY_SEND,
+    DUMMY_FLOW,
+    SCHEMA_APPLY_MIGRATION,
+    SCHEMA_VALIDATE_MIGRATION,
+]

--- a/backend/tests/unit/api/conftest.py
+++ b/backend/tests/unit/api/conftest.py
@@ -11,6 +11,7 @@ from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
+from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 
 
 @pytest.fixture
@@ -53,6 +54,15 @@ def rpc_bus_simulator(helper, db):
     config.OVERRIDE.message_bus = bus
     yield bus
     config.OVERRIDE.message_bus = original
+
+
+@pytest.fixture()
+def workflow_local():
+    original = config.OVERRIDE.workflow
+    workflow = WorkflowLocalExecution()
+    config.OVERRIDE.workflow = workflow
+    yield workflow
+    config.OVERRIDE.workflow = original
 
 
 @pytest.fixture

--- a/backend/tests/unit/api/test_20_graphql_api.py
+++ b/backend/tests/unit/api/test_20_graphql_api.py
@@ -221,7 +221,14 @@ async def test_download_schema(db: InfrahubDatabase, client, client_headers):
 
 
 async def test_query_at_previous_schema(
-    db: InfrahubDatabase, client, admin_headers, default_branch: Branch, authentication_base, car_person_data
+    db: InfrahubDatabase,
+    client,
+    admin_headers,
+    default_branch: Branch,
+    authentication_base,
+    prefect_test_fixture,
+    workflow_local,
+    car_person_data,
 ):
     # Load the schema in the database
     schema = registry.schema.get_schema_branch(name=default_branch.name)

--- a/backend/tests/unit/core/constraint_validators/test_task_schema_validate_migrations.py
+++ b/backend/tests/unit/core/constraint_validators/test_task_schema_validate_migrations.py
@@ -1,0 +1,49 @@
+from infrahub_sdk import InfrahubClient
+
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.constants import SchemaPathType
+from infrahub.core.models import SchemaUpdateConstraintInfo
+from infrahub.core.node import Node
+from infrahub.core.path import SchemaPath
+from infrahub.core.validators.models.validate_migration import SchemaValidateMigrationData
+from infrahub.core.validators.tasks import schema_validate_migrations
+from infrahub.database import InfrahubDatabase
+from infrahub.services import InfrahubServices, services
+from infrahub.services.adapters.message_bus.local import BusSimulator
+from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
+
+
+async def test_schema_validate_migrations(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    prefect_test_fixture,
+    car_accord_main: Node,
+    car_volt_main: Node,
+    person_john_main,
+    helper,
+):
+    schema = registry.schema.get_schema_branch(name=default_branch.name).duplicate()
+    person_schema = schema.get(name="TestPerson")
+    name_attr = person_schema.get_attribute(name="name")
+    name_attr.regex = r"^[A-Z]+$"
+    schema.set(name="TestPerson", schema=person_schema)
+
+    constraints = [
+        SchemaUpdateConstraintInfo(
+            constraint_name="attribute.regex.update",
+            path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="name"),
+        )
+    ]
+
+    services.service = InfrahubServices(
+        message_bus=BusSimulator(database=db), client=InfrahubClient(), workflow=WorkflowLocalExecution(), database=db
+    )
+
+    message = SchemaValidateMigrationData(branch=default_branch, schema_branch=schema, constraints=constraints)
+    errors = await schema_validate_migrations(
+        message=message,
+    )
+
+    assert len(errors) == 1
+    assert "is not compatible with the constraint 'attribute.regex.update'" in errors[0]

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -1,4 +1,5 @@
 import copy
+import json
 import re
 import uuid
 
@@ -1487,6 +1488,25 @@ async def test_schema_branch_validate_count_against_cardinality_invalid(relation
     schema_branch.process_pre_validation()
     with pytest.raises(ValueError):
         schema_branch.validate_count_against_cardinality()
+
+
+async def test_schema_branch_from_dict_schema_object():
+    schema = SchemaRoot(**core_models)
+
+    schema_branch = SchemaBranch(cache={}, name="test")
+    schema_branch.load_schema(schema=schema)
+
+    exported = schema_branch.to_dict_schema_object()
+
+    exported_json = json.dumps(exported, default=lambda x: x.dict())
+
+    exported_dict = json.loads(exported_json)
+    schema_branch_after = SchemaBranch.from_dict_schema_object(data=exported_dict)
+
+    assert (
+        schema_branch_after.get_node(name=InfrahubKind.TAG).get_hash()
+        == schema_branch.get_node(name=InfrahubKind.TAG).get_hash()
+    )
 
 
 async def test_schema_branch_process_filters(


### PR DESCRIPTION
This PR converts the `schema_validators_checker` and `schema_migrations_runner` to flow in prefect.

For now, I've replaced both of them in the REST API `/api/schema/load` & `/api/schema/load` and in the cli command `infrahub db update-core-schema`
I tried to update the GraphQL mutations as well but I faced some circular dependencies that I couldn't resolve quickly enough
Since this PR is includes some other changes that are important to push forward the migration to prefect I think it's best to merge what we already have and fix the circular dependencies in another PR.

Because prefect is heavily using Pydantic for the validation of parameters and the serialization of input data, we need to make all Class/objects that we are passing to a flow serializable. 
For the new flows to work I had to make `SchemaBranch` serializable.
