### PR TITLE
Enforce permission edit_default_branch when loading schema

### DIFF
--- a/backend/infrahub/api/dependencies.py
+++ b/backend/infrahub/api/dependencies.py
@@ -118,7 +118,7 @@ async def get_current_user(
     if config.SETTINGS.main.allow_anonymous_access and request.method.lower() in ["get", "options"]:
         return account_session
 
-    if request.method.lower() == "post" and account_session.read_only:
+    if request.method.lower() == "post" and account_session.read_only and account_session.authenticated:
         raise PermissionDeniedError("You are not allowed to perform this operation")
 
     raise AuthorizationError("Authentication is required")

--- a/backend/infrahub/api/schema.py
+++ b/backend/infrahub/api/schema.py
@@ -260,6 +260,17 @@ async def load_schema(
         ):
             raise PermissionDeniedError("You are not allowed to manage the schema")
 
+        if branch.name in (GLOBAL_BRANCH_NAME, registry.default_branch) and not await permission_backend.has_permission(
+            db=db,
+            account_session=account_session,
+            permission=GlobalPermission(
+                action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value,
+                decision=PermissionDecision.ALLOW_DEFAULT.value,
+            ),
+            branch=branch,
+        ):
+            raise PermissionDeniedError("You are not allowed to edit the schema in the default branch")
+
     service: InfrahubServices = request.app.state.service
     log.info("schema_load_request", branch=branch.name)
 

--- a/changelog/+anonymous.fixed.md
+++ b/changelog/+anonymous.fixed.md
@@ -1,0 +1,1 @@
+Anonymous user will get a 401 response when trying to load a schema

--- a/changelog/4958.fixed.md
+++ b/changelog/4958.fixed.md
@@ -1,0 +1,1 @@
+Permission edit_default_branch is now enforced properly when loading a schema


### PR DESCRIPTION
Fixes #4958

I also took the opportunity to return 401 for anonymous users that are trying to make some changes instead of 403