### PR TITLE
Cleanup git tasks, add description and flow name

### DIFF
--- a/backend/infrahub/git/models.py
+++ b/backend/infrahub/git/models.py
@@ -18,7 +18,7 @@ class RequestArtifactGenerate(BaseModel):
     """Runs to generate an artifact"""
 
     artifact_name: str = Field(..., description="Name of the artifact")
-    artifact_definition: str = Field(..., description="The the ID of the artifact definition")
+    artifact_definition: str = Field(..., description="The ID of the artifact definition")
     commit: str = Field(..., description="The commit to target")
     content_type: str = Field(..., description="Content type of the artifact")
     transform_type: str = Field(..., description="The type of transform associated with this artifact")

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -1,5 +1,6 @@
 from infrahub_sdk import InfrahubClient
 from prefect import flow, task
+from prefect.logging import get_run_logger
 
 from infrahub import lock
 from infrahub.core.constants import InfrahubKind, RepositoryInternalStatus
@@ -8,10 +9,9 @@ from infrahub.core.registry import registry
 from infrahub.exceptions import RepositoryError
 from infrahub.services import services
 
-from ..log import get_logger
 from ..tasks.artifact import define_artifact
 from ..workflows.catalogue import REQUEST_ARTIFACT_DEFINITION_GENERATE, REQUEST_ARTIFACT_GENERATE
-from ..workflows.utils import add_branch_tag
+from ..workflows.utils import add_branch_tag, add_related_node_tag
 from .models import (
     GitRepositoryAdd,
     GitRepositoryAddReadOnly,
@@ -21,8 +21,6 @@ from .models import (
     RequestArtifactGenerate,
 )
 from .repository import InfrahubReadOnlyRepository, InfrahubRepository, get_initialized_repo
-
-log = get_logger()
 
 
 @flow(
@@ -82,7 +80,7 @@ async def add_git_repository_read_only(model: GitRepositoryAddReadOnly) -> None:
                 await repo.sync_from_remote()
 
 
-@flow(name="git_repositories_create_branch")
+@flow(name="git_repositories_create_branch", flow_run_name="Create branch {branch} on all eligible repositories")
 async def create_branch(branch: str, branch_id: str) -> None:
     """Request to the creation of git branches in available repositories."""
     service = services.service
@@ -106,7 +104,7 @@ async def create_branch(branch: str, branch_id: str) -> None:
         pass
 
 
-@flow(name="git_repositories_sync")
+@flow(name="git_repositories_sync", flow_run_name="Sync all repositories")
 async def sync_remote_repositories() -> None:
     service = services.service
 
@@ -174,17 +172,26 @@ async def sync_remote_repositories() -> None:
                 )
 
 
-@task
+@task(task_run_name="Create branch on repository {repository_name}")
 async def git_branch_create(
     client: InfrahubClient, branch: str, branch_id: str, repository_id: str, repository_name: str
 ) -> None:
+    await add_branch_tag(branch_name=branch)
+    await add_related_node_tag(node_id=repository_id)
+
     repo = await InfrahubRepository.init(id=repository_id, name=repository_name, client=client)
     async with lock.registry.get(name=repository_name, namespace="repository"):
         await repo.create_branch_in_git(branch_name=branch, branch_id=branch_id)
 
 
-@flow(name="artifact-definition-generate")
+@flow(
+    name="artifact-definition-generate",
+    description="Generate all artifact definitions on a given branch",
+    flow_run_name="Generate all artifact definitions on branch {branch}",
+)
 async def generate_artifact_definition(branch: str) -> None:
+    await add_branch_tag(branch_name=branch)
+
     service = services.service
     artifact_definitions = await service.client.all(kind=InfrahubKind.ARTIFACTDEFINITION, branch=branch, include=["id"])
 
@@ -195,11 +202,19 @@ async def generate_artifact_definition(branch: str) -> None:
         )
 
 
-@flow(name="artifact-generate")
+@flow(
+    name="artifact-generate",
+    description="Generate a single artifact",
+    flow_run_name="Generate Artifact: {model.artifact_name} for {model.target_name}",
+)
 async def generate_artifact(model: RequestArtifactGenerate) -> None:
-    log.debug("Generating artifact", message=model)
+    await add_branch_tag(branch_name=model.branch_name)
+    # NOTE Not sure if we should use the target_id, the artifact or the artifact definition as the related node
+    await add_related_node_tag(node_id=model.target_id)
 
     service = services.service
+
+    log = get_run_logger()
 
     repo = await get_initialized_repo(
         repository_id=model.repository_id,
@@ -212,23 +227,27 @@ async def generate_artifact(model: RequestArtifactGenerate) -> None:
 
     try:
         result = await repo.render_artifact(artifact=artifact, message=model)
-        log.debug(
-            "Generated artifact",
-            name=model.artifact_name,
-            changed=result.changed,
-            checksum=result.checksum,
-            artifact_id=result.artifact_id,
-            storage_id=result.storage_id,
-        )
-    except Exception as exc:  # pylint: disable=broad-except
-        log.exception("Failed to generate artifact", error=exc)
+        if result.changed:
+            log.info("Artifact already up to date")
+        else:
+            log.info(
+                f"New version of the artifact available in the store with the ID {result.storage_id}",
+                extra={"checksum": result.checksum},
+            )
+    except Exception:  # pylint: disable=broad-except
         artifact.status.value = "Error"
         await artifact.save()
+        raise
 
 
-@flow(name="request_artifact_definitions_generate")
+@flow(
+    name="request_artifact_definitions_generate",
+    description="Trigger rendering of all Artifacts for a given Artifact Definition",
+    flow_run_name="Trigger rendering of Artifacts for {model.artifact_definition}",
+)
 async def generate_request_artifact_definition(model: RequestArtifactDefinitionGenerate) -> None:
     await add_branch_tag(branch_name=model.branch)
+    await add_related_node_tag(node_id=model.artifact_definition)
 
     service = services.service
     artifact_definition = await service.client.get(
@@ -300,57 +319,62 @@ async def generate_request_artifact_definition(model: RequestArtifactDefinitionG
         )
 
 
-@flow(name="git-repository-pull-read-only")
+@flow(
+    name="git-repository-pull-read-only",
+    flow_run_name="Pulling read only repository",
+)
 async def pull_read_only(model: GitRepositoryPullReadOnly) -> None:
+    await add_branch_tag(branch_name=model.infrahub_branch_name)
+    await add_related_node_tag(node_id=model.repository_id)
+
+    log = get_run_logger()
+
     service = services.service
     if not model.ref and not model.commit:
-        log.warning(
-            "No commit or ref in GitRepositoryPullReadOnly message",
-            name=model.repository_name,
-            repository_id=model.repository_id,
-        )
+        log.warning("No commit or ref in GitRepositoryPullReadOnly message")
         return
-    async with service.git_report(related_node=model.repository_id, title="Pulling read-only repository") as git_report:
-        async with lock.registry.get(name=model.repository_name, namespace="repository"):
-            init_failed = False
-            try:
-                repo = await InfrahubReadOnlyRepository.init(
-                    id=model.repository_id,
-                    name=model.repository_name,
-                    location=model.location,
-                    client=service.client,
-                    ref=model.ref,
-                    infrahub_branch_name=model.infrahub_branch_name,
-                    task_report=git_report,
-                )
-            except RepositoryError:
-                init_failed = True
 
-            if init_failed:
-                repo = await InfrahubReadOnlyRepository.new(
-                    id=model.repository_id,
-                    name=model.repository_name,
-                    location=model.location,
-                    client=service.client,
-                    ref=model.ref,
-                    infrahub_branch_name=model.infrahub_branch_name,
-                    task_report=git_report,
-                )
+    async with lock.registry.get(name=model.repository_name, namespace="repository"):
+        init_failed = False
+        try:
+            repo = await InfrahubReadOnlyRepository.init(
+                id=model.repository_id,
+                name=model.repository_name,
+                location=model.location,
+                client=service.client,
+                ref=model.ref,
+                infrahub_branch_name=model.infrahub_branch_name,
+                # task_report=git_report,
+            )
+        except RepositoryError:
+            init_failed = True
 
-            await repo.import_objects_from_files(infrahub_branch_name=model.infrahub_branch_name, commit=model.commit)
-            await repo.sync_from_remote(commit=model.commit)
+        if init_failed:
+            repo = await InfrahubReadOnlyRepository.new(
+                id=model.repository_id,
+                name=model.repository_name,
+                location=model.location,
+                client=service.client,
+                ref=model.ref,
+                infrahub_branch_name=model.infrahub_branch_name,
+                # task_report=git_report,
+            )
+
+        await repo.import_objects_from_files(infrahub_branch_name=model.infrahub_branch_name, commit=model.commit)
+        await repo.sync_from_remote(commit=model.commit)
 
 
-@flow(name="git-repository-merge")
+@flow(
+    name="git-repository-merge",
+    description="merge a branch on a given Git Pepository",
+    flow_run_name="Merge branch {model.source_branch} into {model.destination_branch} [{model.repository_name}]",
+)
 async def merge_git_repository(model: GitRepositoryMerge) -> None:
+    await add_branch_tag(branch_name=model.destination_branch)
+    await add_related_node_tag(node_id=model.repository_id)
     service = services.service
-    log.info(
-        "Merging repository branch",
-        repository_name=model.repository_name,
-        repository_id=model.repository_id,
-        source_branch=model.source_branch,
-        destination_branch=model.destination_branch,
-    )
+
+    log = get_run_logger()
 
     repo = await InfrahubRepository.init(
         id=model.repository_id,
@@ -369,9 +393,11 @@ async def merge_git_repository(model: GitRepositoryMerge) -> None:
 
         commit = repo.get_commit_value(branch_name=repo.default_branch, remote=False)
         repo_main.commit.value = commit
-
         await repo_main.save()
+        log.info(f"Internal Status updated to {RepositoryInternalStatus.ACTIVE.value}")
+        log.debug(f"Commit updated to {commit}")
 
     else:
         async with lock.registry.get(name=model.repository_name, namespace="repository"):
+            log.debug(f"Lock acquired for repository:{model.repository_name}")
             await repo.merge(source_branch=model.source_branch, dest_branch=model.destination_branch)

--- a/backend/infrahub/tasks/artifact.py
+++ b/backend/infrahub/tasks/artifact.py
@@ -1,27 +1,24 @@
 from typing import Union
 
-from infrahub_sdk.node import InfrahubNode
+from infrahub_sdk.protocols import CoreArtifact
 from prefect import task
 
 from infrahub import lock
-from infrahub.core.constants import InfrahubKind
 from infrahub.git.models import RequestArtifactGenerate
 from infrahub.message_bus import messages
 from infrahub.services import InfrahubServices
 
 
-@task
+@task(persist_result=False)
 async def define_artifact(
     message: Union[messages.CheckArtifactCreate, RequestArtifactGenerate], service: InfrahubServices
-) -> InfrahubNode:
+) -> CoreArtifact:
     if message.artifact_id:
-        artifact = await service.client.get(
-            kind=InfrahubKind.ARTIFACT, id=message.artifact_id, branch=message.branch_name
-        )
+        artifact = await service.client.get(kind=CoreArtifact, id=message.artifact_id, branch=message.branch_name)
     else:
         async with lock.registry.get(f"{message.target_id}-{message.artifact_definition}", namespace="artifact"):
             artifacts = await service.client.filters(
-                kind=InfrahubKind.ARTIFACT,
+                kind=CoreArtifact,
                 branch=message.branch_name,
                 definition__ids=[message.artifact_definition],
                 object__ids=[message.target_id],
@@ -30,7 +27,7 @@ async def define_artifact(
                 artifact = artifacts[0]
             else:
                 artifact = await service.client.create(
-                    kind=InfrahubKind.ARTIFACT,
+                    kind=CoreArtifact,
                     branch=message.branch_name,
                     data={
                         "name": message.artifact_name,

--- a/backend/infrahub/workflows/utils.py
+++ b/backend/infrahub/workflows/utils.py
@@ -4,9 +4,19 @@ from prefect.runtime import flow_run
 from .constants import WorkflowTag
 
 
-async def add_branch_tag(branch_name: str) -> None:
+async def add_tags(tags: list[str]) -> None:
     client = get_client(sync_client=False)
     current_flow_run_id = flow_run.id
     current_tags: list[str] = flow_run.tags
-    new_tags = current_tags + [WorkflowTag.BRANCH.render(identifier=branch_name)]
+    new_tags = current_tags + tags
     await client.update_flow_run(current_flow_run_id, tags=list(new_tags))
+
+
+async def add_branch_tag(branch_name: str) -> None:
+    tag = WorkflowTag.BRANCH.render(identifier=branch_name)
+    await add_tags(tags=[tag])
+
+
+async def add_related_node_tag(node_id: str) -> None:
+    tag = WorkflowTag.RELATED_NODE.render(identifier=node_id)
+    await add_tags(tags=[tag])

--- a/backend/tests/unit/git/test_git_rpc.py
+++ b/backend/tests/unit/git/test_git_rpc.py
@@ -302,7 +302,6 @@ class TestPullReadOnly:
             client=self.client,
             ref=self.ref,
             infrahub_branch_name=self.infrahub_branch_name,
-            task_report=self.git_report,
         )
         self.mock_repo.import_objects_from_files.assert_awaited_once_with(
             infrahub_branch_name=self.infrahub_branch_name, commit=self.commit
@@ -322,7 +321,6 @@ class TestPullReadOnly:
             client=self.client,
             ref=self.ref,
             infrahub_branch_name=self.infrahub_branch_name,
-            task_report=self.git_report,
         )
         self.mock_repo_class.new.assert_awaited_once_with(
             id=self.repo_id,
@@ -331,7 +329,6 @@ class TestPullReadOnly:
             client=self.client,
             ref=self.ref,
             infrahub_branch_name=self.infrahub_branch_name,
-            task_report=self.git_report,
         )
         self.mock_repo.import_objects_from_files.assert_awaited_once_with(
             infrahub_branch_name=self.infrahub_branch_name, commit=self.commit

--- a/backend/tests/unit/graphql/mutations/test_proposed_change.py
+++ b/backend/tests/unit/graphql/mutations/test_proposed_change.py
@@ -13,6 +13,7 @@ from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.message_bus import messages
 from infrahub.permissions.local_backend import LocalPermissionBackend
 from infrahub.services import InfrahubServices
+from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from tests.adapters.message_bus import BusRecorder
 from tests.helpers.graphql import graphql_mutation
 
@@ -207,9 +208,15 @@ async def test_merge_proposed_change_permission_failure(
     branch_name = "merge-proposed-change-perm"
     await create_branch(branch_name=branch_name, db=db)
 
+    service = InfrahubServices(database=db, workflow=WorkflowLocalExecution())
+
     proposed_change = await Node.init(db=db, schema=InfrahubKind.PROPOSEDCHANGE)
     await proposed_change.new(
-        db=db, name="pc-merge-perm-1234", destination_branch="main", source_branch=branch_name, state="open"
+        db=db,
+        name="pc-merge-perm-1234",
+        destination_branch="main",
+        source_branch=branch_name,
+        state="open",
     )
     await proposed_change.save(db=db)
 
@@ -218,6 +225,7 @@ async def test_merge_proposed_change_permission_failure(
         db=db,
         variables={"proposed_change": proposed_change.id, "state": "merged"},
         account_session=session_first_account,
+        service=service,
     )
 
     assert update_status.errors
@@ -228,6 +236,7 @@ async def test_merge_proposed_change_permission_failure(
         db=db,
         variables={"proposed_change": proposed_change.id, "state": "merged"},
         account_session=session_admin,
+        service=service,
     )
 
     assert not update_status.errors


### PR DESCRIPTION
Mainly cleanup related  the migration to Prefect
- add flow_run_name on a few flow
- Add a new `add_related_node_tag` function to associate a flow with an object
- Remove some logs that are not required anymore