### PR TITLE
Remove stable parameter from installation guide

### DIFF
--- a/docs/docs/guides/installation.mdx
+++ b/docs/docs/guides/installation.mdx
@@ -64,7 +64,7 @@ cd ~/source/infrahub/
 Next, clone the Infrahub GitHub repository into the current directory.
 
 ```shell
-git clone --recursive -b stable --depth 1 https://github.com/opsmill/infrahub.git
+git clone --recursive --depth 1 https://github.com/opsmill/infrahub.git
 ```
 
 :::note


### PR DESCRIPTION
We recently introduced changes to docker compose file. This was creating a discrepancy between the docker file (on develop branch) and the demo docker images (on stable). Thus the command `invoke demo.start` wasn't working anymore from develop branch. This has been solved with the newest release.