### PR TITLE
Avoid shadowing 'at' in get_branch_oarams

### DIFF
--- a/backend/infrahub/api/dependencies.py
+++ b/backend/infrahub/api/dependencies.py
@@ -85,9 +85,8 @@ async def get_branch_params(
     at: Optional[str] = Query(None, description="Time to use for the query, in absolute or relative format"),
 ) -> BranchParams:
     branch = await registry.get_branch(db=db, branch=branch_name)
-    at = Timestamp(at)
 
-    return BranchParams(branch=branch, at=at)
+    return BranchParams(branch=branch, at=Timestamp(at))
 
 
 async def get_branch_dep(


### PR DESCRIPTION
While looking at these dependencies I noticed that we were shadowing the `at` variable that's defined as an `Optional[str]` in the function signature and then we override it to a `Timestamp` object. However there is no need to even redefine this variable so I just moved the call to `Timestamp` directly to the BranchParams creation.