### PR TITLE
IFC-779 Restore original enum handling and fix tests

### DIFF
--- a/backend/infrahub/core/enums.py
+++ b/backend/infrahub/core/enums.py
@@ -9,7 +9,7 @@ def generate_python_enum(name: str, options: list[Any]) -> type[enum.Enum]:
     main_attrs = {}
     for option in options:
         if isinstance(option, int):
-            enum_name = f"Value_{option!s}"
+            enum_name = str(option)
         else:
             enum_name = "_".join(re.findall(ENUM_NAME_REGEX, option)).upper()
 

--- a/backend/infrahub/graphql/enums.py
+++ b/backend/infrahub/graphql/enums.py
@@ -16,11 +16,7 @@ def get_enum_attribute_type_name(node_schema: MainSchemaTypes, attr_schema: Attr
 def generate_graphql_enum(name: str, options: List[Any]) -> graphene.Enum:
     def description_func(value: Any) -> str:
         if value:
-            try:
-                int(value.value)
-                return value.name
-            except ValueError:
-                return value.value
+            return value.value
         return f"Enum for {name}"
 
     py_enum = generate_python_enum(name=name, options=options)

--- a/backend/tests/unit/core/test_enums.py
+++ b/backend/tests/unit/core/test_enums.py
@@ -18,5 +18,5 @@ def test_generate_python_enum_with_integers():
 
     enum_two = enum_class(2)
     assert isinstance(enum_two, enum.Enum)
-    assert {enum.name for enum in enum_class} == {"Value_2", "Value_5", "Value_14"}
+    assert {enum.name for enum in enum_class} == {"2", "5", "14"}
     assert {enum.value for enum in enum_class} == {2, 5, 14}


### PR DESCRIPTION
Move tests that takes cares of testing the GraphQL enum experimental feature at the end of the test file to avoid breaking the test suite.