### PR TITLE
Fix number pool allocation report for deleted nodes

### DIFF
--- a/backend/tests/unit/core/resource_manager/test_number_pool.py
+++ b/backend/tests/unit/core/resource_manager/test_number_pool.py
@@ -24,3 +24,10 @@ async def test_allocate_from_number_pool(db: InfrahubDatabase, default_branch: B
 
     assert ticket1.ticket_id.value == 1
     assert ticket2.ticket_id.value == 2
+
+    # If a resource is deleted the allocated number should be returned to the pool
+    await ticket2.delete(db=db)
+    recreated_ticket2 = await Node.init(db=db, schema=TICKET.kind)
+    await recreated_ticket2.new(db=db, title="ticket2", ticket_id={"from_pool": {"id": np1.id}})
+    await recreated_ticket2.save(db=db)
+    assert recreated_ticket2.ticket_id.value == 2


### PR DESCRIPTION
This PR updates the `NumberPoolGetAllocated` query to correctly avoid listing deleted nodes when displaying the allocated entries of the number pool. The `NumberPoolGetUsed` query has been updated to ensure that we only count entries that are linked to a correct attribute type that is currently active.

Fixes #4617.

While this PR corrects the allocation report there is still a reference internally for the allocation so more work is needed to correctly release the number back into the pool. This might be something we need to look at as an event that gets triggered when we delete nodes. We have this situation for the address pools as well.