### PR TITLE
Add `invoke pull` command to pull latest changes from git

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -3,6 +3,7 @@
 from invoke import Collection, Context, task
 
 from . import backend, demo, dev, docs, main, performance, schema, sdk
+from .utils import ESCAPED_REPO_PATH
 
 ns = Collection()
 ns.add_collection(sdk)
@@ -35,6 +36,16 @@ def lint_all(context: Context) -> None:
     backend.lint(context)
 
 
+@task
+def pull(context: Context) -> None:
+    """Pull the latest changes from Github and update the submodule to the proper commit."""
+    commands = ["git pull", "git submodule update"]
+    with context.cd(ESCAPED_REPO_PATH):
+        for command in commands:
+            context.run(command, pty=True)
+
+
 ns.add_task(format_all)
 ns.add_task(lint_all)
 ns.add_task(yamllint)
+ns.add_task(pull)


### PR DESCRIPTION
This PR adds a new invoke command `invoke pull` as an alias to run `git submodules update` and `git pull` together 

The command `git submodules update` is required because we are often using different version of the SDK in `stable` and `develop` so we need to make sure we are also updating the submodules after switching branches or after pulling the latest changes from a branch

Would be good to include this command in #4516