### PR TITLE
Add final uuid to order_by clause

### DIFF
--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -859,6 +859,7 @@ class NodeGetListQuery(Query):
                 self.order_by.append(far.final_value_query_variable)
                 continue
             self.order_by.append(far.node_value_query_variable)
+        self.order_by.append("n.uuid")
 
     async def _add_node_filter_attributes(
         self,

--- a/backend/tests/helpers/schema/__init__.py
+++ b/backend/tests/helpers/schema/__init__.py
@@ -9,6 +9,7 @@ from .car import CAR
 from .manufacturer import MANUFACTURER
 from .person import PERSON
 from .ticket import TICKET
+from .widget import WIDGET
 
 if TYPE_CHECKING:
     from infrahub.database import InfrahubDatabase
@@ -29,4 +30,4 @@ async def load_schema(db: InfrahubDatabase, schema: SchemaRoot, branch_name: str
     )
 
 
-__all__ = ["CAR", "CAR_SCHEMA", "MANUFACTURER", "PERSON", "TICKET"]
+__all__ = ["CAR", "CAR_SCHEMA", "MANUFACTURER", "PERSON", "TICKET", "WIDGET"]

--- a/backend/tests/helpers/schema/widget.py
+++ b/backend/tests/helpers/schema/widget.py
@@ -1,0 +1,16 @@
+from infrahub.core.schema import AttributeSchema, NodeSchema
+
+WIDGET = NodeSchema(
+    name="Widget",
+    namespace="Testing",
+    label="Widget",
+    default_filter="name__value",
+    order_by=["name__value"],
+    attributes=[
+        AttributeSchema(name="name", kind="Text", optional=False),
+        AttributeSchema(name="description", kind="Text", optional=True),
+        AttributeSchema(name="height", kind="Number", optional=True),
+        AttributeSchema(name="weight", kind="Number", optional=True),
+    ],
+    inherit_from=["LineageOwner", "LineageSource"],
+)


### PR DESCRIPTION
Currently there's a problem with the pagination that can show up on some node types depending on what the node schema looks like. The failing condition seems to be if the node has an `order_by` clause and that it's looking at a field that is non unique. This can happen with interfaces where we typically have multiple interfaces called `Ethernet1`, as the initial query used to find nodes start by ordering by this field there's a possibility that the same node would show up on multiple pages.

This PR solves this problem by adding a final sorting option where we sort by the non unique name first followed by the uuid of the node which should never be duplicated.

Fixes #4700