### PR TITLE
Format to max two decimals

### DIFF
--- a/backend/infrahub/workflows/utils.py
+++ b/backend/infrahub/workflows/utils.py
@@ -57,7 +57,7 @@ async def wait_for_schema_to_converge(
 
         if iteration >= max_iterations:
             log.warning(
-                f"Schema had not converged after {delay * iteration} seconds, refreshing schema on local worker manually"
+                f"Schema had not converged after {delay * iteration:.2f} seconds, refreshing schema on local worker manually"
             )
             async with service.database.start_session() as db:
                 await refresh_branches(db=db)


### PR DESCRIPTION
This is to get rid of log entries that look like this:

```python
2024-11-21T13:27:00.044732Z [info     ] Schema converged after 0.6000000000000001 seconds [prefect.flow_runs]
```
So that we instead get

```python
2024-11-21T13:27:00.044732Z [info     ] Schema converged after 0.60 seconds [prefect.flow_runs]
```
