### PR TITLE
update WIP diff merge query to handle relationships and attributes

### DIFF
--- a/backend/infrahub/core/diff/merger/model.py
+++ b/backend/infrahub/core/diff/merger/model.py
@@ -1,0 +1,19 @@
+from typing_extensions import TypedDict
+
+
+class RelationshipMergeDict(TypedDict):
+    peer_id: str
+    name: str
+    action: str
+
+
+class AttributeMergeDict(TypedDict):
+    name: str
+    action: str
+
+
+class NodeMergeDict(TypedDict):
+    uuid: str
+    action: str
+    attributes: list[AttributeMergeDict]
+    relationships: list[RelationshipMergeDict]

--- a/backend/infrahub/core/diff/merger/serializer.py
+++ b/backend/infrahub/core/diff/merger/serializer.py
@@ -1,11 +1,22 @@
-from typing import Any
-
 from infrahub.core.constants import DiffAction
+from infrahub.core.constants.database import DatabaseEdgeType
+from infrahub.core.schema.schema_branch import SchemaBranch
 
-from ..model.path import ConflictSelection, EnrichedDiffConflict, EnrichedDiffRoot
+from ..model.path import (
+    ConflictSelection,
+    EnrichedDiffAttribute,
+    EnrichedDiffConflict,
+    EnrichedDiffRoot,
+    EnrichedDiffSingleRelationship,
+)
+from .model import AttributeMergeDict, NodeMergeDict, RelationshipMergeDict
 
 
 class DiffMergeSerializer:
+    def __init__(self, schema_branch: SchemaBranch) -> None:
+        self.schema_branch = schema_branch
+        self._relationship_id_cache: dict[tuple[str, str], str] = {}
+
     def _get_action(self, action: DiffAction, conflict: EnrichedDiffConflict | None) -> DiffAction:
         if not conflict:
             return action
@@ -15,14 +26,78 @@ class DiffMergeSerializer:
             return conflict.diff_branch_action
         raise ValueError(f"conflict {conflict.uuid} does not have a branch selection")
 
-    async def serialize(self, diff: EnrichedDiffRoot) -> list[dict[str, Any]]:
+    def _to_action_str(self, action: DiffAction) -> str:
+        return str(action.value).upper()
+
+    def _get_relationship_identifier(self, schema_kind_str: str, relationship_name: str) -> str:
+        cache_key = (schema_kind_str, relationship_name)
+        if cache_key in self._relationship_id_cache:
+            return self._relationship_id_cache[cache_key]
+        node_schema = self.schema_branch.get(name=schema_kind_str, duplicate=False)
+        relationship_schema = node_schema.get_relationship(name=relationship_name)
+        relationship_identifier = relationship_schema.get_identifier()
+        self._relationship_id_cache[cache_key] = relationship_identifier
+        return relationship_identifier
+
+    async def serialize(self, diff: EnrichedDiffRoot) -> list[NodeMergeDict]:
         serialized_node_diffs = []
         for node in diff.nodes:
             node_action = self._get_action(action=node.action, conflict=node.conflict)
+            attribute_diffs = [self._serialize_attribute(attribute_diff=attr_diff) for attr_diff in node.attributes]
+            relationship_diffs = []
+            for rel_diff in node.relationships:
+                relationship_identifier = self._get_relationship_identifier(
+                    schema_kind_str=node.kind, relationship_name=rel_diff.name
+                )
+                for relationship_element_diff in rel_diff.relationships:
+                    relationship_diffs.extend(
+                        self._serialize_relationship_element(
+                            relationship_diff=relationship_element_diff, relationship_identifier=relationship_identifier
+                        )
+                    )
             serialized_node_diffs.append(
-                {
-                    "action": str(node_action.value).upper(),
-                    "uuid": node.uuid,
-                }
+                NodeMergeDict(
+                    uuid=node.uuid,
+                    action=self._to_action_str(action=node_action),
+                    attributes=attribute_diffs,
+                    relationships=relationship_diffs,
+                )
             )
         return serialized_node_diffs
+
+    def _serialize_attribute(self, attribute_diff: EnrichedDiffAttribute) -> AttributeMergeDict:
+        return AttributeMergeDict(
+            name=attribute_diff.name,
+            action=self._to_action_str(action=attribute_diff.action),
+        )
+
+    def _serialize_relationship_element(
+        self, relationship_diff: EnrichedDiffSingleRelationship, relationship_identifier: str
+    ) -> list[RelationshipMergeDict]:
+        relationship_dicts = []
+        for property_diff in relationship_diff.properties:
+            if property_diff.property_type is not DatabaseEdgeType.IS_RELATED:
+                continue
+            action = property_diff.action
+            new_value = relationship_diff.peer_id
+            if property_diff.conflict and property_diff.conflict.selected_branch is ConflictSelection.BASE_BRANCH:
+                action = property_diff.conflict.base_branch_action
+                if property_diff.conflict.base_branch_value:
+                    new_value = property_diff.conflict.base_branch_value
+            actions = [action]
+            if property_diff.action is DiffAction.UPDATED:
+                actions = [DiffAction.ADDED, DiffAction.REMOVED]
+            actions_and_values: list[tuple[DiffAction, str]] = []
+            for action in actions:
+                if action is DiffAction.ADDED:
+                    actions_and_values.append((action, new_value))
+                elif action is DiffAction.REMOVED and property_diff.previous_value:
+                    actions_and_values.append((action, property_diff.previous_value))
+
+        for action, value in actions_and_values:
+            relationship_dicts.append(
+                RelationshipMergeDict(
+                    peer_id=value, name=relationship_identifier, action=self._to_action_str(action=action)
+                )
+            )
+        return relationship_dicts

--- a/backend/infrahub/core/diff/query/merge.py
+++ b/backend/infrahub/core/diff/query/merge.py
@@ -55,27 +55,16 @@ CALL {
         MATCH (root:Root)
         MATCH (n:Node {uuid: node_diff_map.uuid})
         // ------------------------------
-        // check if IS_PART_OF relationship with node_rel_status already exists on the target branch
-        // ------------------------------
-        CALL {
-            WITH root, n, node_rel_status
-            OPTIONAL MATCH (root)<-[r_root:IS_PART_OF {branch: $target_branch}]-(n)
-            WHERE r_root.status = node_rel_status
-            AND r_root.from <= $at
-            AND (r_root.to >= $at OR r_root.to IS NULL)
-            RETURN r_root
-        }
-        // ------------------------------
         // set IS_PART_OF.to on source branch and, optionally, target branch
         // ------------------------------
-        WITH root, r_root, n, node_rel_status
+        WITH root, n, node_rel_status
         CALL {
             WITH root, n, node_rel_status
             OPTIONAL MATCH (root)<-[source_r_root:IS_PART_OF {branch: $source_branch, status: node_rel_status}]-(n)
             WHERE source_r_root.from <= $at AND source_r_root.to IS NULL
             SET source_r_root.to = $at
         }
-        WITH root, r_root, n, node_rel_status
+        WITH root, n, node_rel_status
         CALL {
             WITH root, n, node_rel_status
             OPTIONAL MATCH (root)<-[target_r_root:IS_PART_OF {branch: $target_branch, status: "active"}]-(n)
@@ -86,10 +75,142 @@ CALL {
         // ------------------------------
         // create new IS_PART_OF relationship on target_branch
         // ------------------------------
-        WITH root, r_root, n, node_rel_status
-        WHERE r_root IS NULL
-        CREATE (root)<-[:IS_PART_OF { branch: $target_branch, branch_level: $branch_level, from: $at, status: node_rel_status }]-(n)
+        WITH root, n, node_rel_status
+        CALL {
+            WITH root, n, node_rel_status
+            OPTIONAL MATCH (root)<-[r_root:IS_PART_OF {branch: $target_branch}]-(n)
+            WHERE r_root.status = node_rel_status
+            AND r_root.from <= $at
+            AND (r_root.to >= $at OR r_root.to IS NULL)
+            WITH root, r_root, n, node_rel_status
+            WHERE r_root IS NULL
+            CREATE (root)
+                <-[:IS_PART_OF { branch: $target_branch, branch_level: $branch_level, from: $at, status: node_rel_status }]
+                -(n)
+        }
+        RETURN n
+    }
+    WITH n, node_diff_map
+    CALL {
+        WITH n, node_diff_map
+        UNWIND node_diff_map.attributes AS attribute_diff_map
+        // ------------------------------
+        // handle updates for attributes under this node
+        // ------------------------------
+        CALL {
+            WITH n, attribute_diff_map
+            WITH n, attribute_diff_map.name AS attr_name, CASE
+                WHEN attribute_diff_map.action = "ADDED" THEN "active"
+                WHEN attribute_diff_map.action = "REMOVED" THEN "deleted"
+                ELSE NULL
+            END AS attr_rel_status
+            CALL {
+                WITH n, attr_name
+                MATCH (n)-[:HAS_ATTRIBUTE]->(a:Attribute {name: attr_name})
+                RETURN a
+                LIMIT 1
+            }
+            WITH n, attr_rel_status, a
+            // ------------------------------
+            // set HAS_ATTRIBUTE.to on source branch if necessary
+            // ------------------------------
+            CALL {
+                WITH n, attr_rel_status, a
+                OPTIONAL MATCH (n)
+                    -[source_r_attr:HAS_ATTRIBUTE {branch: $source_branch, status: attr_rel_status}]
+                    ->(a)
+                WHERE source_r_attr.from <= $at AND source_r_attr.to IS NULL
+                SET source_r_attr.to = $at
+            }
+            WITH n, attr_rel_status, a
+            // ------------------------------
+            // conditionally create new HAS_ATTRIBUTE relationship on target_branch, if necessary
+            // ------------------------------
+            CALL {
+                WITH n, attr_rel_status, a
+                OPTIONAL MATCH (n)-[r_attr:HAS_ATTRIBUTE {branch: $target_branch}]->(a)
+                WHERE r_attr.status = attr_rel_status
+                AND r_attr.from <= $at
+                AND (r_attr.to >= $at OR r_attr.to IS NULL)
+                WITH n, r_attr, attr_rel_status, a
+                WHERE r_attr IS NULL
+                CREATE (n)-[:HAS_ATTRIBUTE { branch: $target_branch, branch_level: $branch_level, from: $at, status: attr_rel_status }]->(a)
+            }
+            RETURN a
+        }
+    }
+    WITH n, node_diff_map
+    CALL {
+        WITH n,node_diff_map
+        UNWIND node_diff_map.relationships AS relationship_diff_map
+        // ------------------------------
+        // handle updates for relationships under this node
+        // ------------------------------
+        CALL {
+            WITH n, relationship_diff_map
+            WITH n, relationship_diff_map.peer_id AS rel_peer_id, relationship_diff_map.name AS rel_name, CASE
+                WHEN relationship_diff_map.action = "ADDED" THEN "active"
+                WHEN relationship_diff_map.action = "REMOVED" THEN "deleted"
+                ELSE NULL
+            END AS related_rel_status
+            // ------------------------------
+            // set IS_RELATED.to on source branch and, optionally, target_branch
+            // ------------------------------
+            CALL {
+                WITH n, rel_name, rel_peer_id, related_rel_status
+                MATCH (n)
+                    -[source_r_rel_1:IS_RELATED {branch: $source_branch, status: related_rel_status}]
+                    -(r:Relationship {name: rel_name})
+                    -[source_r_rel_2:IS_RELATED {branch: $source_branch, status: related_rel_status}]
+                    -(:Node {uuid: rel_peer_id})
+                WHERE source_r_rel_1.from <= $at AND source_r_rel_1.to IS NULL
+                AND source_r_rel_2.from <= $at AND source_r_rel_2.to IS NULL
+                SET source_r_rel_1.to = $at
+                SET source_r_rel_2.to = $at
+                RETURN r
+            }
+            WITH n, r, rel_name, rel_peer_id, related_rel_status
+            CALL {
+                WITH n, rel_name, rel_peer_id, related_rel_status
+                OPTIONAL MATCH (n)
+                    -[target_r_rel_1:IS_RELATED {branch: $target_branch, status: "active"}]
+                    -(:Relationship {name: rel_name})
+                    -[target_r_rel_2:IS_RELATED {branch: $target_branch, status: "active"}]
+                    -(:Node {uuid: rel_peer_id})
+                WHERE related_rel_status = "deleted"
+                AND target_r_rel_1.from <= $at AND target_r_rel_1.to IS NULL
+                AND target_r_rel_2.from <= $at AND target_r_rel_2.to IS NULL
+                SET target_r_rel_1.to = $at
+                SET target_r_rel_2.to = $at
+            }
+            WITH n, r, rel_name, rel_peer_id, related_rel_status
+            // ------------------------------
+            // conditionally create new IS_RELATED relationships on target_branch, if necessary
+            // ------------------------------
+            CALL {
+                WITH n, r, rel_name, rel_peer_id, related_rel_status
+                MATCH (p:Node {uuid: rel_peer_id})
+                OPTIONAL MATCH (n)
+                    -[r_rel_1:IS_RELATED {branch: $target_branch, status: related_rel_status}]
+                    -(:Relationship {name: rel_name})
+                    -[r_rel_2:IS_RELATED {branch: $target_branch, status: related_rel_status}]
+                    -(p)
+                WHERE r_rel_1.from <= $at
+                AND (r_rel_1.to >= $at OR r_rel_1.to IS NULL)
+                AND r_rel_2.from <= $at
+                AND (r_rel_2.to >= $at OR r_rel_2.to IS NULL)
+                WITH n, r, p, related_rel_status, r_rel_1, r_rel_2
+                WHERE r_rel_1 IS NULL
+                AND r_rel_2 IS NULL
+                CREATE (n)
+                    -[:IS_RELATED {branch: $target_branch, branch_level: $branch_level, from: $at, status: related_rel_status}]
+                    ->(r)
+                    <-[:IS_RELATED {branch: $target_branch, branch_level: $branch_level, from: $at, status: related_rel_status}]
+                    -(p)
+            }
+        }
     }
 }
+RETURN NULL AS done
         """
         self.add_to_query(query=query)


### PR DESCRIPTION
IFC-675

adds relationships and attributes to the diff merge query. properties are still to come

will need many more unit and integration tests once the properties logic is in place, but this is hard to test outside of the database right now b/c we always expect relationships and attributes to have properties associated with them