### PR TITLE
Add validation for hierarchy parent and children

### DIFF
--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -35,6 +35,7 @@ from infrahub.core.node.ipam import BuiltinIPPrefix
 from infrahub.core.node.resource_manager.ip_address_pool import CoreIPAddressPool
 from infrahub.core.node.resource_manager.ip_prefix_pool import CoreIPPrefixPool
 from infrahub.core.protocols_base import CoreNode
+from infrahub.core.relationship import RelationshipManager
 from infrahub.core.schema import (
     GenericSchema,
     NodeSchema,
@@ -2060,6 +2061,42 @@ async def hierarchical_location_schema_simple(db: InfrahubDatabase, default_bran
 
     schema = SchemaRoot(**SCHEMA)
     registry.schema.register_schema(schema=schema, branch=default_branch.name)
+
+
+@pytest.fixture
+async def location_generic_protocol():
+    class LocationGeneric(CoreNode):
+        name: String
+        status: StringOptional
+        things: RelationshipManager
+        parent: RelationshipManager
+        children: RelationshipManager
+
+    return LocationGeneric
+
+
+@pytest.fixture
+async def location_site_protocol(location_generic_protocol):
+    class LocationSite(location_generic_protocol):
+        pass
+
+    return LocationSite
+
+
+@pytest.fixture
+async def location_region_protocol(location_generic_protocol):
+    class LocationRegion(location_generic_protocol):
+        pass
+
+    return LocationRegion
+
+
+@pytest.fixture
+async def location_rack_protocol(location_generic_protocol):
+    class LocationRack(location_generic_protocol):
+        pass
+
+    return LocationRack
 
 
 @pytest.fixture

--- a/backend/tests/unit/core/hierarchy/test_hierarchy_create.py
+++ b/backend/tests/unit/core/hierarchy/test_hierarchy_create.py
@@ -1,0 +1,24 @@
+import pytest
+
+from infrahub.core import registry
+from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
+from infrahub.database import InfrahubDatabase
+from infrahub.exceptions import ValidationError
+
+
+async def test_create_node_with_invalid_hierarchy(db: InfrahubDatabase, hierarchical_location_data):
+    region_schema = registry.schema.get_node_schema(name="LocationRegion", duplicate=True)
+    rack_schema = registry.schema.get_node_schema(name="LocationRack", duplicate=True)
+    europe = await NodeManager.get_one(db=db, id=hierarchical_location_data["europe"].id)
+    city = await NodeManager.get_one(db=db, id=hierarchical_location_data["seattle"].id)
+
+    with pytest.raises(ValidationError) as exc:
+        region = await Node.init(db=db, schema=region_schema)
+        await region.new(db=db, name="region2", parent=city)
+    assert "Not supported to assign a value to parent" in str(exc.value)
+
+    with pytest.raises(ValidationError) as exc:
+        rack = await Node.init(db=db, schema=rack_schema)
+        await rack.new(db=db, name="rack2", parent=city, children=[europe])
+    assert "Not supported to assign some children" in str(exc.value)

--- a/changelog/4325.fixed.md
+++ b/changelog/4325.fixed.md
@@ -1,0 +1,1 @@
+Hierarchical node that don't have a parent or a children defined in the schema will properly enforce that constraint


### PR DESCRIPTION
Fixes #4325 

Enforce the constraints defined in the schema that when a hierarchical node doesn't have a parent or children