### PR TITLE
Fix metric missing the query name in Prometheus data

### DIFF
--- a/backend/infrahub/core/node/standard.py
+++ b/backend/infrahub/core/node/standard.py
@@ -207,9 +207,11 @@ class StandardNode(BaseModel):
 
     @classmethod
     async def get_list(
-        cls, db: InfrahubDatabase, limit: int = 1000, ids: Optional[list[str]] = None, **kwargs
+        cls, db: InfrahubDatabase, limit: int = 1000, ids: list[str] | None = None, name: str | None = None, **kwargs
     ) -> list[Self]:
-        query: Query = await StandardNodeGetListQuery.init(db=db, node_class=cls, ids=ids, limit=limit, **kwargs)
+        query: Query = await StandardNodeGetListQuery.init(
+            db=db, node_class=cls, ids=ids, node_name=name, limit=limit, **kwargs
+        )
         await query.execute(db=db)
 
         return [cls.from_db(result.get("n")) for result in query.get_results()]

--- a/backend/infrahub/core/query/standard_node.py
+++ b/backend/infrahub/core/query/standard_node.py
@@ -126,10 +126,10 @@ class StandardNodeGetListQuery(Query):
     type: QueryType = QueryType.WRITE
 
     def __init__(
-        self, node_class: StandardNode, ids: Optional[list[str]] = None, name: Optional[str] = None, **kwargs: Any
+        self, node_class: StandardNode, ids: Optional[list[str]] = None, node_name: Optional[str] = None, **kwargs: Any
     ) -> None:
         self.ids = ids
-        self.name = name
+        self.node_name = node_name
         self.node_class = node_class
 
         super().__init__(**kwargs)
@@ -139,9 +139,9 @@ class StandardNodeGetListQuery(Query):
         if self.ids:
             filters.append("n.uuid in $ids_value")
             self.params["ids_value"] = self.ids
-        if self.name:
+        if self.node_name:
             filters.append("n.name = $name")
-            self.params["name"] = self.name
+            self.params["name"] = self.node_name
 
         where = ""
         if filters:

--- a/changelog/+metric-none.fixed.md
+++ b/changelog/+metric-none.fixed.md
@@ -1,0 +1,1 @@
+Fix metric missing the query name in Prometheus data


### PR DESCRIPTION
This PR fixes a small issue where some metrics in prometheus wouldn't report properly the name of the query. 
The issue was related to the `StandardNodeGetListQuery` query that was overwriting by default the attribute `name`