### PR TITLE
add support for merging relationship properties

### DIFF
--- a/backend/tests/unit/core/diff/test_diff_merger.py
+++ b/backend/tests/unit/core/diff/test_diff_merger.py
@@ -64,6 +64,7 @@ class TestMergeDiff:
     async def person_node_branch(self, db: InfrahubDatabase, source_branch: Branch, car_person_schema) -> Node:
         new_node = await Node.init(db=db, schema="TestPerson", branch=source_branch)
         await new_node.new(db=db, name="Albert", height=172)
+        new_node.height.is_protected = True
         await new_node.save(db=db)
         return new_node
 
@@ -84,11 +85,27 @@ class TestMergeDiff:
         return new_node
 
     @pytest.fixture
+    async def person_node_main2(self, db: InfrahubDatabase, default_branch: Branch, car_person_schema) -> Node:
+        new_node = await Node.init(db=db, schema="TestPerson", branch=default_branch)
+        await new_node.new(db=db, name="Jermaine", height=165)
+        await new_node.save(db=db)
+        return new_node
+
+    @pytest.fixture
     async def car_node_main(
         self, db: InfrahubDatabase, default_branch: Branch, person_node_main: Node, car_person_schema
     ) -> Node:
         new_node = await Node.init(db=db, schema="TestCar", branch=default_branch)
         await new_node.new(db=db, name="El Camino", color="black", nbr_seats=5, owner=person_node_main)
+        await new_node.save(db=db)
+        return new_node
+
+    @pytest.fixture
+    async def car_node_main2(
+        self, db: InfrahubDatabase, default_branch: Branch, person_node_main2: Node, car_person_schema
+    ) -> Node:
+        new_node = await Node.init(db=db, schema="TestCar", branch=default_branch)
+        await new_node.new(db=db, name="Civic", color="purple", nbr_seats=5, owner=person_node_main2)
         await new_node.save(db=db)
         return new_node
 
@@ -250,7 +267,7 @@ class TestMergeDiff:
         added_rel_is_protected_property = EnrichedPropertyFactory.build(
             property_type=DatabaseEdgeType.IS_PROTECTED,
             previous_value=None,
-            new_value="True",
+            new_value="False",
             action=DiffAction.ADDED,
             conflict=None,
         )
@@ -292,6 +309,7 @@ class TestMergeDiff:
             uuid=node.get_id(), action=action, kind=node.get_kind(), label="", attributes=set(), relationships=set()
         )
 
+    @pytest.mark.parametrize("check_idempotent", [False, True])
     async def test_merge_node_added(
         self,
         db: InfrahubDatabase,
@@ -303,54 +321,23 @@ class TestMergeDiff:
         diff_merger: DiffMerger,
         empty_diff_root: EnrichedDiffRoot,
         added_person_node_diff: EnrichedDiffNode,
+        check_idempotent: bool,
     ):
         empty_diff_root.nodes = {added_person_node_diff}
         mock_diff_repository.get_one.return_value = empty_diff_root
         at = Timestamp()
 
         await diff_merger.merge_graph(at=at)
+        if check_idempotent:
+            await diff_merger.merge_graph(at=at)
 
-        mock_diff_repository.get_one.assert_awaited_once_with(
-            diff_branch_name=source_branch.name, tracking_id=BranchTrackingId(name=source_branch.name)
-        )
-        retrieved_node = await NodeManager.get_one(
-            db=db, id=person_node_branch.id, branch=default_branch, include_owner=True, include_source=True
-        )
-        assert retrieved_node.get_updated_at() == at
-        assert retrieved_node.height.value == person_node_branch.height.value
-        owner_node = await retrieved_node.height.get_owner(db=db)
-        assert owner_node.id == retrieved_node.id
-        assert retrieved_node.height.is_visible is True
-        assert retrieved_node.height.is_protected is True
-        car_rel_elements = await retrieved_node.cars.get(db=db)
-        car_elements_by_peer_id = {c.get_peer_id(): c for c in car_rel_elements}
-        assert set(car_elements_by_peer_id.keys()) == {car_node_branch.id}
-        car_element = car_elements_by_peer_id[car_node_branch.id]
-        assert car_element.source_id == car_node_branch.id
-
-    async def test_merge_node_added_idempotent(
-        self,
-        db: InfrahubDatabase,
-        default_branch: Branch,
-        source_branch: Branch,
-        person_node_branch: Node,
-        car_node_branch: Node,
-        mock_diff_repository: DiffRepository,
-        diff_merger: DiffMerger,
-        empty_diff_root: EnrichedDiffRoot,
-        added_person_node_diff: EnrichedDiffNode,
-    ):
-        empty_diff_root.nodes = {added_person_node_diff}
-        mock_diff_repository.get_one.return_value = empty_diff_root
-        at = Timestamp()
-
-        await diff_merger.merge_graph(at=at)
-        await diff_merger.merge_graph(at=at)
-
-        assert mock_diff_repository.get_one.await_args_list == [
-            call(diff_branch_name=source_branch.name, tracking_id=BranchTrackingId(name=source_branch.name)),
+        expected_awaits = [
             call(diff_branch_name=source_branch.name, tracking_id=BranchTrackingId(name=source_branch.name)),
         ]
+        if check_idempotent:
+            expected_awaits *= 2
+        assert mock_diff_repository.get_one.await_args_list == expected_awaits
+
         retrieved_node = await NodeManager.get_one(
             db=db, id=person_node_branch.id, branch=default_branch, include_owner=True, include_source=True
         )
@@ -366,6 +353,7 @@ class TestMergeDiff:
         car_element = car_elements_by_peer_id[car_node_branch.id]
         assert car_element.source_id == car_node_branch.id
 
+    @pytest.mark.parametrize("check_idempotent", [False, True])
     async def test_merge_node_deleted(
         self,
         db: InfrahubDatabase,
@@ -377,6 +365,7 @@ class TestMergeDiff:
         diff_merger: DiffMerger,
         empty_diff_root: EnrichedDiffRoot,
         deleted_person_node_diff: EnrichedDiffNode,
+        check_idempotent: bool,
     ):
         person_branch = await NodeManager.get_one(db=db, branch=source_branch, id=person_node_main.id)
         await person_branch.delete(db=db)
@@ -385,38 +374,15 @@ class TestMergeDiff:
         at = Timestamp()
 
         await diff_merger.merge_graph(at=at)
+        if check_idempotent:
+            await diff_merger.merge_graph(at=at)
 
-        mock_diff_repository.get_one.assert_awaited_once_with(
-            diff_branch_name=source_branch.name, tracking_id=BranchTrackingId(name=source_branch.name)
-        )
-        with pytest.raises(NodeNotFoundError):
-            await NodeManager.get_one(db=db, branch=default_branch, id=person_node_main.id, raise_on_error=True)
-
-    async def test_merge_node_deleted_idempotent(
-        self,
-        db: InfrahubDatabase,
-        default_branch: Branch,
-        person_node_main: Node,
-        car_node_main: Node,
-        source_branch: Branch,
-        mock_diff_repository: DiffRepository,
-        diff_merger: DiffMerger,
-        empty_diff_root: EnrichedDiffRoot,
-        deleted_person_node_diff: EnrichedDiffNode,
-    ):
-        person_branch = await NodeManager.get_one(db=db, branch=source_branch, id=person_node_main.id)
-        await person_branch.delete(db=db)
-        empty_diff_root.nodes = {deleted_person_node_diff}
-        mock_diff_repository.get_one.return_value = empty_diff_root
-        at = Timestamp()
-
-        await diff_merger.merge_graph(at=at)
-        await diff_merger.merge_graph(at=at)
-
-        assert mock_diff_repository.get_one.await_args_list == [
-            call(diff_branch_name=source_branch.name, tracking_id=BranchTrackingId(name=source_branch.name)),
+        expected_awaits = [
             call(diff_branch_name=source_branch.name, tracking_id=BranchTrackingId(name=source_branch.name)),
         ]
+        if check_idempotent:
+            expected_awaits *= 2
+        assert mock_diff_repository.get_one.await_args_list == expected_awaits
 
         with pytest.raises(NodeNotFoundError):
             await NodeManager.get_one(db=db, branch=default_branch, id=person_node_main.id, raise_on_error=True)
@@ -459,6 +425,240 @@ class TestMergeDiff:
             with pytest.raises(NodeNotFoundError):
                 await NodeManager.get_one(db=db, branch=default_branch, id=person_node_main.id, raise_on_error=True)
         else:
-            target_car = await NodeManager.get_one(db=db, branch=default_branch, id=person_node_branch.id)
-            assert target_car.id == person_node_branch.id
-            assert target_car.get_updated_at() < at
+            target_person = await NodeManager.get_one(db=db, branch=default_branch, id=person_node_branch.id)
+            assert target_person.id == person_node_branch.id
+            assert target_person.get_updated_at() < at
+
+    @pytest.fixture
+    def updated_person_node_diff(
+        self, person_node_main, car_node_main, person_node_main2, car_node_main2
+    ) -> EnrichedDiffNode:
+        updated_node_diff = self._get_empty_node_diff(node=person_node_main, action=DiffAction.UPDATED)
+        # attributes
+        updated_height_value_property = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.HAS_VALUE,
+            previous_value=str(person_node_main.height.value),
+            new_value=str(person_node_main.height.value + 1),
+            action=DiffAction.UPDATED,
+            conflict=None,
+        )
+        added_height_owner_property = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.HAS_OWNER,
+            previous_value=None,
+            new_value=str(person_node_main.id),
+            action=DiffAction.ADDED,
+            conflict=None,
+        )
+        updated_height_attribute_diff = EnrichedAttributeFactory.build(
+            name="height",
+            action=DiffAction.UPDATED,
+            properties={updated_height_value_property, added_height_owner_property},
+        )
+        updated_name_value_property = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.HAS_VALUE,
+            previous_value=str(person_node_main.name.value),
+            new_value=str(person_node_main.name.value + "-branch"),
+            action=DiffAction.UPDATED,
+            conflict=EnrichedConflictFactory.build(
+                base_branch_action=DiffAction.UPDATED,
+                base_branch_value="whatever",
+                diff_branch_action=DiffAction.UPDATED,
+                diff_branch_value=str(person_node_main.name.value + "-branch"),
+                selected_branch=ConflictSelection.DIFF_BRANCH,
+            ),
+        )
+        updated_name_attribute_diff = EnrichedAttributeFactory.build(
+            name="name",
+            action=DiffAction.UPDATED,
+            properties={updated_name_value_property},
+        )
+        updated_node_diff.attributes = {updated_height_attribute_diff, updated_name_attribute_diff}
+        # relationships
+        deleted_is_related_property = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.IS_RELATED,
+            previous_value=car_node_main.id,
+            new_value=None,
+            action=DiffAction.REMOVED,
+            conflict=None,
+        )
+        deleted_rel_is_visible_property = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.IS_VISIBLE,
+            previous_value="True",
+            new_value=None,
+            action=DiffAction.REMOVED,
+            conflict=None,
+        )
+        deleted_rel_is_protected_property = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.IS_PROTECTED,
+            previous_value="False",
+            new_value=None,
+            action=DiffAction.REMOVED,
+            conflict=None,
+        )
+        deleted_rel_source_property = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.HAS_SOURCE,
+            previous_value=person_node_main2.id,
+            new_value=None,
+            action=DiffAction.REMOVED,
+            conflict=None,
+        )
+        deleted_rel_owner_property = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.HAS_OWNER,
+            previous_value=car_node_main2.id,
+            new_value=None,
+            action=DiffAction.REMOVED,
+            conflict=None,
+        )
+        deleted_relationship_element = EnrichedRelationshipElementFactory.build(
+            action=DiffAction.REMOVED,
+            peer_id=car_node_main.id,
+            conflict=None,
+            properties={
+                deleted_is_related_property,
+                deleted_rel_is_visible_property,
+                deleted_rel_is_protected_property,
+                deleted_rel_source_property,
+                deleted_rel_owner_property,
+            },
+        )
+        deleted_relationship = EnrichedRelationshipGroupFactory.build(
+            name="cars",
+            relationships={deleted_relationship_element},
+            action=DiffAction.UPDATED,
+        )
+        updated_node_diff.relationships = {deleted_relationship}
+        return updated_node_diff
+
+    @pytest.fixture
+    def updated_car_diff(self, person_node_main, car_node_main, person_node_main2, car_node_main2) -> EnrichedDiffNode:
+        updated_node_diff = self._get_empty_node_diff(node=car_node_main, action=DiffAction.UPDATED)
+        # relationships
+        updated_is_related_property = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.IS_RELATED,
+            previous_value=person_node_main.id,
+            new_value=person_node_main2.id,
+            action=DiffAction.UPDATED,
+            conflict=None,
+        )
+        updated_rel_source_property = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.HAS_SOURCE,
+            previous_value=person_node_main2.id,
+            new_value=person_node_main.id,
+            action=DiffAction.UPDATED,
+            conflict=None,
+        )
+        updated_rel_owner_property = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.HAS_OWNER,
+            previous_value=car_node_main2.id,
+            new_value=car_node_main.id,
+            action=DiffAction.UPDATED,
+            conflict=None,
+        )
+        updated_rel_is_protected_property = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.IS_PROTECTED,
+            previous_value="False",
+            new_value="True",
+            action=DiffAction.UPDATED,
+            conflict=None,
+        )
+        updated_relationship_element = EnrichedRelationshipElementFactory.build(
+            action=DiffAction.UPDATED,
+            peer_id=person_node_main2.id,
+            conflict=None,
+            properties={
+                updated_is_related_property,
+                updated_rel_source_property,
+                updated_rel_owner_property,
+                updated_rel_is_protected_property,
+            },
+        )
+        updated_relationship = EnrichedRelationshipGroupFactory.build(
+            name="owner",
+            relationships={updated_relationship_element},
+            action=DiffAction.UPDATED,
+        )
+        updated_node_diff.relationships = {updated_relationship}
+        return updated_node_diff
+
+    @pytest.mark.parametrize("check_idempotent", [False, True])
+    async def test_merge_node_updated(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        person_node_main: Node,
+        person_node_main2: Node,
+        car_node_main: Node,
+        car_node_main2: Node,
+        mock_diff_repository: DiffRepository,
+        diff_merger: DiffMerger,
+        empty_diff_root: EnrichedDiffRoot,
+        updated_person_node_diff: EnrichedDiffNode,
+        updated_car_diff: EnrichedDiffNode,
+        check_idempotent: bool,
+    ):
+        car_main = await NodeManager.get_one(db=db, branch=default_branch, id=car_node_main.id)
+        await car_main.owner.update(
+            db=db,
+            data={
+                "id": person_node_main.id,
+                "_relation__owner": car_node_main2.id,
+                "_relation__source": person_node_main2.id,
+            },
+        )
+        await car_main.owner.save(db=db)
+
+        source_branch = await create_branch(db=db, branch_name="source")
+
+        person_branch = await NodeManager.get_one(db=db, branch=source_branch, id=person_node_main.id)
+        person_branch.height.value += 1
+        person_branch.height.set_owner(value=person_branch.id)
+        person_branch.name.value += "-branch"
+        await person_branch.save(db=db)
+
+        car_branch = await NodeManager.get_one(db=db, branch=source_branch, id=car_node_main.id)
+        await car_branch.owner.update(
+            db=db,
+            data={
+                "id": person_node_main2.id,
+                "_relation__owner": car_node_main.id,
+                "_relation__source": person_node_main.id,
+                "_relation__is_protected": True,
+            },
+        )
+        await car_branch.save(db=db)
+
+        empty_diff_root.nodes = {updated_person_node_diff, updated_car_diff}
+        mock_diff_repository.get_one.return_value = empty_diff_root
+        at = Timestamp()
+
+        await diff_merger.merge_graph(at=at)
+        if check_idempotent:
+            await diff_merger.merge_graph(at=at)
+
+        expected_awaits = [
+            call(diff_branch_name=source_branch.name, tracking_id=BranchTrackingId(name=source_branch.name)),
+        ]
+        if check_idempotent:
+            expected_awaits *= 2
+        assert mock_diff_repository.get_one.await_args_list == expected_awaits
+        updated_person = await NodeManager.get_one(
+            db=db, branch=default_branch, id=person_node_main.id, include_owner=True
+        )
+        assert updated_person.get_updated_at() < at
+        assert updated_person.height.value == person_node_main.height.value + 1
+        owner_node = await updated_person.height.get_owner(db=db)
+        assert owner_node.id == person_node_main.id
+        assert updated_person.name.value == person_node_main.name.value + "-branch"
+        car_rels = await updated_person.cars.get(db=db)
+        assert len(car_rels) == 0
+        updated_car = await NodeManager.get_one(
+            db=db, branch=default_branch, id=car_node_main.id, include_owner=True, include_source=True
+        )
+        owner_rel = await updated_car.owner.get(db=db)
+        assert owner_rel.is_protected is True
+        assert owner_rel.is_visible is True
+        assert owner_rel.peer_id == person_node_main2.id
+        rel_owner_node = await owner_rel.get_owner(db=db)
+        assert rel_owner_node.id == car_node_main.id
+        rel_source_node = await owner_rel.get_source(db=db)
+        assert rel_source_node.id == person_node_main.id


### PR DESCRIPTION
IFC-675

more unit tests
support for adding/deleting/updating relationship properties in a merge

there is some special handling required for updates to a cardinality=one relationship where IS_PROTECTED or IS_VISIBLE are NOT updated b/c the diff does not record changes to the IS_PROTECTED or IS_VISIBLE property(ies) in that case, BUT we still need to update those edges in the database to be active on main. the unit tests indicate that my logic works for this case, but there is probably a better way to handle it

still need to add integration tests