### PR TITLE
Add branch support to computed attributes based on Jinja2

### DIFF
--- a/backend/infrahub/computed_attribute/constants.py
+++ b/backend/infrahub/computed_attribute/constants.py
@@ -1,7 +1,10 @@
+PROCESS_JINJA2_AUTOMATION_NAME_PREFIX = "Computed-attribute-process-jinja2"
+PROCESS_PYTHON_AUTOMATION_NAME_PREFIX = "Computed-attribute-process-python"
+
 PROCESS_AUTOMATION_NAME_PREFIX = "Computed-attribute-process"
 QUERY_AUTOMATION_NAME_PREFIX = "Computed-attribute-query"
 
-PROCESS_AUTOMATION_NAME = PROCESS_AUTOMATION_NAME_PREFIX + "::{identifier}::{scope}"
+PROCESS_AUTOMATION_NAME = "{prefix}::{identifier}::{scope}"
 QUERY_AUTOMATION_NAME = QUERY_AUTOMATION_NAME_PREFIX + "::{identifier}::{scope}"
 
 VALID_KINDS = ["Text", "URL"]

--- a/backend/infrahub/computed_attribute/models.py
+++ b/backend/infrahub/computed_attribute/models.py
@@ -9,6 +9,8 @@ from pydantic import BaseModel, Field
 from typing_extensions import Self
 
 if TYPE_CHECKING:
+    from uuid import UUID
+
     from infrahub.core.schema.schema_branch_computed import PythonDefinition
 
 
@@ -42,6 +44,14 @@ class ComputedAttributeAutomations(BaseModel):
         if identifier in self.data and scope in self.data[identifier]:
             return True
         return False
+
+    def return_obsolete(self, keep: list[UUID]) -> list[UUID]:
+        remove = []
+        for identifier in self.data.values():
+            for automation in identifier.values():
+                if automation.id not in keep:
+                    remove.append(automation.id)
+        return remove
 
 
 @dataclass

--- a/backend/infrahub/computed_attribute/tasks.py
+++ b/backend/infrahub/computed_attribute/tasks.py
@@ -28,7 +28,8 @@ from infrahub.workflows.utils import add_branch_tag, wait_for_schema_to_converge
 
 from .constants import (
     PROCESS_AUTOMATION_NAME,
-    PROCESS_AUTOMATION_NAME_PREFIX,
+    PROCESS_JINJA2_AUTOMATION_NAME_PREFIX,
+    PROCESS_PYTHON_AUTOMATION_NAME_PREFIX,
     QUERY_AUTOMATION_NAME,
     QUERY_AUTOMATION_NAME_PREFIX,
 )
@@ -263,12 +264,14 @@ async def trigger_update_jinja2_computed_attributes(
 
 
 @flow(name="computed-attribute-setup", flow_run_name="Setup computed attributes in task-manager")
-async def computed_attribute_setup() -> None:
+async def computed_attribute_setup(branch_name: str | None = None) -> None:
     service = services.service
+    branch_name = branch_name or registry.default_branch
     log = get_run_logger()
-    await wait_for_schema_to_converge(branch_name=registry.default_branch, service=service, log=log)
+    await wait_for_schema_to_converge(branch_name=branch_name, service=service, log=log)
 
-    schema_branch = registry.schema.get_schema_branch(name=registry.default_branch)
+    branches_with_diff_from_main = registry.get_altered_schema_branches()
+    schema_branch = registry.schema.get_schema_branch(name=branch_name)
 
     async with get_client(sync_client=False) as client:
         deployments = {
@@ -283,24 +286,31 @@ async def computed_attribute_setup() -> None:
         deployment_id_jinja = deployments[PROCESS_COMPUTED_MACRO.name].id
 
         automations = await client.read_automations()
-        existing_computed_attr_automations = ComputedAttributeAutomations.from_prefect(automations=automations)
-
+        existing_computed_attr_automations = ComputedAttributeAutomations.from_prefect(
+            automations=automations, prefix=PROCESS_JINJA2_AUTOMATION_NAME_PREFIX
+        )
+        automations_to_keep = []
         mapping = schema_branch.computed_attributes.get_jinja2_target_map()
         for computed_attribute, source_node_types in mapping.items():
             log.info(f"processing {computed_attribute.key_name}")
-            scope = "default"
+            scope = registry.default_branch
 
             automation = AutomationCore(
                 name=PROCESS_AUTOMATION_NAME.format(
-                    prefix=PROCESS_AUTOMATION_NAME_PREFIX, identifier=computed_attribute.key_name, scope=scope
+                    prefix=PROCESS_JINJA2_AUTOMATION_NAME_PREFIX, identifier=computed_attribute.key_name, scope=scope
                 ),
-                description=f"Process value of the computed attribute for {computed_attribute.key_name} [{scope}]",
+                description=f"Process value of the computed attribute for {computed_attribute.key_name} [{scope}] and branches with the same schema",
                 enabled=True,
                 trigger=EventTrigger(
                     posture=Posture.Reactive,
                     expect={"infrahub.node.*"},
                     within=timedelta(0),
-                    match=ResourceSpecification({"infrahub.node.kind": source_node_types}),
+                    match=ResourceSpecification(
+                        {
+                            "infrahub.node.kind": source_node_types,
+                            "infrahub.branch.name": [f"!{branch}" for branch in branches_with_diff_from_main],
+                        }
+                    ),
                     threshold=1,
                 ),
                 actions=[
@@ -322,26 +332,101 @@ async def computed_attribute_setup() -> None:
             if existing_computed_attr_automations.has(identifier=computed_attribute.key_name, scope=scope):
                 existing = existing_computed_attr_automations.get(identifier=computed_attribute.key_name, scope=scope)
                 await client.update_automation(automation_id=existing.id, automation=automation)
+                automations_to_keep.append(existing.id)
                 log.info(f"{computed_attribute.key_name} Updated")
             else:
-                await client.create_automation(automation=automation)
+                automation_id = await client.create_automation(automation=automation)
+                automations_to_keep.append(automation_id)
                 log.info(f"{computed_attribute.key_name} Created")
 
-            await service.workflow.submit_workflow(
-                workflow=TRIGGER_UPDATE_JINJA_COMPUTED_ATTRIBUTES,
-                parameters={
-                    "branch_name": registry.default_branch,
-                    "computed_attribute_name": computed_attribute.attribute.name,
-                    "computed_attribute_kind": computed_attribute.kind,
-                },
-            )
+            if branch_name == registry.default_branch:
+                await service.workflow.submit_workflow(
+                    workflow=TRIGGER_UPDATE_JINJA_COMPUTED_ATTRIBUTES,
+                    parameters={
+                        "branch_name": registry.default_branch,
+                        "computed_attribute_name": computed_attribute.attribute.name,
+                        "computed_attribute_kind": computed_attribute.kind,
+                    },
+                )
+
+        for diff_branch in branches_with_diff_from_main:
+            schema_branch = registry.schema.get_schema_branch(name=diff_branch)
+
+            mapping = schema_branch.computed_attributes.get_jinja2_target_map()
+            for computed_attribute, source_node_types in mapping.items():
+                log.info(f"processing {computed_attribute.key_name}")
+                scope = diff_branch
+
+                automation = AutomationCore(
+                    name=PROCESS_AUTOMATION_NAME.format(
+                        prefix=PROCESS_PYTHON_AUTOMATION_NAME_PREFIX,
+                        identifier=computed_attribute.key_name,
+                        scope=scope,
+                    ),
+                    description=f"Process value of the computed attribute for {computed_attribute.key_name} [{scope}]",
+                    enabled=True,
+                    trigger=EventTrigger(
+                        posture=Posture.Reactive,
+                        expect={"infrahub.node.*"},
+                        within=timedelta(0),
+                        match=ResourceSpecification(
+                            {
+                                "infrahub.node.kind": source_node_types,
+                                "infrahub.branch.name": scope,
+                            }
+                        ),
+                        threshold=1,
+                    ),
+                    actions=[
+                        RunDeployment(
+                            source="selected",
+                            deployment_id=deployment_id_jinja,
+                            parameters={
+                                "branch_name": "{{ event.resource['infrahub.branch.name'] }}",
+                                "node_kind": "{{ event.resource['infrahub.node.kind'] }}",
+                                "object_id": "{{ event.resource['infrahub.node.id'] }}",
+                                "computed_attribute_name": computed_attribute.attribute.name,
+                                "computed_attribute_kind": computed_attribute.kind,
+                            },
+                            job_variables={},
+                        )
+                    ],
+                )
+
+                if existing_computed_attr_automations.has(identifier=computed_attribute.key_name, scope=scope):
+                    existing = existing_computed_attr_automations.get(
+                        identifier=computed_attribute.key_name, scope=scope
+                    )
+                    await client.update_automation(automation_id=existing.id, automation=automation)
+                    automations_to_keep.append(existing.id)
+                    log.info(f"{computed_attribute.key_name} Updated")
+                else:
+                    automation_id = await client.create_automation(automation=automation)
+                    automations_to_keep.append(automation_id)
+                    log.info(f"{computed_attribute.key_name} Created")
+
+                if branch_name == diff_branch:
+                    await service.workflow.submit_workflow(
+                        workflow=TRIGGER_UPDATE_JINJA_COMPUTED_ATTRIBUTES,
+                        parameters={
+                            "branch_name": branch_name,
+                            "computed_attribute_name": computed_attribute.attribute.name,
+                            "computed_attribute_kind": computed_attribute.kind,
+                        },
+                    )
+
+        automations_to_remove = existing_computed_attr_automations.return_obsolete(keep=automations_to_keep)
+        for automation_to_remove in automations_to_remove:
+            await client.delete_automation(automation_id=automation_to_remove)
 
 
 @flow(
     name="computed-attribute-setup-python",
     flow_run_name="Setup computed attributes for Python transforms in task-manager",
 )
-async def computed_attribute_setup_python() -> None:
+async def computed_attribute_setup_python(
+    branch_name: str | None = None,  # pylint: disable=unused-argument
+) -> None:
     log = get_run_logger()
     service = services.service
     await wait_for_schema_to_converge(branch_name=registry.default_branch, service=service, log=log)
@@ -403,7 +488,7 @@ async def computed_attribute_setup_python() -> None:
 
         automations = await client.read_automations()
         existing_computed_attr_process_automations = ComputedAttributeAutomations.from_prefect(
-            automations=automations, prefix=PROCESS_AUTOMATION_NAME_PREFIX
+            automations=automations, prefix=PROCESS_PYTHON_AUTOMATION_NAME_PREFIX
         )
         existing_computed_attr_query_automations = ComputedAttributeAutomations.from_prefect(
             automations=automations, prefix=QUERY_AUTOMATION_NAME_PREFIX
@@ -415,7 +500,7 @@ async def computed_attribute_setup_python() -> None:
 
             automation = AutomationCore(
                 name=PROCESS_AUTOMATION_NAME.format(
-                    prefix=PROCESS_AUTOMATION_NAME_PREFIX,
+                    prefix=PROCESS_PYTHON_AUTOMATION_NAME_PREFIX,
                     identifier=computed_attribute.computed_attribute.key_name,
                     scope=scope,
                 ),

--- a/backend/infrahub/core/registry.py
+++ b/backend/infrahub/core/registry.py
@@ -220,5 +220,16 @@ class Registry:
     def get_global_branch(self) -> Branch:
         return self.get_branch_from_registry(branch=GLOBAL_BRANCH_NAME)
 
+    def get_altered_schema_branches(self) -> list[str]:
+        """Return a list of branch names that has a different hash than the default branch"""
+        # altered_branches = []
+        default_branch = self.branch[registry.default_branch]
+        return [
+            name
+            for name, branch in self.branch.items()
+            if name not in [registry.default_branch, GLOBAL_BRANCH_NAME]
+            and branch.active_schema_hash.main != default_branch.active_schema_hash.main
+        ]
+
 
 registry = Registry()

--- a/backend/infrahub/schema/tasks.py
+++ b/backend/infrahub/schema/tasks.py
@@ -52,13 +52,17 @@ async def schema_updated_setup() -> None:
                 RunDeployment(
                     source="selected",
                     deployment_id=deployment_id_computed_attribute_setup,
-                    parameters={},
+                    parameters={
+                        "branch_name": "{{ event.resource['infrahub.branch.name'] }}",
+                    },
                     job_variables={},
                 ),
                 RunDeployment(
                     source="selected",
                     deployment_id=deployment_id_computed_attribute_setup_python,
-                    parameters={},
+                    parameters={
+                        "branch_name": "{{ event.resource['infrahub.branch.name'] }}",
+                    },
                     job_variables={},
                 ),
             ],

--- a/backend/tests/unit/computed_attribute/test_models.py
+++ b/backend/tests/unit/computed_attribute/test_models.py
@@ -34,10 +34,22 @@ def generate_automation(
 
 async def test_load_from_prefect():
     automations: list[Automation] = [
-        generate_automation(name=PROCESS_AUTOMATION_NAME.format(identifier="AAAAA", scope="default")),
-        generate_automation(name=PROCESS_AUTOMATION_NAME.format(identifier="AAAAA", scope="yyyy")),
-        generate_automation(name=PROCESS_AUTOMATION_NAME.format(identifier="BBBBB", scope="default")),
-        generate_automation(name=QUERY_AUTOMATION_NAME.format(identifier="CCCCC", scope="default")),
+        generate_automation(
+            name=PROCESS_AUTOMATION_NAME.format(
+                prefix=PROCESS_AUTOMATION_NAME_PREFIX, identifier="AAAAA", scope="default"
+            )
+        ),
+        generate_automation(
+            name=PROCESS_AUTOMATION_NAME.format(prefix=PROCESS_AUTOMATION_NAME_PREFIX, identifier="AAAAA", scope="yyyy")
+        ),
+        generate_automation(
+            name=PROCESS_AUTOMATION_NAME.format(
+                prefix=PROCESS_AUTOMATION_NAME_PREFIX, identifier="BBBBB", scope="default"
+            )
+        ),
+        generate_automation(
+            name=QUERY_AUTOMATION_NAME.format(prefix=QUERY_AUTOMATION_NAME_PREFIX, identifier="CCCCC", scope="default")
+        ),
         generate_automation(name="anothername"),
     ]
 


### PR DESCRIPTION
This PR adds support for branches with Jinja2 based computed attributes.

Changes:

* Some rearrangement of the constants and prefix names
* Added a function to the registry that returns the name of branches with a hash that differs from the default branch
* Change the automations for each computed attribute so that for the "converged branches" i.e. those that are the same as the default branch we have an automation that triggers if the current branch is not in the list of branches that have not yet converged
* Added one or more optional automations that match any branch that have converged
* Modified the recalculation of existing attributes so that they are rerendered for the current branch