### PR TITLE
Benchmark Utility Output Folder

### DIFF
--- a/utilities/benchmark/Dockerfile
+++ b/utilities/benchmark/Dockerfile
@@ -15,4 +15,9 @@ RUN bash -c 'curl -o pt_linux.zip https://www.passmark.com/downloads/pt_linux_$(
     apt-get clean all && \
     rm -rf /var/lib/apt/lists/*
 
+RUN mkdir -p /data
+RUN chmod 777 /data
+
+WORKDIR /data
+
 CMD /entrypoint.sh


### PR DESCRIPTION
- To allow benchmarking to be done on K8s with a PVC there needs to be a specific mountpoint for the PVC
- By default the script writes to / as root
- This PR changes it to /data
- It also allows the benchmark to be run as a none root user