### PR TITLE
Move account resolver from schema.py to resolver.py

### DIFF
--- a/backend/infrahub/graphql/manager.py
+++ b/backend/infrahub/graphql/manager.py
@@ -41,6 +41,7 @@ from .queries.diff.diff import (
     DiffSummaryElementRelationshipOne,
 )
 from .resolver import (
+    account_resolver,
     ancestors_resolver,
     default_paginated_list_resolver,
     default_resolver,
@@ -48,7 +49,7 @@ from .resolver import (
     many_relationship_resolver,
     single_relationship_resolver,
 )
-from .schema import InfrahubBaseMutation, InfrahubBaseQuery, account_resolver
+from .schema import InfrahubBaseMutation, InfrahubBaseQuery
 from .subscription import InfrahubBaseSubscription
 from .types import (
     InfrahubInterface,

--- a/backend/infrahub/graphql/schema.py
+++ b/backend/infrahub/graphql/schema.py
@@ -1,13 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from graphene import ObjectType
-from infrahub_sdk.utils import extract_fields
-
-from infrahub.core.constants import InfrahubKind
-from infrahub.core.manager import NodeManager
-from infrahub.exceptions import NodeNotFoundError
 
 from .mutations.account import (
     InfrahubAccountSelfUpdate,
@@ -60,32 +53,6 @@ from .queries import (
     Task,
 )
 from .queries.diff.tree import DiffTreeQuery, DiffTreeSummaryQuery
-
-if TYPE_CHECKING:
-    from graphql import GraphQLResolveInfo
-
-    from . import GraphqlContext
-
-
-# pylint: disable=unused-argument
-
-
-async def account_resolver(root, info: GraphQLResolveInfo):
-    fields = await extract_fields(info.field_nodes[0].selection_set)
-    context: GraphqlContext = info.context
-
-    async with context.db.start_session() as db:
-        results = await NodeManager.query(
-            schema=InfrahubKind.GENERICACCOUNT,
-            filters={"ids": [context.account_session.account_id]},
-            fields=fields,
-            db=db,
-        )
-        if results:
-            account_profile = await results[0].to_graphql(db=db, fields=fields)
-            return account_profile
-
-        raise NodeNotFoundError(node_type=InfrahubKind.GENERICACCOUNT, identifier=context.account_session.account_id)
 
 
 class InfrahubBaseQuery(ObjectType):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -332,10 +332,6 @@ module = "infrahub.graphql.resolver"
 ignore_errors = true
 
 [[tool.mypy.overrides]]
-module = "infrahub.graphql.schema"
-ignore_errors = true
-
-[[tool.mypy.overrides]]
 module = "infrahub.graphql.subscription"
 ignore_errors = true
 


### PR DESCRIPTION
Due to this we can also remove the mypy ignore statement for schema, the resolver file still has a few issues to fix.

The only change is that I've moved account_resolver and added a `dict` as the returned typ.