### PR TITLE
Fix custom provider and swap out json -> data in payload

### DIFF
--- a/backend/infrahub/api/oauth2.py
+++ b/backend/infrahub/api/oauth2.py
@@ -93,7 +93,7 @@ async def token(
         "grant_type": "authorization_code",
     }
 
-    token_response = await service.http.post(provider.token_url, json=token_data)
+    token_response = await service.http.post(provider.token_url, data=token_data)
     _validate_response(response=token_response)
     payload = token_response.json()
 

--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -366,8 +366,6 @@ class SecurityOAuth2BaseSettings(BaseSettings):
 class SecurityOAuth2Settings(SecurityOAuth2BaseSettings):
     """Common base for Oauth2 providers"""
 
-    model_config = SettingsConfigDict(env_prefix="INFRAHUB_OAUTH2_CUSTOM_")
-
     client_id: str = Field(..., description="Client ID of the application created in the auth provider")
     client_secret: str = Field(..., description="Client secret as defined in auth provider")
     authorization_url: str = Field(...)
@@ -381,8 +379,10 @@ class SecurityOAuth2Settings(SecurityOAuth2BaseSettings):
         return " ".join(self.scope)
 
 
-class SecurityOAuth2Custom(SecurityOAuth2BaseSettings):
+class SecurityOAuth2Custom(SecurityOAuth2Settings):
     """Common base for Oauth2 providers"""
+
+    model_config = SettingsConfigDict(env_prefix="INFRAHUB_OAUTH2_CUSTOM_")
 
     display_label: str = Field(default="Custom SSO")
 
@@ -451,7 +451,7 @@ class SecuritySettings(BaseSettings):
     @model_validator(mode="after")
     def check_oauth2_provider_settings(self) -> Self:
         mapped_providers: dict[Oauth2Provider, type[SecurityOAuth2BaseSettings]] = {
-            Oauth2Provider.CUSTOM: SecurityOAuth2Settings,
+            Oauth2Provider.CUSTOM: SecurityOAuth2Custom,
             Oauth2Provider.GOOGLE: SecurityOAuth2Google,
         }
         for oauth2_provider in self.oauth2_providers:

--- a/backend/infrahub/services/adapters/http/__init__.py
+++ b/backend/infrahub/services/adapters/http/__init__.py
@@ -13,6 +13,11 @@ class InfrahubHTTP:
         """Initialize the HTTP adapter"""
 
     async def post(
-        self, url: str, json: Any | None = None, headers: dict[str, Any] | None = None, verify: bool | None = None
+        self,
+        url: str,
+        data: Any | None = None,
+        json: Any | None = None,
+        headers: dict[str, Any] | None = None,
+        verify: bool | None = None,
     ) -> httpx.Response:
         raise NotImplementedError()

--- a/backend/infrahub/services/adapters/http/httpx.py
+++ b/backend/infrahub/services/adapters/http/httpx.py
@@ -35,12 +35,15 @@ class HttpxAdapter(InfrahubHTTP):
         self,
         method: str,
         url: str,
+        data: Any | None = None,
         json: Any | None = None,
         headers: dict[str, Any] | None = None,
         verify: bool | None = None,
     ) -> httpx.Response:
         """Returns an httpx.Response object or raises HTTPServerError or child classes."""
         params: dict[str, Any] = {}
+        if data:
+            params["data"] = data
         if json:
             params["json"] = json
         async with httpx.AsyncClient(verify=self.verify_tls(verify=verify)) as client:
@@ -68,6 +71,11 @@ class HttpxAdapter(InfrahubHTTP):
         return response
 
     async def post(
-        self, url: str, json: Any | None = None, headers: dict[str, Any] | None = None, verify: bool | None = None
+        self,
+        url: str,
+        data: Any | None = None,
+        json: Any | None = None,
+        headers: dict[str, Any] | None = None,
+        verify: bool | None = None,
     ) -> httpx.Response:
-        return await self._request(method="post", url=url, json=json, headers=headers, verify=verify)
+        return await self._request(method="post", url=url, data=data, json=json, headers=headers, verify=verify)


### PR DESCRIPTION
When testing with [Keycloak](https://www.keycloak.org/) as an OAuth2 provider I ran into some errors:

### How data is sent to the provider

I was posting with httpx using the "json" format however it seems like most providers would expect "data" (`application/x-www-form-urlencoded`). Due to this I added a "data" parameter within the http adapter and swapped to using data. Google supports both data and json.

### Changes to the configuration

There was some slight errors in the config with regards to which class had the `model_config = SettingsConfigDict(env_prefix="INFRAHUB_OAUTH2_CUSTOM_")` setting. The idea is that you'd be able to have two custom providers which is why this change is required.