### PR TITLE
Restore logs for local testing

### DIFF
--- a/backend/infrahub/log.py
+++ b/backend/infrahub/log.py
@@ -29,7 +29,7 @@ def set_log_data(key: str, value: Any) -> None:
     structlog.contextvars.bind_contextvars(**{key: value})
 
 
-def configure_logging(production: bool = True, log_level: str = "INFO") -> None:
+def configure_logging(production: bool, log_level: str) -> None:
     # Importing prefect.main here triggers prefect.logging.configuration.setup_logging()
     # to be executed, this function wipes out the previous logging configuration and
     # starts from a clean slate. After this has been imported once we can reinject

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,5 +1,6 @@
 import asyncio
 import importlib
+import logging
 import os
 import sys
 import time
@@ -61,6 +62,7 @@ from tests.helpers.constants import (
 from tests.helpers.utils import get_exposed_port, start_neo4j_container
 
 ResponseClass = TypeVar("ResponseClass")
+DEFAULT_TESTING_LOG_LEVEL = "WARNING"
 
 
 def pytest_addoption(parser):
@@ -77,6 +79,15 @@ def pytest_configure(config):
 
     if not config.option.neo4j:
         setattr(config.option, "markexpr", markexpr)
+
+    log_level = config.option.log_level
+    log_level = log_level if log_level is not None else DEFAULT_TESTING_LOG_LEVEL
+
+    # We can't control logging through INFRAHUB_LOG_LEVEL and PREFECT_LOGGING_LEVEL here
+    # because logging configuration has already been setup when `log.py` is imported,
+    # thus we directly set level of corresponding loggers.
+    logging.getLogger().setLevel(log_level)  # root logger
+    logging.getLogger("prefect").setLevel(log_level)  # prefect logger
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/backend/tests/unit/git_credential/test_git_helper.py
+++ b/backend/tests/unit/git_credential/test_git_helper.py
@@ -1,7 +1,13 @@
+from unittest.mock import patch
+
 import pytest
 from typer.testing import CliRunner
 
-from infrahub.git_credential.helper import app, parse_helper_get_input
+# This patch prevents `OSError: pytest: reading from stdin while output is captured!  Consider using `-s`.`
+# to be raised at import time. Patching is not an issue as `sys.stdin` is not used
+# as runner.invoke also patches `sys.stdin`.
+with patch("sys.stdin"):
+    from infrahub.git_credential.helper import app, parse_helper_get_input
 
 runner = CliRunner(mix_stderr=False)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,7 +187,7 @@ filterwarnings = [
     "ignore:Deprecated call to",
     "ignore:pkg_resources is deprecated as an API",          # Remove on https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2181 has been fixed
 ]
-addopts = "-vs --cov-report term-missing --cov-report xml --dist loadscope --junitxml=pytest-junit.xml"
+addopts = "-v --cov-report term-missing --cov-report xml --dist loadscope --junitxml=pytest-junit.xml"
 junit_duration_report = "call"
 
 [tool.pytest_env]


### PR DESCRIPTION
Current local testing log level is too low and we are missing some errors. In particular, prefect worker errors are not showing up locally when they happen. I also plan to do another PR in order to log graphql queries/mutations errors, so we have full stacktrace instead of only error message.