### PR TITLE
Add dev profile for docker compose

### DIFF
--- a/development/docker-compose-deps.yml
+++ b/development/docker-compose-deps.yml
@@ -20,6 +20,7 @@ services:
       timeout: 5s
       retries: 3
   task-manager:
+    profiles: [dev]
     image: "${TASK_MANAGER_DOCKER_IMAGE:-prefecthq/prefect:3.0-python3.12}"
     command: prefect server start --host 0.0.0.0 --ui
     environment:
@@ -36,6 +37,7 @@ services:
     depends_on:
       - task-manager-db
   task-manager-db:
+    profiles: [dev]
     image: postgres:16-alpine
     environment:
       - POSTGRES_USER=postgres

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -113,6 +113,7 @@ services:
         condition: service_healthy
       task-manager:
         condition: service_healthy
+        required: false
     environment:
       <<: *infrahub_config
       INFRAHUB_CONFIG: /source/development/infrahub.toml
@@ -169,7 +170,9 @@ services:
     labels:
       com.github.run_id: "${GITHUB_RUN_ID:-unknown}"
       com.github.job: "${JOB_NAME:-unknown}"
+
   task-runner-internal:
+    profiles: [dev]
     deploy:
       mode: replicated
       replicas: 1

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -26,14 +26,12 @@ def yamllint(context: Context):
 @task(name="format")
 def format_all(context: Context):
     main.format_all(context)
-    sdk.format_all(context)
     backend.format_all(context)
 
 
 @task(name="lint")
 def lint_all(context: Context):
     yamllint(context)
-    sdk.lint(context)
     backend.lint(context)
 
 

--- a/tasks/demo.py
+++ b/tasks/demo.py
@@ -21,13 +21,14 @@ from .shared import (
     BUILD_NAME,
     INFRAHUB_DATABASE,
     PYTHON_VER,
+    Namespace,
     build_compose_files_cmd,
     execute_command,
     get_env_vars,
 )
 from .utils import ESCAPED_REPO_PATH
 
-NAMESPACE = "DEMO"
+NAMESPACE = Namespace.DEFAULT
 
 
 @task(optional=["database"])

--- a/tasks/dev.py
+++ b/tasks/dev.py
@@ -23,9 +23,11 @@ from .shared import (
     BUILD_NAME,
     INFRAHUB_DATABASE,
     PYTHON_VER,
+    Namespace,
     build_compose_files_cmd,
     build_dev_compose_files_cmd,
     execute_command,
+    get_compose_cmd,
     get_env_vars,
 )
 from .utils import ESCAPED_REPO_PATH
@@ -34,7 +36,7 @@ if TYPE_CHECKING:
     from invoke.context import Context
 
 
-NAMESPACE = "DEV"
+NAMESPACE = Namespace.DEV
 
 
 @task(optional=["database"])
@@ -62,7 +64,8 @@ def debug(context: Context, database: str = INFRAHUB_DATABASE):
     """Start a local instance of Infrahub in debug mode."""
     with context.cd(ESCAPED_REPO_PATH):
         compose_files_cmd = build_compose_files_cmd(database=database)
-        command = f"{get_env_vars(context, namespace=NAMESPACE)} docker compose {compose_files_cmd} -p {BUILD_NAME} up"
+        compose_cmd = get_compose_cmd(namespace=NAMESPACE)
+        command = f"{get_env_vars(context, namespace=NAMESPACE)} {compose_cmd} {compose_files_cmd} -p {BUILD_NAME} up"
         execute_command(context=context, command=command)
 
 
@@ -71,8 +74,9 @@ def deps(context: Context, database: str = INFRAHUB_DATABASE):
     """Start local instances of dependencies (Databases and Message Bus)."""
     with context.cd(ESCAPED_REPO_PATH):
         dev_compose_files_cmd = build_dev_compose_files_cmd(database=database)
+        compose_cmd = get_compose_cmd(namespace=NAMESPACE)
         command = (
-            f"{get_env_vars(context, namespace=NAMESPACE)} docker compose {dev_compose_files_cmd} -p {BUILD_NAME} up -d"
+            f"{get_env_vars(context, namespace=NAMESPACE)} {compose_cmd} {dev_compose_files_cmd} -p {BUILD_NAME} up -d"
         )
         execute_command(context=context, command=command)
 
@@ -93,7 +97,8 @@ def infra_git_create(
     """Load some demo data."""
     with context.cd(ESCAPED_REPO_PATH):
         compose_files_cmd = build_compose_files_cmd(database=database, namespace=NAMESPACE)
-        base_cmd = f"{get_env_vars(context, namespace=NAMESPACE)} docker compose {compose_files_cmd} -p {BUILD_NAME}"
+        compose_cmd = get_compose_cmd(namespace=NAMESPACE)
+        base_cmd = f"{get_env_vars(context, namespace=NAMESPACE)} {compose_cmd} {compose_files_cmd} -p {BUILD_NAME}"
         execute_command(
             context=context,
             command=f"{base_cmd} run infrahub-git infrahubctl repository add {name} {location}",
@@ -106,7 +111,8 @@ def infra_git_import(context: Context, database: str = INFRAHUB_DATABASE):
     REPO_NAME = "infrahub-demo-edge"
     with context.cd(ESCAPED_REPO_PATH):
         compose_files_cmd = build_compose_files_cmd(database=database, namespace=NAMESPACE)
-        base_cmd = f"{get_env_vars(context, namespace=NAMESPACE)} docker compose {compose_files_cmd} -p {BUILD_NAME}"
+        compose_cmd = get_compose_cmd(namespace=NAMESPACE)
+        base_cmd = f"{get_env_vars(context, namespace=NAMESPACE)} {compose_cmd} {compose_files_cmd} -p {BUILD_NAME}"
         execute_command(
             context=context,
             command=f"{base_cmd} run infrahub-git cp -r backend/tests/fixtures/repos/{REPO_NAME}/initial__main /remote/{REPO_NAME}",

--- a/tasks/infra_ops.py
+++ b/tasks/infra_ops.py
@@ -2,27 +2,29 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from .shared import BUILD_NAME, build_compose_files_cmd, execute_command, get_env_vars
+from .shared import BUILD_NAME, Namespace, build_compose_files_cmd, execute_command, get_compose_cmd, get_env_vars
 from .utils import ESCAPED_REPO_PATH
 
 if TYPE_CHECKING:
     from invoke.context import Context
 
 
-def load_infrastructure_data(context: Context, database: str, namespace: str) -> None:
+def load_infrastructure_data(context: Context, database: str, namespace: Namespace) -> None:
     with context.cd(ESCAPED_REPO_PATH):
         compose_files_cmd = build_compose_files_cmd(database=database, namespace=namespace)
-        base_cmd = f"{get_env_vars(context, namespace=namespace)} docker compose {compose_files_cmd} -p {BUILD_NAME}"
+        compose_cmd = get_compose_cmd(namespace=namespace)
+        base_cmd = f"{get_env_vars(context, namespace=namespace)} {compose_cmd} {compose_files_cmd} -p {BUILD_NAME}"
         command = f"{base_cmd} run infrahub-git infrahubctl run models/infrastructure_edge.py"
         execute_command(context=context, command=command)
 
 
 def load_infrastructure_schema(
-    context: Context, database: str, namespace: str, add_wait: bool = True, target: str = "models/base"
+    context: Context, database: str, namespace: Namespace, add_wait: bool = True, target: str = "models/base"
 ) -> None:
     with context.cd(ESCAPED_REPO_PATH):
         compose_files_cmd = build_compose_files_cmd(database=database, namespace=namespace)
-        base_cmd = f"{get_env_vars(context, namespace=namespace)} docker compose {compose_files_cmd} -p {BUILD_NAME}"
+        compose_cmd = get_compose_cmd(namespace=namespace)
+        base_cmd = f"{get_env_vars(context, namespace=namespace)} {compose_cmd} {compose_files_cmd} -p {BUILD_NAME}"
         command = f"{base_cmd} run infrahub-git infrahubctl schema load {target}"
         if add_wait:
             command += " --wait 30"


### PR DESCRIPTION
After #4147, the demo environment wasn't working anymore in the develop branch because of the new containers that are now required for the dev environment to work.

After some investigation, I found that docker compose support the concept of `profile` exactly for this use case. Profile in `docker compose` gives us the ability to start different containers based on the profile. 

For now I've added only one profile `dev` and I've updated the invoke tasks to automatically insert the name of the profile when we are running dev commands but in the. future it would be interesting to see if we could use profiles to reduce the number of docker compose files we have in the development directory ..

Also, I've converted the parameter `namespace` in invoke into an Enum to make it easier to understand what values are supported