### PR TITLE
Example to highlight schema load issue when renaming nodes (Tests will fail)

### DIFF
--- a/backend/tests/integration/schema_lifecycle/test_schema_migration_main.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_migration_main.py
@@ -202,6 +202,9 @@ class TestSchemaLifecycleMain(TestSchemaLifecycleBase):
 
         response = await client.schema.load(schemas=[schema_step03])
         assert not response.errors
+        _ = await client.all(
+            kind="BuiltinTag",
+        )
 
         # Ensure that we can query the existing node with the new schema
         persons = await registry.manager.query(db=db, schema=PERSON_KIND, filters={"firstname__value": "John"})


### PR DESCRIPTION
This small change causes the test to fail even though it shouldn't.