### PR TITLE
Properly delete inherited attribute and relationship on Node

### DIFF
--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1275,6 +1275,7 @@ class SchemaBranch:
             self.set(name=name, schema=node)
 
     def cleanup_inherited_elements(self) -> None:
+        # pylint: disable=too-many-branches
         for name in self.node_names:
             node = self.get_node(name=name, duplicate=False)
 

--- a/changelog/4301.fixed.md
+++ b/changelog/4301.fixed.md
@@ -1,0 +1,1 @@
+In the schema, properly delete inherited attribute and relationship on Node  when the original attribute or relationship are being deleted on the Generic.


### PR DESCRIPTION
Fixes #4301 

This PR fixes #4301 by validating that all inherited attributes and relationships are accounted for. This way if the Generic is being updated or even removed from the attributes the associated nodes will be updated as well
