### PR TITLE
TestInfrahubApp.client fixture set services.service.client

### DIFF
--- a/backend/tests/integration/diff/test_diff_rebase.py
+++ b/backend/tests/integration/diff/test_diff_rebase.py
@@ -290,7 +290,6 @@ class TestDiffRebase(TestInfrahubApp):
         branch_1: Branch,
         branch_2: Branch,
         diff_repository: DiffRepository,
-        set_service_client,
     ):
         kara_id = initial_dataset["kara"].id
         jesko_id = initial_dataset["jesko"].id
@@ -376,7 +375,6 @@ class TestDiffRebase(TestInfrahubApp):
         branch_2: Branch,
         diff_repository: DiffRepository,
         initial_dataset,
-        set_service_client,
     ):
         cyberdyne_id = initial_dataset["cyberdyne"].id
         branch_2_diff = await diff_repository.get_one(

--- a/backend/tests/integration/git/test_readonly_repository.py
+++ b/backend/tests/integration/git/test_readonly_repository.py
@@ -58,7 +58,6 @@ class TestCreateReadOnlyRepository(TestInfrahubApp):
         initial_dataset: None,
         git_repos_source_dir_module_scope: Path,
         client: InfrahubClient,
-        set_service_client,
     ) -> None:
         branch = await client.branch.create(branch_name="ro_repository", sync_with_git=False)
 
@@ -85,14 +84,19 @@ class TestCreateReadOnlyRepository(TestInfrahubApp):
         assert check_definition.file_path.value == "checks/car_overview.py"
 
     async def test_step02_validate_generated_artifacts(
-        self, db: InfrahubDatabase, client: InfrahubClient, set_service_client
+        self,
+        db: InfrahubDatabase,
+        client: InfrahubClient,
     ):
         artifacts = await client.all(kind=InfrahubKind.ARTIFACT, branch="ro_repository")
         assert artifacts
         assert artifacts[0].name.value == "Ownership report"
 
     async def test_step03_merge_branch(
-        self, db: InfrahubDatabase, client: InfrahubClient, helper: TestHelper, set_service_client
+        self,
+        db: InfrahubDatabase,
+        client: InfrahubClient,
+        helper: TestHelper,
     ):
         await client.branch.merge(branch_name="ro_repository")
 

--- a/backend/tests/integration/ipam/test_ipam_merge_reconcile.py
+++ b/backend/tests/integration/ipam/test_ipam_merge_reconcile.py
@@ -40,7 +40,12 @@ class TestIpamMergeReconcile(TestIpamReconcileBase):
         return await create_branch(db=db, branch_name="delete_prefix")
 
     async def test_step01_add_address(
-        self, db: InfrahubDatabase, initial_dataset, client: InfrahubClient, branch_1, new_address_1, set_service_client
+        self,
+        db: InfrahubDatabase,
+        initial_dataset,
+        client: InfrahubClient,
+        branch_1,
+        new_address_1,
     ) -> None:
         success = await client.branch.merge(branch_name=branch_1.name)
         assert success is True
@@ -51,7 +56,12 @@ class TestIpamMergeReconcile(TestIpamReconcileBase):
         assert parent_rels[0].peer_id == initial_dataset["net140"].id
 
     async def test_step02_add_delete_prefix(
-        self, db: InfrahubDatabase, initial_dataset, client: InfrahubClient, branch_2, new_address_1, set_service_client
+        self,
+        db: InfrahubDatabase,
+        initial_dataset,
+        client: InfrahubClient,
+        branch_2,
+        new_address_1,
     ) -> None:
         prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=branch_2)
         new_prefix = await Node.init(schema=prefix_schema, db=db, branch=registry.default_branch)

--- a/backend/tests/integration/ipam/test_proposed_change_reconcile.py
+++ b/backend/tests/integration/ipam/test_proposed_change_reconcile.py
@@ -51,7 +51,12 @@ class TestProposedChangeReconcile(TestIpamReconcileBase):
         return await create_branch(db=db, branch_name="delete_prefix")
 
     async def test_step01_add_address(
-        self, db: InfrahubDatabase, initial_dataset, client: InfrahubClient, branch_1, new_address_1, set_service_client
+        self,
+        db: InfrahubDatabase,
+        initial_dataset,
+        client: InfrahubClient,
+        branch_1,
+        new_address_1,
     ) -> None:
         proposed_change_create = await client.create(
             kind=InfrahubKind.PROPOSEDCHANGE,
@@ -67,7 +72,12 @@ class TestProposedChangeReconcile(TestIpamReconcileBase):
         assert parent_rels[0].peer_id == initial_dataset["net140"].id
 
     async def test_step02_add_delete_prefix(
-        self, db: InfrahubDatabase, initial_dataset, client: InfrahubClient, branch_2, new_address_1, set_service_client
+        self,
+        db: InfrahubDatabase,
+        initial_dataset,
+        client: InfrahubClient,
+        branch_2,
+        new_address_1,
     ) -> None:
         proposed_change_create = await client.create(
             kind=InfrahubKind.PROPOSEDCHANGE,

--- a/backend/tests/integration/proposed_change/test_proposed_change_repository.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_repository.py
@@ -71,11 +71,11 @@ class TestProposedChangePipelineRepository(TestInfrahubApp):
         await richard.new(db=db, name="Richard", height=180, description="The less famous Richard Doe")
         await richard.save(db=db)
 
-    @pytest.mark.xfail(
-        reason="FIXME Test is passing locally but it's failing in CI, could be related to #4685 and/or #4699"
-    )
     async def test_create_proposed_change(
-        self, db: InfrahubDatabase, initial_dataset: None, client: InfrahubClient, set_service_client
+        self,
+        db: InfrahubDatabase,
+        initial_dataset: None,
+        client: InfrahubClient,
     ) -> None:
         proposed_change_create = await client.create(
             kind=InfrahubKind.PROPOSEDCHANGE,


### PR DESCRIPTION
Within our tests we use a local worker which rely on server's `services.service` which client is not initialized. Now, `TestInfrahubApp.client` fixture set `services.service.client` so these tests do not break. Note that in production, worker's `services.service` is correctly initialized with a client through `InfrahubWorkerAsync.setup`. We might want to factorize some code related to `services` initialization between worker and server at some point though.