### PR TITLE
Refactor QueryAnalyzer to GraphProfileGenerator for query benchmarks

### DIFF
--- a/backend/tests/query_benchmark/conftest.py
+++ b/backend/tests/query_benchmark/conftest.py
@@ -5,6 +5,7 @@ import pytest
 
 from infrahub.core.constants import BranchSupportType
 from infrahub.core.schema import SchemaRoot
+from tests.helpers.query_benchmark.db_query_profiler import GraphProfileGenerator
 
 RESULTS_FOLDER = Path(__file__).resolve().parent / "query_performance_results"
 
@@ -54,10 +55,19 @@ async def car_person_schema_root() -> SchemaRoot:
                 ],
                 "relationships": [
                     {"name": "cars", "peer": "TestCar", "cardinality": "many"},
-                    {"name": "animal", "peer": "TestAnimal", "cardinality": "one"},
                 ],
             },
         ],
     }
 
     return SchemaRoot(**schema)
+
+
+@pytest.fixture(scope="session")
+async def graph_generator() -> GraphProfileGenerator:
+    """
+    Use GraphProfileGenerator as a fixture as it may allow to properly generate graphs from
+    distinct tests, instead of having each test managing its own display.
+    """
+
+    return GraphProfileGenerator()

--- a/backend/tests/query_benchmark/test_node_unique_attribute_constraint.py
+++ b/backend/tests/query_benchmark/test_node_unique_attribute_constraint.py
@@ -18,7 +18,7 @@ from tests.helpers.query_benchmark.car_person_generators import (
     CarGeneratorWithOwnerHavingUniqueCar,
 )
 from tests.helpers.query_benchmark.data_generator import load_data_and_profile
-from tests.helpers.query_benchmark.db_query_profiler import BenchmarkConfig
+from tests.helpers.query_benchmark.db_query_profiler import BenchmarkConfig, GraphProfileGenerator
 from tests.query_benchmark.conftest import RESULTS_FOLDER
 from tests.query_benchmark.utils import start_db_and_create_default_branch
 
@@ -28,7 +28,12 @@ log = get_logger()
 
 
 async def benchmark_uniqueness_query(
-    query_request, car_person_schema_root, benchmark_config: BenchmarkConfig, test_params_label: str, test_name: str
+    query_request,
+    car_person_schema_root,
+    graph_generator: GraphProfileGenerator,
+    benchmark_config: BenchmarkConfig,
+    test_params_label: str,
+    test_name: str,
 ):
     """
     Profile NodeUniqueAttributeConstraintQuery with a given query_request / configuration, using a Car generator.
@@ -68,6 +73,7 @@ async def benchmark_uniqueness_query(
         nb_elements=nb_cars,
         graphs_output_location=graph_output_location,
         test_label=test_params_label,
+        graph_generator=graph_generator,
     )
 
 
@@ -96,7 +102,7 @@ async def benchmark_uniqueness_query(
         ),
     ],
 )
-async def test_multiple_constraints(query_request, car_person_schema_root):
+async def test_multiple_constraints(query_request, car_person_schema_root, graph_generator):
     benchmark_config = BenchmarkConfig(neo4j_runtime=Neo4jRuntime.DEFAULT, neo4j_image=NEO4J_ENTERPRISE_IMAGE)
     await benchmark_uniqueness_query(
         query_request=query_request,
@@ -104,6 +110,7 @@ async def test_multiple_constraints(query_request, car_person_schema_root):
         benchmark_config=benchmark_config,
         test_params_label=str(query_request),
         test_name=inspect.currentframe().f_code.co_name,
+        graph_generator=graph_generator,
     )
 
 
@@ -115,7 +122,7 @@ async def test_multiple_constraints(query_request, car_person_schema_root):
         BenchmarkConfig(neo4j_runtime=Neo4jRuntime.PARALLEL, neo4j_image=NEO4J_ENTERPRISE_IMAGE),
     ],
 )
-async def test_multiple_runtimes(benchmark_config, car_person_schema_root):
+async def test_multiple_runtimes(benchmark_config, car_person_schema_root, graph_generator):
     query_request = NodeUniquenessQueryRequest(
         kind="TestCar",
         unique_attribute_paths={
@@ -133,6 +140,7 @@ async def test_multiple_runtimes(benchmark_config, car_person_schema_root):
         benchmark_config=benchmark_config,
         test_params_label=str(benchmark_config),
         test_name=inspect.currentframe().f_code.co_name,
+        graph_generator=graph_generator,
     )
 
 
@@ -140,10 +148,10 @@ async def test_multiple_runtimes(benchmark_config, car_person_schema_root):
     "benchmark_config",
     [
         BenchmarkConfig(neo4j_runtime=Neo4jRuntime.PARALLEL, neo4j_image=NEO4J_ENTERPRISE_IMAGE, load_db_indexes=False),
-        BenchmarkConfig(neo4j_runtime=Neo4jRuntime.PARALLEL, neo4j_image=NEO4J_ENTERPRISE_IMAGE, load_db_indexes=True),
+        # BenchmarkConfig(neo4j_runtime=Neo4jRuntime.PARALLEL, neo4j_image=NEO4J_ENTERPRISE_IMAGE, load_db_indexes=True),
     ],
 )
-async def test_indexes(benchmark_config, car_person_schema_root):
+async def test_indexes(benchmark_config, car_person_schema_root, graph_generator):
     query_request = NodeUniquenessQueryRequest(
         kind="TestCar",
         unique_attribute_paths={
@@ -161,4 +169,5 @@ async def test_indexes(benchmark_config, car_person_schema_root):
         benchmark_config=benchmark_config,
         test_params_label=str(benchmark_config),
         test_name=inspect.currentframe().f_code.co_name,
+        graph_generator=graph_generator,
     )


### PR DESCRIPTION
This PR refactors `QueyrAnalyzer` to `GraphProfileGenerator`:
- `QueryMeasurement` computed when profiling are now stored directly within `InfrahubDatabaseProfiler`.
- `GraphProfileGenerator` is only responsible for generating graphes out of a list of `QueryMeasurement`.
- `graph_generator` is meant to be used as a scope-session fixture as it may be later used to handle graphs generation/display of distinct tests.