### PR TITLE
Create section in the menu for each top level items automatically imported from the schema

### DIFF
--- a/backend/infrahub/menu/generator.py
+++ b/backend/infrahub/menu/generator.py
@@ -109,6 +109,10 @@ async def generate_menu(db: InfrahubDatabase, branch: Branch, menu_items: list[C
                 continue
 
             if not schema.menu_placement:
+                first_element = MenuItemDict.from_schema(model=schema)
+                first_element.identifier = f"{first_element.identifier}Sub"
+                first_element.order_weight = 1
+                menu_item.children[first_element.identifier] = first_element
                 structure.data[menu_item.identifier] = menu_item
                 items_to_add[item_name] = True
             elif menu_placement := structure.find_item(name=schema.menu_placement):

--- a/backend/tests/unit/menu/test_generator.py
+++ b/backend/tests/unit/menu/test_generator.py
@@ -86,6 +86,7 @@ async def test_generate_menu_top_level(
     assert menu
     assert "TestMenu0" in menu.data.keys()
     assert "TestCar" in menu.data.keys()
+    assert "TestCarSub" in menu.data["TestCar"].children.keys()
 
 
 async def test_generate_menu_default(


### PR DESCRIPTION
Currently all elements of the schema that don't have a matching menu items and that don't have a menu_placement defined will be automatically placed at the top level of the menu

If some other items are trying to be placed under the top level one (using menu placement) the link on the top menu items won't be accessible anymore

To prevent this situation, it has been decided that for each elements of the schema that will be placed at the top level, we'll automatically create a sub menu item with the same name / link. 