### PR TITLE
Sort hashes of signature fields and save branch hash back to DB if the DB hash is incorrect

### DIFF
--- a/backend/infrahub/core/initialization.py
+++ b/backend/infrahub/core/initialization.py
@@ -160,6 +160,7 @@ async def initialization(db: InfrahubDatabase) -> None:
                 hash_new=default_branch.active_schema_hash.main,
                 branch=default_branch.name,
             )
+            await default_branch.save(db=db)
 
         for branch in list(registry.branch.values()):
             if branch.name in [default_branch.name, GLOBAL_BRANCH_NAME]:
@@ -175,6 +176,7 @@ async def initialization(db: InfrahubDatabase) -> None:
                     f" {hash_in_db!r} >> {branch.active_schema_hash.main!r}",
                     branch=branch.name,
                 )
+                await branch.save(db=db)
 
     # ---------------------------------------------------
     # Load Default Namespace

--- a/backend/infrahub/core/models.py
+++ b/backend/infrahub/core/models.py
@@ -366,7 +366,7 @@ class HashableModel(BaseModel):
         else:
             hashes.append(cls._get_hash_value(value))
 
-        return hashes
+        return sorted(hashes)
 
     @property
     def _sorting_id(self) -> tuple[Any]:


### PR DESCRIPTION
While troubleshooting #4682 I realized that there was something wrong with how branches are created and in my database any branch that I created would have a different schema hash compared to "main". This leads to a situation where we always download a new branch from the database.

The call to update the hash of a branch here:
https://github.com/opsmill/infrahub/blob/infrahub-v0.16.4/backend/infrahub/graphql/mutations/branch.py#L89

Will (depending on schema) produce a different hash than the main branch.

There might be others but I tracked this problem down to `_get_signature_field()` where it looks like we've thought about this before where we order the values. It might be that we now have list of lists and only sort by the outer list.

```yaml
nodes:
  - name: BackBoneService
    namespace: Infra
    description: "Backbone Service"
    label: "Backbone Service"
    icon: "carbon:container-services"
    inherit_from:
      - InfraService
    uniqueness_constraints:
      - ["circuit_id__value", "internal_circuit_id__value"]
```

I.e in this example we'd sort the uniqueness_constraints list but not the content so we could get different load orders:

```
["circuit_id__value", "internal_circuit_id__value"]
```
vs.

```
["internal_circuit_id__value", "circuit_id__value"]
```

I haven't dug deep into this so the last part is just me guessing.

Another problem that can occur is when we restart Infrahub, and pull the branch information from the database then we have a function that checks if the hash coming from the database is valid or not, if the DB hash is invalid we log a warning and just proceed instead of saving back the hash to the database. This often leads to us being in a situation where the schema hash differs between branches which is especially problematic when we create a new branch and the logic to populate the registry thinks that it needs to load all of the schema from the database instead of using the local cache.