### PR TITLE
IFC-669 Add permission management global permission

### DIFF
--- a/backend/infrahub/core/constants/__init__.py
+++ b/backend/infrahub/core/constants/__init__.py
@@ -56,6 +56,7 @@ class GlobalPermissions(InfrahubStringEnum):
     MERGE_BRANCH = "merge_branch"
     MERGE_PROPOSED_CHANGE = "merge_proposed_change"
     MANAGE_ACCOUNTS = "manage_accounts"
+    MANAGE_PERMISSIONS = "manage_permissions"
 
 
 class PermissionAction(InfrahubStringEnum):

--- a/backend/infrahub/graphql/api/dependencies.py
+++ b/backend/infrahub/graphql/api/dependencies.py
@@ -11,6 +11,7 @@ from ..auth.query_permission_checker.merge_operation_checker import MergeBranchP
 from ..auth.query_permission_checker.object_permission_checker import (
     AccountManagerPermissionChecker,
     ObjectPermissionChecker,
+    PermissionManagerPermissionChecker,
 )
 from ..auth.query_permission_checker.read_only_checker import ReadOnlyGraphQLPermissionChecker
 from ..auth.query_permission_checker.read_write_checker import ReadWriteGraphQLPermissionChecker
@@ -29,6 +30,7 @@ def build_graphql_query_permission_checker() -> GraphQLQueryPermissionChecker:
             DefaultBranchPermissionChecker(),
             MergeBranchPermissionChecker(),
             AccountManagerPermissionChecker(),
+            PermissionManagerPermissionChecker(),
             ObjectPermissionChecker(),
             ReadWriteGraphQLPermissionChecker(),  # Deprecated, will be replace by either a global permission or object permissions
             ReadOnlyGraphQLPermissionChecker(),  # Deprecated, will be replace by either a global permission or object permissions

--- a/backend/infrahub/graphql/auth/query_permission_checker/object_permission_checker.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/object_permission_checker.py
@@ -158,14 +158,10 @@ class PermissionManagerPermissionChecker(GraphQLQueryPermissionCheckerInterface)
         if not is_permission_operation:
             return CheckerResolution.NEXT_CHECKER
 
-        has_permission = False
         for permission_backend in registry.permission_backends:
-            if has_permission := await permission_backend.has_permission(
+            if not await permission_backend.has_permission(
                 db=db, account_id=account_session.account_id, permission=self.permission_required, branch=branch
             ):
-                break
-
-        if not has_permission:
-            raise PermissionDeniedError("You do not have the permission to manage permissions")
+                raise PermissionDeniedError("You do not have the permission to manage permissions")
 
         return CheckerResolution.NEXT_CHECKER

--- a/backend/infrahub/graphql/auth/query_permission_checker/object_permission_checker.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/object_permission_checker.py
@@ -124,3 +124,48 @@ class AccountManagerPermissionChecker(GraphQLQueryPermissionCheckerInterface):
             raise PermissionDeniedError("You do not have the permission to manage user accounts, groups or roles")
 
         return CheckerResolution.NEXT_CHECKER
+
+
+class PermissionManagerPermissionChecker(GraphQLQueryPermissionCheckerInterface):
+    """Checker that makes sure a user account can perform actions on permission related object.
+
+    This is similar to object permission checker except that we care for any operations on any permission related kinds.
+    """
+
+    permission_required = f"global:{GlobalPermissions.MANAGE_PERMISSIONS.value}:{PermissionDecision.ALLOW.value}"
+
+    async def supports(self, db: InfrahubDatabase, account_session: AccountSession, branch: Branch) -> bool:
+        return account_session.authenticated
+
+    async def check(
+        self,
+        db: InfrahubDatabase,
+        account_session: AccountSession,
+        analyzed_query: InfrahubGraphQLQueryAnalyzer,
+        query_parameters: GraphqlParams,
+        branch: Branch,
+    ) -> CheckerResolution:
+        is_permission_operation = False
+        kinds = await analyzed_query.get_models_in_use(types=query_parameters.context.types)
+
+        for kind in kinds:
+            schema = get_schema(db=db, branch=branch, node_schema=kind)
+            if is_permission_operation := kind in (InfrahubKind.GLOBALPERMISSION, InfrahubKind.OBJECTPERMISSION) or (
+                isinstance(schema, NodeSchema) and InfrahubKind.BASEPERMISSION in schema.inherit_from
+            ):
+                break
+
+        if not is_permission_operation:
+            return CheckerResolution.NEXT_CHECKER
+
+        has_permission = False
+        for permission_backend in registry.permission_backends:
+            if has_permission := await permission_backend.has_permission(
+                db=db, account_id=account_session.account_id, permission=self.permission_required, branch=branch
+            ):
+                break
+
+        if not has_permission:
+            raise PermissionDeniedError("You do not have the permission to manage permissions")
+
+        return CheckerResolution.NEXT_CHECKER

--- a/backend/tests/unit/graphql/auth/query_permission_checker/test_object_permission_checker.py
+++ b/backend/tests/unit/graphql/auth/query_permission_checker/test_object_permission_checker.py
@@ -22,6 +22,7 @@ from infrahub.graphql.auth.query_permission_checker.interface import CheckerReso
 from infrahub.graphql.auth.query_permission_checker.object_permission_checker import (
     AccountManagerPermissionChecker,
     ObjectPermissionChecker,
+    PermissionManagerPermissionChecker,
 )
 from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.permissions.local_backend import LocalPermissionBackend
@@ -122,6 +123,60 @@ query {
   AccountProfile {
     name {
       value
+    }
+  }
+}
+"""
+
+MUTATION_GLOBAL_PERMISSION = """
+mutation {
+  CoreGlobalPermissionCreate(data: {
+    name: {value: "Merge branch"}
+    action: {value: "merge_branch"}
+  }) {
+    ok
+    object {
+      identifier {
+        value
+      }
+    }
+  }
+}
+"""
+
+MUTATION_OBJECT_PERMISSION = """
+mutation {
+  CoreObjectPermissionCreate(data: {
+    branch: {value: "*"}
+    namespace: {value: "*"}
+    name: {value: "*"}
+  }) {
+    ok
+    object {
+      identifier {
+        value
+      }
+    }
+  }
+}
+"""
+
+QUERY_ACCOUNT_PERMISSIONS = """
+query {
+  InfrahubPermissions {
+    global_permissions {
+      edges {
+        node {
+          identifier
+        }
+      }
+    }
+    object_permissions {
+      edges {
+        node {
+          identifier
+        }
+      }
     }
   }
 }
@@ -293,7 +348,7 @@ class TestAccountManagerPermissions:
 
         permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
         await permission.new(
-            db=db, name=GlobalPermissions.EDIT_DEFAULT_BRANCH.value, action=GlobalPermissions.MANAGE_ACCOUNTS.value
+            db=db, name=GlobalPermissions.MANAGE_ACCOUNTS.value, action=GlobalPermissions.MANAGE_ACCOUNTS.value
         )
         await permission.save(db=db)
 
@@ -384,6 +439,120 @@ class TestAccountManagerPermissions:
             with pytest.raises(
                 PermissionDeniedError, match=r"You do not have the permission to manage user accounts, groups or roles"
             ):
+                await checker.check(
+                    db=db,
+                    account_session=session,
+                    analyzed_query=analyzed_query,
+                    query_parameters=gql_params,
+                    branch=permissions_helper.default_branch,
+                )
+
+
+class TestPermissionManagerPermissions:
+    async def test_setup(
+        self,
+        db: InfrahubDatabase,
+        register_core_models_schema: None,
+        default_branch: Branch,
+        permissions_helper: PermissionsHelper,
+        first_account: CoreAccount,
+        second_account: CoreAccount,
+    ):
+        registry.permission_backends = [LocalPermissionBackend()]
+        permissions_helper._default_branch = default_branch
+
+        permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
+        await permission.new(
+            db=db, name=GlobalPermissions.MANAGE_PERMISSIONS.value, action=GlobalPermissions.MANAGE_PERMISSIONS.value
+        )
+        await permission.save(db=db)
+
+        role = await Node.init(db=db, schema=InfrahubKind.ACCOUNTROLE)
+        await role.new(db=db, name="admin", permissions=[permission])
+        await role.save(db=db)
+
+        group = await Node.init(db=db, schema=InfrahubKind.ACCOUNTGROUP)
+        await group.new(db=db, name="admin", roles=[role])
+        await group.save(db=db)
+
+        await group.members.add(db=db, data={"id": first_account.id})
+        await group.members.save(db=db)
+
+        permissions_helper._first = first_account
+        permissions_helper._second = second_account
+
+    @pytest.mark.parametrize(
+        "user",
+        [
+            AccountSession(account_id="abc", auth_type=AuthType.JWT, role=AccountRole.ADMIN),
+            AccountSession(authenticated=False, account_id="anonymous", auth_type=AuthType.NONE),
+        ],
+    )
+    async def test_supports_manage_accounts_permission_accounts(
+        self, user: AccountSession, db: InfrahubDatabase, permissions_helper: PermissionsHelper
+    ):
+        checker = PermissionManagerPermissionChecker()
+        is_supported = await checker.supports(db=db, account_session=user, branch=permissions_helper.default_branch)
+        assert is_supported == user.authenticated
+
+    @pytest.mark.parametrize(
+        "operation", [MUTATION_GLOBAL_PERMISSION, MUTATION_OBJECT_PERMISSION, QUERY_ACCOUNT_PERMISSIONS]
+    )
+    async def test_account_with_permission(
+        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper, operation: str
+    ):
+        checker = PermissionManagerPermissionChecker()
+        session = AccountSession(
+            authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
+        )
+
+        gql_params = prepare_graphql_params(db=db, include_mutation=True, branch=permissions_helper.default_branch)
+        analyzed_query = InfrahubGraphQLQueryAnalyzer(
+            query=operation, schema=gql_params.schema, branch=permissions_helper.default_branch
+        )
+
+        resolution = await checker.check(
+            db=db,
+            account_session=session,
+            analyzed_query=analyzed_query,
+            query_parameters=gql_params,
+            branch=permissions_helper.default_branch,
+        )
+        assert resolution == CheckerResolution.NEXT_CHECKER
+
+    @pytest.mark.parametrize(
+        "operation,must_raise",
+        [
+            (MUTATION_GLOBAL_PERMISSION, True),
+            (MUTATION_OBJECT_PERMISSION, True),
+            (QUERY_TAGS, False),
+            (QUERY_ACCOUNT_PERMISSIONS, False),
+        ],
+    )
+    async def test_account_without_permission(
+        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper, operation: str, must_raise: bool
+    ):
+        checker = PermissionManagerPermissionChecker()
+        session = AccountSession(
+            authenticated=True, account_id=permissions_helper.second.id, session_id=str(uuid4()), auth_type=AuthType.JWT
+        )
+
+        gql_params = prepare_graphql_params(db=db, include_mutation=True, branch=permissions_helper.default_branch)
+        analyzed_query = InfrahubGraphQLQueryAnalyzer(
+            query=operation, schema=gql_params.schema, branch=permissions_helper.default_branch
+        )
+
+        if not must_raise:
+            resolution = await checker.check(
+                db=db,
+                account_session=session,
+                analyzed_query=analyzed_query,
+                query_parameters=gql_params,
+                branch=permissions_helper.default_branch,
+            )
+            assert resolution == CheckerResolution.NEXT_CHECKER
+        else:
+            with pytest.raises(PermissionDeniedError, match=r"You do not have the permission to manage permissions"):
                 await checker.check(
                     db=db,
                     account_session=session,


### PR DESCRIPTION
Implements and validates a permission checker to ensure that only user with a dedicated global permission can add/edit/delete permissions.