### PR TITLE
Check perm the same way everywhere

### DIFF
--- a/backend/infrahub/api/artifact.py
+++ b/backend/infrahub/api/artifact.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 from infrahub.api.dependencies import BranchParams, get_branch_params, get_current_user, get_db
 from infrahub.core import registry
 from infrahub.core.account import ObjectPermission
-from infrahub.core.constants import InfrahubKind, PermissionAction
+from infrahub.core.constants import GLOBAL_BRANCH_NAME, InfrahubKind, PermissionAction
 from infrahub.core.protocols import CoreArtifactDefinition
 from infrahub.database import InfrahubDatabase  # noqa: TCH001
 from infrahub.exceptions import NodeNotFoundError, PermissionDeniedError
@@ -65,7 +65,7 @@ async def generate_artifact(
 ) -> None:
     permission_decision = (
         PermissionDecisionFlag.ALLOW_DEFAULT
-        if branch_params.branch.name == registry.default_branch
+        if branch_params.branch.name in (GLOBAL_BRANCH_NAME, registry.default_branch)
         else PermissionDecisionFlag.ALLOW_OTHER
     )
     for permission in [
@@ -74,9 +74,10 @@ async def generate_artifact(
     ]:
         has_permission = False
         for permission_backend in registry.permission_backends:
-            has_permission = await permission_backend.has_permission(
+            if has_permission := await permission_backend.has_permission(
                 db=db, account_session=account_session, permission=permission, branch=branch_params.branch
-            )
+            ):
+                break
         if not has_permission:
             raise PermissionDeniedError(f"You do not have the following permission: {permission}")
 

--- a/backend/infrahub/api/schema.py
+++ b/backend/infrahub/api/schema.py
@@ -262,7 +262,7 @@ async def load_schema(
             )
 
         if not has_branch_permission:
-            has_branch_permission = permission_backend.has_permission(
+            has_branch_permission = await permission_backend.has_permission(
                 db=db,
                 account_session=account_session,
                 permission=GlobalPermission(

--- a/backend/infrahub/api/schema.py
+++ b/backend/infrahub/api/schema.py
@@ -243,8 +243,9 @@ async def load_schema(
     branch: Branch = Depends(get_branch_dep),
     account_session: AccountSession = Depends(get_current_user),
 ) -> SchemaUpdate:
+    has_permission = False
     for permission_backend in registry.permission_backends:
-        if not await permission_backend.has_permission(
+        has_permission = await permission_backend.has_permission(
             db=db,
             account_session=account_session,
             permission=GlobalPermission(
@@ -256,19 +257,23 @@ async def load_schema(
                 ).value,
             ),
             branch=branch,
-        ):
-            raise PermissionDeniedError("You are not allowed to manage the schema")
+        )
+        if branch.name in (GLOBAL_BRANCH_NAME, registry.default_branch):
+            has_permission &= await permission_backend.has_permission(
+                db=db,
+                account_session=account_session,
+                permission=GlobalPermission(
+                    action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value,
+                    decision=PermissionDecision.ALLOW_DEFAULT.value,
+                ),
+                branch=branch,
+            )
 
-        if branch.name in (GLOBAL_BRANCH_NAME, registry.default_branch) and not await permission_backend.has_permission(
-            db=db,
-            account_session=account_session,
-            permission=GlobalPermission(
-                action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value,
-                decision=PermissionDecision.ALLOW_DEFAULT.value,
-            ),
-            branch=branch,
-        ):
-            raise PermissionDeniedError("You are not allowed to edit the schema in the default branch")
+        if has_permission:
+            break
+
+    if not has_permission:
+        raise PermissionDeniedError("You are not allowed to manage the schema")
 
     service: InfrahubServices = request.app.state.service
     log.info("schema_load_request", branch=branch.name)

--- a/backend/infrahub/api/schema.py
+++ b/backend/infrahub/api/schema.py
@@ -275,8 +275,10 @@ async def load_schema(
         if has_permission and has_branch_permission:
             break
 
-    if not has_permission or not has_branch_permission:
+    if not has_permission:
         raise PermissionDeniedError("You are not allowed to manage the schema")
+    if not has_branch_permission:
+        raise PermissionDeniedError("You are not allowed to edit the schema in the default branch")
 
     service: InfrahubServices = request.app.state.service
     log.info("schema_load_request", branch=branch.name)

--- a/backend/infrahub/api/schema.py
+++ b/backend/infrahub/api/schema.py
@@ -244,22 +244,25 @@ async def load_schema(
     account_session: AccountSession = Depends(get_current_user),
 ) -> SchemaUpdate:
     has_permission = False
+    has_branch_permission = branch.name not in (GLOBAL_BRANCH_NAME, registry.default_branch)
     for permission_backend in registry.permission_backends:
-        has_permission = await permission_backend.has_permission(
-            db=db,
-            account_session=account_session,
-            permission=GlobalPermission(
-                action=GlobalPermissions.MANAGE_SCHEMA.value,
-                decision=(
-                    PermissionDecision.ALLOW_DEFAULT
-                    if branch.name in (GLOBAL_BRANCH_NAME, registry.default_branch)
-                    else PermissionDecision.ALLOW_OTHER
-                ).value,
-            ),
-            branch=branch,
-        )
-        if branch.name in (GLOBAL_BRANCH_NAME, registry.default_branch):
-            has_permission &= await permission_backend.has_permission(
+        if not has_permission:
+            has_permission = await permission_backend.has_permission(
+                db=db,
+                account_session=account_session,
+                permission=GlobalPermission(
+                    action=GlobalPermissions.MANAGE_SCHEMA.value,
+                    decision=(
+                        PermissionDecision.ALLOW_DEFAULT
+                        if branch.name in (GLOBAL_BRANCH_NAME, registry.default_branch)
+                        else PermissionDecision.ALLOW_OTHER
+                    ).value,
+                ),
+                branch=branch,
+            )
+
+        if not has_branch_permission:
+            has_branch_permission = permission_backend.has_permission(
                 db=db,
                 account_session=account_session,
                 permission=GlobalPermission(
@@ -269,10 +272,10 @@ async def load_schema(
                 branch=branch,
             )
 
-        if has_permission:
+        if has_permission and has_branch_permission:
             break
 
-    if not has_permission:
+    if not has_permission or not has_branch_permission:
         raise PermissionDeniedError("You are not allowed to manage the schema")
 
     service: InfrahubServices = request.app.state.service

--- a/backend/infrahub/graphql/auth/query_permission_checker/default_branch_checker.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/default_branch_checker.py
@@ -37,12 +37,11 @@ class DefaultBranchPermissionChecker(GraphQLQueryPermissionCheckerInterface):
         query_parameters: GraphqlParams,
         branch: Branch,
     ) -> CheckerResolution:
-        can_edit_default_branch = False
+        has_permission = False
         for permission_backend in registry.permission_backends:
-            can_edit_default_branch = await permission_backend.has_permission(
+            if has_permission := await permission_backend.has_permission(
                 db=db, account_session=account_session, permission=self.permission_required, branch=branch
-            )
-            if can_edit_default_branch:
+            ):
                 break
 
         operates_on_default_branch = analyzed_query.branch is None or analyzed_query.branch.name in (
@@ -54,7 +53,7 @@ class DefaultBranchPermissionChecker(GraphQLQueryPermissionCheckerInterface):
         )
 
         if (
-            not can_edit_default_branch
+            not has_permission
             and operates_on_default_branch
             and analyzed_query.contains_mutation
             and not is_exempt_operation

--- a/backend/infrahub/graphql/auth/query_permission_checker/merge_operation_checker.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/merge_operation_checker.py
@@ -31,15 +31,14 @@ class MergeBranchPermissionChecker(GraphQLQueryPermissionCheckerInterface):
         branch: Branch,
     ) -> CheckerResolution:
         if "BranchMerge" in [operation.name for operation in analyzed_query.operations]:
-            can_merge_branch = False
+            has_permission = False
             for permission_backend in registry.permission_backends:
-                can_merge_branch = await permission_backend.has_permission(
+                if has_permission := await permission_backend.has_permission(
                     db=db, account_session=account_session, permission=self.permission_required, branch=branch
-                )
-                if can_merge_branch:
+                ):
                     break
 
-            if not can_merge_branch:
+            if not has_permission:
                 raise PermissionDeniedError("You are not allowed to merge a branch")
 
             return CheckerResolution.TERMINATE

--- a/backend/infrahub/graphql/auth/query_permission_checker/object_permission_checker.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/object_permission_checker.py
@@ -72,9 +72,10 @@ class ObjectPermissionChecker(GraphQLQueryPermissionCheckerInterface):
         for permission in permissions:
             has_permission = False
             for permission_backend in registry.permission_backends:
-                has_permission = await permission_backend.has_permission(
+                if has_permission := await permission_backend.has_permission(
                     db=db, account_session=account_session, permission=permission, branch=branch
-                )
+                ):
+                    break
             if not has_permission:
                 raise PermissionDeniedError(f"You do not have the following permission: {permission}")
 
@@ -168,11 +169,15 @@ class PermissionManagerPermissionChecker(GraphQLQueryPermissionCheckerInterface)
         if not is_permission_operation:
             return CheckerResolution.NEXT_CHECKER
 
+        has_permission = False
         for permission_backend in registry.permission_backends:
-            if not await permission_backend.has_permission(
+            if has_permission := await permission_backend.has_permission(
                 db=db, account_session=account_session, permission=self.permission_required, branch=branch
             ):
-                raise PermissionDeniedError("You do not have the permission to manage permissions")
+                break
+
+        if not has_permission:
+            raise PermissionDeniedError("You do not have the permission to manage permissions")
 
         return CheckerResolution.NEXT_CHECKER
 
@@ -213,10 +218,14 @@ class RepositoryManagerPermissionChecker(GraphQLQueryPermissionCheckerInterface)
         if not is_repository_operation or not analyzed_query.contains_mutation:
             return CheckerResolution.NEXT_CHECKER
 
+        has_permission = False
         for permission_backend in registry.permission_backends:
-            if not await permission_backend.has_permission(
+            if has_permission := await permission_backend.has_permission(
                 db=db, account_session=account_session, permission=self.permission_required, branch=branch
             ):
-                raise PermissionDeniedError("You do not have the permission to manage repositories")
+                break
+
+        if not has_permission:
+            raise PermissionDeniedError("You do not have the permission to manage repositories")
 
         return CheckerResolution.NEXT_CHECKER

--- a/changelog/+perm-check.fixed.md
+++ b/changelog/+perm-check.fixed.md
@@ -1,0 +1,1 @@
+Fix permission check when using multiple backends, if one grants a permission the next ones must not be queried.


### PR DESCRIPTION
When permissions are checked for a given action, as soon as a backend tells that the permission is granted, other backends do not need to be queried.