### PR TITLE
remove parent nodes from copy during diff combine

### DIFF
--- a/backend/infrahub/core/diff/combiner.py
+++ b/backend/infrahub/core/diff/combiner.py
@@ -314,22 +314,25 @@ class DiffCombiner:
             combined_relationships.add(copied)
         return combined_relationships
 
+    def _copy_node_without_parents(self, node: EnrichedDiffNode) -> EnrichedDiffNode:
+        rels_without_parents = {replace(r, nodes=set()) for r in node.relationships}
+        node_without_parents = replace(node, relationships=rels_without_parents)
+        return deepcopy(node_without_parents)
+
     def _combine_nodes(self, node_pairs: list[NodePair]) -> set[EnrichedDiffNode]:
         combined_nodes: set[EnrichedDiffNode] = set()
         for node_pair in node_pairs:
             if node_pair.earlier is None:
                 if node_pair.later is not None:
-                    copied = deepcopy(node_pair.later)
+                    copied = self._copy_node_without_parents(node_pair.later)
                     for rel in copied.relationships:
-                        rel.nodes = set()
                         rel.reset_summaries()
                     combined_nodes.add(copied)
                 continue
             if node_pair.later is None:
                 if node_pair.earlier is not None:
-                    copied = deepcopy(node_pair.earlier)
+                    copied = self._copy_node_without_parents(node_pair.earlier)
                     for rel in copied.relationships:
-                        rel.nodes = set()
                         rel.reset_summaries()
                     combined_nodes.add(copied)
                 continue

--- a/backend/infrahub/core/diff/model/path.py
+++ b/backend/infrahub/core/diff/model/path.py
@@ -706,6 +706,34 @@ class DatabasePath:  # pylint: disable=too-many-public-methods
             return None
         return str(self.property_node.get("kind"))
 
+    @property
+    def possible_relationship_directions(self) -> list[RelationshipDirection]:
+        path_to_node = "Node" in self.property_node.labels
+        attr_start_node = self.path_to_attribute.start_node
+        attr_end_node = self.path_to_attribute.end_node
+        prop_start_node = self.path_to_property.start_node
+        prop_end_node = self.path_to_property.end_node
+        if path_to_node and (
+            attr_start_node
+            and attr_start_node.element_id == self.node_node.element_id
+            and prop_start_node
+            and prop_start_node.element_id == self.attribute_node.element_id
+        ):
+            return [RelationshipDirection.OUTBOUND]
+        if path_to_node and (
+            attr_end_node
+            and attr_end_node.element_id == self.node_node.element_id
+            and prop_end_node
+            and prop_end_node.element_id == self.attribute_node.element_id
+        ):
+            return [RelationshipDirection.INBOUND]
+        # if we only have one Node->Relationship path, we cannot fully determine the relationship direction
+        if attr_start_node and attr_start_node.element_id == self.node_node.element_id:
+            return [RelationshipDirection.OUTBOUND, RelationshipDirection.BIDIR]
+        if attr_end_node and attr_end_node.element_id == self.node_node.element_id:
+            return [RelationshipDirection.INBOUND, RelationshipDirection.BIDIR]
+        return [RelationshipDirection.BIDIR, RelationshipDirection.INBOUND, RelationshipDirection.OUTBOUND]
+
 
 @dataclass
 class EnrichedNodeCreateRequest:

--- a/changelog/+diff-hierarchy-add.fixed.md
+++ b/changelog/+diff-hierarchy-add.fixed.md
@@ -1,0 +1,1 @@
+Fix bug in incremental diff addition for nodes within a hierarchy


### PR DESCRIPTION
IFC-928

cherry-pick #4889  back to `stable` b/c it could be the root cause of the bug

might fix an issue that can come up when combining diff nodes that contain nested parent nodes. for example, a diff for an interface that contains a reference to its device.

judging from the logs, calling `deepcopy` on an `EnrichedDiffNode` can result in an `AttributeError` being raised `'EnrichedDiffNode' object has no attribute 'uuid'`. I am still trying to identify the root cause of this error, but this is a good change to make, whether it completely addresses or not