### PR TITLE
Create default roles and cleanups

### DIFF
--- a/backend/infrahub/graphql/analyzer.py
+++ b/backend/infrahub/graphql/analyzer.py
@@ -22,6 +22,10 @@ class InfrahubGraphQLQueryAnalyzer(GraphQLQueryAnalyzer):
         self.query_variables: dict[str, Any] = query_variables or {}
         super().__init__(query=query, schema=schema)
 
+    @property
+    def operation_names(self) -> list[str]:
+        return [operation.name for operation in self.operations if operation.name is not None]
+
     async def get_models_in_use(self, types: dict[str, Any]) -> set[str]:
         """List of Infrahub models that are referenced in the query."""
         graphql_types = set()

--- a/backend/infrahub/graphql/auth/query_permission_checker/default_branch_checker.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/default_branch_checker.py
@@ -17,7 +17,13 @@ class DefaultBranchPermissionChecker(GraphQLQueryPermissionCheckerInterface):
     permission_required = GlobalPermission(
         id="", name="", action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value, decision=PermissionDecision.ALLOW_ALL.value
     )
-    exempt_operations = ["BranchCreate"]
+    exempt_operations = [
+        "BranchCreate",
+        "DiffUpdate",
+        "InfrahubAccountSelfUpdate",
+        "InfrahubAccountTokenCreate",
+        "InfrahubAccountTokenDelete",
+    ]
 
     async def supports(self, db: InfrahubDatabase, account_session: AccountSession, branch: Branch) -> bool:
         return account_session.authenticated
@@ -42,9 +48,8 @@ class DefaultBranchPermissionChecker(GraphQLQueryPermissionCheckerInterface):
             GLOBAL_BRANCH_NAME,
             registry.default_branch,
         )
-        is_exempt_operation = analyzed_query.operation_name is not None and (
-            analyzed_query.operation_name in self.exempt_operations
-            or analyzed_query.operation_name.startswith("InfrahubAccount")  # Allow user to manage self
+        is_exempt_operation = all(
+            operation_name in self.exempt_operations for operation_name in analyzed_query.operation_names
         )
 
         if (

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -112,7 +112,7 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
                     permission=GlobalPermission(
                         id="",
                         name="",
-                        action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value,
+                        action=GlobalPermissions.MERGE_PROPOSED_CHANGE.value,
                         decision=PermissionDecision.ALLOW_ALL.value,
                     ),
                     branch=branch,

--- a/backend/tests/unit/graphql/auth/query_permission_checker/test_default_branch_checker.py
+++ b/backend/tests/unit/graphql/auth/query_permission_checker/test_default_branch_checker.py
@@ -87,7 +87,7 @@ class TestDefaultBranchPermission:
         graphql_query.branch = MagicMock()
         graphql_query.branch.name = branch_name
         graphql_query.contains_mutation = contains_mutation
-        graphql_query.operation_name = "CreateTags"
+        graphql_query.operation_names = ["CreateTags"]
 
         resolution = await checker.check(
             db=db,
@@ -114,7 +114,7 @@ class TestDefaultBranchPermission:
         graphql_query.branch = MagicMock()
         graphql_query.branch.name = branch_name
         graphql_query.contains_mutation = contains_mutation
-        graphql_query.operation_name = "CreateTags"
+        graphql_query.operation_names = ["CreateTags"]
 
         if not contains_mutation or branch_name != "main":
             resolution = await checker.check(

--- a/frontend/app/tests/e2e/role-management/read.spec.ts
+++ b/frontend/app/tests/e2e/role-management/read.spec.ts
@@ -8,10 +8,10 @@ test.describe("Role management - READ", () => {
 
     await test.step("check counts", async () => {
       await expect(page.getByRole("link", { name: "Accounts 9" })).toBeVisible();
-      await expect(page.getByRole("link", { name: "Groups 1" })).toBeVisible();
-      await expect(page.getByRole("link", { name: "Roles 1" })).toBeVisible();
-      await expect(page.getByRole("link", { name: "Global Permissions 1" })).toBeVisible();
-      await expect(page.getByRole("link", { name: "Object Permissions 0" })).toBeVisible();
+      await expect(page.getByRole("link", { name: "Groups 2" })).toBeVisible();
+      await expect(page.getByRole("link", { name: "Roles 2" })).toBeVisible();
+      await expect(page.getByRole("link", { name: "Global Permissions 4" })).toBeVisible();
+      await expect(page.getByRole("link", { name: "Object Permissions 2" })).toBeVisible();
     });
 
     await test.step("check accounts view", async () => {
@@ -20,13 +20,13 @@ test.describe("Role management - READ", () => {
     });
 
     await test.step("check groups view", async () => {
-      await page.getByRole("link", { name: "Groups 1" }).click();
+      await page.getByRole("link", { name: "Groups 2" }).click();
       await expect(page.getByRole("cell", { name: "Administrators" })).toBeVisible();
       await expect(page.getByRole("cell", { name: "+ 4" })).toBeVisible();
     });
 
     await test.step("check roles view", async () => {
-      await page.getByRole("link", { name: "Roles 1" }).click();
+      await page.getByRole("link", { name: "Roles 2" }).click();
       await expect(page.getByRole("cell", { name: "Super Administrator" })).toBeVisible();
       await expect(page.getByRole("cell", { name: "1" }).first()).toBeVisible();
     });


### PR DESCRIPTION
This PR introduces a default role called General Access along with an account group called "Infrahub Users", the idea would be that admins would place new accounts in this group as they are created.

The Infrahub Users groups is assigned permissions to:

* Read all objects regardless of branch
* Modify objects on non-default branches
* Merge proposed changes
* Manage repositories
* Manage schemas

With this in place a new problem that arose was that all new accounts are created with the default role "read-only", in order to not completely break the anonymous access there's a slight change in the way that roles are assigned when users login, if the user has the `read-only` role we will swap it out to `read-write`. This will happen behind the scenes and will also be removed in Infrahub 1.1 when we clear out the old roles completely.

I've replaced the call that looks at the user created operationName for GraphQL and instead look at the actual names for the mutations in order to determine what is allowed.

I swapped the permission required to merge a branch from `EDIT_DEFAULT_BRANCH` -> `MERGE_PROPOSED_CHANGE`.

Finally updated some tests to account for the changes.