### PR TITLE
Cleanup logic for computed attributes

### DIFF
--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any, Callable, Iterator, Optional, Union
 
 from infrahub_sdk.topological_sort import DependencyCycleExistsError, topological_sort
 from infrahub_sdk.utils import compare_lists, deep_merge_dict, duplicates, intersection
-from pydantic import BaseModel, Field
 from typing_extensions import Self
 
 from infrahub.core.constants import (
@@ -61,54 +60,7 @@ log = get_logger()
 if TYPE_CHECKING:
     from pydantic import ValidationInfo
 
-
 # pylint: disable=redefined-builtin,too-many-public-methods,too-many-lines
-class ComputedAttributeTarget(BaseModel):
-    kind: str
-    attribute: AttributeSchema
-    filter_keys: list[str] = Field(default_factory=list)
-
-    @property
-    def key_name(self) -> str:
-        return f"{self.kind}_{self.attribute.name}"
-
-    @property
-    def node_filters(self) -> list[str]:
-        if self.filter_keys:
-            return self.filter_keys
-
-        return ["ids"]
-
-    def __hash__(self):
-        return hash((self.kind, self.attribute, tuple(self.filter_keys)))
-
-
-class RegisteredNodeComputedAttribute(BaseModel):
-    local_fields: dict[str, list[ComputedAttributeTarget]] = Field(
-        default_factory=dict,
-        description="These are fields local to the modified node, which can include the names of attributes and relationships",
-    )
-    relationships: dict[str, list[ComputedAttributeTarget]] = Field(
-        default_factory=dict,
-        description="These relationships refer to the name of the relationship as seen from the source node.",
-    )
-
-    def get_targets(self, updates: list[str] | None = None) -> list[ComputedAttributeTarget]:
-        targets: dict[str, ComputedAttributeTarget] = {}
-        for attribute, entries in self.local_fields.items():
-            if updates and attribute not in updates:
-                continue
-
-            for entry in entries:
-                if entry.key_name not in targets:
-                    targets[entry.key_name] = entry
-
-        for relationship_name, entries in self.relationships.items():
-            for entry in entries:
-                if entry.key_name in targets:
-                    targets[entry.key_name].filter_keys.append(f"{relationship_name}__ids")
-
-        return list(targets.values())
 
 
 class SchemaBranch:
@@ -119,7 +71,6 @@ class SchemaBranch:
         self.generics: dict[str, str] = {}
         self.profiles: dict[str, str] = {}
         self.computed_attributes = ComputedAttributes()
-        self._computed_jinja2_attribute_map: dict[str, RegisteredNodeComputedAttribute] = {}
 
         if data:
             self.nodes = data.get("nodes", {})
@@ -955,7 +906,6 @@ class SchemaBranch:
 
     def validate_computed_attributes(self) -> None:
         self.computed_attributes = ComputedAttributes()
-        self._computed_jinja2_attribute_map = {}
         for name in self.nodes.keys():
             node_schema = self.get_node(name=name, duplicate=False)
             for attribute in node_schema.attributes:
@@ -1020,7 +970,9 @@ class SchemaBranch:
                         f"{node.kind}: Attribute {attribute.name!r} the '{variable}' variable is a reference to itself"
                     )
 
-                self._register_computed_attribute_target(node=node, attribute=attribute, schema_path=schema_path)
+                self.computed_attributes.register_computed_jinja2(
+                    node=node, attribute=attribute, schema_path=schema_path
+                )
 
         elif attribute.computed_attribute.kind == ComputedAttributeKind.TRANSFORM_PYTHON and not attribute.optional:
             raise ValueError(
@@ -1029,54 +981,6 @@ class SchemaBranch:
 
         elif attribute.computed_attribute.kind == ComputedAttributeKind.TRANSFORM_PYTHON:
             self.computed_attributes.add_python_attribute(node=node, attribute=attribute)
-
-    def get_impacted_macros(self, kind: str, updates: list[str] | None = None) -> list[ComputedAttributeTarget]:
-        if mapping := self._computed_jinja2_attribute_map.get(kind):
-            return mapping.get_targets(updates=updates)
-
-        return []
-
-    def _register_computed_attribute_target(
-        self, node: NodeSchema, attribute: AttributeSchema, schema_path: SchemaAttributePath
-    ) -> None:
-        key = node.kind
-        if schema_path.is_type_relationship:
-            key = schema_path.active_relationship_schema.peer
-
-        if key not in self._computed_jinja2_attribute_map:
-            self._computed_jinja2_attribute_map[key] = RegisteredNodeComputedAttribute()
-
-        source_attribute = ComputedAttributeTarget(kind=node.kind, attribute=attribute)
-        trigger_node = self._computed_jinja2_attribute_map[key]
-        if schema_path.is_type_attribute:
-            if schema_path.active_attribute_schema.name not in trigger_node.local_fields:
-                trigger_node.local_fields[schema_path.active_attribute_schema.name] = []
-
-            trigger_node.local_fields[schema_path.active_attribute_schema.name].append(source_attribute)
-        elif schema_path.is_type_relationship:
-            if schema_path.active_attribute_schema.name not in trigger_node.local_fields:
-                trigger_node.local_fields[schema_path.active_attribute_schema.name] = []
-
-            trigger_node.local_fields[schema_path.active_attribute_schema.name].append(source_attribute)
-
-            if schema_path.active_relationship_schema.name not in trigger_node.relationships:
-                trigger_node.relationships[schema_path.active_relationship_schema.name] = []
-
-            trigger_node.relationships[schema_path.active_relationship_schema.name].append(source_attribute)
-
-            if source_attribute.kind not in self._computed_jinja2_attribute_map:
-                self._computed_jinja2_attribute_map[source_attribute.kind] = RegisteredNodeComputedAttribute()
-
-            if (
-                schema_path.active_relationship_schema.name
-                not in self._computed_jinja2_attribute_map[source_attribute.kind].local_fields
-            ):
-                self._computed_jinja2_attribute_map[source_attribute.kind].local_fields[
-                    schema_path.active_relationship_schema.name
-                ] = []
-            self._computed_jinja2_attribute_map[source_attribute.kind].local_fields[
-                schema_path.active_relationship_schema.name
-            ].append(source_attribute)
 
     def validate_count_against_cardinality(self) -> None:
         """Validate every RelationshipSchema cardinality against the min_count and max_count."""

--- a/backend/infrahub/core/schema/schema_branch_computed.py
+++ b/backend/infrahub/core/schema/schema_branch_computed.py
@@ -1,9 +1,14 @@
-from dataclasses import dataclass
+from __future__ import annotations
 
-from infrahub.core.schema import (
-    AttributeSchema,
-    NodeSchema,
-)
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+from infrahub.core.schema import AttributeSchema  # noqa: TCH001
+
+if TYPE_CHECKING:
+    from infrahub.core.schema import NodeSchema, SchemaAttributePath
 
 
 @dataclass
@@ -16,9 +21,58 @@ class PythonDefinition:
         return f"{self.kind}_{self.attribute.name}"
 
 
+class ComputedAttributeTarget(BaseModel):
+    kind: str
+    attribute: AttributeSchema
+    filter_keys: list[str] = Field(default_factory=list)
+
+    @property
+    def key_name(self) -> str:
+        return f"{self.kind}_{self.attribute.name}"
+
+    @property
+    def node_filters(self) -> list[str]:
+        if self.filter_keys:
+            return self.filter_keys
+
+        return ["ids"]
+
+    def __hash__(self) -> int:
+        return hash((self.kind, self.attribute, tuple(self.filter_keys)))
+
+
+class RegisteredNodeComputedAttribute(BaseModel):
+    local_fields: dict[str, list[ComputedAttributeTarget]] = Field(
+        default_factory=dict,
+        description="These are fields local to the modified node, which can include the names of attributes and relationships",
+    )
+    relationships: dict[str, list[ComputedAttributeTarget]] = Field(
+        default_factory=dict,
+        description="These relationships refer to the name of the relationship as seen from the source node.",
+    )
+
+    def get_targets(self, updates: list[str] | None = None) -> list[ComputedAttributeTarget]:
+        targets: dict[str, ComputedAttributeTarget] = {}
+        for attribute, entries in self.local_fields.items():
+            if updates and attribute not in updates:
+                continue
+
+            for entry in entries:
+                if entry.key_name not in targets:
+                    targets[entry.key_name] = entry
+
+        for relationship_name, entries in self.relationships.items():
+            for entry in entries:
+                if entry.key_name in targets:
+                    targets[entry.key_name].filter_keys.append(f"{relationship_name}__ids")
+
+        return list(targets.values())
+
+
 class ComputedAttributes:
     def __init__(self) -> None:
         self._computed_python_transform_attribute_map: dict[str, list[AttributeSchema]] = {}
+        self._computed_jinja2_attribute_map: dict[str, RegisteredNodeComputedAttribute] = {}
 
     def add_python_attribute(self, node: NodeSchema, attribute: AttributeSchema) -> None:
         if node.kind not in self._computed_python_transform_attribute_map:
@@ -43,3 +97,63 @@ class ComputedAttributes:
                     )
 
         return computed_attributes
+
+    def register_computed_jinja2(
+        self, node: NodeSchema, attribute: AttributeSchema, schema_path: SchemaAttributePath
+    ) -> None:
+        key = node.kind
+        if schema_path.is_type_relationship:
+            key = schema_path.active_relationship_schema.peer
+
+        if key not in self._computed_jinja2_attribute_map:
+            self._computed_jinja2_attribute_map[key] = RegisteredNodeComputedAttribute()
+
+        source_attribute = ComputedAttributeTarget(kind=node.kind, attribute=attribute)
+        trigger_node = self._computed_jinja2_attribute_map[key]
+        if schema_path.is_type_attribute:
+            if schema_path.active_attribute_schema.name not in trigger_node.local_fields:
+                trigger_node.local_fields[schema_path.active_attribute_schema.name] = []
+
+            trigger_node.local_fields[schema_path.active_attribute_schema.name].append(source_attribute)
+        elif schema_path.is_type_relationship:
+            if schema_path.active_attribute_schema.name not in trigger_node.local_fields:
+                trigger_node.local_fields[schema_path.active_attribute_schema.name] = []
+
+            trigger_node.local_fields[schema_path.active_attribute_schema.name].append(source_attribute)
+
+            if schema_path.active_relationship_schema.name not in trigger_node.relationships:
+                trigger_node.relationships[schema_path.active_relationship_schema.name] = []
+
+            trigger_node.relationships[schema_path.active_relationship_schema.name].append(source_attribute)
+
+            if source_attribute.kind not in self._computed_jinja2_attribute_map:
+                self._computed_jinja2_attribute_map[source_attribute.kind] = RegisteredNodeComputedAttribute()
+
+            if (
+                schema_path.active_relationship_schema.name
+                not in self._computed_jinja2_attribute_map[source_attribute.kind].local_fields
+            ):
+                self._computed_jinja2_attribute_map[source_attribute.kind].local_fields[
+                    schema_path.active_relationship_schema.name
+                ] = []
+            self._computed_jinja2_attribute_map[source_attribute.kind].local_fields[
+                schema_path.active_relationship_schema.name
+            ].append(source_attribute)
+
+    def get_impacted_jinja2_targets(self, kind: str, updates: list[str] | None = None) -> list[ComputedAttributeTarget]:
+        if mapping := self._computed_jinja2_attribute_map.get(kind):
+            return mapping.get_targets(updates=updates)
+
+        return []
+
+    def get_jinja2_target_map(self) -> dict[ComputedAttributeTarget, list[str]]:
+        mapping: dict[ComputedAttributeTarget, set[str]] = {}
+
+        for node, registered_computed_attribute in self._computed_jinja2_attribute_map.items():
+            for local_fields in registered_computed_attribute.local_fields.values():
+                for local_field in local_fields:
+                    if local_field not in mapping:
+                        mapping[local_field] = set()
+                    mapping[local_field].add(node)
+
+        return {key: list(value) for key, value in mapping.items()}


### PR DESCRIPTION
This PR mainly moves code around so that it will be easier to read in the future. Logic that used to live within SchemaBranch has been moved to a more specialized object to avoid additional complexity within SchemaBranch.