### PR TITLE
Default to using HTTP GET for UserInfo endpoints

### DIFF
--- a/backend/infrahub/api/oauth2.py
+++ b/backend/infrahub/api/oauth2.py
@@ -91,7 +91,11 @@ async def token(
     payload = token_response.json()
 
     headers = {"Authorization": f"{payload.get('token_type')} {payload.get('access_token')}"}
-    userinfo_response = await service.http.post(provider.userinfo_url, headers=headers)
+    if provider.userinfo_method == config.UserInfoMethod.GET:
+        userinfo_response = await service.http.get(provider.userinfo_url, headers=headers)
+    else:
+        userinfo_response = await service.http.post(provider.userinfo_url, headers=headers)
+
     _validate_response(response=userinfo_response)
     user_info = userinfo_response.json()
     sso_groups = user_info.get("groups", [])

--- a/backend/infrahub/api/oidc.py
+++ b/backend/infrahub/api/oidc.py
@@ -129,7 +129,12 @@ async def token(
     payload = token_response.json()
 
     headers = {"Authorization": f"{payload.get('token_type')} {payload.get('access_token')}"}
-    userinfo_response = await service.http.post(str(oidc_config.userinfo_endpoint), headers=headers)
+
+    if provider.userinfo_method == config.UserInfoMethod.GET:
+        userinfo_response = await service.http.get(str(oidc_config.userinfo_endpoint), headers=headers)
+    else:
+        userinfo_response = await service.http.post(str(oidc_config.userinfo_endpoint), headers=headers)
+
     _validate_response(response=userinfo_response)
     user_info = userinfo_response.json()
 

--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -36,6 +36,11 @@ def default_cors_allow_headers() -> list[str]:
     return ["accept", "authorization", "content-type", "user-agent", "x-csrftoken", "x-requested-with"]
 
 
+class UserInfoMethod(str, Enum):
+    POST = "post"
+    GET = "get"
+
+
 class SSOProtocol(str, Enum):
     OAUTH2 = "oauth2"
     OIDC = "oidc"
@@ -421,6 +426,7 @@ class SecurityOIDCBaseSettings(BaseSettings):
 
     icon: str = Field(default="mdi:account-key")
     display_label: str = Field(default="Single Sign on")
+    userinfo_method: UserInfoMethod = Field(default=UserInfoMethod.GET)
 
 
 class SecurityOIDCSettings(SecurityOIDCBaseSettings):
@@ -464,6 +470,7 @@ class SecurityOAuth2BaseSettings(BaseSettings):
     """Baseclass for typing"""
 
     icon: str = Field(default="mdi:account-key")
+    userinfo_method: UserInfoMethod = Field(default=UserInfoMethod.GET)
 
 
 class SecurityOAuth2Settings(SecurityOAuth2BaseSettings):
@@ -804,7 +811,7 @@ def load(config_file_name: str = "infrahub.toml", config_data: Optional[dict[str
         config_string = Path(config_file_name).read_text(encoding="utf-8")
         config_tmp = toml.loads(config_string)
 
-        SETTINGS.settings = Settings(**config_tmp)
+        return Settings(**config_tmp)
 
     return Settings()
 

--- a/backend/tests/fixtures/config_files/sso_config_methods.toml
+++ b/backend/tests/fixtures/config_files/sso_config_methods.toml
@@ -1,0 +1,42 @@
+[security]
+oauth2_providers = ["provider1", "provider2"]
+oidc_providers = ["provider1", "provider2"]
+
+
+[security.oauth2_provider_settings.provider1]
+client_id = "infrahub-user-client"
+client_secret = "edPf4IaquQaqns7t3s95mLhKKYdwL1up"
+authorization_url = "http://localhost:8180/realms/infrahub-users/protocol/openid-connect/auth"
+token_url = "http://localhost:8180/realms/infrahub-users/protocol/openid-connect/token"
+userinfo_url = "http://localhost:8180/infrahub-users/infrahub/protocol/openid-connect/userinfo"
+display_label = "Keycloak Users"
+icon = "mdi:security-lock-outline"
+userinfo_method = "post"
+
+[security.oauth2_provider_settings.provider2]
+client_id = "infrahub-admin-client"
+client_secret = "t3s95mLhKKYdwL1up-edPf4IaquQaqns7"
+authorization_url = "http://localhost:8180/realms/infrahub-admins/protocol/openid-connect/auth"
+token_url = "http://localhost:8180/realms/infrahub-admins/protocol/openid-connect/token"
+userinfo_url = "http://localhost:8180/realms/infrahub-admins/protocol/openid-connect/userinfo"
+display_label = "Keycloak Users"
+icon = "mdi:security-lock-outline"
+
+
+[security.oidc_provider_settings.provider1]
+client_id = "infrahub-user-client"
+client_secret = "edPf4IaquQaqns7t3s95mLhKKYdwL1up"
+discovery_url = "http://localhost:8180/realms/infrahub-users/.well-known/openid-configuration"
+display_label = "OIDC Users"
+icon = "mdi:security-lock-outline"
+userinfo_method = "post"
+
+
+[security.oidc_provider_settings.provider2]
+client_id = "infrahub-admin-client"
+client_secret = "t3s95mLhKKYdwL1up-edPf4IaquQaqns7"
+discovery_url = "http://localhost:8180/realms/infrahub-admins/.well-known/openid-configuration"
+display_label = "OIDC Admins"
+icon = "mdi:security-lock-outline"
+userinfo_method = "get"
+

--- a/backend/tests/unit/test_config.py
+++ b/backend/tests/unit/test_config.py
@@ -1,0 +1,22 @@
+from infrahub.config import UserInfoMethod, load
+from tests.conftest import TestHelper
+
+
+def test_load_sso_config(helper: TestHelper) -> None:
+    fixture_dir = helper.get_fixtures_dir()
+    config_file = str(fixture_dir / "config_files" / "sso_config_methods.toml")
+
+    config = load(config_file_name=config_file)
+    assert config.security.public_sso_config.enabled
+    assert len(config.security.public_sso_config.providers) == 4
+
+    oauth_provider1 = config.security.get_oauth2_provider("provider1")
+    oauth_provider2 = config.security.get_oauth2_provider("provider2")
+
+    oidc_provider1 = config.security.get_oidc_provider("provider1")
+    oidc_provider2 = config.security.get_oidc_provider("provider2")
+
+    assert oauth_provider1.userinfo_method == UserInfoMethod.POST
+    assert oauth_provider2.userinfo_method == UserInfoMethod.GET
+    assert oidc_provider1.userinfo_method == UserInfoMethod.POST
+    assert oidc_provider2.userinfo_method == UserInfoMethod.GET

--- a/changelog/4898.fixed.md
+++ b/changelog/4898.fixed.md
@@ -1,0 +1,1 @@
+Default to using HTTP GET for UserInfo endpoints (OAuth2/OIDC)


### PR DESCRIPTION
* Allows users to configure the HTTP method for the UserInfo endpoint
* Fix in infrahub.config.load() to properly return the settings of a provider file
* Added some tests as the parsing of the config has gotten more complex

Fixes #4898

Replaces #4913 targeted for `develop`.