### PR TITLE
Change default OAuth2 redirect behaviour

### DIFF
--- a/backend/infrahub/api/oauth2.py
+++ b/backend/infrahub/api/oauth2.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import os
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
+from urllib.parse import urljoin
 from uuid import uuid4
 
 from authlib.integrations.httpx_client import AsyncOAuth2Client
@@ -15,20 +15,24 @@ from infrahub.auth import create_db_refresh_token, generate_access_token, genera
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
-from infrahub.exceptions import ProcessingError
+from infrahub.exceptions import GatewayError, ProcessingError
+from infrahub.log import get_logger
 from infrahub.message_bus.types import KVTTL
 
 if TYPE_CHECKING:
+    import httpx
+
     from infrahub.database import InfrahubDatabase
     from infrahub.services import InfrahubServices
 
+log = get_logger()
 router = APIRouter(prefix="/oauth2")
 
 
 def _get_redirect_url(request: Request, provider_name: str) -> str:
     """This function is mostly to support local development when the frontend runs on different ports compared to the API."""
-    default_redirect = f"{request.base_url}api/oauth2/{provider_name}/token"
-    return os.getenv("REDIRECT_URL") or default_redirect
+    base_url = config.SETTINGS.dev.frontend_url or str(request.base_url)
+    return urljoin(base_url, f"auth/oauth2/{provider_name}/callback")
 
 
 @router.get("/{provider_name:str}/authorize")
@@ -55,10 +59,10 @@ async def authorize(
         key=f"security:oauth2:provider:{provider_name}:state:{state}", value=state, expires=KVTTL.TWO_HOURS
     )
 
-    if os.getenv("FRONTEND_REDIRECT") == "false":
-        return RedirectResponse(url=authorization_uri)
+    if config.SETTINGS.dev.frontend_redirect_sso:
+        return JSONResponse(content={"url": authorization_uri})
 
-    return JSONResponse(content={"url": authorization_uri})
+    return RedirectResponse(url=authorization_uri)
 
 
 @router.get("/{provider_name:str}/token")
@@ -90,12 +94,12 @@ async def token(
     }
 
     token_response = await service.http.post(provider.token_url, json=token_data)
-    token_response.raise_for_status()
+    _validate_response(response=token_response)
     payload = token_response.json()
 
     headers = {"Authorization": f"{payload.get('token_type')} {payload.get('access_token')}"}
     userinfo_response = await service.http.post(provider.userinfo_url, headers=headers)
-    userinfo_response.raise_for_status()
+    _validate_response(response=userinfo_response)
     user_info = userinfo_response.json()
 
     account = await NodeManager.get_one_by_default_filter(db=db, id=user_info["name"], kind=InfrahubKind.ACCOUNT)
@@ -123,3 +127,16 @@ async def token(
     )
 
     return user_token
+
+
+def _validate_response(response: httpx.Response) -> None:
+    if 200 <= response.status_code <= 299:
+        return
+
+    log.error(
+        "Invalid response for OAuth authentiation",
+        url=response.url,
+        status_code=response.status_code,
+        body=response.json(),
+    )
+    raise GatewayError(message="Invalid response from Authentication provider")

--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -207,6 +207,21 @@ class DatabaseSettings(BaseSettings):
         return self.database or self.db_type.value
 
 
+class DevelopmentSettings(BaseSettings):
+    """The development settings are only relevant for local development"""
+
+    model_config = SettingsConfigDict(env_prefix="INFRAHUB_DEV_")
+
+    frontend_url: Optional[str] = Field(
+        default=None,
+        description="Define the URL of the frontend, useful for OAuth2 development when the frontend and backend use different ports.",
+    )
+    frontend_redirect_sso: bool = Field(
+        default=False,
+        description="Indicates of the frontend should be responsible for the SSO redirection",
+    )
+
+
 class BrokerSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="INFRAHUB_BROKER_")
     enable: bool = True
@@ -490,7 +505,7 @@ class Override:
 
 
 @dataclass
-class ConfiguredSettings:
+class ConfiguredSettings:  # pylint: disable=too-many-public-methods
     settings: Optional[Settings] = None
 
     def initialize(self, config_file: Optional[str] = None) -> None:
@@ -550,6 +565,10 @@ class ConfiguredSettings:
         return self.active_settings.cache
 
     @property
+    def dev(self) -> DevelopmentSettings:
+        return self.active_settings.dev
+
+    @property
     def workflow(self) -> WorkflowSettings:
         return self.active_settings.workflow
 
@@ -592,6 +611,7 @@ class Settings(BaseSettings):
     main: MainSettings = MainSettings()
     api: ApiSettings = ApiSettings()
     git: GitSettings = GitSettings()
+    dev: DevelopmentSettings = DevelopmentSettings()
     http: HTTPSettings = HTTPSettings()
     database: DatabaseSettings = DatabaseSettings()
     broker: BrokerSettings = BrokerSettings()

--- a/backend/infrahub/exceptions.py
+++ b/backend/infrahub/exceptions.py
@@ -241,6 +241,13 @@ class QueryValidationError(Error):
         self.message = message
 
 
+class GatewayError(Error):
+    HTTP_CODE = 502
+
+    def __init__(self, message: str):
+        self.message = message
+
+
 class MigrationError(Error):
     HTTP_CODE = 502
 


### PR DESCRIPTION
This PR changes the default redirect behaviour of the OAuth2 provider so that Infrahub redirects to the OAuth provider directly when visiting the authorize url. Due to this it is no longer required to set the `FRONTEND_REDIRECT` environment variable. While working with this we can still revert to the other behaviour by setting `INFRAHUB_OAUTH2_AUTHORIZE_REDIRECT=false` which will return a JSON data containing the redirect URL instead.

The other change is that the `REDIRECT_URL` url has been removed, now the backend will correctly return the /auth/[provider_name]/callback url expected by the frontend. However as we are developing using different ports another environment variable is required:

```env
INFRAHUB_FRONTEND_URL=http://localhost:8080
```

Without this the redirect_uri would be set to `http://localhost:8000/auth/google/callback` if using Google.

The last change to this PR is a slight cleanup of the error handling instead of using a raw response.raise_for_status() we have a helper function that does this and provides correct return codes to the end user.