### PR TITLE
Fixes create schema guide

### DIFF
--- a/docs/docs/guides/create-schema.mdx
+++ b/docs/docs/guides/create-schema.mdx
@@ -150,13 +150,7 @@ You can verify that both the Device and Interface were added to Infrahub by navi
 
 ![schema page screenshot](../media/guides/create_schema_2.png)
 
-Finally, you can merge the `network-device-schema` branch to 'main' by running the following command.
-
-```shell
-infrahubctl branch merge network-device-schema
-```
-
-We have now successfully created our first schema, loaded into a branch into Infrahub, created the first nodes and merged the changes into the main branch of Infrahub.
+We have now successfully created our first schema, loaded into a branch into Infrahub and created the first nodes in the `network-device-schema` branch in Infrahub.
 
 ## 2. Adding relationships to the nodes
 


### PR DESCRIPTION
In #4785 the create schema guide was modified. 
Particularly in the first section a statement was added to merge a branch into main. This brakes the flow of the rest of the guide.