### PR TITLE
Docs & Demo Updates: Remove build option and update documentation

### DIFF
--- a/.devcontainer/onCreateCommand.sh
+++ b/.devcontainer/onCreateCommand.sh
@@ -8,4 +8,4 @@ poetry install --no-interaction --no-ansi
 
 git submodule update --init
 
-invoke demo.build
+invoke demo.pull

--- a/.devcontainer/updateContentCommand.sh
+++ b/.devcontainer/updateContentCommand.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export WEB_CONCURRENCY=2
-invoke demo.build demo.start
+invoke demo.start
 sleep 120
 docker logs infrahub-server-1
 invoke demo.load-infra-schema

--- a/.vale/styles/spelling-exceptions.txt
+++ b/.vale/styles/spelling-exceptions.txt
@@ -115,3 +115,5 @@ Version Control
 Vitest
 Yaml
 yamllint
+vscode
+VSCode

--- a/docs/docs/development/docs.mdx
+++ b/docs/docs/development/docs.mdx
@@ -9,11 +9,11 @@ import SnippetFrontendReqs from "../snippets/pre-reqs-frontend.mdx"
 
 Welcome to the Infrahub documentation guide. This document aims to answer any questions that may come up when creating or updating documentation.
 
-## Base Prerequisites
+## Base prerequisites
 
 <SnippetBaseReqs />
 
-## Frontend Prerequisites
+## Frontend prerequisites
 
 <SnippetFrontendReqs />
 
@@ -76,7 +76,7 @@ Infrahub uses [Vale](https://vale.sh) to check grammar, style, and word usage. Y
 
 Most Vale warnings match up with the [style guide](#style-guide) explanations below. Other warnings often fall into the `Infrahub.spelling` rule. These are caused by misspellings, product names, names of people, or otherwise unknown technical terms. See the [procedures for updating rules](#spelling-errors) below for details on adding terms to the approved list.
 
-### Install VSCode linting extensions
+### Install vscode linting extensions
 
 It is preferred to install extensions into VSCode so that you can see the visual errors and fix them as you write documentation.
 

--- a/docs/docs/development/docs.mdx
+++ b/docs/docs/development/docs.mdx
@@ -1,34 +1,72 @@
 ---
 title: Documentation guide
 ---
+import ReferenceLink from "../../src/components/Card";
+import SnippetBaseReqs from "../snippets/pre-reqs-base.mdx"
+import SnippetFrontendReqs from "../snippets/pre-reqs-frontend.mdx"
 
 # Documentation guide
 
 Welcome to the Infrahub documentation guide. This document aims to answer any questions that may come up when creating or updating documentation.
 
+## Base Prerequisites
+
+<SnippetBaseReqs />
+
+## Frontend Prerequisites
+
+<SnippetFrontendReqs />
+
 ## Working with the docs site locally
 
-The recommended way to run and build the docs locally is with Infrahub's suite of `invoke`-driven tasks. To run the commands, you should:
+The recommended way to run and build the docs locally is with Infrahub's suite of `invoke`-driven tasks.
 
-1. Install [`python`](https://www.python.org/).
-2. Install [`invoke`](https://www.pyinvoke.org/).
-3. Install [`poetry`](https://python-poetry.org/).
-4. Run `poetry install` from the Infrahub project directory.
-5. Install [Node.js (and npm)](https://nodejs.org/en).
+Use the Invoke tasks to build the documentation and generate source code derived documentation.
 
-Once these requirements are met, you'll have access to the doc task list.
+```shell
+invoke docs.build docs.generate
+```
+
+Once the documentation has been built, make sure to validate the documentation.
+
+```shell
+invoke docs.validate
+```
+
+After the documentation has been validated, it can be served locally on port **3000**.
+
+```shell
+invoke docs.serve
+```
+
+<ReferenceLink title="Explore the local documentation" url="http://localhost:3000/" openInNewTab />
+
+To see more documentation Invoke tasks use the help functionality.
 
 ```shell
 invoke -l docs
 ```
 
-The primary commands are as follows:
+```shell
+Available 'docs' tasks:
 
-- `invoke docs.install`: Install the documentation dependencies via `npm`.
-- `invoke docs.build`: Build the documentation website.
-- `invoke docs.generate`: Generate source-derived documentation pages (such as the schema and Jinja templates).
-- `invoke docs.serve`: Run a local development server for the documentation website.
-- `invoke docs.validate`: Validate that the generated documentation has been committed to git.
+  .build                   Build documentation website.
+  .format                  This will run all formatter.
+  .format-markdownlint     Run markdownlint-cli2 to format all .md/mdx files.
+  .generate                Generate all documentation output from code.
+  .generate-bus-events     Generate documentation for the Bus events.
+  .generate-infrahub-cli   Generate documentation for the infrahub cli.
+  .generate-infrahubctl    Generate documentation for the infrahubctl cli.
+  .generate-python-sdk     Generate documentation for the Python SDK.
+  .generate-repository     Generate documentation for the repository configuration file.
+  .generate-schema         Generate documentation for the schema.
+  .install                 Install documentation dependencies.
+  .lint                    This will run all linter.
+  .markdownlint
+  .serve                   Run documentation server in development mode.
+  .vale                    Run vale to validate the documentation.
+  .validate                Validate that the generated documentation is committed to Git.
+```
 
 ## Linting and automation
 
@@ -38,9 +76,12 @@ Infrahub uses [Vale](https://vale.sh) to check grammar, style, and word usage. Y
 
 Most Vale warnings match up with the [style guide](#style-guide) explanations below. Other warnings often fall into the `Infrahub.spelling` rule. These are caused by misspellings, product names, names of people, or otherwise unknown technical terms. See the [procedures for updating rules](#spelling-errors) below for details on adding terms to the approved list.
 
-### Install linters locally
+### Install VSCode linting extensions
 
-The preferred way to work on the documentation with Vale and markdownlint is directly in an editor. Install the [Vale](https://marketplace.visualstudio.com/items?itemName=chrischinchilla.vale-vscode) and [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) VS Code plugins to enable in-editor warnings.
+It is preferred to install extensions into VSCode so that you can see the visual errors and fix them as you write documentation.
+
+- [Vale](https://marketplace.visualstudio.com/items?itemName=chrischinchilla.vale-vscode)
+- [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)
 
 ### Disabling Vale and markdownlint
 
@@ -91,26 +132,42 @@ When writing documentation, it's essential to guide the reader's attention to sp
 - **Info:** Use info blocks for additional, helpful information that isn't required to complete the task but offers more context or useful tips.
 
   ```markdown
-  > **Info**: This feature is available in version 2.1 and later.
+  :::info
   ```
+
+  **Example**
+  :::info This feature is available in version 2.1 and later.
+  :::
 
 - **Success:** Use success blocks to highlight expected outcomes and "status checks" to ensure the reader is on track with the guide. These blocks can reinforce the reader's progress and provide positive feedback.
 
   ```markdown
-  > **Success**: If you've followed the steps correctly, your installation should now be complete.
+  :::success
   ```
+
+  **Example**
+  :::success If you've followed the steps correctly, your installation should now be complete.
+  :::
 
 - **Warning:** Warning blocks should be used to highlight common errors or mistakes that may occur during the process. They serve as preventive measures to help the reader avoid potential pitfalls.
 
   ```markdown
-  > **Warning**: Ensure you've backed up your files before proceeding with this step to prevent data loss.
+  :::warning
   ```
+
+  **Example**
+  :::warning Ensure you've backed up your files before proceeding with this step to prevent data loss.
+  :::
 
 - **Danger:** Use danger blocks to highlight irreversible or breaking actions. These notifications are critical for steps that could significantly affect the system or data if mishandled.
 
   ```markdown
-  > **Danger**: This action will permanently delete your data and cannot be undone.
+  :::danger
   ```
+
+  **Example**
+  :::danger This action will permanently delete your data and cannot be undone.
+  :::
 
 Incorporating these blocks into your documentation makes it more interactive and user-friendly, guiding the reader through different stages of their learning or implementation process with visual cues that emphasize the significance of each piece of information.
 

--- a/docs/docs/development/frontend/getting-set-up.mdx
+++ b/docs/docs/development/frontend/getting-set-up.mdx
@@ -9,7 +9,7 @@ title: Getting set up
 Make sure [Infrahub Backend](../backend.mdx) is up and running. If not, in your terminal execute:
 
 ```shell
-invoke demo.destroy demo.build demo.start demo.load-infra-schema demo.load-infra-data
+invoke demo.destroy demo.start demo.load-infra-schema demo.load-infra-data
 ```
 
 :::

--- a/docs/docs/guides/installation.mdx
+++ b/docs/docs/guides/installation.mdx
@@ -151,11 +151,11 @@ Please reach out if you need some help and feel free to send a PR with the insta
 </TabItem>
 </Tabs>
 
-Once docker desktop and invoke are installed you can start and initialize the Infrahub demo environment with the following command:
+Once docker desktop and invoke are installed you can start and initialize Infrahub:
 
 ```shell
 cd infrahub
-invoke demo.start demo.load-infra-schema demo.load-infra-data
+invoke demo.start
 ```
 
 <ReferenceLink title="Check the documentation of the demo environment for more information" url="/topics/local-demo-environment" />

--- a/docs/docs/snippets/pre-reqs-base.mdx
+++ b/docs/docs/snippets/pre-reqs-base.mdx
@@ -1,0 +1,5 @@
+| Prerequisite Tool(s)                    | Post Installation Steps   |
+| --------------------------------------- | :-----------------------: |
+| [Python](https://www.python.org/)       |                           |
+| [Invoke](https://www.pyinvoke.org/)     |                           |
+| [Poetry](https://python-poetry.org/)    | `poetry install`          |

--- a/docs/docs/snippets/pre-reqs-frontend.mdx
+++ b/docs/docs/snippets/pre-reqs-frontend.mdx
@@ -1,0 +1,7 @@
+| Prerequisite Tool(s)                                              | Post Installation Steps   |
+| ----------------------------------------------------------------- | :-----------------------: |
+| [Node.js (and npm)](https://nodejs.org/en)                        | `docs.install`            |
+| [Vale](https://vale.sh/)                                          |                           |
+| [Markdownlint-cli2](https://github.com/DavidAnson/markdownlint)   |                           |
+
+:::warning Supported Node versions: `22`.

--- a/docs/docs/topics/local-demo-environment.mdx
+++ b/docs/docs/topics/local-demo-environment.mdx
@@ -10,15 +10,18 @@ It's designed to be controlled by `invoke` using a list of predefined commands.
 
 | Command                  | Description                                                               |
 | ------------------------ | ------------------------------------------------------------------------- |
-| `demo.build`             | Build an image with the provided name and Python version.                 |
+| `demo.pull`              | Pull external containers from registry.                                   |
 | `demo.start`             | Start a local instance of Infrahub within docker compose.                 |
 | `demo.stop`              | Stop the running instance of Infrahub.                                    |
+| `demo.restart`           | Restart Infrahub API Server and Task worker within docker compose.        |
 | `demo.destroy`           | Destroy all containers and volumes.                                       |
+| `demo.migrate`           | Apply the latest database migrations.                                     |
 | `demo.cli-git`           | Launch a bash shell inside the running Infrahub container.                |
 | `demo.cli-server`        | Launch a bash shell inside the running Infrahub container.                |
 | `demo.status`            | Display the status of all containers.                                     |
 | `demo.load-infra-schema` | Load the `infrastructure_base` schema into Infrahub.                      |
 | `demo.load-infra-data`   | Generate some data representing a small network with 6 devices.           |
+| `demo.load-infra-menu`   | Generate some data representing a small network with 6 devices.           |
 
 ## Topology
 

--- a/docs/docs/tutorials/getting-started/introduction-to-infrahub.mdx
+++ b/docs/docs/tutorials/getting-started/introduction-to-infrahub.mdx
@@ -23,3 +23,7 @@ During this tutorial we'll mainly use the Frontend, the `infrahubctl` CLI and th
 | **GraphDB**     | Main database based on neo4j where all information in the graph are stored.                                  | ---                                                            |
 | **Cache**       | Cache based on Redis. Mainly used to support the reservation of shared resources across all components.      | ---                                                            |
 | **Message bus** | Message bus based on RabbitMQ to allow all components to interact.                                           | ---                                                            |
+
+## Installing Infrahub
+
+Please follow the [Installation Guide](/guides/installation) to spin up Infrahub before continuing the tutorial.

--- a/tasks/demo.py
+++ b/tasks/demo.py
@@ -1,12 +1,11 @@
 """Replacement for Makefile."""
 
-from typing import Optional
+# from typing import Optional
 
 from invoke.context import Context
 from invoke.tasks import task
 
 from .container_ops import (
-    build_images,
     destroy_environment,
     migrate_database,
     pull_images,
@@ -20,7 +19,6 @@ from .infra_ops import load_infrastructure_data, load_infrastructure_menu, load_
 from .shared import (
     BUILD_NAME,
     INFRAHUB_DATABASE,
-    PYTHON_VER,
     SERVICE_SERVER_NAME,
     SERVICE_WORKER_NAME,
     Namespace,
@@ -31,26 +29,6 @@ from .shared import (
 from .utils import ESCAPED_REPO_PATH
 
 NAMESPACE = Namespace.DEFAULT
-
-
-@task(optional=["database"])
-def build(
-    context: Context,
-    service: Optional[str] = None,
-    python_ver: str = PYTHON_VER,
-    nocache: bool = False,
-    database: str = INFRAHUB_DATABASE,
-) -> None:
-    """Build an image with the provided name and python version.
-
-    Args:
-        context (obj): Used to run specific commands
-        python_ver (str): Define the Python version docker image to build from
-        nocache (bool): Do not use cache when building the image
-    """
-    build_images(
-        context=context, service=service, python_ver=python_ver, nocache=nocache, database=database, namespace=NAMESPACE
-    )
 
 
 @task(optional=["database"])


### PR DESCRIPTION
- Remove `demo.build` as an Invoke task to ensure demo is running on the latest published release
- Remove documentation and update **.devcontainer** to either remove/update `demo.build` -> `demo.pull`
- Update Guide/Tutorials for installing Infrahub to point to the guide and make the "Installing Infrahub" guide to not load any demo data (Data/Schema loading happens either in later guides/tutorials)
- Update docs for building documentation locally