### PR TITLE
Remove root parameter from methods called by .mutate()

### DIFF
--- a/backend/infrahub/graphql/mutations/artifact_definition.py
+++ b/backend/infrahub/graphql/mutations/artifact_definition.py
@@ -44,7 +44,6 @@ class InfrahubArtifactDefinitionMutation(InfrahubMutationMixin, Mutation):
     @classmethod
     async def mutate_create(
         cls,
-        root: dict,
         info: GraphQLResolveInfo,
         data: InputObjectType,
         branch: Branch,
@@ -53,7 +52,7 @@ class InfrahubArtifactDefinitionMutation(InfrahubMutationMixin, Mutation):
     ) -> tuple[Node, Self]:
         context: GraphqlContext = info.context
 
-        artifact_definition, result = await super().mutate_create(root=root, info=info, data=data, branch=branch, at=at)
+        artifact_definition, result = await super().mutate_create(info=info, data=data, branch=branch, at=at)
 
         events = [
             messages.RequestArtifactDefinitionGenerate(artifact_definition=artifact_definition.id, branch=branch.name),
@@ -68,7 +67,6 @@ class InfrahubArtifactDefinitionMutation(InfrahubMutationMixin, Mutation):
     @classmethod
     async def mutate_update(
         cls,
-        root: dict,
         info: GraphQLResolveInfo,
         data: InputObjectType,
         branch: Branch,
@@ -78,7 +76,7 @@ class InfrahubArtifactDefinitionMutation(InfrahubMutationMixin, Mutation):
     ) -> tuple[Node, Self]:
         context: GraphqlContext = info.context
 
-        artifact_definition, result = await super().mutate_update(root=root, info=info, data=data, branch=branch, at=at)
+        artifact_definition, result = await super().mutate_update(info=info, data=data, branch=branch, at=at)
 
         events = [
             messages.RequestArtifactDefinitionGenerate(artifact_definition=artifact_definition.id, branch=branch.name),

--- a/backend/infrahub/graphql/mutations/graphql_query.py
+++ b/backend/infrahub/graphql/mutations/graphql_query.py
@@ -60,7 +60,6 @@ class InfrahubGraphQLQueryMutation(InfrahubMutationMixin, Mutation):
     @classmethod
     async def mutate_create(
         cls,
-        root: dict,
         info: GraphQLResolveInfo,
         data: InputObjectType,
         branch: Branch,
@@ -71,14 +70,13 @@ class InfrahubGraphQLQueryMutation(InfrahubMutationMixin, Mutation):
 
         data.update(await cls.extract_query_info(info=info, data=data, branch=context.branch))
 
-        obj, result = await super().mutate_create(root=root, info=info, data=data, branch=branch, at=at)
+        obj, result = await super().mutate_create(info=info, data=data, branch=branch, at=at)
 
         return obj, result
 
     @classmethod
     async def mutate_update(
         cls,
-        root: dict,
         info: GraphQLResolveInfo,
         data: InputObjectType,
         branch: Branch,
@@ -90,6 +88,6 @@ class InfrahubGraphQLQueryMutation(InfrahubMutationMixin, Mutation):
 
         data.update(await cls.extract_query_info(info=info, data=data, branch=context.branch))
 
-        obj, result = await super().mutate_update(root=root, info=info, data=data, branch=branch, at=at)
+        obj, result = await super().mutate_update(info=info, data=data, branch=branch, at=at)
 
         return obj, result

--- a/backend/infrahub/graphql/mutations/ipam.py
+++ b/backend/infrahub/graphql/mutations/ipam.py
@@ -64,7 +64,6 @@ class InfrahubIPNamespaceMutation(InfrahubMutationMixin, Mutation):
     @classmethod
     async def mutate_delete(
         cls,
-        root,
         info: GraphQLResolveInfo,
         data: InputObjectType,
         branch: Branch,
@@ -73,7 +72,7 @@ class InfrahubIPNamespaceMutation(InfrahubMutationMixin, Mutation):
         if data["id"] == registry.default_ipnamespace:
             raise ValueError("Cannot delete default IPAM namespace")
 
-        return await super().mutate_delete(root=root, info=info, data=data, branch=branch, at=at)
+        return await super().mutate_delete(info=info, data=data, branch=branch, at=at)
 
 
 class InfrahubIPAddressMutation(InfrahubMutationMixin, Mutation):
@@ -98,7 +97,6 @@ class InfrahubIPAddressMutation(InfrahubMutationMixin, Mutation):
     @retry_db_transaction(name="ipaddress_create")
     async def mutate_create(
         cls,
-        root: dict,
         info: GraphQLResolveInfo,
         data: InputObjectType,
         branch: Branch,
@@ -125,7 +123,6 @@ class InfrahubIPAddressMutation(InfrahubMutationMixin, Mutation):
     @retry_db_transaction(name="ipaddress_update")
     async def mutate_update(
         cls,
-        root: dict,
         info: GraphQLResolveInfo,
         data: InputObjectType,
         branch: Branch,
@@ -165,7 +162,6 @@ class InfrahubIPAddressMutation(InfrahubMutationMixin, Mutation):
     @classmethod
     async def mutate_upsert(
         cls,
-        root: dict,
         info: GraphQLResolveInfo,
         data: InputObjectType,
         branch: Branch,
@@ -178,7 +174,7 @@ class InfrahubIPAddressMutation(InfrahubMutationMixin, Mutation):
 
         await validate_namespace(db=db, data=data)
         prefix, result, created = await super().mutate_upsert(
-            root=root, info=info, data=data, branch=branch, at=at, node_getters=node_getters, database=db
+            info=info, data=data, branch=branch, at=at, node_getters=node_getters, database=db
         )
 
         return prefix, result, created
@@ -186,13 +182,12 @@ class InfrahubIPAddressMutation(InfrahubMutationMixin, Mutation):
     @classmethod
     async def mutate_delete(
         cls,
-        root,
         info: GraphQLResolveInfo,
         data: InputObjectType,
         branch: Branch,
         at: str,
     ):
-        return await super().mutate_delete(root=root, info=info, data=data, branch=branch, at=at)
+        return await super().mutate_delete(info=info, data=data, branch=branch, at=at)
 
 
 class InfrahubIPPrefixMutation(InfrahubMutationMixin, Mutation):
@@ -217,7 +212,6 @@ class InfrahubIPPrefixMutation(InfrahubMutationMixin, Mutation):
     @retry_db_transaction(name="ipprefix_create")
     async def mutate_create(
         cls,
-        root: dict,
         info: GraphQLResolveInfo,
         data: InputObjectType,
         branch: Branch,
@@ -244,7 +238,6 @@ class InfrahubIPPrefixMutation(InfrahubMutationMixin, Mutation):
     @retry_db_transaction(name="ipprefix_update")
     async def mutate_update(
         cls,
-        root: dict,
         info: GraphQLResolveInfo,
         data: InputObjectType,
         branch: Branch,
@@ -284,7 +277,6 @@ class InfrahubIPPrefixMutation(InfrahubMutationMixin, Mutation):
     @classmethod
     async def mutate_upsert(
         cls,
-        root: dict,
         info: GraphQLResolveInfo,
         data: InputObjectType,
         branch: Branch,
@@ -297,7 +289,7 @@ class InfrahubIPPrefixMutation(InfrahubMutationMixin, Mutation):
 
         await validate_namespace(db=db, data=data)
         prefix, result, created = await super().mutate_upsert(
-            root=root, info=info, data=data, branch=branch, at=at, node_getters=node_getters, database=db
+            info=info, data=data, branch=branch, at=at, node_getters=node_getters, database=db
         )
 
         return prefix, result, created
@@ -306,7 +298,6 @@ class InfrahubIPPrefixMutation(InfrahubMutationMixin, Mutation):
     @retry_db_transaction(name="ipprefix_delete")
     async def mutate_delete(
         cls,
-        root,
         info: GraphQLResolveInfo,
         data: InputObjectType,
         branch: Branch,

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -45,7 +45,6 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
     @retry_db_transaction(name="proposed_change_create")
     async def mutate_create(
         cls,
-        root: dict,
         info: GraphQLResolveInfo,
         data: InputObjectType,
         branch: Branch,
@@ -57,7 +56,7 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
 
         async with db.start_transaction() as dbt:
             proposed_change, result = await super().mutate_create(
-                root=root, info=info, data=data, branch=branch, at=at, database=dbt
+                info=info, data=data, branch=branch, at=at, database=dbt
             )
             destination_branch = proposed_change.destination_branch.value
             source_branch = await _get_source_branch(db=dbt, name=proposed_change.source_branch.value)
@@ -87,7 +86,6 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
     @retry_db_transaction(name="proposed_change_update")
     async def mutate_update(
         cls,
-        root: dict,
         info: GraphQLResolveInfo,
         data: InputObjectType,
         branch: Branch,
@@ -117,7 +115,7 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
         merger: Optional[BranchMerger] = None
         async with context.db.start_transaction() as dbt:
             proposed_change, result = await super().mutate_update(
-                root=root, info=info, data=data, branch=branch, at=at, database=dbt, node=obj
+                info=info, data=data, branch=branch, at=at, database=dbt, node=obj
             )
 
             if updated_state == ProposedChangeState.MERGED:

--- a/backend/infrahub/graphql/mutations/repository.py
+++ b/backend/infrahub/graphql/mutations/repository.py
@@ -45,7 +45,6 @@ class InfrahubRepositoryMutation(InfrahubMutationMixin, Mutation):
     @classmethod
     async def mutate_create(
         cls,
-        root: dict,
         info: GraphQLResolveInfo,
         data: InputObjectType,
         branch: Branch,
@@ -56,7 +55,7 @@ class InfrahubRepositoryMutation(InfrahubMutationMixin, Mutation):
 
         cleanup_payload(data)
         # Create the object in the database
-        obj, result = await super().mutate_create(root, info, data, branch, at)
+        obj, result = await super().mutate_create(info, data, branch, at)
         obj = cast(CoreGenericRepository, obj)
 
         # First check the connectivity to the remote repository
@@ -120,7 +119,6 @@ class InfrahubRepositoryMutation(InfrahubMutationMixin, Mutation):
     @classmethod
     async def mutate_update(
         cls,
-        root: dict,
         info: GraphQLResolveInfo,
         data: InputObjectType,
         branch: Branch,
@@ -142,7 +140,7 @@ class InfrahubRepositoryMutation(InfrahubMutationMixin, Mutation):
                 include_source=True,
             )
         if node.get_kind() != InfrahubKind.READONLYREPOSITORY:
-            return await super().mutate_update(root, info, data, branch, at, database=context.db, node=node)
+            return await super().mutate_update(info, data, branch, at, database=context.db, node=node)
 
         node = cast(CoreReadOnlyRepository, node)
         current_commit = node.commit.value
@@ -154,7 +152,7 @@ class InfrahubRepositoryMutation(InfrahubMutationMixin, Mutation):
         if data.ref and data.ref.value:
             new_ref = data.ref.value
 
-        obj, result = await super().mutate_update(root, info, data, branch, at, database=context.db, node=node)
+        obj, result = await super().mutate_update(info, data, branch, at, database=context.db, node=node)
         obj = cast(CoreReadOnlyRepository, obj)
 
         send_update_message = (new_commit and new_commit != current_commit) or (new_ref and new_ref != current_ref)

--- a/backend/infrahub/graphql/mutations/resource_manager.py
+++ b/backend/infrahub/graphql/mutations/resource_manager.py
@@ -171,7 +171,6 @@ class InfrahubNumberPoolMutation(InfrahubMutationMixin, Mutation):
     @classmethod
     async def mutate_create(
         cls,
-        root: dict,
         info: GraphQLResolveInfo,
         data: InputObjectType,
         branch: Branch,
@@ -197,12 +196,11 @@ class InfrahubNumberPoolMutation(InfrahubMutationMixin, Mutation):
         if data["start_range"].value > data["end_range"].value:
             raise ValidationError(input_value="start_range can't be larger than end_range")
 
-        return await super().mutate_create(root=root, info=info, data=data, branch=branch, at=at)
+        return await super().mutate_create(info=info, data=data, branch=branch, at=at)
 
     @classmethod
     async def mutate_update(
         cls,
-        root: dict,
         info: GraphQLResolveInfo,
         data: InputObjectType,
         branch: Branch,
@@ -218,7 +216,7 @@ class InfrahubNumberPoolMutation(InfrahubMutationMixin, Mutation):
 
         async with context.db.start_transaction() as dbt:
             number_pool, result = await super().mutate_update(
-                root=root, info=info, data=data, branch=branch, at=at, database=dbt, node=node
+                info=info, data=data, branch=branch, at=at, database=dbt, node=node
             )
             if number_pool.start_range.value > number_pool.end_range.value:  # type: ignore[attr-defined]
                 raise ValidationError(input_value="start_range can't be larger than end_range")


### PR DESCRIPTION
I was looking at typing improvements and some of these `root` parameters didn't have any type hints. However, we never use them it's just something that gets sent in to the first call to .mutate(). I don't know if there's a current need to send this unused parameter to all other functions.