### PR TITLE
Migrate EventSchemaUpdate to InfrahubEvent

### DIFF
--- a/backend/infrahub/events/schema_action.py
+++ b/backend/infrahub/events/schema_action.py
@@ -1,0 +1,35 @@
+from typing import Any
+
+from pydantic import Field
+
+from infrahub.message_bus import InfrahubMessage
+from infrahub.message_bus.messages.event_schema_update import EventSchemaUpdate
+
+from .models import InfrahubBranchEvent
+
+
+class SchemaUpdatedEvent(InfrahubBranchEvent):
+    """Event generated when the schema within a branch has been updated."""
+
+    schema_hash: str = Field(..., description="Schema hash after the update")
+
+    def get_name(self) -> str:
+        return f"{self.get_event_namespace()}.schema.update"
+
+    def get_resource(self) -> dict[str, str]:
+        return {
+            "prefect.resource.id": f"infrahub.schema_branch.{self.branch}",
+            "infrahub.branch.name": self.branch,
+            "infrahub.branch.schema_hash": self.schema_hash,
+        }
+
+    def get_payload(self) -> dict[str, Any]:
+        return {"branch": self.branch, "schema_hash": self.schema_hash}
+
+    def get_messages(self) -> list[InfrahubMessage]:
+        return [
+            EventSchemaUpdate(
+                branch=self.branch,
+                meta=self.get_message_meta(),
+            )
+        ]

--- a/backend/infrahub/schema/constants.py
+++ b/backend/infrahub/schema/constants.py
@@ -1,0 +1,1 @@
+AUTOMATION_NAME = "Trigger-schema-update-event"

--- a/backend/infrahub/schema/tasks.py
+++ b/backend/infrahub/schema/tasks.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from prefect import flow
+from prefect.automations import AutomationCore
+from prefect.client.orchestration import get_client
+from prefect.client.schemas.filters import DeploymentFilter, DeploymentFilterName
+from prefect.events.actions import RunDeployment
+from prefect.events.schemas.automations import EventTrigger, Posture
+from prefect.logging import get_run_logger
+
+from infrahub.workflows.catalogue import COMPUTED_ATTRIBUTE_SETUP
+
+from .constants import AUTOMATION_NAME
+
+
+@flow(name="schema-updated-setup", flow_run_name="Setup schema updated event in task-manager")
+async def schema_updated_setup() -> None:
+    log = get_run_logger()
+
+    async with get_client(sync_client=False) as client:
+        deployments = {
+            item.name: item
+            for item in await client.read_deployments(
+                deployment_filter=DeploymentFilter(
+                    name=DeploymentFilterName(
+                        any_=[
+                            COMPUTED_ATTRIBUTE_SETUP.name,
+                        ]
+                    )
+                )
+            )
+        }
+        if COMPUTED_ATTRIBUTE_SETUP.name not in deployments:
+            raise ValueError("Unable to find the deployment for PROCESS_COMPUTED_MACRO")
+
+        deployment_id_computed_attribute_setup = deployments[COMPUTED_ATTRIBUTE_SETUP.name].id
+
+        schema_update_automation = await client.find_automation(id_or_name=AUTOMATION_NAME)
+
+        automation = AutomationCore(
+            name=AUTOMATION_NAME,
+            description="Trigger actions on schema update event",
+            enabled=True,
+            trigger=EventTrigger(
+                posture=Posture.Reactive,
+                expect={"infrahub.schema.update"},
+                within=timedelta(0),
+                threshold=1,
+            ),
+            actions=[
+                RunDeployment(
+                    source="selected",
+                    deployment_id=deployment_id_computed_attribute_setup,
+                    parameters={},
+                    job_variables={},
+                )
+            ],
+        )
+
+        if schema_update_automation:
+            await client.update_automation(automation_id=schema_update_automation.id, automation=automation)
+            log.info(f"{AUTOMATION_NAME} Updated")
+        else:
+            await client.create_automation(automation=automation)
+            log.info(f"{AUTOMATION_NAME} Created")

--- a/backend/infrahub/services/adapters/workflow/worker.py
+++ b/backend/infrahub/services/adapters/workflow/worker.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, overload
 
-from prefect.client.schemas import StateType
+from prefect.client.schemas.objects import StateType
 from prefect.deployments import run_deployment
 
 from infrahub.workflows.initialization import setup_task_manager

--- a/backend/infrahub/workflows/catalogue.py
+++ b/backend/infrahub/workflows/catalogue.py
@@ -247,6 +247,13 @@ REQUEST_PROPOSED_CHANGE_DATA_INTEGRITY = WorkflowDefinition(
     function="run_proposed_change_data_integrity_check",
 )
 
+SCHEMA_UPDATED_SETUP = WorkflowDefinition(
+    name="schema-updated-setup",
+    type=WorkflowType.INTERNAL,
+    module="infrahub.schema.tasks",
+    function="schema_updated_setup",
+)
+
 
 worker_pools = [INFRAHUB_WORKER_POOL]
 
@@ -284,4 +291,5 @@ workflows = [
     COMPUTED_ATTRIBUTE_SETUP,
     UPDATE_COMPUTED_ATTRIBUTE_TRANSFORM,
     REQUEST_PROPOSED_CHANGE_DATA_INTEGRITY,
+    SCHEMA_UPDATED_SETUP,
 ]

--- a/backend/infrahub/workflows/initialization.py
+++ b/backend/infrahub/workflows/initialization.py
@@ -7,7 +7,7 @@ from prefect.logging import get_run_logger
 
 from infrahub import config
 
-from .catalogue import worker_pools, workflows
+from .catalogue import SCHEMA_UPDATED_SETUP, worker_pools, workflows
 from .models import TASK_RESULT_STORAGE_NAME
 
 
@@ -36,6 +36,9 @@ async def setup_deployments(client: PrefectClient) -> None:
         work_pool = worker_pools[0]
         await workflow.save(client=client, work_pool=work_pool)
         log.info(f"Flow {workflow.name}, created successfully ... ")
+
+    schema_update_setup = SCHEMA_UPDATED_SETUP.get_function()
+    await schema_update_setup()
 
 
 @task(name="task-manager-setup-blocks", task_run_name="Setup Blocks")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -330,7 +330,12 @@ ignore_errors = true
 
 [[tool.mypy.overrides]]
 module = "infrahub.graphql.mutations.schema"
-ignore_errors = true
+disable_error_code = [
+    "arg-type",
+    "operator",
+    "union-attr",
+]
+
 
 [[tool.mypy.overrides]]
 module = "infrahub.graphql.resolver"


### PR DESCRIPTION
This PR migrates the `EventSchemaUpdate` messate to an `SchemaUpdatedEvent`. As part of this the old message `EventSchemaUpdate` will be completely removed as it was only responsible for sending another message of broadcast type i.e.

```python
@flow(name="event-schema-update")
async def update(message: messages.EventSchemaUpdate, service: InfrahubServices) -> None:
    log.info("run_message", branch=message.branch)

    msg = messages.RefreshRegistryBranches()

    msg.assign_meta(parent=message)
    await service.send(message=msg)

```

The original though was that this would be an entrypoint for other types of automations that we wanted to add later. As it will be now with prefect the EventSchemaUpdate will just slow things down as with the current plans we won't add more logic here. So it would be cleaner to send the broadcast message directly.

* infrahub/api/schema.py

Here I've removed the call to setup the workflow for COMPUTED_ATTRIBUTE_SETUP so that it instead is done in an automation.

* Changes to the WorkflowWorkerExecution class and the setup_task_manager method

I changed WorkflowWorkerExecution to use the `service` object provided by the initialize() method and send it to setup_task_manager as an optional argument. This is to have access to the service when calling `service.workflow.submit_workflow(workflow=SCHEMA_UPDATED_SETUP)` I'm not sure this is the best way to do this, but we want this automation to be in place when we start.

* Testing

Once more things are controlled by automations within Prefect I'm not certain how we will test everything correctly. While we'll start with component tests I think we want to have something proper for end to end very soon.