### PR TITLE
Add OAuth2 support for basic login

### DIFF
--- a/backend/infrahub/api/__init__.py
+++ b/backend/infrahub/api/__init__.py
@@ -14,6 +14,7 @@ from infrahub.api import (
     file,
     internal,
     menu,
+    oauth2,
     query,
     schema,
     storage,
@@ -29,6 +30,7 @@ router.include_router(diff.router)
 router.include_router(file.router)
 router.include_router(internal.router)
 router.include_router(menu.router)
+router.include_router(oauth2.router)
 router.include_router(query.router)
 router.include_router(schema.router)
 router.include_router(storage.router)

--- a/backend/infrahub/api/internal.py
+++ b/backend/infrahub/api/internal.py
@@ -20,6 +20,7 @@ class ConfigAPI(BaseModel):
     logging: LoggingSettings
     analytics: AnalyticsSettings
     experimental_features: ExperimentalFeaturesSettings
+    sso: config.SSOInfo
 
 
 class InfoAPI(BaseModel):
@@ -34,6 +35,7 @@ async def get_config() -> ConfigAPI:
         logging=config.SETTINGS.logging,
         analytics=config.SETTINGS.analytics,
         experimental_features=config.SETTINGS.experimental_features,
+        sso=config.SETTINGS.security.public_sso_config,
     )
 
 

--- a/backend/infrahub/api/oauth2.py
+++ b/backend/infrahub/api/oauth2.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from authlib.integrations.httpx_client import AsyncOAuth2Client
+from fastapi import APIRouter, Depends, Request, Response
+from fastapi.responses import JSONResponse, RedirectResponse
+
+from infrahub import config, models
+from infrahub.api.dependencies import get_db
+from infrahub.auth import create_db_refresh_token, generate_access_token, generate_refresh_token
+from infrahub.core.constants import InfrahubKind
+from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
+from infrahub.exceptions import ProcessingError
+from infrahub.message_bus.types import KVTTL
+
+if TYPE_CHECKING:
+    from infrahub.database import InfrahubDatabase
+    from infrahub.services import InfrahubServices
+
+router = APIRouter(prefix="/oauth2")
+
+
+def _get_redirect_url(request: Request, provider_name: str) -> str:
+    """This function is mostly to support local development when the frontend runs on different ports compared to the API."""
+    default_redirect = f"{request.base_url}api/oauth2/{provider_name}/token"
+    return os.getenv("REDIRECT_URL") or default_redirect
+
+
+@router.get("/{provider_name:str}/authorize")
+async def authorize(
+    request: Request,
+    provider_name: str,
+) -> Response:
+    provider = config.SETTINGS.security.get_provider(provider=provider_name)
+    client = AsyncOAuth2Client(
+        client_id=provider.client_id,
+        client_secret=provider.client_secret,
+        scope=provider.scope,
+    )
+
+    redirect_uri = _get_redirect_url(request=request, provider_name=provider_name)
+
+    authorization_uri, state = client.create_authorization_url(
+        url=provider.authorization_url, redirect_uri=redirect_uri, scope=provider.scope
+    )
+
+    service: InfrahubServices = request.app.state.service
+
+    await service.cache.set(
+        key=f"security:oauth2:provider:{provider_name}:state:{state}", value=state, expires=KVTTL.TWO_HOURS
+    )
+
+    if os.getenv("FRONTEND_REDIRECT") == "false":
+        return RedirectResponse(url=authorization_uri)
+
+    return JSONResponse(content={"url": authorization_uri})
+
+
+@router.get("/{provider_name:str}/token")
+async def token(
+    request: Request,
+    response: Response,
+    provider_name: str,
+    state: str,
+    code: str,
+    db: InfrahubDatabase = Depends(get_db),
+) -> models.UserToken:
+    provider = config.SETTINGS.security.get_provider(provider=provider_name)
+
+    service: InfrahubServices = request.app.state.service
+
+    cache_key = f"security:oauth2:provider:{provider_name}:state:{state}"
+    stored_state = await service.cache.get(key=cache_key)
+    await service.cache.delete(key=cache_key)
+
+    if state != stored_state:
+        raise ProcessingError(message="Invalid 'state' parameter")
+
+    token_data = {
+        "code": code,
+        "client_id": provider.client_id,
+        "client_secret": provider.client_secret,
+        "redirect_uri": _get_redirect_url(request=request, provider_name=provider_name),
+        "grant_type": "authorization_code",
+    }
+
+    token_response = await service.http.post(provider.token_url, json=token_data)
+    token_response.raise_for_status()
+    payload = token_response.json()
+
+    headers = {"Authorization": f"{payload.get('token_type')} {payload.get('access_token')}"}
+    userinfo_response = await service.http.post(provider.userinfo_url, headers=headers)
+    userinfo_response.raise_for_status()
+    user_info = userinfo_response.json()
+
+    account = await NodeManager.get_one_by_default_filter(db=db, id=user_info["name"], kind=InfrahubKind.ACCOUNT)
+
+    if not account:
+        account = await Node.init(db=db, schema=InfrahubKind.ACCOUNT)
+        await account.new(db=db, name=user_info["name"], account_type="User", role="admin", password=str(uuid4()))
+        await account.save(db=db)
+
+    now = datetime.now(tz=timezone.utc)
+    refresh_expires = now + timedelta(seconds=config.SETTINGS.security.refresh_token_lifetime)
+    session_id = await create_db_refresh_token(db=db, account_id=account.id, expiration=refresh_expires)
+    access_token = generate_access_token(account_id=account.id, role=account.role.value.value, session_id=session_id)
+    refresh_token = generate_refresh_token(account_id=account.id, session_id=session_id, expiration=refresh_expires)
+    user_token = models.UserToken(access_token=access_token, refresh_token=refresh_token)
+
+    response.set_cookie(
+        "access_token", user_token.access_token, httponly=True, max_age=config.SETTINGS.security.access_token_lifetime
+    )
+    response.set_cookie(
+        "refresh_token",
+        user_token.refresh_token,
+        httponly=True,
+        max_age=config.SETTINGS.security.refresh_token_lifetime,
+    )
+
+    return user_token

--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -10,12 +10,12 @@ from typing import TYPE_CHECKING, Any, Optional
 
 import toml
 from infrahub_sdk import generate_uuid
-from pydantic import AliasChoices, Field, ValidationError, model_validator
+from pydantic import AliasChoices, BaseModel, Field, PrivateAttr, ValidationError, computed_field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing_extensions import Self
 
 from infrahub.database.constants import DatabaseType
-from infrahub.exceptions import InitializationError
+from infrahub.exceptions import InitializationError, ProcessingError
 
 if TYPE_CHECKING:
     from infrahub.services.adapters.cache import InfrahubCache
@@ -33,6 +33,38 @@ def default_cors_allow_methods() -> list[str]:
 
 def default_cors_allow_headers() -> list[str]:
     return ["accept", "authorization", "content-type", "user-agent", "x-csrftoken", "x-requested-with"]
+
+
+class SSOProtocol(str, Enum):
+    OAUTH2 = "oauth2"
+
+
+class Oauth2Provider(str, Enum):
+    GOOGLE = "google"
+    CUSTOM = "custom"
+
+
+class SSOInfo(BaseModel):
+    providers: list[OAuth2ProviderInfo] = Field(default_factory=list)
+
+    @computed_field
+    def enabled(self) -> bool:
+        return bool(self.providers)
+
+
+class OAuth2ProviderInfo(BaseModel):
+    name: str
+    display_label: str
+    icon: str
+    protocol: SSOProtocol
+
+    @computed_field
+    def authorize_path(self) -> str:
+        return f"/api/oauth2/{self.name}/authorize"
+
+    @computed_field
+    def token_path(self) -> str:
+        return f"/api/oauth2/{self.name}/token"
 
 
 class StorageDriver(str, Enum):
@@ -297,6 +329,50 @@ class InitialSettings(BaseSettings):
         return self
 
 
+class SecurityOAuth2BaseSettings(BaseSettings):
+    """Baseclass for typing"""
+
+    icon: str = Field(default="mdi:account-key")
+
+
+class SecurityOAuth2Settings(SecurityOAuth2BaseSettings):
+    """Common base for Oauth2 providers"""
+
+    model_config = SettingsConfigDict(env_prefix="INFRAHUB_OAUTH2_CUSTOM_")
+
+    client_id: str = Field(..., description="Client ID of the application created in the auth provider")
+    client_secret: str = Field(..., description="Client secret as defined in auth provider")
+    authorization_url: str = Field(...)
+    token_url: str = Field(...)
+    userinfo_url: str = Field(...)
+    scope: list[str] = Field(...)
+    display_label: str = Field(default="Single Sign on")
+
+    @property
+    def scope_as_str(self) -> str:
+        return " ".join(self.scope)
+
+
+class SecurityOAuth2Custom(SecurityOAuth2BaseSettings):
+    """Common base for Oauth2 providers"""
+
+    display_label: str = Field(default="Custom SSO")
+
+
+def _google_oauth2_default_scopes() -> list[str]:
+    return ["openid", "profile", "email"]
+
+
+class SecurityOAuth2Google(SecurityOAuth2Settings):
+    model_config = SettingsConfigDict(env_prefix="INFRAHUB_OAUTH2_GOOGLE_")
+    authorization_url: str = Field(default="https://accounts.google.com/o/oauth2/auth")
+    token_url: str = Field(default="https://oauth2.googleapis.com/token")
+    userinfo_url: str = Field(default="https://www.googleapis.com/oauth2/v3/userinfo")
+    icon: str = Field(default="mdi:google")
+    scope: list[str] = Field(default_factory=_google_oauth2_default_scopes)
+    display_label: str = Field(default="Google")
+
+
 class MiscellaneousSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="INFRAHUB_MISC_")
     print_query_details: bool = False
@@ -341,6 +417,41 @@ class SecuritySettings(BaseSettings):
     secret_key: str = Field(
         default_factory=generate_uuid, description="The secret key used to validate authentication tokens"
     )
+    oauth2_providers: list[Oauth2Provider] = Field(default_factory=list, description="The selected OAuth2 providers")
+    _oauth2_settings: dict[str, SecurityOAuth2Settings] = PrivateAttr(default_factory=dict)
+
+    @model_validator(mode="after")
+    def check_oauth2_provider_settings(self) -> Self:
+        mapped_providers: dict[Oauth2Provider, type[SecurityOAuth2BaseSettings]] = {
+            Oauth2Provider.CUSTOM: SecurityOAuth2Settings,
+            Oauth2Provider.GOOGLE: SecurityOAuth2Google,
+        }
+        for oauth2_provider in self.oauth2_providers:
+            provider = mapped_providers[oauth2_provider]()
+            if isinstance(provider, SecurityOAuth2Settings):
+                self._oauth2_settings[oauth2_provider.value] = provider
+
+        return self
+
+    def get_provider(self, provider: str) -> SecurityOAuth2Settings:
+        if provider in self._oauth2_settings:
+            return self._oauth2_settings[provider]
+
+        raise ProcessingError(message=f"The provider {provider} has not been initialized")
+
+    @property
+    def public_sso_config(self) -> SSOInfo:
+        return SSOInfo(
+            providers=[
+                OAuth2ProviderInfo(
+                    name=provider,
+                    display_label=self._oauth2_settings[provider].display_label,
+                    icon=self._oauth2_settings[provider].icon,
+                    protocol=SSOProtocol.OAUTH2,
+                )
+                for provider in self._oauth2_settings
+            ]
+        )
 
 
 class TraceSettings(BaseSettings):

--- a/backend/infrahub/services/adapters/http/__init__.py
+++ b/backend/infrahub/services/adapters/http/__init__.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    import httpx
+
     from infrahub.services import InfrahubServices
 
 
@@ -12,5 +14,5 @@ class InfrahubHTTP:
 
     async def post(
         self, url: str, json: Any | None = None, headers: dict[str, Any] | None = None, verify: bool | None = None
-    ) -> None:
+    ) -> httpx.Response:
         raise NotImplementedError()

--- a/backend/infrahub/services/adapters/http/httpx.py
+++ b/backend/infrahub/services/adapters/http/httpx.py
@@ -10,10 +10,10 @@ from infrahub.services.adapters.http import InfrahubHTTP
 class HttpxAdapter(InfrahubHTTP):
     async def post(
         self, url: str, json: Any | None = None, headers: dict[str, Any] | None = None, verify: bool | None = None
-    ) -> None:
+    ) -> httpx.Response:
         # Later verify will be controlled by the base settings for the HTTP adapter instead of defaulting
         # to True
         verify = verify if verify is not None else True
         headers = headers or {}
         async with httpx.AsyncClient(verify=verify) as client:
-            await client.post(url=url, json=json, headers=headers)
+            return await client.post(url=url, json=json, headers=headers)

--- a/backend/tests/unit/api/test_50_config_api.py
+++ b/backend/tests/unit/api/test_50_config_api.py
@@ -13,4 +13,4 @@ async def test_config_endpoint(db: InfrahubDatabase, client, client_headers, def
 
     config = response.json()
 
-    assert sorted(config.keys()) == ["analytics", "experimental_features", "logging", "main"]
+    assert sorted(config.keys()) == ["analytics", "experimental_features", "logging", "main", "sso"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -301,6 +301,20 @@ tests = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4
 tests-mypy = ["mypy (>=1.11.1)", "pytest-mypy-plugins"]
 
 [[package]]
+name = "authlib"
+version = "1.3.2"
+description = "The ultimate Python library in building OAuth and OpenID Connect servers and clients."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "Authlib-1.3.2-py2.py3-none-any.whl", hash = "sha256:ede026a95e9f5cdc2d4364a52103f5405e75aa156357e831ef2bfd0bc5094dfc"},
+    {file = "authlib-1.3.2.tar.gz", hash = "sha256:4b16130117f9eb82aa6eec97f6dd4673c3f960ac0283ccdae2897ee4bc030ba2"},
+]
+
+[package.dependencies]
+cryptography = "*"
+
+[[package]]
 name = "bcrypt"
 version = "4.1.3"
 description = "Modern password hashing for your software and your servers"
@@ -5233,24 +5247,24 @@ python-versions = ">=3.6"
 files = [
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b42169467c42b692c19cf539c38d4602069d8c1505e97b86387fcf7afb766e1d"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:07238db9cbdf8fc1e9de2489a4f68474e70dffcb32232db7c08fa61ca0c7c462"},
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:d92f81886165cb14d7b067ef37e142256f1c6a90a65cd156b063a43da1708cfd"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:fff3573c2db359f091e1589c3d7c5fc2f86f5bdb6f24252c2d8e539d4e45f412"},
-    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux_2_24_aarch64.whl", hash = "sha256:aa2267c6a303eb483de8d02db2871afb5c5fc15618d894300b88958f729ad74f"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:840f0c7f194986a63d2c2465ca63af8ccbbc90ab1c6001b1978f05119b5e7334"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:024cfe1fc7c7f4e1aff4a81e718109e13409767e4f871443cbff3dba3578203d"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-win32.whl", hash = "sha256:c69212f63169ec1cfc9bb44723bf2917cbbd8f6191a00ef3410f5a7fe300722d"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-win_amd64.whl", hash = "sha256:cabddb8d8ead485e255fe80429f833172b4cadf99274db39abc080e068cbcc31"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:bef08cd86169d9eafb3ccb0a39edb11d8e25f3dae2b28f5c52fd997521133069"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:b16420e621d26fdfa949a8b4b47ade8810c56002f5389970db4ddda51dbff248"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:b5edda50e5e9e15e54a6a8a0070302b00c518a9d32accc2346ad6c984aacd279"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:25c515e350e5b739842fc3228d662413ef28f295791af5e5110b543cf0b57d9b"},
-    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux_2_24_aarch64.whl", hash = "sha256:1707814f0d9791df063f8c19bb51b0d1278b8e9a2353abbb676c2f685dee6afe"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:46d378daaac94f454b3a0e3d8d78cafd78a026b1d71443f4966c696b48a6d899"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:09b055c05697b38ecacb7ac50bdab2240bfca1a0c4872b0fd309bb07dc9aa3a9"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-win32.whl", hash = "sha256:53a300ed9cea38cf5a2a9b069058137c2ca1ce658a874b79baceb8f892f915a7"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-win_amd64.whl", hash = "sha256:c2a72e9109ea74e511e29032f3b670835f8a59bbdc9ce692c5b4ed91ccf1eedb"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:ebc06178e8821efc9692ea7544aa5644217358490145629914d8020042c24aa1"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:edaef1c1200c4b4cb914583150dcaa3bc30e592e907c01117c08b13a07255ec2"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:7048c338b6c86627afb27faecf418768acb6331fc24cfa56c93e8c9780f815fa"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d176b57452ab5b7028ac47e7b3cf644bcfdc8cacfecf7e71759f7f51a59e5c92"},
-    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-manylinux_2_24_aarch64.whl", hash = "sha256:1dc67314e7e1086c9fdf2680b7b6c2be1c0d8e3a8279f2e993ca2a7545fecf62"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:3213ece08ea033eb159ac52ae052a4899b56ecc124bb80020d9bbceeb50258e9"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aab7fd643f71d7946f2ee58cc88c9b7bfc97debd71dcc93e03e2d174628e7e2d"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-win32.whl", hash = "sha256:5c365d91c88390c8d0a8545df0b5857172824b1c604e867161e6b3d59a827eaa"},
@@ -5258,7 +5272,7 @@ files = [
     {file = "ruamel.yaml.clib-0.2.8-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a5aa27bad2bb83670b71683aae140a1f52b0857a2deff56ad3f6c13a017a26ed"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c58ecd827313af6864893e7af0a3bb85fd529f862b6adbefe14643947cfe2942"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-macosx_12_0_arm64.whl", hash = "sha256:f481f16baec5290e45aebdc2a5168ebc6d35189ae6fea7a58787613a25f6e875"},
-    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux_2_24_aarch64.whl", hash = "sha256:77159f5d5b5c14f7c34073862a6b7d34944075d9f93e681638f6d753606c6ce6"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:3fcc54cb0c8b811ff66082de1680b4b14cf8a81dce0d4fbf665c2265a81e07a1"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:7f67a1ee819dc4562d444bbafb135832b0b909f81cc90f7aa00260968c9ca1b3"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:4ecbf9c3e19f9562c7fdd462e8d18dd902a47ca046a2e64dba80699f0b6c09b7"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:87ea5ff66d8064301a154b3933ae406b0863402a799b16e4a1d24d9fbbcbe0d3"},
@@ -5266,7 +5280,7 @@ files = [
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-win_amd64.whl", hash = "sha256:3f215c5daf6a9d7bbed4a0a4f760f3113b10e82ff4c5c44bec20a68c8014f675"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1b617618914cb00bf5c34d4357c37aa15183fa229b24767259657746c9077615"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:a6a9ffd280b71ad062eae53ac1659ad86a17f59a0fdc7699fd9be40525153337"},
-    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux_2_24_aarch64.whl", hash = "sha256:305889baa4043a09e5b76f8e2a51d4ffba44259f6b4c72dec8ca56207d9c6fe1"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:665f58bfd29b167039f714c6998178d27ccd83984084c286110ef26b230f259f"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:700e4ebb569e59e16a976857c8798aee258dceac7c7d6b50cab63e080058df91"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:e2b4c44b60eadec492926a7270abb100ef9f72798e18743939bdbf037aab8c28"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:e79e5db08739731b0ce4850bed599235d601701d5694c36570a99a0c5ca41a9d"},
@@ -5274,7 +5288,7 @@ files = [
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-win_amd64.whl", hash = "sha256:56f4252222c067b4ce51ae12cbac231bce32aee1d33fbfc9d17e5b8d6966c312"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:03d1162b6d1df1caa3a4bd27aa51ce17c9afc2046c31b0ad60a0a96ec22f8001"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:bba64af9fa9cebe325a62fa398760f5c7206b215201b0ec825005f1b18b9bccf"},
-    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux_2_24_aarch64.whl", hash = "sha256:a1a45e0bb052edf6a1d3a93baef85319733a888363938e1fc9924cb00c8df24c"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:9eb5dee2772b0f704ca2e45b1713e4e5198c18f515b52743576d196348f374d3"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:da09ad1c359a728e112d60116f626cc9f29730ff3e0e7db72b9a2dbc2e4beed5"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:184565012b60405d93838167f425713180b949e9d8dd0bbc7b49f074407c5a8b"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a75879bacf2c987c003368cf14bed0ffe99e8e85acfa6c0bfffc21a090f16880"},
@@ -6481,4 +6495,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10, < 3.13"
-content-hash = "33667138b2f3b47eddebb9f752aad1d14938545ea8c479c6ce75ded3318bebae"
+content-hash = "a098ee689d51a0e75af317dbb744d6b4a62d4ab76953191a7e07869dd1680072"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ opentelemetry-exporter-otlp-proto-grpc = "^1.24.0"
 opentelemetry-exporter-otlp-proto-http = "^1.24.0"
 nats-py = "^2.7.2"
 netaddr = "1.3.0"
+authlib = "1.3.2"
 
 [tool.poetry.group.dev.dependencies]
 yamllint = "*"


### PR DESCRIPTION
This PR supersedes #4358. 

This PR adds support to login with OAuth2, primarily with Google although there is code to enable a custom provider.

Until the frontend code is done we are still required to set the `REDIRECT_URL` variable just like in the previous PR. Once we have the initial support in the frontend we'll remove this requirement.

This would be how you enable multiple providers:

```bash
export INFRAHUB_SECURITY_OAUTH2_PROVIDERS=["google","custom"]
```

For the initial test one of these should be used:


```bash
export INFRAHUB_SECURITY_OAUTH2_PROVIDERS=["google"]
export INFRAHUB_SECURITY_OAUTH2_PROVIDERS=[\"google\"]
```

These will also be required:

```bash
export INFRAHUB_OAUTH2_GOOGLE_CLIENT_ID=xxx
export INFRAHUB_OAUTH2_GOOGLE_CLIENT_SECRET=xxx
```

In this version we create the account as an admin. This is temporary and will be in later PRs when we add authorization.
