### PR TITLE
Migrate RequestProposedChangeRunTests to Prefect

### DIFF
--- a/backend/infrahub/message_bus/messages/__init__.py
+++ b/backend/infrahub/message_bus/messages/__init__.py
@@ -16,7 +16,6 @@ from .finalize_validator_execution import FinalizeValidatorExecution
 from .git_file_get import GitFileGet, GitFileGetResponse
 from .git_repository_connectivity import GitRepositoryConnectivity
 from .proposed_change.request_proposedchange_refreshartifacts import RequestProposedChangeRefreshArtifacts
-from .proposed_change.request_proposedchange_runtests import RequestProposedChangeRunTests
 from .refresh_git_fetch import RefreshGitFetch
 from .refresh_registry_branches import RefreshRegistryBranches
 from .refresh_registry_rebasedbranch import RefreshRegistryRebasedBranch
@@ -57,7 +56,6 @@ MESSAGE_MAP: dict[str, type[InfrahubMessage]] = {
     "request.generator_definition.check": RequestGeneratorDefinitionCheck,
     "request.proposed_change.pipeline": RequestProposedChangePipeline,
     "request.proposed_change.refresh_artifacts": RequestProposedChangeRefreshArtifacts,
-    "request.proposed_change.run_tests": RequestProposedChangeRunTests,
     "request.repository.checks": RequestRepositoryChecks,
     "request.repository.user_checks": RequestRepositoryUserChecks,
     "send.echo.request": SendEchoRequest,

--- a/backend/infrahub/message_bus/messages/proposed_change/request_proposedchange_runtests.py
+++ b/backend/infrahub/message_bus/messages/proposed_change/request_proposedchange_runtests.py
@@ -1,5 +1,0 @@
-from .base_with_diff import BaseProposedChangeWithDiffMessage
-
-
-class RequestProposedChangeRunTests(BaseProposedChangeWithDiffMessage):
-    """Sent trigger to run tests (smoke, units, integrations) for a proposed change."""

--- a/backend/infrahub/message_bus/operations/__init__.py
+++ b/backend/infrahub/message_bus/operations/__init__.py
@@ -42,7 +42,6 @@ COMMAND_MAP = {
     "request.artifact_definition.check": requests.artifact_definition.check,
     "request.proposed_change.pipeline": requests.proposed_change.pipeline,
     "request.proposed_change.refresh_artifacts": requests.proposed_change.refresh_artifacts,
-    "request.proposed_change.run_tests": requests.proposed_change.run_tests,
     "request.repository.checks": requests.repository.checks,
     "request.repository.user_checks": requests.repository.user_checks,
     "send.echo.request": send.echo.request,

--- a/backend/infrahub/message_bus/operations/requests/proposed_change.py
+++ b/backend/infrahub/message_bus/operations/requests/proposed_change.py
@@ -1,22 +1,16 @@
 from __future__ import annotations
 
-import asyncio
-import os
-import sys
 from enum import IntFlag
-from pathlib import Path
-from typing import TYPE_CHECKING, Union
 
-import pytest
 from prefect import flow
 from pydantic import BaseModel
 
-from infrahub import config, lock
+from infrahub import lock
 from infrahub.core.constants import CheckType, InfrahubKind, RepositoryInternalStatus
 from infrahub.core.diff.coordinator import DiffCoordinator
 from infrahub.core.registry import registry
 from infrahub.dependencies.registry import get_component_registry
-from infrahub.git.repository import InfrahubRepository, get_initialized_repo
+from infrahub.git.repository import InfrahubRepository
 from infrahub.log import get_logger
 from infrahub.message_bus import InfrahubMessage, messages
 from infrahub.message_bus.types import (
@@ -30,19 +24,16 @@ from infrahub.proposed_change.models import (
     RequestProposedChangeRepositoryChecks,
     RequestProposedChangeRunGenerators,
     RequestProposedChangeSchemaIntegrity,
+    RequestProposedChangeUserTests,
 )
-from infrahub.pytest_plugin import InfrahubBackendPlugin
 from infrahub.services import InfrahubServices  # noqa: TCH001
 from infrahub.workflows.catalogue import (
     REQUEST_PROPOSED_CHANGE_DATA_INTEGRITY,
     REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS,
     REQUEST_PROPOSED_CHANGE_RUN_GENERATORS,
     REQUEST_PROPOSED_CHANGE_SCHEMA_INTEGRITY,
+    REQUEST_PROPOSED_CHANGE_USER_TESTS,
 )
-
-if TYPE_CHECKING:
-    from infrahub_sdk.node import InfrahubNode
-
 
 log = get_logger()
 
@@ -175,14 +166,17 @@ async def pipeline(message: messages.RequestProposedChangePipeline, service: Inf
         )
 
     if message.check_type in [CheckType.ALL, CheckType.TEST]:
-        events.append(
-            messages.RequestProposedChangeRunTests(
-                proposed_change=message.proposed_change,
-                source_branch=message.source_branch,
-                source_branch_sync_with_git=message.source_branch_sync_with_git,
-                destination_branch=message.destination_branch,
-                branch_diff=branch_diff,
-            )
+        await service.workflow.submit_workflow(
+            workflow=REQUEST_PROPOSED_CHANGE_USER_TESTS,
+            parameters={
+                "model": RequestProposedChangeUserTests(
+                    proposed_change=message.proposed_change,
+                    source_branch=message.source_branch,
+                    source_branch_sync_with_git=message.source_branch_sync_with_git,
+                    destination_branch=message.destination_branch,
+                    branch_diff=branch_diff,
+                )
+            },
         )
 
     for event in events:
@@ -317,73 +311,6 @@ query GatherGraphQLQuerySubscribers($members: [ID!]) {
   }
 }
 """
-
-
-@flow(
-    name="proposed-changed-run-tests",
-    flow_run_name="Running_repository_tests on proposed change {message.proposed_change}",
-)
-async def run_tests(message: messages.RequestProposedChangeRunTests, service: InfrahubServices) -> None:
-    proposed_change = await service.client.get(kind=InfrahubKind.PROPOSEDCHANGE, id=message.proposed_change)
-
-    def _execute(
-        directory: Path, repository: ProposedChangeRepository, proposed_change: InfrahubNode
-    ) -> Union[int, pytest.ExitCode]:
-        config_file = str(directory / ".infrahub.yml")
-        test_directory = directory / "tests"
-
-        if not test_directory.is_dir():
-            log.debug(
-                event="repository_tests_ignored",
-                proposed_change=proposed_change,
-                repository=repository.repository_name,
-                message="tests directory not found",
-            )
-            return 1
-
-        # Redirect stdout/stderr to avoid showing pytest lines in the git agent
-        old_out = sys.stdout
-        old_err = sys.stderr
-
-        with Path(os.devnull).open(mode="w", encoding="utf-8") as devnull:
-            sys.stdout = devnull
-            sys.stderr = devnull
-
-            exit_code = pytest.main(
-                [
-                    str(test_directory),
-                    f"--infrahub-repo-config={config_file}",
-                    f"--infrahub-address={config.SETTINGS.main.internal_address}",
-                    "-qqqq",
-                    "-s",
-                ],
-                plugins=[InfrahubBackendPlugin(service.client.config, repository.repository_id, proposed_change.id)],
-            )
-
-        # Restore stdout/stderr back to their orignal states
-        sys.stdout = old_out
-        sys.stderr = old_err
-
-        return exit_code
-
-    for repository in message.branch_diff.repositories:
-        if message.source_branch_sync_with_git:
-            repo = await get_initialized_repo(
-                repository_id=repository.repository_id,
-                name=repository.repository_name,
-                service=service,
-                repository_kind=repository.kind,
-            )
-            commit = repo.get_commit_value(proposed_change.source_branch.value)
-            worktree_directory = Path(repo.get_commit_worktree(commit=commit).directory)
-
-            return_code = await asyncio.to_thread(_execute, worktree_directory, repository, proposed_change)
-            log.info(
-                event="repository_tests_completed",
-                proposed_change=message.proposed_change,
-                repository=repository.repository_name,
-                return_code=return_code,
-            )
 
 
 DESTINATION_ALLREPOSITORIES = """

--- a/backend/infrahub/proposed_change/models.py
+++ b/backend/infrahub/proposed_change/models.py
@@ -22,3 +22,7 @@ class RequestProposedChangeRepositoryChecks(BaseProposedChangeWithDiffMessage):
 
 class RequestProposedChangeSchemaIntegrity(BaseProposedChangeWithDiffMessage):
     """Sent trigger schema integrity checks for a proposed change"""
+
+
+class RequestProposedChangeUserTests(BaseProposedChangeWithDiffMessage):
+    """Sent trigger to run tests (smoke, units, integrations) for a proposed change."""

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import asyncio
+import os
+import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 
+import pytest
 from infrahub_sdk.protocols import CoreProposedChange
 from prefect import flow, task
 from prefect.client.schemas.objects import (
@@ -10,6 +15,7 @@ from prefect.client.schemas.objects import (
 from prefect.logging import get_run_logger
 from prefect.states import Completed, Failed
 
+from infrahub import config
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.branch.tasks import merge_branch
@@ -24,6 +30,8 @@ from infrahub.core.validators.checker import schema_validators_checker
 from infrahub.core.validators.determiner import ConstraintValidatorDeterminer
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.generators.models import ProposedChangeGeneratorDefinition
+from infrahub.git.repository import get_initialized_repo
+from infrahub.log import get_logger
 from infrahub.message_bus import InfrahubMessage, messages
 from infrahub.message_bus.operations.requests.proposed_change import DefinitionSelect
 from infrahub.proposed_change.constants import ProposedChangeState
@@ -32,13 +40,18 @@ from infrahub.proposed_change.models import (
     RequestProposedChangeRepositoryChecks,
     RequestProposedChangeRunGenerators,
     RequestProposedChangeSchemaIntegrity,
+    RequestProposedChangeUserTests,
 )
+from infrahub.pytest_plugin import InfrahubBackendPlugin
 from infrahub.services import services
 from infrahub.workflows.catalogue import REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS
 
 if TYPE_CHECKING:
+    from infrahub_sdk.node import InfrahubNode
+
     from infrahub.core.models import SchemaUpdateConstraintInfo
     from infrahub.core.schema.schema_branch import SchemaBranch
+    from infrahub.message_bus.types import ProposedChangeRepository
 
 
 async def _proposed_change_transition_state(
@@ -386,3 +399,68 @@ async def repository_checks(model: RequestProposedChangeRepositoryChecks) -> Non
     for event in events:
         event.assign_meta(parent=model)
         await service.send(message=event)
+
+
+@flow(
+    name="proposed-changed-user-tests",
+    flow_run_name="Running_repository_tests on proposed change {model.proposed_change}",
+)
+async def run_proposed_change_user_tests(model: RequestProposedChangeUserTests) -> None:
+    service = services.service
+    log = get_run_logger()
+    proposed_change = await service.client.get(kind=InfrahubKind.PROPOSEDCHANGE, id=model.proposed_change)
+
+    def _execute(
+        directory: Path, repository: ProposedChangeRepository, proposed_change: InfrahubNode
+    ) -> int | pytest.ExitCode:
+        config_file = str(directory / ".infrahub.yml")
+        test_directory = directory / "tests"
+        log = get_logger()
+
+        if not test_directory.is_dir():
+            log.debug(
+                event="repository_tests_ignored",
+                proposed_change=proposed_change,
+                repository=repository.repository_name,
+                message="tests directory not found",
+            )
+            return 1
+
+        # Redirect stdout/stderr to avoid showing pytest lines in the git agent
+        old_out = sys.stdout
+        old_err = sys.stderr
+
+        with Path(os.devnull).open(mode="w", encoding="utf-8") as devnull:
+            sys.stdout = devnull
+            sys.stderr = devnull
+
+            exit_code = pytest.main(
+                [
+                    str(test_directory),
+                    f"--infrahub-repo-config={config_file}",
+                    f"--infrahub-address={config.SETTINGS.main.internal_address}",
+                    "-qqqq",
+                    "-s",
+                ],
+                plugins=[InfrahubBackendPlugin(service.client.config, repository.repository_id, proposed_change.id)],
+            )
+
+        # Restore stdout/stderr back to their orignal states
+        sys.stdout = old_out
+        sys.stderr = old_err
+
+        return exit_code
+
+    for repository in model.branch_diff.repositories:
+        if model.source_branch_sync_with_git:
+            repo = await get_initialized_repo(
+                repository_id=repository.repository_id,
+                name=repository.repository_name,
+                service=service,
+                repository_kind=repository.kind,
+            )
+            commit = repo.get_commit_value(proposed_change.source_branch.value)
+            worktree_directory = Path(repo.get_commit_worktree(commit=commit).directory)
+
+            return_code = await asyncio.to_thread(_execute, worktree_directory, repository, proposed_change)
+            log.info(msg=f"repository_tests_completed return_code={return_code}")

--- a/backend/infrahub/workflows/catalogue.py
+++ b/backend/infrahub/workflows/catalogue.py
@@ -289,6 +289,13 @@ REQUEST_PROPOSED_CHANGE_SCHEMA_INTEGRITY = WorkflowDefinition(
     function="run_proposed_change_schema_integrity_check",
 )
 
+REQUEST_PROPOSED_CHANGE_USER_TESTS = WorkflowDefinition(
+    name="proposed-changed-user-tests",
+    type=WorkflowType.INTERNAL,
+    module="infrahub.proposed_change.tasks",
+    function="run_proposed_change_user_tests",
+)
+
 AUTOMATION_SCHEMA_UPDATED = WorkflowDefinition(
     name="schema-updated-setup",
     type=WorkflowType.INTERNAL,
@@ -371,6 +378,7 @@ workflows = [
     REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS,
     REQUEST_PROPOSED_CHANGE_RUN_GENERATORS,
     REQUEST_PROPOSED_CHANGE_SCHEMA_INTEGRITY,
+    REQUEST_PROPOSED_CHANGE_USER_TESTS,
     SCHEMA_APPLY_MIGRATION,
     SCHEMA_VALIDATE_MIGRATION,
     TRANSFORM_JINJA2_RENDER,

--- a/backend/tests/integration/message_bus/operations/request/test_proposed_change.py
+++ b/backend/tests/integration/message_bus/operations/request/test_proposed_change.py
@@ -153,13 +153,11 @@ async def test_run_pipeline_validate_requested_jobs(
 
         assert sorted(bus_pre_data_changes.seen_routing_keys) == [
             "request.proposed_change.refresh_artifacts",
-            "request.proposed_change.run_tests",
             "request.repository.user_checks",
         ]
 
         assert sorted(bus_post_data_changes.seen_routing_keys) == [
             "request.proposed_change.refresh_artifacts",
-            "request.proposed_change.run_tests",
             "request.repository.user_checks",
             "schema.validator.path",
         ]

--- a/docs/docs/reference/message-bus-events.mdx
+++ b/docs/docs/reference/message-bus-events.mdx
@@ -554,24 +554,6 @@ For more detailed explanations on how to use these events within Infrahub, see t
 | **destination_branch** | The destination branch of the proposed change | string | None |
 | **branch_diff** | The calculated diff between the two branches | N/A | None |
 <!-- vale on -->
-<!-- vale off -->
-#### Event request.proposed_change.run_tests
-<!-- vale on -->
-
-**Description**: Sent trigger to run tests (smoke, units, integrations) for a proposed change.
-
-**Priority**: 3
-
-<!-- vale off -->
-| Key | Description | Type | Default Value |
-|-----|-------------|------|---------------|
-| **meta** | Meta properties for the message | N/A | None |
-| **proposed_change** | The unique ID of the Proposed Change | string | None |
-| **source_branch** | The source branch of the proposed change | string | None |
-| **source_branch_sync_with_git** | Indicates if the source branch should sync with git | boolean | None |
-| **destination_branch** | The destination branch of the proposed change | string | None |
-| **branch_diff** | The calculated diff between the two branches | N/A | None |
-<!-- vale on -->
 
 <!-- vale off -->
 ### Request Repository
@@ -1211,25 +1193,6 @@ For more detailed explanations on how to use these events within Infrahub, see t
 <!-- vale on -->
 
 **Description**: Sent trigger the refresh of artifacts that are impacted by the proposed change.
-
-**Priority**: 3
-
-
-<!-- vale off -->
-| Key | Description | Type | Default Value |
-|-----|-------------|------|---------------|
-| **meta** | Meta properties for the message | N/A | None |
-| **proposed_change** | The unique ID of the Proposed Change | string | None |
-| **source_branch** | The source branch of the proposed change | string | None |
-| **source_branch_sync_with_git** | Indicates if the source branch should sync with git | boolean | None |
-| **destination_branch** | The destination branch of the proposed change | string | None |
-| **branch_diff** | The calculated diff between the two branches | N/A | None |
-<!-- vale on -->
-<!-- vale off -->
-#### Event request.proposed_change.run_tests
-<!-- vale on -->
-
-**Description**: Sent trigger to run tests (smoke, units, integrations) for a proposed change.
 
 **Priority**: 3
 


### PR DESCRIPTION
I've migrated this code pretty much as is. I think we should revisit this again and change some things, such as adding a context manager around the hijacking of the sys.stdout and sys.stderr and also review how do actually do the testing. It would also be interesting to support purely synchronous tasks in the future so that we don't have to do this workaround in a thread.