### PR TITLE
Loosen requirements for when to regenerate artifacts

### DIFF
--- a/backend/infrahub/message_bus/operations/requests/artifact_definition.py
+++ b/backend/infrahub/message_bus/operations/requests/artifact_definition.py
@@ -130,7 +130,7 @@ async def check(message: messages.RequestArtifactDefinitionCheck, service: Infra
         await service.send(message=event)
 
 
-def _render_artifact(artifact_id: Optional[str], managed_branch: bool, impacted_artifacts: list[str]) -> bool:
+def _render_artifact(artifact_id: Optional[str], managed_branch: bool, impacted_artifacts: list[str]) -> bool:  # pylint: disable=unused-argument
     """Returns a boolean to indicate if an artifact should be generated or not.
     Will return true if:
         * The artifact_id wasn't set which could be that it's a new object that doesn't have a previous artifact
@@ -139,6 +139,9 @@ def _render_artifact(artifact_id: Optional[str], managed_branch: bool, impacted_
     Will return false if:
         * The source branch is a data only branch and the artifact_id exists and is not in the impacted list
     """
-    if not artifact_id or managed_branch:
-        return True
-    return artifact_id in impacted_artifacts
+
+    # if not artifact_id or managed_branch:
+    #    return True
+    # return artifact_id in impacted_artifacts
+    # Temporary workaround tracked in https://github.com/opsmill/infrahub/issues/4991
+    return True

--- a/changelog/4198.fixed.md
+++ b/changelog/4198.fixed.md
@@ -1,0 +1,1 @@
+Loosened up logic to determine when an artifact needs to be regenerated during a proposed change. This is to ensure that we always generate a new artifact if required. Until some other parts are refactored this will also need that we will generate artifacts in a few situations where it's not strictly required. This last part is a temporary solution.


### PR DESCRIPTION
This PR removes the check for membership of a GraphQL query group when it comes to determining if an artifact needs to be regenerated during a proposed change. This is a short term solution to fix a bug and not the behaviour we want to have. I have opened #4991 as a follow up issue that also describes the problem and what needs to happen moving forward.

Fixes #4198