### PR TITLE
Add support for nested model in HashableModel.update

### DIFF
--- a/backend/infrahub/core/models.py
+++ b/backend/infrahub/core/models.py
@@ -477,6 +477,7 @@ class HashableModel(BaseModel):
         Currently this method works for the following type of fields
             int, str, bool, float: If present the value from Other is overwriting the local value
             list[BaseSchemaModel]: The list will be merge if all elements in the list have a _sorting_id and if it's unique.
+            HashableModel: the value will be merged using update()
 
         TODO Implement other fields type like dict
         """
@@ -500,6 +501,11 @@ class HashableModel(BaseModel):
                     field_name=field_name, attr_local=attr_local, attr_other=attr_other
                 )
                 setattr(self, field_name, new_attr)
+                continue
+
+            if isinstance(attr_local, HashableModel) and isinstance(attr_other, HashableModel):
+                attr_local.update(attr_other)
+                continue
 
         return self
 

--- a/backend/tests/unit/core/test_model_hashable.py
+++ b/backend/tests/unit/core/test_model_hashable.py
@@ -291,3 +291,38 @@ def test_diff_nested_objects():
         "changed": {"subs": None, "value4": {"added": {}, "changed": {"value2": None}, "removed": {}}},
         "removed": {},
     }
+
+
+def test_update_nested_objects():
+    class MySubElement(HashableModel):
+        _sort_by: list[str] = ["name"]
+        name: str
+        value1: Optional[str] = None
+        value2: Optional[int] = None
+
+    class MyTopElement(HashableModel):
+        _sort_by: list[str] = ["name"]
+        name: str
+        value1: Optional[str] = None
+        value2: Optional[int] = None
+        value3: list[str]
+        value4: MySubElement
+        subs: list[MySubElement]
+
+    node1 = MyTopElement(
+        name="node1",
+        value1="first",
+        value2=2,
+        value3=["one", "two"],
+        value4=MySubElement(name="apple", value2=1254),
+        subs=[MySubElement(name="orange", value1="tochange", value2=22), MySubElement(name="coconut")],
+    )
+
+    node2 = node1.duplicate()
+    node2.subs[0].value1 = "new in node2"
+    node2.value4.value2 = 987654
+
+    node1.update(node2)
+
+    assert node1.value4.value2 == node2.value4.value2
+    assert sorted(node1.subs) == sorted(node2.subs)


### PR DESCRIPTION
This change is required to properly identify when the value of a computed_attribute as changed in the schema
 