### PR TITLE
install docs cleanup

### DIFF
--- a/docs/docs/development/backend.mdx
+++ b/docs/docs/development/backend.mdx
@@ -13,7 +13,7 @@ In order start developing on Infrahub backend, it is recommended to have a decen
 
 To fetch Infrahub's code, we will use Git and we will use the `develop` branch (default).
 
-```bash
+```shell
 git clone --recursive git@github.com:opsmill/infrahub.git
 cd infrahub
 ```
@@ -22,7 +22,7 @@ cd infrahub
 
 Most of Infrahub and tools around it rely on some settings. These settings are in general set as environment variables, dealing with many of these can be hard to maintain and manage. We can use a tool such as [direnv](https://direnv.net/) to help. It allows to define environment variables (or pretty much anything bash can make sense of) in a file that will be interpreted when entering a given directory. Here is an example of a `.envrc` file providing development friendly setting values:
 
-```bash
+```shell
 export INFRAHUB_PRODUCTION=false
 export INFRAHUB_SECURITY_SECRET_KEY=super-secret
 export INFRAHUB_USERNAME=admin
@@ -48,32 +48,32 @@ Infrahub uses several external services to work:
 
 To run all these services, we will use Docker, but for local development some ports will need to be bound to local ones. To do so, a very basic Docker Compose override file is provided in the `development` directory, but it has a `tmp` extension which makes Compose ignore it by default. We will copy this file to a new one without the `tmp` extension. In a development environment, having only the services in Docker and Infrahub running on local Python is convenient to take advantage of the server auto-reload feature when making changes.
 
-```bash
+```shell
 cp development/docker-compose.dev-override.yml.tmp development/docker-compose.dev-override.yml
 ```
 
 Now we need to make sure we have a compatible version of Python that Infrahub can run on top of, Poetry to create virtual environment and Invoke to run commands. Invoke can be installed in many ways, but we recommend to use the `pipx` way to get it available user wide while without messing with the system Python. Assuming we have these utilities ready, we can run the following commands to build a proper Python environment:
 
-```bash
+```shell
 cd infrahub # or the directory of your choice
 poetry install
 ```
 
 Now it's time to bring the required services up, and for that we have demo commands:
 
-```bash
+```shell
 invoke dev.destroy dev.deps
 ```
 
 This will actually pass two commands, one to destroy any remains of a previous run and one to start services. So this will effectively bring up clean services without leftovers. We can see which services are running by using:
 
-```bash
+```shell
 poetry run invoke dev.status
 ```
 
 This should yield a Docker output like the following:
 
-```bash
+```shell
 NAME                       IMAGE                      COMMAND                  SERVICE         CREATED       STATUS                 PORTS
 infrahub-cache-1           redis:7.2                  "docker-entrypoint.s…"   cache           2 hours ago   Up 2 hours (healthy)   0.0.0.0:6379->6379/tcp
 infrahub-database-1        memgraph/memgraph:2.13.0   "/usr/lib/memgraph/m…"   database        2 hours ago   Up 2 hours (healthy)   0.0.0.0:7444->7444/tcp, 0.0.0.0:7474->7474/tcp, 0.0.0.0:7687->7687/tcp
@@ -86,7 +86,7 @@ When following a guide, like the [installation guide](/guides/installation.mdx),
 
 With the required services working and properly setup Python virtual environment we can now run the Infrahub test suite to make sure the code works as intended.
 
-```bash
+```shell
 INFRAHUB_LOG_LEVEL=CRITICAL pytest -v backend/tests/unit
 ```
 
@@ -96,7 +96,7 @@ The environment variable at the beginning of the command is useful to have a muc
 
 We can run the Infrahub server with the built-in command:
 
-```bash
+```shell
 infrahub server start --debug
 ```
 
@@ -111,7 +111,7 @@ For running the frontend, please refer to its [dedicated documentation section](
 
 For testing code changes, you may want to load a new schema from a YAML file. This can be performed in the development environment using:
 
-```bash
+```shell
 poetry run infrahubctl schema load ${PATH_TO_SCHEMA_FILE}
 ```
 
@@ -119,6 +119,6 @@ poetry run infrahubctl schema load ${PATH_TO_SCHEMA_FILE}
 
 Formatting code in the backend relies on [Ruff](https://docs.astral.sh/ruff/) and [yamllint](https://yamllint.readthedocs.io/en/stable/). To ensure all files are as close as possible to the expected format, it is recommended to run the `format` command:
 
-```bash
+```shell
 poetry run invoke format
 ```

--- a/docs/docs/development/docs.mdx
+++ b/docs/docs/development/docs.mdx
@@ -18,7 +18,7 @@ The recommended way to run and build the docs locally is with Infrahub's suite o
 
 Once these requirements are met, you'll have access to the doc task list.
 
-```bash
+```shell
 invoke -l docs
 ```
 
@@ -195,7 +195,7 @@ await saveScreenshotForDocs(page, "my-screenshot-name");
 
 To update all documentation screenshots, run:
 
-```bash
+```shell
 cd frontend/app
 npm run test:e2e:screenshots
 ```
@@ -292,7 +292,7 @@ Feature: Explanation of feature
 When creating a code block or snippet with three backticks, make sure to include a language designation.
 <!-- markdownlint-disable -->
 ~~~md
-```bash
+```shell
 this is a shell script
 ```
 ~~~

--- a/docs/docs/development/frontend/getting-set-up.mdx
+++ b/docs/docs/development/frontend/getting-set-up.mdx
@@ -8,7 +8,7 @@ title: Getting set up
 
 Make sure [Infrahub Backend](../backend.mdx) is up and running. If not, in your terminal execute:
 
-```bash
+```shell
 invoke demo.destroy demo.build demo.start demo.load-infra-schema demo.load-infra-data
 ```
 
@@ -16,21 +16,21 @@ invoke demo.destroy demo.build demo.start demo.load-infra-schema demo.load-infra
 
 Infrahub is built with React. Make sure you're running Node.js 20+ and NPM 9+, to verify do:
 
-```bash
+```shell
 node --version
 npm --version
 ```
 
 ## 1. Install dependencies
 
-```bash
+```shell
 cd frontend/app
 npm install
 ```
 
 ## 2. Start a local server
 
-```bash
+```shell
 npm start
 ```
 
@@ -40,7 +40,7 @@ To can access your local server at [http://localhost:8080/](http://localhost:808
 
 ### Unit tests
 
-```bash
+```shell
 npm run test
 
 # same with coverage
@@ -49,13 +49,13 @@ npm run test:coverage
 
 ### Integration tests
 
-```bash
+```shell
 npm run cypress:run:component
 ```
 
 ### E2E tests
 
-```bash
+```shell
 npm run test:e2e
 ```
 

--- a/docs/docs/development/frontend/readme.mdx
+++ b/docs/docs/development/frontend/readme.mdx
@@ -27,7 +27,7 @@ For testing, we rely on:
 
 To access Infrahub's codebase, use Git and switch to the `develop` branch to access the latest changes. All frontend code resides in `/frontend`.
 
-```bash
+```shell
 git clone --recursive git@github.com:opsmill/infrahub.git
 cd infrahub/frontend
 ```

--- a/docs/docs/development/frontend/testing-guidelines.mdx
+++ b/docs/docs/development/frontend/testing-guidelines.mdx
@@ -30,7 +30,7 @@ E2E tests are located in `/frontend/app/tests/e2e`.
 
 [Playwright](https://playwright.dev/docs/codegen) can automatically generate tests as you perform actions in the browser, making it a quick way to start testing:
 
-```bash
+```shell
 npx playwright codegen
 ```
 
@@ -81,7 +81,7 @@ page.getByRole("button", { name: "Save" });
 
 2. Structure tests with steps for better readability:
 
-```bash
+```shell
 # headless mode
 npm run test:e2e
 
@@ -97,13 +97,13 @@ npm run test:e2e:ui
 
 ## Integration tests
 
-```bash
+```shell
 npm run cypress:run:component
 ```
 
 ## Unit tests
 
-```bash
+```shell
 npm run test
 
 # same with coverage

--- a/docs/docs/faq/faq.mdx
+++ b/docs/docs/faq/faq.mdx
@@ -129,7 +129,7 @@ Please see the documentation on [integrations](../integrations) for more informa
 
 Infrahub collects anonymous usage metrics and sends them to OpsMill servers for analysis and improvement purposes. No personally identifiable information is collected. If you prefer to opt-out of telemetry collection, you can do so by setting the `INFRAHUB_TELEMETRY_OPTOUT` environment variable to `true`:
 
-```bash
+```shell
 export INFRAHUB_TELEMETRY_OPTOUT=true
 ```
 

--- a/docs/docs/guides/artifact.mdx
+++ b/docs/docs/guides/artifact.mdx
@@ -45,7 +45,7 @@ More details on the `.infrahub.yml` file format can be found in [.infrahub.yml t
 
 Commit the changes to the repository and push them to the Git server
 
-```bash
+```shell
 git add .
 git commit -m "add tags_config_file artifact definition"
 git push origin main

--- a/docs/docs/guides/check.mdx
+++ b/docs/docs/guides/check.mdx
@@ -25,7 +25,7 @@ As the first step we need to have some data in the database to actually query.
 Create three tags, called "color-red", "color-green", "blue", either using the frontend or by submitting three GraphQL mutations as per below (just swapping out the name of the color each time).
 Note that the "blue" tag is following a different naming scheme compared to the other tags. This is on purpose and is needed for the rest of the guide.
 
-```GraphQL
+```graphql
 mutation CreateTags {
   BuiltinTagCreate(
       data: {name: {value: "color-red"}, description: {value: "The red tag"}}
@@ -40,7 +40,7 @@ mutation CreateTags {
 
 The next step is to create a query that returns the data we just created. The rest of this guide assumes that the following query will return a response similar to the response below the query.
 
-```GraphQL
+```graphql
 query TagsQuery {
   BuiltinTag {
     edges {
@@ -102,7 +102,7 @@ Response to the tags query:
 
 Create a local directory on your computer.
 
-```bash
+```shell
 mkdir tags_check
 ```
 
@@ -207,7 +207,7 @@ Within the `tags_check` folder you should now have 3 files:
 
 Before we can test our transform we must add the files to a local Git repository.
 
-```bash
+```shell
 git init --initial-branch=main
 git add .
 git commit -m "First commit"
@@ -217,14 +217,14 @@ git commit -m "First commit"
 
 Using infrahubctl you can first verify that the `.infrahub.yml` file is formatted correctly by listing available checks.
 
-```bash title="❯ infrahubctl check --list"
+```shell title="❯ infrahubctl check --list"
 Python checks defined in repository: 1
 check_color_tags_name (tags_check.py::ColorTagsCheck) Target: -global-
 ```
 
 Run the check by specifying the name of the check as an argument.
 
-```bash title="❯ infrahubctl check check_color_tags_name"
+```shell title="❯ infrahubctl check check_color_tags_name"
 [09:23:25] INFO     HTTP Request: POST http://localhost:8000/graphql "HTTP/1.1 200 OK"
            ERROR    tags_check::ColorTagsCheck: FAILED
            ERROR      Invalid tag name: blue
@@ -352,7 +352,7 @@ We need to modify the GraphQL query with the `name` parameter. The GraphQL query
 
 Replace the contents of the `tags_check.gql` file with the following contents.
 
-```GraphQL
+```graphql
 query TagsQuery($name: String!) {
   BuiltinTag(name__value: $name) {
     edges {
@@ -371,7 +371,7 @@ query TagsQuery($name: String!) {
 
 ### 5. Test the `check_color_tags_name` check
 
-```bash title="❯ infrahubctl check check_color_tags_name"
+```shell title="❯ infrahubctl check check_color_tags_name"
 ``[11:50:43] INFO     HTTP Request: GET http://localhost:8000/api/schema/?branch=main "HTTP/1.1 200 OK"
            INFO     HTTP Request: POST http://localhost:8000/graphql/main "HTTP/1.1 200 OK"
            INFO     HTTP Request: POST http://localhost:8000/graphql/main "HTTP/1.1 200 OK"
@@ -493,7 +493,7 @@ We now have 2 targeted checks defined, each targeting its own set of tags, with 
 
 Verify that we have 2 checks defined using the `infrahubctl` command.
 
-```bash title="❯ infrahubctl check --list"
+```shell title="❯ infrahubctl check --list"
 Python checks defined in repository: 2
 check_color_tags_name (tags_check.py::ColorTagsCheck) Target: ColorTags
 check_number_tags_name (tags_check.py::NumberTagsCheck) Target: NumberTags
@@ -501,7 +501,7 @@ check_number_tags_name (tags_check.py::NumberTagsCheck) Target: NumberTags
 
 Check that the `check_color_tags_name` fails because of the tag `blue` not complying with the naming scheme:
 
-```bash title="❯ infrahubctl check check_color_tags_name"
+```shell title="❯ infrahubctl check check_color_tags_name"
 [14:04:50] INFO     HTTP Request: GET http://localhost:8000/api/schema/?branch=main "HTTP/1.1 200 OK
 [14:04:51] INFO     HTTP Request: POST http://localhost:8000/graphql/main "HTTP/1.1 200 OK"
            INFO     HTTP Request: POST http://localhost:8000/graphql/main "HTTP/1.1 200 OK"
@@ -518,7 +518,7 @@ Check that the `check_color_tags_name` fails because of the tag `blue` not compl
 
 Check that the `check_number_tags_name` succeeds:
 
-```bash title="❯ infrahubctl check check_number_tags_name"
+```shell title="❯ infrahubctl check check_number_tags_name"
 [14:09:32] INFO     HTTP Request: GET http://localhost:8000/api/schema/?branch=main "HTTP/1.1 200 OK"
            INFO     HTTP Request: POST http://localhost:8000/graphql/main "HTTP/1.1 200 OK"
            INFO     HTTP Request: POST http://localhost:8000/graphql/main "HTTP/1.1 200 OK"

--- a/docs/docs/guides/create-schema.mdx
+++ b/docs/docs/guides/create-schema.mdx
@@ -78,13 +78,13 @@ nodes:
 
 Create a branch `network-device-schema` in Infrahub
 
-```bash
+```shell
 infrahubctl branch create network-device-schema
 ```
 
 Load the schema into Infrahub in the `network-device-schema` branch
 
-```bash
+```shell
 infrahubctl schema load --branch network-device-schema /tmp/schema_guide.yml
 ```
 
@@ -158,13 +158,13 @@ nodes:
 
 Create a new branch to load the new version of our schema
 
-```bash
+```shell
 infrahubctl branch create network-device-relations
 ```
 
 Load the schema in the branch
 
-```bash
+```shell
 infrahubctl schema load --branch network-device-relations /tmp/schema_guide.yml
 ```
 
@@ -255,13 +255,13 @@ nodes:
 
 Create a new branch to load the new version of our schema
 
-```bash
+```shell
 infrahubctl branch create network-device-generics
 ```
 
 Load the schema in the branch
 
-```bash
+```shell
 infrahubctl schema load --branch network-device-generics /tmp/schema_guide.yml
 ```
 
@@ -387,11 +387,11 @@ nodes:
 
 Use the `infrahubctl schema check` command to validate the schema and to get a `diff` of the schema changes that will be performed
 
-```bash
+```shell
 infrahubctl schema check --branch network-device-generics /tmp/schema_guide.yml
 ```
 
-```bash
+```shell
  schema '/tmp/schema_guide.yml' is Valid!
 diff:
         added: {}
@@ -455,7 +455,7 @@ diff:
 
 Load the schema into `network-device-generics` branch in Infrahub
 
-```bash
+```shell
 infrahubctl schema load --branch network-device-generics /tmp/schema_guide.yml
 ```
 

--- a/docs/docs/guides/generator.mdx
+++ b/docs/docs/guides/generator.mdx
@@ -87,7 +87,7 @@ query Widgets($name: String!) {
 
 Create a local directory on your computer where we will store the generator files.
 
-```bash
+```shell
 mkdir example_generator
 ```
 
@@ -168,7 +168,7 @@ Within the `example_generator` folder you should now have 3 files:
 
 Before we can test our generator we must add the files to a local Git repository.
 
-```bash
+```shell
 git init --initial-branch=main
 git add .
 git commit -m "First commit"
@@ -178,7 +178,7 @@ git commit -m "First commit"
 
 Using infrahubctl you can first verify that the `.infrahub.yml` file is formatted correctly by listing available generators.
 
-```bash title="❯ infrahubctl generator --list"
+```shell title="❯ infrahubctl generator --list"
 Generators defined in repository: 1
 widget_generator (widget_generator.py::Generator) Target: widgets
 ```
@@ -189,13 +189,13 @@ When running a generator with `infrahubctl` the [SDK tracking](/python-sdk/topic
 
 :::
 
-```bash
+```shell
 infrahubctl branch create test-branch1
 ```
 
 Then we can try to run the generator within this branch.
 
-```bash
+```shell
 infrahubctl generator widget_generator --branch=test-branch1 name=widget1
 infrahubctl generator widget_generator --branch=test-branch1 name=widget2
 ```

--- a/docs/docs/guides/groups.mdx
+++ b/docs/docs/guides/groups.mdx
@@ -27,7 +27,7 @@ Then we will add members to the group.
 
 Execute this GraphQL mutation to create the group `TagConfigGroup`.
 
-```GraphQL
+```graphql
 mutation CreateGroup {
   CoreStandardGroupCreate (data: {name: {value: "TagConfigGroup"}}) {
     ok
@@ -46,7 +46,7 @@ We will be adding the `red` and `blue` tag to the `TagConfigGroup` group that we
 
 We need to retrieve the ids of the `red` and `blue` tag. Execute the following GraphQL query and take note of the ids.
 
-```GraphQL
+```graphql
 query {
   BuiltinTag (name__values: ["red","blue"]) {
     edges {
@@ -82,7 +82,7 @@ mutation UpdateGroupMembers {
 ![Adding members in group](../media/group_tagconfig_grp_adding_members.png)
 The resulting mutation should look like this (note that the ids will be different in your case).
 
-```GraphQL
+```graphql
 mutation UpdateGroupMembers {
   CoreStandardGroupUpdate(
     data: {

--- a/docs/docs/guides/import-schema.mdx
+++ b/docs/docs/guides/import-schema.mdx
@@ -44,7 +44,7 @@ Schema files can be loaded into Infrahub with the `infrahubctl` command or direc
 <!-- vale on -->
 The `infrahubctl` command can be used to load individual schema files or multiple files as part of a directory.
 
-```bash
+```shell
 infrahubctl schema load <path to schema file or a directory> <path to schema file or a directory>
 ```
 

--- a/docs/docs/guides/installation.mdx
+++ b/docs/docs/guides/installation.mdx
@@ -164,8 +164,8 @@ invoke demo.start demo.load-infra-schema demo.load-infra-data
 
 The Infrahub GitHub repository is designed to launch an instance via [GitHub Codespaces](https://docs.github.com/en/codespaces/overview). We have two devcontainer configurations:
 <!-- vale off -->
-- **infrahub:** a deployment running without any [Schema](/tutorials/getting-started/schema) or data pre-installed
-- **infrahub-demo:** a deployment running the [demo environment](/topics/local-demo-environment)
+* **infrahub:** a deployment running without any [Schema](/tutorials/getting-started/schema) or data pre-installed
+* **infrahub-demo:** a deployment running the [demo environment](/topics/local-demo-environment)
 <!-- vale on -->
 |  No Data | Demo Data |
 |---|---|
@@ -187,10 +187,10 @@ A first version of our K8S helm-chart is available in our repository.
 
 The following are required for production deployments using Helm:
 
-- data persistence must be enabled (except for the Infrahub API Server if using S3 storage)
-- multiple replicas of the Infrahub API Server and Infrahub Git Agents should be deployed: you can make use of the `affinity` variable to define the affinity policy for the pods
-- a shared storage should be available for use by the Git Agents (through a StorageClass that supports RWX accesses)
-- S3 storage should be configured for the Infrahub API Server
+* data persistence must be enabled (except for the Infrahub API Server if using S3 storage)
+* multiple replicas of the Infrahub API Server and Infrahub Git Agents should be deployed: you can make use of the `affinity` variable to define the affinity policy for the pods
+* a shared storage should be available for use by the Git Agents (through a StorageClass that supports RWX accesses)
+* S3 storage should be configured for the Infrahub API Server
 
 You can use the following values example:
 

--- a/docs/docs/guides/installation.mdx
+++ b/docs/docs/guides/installation.mdx
@@ -8,16 +8,11 @@ import ReferenceLink from "../../src/components/Card";
 
 # Installing Infrahub
 
-Infrahub is deployed as a container-based architecture, comprised of multiple components. The main components are:
+Infrahub is deployed as a container-based architecture, and can be deployed for testing or production use in a number of different ways:
 
-- A **Frontend** written in React.
-- An **API server** written in Python with FastAPI.
-- A **Git agent** to manage the interaction with external Git repositories.
-- A **Graph database** based on `Neo4j`.
-- A **Message bus** based on `RabbitMQ`.
-- A **Cache** based on `redis`.
-
-Refer to [Architecture](/topics/architecture) for a more in-depth view of the components' interaction.
+* [Quick start via curl](#quick-start-via-curl)
+* [Docker Compose](#docker-compose)
+* [K8s with Helm charts](#k8s-with-helm-charts)
 
 ## Hardware requirements
 
@@ -25,24 +20,30 @@ Please ensure the systems on which you want to install Infrahub meet the [hardwa
 
 ## Quick start via curl
 
-To quickly test Infrahub locally:
+To quickly spin up Infrahub locally:
 
-```bash
-curl https://infrahub.opsmill.io | docker compose -f - up -d
+```shell
+curl https://infrahub.opsmill.io | sudo docker compose -f - up -d
 ```
 
 Alternative examples:
 
-```bash
-curl https://infrahub.opsmill.io/develop | docker compose -f - up -d
-curl https://infrahub.opsmill.io/0.15.2 | docker compose -f - up -d
+```shell
+curl https://infrahub.opsmill.io/develop | sudo docker compose -f - up -d
+curl https://infrahub.opsmill.io/0.15.2 | sudo docker compose -f - up -d
+```
+
+To spin down and remove an Infrahub environment:
+
+```shell
+curl https://infrahub.opsmill.io | sudo docker compose -f - down -v
 ```
 
 ## From Git repository
 
 Create the base directory for the Infrahub installation. For this guide, we'll use `/opt/infrahub`.
 
-```bash
+```shell
 sudo mkdir -p /opt/infrahub/
 cd /opt/infrahub/
 ```
@@ -55,15 +56,15 @@ Depending on your system configuration, you might have to give other users write
 
 Usage of the `/opt/infrahub` directory is merely a suggestion. You can use any directory on your system, especially for development or demo purposes.
 
-```bash
+```shell
 mkdir -p ~/source/infrahub/
 cd ~/source/infrahub/
 ```
 
-Next, clone the `stable` branch of the Infrahub GitHub repository into the current directory. (This branch always holds the current stable release)
+Next, clone the Infrahub GitHub repository into the current directory.
 
-```bash
-git clone --recursive -b stable --depth 1 https://github.com/opsmill/infrahub.git
+```shell
+git clone --recursive --depth 1 https://github.com/opsmill/infrahub.git
 ```
 
 :::note
@@ -74,7 +75,7 @@ The command above utilizes a "shallow clone" to retrieve only the most recent co
 
 The `git clone` command should generate output similar to the following:
 
-```bash
+```shell
 Cloning into '.'...
 remote: Enumerating objects: 1312, done.
 remote: Counting objects: 100% (1312/1312), done.
@@ -90,9 +91,9 @@ The recommended way to run Infrahub is to use the Docker Compose files included 
 
 The pre-requisites for this type of deployment are to have:
 
-- [Invoke](https://www.pyinvoke.org) (version 2 minimum)
-- [Toml](https://toml.io/en/)
-- [Docker](https://docs.docker.com/engine/install/) (version 24.x minimum)
+* [Invoke](https://www.pyinvoke.org) (version 2 minimum)
+* [Toml](https://toml.io/en/)
+* [Docker](https://docs.docker.com/engine/install/) (version 24.x minimum)
 
 <Tabs>
 <TabItem value="MacOS" default>
@@ -101,8 +102,8 @@ The pre-requisites for this type of deployment are to have:
 On MacOS, Python is installed by default so you should be able to install `invoke` directly.
 Invoke works best when you install it in the main Python environment, but you can also install it in a virtual environment if you prefer. To install `invoke` and `toml`, run the following command:
 
-```bash
-pip install invoke toml
+```shell
+pip3 install invoke toml
 ```
 
 #### Docker
@@ -110,14 +111,8 @@ pip install invoke toml
 To install Docker, follow the [official instructions on the Docker website](https://docs.docker.com/desktop/install/mac-install/) for your platform.
 </TabItem>
 <TabItem value="Windows">
-On Windows, install a Linux VM via WSL2 and follow the installation guide for Ubuntu.
+On Windows, install a Linux VM via [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) and follow the installation guide for Ubuntu.
 
-:::warning
-
-The native support on Windows is currently under investigation and is being tracked in [issue 794](https://github.com/opsmill/infrahub/issues/794).
-Please add a comment to the issue if this is something that would be useful to you.
-
-:::
 </TabItem>
 <TabItem value="Ubuntu">
 :::warning
@@ -129,7 +124,18 @@ On Ubuntu, depending on which distribution you're running, there is a good chanc
 #### Invoke
 
 Invoke is a Python package commonly installed by running `pip install invoke toml`.
-If Python is not already installed on your system, install it first with `sudo apt install python3-pip`.
+If Python pip is not already installed on your system, install it first with `sudo apt install python3-pip`.
+
+:::note
+
+Ensure that the path to your python binaries are defined in your shell's `$PATH` variable. On Ubuntu 22.04, an example could be:
+
+```shell
+echo 'export PATH="$PATH:~/.local/bin"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+:::
 
 #### Docker
 
@@ -145,10 +151,11 @@ Please reach out if you need some help and feel free to send a PR with the insta
 </TabItem>
 </Tabs>
 
-Once docker desktop and invoke are installed you can build, start, and initialize the Infrahub demo environment with the following command:
+Once docker desktop and invoke are installed you can start and initialize the Infrahub demo environment with the following command:
 
-```bash
-invoke demo.build demo.start demo.load-infra-schema demo.load-infra-data
+```shell
+cd infrahub
+invoke demo.start demo.load-infra-schema demo.load-infra-data
 ```
 
 <ReferenceLink title="Check the documentation of the demo environment for more information" url="/topics/local-demo-environment" />
@@ -251,12 +258,12 @@ nfs-server-provisioner:
   enabled: false
 ```
 
-```bash
+```shell
 helm install infrahub -f values.yml path/to/infrahub/chart
 ```
 
 You can also install the chart using the OpsMill registry.
 
-```bash
+```shell
 helm install infrahub -f values.yml oci://registry.opsmill.io/opsmill/chart/infrahub
 ```

--- a/docs/docs/guides/jinja2-transform.mdx
+++ b/docs/docs/guides/jinja2-transform.mdx
@@ -24,7 +24,7 @@ As the first step we need to have some data in the database to actually query.
 
 Create three tags, called "red", "green", "blue", either using the frontend or by submitting three GraphQL mutations as per below (just swapping out the name of the color each time).
 
-```GraphQL
+```graphql
 mutation CreateTags {
   BuiltinTagCreate(
     data: {name: {value: "red"}, description: {value: "The red tag"}}
@@ -39,7 +39,7 @@ mutation CreateTags {
 
 The next step is to create a query that returns the data we just created. The rest of this guide assumes that the following query will return a response similar to the response below the query.
 
-```GraphQL
+```graphql
 query TagsQuery {
   BuiltinTag {
     edges {
@@ -103,13 +103,13 @@ While it would be possible to create a transform that targets all of these tags,
 
 Create a local directory on your computer.
 
-```bash
+```shell
 mkdir tags_render
 ```
 
 Then save the below query as a text file named tags_query.gql.
 
-```GraphQL
+```graphql
 query TagsQuery($tag: String!) {
   BuiltinTag(name__value: $tag) {
     edges {
@@ -178,7 +178,7 @@ Within the `tags_render` folder you should now have tree files:
 
 Before we can test our transform we must add the files to a local Git repository.
 
-```bash
+```shell
 git init --initial-branch=main
 git add .
 git commit -m "First commit"
@@ -188,7 +188,7 @@ git commit -m "First commit"
 
 Using infrahubctl you can first verify that the `.infrahub.yml` file is formatted correctly by listing available transforms.
 
-```bash
+```shell
 
  Usage: infrahubctl render [OPTIONS] TRANSFORM_NAME [VARIABLES]...
 
@@ -210,7 +210,7 @@ Using infrahubctl you can first verify that the `.infrahub.yml` file is formatte
 
 Examples
 
-```bash
+```shell
 infrahubctl render <transform name or ID> my-param=XXXXX my-other-param=YYYYY
 ```
 

--- a/docs/docs/guides/object-storage.mdx
+++ b/docs/docs/guides/object-storage.mdx
@@ -74,7 +74,7 @@ You might have to change the X-INFRAHUB-KEY header value to the API token of you
 
 :::
 
-```sh
+```shell
 curl -X POST --header "Content-Type: application/json" --header "X-INFRAHUB-KEY: 06438eb2-8019-4776-878c-0941b1f1d1ec" http://localhost:8000/api/storage/upload/content --data '{"content": "interface Ethernet1\n  description: Connected to Ethernet2"}'
 ```
 
@@ -84,6 +84,6 @@ curl -X POST --header "Content-Type: application/json" --header "X-INFRAHUB-KEY:
 
 Retrieving the object works as described in the previous step.
 
-```sh
+```shell
 curl --header "X-INFRAHUB-KEY: 06438eb2-8019-4776-878c-0941b1f1d1ec" http://localhost:8000/api/storage/object/17d19962-4420-4972-334d-c51beb03e477
 ```

--- a/docs/docs/guides/python-transform.mdx
+++ b/docs/docs/guides/python-transform.mdx
@@ -26,7 +26,7 @@ As the first step we need to have some data in the database to actually query.
 
 Create three tags, called "red", "green", "blue", either using the frontend or by submitting three GraphQL mutations as per below (just swapping out the name of the color each time).
 
-```GraphQL #1-2
+```graphql #1-2
 mutation CreateTags {
   BuiltinTagCreate(
     data: {name: {value: "red"}, description: {value: "The red tag"}}
@@ -41,7 +41,7 @@ mutation CreateTags {
 
 The next step is to create a query that returns the data we just created. The rest of this guide assumes that the following query will return a response similar to the response below the query.
 
-```GraphQL #1-2
+```graphql #1-2
 query TagsQuery {
   BuiltinTag {
     edges {
@@ -105,13 +105,13 @@ While it would be possible to create a transform that targets all of these tags,
 
 Create a local directory on your computer:
 
-```bash
+```shell
 mkdir tags_transform
 ```
 
 Then save the below query as a text file named `tags_query.gql`:
 
-```GraphQL #1-2
+```graphql #1-2
 query TagsQuery($tag: String!) {
   BuiltinTag(name__value: $tag) {
     edges {
@@ -256,7 +256,7 @@ Within the `tags_transform` folder you should now have 3 files:
 
 Before we can test our transform we must add the files to a local Git repository.
 
-```bash
+```shell
 git init --initial-branch=main
 git add .
 git commit -m "First commit"
@@ -266,7 +266,7 @@ git commit -m "First commit"
 
 Using infrahubctl you can first verify that the `.infrahub.yml` file is formatted correctly by listing available transforms.
 
-```bash title="❯ infrahubctl transform --list"
+```shell title="❯ infrahubctl transform --list"
 Python transforms defined in repository: 1
 tags_transform (tags_transform.py::TagsTransform)
 ```
@@ -274,7 +274,7 @@ tags_transform (tags_transform.py::TagsTransform)
 :::info
 Trying to run the transform with just the name will produce an error.
 
-```bash title="❯ infrahubctl transform tags_transform"
+```shell title="❯ infrahubctl transform tags_transform"
 1 error(s) occurred while executing the query
  - Message: Variable '$tag' of required type 'String!' was not provided.
    Location: [{'line': 1, 'column': 17}]

--- a/docs/docs/guides/repository.mdx
+++ b/docs/docs/guides/repository.mdx
@@ -78,7 +78,7 @@ Using the GraphQL Interface, it is possible to add a `Repository` or `Read-only 
 1. Open the [GraphQL Interface](http://localhost:8000/graphql).
 2. If needed, i.e., your repository is private, create a Credential object to hold your username / password.
 
-```GraphQL
+```graphql
   # Endpoint: http://127.0.0.1:8000/graphql/main
   mutation {
     CorePasswordCredentialCreate(
@@ -101,7 +101,7 @@ Using the GraphQL Interface, it is possible to add a `Repository` or `Read-only 
 <Tabs>
   <TabItem value="Repository" default>
 
-```GraphQL
+```graphql
   # Endpoint: http://127.0.0.1:8000/graphql/main
   mutation {
     CoreRepositoryCreate(
@@ -123,7 +123,7 @@ Using the GraphQL Interface, it is possible to add a `Repository` or `Read-only 
   <TabItem value="Read-only Repository">
     **Make sure that you are on the correct Infrahub branch.** Unlike a Repository, a Read-only Repository will only pull files into the Infrahub branch on which it was created.
 
-```GraphQL
+```graphql
   # Endpoint : http://127.0.0.1:8000/graphql/<branch>
   mutation {
     CoreReadOnlyRepositoryCreate(
@@ -238,7 +238,7 @@ Unlike `Repository`, Infrahub does not automatically update `Read-only Repositor
 1. Open the [GraphQL Interface](http://localhost:8000/graphql).
 2. Copy-paste the correct mutation from below and complete the information
 
-```GraphQL
+```graphql
   # Endpoint : http://127.0.0.1:8000/graphql/main
   mutation {
     CoreReadOnlyRepositoryUpdate(
@@ -310,7 +310,7 @@ RUN update-ca-certificates
 
 We then have to build a Docker image from the Dockerfile. We can do this by executing this command
 
-```bash
+```shell
 INFRAHUB_VERSION=0.16.0 && docker build --build-arg INFRAHUB_VERSION=$INFRAHUB_VERSION -f Dockerfile -t custom/infrahub:${INFRAHUB_VERSION}
 ```
 
@@ -354,7 +354,7 @@ RUN git config --global http.sslVerify "false"
 
 We then have to build a Docker image from the Dockerfile. We can do this by executing this command
 
-```bash
+```shell
 INFRAHUB_VERSION=0.16.0 && docker build --build-arg INFRAHUB_VERSION=$INFRAHUB_VERSION -f Dockerfile -t custom/infrahub:${INFRAHUB_VERSION}
 ```
 
@@ -398,7 +398,7 @@ RUN git config --global http.proxy http://user:password@internal.proxy:8080
 
 We then have to build a Docker image from the Dockerfile. We can do this by executing this command
 
-```bash
+```shell
 INFRAHUB_VERSION=0.16.0 && docker build --build-arg INFRAHUB_VERSION=$INFRAHUB_VERSION -f Dockerfile -t custom/infrahub:${INFRAHUB_VERSION}
 ```
 

--- a/docs/docs/guides/resource-manager.mdx
+++ b/docs/docs/guides/resource-manager.mdx
@@ -53,7 +53,7 @@ nodes:
 
 Load the schema with the `infrahubctl` command.
 
-```bash title="❯ infrahubctl schema load /tmp/schema.yml"
+```shell title="❯ infrahubctl schema load /tmp/schema.yml"
  schema '/tmp/schema.yml' loaded successfully
  1 schema processed in 6.846 seconds.
 ```
@@ -221,7 +221,7 @@ Without this behavior we could allocate the resource multiple times, which shoul
 
 Create a branch named `test`
 
-```bash title="❯ infrahubctl branch create test"
+```shell title="❯ infrahubctl branch create test"
 Branch 'test' created successfully (17d28fe4-a2d7-93ec-35a4-c51c5c804f05).
 ```
 

--- a/docs/docs/infrahubctl/infrahubctl-branch.mdx
+++ b/docs/docs/infrahubctl/infrahubctl-branch.mdx
@@ -6,7 +6,7 @@ List, create, merge, rebase ..
 
 **Usage**:
 
-```console
+```shell
 $ infrahubctl branch [OPTIONS] COMMAND [ARGS]...
 ```
 
@@ -31,7 +31,7 @@ Create a new branch.
 
 **Usage**:
 
-```console
+```shell
 $ infrahubctl branch create [OPTIONS] BRANCH_NAME
 ```
 
@@ -52,7 +52,7 @@ Delete a branch.
 
 **Usage**:
 
-```console
+```shell
 $ infrahubctl branch delete [OPTIONS] BRANCH_NAME
 ```
 
@@ -71,7 +71,7 @@ List all existing branches.
 
 **Usage**:
 
-```console
+```shell
 $ infrahubctl branch list [OPTIONS]
 ```
 
@@ -86,7 +86,7 @@ Merge a Branch with main.
 
 **Usage**:
 
-```console
+```shell
 $ infrahubctl branch merge [OPTIONS] BRANCH_NAME
 ```
 
@@ -105,7 +105,7 @@ Rebase a Branch with main.
 
 **Usage**:
 
-```console
+```shell
 $ infrahubctl branch rebase [OPTIONS] BRANCH_NAME
 ```
 
@@ -124,7 +124,7 @@ Validate if a branch has some conflict and is passing all the tests (NOT IMPLEME
 
 **Usage**:
 
-```console
+```shell
 $ infrahubctl branch validate [OPTIONS] BRANCH_NAME
 ```
 

--- a/docs/docs/infrahubctl/infrahubctl-check.mdx
+++ b/docs/docs/infrahubctl/infrahubctl-check.mdx
@@ -4,7 +4,7 @@ Execute user-defined checks.
 
 **Usage**:
 
-```console
+```shell
 $ infrahubctl check [OPTIONS] [CHECK_NAME] [VARIABLES]...
 ```
 

--- a/docs/docs/infrahubctl/infrahubctl-dump.mdx
+++ b/docs/docs/infrahubctl/infrahubctl-dump.mdx
@@ -4,7 +4,7 @@ Export nodes and their relationships out of the database.
 
 **Usage**:
 
-```console
+```shell
 $ infrahubctl dump [OPTIONS]
 ```
 

--- a/docs/docs/infrahubctl/infrahubctl-generator.mdx
+++ b/docs/docs/infrahubctl/infrahubctl-generator.mdx
@@ -4,7 +4,7 @@ Run a generator script.
 
 **Usage**:
 
-```console
+```shell
 $ infrahubctl generator [OPTIONS] [GENERATOR_NAME] [VARIABLES]...
 ```
 

--- a/docs/docs/infrahubctl/infrahubctl-load.mdx
+++ b/docs/docs/infrahubctl/infrahubctl-load.mdx
@@ -4,7 +4,7 @@ Import nodes and their relationships into the database.
 
 **Usage**:
 
-```console
+```shell
 $ infrahubctl load [OPTIONS]
 ```
 

--- a/docs/docs/infrahubctl/infrahubctl-protocols.mdx
+++ b/docs/docs/infrahubctl/infrahubctl-protocols.mdx
@@ -4,7 +4,7 @@ Export Python protocols corresponding to a schema.
 
 **Usage**:
 
-```console
+```shell
 $ infrahubctl protocols [OPTIONS]
 ```
 

--- a/docs/docs/infrahubctl/infrahubctl-render.mdx
+++ b/docs/docs/infrahubctl/infrahubctl-render.mdx
@@ -4,7 +4,7 @@ Render a local Jinja2 Transform for debugging purpose.
 
 **Usage**:
 
-```console
+```shell
 $ infrahubctl render [OPTIONS] [TRANSFORM_NAME] [VARIABLES]...
 ```
 

--- a/docs/docs/infrahubctl/infrahubctl-repository.mdx
+++ b/docs/docs/infrahubctl/infrahubctl-repository.mdx
@@ -6,7 +6,7 @@ List, create, delete ..
 
 **Usage**:
 
-```console
+```shell
 $ infrahubctl repository [OPTIONS] COMMAND [ARGS]...
 ```
 
@@ -26,7 +26,7 @@ Add a new repository.
 
 **Usage**:
 
-```console
+```shell
 $ infrahubctl repository add [OPTIONS] NAME LOCATION
 ```
 

--- a/docs/docs/infrahubctl/infrahubctl-run.mdx
+++ b/docs/docs/infrahubctl/infrahubctl-run.mdx
@@ -4,7 +4,7 @@ Execute a script.
 
 **Usage**:
 
-```console
+```shell
 $ infrahubctl run [OPTIONS] SCRIPT [VARIABLES]...
 ```
 

--- a/docs/docs/infrahubctl/infrahubctl-schema.mdx
+++ b/docs/docs/infrahubctl/infrahubctl-schema.mdx
@@ -4,7 +4,7 @@ Manage the schema in a remote Infrahub instance.
 
 **Usage**:
 
-```console
+```shell
 $ infrahubctl schema [OPTIONS] COMMAND [ARGS]...
 ```
 
@@ -25,7 +25,7 @@ Check if schema files are valid and what would be the impact of loading them wit
 
 **Usage**:
 
-```console
+```shell
 $ infrahubctl schema check [OPTIONS] SCHEMAS...
 ```
 
@@ -46,7 +46,7 @@ Load one or multiple schema files into Infrahub.
 
 **Usage**:
 
-```console
+```shell
 $ infrahubctl schema load [OPTIONS] SCHEMAS...
 ```
 

--- a/docs/docs/infrahubctl/infrahubctl-transform.mdx
+++ b/docs/docs/infrahubctl/infrahubctl-transform.mdx
@@ -4,7 +4,7 @@ Render a local transform (TransformPython) for debugging purpose.
 
 **Usage**:
 
-```console
+```shell
 $ infrahubctl transform [OPTIONS] [TRANSFORM_NAME] [VARIABLES]...
 ```
 

--- a/docs/docs/infrahubctl/infrahubctl-validate.mdx
+++ b/docs/docs/infrahubctl/infrahubctl-validate.mdx
@@ -4,7 +4,7 @@ Helper to validate the format of various files.
 
 **Usage**:
 
-```console
+```shell
 $ infrahubctl validate [OPTIONS] COMMAND [ARGS]...
 ```
 
@@ -25,7 +25,7 @@ Validate the format of a GraphQL Query stored locally by executing it on a remot
 
 **Usage**:
 
-```console
+```shell
 $ infrahubctl validate graphql-query [OPTIONS] QUERY [VARIABLES]...
 ```
 
@@ -48,7 +48,7 @@ Validate the format of a schema file either in JSON or YAML
 
 **Usage**:
 
-```console
+```shell
 $ infrahubctl validate schema [OPTIONS] SCHEMA
 ```
 

--- a/docs/docs/infrahubctl/infrahubctl-version.mdx
+++ b/docs/docs/infrahubctl/infrahubctl-version.mdx
@@ -4,7 +4,7 @@ Display the version of Infrahub and the version of the Python SDK in use.
 
 **Usage**:
 
-```console
+```shell
 $ infrahubctl version [OPTIONS]
 ```
 

--- a/docs/docs/integrations/sync/guides/installation.mdx
+++ b/docs/docs/integrations/sync/guides/installation.mdx
@@ -5,7 +5,7 @@ title: Installing Infrahub sync
 
 Infrahub Sync is available on [PyPI](https://pypi.org/project/infrahub-sync/) and can be installed using the pip package installer. It is recommended to install the Sync into a virtual environment.
 
-```bash
+```shell
 python3 -m venv .venv
 source .venv/bin/activate
 pip install infrahub-sync

--- a/docs/docs/integrations/sync/guides/run.mdx
+++ b/docs/docs/integrations/sync/guides/run.mdx
@@ -17,7 +17,7 @@ To create a new configuration, please refer to the guide [Creating a new Sync In
 
 ### Command
 
-```bash
+```shell
 infrahub-sync generate --name <sync_project_name> --directory <your_configuration_directory>
 ```
 
@@ -34,7 +34,7 @@ The `diff` command lets you see the differences between your source and destinat
 
 ### Command
 
-```bash
+```shell
 infrahub-sync diff --name <sync_project_name> --directory <your_configuration_directory>
 ```
 
@@ -51,7 +51,7 @@ Once you're ready to synchronize the data between your source and destination, y
 
 ### Command
 
-```bash
+```shell
 infrahub-sync sync --name <sync_project_name> --directory <your_configuration_directory>
 ```
 
@@ -71,6 +71,6 @@ The `sync` command also supports additional flags for displaying progress and ma
 
 For example:
 
-```bash
+```shell
 infrahub-sync sync --name my_project --directory configs --diff --show-progress
 ```

--- a/docs/docs/integrations/sync/reference/cli.mdx
+++ b/docs/docs/integrations/sync/reference/cli.mdx
@@ -2,7 +2,7 @@
 
 **Usage**:
 
-```console
+```shell
 $ infrahub-sync [OPTIONS] COMMAND [ARGS]...
 ```
 
@@ -25,7 +25,7 @@ Calculate and print the differences between the source and the destination syste
 
 **Usage**:
 
-```console
+```shell
 $ infrahub-sync diff [OPTIONS]
 ```
 
@@ -44,7 +44,7 @@ Generate all the python files for a given sync based on the configuration.
 
 **Usage**:
 
-```console
+```shell
 $ infrahub-sync generate [OPTIONS]
 ```
 
@@ -61,7 +61,7 @@ List all available SYNC projects.
 
 **Usage**:
 
-```console
+```shell
 $ infrahub-sync list [OPTIONS]
 ```
 
@@ -76,7 +76,7 @@ Synchronize the data between source and the destination systems for a given proj
 
 **Usage**:
 
-```console
+```shell
 $ infrahub-sync sync [OPTIONS]
 ```
 

--- a/docs/docs/python-sdk/guides/installation.mdx
+++ b/docs/docs/python-sdk/guides/installation.mdx
@@ -5,7 +5,7 @@ title: Installing infrahub-sdk
 
 The Infrahub SDK for Python is available on [PyPI](https://pypi.org/project/infrahub-sdk/) and can be installed using the pip package installer. It is recommended to install the SDK into a virtual environment.
 
-```bash
+```shell
 python3 -m venv .venv
 source .venv/bin/activate
 pip install infrahub-sdk
@@ -20,7 +20,7 @@ Extras can be installed as part of the Python SDK and are not installed by defau
 
 The `ctl` extra provides the `infrahubctl` command, which allows you to interact with an Infrahub instance.
 
-```bash
+```shell
 pip install 'infrahub-sdk[ctl]'
 ```
 <!-- vale off -->
@@ -29,7 +29,7 @@ pip install 'infrahub-sdk[ctl]'
 
 The `tests` extra provides all the components for the testing framework of Transforms, Queries and Checks.
 
-```bash
+```shell
 pip install 'infrahub-sdk[tests]'
 ```
 <!-- vale off -->
@@ -38,6 +38,6 @@ pip install 'infrahub-sdk[tests]'
 
 Installs `infrahub-sdk` together with all the extras.
 
-```bash
+```shell
 pip install 'infrahub-sdk[all]'
 ```

--- a/docs/docs/python-sdk/guides/resource-manager.mdx
+++ b/docs/docs/python-sdk/guides/resource-manager.mdx
@@ -56,7 +56,7 @@ nodes:
 
 Load the schema with the `infrahubctl` command.
 
-```bash title="❯ infrahubctl schema load /tmp/schema.yml"
+```shell title="❯ infrahubctl schema load /tmp/schema.yml"
  schema '/tmp/schema.yml' loaded successfully
  1 schema processed in 6.846 seconds.
 ```

--- a/docs/docs/reference/infrahub-cli/infrahub-db.mdx
+++ b/docs/docs/reference/infrahub-cli/infrahub-db.mdx
@@ -4,7 +4,7 @@ Manage the graph in the database.
 
 **Usage**:
 
-```console
+```shell
 $ infrahub db [OPTIONS] COMMAND [ARGS]...
 ```
 
@@ -29,7 +29,7 @@ Manage Database Constraints
 
 **Usage**:
 
-```console
+```shell
 $ infrahub db constraint [OPTIONS] [ACTION]:[show|add|drop] [CONFIG_FILE]
 ```
 
@@ -48,7 +48,7 @@ Manage Database Indexes
 
 **Usage**:
 
-```console
+```shell
 $ infrahub db index [OPTIONS] [ACTION]:[show|add|drop] [CONFIG_FILE]
 ```
 
@@ -67,7 +67,7 @@ Erase the content of the database and initialize it with the core schema.
 
 **Usage**:
 
-```console
+```shell
 $ infrahub db init [OPTIONS]
 ```
 
@@ -82,7 +82,7 @@ Load test data into the database from the `test_data` directory.
 
 **Usage**:
 
-```console
+```shell
 $ infrahub db load-test-data [OPTIONS]
 ```
 
@@ -98,7 +98,7 @@ Check the current format of the internal graph and apply the necessary migration
 
 **Usage**:
 
-```console
+```shell
 $ infrahub db migrate [OPTIONS] [CONFIG_FILE]
 ```
 
@@ -117,7 +117,7 @@ Check the current format of the internal graph and apply the necessary migration
 
 **Usage**:
 
-```console
+```shell
 $ infrahub db update-core-schema [OPTIONS] [CONFIG_FILE]
 ```
 

--- a/docs/docs/reference/infrahub-cli/infrahub-git-agent.mdx
+++ b/docs/docs/reference/infrahub-cli/infrahub-git-agent.mdx
@@ -4,7 +4,7 @@ Control the Git Agent.
 
 **Usage**:
 
-```console
+```shell
 $ infrahub git-agent [OPTIONS] COMMAND [ARGS]...
 ```
 
@@ -24,7 +24,7 @@ Start Infrahub Git Agent.
 
 **Usage**:
 
-```console
+```shell
 $ infrahub git-agent start [OPTIONS] [PORT]
 ```
 

--- a/docs/docs/reference/infrahub-cli/infrahub-server.mdx
+++ b/docs/docs/reference/infrahub-cli/infrahub-server.mdx
@@ -4,7 +4,7 @@ Control the API Server.
 
 **Usage**:
 
-```console
+```shell
 $ infrahub server [OPTIONS] COMMAND [ARGS]...
 ```
 
@@ -24,7 +24,7 @@ Start Infrahub in Debug Mode with reload enabled.
 
 **Usage**:
 
-```console
+```shell
 $ infrahub server start [OPTIONS]
 ```
 

--- a/docs/docs/release-notes/infrahub/release-0_15.mdx
+++ b/docs/docs/release-notes/infrahub/release-0_15.mdx
@@ -77,7 +77,7 @@ Added the initial version of the Infrahub Sync adapter for IP Fabric.
 In most GraphQL queries, it’s now possible to search for objects based on the absence of an attribute or a relationship using the new isnull filter. For example, the following query returns all groups that have a parent group defined:
 As an example the following query will return all groups that have a parent group defined.
 
-```GraphQL
+```graphql
 query {
   CoreGroup(parent__isnull: false){
     edges {

--- a/docs/docs/release-notes/infrahub/release-0_7.mdx
+++ b/docs/docs/release-notes/infrahub/release-0_7.mdx
@@ -100,7 +100,7 @@ Several changes to the Architecture have been introduced to prepare the deployme
 
 It's mandatory to completely rebuild your demo environment with the following commands.
 
-```bash
+```shell
 invoke demo.destroy demo.build demo.init demo.start
 invoke demo.load-infra-schema
 invoke demo.load-infra-data

--- a/docs/docs/topics/architecture.mdx
+++ b/docs/docs/topics/architecture.mdx
@@ -85,7 +85,7 @@ Any Git server. The most popular being: GitHub, GitLab, or Bitbucket.
 Infrahub supports TLS connections toward the dependencies above.
 The following configuration variables are available to configure TLS:
 
-```bash
+```shell
 INFRAHUB_BROKER_TLS_CA_FILE=/opt/ssl/ca.pem # File path to a CA certificate or bundle in PEM format
 INFRAHUB_BROKER_TLS_ENABLED=true # Boolean to enable TLS connections (allowed values: 1, True, true, 0, False, false)
 INFRAHUB_BROKER_TLS_INSECURE=true # Boolean to ignore certificate verification, useful for self-signed certificates (CA is not verified, expiry is not verified, hostname is not verified)
@@ -102,7 +102,7 @@ INFRAHUB_DB_TLS_INSECURE
 
 You can configure TLS for Neo4j using the following Docker environment variables:
 
-```bash
+```shell
 NEO4J_dbms_ssl_policy_bolt_enabled=true
 NEO4J_dbms_ssl_policy_bolt_base__directory=/opt/ssl
 NEO4J_dbms_ssl_policy_bolt_private__key=cert.key

--- a/docs/docs/topics/hardware-requirements.mdx
+++ b/docs/docs/topics/hardware-requirements.mdx
@@ -23,7 +23,7 @@ Even with the right amount of CPU core and memory, there are some other factors 
 
 The tool can run on any system using docker with the following command `docker run --pull always --rm registry.opsmill.io/opsmill/bench`
 
-```bash title="❯ docker run --pull always --rm registry.opsmill.io/opsmill/bench"
+```shell title="❯ docker run --pull always --rm registry.opsmill.io/opsmill/bench"
 
 latest: Pulling from opsmill/bench
 09f376ebb190: Already exists

--- a/docs/docs/topics/local-demo-environment.mdx
+++ b/docs/docs/topics/local-demo-environment.mdx
@@ -53,7 +53,7 @@ On a Laptop, both Docker & Docker Compose can be installed by installing [Docker
 
 Initialize the database and start the application
 
-```bash
+```shell
 invoke demo.start
 ```
 
@@ -61,7 +61,7 @@ invoke demo.start
 
 Once you have an environment up and running you can load your own schema or you can explore the one provided with the project using the following commands.
 
-```bash
+```shell
 invoke demo.load-infra-schema
 invoke demo.load-infra-data
 ```
@@ -86,7 +86,7 @@ On a Linux system, the system will try to automatically detect if `sudo` is requ
 
 It's possible to control this setting with the environment variable: `INVOKE_SUDO`
 
-```bash
+```shell
 export INVOKE_SUDO=1 to force sudo
 export INVOKE_SUDO=0 to disable it completely
 ```
@@ -97,7 +97,7 @@ On Linux and MacOS, all commands will be executed with PTY enabled by default.
 
 It's possible to control this setting with the environment variable: `INVOKE_PTY`
 
-```bash
+```shell
 export INVOKE_PTY=1 to force pty
 export INVOKE_PTY=0 to disable it completely
 ```

--- a/docs/docs/topics/schema.mdx
+++ b/docs/docs/topics/schema.mdx
@@ -620,13 +620,13 @@ The `infrahubctl` command can be used to check & load individual schema files or
 The `infrahub schema check` command will validate if a given schema is valid and it will return a summary of the changes
 that will be applied to the schema if the schema was loaded.
 
-```bash
+```shell
 infrahubctl schema check <path to schema file or a directory> <path to schema file or a directory> [--branch <branch_name>]
 ```
 
 The `infrahub schema load` command will load the schemas into Infrahub into the specified branch.
 
-```bash
+```shell
 infrahubctl schema load <path to schema file or a directory> <path to schema file or a directory> [--branch <branch_name>]
 ```
 

--- a/docs/docs/topics/version-control.mdx
+++ b/docs/docs/topics/version-control.mdx
@@ -82,7 +82,7 @@ Creating a branch won't create a copy of the database, only the changes applied 
 
   Use the command below to create a new branch named `cr1234`
 
-  ```bash
+  ```shell
   infrahubctl branch create cr1234
   ```
 

--- a/docs/docs/tutorials/getting-started/branches.mdx
+++ b/docs/docs/tutorials/getting-started/branches.mdx
@@ -25,7 +25,7 @@ Branch names are fairly permissive, but must conform to [git ref format](https:/
 
   Use the command below to create a new branch named `cr1234`
 
-  ```bash
+  ```shell
   infrahubctl branch create cr1234
   ```
 
@@ -117,7 +117,7 @@ To view changes and merge a branch you need to:
 
   Use the command below to create a new branch named `cr1234`.
 
-  ```bash
+  ```shell
   infrahubctl branch merge cr1234
   ```
 

--- a/docs/docs/tutorials/getting-started/readme.mdx
+++ b/docs/docs/tutorials/getting-started/readme.mdx
@@ -52,7 +52,7 @@ Refer to the [Installation Documentation](/guides/installation).
 
 Initialize the database and start the application
 
-```bash
+```shell
 invoke demo.start
 ```
 
@@ -61,18 +61,10 @@ invoke demo.start
 - `invoke demo.start` : Start all the containers in detached mode.
 - `invoke demo.stop` : Stop All the containers
 - `invoke demo.destroy` : Destroy all containers and volumes.
-- `INFRAHUB_IMAGE_VER=local invoke demo.build demo.start`: Build and start Infrahub using the local version.
-- `INFRAHUB_IMAGE_VER=develop invoke demo.start`: Start Infrahub using the latest development image.
-
-:::info
-
-`invoke demo.debug` can be used as an alternative to `invoke demo.start`, the main difference is that it will stay *attached* to the containers and all the logs will be displayed in real time in the CLI.
-
-:::
 
 ## Accounts available for the tutorial
 
-At this stage only one Account existed on Infrahub `admin`.
+At this stage only one login account exists on Infrahub: `admin`.
 
 :::info
 

--- a/docs/docs/tutorials/getting-started/schema.mdx
+++ b/docs/docs/tutorials/getting-started/schema.mdx
@@ -45,13 +45,13 @@ A "base" schema with these types of models and more is available in the `models/
 
 Use the following command to load these new models into Infrahub
 
-```bash
+```shell
 invoke demo.load-infra-schema
 ```
 
 <details>
   <summary>Expected Results</summary>
-  ```bash
+  ```shell
   > invoke demo.load-infra-schema
   --- abbreviated ---
   schema 'models/base/dcim.yml' loaded successfully
@@ -82,13 +82,13 @@ In order to have more meaningful data to explore, we'll use a sample topology of
 
 Use the following command to load these new models into Infrahub:
 
-```bash
+```shell
 invoke demo.load-infra-data
 ```
 
 <details>
   <summary>Expected Results</summary>
-  ```bash
+  ```shell
   > invoke demo.load-infra-data
   --- abbreviated ---
   [13:27:39] INFO     Create a new Branch and Change the IP addresses between edge1 and edge2 on the selected site            infrastructure_edge.py:648


### PR DESCRIPTION
Made the following changes to the docs:

- Ran through docs/docs/guides/installation and made sure it's up to date
  - Added `sudo` to the `curl` commands
  - Added a spin-down command to the `curl` commands
  - Removed references to the `stable` branch
  - Removed references to `demo.build` as it's no longer needed
- Replaced [```sh || ```bash || ```console] with ```shell for consistency
- Replaced ```Graphql with ```graphql for consistency
