### PR TITLE
Add CODEOWNERS for easy tagging of reviewers based on folder structure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+/backend/ @opsmill/backend
+/frontend/ @opsmill/frontend
+/docs/ @opsmill/customer-success @opsmill/backend @opsmill/frontend
+/docker-compose.yml @opsmill/cloud


### PR DESCRIPTION
This should add reviewers automatically based on the directories and groups tied to that folder structure. This is a basic start that should cover the most common uses.

Eventually, we could edit the repository settings to require approvals from the **CODEOWNERS** prior to merging PRs.