### PR TITLE
Add RabbitMQ reconnect callback

### DIFF
--- a/backend/infrahub/services/adapters/message_bus/rabbitmq.py
+++ b/backend/infrahub/services/adapters/message_bus/rabbitmq.py
@@ -96,8 +96,13 @@ class RabbitMQMessageBus(InfrahubMessageBus):
                 "cafile": self.settings.tls_ca_file or "",
             },
         )
+        self.connection.reconnect_callbacks.add(self.on_reconnect, weak=False)
 
+        await self._initialize_connection()
+
+    async def _initialize_connection(self) -> None:
         self.channel = await self.connection.channel()
+
         if self.service.component_type == ComponentType.API_SERVER:
             await self._initialize_api_server()
         elif self.service.component_type == ComponentType.GIT_AGENT:
@@ -127,6 +132,13 @@ class RabbitMQMessageBus(InfrahubMessageBus):
                 await execute_message(routing_key=message.routing_key, message_body=message.body, service=self.service)
             else:
                 self.service.log.error("Invalid message received", message=f"{message!r}")
+
+    async def on_reconnect(
+        self,
+        weak: bool = False,  # pylint: disable=unused-argument
+    ) -> None:
+        self.service.log.info("Reconnected to RabbitMQ, reinitializing connection")
+        await self._initialize_connection()
 
     async def _initialize_api_server(self) -> None:
         self.callback_queue = await self.channel.declare_queue(name=f"api-callback-{WORKER_IDENTITY}", exclusive=True)


### PR DESCRIPTION
This PR adds a reconnect callback to RabbitMQ which reinitializes the connection environment. This can be needed if the queues have been deleted or doesn't exist within the container/pod.