### PR TITLE
Ensure to only save the computed attribute on mutation

### DIFF
--- a/backend/infrahub/graphql/mutations/computed_attribute.py
+++ b/backend/infrahub/graphql/mutations/computed_attribute.py
@@ -92,7 +92,7 @@ class UpdateComputedAttribute(Mutation):
             )
         if attribute_field.value != str(data.value):
             attribute_field.value = str(data.value)
-            await target_node.save(db=context.db)
+            await target_node.save(db=context.db, fields=[str(data.attribute)])
 
             log_data = get_log_data()
             request_id = log_data.get("request_id", "")


### PR DESCRIPTION
I thought that I'd added this code already as we did for the main mutation. I.e. the save code should only try to update the attribute that is relevant for this mutation and not try to save back the other attributes or relationships that wouldn't have been changed by this mutation.