### PR TITLE
Remove Profile in registry for renamed schema nodes

### DIFF
--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1642,6 +1642,12 @@ class SchemaBranch:
             profile = self.generate_profile_from_node(node=node)
             self.set(name=profile.kind, schema=profile)
             profile_schema_kinds.add(profile.kind)
+
+        for previous_profile in list(self.profiles.keys()):
+            # Ensure that we remove previous profile schemas if a node has been renamed
+            if previous_profile not in profile_schema_kinds:
+                self.delete(name=previous_profile)
+
         if not profile_schema_kinds:
             return
 

--- a/backend/tests/integration/schema_lifecycle/test_schema_migration_main.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_migration_main.py
@@ -209,6 +209,12 @@ class TestSchemaLifecycleMain(TestSchemaLifecycleBase):
         john = persons[0]
         assert not hasattr(john, "height")
 
+        # Ensure that we can query the existing node with graphql endpoint
+        api_persons = await client.filters(kind=PERSON_KIND, firstname__value="John")
+        assert len(api_persons) == 1
+        api_john = api_persons[0]
+        assert not hasattr(api_john, "height")
+
         manufacturers = await registry.manager.query(
             db=db, schema=MANUFACTURER_KIND_03, filters={"name__value": "honda"}
         )

--- a/changelog/4909.fixed.md
+++ b/changelog/4909.fixed.md
@@ -1,0 +1,1 @@
+Remove Profile in registry for renamed schema nodes


### PR DESCRIPTION
This PR fixes an issue where the GraphQL API can break completely on the API worker that is handling a request containing a schema upgrade that renames one of the nodes within the schema. I tracked it down to be caused by the old profile lingering in the registry which causes the generator for the GraphQL schema to break.

So if we had a node called `TestingManufacturer` the first time we load the schema we'd also create a profile called `ProfileTestingManufacturer`. If we then submit an update where we rename `TestingManufacturer` to `TestingCarMaker` we'd create a new profile called `ProfileTestingCarMaker` however we'd leave `ProfileTestingManufacturer` intact in the local registry and the next time we try to build the GraphQL schema that process fails.

Fixes #4909

