### PR TITLE
Returns a proper error message when trying to load a schema with a generic with the same Kind as an existing node

### DIFF
--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -429,6 +429,14 @@ class SchemaBranch:
                         self.delete(name=new_item.kind)
                 else:
                     new_item = self.get(name=item.kind)
+
+                if (new_item.is_node_schema and not item.is_node_schema) or (
+                    new_item.is_generic_schema and not item.is_generic_schema
+                ):
+                    current_node_type = "Node" if new_item.is_node_schema else "Generic"
+                    raise ValidationError(
+                        f"{item.kind} already exist in the schema as a {current_node_type}. Either rename it or delete the existing one."
+                    )
                 new_item.update(item)
                 self.set(name=item.kind, schema=new_item)
             except SchemaNotFoundError:

--- a/changelog/4837.fixed.md
+++ b/changelog/4837.fixed.md
@@ -1,0 +1,1 @@
+Infrahub returns a proper error message when trying to load a schema with generic with the same Kind as an existing node.


### PR DESCRIPTION
Fixes #4837 