### PR TITLE
drop tracking id from any diffs using it after a merge completes

### DIFF
--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -8,6 +8,7 @@ from infrahub.core.branch import Branch
 from infrahub.core.diff.coordinator import DiffCoordinator
 from infrahub.core.diff.ipam_diff_parser import IpamDiffParser
 from infrahub.core.diff.merger.merger import DiffMerger
+from infrahub.core.diff.model.path import BranchTrackingId
 from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.merge import BranchMerger
 from infrahub.core.migrations.schema.models import SchemaApplyMigrationData
@@ -185,6 +186,11 @@ async def merge_branch(branch: str, conflict_resolution: dict[str, bool] | None 
         workflow=IPAM_RECONCILIATION,
         parameters={"branch": registry.default_branch, "ipam_node_details": ipam_node_details},
     )
+    # -------------------------------------------------------------
+    # remove tracking ID from the diff because there is no diff after the merge
+    # -------------------------------------------------------------
+    diff_repository = await component_registry.get_component(DiffRepository, db=service.database, branch=obj)
+    await diff_repository.drop_tracking_ids(tracking_ids=[BranchTrackingId(name=obj.name)])
 
     # -------------------------------------------------------------
     # Generate an event to indicate that a branch has been merged

--- a/backend/infrahub/core/diff/query/drop_tracking_id.py
+++ b/backend/infrahub/core/diff/query/drop_tracking_id.py
@@ -1,0 +1,25 @@
+from typing import Any
+
+from infrahub.core.query import Query, QueryType
+from infrahub.database import InfrahubDatabase
+
+from ..model.path import TrackingId
+
+
+class EnrichedDiffDropTrackingIdQuery(Query):
+    name = "enriched_diff_drop_tracking_id"
+    type = QueryType.WRITE
+    insert_return = False
+
+    def __init__(self, tracking_ids: list[TrackingId], **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.tracking_ids = tracking_ids
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:
+        self.params = {"tracking_ids": [t_id.serialize() for t_id in self.tracking_ids]}
+        query = """
+        MATCH (d_root:DiffRoot)
+        WHERE d_root.tracking_id IN $tracking_ids
+        SET d_root.tracking_id = NULL
+        """
+        self.add_to_query(query=query)

--- a/backend/infrahub/core/diff/repository/repository.py
+++ b/backend/infrahub/core/diff/repository/repository.py
@@ -20,6 +20,7 @@ from ..model.path import (
 from ..query.delete_query import EnrichedDiffDeleteQuery
 from ..query.diff_get import EnrichedDiffGetQuery
 from ..query.diff_summary import DiffSummaryCounters, DiffSummaryQuery
+from ..query.drop_tracking_id import EnrichedDiffDropTrackingIdQuery
 from ..query.empty_roots import EnrichedDiffEmptyRootsQuery
 from ..query.filters import EnrichedDiffQueryFilters
 from ..query.get_conflict_query import EnrichedDiffConflictQuery
@@ -247,3 +248,7 @@ class DiffRepository:
         )
         await query.execute(db=self.db)
         return await query.get_field_summaries()
+
+    async def drop_tracking_ids(self, tracking_ids: list[TrackingId]) -> None:
+        query = await EnrichedDiffDropTrackingIdQuery.init(db=self.db, tracking_ids=tracking_ids)
+        await query.execute(db=self.db)

--- a/backend/tests/unit/core/diff/test_diff_repository.py
+++ b/backend/tests/unit/core/diff/test_diff_repository.py
@@ -614,3 +614,34 @@ class TestDiffRepositorySaveAndLoad:
         )
         retrieved_map = {summary.kind: summary for summary in retrieved_node_field_summaries}
         assert expected_map == retrieved_map
+
+    async def test_drop_tracking_ids(self, diff_repository: DiffRepository, reset_database):
+        base_branch_name = "main"
+        no_tracking_id_diff = EnrichedRootFactory.build(base_branch_name=base_branch_name, tracking_id=None)
+        await self._save_single_diff(diff_repository=diff_repository, enriched_diff=no_tracking_id_diff)
+        tracking_id_diff_1 = EnrichedRootFactory.build(base_branch_name=base_branch_name)
+        tracking_id_1 = BranchTrackingId(name=tracking_id_diff_1.diff_branch_name)
+        tracking_id_diff_1.tracking_id = tracking_id_1
+        await self._save_single_diff(diff_repository=diff_repository, enriched_diff=tracking_id_diff_1)
+        tracking_id_diff_2 = EnrichedRootFactory.build(base_branch_name=base_branch_name)
+        tracking_id_2 = BranchTrackingId(name=tracking_id_diff_2.diff_branch_name)
+        tracking_id_diff_2.tracking_id = tracking_id_2
+        await self._save_single_diff(diff_repository=diff_repository, enriched_diff=tracking_id_diff_2)
+
+        await diff_repository.drop_tracking_ids(tracking_ids=[tracking_id_1])
+
+        # verify tracking ID 1 diff cannot be retrieved by tracking ID
+        with pytest.raises(ResourceNotFoundError, match="Cannot find diff"):
+            await diff_repository.get_one(
+                diff_branch_name=tracking_id_diff_1.diff_branch_name, tracking_id=tracking_id_1
+            )
+        # verify tracking ID 2 diff can be retrieved by tracking ID
+        diff_2 = await diff_repository.get_one(
+            diff_branch_name=tracking_id_diff_2.diff_branch_name, tracking_id=tracking_id_2
+        )
+        assert diff_2.tracking_id == tracking_id_2
+        # verify tracking ID 1 diff can be retrieved by UUID and has no tracking ID
+        diff_1 = await diff_repository.get_one(
+            diff_branch_name=tracking_id_diff_1.diff_branch_name, diff_id=tracking_id_diff_1.uuid
+        )
+        assert diff_1.tracking_id is None


### PR DESCRIPTION
IFC-964

remove tracking_id from diffs for a given branch after it is merged. see Jira issue for more details. basically, once a branch is merged, there is no longer a diff and we do not need to track it. if the user makes more changes to this branch, we will generate a new diff with the tracking id
