### PR TITLE
Fix performance issue for count only queries

### DIFF
--- a/backend/infrahub/graphql/types/mixin.py
+++ b/backend/infrahub/graphql/types/mixin.py
@@ -51,20 +51,22 @@ class GetListMixin:
             edges = fields.get("edges", {})
             node_fields = edges.get("node", {})
 
-            objs = await NodeManager.query(
-                db=db,
-                schema=cls._meta.schema,
-                filters=filters or None,
-                fields=node_fields,
-                at=context.at,
-                branch=context.branch,
-                limit=limit,
-                offset=offset,
-                account=context.account_session,
-                include_source=True,
-                include_owner=True,
-                partial_match=partial_match,
-            )
+            objs = []
+            if edges or "hfid" in filters:
+                objs = await NodeManager.query(
+                    db=db,
+                    schema=cls._meta.schema,
+                    filters=filters or None,
+                    fields=node_fields,
+                    at=context.at,
+                    branch=context.branch,
+                    limit=limit,
+                    offset=offset,
+                    account=context.account_session,
+                    include_source=True,
+                    include_owner=True,
+                    partial_match=partial_match,
+                )
 
             if "count" in fields:
                 if filters.get("hfid"):

--- a/changelog/4454.fixed.md
+++ b/changelog/4454.fixed.md
@@ -1,0 +1,1 @@
+Fix performance issue for GraphQL queries that only count nodes.


### PR DESCRIPTION
This PR fixes a problem in the get_list mixin where we always ran the full query even if the user only requested a count of the nodes.

Fixes #4454

Note: Due to changes that have already been made to the `develop` branch this will probably cause a merge conflict when we merge `stable` back the next time.