### PR TITLE
Add more filters to InfrahubTask query and return workflow name

### DIFF
--- a/backend/infrahub/graphql/types/task.py
+++ b/backend/infrahub/graphql/types/task.py
@@ -19,6 +19,7 @@ class Task(ObjectType):
     conclusion = String(required=True)
     state = TaskState(required=False)
     progress = Float(required=False)
+    workflow = String(required=False)
     branch = String(required=False)
     created_at = String(required=True)
     updated_at = String(required=True)

--- a/backend/infrahub/tasks/dummy.py
+++ b/backend/infrahub/tasks/dummy.py
@@ -33,12 +33,12 @@ async def aggregate_name(firstname: str, lastname: str) -> str:
     return f"{firstname}, {lastname}"
 
 
-@flow(persist_result=True)
+@flow(name="dummy-flow", persist_result=True)
 async def dummy_flow(data: DummyInput) -> DummyOutput:
     return DummyOutput(full_name=await aggregate_name(firstname=data.firstname, lastname=data.lastname))
 
 
-@flow(persist_result=True)
+@flow(name="dummy-flow-broken", persist_result=True)
 async def dummy_flow_broken(data: DummyInput) -> DummyOutput:
     response = await aggregate_name(firstname=data.firstname, lastname=data.lastname)
     return DummyOutput(not_valid=response)  # type: ignore[call-arg]


### PR DESCRIPTION
This PR extend the InfrahubTask query with 3 additional filters
- state: list of state `[RUNNING, SCHEDULED]` 
- workflow: list of workflow name to match (*)
- q: free text search

InfrahubTask can also return the name of the workflow associated with each task in the payload

* We still need to document properly what are the names of the workflow built into Infrahub, for now the best option is to check what is the name of the workflow being returned by the query
