### PR TITLE
Restructure device management menu

### DIFF
--- a/frontend/app/tests/e2e/role-management/read.spec.ts
+++ b/frontend/app/tests/e2e/role-management/read.spec.ts
@@ -24,9 +24,11 @@ test.describe("Role management - READ", () => {
 
     await test.step("check groups view", async () => {
       await page.getByRole("link", { name: "Groups 6" }).click();
+      await expect(page.getByText("Showing 1 to 6 of 6 results")).toBeVisible();
+      await expect(
+        page.getByTestId("breadcrumb-navigation").getByRole("link", { name: "Groups" })
+      ).toBeVisible();
       await expect(page.getByRole("cell", { name: "Operations Team" })).toBeVisible();
-      // Need to create more user to trigger this
-      // await expect(page.getByRole("cell", { name: "+ 4" })).toBeVisible();
     });
 
     await test.step("check roles view", async () => {

--- a/frontend/app/tests/e2e/tutorial/tutorial-4_integration-with-git.spec.ts
+++ b/frontend/app/tests/e2e/tutorial/tutorial-4_integration-with-git.spec.ts
@@ -29,7 +29,7 @@ test.describe("Getting started with Infrahub - Integration with Git", () => {
 
     await test.step("go to interface Ethernet 1 for atl1-edge1", async () => {
       await page.getByTestId("sidebar").getByRole("button", { name: "Device Management" }).click();
-      await page.getByRole("link", { name: "Device" }).click();
+      await page.getByRole("menuitem", { name: "Device", exact: true }).click();
       await page.getByLabel("Device Management").press("Escape");
 
       await expect(page.getByText("Generic Device object")).toBeVisible();

--- a/frontend/app/tests/e2e/tutorial/tutorial-4_integration-with-git.spec.ts
+++ b/frontend/app/tests/e2e/tutorial/tutorial-4_integration-with-git.spec.ts
@@ -30,7 +30,6 @@ test.describe("Getting started with Infrahub - Integration with Git", () => {
     await test.step("go to interface Ethernet 1 for atl1-edge1", async () => {
       await page.getByTestId("sidebar").getByRole("button", { name: "Device Management" }).click();
       await page.getByRole("menuitem", { name: "Device", exact: true }).click();
-      await page.getByLabel("Device Management").press("Escape");
 
       await expect(page.getByText("Generic Device object")).toBeVisible();
       await page.getByRole("link", { name: "atl1-edge1" }).click();

--- a/models/base_menu.yml
+++ b/models/base_menu.yml
@@ -78,12 +78,16 @@ spec:
       children:
         data:
           - namespace: Infra
-            name: Device
-            label: Device
-            kind: InfraDevice
+            name: NetworkDeviceMenu
+            label: Network Device
             icon: "mdi:server"
             children:
               data:
+                - namespace: Infra
+                  name: Device
+                  label: Device
+                  kind: InfraDevice
+                  icon: "mdi:server"
                 - name: Interface
                   namespace: Infra
                   label: "Interface"
@@ -91,22 +95,29 @@ spec:
                   kind: InfraInterface
 
           - namespace: Infra
+            name: MlagMenu
+            label: MLAG
+            icon: "eos-icons:cluster-management"
+            children:
+              data:
+                - name: MlagDomain
+                  namespace: Infra
+                  label: "MLAG Domain"
+                  icon: "eos-icons:cluster-management"
+                  kind: InfraMlagDomain
+
+                - name: MlagInterface
+                  namespace: Infra
+                  label: "MLAG Interface"
+                  icon: "mdi:ethernet"
+                  kind: InfraMlagInterface
+
+          - namespace: Infra
             name: Platform
             label: Platform
             kind: InfraPlatform
             icon: "mdi:application-cog-outline"
 
-          - name: MlagDomain
-            namespace: Infra
-            label: "MLAG Domain"
-            icon: "eos-icons:cluster-management"
-            kind: InfraMlagDomain
-
-          - name: MlagInterface
-            namespace: Infra
-            label: "MLAG Interface"
-            icon: "mdi:ethernet"
-            kind: InfraMlagInterface
 
     - namespace: Infra
       name: CircuitMenu


### PR DESCRIPTION
Restructures the device management menu in the demo menu, to avoid having a sub-menu item that is both a link and a collapsible sub-menu. This should be revisited when we have a better solution for that.
![image](https://github.com/user-attachments/assets/150de192-d576-4252-b667-c03f888bdc1e)



