### PR TITLE
Make permission report branch relative

### DIFF
--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -512,9 +512,6 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin):
                     )
                 continue
 
-            if field_name == "permissions":
-                response["permissions"] = {"view": "ALLOW", "update": "ALLOW"}
-
             if field_name.startswith("_"):
                 field = getattr(self, field_name[1:])
             else:

--- a/backend/infrahub/graphql/types/attribute.py
+++ b/backend/infrahub/graphql/types/attribute.py
@@ -7,7 +7,7 @@ from graphene.types.generic import GenericScalar
 
 from infrahub.core import registry
 
-from .enums import PermissionDecision
+from .enums import BranchAwarePermissionDecision
 from .interface import InfrahubInterface
 
 
@@ -57,7 +57,7 @@ class RelatedPrefixNodeInput(InputObjectType):
 
 
 class PermissionType(ObjectType):
-    update_value = Field(PermissionDecision, required=False)
+    update_value = Field(BranchAwarePermissionDecision, required=False)
 
 
 class AttributeInterface(InfrahubInterface):

--- a/backend/infrahub/graphql/types/attribute.py
+++ b/backend/infrahub/graphql/types/attribute.py
@@ -7,7 +7,7 @@ from graphene.types.generic import GenericScalar
 
 from infrahub.core import registry
 
-from .enums import BranchAwarePermissionDecision
+from .enums import BranchRelativePermissionDecision
 from .interface import InfrahubInterface
 
 
@@ -57,7 +57,7 @@ class RelatedPrefixNodeInput(InputObjectType):
 
 
 class PermissionType(ObjectType):
-    update_value = Field(BranchAwarePermissionDecision, required=False)
+    update_value = Field(BranchRelativePermissionDecision, required=False)
 
 
 class AttributeInterface(InfrahubInterface):

--- a/backend/infrahub/graphql/types/enums.py
+++ b/backend/infrahub/graphql/types/enums.py
@@ -1,9 +1,10 @@
 from graphene import Enum
 
 from infrahub.core import constants
+from infrahub.permissions import constants as permission_constants
 
 CheckType = Enum.from_enum(constants.CheckType)
 
 Severity = Enum.from_enum(constants.Severity)
 
-PermissionDecision = Enum.from_enum(constants.PermissionDecision)
+BranchAwarePermissionDecision = Enum.from_enum(permission_constants.BranchAwarePermissionDecision)

--- a/backend/infrahub/graphql/types/enums.py
+++ b/backend/infrahub/graphql/types/enums.py
@@ -7,4 +7,4 @@ CheckType = Enum.from_enum(constants.CheckType)
 
 Severity = Enum.from_enum(constants.Severity)
 
-BranchAwarePermissionDecision = Enum.from_enum(permission_constants.BranchAwarePermissionDecision)
+BranchRelativePermissionDecision = Enum.from_enum(permission_constants.BranchRelativePermissionDecision)

--- a/backend/infrahub/graphql/types/permission.py
+++ b/backend/infrahub/graphql/types/permission.py
@@ -2,20 +2,28 @@ from __future__ import annotations
 
 from graphene import Field, Int, List, ObjectType, String
 
-from infrahub.graphql.types.enums import PermissionDecision
+from infrahub.graphql.types.enums import BranchAwarePermissionDecision
 
 
 class ObjectPermission(ObjectType):
     kind = Field(String, required=True, description="The kind this permission refers to.")
-    view = Field(PermissionDecision, required=True, description="Indicates the permission level for the read action.")
+    view = Field(
+        BranchAwarePermissionDecision, required=True, description="Indicates the permission level for the read action."
+    )
     create = Field(
-        PermissionDecision, required=True, description="Indicates the permission level for the create action."
+        BranchAwarePermissionDecision,
+        required=True,
+        description="Indicates the permission level for the create action.",
     )
     update = Field(
-        PermissionDecision, required=True, description="Indicates the permission level for the update action."
+        BranchAwarePermissionDecision,
+        required=True,
+        description="Indicates the permission level for the update action.",
     )
     delete = Field(
-        PermissionDecision, required=True, description="Indicates the permission level for the delete action."
+        BranchAwarePermissionDecision,
+        required=True,
+        description="Indicates the permission level for the delete action.",
     )
 
 

--- a/backend/infrahub/graphql/types/permission.py
+++ b/backend/infrahub/graphql/types/permission.py
@@ -2,26 +2,28 @@ from __future__ import annotations
 
 from graphene import Field, Int, List, ObjectType, String
 
-from infrahub.graphql.types.enums import BranchAwarePermissionDecision
+from infrahub.graphql.types.enums import BranchRelativePermissionDecision
 
 
 class ObjectPermission(ObjectType):
     kind = Field(String, required=True, description="The kind this permission refers to.")
     view = Field(
-        BranchAwarePermissionDecision, required=True, description="Indicates the permission level for the read action."
+        BranchRelativePermissionDecision,
+        required=True,
+        description="Indicates the permission level for the read action.",
     )
     create = Field(
-        BranchAwarePermissionDecision,
+        BranchRelativePermissionDecision,
         required=True,
         description="Indicates the permission level for the create action.",
     )
     update = Field(
-        BranchAwarePermissionDecision,
+        BranchRelativePermissionDecision,
         required=True,
         description="Indicates the permission level for the update action.",
     )
     delete = Field(
-        BranchAwarePermissionDecision,
+        BranchRelativePermissionDecision,
         required=True,
         description="Indicates the permission level for the delete action.",
     )

--- a/backend/infrahub/permissions/constants.py
+++ b/backend/infrahub/permissions/constants.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from enum import IntFlag
+from enum import IntFlag, StrEnum, auto
 from typing import TYPE_CHECKING, TypedDict
 
 if TYPE_CHECKING:
@@ -17,3 +17,12 @@ class PermissionDecisionFlag(IntFlag):
     ALLOW_DEFAULT = 2
     ALLOW_OTHER = 4
     ALLOW_ALL = ALLOW_DEFAULT | ALLOW_OTHER
+
+
+class BranchAwarePermissionDecision(StrEnum):
+    """This enum is only used to communicate a permission decision relative to a branch."""
+
+    DENY = auto()
+    ALLOW = auto()
+    ALLOW_DEFAULT = auto()
+    ALLOW_OTHER = auto()

--- a/backend/infrahub/permissions/constants.py
+++ b/backend/infrahub/permissions/constants.py
@@ -19,7 +19,7 @@ class PermissionDecisionFlag(IntFlag):
     ALLOW_ALL = ALLOW_DEFAULT | ALLOW_OTHER
 
 
-class BranchAwarePermissionDecision(StrEnum):
+class BranchRelativePermissionDecision(StrEnum):
     """This enum is only used to communicate a permission decision relative to a branch."""
 
     DENY = auto()

--- a/backend/infrahub/permissions/report.py
+++ b/backend/infrahub/permissions/report.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from infrahub.core import registry
 from infrahub.core.account import GlobalPermission
 from infrahub.core.constants import GLOBAL_BRANCH_NAME, GlobalPermissions, PermissionDecision
-from infrahub.permissions.constants import AssignedPermissions, BranchAwarePermissionDecision, PermissionDecisionFlag
+from infrahub.permissions.constants import AssignedPermissions, BranchRelativePermissionDecision, PermissionDecisionFlag
 from infrahub.permissions.local_backend import LocalPermissionBackend
 
 if TYPE_CHECKING:
@@ -25,11 +25,11 @@ def get_permission_report(
     action: str,
     is_super_admin: bool = False,
     can_edit_default_branch: bool = False,  # pylint: disable=unused-argument
-) -> BranchAwarePermissionDecision:
+) -> BranchRelativePermissionDecision:
     is_default_branch = branch.name in (GLOBAL_BRANCH_NAME, registry.default_branch)
 
     if is_super_admin:
-        return BranchAwarePermissionDecision.ALLOW
+        return BranchRelativePermissionDecision.ALLOW
 
     decision = backend.report_object_permission(
         permissions=permissions["object_permissions"], namespace=node.namespace, name=node.name, action=action
@@ -44,13 +44,13 @@ def get_permission_report(
         or (decision & PermissionDecisionFlag.ALLOW_DEFAULT and is_default_branch)
         or (decision & PermissionDecisionFlag.ALLOW_OTHER and not is_default_branch)
     ):
-        return BranchAwarePermissionDecision.ALLOW
+        return BranchRelativePermissionDecision.ALLOW
     if decision & PermissionDecisionFlag.ALLOW_DEFAULT:
-        return BranchAwarePermissionDecision.ALLOW_DEFAULT
+        return BranchRelativePermissionDecision.ALLOW_DEFAULT
     if decision & PermissionDecisionFlag.ALLOW_OTHER:
-        return BranchAwarePermissionDecision.ALLOW_OTHER
+        return BranchRelativePermissionDecision.ALLOW_OTHER
 
-    return BranchAwarePermissionDecision.DENY
+    return BranchRelativePermissionDecision.DENY
 
 
 async def report_schema_permissions(

--- a/backend/infrahub/permissions/report.py
+++ b/backend/infrahub/permissions/report.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from infrahub.core import registry
 from infrahub.core.account import GlobalPermission
-from infrahub.core.constants import GlobalPermissions, PermissionDecision
-from infrahub.permissions.constants import AssignedPermissions, PermissionDecisionFlag
+from infrahub.core.constants import GLOBAL_BRANCH_NAME, GlobalPermissions, PermissionDecision
+from infrahub.permissions.constants import AssignedPermissions, BranchAwarePermissionDecision, PermissionDecisionFlag
 from infrahub.permissions.local_backend import LocalPermissionBackend
 
 if TYPE_CHECKING:
@@ -19,13 +20,16 @@ if TYPE_CHECKING:
 def get_permission_report(
     backend: PermissionBackend,
     permissions: AssignedPermissions,
+    branch: Branch,
     node: MainSchemaTypes,
     action: str,
     is_super_admin: bool = False,
     can_edit_default_branch: bool = False,  # pylint: disable=unused-argument
-) -> PermissionDecisionFlag:
+) -> BranchAwarePermissionDecision:
+    is_default_branch = branch.name in (GLOBAL_BRANCH_NAME, registry.default_branch)
+
     if is_super_admin:
-        return PermissionDecisionFlag.ALLOW_ALL
+        return BranchAwarePermissionDecision.ALLOW
 
     decision = backend.report_object_permission(
         permissions=permissions["object_permissions"], namespace=node.namespace, name=node.name, action=action
@@ -35,7 +39,18 @@ def get_permission_report(
     # if can_edit_default_branch:
     #     decision |= PermissionDecisionFlag.ALLOW_DEFAULT
 
-    return decision
+    if (
+        decision == PermissionDecisionFlag.ALLOW_ALL
+        or (decision & PermissionDecisionFlag.ALLOW_DEFAULT and is_default_branch)
+        or (decision & PermissionDecisionFlag.ALLOW_OTHER and not is_default_branch)
+    ):
+        return BranchAwarePermissionDecision.ALLOW
+    if decision & PermissionDecisionFlag.ALLOW_DEFAULT:
+        return BranchAwarePermissionDecision.ALLOW_DEFAULT
+    if decision & PermissionDecisionFlag.ALLOW_OTHER:
+        return BranchAwarePermissionDecision.ALLOW_OTHER
+
+    return BranchAwarePermissionDecision.DENY
 
 
 async def report_schema_permissions(
@@ -65,6 +80,7 @@ async def report_schema_permissions(
                 "create": get_permission_report(
                     backend=perm_backend,
                     permissions=permissions,
+                    branch=branch,
                     node=node,
                     action="create",
                     is_super_admin=is_super_admin,
@@ -73,6 +89,7 @@ async def report_schema_permissions(
                 "delete": get_permission_report(
                     backend=perm_backend,
                     permissions=permissions,
+                    branch=branch,
                     node=node,
                     action="delete",
                     is_super_admin=is_super_admin,
@@ -81,6 +98,7 @@ async def report_schema_permissions(
                 "update": get_permission_report(
                     backend=perm_backend,
                     permissions=permissions,
+                    branch=branch,
                     node=node,
                     action="update",
                     is_super_admin=is_super_admin,
@@ -89,6 +107,7 @@ async def report_schema_permissions(
                 "view": get_permission_report(
                     backend=perm_backend,
                     permissions=permissions,
+                    branch=branch,
                     node=node,
                     action="view",
                     is_super_admin=is_super_admin,

--- a/backend/infrahub/permissions/types.py
+++ b/backend/infrahub/permissions/types.py
@@ -1,30 +1,14 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, TypedDict
 
 if TYPE_CHECKING:
-    from infrahub.permissions.constants import PermissionDecisionFlag
+    from infrahub.permissions.constants import BranchAwarePermissionDecision
 
 
 class KindPermissions(TypedDict):
     kind: str
-    create: PermissionDecisionFlag
-    delete: PermissionDecisionFlag
-    update: PermissionDecisionFlag
-    view: PermissionDecisionFlag
-
-
-@dataclass
-class GlobalPermissionToVerify:
-    name: str
-    action: str
-    decision: PermissionDecisionFlag
-
-
-@dataclass
-class ObjectPermissionToVerify:
-    namespace: str
-    name: str
-    action: str
-    decision: PermissionDecisionFlag
+    create: BranchAwarePermissionDecision
+    delete: BranchAwarePermissionDecision
+    update: BranchAwarePermissionDecision
+    view: BranchAwarePermissionDecision

--- a/backend/infrahub/permissions/types.py
+++ b/backend/infrahub/permissions/types.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, TypedDict
 
 if TYPE_CHECKING:
-    from infrahub.permissions.constants import BranchAwarePermissionDecision
+    from infrahub.permissions.constants import BranchRelativePermissionDecision
 
 
 class KindPermissions(TypedDict):
     kind: str
-    create: BranchAwarePermissionDecision
-    delete: BranchAwarePermissionDecision
-    update: BranchAwarePermissionDecision
-    view: BranchAwarePermissionDecision
+    create: BranchRelativePermissionDecision
+    delete: BranchRelativePermissionDecision
+    update: BranchRelativePermissionDecision
+    view: BranchRelativePermissionDecision

--- a/backend/tests/unit/graphql/queries/test_list_permissions.py
+++ b/backend/tests/unit/graphql/queries/test_list_permissions.py
@@ -12,8 +12,7 @@ from infrahub.core.initialization import create_branch
 from infrahub.core.node import Node
 from infrahub.core.registry import registry
 from infrahub.graphql.initialization import prepare_graphql_params
-from infrahub.graphql.types.permission import PermissionDecision
-from infrahub.permissions.constants import PermissionDecisionFlag
+from infrahub.permissions.constants import BranchAwarePermissionDecision, PermissionDecisionFlag
 from infrahub.permissions.local_backend import LocalPermissionBackend
 
 if TYPE_CHECKING:
@@ -173,10 +172,10 @@ class TestObjectPermissions:
         assert result.data["BuiltinTag"]["permissions"]["edges"][0] == {
             "node": {
                 "kind": "BuiltinTag",
-                "create": PermissionDecision.ALLOW_OTHER.name,
-                "update": PermissionDecision.DENY.name,
-                "delete": PermissionDecision.ALLOW_OTHER.name,
-                "view": PermissionDecision.ALLOW_ALL.name,
+                "create": BranchAwarePermissionDecision.ALLOW_OTHER.name,
+                "update": BranchAwarePermissionDecision.DENY.name,
+                "delete": BranchAwarePermissionDecision.ALLOW_OTHER.name,
+                "view": BranchAwarePermissionDecision.ALLOW.name,
             }
         }
 
@@ -196,10 +195,10 @@ class TestObjectPermissions:
         assert result.data["BuiltinTag"]["permissions"]["edges"][0] == {
             "node": {
                 "kind": "BuiltinTag",
-                "create": PermissionDecision.ALLOW_OTHER.name,
-                "update": PermissionDecision.DENY.name,
-                "delete": PermissionDecision.ALLOW_OTHER.name,
-                "view": PermissionDecision.ALLOW_ALL.name,
+                "create": BranchAwarePermissionDecision.ALLOW.name,
+                "update": BranchAwarePermissionDecision.DENY.name,
+                "delete": BranchAwarePermissionDecision.ALLOW.name,
+                "view": BranchAwarePermissionDecision.ALLOW.name,
             }
         }
 
@@ -226,28 +225,28 @@ class TestObjectPermissions:
         assert {
             "node": {
                 "kind": "CoreGenericRepository",
-                "create": PermissionDecision.ALLOW_OTHER.name,
-                "update": PermissionDecision.ALLOW_OTHER.name,
-                "delete": PermissionDecision.ALLOW_OTHER.name,
-                "view": PermissionDecision.ALLOW_ALL.name,
+                "create": BranchAwarePermissionDecision.ALLOW_OTHER.name,
+                "update": BranchAwarePermissionDecision.ALLOW_OTHER.name,
+                "delete": BranchAwarePermissionDecision.ALLOW_OTHER.name,
+                "view": BranchAwarePermissionDecision.ALLOW.name,
             }
         } in result.data["CoreGenericRepository"]["permissions"]["edges"]
         assert {
             "node": {
                 "kind": "CoreRepository",
-                "create": PermissionDecision.ALLOW_OTHER.name,
-                "update": PermissionDecision.ALLOW_OTHER.name,
-                "delete": PermissionDecision.ALLOW_OTHER.name,
-                "view": PermissionDecision.ALLOW_ALL.name,
+                "create": BranchAwarePermissionDecision.ALLOW_OTHER.name,
+                "update": BranchAwarePermissionDecision.ALLOW_OTHER.name,
+                "delete": BranchAwarePermissionDecision.ALLOW_OTHER.name,
+                "view": BranchAwarePermissionDecision.ALLOW.name,
             }
         } in result.data["CoreGenericRepository"]["permissions"]["edges"]
         assert {
             "node": {
                 "kind": "CoreReadOnlyRepository",
-                "create": PermissionDecision.ALLOW_OTHER.name,
-                "update": PermissionDecision.ALLOW_OTHER.name,
-                "delete": PermissionDecision.ALLOW_OTHER.name,
-                "view": PermissionDecision.ALLOW_ALL.name,
+                "create": BranchAwarePermissionDecision.ALLOW_OTHER.name,
+                "update": BranchAwarePermissionDecision.ALLOW_OTHER.name,
+                "delete": BranchAwarePermissionDecision.ALLOW_OTHER.name,
+                "view": BranchAwarePermissionDecision.ALLOW.name,
             }
         } in result.data["CoreGenericRepository"]["permissions"]["edges"]
 
@@ -270,10 +269,10 @@ class TestObjectPermissions:
         assert result.data["CoreAccountRole"]["permissions"]["edges"][0] == {
             "node": {
                 "kind": "CoreAccountRole",
-                "create": PermissionDecision.ALLOW_OTHER.name,
-                "update": PermissionDecision.ALLOW_OTHER.name,
-                "delete": PermissionDecision.ALLOW_OTHER.name,
-                "view": PermissionDecision.ALLOW_ALL.name,
+                "create": BranchAwarePermissionDecision.ALLOW_OTHER.name,
+                "update": BranchAwarePermissionDecision.ALLOW_OTHER.name,
+                "delete": BranchAwarePermissionDecision.ALLOW_OTHER.name,
+                "view": BranchAwarePermissionDecision.ALLOW.name,
             }
         }
         assert result.data["CoreAccountRole"]["edges"][0]["node"]["display_label"] == "admin"
@@ -384,7 +383,7 @@ class TestAttributePermissions:
         assert result.data
         assert result.data["BuiltinTag"]["count"] == 1
         assert result.data["BuiltinTag"]["edges"][0]["node"]["name"]["permissions"] == {
-            "update_value": PermissionDecision.ALLOW_OTHER.name
+            "update_value": BranchAwarePermissionDecision.ALLOW_OTHER.name
         }
 
     async def test_first_account_tags_non_main_branch(
@@ -406,5 +405,5 @@ class TestAttributePermissions:
         assert result.data
         assert result.data["BuiltinTag"]["count"] == 1
         assert result.data["BuiltinTag"]["edges"][0]["node"]["name"]["permissions"] == {
-            "update_value": PermissionDecision.ALLOW_OTHER.name
+            "update_value": BranchAwarePermissionDecision.ALLOW.name
         }

--- a/backend/tests/unit/graphql/queries/test_list_permissions.py
+++ b/backend/tests/unit/graphql/queries/test_list_permissions.py
@@ -12,7 +12,7 @@ from infrahub.core.initialization import create_branch
 from infrahub.core.node import Node
 from infrahub.core.registry import registry
 from infrahub.graphql.initialization import prepare_graphql_params
-from infrahub.permissions.constants import BranchAwarePermissionDecision, PermissionDecisionFlag
+from infrahub.permissions.constants import BranchRelativePermissionDecision, PermissionDecisionFlag
 from infrahub.permissions.local_backend import LocalPermissionBackend
 
 if TYPE_CHECKING:
@@ -172,10 +172,10 @@ class TestObjectPermissions:
         assert result.data["BuiltinTag"]["permissions"]["edges"][0] == {
             "node": {
                 "kind": "BuiltinTag",
-                "create": BranchAwarePermissionDecision.ALLOW_OTHER.name,
-                "update": BranchAwarePermissionDecision.DENY.name,
-                "delete": BranchAwarePermissionDecision.ALLOW_OTHER.name,
-                "view": BranchAwarePermissionDecision.ALLOW.name,
+                "create": BranchRelativePermissionDecision.ALLOW_OTHER.name,
+                "update": BranchRelativePermissionDecision.DENY.name,
+                "delete": BranchRelativePermissionDecision.ALLOW_OTHER.name,
+                "view": BranchRelativePermissionDecision.ALLOW.name,
             }
         }
 
@@ -195,10 +195,10 @@ class TestObjectPermissions:
         assert result.data["BuiltinTag"]["permissions"]["edges"][0] == {
             "node": {
                 "kind": "BuiltinTag",
-                "create": BranchAwarePermissionDecision.ALLOW.name,
-                "update": BranchAwarePermissionDecision.DENY.name,
-                "delete": BranchAwarePermissionDecision.ALLOW.name,
-                "view": BranchAwarePermissionDecision.ALLOW.name,
+                "create": BranchRelativePermissionDecision.ALLOW.name,
+                "update": BranchRelativePermissionDecision.DENY.name,
+                "delete": BranchRelativePermissionDecision.ALLOW.name,
+                "view": BranchRelativePermissionDecision.ALLOW.name,
             }
         }
 
@@ -225,28 +225,28 @@ class TestObjectPermissions:
         assert {
             "node": {
                 "kind": "CoreGenericRepository",
-                "create": BranchAwarePermissionDecision.ALLOW_OTHER.name,
-                "update": BranchAwarePermissionDecision.ALLOW_OTHER.name,
-                "delete": BranchAwarePermissionDecision.ALLOW_OTHER.name,
-                "view": BranchAwarePermissionDecision.ALLOW.name,
+                "create": BranchRelativePermissionDecision.ALLOW_OTHER.name,
+                "update": BranchRelativePermissionDecision.ALLOW_OTHER.name,
+                "delete": BranchRelativePermissionDecision.ALLOW_OTHER.name,
+                "view": BranchRelativePermissionDecision.ALLOW.name,
             }
         } in result.data["CoreGenericRepository"]["permissions"]["edges"]
         assert {
             "node": {
                 "kind": "CoreRepository",
-                "create": BranchAwarePermissionDecision.ALLOW_OTHER.name,
-                "update": BranchAwarePermissionDecision.ALLOW_OTHER.name,
-                "delete": BranchAwarePermissionDecision.ALLOW_OTHER.name,
-                "view": BranchAwarePermissionDecision.ALLOW.name,
+                "create": BranchRelativePermissionDecision.ALLOW_OTHER.name,
+                "update": BranchRelativePermissionDecision.ALLOW_OTHER.name,
+                "delete": BranchRelativePermissionDecision.ALLOW_OTHER.name,
+                "view": BranchRelativePermissionDecision.ALLOW.name,
             }
         } in result.data["CoreGenericRepository"]["permissions"]["edges"]
         assert {
             "node": {
                 "kind": "CoreReadOnlyRepository",
-                "create": BranchAwarePermissionDecision.ALLOW_OTHER.name,
-                "update": BranchAwarePermissionDecision.ALLOW_OTHER.name,
-                "delete": BranchAwarePermissionDecision.ALLOW_OTHER.name,
-                "view": BranchAwarePermissionDecision.ALLOW.name,
+                "create": BranchRelativePermissionDecision.ALLOW_OTHER.name,
+                "update": BranchRelativePermissionDecision.ALLOW_OTHER.name,
+                "delete": BranchRelativePermissionDecision.ALLOW_OTHER.name,
+                "view": BranchRelativePermissionDecision.ALLOW.name,
             }
         } in result.data["CoreGenericRepository"]["permissions"]["edges"]
 
@@ -269,10 +269,10 @@ class TestObjectPermissions:
         assert result.data["CoreAccountRole"]["permissions"]["edges"][0] == {
             "node": {
                 "kind": "CoreAccountRole",
-                "create": BranchAwarePermissionDecision.ALLOW_OTHER.name,
-                "update": BranchAwarePermissionDecision.ALLOW_OTHER.name,
-                "delete": BranchAwarePermissionDecision.ALLOW_OTHER.name,
-                "view": BranchAwarePermissionDecision.ALLOW.name,
+                "create": BranchRelativePermissionDecision.ALLOW_OTHER.name,
+                "update": BranchRelativePermissionDecision.ALLOW_OTHER.name,
+                "delete": BranchRelativePermissionDecision.ALLOW_OTHER.name,
+                "view": BranchRelativePermissionDecision.ALLOW.name,
             }
         }
         assert result.data["CoreAccountRole"]["edges"][0]["node"]["display_label"] == "admin"
@@ -383,7 +383,7 @@ class TestAttributePermissions:
         assert result.data
         assert result.data["BuiltinTag"]["count"] == 1
         assert result.data["BuiltinTag"]["edges"][0]["node"]["name"]["permissions"] == {
-            "update_value": BranchAwarePermissionDecision.ALLOW_OTHER.name
+            "update_value": BranchRelativePermissionDecision.ALLOW_OTHER.name
         }
 
     async def test_first_account_tags_non_main_branch(
@@ -405,5 +405,5 @@ class TestAttributePermissions:
         assert result.data
         assert result.data["BuiltinTag"]["count"] == 1
         assert result.data["BuiltinTag"]["edges"][0]["node"]["name"]["permissions"] == {
-            "update_value": BranchAwarePermissionDecision.ALLOW.name
+            "update_value": BranchRelativePermissionDecision.ALLOW.name
         }

--- a/frontend/app/src/screens/permission/types.ts
+++ b/frontend/app/src/screens/permission/types.ts
@@ -1,4 +1,4 @@
-export type PermissionDecisionData = "DENY" | "ALLOW_ALL" | "ALLOW_DEFAULT" | "ALLOW_OTHER";
+export type PermissionDecisionData = "ALLOW" | "ALLOW_DEFAULT" | "ALLOW_OTHER" | "DENY";
 
 export type PermissionAction = "view" | "create" | "update" | "delete";
 

--- a/frontend/app/tests/mocks/data/devices.ts
+++ b/frontend/app/tests/mocks/data/devices.ts
@@ -1761,10 +1761,10 @@ export const getPermissionsData = {
           {
             node: {
               kind: "InfraDevice",
-              view: "ALLOW_ALL",
-              create: "ALLOW_ALL",
-              update: "ALLOW_ALL",
-              delete: "ALLOW_ALL",
+              view: "ALLOW",
+              create: "ALLOW",
+              update: "ALLOW",
+              delete: "ALLOW",
               __typename: "ObjectPermission",
             },
             __typename: "ObjectPermissionNode",

--- a/frontend/app/tests/mocks/data/permissions.ts
+++ b/frontend/app/tests/mocks/data/permissions.ts
@@ -3,10 +3,10 @@ export const permissionsAllow = {
     {
       node: {
         kind: "InfraDevice",
-        view: "ALLOW_ALL",
-        create: "ALLOW_ALL",
-        update: "ALLOW_ALL",
-        delete: "ALLOW_ALL",
+        view: "ALLOW",
+        create: "ALLOW",
+        update: "ALLOW",
+        delete: "ALLOW",
         __typename: "ObjectPermission",
       },
       __typename: "ObjectPermissionNode",


### PR DESCRIPTION
This will allow user to see permission decision according to what branch they are in. For instance, if a user is in the default branch and has the permission to do something, report will say "allow". In the same case, but in a non-default branch, without the permission to do the same thing, report will say "allow_default". Other cases are also covered.