### PR TITLE
Convert BranchMerge mutation to a prefect task

### DIFF
--- a/backend/infrahub/graphql/mutations/branch.py
+++ b/backend/infrahub/graphql/mutations/branch.py
@@ -11,21 +11,18 @@ from typing_extensions import Self
 from infrahub import lock
 from infrahub.core import registry
 from infrahub.core.branch import Branch
-from infrahub.core.diff.coordinator import DiffCoordinator
-from infrahub.core.diff.merger.merger import DiffMerger
-from infrahub.core.diff.repository.repository import DiffRepository
-from infrahub.core.merge import BranchMerger
 from infrahub.core.task import UserTask
-from infrahub.core.validators.determiner import ConstraintValidatorDeterminer
-from infrahub.core.validators.models.validate_migration import SchemaValidateMigrationData
-from infrahub.core.validators.tasks import schema_validate_migrations
 from infrahub.database import retry_db_transaction
-from infrahub.dependencies.registry import get_component_registry
-from infrahub.exceptions import BranchNotFoundError, ValidationError
+from infrahub.exceptions import BranchNotFoundError
 from infrahub.log import get_log_data, get_logger
 from infrahub.message_bus import Meta, messages
 from infrahub.worker import WORKER_IDENTITY
-from infrahub.workflows.catalogue import BRANCH_DELETE, BRANCH_MERGE, BRANCH_REBASE, BRANCH_VALIDATE
+from infrahub.workflows.catalogue import (
+    BRANCH_DELETE,
+    BRANCH_MERGE_MUTATION,
+    BRANCH_REBASE,
+    BRANCH_VALIDATE,
+)
 
 from ..types import BranchType
 
@@ -256,60 +253,33 @@ class BranchValidate(Mutation):
 class BranchMerge(Mutation):
     class Arguments:
         data = BranchNameInput(required=True)
+        wait_until_completion = Boolean(required=False)
 
     ok = Boolean()
     object = Field(BranchType)
+    task = Field(TaskInfo, required=False)
 
     @classmethod
-    async def mutate(cls, root: dict, info: GraphQLResolveInfo, data: BranchNameInput) -> Self:
-        context: GraphqlContext = info.context
+    async def mutate(
+        cls, root: dict, info: GraphQLResolveInfo, data: BranchNameInput, wait_until_completion: bool = True
+    ) -> Self:
+        branch_name = data["name"]
+        task: dict | None = None
 
-        if not context.service:
-            raise ValueError("Service must be provided to merge a branch.")
-
-        obj = await Branch.get_by_name(db=context.db, name=data["name"])
-        base_branch = await Branch.get_by_name(db=context.db, name=registry.default_branch)
-
-        component_registry = get_component_registry()
-        diff_coordinator = await component_registry.get_component(DiffCoordinator, db=context.db, branch=obj)
-        diff_repository = await component_registry.get_component(DiffRepository, db=context.db, branch=obj)
-        diff_merger = await component_registry.get_component(DiffMerger, db=context.db, branch=obj)
-        enriched_diff = await diff_coordinator.update_branch_diff(base_branch=base_branch, diff_branch=obj)
-        if enriched_diff.get_all_conflicts():
-            raise ValidationError(
-                f"Branch {obj.name} contains conflicts with the default branch."
-                " Please create a Proposed Change to resolve the conflicts or manually update them before merging."
+        if wait_until_completion:
+            await info.context.active_service.workflow.execute_workflow(
+                workflow=BRANCH_MERGE_MUTATION, parameters={"branch": branch_name}
             )
-        node_diff_field_summaries = await diff_repository.get_node_field_summaries(
-            diff_branch_name=enriched_diff.diff_branch_name, diff_id=enriched_diff.uuid
-        )
-
-        merger = BranchMerger(
-            db=context.db,
-            diff_coordinator=diff_coordinator,
-            diff_merger=diff_merger,
-            source_branch=obj,
-            service=context.service,
-        )
-        candidate_schema = merger.get_candidate_schema()
-        determiner = ConstraintValidatorDeterminer(schema_branch=candidate_schema)
-        constraints = await determiner.get_constraints(node_diffs=node_diff_field_summaries)
-        if obj.has_schema_changes:
-            constraints += await merger.calculate_validations(target_schema=candidate_schema)
-
-        if constraints:
-            error_messages = await schema_validate_migrations(
-                message=SchemaValidateMigrationData(branch=obj, schema_branch=candidate_schema, constraints=constraints)
+        else:
+            workflow = await info.context.active_service.workflow.submit_workflow(
+                workflow=BRANCH_MERGE_MUTATION, parameters={"branch": branch_name}
             )
-            if error_messages:
-                raise ValidationError(",\n".join(error_messages))
-
-        await context.service.workflow.execute_workflow(workflow=BRANCH_MERGE, parameters={"branch": obj.name})
+            task = {"id": workflow.id}
 
         # Pull the latest information about the branch from the database directly
-        obj = await Branch.get_by_name(db=context.db, name=data["name"])
+        obj = await Branch.get_by_name(db=info.context.db, name=branch_name)
 
         fields = await extract_fields(info.field_nodes[0].selection_set)
         ok = True
 
-        return cls(object=await obj.to_graphql(fields=fields.get("object", {})), ok=ok)
+        return cls(object=await obj.to_graphql(fields=fields.get("object", {})), ok=ok, task=task)

--- a/backend/infrahub/graphql/mutations/tasks.py
+++ b/backend/infrahub/graphql/mutations/tasks.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from prefect import flow
+
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.diff.coordinator import DiffCoordinator
+from infrahub.core.diff.merger.merger import DiffMerger
+from infrahub.core.diff.repository.repository import DiffRepository
+from infrahub.core.merge import BranchMerger
+from infrahub.core.validators.determiner import ConstraintValidatorDeterminer
+from infrahub.core.validators.models.validate_migration import SchemaValidateMigrationData
+from infrahub.core.validators.tasks import schema_validate_migrations
+from infrahub.dependencies.registry import get_component_registry
+from infrahub.exceptions import ValidationError
+from infrahub.services import services
+from infrahub.workflows.catalogue import BRANCH_MERGE
+from infrahub.workflows.utils import add_branch_tag
+
+
+@flow(name="merge-branch-mutation", flow_run_name="Merge branch graphQL mutation")
+async def merge_branch_mutation(branch: str) -> None:
+    service = services.service
+    db = service.database
+
+    await add_branch_tag(branch)
+
+    obj = await Branch.get_by_name(db=db, name=branch)
+    base_branch = await Branch.get_by_name(db=db, name=registry.default_branch)
+
+    component_registry = get_component_registry()
+    diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=obj)
+    diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=obj)
+    diff_merger = await component_registry.get_component(DiffMerger, db=db, branch=obj)
+    enriched_diff = await diff_coordinator.update_branch_diff(base_branch=base_branch, diff_branch=obj)
+    if enriched_diff.get_all_conflicts():
+        raise ValidationError(
+            f"Branch {obj.name} contains conflicts with the default branch."
+            " Please create a Proposed Change to resolve the conflicts or manually update them before merging."
+        )
+    node_diff_field_summaries = await diff_repository.get_node_field_summaries(
+        diff_branch_name=enriched_diff.diff_branch_name, diff_id=enriched_diff.uuid
+    )
+
+    merger = BranchMerger(
+        db=db,
+        diff_coordinator=diff_coordinator,
+        diff_merger=diff_merger,
+        source_branch=obj,
+        service=service,
+    )
+    candidate_schema = merger.get_candidate_schema()
+    determiner = ConstraintValidatorDeterminer(schema_branch=candidate_schema)
+    constraints = await determiner.get_constraints(node_diffs=node_diff_field_summaries)
+    if obj.has_schema_changes:
+        constraints += await merger.calculate_validations(target_schema=candidate_schema)
+
+    if constraints:
+        error_messages = await schema_validate_migrations(
+            message=SchemaValidateMigrationData(branch=obj, schema_branch=candidate_schema, constraints=constraints)
+        )
+        if error_messages:
+            raise ValidationError(",\n".join(error_messages))
+
+    await service.workflow.execute_workflow(workflow=BRANCH_MERGE, parameters={"branch": obj.name})

--- a/backend/infrahub/workflows/catalogue.py
+++ b/backend/infrahub/workflows/catalogue.py
@@ -176,6 +176,14 @@ BRANCH_MERGE = WorkflowDefinition(
     tags=[WorkflowTag.DATABASE_CHANGE],
 )
 
+BRANCH_MERGE_MUTATION = WorkflowDefinition(
+    name="merge-branch-mutation",
+    type=WorkflowType.INTERNAL,
+    module="infrahub.graphql.mutations.tasks",
+    function="merge_branch_mutation",
+    tags=[WorkflowTag.DATABASE_CHANGE],
+)
+
 BRANCH_DELETE = WorkflowDefinition(
     name="branch-delete",
     type=WorkflowType.INTERNAL,
@@ -251,6 +259,7 @@ workflows = [
     BRANCH_MERGE,
     BRANCH_DELETE,
     BRANCH_VALIDATE,
+    BRANCH_MERGE_MUTATION,
     REQUEST_ARTIFACT_DEFINITION_GENERATE,
     REQUEST_GENERATOR_RUN,
     REQUEST_DIFF_UPDATE,

--- a/backend/tests/functional/branch/test_graphql_mutation.py
+++ b/backend/tests/functional/branch/test_graphql_mutation.py
@@ -186,3 +186,37 @@ class TestBranchMutations(TestInfrahubApp):
         with pytest.raises(GraphQLError) as exc:
             await client.execute_graphql(query=query.render())
         assert "branch has some conflicts" in exc.value.message
+
+    async def test_branch_merge(self, initial_dataset: str, client: InfrahubClient) -> None:
+        """
+        Test BranchMerge graphql endpoint, not actual merge logic.
+        """
+
+        branch = await client.branch.create(branch_name="branch_to_merge_sync")
+
+        query = Mutation(
+            mutation="BranchMerge",
+            input_data={"data": {"name": branch.name}},
+            query={"ok": None, "task": {"id": None}, "object": {"id": None}},
+        )
+        result = await client.execute_graphql(query=query.render())
+        assert result["BranchMerge"]["ok"] is True
+        assert result["BranchMerge"]["object"]["id"] == branch.id
+        assert result["BranchMerge"]["task"] is None
+
+    async def test_branch_merge_async(self, initial_dataset: str, client: InfrahubClient) -> None:
+        """
+        Test BranchMerge graphql endpoint with asynchronous feature, not actual merge logic.
+        """
+
+        branch = await client.branch.create(branch_name="branch_to_merge")
+
+        query = Mutation(
+            mutation="BranchMerge",
+            input_data={"data": {"name": branch.name}, "wait_until_completion": False},
+            query={"ok": None, "task": {"id": None}, "object": {"id": None}},
+        )
+        result = await client.execute_graphql(query=query.render())
+        assert result["BranchMerge"]["ok"] is True
+        assert result["BranchMerge"]["object"]["id"] == branch.id
+        assert result["BranchMerge"]["task"]["id"]

--- a/backend/tests/helpers/utils.py
+++ b/backend/tests/helpers/utils.py
@@ -1,12 +1,10 @@
 from contextlib import contextmanager
 from typing import Generator
 
-from infrahub_sdk import InfrahubClient
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
 
 from infrahub.services import InfrahubServices, services
-from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from tests.helpers.constants import PORT_BOLT_NEO4J, PORT_HTTP_NEO4J
 
 
@@ -38,14 +36,13 @@ def start_neo4j_container(neo4j_image: str) -> DockerContainer:
 
 
 @contextmanager
-def init_service_with_client(client: InfrahubClient) -> Generator:
+def init_global_service(service: InfrahubServices) -> Generator:
     """
-    This helper is needed for tests defining a specific client while `service` still needs to be accessed
-    through a global variable within prefect tasks.
+    `service` needs to be accessed through a global variable within prefect tasks, this utility
+    helps for restoring original `service` values so tests do no have side effects.
     """
 
     original = services.service
-    service = InfrahubServices(client=client, workflow=WorkflowLocalExecution())
     services.service = service
     try:
         yield service

--- a/backend/tests/unit/message_bus/operations/requests/test_graphql_query_group.py
+++ b/backend/tests/unit/message_bus/operations/requests/test_graphql_query_group.py
@@ -11,7 +11,9 @@ from pytest_httpx import HTTPXMock
 from infrahub.database import InfrahubDatabase
 from infrahub.groups.models import RequestGraphQLQueryGroupUpdate
 from infrahub.groups.tasks import update_graphql_query_group
-from tests.helpers.utils import init_service_with_client
+from infrahub.services import InfrahubServices
+from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
+from tests.helpers.utils import init_global_service
 
 
 @pytest.fixture
@@ -45,8 +47,9 @@ async def test_graphql_group_update(db: InfrahubDatabase, httpx_mock: HTTPXMock,
     client = InfrahubClient(
         config=config,
     )
+    service = InfrahubServices(client=client, workflow=WorkflowLocalExecution())
 
-    with init_service_with_client(client=client), patch("infrahub.groups.tasks.add_branch_tag"):
+    with init_global_service(service), patch("infrahub.groups.tasks.add_branch_tag"):
         # add_branch_tag requires a prefect client, ie it does not work with WorkflowLocal
         response1 = {
             "data": {


### PR DESCRIPTION
`BranchMerge` mutation now uses a new `BRANCH_MERGE_MUTATION` workflow. This flow relies on another workflow `BRANCH_MERGE`, which is also used within `ProposedChanges` mutation. Thus we cannot simply put all `BranchMerge` logic within current `BRANCH_MERGE` at it might break `ProposedChanges` mutation behavior.