### PR TITLE
Add order_weight to multiple attributes and relationships in the demo schema

### DIFF
--- a/changelog/+order-weight-demo-schema.fixed.md
+++ b/changelog/+order-weight-demo-schema.fixed.md
@@ -1,0 +1,1 @@
+Add order_weight property to multiple attributes and relationships in the demo schema to improve how some models are displayed in the list views

--- a/frontend/app/tests/e2e/objects/object-filters.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-filters.spec.ts
@@ -81,7 +81,9 @@ test.describe("Object filters", () => {
     await page.getByRole("option", { name: "atl1-core1" }).click();
     await page.getByRole("button", { name: "Apply filters" }).click();
 
-    await expect(page.getByRole("row", { name: "InfraInterfaceL3 Loopback0" })).toBeVisible();
+    await expect(
+      page.getByRole("row", { name: "InfraInterfaceL3 atl1-core1 Loopback0" })
+    ).toBeVisible();
     await expect(page.getByRole("link", { name: "Connected to jfk1-edge2" })).toBeHidden();
   });
 

--- a/models/base/dcim.yml
+++ b/models/base/dcim.yml
@@ -100,6 +100,7 @@ generics:
         identifier: "device__interface"
         optional: false
         cardinality: one
+        order_weight: 1
         kind: Parent
       - name: tags
         peer: BuiltinTag
@@ -157,6 +158,7 @@ generics:
     relationships:
       - name: mlag_domain
         label: MLAG Domain
+        order_weight: 1
         peer: InfraMlagDomain
         kind: Attribute
         cardinality: one
@@ -240,6 +242,7 @@ nodes:
         optional: false
         cardinality: one
         kind: Attribute
+        order_weight: 1
         identifier: "site__devices"
       - name: interfaces
         peer: InfraInterface
@@ -474,12 +477,14 @@ nodes:
       - name: circuit_id
         kind: Text
         unique: true
+        order_weight: 2
       - name: description
         kind: Text
         optional: true
       - name: vendor_id
         kind: Text
         optional: true
+        order_weight: 3
       - name: status
         kind: Dropdown
         choices:
@@ -521,6 +526,7 @@ nodes:
         optional: false
         cardinality: one
         kind: Attribute
+        order_weight: 1
       - name: endpoints
         peer: InfraCircuitEndpoint
         optional: true

--- a/models/base/ipam.yml
+++ b/models/base/ipam.yml
@@ -39,11 +39,13 @@ nodes:
       - name: name
         kind: Text
         unique: true
+        order_weight: 2
       - name: description
         kind: Text
         optional: true
       - name: vlan_id
         kind: Number
+        order_weight: 3
       - name: status
         kind: Dropdown
         choices:
@@ -86,6 +88,7 @@ nodes:
         cardinality: one
         kind: Attribute
         identifier: "site__vlans"
+        order_weight: 1
       - name: gateway
         label: L3 Gateway
         peer: InfraInterfaceL3

--- a/models/base/routing.yml
+++ b/models/base/routing.yml
@@ -18,9 +18,11 @@ nodes:
       - name: name
         kind: Text
         unique: true
+        order_weight: 1
       - name: asn
         kind: Number
         unique: true
+        order_weight: 2
       - name: description
         kind: Text
         optional: true
@@ -30,6 +32,7 @@ nodes:
         optional: false
         cardinality: one
         kind: Attribute
+        order_weight: 3
   - name: BGPPeerGroup
     namespace: Infra
     description: "A BGP Peer Group is used to regroup parameters that are shared across multiple peers"
@@ -45,15 +48,18 @@ nodes:
       - name: name
         kind: Text
         unique: true
+        order_weight: 1
       - name: description
         kind: Text
         optional: true
       - name: import_policies
         kind: Text
         optional: true
+        order_weight: 4
       - name: export_policies
         kind: Text
         optional: true
+        order_weight: 5
     relationships:
       - name: local_as
         identifier: bgppeergroup__local_as
@@ -61,12 +67,14 @@ nodes:
         optional: true
         cardinality: one
         kind: Attribute
+        order_weight: 2
       - name: remote_as
         identifier: bgppeergroup__remote_as
         peer: InfraAutonomousSystem
         optional: true
         cardinality: one
         kind: Attribute
+        order_weight: 3
   - name: BGPSession
     namespace: Infra
     description: "A BGP Session represent a point to point connection between two routers"
@@ -82,17 +90,21 @@ nodes:
       - name: type
         kind: Text
         enum: [EXTERNAL, INTERNAL]
+        order_weight: 1
       - name: description
         kind: Text
         optional: true
       - name: import_policies
         kind: Text
         optional: true
+        order_weight: 8
       - name: export_policies
         kind: Text
         optional: true
+        order_weight: 9
       - name: status
         kind: Dropdown
+        order_weight: 6
         choices:
           - name: active
             label: Active
@@ -112,6 +124,7 @@ nodes:
             color: "#bfbfbf"
       - name: role
         kind: Dropdown
+        order_weight: 7
         choices:
           - name: backbone
             label: Backbone
@@ -132,24 +145,28 @@ nodes:
         optional: true
         cardinality: one
         kind: Attribute
+        order_weight: 2
       - name: remote_as
         identifier: bgpsession__remote_as
         peer: InfraAutonomousSystem
         optional: false
         cardinality: one
         kind: Attribute
+        order_weight: 3
       - name: local_ip
         identifier: bgpsession__local_ip
         peer: BuiltinIPAddress
         optional: true
         cardinality: one
         kind: Attribute
+        order_weight: 4
       - name: remote_ip
         identifier: bgpsession__remote_ip
         peer: BuiltinIPAddress
         optional: false
         cardinality: one
         kind: Attribute
+        order_weight: 5
       - name: device
         peer: InfraDevice
         optional: false

--- a/models/base/service.yml
+++ b/models/base/service.yml
@@ -15,6 +15,7 @@ generics:
         kind: Text
         label: Name
         optional: false
+        order_weight: 1
 nodes:
   - name: BackBoneService
     namespace: Infra
@@ -30,24 +31,31 @@ nodes:
         kind: Text
         label: Circuit ID
         optional: false
+        order_weight: 3
       - name: internal_circuit_id
         kind: Text
         label: Internal Circuit ID
         optional: false
+        order_weight: 2
     relationships:
       - name: provider
         cardinality: one
         peer: OrganizationProvider
         optional: false
+        kind: Attribute
       - name: site_a
         label: Site A
         cardinality: one
         peer: LocationSite
         optional: false
         identifier: infrabackboneservice__location_site_a
+        kind: Attribute
+        order_weight: 4
       - name: site_b
         label: Site B
         cardinality: one
         peer: LocationSite
         optional: false
         identifier: infrabackboneservice__location_site_b
+        kind: Attribute
+        order_weight: 5


### PR DESCRIPTION
Add order_weight to multiple attributes and relationships in the demo schema
Improves the visual aspects of how certain nodes are getting displayed in the list view of Infrahub