### PR TITLE
Corrections to branch support for jinja2 attributes

### DIFF
--- a/backend/infrahub/computed_attribute/tasks.py
+++ b/backend/infrahub/computed_attribute/tasks.py
@@ -175,7 +175,11 @@ async def process_jinja2(
 
     await add_tags(branches=[branch_name])
 
-    schema_branch = registry.schema.get_schema_branch(name=branch_name)
+    target_branch_schema = (
+        branch_name if branch_name in registry.get_altered_schema_branches() else registry.default_branch
+    )
+    schema_branch = registry.schema.get_schema_branch(name=target_branch_schema)
+    await service.client.schema.all(branch=branch_name, refresh=True)
 
     computed_macros = [
         attrib
@@ -189,7 +193,11 @@ async def process_jinja2(
         for id_filter in computed_macro.node_filters:
             filters = {id_filter: object_id}
             nodes = await service.client.filters(
-                kind=computed_macro.kind, prefetch_relationships=True, populate_store=True, **filters
+                kind=computed_macro.kind,
+                branch=branch_name,
+                prefetch_relationships=True,
+                populate_store=True,
+                **filters,
             )
             found.extend(nodes)
 


### PR DESCRIPTION
This PR fixes some issues around branch support.

1. If we're running against a non-main branch but that branch is using the same schema as main the schema_branch was not correct so we load the settings on the main branch if the branch has the same hash as main
2. We updated the nodes within the correct branch, however the initial query for nodes didn't include the branch parameter so we'd always query for nodes in the default branch
3. If the schema has changed in a branch and the old branch has been cached in the SDK already it could lead to errors as described in IFC-954. As a workaround we ensure that we update the SDK schema for the branch before continuing. I have also opened https://github.com/opsmill/infrahub-sdk-python/issues/152 to improve the management of cached schemas in the SDK in the future and give us a way to only optionally refresh the cached schema if the stored hash is different compared to the expected current one.