### PR TITLE
Initialize transform using `__init__()`

### DIFF
--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -1229,11 +1229,9 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):  # pylint: disable=t
 
             module = importlib.import_module(file_info.module_name)
 
-            transform_class: InfrahubTransform = getattr(module, class_name)
+            transform_class: type[InfrahubTransform] = getattr(module, class_name)
 
-            transform = await transform_class.init(
-                root_directory=commit_worktree.directory, branch=branch_name, client=client
-            )
+            transform = transform_class(root_directory=commit_worktree.directory, branch=branch_name, client=client)
             return await transform.run(data=data)
 
         except ModuleNotFoundError as exc:


### PR DESCRIPTION
This change is in preparation of https://github.com/opsmill/infrahub-sdk-python/issues/81.

Instead of creating a transform instance with:

```python
transform = await Transform.init()
```
We use:

```python
transform = Transform()
```

One of the goals here is to avoid having InfrahubClient as an import outside of TYPE_CHECKING within the main transforms file.
