### PR TITLE
Integrate Prefect Flow data into existing InfrahubTask query

### DIFF
--- a/backend/infrahub/core/task/task.py
+++ b/backend/infrahub/core/task/task.py
@@ -1,5 +1,16 @@
-from typing import Any, Optional
+from collections import defaultdict
+from typing import TYPE_CHECKING, Any, Optional
 
+from prefect.client.orchestration import get_client
+from prefect.client.schemas.filters import (
+    FlowRunFilter,
+    FlowRunFilterTags,
+    LogFilter,
+    LogFilterFlowRunId,
+)
+from prefect.client.schemas.sorting import (
+    FlowRunSort,
+)
 from pydantic import ConfigDict, Field
 
 from infrahub.core.constants import TaskConclusion
@@ -10,8 +21,14 @@ from infrahub.core.query.task import TaskNodeCreateQuery, TaskNodeQuery, TaskNod
 from infrahub.core.timestamp import current_timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.utils import get_nested_dict
+from infrahub.workflows.constants import TAG_NAMESPACE, WorkflowTag
 
 from .task_log import TaskLog
+
+if TYPE_CHECKING:
+    from prefect.client.schemas.objects import Log as PrefectLog
+
+LOG_LEVEL_MAPPING = {10: "debug", 20: "info", 30: "warning", 40: "error", 50: "critical"}
 
 
 class Task(StandardNode):
@@ -91,3 +108,83 @@ class Task(StandardNode):
             )
 
         return {"count": count, "edges": nodes}
+
+
+class NewTask:
+    @classmethod
+    async def query(
+        cls,
+        fields: dict[str, Any],
+        related_nodes: list[str],
+        branch: str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        nodes: list[dict] = []
+        count = None
+
+        log_fields = get_nested_dict(nested_dict=fields, keys=["edges", "node", "logs", "edges", "node"])
+        logs_flow: dict[str, list[PrefectLog]] = defaultdict(list)
+
+        async with get_client(sync_client=False) as client:
+            tags = [TAG_NAMESPACE]
+
+            if branch:
+                tags.append(WorkflowTag.BRANCH.render(identifier=branch))
+
+            # We only support one related node for now, need to investigate HOW (and IF) we can support more
+            if related_nodes:
+                tags.append(WorkflowTag.RELATED_NODE.render(identifier=related_nodes[0]))
+
+            flow_run_filters = FlowRunFilter(
+                tags=FlowRunFilterTags(all_=tags),
+            )
+
+            flows = await client.read_flow_runs(
+                flow_run_filter=flow_run_filters,
+                limit=limit,
+                offset=offset,
+                sort=FlowRunSort.START_TIME_DESC,
+            )
+
+            # For now count will just return the number of objects in the response
+            # it won't work well with pagination but it doesn't look like Prefect provide a good option to count all flows
+            if "count" in fields:
+                count = len(flows)
+
+            if log_fields:
+                flow_ids = [flow.id for flow in flows]
+                all_logs = await client.read_logs(log_filter=LogFilter(flow_run_id=LogFilterFlowRunId(any_=flow_ids)))
+                for log in all_logs:
+                    logs_flow[log.flow_run_id].append(log)
+
+            for flow in flows:
+                logs = []
+                if log_fields:
+                    logs = [
+                        {
+                            "node": {
+                                "message": log.message,
+                                "severity": LOG_LEVEL_MAPPING.get(log.level, "error"),
+                                "timestamp": log.timestamp.to_iso8601_string(),
+                            }
+                        }
+                        for log in logs_flow[flow.id]
+                    ]
+
+                nodes.append(
+                    {
+                        "node": {
+                            "title": flow.name,
+                            "conclusion": flow.state_name,
+                            "related_node": "",
+                            "related_node_kind": "",
+                            "created_at": flow.created.to_iso8601_string(),
+                            "updated_at": flow.updated.to_iso8601_string(),
+                            "id": flow.id,
+                            "logs": {"edges": logs},
+                        }
+                    }
+                )
+
+        return {"count": count or 0, "edges": nodes}

--- a/backend/infrahub/graphql/queries/task.py
+++ b/backend/infrahub/graphql/queries/task.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from graphene import Field, Int, List, ObjectType, String
 from infrahub_sdk.utils import extract_fields_first_node
 
-from infrahub.core.task import Task as TaskNode
-from infrahub.graphql.types import TaskNodes
+from infrahub.core.task.task import NewTask as TaskNewNode
+from infrahub.core.task.task import Task as TaskNode
+from infrahub.graphql.types.task import TaskNodes
 
 if TYPE_CHECKING:
     from graphql import GraphQLResolveInfo
@@ -24,23 +25,45 @@ class Tasks(ObjectType):
         info: GraphQLResolveInfo,
         limit: int = 10,
         offset: int = 0,
-        ids: Optional[list] = None,
-        related_node__ids: Optional[list] = None,
+        ids: list | None = None,
+        branch: str | None = None,
+        related_node__ids: list | None = None,
     ) -> dict[str, Any]:
         related_nodes = related_node__ids or []
         ids = ids or []
-        return await Tasks.query(info=info, limit=limit, offset=offset, ids=ids, related_nodes=related_nodes)
+        return await Tasks.query(
+            info=info, branch=branch, limit=limit, offset=offset, ids=ids, related_nodes=related_nodes
+        )
 
     @classmethod
     async def query(
-        cls, info: GraphQLResolveInfo, limit: int, offset: int, related_nodes: list[str], ids: list[str]
+        cls,
+        info: GraphQLResolveInfo,
+        limit: int,
+        offset: int,
+        related_nodes: list[str],
+        ids: list[str],
+        branch: str | None,
     ) -> dict[str, Any]:
         context: GraphqlContext = info.context
         fields = await extract_fields_first_node(info)
 
-        return await TaskNode.query(
-            db=context.db, fields=fields, limit=limit, offset=offset, ids=ids, related_nodes=related_nodes
+        # During the migration, query both Prefect and Infrahub to get the list of tasks
+        if not branch:
+            infrahub_tasks = await TaskNode.query(
+                db=context.db, fields=fields, limit=limit, offset=offset, ids=ids, related_nodes=related_nodes
+            )
+        else:
+            infrahub_tasks = {}
+
+        prefect_tasks = await TaskNewNode.query(
+            fields=fields, branch=branch, related_nodes=related_nodes, limit=limit, offset=offset
         )
+
+        return {
+            "count": infrahub_tasks.get("count", 0) + prefect_tasks.get("count", 0),
+            "edges": infrahub_tasks.get("edges", []) + prefect_tasks.get("edges", []),
+        }
 
 
 Task = Field(
@@ -49,5 +72,6 @@ Task = Field(
     limit=Int(required=False),
     offset=Int(required=False),
     related_node__ids=List(String),
+    branch=String(required=False),
     ids=List(String),
 )

--- a/backend/infrahub/graphql/schema.py
+++ b/backend/infrahub/graphql/schema.py
@@ -50,9 +50,9 @@ from .queries import (
     InfrahubSearchAnywhere,
     InfrahubStatus,
     Relationship,
-    Task,
 )
 from .queries.diff.tree import DiffTreeQuery, DiffTreeSummaryQuery
+from .queries.task import Task
 
 
 class InfrahubBaseQuery(ObjectType):

--- a/backend/infrahub/workflows/constants.py
+++ b/backend/infrahub/workflows/constants.py
@@ -13,6 +13,7 @@ class WorkflowTag(InfrahubStringEnum):
     BRANCH = "branch/{identifier}"
     WORKFLOWTYPE = "workflow-type/{identifier}"
     DATABASE_CHANGE = "database-change"
+    RELATED_NODE = "node/{identifier}"
 
     def render(self, identifier: str | None = None) -> str:
         if identifier is None:

--- a/backend/infrahub/workflows/models.py
+++ b/backend/infrahub/workflows/models.py
@@ -12,7 +12,7 @@ from typing_extensions import Self
 from infrahub import __version__
 from infrahub.core.constants import BranchSupportType
 
-from .constants import WorkflowTag, WorkflowType
+from .constants import TAG_NAMESPACE, WorkflowTag, WorkflowType
 
 TASK_RESULT_STORAGE_NAME = "infrahub-storage"
 
@@ -61,7 +61,7 @@ class WorkflowDefinition(BaseModel):
         return payload
 
     def get_tags(self) -> list[str]:
-        tags: list[str] = [WorkflowTag.WORKFLOWTYPE.render(identifier=self.type.value)]
+        tags: list[str] = [TAG_NAMESPACE, WorkflowTag.WORKFLOWTYPE.render(identifier=self.type.value)]
         tags += [tag.render() for tag in self.tags]
         return tags
 

--- a/backend/tests/unit/graphql/queries/test_task.py
+++ b/backend/tests/unit/graphql/queries/test_task.py
@@ -1,13 +1,19 @@
 from typing import Any, Dict
 from uuid import uuid4
 
+import pytest
 from graphql import ExecutionResult, graphql
+from prefect.client.orchestration import PrefectClient, get_client
+from prefect.states import State
+from prefect.testing.utilities import prefect_test_harness
 
 from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
+from infrahub.tasks.dummy import dummy_flow
+from infrahub.workflows.constants import TAG_NAMESPACE, WorkflowTag
 
 CREATE_TASK = """
 mutation CreateTask(
@@ -89,7 +95,79 @@ query TaskQuery(
 """
 
 
-async def test_task_query(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None):
+@pytest.fixture
+def local_prefect_server():
+    with prefect_test_harness():
+        yield
+
+
+@pytest.fixture
+async def tag_blue(db: InfrahubDatabase, default_branch: Branch) -> Node:
+    blue = await Node.init(db=db, schema=InfrahubKind.TAG, branch=default_branch)
+    await blue.new(db=db, name="Blue", description="The Blue tag")
+    await blue.save(db=db)
+    return blue
+
+
+@pytest.fixture
+async def account_bob(db: InfrahubDatabase, default_branch: Branch) -> Node:
+    bob = await Node.init(db=db, schema=InfrahubKind.ACCOUNT, branch=default_branch)
+    await bob.new(db=db, name="bob", password=str(uuid4()))
+    await bob.save(db=db)
+    return bob
+
+
+@pytest.fixture
+async def prefect_client(local_prefect_server):
+    async with get_client(sync_client=False) as client:
+        yield client
+
+
+@pytest.fixture
+async def flow_runs_data(prefect_client: PrefectClient, tag_blue):
+    branch1_tag = WorkflowTag.BRANCH.render(identifier="branch1")
+
+    items = [
+        await prefect_client.create_flow_run(
+            flow=dummy_flow,
+            name="dummy-completed-internal-tag-br1",
+            parameters={"firstname": "john", "lastname": "doe"},
+            tags=[TAG_NAMESPACE, branch1_tag],
+            state=State(type="COMPLETED"),
+        ),
+        await prefect_client.create_flow_run(
+            flow=dummy_flow,
+            name="dummy-completed-no-tag",
+            parameters={"firstname": "jane", "lastname": "doe"},
+            tags=[],
+            state=State(type="COMPLETED"),
+        ),
+        await prefect_client.create_flow_run(
+            flow=dummy_flow,
+            name="dummy-scheduled-internal-tag",
+            parameters={"firstname": "xxxx", "lastname": "yyy"},
+            tags=[TAG_NAMESPACE, WorkflowTag.RELATED_NODE.render(identifier=tag_blue.get_id())],
+            state=State(type="SCHEDULED"),
+        ),
+    ]
+
+    return {item.name: item for item in items}
+
+
+async def run_query(db: InfrahubDatabase, branch: Branch, query: str, variables: Dict[str, Any]) -> ExecutionResult:
+    gql_params = prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    return await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values=variables,
+    )
+
+
+async def test_task_query_infrahub(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None, local_prefect_server
+):
     red = await Node.init(db=db, schema=InfrahubKind.TAG, branch=default_branch)
     await red.new(db=db, name="Red", description="The Red tag")
     await red.save(db=db)
@@ -118,6 +196,7 @@ async def test_task_query(db: InfrahubDatabase, default_branch: Branch, register
             "logs": {"message": "Starting task", "severity": "INFO"},
         },
     )
+    assert result.errors is None
     assert result.data
 
     result = await run_query(
@@ -132,6 +211,7 @@ async def test_task_query(db: InfrahubDatabase, default_branch: Branch, register
             "logs": {"message": "Starting task", "severity": "INFO"},
         },
     )
+    assert result.errors is None
     assert result.data
 
     result = await run_query(
@@ -146,6 +226,7 @@ async def test_task_query(db: InfrahubDatabase, default_branch: Branch, register
             "logs": {"message": "Starting task", "severity": "INFO"},
         },
     )
+    assert result.errors is None
     assert result.data
 
     result = await run_query(
@@ -160,6 +241,7 @@ async def test_task_query(db: InfrahubDatabase, default_branch: Branch, register
             "logs": {"message": "Starting task", "severity": "INFO"},
         },
     )
+    assert result.errors is None
     assert result.data
 
     result = await run_query(
@@ -177,6 +259,7 @@ async def test_task_query(db: InfrahubDatabase, default_branch: Branch, register
             ],
         },
     )
+    assert result.errors is None
     assert result.data
 
     all_tasks = await run_query(
@@ -185,6 +268,7 @@ async def test_task_query(db: InfrahubDatabase, default_branch: Branch, register
         query=QUERY_TASK,
         variables={},
     )
+    assert all_tasks.errors is None
     assert all_tasks.data
     assert all_tasks.data["InfrahubTask"]["count"] == 5
 
@@ -194,6 +278,7 @@ async def test_task_query(db: InfrahubDatabase, default_branch: Branch, register
         query=QUERY_TASK,
         variables={"related_nodes": blue.get_id()},
     )
+    assert blue_tasks.errors is None
     assert blue_tasks.data
     assert blue_tasks.data["InfrahubTask"]["count"] == 3
 
@@ -203,6 +288,7 @@ async def test_task_query(db: InfrahubDatabase, default_branch: Branch, register
         query=QUERY_TASK,
         variables={"related_nodes": [red.get_id(), blue.get_id()]},
     )
+    assert red_blue_tasks.errors is None
     assert red_blue_tasks.data
     assert red_blue_tasks.data["InfrahubTask"]["count"] == 4
 
@@ -212,6 +298,7 @@ async def test_task_query(db: InfrahubDatabase, default_branch: Branch, register
         query=QUERY_TASK_WITH_LOGS,
         variables={},
     )
+    assert all_logs.errors is None
     assert all_logs.data
     logs = []
     for task in all_logs.data["InfrahubTask"]["edges"]:
@@ -220,12 +307,130 @@ async def test_task_query(db: InfrahubDatabase, default_branch: Branch, register
     assert len(logs) == 6
 
 
-async def run_query(db: InfrahubDatabase, branch: Branch, query: str, variables: Dict[str, Any]) -> ExecutionResult:
-    gql_params = prepare_graphql_params(db=db, include_subscription=False, branch=branch)
-    return await graphql(
-        schema=gql_params.schema,
-        source=query,
-        context_value=gql_params.context,
-        root_value=None,
-        variable_values=variables,
+async def test_task_query_prefect(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None, flow_runs_data
+):
+    result = await run_query(
+        db=db,
+        branch=default_branch,
+        query=QUERY_TASK_WITH_LOGS,
+        variables={},
     )
+    assert result.errors is None
+    assert result.data
+
+    assert len(result.data["InfrahubTask"]["edges"]) == 2
+    assert result.data["InfrahubTask"]["count"] == 2
+
+
+async def test_task_query_filter_branch(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None, flow_runs_data
+):
+    QUERY = """
+    query TaskQuery(
+        $branch_name: String!
+    ) {
+        InfrahubTask(branch: $branch_name) {
+            count
+            edges {
+                node {
+                    id
+                }
+            }
+        }
+    }
+    """
+    result = await run_query(
+        db=db,
+        branch=default_branch,
+        query=QUERY,
+        variables={"branch_name": "branch1"},
+    )
+    assert result.errors is None
+    assert result.data
+
+    assert len(result.data["InfrahubTask"]["edges"]) == 1
+    assert result.data["InfrahubTask"]["count"] == 1
+
+
+async def test_task_query_filter_node(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: None,
+    tag_blue,
+    account_bob,
+    flow_runs_data,
+):
+    QUERY = """
+    query TaskQuery(
+        $related_nodes: [String]
+    ) {
+        InfrahubTask(related_node__ids: $related_nodes) {
+            count
+            edges {
+                node {
+                    id
+                }
+            }
+        }
+    }
+    """
+    result = await run_query(
+        db=db,
+        branch=default_branch,
+        query=QUERY,
+        variables={"related_nodes": [tag_blue.get_id()]},
+    )
+    assert result.errors is None
+    assert result.data
+
+    assert len(result.data["InfrahubTask"]["edges"]) == 1
+    assert result.data["InfrahubTask"]["count"] == 1
+
+    result = await run_query(
+        db=db,
+        branch=default_branch,
+        query=QUERY,
+        variables={"related_nodes": [account_bob.get_id()]},
+    )
+    assert result.errors is None
+    assert result.data
+
+    assert len(result.data["InfrahubTask"]["edges"]) == 0
+    assert result.data["InfrahubTask"]["count"] == 0
+
+
+async def test_task_query_both(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: None,
+    tag_blue,
+    account_bob,
+    flow_runs_data,
+):
+    result = await run_query(
+        db=db,
+        branch=default_branch,
+        query=CREATE_TASK,
+        variables={
+            "conclusion": "UNKNOWN",
+            "title": "Blue Task 1",
+            "related_node": tag_blue.get_id(),
+            "created_by": account_bob.get_id(),
+            "logs": {"message": "Starting task", "severity": "INFO"},
+        },
+    )
+    assert result.errors is None
+    assert result.data
+
+    all_logs = await run_query(
+        db=db,
+        branch=default_branch,
+        query=QUERY_TASK_WITH_LOGS,
+        variables={},
+    )
+    assert all_logs.errors is None
+    assert all_logs.data
+
+    assert len(all_logs.data["InfrahubTask"]["edges"]) == 3
+    assert all_logs.data["InfrahubTask"]["count"] == 3


### PR DESCRIPTION
In preparation for the migration of the task / logs to prefect, this PR extend the `InfrahubTask` query to return the information from the internal database and from Prefect.
This way we can migrate each task individually without having to do a disruptive switch

To recreate the concept of related_nodes, I've added a new tag in Prefect and I've also added a new simple tag `infrahub.app` to quickly identify infrahub related flows from prefect specific one.
