### PR TITLE
fix(helm): enable rabbitmq startup probe

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.2.5
+version: 3.2.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -164,6 +164,8 @@ rabbitmq:
     password: infrahub
   metrics:
     enabled: true
+  startupProbe:
+    enabled: true
 
 # ----------- NFS Server -----------
 nfs-server-provisioner:


### PR DESCRIPTION
This avoids some race conditions on infrahub startup where the queues disappear because infrahub created them while rabbitmq was initializing. Enabling the startup probe ensures that rabbitmq is fully started and ready.