### PR TITLE
Wait until schema convergence when syncing a repo with schema updates

### DIFF
--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -501,7 +501,9 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):  # pylint: disable=t
                     message=f"Schema not valid, found '{len(exc.errors())}' error(s) in {schema_file.identifier} : {exc}",
                 ) from exc
 
-        response = await self.sdk.schema.load(schemas=[item.content for item in schemas_data], branch=branch_name)
+        response = await self.sdk.schema.load(
+            schemas=[item.content for item in schemas_data], branch=branch_name, wait_until_converged=True
+        )
 
         if response.errors:
             error_messages = []

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -107,7 +107,10 @@ class TestInfrahubApp(TestInfrahub):
         self, test_client: InfrahubTestClient, api_token: str, bus_simulator: BusSimulator
     ) -> InfrahubClient:
         config = Config(
-            api_token=api_token, requester=test_client.async_request, sync_requester=test_client.sync_request
+            api_token=api_token,
+            requester=test_client.async_request,
+            sync_requester=test_client.sync_request,
+            schema_converge_timeout=5,
         )
 
         sdk_client = InfrahubClient(config=config)

--- a/changelog/5051.fixed.md
+++ b/changelog/5051.fixed.md
@@ -1,0 +1,1 @@
+Added a check on repository import and sync to wait until the schema has converged before importing additional objects when the repository contains an updated schema.


### PR DESCRIPTION
This PR adds some code so that we'd wait for the schema of a given branch to have converged before we move forward with the import of additional objects. 

For now I've done a minimalistic fix that shouldn't cause any issues when brought back to `develop` with regards to changes we've done to logging etc. I think we probably do want to modify this in the future and move some of the logic into the SDK instead.

Fixes #5051