### PR TITLE
update IpamDiffParser to use new diff

### DIFF
--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -114,10 +114,9 @@ async def rebase_branch(branch: str) -> None:
     # -------------------------------------------------------------
     # Trigger the reconciliation of IPAM data after the rebase
     # -------------------------------------------------------------
-    differ = await merger.get_graph_diff()
     diff_parser = IpamDiffParser(
         db=service.database,
-        differ=differ,
+        diff_repository=diff_repository,
         source_branch_name=obj.name,
         target_branch_name=registry.default_branch,
     )
@@ -187,10 +186,10 @@ async def merge_branch(branch: str) -> None:
         # -------------------------------------------------------------
         # Trigger the reconciliation of IPAM data after the merge
         # -------------------------------------------------------------
-        differ = await merger.get_graph_diff()
+        diff_repository = await component_registry.get_component(DiffRepository, db=service.database, branch=obj)
         diff_parser = IpamDiffParser(
-            db=db,
-            differ=differ,
+            db=service.database,
+            diff_repository=diff_repository,
             source_branch_name=obj.name,
             target_branch_name=registry.default_branch,
         )

--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -114,16 +114,15 @@ async def rebase_branch(branch: str) -> None:
     # -------------------------------------------------------------
     # Trigger the reconciliation of IPAM data after the rebase
     # -------------------------------------------------------------
-    diff_parser = IpamDiffParser(
-        db=service.database,
-        diff_repository=diff_repository,
+    diff_parser = await component_registry.get_component(IpamDiffParser, db=service.database, branch=obj)
+    ipam_node_details = await diff_parser.get_changed_ipam_node_details(
         source_branch_name=obj.name,
         target_branch_name=registry.default_branch,
     )
-    ipam_node_details = await diff_parser.get_changed_ipam_node_details()
-    await service.workflow.submit_workflow(
-        workflow=IPAM_RECONCILIATION, parameters={"branch": obj.name, "ipam_node_details": ipam_node_details}
-    )
+    if ipam_node_details:
+        await service.workflow.submit_workflow(
+            workflow=IPAM_RECONCILIATION, parameters={"branch": obj.name, "ipam_node_details": ipam_node_details}
+        )
 
     # -------------------------------------------------------------
     # Generate an event to indicate that a branch has been rebased
@@ -186,18 +185,16 @@ async def merge_branch(branch: str) -> None:
         # -------------------------------------------------------------
         # Trigger the reconciliation of IPAM data after the merge
         # -------------------------------------------------------------
-        diff_repository = await component_registry.get_component(DiffRepository, db=service.database, branch=obj)
-        diff_parser = IpamDiffParser(
-            db=service.database,
-            diff_repository=diff_repository,
+        diff_parser = await component_registry.get_component(IpamDiffParser, db=service.database, branch=obj)
+        ipam_node_details = await diff_parser.get_changed_ipam_node_details(
             source_branch_name=obj.name,
             target_branch_name=registry.default_branch,
         )
-        ipam_node_details = await diff_parser.get_changed_ipam_node_details()
-        await service.workflow.submit_workflow(
-            workflow=IPAM_RECONCILIATION,
-            parameters={"branch": registry.default_branch, "ipam_node_details": ipam_node_details},
-        )
+        if ipam_node_details:
+            await service.workflow.submit_workflow(
+                workflow=IPAM_RECONCILIATION,
+                parameters={"branch": registry.default_branch, "ipam_node_details": ipam_node_details},
+            )
 
         # -------------------------------------------------------------
         # Generate an event to indicate that a branch has been merged

--- a/backend/infrahub/core/diff/ipam_diff_parser.py
+++ b/backend/infrahub/core/diff/ipam_diff_parser.py
@@ -1,9 +1,10 @@
 from dataclasses import dataclass
 from typing import Optional
 
-from infrahub.core.constants import DiffAction, InfrahubKind
+from infrahub.core.constants import DiffAction
 from infrahub.core.constants.database import DatabaseEdgeType
 from infrahub.core.diff.model.path import BranchTrackingId
+from infrahub.core.ipam.kinds_getter import IpamKindsGetter
 from infrahub.core.ipam.model import IpamNodeDetails
 from infrahub.core.manager import NodeManager
 from infrahub.database import InfrahubDatabase
@@ -26,42 +27,28 @@ class IpamDiffParser:
         self,
         db: InfrahubDatabase,
         diff_repository: DiffRepository,
-        source_branch_name: str,
-        target_branch_name: str,
+        ip_kinds_getter: IpamKindsGetter,
     ) -> None:
         self.db = db
         self.diff_repo = diff_repository
-        self.source_branch_name = source_branch_name
-        self.target_branch_name = target_branch_name
+        self.ip_kinds_getter = ip_kinds_getter
 
-    async def get_changed_ipam_node_details(self) -> list[IpamNodeDetails]:
-        prefix_generic_schema_source = self.db.schema.get(
-            InfrahubKind.IPPREFIX, branch=self.source_branch_name, duplicate=False
+    async def get_changed_ipam_node_details(
+        self, source_branch_name: str, target_branch_name: str
+    ) -> list[IpamNodeDetails]:
+        ip_address_kinds = await self.ip_kinds_getter.get_ipam_address_kinds(
+            branch_names=[source_branch_name, target_branch_name]
         )
-        prefix_generic_schema_target = self.db.schema.get(
-            InfrahubKind.IPPREFIX, branch=self.target_branch_name, duplicate=False
-        )
-        address_generic_schema_source = self.db.schema.get(
-            InfrahubKind.IPADDRESS, branch=self.source_branch_name, duplicate=False
-        )
-        address_generic_schema_target = self.db.schema.get(
-            InfrahubKind.IPADDRESS, branch=self.target_branch_name, duplicate=False
-        )
-
-        ip_address_kinds = set(
-            getattr(address_generic_schema_target, "used_by", [])
-            + getattr(address_generic_schema_source, "used_by", [])
-        )
-        ip_prefix_kinds = set(
-            getattr(prefix_generic_schema_target, "used_by", []) + getattr(prefix_generic_schema_source, "used_by", [])
+        ip_prefix_kinds = await self.ip_kinds_getter.get_ipam_prefix_kinds(
+            branch_names=[source_branch_name, target_branch_name]
         )
         if not ip_address_kinds and not ip_prefix_kinds:
             return []
 
         enriched_diffs = await self.diff_repo.get(
-            base_branch_name=self.target_branch_name,
-            diff_branch_names=[self.source_branch_name],
-            tracking_id=BranchTrackingId(name=self.source_branch_name),
+            base_branch_name=target_branch_name,
+            diff_branch_names=[source_branch_name],
+            tracking_id=BranchTrackingId(name=source_branch_name),
             filters={
                 "kind": {"includes": list(ip_address_kinds | ip_prefix_kinds)},
                 "status": {"excludes": {DiffAction.UNCHANGED}},
@@ -89,7 +76,11 @@ class IpamDiffParser:
                         ip_value=ip_value,
                     )
                 )
-        await self._add_missing_values(changed_node_details=changed_node_details)
+        await self._add_missing_values(
+            source_branch_name=source_branch_name,
+            target_branch_name=target_branch_name,
+            changed_node_details=changed_node_details,
+        )
 
         return [
             IpamNodeDetails(
@@ -128,7 +119,9 @@ class IpamDiffParser:
             if cnd.ip_value and cnd.namespace_id:
                 uuids_missing_data.remove(cnd.node_uuid)
 
-    async def _add_missing_values(self, changed_node_details: list[ChangedIpamNodeDetails]) -> None:
+    async def _add_missing_values(
+        self, source_branch_name: str, target_branch_name: str, changed_node_details: list[ChangedIpamNodeDetails]
+    ) -> None:
         uuids_missing_data = {
             cnd.node_uuid for cnd in changed_node_details if cnd.ip_value is None or cnd.namespace_id is None
         }
@@ -136,7 +129,7 @@ class IpamDiffParser:
             return
 
         await self._add_missing_values_branch(
-            branch_name=self.source_branch_name,
+            branch_name=source_branch_name,
             changed_node_details=changed_node_details,
             uuids_missing_data=uuids_missing_data,
         )
@@ -144,7 +137,7 @@ class IpamDiffParser:
             return
 
         await self._add_missing_values_branch(
-            branch_name=self.target_branch_name,
+            branch_name=target_branch_name,
             changed_node_details=changed_node_details,
             uuids_missing_data=uuids_missing_data,
         )

--- a/backend/infrahub/core/ipam/kinds_getter.py
+++ b/backend/infrahub/core/ipam/kinds_getter.py
@@ -1,0 +1,45 @@
+from typing import Iterable
+
+from infrahub.core.constants import InfrahubKind
+from infrahub.database import InfrahubDatabase
+
+
+class IpamKindsGetter:
+    def __init__(self, db: InfrahubDatabase) -> None:
+        self.db = db
+
+    async def get_ipam_address_kinds(self, branch_names: Iterable[str]) -> set[str]:
+        ip_address_kinds: set[str] = set()
+        for branch_name in branch_names:
+            address_generic_schema_source = self.db.schema.get(
+                InfrahubKind.IPADDRESS, branch=branch_name, duplicate=False
+            )
+            address_generic_schema_target = self.db.schema.get(
+                InfrahubKind.IPADDRESS, branch=branch_name, duplicate=False
+            )
+
+            ip_address_kinds.update(
+                set(
+                    getattr(address_generic_schema_target, "used_by", [])
+                    + getattr(address_generic_schema_source, "used_by", [])
+                )
+            )
+        return ip_address_kinds
+
+    async def get_ipam_prefix_kinds(self, branch_names: Iterable[str]) -> set[str]:
+        ip_prefix_kinds: set[str] = set()
+        for branch_name in branch_names:
+            prefix_generic_schema_source = self.db.schema.get(
+                InfrahubKind.IPPREFIX, branch=branch_name, duplicate=False
+            )
+            prefix_generic_schema_target = self.db.schema.get(
+                InfrahubKind.IPPREFIX, branch=branch_name, duplicate=False
+            )
+
+            ip_prefix_kinds.update(
+                set(
+                    getattr(prefix_generic_schema_source, "used_by", [])
+                    + getattr(prefix_generic_schema_target, "used_by", [])
+                )
+            )
+        return ip_prefix_kinds

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -1206,6 +1206,7 @@ class NodeGetHierarchyQuery(Query):
             WITH %(with_clause)s
             RETURN peer as peer1, all(r IN relationships(path) WHERE (r.status = "active")) AS is_active
             ORDER BY branch_level DESC, froms[-1] DESC, froms[-2] DESC, is_active DESC
+            LIMIT 1
         }
         WITH peer1 as peer, is_active
         """ % {"filter": filter_str, "branch_filter": branch_filter, "with_clause": with_clause}

--- a/backend/infrahub/dependencies/builder/diff/ipam_diff_parser.py
+++ b/backend/infrahub/dependencies/builder/diff/ipam_diff_parser.py
@@ -1,0 +1,15 @@
+from infrahub.core.diff.ipam_diff_parser import IpamDiffParser
+from infrahub.dependencies.interface import DependencyBuilder, DependencyBuilderContext
+
+from ..ip.kinds_getter import IpamKindsGetterDependency
+from .repository import DiffRepositoryDependency
+
+
+class IpamDiffParserDependency(DependencyBuilder[IpamDiffParser]):
+    @classmethod
+    def build(cls, context: DependencyBuilderContext) -> IpamDiffParser:
+        return IpamDiffParser(
+            db=context.db,
+            diff_repository=DiffRepositoryDependency.build(context=context),
+            ip_kinds_getter=IpamKindsGetterDependency.build(context=context),
+        )

--- a/backend/infrahub/dependencies/builder/ip/kinds_getter.py
+++ b/backend/infrahub/dependencies/builder/ip/kinds_getter.py
@@ -1,0 +1,8 @@
+from infrahub.core.ipam.kinds_getter import IpamKindsGetter
+from infrahub.dependencies.interface import DependencyBuilder, DependencyBuilderContext
+
+
+class IpamKindsGetterDependency(DependencyBuilder[IpamKindsGetter]):
+    @classmethod
+    def build(cls, context: DependencyBuilderContext) -> IpamKindsGetter:
+        return IpamKindsGetter(db=context.db)

--- a/backend/infrahub/dependencies/registry.py
+++ b/backend/infrahub/dependencies/registry.py
@@ -18,7 +18,9 @@ from .builder.diff.diff_merger import DiffMergerDependency
 from .builder.diff.enricher.aggregated import DiffAggregatedEnricherDependency
 from .builder.diff.enricher.cardinality_one import DiffCardinalityOneEnricherDependency
 from .builder.diff.enricher.hierarchy import DiffHierarchyEnricherDependency
+from .builder.diff.ipam_diff_parser import IpamDiffParserDependency
 from .builder.diff.repository import DiffRepositoryDependency
+from .builder.ip.kinds_getter import IpamKindsGetterDependency
 from .builder.node.delete_validator import NodeDeleteValidatorDependency
 from .component.registry import ComponentDependencyRegistry
 
@@ -37,6 +39,8 @@ def build_component_registry() -> ComponentDependencyRegistry:
     component_registry.track_dependency(RelationshipPeerKindConstraintDependency)
     component_registry.track_dependency(NodeConstraintRunnerDependency)
     component_registry.track_dependency(NodeDeleteValidatorDependency)
+    component_registry.track_dependency(IpamKindsGetterDependency)
+    component_registry.track_dependency(IpamDiffParserDependency)
     component_registry.track_dependency(DiffCardinalityOneEnricherDependency)
     component_registry.track_dependency(DiffHierarchyEnricherDependency)
     component_registry.track_dependency(DiffAggregatedEnricherDependency)

--- a/backend/tests/integration/ipam/test_ipam_rebase_reconcile.py
+++ b/backend/tests/integration/ipam/test_ipam_rebase_reconcile.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
-import ipaddress
 from typing import TYPE_CHECKING
+
+from graphql import graphql
 
 from infrahub.core import registry
 from infrahub.core.initialization import create_branch
-from infrahub.core.ipam.reconciler import IpamReconciler
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
+from infrahub.graphql.initialization import prepare_graphql_params
 
 from .base import TestIpamReconcileBase
 
@@ -15,6 +16,46 @@ if TYPE_CHECKING:
     from infrahub_sdk import InfrahubClient
 
     from infrahub.database import InfrahubDatabase
+
+CREATE_IPPREFIX = """
+mutation CreatePrefix($prefix: String!, $namespace_id: String!) {
+    IpamIPPrefixCreate(
+        data: {
+            prefix: {
+                value: $prefix
+            }
+            ip_namespace: {
+                id: $namespace_id
+            }
+        }
+    ) {
+        ok
+        object {
+            id
+        }
+    }
+}
+"""
+
+CREATE_IPADDRESS = """
+mutation CreateAddress($address: String!, $namespace_id: String!) {
+    IpamIPAddressCreate(
+        data: {
+            address: {
+                value: $address
+            }
+            ip_namespace: {
+                id: $namespace_id
+            }
+        }
+    ) {
+        ok
+        object {
+            id
+        }
+    }
+}
+"""
 
 
 class TestIpamRebaseReconcile(TestIpamReconcileBase):
@@ -46,11 +87,21 @@ class TestIpamRebaseReconcile(TestIpamReconcileBase):
         client: InfrahubClient,
     ) -> None:
         branch = await create_branch(db=db, branch_name="delete_prefix")
-        prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=branch)
 
-        new_prefix = await Node.init(schema=prefix_schema, db=db, branch=registry.default_branch)
-        await new_prefix.new(db=db, prefix="10.10.0.0/17", ip_namespace=initial_dataset["ns1"].id)
-        await new_prefix.save(db=db)
+        gql_params = prepare_graphql_params(db=db, include_subscription=False, branch=registry.default_branch)
+        result = await graphql(
+            schema=gql_params.schema,
+            source=CREATE_IPPREFIX,
+            context_value=gql_params.context,
+            variable_values={"prefix": "10.0.0.0/7", "namespace_id": initial_dataset["ns1"].id},
+        )
+        assert not result.errors
+        assert result.data
+        assert result.data["IpamIPPrefixCreate"]
+        assert result.data["IpamIPPrefixCreate"]["ok"]
+        assert result.data["IpamIPPrefixCreate"]["object"]["id"]
+        new_prefix_id = result.data["IpamIPPrefixCreate"]["object"]["id"]
+
         deleted_prefix_branch = await NodeManager.get_one(db=db, branch=branch, id=initial_dataset["net140"].id)
         assert deleted_prefix_branch
         await deleted_prefix_branch.delete(db=db)
@@ -60,18 +111,29 @@ class TestIpamRebaseReconcile(TestIpamReconcileBase):
 
         deleted_prefix = await NodeManager.get_one(db=db, branch=branch.name, id=deleted_prefix_branch.id)
         assert deleted_prefix is None
-        new_prefix_branch = await NodeManager.get_one(db=db, branch=branch.name, id=new_prefix.id)
+        new_prefix_branch = await NodeManager.get_one(db=db, branch=branch.name, id=new_prefix_id)
+        assert new_prefix_branch.is_top_level.value is True
         parent_rels = await new_prefix_branch.parent.get_relationships(db=db)  # type: ignore[union-attr]
-        assert len(parent_rels) == 1
-        assert parent_rels[0].peer_id == initial_dataset["net146"].id
+        assert len(parent_rels) == 0
         children_rels = await new_prefix_branch.children.get_relationships(db=db)  # type: ignore[union-attr]
+        assert len(children_rels) == 1
+        assert {child.peer_id for child in children_rels} == {initial_dataset["net146"].id}
+        address_rels = await new_prefix_branch.ip_addresses.get_relationships(db=db)  # type: ignore[union-attr]
+        assert len(address_rels) == 0
+
+        net_146_prefix_branch = await NodeManager.get_one(db=db, branch=branch.name, id=initial_dataset["net146"].id)
+        assert net_146_prefix_branch.is_top_level.value is False
+        parent_rels = await net_146_prefix_branch.parent.get_relationships(db=db)  # type: ignore[union-attr]
+        assert len(parent_rels) == 1
+        assert parent_rels[0].peer_id == new_prefix_id
+        children_rels = await net_146_prefix_branch.children.get_relationships(db=db)  # type: ignore[union-attr]
         assert len(children_rels) == 3
         assert {child.peer_id for child in children_rels} == {
             initial_dataset["net142"].id,
             initial_dataset["net144"].id,
             initial_dataset["net145"].id,
         }
-        address_rels = await new_prefix_branch.ip_addresses.get_relationships(db=db)  # type: ignore[union-attr]
+        address_rels = await net_146_prefix_branch.ip_addresses.get_relationships(db=db)  # type: ignore[union-attr]
         assert len(address_rels) == 1
         assert address_rels[0].peer_id == initial_dataset["address10"].id
 
@@ -82,40 +144,77 @@ class TestIpamRebaseReconcile(TestIpamReconcileBase):
         client: InfrahubClient,
     ) -> None:
         branch = await create_branch(db=db, branch_name="interlinked")
-        prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=branch)
-        address_schema = registry.schema.get_node_schema(name="IpamIPAddress", branch=branch)
 
-        net_10_0_0_0_7 = await Node.init(schema=prefix_schema, db=db, branch=branch)
-        await net_10_0_0_0_7.new(db=db, prefix="10.0.0.0/7", ip_namespace=initial_dataset["ns1"].id)
-        await net_10_0_0_0_7.save(db=db)
-        net_10_0_0_0_15 = await Node.init(schema=prefix_schema, db=db, branch=branch)
-        await net_10_0_0_0_15.new(
-            db=db, prefix="10.0.0.0/15", parent=net_10_0_0_0_7.id, ip_namespace=initial_dataset["ns1"].id
+        gql_params = prepare_graphql_params(db=db, include_subscription=False, branch=registry.default_branch)
+        result = await graphql(
+            schema=gql_params.schema,
+            source=CREATE_IPPREFIX,
+            context_value=gql_params.context,
+            variable_values={"prefix": "10.0.0.0/7", "namespace_id": initial_dataset["ns1"].id},
         )
-        await net_10_0_0_0_15.save(db=db)
-        net_10_10_8_0_22 = await Node.init(schema=prefix_schema, db=db, branch=branch)
-        await net_10_10_8_0_22.new(
-            db=db, prefix="10.10.8.0/22", parent=net_10_0_0_0_15.id, ip_namespace=initial_dataset["ns1"].id
+        assert not result.errors
+        assert result.data
+        assert result.data["IpamIPPrefixCreate"]
+        assert result.data["IpamIPPrefixCreate"]["ok"]
+        assert result.data["IpamIPPrefixCreate"]["object"]["id"]
+        net_10_0_0_0_7_id = result.data["IpamIPPrefixCreate"]["object"]["id"]
+
+        gql_params = prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+        result = await graphql(
+            schema=gql_params.schema,
+            source=CREATE_IPPREFIX,
+            context_value=gql_params.context,
+            variable_values={
+                "prefix": "10.0.0.0/15",
+                "namespace_id": initial_dataset["ns1"].id,
+            },
         )
-        await net_10_10_8_0_22.save(db=db)
-        address_10_10_1_2 = await Node.init(schema=address_schema, db=db, branch=branch)
-        await address_10_10_1_2.new(
-            db=db, address="10.10.1.2", ip_prefix=net_10_10_8_0_22.id, ip_namespace=initial_dataset["ns1"].id
+        assert not result.errors
+        assert result.data
+        assert result.data["IpamIPPrefixCreate"]
+        assert result.data["IpamIPPrefixCreate"]["ok"]
+        assert result.data["IpamIPPrefixCreate"]["object"]["id"]
+        net_10_0_0_0_15_id = result.data["IpamIPPrefixCreate"]["object"]["id"]
+
+        gql_params = prepare_graphql_params(db=db, include_subscription=False, branch=registry.default_branch)
+        result = await graphql(
+            schema=gql_params.schema,
+            source=CREATE_IPPREFIX,
+            context_value=gql_params.context,
+            variable_values={
+                "prefix": "10.10.8.0/22",
+                "namespace_id": initial_dataset["ns1"].id,
+            },
         )
-        await address_10_10_1_2.save(db=db)
-        reconciler = IpamReconciler(db=db, branch=registry.get_branch_from_registry())
-        await reconciler.reconcile(
-            ip_value=ipaddress.ip_network(initial_dataset["net143"].prefix.value),
-            namespace=initial_dataset["ns1"].id,
-            node_uuid=initial_dataset["net143"].id,
-            is_delete=True,
+        assert not result.errors
+        assert result.data
+        assert result.data["IpamIPPrefixCreate"]
+        assert result.data["IpamIPPrefixCreate"]["ok"]
+        assert result.data["IpamIPPrefixCreate"]["object"]["id"]
+        net_10_10_8_0_22_id = result.data["IpamIPPrefixCreate"]["object"]["id"]
+
+        gql_params = prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+        result = await graphql(
+            schema=gql_params.schema,
+            source=CREATE_IPADDRESS,
+            context_value=gql_params.context,
+            variable_values={
+                "address": "10.10.1.2",
+                "namespace_id": initial_dataset["ns1"].id,
+            },
         )
+        assert not result.errors
+        assert result.data
+        assert result.data["IpamIPAddressCreate"]
+        assert result.data["IpamIPAddressCreate"]["ok"]
+        assert result.data["IpamIPAddressCreate"]["object"]["id"]
+        address_10_10_1_2_id = result.data["IpamIPAddressCreate"]["object"]["id"]
 
         success = await client.branch.rebase(branch_name=branch.name)
         assert success is True
 
         # 10.10.0.0/7
-        net_10_0_0_0_7_check = await NodeManager.get_one(db=db, branch=branch.name, id=net_10_0_0_0_7.id)
+        net_10_0_0_0_7_check = await NodeManager.get_one(db=db, branch=branch.name, id=net_10_0_0_0_7_id)
         parent_rels = await net_10_0_0_0_7_check.parent.get_relationships(db=db)  # type: ignore[union-attr]
         assert len(parent_rels) == 0
         child_rels = await net_10_0_0_0_7_check.children.get_relationships(db=db)  # type: ignore[union-attr]
@@ -125,12 +224,12 @@ class TestIpamRebaseReconcile(TestIpamReconcileBase):
         net146_branch = await NodeManager.get_one(db=db, branch=branch.name, id=initial_dataset["net146"].id)
         parent_rels = await net146_branch.parent.get_relationships(db=db)  # type: ignore[union-attr]
         assert len(parent_rels) == 1
-        assert parent_rels[0].peer_id == net_10_0_0_0_7.id
+        assert parent_rels[0].peer_id == net_10_0_0_0_7_id
         child_rels = await net146_branch.children.get_relationships(db=db)  # type: ignore[union-attr]
         assert len(child_rels) == 2
-        assert {c.peer_id for c in child_rels} == {net_10_0_0_0_15.id, initial_dataset["net140"].id}
+        assert {c.peer_id for c in child_rels} == {net_10_0_0_0_15_id, initial_dataset["net140"].id}
         # 10.10.0.0/15
-        net_10_0_0_0_15_check = await NodeManager.get_one(db=db, branch=branch.name, id=net_10_0_0_0_15.id)
+        net_10_0_0_0_15_check = await NodeManager.get_one(db=db, branch=branch.name, id=net_10_0_0_0_15_id)
         parent_rels = await net_10_0_0_0_15_check.parent.get_relationships(db=db)  # type: ignore[union-attr]
         assert len(parent_rels) == 1
         assert parent_rels[0].peer_id == initial_dataset["net146"].id
@@ -142,33 +241,23 @@ class TestIpamRebaseReconcile(TestIpamReconcileBase):
         assert len(parent_rels) == 1
         assert parent_rels[0].peer_id == initial_dataset["net146"].id
         child_rels = await net140_branch.children.get_relationships(db=db)  # type: ignore[union-attr]
-        assert len(child_rels) == 3
+        assert len(child_rels) == 4
         assert {c.peer_id for c in child_rels} == {
             initial_dataset["net142"].id,
             initial_dataset["net144"].id,
             initial_dataset["net145"].id,
+            net_10_10_8_0_22_id,
         }
         child_addr_rels = await net140_branch.ip_addresses.get_relationships(db=db)  # type: ignore[union-attr]
         assert len(child_addr_rels) == 1
         assert child_addr_rels[0].peer_id == initial_dataset["address10"].id
-        # 10.10.0.0/17
-        net_10_10_0_0_17_branch = (
-            await NodeManager.query(
-                db=db, branch=branch, schema=prefix_schema, filters={"prefix__value": "10.10.0.0/17"}
-            )
-        )[0]
-        child_rels = await net_10_10_0_0_17_branch.children.get_relationships(db=db)  # type: ignore[attr-defined]
-        assert len(child_rels) == 1
-        assert child_rels[0].peer_id == net_10_10_8_0_22.id
-        # FIXME, this doesn't look correct
-        # # 10.10.1.1
-        # address11_branch = await NodeManager.get_one(db=db, branch=branch, id=initial_dataset["address11"].id)
-        # prefix_rels = await address11_branch.ip_prefix.get_relationships(db=db)  # type: ignore[union-attr]
-        # address11_branch_ip_prefix = await address11_branch.ip_prefix.get_peer(db=db)  # type: ignore[union-attr]
-        # assert len(prefix_rels) == 1
-        # assert prefix_rels[0].peer_id == initial_dataset["net142"].id
-        # # 10.10.1.2
-        # address_10_10_1_2_branch = await NodeManager.get_one(db=db, branch=branch, id=address_10_10_1_2.id)
-        # prefix_rels = await address_10_10_1_2_branch.ip_prefix.get_relationships(db=db)  # type: ignore[union-attr]
-        # assert len(prefix_rels) == 1
-        # assert prefix_rels[0].peer_id == initial_dataset["net142"].id
+        # 10.10.1.1
+        address11_branch = await NodeManager.get_one(db=db, branch=branch, id=initial_dataset["address11"].id)
+        prefix_rels = await address11_branch.ip_prefix.get_relationships(db=db)  # type: ignore[union-attr]
+        assert len(prefix_rels) == 1
+        assert prefix_rels[0].peer_id == initial_dataset["net143"].id
+        # 10.10.1.2
+        address_10_10_1_2_branch = await NodeManager.get_one(db=db, branch=branch, id=address_10_10_1_2_id)
+        prefix_rels = await address_10_10_1_2_branch.ip_prefix.get_relationships(db=db)  # type: ignore[union-attr]
+        assert len(prefix_rels) == 1
+        assert prefix_rels[0].peer_id == initial_dataset["net143"].id

--- a/backend/tests/unit/core/diff/test_diff_hierarchy_enricher.py
+++ b/backend/tests/unit/core/diff/test_diff_hierarchy_enricher.py
@@ -64,6 +64,7 @@ async def test_node_hierarchy(db: InfrahubDatabase, default_branch, hierarchical
 
     rack1 = hierarchical_location_data["paris-r1"]
     site1 = hierarchical_location_data["paris"]
+    europe = hierarchical_location_data["europe"]
 
     diff_node = EnrichedNodeFactory.build(uuid=rack1.get_id(), kind=rack1.get_kind(), relationships=set())
     diff_root = EnrichedRootFactory.build(
@@ -76,8 +77,15 @@ async def test_node_hierarchy(db: InfrahubDatabase, default_branch, hierarchical
 
     rack1_node = diff_root.get_node(node_uuid=rack1.get_id())
     site1_node = diff_root.get_node(node_uuid=site1.get_id())
+    europe_node = diff_root.get_node(node_uuid=europe.get_id())
 
     assert len(rack1_node.relationships) == 1
+    rack1_rel = rack1_node.relationships.pop()
+    assert rack1_rel.name == "parent"
+    assert rack1_rel.action is DiffAction.UNCHANGED
+    assert len(rack1_rel.nodes) == 1
+    rack1_parent_node = rack1_rel.nodes.pop()
+    assert rack1_parent_node.uuid == site1.id
 
     assert site1_node.action == DiffAction.UNCHANGED
     assert len(site1_node.relationships) == 1
@@ -85,3 +93,8 @@ async def test_node_hierarchy(db: InfrahubDatabase, default_branch, hierarchical
     assert site1_rel.action == DiffAction.UNCHANGED
     assert site1_rel.name == "parent"
     assert len(site1_rel.nodes) == 1
+    site1_parent_node = site1_rel.nodes.pop()
+    assert site1_parent_node.uuid == europe.id
+
+    assert europe_node.action == DiffAction.UNCHANGED
+    assert len(europe_node.relationships) == 0

--- a/backend/tests/unit/core/ipam/test_ipam_diff_parser.py
+++ b/backend/tests/unit/core/ipam/test_ipam_diff_parser.py
@@ -1,12 +1,14 @@
 from infrahub.core import registry
 from infrahub.core.branch import Branch
-from infrahub.core.diff.branch_differ import BranchDiffer
+from infrahub.core.diff.coordinator import DiffCoordinator
 from infrahub.core.diff.ipam_diff_parser import IpamDiffParser
+from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.initialization import create_branch
 from infrahub.core.ipam.model import IpamNodeDetails
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
+from infrahub.dependencies.registry import get_component_registry
 
 
 async def test_ipam_diff_parser_update(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
@@ -21,9 +23,12 @@ async def test_ipam_diff_parser_update(db: InfrahubDatabase, default_branch: Bra
     address11_branch.address.value = "10.10.1.2/32"
     await address11_branch.save(db=db)
 
-    differ = await BranchDiffer.init(db=db, branch=branch_2)
+    component_registry = get_component_registry()
+    diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch_2)
+    await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch_2)
+    diff_repo = await component_registry.get_component(DiffRepository, db=db, branch=branch_2)
     parser = IpamDiffParser(
-        db=db, differ=differ, source_branch_name=branch_2.name, target_branch_name=default_branch.name
+        db=db, diff_repository=diff_repo, source_branch_name=branch_2.name, target_branch_name=default_branch.name
     )
     ipam_diffs = await parser.get_changed_ipam_node_details()
 
@@ -64,9 +69,12 @@ async def test_ipam_diff_parser_create(db: InfrahubDatabase, default_branch: Bra
     await new_address_branch.new(db=db, address="10.10.4.5/32", ip_namespace=ip_dataset_01["ns2"].id)
     await new_address_branch.save(db=db)
 
-    differ = await BranchDiffer.init(db=db, branch=branch_2)
+    component_registry = get_component_registry()
+    diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch_2)
+    await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch_2)
+    diff_repo = await component_registry.get_component(DiffRepository, db=db, branch=branch_2)
     parser = IpamDiffParser(
-        db=db, differ=differ, source_branch_name=branch_2.name, target_branch_name=default_branch.name
+        db=db, diff_repository=diff_repo, source_branch_name=branch_2.name, target_branch_name=default_branch.name
     )
     ipam_diffs = await parser.get_changed_ipam_node_details()
 
@@ -95,6 +103,8 @@ async def test_ipam_diff_parser_create(db: InfrahubDatabase, default_branch: Bra
 
 async def test_ipam_diff_parser_delete(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
     branch_2 = await create_branch(db=db, branch_name="branch_2")
+    net_140 = ip_dataset_01["net140"]
+    net_143 = ip_dataset_01["net143"]
 
     # delete prefix
     net146_branch = await NodeManager.get_one(db=db, branch=branch_2, id=ip_dataset_01["net146"].id)
@@ -103,13 +113,16 @@ async def test_ipam_diff_parser_delete(db: InfrahubDatabase, default_branch: Bra
     address11_branch = await NodeManager.get_one(db=db, branch=branch_2, id=ip_dataset_01["address11"].id)
     await address11_branch.delete(db=db)
 
-    differ = await BranchDiffer.init(db=db, branch=branch_2)
+    component_registry = get_component_registry()
+    diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch_2)
+    await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch_2)
+    diff_repo = await component_registry.get_component(DiffRepository, db=db, branch=branch_2)
     parser = IpamDiffParser(
-        db=db, differ=differ, source_branch_name=branch_2.name, target_branch_name=default_branch.name
+        db=db, diff_repository=diff_repo, source_branch_name=branch_2.name, target_branch_name=default_branch.name
     )
     ipam_diffs = await parser.get_changed_ipam_node_details()
 
-    assert len(ipam_diffs) == 2
+    assert len(ipam_diffs) == 4
     assert (
         IpamNodeDetails(
             node_uuid=net146_branch.id,
@@ -127,6 +140,26 @@ async def test_ipam_diff_parser_delete(db: InfrahubDatabase, default_branch: Bra
             is_address=True,
             namespace_id=ip_dataset_01["ns1"].id,
             ip_value=address11_branch.address.value,
+        )
+        in ipam_diffs
+    )
+    assert (
+        IpamNodeDetails(
+            node_uuid=net_140.id,
+            is_delete=False,
+            is_address=False,
+            namespace_id=ip_dataset_01["ns1"].id,
+            ip_value=net_140.prefix.value,
+        )
+        in ipam_diffs
+    )
+    assert (
+        IpamNodeDetails(
+            node_uuid=net_143.id,
+            is_delete=False,
+            is_address=False,
+            namespace_id=ip_dataset_01["ns1"].id,
+            ip_value=net_143.prefix.value,
         )
         in ipam_diffs
     )

--- a/backend/tests/unit/core/ipam/test_ipam_diff_parser.py
+++ b/backend/tests/unit/core/ipam/test_ipam_diff_parser.py
@@ -2,7 +2,6 @@ from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.diff.coordinator import DiffCoordinator
 from infrahub.core.diff.ipam_diff_parser import IpamDiffParser
-from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.initialization import create_branch
 from infrahub.core.ipam.model import IpamNodeDetails
 from infrahub.core.manager import NodeManager
@@ -26,11 +25,10 @@ async def test_ipam_diff_parser_update(db: InfrahubDatabase, default_branch: Bra
     component_registry = get_component_registry()
     diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch_2)
     await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch_2)
-    diff_repo = await component_registry.get_component(DiffRepository, db=db, branch=branch_2)
-    parser = IpamDiffParser(
-        db=db, diff_repository=diff_repo, source_branch_name=branch_2.name, target_branch_name=default_branch.name
+    parser = await component_registry.get_component(IpamDiffParser, db=db, branch=branch_2)
+    ipam_diffs = await parser.get_changed_ipam_node_details(
+        source_branch_name=branch_2.name, target_branch_name=default_branch.name
     )
-    ipam_diffs = await parser.get_changed_ipam_node_details()
 
     assert len(ipam_diffs) == 2
     assert (
@@ -72,11 +70,10 @@ async def test_ipam_diff_parser_create(db: InfrahubDatabase, default_branch: Bra
     component_registry = get_component_registry()
     diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch_2)
     await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch_2)
-    diff_repo = await component_registry.get_component(DiffRepository, db=db, branch=branch_2)
-    parser = IpamDiffParser(
-        db=db, diff_repository=diff_repo, source_branch_name=branch_2.name, target_branch_name=default_branch.name
+    parser = await component_registry.get_component(IpamDiffParser, db=db, branch=branch_2)
+    ipam_diffs = await parser.get_changed_ipam_node_details(
+        source_branch_name=branch_2.name, target_branch_name=default_branch.name
     )
-    ipam_diffs = await parser.get_changed_ipam_node_details()
 
     assert len(ipam_diffs) == 2
     assert (
@@ -116,11 +113,10 @@ async def test_ipam_diff_parser_delete(db: InfrahubDatabase, default_branch: Bra
     component_registry = get_component_registry()
     diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch_2)
     await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch_2)
-    diff_repo = await component_registry.get_component(DiffRepository, db=db, branch=branch_2)
-    parser = IpamDiffParser(
-        db=db, diff_repository=diff_repo, source_branch_name=branch_2.name, target_branch_name=default_branch.name
+    parser = await component_registry.get_component(IpamDiffParser, db=db, branch=branch_2)
+    ipam_diffs = await parser.get_changed_ipam_node_details(
+        source_branch_name=branch_2.name, target_branch_name=default_branch.name
     )
-    ipam_diffs = await parser.get_changed_ipam_node_details()
 
     assert len(ipam_diffs) == 4
     assert (


### PR DESCRIPTION
IFC-878

update `IpamDiffParser` to use the new diff

also update some of the Ipam integration tests b/c some of them were actually doing something illegal and allowing a rebase when conflicts should have prevented it

I saw one of the ipam integration tests fail 2 times over ~50 runs, but was unable to reproduce it reliably. I suspect that something is going wrong in Ipam reconciliation depending on the order in which the reconciliation tasks for each updated IP-related node are run, but I am not certain