### PR TITLE
Avoid useless call to schema load api on repo import

### DIFF
--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -472,6 +472,11 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):  # pylint: disable=t
                     schema_file.load_content()
                     schemas_data.append(schema_file)
 
+        if not schemas_data:
+            # If the repository doesn't contain any schema files there is no reason to continue
+            # and send an empty list to the API
+            return
+
         for schema_file in schemas_data:
             if schema_file.valid:
                 continue

--- a/changelog/+9b1d29f3.fixed.md
+++ b/changelog/+9b1d29f3.fixed.md
@@ -1,0 +1,1 @@
+Avoid sending an empty list to the load schema API on repository import if it's not required


### PR DESCRIPTION
I noticed locally that I had a repo import fail because the schema load API timed out after two minutes, however I didn't have any schemas within my repo so the API should never have been called.

There's also a problem on the actual API in the sense that it can waste time and resources if a user calls it with an empty array. If this is done we can either report it as a user error alternatively we send back a `SchemaUpdate` indicating that the hash remained the same and that there were no updates. Thoughts around this?

Targeting `stable` so it's included in 1.0.1.