### PR TITLE
add merge rollback logic

### DIFF
--- a/backend/infrahub/core/diff/merger/merger.py
+++ b/backend/infrahub/core/diff/merger/merger.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from infrahub.core import registry
 from infrahub.core.diff.model.path import BranchTrackingId
-from infrahub.core.diff.query.merge import DiffMergePropertiesQuery, DiffMergeQuery
+from infrahub.core.diff.query.merge import DiffMergePropertiesQuery, DiffMergeQuery, DiffMergeRollbackQuery
 
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
@@ -65,3 +65,9 @@ class DiffMerger:
         self.source_branch.branched_from = at.to_string()
         await self.source_branch.save(db=self.db)
         registry.branch[self.source_branch.name] = self.source_branch
+
+    async def rollback(self, at: Timestamp) -> None:
+        rollback_query = await DiffMergeRollbackQuery.init(
+            db=self.db, branch=self.source_branch, target_branch=self.destination_branch, at=at
+        )
+        await rollback_query.execute(db=self.db)

--- a/backend/infrahub/exceptions.py
+++ b/backend/infrahub/exceptions.py
@@ -317,3 +317,11 @@ class HTTPServerTimeoutError(HTTPServerError):
 
 class HTTPServerSSLError(HTTPServerError):
     HTTP_CODE = 503
+
+
+class MergeFailedError(Error):
+    HTTP_CODE: int = 500
+
+    def __init__(self, branch_name: str) -> None:
+        self.message = f"Failed to merge branch '{branch_name}'"
+        super().__init__(self.message)

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -140,7 +140,6 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
             )
 
             if updated_state == ProposedChangeState.MERGED:
-                conflict_resolution: dict[str, bool] = {}
                 source_branch = await Branch.get_by_name(db=dbt, name=proposed_change.source_branch.value)
                 validations = await proposed_change.validations.get_peers(db=dbt)
                 for validation in validations.values():
@@ -158,13 +157,10 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
                                 raise ValidationError(
                                     "Data conflicts found on branch and missing decisions about what branch to keep"
                                 )
-                            if check.conflicts.value:
-                                keep_source_value = check.keep_branch.value.value == "source"
-                                conflict_resolution[check.conflicts.value[0]["path"]] = keep_source_value
 
                 await context.service.workflow.execute_workflow(
                     workflow=BRANCH_MERGE,
-                    parameters={"branch": source_branch.name, "conflict_resolution": conflict_resolution},
+                    parameters={"branch": source_branch.name},
                 )
 
         return proposed_change, result

--- a/backend/tests/integration/diff/test_merge_rollback.py
+++ b/backend/tests/integration/diff/test_merge_rollback.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from infrahub_sdk.exceptions import GraphQLError
+
+from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.merge import BranchMerger
+from infrahub.core.node import Node
+from infrahub.services.adapters.cache.redis import RedisCache
+from tests.constants import TestKind
+from tests.helpers.schema import CAR_SCHEMA, load_schema
+from tests.helpers.test_app import TestInfrahubApp
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClient
+
+    from infrahub.core.branch.models import Branch
+    from infrahub.database import InfrahubDatabase
+    from tests.adapters.message_bus import BusSimulator
+
+
+BRANCH_MERGE = """
+mutation($branch: String!) {
+    BranchMerge(data: { name: $branch }) {
+        ok
+    }
+}
+"""
+
+
+class BrokenBranchMerger:
+    def __init__(self, *args, **kwargs) -> None:
+        self.real_merger = BranchMerger(*args, **kwargs)
+
+    async def merge(self, at=None) -> None:
+        await self.real_merger.merge(at=at)
+        raise ValueError("This is broken on purpose")
+
+    async def rollback(self) -> None:
+        await self.real_merger.rollback()
+
+
+class TestBranchMergeRollback(TestInfrahubApp):
+    @pytest.fixture(scope="class")
+    async def initial_dataset(
+        self,
+        db: InfrahubDatabase,
+        initialize_registry: None,
+        bus_simulator: BusSimulator,
+        prefect_test_fixture: None,
+    ) -> dict[str, Node]:
+        await load_schema(db, schema=CAR_SCHEMA)
+
+        bus_simulator.service.cache = RedisCache()
+
+        john = await Node.init(schema=TestKind.PERSON, db=db)
+        await john.new(db=db, name="John", height=175, description="The famous Joe Doe")
+        await john.save(db=db)
+        kara = await Node.init(schema=TestKind.PERSON, db=db)
+        await kara.new(db=db, name="Kara Thrace", height=165, description="Starbuck")
+        await kara.save(db=db)
+        murphy = await Node.init(schema=TestKind.PERSON, db=db)
+        await murphy.new(db=db, name="Alex Murphy", height=185, description="Robocop")
+        await murphy.save(db=db)
+        omnicorp = await Node.init(schema=TestKind.MANUFACTURER, db=db)
+        await omnicorp.new(db=db, name="Omnicorp", customers=[murphy])
+        await omnicorp.save(db=db)
+        cyberdyne = await Node.init(schema=TestKind.MANUFACTURER, db=db)
+        await cyberdyne.new(db=db, name="Cyberdyne")
+        await cyberdyne.save(db=db)
+
+        t_800 = await Node.init(schema=TestKind.CAR, db=db)
+        await t_800.new(
+            db=db,
+            name="Cyberdyne systems model 101",
+            color="Chrome",
+            description="killing machine with secret heart of gold",
+            owner=john,
+            manufacturer=cyberdyne,
+        )
+        await t_800.save(db=db)
+        ed_209 = await Node.init(schema=TestKind.CAR, db=db)
+        await ed_209.new(
+            db=db,
+            name="ED-209",
+            color="Chrome",
+            description="still working on doing stairs",
+            owner=murphy,
+            manufacturer=omnicorp,
+        )
+        await ed_209.save(db=db)
+
+        return {
+            "john": john,
+            "kara": kara,
+            "murphy": murphy,
+            "omnicorp": omnicorp,
+            "cyberdyne": cyberdyne,
+            "t_800": t_800,
+            "ed_209": ed_209,
+        }
+
+    @pytest.fixture(scope="class")
+    async def branch1(self, db: InfrahubDatabase) -> Branch:
+        return await create_branch(db=db, branch_name="branch1")
+
+    @pytest.fixture(scope="class")
+    async def branch1_data(self, db: InfrahubDatabase, initial_dataset: dict[str, Node], branch1: Branch) -> dict[str, Node]:
+        kara_branch = await NodeManager.get_one(db=db, branch=branch1, id=initial_dataset["kara"].id)
+        await kara_branch.delete(db=db)
+
+        sarah = await Node.init(schema=TestKind.PERSON, db=db, branch=branch1)
+        await sarah.new(db=db, name="Sarah", height=161, description="no fate")
+        await sarah.save(db=db)
+
+        t_800_branch = await NodeManager.get_one(db=db, branch=branch1, id=initial_dataset["t_800"].id)
+        await t_800_branch.owner.update(db=db, data=sarah)
+        await t_800_branch.save(db=db)
+
+        ocp_branch = await NodeManager.get_one(db=db, branch=branch1, id=initial_dataset["omnicorp"].id)
+        ocp_branch.name.value = "Omni Consumer Products"
+        await ocp_branch.save(db=db)
+
+        return {"sarah": sarah}
+
+    async def test_merge_branch_rollback(
+        self,
+        db: InfrahubDatabase,
+        client: InfrahubClient,
+        initial_dataset: dict[str, Node],
+        branch1: Branch,
+        branch1_data: dict[str, Node],
+    ) -> None:
+        with patch("infrahub.core.branch.tasks.BranchMerger", new=BrokenBranchMerger):
+            with pytest.raises(GraphQLError) as exc:
+                await client.execute_graphql(query=BRANCH_MERGE, variables={"branch": branch1.name})
+
+            assert exc
+            assert f"Failed to merge branch '{branch1.name}'" in exc.value.message
+
+        # check that the changes on the branch have all been rolled back
+        kara_main = await NodeManager.get_one(db=db, id=initial_dataset["kara"].id)
+        assert kara_main.id
+
+        sarah = await NodeManager.get_one(db=db, id=branch1_data["sarah"].id)
+        assert sarah is None
+
+        t_800_main = await NodeManager.get_one(db=db, id=initial_dataset["t_800"].id)
+        owner_peer = await t_800_main.owner.get_peer(db=db)
+        assert owner_peer.id == initial_dataset["john"].id
+
+        ocp_main = await NodeManager.get_one(db=db, id=initial_dataset["omnicorp"].id)
+        assert ocp_main.name.value == "Omnicorp"

--- a/backend/tests/integration/diff/test_merge_rollback.py
+++ b/backend/tests/integration/diff/test_merge_rollback.py
@@ -109,7 +109,9 @@ class TestBranchMergeRollback(TestInfrahubApp):
         return await create_branch(db=db, branch_name="branch1")
 
     @pytest.fixture(scope="class")
-    async def branch1_data(self, db: InfrahubDatabase, initial_dataset: dict[str, Node], branch1: Branch) -> dict[str, Node]:
+    async def branch1_data(
+        self, db: InfrahubDatabase, initial_dataset: dict[str, Node], branch1: Branch
+    ) -> dict[str, Node]:
         kara_branch = await NodeManager.get_one(db=db, branch=branch1, id=initial_dataset["kara"].id)
         await kara_branch.delete(db=db)
 

--- a/backend/tests/unit/core/diff/test_diff_and_merge.py
+++ b/backend/tests/unit/core/diff/test_diff_and_merge.py
@@ -74,10 +74,11 @@ class TestDiffAndMerge:
             db=db, branch=branch2, schema=schema_branch, limit=["TestCar", "TestPerson"], update_db=True
         )
 
+        at = Timestamp()
         diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
         await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch2)
         diff_merger = await self._get_diff_merger(db=db, branch=branch2)
-        await diff_merger.merge_graph(at=Timestamp())
+        await diff_merger.merge_graph(at=at)
 
         updated_schema = await registry.schema.load_schema_from_db(db=db, branch=default_branch)
         car_schema_main = updated_schema.get(name="TestCar", duplicate=False)
@@ -87,6 +88,15 @@ class TestDiffAndMerge:
         assert new_bool_attr.default_value is False
         new_str_attr = car_schema_main.get_attribute(name="nickname")
         assert new_str_attr.default_value == "car"
+
+        await diff_merger.rollback(at=at)
+
+        rolled_back_schema = await registry.schema.load_schema_from_db(db=db, branch=default_branch)
+        car_schema_main = rolled_back_schema.get(name="TestCar", duplicate=False)
+        attribute_names = car_schema_main.attribute_names
+        assert "num_cupholders" not in attribute_names
+        assert "is_cool" not in attribute_names
+        assert "nickname" not in attribute_names
 
     @pytest.mark.parametrize(
         "conflict_selection,expected_value",
@@ -112,6 +122,7 @@ class TestDiffAndMerge:
         john_branch.name.value = "John-branch"
         await john_branch.save(db=db)
 
+        at = Timestamp()
         diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
         enriched_diff = await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch2)
         conflicts_map = enriched_diff.get_all_conflicts()
@@ -119,10 +130,15 @@ class TestDiffAndMerge:
         conflict = next(iter(conflicts_map.values()))
         await diff_repository.update_conflict_by_id(conflict_id=conflict.uuid, selection=conflict_selection)
         diff_merger = await self._get_diff_merger(db=db, branch=branch2)
-        await diff_merger.merge_graph(at=Timestamp())
+        await diff_merger.merge_graph(at=at)
 
         updated_john = await NodeManager.get_one(db=db, id=person_john_main.id)
         assert updated_john.name.value == expected_value
+
+        await diff_merger.rollback(at=at)
+
+        rolled_back_john = await NodeManager.get_one(db=db, id=person_john_main.id)
+        assert rolled_back_john.name.value == "John-main"
 
     @pytest.mark.parametrize(
         "conflict_selection",
@@ -148,6 +164,7 @@ class TestDiffAndMerge:
         await car_branch.owner.update(db=db, data=person_jane_main)
         await car_branch.save(db=db)
 
+        at = Timestamp()
         diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
         enriched_diff = await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch2)
         conflicts_map = enriched_diff.get_all_conflicts()
@@ -155,7 +172,7 @@ class TestDiffAndMerge:
         conflict = next(iter(conflicts_map.values()))
         await diff_repository.update_conflict_by_id(conflict_id=conflict.uuid, selection=conflict_selection)
         diff_merger = await self._get_diff_merger(db=db, branch=branch2)
-        await diff_merger.merge_graph(at=Timestamp())
+        await diff_merger.merge_graph(at=at)
 
         updated_car = await NodeManager.get_one(db=db, id=car_accord_main.id)
         owner_rel = await updated_car.owner.get(db=db)
@@ -163,6 +180,12 @@ class TestDiffAndMerge:
             assert owner_rel.peer_id == person_alfred_main.id
         if conflict_selection is ConflictSelection.DIFF_BRANCH:
             assert owner_rel.peer_id == person_jane_main.id
+
+        await diff_merger.rollback(at=at)
+
+        rolled_back_car = await NodeManager.get_one(db=db, id=car_accord_main.id)
+        owner_rel = await rolled_back_car.owner.get(db=db)
+        assert owner_rel.peer_id == person_alfred_main.id
 
     @pytest.mark.parametrize(
         "conflict_selection",
@@ -187,6 +210,7 @@ class TestDiffAndMerge:
         john_branch.name.source = person_jane_main
         await john_branch.save(db=db)
 
+        at = Timestamp()
         diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
         enriched_diff = await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch2)
         conflicts_map = enriched_diff.get_all_conflicts()
@@ -194,7 +218,7 @@ class TestDiffAndMerge:
         conflict = next(iter(conflicts_map.values()))
         await diff_repository.update_conflict_by_id(conflict_id=conflict.uuid, selection=conflict_selection)
         diff_merger = await self._get_diff_merger(db=db, branch=branch2)
-        await diff_merger.merge_graph(at=Timestamp())
+        await diff_merger.merge_graph(at=at)
 
         updated_john = await NodeManager.get_one(db=db, id=person_john_main.id, include_source=True)
 
@@ -203,6 +227,12 @@ class TestDiffAndMerge:
             assert attr_source.id == person_alfred_main.id
         if conflict_selection is ConflictSelection.DIFF_BRANCH:
             assert attr_source.id == person_jane_main.id
+
+        await diff_merger.rollback(at=at)
+
+        rolled_back_john = await NodeManager.get_one(db=db, id=person_john_main.id, include_source=True)
+        attr_source = await rolled_back_john.name.get_source(db=db)
+        assert attr_source.id == person_alfred_main.id
 
     @pytest.mark.parametrize(
         "conflict_selection",
@@ -228,6 +258,7 @@ class TestDiffAndMerge:
         await car_branch.owner.update(db=db, data={"id": person_john_main.id, "_relation__owner": person_jane_main.id})
         await car_branch.save(db=db)
 
+        at = Timestamp()
         diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
         enriched_diff = await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch2)
         conflicts_map = enriched_diff.get_all_conflicts()
@@ -236,7 +267,7 @@ class TestDiffAndMerge:
         for conflict in conflicts_map.values():
             await diff_repository.update_conflict_by_id(conflict_id=conflict.uuid, selection=conflict_selection)
         diff_merger = await self._get_diff_merger(db=db, branch=branch2)
-        await diff_merger.merge_graph(at=Timestamp())
+        await diff_merger.merge_graph(at=at)
 
         updated_car = await NodeManager.get_one(db=db, id=car_accord_main.id, include_owner=True)
         owner_rel = await updated_car.owner.get(db=db)
@@ -245,3 +276,10 @@ class TestDiffAndMerge:
             assert owner_prop.id == person_alfred_main.id
         if conflict_selection is ConflictSelection.DIFF_BRANCH:
             assert owner_prop.id == person_jane_main.id
+
+        await diff_merger.rollback(at=at)
+
+        rolled_back_car = await NodeManager.get_one(db=db, id=car_accord_main.id, include_owner=True)
+        owner_rel = await rolled_back_car.owner.get(db=db)
+        owner_prop = await owner_rel.get_owner(db=db)
+        assert owner_prop.id == person_alfred_main.id


### PR DESCRIPTION
fixes #4448 
IFC-732

moves the call to merge a branch out of a transaction b/c a large merge was too big of a transaction and caused an OOM error
instead of a transaction, the merge is inside of a try-except block that will use a new query to roll the merge back
- also fixes a bug in the merge query that prevented IS_RELATED edges from getting set to status="deleted" in some scenarios where the was a conflict
- and removes the `conflict_resolution` argument to the merge, b/c conflict information is stored in the diff now