### PR TITLE
Use selective updates when saving a Node object

### DIFF
--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -548,28 +548,38 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
                 identifier = f"{rel.schema.identifier}::{rel.peer_id}"
                 rel.id, rel.db_id = new_ids[identifier]
 
-    async def _update(self, db: InfrahubDatabase, at: Optional[Timestamp] = None) -> None:
+    async def _update(
+        self, db: InfrahubDatabase, at: Optional[Timestamp] = None, fields: list[str] | None = None
+    ) -> None:
         """Update the node in the database if needed."""
 
         update_at = Timestamp(at)
 
         # Go over the list of Attribute and update them one by one
         for name in self._attributes:
-            attr: BaseAttribute = getattr(self, name)
-            await attr.save(at=update_at, db=db)
+            if fields and name in fields:
+                attr: BaseAttribute = getattr(self, name)
+                await attr.save(at=update_at, db=db)
+            else:
+                attr: BaseAttribute = getattr(self, name)
+                await attr.save(at=update_at, db=db)
 
         # Go over the list of relationships and update them one by one
         for name in self._relationships:
-            rel: RelationshipManager = getattr(self, name)
-            await rel.save(at=update_at, db=db)
+            if fields and name in fields:
+                rel: RelationshipManager = getattr(self, name)
+                await rel.save(at=update_at, db=db)
+            else:
+                attr: BaseAttribute = getattr(self, name)
+                await attr.save(at=update_at, db=db)
 
-    async def save(self, db: InfrahubDatabase, at: Optional[Timestamp] = None) -> Self:
+    async def save(self, db: InfrahubDatabase, at: Optional[Timestamp] = None, fields: list[str] | None = None) -> Self:
         """Create or Update the Node in the database."""
 
         save_at = Timestamp(at)
 
         if self._existing:
-            await self._update(at=save_at, db=db)
+            await self._update(at=save_at, db=db, fields=fields)
             return self
 
         await self._create(at=save_at, db=db)

--- a/backend/infrahub/graphql/mutations/computed_attribute.py
+++ b/backend/infrahub/graphql/mutations/computed_attribute.py
@@ -87,9 +87,9 @@ class UpdateComputedAttribute(Mutation):
                 identifier=str(data.id),
                 message="The indicated not does not have the specified attribute_name",
             )
-
-        attribute_field.value = str(data.value)
-        await target_node.save(db=context.db)
+        if attribute_field.value != str(data.value):
+            attribute_field.value = str(data.value)
+            await target_node.save(db=context.db)
 
         result: dict[str, Any] = {"ok": True}
 

--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -259,7 +259,7 @@ class InfrahubMutationMixin:
             operation=cls.__name__, node_id=node_id, account_session=context.account_session, fields=fields
         )
 
-        await obj.save(db=db)
+        await obj.save(db=db, fields=fields)
         obj = await cls._refresh_for_profile_update(
             db=db, branch=branch, obj=obj, previous_profile_ids=before_mutate_profile_ids
         )


### PR DESCRIPTION
* Will speed up the update as we don't have to query for fields that aren't actually updated in a mutation
* Would prevent race conditions when two processes are updating different attributes on a node
* Change the computed_attribute mutation to not event attempt to save the value if there hasn't been any update.