### PR TITLE
Add function to wait for schema to converge

### DIFF
--- a/backend/infrahub/api/schema.py
+++ b/backend/infrahub/api/schema.py
@@ -338,6 +338,8 @@ async def load_schema(
         if migration_error_msgs:
             raise MigrationError(message=",\n".join(migration_error_msgs))
 
+    await service.component.refresh_schema_hash(branches=[branch.name])
+
     log_data = get_log_data()
     request_id = log_data.get("request_id", "")
     event = SchemaUpdatedEvent(
@@ -346,8 +348,6 @@ async def load_schema(
         meta=EventMeta(initiator_id=WORKER_IDENTITY, request_id=request_id, account_id=account_session.account_id),
     )
     await service.event.send(event=event)
-
-    await service.component.refresh_schema_hash(branches=[branch.name])
 
     return SchemaUpdate(hash=updated_hash, previous_hash=original_hash, diff=result.diff)
 

--- a/backend/infrahub/graphql/mutations/schema.py
+++ b/backend/infrahub/graphql/mutations/schema.py
@@ -290,6 +290,8 @@ async def update_registry(
                 log.info("Schema has been updated", branch=branch.name, hash=branch.active_schema_hash.main)
                 await branch.save(db=dbt)
 
+            await service.component.refresh_schema_hash(branches=[branch.name])
+
             log_data = get_log_data()
             request_id = log_data.get("request_id", "")
             event = SchemaUpdatedEvent(
@@ -302,5 +304,3 @@ async def update_registry(
                 ),
             )
             await service.event.send(event=event)
-
-            await service.component.refresh_schema_hash(branches=[branch.name])

--- a/backend/infrahub/workflows/utils.py
+++ b/backend/infrahub/workflows/utils.py
@@ -1,7 +1,20 @@
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
 from prefect import get_client
 from prefect.runtime import flow_run
 
+from infrahub.core.registry import registry
+from infrahub.tasks.registry import refresh_branches
+
 from .constants import WorkflowTag
+
+if TYPE_CHECKING:
+    import logging
+
+    from infrahub.services import InfrahubServices
 
 
 async def add_tags(tags: list[str]) -> None:
@@ -20,3 +33,36 @@ async def add_branch_tag(branch_name: str) -> None:
 async def add_related_node_tag(node_id: str) -> None:
     tag = WorkflowTag.RELATED_NODE.render(identifier=node_id)
     await add_tags(tags=[tag])
+
+
+async def wait_for_schema_to_converge(
+    branch_name: str, service: InfrahubServices, log: logging.Logger | logging.LoggerAdapter
+) -> None:
+    has_converged = False
+    branch_id = branch_name
+    if branch := registry.branch.get(branch_name):
+        branch_id = branch.get_id()
+
+    delay = 0.2
+    max_iterations = delay * 5 * 30
+    iteration = 0
+    while not has_converged:
+        workers = await service.component.list_workers(branch=branch_id, schema_hash=True)
+
+        hashes = {worker.schema_hash for worker in workers if worker.active}
+        if len(hashes) == 1:
+            has_converged = True
+        else:
+            await asyncio.sleep(delay=delay)
+
+        if iteration >= max_iterations:
+            log.warning(
+                f"Schema had not converged after {delay * iteration} seconds, refreshing schema on local worker manually"
+            )
+            async with service.database.start_session() as db:
+                await refresh_branches(db=db)
+            return
+
+        iteration += 1
+
+    log.info(f"Schema converged after {delay * iteration} seconds")


### PR DESCRIPTION
After the schema has been updated or whenever we setup an automation for computed attributes we want the schema on all workers to be in sync. This PR adds a task that waits for all workers to have converged or as a final step if they haven't converged in 30 seconds we at least refresh the schema on the current node.