### PR TITLE
Use absolute paths for SDK imports

### DIFF
--- a/backend/infrahub/api/storage.py
+++ b/backend/infrahub/api/storage.py
@@ -1,7 +1,7 @@
 import hashlib
 
 from fastapi import APIRouter, Depends, File, Response, UploadFile
-from infrahub_sdk import UUIDT
+from infrahub_sdk.uuidt import UUIDT
 from pydantic import BaseModel
 
 from infrahub.api.dependencies import get_current_user

--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
 import toml
-from infrahub_sdk import generate_uuid
+from infrahub_sdk.utils import generate_uuid
 from pydantic import AliasChoices, BaseModel, Field, PrivateAttr, ValidationError, computed_field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing_extensions import Self

--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -7,9 +7,9 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 
 import netaddr
 import ujson
-from infrahub_sdk import UUIDT
 from infrahub_sdk.timestamp import TimestampFormatError
 from infrahub_sdk.utils import is_valid_url
+from infrahub_sdk.uuidt import UUIDT
 from pydantic import BaseModel, Field
 
 from infrahub import config

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union, overload
 
-from infrahub_sdk import UUIDT
 from infrahub_sdk.utils import is_valid_uuid
+from infrahub_sdk.uuidt import UUIDT
 
 from infrahub.core import registry
 from infrahub.core.constants import BranchSupportType, InfrahubKind, RelationshipCardinality

--- a/backend/infrahub/core/node/standard.py
+++ b/backend/infrahub/core/node/standard.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union, get_args, get_origin
 from uuid import UUID
 
 import ujson
-from infrahub_sdk import UUIDT
+from infrahub_sdk.uuidt import UUIDT
 from pydantic import BaseModel
 
 from infrahub.core.constants import NULL_VALUE

--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Generator, Optional, Union
 
-from infrahub_sdk import UUIDT
+from infrahub_sdk.uuidt import UUIDT
 
 from infrahub.core.constants import RelationshipDirection, RelationshipStatus
 from infrahub.core.query import Query, QueryType

--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -17,8 +17,8 @@ from typing import (
     overload,
 )
 
-from infrahub_sdk import UUIDT
 from infrahub_sdk.utils import intersection, is_valid_uuid
+from infrahub_sdk.uuidt import UUIDT
 from pydantic import BaseModel, Field
 
 from infrahub.core import registry

--- a/backend/infrahub/core/timestamp.py
+++ b/backend/infrahub/core/timestamp.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from infrahub_sdk import Timestamp as BaseTimestamp
+from infrahub_sdk.timestamp import Timestamp as BaseTimestamp
 
 if TYPE_CHECKING:
     from pendulum.datetime import DateTime

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -10,12 +10,8 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 import jinja2
 import ujson
 import yaml
-from infrahub_sdk import (
-    InfrahubClient,
-    InfrahubNode,
-    InfrahubRepositoryConfig,
-    ValidationError,
-)
+from infrahub_sdk import InfrahubClient  # noqa: TCH002
+from infrahub_sdk.exceptions import ValidationError
 from infrahub_sdk.protocols import (
     CoreArtifact,
     CoreArtifactDefinition,
@@ -31,6 +27,7 @@ from infrahub_sdk.schema import (
     InfrahubGeneratorDefinitionConfig,
     InfrahubJinja2TransformConfig,
     InfrahubPythonTransformConfig,
+    InfrahubRepositoryConfig,
 )
 from infrahub_sdk.utils import compare_lists
 from infrahub_sdk.yaml import SchemaFile
@@ -46,6 +43,7 @@ if TYPE_CHECKING:
     import types
 
     from infrahub_sdk.checks import InfrahubCheck
+    from infrahub_sdk.node import InfrahubNode
     from infrahub_sdk.schema import InfrahubRepositoryArtifactDefinitionConfig
     from infrahub_sdk.transforms import InfrahubTransform
 

--- a/backend/infrahub/git/repository.py
+++ b/backend/infrahub/git/repository.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any, Optional, Union
 
 from git.exc import BadName, GitCommandError
-from infrahub_sdk import GraphQLError
+from infrahub_sdk.exceptions import GraphQLError
 from pydantic import Field
 
 from infrahub.core.constants import InfrahubKind, RepositoryInternalStatus

--- a/backend/infrahub/graphql/mutations/account.py
+++ b/backend/infrahub/graphql/mutations/account.py
@@ -2,8 +2,8 @@ from typing import TYPE_CHECKING, Any, Dict
 
 from graphene import Boolean, Field, InputField, InputObjectType, Mutation, String
 from graphql import GraphQLResolveInfo
-from infrahub_sdk import UUIDT
 from infrahub_sdk.utils import extract_fields
+from infrahub_sdk.uuidt import UUIDT
 from typing_extensions import Self
 
 from infrahub.auth import AuthType

--- a/backend/infrahub/message_bus/operations/check/generator.py
+++ b/backend/infrahub/message_bus/operations/check/generator.py
@@ -1,7 +1,7 @@
 import os
 
-from infrahub_sdk import InfrahubNode
 from infrahub_sdk.exceptions import ModuleImportError
+from infrahub_sdk.node import InfrahubNode
 from infrahub_sdk.schema import InfrahubGeneratorDefinitionConfig
 from prefect import flow
 

--- a/backend/infrahub/message_bus/operations/check/repository.py
+++ b/backend/infrahub/message_bus/operations/check/repository.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from infrahub_sdk import UUIDT
+from infrahub_sdk.uuidt import UUIDT
 from prefect import flow
 
 from infrahub import lock

--- a/backend/infrahub/message_bus/operations/requests/artifact_definition.py
+++ b/backend/infrahub/message_bus/operations/requests/artifact_definition.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from infrahub_sdk import UUIDT
+from infrahub_sdk.uuidt import UUIDT
 from prefect import flow
 
 from infrahub.core.constants import InfrahubKind, ValidatorConclusion, ValidatorState

--- a/backend/infrahub/message_bus/operations/requests/generator.py
+++ b/backend/infrahub/message_bus/operations/requests/generator.py
@@ -1,7 +1,7 @@
 import os
 
-from infrahub_sdk import InfrahubNode
 from infrahub_sdk.exceptions import ModuleImportError
+from infrahub_sdk.node import InfrahubNode
 from infrahub_sdk.protocols import CoreGeneratorInstance
 from infrahub_sdk.schema import InfrahubGeneratorDefinitionConfig
 from prefect import flow

--- a/backend/infrahub/message_bus/operations/requests/generator_definition.py
+++ b/backend/infrahub/message_bus/operations/requests/generator_definition.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from infrahub_sdk import UUIDT
+from infrahub_sdk.uuidt import UUIDT
 from prefect import flow
 
 from infrahub.core.constants import InfrahubKind, ValidatorConclusion, ValidatorState

--- a/backend/infrahub/message_bus/operations/requests/graphql_query_group.py
+++ b/backend/infrahub/message_bus/operations/requests/graphql_query_group.py
@@ -1,6 +1,7 @@
 from typing import List
 
-from infrahub_sdk import InfrahubClient, InfrahubNode
+from infrahub_sdk import InfrahubClient
+from infrahub_sdk.node import InfrahubNode
 from infrahub_sdk.utils import dict_hash
 from prefect import flow
 

--- a/backend/infrahub/message_bus/operations/requests/repository.py
+++ b/backend/infrahub/message_bus/operations/requests/repository.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from infrahub_sdk import UUIDT
+from infrahub_sdk.uuidt import UUIDT
 from prefect import flow
 
 from infrahub.core.constants import InfrahubKind

--- a/backend/infrahub/services/adapters/message_bus/local.py
+++ b/backend/infrahub/services/adapters/message_bus/local.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Optional, TypeVar
 
 import ujson
-from infrahub_sdk import UUIDT
+from infrahub_sdk.uuidt import UUIDT
 
 from infrahub.dependencies.registry import build_component_registry
 from infrahub.message_bus import InfrahubMessage, Meta

--- a/backend/infrahub/services/adapters/message_bus/nats.py
+++ b/backend/infrahub/services/adapters/message_bus/nats.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Awaitable, Callable, MutableMapping, Optional,
 
 import nats
 import ujson
-from infrahub_sdk import UUIDT
+from infrahub_sdk.uuidt import UUIDT
 from opentelemetry import context, propagate, trace
 from opentelemetry.instrumentation.utils import is_instrumentation_enabled
 

--- a/backend/infrahub/services/adapters/message_bus/rabbitmq.py
+++ b/backend/infrahub/services/adapters/message_bus/rabbitmq.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Awaitable, Callable, MutableMapping, Optional,
 import aio_pika
 import opentelemetry.instrumentation.aio_pika.span_builder
 import ujson
-from infrahub_sdk import UUIDT
+from infrahub_sdk.uuidt import UUIDT
 from opentelemetry.instrumentation.aio_pika import AioPikaInstrumentor
 from opentelemetry.semconv.trace import SpanAttributes
 

--- a/backend/infrahub/tasks/artifact.py
+++ b/backend/infrahub/tasks/artifact.py
@@ -1,6 +1,6 @@
 from typing import Union
 
-from infrahub_sdk import InfrahubNode
+from infrahub_sdk.node import InfrahubNode
 
 from infrahub import lock
 from infrahub.core.constants import InfrahubKind

--- a/backend/tests/adapters/message_bus.py
+++ b/backend/tests/adapters/message_bus.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from typing import Optional, TypeVar
 
 import ujson
-from infrahub_sdk import UUIDT
+from infrahub_sdk.uuidt import UUIDT
 
 from infrahub.components import ComponentType
 from infrahub.database import InfrahubDatabase

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -2,7 +2,8 @@ import os
 from typing import Generator
 
 import pytest
-from infrahub_sdk import UUIDT, Config, InfrahubClient
+from infrahub_sdk import Config, InfrahubClient
+from infrahub_sdk.uuidt import UUIDT
 
 from infrahub import config
 from infrahub.core import registry

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 
 import pytest
 import yaml
-from infrahub_sdk import UUIDT
+from infrahub_sdk.uuidt import UUIDT
 from prefect.testing.utilities import prefect_test_harness
 
 from infrahub import config

--- a/backend/tests/integration/git/test_git_repository.py
+++ b/backend/tests/integration/git/test_git_repository.py
@@ -3,7 +3,8 @@ from pathlib import Path
 
 import pytest
 import yaml
-from infrahub_sdk import Config, InfrahubClient, NodeNotFoundError
+from infrahub_sdk import Config, InfrahubClient
+from infrahub_sdk.exceptions import NodeNotFoundError
 
 from infrahub import config
 from infrahub.core import registry

--- a/backend/tests/test_data/dataset03.py
+++ b/backend/tests/test_data/dataset03.py
@@ -2,7 +2,7 @@ import copy
 from collections import defaultdict
 from ipaddress import IPv4Network
 
-from infrahub_sdk import UUIDT
+from infrahub_sdk.uuidt import UUIDT
 
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -6,7 +6,8 @@ from typing import Any, Dict
 
 import pendulum
 import pytest
-from infrahub_sdk import UUIDT, Config, InfrahubClient
+from infrahub_sdk import Config, InfrahubClient
+from infrahub_sdk.uuidt import UUIDT
 from neo4j._codec.hydration.v1 import HydrationHandler
 from pytest_httpx import HTTPXMock
 

--- a/backend/tests/unit/core/migrations/graph/test_001.py
+++ b/backend/tests/unit/core/migrations/graph/test_001.py
@@ -1,4 +1,4 @@
-from infrahub_sdk import UUIDT
+from infrahub_sdk.uuidt import UUIDT
 
 from infrahub.core.migrations.graph import Migration001
 from infrahub.database import InfrahubDatabase

--- a/backend/tests/unit/core/migrations/schema/test_node_attribute_add.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_attribute_add.py
@@ -1,7 +1,8 @@
 import uuid
 
 import pytest
-from infrahub_sdk import UUIDT, InfrahubClient
+from infrahub_sdk import InfrahubClient
+from infrahub_sdk.uuidt import UUIDT
 
 from infrahub.core.constants import SchemaPathType
 from infrahub.core.migrations.schema.node_attribute_add import (

--- a/backend/tests/unit/core/migrations/schema/test_node_remove.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_remove.py
@@ -1,4 +1,5 @@
-from infrahub_sdk import UUIDT, InfrahubClient
+from infrahub_sdk import InfrahubClient
+from infrahub_sdk.uuidt import UUIDT
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch

--- a/backend/tests/unit/core/test_attribute.py
+++ b/backend/tests/unit/core/test_attribute.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 import pytest
-from infrahub_sdk import UUIDT
+from infrahub_sdk.uuidt import UUIDT
 
 from infrahub import config
 from infrahub.core.attribute import (

--- a/backend/tests/unit/core/test_manager_node.py
+++ b/backend/tests/unit/core/test_manager_node.py
@@ -1,5 +1,5 @@
 import pytest
-from infrahub_sdk import UUIDT
+from infrahub_sdk.uuidt import UUIDT
 
 from infrahub.core.branch import Branch
 from infrahub.core.initialization import create_branch

--- a/backend/tests/unit/core/test_node.py
+++ b/backend/tests/unit/core/test_node.py
@@ -1,5 +1,5 @@
 import pytest
-from infrahub_sdk import UUIDT
+from infrahub_sdk.uuidt import UUIDT
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch

--- a/backend/tests/unit/git/conftest.py
+++ b/backend/tests/unit/git/conftest.py
@@ -8,9 +8,11 @@ from typing import Dict
 import pytest
 import ujson
 from git import Repo
-from infrahub_sdk import UUIDT, Config, InfrahubClient, InfrahubNode
-from infrahub_sdk import SchemaRoot as ClientSchemaRoot
+from infrahub_sdk import Config, InfrahubClient
 from infrahub_sdk.branch import BranchData
+from infrahub_sdk.node import InfrahubNode
+from infrahub_sdk.schema import SchemaRoot as ClientSchemaRoot
+from infrahub_sdk.uuidt import UUIDT
 from pytest_httpx import HTTPXMock
 
 from infrahub.core.constants import InfrahubKind

--- a/backend/tests/unit/git/test_git_read_only_repository.py
+++ b/backend/tests/unit/git/test_git_read_only_repository.py
@@ -2,8 +2,8 @@ import os
 from typing import Dict
 from unittest.mock import AsyncMock
 
-from infrahub_sdk import UUIDT
 from infrahub_sdk.client import Config, InfrahubClient
+from infrahub_sdk.uuidt import UUIDT
 
 from infrahub.git.repository import InfrahubReadOnlyRepository
 from tests.helpers.test_client import dummy_async_request

--- a/backend/tests/unit/git/test_git_repository.py
+++ b/backend/tests/unit/git/test_git_repository.py
@@ -3,8 +3,10 @@ from pathlib import Path
 
 import pytest
 from git import Repo
-from infrahub_sdk import UUIDT, Config, InfrahubClient, InfrahubNode
+from infrahub_sdk import Config, InfrahubClient
 from infrahub_sdk.branch import BranchData
+from infrahub_sdk.node import InfrahubNode
+from infrahub_sdk.uuidt import UUIDT
 from pytest_httpx._httpx_mock import HTTPXMock
 
 from infrahub.core.constants import InfrahubKind

--- a/backend/tests/unit/git/test_git_rpc.py
+++ b/backend/tests/unit/git/test_git_rpc.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Optional
 from unittest.mock import AsyncMock, patch
 
-from infrahub_sdk import UUIDT, Config, InfrahubClient
+from infrahub_sdk import Config, InfrahubClient
+from infrahub_sdk.uuidt import UUIDT
 from typing_extensions import Self
 
 from infrahub.core.constants import InfrahubKind, RepositoryInternalStatus

--- a/backend/tests/unit/git/test_git_transform.py
+++ b/backend/tests/unit/git/test_git_transform.py
@@ -1,4 +1,4 @@
-from infrahub_sdk import UUIDT
+from infrahub_sdk.uuidt import UUIDT
 
 from infrahub.core.constants import InfrahubKind
 from infrahub.git import InfrahubRepository

--- a/backend/tests/unit/graphql/test_mutation_relationship.py
+++ b/backend/tests/unit/graphql/test_mutation_relationship.py
@@ -1,5 +1,5 @@
 from graphql import graphql
-from infrahub_sdk import UUIDT
+from infrahub_sdk.uuidt import UUIDT
 
 from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind

--- a/backend/tests/unit/storage/test_local_storage.py
+++ b/backend/tests/unit/storage/test_local_storage.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import fastapi_storages
 import pytest
-from infrahub_sdk import UUIDT
+from infrahub_sdk.uuidt import UUIDT
 
 from infrahub import config
 from infrahub.exceptions import NodeNotFoundError

--- a/models/examples/security/infrastructure_security.py
+++ b/models/examples/security/infrastructure_security.py
@@ -2,7 +2,9 @@ import logging
 import random
 from ipaddress import IPv4Interface, IPv4Network
 
-from infrahub_sdk import InfrahubClient, InfrahubNode, NodeStore
+from infrahub_sdk import InfrahubClient
+from infrahub_sdk.node import InfrahubNode
+from infrahub_sdk.store import NodeStore
 
 from infrahub_sdk.protocols import CoreAccount
 

--- a/models/infrastructure_edge.py
+++ b/models/infrastructure_edge.py
@@ -7,7 +7,7 @@ from enum import Enum
 from ipaddress import IPv4Network, IPv6Network
 from typing import Optional, cast
 
-from infrahub_sdk import UUIDT, InfrahubClient, NodeStore
+from infrahub_sdk import InfrahubClient
 from infrahub_sdk.batch import InfrahubBatch
 from infrahub_sdk.protocols import (
     CoreAccount,
@@ -18,6 +18,8 @@ from infrahub_sdk.protocols import (
     IpamNamespace,
 )
 from infrahub_sdk.protocols_base import CoreNode
+from infrahub_sdk.store import NodeStore
+from infrahub_sdk.uuidt import UUIDT
 from protocols import (
     InfraAutonomousSystem,
     InfraBGPSession,


### PR DESCRIPTION
This PR depends on https://github.com/opsmill/infrahub-sdk-python/pull/93, after that PR has been merged this PR be rebased to instead point to the latest develop commit for Infrahub SDK.