### PR TITLE
Disable docker compose ansi control characters on dumb terminals

### DIFF
--- a/changelog/+compose-ansi.fixed.md
+++ b/changelog/+compose-ansi.fixed.md
@@ -1,0 +1,1 @@
+Fixes an issue where docker compose would output ANSI control characters that don't support it

--- a/tasks/shared.py
+++ b/tasks/shared.py
@@ -186,12 +186,22 @@ def check_environment(context: Context) -> dict:
     return params
 
 
+def dumb_terminal() -> bool:
+    return os.getenv("TERM", "").lower() == "dumb"
+
+
 def get_compose_cmd(namespace: Namespace) -> str:
-    profile = ""
+    options = []
+
     if namespace == Namespace.DEV:
-        profile = "--profile dev"
-    if profile:
-        return f"docker compose {profile}"
+        options.append("--profile dev")
+
+    if dumb_terminal():
+        options.append("--ansi never")
+
+    if len(options) > 0:
+        return f"docker compose {' '.join(options)}"
+
     return "docker compose"
 
 


### PR DESCRIPTION
Disable docker compose outputting ANSI control characters on terminals that do not support it, for our invoke tasks.
Like Emacs's eshell-mode, shell-mode, compilation-mode, ...

An extra option will be added to the compose command (--ansi never) when we detect a "dumb" terminal through the `TERM` environment variable.