### PR TITLE
bubble UNCHANGED action up when combining diffs

### DIFF
--- a/backend/infrahub/core/diff/combiner.py
+++ b/backend/infrahub/core/diff/combiner.py
@@ -148,17 +148,18 @@ class DiffCombiner:
                 combined_properties.add(deepcopy(earlier_property))
                 continue
             later_property = later_props_by_type[earlier_property.property_type]
-            if not self._should_include(earlier=earlier_property.action, later=later_property.action):
+            if earlier_property.action is DiffAction.ADDED and later_property.action is DiffAction.REMOVED:
                 continue
+            combined_action = self._combine_actions(earlier=earlier_property.action, later=later_property.action)
             if earlier_property.previous_value == later_property.new_value:
-                continue
+                combined_action = DiffAction.UNCHANGED
             combined_conflict = self.combine_conflicts(earlier=earlier_property.conflict, later=later_property.conflict)
             combined_properties.add(
                 replace(
                     later_property,
                     previous_label=earlier_property.previous_label,
                     previous_value=earlier_property.previous_value,
-                    action=self._combine_actions(earlier=earlier_property.action, later=later_property.action),
+                    action=combined_action,
                     conflict=combined_conflict,
                 )
             )
@@ -181,19 +182,20 @@ class DiffCombiner:
             later_attribute = later_attrs_by_name[earlier_attribute.name]
             if not self._should_include(earlier=earlier_attribute.action, later=later_attribute.action):
                 continue
-            combined_action = self._combine_actions(earlier=earlier_attribute.action, later=later_attribute.action)
             combined_properties = self._combine_properties(
                 earlier_properties=earlier_attribute.properties, later_properties=later_attribute.properties
             )
+            if all(p.action is DiffAction.UNCHANGED for p in combined_properties):
+                combined_action = DiffAction.UNCHANGED
+            else:
+                combined_action = self._combine_actions(earlier=earlier_attribute.action, later=later_attribute.action)
             if combined_properties:
                 combined_attribute = EnrichedDiffAttribute(
                     name=later_attribute.name,
                     changed_at=later_attribute.changed_at,
                     action=combined_action,
                     path_identifier=later_attribute.path_identifier,
-                    properties=self._combine_properties(
-                        earlier_properties=earlier_attribute.properties, later_properties=later_attribute.properties
-                    ),
+                    properties=combined_properties,
                 )
                 combined_attributes.add(combined_attribute)
         combined_attributes |= {
@@ -214,6 +216,8 @@ class DiffCombiner:
             combined_properties = self._combine_properties(
                 earlier_properties=combined_properties, later_properties=element.properties
             )
+        if all(p.action is DiffAction.UNCHANGED for p in combined_properties):
+            combined_action = DiffAction.UNCHANGED
         final_element = ordered_elements[-1]
         peer_id = final_element.peer_id
         peer_label = final_element.peer_label
@@ -253,15 +257,20 @@ class DiffCombiner:
             later_element = later_elements_by_peer_id[earlier_element.peer_id]
             if not self._should_include(earlier=earlier_element.action, later=later_element.action):
                 continue
+            combined_properties = self._combine_properties(
+                earlier_properties=earlier_element.properties, later_properties=later_element.properties
+            )
+            if all(p.action is DiffAction.UNCHANGED for p in combined_properties):
+                combined_action = DiffAction.UNCHANGED
+            else:
+                combined_action = self._combine_actions(earlier=earlier_element.action, later=later_element.action)
             combined_element = EnrichedDiffSingleRelationship(
                 changed_at=later_element.changed_at,
-                action=self._combine_actions(earlier=earlier_element.action, later=later_element.action),
+                action=combined_action,
                 peer_id=later_element.peer_id,
                 peer_label=later_element.peer_label,
                 path_identifier=later_element.path_identifier,
-                properties=self._combine_properties(
-                    earlier_properties=earlier_element.properties, later_properties=later_element.properties
-                ),
+                properties=combined_properties,
             )
             combined_elements.add(combined_element)
         combined_elements |= {
@@ -299,6 +308,12 @@ class DiffCombiner:
                     earlier_elements=earlier_relationship.relationships, later_elements=later_relationship.relationships
                 )
             combined_relationship_elements = {cre for cre in combined_relationship_elements if cre.properties}
+            if all(cre.action is DiffAction.UNCHANGED for cre in combined_relationship_elements):
+                combined_action = DiffAction.UNCHANGED
+            else:
+                combined_action = self._combine_actions(
+                    earlier=earlier_relationship.action, later=later_relationship.action
+                )
             parent_rel_name = self._get_parent_relationship_name(node_id=node_id)
             includes_parent = parent_rel_name == later_relationship.name
             if combined_relationship_elements or includes_parent:
@@ -307,7 +322,7 @@ class DiffCombiner:
                     label=later_relationship.label,
                     cardinality=later_relationship.cardinality,
                     changed_at=later_relationship.changed_at or earlier_relationship.changed_at,
-                    action=self._combine_actions(earlier=earlier_relationship.action, later=later_relationship.action),
+                    action=combined_action,
                     path_identifier=later_relationship.path_identifier,
                     relationships=combined_relationship_elements,
                     nodes=set(),
@@ -351,7 +366,12 @@ class DiffCombiner:
                 later_relationships=node_pair.later.relationships,
                 node_id=node_pair.later.uuid,
             )
-            combined_action = self._combine_actions(earlier=node_pair.earlier.action, later=node_pair.later.action)
+            if all(ca.action is DiffAction.UNCHANGED for ca in combined_attributes) and all(
+                cr.action is DiffAction.UNCHANGED for cr in combined_relationships
+            ):
+                combined_action = DiffAction.UNCHANGED
+            else:
+                combined_action = self._combine_actions(earlier=node_pair.earlier.action, later=node_pair.later.action)
             combined_conflict = self.combine_conflicts(
                 earlier=node_pair.earlier.conflict, later=node_pair.later.conflict
             )

--- a/backend/infrahub/core/diff/conflicts_enricher.py
+++ b/backend/infrahub/core/diff/conflicts_enricher.py
@@ -51,7 +51,10 @@ class ConflictsEnricher:
             branch_node.clear_conflicts()
 
     def _add_node_conflicts(self, base_node: EnrichedDiffNode, branch_node: EnrichedDiffNode) -> None:
-        if base_node.action != branch_node.action:
+        if base_node.action != branch_node.action and DiffAction.UNCHANGED not in {
+            base_node.action,
+            branch_node.action,
+        }:
             self._add_node_conflict(base_node=base_node, branch_node=branch_node)
         elif branch_node.conflict:
             branch_node.conflict = None
@@ -112,18 +115,22 @@ class ConflictsEnricher:
         branch_property_map = {p.property_type: p for p in branch_attribute.properties}
         common_property_types = set(base_property_map.keys()) & set(branch_property_map.keys())
         for branch_property in branch_attribute.properties:
-            if branch_property.property_type in common_property_types:
-                base_property = base_property_map[branch_property.property_type]
-                same_value = self._have_same_value(base_property=base_property, branch_property=branch_property)
-                if not same_value:
-                    self._add_property_conflict(
-                        base_property=base_property,
-                        branch_property=branch_property,
-                    )
-                elif branch_property.conflict:
-                    branch_property.conflict = None
-            else:
+            if branch_property.property_type not in common_property_types:
                 branch_property.conflict = None
+                continue
+            base_property = base_property_map[branch_property.property_type]
+            property_actions = {branch_property.action, base_property.action}
+            if DiffAction.UNCHANGED in property_actions:
+                branch_property.conflict = None
+                continue
+            same_value = self._have_same_value(base_property=base_property, branch_property=branch_property)
+            if same_value:
+                branch_property.conflict = None
+                continue
+            self._add_property_conflict(
+                base_property=base_property,
+                branch_property=branch_property,
+            )
 
     def _add_relationship_conflicts(
         self,
@@ -147,15 +154,15 @@ class ConflictsEnricher:
         branch_peer_id_map = {element.peer_id: element for element in branch_relationship.relationships}
         common_peer_ids = set(base_peer_id_map.keys()) & set(branch_peer_id_map.keys())
         for branch_element in branch_relationship.relationships:
-            if branch_element.peer_id in common_peer_ids:
-                base_element = base_peer_id_map[branch_element.peer_id]
-                self._add_relationship_conflicts_for_one_peer(
-                    base_element=base_element,
-                    branch_element=branch_element,
-                    is_cardinality_one=is_cardinality_one,
-                )
-            else:
+            if branch_element.peer_id not in common_peer_ids:
                 branch_element.clear_conflicts()
+                continue
+            base_element = base_peer_id_map[branch_element.peer_id]
+            self._add_relationship_conflicts_for_one_peer(
+                base_element=base_element,
+                branch_element=branch_element,
+                is_cardinality_one=is_cardinality_one,
+            )
 
     def _add_relationship_conflicts_for_one_peer(
         self,
@@ -171,11 +178,13 @@ class ConflictsEnricher:
                 branch_property.conflict = None
                 continue
             base_property = base_properties_by_type[branch_property.property_type]
+            includes_unchanged = DiffAction.UNCHANGED in {branch_property.action, base_property.action}
             same_value = self._have_same_value(base_property=base_property, branch_property=branch_property)
             # special handling for cardinality-one peer ID conflict
             if branch_property.property_type is DatabaseEdgeType.IS_RELATED and is_cardinality_one:
-                if same_value:
+                if same_value or includes_unchanged:
                     branch_element.conflict = None
+                    branch_property.conflict = None
                     continue
                 if branch_element.conflict:
                     conflict_uuid = branch_element.conflict.uuid
@@ -195,7 +204,7 @@ class ConflictsEnricher:
                 )
                 branch_element.conflict = conflict
                 continue
-            if same_value:
+            if same_value or includes_unchanged:
                 branch_property.conflict = None
                 continue
             if branch_property.conflict:

--- a/backend/infrahub/core/diff/enricher/cardinality_one.py
+++ b/backend/infrahub/core/diff/enricher/cardinality_one.py
@@ -92,8 +92,6 @@ class DiffCardinalityOneEnricher(DiffEnricherInterface):
             prop_action = self._determine_action(
                 previous_value=earliest_prop.previous_value, new_value=latest_prop.new_value
             )
-            if prop_action is DiffAction.UNCHANGED:
-                continue
             consolidated_properties.add(
                 EnrichedDiffProperty(
                     property_type=prop_type,

--- a/backend/infrahub/core/diff/merger/serializer.py
+++ b/backend/infrahub/core/diff/merger/serializer.py
@@ -156,6 +156,10 @@ class DiffMergeSerializer:
         serialized_node_diffs = []
         serialized_property_diffs: list[AttributePropertyMergeDict | RelationshipPropertyMergeDict] = []
         for node in diff.nodes:
+            # if there is a node-level conflict and the base branch version is selected
+            # then we don't need to alter this node during the merge
+            if node.conflict and node.conflict.selected_branch is ConflictSelection.BASE_BRANCH:
+                continue
             node_action = self._get_action(action=node.action, conflict=node.conflict)
             serial_attr_diffs = []
             for attr_diff in node.attributes:
@@ -303,11 +307,13 @@ class DiffMergeSerializer:
         relationship_dicts = []
         added_property_dicts = self._get_default_property_merge_dicts(action=DiffAction.ADDED)
         removed_property_dicts = self._get_default_property_merge_dicts(action=DiffAction.REMOVED)
-        other_property_dicts: dict[DatabaseEdgeType, PropertyMergeDict] = {}
         actions_and_peers = self._get_actions_and_peers(relationship_diff=relationship_diff)
         added_peer_ids = [peer_id for action, peer_id in actions_and_peers if action is DiffAction.ADDED]
         removed_peer_ids = [peer_id for action, peer_id in actions_and_peers if action is DiffAction.REMOVED]
-
+        if not added_peer_ids:
+            added_peer_ids = [relationship_diff.peer_id]
+        if not removed_peer_ids:
+            removed_peer_ids = [relationship_diff.peer_id]
         for action, peer_id in actions_and_peers:
             if (
                 peer_id
@@ -334,17 +340,14 @@ class DiffMergeSerializer:
                     action=self._to_action_str(action=action),
                     value=value,
                 )
-                if added_peer_ids and action is DiffAction.ADDED:
+                if action is DiffAction.ADDED:
                     added_property_dicts[property_diff.property_type] = property_dict
-                elif removed_peer_ids and action is DiffAction.REMOVED:
+                elif action is DiffAction.REMOVED:
                     removed_property_dicts[property_diff.property_type] = property_dict
-                else:
-                    other_property_dicts[property_diff.property_type] = property_dict
         relationship_property_dicts = []
-        peers_and_property_dics = [(peer_id, added_property_dicts) for peer_id in added_peer_ids]
-        peers_and_property_dics += [(peer_id, removed_property_dicts) for peer_id in removed_peer_ids]
-        peers_and_property_dics += [(relationship_diff.peer_id, other_property_dicts)]
-        for peer_id, property_dicts in peers_and_property_dics:
+        peers_and_property_dicts = [(peer_id, added_property_dicts) for peer_id in added_peer_ids]
+        peers_and_property_dicts += [(peer_id, removed_property_dicts) for peer_id in removed_peer_ids]
+        for peer_id, property_dicts in peers_and_property_dicts:
             if (
                 peer_id
                 and property_dicts

--- a/backend/infrahub/core/diff/merger/serializer.py
+++ b/backend/infrahub/core/diff/merger/serializer.py
@@ -305,8 +305,6 @@ class DiffMergeSerializer:
         if relationship_diff.conflict and relationship_diff.conflict.selected_branch is ConflictSelection.BASE_BRANCH:
             return ([], [])
         relationship_dicts = []
-        added_property_dicts = self._get_default_property_merge_dicts(action=DiffAction.ADDED)
-        removed_property_dicts = self._get_default_property_merge_dicts(action=DiffAction.REMOVED)
         actions_and_peers = self._get_actions_and_peers(relationship_diff=relationship_diff)
         added_peer_ids = [peer_id for action, peer_id in actions_and_peers if action is DiffAction.ADDED]
         removed_peer_ids = [peer_id for action, peer_id in actions_and_peers if action is DiffAction.REMOVED]
@@ -324,7 +322,26 @@ class DiffMergeSerializer:
                         peer_id=peer_id, name=relationship_identifier, action=self._to_action_str(action=action)
                     )
                 )
-        for property_diff in relationship_diff.properties:
+        relationship_property_dicts = self._serialize_relationship_properties(
+            node_uuid=node_uuid,
+            relationship_identifier=relationship_identifier,
+            relationship_diff_properties=relationship_diff.properties,
+            added_peer_ids=added_peer_ids,
+            removed_peer_ids=removed_peer_ids,
+        )
+        return relationship_dicts, relationship_property_dicts
+
+    def _serialize_relationship_properties(
+        self,
+        node_uuid: str,
+        relationship_identifier: str,
+        relationship_diff_properties: set[EnrichedDiffProperty],
+        added_peer_ids: list[str],
+        removed_peer_ids: list[str],
+    ) -> list[RelationshipPropertyMergeDict]:
+        added_property_dicts = self._get_default_property_merge_dicts(action=DiffAction.ADDED)
+        removed_property_dicts = self._get_default_property_merge_dicts(action=DiffAction.REMOVED)
+        for property_diff in relationship_diff_properties:
             if property_diff.property_type is DatabaseEdgeType.IS_RELATED:
                 # handled above
                 continue
@@ -345,8 +362,10 @@ class DiffMergeSerializer:
                 elif action is DiffAction.REMOVED:
                     removed_property_dicts[property_diff.property_type] = property_dict
         relationship_property_dicts = []
-        peers_and_property_dicts = [(peer_id, added_property_dicts) for peer_id in added_peer_ids]
-        peers_and_property_dicts += [(peer_id, removed_property_dicts) for peer_id in removed_peer_ids]
+        if added_property_dicts:
+            peers_and_property_dicts = [(peer_id, added_property_dicts) for peer_id in added_peer_ids]
+        if removed_property_dicts:
+            peers_and_property_dicts += [(peer_id, removed_property_dicts) for peer_id in removed_peer_ids]
         for peer_id, property_dicts in peers_and_property_dicts:
             if (
                 peer_id
@@ -361,4 +380,4 @@ class DiffMergeSerializer:
                         properties=list(property_dicts.values()),
                     )
                 )
-        return relationship_dicts, relationship_property_dicts
+        return relationship_property_dicts

--- a/backend/infrahub/core/query/__init__.py
+++ b/backend/infrahub/core/query/__init__.py
@@ -648,9 +648,9 @@ class Query(ABC):
             attrs_info[tuple(identifier)].append(info)
 
         for values in attrs_info.values():
-            attr_info = sorted(values, key=lambda i: (i["branch_score"], i["time_score"], i["deleted"]), reverse=True)[
-                0
-            ]
+            attr_info = sorted(
+                values, key=lambda i: (i["branch_score"], i["time_score"], not i["deleted"]), reverse=True
+            )[0]
             if attr_info["deleted"]:
                 continue
 

--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -448,7 +448,6 @@ class RelationshipDeleteQuery(RelationshipQuery):
         r1 = f"{arrows.left.start}[r1:{self.rel_type} $rel_prop ]{arrows.left.end}"
         r2 = f"{arrows.right.start}[r2:{self.rel_type} $rel_prop ]{arrows.right.end}"
 
-        # Specifying relationship type might improve query performance here.
         query = """
         MATCH (s:Node { uuid: $source_id })-[:IS_RELATED]-(rl:Relationship {uuid: $rel_id})-[:IS_RELATED]-(d:Node { uuid: $destination_id })
         WITH s, rl, d

--- a/backend/tests/integration/diff/test_diff_incremental_addition.py
+++ b/backend/tests/integration/diff/test_diff_incremental_addition.py
@@ -380,12 +380,17 @@ class TestDiffUpdateConflict(TestInfrahubApp):
         assert rel_element.conflict.diff_branch_value == marty.get_id()
         properties_by_type = {p.property_type: p for p in rel_element.properties}
         # is_visible is still true, although on a different peeer
-        assert set(properties_by_type.keys()) == {DatabaseEdgeType.IS_RELATED}
+        assert set(properties_by_type.keys()) == {DatabaseEdgeType.IS_RELATED, DatabaseEdgeType.IS_PROTECTED}
         related_prop = properties_by_type[DatabaseEdgeType.IS_RELATED]
         assert related_prop.previous_value == doc_brown.get_id()
         assert related_prop.new_value == marty.get_id()
         assert related_prop.action is DiffAction.UPDATED
         assert related_prop.conflict is None
+        protected_prop = properties_by_type[DatabaseEdgeType.IS_PROTECTED]
+        assert protected_prop.previous_value == "True"
+        assert protected_prop.new_value == "True"
+        assert protected_prop.action is DiffAction.UNCHANGED
+        assert protected_prop.conflict is None
 
     async def test_update_previous_owner_protected_on_branch(
         self,

--- a/backend/tests/integration/diff/test_diff_incremental_addition.py
+++ b/backend/tests/integration/diff/test_diff_incremental_addition.py
@@ -229,13 +229,21 @@ class TestDiffUpdateConflict(TestInfrahubApp):
         assert rel_element.conflict.diff_branch_action is DiffAction.UPDATED
         assert rel_element.conflict.diff_branch_value == marty.get_id()
         properties_by_type = {p.property_type: p for p in rel_element.properties}
-        # is_visible is still true, although on a different peeer
-        assert set(properties_by_type.keys()) == {DatabaseEdgeType.IS_RELATED, DatabaseEdgeType.IS_PROTECTED}
+        assert set(properties_by_type.keys()) == {
+            DatabaseEdgeType.IS_RELATED,
+            DatabaseEdgeType.IS_PROTECTED,
+            DatabaseEdgeType.IS_VISIBLE,
+        }
         related_prop = properties_by_type[DatabaseEdgeType.IS_RELATED]
         assert related_prop.previous_value == doc_brown.get_id()
         assert related_prop.new_value == marty.get_id()
         assert related_prop.action is DiffAction.UPDATED
         assert related_prop.conflict is None
+        visible_prop = properties_by_type[DatabaseEdgeType.IS_VISIBLE]
+        assert visible_prop.previous_value == "True"
+        assert visible_prop.new_value == "True"
+        assert visible_prop.action is DiffAction.UNCHANGED
+        assert visible_prop.conflict is None
         protected_prop = properties_by_type[DatabaseEdgeType.IS_PROTECTED]
         assert protected_prop.previous_value == "True"
         assert protected_prop.new_value == "False"
@@ -306,12 +314,21 @@ class TestDiffUpdateConflict(TestInfrahubApp):
         assert rel_element.conflict.diff_branch_value == marty.get_id()
         properties_by_type = {p.property_type: p for p in rel_element.properties}
         # is_visible is still true, although on a different peeer
-        assert set(properties_by_type.keys()) == {DatabaseEdgeType.IS_RELATED, DatabaseEdgeType.IS_PROTECTED}
+        assert set(properties_by_type.keys()) == {
+            DatabaseEdgeType.IS_RELATED,
+            DatabaseEdgeType.IS_PROTECTED,
+            DatabaseEdgeType.IS_VISIBLE,
+        }
         related_prop = properties_by_type[DatabaseEdgeType.IS_RELATED]
         assert related_prop.previous_value == doc_brown.get_id()
         assert related_prop.new_value == marty.get_id()
         assert related_prop.action is DiffAction.UPDATED
         assert related_prop.conflict is None
+        visible_prop = properties_by_type[DatabaseEdgeType.IS_VISIBLE]
+        assert visible_prop.previous_value == "True"
+        assert str(visible_prop.new_value) == "True"
+        assert visible_prop.action is DiffAction.UNCHANGED
+        assert not visible_prop.conflict
         protected_prop = properties_by_type[DatabaseEdgeType.IS_PROTECTED]
         assert protected_prop.previous_value == "True"
         assert str(protected_prop.new_value) == "False"
@@ -379,13 +396,21 @@ class TestDiffUpdateConflict(TestInfrahubApp):
         assert rel_element.conflict.diff_branch_action is DiffAction.UPDATED
         assert rel_element.conflict.diff_branch_value == marty.get_id()
         properties_by_type = {p.property_type: p for p in rel_element.properties}
-        # is_visible is still true, although on a different peeer
-        assert set(properties_by_type.keys()) == {DatabaseEdgeType.IS_RELATED, DatabaseEdgeType.IS_PROTECTED}
+        assert set(properties_by_type.keys()) == {
+            DatabaseEdgeType.IS_RELATED,
+            DatabaseEdgeType.IS_PROTECTED,
+            DatabaseEdgeType.IS_VISIBLE,
+        }
         related_prop = properties_by_type[DatabaseEdgeType.IS_RELATED]
         assert related_prop.previous_value == doc_brown.get_id()
         assert related_prop.new_value == marty.get_id()
         assert related_prop.action is DiffAction.UPDATED
         assert related_prop.conflict is None
+        visible_prop = properties_by_type[DatabaseEdgeType.IS_VISIBLE]
+        assert visible_prop.previous_value == "True"
+        assert visible_prop.new_value == "True"
+        assert visible_prop.action is DiffAction.UNCHANGED
+        assert visible_prop.conflict is None
         protected_prop = properties_by_type[DatabaseEdgeType.IS_PROTECTED]
         assert protected_prop.previous_value == "True"
         assert protected_prop.new_value == "True"

--- a/backend/tests/integration/diff/test_diff_merge.py
+++ b/backend/tests/integration/diff/test_diff_merge.py
@@ -132,13 +132,7 @@ class TestDiffMerge(TestInfrahubApp):
         owner_peer = await delorean_main.owner.get_peer(db=db)
         assert owner_peer.get_id() == marty_id
 
-    @pytest.mark.parametrize(
-        "delete_on_branch",
-        (
-            True,
-            False,
-        ),
-    )
+    @pytest.mark.parametrize("delete_on_branch", (True, False))
     async def test_node_delete_conflict(
         self,
         db: InfrahubDatabase,
@@ -157,19 +151,19 @@ class TestDiffMerge(TestInfrahubApp):
         else:
             delete_branch = diff_branch
             update_branch = default_branch
-        person_main = await NodeManager.get_one(db=db, id=new_person.id, branch=delete_branch)
-        await person_main.delete(db=db)
+        person_deleted = await NodeManager.get_one(db=db, id=new_person.id, branch=delete_branch)
+        await person_deleted.delete(db=db)
 
         # updates on branch for node deleted on main
-        person_branch = await NodeManager.get_one(db=db, id=new_person.id, branch=update_branch)
-        person_branch.description.value = "musician"
-        await person_branch.save(db=db)
+        person_updated = await NodeManager.get_one(db=db, id=new_person.id, branch=update_branch)
+        person_updated.description.value = "musician"
+        await person_updated.save(db=db)
         new_car = await Node.init(schema=TestKind.CAR, db=db, branch=update_branch)
         await new_car.new(
             db=db,
             name="Pinto",
             color="charred",
-            owner=person_branch,
+            owner=person_updated,
             manufacturer=initial_dataset["dmc"].id,
         )
         await new_car.save(db=db)
@@ -177,8 +171,8 @@ class TestDiffMerge(TestInfrahubApp):
         # check that the expected node-level conflict exists
         enriched_diff = await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=diff_branch)
         conflicts_map = enriched_diff.get_all_conflicts()
-        assert set(conflicts_map.keys()) == {f"data/{person_branch.id}"}
-        conflict = conflicts_map[f"data/{person_branch.id}"]
+        assert set(conflicts_map.keys()) == {f"data/{person_updated.id}"}
+        conflict = conflicts_map[f"data/{person_updated.id}"]
         if delete_on_branch:
             assert conflict.base_branch_action is DiffAction.REMOVED
             assert conflict.diff_branch_action is DiffAction.UPDATED
@@ -188,9 +182,9 @@ class TestDiffMerge(TestInfrahubApp):
         assert conflict.resolvable is False
 
         # manually undo updates on branch to resolve conflict
-        person_branch = await NodeManager.get_one(db=db, id=new_person.id, branch=update_branch)
-        person_branch.description.value = None
-        await person_branch.save(db=db)
+        person_updated = await NodeManager.get_one(db=db, id=new_person.id, branch=update_branch)
+        person_updated.description.value = None
+        await person_updated.save(db=db)
         car_branch = await NodeManager.get_one(db=db, id=new_car.id, branch=update_branch)
         await car_branch.owner.update(db=db, data=initial_dataset["biff"].id)
         await car_branch.save(db=db)
@@ -206,8 +200,8 @@ class TestDiffMerge(TestInfrahubApp):
         await diff_merger.merge_graph(at=right_now)
 
         # check that the person is deleted on main
-        person_main = await NodeManager.get_one(db=db, id=new_person.id)
-        assert person_main is None
+        person_deleted = await NodeManager.get_one(db=db, id=new_person.id)
+        assert person_deleted is None
         car_main = await NodeManager.get_one(db=db, id=new_car.id)
         owner_peer = await car_main.owner.get_peer(db=db)
         assert owner_peer.id == initial_dataset["biff"].id

--- a/backend/tests/integration/diff/test_diff_rebase.py
+++ b/backend/tests/integration/diff/test_diff_rebase.py
@@ -243,13 +243,21 @@ class TestDiffRebase(TestInfrahubApp):
             assert manufacturer_element.peer_id == new_peer_id
             assert manufacturer_element.action is DiffAction.UPDATED
             assert manufacturer_element.conflict is None
-            assert len(manufacturer_element.properties) == 1
-            related_prop = manufacturer_element.properties.pop()
-            assert related_prop.property_type is DatabaseEdgeType.IS_RELATED
+            properties_by_type = {p.property_type: p for p in manufacturer_element.properties}
+            assert set(properties_by_type.keys()) == {
+                DatabaseEdgeType.IS_RELATED,
+                DatabaseEdgeType.IS_VISIBLE,
+                DatabaseEdgeType.IS_PROTECTED,
+            }
+            related_prop = properties_by_type[DatabaseEdgeType.IS_RELATED]
             assert related_prop.action is DiffAction.UPDATED
             assert related_prop.previous_value == koenigsegg_id
             assert related_prop.new_value == new_peer_id
             assert related_prop.conflict is None
+            for prop_type, value in ((DatabaseEdgeType.IS_VISIBLE, "True"), (DatabaseEdgeType.IS_PROTECTED, "False")):
+                diff_prop = properties_by_type[prop_type]
+                assert diff_prop.action is DiffAction.UNCHANGED
+                assert diff_prop.previous_value == diff_prop.new_value == value
             for manufacturer_id, expected_action in (
                 (koenigsegg_id, DiffAction.REMOVED),
                 (new_peer_id, DiffAction.ADDED),
@@ -335,13 +343,22 @@ class TestDiffRebase(TestInfrahubApp):
         assert manufacturer_element.conflict.base_branch_value == cyberdyne_id
         assert manufacturer_element.conflict.diff_branch_action is DiffAction.UPDATED
         assert manufacturer_element.conflict.diff_branch_value == omnicorp_id
-        assert len(manufacturer_element.properties) == 1
-        related_prop = manufacturer_element.properties.pop()
+        properties_by_type = {p.property_type: p for p in manufacturer_element.properties}
+        assert set(properties_by_type.keys()) == {
+            DatabaseEdgeType.IS_RELATED,
+            DatabaseEdgeType.IS_VISIBLE,
+            DatabaseEdgeType.IS_PROTECTED,
+        }
+        related_prop = properties_by_type[DatabaseEdgeType.IS_RELATED]
         assert related_prop.property_type is DatabaseEdgeType.IS_RELATED
         assert related_prop.action is DiffAction.UPDATED
         assert related_prop.previous_value == koenigsegg_id
         assert related_prop.new_value == omnicorp_id
         assert related_prop.conflict is None
+        for prop_type, value in ((DatabaseEdgeType.IS_VISIBLE, "True"), (DatabaseEdgeType.IS_PROTECTED, "False")):
+            diff_prop = properties_by_type[prop_type]
+            assert diff_prop.action is DiffAction.UNCHANGED
+            assert diff_prop.previous_value == diff_prop.new_value == value
         for manufacturer_id, expected_action in ((koenigsegg_id, DiffAction.REMOVED), (omnicorp_id, DiffAction.ADDED)):
             manufacturer_node = nodes_by_id[manufacturer_id]
             assert len(manufacturer_node.relationships) == 1
@@ -421,13 +438,22 @@ class TestDiffRebase(TestInfrahubApp):
         assert manufacturer_element.peer_id == cyberdyne_id
         assert manufacturer_element.action is DiffAction.UPDATED
         assert manufacturer_element.conflict is None
-        assert len(manufacturer_element.properties) == 1
-        related_prop = manufacturer_element.properties.pop()
+        properties_by_type = {p.property_type: p for p in manufacturer_element.properties}
+        assert set(properties_by_type.keys()) == {
+            DatabaseEdgeType.IS_RELATED,
+            DatabaseEdgeType.IS_VISIBLE,
+            DatabaseEdgeType.IS_PROTECTED,
+        }
+        related_prop = properties_by_type[DatabaseEdgeType.IS_RELATED]
         assert related_prop.property_type is DatabaseEdgeType.IS_RELATED
         assert related_prop.action is DiffAction.UPDATED
         assert related_prop.previous_value == koenigsegg_id
         assert related_prop.new_value == cyberdyne_id
         assert related_prop.conflict is None
+        for prop_type, value in ((DatabaseEdgeType.IS_VISIBLE, "True"), (DatabaseEdgeType.IS_PROTECTED, "False")):
+            diff_prop = properties_by_type[prop_type]
+            assert diff_prop.action is DiffAction.UNCHANGED
+            assert diff_prop.previous_value == diff_prop.new_value == value
         for manufacturer_id, expected_action in ((koenigsegg_id, DiffAction.REMOVED), (cyberdyne_id, DiffAction.ADDED)):
             manufacturer_node = nodes_by_id[manufacturer_id]
             assert len(manufacturer_node.relationships) == 1

--- a/backend/tests/integration/diff/test_diff_update.py
+++ b/backend/tests/integration/diff/test_diff_update.py
@@ -1075,9 +1075,10 @@ class TestDiffUpdateConflict(TestInfrahubApp):
 
         # check EnrichedDiff
         diff = await self.get_branch_diff(db=db, branch=diff_branch)
-        assert len(diff.nodes) == 8
+        assert len(diff.nodes) == 9
         nodes_by_id = {n.uuid: n for n in diff.nodes}
-        assert kara_main.get_id() not in nodes_by_id
+        resolved_kara_node = nodes_by_id[kara_main.id]
+        assert resolved_kara_node.action is DiffAction.UNCHANGED
         # check CoreDataChecks
         _, data_validator = await self._get_proposed_change_and_data_validator(db=db)
         core_data_checks = await data_validator.checks.get_peers(db=db)  # type: ignore[attr-defined]

--- a/backend/tests/unit/core/diff/test_cardinality_one_enricher.py
+++ b/backend/tests/unit/core/diff/test_cardinality_one_enricher.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from dataclasses import replace
 from uuid import uuid4
 
 from infrahub.core.constants import DiffAction, RelationshipCardinality
@@ -254,6 +255,12 @@ class TestDiffCardinalityOneEnricher:
 
         await enricher.enrich(enriched_diff_root=diff_root, calculated_diffs=None)
 
+        expected_related_prop = replace(
+            is_related_prop_2,
+            action=DiffAction.UNCHANGED,
+            previous_value=is_related_prop_1.previous_value,
+            path_identifier="",
+        )
         assert len(diff_root.nodes) == 1
         diff_node = diff_root.nodes.pop()
         assert len(diff_node.relationships) == 1
@@ -266,6 +273,7 @@ class TestDiffCardinalityOneEnricher:
         assert diff_rel_element.peer_label == diff_rel_element_2.peer_label
         assert diff_rel_element.conflict is None
         diff_properties = diff_rel_element.properties
-        assert len(diff_properties) == 2
+        assert len(diff_properties) == 3
         assert has_owner_prop_1 in diff_properties
         assert has_source_prop_2 in diff_properties
+        assert expected_related_prop in diff_properties

--- a/backend/tests/unit/core/diff/test_conflicts_enricher.py
+++ b/backend/tests/unit/core/diff/test_conflicts_enricher.py
@@ -1,6 +1,8 @@
 import random
 from uuid import uuid4
 
+import pytest
+
 from infrahub.core.branch import Branch
 from infrahub.core.constants import DiffAction, RelationshipCardinality
 from infrahub.core.constants.database import DatabaseEdgeType
@@ -464,6 +466,80 @@ class TestConflictsEnricher:
                 for prop in attribute.properties:
                     assert prop.conflict is None
 
+    async def test_unchanged_attribute_property_clears_conflict(self, db: InfrahubDatabase):
+        attribute_name = "smell"
+        node_uuid = str(uuid4())
+        node_kind = "SomethingSmelly"
+        base_property_1 = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.HAS_VALUE, action=DiffAction.UNCHANGED, new_value="potato salad"
+        )
+        base_property_2 = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.IS_VISIBLE, action=DiffAction.UPDATED, new_value="True"
+        )
+        base_properties = {
+            base_property_1,
+            base_property_2,
+            EnrichedPropertyFactory.build(property_type=DatabaseEdgeType.HAS_SOURCE),
+        }
+        base_attributes = {
+            EnrichedAttributeFactory.build(),
+            EnrichedAttributeFactory.build(properties=base_properties, name=attribute_name),
+        }
+        base_nodes = {
+            EnrichedNodeFactory.build(
+                uuid=node_uuid,
+                kind=node_kind,
+                action=DiffAction.UPDATED,
+                attributes=base_attributes,
+                relationships=set(),
+            ),
+            EnrichedNodeFactory.build(relationships=set()),
+        }
+        base_root = EnrichedRootFactory.build(nodes=base_nodes)
+        branch_conflict_property = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.HAS_VALUE,
+            action=DiffAction.UPDATED,
+            new_value="ham sandwich",
+            conflict=EnrichedConflictFactory.build(),
+        )
+        branch_conflict_property_2 = EnrichedPropertyFactory.build(
+            property_type=DatabaseEdgeType.IS_VISIBLE,
+            action=DiffAction.UNCHANGED,
+            previous_value="False",
+            new_value="False",
+            conflict=EnrichedConflictFactory.build(),
+        )
+        branch_properties = {
+            branch_conflict_property,
+            branch_conflict_property_2,
+            EnrichedPropertyFactory.build(
+                property_type=DatabaseEdgeType.IS_PROTECTED, conflict=EnrichedConflictFactory.build()
+            ),
+        }
+        branch_attributes = {
+            EnrichedAttributeFactory.build(),
+            EnrichedAttributeFactory.build(properties=branch_properties, name=attribute_name),
+        }
+        branch_nodes = {
+            EnrichedNodeFactory.build(
+                uuid=node_uuid,
+                kind=node_kind,
+                action=DiffAction.UPDATED,
+                attributes=branch_attributes,
+                relationships=set(),
+            ),
+            EnrichedNodeFactory.build(relationships=set()),
+        }
+        branch_root = EnrichedRootFactory.build(nodes=branch_nodes)
+
+        await self.__call_system_under_test(db=db, base_enriched_diff=base_root, branch_enriched_diff=branch_root)
+
+        for node in branch_root.nodes:
+            assert node.conflict is None
+            for attribute in node.attributes:
+                for prop in attribute.properties:
+                    assert prop.conflict is None
+
     async def test_manually_fixed_cardinality_one_conflict_cleared(self, db: InfrahubDatabase, car_person_schema):
         branch = await create_branch(db=db, branch_name="branch")
         property_type = DatabaseEdgeType.IS_RELATED
@@ -540,7 +616,93 @@ class TestConflictsEnricher:
                 for rel_element in rel.relationships:
                     assert rel_element.conflict is None
 
-    async def test_manually_fixed_cardinality_many_conflicts_cleared(self, db: InfrahubDatabase, car_person_schema):
+    @pytest.mark.parametrize(
+        "base_action,branch_action",
+        [(DiffAction.UNCHANGED, DiffAction.ADDED), (DiffAction.REMOVED, DiffAction.UNCHANGED)],
+    )
+    async def test_unchanged_cardinality_one_clears_conflicts(
+        self, db: InfrahubDatabase, car_person_schema, base_action, branch_action
+    ):
+        branch = await create_branch(db=db, branch_name="branch")
+        property_type = DatabaseEdgeType.IS_RELATED
+        relationship_name = "owner"
+        node_uuid = str(uuid4())
+        node_kind = "TestCar"
+        peer_id = str(uuid4())
+        base_properties = {
+            EnrichedPropertyFactory.build(property_type=DatabaseEdgeType.IS_VISIBLE),
+            EnrichedPropertyFactory.build(property_type=property_type, action=base_action),
+        }
+        base_relationships = {
+            EnrichedRelationshipGroupFactory.build(
+                name=relationship_name,
+                relationships={
+                    EnrichedRelationshipElementFactory.build(
+                        peer_id=peer_id, properties=base_properties, action=DiffAction.UPDATED
+                    )
+                },
+                cardinality=RelationshipCardinality.ONE,
+            )
+        }
+        base_nodes = {
+            EnrichedNodeFactory.build(
+                uuid=node_uuid,
+                kind=node_kind,
+                action=DiffAction.UPDATED,
+                relationships=base_relationships,
+            ),
+            EnrichedNodeFactory.build(relationships=set()),
+        }
+        base_root = EnrichedRootFactory.build(nodes=base_nodes)
+        branch_conflict_property = EnrichedPropertyFactory.build(
+            property_type=property_type,
+            previous_value=peer_id,
+            action=branch_action,
+            conflict=EnrichedConflictFactory.build(),
+        )
+        branch_properties = {
+            branch_conflict_property,
+            EnrichedPropertyFactory.build(property_type=DatabaseEdgeType.HAS_OWNER),
+        }
+        branch_relationships = {
+            EnrichedRelationshipGroupFactory.build(
+                name=relationship_name,
+                relationships={
+                    EnrichedRelationshipElementFactory.build(
+                        peer_id=peer_id,
+                        properties=branch_properties,
+                        action=DiffAction.REMOVED,
+                        conflict=EnrichedConflictFactory.build(),
+                    )
+                },
+                cardinality=RelationshipCardinality.ONE,
+            )
+        }
+        branch_nodes = {
+            EnrichedNodeFactory.build(
+                uuid=node_uuid,
+                kind=node_kind,
+                action=DiffAction.UPDATED,
+                relationships=branch_relationships,
+            ),
+            EnrichedNodeFactory.build(relationships=set()),
+        }
+        branch_root = EnrichedRootFactory.build(nodes=branch_nodes, diff_branch_name=branch.name)
+
+        await self.__call_system_under_test(db=db, base_enriched_diff=base_root, branch_enriched_diff=branch_root)
+
+        for node in branch_root.nodes:
+            assert node.conflict is None
+            for attribute in node.attributes:
+                for prop in attribute.properties:
+                    assert prop.conflict is None
+            for rel in node.relationships:
+                for rel_element in rel.relationships:
+                    assert rel_element.conflict is None
+                    for prop in rel_element.properties:
+                        assert prop.conflict is None
+
+    async def test_unchanged_cardinality_many_rel_clears_conflict(self, db: InfrahubDatabase, car_person_schema):
         branch = await create_branch(db=db, branch_name="branch")
         peer_id_1 = str(uuid4())
         peer_id_2 = str(uuid4())
@@ -549,14 +711,28 @@ class TestConflictsEnricher:
         previous_property_value_1 = str(uuid4())
         branch_property_value_1 = str(uuid4())
         previous_property_value_2 = str(uuid4())
-        branch_property_value_2 = str(uuid4())
         relationship_name = "cars"
         node_uuid = str(uuid4())
         node_kind = "TestPerson"
+        base_conflict_property_1 = EnrichedPropertyFactory.build(
+            property_type=conflict_property_type_1,
+            previous_value=previous_property_value_1,
+            new_value=previous_property_value_1,
+            action=DiffAction.UNCHANGED,
+        )
         base_properties_1 = {
+            base_conflict_property_1,
             EnrichedPropertyFactory.build(property_type=DatabaseEdgeType.IS_VISIBLE),
         }
+        base_conflict_property_2 = EnrichedPropertyFactory.build(
+            property_type=conflict_property_type_2,
+            previous_value=previous_property_value_2,
+            new_value=str(uuid4()),
+            action=DiffAction.UPDATED,
+            conflict=EnrichedConflictFactory.build(),
+        )
         base_properties_2 = {
+            base_conflict_property_2,
             EnrichedPropertyFactory.build(property_type=DatabaseEdgeType.IS_PROTECTED),
         }
         base_relationships = {
@@ -593,9 +769,8 @@ class TestConflictsEnricher:
         branch_conflict_property_2 = EnrichedPropertyFactory.build(
             property_type=conflict_property_type_2,
             previous_value=previous_property_value_2,
-            new_value=branch_property_value_2,
-            action=DiffAction.REMOVED,
-            conflict=EnrichedConflictFactory.build(),
+            new_value=previous_property_value_2,
+            action=DiffAction.UNCHANGED,
         )
         branch_properties_2 = {
             branch_conflict_property_2,
@@ -634,6 +809,31 @@ class TestConflictsEnricher:
                     assert element.conflict is None
                     for element_prop in element.properties:
                         assert element_prop.conflict is None
+
+    @pytest.mark.parametrize(
+        "base_action,branch_action",
+        [(DiffAction.UNCHANGED, DiffAction.UPDATED), (DiffAction.ADDED, DiffAction.UNCHANGED)],
+    )
+    async def test_unchanged_node_clears_conflict(self, db: InfrahubDatabase, base_action, branch_action):
+        node_uuid = str(uuid4())
+        node_kind = "SomethingSmelly"
+        base_node = EnrichedNodeFactory.build(uuid=node_uuid, kind=node_kind, action=base_action, relationships=set())
+        base_nodes = {base_node, EnrichedNodeFactory.build(relationships=set())}
+        branch_conflict_node = EnrichedNodeFactory.build(
+            uuid=node_uuid,
+            kind=node_kind,
+            action=branch_action,
+            relationships=set(),
+            conflict=EnrichedConflictFactory.build(),
+        )
+        branch_nodes = {branch_conflict_node, EnrichedNodeFactory.build(relationships=set())}
+        base_root = EnrichedRootFactory.build(nodes=base_nodes)
+        branch_root = EnrichedRootFactory.build(nodes=branch_nodes)
+
+        await self.__call_system_under_test(db=db, base_enriched_diff=base_root, branch_enriched_diff=branch_root)
+
+        for node in branch_root.nodes:
+            assert node.conflict is None
 
     async def test_manually_fixed_node_conflict_cleared(self, db: InfrahubDatabase):
         node_uuid = str(uuid4())

--- a/backend/tests/unit/core/diff/test_diff_and_merge.py
+++ b/backend/tests/unit/core/diff/test_diff_and_merge.py
@@ -482,11 +482,53 @@ class TestDiffAndMerge:
         assert len(owner_rels) == 1
         assert owner_rels[0].peer_id == person.id
 
+    async def test_update_individual_relationship_properties_one_at_a_time(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        person_john_main,
+        person_jane_main,
+        car_accord_main,
+        car_camry_main,
+    ):
+        branch2 = await create_branch(db=db, branch_name="branch2")
+        car_branch = await NodeManager.get_one(db=db, branch=branch2, id=car_accord_main.id)
+        await car_branch.owner.update(db=db, data={"id": person_john_main.id, "_relation__is_protected": True})
+        await car_branch.save(db=db)
+
+        diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
+        await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch2)
+
+        car_branch = await NodeManager.get_one(db=db, branch=branch2, id=car_accord_main.id)
+        await car_branch.owner.update(db=db, data={"id": person_john_main.id, "_relation__is_visible": False})
+        await car_branch.save(db=db)
+
+        await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch2)
+
+        at = Timestamp()
+        diff_merger = await self._get_diff_merger(db=db, branch=branch2)
+        await diff_merger.merge_graph(at=at)
+
+        # validate that the properties were correctly updated
+        updated_car = await NodeManager.get_one(db=db, id=car_accord_main.id)
+        owner_rel = await updated_car.owner.get(db=db)
+        assert owner_rel.peer_id == person_john_main.id
+        assert owner_rel.is_protected is True
+        assert owner_rel.is_visible is False
+
+        await diff_merger.rollback(at=at)
+
+        # validate that the properties were correctly rolled back
+        updated_car = await NodeManager.get_one(db=db, id=car_accord_main.id)
+        owner_rel = await updated_car.owner.get(db=db)
+        assert owner_rel.peer_id == person_john_main.id
+        assert owner_rel.is_protected is False
+        assert owner_rel.is_visible is True
+
     async def test_branch_delete_with_added_base_relationship(
         self,
         db: InfrahubDatabase,
         default_branch: Branch,
-        diff_repository: DiffRepository,
         person_john_main,
         person_jane_main,
         person_alfred_main,
@@ -527,6 +569,13 @@ class TestDiffAndMerge:
         # validate that the car was deleted
         updated_car = await NodeManager.get_one(db=db, id=car_accord_main.id)
         assert updated_car is None
+        # validate that the relationships were deleted
+        alfred_main = await NodeManager.get_one(db=db, id=person_alfred_main.id)
+        cars_rels = await alfred_main.cars.get(db=db)
+        assert len(cars_rels) == 0
+        john_main = await NodeManager.get_one(db=db, id=person_john_main.id)
+        cars_rels = await john_main.cars.get(db=db)
+        assert len(cars_rels) == 0
 
         await diff_merger.rollback(at=at)
 
@@ -535,3 +584,62 @@ class TestDiffAndMerge:
         assert owner_rel.peer_id == person_john_main.id
         assert owner_rel.is_protected is False
         assert owner_rel.is_visible is True
+
+    async def test_base_delete_with_added_branch_relationship(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        diff_repository: DiffRepository,
+        person_john_main,
+        person_jane_main,
+        person_alfred_main,
+        car_accord_main,
+        car_camry_main,
+    ):
+        branch2 = await create_branch(db=db, branch_name="branch2")
+        car_branch = await NodeManager.get_one(db=db, branch=branch2, id=car_accord_main.id)
+        await car_branch.owner.update(db=db, data={"id": person_alfred_main.id, "_relation__is_protected": True})
+        await car_branch.save(db=db)
+        car_main = await NodeManager.get_one(db=db, id=car_accord_main.id)
+        await car_main.delete(db=db)
+
+        diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
+        enriched_diff = await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch2)
+        conflicts_map = enriched_diff.get_all_conflicts()
+        # check the conflict
+        assert len(conflicts_map) == 1
+        conflict_node = enriched_diff.get_node(node_uuid=car_branch.id)
+        assert conflict_node.conflict
+        assert conflict_node.conflict.base_branch_action is DiffAction.REMOVED
+        assert conflict_node.conflict.diff_branch_action is DiffAction.UPDATED
+
+        # manually resolve the conflict
+        car_branch = await NodeManager.get_one(db=db, branch=branch2, id=car_accord_main.id)
+        await car_branch.owner.update(db=db, data={"id": person_john_main.id, "_relation__is_protected": False})
+        await car_branch.save(db=db)
+
+        # check that the conflict is removed
+        enriched_diff = await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch2)
+        conflicts_map = enriched_diff.get_all_conflicts()
+        assert len(conflicts_map) == 0
+
+        at = Timestamp()
+        diff_merger = await self._get_diff_merger(db=db, branch=branch2)
+        await diff_merger.merge_graph(at=at)
+
+        # validate that the car remains deleted
+        updated_car = await NodeManager.get_one(db=db, id=car_accord_main.id)
+        assert updated_car is None
+        # validate that the relationships do not exist
+        alfred_main = await NodeManager.get_one(db=db, id=person_alfred_main.id)
+        cars_rels = await alfred_main.cars.get(db=db)
+        assert len(cars_rels) == 0
+        john_main = await NodeManager.get_one(db=db, id=person_john_main.id)
+        cars_rels = await john_main.cars.get(db=db)
+        assert len(cars_rels) == 0
+
+        await diff_merger.rollback(at=at)
+
+        # validate that car remains deleted after rollback
+        rolled_back_car = await NodeManager.get_one(db=db, id=car_accord_main.id)
+        assert rolled_back_car is None

--- a/backend/tests/unit/core/diff/test_diff_and_merge.py
+++ b/backend/tests/unit/core/diff/test_diff_and_merge.py
@@ -481,3 +481,57 @@ class TestDiffAndMerge:
         )
         assert len(owner_rels) == 1
         assert owner_rels[0].peer_id == person.id
+
+    async def test_branch_delete_with_added_base_relationship(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        diff_repository: DiffRepository,
+        person_john_main,
+        person_jane_main,
+        person_alfred_main,
+        car_accord_main,
+        car_camry_main,
+    ):
+        branch2 = await create_branch(db=db, branch_name="branch2")
+        car_main = await NodeManager.get_one(db=db, id=car_accord_main.id)
+        await car_main.owner.update(db=db, data={"id": person_alfred_main.id, "_relation__is_protected": True})
+        await car_main.save(db=db)
+        car_branch = await NodeManager.get_one(db=db, branch=branch2, id=car_accord_main.id)
+        await car_branch.delete(db=db)
+
+        diff_coordinator = await self._get_diff_coordinator(db=db, branch=branch2)
+        enriched_diff = await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch2)
+        conflicts_map = enriched_diff.get_all_conflicts()
+        # check the conflict
+        assert len(conflicts_map) == 1
+        conflict_node = enriched_diff.get_node(node_uuid=car_main.id)
+        assert conflict_node.conflict
+        assert conflict_node.conflict.base_branch_action is DiffAction.UPDATED
+        assert conflict_node.conflict.diff_branch_action is DiffAction.REMOVED
+
+        # manually resolve the conflict
+        car_main = await NodeManager.get_one(db=db, id=car_accord_main.id)
+        await car_main.owner.update(db=db, data={"id": person_john_main.id, "_relation__is_protected": False})
+        await car_main.save(db=db)
+
+        # check that the conflict is removed
+        enriched_diff = await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch2)
+        conflicts_map = enriched_diff.get_all_conflicts()
+        assert len(conflicts_map) == 0
+
+        at = Timestamp()
+        diff_merger = await self._get_diff_merger(db=db, branch=branch2)
+        await diff_merger.merge_graph(at=at)
+
+        # validate that the car was deleted
+        updated_car = await NodeManager.get_one(db=db, id=car_accord_main.id)
+        assert updated_car is None
+
+        await diff_merger.rollback(at=at)
+
+        rolled_back_car = await NodeManager.get_one(db=db, id=car_accord_main.id, include_owner=True)
+        owner_rel = await rolled_back_car.owner.get(db=db)
+        assert owner_rel.peer_id == person_john_main.id
+        assert owner_rel.is_protected is False
+        assert owner_rel.is_visible is True

--- a/backend/tests/unit/core/diff/test_diff_calculator.py
+++ b/backend/tests/unit/core/diff/test_diff_calculator.py
@@ -1487,7 +1487,7 @@ async def test_diff_attribute_branch_update_with_previous_base_update_ignored(
         from_time=from_time,
         to_time=Timestamp(),
         previous_node_specifiers={NodeFieldSpecifier(node_uuid=alfred_main.id, field_name="name")},
-        include_unchanged=False,
+        include_unchanged=True,
     )
 
     base_root_path = calculated_diffs.base_branch_diff
@@ -1540,7 +1540,7 @@ async def test_diff_attribute_branch_update_with_concurrent_base_update_captured
         from_time=from_time,
         to_time=Timestamp(),
         previous_node_specifiers={NodeFieldSpecifier(node_uuid=alfred_main.id, field_name="name")},
-        include_unchanged=False,
+        include_unchanged=True,
     )
 
     base_root_path = calculated_diffs.base_branch_diff
@@ -1678,18 +1678,18 @@ async def test_diff_attribute_branch_update_with_separate_previous_base_update_c
             NodeFieldSpecifier(node_uuid=car_accord_main.id, field_name="color"),
             NodeFieldSpecifier(node_uuid=person_alfred_main.id, field_name="name"),
         },
-        include_unchanged=False,
+        include_unchanged=True,
     )
 
     base_root_path = calculated_diffs.base_branch_diff
     assert base_root_path.branch == default_branch.name
     nodes_by_id = {n.uuid: n for n in base_root_path.nodes}
-    assert set(nodes_by_id.keys()) == {car_accord_main.id}
+    assert set(nodes_by_id.keys()) == {car_accord_main.id, person_alfred_main.id}
     # car on main
     node_diff = nodes_by_id[car_accord_main.id]
-    assert node_diff.uuid == car_accord_main.id
     assert node_diff.kind == "TestCar"
     assert node_diff.action is DiffAction.UPDATED
+    assert len(node_diff.relationships) == 0
     assert len(node_diff.attributes) == 1
     attribute_diff = node_diff.attributes[0]
     assert attribute_diff.name == "color"
@@ -1701,6 +1701,21 @@ async def test_diff_attribute_branch_update_with_separate_previous_base_update_c
     assert property_diff.new_value == "BLURPLE"
     assert property_diff.action is DiffAction.UPDATED
     assert base_before_change < property_diff.changed_at < base_after_change
+    # alfred on main
+    node_diff = nodes_by_id[person_alfred_main.id]
+    assert node_diff.kind == "TestPerson"
+    assert node_diff.action is DiffAction.UNCHANGED
+    assert len(node_diff.relationships) == 0
+    assert len(node_diff.attributes) == 1
+    attribute_diff = node_diff.attributes[0]
+    assert attribute_diff.name == "name"
+    assert attribute_diff.action is DiffAction.UNCHANGED
+    assert len(attribute_diff.properties) == 1
+    property_diff = attribute_diff.properties[0]
+    assert property_diff.property_type == DatabaseEdgeType.HAS_VALUE
+    assert property_diff.previous_value == person_alfred_main.name.value
+    assert property_diff.new_value == person_alfred_main.name.value
+    assert property_diff.action is DiffAction.UNCHANGED
 
     branch_root_path = calculated_diffs.diff_branch_diff
     assert branch_root_path.branch == branch.name
@@ -2698,3 +2713,103 @@ async def test_create_aware_and_agnostic_nodes_on_branch(
     rel_diff = node_diff.relationships.pop()
     assert rel_diff.name == "cars"
     assert rel_diff.action is DiffAction.UPDATED
+
+
+async def test_diff_relationship_update_includes_unchanged_properties(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    person_alfred_main: Node,
+    person_john_main: Node,
+    car_accord_main: Node,
+):
+    branch = await create_branch(db=db, branch_name="branch")
+    from_time = Timestamp()
+    car_branch = await NodeManager.get_one(db=db, branch=branch, id=car_accord_main.id)
+    await car_branch.owner.update(db=db, data=person_alfred_main)
+    await car_branch.save(db=db)
+
+    diff_calculator = DiffCalculator(db=db)
+
+    calculated_diffs = await diff_calculator.calculate_diff(
+        base_branch=default_branch,
+        diff_branch=branch,
+        from_time=from_time,
+        to_time=Timestamp(),
+        include_unchanged=True,
+    )
+
+    base_root_path = calculated_diffs.base_branch_diff
+    assert base_root_path.branch == default_branch.name
+    assert len(base_root_path.nodes) == 0
+    nodes_by_id = {n.uuid: n for n in base_root_path.nodes}
+
+    branch_diff_path = calculated_diffs.diff_branch_diff
+    assert branch_diff_path.branch == branch.name
+    nodes_by_id = {n.uuid: n for n in branch_diff_path.nodes}
+    assert set(nodes_by_id.keys()) == {car_accord_main.id, person_john_main.id, person_alfred_main.id}
+    # car on branch
+    node_diff = nodes_by_id[car_accord_main.id]
+    assert node_diff.kind == "TestCar"
+    assert node_diff.action is DiffAction.UPDATED
+    assert len(node_diff.attributes) == 0
+    assert len(node_diff.relationships) == 1
+    diff_rel = node_diff.relationships.pop()
+    assert diff_rel.name == "owner"
+    assert diff_rel.action is DiffAction.UPDATED
+    elements_by_peer_id = {e.peer_id: e for e in diff_rel.relationships}
+    assert set(elements_by_peer_id.keys()) == {person_john_main.id, person_alfred_main.id}
+    alfred_owner_diff = elements_by_peer_id[person_alfred_main.id]
+    properties_by_type = {p.property_type: p for p in alfred_owner_diff.properties}
+    assert set(properties_by_type.keys()) == {
+        DatabaseEdgeType.IS_RELATED,
+        DatabaseEdgeType.IS_VISIBLE,
+        DatabaseEdgeType.IS_PROTECTED,
+    }
+    # TODO: finish or remove test
+
+
+async def test_diff_relationship_property_update_on_main(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    person_alfred_main: Node,
+    person_john_main: Node,
+    car_accord_main: Node,
+):
+    branch = await create_branch(db=db, branch_name="branch")
+    car_main = await NodeManager.get_one(db=db, branch=default_branch, id=car_accord_main.id)
+    await car_main.owner.update(db=db, data=person_alfred_main)
+    await car_main.save(db=db)
+
+    from_time = Timestamp()
+    car_main = await NodeManager.get_one(db=db, branch=default_branch, id=car_accord_main.id)
+    await car_main.owner.update(db=db, data=person_john_main)
+    await car_main.save(db=db)
+    car_schema = car_main.get_schema()
+    owner_rel_schema = car_schema.get_relationship(name="owner")
+
+    diff_calculator = DiffCalculator(db=db)
+
+    calculated_diffs = await diff_calculator.calculate_diff(
+        base_branch=default_branch,
+        diff_branch=branch,
+        from_time=from_time,
+        to_time=Timestamp(),
+        previous_node_specifiers={
+            NodeFieldSpecifier(node_uuid=car_accord_main.id, field_name=owner_rel_schema.get_identifier()),
+        },
+        include_unchanged=True,
+    )
+
+    base_root_path = calculated_diffs.base_branch_diff
+    assert base_root_path.branch == default_branch.name
+    assert len(base_root_path.nodes) == 1
+    nodes_by_id = {n.uuid: n for n in base_root_path.nodes}
+    # car on main
+    node_diff = nodes_by_id[car_accord_main.id]
+    assert node_diff.kind == "TestCar"
+    assert node_diff.action is DiffAction.UPDATED
+    assert len(node_diff.attributes) == 0
+    assert len(node_diff.relationships) == 1
+    diff_rel = node_diff.relationships.pop()
+    assert diff_rel.name == "owner"
+    assert diff_rel.action is DiffAction.UPDATED

--- a/backend/tests/unit/core/diff/test_diff_calculator.py
+++ b/backend/tests/unit/core/diff/test_diff_calculator.py
@@ -2765,7 +2765,69 @@ async def test_diff_relationship_update_includes_unchanged_properties(
         DatabaseEdgeType.IS_VISIBLE,
         DatabaseEdgeType.IS_PROTECTED,
     }
-    # TODO: finish or remove test
+    related_prop = properties_by_type[DatabaseEdgeType.IS_RELATED]
+    assert related_prop.action is DiffAction.ADDED
+    assert related_prop.previous_value is None
+    assert related_prop.new_value == person_alfred_main.id
+    for prop_type, value in ((DatabaseEdgeType.IS_VISIBLE, True), (DatabaseEdgeType.IS_PROTECTED, False)):
+        prop_diff = properties_by_type[prop_type]
+        assert prop_diff.action is DiffAction.ADDED
+        assert prop_diff.previous_value is None
+        assert prop_diff.new_value == value
+    # john on branch
+    node_diff = nodes_by_id[person_john_main.id]
+    assert node_diff.kind == "TestPerson"
+    assert node_diff.action is DiffAction.UPDATED
+    assert len(node_diff.attributes) == 0
+    assert len(node_diff.relationships) == 1
+    diff_rel = node_diff.relationships.pop()
+    assert diff_rel.name == "cars"
+    assert diff_rel.action is DiffAction.UPDATED
+    elements_by_peer_id = {e.peer_id: e for e in diff_rel.relationships}
+    assert set(elements_by_peer_id.keys()) == {car_accord_main.id}
+    accord_cars_diff = elements_by_peer_id[car_accord_main.id]
+    properties_by_type = {p.property_type: p for p in accord_cars_diff.properties}
+    assert set(properties_by_type.keys()) == {
+        DatabaseEdgeType.IS_RELATED,
+        DatabaseEdgeType.IS_VISIBLE,
+        DatabaseEdgeType.IS_PROTECTED,
+    }
+    related_prop = properties_by_type[DatabaseEdgeType.IS_RELATED]
+    assert related_prop.action is DiffAction.REMOVED
+    assert related_prop.previous_value == car_accord_main.id
+    assert related_prop.new_value is None
+    for prop_type, value in ((DatabaseEdgeType.IS_VISIBLE, True), (DatabaseEdgeType.IS_PROTECTED, False)):
+        prop_diff = properties_by_type[prop_type]
+        assert prop_diff.action is DiffAction.REMOVED
+        assert prop_diff.previous_value == value
+        assert prop_diff.new_value is None
+    # alfred on branch
+    node_diff = nodes_by_id[person_alfred_main.id]
+    assert node_diff.kind == "TestPerson"
+    assert node_diff.action is DiffAction.UPDATED
+    assert len(node_diff.attributes) == 0
+    assert len(node_diff.relationships) == 1
+    diff_rel = node_diff.relationships.pop()
+    assert diff_rel.name == "cars"
+    assert diff_rel.action is DiffAction.UPDATED
+    elements_by_peer_id = {e.peer_id: e for e in diff_rel.relationships}
+    assert set(elements_by_peer_id.keys()) == {car_accord_main.id}
+    accord_cars_diff = elements_by_peer_id[car_accord_main.id]
+    properties_by_type = {p.property_type: p for p in accord_cars_diff.properties}
+    assert set(properties_by_type.keys()) == {
+        DatabaseEdgeType.IS_RELATED,
+        DatabaseEdgeType.IS_VISIBLE,
+        DatabaseEdgeType.IS_PROTECTED,
+    }
+    related_prop = properties_by_type[DatabaseEdgeType.IS_RELATED]
+    assert related_prop.action is DiffAction.ADDED
+    assert related_prop.previous_value is None
+    assert related_prop.new_value == car_accord_main.id
+    for prop_type, value in ((DatabaseEdgeType.IS_VISIBLE, True), (DatabaseEdgeType.IS_PROTECTED, False)):
+        prop_diff = properties_by_type[prop_type]
+        assert prop_diff.action is DiffAction.ADDED
+        assert prop_diff.previous_value is None
+        assert prop_diff.new_value == value
 
 
 async def test_diff_relationship_property_update_on_main(
@@ -2812,4 +2874,4 @@ async def test_diff_relationship_property_update_on_main(
     assert len(node_diff.relationships) == 1
     diff_rel = node_diff.relationships.pop()
     assert diff_rel.name == "owner"
-    assert diff_rel.action is DiffAction.UPDATED
+    assert diff_rel.action is DiffAction.ADDED

--- a/backend/tests/unit/core/diff/test_diff_combiner.py
+++ b/backend/tests/unit/core/diff/test_diff_combiner.py
@@ -141,8 +141,9 @@ class TestDiffCombiner:
     async def test_node_action_addition(self, action_1, action_2, expected_action):
         node_1_conflict = EnrichedConflictFactory.build()
         node_2_conflict = replace(node_1_conflict, selected_branch=ConflictSelection.DIFF_BRANCH)
+        diff_node_1_attr = EnrichedAttributeFactory.build(action=DiffAction.ADDED)
         diff_node_1 = EnrichedNodeFactory.build(
-            action=action_1, attributes=set(), relationships=set(), conflict=node_1_conflict
+            action=action_1, attributes={diff_node_1_attr}, relationships=set(), conflict=node_1_conflict
         )
         diff_node_2 = EnrichedNodeFactory.build(
             uuid=diff_node_1.uuid,
@@ -168,7 +169,7 @@ class TestDiffCombiner:
                 changed_at=diff_node_2.changed_at,
                 action=expected_action,
                 path_identifier=diff_node_2.path_identifier,
-                attributes=set(),
+                attributes={diff_node_1_attr},
                 relationships=set(),
                 conflict=node_2_conflict,
             )
@@ -177,14 +178,18 @@ class TestDiffCombiner:
 
     async def test_stale_parent_node_removed(self):
         parent_node_1 = EnrichedNodeFactory.build(action=DiffAction.UNCHANGED, attributes=set(), relationships=set())
+        element_1 = EnrichedRelationshipElementFactory.build(action=DiffAction.UPDATED)
         relationship_1 = EnrichedRelationshipGroupFactory.build(
             name="smells",
             label="Olfactory essences",
             action=DiffAction.UPDATED,
-            relationships=set(),
+            relationships={element_1},
             nodes={parent_node_1},
         )
-        child_node_1 = EnrichedNodeFactory.build(action=DiffAction.ADDED, relationships={relationship_1})
+        attr_1 = EnrichedAttributeFactory.build(action=DiffAction.UPDATED)
+        child_node_1 = EnrichedNodeFactory.build(
+            action=DiffAction.ADDED, relationships={relationship_1}, attributes={attr_1}
+        )
         self.diff_root_1.nodes = {parent_node_1, child_node_1}
         parent_node_2 = EnrichedNodeFactory.build(action=DiffAction.UNCHANGED, attributes=set(), relationships=set())
         relationship_2 = EnrichedRelationshipGroupFactory.build(
@@ -209,12 +214,12 @@ class TestDiffCombiner:
         self.expected_combined.uuid = combined.uuid
         self.expected_combined.partner_uuid = combined.partner_uuid
         expected_parent_node = replace(parent_node_2)
-        expected_rel = replace(relationship_2, nodes={expected_parent_node})
+        expected_rel = replace(relationship_2, nodes={expected_parent_node}, relationships={element_1})
         expected_child_node = replace(
             child_node_2,
             action=DiffAction.ADDED,
             relationships={expected_rel},
-            attributes=child_node_1.attributes | child_node_2.attributes,
+            attributes={attr_1} | child_node_2.attributes,
             conflict=None,
         )
         self.expected_combined.nodes = {expected_parent_node, expected_child_node}
@@ -642,11 +647,12 @@ class TestDiffCombiner:
         early_parent_node = EnrichedNodeFactory.build(
             action=DiffAction.UNCHANGED, relationships=set(), attributes=set()
         )
+        element_1 = EnrichedRelationshipElementFactory.build(action=DiffAction.ADDED)
         early_relationship = EnrichedRelationshipGroupFactory.build(
             name=relationship_name,
             action=DiffAction.ADDED,
             cardinality=RelationshipCardinality.MANY,
-            relationships=set(),
+            relationships={element_1},
             nodes={early_parent_node},
         )
         later_parent_node = EnrichedNodeFactory.build(
@@ -680,7 +686,7 @@ class TestDiffCombiner:
             changed_at=later_relationship.changed_at,
             action=DiffAction.ADDED,
             path_identifier=later_relationship.path_identifier,
-            relationships=set(),
+            relationships={element_1},
             nodes={later_parent_node},
         )
         expected_node = EnrichedDiffNode(
@@ -823,7 +829,11 @@ class TestDiffCombiner:
             changed_at=Timestamp(),
         )
         child_node_1 = EnrichedNodeFactory.build(
-            uuid=child_node_uuid, kind="ThisKind", action=DiffAction.UPDATED, relationships={parent_rel_1}
+            uuid=child_node_uuid,
+            kind="ThisKind",
+            action=DiffAction.UPDATED,
+            relationships={parent_rel_1},
+            attributes={EnrichedAttributeFactory.build(action=DiffAction.UPDATED)},
         )
         child_node_2 = EnrichedNodeFactory.build(
             uuid=child_node_uuid,
@@ -874,7 +884,9 @@ class TestDiffCombiner:
         parent_node_2 = EnrichedNodeFactory.build(
             action=DiffAction.UNCHANGED, attributes=set(), relationships=set(), changed_at=Timestamp()
         )
-        child_element_1 = EnrichedRelationshipElementFactory.build()
+        child_element_1 = EnrichedRelationshipElementFactory.build(
+            action=DiffAction.UPDATED, properties={EnrichedPropertyFactory.build(action=DiffAction.UPDATED)}
+        )
         child_rel_1 = EnrichedRelationshipGroupFactory.build(
             name=relationship_name,
             relationships={child_element_1},
@@ -933,19 +945,27 @@ class TestDiffCombiner:
         self.expected_combined.nodes = {expected_parent_1, expected_parent_2, expected_child_node}
         assert combined == self.expected_combined
 
-    async def test_resetting_attr_removes_it_from_diff(self):
+    async def test_resetting_attr_makes_it_unchanged(self):
         updated_attr_name = "length"
+        previous_value = str(uuid4())
+        new_value = str(uuid4())
         updated_attr_value_property_1 = EnrichedPropertyFactory.build(
             property_type=DatabaseEdgeType.HAS_VALUE,
             action=DiffAction.UPDATED,
-            previous_value=str(uuid4()),
-            new_value=str(uuid4()),
+            previous_value=previous_value,
+            new_value=new_value,
         )
         updated_attr_value_property_2 = EnrichedPropertyFactory.build(
             property_type=DatabaseEdgeType.HAS_VALUE,
             action=DiffAction.UPDATED,
-            previous_value=updated_attr_value_property_1.new_value,
-            new_value=updated_attr_value_property_1.previous_value,
+            previous_value=new_value,
+            new_value=previous_value,
+        )
+        expected_combined_property = replace(
+            updated_attr_value_property_2,
+            action=DiffAction.UNCHANGED,
+            previous_value=previous_value,
+            new_value=previous_value,
         )
         updated_attribute_1 = EnrichedAttributeFactory.build(
             name=updated_attr_name,
@@ -954,6 +974,9 @@ class TestDiffCombiner:
         )
         updated_attribute_2 = EnrichedAttributeFactory.build(
             name=updated_attr_name, action=DiffAction.UPDATED, properties={updated_attr_value_property_2}
+        )
+        expected_combined_attribute = replace(
+            updated_attribute_2, action=DiffAction.UNCHANGED, properties={expected_combined_property}
         )
         earlier_node_2 = EnrichedNodeFactory.build(
             action=DiffAction.UPDATED, attributes={updated_attribute_1}, relationships=set()
@@ -966,11 +989,14 @@ class TestDiffCombiner:
             relationships=set(),
             changed_at=Timestamp(),
         )
+        expected_combined_node = replace(
+            later_node_2, action=DiffAction.UNCHANGED, attributes={expected_combined_attribute}
+        )
 
         self.diff_root_1.nodes = {earlier_node_2}
         self.diff_root_2.nodes = {later_node_2}
 
-        self.expected_combined.nodes = set()
+        self.expected_combined.nodes = {expected_combined_node}
 
         combined = await self.__call_system_under_test(self.diff_root_1, self.diff_root_2)
 
@@ -978,7 +1004,7 @@ class TestDiffCombiner:
         self.expected_combined.partner_uuid = combined.partner_uuid
         assert combined == self.expected_combined
 
-    async def test_resetting_relationship_one_removes_it_from_diff(self, with_schema_manager):
+    async def test_resetting_relationship_one_makes_it_unchanged(self, with_schema_manager):
         relationship_name = "owner"
         old_peer_id = str(uuid4())
         intermediate_peer_id = str(uuid4())
@@ -1039,13 +1065,19 @@ class TestDiffCombiner:
         self.diff_root_1.nodes = {early_node}
         self.diff_root_2.nodes = {later_node}
 
+        expected_peer_property = replace(
+            later_peer_property,
+            action=DiffAction.UNCHANGED,
+            previous_value=old_peer_id,
+            new_value=old_peer_id,
+        )
         expected_relationship_element = EnrichedDiffSingleRelationship(
             changed_at=later_element.changed_at,
             action=DiffAction.UPDATED,
             peer_id=old_peer_id,
             peer_label=later_element.peer_label,
             path_identifier=later_element.path_identifier,
-            properties={early_only_property, later_only_property},
+            properties={early_only_property, later_only_property, expected_peer_property},
             conflict=later_element.conflict,
         )
         expected_relationship = EnrichedDiffRelationship(
@@ -1075,7 +1107,7 @@ class TestDiffCombiner:
         self.expected_combined.partner_uuid = combined.partner_uuid
         assert combined == self.expected_combined
 
-    async def test_resetting_relationship_many_removes_it_from_diff(self, with_schema_manager):
+    async def test_resetting_relationship_many_makes_it_unchanged(self, with_schema_manager):
         rel_prop_types = [DatabaseEdgeType.HAS_OWNER, DatabaseEdgeType.HAS_SOURCE, DatabaseEdgeType.IS_RELATED]
         relationship_name = "cars"
         peer_id_1 = str(uuid4())
@@ -1083,21 +1115,26 @@ class TestDiffCombiner:
 
         peer_1_props_1 = set()
         peer_1_props_2 = set()
+        expected_peer_props = set()
         for rpt in rel_prop_types:
             a1 = EnrichedPropertyFactory.build(
                 action=DiffAction.UPDATED, previous_value=str(uuid4()), new_value=str(uuid4()), property_type=rpt
             )
             a2 = EnrichedPropertyFactory.build(
-                action=DiffAction.UPDATED, property_type=rpt, new_value=a1.previous_value
+                action=DiffAction.UPDATED, property_type=rpt, previous_value=a1.new_value, new_value=a1.previous_value
             )
             peer_1_props_1.add(a1)
             peer_1_props_2.add(a2)
+            expected_peer_props.add(
+                replace(a2, action=DiffAction.UNCHANGED, previous_value=a1.previous_value, new_value=a1.previous_value)
+            )
         updated_element_1_1 = EnrichedRelationshipElementFactory.build(
             action=DiffAction.ADDED, peer_id=peer_id_1, properties=peer_1_props_1
         )
         updated_element_2_2 = EnrichedRelationshipElementFactory.build(
             action=DiffAction.UPDATED, peer_id=peer_id_1, properties=peer_1_props_2
         )
+        expected_element_1 = replace(updated_element_2_2, action=DiffAction.UNCHANGED, properties=expected_peer_props)
         updated_property_1 = EnrichedPropertyFactory.build(
             property_type=DatabaseEdgeType.HAS_OWNER, previous_value=str(uuid4()), action=DiffAction.UPDATED
         )
@@ -1112,6 +1149,13 @@ class TestDiffCombiner:
         updated_element_2 = EnrichedRelationshipElementFactory.build(
             action=DiffAction.UPDATED, peer_id=peer_id_2, properties={updated_property_2}
         )
+        expected_property_2 = replace(
+            updated_property_2,
+            action=DiffAction.UNCHANGED,
+            previous_value=updated_property_1.previous_value,
+            new_value=updated_property_1.previous_value,
+        )
+        expected_element_2 = replace(updated_element_2, action=DiffAction.UNCHANGED, properties={expected_property_2})
         relationship_group_1 = EnrichedRelationshipGroupFactory.build(
             name=relationship_name,
             action=DiffAction.UPDATED,
@@ -1127,6 +1171,9 @@ class TestDiffCombiner:
             changed_at=Timestamp(),
             nodes=set(),
         )
+        expected_group = replace(
+            relationship_group_2, action=DiffAction.UNCHANGED, relationships={expected_element_1, expected_element_2}
+        )
         node_1 = EnrichedNodeFactory.build(
             kind="TestPerson", action=DiffAction.UPDATED, relationships={relationship_group_1}
         )
@@ -1135,12 +1182,11 @@ class TestDiffCombiner:
             kind=node_1.kind,
             action=DiffAction.UPDATED,
             relationships={relationship_group_2},
+            attributes={EnrichedAttributeFactory.build(action=DiffAction.UPDATED)},
             changed_at=Timestamp(),
         )
         self.diff_root_1.nodes = {node_1}
         self.diff_root_2.nodes = {node_2}
-
-        self.expected_combined.nodes = set()
 
         combined = await self.__call_system_under_test(self.diff_root_1, self.diff_root_2)
 
@@ -1153,7 +1199,9 @@ class TestDiffCombiner:
             changed_at=node_2.changed_at,
             action=DiffAction.UPDATED,
             path_identifier=node_2.path_identifier,
-            relationships=set(),
+            relationships={expected_group},
             attributes=(node_1.attributes | node_2.attributes),
         )
         self.expected_combined.nodes = {expected_node}
+
+        assert self.expected_combined == combined

--- a/backend/tests/unit/graphql/test_diff_tree_query.py
+++ b/backend/tests/unit/graphql/test_diff_tree_query.py
@@ -33,7 +33,7 @@ IS_VISIBLE_TYPE = "IS_VISIBLE"
 
 DIFF_TREE_QUERY = """
 query GetDiffTree($branch: String){
-    DiffTree (branch: $branch) {
+    DiffTree (branch: $branch, filters: {status: {excludes: UNCHANGED}}) {
         base_branch
         diff_branch
         from_time
@@ -494,7 +494,20 @@ async def test_diff_tree_one_relationship_change(
         "conflict": None,
     }
     owner_properties_by_type = {p["property_type"]: p for p in owner_properties}
-    assert set(owner_properties_by_type.keys()) == {IS_RELATED_TYPE}
+    assert set(owner_properties_by_type.keys()) == {IS_RELATED_TYPE, IS_PROTECTED_TYPE, IS_VISIBLE_TYPE}
+    owner_prop = owner_properties_by_type[IS_RELATED_TYPE]
+    owner_prop_changed_at = owner_prop["last_changed_at"]
+    assert before_change_datetime < datetime.fromisoformat(owner_prop_changed_at) < after_change_datetime
+    assert owner_prop == {
+        "property_type": IS_RELATED_TYPE,
+        "last_changed_at": owner_prop_changed_at,
+        "previous_value": person_john_main.id,
+        "new_value": person_jane_main.id,
+        "previous_label": john_label,
+        "new_label": jane_label,
+        "status": UPDATED_ACTION,
+        "conflict": None,
+    }
     owner_prop = owner_properties_by_type[IS_RELATED_TYPE]
     owner_prop_changed_at = owner_prop["last_changed_at"]
     assert before_change_datetime < datetime.fromisoformat(owner_prop_changed_at) < after_change_datetime

--- a/changelog/+merge-rel-metadata.fixed.md
+++ b/changelog/+merge-rel-metadata.fixed.md
@@ -1,0 +1,1 @@
+Fix a bug that prevented updating a relationship during a merge if ONLY the metadata was updated and not the peer.


### PR DESCRIPTION
IFC-312
IFC-939

changes to allow users to undo a change in a diff by manually reversing it. this is necessary now that we can identify node-level conflicts and we do not allow users to select a resolution for them.

overview of the changes
- handle correctly identifying and preserving action=UNCHANGED entities when combining two diffs. we need to hold on to UNCHANGED nodes (and all of their elements) so that we can identify the correct previous values if the nodes is updated again in an incremental diff
- update the conflicts enricher to handle UNCHANGED nodes by removing any pre-existing conflicts if either the earlier or later node becomes action=UNCHANGED. b/c an UNCHANGED node, by definition, cannot have a conflict
- update the cardinality=one enricher to preserve UNCHANGED nodes
- update the diff merge serializer to correctly handle metadata property changes with no peer changes
- roughly one billion test updates to test new things and update things for these changes