### PR TITLE
IFC-840 fix serialization problem for node name update migration

### DIFF
--- a/backend/infrahub/core/migrations/graph/m012_convert_account_generic.py
+++ b/backend/infrahub/core/migrations/graph/m012_convert_account_generic.py
@@ -85,12 +85,14 @@ class Migration012AddLabelData(NodeDuplicateQuery):
                 InfrahubKind.LINEAGEOWNER,
                 InfrahubKind.LINEAGESOURCE,
             ],
+            kind=InfrahubKind.ACCOUNT,
         )
         previous_node = SchemaNodeInfo(
             name="Account",
             namespace="Core",
             branch_support=BranchSupportType.AGNOSTIC.value,
             labels=[InfrahubKind.ACCOUNT, InfrahubKind.LINEAGEOWNER, InfrahubKind.LINEAGESOURCE],
+            kind=InfrahubKind.ACCOUNT,
         )
 
         branch = Branch(

--- a/backend/infrahub/core/migrations/query/node_duplicate.py
+++ b/backend/infrahub/core/migrations/query/node_duplicate.py
@@ -19,10 +19,7 @@ class SchemaNodeInfo(BaseModel):
     namespace: str
     branch_support: str = BranchSupportType.AWARE.value
     labels: list[str]
-
-    @property
-    def kind(self) -> str:
-        return self.namespace + self.name
+    kind: str
 
 
 class NodeDuplicateQuery(Query):

--- a/backend/infrahub/core/migrations/schema/node_kind_update.py
+++ b/backend/infrahub/core/migrations/schema/node_kind_update.py
@@ -19,12 +19,14 @@ class NodeKindUpdateMigrationQuery01(MigrationQuery, NodeDuplicateQuery):
             namespace=migration.new_schema.namespace,
             branch_support=migration.new_schema.branch.value,
             labels=migration.new_schema.get_labels(),
+            kind=migration.new_schema.kind,
         )
         previous_node = SchemaNodeInfo(
             name=migration.previous_schema.name,
             namespace=migration.previous_schema.namespace,
             branch_support=migration.previous_schema.branch.value,
             labels=migration.previous_schema.get_labels(),
+            kind=migration.previous_schema.kind,
         )
         super().__init__(migration=migration, new_node=new_node, previous_node=previous_node, **kwargs)
 


### PR DESCRIPTION
IFC-840

fix issue with node schema serialization that resulted in `Node` nodes without a `kind` being created on the database
looks like the `kind` property in `SchemaNodeInfo` stopped getting serialized at some point