### PR TITLE
Add exceptions and config for HTTP adapter

### DIFF
--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -303,6 +303,19 @@ class GitSettings(BaseSettings):
     )
 
 
+class HTTPSettings(BaseSettings):
+    """The HTTP settings control how Infrahub interacts with external HTTP servers
+
+    This can be things like webhooks and OAuth2 providers"""
+
+    model_config = SettingsConfigDict(env_prefix="INFRAHUB_HTTP_")
+    timeout: int = Field(default=10, description="Default connection timeout in seconds")
+    tls_insecure: bool = Field(
+        default=False,
+        description="Indicates if Infrahub will validate server certificates or if the validation is ignored.",
+    )
+
+
 class InitialSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="INFRAHUB_INITIAL_")
     default_branch: str = Field(
@@ -521,6 +534,10 @@ class ConfiguredSettings:
         return self.active_settings.git
 
     @property
+    def http(self) -> HTTPSettings:
+        return self.active_settings.http
+
+    @property
     def database(self) -> DatabaseSettings:
         return self.active_settings.database
 
@@ -575,6 +592,7 @@ class Settings(BaseSettings):
     main: MainSettings = MainSettings()
     api: ApiSettings = ApiSettings()
     git: GitSettings = GitSettings()
+    http: HTTPSettings = HTTPSettings()
     database: DatabaseSettings = DatabaseSettings()
     broker: BrokerSettings = BrokerSettings()
     cache: CacheSettings = CacheSettings()

--- a/backend/infrahub/exceptions.py
+++ b/backend/infrahub/exceptions.py
@@ -293,3 +293,20 @@ class DiffRangeValidationError(DiffError): ...
 
 
 class DiffFromRequiredOnDefaultBranchError(DiffError): ...
+
+
+class HTTPServerError(Error):
+    """Errors raised when communicating with external HTTP servers"""
+
+    HTTP_CODE = 502
+
+    def __init__(self, message: str):
+        self.message = message
+
+
+class HTTPServerTimeoutError(HTTPServerError):
+    HTTP_CODE = 504
+
+
+class HTTPServerSSLError(HTTPServerError):
+    HTTP_CODE = 503

--- a/backend/infrahub/services/adapters/http/httpx.py
+++ b/backend/infrahub/services/adapters/http/httpx.py
@@ -1,19 +1,73 @@
 from __future__ import annotations
 
-from typing import Any
+import ssl
+from typing import TYPE_CHECKING, Any
 
 import httpx
 
+from infrahub import config
+from infrahub.exceptions import HTTPServerError, HTTPServerSSLError, HTTPServerTimeoutError
 from infrahub.services.adapters.http import InfrahubHTTP
+
+if TYPE_CHECKING:
+    from infrahub.services import InfrahubServices
 
 
 class HttpxAdapter(InfrahubHTTP):
+    settings: config.HTTPSettings
+    service: InfrahubServices
+
+    async def initialize(self, service: InfrahubServices) -> None:
+        """Initialize the HTTP adapter"""
+        self.service = service
+        self.settings = config.SETTINGS.http
+
+    def verify_tls(self, verify: bool | None = None) -> bool:
+        if verify is not None:
+            return verify
+
+        if self.settings.tls_insecure is True:
+            return False
+
+        return True
+
+    async def _request(
+        self,
+        method: str,
+        url: str,
+        json: Any | None = None,
+        headers: dict[str, Any] | None = None,
+        verify: bool | None = None,
+    ) -> httpx.Response:
+        """Returns an httpx.Response object or raises HTTPServerError or child classes."""
+        params: dict[str, Any] = {}
+        if json:
+            params["json"] = json
+        async with httpx.AsyncClient(verify=self.verify_tls(verify=verify)) as client:
+            try:
+                response = await client.request(
+                    method=method,
+                    url=url,
+                    headers=headers,
+                    timeout=self.settings.timeout,
+                    **params,
+                )
+            except ssl.SSLCertVerificationError as exc:
+                self.service.log.info(f"TLS verification failed for connection to {url}")
+                raise HTTPServerSSLError(message=f"Unable to validate TLS certificate for connection to {url}") from exc
+            except httpx.ReadTimeout as exc:
+                self.service.log.info(f"Connection timed out when trying to reach {url}")
+                raise HTTPServerTimeoutError(
+                    message=f"Connection to {url} timed out after {self.settings.timeout}"
+                ) from exc
+            except httpx.RequestError as exc:
+                # Catch all error from httpx
+                self.service.log.warning(f"Unhandled HTTP error for {url} ({exc})")
+                raise HTTPServerError(message=f"Unknown http error when connecting to {url}") from exc
+
+        return response
+
     async def post(
         self, url: str, json: Any | None = None, headers: dict[str, Any] | None = None, verify: bool | None = None
     ) -> httpx.Response:
-        # Later verify will be controlled by the base settings for the HTTP adapter instead of defaulting
-        # to True
-        verify = verify if verify is not None else True
-        headers = headers or {}
-        async with httpx.AsyncClient(verify=verify) as client:
-            return await client.post(url=url, json=json, headers=headers)
+        return await self._request(method="post", url=url, json=json, headers=headers, verify=verify)


### PR DESCRIPTION
This will be used for generic http requests from Infrahub such as for OAuth2 communication, webhooks, telemetry etc.

Currently it allows users to configure if TLS verification should be enabled or disabled at a global level as well as the ability to set a timeout for external webservers.

It also provides some custom Infrahub exceptions when communicating with external servers. These are mostly around communication errors such as TLS, timeout or network issues. More specific errors can be added to this.

Other features that will be useful here is the ability to set custom CA certificates and proxy settings. For now I just added what I needed.