### PR TITLE
Add description to permission schema

### DIFF
--- a/backend/infrahub/api/schema.py
+++ b/backend/infrahub/api/schema.py
@@ -249,8 +249,6 @@ async def load_schema(
             db=db,
             account_id=account_session.account_id,
             permission=GlobalPermission(
-                id="",
-                name="",
                 action=GlobalPermissions.MANAGE_SCHEMA.value,
                 decision=(
                     PermissionDecision.ALLOW_DEFAULT

--- a/backend/infrahub/core/account.py
+++ b/backend/infrahub/core/account.py
@@ -110,24 +110,13 @@ class AccountGlobalPermissionQuery(Query):
 
         CALL {
             WITH global_permission
-            MATCH (global_permission)-[r1:HAS_ATTRIBUTE]->(:Attribute {name: "description"})-[r2:HAS_VALUE]->(global_permission_description:AttributeValue)
-            WHERE all(r IN [r1, r2] WHERE (%(branch_filter)s))
-            RETURN global_permission_description, (r1.status = "active" AND r2.status = "active") AS is_active
-            ORDER BY r2.branch_level DESC, r2.from DESC, r1.branch_level DESC, r1.from DESC
-            LIMIT 1
-        }
-        WITH global_permission, global_permission_description, is_active AS gpn_is_active
-        WHERE gpn_is_active = TRUE
-
-        CALL {
-            WITH global_permission
             MATCH (global_permission)-[r1:HAS_ATTRIBUTE]->(:Attribute {name: "action"})-[r2:HAS_VALUE]->(global_permission_action:AttributeValue)
             WHERE all(r IN [r1, r2] WHERE (%(branch_filter)s))
             RETURN global_permission_action, (r1.status = "active" AND r2.status = "active") AS is_active
             ORDER BY r2.branch_level DESC, r2.from DESC, r1.branch_level DESC, r1.from DESC
             LIMIT 1
         }
-        WITH global_permission, global_permission_description, global_permission_action, is_active AS gpa_is_active
+        WITH global_permission, global_permission_action, is_active AS gpa_is_active
         WHERE gpa_is_active = TRUE
 
         CALL {
@@ -138,7 +127,7 @@ class AccountGlobalPermissionQuery(Query):
             ORDER BY r2.branch_level DESC, r2.from DESC, r1.branch_level DESC, r1.from DESC
             LIMIT 1
         }
-        WITH global_permission, global_permission_description, global_permission_action, global_permission_decision, is_active AS gpd_is_active
+        WITH global_permission, global_permission_action, global_permission_decision, is_active AS gpd_is_active
         WHERE gpd_is_active = TRUE
         """ % {
             "branch_filter": branch_filter,
@@ -150,12 +139,7 @@ class AccountGlobalPermissionQuery(Query):
 
         self.add_to_query(query)
 
-        self.return_labels = [
-            "global_permission",
-            "global_permission_description",
-            "global_permission_action",
-            "global_permission_decision",
-        ]
+        self.return_labels = ["global_permission", "global_permission_action", "global_permission_decision"]
 
     def get_permissions(self) -> list[GlobalPermission]:
         permissions: list[GlobalPermission] = []
@@ -164,7 +148,6 @@ class AccountGlobalPermissionQuery(Query):
             permissions.append(
                 GlobalPermission(
                     id=result.get("global_permission").get("uuid"),
-                    description=result.get("global_permission_description").get("value"),
                     action=result.get("global_permission_action").get("value"),
                     decision=result.get("global_permission_decision").get("value"),
                 )
@@ -240,24 +223,13 @@ class AccountObjectPermissionQuery(Query):
 
         CALL {
             WITH object_permission
-            MATCH (object_permission)-[r1:HAS_ATTRIBUTE]->(:Attribute {name: "description"})-[r2:HAS_VALUE]->(object_permission_description:AttributeValue)
-            WHERE all(r IN [r1, r2] WHERE (%(branch_filter)s))
-            RETURN object_permission_description, (r1.status = "active" AND r2.status = "active") AS is_active
-            ORDER BY r2.branch_level DESC, r2.from DESC, r1.branch_level DESC, r1.from DESC
-            LIMIT 1
-        }
-        WITH object_permission, object_permission_description, is_active AS opn_is_active
-        WHERE opn_is_active = TRUE
-
-        CALL {
-            WITH object_permission
             MATCH (object_permission)-[r1:HAS_ATTRIBUTE]->(:Attribute {name: "namespace"})-[r2:HAS_VALUE]->(object_permission_namespace:AttributeValue)
             WHERE all(r IN [r1, r2] WHERE (%(branch_filter)s))
             RETURN object_permission_namespace, (r1.status = "active" AND r2.status = "active") AS is_active
             ORDER BY r2.branch_level DESC, r2.from DESC, r1.branch_level DESC, r1.from DESC
             LIMIT 1
         }
-        WITH object_permission, object_permission_description, object_permission_namespace, is_active AS opn_is_active
+        WITH object_permission, object_permission_namespace, is_active AS opn_is_active
         WHERE opn_is_active = TRUE
         CALL {
             WITH object_permission
@@ -267,7 +239,7 @@ class AccountObjectPermissionQuery(Query):
             ORDER BY r2.branch_level DESC, r2.from DESC, r1.branch_level DESC, r1.from DESC
             LIMIT 1
         }
-        WITH object_permission, object_permission_description, object_permission_namespace, object_permission_name, is_active AS opn_is_active
+        WITH object_permission, object_permission_namespace, object_permission_name, is_active AS opn_is_active
         WHERE opn_is_active = TRUE
         CALL {
             WITH object_permission
@@ -277,7 +249,7 @@ class AccountObjectPermissionQuery(Query):
             ORDER BY r2.branch_level DESC, r2.from DESC, r1.branch_level DESC, r1.from DESC
             LIMIT 1
         }
-        WITH object_permission, object_permission_description, object_permission_namespace, object_permission_name, object_permission_action, is_active AS opa_is_active
+        WITH object_permission, object_permission_namespace, object_permission_name, object_permission_action, is_active AS opa_is_active
         WHERE opa_is_active = TRUE
         CALL {
             WITH object_permission
@@ -287,7 +259,7 @@ class AccountObjectPermissionQuery(Query):
             ORDER BY r2.branch_level DESC, r2.from DESC, r1.branch_level DESC, r1.from DESC
             LIMIT 1
         }
-        WITH object_permission, object_permission_description, object_permission_namespace, object_permission_name, object_permission_action, object_permission_decision, is_active AS opd_is_active
+        WITH object_permission, object_permission_namespace, object_permission_name, object_permission_action, object_permission_decision, is_active AS opd_is_active
         WHERE opd_is_active = TRUE
         """ % {
             "branch_filter": branch_filter,
@@ -301,7 +273,6 @@ class AccountObjectPermissionQuery(Query):
 
         self.return_labels = [
             "object_permission",
-            "object_permission_description",
             "object_permission_namespace",
             "object_permission_name",
             "object_permission_action",
@@ -314,7 +285,6 @@ class AccountObjectPermissionQuery(Query):
             permissions.append(
                 ObjectPermission(
                     id=result.get("object_permission").get("uuid"),
-                    description=result.get("object_permission_description").get("value"),
                     namespace=result.get("object_permission_namespace").get("value"),
                     name=result.get("object_permission_name").get("value"),
                     action=result.get("object_permission_action").get("value"),

--- a/backend/infrahub/core/initialization.py
+++ b/backend/infrahub/core/initialization.py
@@ -32,7 +32,6 @@ from infrahub.menu.menu import default_menu
 from infrahub.menu.utils import create_menu_children
 from infrahub.permissions import PermissionBackend
 from infrahub.storage import InfrahubObjectStorage
-from infrahub.utils import format_label
 
 log = get_logger()
 
@@ -307,9 +306,9 @@ async def create_super_administrator_role(db: InfrahubDatabase) -> Node:
     permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
     await permission.new(
         db=db,
-        name=format_label(GlobalPermissions.SUPER_ADMIN.value),
         action=GlobalPermissions.SUPER_ADMIN.value,
         decision=PermissionDecision.ALLOW_ALL.value,
+        description="Allow a user to do anything",
     )
     await permission.save(db=db)
     log.info(f"Created global permission: {GlobalPermissions.SUPER_ADMIN}")
@@ -327,43 +326,43 @@ async def create_default_roles(db: InfrahubDatabase) -> Node:
     repo_permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
     await repo_permission.new(
         db=db,
-        name=format_label(GlobalPermissions.MANAGE_REPOSITORIES.value),
         action=GlobalPermissions.MANAGE_REPOSITORIES.value,
         decision=PermissionDecision.ALLOW_ALL.value,
+        description="Allow a user to manage repositories",
     )
     await repo_permission.save(db=db)
 
     schema_permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
     await schema_permission.new(
         db=db,
-        name=format_label(GlobalPermissions.MANAGE_SCHEMA.value),
         action=GlobalPermissions.MANAGE_SCHEMA.value,
         decision=PermissionDecision.ALLOW_ALL.value,
+        description="Allow a user to manage the schema",
     )
     await schema_permission.save(db=db)
 
     proposed_change_permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
     await proposed_change_permission.new(
         db=db,
-        name=format_label(GlobalPermissions.MERGE_PROPOSED_CHANGE.value),
         action=GlobalPermissions.MERGE_PROPOSED_CHANGE.value,
         decision=PermissionDecision.ALLOW_ALL.value,
+        description="Allow a user to merge proposed changes",
     )
     await proposed_change_permission.save(db=db)
 
     # Other permissions, created to keep references of them from the start
-    for permission_action in (
-        GlobalPermissions.EDIT_DEFAULT_BRANCH,
-        GlobalPermissions.MANAGE_ACCOUNTS,
-        GlobalPermissions.MANAGE_PERMISSIONS,
-        GlobalPermissions.MERGE_BRANCH,
+    for permission_action, permission_description in (
+        (GlobalPermissions.EDIT_DEFAULT_BRANCH, "Allow a user to change data in the default branch"),
+        (GlobalPermissions.MANAGE_ACCOUNTS, "Allow a user to manage accounts, account roles and account groups"),
+        (GlobalPermissions.MANAGE_PERMISSIONS, "Allow a user to manage permissions"),
+        (GlobalPermissions.MERGE_BRANCH, "Allow a user to merge branches"),
     ):
         permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
         await permission.new(
             db=db,
-            name=format_label(permission_action.value),
             action=permission_action.value,
             decision=PermissionDecision.ALLOW_ALL.value,
+            description=permission_description,
         )
         await permission.save(db=db)
 
@@ -374,6 +373,7 @@ async def create_default_roles(db: InfrahubDatabase) -> Node:
         namespace="*",
         action=PermissionAction.VIEW.value,
         decision=PermissionDecision.ALLOW_ALL.value,
+        description="Allow a user to view any object in any branch",
     )
     await view_permission.save(db=db)
 
@@ -384,6 +384,7 @@ async def create_default_roles(db: InfrahubDatabase) -> Node:
         namespace="*",
         action=PermissionAction.ANY.value,
         decision=PermissionDecision.ALLOW_OTHER.value,
+        description="Allow a user to change data in non-default branches",
     )
     await modify_permission.save(db=db)
 

--- a/backend/infrahub/core/protocols.py
+++ b/backend/infrahub/core/protocols.py
@@ -68,7 +68,6 @@ class CoreArtifactTarget(CoreNode):
 
 class CoreBasePermission(CoreNode):
     description: StringOptional
-    decision: Enum
     identifier: StringOptional
     roles: RelationshipManager
 
@@ -345,6 +344,7 @@ class CoreGeneratorValidator(CoreValidator):
 
 class CoreGlobalPermission(CoreBasePermission):
     action: Dropdown
+    decision: Enum
 
 
 class CoreGraphQLQuery(CoreNode):
@@ -395,6 +395,7 @@ class CoreObjectPermission(CoreBasePermission):
     namespace: String
     name: String
     action: Enum
+    decision: Enum
 
 
 class CoreObjectThread(CoreThread):

--- a/backend/infrahub/core/protocols.py
+++ b/backend/infrahub/core/protocols.py
@@ -67,6 +67,7 @@ class CoreArtifactTarget(CoreNode):
 
 
 class CoreBasePermission(CoreNode):
+    description: StringOptional
     decision: Enum
     identifier: StringOptional
     roles: RelationshipManager
@@ -343,7 +344,6 @@ class CoreGeneratorValidator(CoreValidator):
 
 
 class CoreGlobalPermission(CoreBasePermission):
-    name: String
     action: Dropdown
 
 

--- a/backend/infrahub/core/schema/definitions/core.py
+++ b/backend/infrahub/core/schema/definitions/core.py
@@ -935,6 +935,7 @@ core_models: dict[str, Any] = {
             "include_in_menu": False,
             "generate_profile": False,
             "attributes": [
+                {"name": "description", "kind": "Text", "optional": True},
                 {
                     "name": "decision",
                     "kind": "Number",
@@ -2169,13 +2170,12 @@ core_models: dict[str, Any] = {
             "description": "A permission that grants global rights to perform actions in Infrahub",
             "label": "Global permission",
             "include_in_menu": False,
-            "order_by": ["name__value", "action__value"],
-            "display_labels": ["name__value"],
+            "order_by": ["action__value"],
+            "display_labels": ["action__value"],
             "generate_profile": False,
             "inherit_from": [InfrahubKind.BASEPERMISSION],
             "branch": BranchSupportType.AGNOSTIC.value,
             "attributes": [
-                {"name": "name", "kind": "Text", "unique": True, "order_weight": 1000},
                 {
                     "name": "action",
                     "kind": "Dropdown",

--- a/backend/infrahub/core/schema/definitions/core.py
+++ b/backend/infrahub/core/schema/definitions/core.py
@@ -943,8 +943,8 @@ core_models: dict[str, Any] = {
                     "default_value": PermissionDecision.ALLOW_ALL.value,
                     "order_weight": 5000,
                     "description": (
-                        "Decide whether to deny or allow the action. If allowed, it can be configured for the default branch, any other "
-                        "branches or all branches"
+                        "Decide to deny or allow the action. If allowed, it can be configured for the default branch, any other branches or all "
+                        "branches"
                     ),
                 },
                 {

--- a/backend/infrahub/core/schema/definitions/core.py
+++ b/backend/infrahub/core/schema/definitions/core.py
@@ -937,17 +937,6 @@ core_models: dict[str, Any] = {
             "attributes": [
                 {"name": "description", "kind": "Text", "optional": True},
                 {
-                    "name": "decision",
-                    "kind": "Number",
-                    "enum": PermissionDecision.available_types(),
-                    "default_value": PermissionDecision.ALLOW_ALL.value,
-                    "order_weight": 5000,
-                    "description": (
-                        "Decide to deny or allow the action. If allowed, it can be configured for the default branch, any other branches or all "
-                        "branches"
-                    ),
-                },
-                {
                     "name": "identifier",
                     "kind": "Text",
                     "read_only": True,
@@ -2186,6 +2175,14 @@ core_models: dict[str, Any] = {
                     "choices": [{"name": permission.value} for permission in GlobalPermissions],
                     "order_weight": 2000,
                 },
+                {
+                    "name": "decision",
+                    "kind": "Number",
+                    "enum": PermissionDecision.available_types(),
+                    "default_value": PermissionDecision.ALLOW_ALL.value,
+                    "order_weight": 3000,
+                    "description": "Decide to deny or allow the action at a global level",
+                },
             ],
         },
         {
@@ -2208,6 +2205,17 @@ core_models: dict[str, Any] = {
                     "enum": PermissionAction.available_types(),
                     "default_value": PermissionAction.ANY.value,
                     "order_weight": 4000,
+                },
+                {
+                    "name": "decision",
+                    "kind": "Number",
+                    "enum": PermissionDecision.available_types(),
+                    "default_value": PermissionDecision.ALLOW_ALL.value,
+                    "order_weight": 5000,
+                    "description": (
+                        "Decide to deny or allow the action. If allowed, it can be configured for the default branch, any other branches or all "
+                        "branches"
+                    ),
                 },
             ],
         },

--- a/backend/infrahub/core/schema/definitions/core.py
+++ b/backend/infrahub/core/schema/definitions/core.py
@@ -942,6 +942,10 @@ core_models: dict[str, Any] = {
                     "enum": PermissionDecision.available_types(),
                     "default_value": PermissionDecision.ALLOW_ALL.value,
                     "order_weight": 5000,
+                    "description": (
+                        "Decide whether to deny or allow the action. If allowed, it can be configured for the default branch, any other "
+                        "branches or all branches"
+                    ),
                 },
                 {
                     "name": "identifier",

--- a/backend/infrahub/graphql/auth/query_permission_checker/default_branch_checker.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/default_branch_checker.py
@@ -15,7 +15,7 @@ class DefaultBranchPermissionChecker(GraphQLQueryPermissionCheckerInterface):
     """Checker that makes sure a user account can edit data in the default branch."""
 
     permission_required = GlobalPermission(
-        id="", name="", action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value, decision=PermissionDecision.ALLOW_ALL.value
+        action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value, decision=PermissionDecision.ALLOW_ALL.value
     )
     exempt_operations = [
         "BranchCreate",

--- a/backend/infrahub/graphql/auth/query_permission_checker/merge_operation_checker.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/merge_operation_checker.py
@@ -15,7 +15,7 @@ class MergeBranchPermissionChecker(GraphQLQueryPermissionCheckerInterface):
     """Checker that makes sure a user account can merge a branch without going through a proposed change."""
 
     permission_required = GlobalPermission(
-        id="", name="", action=GlobalPermissions.MERGE_BRANCH.value, decision=PermissionDecision.ALLOW_ALL.value
+        action=GlobalPermissions.MERGE_BRANCH.value, decision=PermissionDecision.ALLOW_ALL.value
     )
 
     async def supports(self, db: InfrahubDatabase, account_session: AccountSession, branch: Branch) -> bool:

--- a/backend/infrahub/graphql/auth/query_permission_checker/object_permission_checker.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/object_permission_checker.py
@@ -61,7 +61,6 @@ class ObjectPermissionChecker(GraphQLQueryPermissionCheckerInterface):
                 extracted_words = extract_camelcase_words(kind)
                 permissions.append(
                     ObjectPermission(
-                        id="",
                         namespace=extracted_words[0],
                         name="".join(extracted_words[1:]),
                         action=action.lower(),
@@ -88,7 +87,7 @@ class AccountManagerPermissionChecker(GraphQLQueryPermissionCheckerInterface):
     """
 
     permission_required = GlobalPermission(
-        id="", name="", action=GlobalPermissions.MANAGE_ACCOUNTS.value, decision=PermissionDecision.ALLOW_ALL.value
+        action=GlobalPermissions.MANAGE_ACCOUNTS.value, decision=PermissionDecision.ALLOW_ALL.value
     )
 
     async def supports(self, db: InfrahubDatabase, account_session: AccountSession, branch: Branch) -> bool:
@@ -139,7 +138,7 @@ class PermissionManagerPermissionChecker(GraphQLQueryPermissionCheckerInterface)
     """
 
     permission_required = GlobalPermission(
-        id="", name="", action=GlobalPermissions.MANAGE_PERMISSIONS.value, decision=PermissionDecision.ALLOW_ALL.value
+        action=GlobalPermissions.MANAGE_PERMISSIONS.value, decision=PermissionDecision.ALLOW_ALL.value
     )
 
     async def supports(self, db: InfrahubDatabase, account_session: AccountSession, branch: Branch) -> bool:
@@ -184,7 +183,7 @@ class RepositoryManagerPermissionChecker(GraphQLQueryPermissionCheckerInterface)
     """
 
     permission_required = GlobalPermission(
-        id="", name="", action=GlobalPermissions.MANAGE_REPOSITORIES.value, decision=PermissionDecision.ALLOW_ALL.value
+        action=GlobalPermissions.MANAGE_REPOSITORIES.value, decision=PermissionDecision.ALLOW_ALL.value
     )
 
     async def supports(self, db: InfrahubDatabase, account_session: AccountSession, branch: Branch) -> bool:

--- a/backend/infrahub/graphql/auth/query_permission_checker/super_admin_checker.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/super_admin_checker.py
@@ -14,7 +14,7 @@ class SuperAdminPermissionChecker(GraphQLQueryPermissionCheckerInterface):
     """Checker allows a user to do anything (if the checker runs first)."""
 
     permission_required = GlobalPermission(
-        id="", name="", action=GlobalPermissions.SUPER_ADMIN.value, decision=PermissionDecision.ALLOW_ALL.value
+        action=GlobalPermissions.SUPER_ADMIN.value, decision=PermissionDecision.ALLOW_ALL.value
     )
 
     async def supports(self, db: InfrahubDatabase, account_session: AccountSession, branch: Branch) -> bool:

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -110,8 +110,6 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
                     db=context.db,
                     account_id=context.active_account_session.account_id,
                     permission=GlobalPermission(
-                        id="",
-                        name="",
                         action=GlobalPermissions.MERGE_PROPOSED_CHANGE.value,
                         decision=PermissionDecision.ALLOW_ALL.value,
                     ),

--- a/backend/infrahub/graphql/queries/account.py
+++ b/backend/infrahub/graphql/queries/account.py
@@ -70,6 +70,7 @@ AccountToken = Field(
 
 class AccountGlobalPermissionNode(ObjectType):
     id = Field(String, required=True)
+    description = Field(String, required=False)
     name = Field(String, required=True)
     action = Field(String, required=True)
     decision = Field(String, required=True)
@@ -78,7 +79,7 @@ class AccountGlobalPermissionNode(ObjectType):
 
 class AccountObjectPermissionNode(ObjectType):
     id = Field(String, required=True)
-    branch = Field(String, required=True)
+    description = Field(String, required=False)
     namespace = Field(String, required=True)
     name = Field(String, required=True)
     action = Field(String, required=True)
@@ -135,7 +136,7 @@ async def resolve_account_permissions(
             {
                 "node": {
                     "id": obj.id,
-                    "name": obj.name,
+                    "description": obj.description,
                     "action": obj.action,
                     "decision": obj.decision,
                     "identifier": str(obj),
@@ -150,6 +151,7 @@ async def resolve_account_permissions(
             {
                 "node": {
                     "id": obj.id,
+                    "description": obj.description,
                     "namespace": obj.namespace,
                     "name": obj.name,
                     "action": obj.action,

--- a/backend/infrahub/permissions/local_backend.py
+++ b/backend/infrahub/permissions/local_backend.py
@@ -92,7 +92,7 @@ class LocalPermissionBackend(PermissionBackend):
         is_super_admin = self.resolve_global_permission(
             permissions=granted_permissions["global_permissions"],
             permission_to_check=GlobalPermission(
-                id="", name="", action=GlobalPermissions.SUPER_ADMIN, decision=PermissionDecision.ALLOW_ALL
+                action=GlobalPermissions.SUPER_ADMIN, decision=PermissionDecision.ALLOW_ALL
             ),
         )
 

--- a/backend/infrahub/permissions/report.py
+++ b/backend/infrahub/permissions/report.py
@@ -47,16 +47,13 @@ async def report_schema_permissions(
     is_super_admin = perm_backend.resolve_global_permission(
         permissions=permissions["global_permissions"],
         permission_to_check=GlobalPermission(
-            id="", name="", action=GlobalPermissions.SUPER_ADMIN.value, decision=PermissionDecision.ALLOW_ALL.value
+            action=GlobalPermissions.SUPER_ADMIN.value, decision=PermissionDecision.ALLOW_ALL.value
         ),
     )
     can_edit_default_branch = perm_backend.resolve_global_permission(
         permissions=permissions["global_permissions"],
         permission_to_check=GlobalPermission(
-            id="",
-            name="",
-            action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value,
-            decision=PermissionDecision.ALLOW_ALL.value,
+            action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value, decision=PermissionDecision.ALLOW_ALL.value
         ),
     )
 

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -55,7 +55,6 @@ from infrahub.core.utils import delete_all_nodes
 from infrahub.database import InfrahubDatabase
 from infrahub.dependencies.registry import build_component_registry
 from infrahub.git import InfrahubRepository
-from infrahub.utils import format_label
 from tests.helpers.file_repo import FileRepo
 from tests.helpers.test_client import dummy_async_request
 from tests.test_data import dataset01 as ds01

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -2541,10 +2541,7 @@ async def create_test_admin(db: InfrahubDatabase, register_core_models_schema, d
     permissions: list[Node] = []
     global_permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
     await global_permission.new(
-        db=db,
-        name=format_label(GlobalPermissions.SUPER_ADMIN.value),
-        action=GlobalPermissions.SUPER_ADMIN.value,
-        decision=PermissionDecision.ALLOW_ALL.value,
+        db=db, action=GlobalPermissions.SUPER_ADMIN.value, decision=PermissionDecision.ALLOW_ALL.value
     )
     await global_permission.save(db=db)
     permissions.append(global_permission)

--- a/backend/tests/unit/graphql/auth/query_permission_checker/test_default_branch_checker.py
+++ b/backend/tests/unit/graphql/auth/query_permission_checker/test_default_branch_checker.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 import pytest
 
 from infrahub.auth import AccountSession, AuthType
-from infrahub.core.constants import AccountRole, GlobalPermissions, InfrahubKind
+from infrahub.core.constants import AccountRole, GlobalPermissions, InfrahubKind, PermissionDecision
 from infrahub.core.node import Node
 from infrahub.core.registry import registry
 from infrahub.exceptions import PermissionDeniedError
@@ -39,7 +39,7 @@ class TestDefaultBranchPermission:
 
         permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
         await permission.new(
-            db=db, name=GlobalPermissions.EDIT_DEFAULT_BRANCH.value, action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value
+            db=db, action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value, decision=PermissionDecision.ALLOW_ALL.value
         )
         await permission.save(db=db)
 

--- a/backend/tests/unit/graphql/auth/query_permission_checker/test_merge_operation_checker.py
+++ b/backend/tests/unit/graphql/auth/query_permission_checker/test_merge_operation_checker.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 import pytest
 
 from infrahub.auth import AccountSession, AuthType
-from infrahub.core.constants import AccountRole, GlobalPermissions, InfrahubKind
+from infrahub.core.constants import AccountRole, GlobalPermissions, InfrahubKind, PermissionDecision
 from infrahub.core.node import Node
 from infrahub.core.registry import registry
 from infrahub.exceptions import PermissionDeniedError
@@ -39,7 +39,7 @@ class TestMergeBranchPermission:
 
         permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
         await permission.new(
-            db=db, name=GlobalPermissions.MERGE_BRANCH.value, action=GlobalPermissions.MERGE_BRANCH.value
+            db=db, action=GlobalPermissions.MERGE_BRANCH.value, decision=PermissionDecision.ALLOW_ALL.value
         )
         await permission.save(db=db)
 

--- a/backend/tests/unit/graphql/auth/query_permission_checker/test_object_permission_checker.py
+++ b/backend/tests/unit/graphql/auth/query_permission_checker/test_object_permission_checker.py
@@ -232,14 +232,12 @@ class TestObjectPermissions:
         permissions = []
         for object_permission in [
             ObjectPermission(
-                id="",
                 namespace="Builtin",
                 name="*",
                 action=PermissionAction.ANY.value,
                 decision=PermissionDecision.ALLOW_DEFAULT.value,
             ),
             ObjectPermission(
-                id="",
                 namespace="Core",
                 name="GraphQLQuery",
                 action=PermissionAction.VIEW.value,
@@ -376,7 +374,7 @@ class TestAccountManagerPermissions:
 
         permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
         await permission.new(
-            db=db, name=GlobalPermissions.MANAGE_ACCOUNTS.value, action=GlobalPermissions.MANAGE_ACCOUNTS.value
+            db=db, action=GlobalPermissions.MANAGE_ACCOUNTS.value, decision=PermissionDecision.ALLOW_ALL.value
         )
         await permission.save(db=db)
 
@@ -491,7 +489,7 @@ class TestPermissionManagerPermissions:
 
         permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
         await permission.new(
-            db=db, name=GlobalPermissions.MANAGE_PERMISSIONS.value, action=GlobalPermissions.MANAGE_PERMISSIONS.value
+            db=db, action=GlobalPermissions.MANAGE_PERMISSIONS.value, decision=PermissionDecision.ALLOW_ALL.value
         )
         await permission.save(db=db)
 
@@ -605,7 +603,7 @@ class TestRepositoryManagerPermissions:
 
         permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
         await permission.new(
-            db=db, name=GlobalPermissions.MANAGE_REPOSITORIES.value, action=GlobalPermissions.MANAGE_REPOSITORIES.value
+            db=db, action=GlobalPermissions.MANAGE_REPOSITORIES.value, decision=PermissionDecision.ALLOW_ALL.value
         )
         await permission.save(db=db)
 

--- a/backend/tests/unit/graphql/auth/query_permission_checker/test_super_admin_checker.py
+++ b/backend/tests/unit/graphql/auth/query_permission_checker/test_super_admin_checker.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 import pytest
 
 from infrahub.auth import AccountSession, AuthType
-from infrahub.core.constants import AccountRole, GlobalPermissions, InfrahubKind
+from infrahub.core.constants import AccountRole, GlobalPermissions, InfrahubKind, PermissionDecision
 from infrahub.core.node import Node
 from infrahub.core.registry import registry
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
@@ -38,7 +38,7 @@ class TestSuperAdminPermission:
 
         permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
         await permission.new(
-            db=db, name=GlobalPermissions.SUPER_ADMIN.value, action=GlobalPermissions.SUPER_ADMIN.value
+            db=db, action=GlobalPermissions.SUPER_ADMIN.value, decision=PermissionDecision.ALLOW_ALL.value
         )
         await permission.save(db=db)
 

--- a/backend/tests/unit/graphql/queries/test_list_permissions.py
+++ b/backend/tests/unit/graphql/queries/test_list_permissions.py
@@ -104,35 +104,30 @@ class TestObjectPermissions:
         permissions = []
         for object_permission in [
             ObjectPermission(
-                id="",
                 namespace="Builtin",
                 name="*",
                 action=PermissionAction.VIEW.value,
                 decision=PermissionDecisionFlag.ALLOW_ALL,
             ),
             ObjectPermission(
-                id="",
                 namespace="Builtin",
                 name="*",
                 action=PermissionAction.CREATE.value,
                 decision=PermissionDecisionFlag.ALLOW_OTHER,
             ),
             ObjectPermission(
-                id="",
                 namespace="Builtin",
                 name="*",
                 action=PermissionAction.DELETE.value,
                 decision=PermissionDecisionFlag.ALLOW_OTHER,
             ),
             ObjectPermission(
-                id="",
                 namespace="Core",
                 name="*",
                 action=PermissionAction.ANY.value,
                 decision=PermissionDecisionFlag.ALLOW_OTHER,
             ),
             ObjectPermission(
-                id="",
                 namespace="Core",
                 name="*",
                 action=PermissionAction.VIEW.value,
@@ -319,28 +314,24 @@ class TestAttributePermissions:
         permissions = []
         for object_permission in [
             ObjectPermission(
-                id="",
                 namespace="Builtin",
                 name="*",
                 action=PermissionAction.VIEW.value,
                 decision=PermissionDecisionFlag.ALLOW_ALL,
             ),
             ObjectPermission(
-                id="",
                 namespace="Builtin",
                 name="*",
                 action=PermissionAction.CREATE.value,
                 decision=PermissionDecisionFlag.ALLOW_ALL,
             ),
             ObjectPermission(
-                id="",
                 namespace="Builtin",
                 name="*",
                 action=PermissionAction.DELETE.value,
                 decision=PermissionDecisionFlag.ALLOW_ALL,
             ),
             ObjectPermission(
-                id="",
                 namespace="Builtin",
                 name="*",
                 action=PermissionAction.UPDATE.value,

--- a/backend/tests/unit/graphql/test_core_account.py
+++ b/backend/tests/unit/graphql/test_core_account.py
@@ -86,25 +86,14 @@ async def test_permissions(
     assert result.errors is None
     perms = [edge["node"]["identifier"] for edge in result.data["InfrahubPermissions"]["global_permissions"]["edges"]]
     assert perms == [
-        str(
-            GlobalPermission(
-                id="",
-                name=GlobalPermissions.SUPER_ADMIN.value,
-                action=GlobalPermissions.SUPER_ADMIN.value,
-                decision=PermissionDecision.ALLOW_ALL.value,
-            )
-        )
+        str(GlobalPermission(action=GlobalPermissions.SUPER_ADMIN.value, decision=PermissionDecision.ALLOW_ALL.value))
     ]
 
     perms = [edge["node"]["identifier"] for edge in result.data["InfrahubPermissions"]["object_permissions"]["edges"]]
     assert perms == [
         str(
             ObjectPermission(
-                id="",
-                namespace="*",
-                name="*",
-                action=PermissionAction.ANY.value,
-                decision=PermissionDecision.ALLOW_ALL.value,
+                namespace="*", name="*", action=PermissionAction.ANY.value, decision=PermissionDecision.ALLOW_ALL.value
             )
         )
     ]

--- a/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
+++ b/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
@@ -128,8 +128,8 @@ async def test_get_proposed_change_schema_integrity_constraints(
     )
     non_generate_profile_constraints = [c for c in constraints if c.constraint_name != "node.generate_profile.update"]
     # should be updated/removed when ConstraintValidatorDeterminer is updated (#2592)
-    assert len(constraints) == 181
-    assert len(non_generate_profile_constraints) == 109
+    assert len(constraints) == 180
+    assert len(non_generate_profile_constraints) == 108
     dumped_constraints = [c.model_dump() for c in non_generate_profile_constraints]
     assert {
         "constraint_name": "relationship.optional.update",

--- a/backend/tests/unit/permissions/test_backends.py
+++ b/backend/tests/unit/permissions/test_backends.py
@@ -19,11 +19,7 @@ async def test_load_permissions(db: InfrahubDatabase, default_branch: Branch, cr
     assert "object_permissions" in permissions
     assert str(permissions["object_permissions"][0]) == str(
         ObjectPermission(
-            id="",
-            namespace="*",
-            name="*",
-            action=PermissionAction.ANY.value,
-            decision=PermissionDecision.ALLOW_ALL.value,
+            namespace="*", name="*", action=PermissionAction.ANY.value, decision=PermissionDecision.ALLOW_ALL.value
         )
     )
 
@@ -47,10 +43,7 @@ async def test_has_permission_global(
     backend = LocalPermissionBackend()
 
     allow_default_branch_edition = GlobalPermission(
-        id="",
-        action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value,
-        decision=PermissionDecision.ALLOW_ALL.value,
-        name="Edit default branch",
+        action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value, decision=PermissionDecision.ALLOW_ALL.value
     )
 
     role1_permissions = []
@@ -78,12 +71,7 @@ async def test_has_permission_global(
     role2_permissions = []
     for p in [
         allow_default_branch_edition,
-        GlobalPermission(
-            id="",
-            action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value,
-            decision=PermissionDecision.DENY.value,
-            name="Edit default branch",
-        ),
+        GlobalPermission(action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value, decision=PermissionDecision.DENY.value),
     ]:
         obj = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
         await obj.new(db=db, name=p.name, action=p.action, decision=p.decision)
@@ -122,18 +110,10 @@ async def test_has_permission_object(
     role1_permissions = []
     for p in [
         ObjectPermission(
-            id="",
-            namespace="*",
-            name="*",
-            action=PermissionAction.ANY.value,
-            decision=PermissionDecision.ALLOW_ALL.value,
+            namespace="*", name="*", action=PermissionAction.ANY.value, decision=PermissionDecision.ALLOW_ALL.value
         ),
         ObjectPermission(
-            id="",
-            namespace="Builtin",
-            name="Tag",
-            action=PermissionAction.ANY.value,
-            decision=PermissionDecision.DENY.value,
+            namespace="Builtin", name="Tag", action=PermissionAction.ANY.value, decision=PermissionDecision.DENY.value
         ),
     ]:
         obj = await Node.init(db=db, schema=InfrahubKind.OBJECTPERMISSION)
@@ -155,14 +135,9 @@ async def test_has_permission_object(
     role2_permissions = []
     for p in [
         ObjectPermission(
-            id="",
-            namespace="*",
-            name="*",
-            action=PermissionAction.ANY.value,
-            decision=PermissionDecision.DENY.value,
+            namespace="*", name="*", action=PermissionAction.ANY.value, decision=PermissionDecision.DENY.value
         ),
         ObjectPermission(
-            id="",
             namespace="Builtin",
             name="Tag",
             action=PermissionAction.ANY.value,
@@ -186,7 +161,6 @@ async def test_has_permission_object(
     await group2.members.save(db=db)
 
     permission = ObjectPermission(
-        id="",
         namespace="Builtin",
         name="Tag",
         action=PermissionAction.CREATE.value,
@@ -213,18 +187,10 @@ async def test_report_permission_object(
     role1_permissions = []
     for p in [
         ObjectPermission(
-            id="",
-            namespace="*",
-            name="*",
-            action=PermissionAction.ANY.value,
-            decision=PermissionDecision.ALLOW_ALL.value,
+            namespace="*", name="*", action=PermissionAction.ANY.value, decision=PermissionDecision.ALLOW_ALL.value
         ),
         ObjectPermission(
-            id="",
-            namespace="Builtin",
-            name="Tag",
-            action=PermissionAction.ANY.value,
-            decision=PermissionDecision.DENY.value,
+            namespace="Builtin", name="Tag", action=PermissionAction.ANY.value, decision=PermissionDecision.DENY.value
         ),
     ]:
         obj = await Node.init(db=db, schema=InfrahubKind.OBJECTPERMISSION)
@@ -246,14 +212,9 @@ async def test_report_permission_object(
     role2_permissions = []
     for p in [
         ObjectPermission(
-            id="",
-            namespace="*",
-            name="*",
-            action=PermissionAction.ANY.value,
-            decision=PermissionDecision.DENY.value,
+            namespace="*", name="*", action=PermissionAction.ANY.value, decision=PermissionDecision.DENY.value
         ),
         ObjectPermission(
-            id="",
             namespace="Builtin",
             name="Tag",
             action=PermissionAction.ANY.value,

--- a/backend/tests/unit/permissions/test_backends.py
+++ b/backend/tests/unit/permissions/test_backends.py
@@ -74,7 +74,7 @@ async def test_has_permission_global(
         GlobalPermission(action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value, decision=PermissionDecision.DENY.value),
     ]:
         obj = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
-        await obj.new(db=db, name=p.name, action=p.action, decision=p.decision)
+        await obj.new(db=db, action=p.action, decision=p.decision)
         await obj.save(db=db)
         role2_permissions.append(obj)
 

--- a/backend/tests/unit/permissions/test_backends.py
+++ b/backend/tests/unit/permissions/test_backends.py
@@ -48,12 +48,7 @@ async def test_has_permission_global(
 
     role1_permissions = []
     obj = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
-    await obj.new(
-        db=db,
-        name=allow_default_branch_edition.name,
-        action=allow_default_branch_edition.action,
-        decision=allow_default_branch_edition.decision,
-    )
+    await obj.new(db=db, action=allow_default_branch_edition.action, decision=allow_default_branch_edition.decision)
     await obj.save(db=db)
     role1_permissions.append(obj)
 

--- a/frontend/app/src/graphql/queries/role-management/getGlobalPermissions.ts
+++ b/frontend/app/src/graphql/queries/role-management/getGlobalPermissions.ts
@@ -8,9 +8,6 @@ export const GET_ROLE_MANAGEMENT_GLOBAL_PERMISSIONS = gql`
         node {
           id
           display_label
-          name {
-            value
-          }
           action {
             value
           }

--- a/frontend/app/src/screens/role-management/global-permissions-form.tsx
+++ b/frontend/app/src/screens/role-management/global-permissions-form.tsx
@@ -125,6 +125,9 @@ export const GlobalPermissionForm = ({
         <DropdownField
           name="decision"
           label="Decision"
+          description={
+            schema?.attributes?.find((attribute) => attribute.name === "decision")?.description
+          }
           items={globalDecisionOptions}
           rules={{ required: true, validate: { required: isRequired } }}
         />

--- a/frontend/app/src/screens/role-management/global-permissions-form.tsx
+++ b/frontend/app/src/screens/role-management/global-permissions-form.tsx
@@ -19,7 +19,6 @@ import { FieldValues, useForm } from "react-hook-form";
 import { toast } from "react-toastify";
 
 import DropdownField from "@/components/form/fields/dropdown.field";
-import InputField from "@/components/form/fields/input.field";
 import RelationshipField from "@/components/form/fields/relationship.field";
 import { getRelationshipDefaultValue } from "@/components/form/utils/getRelationshipDefaultValue";
 import { isRequired } from "@/components/form/utils/validation";
@@ -47,7 +46,6 @@ export const GlobalPermissionForm = ({
   });
 
   const defaultValues = {
-    name: getCurrentFieldValue("name", currentObject),
     action: getCurrentFieldValue("action", currentObject),
     decision: getCurrentFieldValue("decision", currentObject),
     roles,
@@ -117,17 +115,6 @@ export const GlobalPermissionForm = ({
   return (
     <div className={"bg-custom-white flex flex-col flex-1 overflow-auto p-4"}>
       <Form form={form} onSubmit={handleSubmit}>
-        <InputField
-          name="name"
-          label="Name"
-          rules={{
-            required: true,
-            validate: {
-              required: isRequired,
-            },
-          }}
-        />
-
         <DropdownField
           name="action"
           label="Action"


### PR DESCRIPTION
The description (optional) attribute is used to describe the purpose or effect of a permission. This PR also removes the name attribute from the global permission schema as it would be a duplicate of the description field in its use.