### PR TITLE
Remove scope default config from docs

### DIFF
--- a/docs/docs/guides/sso.mdx
+++ b/docs/docs/guides/sso.mdx
@@ -66,7 +66,6 @@ An example of what the configuration could look like:
   authorization_url = "http://localhost:8180/realms/infrahub/protocol/openid-connect/auth"
   token_url = "http://localhost:8180/realms/infrahub/protocol/openid-connect/token"
   userinfo_url = "http://localhost:8180/realms/infrahub/protocol/openid-connect/userinfo"
-  scopes = ["openid", "profile", "email"]
   display_label = "Internal Server (Keycloak)"
   icon = "mdi:security-lock-outline"
   ```


### PR DESCRIPTION
The scopes wasn't meant to be added here, removing it as it's the default anyway.