### PR TITLE
update branch validate to use new diff

### DIFF
--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -10,10 +10,10 @@ from prefect.states import Completed, Failed
 from infrahub import lock
 from infrahub.core import registry
 from infrahub.core.branch import Branch
-from infrahub.core.diff.branch_differ import BranchDiffer
 from infrahub.core.diff.coordinator import DiffCoordinator
 from infrahub.core.diff.ipam_diff_parser import IpamDiffParser
 from infrahub.core.diff.merger.merger import DiffMerger
+from infrahub.core.diff.model.path import BranchTrackingId
 from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.merge import BranchMerger
 from infrahub.core.migrations.schema.models import SchemaApplyMigrationData
@@ -242,18 +242,17 @@ async def delete_branch(branch: str) -> None:
 )
 async def validate_branch(branch: str) -> State:
     service = services.service
-    log = get_run_logger()
     await add_branch_tag(branch_name=branch)
 
     obj = await Branch.get_by_name(db=service.database, name=branch)
 
-    diff = await BranchDiffer.init(db=service.database, branch=obj)
-    conflicts = await diff.get_conflicts()
+    component_registry = get_component_registry()
+    diff_repo = await component_registry.get_component(DiffRepository, db=service.database, branch=obj)
+    has_conflicts = await diff_repo.diff_has_conflicts(
+        diff_branch_name=obj.name, tracking_id=BranchTrackingId(name=obj.name)
+    )
 
-    for conflict in conflicts:
-        log.error(conflict)
-
-    if conflicts:
+    if has_conflicts:
         return Failed(message="branch has some conflicts")
     return Completed(message="branch is valid")
 

--- a/backend/infrahub/core/diff/query/has_conflicts_query.py
+++ b/backend/infrahub/core/diff/query/has_conflicts_query.py
@@ -1,0 +1,66 @@
+from typing import Any
+
+from infrahub.core.query import Query, QueryType
+from infrahub.database import InfrahubDatabase
+
+from ..model.path import BranchTrackingId
+
+
+class EnrichedDiffHasConflictQuery(Query):
+    name = "enriched_diff_has_conflicts"
+    type = QueryType.READ
+    insert_return = False
+
+    def __init__(
+        self,
+        diff_branch_name: str,
+        tracking_id: BranchTrackingId | None = None,
+        diff_id: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        if (diff_id is None and tracking_id is None) or (diff_id and tracking_id):
+            raise ValueError("EnrichedDiffHasConflictQuery requires one and only one of `tracking_id` or `diff_id`")
+        self.diff_branch_name = diff_branch_name
+        self.tracking_id = tracking_id
+        self.diff_id = diff_id
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:
+        self.params = {
+            "diff_branch_name": self.diff_branch_name,
+            "tracking_id": self.tracking_id.serialize() if self.tracking_id else None,
+            "diff_id": self.diff_id,
+        }
+        query = """
+MATCH (diff_root:DiffRoot)
+WHERE ($diff_id IS NOT NULL AND diff_root.uuid = $diff_id)
+OR ($tracking_id IS NOT NULL AND diff_root.tracking_id = $tracking_id AND diff_root.diff_branch = $diff_branch_name)
+WITH (
+    exists(
+        (diff_root)-[:DIFF_HAS_NODE]->(:DiffNode)-[:DIFF_HAS_CONFLICT]->(:DiffConflict)
+    ) OR exists(
+        (diff_root)-[:DIFF_HAS_NODE]->(:DiffNode)
+        -[:DIFF_HAS_ATTRIBUTE]->(:DiffAttribute)
+        -[:DIFF_HAS_PROPERTY]->(:DiffProperty)
+        -[:DIFF_HAS_CONFLICT]->(:DiffConflict)
+    ) OR exists(
+        (diff_root)-[:DIFF_HAS_NODE]->(:DiffNode)
+        -[:DIFF_HAS_RELATIONSHIP]->(:DiffRelationship)
+        -[:DIFF_HAS_ELEMENT]->(:DiffRelationshipElement)
+        -[:DIFF_HAS_CONFLICT]->(:DiffConflict)
+    ) OR exists(
+        (diff_root)-[:DIFF_HAS_NODE]->(:DiffNode)
+        -[:DIFF_HAS_RELATIONSHIP]->(:DiffRelationship)
+        -[:DIFF_HAS_ELEMENT]->(:DiffRelationshipElement)
+        -[:DIFF_HAS_PROPERTY]->(:DiffProperty)
+        -[:DIFF_HAS_CONFLICT]->(:DiffConflict)
+    )
+) AS has_conflict
+RETURN has_conflict
+        """
+        self.return_labels = ["has_conflict"]
+        self.add_to_query(query=query)
+
+    async def has_conflict(self) -> bool:
+        result = self.get_result()
+        return bool(result and result.get("has_conflict"))

--- a/backend/infrahub/core/diff/repository/repository.py
+++ b/backend/infrahub/core/diff/repository/repository.py
@@ -23,6 +23,7 @@ from ..query.diff_summary import DiffSummaryCounters, DiffSummaryQuery
 from ..query.empty_roots import EnrichedDiffEmptyRootsQuery
 from ..query.filters import EnrichedDiffQueryFilters
 from ..query.get_conflict_query import EnrichedDiffConflictQuery
+from ..query.has_conflicts_query import EnrichedDiffHasConflictQuery
 from ..query.save import EnrichedDiffRootsCreateQuery, EnrichedNodeBatchCreateQuery, EnrichedNodesLinkQuery
 from ..query.time_range_query import EnrichedDiffTimeRangeQuery
 from ..query.update_conflict_query import EnrichedDiffConflictUpdateQuery

--- a/backend/infrahub/core/diff/repository/repository.py
+++ b/backend/infrahub/core/diff/repository/repository.py
@@ -221,6 +221,18 @@ class DiffRepository:
             diff_roots.append(self.deserializer.build_diff_root(root_node=neo4j_node))
         return diff_roots
 
+    async def diff_has_conflicts(
+        self,
+        diff_branch_name: str,
+        tracking_id: TrackingId | None = None,
+        diff_id: str | None = None,
+    ) -> bool:
+        query = await EnrichedDiffHasConflictQuery.init(
+            db=self.db, diff_branch_name=diff_branch_name, tracking_id=tracking_id, diff_id=diff_id
+        )
+        await query.execute(db=self.db)
+        return await query.has_conflict()
+
     async def get_conflict_by_id(self, conflict_id: str) -> EnrichedDiffConflict:
         query = await EnrichedDiffConflictQuery.init(db=self.db, conflict_id=conflict_id)
         await query.execute(db=self.db)

--- a/backend/tests/functional/branch/test_graphql_mutation.py
+++ b/backend/tests/functional/branch/test_graphql_mutation.py
@@ -8,7 +8,9 @@ from infrahub_sdk.graphql import Mutation
 
 from infrahub.core import registry
 from infrahub.core.constants import InfrahubKind
+from infrahub.core.diff.coordinator import DiffCoordinator
 from infrahub.core.node import Node
+from infrahub.dependencies.registry import get_component_registry
 from infrahub.git.directory import get_repositories_directory
 from infrahub.services.adapters.cache.redis import RedisCache
 from tests.constants import TestKind
@@ -189,6 +191,7 @@ class TestBranchMutations(TestInfrahubApp):
         self, db: InfrahubDatabase, default_branch: Branch, initial_dataset: str, client: InfrahubClient
     ) -> None:
         branch = await client.branch.create(branch_name="branch_to_validate_failed")
+        branch_obj = await registry.get_branch(db=db, branch=branch.name)
 
         john_main = await registry.manager.query(
             db=db, schema=TestKind.PERSON, filters={"name__value": "John"}, branch=default_branch
@@ -204,6 +207,10 @@ class TestBranchMutations(TestInfrahubApp):
         await john_main[0].save(db=db)
         john_branch[0].description.value = "description in branch"
         await john_branch[0].save(db=db)
+
+        component_registry = get_component_registry()
+        diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch_obj)
+        await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch_obj)
 
         query = Mutation(
             mutation="BranchValidate",

--- a/backend/tests/unit/core/diff/test_diff_has_conflicts_query.py
+++ b/backend/tests/unit/core/diff/test_diff_has_conflicts_query.py
@@ -1,0 +1,151 @@
+import pytest
+
+from infrahub.core.diff.model.path import (
+    BranchTrackingId,
+    EnrichedDiffs,
+)
+from infrahub.core.diff.repository.deserializer import EnrichedDiffDeserializer
+from infrahub.core.diff.repository.repository import DiffRepository
+from infrahub.database import InfrahubDatabase
+
+from .factories import (
+    EnrichedAttributeFactory,
+    EnrichedConflictFactory,
+    EnrichedNodeFactory,
+    EnrichedPropertyFactory,
+    EnrichedRelationshipElementFactory,
+    EnrichedRelationshipGroupFactory,
+    EnrichedRootFactory,
+)
+
+
+class TestDiffHasConflictsCheck:
+    @pytest.fixture
+    def diff_repository(self, db: InfrahubDatabase) -> DiffRepository:
+        return DiffRepository(db=db, deserializer=EnrichedDiffDeserializer())
+
+    def _get_enriched_diffs(self) -> EnrichedDiffs:
+        branch_diff_root = EnrichedRootFactory.build(
+            base_branch_name="main", nodes={EnrichedNodeFactory.build() for _ in range(3)}
+        )
+        tracking_id = BranchTrackingId(name=branch_diff_root.diff_branch_name)
+        branch_diff_root.tracking_id = tracking_id
+        base_diff_root = EnrichedRootFactory.build(
+            base_branch_name="main",
+            diff_branch_name="main",
+            partner_uuid=branch_diff_root.partner_uuid,
+            tracking_id=tracking_id,
+        )
+        return EnrichedDiffs(
+            base_branch_name="main",
+            diff_branch_name=branch_diff_root.diff_branch_name,
+            diff_branch_diff=branch_diff_root,
+            base_branch_diff=base_diff_root,
+        )
+
+    async def test_query_initialization_failure(self, diff_repository: DiffRepository):
+        with pytest.raises(ValueError, match=r"requires one and only one of `tracking_id` or `diff_id`"):
+            await diff_repository.diff_has_conflicts(diff_branch_name="a")
+
+        with pytest.raises(ValueError, match=r"requires one and only one of `tracking_id` or `diff_id`"):
+            await diff_repository.diff_has_conflicts(
+                diff_branch_name="a", tracking_id=BranchTrackingId(name="abc"), diff_id="123"
+            )
+
+    async def test_has_conflicts_false(self, diff_repository: DiffRepository):
+        enriched_diffs = self._get_enriched_diffs()
+        await diff_repository.save(enriched_diffs=enriched_diffs)
+
+        has_conflicts = await diff_repository.diff_has_conflicts(
+            diff_branch_name=enriched_diffs.diff_branch_name,
+            tracking_id=BranchTrackingId(name=enriched_diffs.diff_branch_name),
+        )
+        assert has_conflicts is False
+
+    async def test_has_conflicts_true_node(self, diff_repository: DiffRepository):
+        enriched_diffs = self._get_enriched_diffs()
+        node = enriched_diffs.diff_branch_diff.nodes.pop()
+        node.conflict = EnrichedConflictFactory.build()
+        enriched_diffs.diff_branch_diff.nodes.add(node)
+        await diff_repository.save(enriched_diffs=enriched_diffs)
+
+        has_conflicts = await diff_repository.diff_has_conflicts(
+            diff_branch_name=enriched_diffs.diff_branch_name,
+            tracking_id=BranchTrackingId(name=enriched_diffs.diff_branch_name),
+        )
+        assert has_conflicts is True
+
+        has_conflicts = await diff_repository.diff_has_conflicts(
+            diff_branch_name=enriched_diffs.diff_branch_name, diff_id=enriched_diffs.diff_branch_diff.uuid
+        )
+        assert has_conflicts is True
+
+    async def test_has_conflicts_true_attribute_property(self, diff_repository: DiffRepository):
+        enriched_diffs = self._get_enriched_diffs()
+        node = enriched_diffs.diff_branch_diff.nodes.pop()
+        node.attributes.add(
+            EnrichedAttributeFactory.build(
+                properties={EnrichedPropertyFactory.build(conflict=EnrichedConflictFactory.build())}
+            )
+        )
+        enriched_diffs.diff_branch_diff.nodes.add(node)
+        await diff_repository.save(enriched_diffs=enriched_diffs)
+
+        has_conflicts = await diff_repository.diff_has_conflicts(
+            diff_branch_name=enriched_diffs.diff_branch_name,
+            tracking_id=BranchTrackingId(name=enriched_diffs.diff_branch_name),
+        )
+        assert has_conflicts is True
+
+        has_conflicts = await diff_repository.diff_has_conflicts(
+            diff_branch_name=enriched_diffs.diff_branch_name, diff_id=enriched_diffs.diff_branch_diff.uuid
+        )
+        assert has_conflicts is True
+
+    async def test_has_conflicts_true_relationship(self, diff_repository: DiffRepository):
+        enriched_diffs = self._get_enriched_diffs()
+        node = enriched_diffs.diff_branch_diff.nodes.pop()
+        node.relationships.add(
+            EnrichedRelationshipGroupFactory.build(
+                relationships={EnrichedRelationshipElementFactory.build(conflict=EnrichedConflictFactory.build())}
+            )
+        )
+        enriched_diffs.diff_branch_diff.nodes.add(node)
+        await diff_repository.save(enriched_diffs=enriched_diffs)
+
+        has_conflicts = await diff_repository.diff_has_conflicts(
+            diff_branch_name=enriched_diffs.diff_branch_name,
+            tracking_id=BranchTrackingId(name=enriched_diffs.diff_branch_name),
+        )
+        assert has_conflicts is True
+
+        has_conflicts = await diff_repository.diff_has_conflicts(
+            diff_branch_name=enriched_diffs.diff_branch_name, diff_id=enriched_diffs.diff_branch_diff.uuid
+        )
+        assert has_conflicts is True
+
+    async def test_has_conflicts_true_relationship_property(self, diff_repository: DiffRepository):
+        enriched_diffs = self._get_enriched_diffs()
+        node = enriched_diffs.diff_branch_diff.nodes.pop()
+        node.relationships.add(
+            EnrichedRelationshipGroupFactory.build(
+                relationships={
+                    EnrichedRelationshipElementFactory.build(
+                        properties={EnrichedPropertyFactory.build(conflict=EnrichedConflictFactory.build())}
+                    )
+                }
+            )
+        )
+        enriched_diffs.diff_branch_diff.nodes.add(node)
+        await diff_repository.save(enriched_diffs=enriched_diffs)
+
+        has_conflicts = await diff_repository.diff_has_conflicts(
+            diff_branch_name=enriched_diffs.diff_branch_name,
+            tracking_id=BranchTrackingId(name=enriched_diffs.diff_branch_name),
+        )
+        assert has_conflicts is True
+
+        has_conflicts = await diff_repository.diff_has_conflicts(
+            diff_branch_name=enriched_diffs.diff_branch_name, diff_id=enriched_diffs.diff_branch_diff.uuid
+        )
+        assert has_conflicts is True


### PR DESCRIPTION
the branch_validate function/workflow was using the old `BranchDiffer` class instead of the new diff

adds a new cypher query and `DiffRepository` method to allow checking if a given diff includes conflicts as quickly as possible