### PR TITLE
Fix confusing path in Docs for backup utility

### DIFF
--- a/docs/docs/guides/database-backup.mdx
+++ b/docs/docs/guides/database-backup.mdx
@@ -4,7 +4,8 @@ title: Database backup and restore
 
 # Database backup and restore examples
 
-This is a guide on how to backup and restore your database using an Infrahub command line tool. Please [see this topic](/topics/database-backup) for the requirements for using the tool and an explanation of how it works.
+This is a guide on how to backup and restore your database using an Infrahub command line tool.
+Please [see this topic](/topics/database-backup) for the requirements for using the tool and an explanation of how it works.
 
 This guide assumes that you cloned the Infrahub repository to your machine, but you can also copy the content of [this tool's Python file](https://github.com/opsmill/infrahub/tree/stable/utilities/db_backup/__main__.py) into a local Python file and run it that way.
 
@@ -27,7 +28,7 @@ In this example, I am running the backup command on the same machine that is run
 ## Restore a backup on a non-default cypher port
 
 ```python
-python local_backup_copy.py neo4j restore /infrahub_backups --database-cypher-port=9876
+python -m utilities.db_backup neo4j restore /infrahub_backups --database-cypher-port=9876
 ```
 
 In this example, I am restoring `.backup` files that exist in the `/infrahub_backups` directory and my Infrahub database container uses a non-standard port for cypher access: `9876` instead of `7687`.


### PR DESCRIPTION
We are suddenly speaking about `local_backup_copy.py` when the rest is using `utilities.db_backup`

There is some information regarding copying the file in the reference page, I think it make more sense to keep the same one here for all the command 