### PR TITLE
fix diff calculation bug around deleted edges

### DIFF
--- a/backend/infrahub/core/branch.py
+++ b/backend/infrahub/core/branch.py
@@ -83,6 +83,11 @@ class Branch(StandardNode):  # pylint: disable=too-many-public-methods
     def set_branched_from(cls, value: str) -> str:
         return Timestamp(value).to_string()
 
+    def get_branched_from(self) -> str:
+        if not self.branched_from:
+            raise RuntimeError(f"branched_from not set for branch {self.name}")
+        return self.branched_from
+
     @field_validator("created_at", mode="before")
     @classmethod
     def set_created_at(cls, value: str) -> str:

--- a/backend/infrahub/core/diff/calculator.py
+++ b/backend/infrahub/core/diff/calculator.py
@@ -21,9 +21,9 @@ class DiffCalculator:
         previous_node_specifiers: set[NodeFieldSpecifier] | None = None,
     ) -> CalculatedDiffs:
         if diff_branch.name == registry.default_branch:
-            diff_branch_create_time = from_time
+            diff_branch_from_time = from_time
         else:
-            diff_branch_create_time = Timestamp(diff_branch.get_created_at())
+            diff_branch_from_time = Timestamp(diff_branch.get_branched_from())
         diff_parser = DiffQueryParser(
             base_branch=base_branch,
             diff_branch=diff_branch,
@@ -35,7 +35,7 @@ class DiffCalculator:
             db=self.db,
             branch=diff_branch,
             base_branch=base_branch,
-            diff_branch_create_time=diff_branch_create_time,
+            diff_branch_from_time=diff_branch_from_time,
             diff_from=from_time,
             diff_to=to_time,
         )
@@ -51,7 +51,7 @@ class DiffCalculator:
                 db=self.db,
                 branch=base_branch,
                 base_branch=base_branch,
-                diff_branch_create_time=diff_branch_create_time,
+                diff_branch_from_time=diff_branch_from_time,
                 diff_from=from_time,
                 diff_to=to_time,
                 current_node_field_specifiers=[

--- a/backend/infrahub/core/diff/calculator.py
+++ b/backend/infrahub/core/diff/calculator.py
@@ -36,6 +36,7 @@ class DiffCalculator:
             branch=diff_branch,
             base_branch=base_branch,
             diff_branch_from_time=diff_branch_from_time,
+            include_previous_values=True,
             diff_from=from_time,
             diff_to=to_time,
         )
@@ -52,6 +53,7 @@ class DiffCalculator:
                 branch=base_branch,
                 base_branch=base_branch,
                 diff_branch_from_time=diff_branch_from_time,
+                include_previous_values=False,
                 diff_from=from_time,
                 diff_to=to_time,
                 current_node_field_specifiers=[

--- a/backend/infrahub/core/diff/calculator.py
+++ b/backend/infrahub/core/diff/calculator.py
@@ -63,8 +63,6 @@ class DiffCalculator:
             for query_result in base_diff_query.get_results():
                 diff_parser.read_result(query_result=query_result)
 
-        # breakpoint()
-
         diff_parser.parse()
         return CalculatedDiffs(
             base_branch_name=base_branch.name,

--- a/backend/infrahub/core/diff/calculator.py
+++ b/backend/infrahub/core/diff/calculator.py
@@ -36,7 +36,6 @@ class DiffCalculator:
             branch=diff_branch,
             base_branch=base_branch,
             diff_branch_from_time=diff_branch_from_time,
-            include_previous_values=True,
             diff_from=from_time,
             diff_to=to_time,
         )
@@ -53,7 +52,6 @@ class DiffCalculator:
                 branch=base_branch,
                 base_branch=base_branch,
                 diff_branch_from_time=diff_branch_from_time,
-                include_previous_values=False,
                 diff_from=from_time,
                 diff_to=to_time,
                 current_node_field_specifiers=[
@@ -64,6 +62,8 @@ class DiffCalculator:
             await base_diff_query.execute(db=self.db)
             for query_result in base_diff_query.get_results():
                 diff_parser.read_result(query_result=query_result)
+
+        # breakpoint()
 
         diff_parser.parse()
         return CalculatedDiffs(

--- a/backend/infrahub/core/diff/query_parser.py
+++ b/backend/infrahub/core/diff/query_parser.py
@@ -160,8 +160,14 @@ class DiffAttributeIntermediate(TrackedStatusUpdates):
         self.timestamp_status_map[database_path.attribute_changed_at] = database_path.attribute_status
 
     def to_diff_attribute(self, from_time: Timestamp) -> DiffAttribute:
-        properties = [prop.to_diff_property(from_time=from_time) for prop in self.properties_by_type.values()]
+        properties = []
+        for prop in self.properties_by_type.values():
+            diff_prop = prop.to_diff_property(from_time=from_time)
+            if diff_prop.action is not DiffAction.UNCHANGED:
+                properties.append(diff_prop)
         action, changed_at = self.get_action_and_timestamp(from_time=from_time)
+        if not properties:
+            action = DiffAction.UNCHANGED
         return DiffAttribute(
             uuid=self.uuid, name=self.name, changed_at=changed_at, action=action, properties=properties
         )
@@ -262,11 +268,15 @@ class DiffSingleRelationshipIntermediate:
             chronological_properties=peer_id_properties, from_time=from_time
         )
         peer_id = peer_final_property.new_value or peer_final_property.previous_value
-        other_final_properties = [
-            self._get_single_relationship_final_property(chronological_properties=property_list, from_time=from_time)
-            for property_type, property_list in self.ordered_properties_by_type.items()
-            if property_type != DatabaseEdgeType.IS_RELATED
-        ]
+        other_final_properties = []
+        for property_type, property_list in self.ordered_properties_by_type.items():
+            if property_type is DatabaseEdgeType.IS_RELATED:
+                continue
+            final_prop = self._get_single_relationship_final_property(
+                chronological_properties=property_list, from_time=from_time
+            )
+            if final_prop.action is not DiffAction.UNCHANGED:
+                other_final_properties.append(final_prop)
         final_properties = [peer_final_property] + other_final_properties
         last_changed_property = max(final_properties, key=lambda fp: fp.changed_at)
         last_changed_at = last_changed_property.changed_at
@@ -330,8 +340,8 @@ class DiffRelationshipIntermediate:
         single_relationships = [
             sr.get_final_single_relationship(from_time=from_time) for sr in self._single_relationship_list
         ]
-        last_changed_relatonship = max(single_relationships, key=lambda r: r.changed_at)
-        last_changed_at = last_changed_relatonship.changed_at
+        last_changed_relationship = max(single_relationships, key=lambda r: r.changed_at)
+        last_changed_at = last_changed_relationship.changed_at
         action = DiffAction.UPDATED
         if last_changed_at < from_time:
             action = DiffAction.UNCHANGED
@@ -358,9 +368,19 @@ class DiffNodeIntermediate(TrackedStatusUpdates):
     relationships_by_name: dict[str, DiffRelationshipIntermediate] = field(default_factory=dict)
 
     def to_diff_node(self, from_time: Timestamp) -> DiffNode:
-        attributes = [attr.to_diff_attribute(from_time=from_time) for attr in self.attributes_by_name.values()]
-        relationships = [rel.to_diff_relationship(from_time=from_time) for rel in self.relationships_by_name.values()]
+        attributes = []
+        for attr in self.attributes_by_name.values():
+            diff_attr = attr.to_diff_attribute(from_time=from_time)
+            if diff_attr.action is not DiffAction.UNCHANGED:
+                attributes.append(diff_attr)
+        relationships = []
+        for rel in self.relationships_by_name.values():
+            diff_rel = rel.to_diff_relationship(from_time=from_time)
+            if diff_rel.action is not DiffAction.UNCHANGED:
+                relationships.append(diff_rel)
         action, changed_at = self.get_action_and_timestamp(from_time=from_time)
+        if not attributes and not relationships:
+            action = DiffAction.UNCHANGED
         return DiffNode(
             uuid=self.uuid,
             kind=self.kind,
@@ -384,8 +404,11 @@ class DiffRootIntermediate:
     def to_diff_root(self, from_time: Timestamp, to_time: Timestamp) -> DiffRoot:
         nodes = []
         for node in self.nodes_by_id.values():
-            if not node.is_empty:
-                nodes.append(node.to_diff_node(from_time=from_time))
+            if node.is_empty:
+                continue
+            diff_node = node.to_diff_node(from_time=from_time)
+            if diff_node.action is not DiffAction.UNCHANGED:
+                nodes.append(diff_node)
         return DiffRoot(uuid=self.uuid, branch=self.branch, nodes=nodes, from_time=from_time, to_time=to_time)
 
 

--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -418,7 +418,7 @@ class RelationshipDataDeleteQuery(RelationshipQuery):
 
         for prop_name, prop in self.data.properties.items():
             self.add_to_query(
-                "CREATE (prop_%s)<-[rel_prop_%s:%s $rel_prop ]-(rl)" % (prop_name, prop_name, prop_name.upper()),
+                "CREATE (prop_%s)<-[rel_prop_%s:%s $rel_prop ]-(rl)" % (prop_name, prop_name, prop.rel.type),
             )
             self.return_labels.append(f"rel_prop_{prop_name}")
 

--- a/backend/tests/integration/diff/test_diff_rebase.py
+++ b/backend/tests/integration/diff/test_diff_rebase.py
@@ -229,6 +229,7 @@ class TestDiffRebase(TestInfrahubApp):
             assert description_attr.name == "description"
             assert len(description_attr.properties) == 1
             value_prop = description_attr.properties.pop()
+            assert value_prop.action is DiffAction.UPDATED
             assert value_prop.property_type is DatabaseEdgeType.HAS_VALUE
             assert value_prop.previous_value == "Starbuck"
             assert value_prop.new_value == new_desc_value
@@ -416,7 +417,6 @@ class TestDiffRebase(TestInfrahubApp):
         kara_id = initial_dataset["kara"].id
         jesko_id = initial_dataset["jesko"].id
         koenigsegg_id = initial_dataset["koenigsegg"].id
-        cyberdyne_id = initial_dataset["cyberdyne"].id
         omnicorp_id = initial_dataset["omnicorp"].id
         before_rebase = Timestamp()
         result = await client.execute_graphql(query=BRANCH_REBASE, variables={"branch": branch_2.name})
@@ -436,14 +436,9 @@ class TestDiffRebase(TestInfrahubApp):
         assert len(description_attr.properties) == 1
         value_prop = description_attr.properties.pop()
         assert value_prop.property_type is DatabaseEdgeType.HAS_VALUE
-        assert value_prop.previous_value == "Starbuck"
+        assert value_prop.previous_value == "branch-1-description"
         assert value_prop.new_value == "branch-2-description"
-        assert value_prop.conflict
-        assert value_prop.conflict.base_branch_action is DiffAction.UPDATED
-        assert value_prop.conflict.base_branch_value == "branch-1-description"
-        assert value_prop.conflict.diff_branch_action is DiffAction.UPDATED
-        assert value_prop.conflict.diff_branch_value == "branch-2-description"
-        assert value_prop.conflict.selected_branch is ConflictSelection.DIFF_BRANCH
+        assert value_prop.conflict is None
         jesko_node = nodes_by_id[jesko_id]
         assert len(jesko_node.relationships) == 1
         manufacturer_rel = jesko_node.relationships.pop()
@@ -452,12 +447,7 @@ class TestDiffRebase(TestInfrahubApp):
         manufacturer_element = manufacturer_rel.relationships.pop()
         assert manufacturer_element.peer_id == omnicorp_id
         assert manufacturer_element.action is DiffAction.UPDATED
-        assert manufacturer_element.conflict
-        assert manufacturer_element.conflict.base_branch_action is DiffAction.UPDATED
-        assert manufacturer_element.conflict.base_branch_value == cyberdyne_id
-        assert manufacturer_element.conflict.diff_branch_action is DiffAction.UPDATED
-        assert manufacturer_element.conflict.diff_branch_value == omnicorp_id
-        assert manufacturer_element.conflict.selected_branch is ConflictSelection.BASE_BRANCH
+        assert manufacturer_element.conflict is None
         assert len(manufacturer_element.properties) == 1
         related_prop = manufacturer_element.properties.pop()
         assert related_prop.property_type is DatabaseEdgeType.IS_RELATED

--- a/backend/tests/unit/core/diff/test_coordinator.py
+++ b/backend/tests/unit/core/diff/test_coordinator.py
@@ -1,0 +1,51 @@
+from unittest.mock import AsyncMock
+
+from infrahub.core.branch import Branch
+from infrahub.core.constants import DiffAction
+from infrahub.core.constants.database import DatabaseEdgeType
+from infrahub.core.diff.coordinator import DiffCoordinator
+from infrahub.core.diff.data_check_synchronizer import DiffDataCheckSynchronizer
+from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
+from infrahub.database import InfrahubDatabase
+from infrahub.dependencies.registry import get_component_registry
+
+
+class TestDiffCoordinator:
+    async def test_node_deleted_after_branching(
+        self, db: InfrahubDatabase, default_branch: Branch, person_john_main: Node
+    ):
+        branch = await create_branch(db=db, branch_name="branch")
+        person_main = await NodeManager.get_one(db=db, branch=default_branch, id=person_john_main.id)
+        await person_main.delete(db=db)
+        person_branch = await NodeManager.get_one(db=db, branch=branch, id=person_john_main.id)
+        await person_branch.delete(db=db)
+
+        component_registry = get_component_registry()
+        diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch)
+        mock_synchronizer = AsyncMock(spec=DiffDataCheckSynchronizer)
+        diff_coordinator.data_check_synchronizer = mock_synchronizer
+        diff = await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch)
+
+        assert diff.base_branch_name == default_branch.name
+        assert diff.diff_branch_name == branch.name
+        nodes_by_id = {n.uuid: n for n in diff.nodes}
+        assert set(nodes_by_id.keys()) == {person_john_main.id}
+        node_diff = nodes_by_id[person_john_main.id]
+        assert node_diff.action is DiffAction.REMOVED
+        assert len(node_diff.relationships) == 0
+        attributes_by_name = {a.name: a for a in node_diff.attributes}
+        assert set(attributes_by_name.keys()) == {"name", "height"}
+        for attr_diff in node_diff.attributes:
+            assert attr_diff.action is DiffAction.REMOVED
+            properties_by_type = {p.property_type: p for p in attr_diff.properties}
+            assert set(properties_by_type.keys()) == {
+                DatabaseEdgeType.HAS_VALUE,
+                DatabaseEdgeType.IS_VISIBLE,
+                DatabaseEdgeType.IS_PROTECTED,
+            }
+            for prop_diff in attr_diff.properties:
+                assert prop_diff.action is DiffAction.REMOVED
+                assert prop_diff.conflict is None
+                assert prop_diff.new_value is None

--- a/backend/tests/unit/core/diff/test_diff_calculator.py
+++ b/backend/tests/unit/core/diff/test_diff_calculator.py
@@ -1558,10 +1558,9 @@ async def test_diff_attribute_branch_update_with_separate_previous_base_update_c
     assert len(attribute_diff.properties) == 1
     property_diff = attribute_diff.properties[0]
     assert property_diff.property_type == DatabaseEdgeType.HAS_VALUE
-    # previous value will have been captured by the previous diff
-    assert property_diff.previous_value is None
+    assert property_diff.previous_value == "#444444"
     assert property_diff.new_value == "BLURPLE"
-    assert property_diff.action is DiffAction.ADDED
+    assert property_diff.action is DiffAction.UPDATED
     assert base_before_change < property_diff.changed_at < base_after_change
     branch_root_path = calculated_diffs.diff_branch_diff
     assert branch_root_path.branch == branch.name


### PR DESCRIPTION
IFC-753

Various fixes following the last round of diff updates

- use branched_from instead of created_at for diff calculation b/c branched_from is updated following a merge or rebase
- clean up how we do diff recalculation following changes to how we store the diffs in 0.16.2
- remove unchanged values from the calculated diff
- fix an error I found by chance in relationship deletes where we would create `OWNER` and `SOURCE` edges in the database instead of `HAS_OWNER` and `HAS_SOURCE`
- fix the diff rebase tests to look for the correct data (no conflicts after a rebase)
- updates to the DiffAllPathsQuery
  - to ignore nodes/attributes/relationships added and deleted within the diff timeframe
  - remove a few filters that prevented correctly handling deleted relationships within a deleted node
  - move the logic to gather previous values and peer IDs to the end of the query, hopefully split this out into its own separate query