### PR TITLE
Add URL as an allowed computed attribute kind

### DIFF
--- a/backend/infrahub/computed_attribute/constants.py
+++ b/backend/infrahub/computed_attribute/constants.py
@@ -3,3 +3,5 @@ QUERY_AUTOMATION_NAME_PREFIX = "Computed-attribute-query"
 
 PROCESS_AUTOMATION_NAME = PROCESS_AUTOMATION_NAME_PREFIX + "::{identifier}::{scope}"
 QUERY_AUTOMATION_NAME = QUERY_AUTOMATION_NAME_PREFIX + "::{identifier}::{scope}"
+
+VALID_KINDS = ["Text", "URL"]

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -10,6 +10,7 @@ from infrahub_sdk.topological_sort import DependencyCycleExistsError, topologica
 from infrahub_sdk.utils import compare_lists, deep_merge_dict, duplicates, intersection
 from typing_extensions import Self
 
+from infrahub.computed_attribute.constants import VALID_KINDS as VALID_COMPUTED_ATTRIBUTE_KINDS
 from infrahub.core.constants import (
     RESERVED_ATTR_GEN_NAMES,
     RESERVED_ATTR_REL_NAMES,
@@ -933,11 +934,11 @@ class SchemaBranch:
 
         if not attribute.read_only:
             raise ValueError(
-                f"{node.kind}: Attribute {attribute.name!r} is a computed jinja2 attribute but not marked as read_only"
+                f"{node.kind}: Attribute {attribute.name!r} is a computed attribute but not marked as read_only"
             )
-        if not attribute.kind == "Text":
+        if attribute.kind not in VALID_COMPUTED_ATTRIBUTE_KINDS:
             raise ValueError(
-                f"{node.kind}: Attribute {attribute.name!r} is a computed jinja2 attribute currently only 'Text' kinds are supported."
+                f"{node.kind}: Attribute {attribute.name!r} is a computed attribute only {VALID_COMPUTED_ATTRIBUTE_KINDS} kinds are supported."
             )
 
         if (

--- a/backend/tests/unit/core/schema/schema_branch/test_validate_computed_attributes.py
+++ b/backend/tests/unit/core/schema/schema_branch/test_validate_computed_attributes.py
@@ -1,5 +1,6 @@
 import pytest
 
+from infrahub.computed_attribute.constants import VALID_KINDS
 from infrahub.core.constants import ComputedAttributeKind, RelationshipCardinality
 from infrahub.core.schema import AttributeSchema, GenericSchema, NodeSchema, RelationshipSchema, SchemaRoot
 from infrahub.core.schema.computed_attribute import ComputedAttribute
@@ -54,7 +55,7 @@ from infrahub.core.schema.schema_branch import SchemaBranch
                     ),
                 ],
             ),
-            "TestingPerson: Attribute 'computed' is a computed jinja2 attribute but not marked as read_only",
+            "TestingPerson: Attribute 'computed' is a computed attribute but not marked as read_only",
             id="missing_read_only",
         ),
         pytest.param(
@@ -227,7 +228,7 @@ from infrahub.core.schema.schema_branch import SchemaBranch
                     ),
                 ],
             ),
-            "TestingPerson: Attribute 'computed' is a computed jinja2 attribute currently only 'Text' kinds are supported.",
+            f"TestingPerson: Attribute 'computed' is a computed attribute only {VALID_KINDS!r} kinds are supported.",
             id="wrong_kind",
         ),
         pytest.param(
@@ -258,9 +259,11 @@ from infrahub.core.schema.schema_branch import SchemaBranch
         ),
     ],
 )
-async def test_schema_protected_generics(schema_root: SchemaRoot, expected_error: str):
+async def test_schema_computed_attribute_violations(schema_root: SchemaRoot, expected_error: str):
     schema = SchemaBranch(cache={}, name="test")
     schema.load_schema(schema=schema_root)
 
-    with pytest.raises(ValueError, match=expected_error):
+    with pytest.raises(ValueError) as exc:
         schema.validate_computed_attributes()
+
+    assert str(exc.value) == expected_error


### PR DESCRIPTION
This is to support computed URL attributes.

The PR also includes some minor cleanup with regards to names and error messages.