### PR TITLE
Fix conflicting permissions resolver.

### DIFF
--- a/backend/infrahub/graphql/manager.py
+++ b/backend/infrahub/graphql/manager.py
@@ -48,6 +48,7 @@ from .resolver import (
     default_resolver,
     descendants_resolver,
     many_relationship_resolver,
+    parent_field_name_resolver,
     single_relationship_resolver,
 )
 from .schema import InfrahubBaseMutation, InfrahubBaseQuery
@@ -886,7 +887,9 @@ class GraphQLSchemaManager:  # pylint: disable=too-many-public-methods
         }
 
         if isinstance(schema, (NodeSchema, GenericSchema)):
-            main_attrs["permissions"] = graphene.Field(PaginatedObjectPermission, required=True)
+            main_attrs["permissions"] = graphene.Field(
+                PaginatedObjectPermission, required=True, resolver=parent_field_name_resolver
+            )
 
         graphql_paginated_object = type(object_name, (InfrahubObject,), main_attrs)
 

--- a/backend/infrahub/graphql/resolver.py
+++ b/backend/infrahub/graphql/resolver.py
@@ -118,6 +118,15 @@ async def default_resolver(*args: Any, **kwargs) -> dict | list[dict] | None:
         return await objs[0].to_graphql(db=db, fields=fields, related_node_ids=context.related_node_ids)
 
 
+async def parent_field_name_resolver(parent: dict[str, dict], info: GraphQLResolveInfo) -> dict:
+    """This resolver gets used when we know that the parent resolver has already gathered the required information.
+
+    An example of this is the permissions field at the top level within default_paginated_list_resolver()
+    """
+
+    return parent[info.field_name]
+
+
 async def default_paginated_list_resolver(
     root: dict,  # pylint: disable=unused-argument
     info: GraphQLResolveInfo,


### PR DESCRIPTION
After adding "permissions" to the top level we can run into problems with specific queries such as this one:

```graphql
query GET_ROLE_MANAGEMENT_ROLES {
  CoreAccountRole {
    permissions {
      count
      edges {
        node {
          kind
        }
      }
    }
    __typename
    edges {
      node {
        display_label
      }
    }
  }
}
```

The response to this query would be:

```json
{
  "data": {
    "CoreAccountRole": null
  },
  "errors": [
    {
      "message": "'id'",
      "locations": [
        {
          "line": 3,
          "column": 5
        }
      ],
      "path": [
        "CoreAccountRole",
        "permissions"
      ]
    }
  ]
}
```

What happens is that we use the `default_resolver` to return the information that we've already gathered and this works for most Node types, however specifically CoreAccountRole has a relationship using the name `permissions` so instead of returning the data correctly when we'd do this for other object types within the default resolver:
https://github.com/opsmill/infrahub/blob/infrahub-v0.16.4/backend/infrahub/graphql/resolver.py#L52-L53

We continue and then instead hit a `KeyError` for the missing `id` key a bit further down:
https://github.com/opsmill/infrahub/blob/infrahub-v0.16.4/backend/infrahub/graphql/resolver.py#L74

This PR introduces a new resolver that is currently only used for the `permissions` and it just returns the information we have already gathered.