### PR TITLE
Log graphql errors while testing

### DIFF
--- a/backend/tests/benchmark/test_graphql_query.py
+++ b/backend/tests/benchmark/test_graphql_query.py
@@ -1,7 +1,6 @@
 import os
 
 import pytest
-from graphql import graphql
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
@@ -20,6 +19,7 @@ from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.utils import delete_all_nodes
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
+from tests.helpers.graphql import graphql
 from tests.test_data.dataset04 import load_data
 
 NBR_WARMUP = int(os.getenv("INFRAHUB_BENCHMARK_NBR_WARMUP", "5"))

--- a/backend/tests/helpers/graphql.py
+++ b/backend/tests/helpers/graphql.py
@@ -1,16 +1,64 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
-from graphql import ExecutionResult, graphql
+from graphql import (
+    ExecutionContext,
+    ExecutionResult,
+    GraphQLFieldResolver,
+    GraphQLSchema,
+    GraphQLTypeResolver,
+    Middleware,
+    Source,
+)
+from graphql import graphql as graphql_core
 
 from infrahub.core.branch import Branch
 from infrahub.graphql.initialization import prepare_graphql_params
+from infrahub.log import get_logger
 from infrahub.services import InfrahubServices, services
 
 if TYPE_CHECKING:
     from infrahub.auth import AccountSession
     from infrahub.database import InfrahubDatabase
+
+
+async def graphql(
+    schema: GraphQLSchema,
+    source: str | Source,
+    root_value: Any = None,
+    context_value: Any = None,
+    variable_values: dict[str, Any] | None = None,
+    operation_name: str | None = None,
+    field_resolver: GraphQLFieldResolver | None = None,
+    type_resolver: GraphQLTypeResolver | None = None,
+    middleware: Middleware | None = None,
+    execution_context_class: type[ExecutionContext] | None = None,
+    is_awaitable: Callable[[Any], bool] | None = None,
+) -> ExecutionResult:
+    """
+    Call `graphql` from graphql core package, and log potential errors to have full stack trace.
+    """
+
+    result = await graphql_core(
+        schema=schema,
+        source=source,
+        root_value=root_value,
+        context_value=context_value,
+        variable_values=variable_values,
+        operation_name=operation_name,
+        field_resolver=field_resolver,
+        type_resolver=type_resolver,
+        middleware=middleware,
+        execution_context_class=execution_context_class,
+        is_awaitable=is_awaitable,
+    )
+    if result.errors is not None:
+        log = get_logger()
+        for error in result.errors:
+            if error.original_error:
+                log.error("Unhandled exception occurred in resolvers", exc_info=error.original_error)
+    return result
 
 
 async def graphql_mutation(

--- a/backend/tests/integration/ipam/test_ipam_rebase_reconcile.py
+++ b/backend/tests/integration/ipam/test_ipam_rebase_reconcile.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
-from graphql import graphql
 
 from infrahub.core import registry
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.graphql.initialization import prepare_graphql_params
+from tests.helpers.graphql import graphql
 
 from .base import TestIpamReconcileBase
 

--- a/backend/tests/integration/ipam/test_ipam_utilization.py
+++ b/backend/tests/integration/ipam/test_ipam_utilization.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
-from graphql import graphql
 
 from infrahub.core import registry
 from infrahub.core.initialization import create_branch, create_ipam_namespace, get_default_ipnamespace
@@ -11,6 +10,7 @@ from infrahub.core.ipam.utilization import PrefixUtilizationGetter
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.graphql.initialization import prepare_graphql_params
+from tests.helpers.graphql import graphql
 from tests.helpers.test_app import TestInfrahubApp
 
 if TYPE_CHECKING:

--- a/backend/tests/integration/profiles/test_profile_lifecycle.py
+++ b/backend/tests/integration/profiles/test_profile_lifecycle.py
@@ -1,5 +1,4 @@
 import pytest
-from graphql import graphql
 from infrahub_sdk.client import InfrahubClient
 
 from infrahub.core import registry
@@ -9,6 +8,7 @@ from infrahub.core.schema.attribute_schema import AttributeSchema
 from infrahub.core.schema.node_schema import NodeSchema
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
+from tests.helpers.graphql import graphql
 from tests.helpers.schema import load_schema
 from tests.helpers.test_app import TestInfrahubApp
 

--- a/backend/tests/unit/graphql/mutations/test_branch.py
+++ b/backend/tests/unit/graphql/mutations/test_branch.py
@@ -1,5 +1,3 @@
-from graphql import graphql
-
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.initialization import create_branch
@@ -9,7 +7,7 @@ from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.services import InfrahubServices, services
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from tests.adapters.message_bus import BusRecorder
-from tests.helpers.graphql import graphql_mutation
+from tests.helpers.graphql import graphql, graphql_mutation
 from tests.helpers.test_app import TestInfrahubApp
 from tests.helpers.utils import init_global_service
 

--- a/backend/tests/unit/graphql/mutations/test_ipam.py
+++ b/backend/tests/unit/graphql/mutations/test_ipam.py
@@ -1,7 +1,5 @@
 import ipaddress
 
-from graphql import graphql
-
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind
@@ -9,6 +7,7 @@ from infrahub.core.node import Node
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
+from tests.helpers.graphql import graphql
 
 CREATE_IPPREFIX = """
 mutation CreatePrefix($prefix: String!) {

--- a/backend/tests/unit/graphql/mutations/test_proposed_change.py
+++ b/backend/tests/unit/graphql/mutations/test_proposed_change.py
@@ -1,7 +1,5 @@
 from uuid import uuid4
 
-from graphql import graphql
-
 from infrahub.auth import AccountSession
 from infrahub.core.branch import Branch
 from infrahub.core.constants import CheckType, InfrahubKind
@@ -15,7 +13,7 @@ from infrahub.permissions.local_backend import LocalPermissionBackend
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from tests.adapters.message_bus import BusRecorder
-from tests.helpers.graphql import graphql_mutation
+from tests.helpers.graphql import graphql, graphql_mutation
 from tests.helpers.utils import init_global_service
 
 CREATE_PROPOSED_CHANGE = """

--- a/backend/tests/unit/graphql/mutations/test_resource_manager.py
+++ b/backend/tests/unit/graphql/mutations/test_resource_manager.py
@@ -1,5 +1,4 @@
 import pytest
-from graphql import graphql
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
@@ -11,6 +10,7 @@ from infrahub.core.schema import SchemaRoot
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
+from tests.helpers.graphql import graphql
 from tests.helpers.schema import TICKET, load_schema
 
 

--- a/backend/tests/unit/graphql/mutations/test_schema.py
+++ b/backend/tests/unit/graphql/mutations/test_schema.py
@@ -1,11 +1,11 @@
 import pytest
-from graphql import graphql
 
 from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import ValidationError
 from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.graphql.mutations.schema import validate_kind, validate_kind_dropdown, validate_kind_enum
+from tests.helpers.graphql import graphql
 
 
 async def test_delete_last_dropdown_option(db: InfrahubDatabase, default_branch, choices_schema):

--- a/backend/tests/unit/graphql/mutations/test_task.py
+++ b/backend/tests/unit/graphql/mutations/test_task.py
@@ -1,8 +1,7 @@
-from graphql import graphql
-
 from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
+from tests.helpers.graphql import graphql
 
 CREATE_TASK = """
 mutation CreateTask(

--- a/backend/tests/unit/graphql/mutations/test_update_generic.py
+++ b/backend/tests/unit/graphql/mutations/test_update_generic.py
@@ -1,9 +1,8 @@
-from graphql import graphql
-
 from infrahub.core.branch import Branch
 from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
+from tests.helpers.graphql import graphql
 
 
 async def test_display_label_generic(db: InfrahubDatabase, animal_person_schema, branch: Branch):

--- a/backend/tests/unit/graphql/profiles/test_mutation_create.py
+++ b/backend/tests/unit/graphql/profiles/test_mutation_create.py
@@ -1,8 +1,7 @@
-from graphql import graphql
-
 from infrahub.core.manager import NodeManager
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
+from tests.helpers.graphql import graphql
 
 
 async def test_create_profile(db: InfrahubDatabase, default_branch, car_person_schema):

--- a/backend/tests/unit/graphql/profiles/test_query.py
+++ b/backend/tests/unit/graphql/profiles/test_query.py
@@ -1,5 +1,4 @@
 import pytest
-from graphql import graphql
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
@@ -10,6 +9,7 @@ from infrahub.core.schema import NodeSchema
 from infrahub.core.schema.generic_schema import GenericSchema
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
+from tests.helpers.graphql import graphql
 
 
 @pytest.fixture

--- a/backend/tests/unit/graphql/queries/test_branch.py
+++ b/backend/tests/unit/graphql/queries/test_branch.py
@@ -1,11 +1,10 @@
 import operator
 
-from graphql import graphql
-
 from infrahub.core.branch import Branch
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.services import services
+from tests.helpers.graphql import graphql
 from tests.helpers.test_app import TestInfrahubApp
 
 

--- a/backend/tests/unit/graphql/queries/test_ipam.py
+++ b/backend/tests/unit/graphql/queries/test_ipam.py
@@ -1,5 +1,4 @@
 import pytest
-from graphql import graphql
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
@@ -8,6 +7,7 @@ from infrahub.core.node import Node
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
+from tests.helpers.graphql import graphql
 
 
 @pytest.fixture

--- a/backend/tests/unit/graphql/queries/test_list_permissions.py
+++ b/backend/tests/unit/graphql/queries/test_list_permissions.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
-from graphql import graphql
-
 from infrahub.auth import AccountSession, AuthType
 from infrahub.core.account import ObjectPermission
 from infrahub.core.constants import InfrahubKind, PermissionAction
@@ -14,6 +12,7 @@ from infrahub.core.registry import registry
 from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.permissions.constants import BranchRelativePermissionDecision, PermissionDecisionFlag
 from infrahub.permissions.local_backend import LocalPermissionBackend
+from tests.helpers.graphql import graphql
 
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch

--- a/backend/tests/unit/graphql/queries/test_relationship.py
+++ b/backend/tests/unit/graphql/queries/test_relationship.py
@@ -1,8 +1,7 @@
-from graphql import graphql
-
 from infrahub.core.branch import Branch
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
+from tests.helpers.graphql import graphql
 
 
 async def test_relationship(

--- a/backend/tests/unit/graphql/queries/test_resource_pool.py
+++ b/backend/tests/unit/graphql/queries/test_resource_pool.py
@@ -1,5 +1,4 @@
 import pytest
-from graphql import graphql
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
@@ -14,6 +13,7 @@ from infrahub.core.schema import SchemaRoot
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
+from tests.helpers.graphql import graphql
 from tests.helpers.schema import TICKET, load_schema
 
 

--- a/backend/tests/unit/graphql/queries/test_search.py
+++ b/backend/tests/unit/graphql/queries/test_search.py
@@ -1,5 +1,4 @@
 import pytest
-from graphql import graphql
 
 from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind
@@ -7,6 +6,7 @@ from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.graphql.queries.search import _collapse_ipv6
+from tests.helpers.graphql import graphql
 
 SEARCH_QUERY = """
 query ($search: String!) {

--- a/backend/tests/unit/graphql/queries/test_task.py
+++ b/backend/tests/unit/graphql/queries/test_task.py
@@ -2,7 +2,7 @@ from typing import Any, Dict
 from uuid import uuid4
 
 import pytest
-from graphql import ExecutionResult, graphql
+from graphql import ExecutionResult
 from infrahub_sdk.graphql import Query
 from prefect.artifacts import ArtifactRequest
 from prefect.client.orchestration import PrefectClient, get_client
@@ -16,6 +16,7 @@ from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.tasks.dummy import dummy_flow, dummy_flow_broken
 from infrahub.workflows.constants import TAG_NAMESPACE, WorkflowTag
+from tests.helpers.graphql import graphql
 
 CREATE_TASK = """
 mutation CreateTask(

--- a/backend/tests/unit/graphql/test_core_account.py
+++ b/backend/tests/unit/graphql/test_core_account.py
@@ -1,5 +1,4 @@
 import bcrypt
-from graphql import graphql
 
 from infrahub.auth import AccountSession, AuthType
 from infrahub.core import registry
@@ -10,6 +9,7 @@ from infrahub.core.manager import NodeManager
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.permissions.local_backend import LocalPermissionBackend
+from tests.helpers.graphql import graphql
 
 
 async def test_everyone_can_update_password(db: InfrahubDatabase, default_branch: Branch, first_account):

--- a/backend/tests/unit/graphql/test_diff_tree_query.py
+++ b/backend/tests/unit/graphql/test_diff_tree_query.py
@@ -2,7 +2,6 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
 import pytest
-from graphql import graphql
 
 from infrahub.core.branch import Branch
 from infrahub.core.diff.coordinator import DiffCoordinator
@@ -20,6 +19,7 @@ from infrahub.database import InfrahubDatabase
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.graphql.enums import ConflictSelection as GraphQLConfictSelection
 from infrahub.graphql.initialization import prepare_graphql_params
+from tests.helpers.graphql import graphql
 
 ADDED_ACTION = "ADDED"
 UPDATED_ACTION = "UPDATED"

--- a/backend/tests/unit/graphql/test_graphql_query.py
+++ b/backend/tests/unit/graphql/test_graphql_query.py
@@ -2,7 +2,6 @@ from typing import Dict, Literal
 
 import pytest
 from deepdiff import DeepDiff
-from graphql import graphql
 
 from infrahub import __version__, config
 from infrahub.core import registry
@@ -15,6 +14,7 @@ from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
+from tests.helpers.graphql import graphql
 
 
 async def test_info_query(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema):

--- a/backend/tests/unit/graphql/test_mutation_artifact_definition.py
+++ b/backend/tests/unit/graphql/test_mutation_artifact_definition.py
@@ -2,7 +2,6 @@ from typing import Dict
 from unittest.mock import call, patch
 
 import pytest
-from graphql import graphql
 
 from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind
@@ -15,6 +14,7 @@ from infrahub.services import InfrahubServices
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from infrahub.workflows.catalogue import REQUEST_ARTIFACT_DEFINITION_GENERATE
 from tests.adapters.message_bus import BusRecorder
+from tests.helpers.graphql import graphql
 
 
 @pytest.fixture

--- a/backend/tests/unit/graphql/test_mutation_create.py
+++ b/backend/tests/unit/graphql/test_mutation_create.py
@@ -1,5 +1,4 @@
 import pytest
-from graphql import graphql
 
 from infrahub import config
 from infrahub.core import registry
@@ -9,6 +8,7 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
+from tests.helpers.graphql import graphql
 
 
 async def test_create_simple_object(db: InfrahubDatabase, default_branch, car_person_schema):

--- a/backend/tests/unit/graphql/test_mutation_create_jinja2_attributes.py
+++ b/backend/tests/unit/graphql/test_mutation_create_jinja2_attributes.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from graphql import graphql
-
 from infrahub.core import registry
 from infrahub.core.node import Node
 from infrahub.core.schema import SchemaRoot, internal_schema
 from infrahub.graphql.initialization import prepare_graphql_params
 from tests.constants import TestKind
+from tests.helpers.graphql import graphql
 from tests.helpers.schema import CHILD, LOCATION_SCHEMA, THING, load_schema
 
 if TYPE_CHECKING:

--- a/backend/tests/unit/graphql/test_mutation_delete.py
+++ b/backend/tests/unit/graphql/test_mutation_delete.py
@@ -1,9 +1,8 @@
-from graphql import graphql
-
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
+from tests.helpers.graphql import graphql
 
 
 async def test_delete_object(db: InfrahubDatabase, default_branch, car_person_schema):

--- a/backend/tests/unit/graphql/test_mutation_graphqlquery.py
+++ b/backend/tests/unit/graphql/test_mutation_graphqlquery.py
@@ -1,10 +1,9 @@
-from graphql import graphql
-
 from infrahub.core import registry
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
+from tests.helpers.graphql import graphql
 
 
 async def test_create_query_no_vars(db: InfrahubDatabase, default_branch, register_core_models_schema):

--- a/backend/tests/unit/graphql/test_mutation_relationship.py
+++ b/backend/tests/unit/graphql/test_mutation_relationship.py
@@ -1,4 +1,3 @@
-from graphql import graphql
 from infrahub_sdk.uuidt import UUIDT
 
 from infrahub.core.branch import Branch
@@ -8,6 +7,7 @@ from infrahub.core.node import Node
 from infrahub.core.utils import count_relationships
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
+from tests.helpers.graphql import graphql
 
 
 async def test_relationship_add(

--- a/backend/tests/unit/graphql/test_mutation_update.py
+++ b/backend/tests/unit/graphql/test_mutation_update.py
@@ -1,5 +1,4 @@
 import pytest
-from graphql import graphql
 
 from infrahub import config
 from infrahub.core import registry
@@ -9,6 +8,7 @@ from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.graphql.manager import GraphQLSchemaManager
+from tests.helpers.graphql import graphql
 
 
 async def test_update_simple_object(db: InfrahubDatabase, person_john_main: Node, branch: Branch):

--- a/backend/tests/unit/graphql/test_mutation_upsert.py
+++ b/backend/tests/unit/graphql/test_mutation_upsert.py
@@ -1,7 +1,5 @@
 from uuid import uuid4
 
-from graphql import graphql
-
 from infrahub.core.branch import Branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
@@ -10,6 +8,7 @@ from infrahub.core.schema import SchemaRoot
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
 from tests.constants import TestKind
+from tests.helpers.graphql import graphql
 from tests.helpers.schema import TICKET
 
 

--- a/backend/tests/unit/graphql/test_parser.py
+++ b/backend/tests/unit/graphql/test_parser.py
@@ -1,9 +1,8 @@
-from graphql import graphql
-
 from infrahub.core.branch import Branch
 from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
+from tests.helpers.graphql import graphql
 
 
 async def test_simple_directive(db: InfrahubDatabase, default_branch: Branch, criticality_schema):


### PR DESCRIPTION
This PR replaces the use of `graphql.graphql` within our tests by a custom `tests.helpers.graphql.graphql` function that logs graphql errors. In this way, graphql server side stack traces are displayed.