### PR TITLE
Set INFRAHUB_PRODUCTION=false for testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,6 +193,7 @@ junit_duration_report = "call"
 [tool.pytest_env]
 PREFECT_LOGGING_LEVEL = "CRITICAL"
 INFRAHUB_LOG_LEVEL = "CRITICAL"
+INFRAHUB_PRODUCTION = false
 
 [tool.mypy]
 pretty = true


### PR DESCRIPTION
This environment variable is only used for logging purposes. Having it set to `False` makes logging to rely on a `ConsoleRenderer` instead of `JsonRenderer`, resulting in more readable logs.