### PR TITLE
Change the match logic for computed jinja attributes

### DIFF
--- a/backend/infrahub/computed_attribute/tasks.py
+++ b/backend/infrahub/computed_attribute/tasks.py
@@ -215,28 +215,30 @@ async def computed_attribute_setup() -> None:
         automations = await client.read_automations()
         existing_computed_attr_automations = ComputedAttributeAutomations.from_prefect(automations=automations)
 
-        computed_attributes: dict[str, ComputedAttributeTarget] = {}
-        for item in schema_branch._computed_jinja2_attribute_map.values():
-            for attrs in list(item.local_fields.values()) + list(item.relationships.values()):
-                for attr in attrs:
-                    if attr.key_name in computed_attributes:
-                        continue
-                    log.info(f"found {attr.key_name}")
-                    computed_attributes[attr.key_name] = attr
+        mapping: dict[ComputedAttributeTarget, set[str]] = {}
 
-        for identifier, computed_attribute in computed_attributes.items():
+        for node, registered_computed_attribute in schema_branch._computed_jinja2_attribute_map.items():
+            for local_fields in registered_computed_attribute.local_fields.values():
+                for local_field in local_fields:
+                    if local_field not in mapping:
+                        mapping[local_field] = set()
+                    mapping[local_field].add(node)
+
+        for computed_attribute, source_node_types in mapping.items():
             log.info(f"processing {computed_attribute.key_name}")
             scope = "default"
 
             automation = AutomationCore(
-                name=AUTOMATION_NAME.format(prefix=AUTOMATION_NAME_PREFIX, identifier=identifier, scope=scope),
-                description=f"Process value of the computed attribute for {identifier} [{scope}]",
+                name=AUTOMATION_NAME.format(
+                    prefix=AUTOMATION_NAME_PREFIX, identifier=computed_attribute.key_name, scope=scope
+                ),
+                description=f"Process value of the computed attribute for {computed_attribute.key_name} [{scope}]",
                 enabled=True,
                 trigger=EventTrigger(
                     posture=Posture.Reactive,
                     expect={"infrahub.node.*"},
                     within=timedelta(0),
-                    match=ResourceSpecification({"infrahub.node.kind": [computed_attribute.kind]}),
+                    match=ResourceSpecification({"infrahub.node.kind": list(source_node_types)}),
                     threshold=1,
                 ),
                 actions=[
@@ -255,8 +257,8 @@ async def computed_attribute_setup() -> None:
                 ],
             )
 
-            if existing_computed_attr_automations.has(identifier=identifier, scope=scope):
-                existing = existing_computed_attr_automations.get(identifier=identifier, scope=scope)
+            if existing_computed_attr_automations.has(identifier=computed_attribute.key_name, scope=scope):
+                existing = existing_computed_attr_automations.get(identifier=computed_attribute.key_name, scope=scope)
                 await client.update_automation(automation_id=existing.id, automation=automation)
                 log.info(f"{computed_attribute.key_name} Updated")
             else:

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -78,6 +78,9 @@ class ComputedAttributeTarget(BaseModel):
 
         return ["ids"]
 
+    def __hash__(self):
+        return hash((self.kind, self.attribute, tuple(self.filter_keys)))
+
 
 class RegisteredNodeComputedAttribute(BaseModel):
     local_fields: dict[str, list[ComputedAttributeTarget]] = Field(


### PR DESCRIPTION
With the current code the computed attributes will only be executed if you mutate the node where that attribute is defined. This PR changes this behaviour so that we run the computed attribute update even when related nodes are updated.

Note once #4894 is merged I want to move the code looking directly in schema_branch._computed_jinja2_attribute_map so that all of that logic instead happens in the in the `ComputedAttributes` class from backend/infrahub/core/schema/schema_branch_computed.py introduced in that PR.

Also as we're still looking at a node as a whole we can get away with using the same automation. But as I understand when we again introduce updates to specific fields I think we'll need to have multiple automations for this each with a unique match statement.