### PR TITLE
Cleanup tests dependencies

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -204,8 +204,8 @@ def neo4j(request: pytest.FixtureRequest, load_settings_before_session) -> Optio
 
 
 @pytest.fixture(scope="session")
-def rabbitmq(request: pytest.FixtureRequest, load_settings_before_session) -> Optional[dict[int, int]]:
-    if not INFRAHUB_USE_TEST_CONTAINERS or config.SETTINGS.cache.driver == config.CacheDriver.NATS:
+def rabbitmq_container(request: pytest.FixtureRequest, load_settings_before_session) -> dict[int, int] | None:
+    if not INFRAHUB_USE_TEST_CONTAINERS or config.SETTINGS.broker.driver != config.BrokerDriver.RabbitMQ:
         return None
 
     container = (
@@ -228,10 +228,25 @@ def rabbitmq(request: pytest.FixtureRequest, load_settings_before_session) -> Op
     }
 
 
+@pytest.fixture(scope="module")
+def rabbitmq(rabbitmq_container: dict[int, int] | None, reload_settings_before_each_module) -> dict[int, int] | None:
+    if (
+        rabbitmq_container
+        and INFRAHUB_USE_TEST_CONTAINERS
+        and config.SETTINGS.broker.driver == config.BrokerDriver.RabbitMQ
+    ):
+        config.SETTINGS.broker.address = "localhost"
+        config.SETTINGS.broker.port = rabbitmq_container[PORT_CLIENT_RABBITMQ]
+        config.SETTINGS.broker.rabbitmq_http_port = rabbitmq_container[PORT_HTTP_RABBITMQ]
+        return rabbitmq_container
+
+    return None
+
+
 # NOTE: This fixture needs to run before initialize_lock_fixture which is guaranteed to run after as it has a module scope.
 @pytest.fixture(scope="session")
-def redis(request: pytest.FixtureRequest, load_settings_before_session) -> Optional[dict[int, int]]:
-    if not INFRAHUB_USE_TEST_CONTAINERS or config.SETTINGS.cache.driver == config.CacheDriver.NATS:
+def redis_container(request: pytest.FixtureRequest, load_settings_before_session) -> dict[int, int] | None:
+    if not INFRAHUB_USE_TEST_CONTAINERS or config.SETTINGS.cache.driver != config.CacheDriver.Redis:
         return None
 
     container = DockerContainer(image="redis:latest").with_exposed_ports(PORT_REDIS)
@@ -244,6 +259,16 @@ def redis(request: pytest.FixtureRequest, load_settings_before_session) -> Optio
     request.addfinalizer(cleanup)
 
     return {PORT_REDIS: get_exposed_port(container, PORT_REDIS)}
+
+
+@pytest.fixture(scope="module")
+def redis(redis_container: dict[int, int] | None, reload_settings_before_each_module) -> dict[int, int] | None:
+    if redis_container and INFRAHUB_USE_TEST_CONTAINERS and config.SETTINGS.cache.driver == config.CacheDriver.Redis:
+        config.SETTINGS.cache.address = "localhost"
+        config.SETTINGS.cache.port = redis_container[PORT_REDIS]
+        return redis_container
+
+    return None
 
 
 def wait_for_memgraph_ready(host, port, timeout=15):
@@ -293,7 +318,7 @@ def memgraph(request: pytest.FixtureRequest, load_settings_before_session) -> Op
 
 
 @pytest.fixture(scope="session")
-def nats(request: pytest.FixtureRequest, load_settings_before_session) -> Optional[dict[int, int]]:
+def nats_container(request: pytest.FixtureRequest, load_settings_before_session) -> Optional[dict[int, int]]:
     if not INFRAHUB_USE_TEST_CONTAINERS or config.SETTINGS.cache.driver != config.CacheDriver.NATS:
         return None
 
@@ -309,42 +334,30 @@ def nats(request: pytest.FixtureRequest, load_settings_before_session) -> Option
     return {PORT_NATS: get_exposed_port(container, PORT_NATS)}
 
 
+@pytest.fixture(scope="module")
+def nats(nats_container: dict[int, int] | None, reload_settings_before_each_module) -> dict[int, int] | None:
+    if nats_container and INFRAHUB_USE_TEST_CONTAINERS and config.SETTINGS.cache.driver == config.CacheDriver.NATS:
+        config.SETTINGS.cache.address = "localhost"
+        config.SETTINGS.cache.port = nats_container[PORT_NATS]
+
+    if nats_container and INFRAHUB_USE_TEST_CONTAINERS and config.SETTINGS.broker.driver == config.BrokerDriver.NATS:
+        config.SETTINGS.broker.address = "localhost"
+        config.SETTINGS.broker.port = nats_container[PORT_NATS]
+
+        return nats_container
+
+    return None
+
+
 @pytest.fixture(scope="session", autouse=True)
 def load_settings_before_session():
     load_and_exit()
 
 
 @pytest.fixture(scope="module", autouse=True)
-def reload_settings_before_each_module(
-    tmpdir_factory,
-    redis: Optional[dict[int, int]],
-    rabbitmq: Optional[dict[int, int]],
-    nats: Optional[dict[int, int]],
-):
-    # Currently, tests assume cache and broker are always up, thus fixtures are always called even for tests not requiring them.
-    # An improvement would be to have cache and broker fixtures used only for tests which actually need them, as we do with 'db' fixture.
-    # Also note that later call to initialize_lock requires redis fixture.
-
+def reload_settings_before_each_module(tmpdir_factory):
     # Settings need to be reloaded between each test module, as some module might modify settings that might break tests within other modules.
     load_and_exit()
-
-    if INFRAHUB_USE_TEST_CONTAINERS:
-        # Cache settings: either Redis or Nats.
-        config.SETTINGS.cache.address = "localhost"
-        if redis is not None:
-            config.SETTINGS.cache.port = redis[PORT_REDIS]
-        else:
-            assert nats is not None
-            config.SETTINGS.cache.port = nats[PORT_NATS]
-
-        # Broker settings: either RabbitMQ or Nats.
-        config.SETTINGS.broker.address = "localhost"
-        if rabbitmq is not None:
-            config.SETTINGS.broker.port = rabbitmq[PORT_CLIENT_RABBITMQ]
-            config.SETTINGS.broker.rabbitmq_http_port = rabbitmq[PORT_HTTP_RABBITMQ]
-        else:
-            assert nats is not None
-            config.SETTINGS.broker.port = nats[PORT_NATS]
 
     # Other settings
     config.SETTINGS.storage.driver = config.StorageDriver.FileSystemStorage
@@ -359,7 +372,7 @@ def reload_settings_before_each_module(
     config.SETTINGS.main.internal_address = "http://mock"
     config.OVERRIDE.message_bus = BusRecorder()
 
-    initialize_lock()
+    initialize_lock(local_only=True)
 
 
 @pytest.fixture

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -90,7 +90,9 @@ class TestInfrahubApp(TestInfrahub):
         return schema_branch
 
     @pytest.fixture(scope="class")
-    async def test_client(self, initialize_registry: None) -> InfrahubTestClient:
+    async def test_client(
+        self, initialize_registry: None, redis: dict[int, int] | None, nats: dict[int, int] | None
+    ) -> InfrahubTestClient:
         await app_initialization(app)
         return InfrahubTestClient(app=app)
 

--- a/backend/tests/integration/git/test_git_repository.py
+++ b/backend/tests/integration/git/test_git_repository.py
@@ -53,7 +53,7 @@ class TestInfrahubClient:
         config.OVERRIDE.workflow = original
 
     @pytest.fixture(scope="class")
-    async def base_dataset(self, db: InfrahubDatabase):
+    async def base_dataset(self, db: InfrahubDatabase, redis, nats):
         await delete_all_nodes(db=db)
         await first_time_initialization(db=db)
         await load_infrastructure_schema(db=db)

--- a/backend/tests/integration/message_bus/operations/request/test_proposed_change.py
+++ b/backend/tests/integration/message_bus/operations/request/test_proposed_change.py
@@ -63,7 +63,7 @@ mutation ProposedChange(
 
 
 @pytest.fixture(scope="module")
-async def test_client(init_db_base) -> AsyncGenerator[InfrahubTestClient, None]:
+async def test_client(init_db_base, redis, nats) -> AsyncGenerator[InfrahubTestClient, None]:
     await app_initialization(app)
     async with InfrahubTestClient(app=app, base_url="http://test") as client:
         yield client

--- a/backend/tests/integration/services/adapters/message_bus/test_rabbitmq.py
+++ b/backend/tests/integration/services/adapters/message_bus/test_rabbitmq.py
@@ -136,7 +136,7 @@ class RabbitMQManager:
 
 
 @pytest.fixture
-async def rabbitmq_api() -> RabbitMQManager:
+async def rabbitmq_api(rabbitmq) -> RabbitMQManager:
     settings = deepcopy(config.SETTINGS.broker)
     settings.virtualhost = "integration-tests"
     manager = RabbitMQManager(settings=settings)

--- a/backend/tests/integration/transform/test_transform_jinja2.py
+++ b/backend/tests/integration/transform/test_transform_jinja2.py
@@ -75,6 +75,8 @@ class TestCreateRepository(TestInfrahubApp):
     async def test_client(
         self,
         base_dataset,
+        redis: dict[int, int] | None,
+        nats: dict[int, int] | None,
     ) -> InfrahubTestClient:
         await app_initialization(app)
         return InfrahubTestClient(app=app)

--- a/backend/tests/integration/user_workflows/test_user_worflow.py
+++ b/backend/tests/integration/user_workflows/test_user_worflow.py
@@ -142,7 +142,7 @@ state = State()
 
 class TestUserWorkflow01:
     @pytest.fixture(scope="class")
-    async def client(self):
+    async def client(self, redis, nats):
         client = TestClient(app)
         return client
 

--- a/backend/tests/unit/api/conftest.py
+++ b/backend/tests/unit/api/conftest.py
@@ -15,7 +15,7 @@ from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 
 
 @pytest.fixture
-def client():
+def client(nats, redis):
     # In order to mock some methods later we can't load app by default because it will automatically load all import in main.py as well
     from infrahub.server import app
 

--- a/backend/tests/unit/api/test_05_query_api.py
+++ b/backend/tests/unit/api/test_05_query_api.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
-from fastapi.testclient import TestClient
 
 from infrahub.core.initialization import create_branch
 from infrahub.message_bus import messages
 
 if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
+
     from infrahub.core.branch import Branch
     from infrahub.core.node import Node
     from infrahub.database import InfrahubDatabase
@@ -25,12 +26,8 @@ async def base_authentication(
 
 
 async def test_query_endpoint_group_no_params(
-    db: InfrahubDatabase, client_headers, default_branch, car_person_data, patch_services
+    db: InfrahubDatabase, client: TestClient, client_headers, default_branch, car_person_data, patch_services
 ):
-    from infrahub.server import app
-
-    client = TestClient(app)
-
     # Must execute in a with block to execute the startup/shutdown events
     with client:
         response = client.get(
@@ -68,11 +65,9 @@ async def test_query_endpoint_group_no_params(
     )
 
 
-async def test_query_endpoint_group_params(db: InfrahubDatabase, client_headers, default_branch, car_person_data):
-    from infrahub.server import app
-
-    client = TestClient(app)
-
+async def test_query_endpoint_group_params(
+    db: InfrahubDatabase, client: TestClient, client_headers, default_branch, car_person_data
+):
     # Must execute in a with block to execute the startup/shutdown events
     with client:
         response = client.get(
@@ -105,7 +100,7 @@ async def test_query_endpoint_group_params(db: InfrahubDatabase, client_headers,
 
 
 async def test_query_endpoint_get_default_branch(
-    db: InfrahubDatabase, client, client_headers, default_branch, car_person_data
+    db: InfrahubDatabase, client: TestClient, client_headers, default_branch, car_person_data
 ):
     # Must execute in a with block to execute the startup/shutdown events
     with client:
@@ -127,7 +122,7 @@ async def test_query_endpoint_get_default_branch(
 
 async def test_query_endpoint_post_no_payload(
     db: InfrahubDatabase,
-    client,
+    client: TestClient,
     admin_headers,
     default_branch,
     car_person_data,
@@ -153,7 +148,7 @@ async def test_query_endpoint_post_no_payload(
 
 async def test_query_endpoint_post_with_params(
     db: InfrahubDatabase,
-    client,
+    client: TestClient,
     admin_headers,
     default_branch,
     car_person_data,
@@ -173,7 +168,7 @@ async def test_query_endpoint_post_with_params(
 
 
 async def test_query_endpoint_branch1(
-    db: InfrahubDatabase, client, client_headers, default_branch, car_person_data, authentication_base
+    db: InfrahubDatabase, client: TestClient, client_headers, default_branch, car_person_data, authentication_base
 ):
     await create_branch(branch_name="branch1", db=db)
 
@@ -196,7 +191,12 @@ async def test_query_endpoint_branch1(
 
 
 async def test_query_endpoint_wrong_query(
-    db: InfrahubDatabase, client, client_headers, default_branch, car_person_schema, register_core_models_schema
+    db: InfrahubDatabase,
+    client: TestClient,
+    client_headers,
+    default_branch,
+    car_person_schema,
+    register_core_models_schema,
 ):
     # Must execute in a with block to execute the startup/shutdown events
     with client:
@@ -209,7 +209,12 @@ async def test_query_endpoint_wrong_query(
 
 
 async def test_query_endpoint_wrong_branch(
-    db: InfrahubDatabase, client, client_headers, default_branch, car_person_schema, register_core_models_schema
+    db: InfrahubDatabase,
+    client: TestClient,
+    client_headers,
+    default_branch,
+    car_person_schema,
+    register_core_models_schema,
 ):
     # Must execute in a with block to execute the startup/shutdown events
     with client:

--- a/backend/tests/unit/api/test_10_transformation_api.py
+++ b/backend/tests/unit/api/test_10_transformation_api.py
@@ -1,5 +1,3 @@
-from fastapi.testclient import TestClient
-
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
@@ -8,12 +6,8 @@ from infrahub.message_bus.messages.transform_python_data import TransformPythonD
 
 
 async def test_transform_endpoint(
-    db: InfrahubDatabase, client_headers, default_branch, rpc_bus, register_core_models_schema, car_person_data
+    db: InfrahubDatabase, client, client_headers, default_branch, rpc_bus, register_core_models_schema, car_person_data
 ):
-    from infrahub.server import app
-
-    client = TestClient(app)
-
     repositories = await NodeManager.query(db=db, schema=InfrahubKind.REPOSITORY)
     queries = await NodeManager.query(db=db, schema=InfrahubKind.GRAPHQLQUERY)
 

--- a/backend/tests/unit/api/test_11_artifact.py
+++ b/backend/tests/unit/api/test_11_artifact.py
@@ -1,5 +1,3 @@
-from fastapi.testclient import TestClient
-
 from infrahub.core import registry
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.node import Node
@@ -9,6 +7,7 @@ from infrahub.message_bus import messages
 
 async def test_artifact_definition_endpoint(
     db: InfrahubDatabase,
+    client,
     admin_headers,
     default_branch,
     rpc_bus,
@@ -17,10 +16,6 @@ async def test_artifact_definition_endpoint(
     car_person_data_generic,
     authentication_base,
 ):
-    from infrahub.server import app
-
-    client = TestClient(app)
-
     g1 = await Node.init(db=db, schema=InfrahubKind.STANDARDGROUP)
     await g1.new(db=db, name="group1", members=[car_person_data_generic["c1"], car_person_data_generic["c2"]])
     await g1.save(db=db)
@@ -64,16 +59,13 @@ async def test_artifact_definition_endpoint(
 
 async def test_artifact_endpoint(
     db: InfrahubDatabase,
+    client,
     admin_headers,
     register_core_models_schema,
     register_builtin_models_schema,
     car_person_data_generic,
     authentication_base,
 ):
-    from infrahub.server import app
-
-    client = TestClient(app)
-
     with client:
         response = client.get("/api/artifact/95008984-16ca-4e58-8323-0899bb60035f", headers=admin_headers)
     assert response.status_code == 404

--- a/backend/tests/unit/api/test_12_file.py
+++ b/backend/tests/unit/api/test_12_file.py
@@ -1,5 +1,3 @@
-from fastapi.testclient import TestClient
-
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
@@ -8,15 +6,12 @@ from infrahub.message_bus import messages
 
 async def test_get_file(
     db: InfrahubDatabase,
+    client,
     client_headers,
     default_branch,
     rpc_bus,
     register_core_models_schema,
 ):
-    from infrahub.server import app
-
-    client = TestClient(app)
-
     r1 = await Node.init(db=db, schema=InfrahubKind.REPOSITORY)
     await r1.new(db=db, name="repo01", location="git@github.com:user/repo01.git")
     await r1.save(db=db)

--- a/backend/tests/unit/api/test_40_schema_api.py
+++ b/backend/tests/unit/api/test_40_schema_api.py
@@ -16,7 +16,7 @@ from infrahub.message_bus.messages.schema_migration_path import (
 
 async def test_schema_read_endpoint_default_branch(
     db: InfrahubDatabase,
-    client,
+    client: TestClient,
     client_headers,
     default_branch: Branch,
     car_person_schema_generics: SchemaRoot,
@@ -92,7 +92,7 @@ async def test_schema_read_endpoint_wrong_branch(
 
 async def test_schema_summary_default_branch(
     db: InfrahubDatabase,
-    client,
+    client: TestClient,
     client_headers,
     default_branch: Branch,
     car_person_schema_generics: SchemaRoot,
@@ -116,7 +116,7 @@ async def test_schema_summary_default_branch(
 
 async def test_schema_kind_default_branch(
     db: InfrahubDatabase,
-    client,
+    client: TestClient,
     client_headers,
     default_branch: Branch,
     car_person_schema_generics: SchemaRoot,
@@ -135,7 +135,6 @@ async def test_schema_kind_default_branch(
 
     assert "id" in schema
     assert "hash" in schema
-    assert "filters" in schema
     assert "relationships" in schema
 
 
@@ -169,7 +168,7 @@ async def test_json_schema_kind_default_branch(
 
 async def test_schema_kind_not_valid(
     db: InfrahubDatabase,
-    client,
+    client: TestClient,
     client_headers,
     default_branch: Branch,
     car_person_schema_generics: SchemaRoot,

--- a/backend/tests/unit/api/test_60_storage.py
+++ b/backend/tests/unit/api/test_60_storage.py
@@ -9,15 +9,16 @@ from infrahub.database import InfrahubDatabase
 
 
 async def test_file_upload(
-    db: InfrahubDatabase, helper, local_storage_dir: str, admin_headers, default_branch: Branch, authentication_base
+    db: InfrahubDatabase,
+    client: TestClient,
+    helper,
+    local_storage_dir: str,
+    admin_headers,
+    default_branch: Branch,
+    authentication_base,
 ):
-    from infrahub.server import app
-
-    client = TestClient(app)
-
     fixture_dir = helper.get_fixtures_dir()
 
-    fixture_dir = helper.get_fixtures_dir()
     files_dir = os.path.join(fixture_dir, "schemas")
     filenames = [item.name for item in os.scandir(files_dir) if item.is_file()]
     file_path = Path(os.path.join(files_dir, filenames[0]))
@@ -40,14 +41,14 @@ async def test_file_upload(
 
 
 async def test_content_upload(
-    db: InfrahubDatabase, helper, local_storage_dir: str, admin_headers, default_branch: Branch, authentication_base
+    db: InfrahubDatabase,
+    client: TestClient,
+    helper,
+    local_storage_dir: str,
+    admin_headers,
+    default_branch: Branch,
+    authentication_base,
 ):
-    from infrahub.server import app
-
-    client = TestClient(app)
-
-    fixture_dir = helper.get_fixtures_dir()
-
     fixture_dir = helper.get_fixtures_dir()
     files_dir = os.path.join(fixture_dir, "schemas")
     filenames = [item.name for item in os.scandir(files_dir) if item.is_file()]

--- a/backend/tests/unit/services/adapters/redis/test_redis.py
+++ b/backend/tests/unit/services/adapters/redis/test_redis.py
@@ -8,7 +8,7 @@ from infrahub.message_bus.types import KVTTL
 from infrahub.services.adapters.cache.redis import RedisCache
 
 
-async def test_get():
+async def test_get(redis):
     if config.SETTINGS.cache.driver != config.CacheDriver.Redis:
         pytest.skip("Must use Redis to run this test")
 
@@ -26,7 +26,7 @@ async def test_get():
     assert after_expiry is None
 
 
-async def test_list_keys():
+async def test_list_keys(redis):
     if config.SETTINGS.cache.driver != config.CacheDriver.Redis:
         pytest.skip("Must use Redis to run this test")
 


### PR DESCRIPTION
Building up on #4404, This PR prevent  `redis`, `rabbitmq` and `nats` to start for all tests by moving the fixtures to the different tests that rely on them

There are still too many tests that rely on Redis right now, mainly because FastAPI initialize the lock automatically and it expect Redis. I think we should move the lock to InfrahubServices to make it easier to control how the lock is initialized during the tests