### PR TITLE
Add DiffAllPathsQuery benchmark

### DIFF
--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -197,9 +197,9 @@ class DatabaseSettings(BaseSettings):
     tls_insecure: bool = Field(default=False, description="Indicates if TLS certificates are verified")
     tls_ca_file: Optional[str] = Field(default=None, description="File path to CA cert or bundle in PEM format")
     query_size_limit: int = Field(
-        default=5000,
+        default=5_000,
         ge=1,
-        le=20000,
+        le=20_000,
         description="The max number of records to fetch in a single query before performing internal pagination.",
     )
     max_depth_search_hierarchy: int = Field(

--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -446,6 +446,7 @@ class RelationshipDeleteQuery(RelationshipQuery):
         r1 = f"{arrows.left.start}[r1:{self.rel_type} $rel_prop ]{arrows.left.end}"
         r2 = f"{arrows.right.start}[r2:{self.rel_type} $rel_prop ]{arrows.right.end}"
 
+        # Specifying relationship type might improve query performance here.
         query = """
         MATCH (s:Node { uuid: $source_id })-[]-(rl:Relationship {uuid: $rel_id})-[]-(d:Node { uuid: $destination_id })
         CREATE (s)%s(rl)

--- a/backend/tests/helpers/query_benchmark/benchmark_config.py
+++ b/backend/tests/helpers/query_benchmark/benchmark_config.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+
+from infrahub.database import Neo4jRuntime
+from tests.helpers.constants import NEO4J_ENTERPRISE_IMAGE
+
+
+@dataclass
+class BenchmarkConfig:
+    neo4j_image: str = NEO4J_ENTERPRISE_IMAGE
+    neo4j_runtime: Neo4jRuntime = Neo4jRuntime.DEFAULT
+    load_db_indexes: bool = False
+
+    def __str__(self) -> str:
+        return f"{self.neo4j_image=} ; runtime: {self.neo4j_runtime} ; indexes: {self.load_db_indexes}"

--- a/backend/tests/helpers/query_benchmark/car_person_generators.py
+++ b/backend/tests/helpers/query_benchmark/car_person_generators.py
@@ -1,8 +1,10 @@
 import random
 import uuid
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from tests.helpers.query_benchmark.data_generator import DataGenerator
 from tests.helpers.query_benchmark.db_query_profiler import InfrahubDatabaseProfiler
@@ -10,34 +12,142 @@ from tests.helpers.query_benchmark.db_query_profiler import InfrahubDatabaseProf
 
 class CarGenerator(DataGenerator):
     async def load_data(self, nb_elements: int) -> None:
-        await self.load_cars(nb_elements)
-
-    async def load_cars(self, nb_cars: int, persons: Optional[dict[str, Node]] = None) -> dict[str, Node]:
-        """
-        Load cars and return a mapping car_name -> car_node.
-        If 'persons' is specified, each car created is linked to a person.
-        """
-
         default_branch = await registry.get_branch(db=self.db)
-        car_schema = registry.schema.get_node_schema(name="TestCar", branch=default_branch)
+        await self.load_cars(default_branch, nb_elements)
+
+    async def load_car_random_name(self, branch: Branch, nbr_seats: int, **kwargs: Any) -> Node:
+        car_schema = registry.schema.get_node_schema(name="TestCar", branch=branch)
+
+        short_id = str(uuid.uuid4())[:8]
+        car_name = f"car-{short_id}"
+        car_node = await Node.init(db=self.db, schema=car_schema, branch=branch)
+        await car_node.new(db=self.db, name=car_name, nbr_seats=nbr_seats, **kwargs)
+
+        return await car_node.save(db=self.db)
+
+    async def load_cars(self, branch: Branch, nb_cars: int, **kwargs: Any) -> dict[str, Node]:
+        cars = {}
+        for _ in range(nb_cars):
+            car_node = await self.load_car_random_name(nbr_seats=4, branch=branch, **kwargs)
+            cars[car_node.name.value] = car_node  # type: ignore[attr-defined]
+
+        return cars
+
+
+class EngineGenerator(DataGenerator):
+    async def load_data(self, nb_elements: int) -> None:
+        default_branch = await registry.get_branch(db=self.db)
+        await self.load_engines(default_branch, nb_elements)
+
+    async def load_engines(self, branch: Branch, nb_cars: int, **kwargs: Any) -> dict[str, Node]:
+        engines = {}
+        for _ in range(nb_cars):
+            engine_node = await self.load_engine_random_name(branch=branch, **kwargs)
+            engines[engine_node.name.value] = engine_node  # type: ignore[attr-defined]
+
+        return engines
+
+    async def load_engine_random_name(self, branch: Branch, **kwargs: Any) -> Node:
+        engine_schema = registry.schema.get_node_schema(name="TestEngine", branch=branch)
+
+        short_id = str(uuid.uuid4())[:8]
+        engine_name = f"engine-{short_id}"
+        engine_node = await Node.init(db=self.db, schema=engine_schema, branch=branch)
+        await engine_node.new(db=self.db, name=engine_name, **kwargs)
+
+        return await engine_node.save(db=self.db)
+
+
+class CarWithDiffInSecondBranchGenerator(CarGenerator):
+    persons: Optional[dict[str, Node]]  # mapping of existing cars names -> node
+    nb_persons: int
+    diff_ratio: float  # 0.1 means 10% of added nodes, 10% of deleted nodes, 10% of modified nodes
+    main_branch: Branch
+    diff_branch: Branch
+
+    def __init__(
+        self, db: InfrahubDatabaseProfiler, nb_persons: int, diff_ratio: float, main_branch: Branch, diff_branch: Branch
+    ) -> None:
+        super().__init__(db)
+        self.persons = None
+        self.nb_persons = nb_persons
+        self.diff_ratio = diff_ratio
+        self.main_branch = main_branch
+        self.diff_branch = diff_branch
+
+    async def init(self) -> None:
+        """Load persons, that will be later connected to generated cars."""
+        self.persons = await PersonGenerator(self.db).load_persons(nb_persons=self.nb_persons)
+
+    async def load_cars_with_multiple_rels(self, branch: Branch, nb_cars: int) -> dict[str, Node]:
+        assert self.persons is not None
+        engine_generator = EngineGenerator(db=self.db)
 
         cars = {}
         for _ in range(nb_cars):
-            short_id = str(uuid.uuid4())[:8]
-            car_name = f"car-{short_id}"
-            car_node = await Node.init(db=self.db, schema=car_schema, branch=default_branch)
-            if persons is not None:
-                random_person = random.choice([persons[person_name] for person_name in persons])
-                await car_node.new(db=self.db, name=car_name, nbr_seats=4, owner=random_person)
-            else:
-                await car_node.new(db=self.db, name=car_name, nbr_seats=4)
-
-            async with self.db.start_session():
-                await car_node.save(db=self.db)
-
-            cars[car_name] = car_node
+            owner = random.choice([self.persons[person_name] for person_name in self.persons])
+            drivers = random.choices([self.persons[person_name] for person_name in self.persons], k=nb_cars)
+            engine = await engine_generator.load_engine_random_name(branch=branch)
+            car = await self.load_car_random_name(
+                branch=branch, nbr_seats=4, owner=owner, drivers=drivers, engine=engine
+            )
+            cars[car.name.value] = car  # type: ignore[attr-defined]
 
         return cars
+
+    async def load_data(self, nb_elements: int) -> None:
+        """
+        Load cars in main branch, rebase diff branch on main branch, then load changes
+        within diff branch according to a given ratio.
+        Differences are:
+        - Updates some cars attributes as well as 1:1, 1:N, N:N relationships.
+        - Add new cars.
+        Note that we do not delete cars within diff branch as it seems to take too long.
+        """
+
+        assert self.persons is not None, "'init' method should be called before 'load_data'"
+
+        if nb_elements == 0:
+            return
+
+        # Load cars in main branch
+        new_cars = await self.load_cars_with_multiple_rels(nb_cars=nb_elements, branch=self.main_branch)
+
+        # Integrate these new cars in diff branch
+        await self.diff_branch.rebase(self.db)
+
+        # Retrieve car nodes from diff branch, including the ones not present in main branch
+        # that were created by prior calls to `load_data`
+        car_schema = registry.schema.get_node_schema(name="TestCar", branch=self.diff_branch)
+        car_nodes = await NodeManager.query(db=self.db, schema=car_schema, branch=self.diff_branch)
+        new_car_nodes = [car_node for car_node in car_nodes if car_node.name.value in new_cars]
+
+        nb_diff = max(int(nb_elements * self.diff_ratio), 1)
+
+        # Update cars in diff branch
+        car_nodes_updatable = new_car_nodes
+        car_nodes_to_update = random.choices(car_nodes_updatable, k=nb_diff)
+        for i, car_node in enumerate(car_nodes_to_update):
+            car_node.name.value = f"updated-car-{str(uuid.uuid4())[:8]}"
+
+            # Permute engines among car nodes to update, so it keeps one-to-one relationship between cars-engines
+            new_engine = car_nodes_to_update[(i + 1) % len(car_nodes_to_update)].engine
+            car_node.engine.update(db=self.db, data=new_engine)
+
+            # Update one-to-many relationship
+            new_owner = random.choice([self.persons[person_name] for person_name in self.persons])
+            car_node.owner.update(db=self.db, data=new_owner)
+
+            # Update many-to-many relationship
+            new_drivers = random.choices([self.persons[person_name] for person_name in self.persons])
+            car_node.drivers.update(db=self.db, data=new_drivers)
+
+            await car_node.save(db=self.db)
+
+        # Add a few cars in diff branch
+        added_cars = await self.load_cars_with_multiple_rels(nb_cars=nb_diff, branch=self.diff_branch)
+
+        assert len(added_cars) == len(car_nodes_to_update) == nb_diff
 
 
 class PersonGenerator(DataGenerator):
@@ -75,42 +185,6 @@ class PersonGenerator(DataGenerator):
             persons_names_to_nodes[person_name] = person_node
 
         return persons_names_to_nodes
-
-
-class PersonFromExistingCarGenerator(PersonGenerator):
-    cars: Optional[dict[str, Node]]  # mapping of existing cars names -> node
-    nb_cars: int
-
-    def __init__(self, db: InfrahubDatabaseProfiler, nb_cars: int) -> None:
-        super().__init__(db)
-        self.nb_cars = nb_cars
-        self.cars = None
-
-    async def init(self) -> None:
-        """Load cars, that will be later connected to generated persons."""
-        self.cars = await CarGenerator(self.db).load_cars(nb_cars=self.nb_cars)
-
-    async def load_data(self, nb_elements: int) -> None:
-        assert self.cars is not None, "'init' method should be called before 'load_data'"
-        await self.load_persons(nb_persons=nb_elements, cars=self.cars)
-
-
-class CarFromExistingPersonGenerator(CarGenerator):
-    persons: Optional[dict[str, Node]]  # mapping of existing cars names -> node
-    nb_persons: int
-
-    def __init__(self, db: InfrahubDatabaseProfiler, nb_persons: int) -> None:
-        super().__init__(db)
-        self.nb_persons = nb_persons
-        self.persons = None
-
-    async def init(self) -> None:
-        """Load persons, that will be later connected to generated cars."""
-        self.persons = await PersonGenerator(self.db).load_persons(nb_persons=self.nb_persons)
-
-    async def load_data(self, nb_elements: int) -> None:
-        assert self.persons is not None, "'init' method should be called before 'load_data'"
-        await self.load_cars(nb_cars=nb_elements, persons=self.persons)
 
 
 class CarGeneratorWithOwnerHavingUniqueCar(CarGenerator):
@@ -154,33 +228,3 @@ class CarGeneratorWithOwnerHavingUniqueCar(CarGenerator):
                 await car_node.save(db=self.db)
 
         self.nb_cars_loaded += nb_elements
-
-
-class CarAndPersonIsolatedGenerator(DataGenerator):
-    def __init__(self, db: InfrahubDatabaseProfiler) -> None:
-        super().__init__(db)
-        self.car_generator: CarGenerator = CarGenerator(db)
-        self.person_generator: PersonGenerator = PersonGenerator(db)
-
-    async def load_data(self, nb_elements: int) -> None:
-        """
-        Load not connected cars and persons. Note that 'nb_elements' cars plus 'nb_elements' persons are loaded.
-        """
-
-        await self.car_generator.load_cars(nb_cars=nb_elements)
-        await self.person_generator.load_persons(nb_persons=nb_elements)
-
-
-class CarAndPersonConnectedGenerator(DataGenerator):
-    def __init__(self, db: InfrahubDatabaseProfiler) -> None:
-        super().__init__(db)
-        self.car_generator: CarGenerator = CarGenerator(db)
-        self.person_generator: PersonGenerator = PersonGenerator(db)
-
-    async def load_data(self, nb_elements: int) -> None:
-        """
-        Load connected cars and persons. Note that 'nb_elements' cars plus 'nb_elements' persons are loaded.
-        """
-
-        persons = await self.person_generator.load_persons(nb_persons=nb_elements)
-        await self.car_generator.load_cars(nb_cars=nb_elements, persons=persons)

--- a/backend/tests/helpers/query_benchmark/data_generator.py
+++ b/backend/tests/helpers/query_benchmark/data_generator.py
@@ -68,6 +68,7 @@ async def load_data_and_profile(
         )
 
         for i, nb_elem_to_load in enumerate(nb_elem_per_batch):
+            print(f"Before loading batch {i=}. Current elements: {i * nb_elem_to_load=}")
             await data_generator.load_data(nb_elements=nb_elem_to_load)
             db_profiling_queries.increase_nb_elements_loaded(nb_elem_to_load)
             profile_memory = i % memory_profiling_rate == 0 if memory_profiling_rate is not None else False

--- a/backend/tests/query_benchmark/test_diff_query.py
+++ b/backend/tests/query_benchmark/test_diff_query.py
@@ -1,0 +1,84 @@
+import inspect
+from pathlib import Path
+
+import pytest
+
+from infrahub.core import registry
+from infrahub.core.initialization import create_branch
+from infrahub.core.query.diff import DiffAllPathsQuery
+from infrahub.core.timestamp import Timestamp
+from infrahub.database.constants import Neo4jRuntime
+from infrahub.log import get_logger
+from tests.helpers.constants import NEO4J_COMMUNITY_IMAGE, NEO4J_ENTERPRISE_IMAGE
+from tests.helpers.query_benchmark.benchmark_config import BenchmarkConfig
+from tests.helpers.query_benchmark.car_person_generators import (
+    CarWithDiffInSecondBranchGenerator,
+)
+from tests.helpers.query_benchmark.data_generator import load_data_and_profile
+from tests.query_benchmark.conftest import RESULTS_FOLDER
+from tests.query_benchmark.utils import start_db_and_create_default_branch
+
+log = get_logger()
+
+# pytestmark = pytest.mark.skip("Not relevant to test this currently.")
+
+
+@pytest.mark.timeout(36000)  # 10 hours
+@pytest.mark.parametrize(
+    "benchmark_config",
+    [
+        BenchmarkConfig(neo4j_runtime=Neo4jRuntime.PARALLEL, neo4j_image=NEO4J_ENTERPRISE_IMAGE, load_db_indexes=False),
+        BenchmarkConfig(neo4j_runtime=Neo4jRuntime.PARALLEL, neo4j_image=NEO4J_ENTERPRISE_IMAGE, load_db_indexes=True),
+        BenchmarkConfig(neo4j_runtime=Neo4jRuntime.DEFAULT, neo4j_image=NEO4J_ENTERPRISE_IMAGE, load_db_indexes=False),
+        BenchmarkConfig(neo4j_runtime=Neo4jRuntime.DEFAULT, neo4j_image=NEO4J_ENTERPRISE_IMAGE, load_db_indexes=True),
+        BenchmarkConfig(neo4j_runtime=Neo4jRuntime.DEFAULT, neo4j_image=NEO4J_COMMUNITY_IMAGE, load_db_indexes=False),
+        BenchmarkConfig(neo4j_runtime=Neo4jRuntime.DEFAULT, neo4j_image=NEO4J_COMMUNITY_IMAGE, load_db_indexes=True),
+    ],
+)
+async def test_diff(benchmark_config, car_person_schema_root, graph_generator, increase_query_size_limit):
+    # Initialization
+    db_profiling_queries, default_branch = await start_db_and_create_default_branch(
+        neo4j_image=benchmark_config.neo4j_image,
+        load_indexes=benchmark_config.load_db_indexes,
+    )
+    registry.schema.register_schema(schema=car_person_schema_root, branch=default_branch.name)
+    diff_branch = await create_branch(branch_name="diff_branch", db=db_profiling_queries)
+
+    # Build function to profile
+    async def init_and_execute():
+        # Need this function to avoid loading data between `init` and `execute` methods.
+        query = await DiffAllPathsQuery.init(
+            db=db_profiling_queries,
+            branch=diff_branch,
+            base_branch=default_branch,
+            diff_branch_from_time=Timestamp(diff_branch.branched_from),
+            diff_from=Timestamp(diff_branch.branched_from),
+            diff_to=Timestamp(),
+        )
+        await query.execute(db=db_profiling_queries)
+        assert len(query.results) != 0, "expected some diff"
+
+    nb_cars = 5000
+    cars_generator = CarWithDiffInSecondBranchGenerator(
+        db=db_profiling_queries,
+        nb_persons=int(nb_cars / 10),
+        diff_ratio=0.2,
+        main_branch=default_branch,
+        diff_branch=diff_branch,
+    )
+
+    test_name = inspect.currentframe().f_code.co_name
+    module_name = Path(__file__).stem
+    graph_output_location = RESULTS_FOLDER / module_name / test_name
+
+    test_label = str(benchmark_config)
+
+    await load_data_and_profile(
+        data_generator=cars_generator,
+        func_call=init_and_execute,
+        profile_frequency=200,
+        nb_elements=nb_cars,
+        graphs_output_location=graph_output_location,
+        test_label=test_label,
+        graph_generator=graph_generator,
+    )


### PR DESCRIPTION
This PR adds a benchmark for `DiffAllPathsQuery`, based on a dedicated data generator `CarWithDiffInSecondBranchGenerator` mainly responsible for:
- Loading cars in  main branch
- Rebasing diff branch on main branch
- Loading changes (attributes/relationships updates, adding new cars) in diff branch

Note that `schema`/`DataGenerator` are still not part of `BenchmarkConfig`. I think `DataGenerator` used for benchmarking might be too close to logic of the test (mainly, the query used) to be defined within `BenchmarkConfig`. We could discuss that at some point @dgarros and I might submit another PR for this.