### PR TITLE
re-enable PTH rules for ruff

### DIFF
--- a/backend/infrahub/api/internal.py
+++ b/backend/infrahub/api/internal.py
@@ -92,7 +92,7 @@ class SearchDocs:
                 self._heading_index = Index.load(heading_json["index"])
         except FileNotFoundError as exc:
             raise NodeNotFoundError(
-                identifier=config.SETTINGS.main.docs_index_path,
+                identifier=str(config.SETTINGS.main.docs_index_path),
                 message="documentation index not found",
                 node_type="file",
             ) from exc

--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -116,7 +116,7 @@ class WorkflowDriver(str, Enum):
 
 class MainSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="INFRAHUB_")
-    docs_index_path: str = Field(
+    docs_index_path: Path = Field(
         default="/opt/infrahub/docs/build/search-index.json",
         description="Full path of saved json containing pre-indexed documentation",
     )
@@ -138,7 +138,7 @@ class MainSettings(BaseSettings):
 class FileSystemStorageSettings(BaseSettings):
     # Make variable lookup case-sensitive to avoid fetching $PATH value
     model_config = SettingsConfigDict(case_sensitive=True)
-    path_: str = Field(
+    path_: Path = Field(
         default="/opt/infrahub/storage",
         alias="path",
         validation_alias=AliasChoices("INFRAHUB_STORAGE_LOCAL_PATH", "infrahub_storage_local_path", "path"),
@@ -678,22 +678,22 @@ class Override:
 class ConfiguredSettings:  # pylint: disable=too-many-public-methods
     settings: Optional[Settings] = None
 
-    def initialize(self, config_file: Optional[str] = None) -> None:
+    def initialize(self, config_file: Path | str | None = None) -> None:
         """Initialize the settings if they have not been initialized."""
         if self.initialized:
             return
         if not config_file:
-            config_file_name = os.environ.get("INFRAHUB_CONFIG", "infrahub.toml")
-            config_file = os.path.abspath(config_file_name)
+            config_file_name: str = os.environ.get("INFRAHUB_CONFIG", "infrahub.toml")
+            config_file = Path(config_file_name).resolve()
         self.settings = load(config_file)
 
-    def initialize_and_exit(self, config_file: Optional[str] = None) -> None:
+    def initialize_and_exit(self, config_file: Path | str | None = None) -> None:
         """Initialize the settings if they have not been initialized, exit on failures."""
         if self.initialized:
             return
         if not config_file:
             config_file_name = os.environ.get("INFRAHUB_CONFIG", "infrahub.toml")
-            config_file = os.path.abspath(config_file_name)
+            config_file = Path(config_file_name).resolve()
         load_and_exit(config_file)
 
     @property
@@ -797,7 +797,7 @@ class Settings(BaseSettings):
     experimental_features: ExperimentalFeaturesSettings = ExperimentalFeaturesSettings()
 
 
-def load(config_file_name: str = "infrahub.toml", config_data: Optional[dict[str, Any]] = None) -> Settings:
+def load(config_file_name: Path | str = "infrahub.toml", config_data: Optional[dict[str, Any]] = None) -> Settings:
     """Load configuration.
 
     Configuration is loaded from a config file in toml format that contains the settings,
@@ -807,8 +807,11 @@ def load(config_file_name: str = "infrahub.toml", config_data: Optional[dict[str
     if config_data:
         return Settings(**config_data)
 
-    if os.path.exists(config_file_name):
-        config_string = Path(config_file_name).read_text(encoding="utf-8")
+    if isinstance(config_file_name, str):
+        config_file_name = Path(config_file_name)
+
+    if config_file_name.exists():
+        config_string = config_file_name.read_text(encoding="utf-8")
         config_tmp = toml.loads(config_string)
 
         return Settings(**config_tmp)
@@ -816,7 +819,7 @@ def load(config_file_name: str = "infrahub.toml", config_data: Optional[dict[str
     return Settings()
 
 
-def load_and_exit(config_file_name: str = "infrahub.toml", config_data: Optional[dict[str, Any]] = None) -> None:
+def load_and_exit(config_file_name: Path | str = "infrahub.toml", config_data: Optional[dict[str, Any]] = None) -> None:
     """Calls load, but wraps it in a try except block.
 
     This is done to handle a ValidationError which is raised when settings are specified but invalid.

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import importlib
-import os
 import sys
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 import jinja2
@@ -412,7 +410,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):  # pylint: disable=t
         branch_wt = self.get_worktree(identifier=commit or branch_name)
 
         config_file_name = ".infrahub.yml"
-        config_file = Path(os.path.join(branch_wt.directory, config_file_name))
+        config_file = branch_wt.directory / config_file_name
         if not config_file.is_file():
             log.debug(
                 f"Unable to find the configuration file {config_file_name}, skipping",

--- a/backend/infrahub/serve/worker.py
+++ b/backend/infrahub/serve/worker.py
@@ -1,6 +1,7 @@
 """Create a Uvicorn worker without the predefined loggers."""
 
 import os
+from pathlib import Path
 from typing import Any
 
 from uvicorn.workers import UvicornWorker
@@ -36,4 +37,4 @@ class InfrahubUvicorn(UvicornWorker):
         self.config.configure_logging()
         if "PROMETHEUS_MULTIPROC_DIR" in os.environ:
             for file in os.scandir(os.environ["PROMETHEUS_MULTIPROC_DIR"]):
-                os.unlink(file.path)
+                Path(file.path).unlink()

--- a/backend/infrahub/server.py
+++ b/backend/infrahub/server.py
@@ -123,11 +123,11 @@ def server_request_hook(span: Span, scope: dict) -> None:  # pylint: disable=unu
 
 FastAPIInstrumentor().instrument_app(app, excluded_urls=".*/metrics", server_request_hook=server_request_hook)
 
-FRONTEND_DIRECTORY = os.environ.get("INFRAHUB_FRONTEND_DIRECTORY", os.path.abspath("frontend/app"))
+FRONTEND_DIRECTORY = os.environ.get("INFRAHUB_FRONTEND_DIRECTORY", Path("frontend/app").resolve())
 FRONTEND_ASSET_DIRECTORY = f"{FRONTEND_DIRECTORY}/dist/assets"
 FRONTEND_FAVICONS_DIRECTORY = f"{FRONTEND_DIRECTORY}/dist/favicons"
 
-DOCS_DIRECTORY = os.environ.get("INFRAHUB_DOCS_DIRECTORY", os.path.abspath("docs"))
+DOCS_DIRECTORY = os.environ.get("INFRAHUB_DOCS_DIRECTORY", Path("docs").resolve())
 DOCS_BUILD_DIRECTORY = f"{DOCS_DIRECTORY}/build"
 
 log = get_logger()
@@ -197,15 +197,15 @@ app.include_router(graphql_router)
 
 app.mount("/api-static", StaticFiles(directory=f"{CURRENT_DIRECTORY}/api/static"), name="static")
 
-if os.path.exists(FRONTEND_ASSET_DIRECTORY) and os.path.isdir(FRONTEND_ASSET_DIRECTORY):
+if Path(FRONTEND_ASSET_DIRECTORY).exists() and Path(FRONTEND_ASSET_DIRECTORY).is_dir():
     app.mount("/assets", StaticFiles(directory=FRONTEND_ASSET_DIRECTORY), "assets")
 
 
-if os.path.exists(FRONTEND_FAVICONS_DIRECTORY) and os.path.isdir(FRONTEND_FAVICONS_DIRECTORY):
+if Path(FRONTEND_FAVICONS_DIRECTORY).exists() and Path(FRONTEND_FAVICONS_DIRECTORY).is_dir():
     app.mount("/favicons", StaticFiles(directory=FRONTEND_FAVICONS_DIRECTORY), "favicons")
 
 
-if os.path.exists(DOCS_BUILD_DIRECTORY) and os.path.isdir(DOCS_BUILD_DIRECTORY):
+if Path(DOCS_BUILD_DIRECTORY).exists() and Path(DOCS_BUILD_DIRECTORY).is_dir():
     app.mount("/docs", StaticFiles(directory=DOCS_BUILD_DIRECTORY, html=True, check_dir=True), name="infrahub-docs")
 
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -157,7 +157,7 @@ def local_storage_dir(tmp_path: Path) -> Path:
     storage_dir.mkdir()
 
     config.SETTINGS.storage.driver = config.StorageDriver.FileSystemStorage
-    config.SETTINGS.storage.local.path_ = str(storage_dir)
+    config.SETTINGS.storage.local.path_ = storage_dir
 
     return storage_dir
 

--- a/backend/tests/helpers/file_repo.py
+++ b/backend/tests/helpers/file_repo.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -67,4 +66,4 @@ class FileRepo:
 
     @property
     def path(self) -> str:
-        return str(os.path.join(self.sources_directory, self.name))
+        return str(Path(self.sources_directory, self.name))

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 from typing import AsyncGenerator, Generator
 
 import pytest
@@ -33,10 +33,10 @@ from .test_client import InfrahubTestClient
 
 class TestInfrahub:
     @pytest.fixture(scope="class")
-    def local_storage_dir(self, tmpdir_factory: pytest.TempdirFactory) -> str:
-        storage_dir = os.path.join(str(tmpdir_factory.getbasetemp().strpath), "storage")
-        if not os.path.exists(storage_dir):
-            os.mkdir(storage_dir)
+    def local_storage_dir(self, tmpdir_factory: pytest.TempdirFactory) -> Path:
+        storage_dir = Path(tmpdir_factory.getbasetemp().strpath, "storage")
+        if not storage_dir.exists():
+            storage_dir.mkdir()
 
         config.SETTINGS.storage.driver = config.StorageDriver.FileSystemStorage
         config.SETTINGS.storage.local.path_ = storage_dir
@@ -44,7 +44,7 @@ class TestInfrahub:
         return storage_dir
 
     @pytest.fixture(scope="class")
-    async def default_branch(self, local_storage_dir: str, db: InfrahubDatabase) -> Branch:
+    async def default_branch(self, local_storage_dir: Path, db: InfrahubDatabase) -> Branch:
         registry.delete_all()
         await delete_all_nodes(db=db)
         await create_root_node(db=db)

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -50,9 +50,9 @@ async def load_infrastructure_schema(db: InfrahubDatabase):
     tmp_schema = branch_schema.duplicate()
 
     for file_name in os.listdir(base_dir):
-        file_path = os.path.join(base_dir, file_name)
+        file_path = Path(base_dir, file_name)
 
-        if file_path.endswith((".yml", ".yaml")):
+        if file_path.suffix in (".yml", ".yaml"):
             schema_txt = Path(file_path).read_text(encoding="utf-8")
             loaded_schema = yaml.safe_load(schema_txt)
             tmp_schema.load_schema(schema=SchemaRoot(**loaded_schema))

--- a/backend/tests/integration/git/test_git_repository.py
+++ b/backend/tests/integration/git/test_git_repository.py
@@ -35,12 +35,13 @@ async def load_infrastructure_schema(db: InfrahubDatabase):
     tmp_schema = branch_schema.duplicate()
 
     for file_name in os.listdir(base_dir):
-        file_path = os.path.join(base_dir, file_name)
+        file_path = base_dir / file_name
+        if file_path.suffix not in (".yml", ".yaml"):
+            continue
+        schema_txt = file_path.read_text(encoding="utf-8")
+        loaded_schema = yaml.safe_load(schema_txt)
+        tmp_schema.load_schema(schema=SchemaRoot(**loaded_schema))
 
-        if file_path.endswith((".yml", ".yaml")):
-            schema_txt = Path(file_path).read_text(encoding="utf-8")
-            loaded_schema = yaml.safe_load(schema_txt)
-            tmp_schema.load_schema(schema=SchemaRoot(**loaded_schema))
     tmp_schema.process()
 
     await registry.schema.update_schema_branch(schema=tmp_schema, db=db, branch=default_branch_name, update_db=True)

--- a/backend/tests/unit/api/test_60_storage.py
+++ b/backend/tests/unit/api/test_60_storage.py
@@ -16,9 +16,7 @@ async def test_file_upload(
     default_branch: Branch,
     authentication_base,
 ):
-    fixture_dir = helper.get_fixtures_dir()
-
-    files_dir = fixture_dir / "schemas"
+    files_dir = helper.get_fixtures_dir() / "schemas"
     filenames = [item.name for item in files_dir.iterdir() if item.is_file()]
     file_path = files_dir / filenames[0]
 
@@ -47,8 +45,7 @@ async def test_content_upload(
     default_branch: Branch,
     authentication_base,
 ):
-    fixture_dir = helper.get_fixtures_dir()
-    files_dir = fixture_dir / "schemas"
+    files_dir = helper.get_fixtures_dir() / "schemas"
     filenames = [item.name for item in files_dir.iterdir() if item.is_file()]
 
     file_content = (files_dir / filenames[0]).read_bytes()

--- a/backend/tests/unit/api/test_internal.py
+++ b/backend/tests/unit/api/test_internal.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import pytest
 
@@ -11,7 +11,7 @@ from tests.helpers.fixtures import get_fixtures_dir
 def override_search_index_path():
     old_search_index_path = config.SETTINGS.main.docs_index_path
     old_search_docs_loader = internal.search_docs_loader
-    config.SETTINGS.main.docs_index_path = os.path.join(get_fixtures_dir(), "docs/search-index.json")
+    config.SETTINGS.main.docs_index_path = Path(get_fixtures_dir(), "docs/search-index.json")
     internal.search_docs_loader = internal.SearchDocs()
     yield
     config.SETTINGS.main.docs_index_path = old_search_index_path
@@ -22,7 +22,7 @@ def override_search_index_path():
 def no_search_index_path():
     old_search_index_path = config.SETTINGS.main.docs_index_path
     old_search_docs_loader = internal.search_docs_loader
-    config.SETTINGS.main.docs_index_path = os.path.join(get_fixtures_dir(), "docs/no-index.json")
+    config.SETTINGS.main.docs_index_path = Path(get_fixtures_dir(), "docs/no-index.json")
     internal.search_docs_loader = internal.SearchDocs()
     yield
     config.SETTINGS.main.docs_index_path = old_search_index_path

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -135,10 +135,9 @@ def s3_storage_bucket() -> str:
 
 @pytest.fixture
 def file1_in_storage(local_storage_dir: Path, helper) -> str:
-    fixture_dir = helper.get_fixtures_dir()
     file1_identifier = str(UUIDT())
 
-    files_dir = fixture_dir / "schemas"
+    files_dir = helper.get_fixtures_dir() / "schemas"
 
     filenames = [item.name for item in files_dir.iterdir() if item.is_file()]
     shutil.copyfile(files_dir / filenames[0], local_storage_dir / file1_identifier)

--- a/backend/tests/unit/git/conftest.py
+++ b/backend/tests/unit/git/conftest.py
@@ -1,4 +1,3 @@
-import os
 import re
 import shutil
 import tarfile
@@ -119,10 +118,9 @@ def git_upstream_repo_10(helper: TestHelper, git_sources_dir: Path) -> dict[str,
     """Git Repository used as part of the  demo-edge tutorial."""
 
     name = "infrahub-demo-edge"
-    fixtures_dir = helper.get_fixtures_dir()
 
     # Extract the fixture package in the source directory
-    with tarfile.open(fixtures_dir / "infrahub-demo-edge-cff6665.tar.gz") as file:
+    with tarfile.open(helper.get_fixtures_dir() / "infrahub-demo-edge-cff6665.tar.gz") as file:
         file.extractall(git_sources_dir)
 
     return {"name": name, "path": git_sources_dir / name}
@@ -660,9 +658,8 @@ async def gql_query_data_02() -> dict:
 
 @pytest.fixture
 async def mock_schema_query_01(helper, httpx_mock: HTTPXMock) -> HTTPXMock:
-    response_text = Path(os.path.join(helper.get_fixtures_dir(), "schemas", "schema_01.json")).read_text(
-        encoding="UTF-8"
-    )
+    schema_file: Path = helper.get_fixtures_dir() / "schemas" / "schema_01.json"
+    response_text = schema_file.read_text(encoding="UTF-8")
 
     httpx_mock.add_response(
         method="GET", url=re.compile(r"^http://mock/api/schema\?branch=(main|cr1234)"), json=ujson.loads(response_text)
@@ -672,9 +669,8 @@ async def mock_schema_query_01(helper, httpx_mock: HTTPXMock) -> HTTPXMock:
 
 @pytest.fixture
 async def mock_schema_query_02(helper, httpx_mock: HTTPXMock) -> HTTPXMock:
-    response_text = Path(os.path.join(helper.get_fixtures_dir(), "schemas", "schema_02.json")).read_text(
-        encoding="UTF-8"
-    )
+    schema_file: Path = helper.get_fixtures_dir() / "schemas" / "schema_02.json"
+    response_text = schema_file.read_text(encoding="UTF-8")
 
     httpx_mock.add_response(method="GET", url="http://mock/api/schema?branch=main", json=ujson.loads(response_text))
     return httpx_mock
@@ -857,9 +853,7 @@ async def gql_query_data_03():
 
 @pytest.fixture
 async def schema_02(client, helper, car_data_01) -> ClientSchemaRoot:
-    full_schema = ujson.loads(
-        Path(os.path.join(helper.get_fixtures_dir(), "schemas", "schema_02.json")).read_text(encoding="UTF-8")
-    )
+    full_schema = ujson.loads(Path(helper.get_fixtures_dir(), "schemas", "schema_02.json").read_text(encoding="UTF-8"))
 
     return ClientSchemaRoot(**full_schema)
 

--- a/backend/tests/unit/git/test_git_repository.py
+++ b/backend/tests/unit/git/test_git_repository.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 import anyio
@@ -124,10 +123,10 @@ async def test_init_existing_repository(git_repo_01: InfrahubRepository):
 
     # Check if all the directories are present
     assert repo.has_origin is True
-    assert os.path.isdir(repo.directory_root)
-    assert os.path.isdir(repo.directory_branches)
-    assert os.path.isdir(repo.directory_commits)
-    assert os.path.isdir(repo.directory_temp)
+    assert repo.directory_root.is_dir()
+    assert repo.directory_branches.is_dir()
+    assert repo.directory_commits.is_dir()
+    assert repo.directory_temp.is_dir()
 
 
 async def test_get_git_repo_main(git_repo_01: InfrahubRepository):
@@ -731,11 +730,11 @@ async def test_calculate_diff_between_commits(
 
     # Add a file
     new_file = "mynewfile.txt"
-    Path(os.path.join(worktree.directory, new_file)).write_text("this is a new file\n", encoding="utf-8")
+    Path(worktree.directory, new_file).write_text("this is a new file\n", encoding="utf-8")
 
     # Remove a file
     file_to_remove = "pyproject.toml"
-    os.remove(os.path.join(worktree.directory, file_to_remove))
+    Path(worktree.directory, file_to_remove).unlink()
 
     git_repo.index.add([new_file])
     git_repo.index.remove([file_to_remove])
@@ -789,11 +788,11 @@ async def test_list_all_files(git_repo_01: InfrahubRepository, branch01: BranchD
 
     # Add a file
     new_file = "mynewfile.txt"
-    Path(os.path.join(worktree.directory, new_file)).write_text("this is a new file\n", encoding="utf-8")
+    Path(worktree.directory, new_file).write_text("this is a new file\n", encoding="utf-8")
 
     # Remove a file
     file_to_remove = "pyproject.toml"
-    os.remove(os.path.join(worktree.directory, file_to_remove))
+    Path(worktree.directory, file_to_remove).unlink()
 
     git_repo.index.add([new_file])
     git_repo.index.remove([file_to_remove])

--- a/backend/tests/unit/message_bus/operations/requests/test_graphql_query_group.py
+++ b/backend/tests/unit/message_bus/operations/requests/test_graphql_query_group.py
@@ -1,4 +1,3 @@
-import os
 import uuid
 from pathlib import Path
 from unittest.mock import patch
@@ -18,9 +17,7 @@ from tests.helpers.utils import init_global_service
 
 @pytest.fixture
 async def mock_schema_query_02(helper, httpx_mock: HTTPXMock) -> HTTPXMock:
-    response_text = Path(os.path.join(helper.get_fixtures_dir(), "schemas", "schema_02.json")).read_text(
-        encoding="UTF-8"
-    )
+    response_text = Path(helper.get_fixtures_dir(), "schemas", "schema_02.json").read_text(encoding="UTF-8")
 
     httpx_mock.add_response(method="GET", url="http://mock/api/schema?branch=main", json=ujson.loads(response_text))
     return httpx_mock

--- a/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
+++ b/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 import pytest
@@ -41,9 +40,7 @@ DST_BRANCH_A = "main"
 
 @pytest.fixture
 async def mock_schema_query_02(helper: TestHelper, httpx_mock: HTTPXMock) -> HTTPXMock:
-    response_text = Path(os.path.join(helper.get_fixtures_dir(), "schemas", "schema_02.json")).read_text(
-        encoding="UTF-8"
-    )
+    response_text = Path(helper.get_fixtures_dir(), "schemas", "schema_02.json").read_text(encoding="UTF-8")
 
     httpx_mock.add_response(method="GET", url="http://mock/api/schema?branch=main", json=ujson.loads(response_text))
     return httpx_mock

--- a/backend/tests/unit/storage/test_local_storage.py
+++ b/backend/tests/unit/storage/test_local_storage.py
@@ -13,7 +13,7 @@ from infrahub.storage import InfrahubObjectStorage
 async def test_init_local(helper, local_storage_dir: Path, file1_in_storage: str):
     storage = await InfrahubObjectStorage.init(settings=config.SETTINGS.storage)
     assert isinstance(storage._storage, fastapi_storages.FileSystemStorage)
-    assert config.SETTINGS.storage.local.path_ == str(local_storage_dir)
+    assert config.SETTINGS.storage.local.path_ == local_storage_dir
 
 
 async def test_init_s3(helper, s3_storage_bucket: str):
@@ -38,10 +38,10 @@ async def test_store_file(helper, local_storage_dir: Path):
     storage = await InfrahubObjectStorage.init(settings=config.SETTINGS.storage)
 
     fixture_dir = helper.get_fixtures_dir()
-    files_dir = os.path.join(fixture_dir, "schemas")
+    files_dir = Path(fixture_dir, "schemas")
     filenames = [item.name for item in os.scandir(files_dir) if item.is_file()]
 
-    content_file1 = Path(os.path.join(files_dir, filenames[0])).read_bytes()
+    content_file1 = Path(files_dir, filenames[0]).read_bytes()
     identifier = str(UUIDT())
     storage.store(identifier=identifier, content=content_file1)
 

--- a/backend/tests/unit/test_config.py
+++ b/backend/tests/unit/test_config.py
@@ -3,8 +3,7 @@ from tests.conftest import TestHelper
 
 
 def test_load_sso_config(helper: TestHelper) -> None:
-    fixture_dir = helper.get_fixtures_dir()
-    config_file = str(fixture_dir / "config_files" / "sso_config_methods.toml")
+    config_file = str(helper.get_fixtures_dir() / "config_files" / "sso_config_methods.toml")
 
     config = load(config_file_name=config_file)
     assert config.security.public_sso_config.enabled

--- a/backend/tests/unit/test_utils.py
+++ b/backend/tests/unit/test_utils.py
@@ -1,7 +1,7 @@
-import os
+from pathlib import Path
 
 from infrahub.utils import get_fixtures_dir
 
 
 def test_get_fixtures_dir():
-    assert os.path.exists(get_fixtures_dir())
+    assert Path.exists(get_fixtures_dir())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -492,16 +492,6 @@ ignore = [
     "PLR6201", # Use a `set` literal when testing for membership
     "PLR6301", # Method could be a function, class method, or static method
     "PLW0603", # Using the global statement to update `SETTINGS` is discouraged
-    "PTH100",  # `os.path.abspath()` should be replaced by `Path.resolve()`
-    "PTH102",  # `os.mkdir()` should be replaced by `Path.mkdir()`
-    "PTH107",  # `os.remove()` should be replaced by `Path.unlink()`
-    "PTH108",  # `os.unlink()` should be replaced by `Path.unlink()`
-    "PTH109",  # `os.getcwd()` should be replaced by `Path.cwd()`
-    "PTH110",  # `os.path.exists()` should be replaced by `Path.exists()`
-    "PTH112",  # `os.path.isdir()` should be replaced by `Path.is_dir()`
-    "PTH113",  # `os.path.isfile()` should be replaced by `Path.is_file()`
-    "PTH117",  # `os.path.isabs()` should be replaced by `Path.is_absolute()`
-    "PTH118",  # `os.path.join()` should be replaced by `Path` with `/` operator
     "RET503",  # Missing explicit `return` at the end of function able to return non-`None` value
     "RET504",  # Unnecessary assignment before `return` statement
     "RUF005",  # Consider `[*list(peers.values()), rfc5735]` instead of concatenation

--- a/tasks/docs.py
+++ b/tasks/docs.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from collections import defaultdict
 from pathlib import Path
@@ -210,7 +209,7 @@ def _generate_infrahub_schema_documentation() -> None:
         template_file = f"{DOCUMENTATION_DIRECTORY}/_templates/schema/{schema_name}.j2"
         output_file = f"{DOCUMENTATION_DIRECTORY}/docs/reference/schema/{schema_name}.mdx"
         output_label = f"docs/docs/reference/schema/{schema_name}.mdx"
-        if not os.path.exists(template_file):
+        if not Path(template_file).exists():
             print(f"Unable to find the template file at {template_file}")
             sys.exit(-1)
 
@@ -275,7 +274,7 @@ def _generate_infrahub_sdk_configuration_documentation() -> None:
     output_file = f"{DOCUMENTATION_DIRECTORY}/docs/python-sdk/reference/config.mdx"
     output_label = "docs/docs/python-sdk/reference/config.mdx"
 
-    if not os.path.exists(template_file):
+    if not Path(template_file).exists():
         print(f"Unable to find the template file at {template_file}")
         sys.exit(-1)
 
@@ -326,7 +325,7 @@ def _generate_infrahub_repository_configuration_documentation() -> None:
     template_file = f"{DOCUMENTATION_DIRECTORY}/_templates/dotinfrahub.j2"
     output_file = f"{DOCUMENTATION_DIRECTORY}/docs/reference/dotinfrahub.mdx"
     output_label = "docs/docs/reference/dotinfrahub.mdx"
-    if not os.path.exists(template_file):
+    if not Path(template_file).exists():
         print(f"Unable to find the template file at {template_file}")
         sys.exit(-1)
 
@@ -386,7 +385,7 @@ def _generate_infrahub_events_documentation() -> None:
 
     print(" - Generate Infrahub Bus Events documentation")
 
-    if not os.path.exists(template_file):
+    if not Path(template_file).exists():
         print(f"Unable to find the template file at {template_file}")
         sys.exit(-1)
 

--- a/tasks/sdk.py
+++ b/tasks/sdk.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 from typing import Optional
 
 from invoke import Context, task
@@ -12,7 +12,7 @@ from .utils import ESCAPED_REPO_PATH
 
 MAIN_DIRECTORY = "python_sdk"
 NAMESPACE = "SDK"
-MAIN_DIRECTORY_PATH = os.path.join(ESCAPED_REPO_PATH, MAIN_DIRECTORY)
+MAIN_DIRECTORY_PATH = Path(ESCAPED_REPO_PATH, MAIN_DIRECTORY)
 
 
 # ----------------------------------------------------------------------------

--- a/tasks/shared.py
+++ b/tasks/shared.py
@@ -45,7 +45,7 @@ TOP_DIRECTORY_NAME = here.parent.name
 BUILD_NAME = os.getenv("INFRAHUB_BUILD_NAME", re.sub(r"[^a-zA-Z0-9_/.]", "", str(TOP_DIRECTORY_NAME)))
 PYTHON_VER = os.getenv("PYTHON_VER", "3.12")
 
-PWD = os.getcwd()
+PWD = Path.cwd()
 
 NBR_WORKERS = int(os.getenv("PYTEST_XDIST_WORKER_COUNT", "1"))
 GITHUB_ACTION = os.getenv("GITHUB_ACTION"), False
@@ -229,7 +229,7 @@ def build_compose_files_cmd(database: str, namespace: Namespace = Namespace.DEFA
     elif database == DatabaseType.NEO4J.value:
         COMPOSE_FILES = COMPOSE_FILES_NEO4J.copy()
 
-    if os.path.exists(OVERRIDE_FILE_NAME):
+    if Path(OVERRIDE_FILE_NAME).exists():
         print("!! Found an override file for docker-compose !!")
         COMPOSE_FILES.append(OVERRIDE_FILE_NAME)
     else:
@@ -253,7 +253,7 @@ def build_dev_compose_files_cmd(database: str) -> str:
     elif database == DatabaseType.NEO4J.value:
         DEV_COMPOSE_FILES = DEV_COMPOSE_FILES_NEO4J.copy()
 
-    if os.path.exists(DEV_OVERRIDE_FILE_NAME):
+    if Path(DEV_OVERRIDE_FILE_NAME).exists():
         print("!! Found a dev override file for docker-compose !!")
         DEV_COMPOSE_FILES.append(DEV_OVERRIDE_FILE_NAME)
 


### PR DESCRIPTION
This PR fixes the following rules that were previously ignored by ruff
- "PTH100",  # `os.path.abspath()` should be replaced by `Path.resolve()`
- "PTH102",  # `os.mkdir()` should be replaced by `Path.mkdir()`
- "PTH107",  # `os.remove()` should be replaced by `Path.unlink()`
- "PTH108",  # `os.unlink()` should be replaced by `Path.unlink()`
- "PTH109",  # `os.getcwd()` should be replaced by `Path.cwd()`
- "PTH110",  # `os.path.exists()` should be replaced by `Path.exists()`
- "PTH112",  # `os.path.isdir()` should be replaced by `Path.is_dir()`
- "PTH113",  # `os.path.isfile()` should be replaced by `Path.is_file()`
- "PTH117",  # `os.path.isabs()` should be replaced by `Path.is_absolute()`
- "PTH118",  # `os.path.join()` should be replaced by `Path` with `/` operator