### PR TITLE
Add support for custom CA bundles to http.adapter

### DIFF
--- a/backend/infrahub/services/adapters/http/httpx.py
+++ b/backend/infrahub/services/adapters/http/httpx.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ssl
+from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -22,14 +23,19 @@ class HttpxAdapter(InfrahubHTTP):
         self.service = service
         self.settings = config.SETTINGS.http
 
-    def verify_tls(self, verify: bool | None = None) -> bool:
-        if verify is not None:
-            return verify
+        # Cache the context during init, this is to avoid issue when a CA bundle might be accessible
+        # when Infrahub initializes but then removed before the first external HTTP call is made.
+        _ = self.tls_context
 
-        if self.settings.tls_insecure is True:
+    @cached_property
+    def tls_context(self) -> ssl.SSLContext:
+        return self.settings.get_tls_context()
+
+    def verify_tls(self, verify: bool | None = None) -> bool | ssl.SSLContext:
+        if verify is False:
             return False
 
-        return True
+        return self.tls_context
 
     async def _request(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -600,6 +600,10 @@ allow-dunder-method-names = [
     "ANN401", # Dynamically typed expressions (typing.Any) are disallowed
 ]
 
+"backend/infrahub/config.py" = [
+    "S323",   # Allow users to create an SSL context that doesn't validate certificates
+]
+
 "backend/infrahub/graphql/mutations/**.py" = [
     ##################################################################################################
     # Review and change the below later                                                              #


### PR DESCRIPTION
This PR adds support for having a custom CA bundle for the http.adapter, unlike other settings I've not reused the existing name of `tls_ca_file` and instead used `tls_ca_bundle` the reason for this is to make it easier to use within a k8s environment where we don't want to map extra file folders. The other `tls_ca_file` options should probably be replaced by something like this.

Alternatively we have one global setting for `tls_ca_bundle` I don't know if it is relevant for most organizations to have different locations to configure what I think will mostly contain the same data.