### PR TITLE
Load and process new schema before replacing registry branch

### DIFF
--- a/backend/infrahub/tasks/registry.py
+++ b/backend/infrahub/tasks/registry.py
@@ -36,14 +36,13 @@ async def refresh_branches(db: InfrahubDatabase) -> None:
                         hash_new=new_branch.active_schema_hash.main,
                         worker=WORKER_IDENTITY,
                     )
+                    await registry.schema.load_schema(db=db, branch=new_branch)
                     registry.branch[new_branch.name] = new_branch
 
-                    await registry.schema.load_schema(db=db, branch=new_branch)
-
             else:
-                registry.branch[new_branch.name] = new_branch
                 log.info("New branch detected, pulling schema", branch=new_branch.name, worker=WORKER_IDENTITY)
                 await registry.schema.load_schema(db=db, branch=new_branch)
+                registry.branch[new_branch.name] = new_branch
 
         for branch_name in list(registry.branch.keys()):
             if branch_name not in active_branches:

--- a/changelog/5008.fixed.md
+++ b/changelog/5008.fixed.md
@@ -1,0 +1,1 @@
+Process new schema before replacing branch in registry to avoid causing the GraphQL schema to be generated while the new schema is still loading


### PR DESCRIPTION
When preparing the GraphQL schema for each request we are using the `prepare_graphql_params()` function which in turn calls `GraphQLSchemaManager.get_manager_for_branch()`

```python
def prepare_graphql_params(
    db: InfrahubDatabase,
    branch: Branch | str,
    at: Timestamp | str | None = None,
    account_session: AccountSession | None = None,
    request: HTTPConnection | None = None,
    service: InfrahubServices | None = None,
    include_query: bool = True,
    include_mutation: bool = True,
    include_subscription: bool = True,
    include_types: bool = True,
) -> GraphqlParams:
    branch = registry.get_branch_from_registry(branch=branch)
    schema_branch = registry.schema.get_schema_branch(name=branch.name)
    gqlm = GraphQLSchemaManager.get_manager_for_branch(branch=branch, schema_branch=schema_branch)
    gql_schema = gqlm.get_graphql_schema(
        include_query=include_query,
        include_mutation=include_mutation,
        include_subscription=include_subscription,
        include_types=include_types,
    )

class GraphQLSchemaManager:

    @classmethod
    def get_manager_for_branch(cls, branch: Branch, schema_branch: SchemaBranch) -> GraphQLSchemaManager:
        if branch.name not in cls._branch_details_by_name:
            branch_details = cls._cache_branch(branch=branch, schema_branch=schema_branch)
            return branch_details.gql_manager
        cached_branch_details = cls._branch_details_by_name[branch.name]
        # try to use the schema_changed_at time b/c it is faster than checking the hash
        if branch.schema_changed_at:
            changed_at_time = Timestamp(branch.schema_changed_at)
            if changed_at_time > cached_branch_details.schema_changed_at:
                cached_branch_details = cls._cache_branch(branch=branch, schema_branch=schema_branch)
            return cached_branch_details.gql_manager
        if branch.schema_hash:
            current_hash = branch.active_schema_hash.main
        else:
            current_hash = schema_branch.get_hash()
        if cached_branch_details.schema_hash != current_hash:
            cached_branch_details = cls._cache_branch(
                branch=branch, schema_branch=schema_branch, schema_hash=current_hash
            )

        return cached_branch_details.gql_manager

```

Once the schema has been updated on a HTTP worker we'll send a request to all other workers that will update their schemas using this function:

```python
async def refresh_branches(db: InfrahubDatabase) -> None:
    """Pull all the branches from the database and update the registry.

    If a branch is already present with a different value for the hash
    We pull the new schema from the database and we update the registry.
    """

    async with lock.registry.local_schema_lock():
        branches = await registry.branch_object.get_list(db=db)
        active_branches = [branch.name for branch in branches]
        for new_branch in branches:
            if new_branch.name in registry.branch:
                branch_registry: Branch = registry.branch[new_branch.name]
                if (
                    branch_registry.schema_hash
                    and branch_registry.schema_hash.main != new_branch.active_schema_hash.main
                ):
                    log.info(
                        "New hash detected",
                        branch=new_branch.name,
                        hash_current=branch_registry.schema_hash.main,
                        hash_new=new_branch.active_schema_hash.main,
                        worker=WORKER_IDENTITY,
                    )
                    registry.branch[new_branch.name] = new_branch

                    await registry.schema.load_schema(db=db, branch=new_branch)

            else:
                registry.branch[new_branch.name] = new_branch
                log.info("New branch detected, pulling schema", branch=new_branch.name, worker=WORKER_IDENTITY)
                await registry.schema.load_schema(db=db, branch=new_branch)

        for branch_name in list(registry.branch.keys()):
            if branch_name not in active_branches:
                del registry.branch[branch_name]
                log.info(
                    f"Removed branch {branch_name!r} from the registry", branch=branch_name, worker=WORKER_IDENTITY
                )
```

I think what happens is that we have ordered this incorrectly if we look specifically at this part:

```python
registry.branch[new_branch.name] = new_branch
await registry.schema.load_schema(db=db, branch=new_branch)
```

Here we replace the branch in the registry with the new `Branch` object and after that we process the schema. If that same worker receives a GraphQL query while loading this schema it will go through the `prepare_graphql_params()` function and in `get_manager_for_branch()` will see that `changed_at_time > cached_branch_details.schema_changed_at` i.e. the new branch has a later changed_at timestamp compared to the previously cached branch. Due to this we move forward with regenerating the GraphQL schema, however this might happen while the new registry schema branch (`await registry.schema.load_schema(db=db, branch=new_branch)`) is still processing the request so we could be missing node objects within the schema_branch in the registry at that time which returns a broken GraphQL schema that we still cache. When the following request comes in we just look at the timestamps and see that the broken one we have in the cache is "good" and present that one to the user.

What I've done in this PR is to simply reverse this order of operations i.e:

```python
await registry.schema.load_schema(db=db, branch=new_branch)
registry.branch[new_branch.name] = new_branch
```
Here we load the schema branch to the registry first and only after that do we replace the branch object in the registry. As we would be using the cached branch for other purposes for other requests it wouldn't matter that the old schema branch is being replaced before replacing the `Branch` object in the registry.

I'm not completely certain if this will impact anything else though.

Fixes #5008
