### PR TITLE
fix(ci): use forked paths-filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           submodules: true
       - name: Check for file changes
-        uses: dorny/paths-filter@v3
+        uses: opsmill/paths-filter@v3.0.2
         id: changes
         with:
           token: ${{ github.token }}


### PR DESCRIPTION
This avoids the following issue:
```
$ git fetch --no-tags --depth=100 origin develop release-1.1
remote: Enumerating objects: 13229, done.
remote: Counting objects: 100% (13229/13229), done.
remote: Compressing objects: 100% (5455/5455), done.
remote: Total 11976 (delta 9024), reused 8910 (delta 6436), pack-reused 0 (from 0)
Receiving objects: 100% (11976/11976), 7.59 MiB | 4.31 MiB/s, done.
Resolving deltas: 100% (9024/9024), completed with 1050 local objects.
From https://github.com/opsmill/infrahub
 * branch            develop    -> FETCH_HEAD
 * branch            release-1.1 -> FETCH_HEAD
 * [new branch]      develop    -> origin/develop
Fetching submodule python_sdk
fatal: remote error: upload-pack: not our ref c9fbb89a97deb5f412c8c448736766d6a3c6cb9b
Errors during submodule fetch:
	python_sdk
```

As we can see, this fetch command also retrieves the default branch (develop) in a single command and also tries to fetch the submodule from the develop branch.
If we run this same command twice, it doesn't fail on the second attempt, so it's must likely a git bug?