### PR TITLE
Trigger Transform computed attributes by GraphQL query group

### DIFF
--- a/backend/infrahub/computed_attribute/constants.py
+++ b/backend/infrahub/computed_attribute/constants.py
@@ -1,3 +1,5 @@
-AUTOMATION_NAME_PREFIX = "Computed-attribute-process"
+PROCESS_AUTOMATION_NAME_PREFIX = "Computed-attribute-process"
+QUERY_AUTOMATION_NAME_PREFIX = "Computed-attribute-query"
 
-AUTOMATION_NAME = AUTOMATION_NAME_PREFIX + "::{identifier}::{scope}"
+PROCESS_AUTOMATION_NAME = PROCESS_AUTOMATION_NAME_PREFIX + "::{identifier}::{scope}"
+QUERY_AUTOMATION_NAME = QUERY_AUTOMATION_NAME_PREFIX + "::{identifier}::{scope}"

--- a/backend/infrahub/computed_attribute/models.py
+++ b/backend/infrahub/computed_attribute/models.py
@@ -8,8 +8,6 @@ from prefect.events.schemas.automations import Automation  # noqa: TCH002
 from pydantic import BaseModel, Field
 from typing_extensions import Self
 
-from .constants import AUTOMATION_NAME_PREFIX
-
 if TYPE_CHECKING:
     from infrahub.core.schema.schema_branch_computed import PythonDefinition
 
@@ -18,10 +16,10 @@ class ComputedAttributeAutomations(BaseModel):
     data: dict[str, dict[str, Automation]] = Field(default_factory=lambda: defaultdict(dict))
 
     @classmethod
-    def from_prefect(cls, automations: list[Automation]) -> Self:
+    def from_prefect(cls, automations: list[Automation], prefix: str = "") -> Self:
         obj = cls()
         for automation in automations:
-            if not automation.name.startswith(AUTOMATION_NAME_PREFIX):
+            if not automation.name.startswith(prefix):
                 continue
 
             name_split = automation.name.split("::")
@@ -55,3 +53,9 @@ class PythonTransformComputedAttribute:
     query_name: str
     query_models: list[str]
     computed_attribute: PythonDefinition
+
+
+@dataclass
+class PythonTransformTarget:
+    kind: str
+    object_id: str

--- a/backend/infrahub/core/schema/schema_branch_computed.py
+++ b/backend/infrahub/core/schema/schema_branch_computed.py
@@ -84,6 +84,9 @@ class ComputedAttributes:
         """Return kinds that have Python attributes defined"""
         return list(self._computed_python_transform_attribute_map.keys())
 
+    def get_python_attributes_per_node(self) -> dict[str, list[AttributeSchema]]:
+        return self._computed_python_transform_attribute_map
+
     @property
     def python_attributes_by_transform(self) -> dict[str, list[PythonDefinition]]:
         computed_attributes: dict[str, list[PythonDefinition]] = {}

--- a/backend/infrahub/workflows/catalogue.py
+++ b/backend/infrahub/workflows/catalogue.py
@@ -256,6 +256,13 @@ UPDATE_COMPUTED_ATTRIBUTE_TRANSFORM = WorkflowDefinition(
     function="process_transform",
 )
 
+QUERY_COMPUTED_ATTRIBUTE_TRANSFORM_TARGETS = WorkflowDefinition(
+    name="query-computed-attribute-transform-targets",
+    type=WorkflowType.INTERNAL,
+    module="infrahub.computed_attribute.tasks",
+    function="query_transform_targets",
+)
+
 REQUEST_PROPOSED_CHANGE_DATA_INTEGRITY = WorkflowDefinition(
     name="proposed-changed-data-integrity",
     type=WorkflowType.INTERNAL,
@@ -318,6 +325,7 @@ workflows = [
     UPDATE_COMPUTED_ATTRIBUTE_TRANSFORM,
     REQUEST_PROPOSED_CHANGE_DATA_INTEGRITY,
     AUTOMATION_SCHEMA_UPDATED,
+    QUERY_COMPUTED_ATTRIBUTE_TRANSFORM_TARGETS,
 ]
 
 automation_setup_workflows = [AUTOMATION_GIT_UPDATED, AUTOMATION_SCHEMA_UPDATED]

--- a/backend/tests/fixtures/repos/computed-attributes-functional/initial__main/.infrahub.yml
+++ b/backend/tests/fixtures/repos/computed-attributes-functional/initial__main/.infrahub.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://schema.infrahub.app/python-sdk/repository-config/develop.json
+---
+python_transforms:
+  - name: TShirtPitch
+    class_name: TShirtPitch
+    file_path: "transforms/tshirt_pitch.py"
+
+queries:
+  - name: tshirt_colors
+    file_path: "transforms/tshirt_colors.gql"

--- a/backend/tests/fixtures/repos/computed-attributes-functional/initial__main/transforms/model.py
+++ b/backend/tests/fixtures/repos/computed-attributes-functional/initial__main/transforms/model.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class Pitch:
+    name: str
+    color: str
+    description: str
+
+    @classmethod
+    def from_data(cls, data: dict[str, Any]) -> Pitch:
+        node = data["TestingTShirt"]["edges"][0]["node"]
+        color = node["color"]["node"]
+        return cls(
+            name=node["name"]["value"],
+            color=color["name"]["value"],
+            description=color["description"]["value"],
+        )
+
+    def render(self) -> str:
+        return f"Buy your {self.name} t-shirt today. Look great in {self.description.lower()}"

--- a/backend/tests/fixtures/repos/computed-attributes-functional/initial__main/transforms/tshirt_colors.gql
+++ b/backend/tests/fixtures/repos/computed-attributes-functional/initial__main/transforms/tshirt_colors.gql
@@ -1,0 +1,21 @@
+query TestingTshirtColor($id: ID!) {
+  TestingTShirt(ids: [$id]) {
+    edges {
+      node {
+        name {
+          value
+        }
+        color {
+          node {
+            name {
+              value
+            }
+            description {
+              value
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/backend/tests/fixtures/repos/computed-attributes-functional/initial__main/transforms/tshirt_pitch.py
+++ b/backend/tests/fixtures/repos/computed-attributes-functional/initial__main/transforms/tshirt_pitch.py
@@ -1,0 +1,13 @@
+from typing import Any
+
+from infrahub_sdk.transforms import InfrahubTransform
+
+from .model import Pitch
+
+
+class TShirtPitch(InfrahubTransform):
+    query = "tshirt_colors"
+
+    async def transform(self, data: dict[str, Any]) -> str:
+        pitch = Pitch.from_data(data=data)
+        return pitch.render()

--- a/backend/tests/functional/computed_attributes/test_computed_attribute.py
+++ b/backend/tests/functional/computed_attributes/test_computed_attribute.py
@@ -4,14 +4,18 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from infrahub.computed_attribute.tasks import process_jinja2
+from infrahub.computed_attribute.tasks import process_jinja2, process_transform, query_transform_targets
+from infrahub.core.constants import InfrahubKind
 from infrahub.core.node import Node
 from infrahub.core.schema import SchemaRoot
 from infrahub.database import InfrahubDatabase
+from tests.helpers.file_repo import FileRepo
 from tests.helpers.schema import COLOR, TSHIRT, load_schema
 from tests.helpers.test_app import TestInfrahubApp
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from infrahub_sdk import InfrahubClient
 
     from infrahub.core.branch import Branch
@@ -26,8 +30,10 @@ class TestComputedAttribute(TestInfrahubApp):
         db: InfrahubDatabase,
         initialize_registry: None,
         client: InfrahubClient,
+        default_branch: Branch,
         bus_simulator: BusSimulator,
         prefect_test_fixture: None,
+        git_repos_source_dir_module_scope: Path,
     ) -> dict[str, Node]:
         await load_schema(db, schema=SchemaRoot(nodes=[COLOR, TSHIRT]), update_db=True)
 
@@ -40,13 +46,32 @@ class TestComputedAttribute(TestInfrahubApp):
         await c2.new(db=db, name="Ocean", description="Deep and calming, like the endless expanse of the ocean.")
         await c2.save(db=db)
 
+        c3 = await Node.init(db=db, schema="TestingColor")
+        await c3.new(db=db, name="Ivory", description="A soft off-white, smooth and classic.")
+        await c3.save(db=db)
+
         t1 = await Node.init(db=db, schema="TestingTShirt")
         await t1.new(db=db, name="Explorer", color=c1)
         await t1.save(db=db)
 
-        return {"c1": c1, "c2": c2, "t1": t1}
+        t2 = await Node.init(db=db, schema="TestingTShirt")
+        await t2.new(db=db, name="Rouge", color=c3)
+        await t2.save(db=db)
 
-    async def test_description_after_color_change(
+        FileRepo(name="computed-attributes-functional", sources_directory=git_repos_source_dir_module_scope)
+        client_repository = await client.create(
+            kind=InfrahubKind.REPOSITORY,
+            data={
+                "name": "computed-attributes-functional",
+                "location": f"{git_repos_source_dir_module_scope}/computed-attributes-functional",
+            },
+            branch=default_branch.name,
+        )
+        await client_repository.save()
+
+        return {"c1": c1, "c2": c2, "c3": c3, "t1": t1, "t2": t2}
+
+    async def test_description_after_color_change_jinja2(
         self, data: dict[str, Node], client: InfrahubClient, default_branch: Branch
     ) -> None:
         tshirt_1 = await client.get(kind="TestingTShirt", id=data["t1"].id)
@@ -59,7 +84,7 @@ class TestComputedAttribute(TestInfrahubApp):
         await tshirt_1.save()
 
         # As we currently don't have a way to trigger on events within these tests we fire the automated workflow
-        # manually here
+        # manually
         await process_jinja2(
             branch_name=default_branch.name,
             node_kind="TestingTShirt",
@@ -73,4 +98,41 @@ class TestComputedAttribute(TestInfrahubApp):
         assert (
             tshirt_updated.description.value
             == "A Ocean Explorer t-shirt. Deep and calming, like the endless expanse of the ocean."
+        )
+
+    async def test_description_after_chainging_color_description_transform(
+        self, data: dict[str, Node], client: InfrahubClient, default_branch: Branch
+    ) -> None:
+        # As we currently don't have a way to trigger on events within these tests we fire the automated workflow
+        # manually
+        tshirt_obj = data["t2"]
+        color_obj = data["c3"]
+
+        tshirt_initial = await client.get(kind="TestingTShirt", id=tshirt_obj.id)
+
+        await process_transform(
+            branch_name=default_branch.name,
+            object_id=tshirt_obj.id,
+            node_kind="TestingTShirt",
+            computed_attribute_name="pitch",
+            computed_attribute_kind="TestingTShirt",
+        )
+
+        tshirt_first_pitch_allocation = await client.get(kind="TestingTShirt", id=tshirt_obj.id)
+
+        color = await client.get(kind="TestingColor", id=color_obj.id)
+        color.description.value = "A soft off-white, smooth and timeless."
+        await color.save()
+
+        await query_transform_targets(branch_name=default_branch.name, node_kind="TestingColor", object_id=color_obj.id)
+
+        tshirt_altered_pitch_allocation = await client.get(kind="TestingTShirt", id=tshirt_obj.id)
+        assert not tshirt_initial.pitch.value
+        assert (
+            tshirt_first_pitch_allocation.pitch.value
+            == "Buy your Rouge t-shirt today. Look great in a soft off-white, smooth and classic."
+        )
+        assert (
+            tshirt_altered_pitch_allocation.pitch.value
+            == "Buy your Rouge t-shirt today. Look great in a soft off-white, smooth and timeless."
         )

--- a/backend/tests/helpers/schema/tshirt.py
+++ b/backend/tests/helpers/schema/tshirt.py
@@ -22,6 +22,16 @@ TSHIRT = NodeSchema(
                 jinja2_template="A {{color__name__value }} {{ name__value}} t-shirt. {{ color__description__value }}",
             ),
         ),
+        AttributeSchema(
+            name="pitch",
+            kind="Text",
+            optional=True,
+            read_only=True,
+            computed_attribute=ComputedAttribute(
+                kind=ComputedAttributeKind.TRANSFORM_PYTHON,
+                transform="TShirtPitch",
+            ),
+        ),
     ],
     relationships=[
         RelationshipSchema(

--- a/backend/tests/unit/computed_attribute/test_models.py
+++ b/backend/tests/unit/computed_attribute/test_models.py
@@ -3,7 +3,12 @@ from datetime import timedelta
 
 from prefect.events.schemas.automations import Automation, EventTrigger, Posture
 
-from infrahub.computed_attribute.constants import AUTOMATION_NAME
+from infrahub.computed_attribute.constants import (
+    PROCESS_AUTOMATION_NAME,
+    PROCESS_AUTOMATION_NAME_PREFIX,
+    QUERY_AUTOMATION_NAME,
+    QUERY_AUTOMATION_NAME_PREFIX,
+)
 from infrahub.computed_attribute.models import ComputedAttributeAutomations
 
 
@@ -29,14 +34,21 @@ def generate_automation(
 
 async def test_load_from_prefect():
     automations: list[Automation] = [
-        generate_automation(name=AUTOMATION_NAME.format(identifier="AAAAA", scope="default")),
-        generate_automation(name=AUTOMATION_NAME.format(identifier="AAAAA", scope="yyyy")),
-        generate_automation(name=AUTOMATION_NAME.format(identifier="BBBBB", scope="default")),
+        generate_automation(name=PROCESS_AUTOMATION_NAME.format(identifier="AAAAA", scope="default")),
+        generate_automation(name=PROCESS_AUTOMATION_NAME.format(identifier="AAAAA", scope="yyyy")),
+        generate_automation(name=PROCESS_AUTOMATION_NAME.format(identifier="BBBBB", scope="default")),
+        generate_automation(name=QUERY_AUTOMATION_NAME.format(identifier="CCCCC", scope="default")),
         generate_automation(name="anothername"),
     ]
 
-    obj = ComputedAttributeAutomations.from_prefect(automations=automations)
+    obj = ComputedAttributeAutomations.from_prefect(automations=automations, prefix=PROCESS_AUTOMATION_NAME_PREFIX)
+    query_obj = ComputedAttributeAutomations.from_prefect(automations=automations, prefix=QUERY_AUTOMATION_NAME_PREFIX)
 
     assert obj.has(identifier="AAAAA", scope="default")
     assert obj.has(identifier="AAAAA", scope="yyyy")
     assert obj.has(identifier="BBBBB", scope="default")
+    assert not obj.has(identifier="CCCCC", scope="default")
+
+    query_obj = ComputedAttributeAutomations.from_prefect(automations=automations, prefix=QUERY_AUTOMATION_NAME_PREFIX)
+    assert not query_obj.has(identifier="AAAAA", scope="default")
+    assert query_obj.has(identifier="CCCCC", scope="default")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,7 +202,13 @@ pretty = true
 ignore_missing_imports = true
 disallow_untyped_defs = true
 disable_error_code = ["type-abstract"]
-exclude = ["^backend/tests/scale", "^backend/tests/unit", "^backend/tests/test_data", "^backend/tests/query_benchmark"]
+exclude = [
+    "^backend/tests/fixtures/repos/*", # To avoid 'Duplicate module named "transforms"'
+    "^backend/tests/scale",
+    "^backend/tests/unit",
+    "^backend/tests/test_data",
+    "^backend/tests/query_benchmark"
+]
 
 [[tool.mypy.overrides]]
 module = "infrahub.*"


### PR DESCRIPTION
Changes:

* Allow for triggering computed attributes based on changes on related nodes using GraphQL query group subscribers
* Adds an automation that consults GraphQL query groups based on the models associated with a given computed attribute.
* The "query" automation will submit a workflow for the previous one once it has found potential candidates to update
* Rename automation name for computed_attributes since we need two automations
* Setup a test repository for the computed attributes along with test cases that update a related node
* Exclude our test repos from mypy due to problems with reusing the same module names in multiple repos (we might want to circle back to this at some later point, but I don't think it's really required)
* Renamed the old test to better highlight the difference between them