### PR TITLE
add validation for branch merge

### DIFF
--- a/backend/infrahub/core/diff/data_check_synchronizer.py
+++ b/backend/infrahub/core/diff/data_check_synchronizer.py
@@ -34,7 +34,7 @@ class DiffDataCheckSynchronizer:
             proposed_changes = []
         if not proposed_changes:
             return []
-        enriched_conflicts = enriched_diff.get_all_conflicts()
+        enriched_conflicts_map = enriched_diff.get_all_conflicts()
         data_conflicts = await self.conflicts_extractor.get_data_conflicts(enriched_diff_root=enriched_diff)
         all_data_checks = []
         for pc in proposed_changes:
@@ -43,7 +43,7 @@ class DiffDataCheckSynchronizer:
             )
             all_data_checks.extend(core_data_checks)
             core_data_checks_by_id = {cdc.enriched_conflict_id.value: cdc for cdc in core_data_checks}  # type: ignore[attr-defined]
-            enriched_conflicts_by_id = {ec.uuid: ec for ec in enriched_conflicts}
+            enriched_conflicts_by_id = {ec.uuid: ec for ec in enriched_conflicts_map.values()}
             for conflict_id, core_data_check in core_data_checks_by_id.items():
                 enriched_conflict = enriched_conflicts_by_id.get(conflict_id)
                 if not enriched_conflict:

--- a/backend/infrahub/core/diff/model/path.py
+++ b/backend/infrahub/core/diff/model/path.py
@@ -170,8 +170,8 @@ class EnrichedDiffAttribute(BaseSummary):
     def __hash__(self) -> int:
         return hash(self.name)
 
-    def get_all_conflicts(self) -> list[EnrichedDiffConflict]:
-        return [prop.conflict for prop in self.properties if prop.conflict]
+    def get_all_conflicts(self) -> dict[str, EnrichedDiffConflict]:
+        return {prop.path_identifier: prop.conflict for prop in self.properties if prop.conflict}
 
     @classmethod
     def from_calculated_attribute(cls, calculated_attribute: DiffAttribute) -> EnrichedDiffAttribute:
@@ -199,11 +199,11 @@ class EnrichedDiffSingleRelationship(BaseSummary):
     def __hash__(self) -> int:
         return hash(self.peer_id)
 
-    def get_all_conflicts(self) -> list[EnrichedDiffConflict]:
-        all_conflicts = []
+    def get_all_conflicts(self) -> dict[str, EnrichedDiffConflict]:
+        all_conflicts: dict[str, EnrichedDiffConflict] = {}
         if self.conflict:
-            all_conflicts.append(self.conflict)
-        all_conflicts.extend([prop.conflict for prop in self.properties if prop.conflict])
+            all_conflicts[self.path_identifier] = self.conflict
+        all_conflicts.update({prop.path_identifier: prop.conflict for prop in self.properties if prop.conflict})
         return all_conflicts
 
     def get_property(self, property_type: DatabaseEdgeType) -> EnrichedDiffProperty:
@@ -239,10 +239,10 @@ class EnrichedDiffRelationship(BaseSummary):
     def __hash__(self) -> int:
         return hash(self.name)
 
-    def get_all_conflicts(self) -> list[EnrichedDiffConflict]:
-        all_conflicts = []
+    def get_all_conflicts(self) -> dict[str, EnrichedDiffConflict]:
+        all_conflicts: dict[str, EnrichedDiffConflict] = {}
         for element in self.relationships:
-            all_conflicts.extend(element.get_all_conflicts())
+            all_conflicts.update(element.get_all_conflicts())
         return all_conflicts
 
     @property
@@ -288,14 +288,14 @@ class EnrichedDiffNode(BaseSummary):
     def __hash__(self) -> int:
         return hash(self.uuid)
 
-    def get_all_conflicts(self) -> list[EnrichedDiffConflict]:
-        all_conflicts = []
+    def get_all_conflicts(self) -> dict[str, EnrichedDiffConflict]:
+        all_conflicts: dict[str, EnrichedDiffConflict] = {}
         if self.conflict:
-            all_conflicts.append(self.conflict)
+            all_conflicts[self.path_identifier] = self.conflict
         for attribute in self.attributes:
-            all_conflicts.extend(attribute.get_all_conflicts())
+            all_conflicts.update(attribute.get_all_conflicts())
         for relationship in self.relationships:
-            all_conflicts.extend(relationship.get_all_conflicts())
+            all_conflicts.update(relationship.get_all_conflicts())
         return all_conflicts
 
     def get_parent_info(self, context: GraphqlContext | None = None) -> ParentNodeInfo | None:
@@ -414,10 +414,10 @@ class EnrichedDiffRoot(BaseSummary):
         except ValueError:
             return False
 
-    def get_all_conflicts(self) -> list[EnrichedDiffConflict]:
-        all_conflicts = []
+    def get_all_conflicts(self) -> dict[str, EnrichedDiffConflict]:
+        all_conflicts: dict[str, EnrichedDiffConflict] = {}
         for node in self.nodes:
-            all_conflicts.extend(node.get_all_conflicts())
+            all_conflicts.update(node.get_all_conflicts())
         return all_conflicts
 
     @classmethod

--- a/backend/infrahub/core/diff/query/merge.py
+++ b/backend/infrahub/core/diff/query/merge.py
@@ -390,7 +390,7 @@ CALL {
             WHERE type(r_prop) = prop_type
             AND r_prop.status = prop_rel_status
             AND r_prop.from <= $at
-            AND (r_prop.to >= $at OR r_prop.to IS NULL)
+            AND (r_prop.to > $at OR r_prop.to IS NULL)
             RETURN r_prop
         }
         WITH attr_rel, prop_rel_status, prop_type, prop_node, r_prop

--- a/backend/tests/integration/diff/test_diff_merge.py
+++ b/backend/tests/integration/diff/test_diff_merge.py
@@ -117,9 +117,9 @@ class TestDiffMerge(TestInfrahubApp):
         marty_id = initial_dataset["marty"].get_id()
 
         enriched_diff = await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=diff_branch)
-        conflicts = enriched_diff.get_all_conflicts()
-        assert len(conflicts) == 1
-        owner_conflict = conflicts[0]
+        conflicts_map = enriched_diff.get_all_conflicts()
+        assert len(conflicts_map) == 1
+        owner_conflict = list(conflicts_map.values())[0]
         await diff_repository.update_conflict_by_id(
             conflict_id=owner_conflict.uuid, selection=ConflictSelection.BASE_BRANCH
         )

--- a/backend/tests/unit/core/test_branch_merge.py
+++ b/backend/tests/unit/core/test_branch_merge.py
@@ -1,7 +1,12 @@
+import pytest
+
 from infrahub.core import registry
 from infrahub.core.branch import Branch
+from infrahub.core.branch.tasks import merge_branch
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.diff.coordinator import DiffCoordinator
+from infrahub.core.diff.model.path import ConflictSelection
+from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.merge import BranchMerger
@@ -12,12 +17,15 @@ from infrahub.core.schema import AttributeSchema
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.dependencies.registry import get_component_registry
+from infrahub.exceptions import ValidationError
 
 
 async def test_validate_graph(db: InfrahubDatabase, base_dataset_02, register_core_models_schema):
     branch1 = await Branch.get_by_name(name="branch1", db=db)
 
-    merger = BranchMerger(db=db, source_branch=branch1)
+    component_registry = get_component_registry()
+    diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch1)
+    merger = BranchMerger(db=db, diff_coordinator=diff_coordinator, source_branch=branch1)
     conflicts = await merger.validate_graph()
 
     assert not conflicts
@@ -28,7 +36,7 @@ async def test_validate_graph(db: InfrahubDatabase, base_dataset_02, register_co
     c1.name.value = "new name"
     await c1.save(db=db)
 
-    merger = BranchMerger(db=db, source_branch=branch1)
+    merger = BranchMerger(db=db, diff_coordinator=diff_coordinator, source_branch=branch1)
     conflicts = await merger.validate_graph()
 
     assert conflicts
@@ -38,7 +46,9 @@ async def test_validate_graph(db: InfrahubDatabase, base_dataset_02, register_co
 async def test_validate_empty_branch(db: InfrahubDatabase, base_dataset_02, register_core_models_schema):
     branch2 = await create_branch(branch_name="branch2", db=db)
 
-    merger = BranchMerger(db=db, source_branch=branch2)
+    component_registry = get_component_registry()
+    diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch2)
+    merger = BranchMerger(db=db, diff_coordinator=diff_coordinator, source_branch=branch2)
     conflicts = await merger.validate_graph()
 
     assert not conflicts
@@ -51,7 +61,7 @@ async def test_merge_graph(db: InfrahubDatabase, default_branch, base_dataset_02
     component_registry = get_component_registry()
     diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch1)
     await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch1)
-    merger = BranchMerger(db=db, source_branch=branch1)
+    merger = BranchMerger(db=db, diff_coordinator=diff_coordinator, source_branch=branch1)
     await merger.merge_graph(at=at)
 
     # Query all cars in MAIN, AFTER the merge
@@ -86,7 +96,7 @@ async def test_merge_graph(db: InfrahubDatabase, default_branch, base_dataset_02
     assert cars[0].nbr_seats.value == 4
 
     # It should be possible to merge a graph even without changes
-    merger = BranchMerger(db=db, source_branch=branch1)
+    merger = BranchMerger(db=db, diff_coordinator=diff_coordinator, source_branch=branch1)
     await merger.merge_graph(at=at)
 
 
@@ -102,7 +112,7 @@ async def test_merge_graph_delete(db: InfrahubDatabase, default_branch, base_dat
     await p3.delete(db=db)
 
     await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch1)
-    merger = BranchMerger(db=db, source_branch=branch1)
+    merger = BranchMerger(db=db, diff_coordinator=diff_coordinator, source_branch=branch1)
     await merger.merge_graph(at=Timestamp())
 
     # Query all cars in MAIN, AFTER the merge
@@ -142,7 +152,7 @@ async def test_merge_relationship_many(
     await org1_main.save(db=db)
 
     await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch1)
-    merger = BranchMerger(db=db, source_branch=branch1)
+    merger = BranchMerger(db=db, diff_coordinator=diff_coordinator, source_branch=branch1)
     await merger.merge_graph(at=Timestamp())
 
     org1_main = await NodeManager.get_one(id=org1.id, db=db)
@@ -190,7 +200,11 @@ async def test_merge_update_schema(
     )
     schema_branch = registry.schema.get_schema_branch(name=branch2.name)
 
-    merger = BranchMerger(db=db, source_branch=branch2, destination_branch=default_branch)
+    component_registry = get_component_registry()
+    diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch2)
+    merger = BranchMerger(
+        db=db, diff_coordinator=diff_coordinator, source_branch=branch2, destination_branch=default_branch
+    )
     assert await merger.update_schema() is True
     assert sorted(merger.migrations, key=lambda x: x.path.get_path()) == sorted(
         [
@@ -237,3 +251,57 @@ async def test_merge_update_schema(
         ],
         key=lambda x: x.path.get_path(),
     )
+
+
+async def test_branch_merge_unresolved_diff_conflict(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    init_service,
+    car_person_schema,
+    car_camry_main,
+):
+    branch2 = await create_branch(db=db, branch_name="branch2")
+    car_main = await NodeManager.get_one(db=db, id=car_camry_main.id)
+    car_main.name.value += "-main"
+    await car_main.save(db=db)
+    car_branch = await NodeManager.get_one(db=db, branch=branch2, id=car_camry_main.id)
+    car_branch.name.value += "-branch"
+    await car_branch.save(db=db)
+
+    with pytest.raises(ValidationError, match="contains conflicts with the default branch that must be resolved"):
+        await merge_branch(branch=branch2.name)
+
+
+async def test_branch_merge_resolved_diff_conflict(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema,
+    init_service,
+    car_person_schema,
+    car_camry_main,
+    helper,
+):
+    bus_simulator = helper.get_message_bus_simulator()
+    init_service.message_bus = bus_simulator
+    bus_simulator.service = init_service
+    branch2 = await create_branch(db=db, branch_name="branch2")
+    car_main = await NodeManager.get_one(db=db, id=car_camry_main.id)
+    car_main.name.value += "-main"
+    main_name = car_main.name.value
+    await car_main.save(db=db)
+    car_branch = await NodeManager.get_one(db=db, branch=branch2, id=car_camry_main.id)
+    car_branch.name.value += "-branch"
+    await car_branch.save(db=db)
+    component_registry = get_component_registry()
+    diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch2)
+    diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=branch2)
+    enriched_diff = await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch2)
+    conflicts_map = enriched_diff.get_all_conflicts()
+    assert len(conflicts_map) == 1
+    for conflict in conflicts_map.values():
+        await diff_repository.update_conflict_by_id(conflict_id=conflict.uuid, selection=ConflictSelection.BASE_BRANCH)
+
+    await merge_branch(branch=branch2.name)
+
+    retrieved_car = await NodeManager.get_one(db=db, id=car_camry_main.id)
+    assert retrieved_car.name.value == main_name

--- a/backend/tests/unit/graphql/test_diff_tree_query.py
+++ b/backend/tests/unit/graphql/test_diff_tree_query.py
@@ -292,7 +292,8 @@ async def test_diff_tree_one_attr_change(
     after_change_datetime = datetime.now(tz=UTC)
 
     enriched_diff = await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=diff_branch)
-    enriched_conflict = enriched_diff.get_all_conflicts()[0]
+    enriched_conflict_map = enriched_diff.get_all_conflicts()
+    enriched_conflict = list(enriched_conflict_map.values())[0]
     await diff_repository.update_conflict_by_id(
         conflict_id=enriched_conflict.uuid, selection=ConflictSelection.DIFF_BRANCH
     )

--- a/changelog/4595.fixed.md
+++ b/changelog/4595.fixed.md
@@ -1,0 +1,1 @@
+Add full validation to BranchMerge and BranchRebase mutations


### PR DESCRIPTION
fixes #4595 
IFC-767

adds validation to the `BranchMerge` mutation to prevent merging a branch with constraint violations or diff conflicts

- also fixes a couple of bugs in the new merge logic and adds some unit tests for them