### PR TITLE
Run git sync every 1 minute

### DIFF
--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -323,7 +323,10 @@ class GitSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="INFRAHUB_GIT_")
     repositories_directory: str = "repositories"
     sync_interval: int = Field(
-        default=10, ge=0, description="Time (in seconds) between git repositories synchronizations"
+        default=10,
+        ge=0,
+        description="Time (in seconds) between git repositories synchronizations",
+        deprecated="This setting is deprecated and not currently in use.",
     )
 
 

--- a/backend/infrahub/workflows/catalogue.py
+++ b/backend/infrahub/workflows/catalogue.py
@@ -95,7 +95,7 @@ REQUEST_ARTIFACT_DEFINITION_GENERATE = WorkflowDefinition(
 GIT_REPOSITORIES_SYNC = WorkflowDefinition(
     name="git_repositories_sync",
     type=WorkflowType.INTERNAL,
-    cron="*/10 * * * *",
+    cron="* * * * *",
     module="infrahub.git.tasks",
     function="sync_remote_repositories",
 )


### PR DESCRIPTION
Changes to 1 minute for git sync interval (was accidentally changed to 10 minutes with the prefect migration), we might revisit this to make it run more often. But also want to consider impact of excessive logging.

Also marks the git sync_interval setting as deprecated for now. As we can't have the config loaded from the start with the current setup it would only be confusing to leave that setting as is.