### PR TITLE
Fix IpamIPAddressCreate mutation in the GraphQL mutation section of the getting started tutorial

### DIFF
--- a/docs/docs/tutorials/getting-started/graphql-mutation.mdx
+++ b/docs/docs/tutorials/getting-started/graphql-mutation.mdx
@@ -54,6 +54,7 @@ mutation {
     ok
     object {
       id
+      hfid
       name {
         value
       }
@@ -65,16 +66,14 @@ mutation {
 }
 ```
 
-Copy the ID of the newly created interface, we'll need it for the next query.
-
 Add a new IP address connected to the new interface.
 
 ```graphql
 # Endpoint : http://127.0.0.1:8000/graphql/cr1234
 mutation {
-  InfraIPAddressCreate(
+  IpamIPAddressCreate(
     data: {
-      interface: { id: "<INTERFACE Ethernet0 UUID>" },
+      interface: { hfid: ["ord1-edge1", "Ethernet0"]},
       address: { value: "192.168.0.2/24" }
     }
   ) {


### PR DESCRIPTION
Partially resolves #4447

In the GraphQL mutation section of the getting started tutorial we were still using a InfraIPAddressCreate mutation, instead of IpamIPAddressCreate mutation.

Also took the opportunity to update the mutation on leveraging the HFID of an interface, to assign the IP address that interface.