### PR TITLE
fix codespaces after Python SDK repository migration

### DIFF
--- a/.devcontainer/onCreateCommand.sh
+++ b/.devcontainer/onCreateCommand.sh
@@ -6,4 +6,6 @@ poetry config virtualenvs.create true
 poetry config virtualenvs.in-project true
 poetry install --no-interaction --no-ansi
 
+git submodule update --init
+
 invoke demo.build

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 git pull
+git submodule update
 invoke demo.start --wait


### PR DESCRIPTION
After the migration of the Python SDK to its own repository, you were unable to build and start Infrahub in Github codespaces.