### PR TITLE
Trigger backend tests on updated SDK commits

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -13,6 +13,9 @@ development_files: &development_files
 backend_files: &backend_files
   - "backend/**"
 
+sdk_files: &sdk_files
+  - "python_sdk" # Catch updates to the submodule commit
+
 infrahub_poetry_files: &infrahub_poetry_files
   - "pyproject.toml"
   - "poetry.lock"
@@ -52,6 +55,7 @@ backend_all:
   - *ci_config
   - *development_files
   - *infrahub_poetry_files
+  - *sdk_files
 
 documentation_all:
   - *development_files


### PR DESCRIPTION
Tested in #4571 to validate that `dorny/paths-filter` sees the submodule changes in the correct way.