### PR TITLE
address circular imports around GraphQLSchemaManager

### DIFF
--- a/backend/infrahub/core/branch.py
+++ b/backend/infrahub/core/branch.py
@@ -119,13 +119,13 @@ class Branch(StandardNode):  # pylint: disable=too-many-public-methods
 
         return False
 
-    def update_schema_hash(self, at: Optional[Union[Timestamp, str]] = None) -> bool:
+    def update_schema_hash(self, at: Timestamp | str | None = None) -> bool:
         latest_schema = registry.schema.get_schema_branch(name=self.name)
-        self.schema_changed_at = Timestamp(at).to_string()
         new_hash = latest_schema.get_hash_full()
         if self.schema_hash and new_hash.main == self.schema_hash.main:
             return False
 
+        self.schema_changed_at = Timestamp(at).to_string()
         self.schema_hash = new_hash
         return True
 

--- a/backend/infrahub/core/schema/manager.py
+++ b/backend/infrahub/core/schema/manager.py
@@ -560,7 +560,6 @@ class SchemaManager(NodeManager):
         branch_schema = await self.load_schema_from_db(
             db=db, branch=branch, schema=current_schema, schema_diff=schema_diff
         )
-        branch_schema.clear_cache()
         self.set_schema_branch(name=branch.name, schema=branch_schema)
         return branch_schema
 

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -118,7 +118,7 @@ class SchemaBranch:
     def get_hash(self) -> str:
         """Calculate the hash for this objects based on the content of nodes and generics.
 
-        Since the object themselves are considered immuable we just need to use the hash from each object to calculate the global hash.
+        Since the object themselves are considered immutable we just need to use the hash from each object to calculate the global hash.
         """
         md5hash = hashlib.md5(usedforsecurity=False)
         for key, value in sorted(tuple(self.nodes.items()) + tuple(self.generics.items())):

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -45,7 +45,6 @@ from infrahub.core.schema import (
 from infrahub.core.schema.definitions.core import core_profile_schema_definition
 from infrahub.core.validators import CONSTRAINT_VALIDATOR_MAP
 from infrahub.exceptions import SchemaNotFoundError, ValidationError
-from infrahub.graphql.manager import GraphQLSchemaManager
 from infrahub.log import get_logger
 from infrahub.types import ATTRIBUTE_TYPES
 from infrahub.utils import format_label
@@ -56,7 +55,6 @@ from .constants import INTERNAL_SCHEMA_NODE_KINDS, SchemaNamespace
 log = get_logger()
 
 if TYPE_CHECKING:
-    from graphql import GraphQLSchema
     from pydantic import ValidationInfo
 
 
@@ -70,8 +68,6 @@ class SchemaBranch:
         self.nodes: dict[str, str] = {}
         self.generics: dict[str, str] = {}
         self.profiles: dict[str, str] = {}
-        self._graphql_schema: Optional[GraphQLSchema] = None
-        self._graphql_manager: Optional[GraphQLSchemaManager] = None
 
         if data:
             self.nodes = data.get("nodes", {})
@@ -164,31 +160,6 @@ class SchemaBranch:
                 cache[node_hash] = node
 
         return cls(cache=cache, data=nodes)
-
-    def clear_cache(self) -> None:
-        self._graphql_manager = None
-        self._graphql_schema = None
-
-    def get_graphql_manager(self) -> GraphQLSchemaManager:
-        if not self._graphql_manager:
-            self._graphql_manager = GraphQLSchemaManager(schema=self)
-        return self._graphql_manager
-
-    def get_graphql_schema(
-        self,
-        include_query: bool = True,
-        include_mutation: bool = True,
-        include_subscription: bool = True,
-        include_types: bool = True,
-    ) -> GraphQLSchema:
-        if not self._graphql_schema:
-            self._graphql_schema = self.get_graphql_manager().generate(
-                include_query=include_query,
-                include_mutation=include_mutation,
-                include_subscription=include_subscription,
-                include_types=include_types,
-            )
-        return self._graphql_schema
 
     def diff(self, other: SchemaBranch) -> SchemaDiff:
         # Identify the nodes or generics that have been added or removed

--- a/backend/infrahub/graphql/api/endpoints.py
+++ b/backend/infrahub/graphql/api/endpoints.py
@@ -4,8 +4,8 @@ from graphql import print_schema
 from starlette.routing import Route, WebSocketRoute
 
 from infrahub.api.dependencies import get_branch_dep
-from infrahub.core import registry
 from infrahub.core.branch import Branch
+from infrahub.graphql.manager import GraphQLSchemaManager
 
 from .dependencies import build_graphql_app
 
@@ -21,7 +21,6 @@ router.routes.append(WebSocketRoute(path="/graphql/{branch_name:str}", endpoint=
 
 @router.get("/schema.graphql", include_in_schema=False)
 async def get_graphql_schema(branch: Branch = Depends(get_branch_dep)) -> PlainTextResponse:
-    schema = registry.schema.get_schema_branch(name=branch.name)
-    gql_schema = schema.get_graphql_schema()
-
-    return PlainTextResponse(content=print_schema(gql_schema))
+    gqlm = GraphQLSchemaManager.get_manager_for_branch(branch=branch)
+    graphql_schema = gqlm.get_graphql_schema()
+    return PlainTextResponse(content=print_schema(graphql_schema))

--- a/backend/infrahub/graphql/api/endpoints.py
+++ b/backend/infrahub/graphql/api/endpoints.py
@@ -4,6 +4,7 @@ from graphql import print_schema
 from starlette.routing import Route, WebSocketRoute
 
 from infrahub.api.dependencies import get_branch_dep
+from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.graphql.manager import GraphQLSchemaManager
 
@@ -21,6 +22,7 @@ router.routes.append(WebSocketRoute(path="/graphql/{branch_name:str}", endpoint=
 
 @router.get("/schema.graphql", include_in_schema=False)
 async def get_graphql_schema(branch: Branch = Depends(get_branch_dep)) -> PlainTextResponse:
-    gqlm = GraphQLSchemaManager.get_manager_for_branch(branch=branch)
+    schema_branch = registry.schema.get_schema_branch(name=branch.name)
+    gqlm = GraphQLSchemaManager.get_manager_for_branch(branch=branch, schema_branch=schema_branch)
     graphql_schema = gqlm.get_graphql_schema()
     return PlainTextResponse(content=print_schema(graphql_schema))

--- a/backend/infrahub/graphql/initialization.py
+++ b/backend/infrahub/graphql/initialization.py
@@ -63,7 +63,8 @@ def prepare_graphql_params(
     include_types: bool = True,
 ) -> GraphqlParams:
     branch = registry.get_branch_from_registry(branch=branch)
-    gqlm = GraphQLSchemaManager.get_manager_for_branch(branch=branch)
+    schema_branch = registry.schema.get_schema_branch(name=branch.name)
+    gqlm = GraphQLSchemaManager.get_manager_for_branch(branch=branch, schema_branch=schema_branch)
     gql_schema = gqlm.get_graphql_schema(
         include_query=include_query,
         include_mutation=include_mutation,

--- a/backend/infrahub/graphql/manager.py
+++ b/backend/infrahub/graphql/manager.py
@@ -115,6 +115,10 @@ class GraphQLSchemaManager:  # pylint: disable=too-many-public-methods
     _branch_details_by_name: dict[str, BranchDetails] = {}
 
     @classmethod
+    def clear_cache(cls) -> None:
+        cls._branch_details_by_name = {}
+
+    @classmethod
     def _cache_branch(
         cls, branch: Branch, schema_branch: SchemaBranch, schema_hash: str | None = None
     ) -> BranchDetails:

--- a/backend/infrahub/graphql/subscription/__init__.py
+++ b/backend/infrahub/graphql/subscription/__init__.py
@@ -1,23 +1,37 @@
-from typing import Any, Iterable, Optional
+from typing import Any, AsyncGenerator
 
-from graphene import ObjectType
+from graphene import Field, Int, ObjectType, Schema, String
+from graphene.types.generic import GenericScalar
 from graphql import GraphQLResolveInfo
 
-from .graphql_query import GraphQLQuerySubscription, resolver_graphql_query
+from .graphql_query import resolver_graphql_query
+
+GraphQLQuerySubscription = Field(
+    GenericScalar(),
+    name=String(),
+    params=GenericScalar(required=False),
+    interval=Int(required=False),
+)
 
 
 class InfrahubBaseSubscription(ObjectType):
     query = GraphQLQuerySubscription
+    graphql_schema: Schema | None = None
 
-    @staticmethod
+    @classmethod
     async def subscribe_query(
+        cls,
         parent: dict,  # pylint: disable=unused-argument
         info: GraphQLResolveInfo,
         name: str,
-        params: Optional[dict[str, Any]] = None,
-        interval: Optional[int] = 10,
-    ) -> Iterable[dict]:
+        params: dict[str, Any] | None = None,
+        interval: int | None = 10,
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        if not cls.graphql_schema:
+            raise RuntimeError("Subscription initialized without graphql schema")
+        if not interval:
+            interval = 10
         async for result in resolver_graphql_query(
-            parent=parent, info=info, name=name, params=params, interval=interval
+            parent=parent, info=info, name=name, graphql_schema=cls.graphql_schema, params=params, interval=interval
         ):
             yield result

--- a/backend/tests/unit/graphql/test_graphql_utils.py
+++ b/backend/tests/unit/graphql/test_graphql_utils.py
@@ -1,11 +1,30 @@
-from graphql import parse
+from graphql import GraphQLSchema, parse
 from infrahub_sdk.utils import extract_fields
 
+from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.analyzer import extract_schema_models
-from infrahub.graphql.initialization import generate_graphql_schema
+from infrahub.graphql.manager import GraphQLSchemaManager
+
+
+def generate_graphql_schema(
+    db: InfrahubDatabase,  # pylint: disable=unused-argument
+    branch: Branch | str,
+    include_query: bool = True,
+    include_mutation: bool = True,
+    include_subscription: bool = True,
+    include_types: bool = True,
+) -> GraphQLSchema:
+    branch = registry.get_branch_from_registry(branch)
+    schema = registry.schema.get_schema_branch(name=branch.name)
+    return GraphQLSchemaManager(schema=schema).generate(
+        include_query=include_query,
+        include_mutation=include_mutation,
+        include_subscription=include_subscription,
+        include_types=include_types,
+    )
 
 
 async def test_schema_models(db: InfrahubDatabase, default_branch: Branch, car_person_schema_generics, query_01: str):

--- a/backend/tests/unit/graphql/test_manager.py
+++ b/backend/tests/unit/graphql/test_manager.py
@@ -266,8 +266,7 @@ async def test_branch_caching_hit(
 ):
     right_now = Timestamp()
     default_branch.schema_changed_at = right_now
-    same_branch = await registry.branch_object.get_by_name(db=db, name=default_branch.name)
-    same_branch.schema_changed_at = right_now
+    same_branch = default_branch.model_copy()
 
     manager1 = GraphQLSchemaManager.get_manager_for_branch(branch=default_branch)
     manager2 = GraphQLSchemaManager.get_manager_for_branch(branch=same_branch)

--- a/backend/tests/unit/graphql/test_mutation_create.py
+++ b/backend/tests/unit/graphql/test_mutation_create.py
@@ -819,8 +819,10 @@ async def test_create_with_attribute_not_valid(db: InfrahubDatabase, default_bra
 
 
 async def test_create_with_uniqueness_constraint_violation(db: InfrahubDatabase, default_branch, car_person_schema):
-    car_schema = registry.schema.get("TestCar", branch=default_branch, duplicate=False)
+    schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+    car_schema = schema_branch.get("TestCar", duplicate=True)
     car_schema.uniqueness_constraints = [["owner", "color"]]
+    schema_branch.set(name="TestCar", schema=car_schema)
 
     p1 = await Node.init(db=db, schema="TestPerson")
     await p1.new(db=db, name="Bruce Wayne", height=180)

--- a/backend/tests/unit/graphql/test_mutation_update.py
+++ b/backend/tests/unit/graphql/test_mutation_update.py
@@ -8,6 +8,7 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
+from infrahub.graphql.manager import GraphQLSchemaManager
 
 
 async def test_update_simple_object(db: InfrahubDatabase, person_john_main: Node, branch: Branch):
@@ -85,6 +86,7 @@ async def test_update_simple_object_with_enum(
     enum_value,
     response_value,
 ):
+    GraphQLSchemaManager.clear_cache()
     config.SETTINGS.experimental_features.graphql_enums = graphql_enums_on
     query = """
     mutation {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,10 +342,6 @@ module = "infrahub.graphql.resolver"
 ignore_errors = true
 
 [[tool.mypy.overrides]]
-module = "infrahub.graphql.subscription"
-ignore_errors = true
-
-[[tool.mypy.overrides]]
 module = "infrahub.graphql.types.standard_node"
 ignore_errors = true
 


### PR DESCRIPTION
removes `GraphQLSchemaManager` references from `SchemaBranch` b/c this dependency has caused circular import errors for me and Graphql-related logic should not be inside of our core logic
you might want to import `SchemaBranch` without wanting to import a bunch of GraphQL stuff too

`SchemaBranch` was caching an instance of `GraphQLSchemaManager` and `GraphQLSchema` which required moving this caching logic over to `GraphQLSchemaManager` which now has some classmethods that cache these instances and use `Branch.schema_changed_at` and `SchemaBranch.schema_hash` to determine when to invalidate a cached instance of `GraphQLSchemaManager`

the CodeSpeed report is correct that my changes make generating a `GraphQLSchema` slower, but this is because there was also a circular dependency within our code to generate a `GraphQLSchema`. `GraphQLSchema.get_gql_subscription` eventually required a complete `GraphQLSchema` within `resolver_graphql_query`. this issue was obscured by caching `GraphQLSchema` on a `SchemaBranch`, but it was an actual circular dependency error b/ `GraphQLSchema.generate` required a complete `GraphQLSchema`, which could only be produced by calling `GraphQLSchema.generate`. my solution was to generate a partial `graphene.Schema` without subscription information and use that partial schema to create the subscription information before generating the full schema. this does take a little longer, but this will be cached once it is created and only need to be recalculated if the schema changes, so I don't think it is too much of a problem