### PR TITLE
special handling for IP relationships in diff and merge

### DIFF
--- a/backend/infrahub/core/diff/calculator.py
+++ b/backend/infrahub/core/diff/calculator.py
@@ -32,13 +32,6 @@ class DiffCalculator:
             from_time=from_time,
             to_time=to_time,
         )
-        # diff_parser = DiffQueryParser(
-        #     base_branch=base_branch,
-        #     diff_branch=diff_branch,
-        #     schema_manager=registry.schema,
-        #     from_time=from_time,
-        #     to_time=to_time,
-        # )
         branch_diff_query = await DiffAllPathsQuery.init(
             db=self.db,
             branch=diff_branch,

--- a/backend/infrahub/core/diff/calculator.py
+++ b/backend/infrahub/core/diff/calculator.py
@@ -9,8 +9,9 @@ from .model.path import CalculatedDiffs, NodeFieldSpecifier
 
 
 class DiffCalculator:
-    def __init__(self, db: InfrahubDatabase) -> None:
+    def __init__(self, db: InfrahubDatabase, diff_query_parser: DiffQueryParser) -> None:
         self.db = db
+        self.query_parser = diff_query_parser
 
     async def calculate_diff(
         self,
@@ -25,13 +26,19 @@ class DiffCalculator:
             diff_branch_from_time = from_time
         else:
             diff_branch_from_time = Timestamp(diff_branch.get_branched_from())
-        diff_parser = DiffQueryParser(
+        self.query_parser.initialize(
             base_branch=base_branch,
             diff_branch=diff_branch,
-            schema_manager=registry.schema,
             from_time=from_time,
             to_time=to_time,
         )
+        # diff_parser = DiffQueryParser(
+        #     base_branch=base_branch,
+        #     diff_branch=diff_branch,
+        #     schema_manager=registry.schema,
+        #     from_time=from_time,
+        #     to_time=to_time,
+        # )
         branch_diff_query = await DiffAllPathsQuery.init(
             db=self.db,
             branch=diff_branch,
@@ -42,10 +49,12 @@ class DiffCalculator:
         )
         await branch_diff_query.execute(db=self.db)
         for query_result in branch_diff_query.get_results():
-            diff_parser.read_result(query_result=query_result)
+            self.query_parser.read_result(query_result=query_result)
 
         if base_branch.name != diff_branch.name:
-            branch_node_specifiers = diff_parser.get_node_field_specifiers_for_branch(branch_name=diff_branch.name)
+            branch_node_specifiers = self.query_parser.get_node_field_specifiers_for_branch(
+                branch_name=diff_branch.name
+            )
             new_node_field_specifiers = branch_node_specifiers - (previous_node_specifiers or set())
             current_node_field_specifiers = (previous_node_specifiers or set()) - new_node_field_specifiers
             base_diff_query = await DiffAllPathsQuery.init(
@@ -62,11 +71,11 @@ class DiffCalculator:
             )
             await base_diff_query.execute(db=self.db)
             for query_result in base_diff_query.get_results():
-                diff_parser.read_result(query_result=query_result)
-        diff_parser.parse(include_unchanged=include_unchanged)
+                self.query_parser.read_result(query_result=query_result)
+        self.query_parser.parse(include_unchanged=include_unchanged)
         return CalculatedDiffs(
             base_branch_name=base_branch.name,
             diff_branch_name=diff_branch.name,
-            base_branch_diff=diff_parser.get_diff_root_for_branch(branch=base_branch.name),
-            diff_branch_diff=diff_parser.get_diff_root_for_branch(branch=diff_branch.name),
+            base_branch_diff=self.query_parser.get_diff_root_for_branch(branch=base_branch.name),
+            diff_branch_diff=self.query_parser.get_diff_root_for_branch(branch=diff_branch.name),
         )

--- a/backend/infrahub/core/diff/combiner.py
+++ b/backend/infrahub/core/diff/combiner.py
@@ -323,6 +323,7 @@ class DiffCombiner:
                     cardinality=later_relationship.cardinality,
                     changed_at=later_relationship.changed_at or earlier_relationship.changed_at,
                     action=combined_action,
+                    is_managed=later_relationship.is_managed,
                     path_identifier=later_relationship.path_identifier,
                     relationships=combined_relationship_elements,
                     nodes=set(),

--- a/backend/infrahub/core/diff/conflicts_enricher.py
+++ b/backend/infrahub/core/diff/conflicts_enricher.py
@@ -3,7 +3,6 @@ from uuid import uuid4
 from infrahub.core.constants import DiffAction, RelationshipCardinality
 from infrahub.core.constants.database import DatabaseEdgeType
 
-from .managed_relationship_checker import ManagedRelationshipChecker
 from .model.path import (
     EnrichedDiffAttribute,
     EnrichedDiffConflict,
@@ -16,8 +15,7 @@ from .model.path import (
 
 
 class ConflictsEnricher:
-    def __init__(self, managed_relationship_checker: ManagedRelationshipChecker) -> None:
-        self.managed_relationship_checker = managed_relationship_checker
+    def __init__(self) -> None:
         self._base_branch_name: str | None = None
         self._diff_branch_name: str | None = None
 
@@ -38,7 +36,6 @@ class ConflictsEnricher:
     ) -> None:
         self._base_branch_name = branch_diff_root.base_branch_name
         self._diff_branch_name = branch_diff_root.diff_branch_name
-        self.managed_relationship_checker.reset()
 
         base_node_map = {n.uuid: n for n in base_diff_root.nodes}
         branch_node_map = {n.uuid: n for n in branch_diff_root.nodes}
@@ -82,7 +79,6 @@ class ConflictsEnricher:
                 self._add_relationship_conflicts(
                     base_relationship=base_relationship,
                     branch_relationship=branch_relationship,
-                    node_kind=branch_node.kind,
                 )
             else:
                 branch_relationship.clear_conflicts()
@@ -137,11 +133,8 @@ class ConflictsEnricher:
             )
 
     def _add_relationship_conflicts(
-        self, base_relationship: EnrichedDiffRelationship, branch_relationship: EnrichedDiffRelationship, node_kind: str
+        self, base_relationship: EnrichedDiffRelationship, branch_relationship: EnrichedDiffRelationship
     ) -> None:
-        is_managed = self.managed_relationship_checker.check(
-            node_kind=node_kind, relationship_name=branch_relationship.name
-        )
         is_cardinality_one = branch_relationship.cardinality is RelationshipCardinality.ONE
         if is_cardinality_one:
             if not base_relationship.relationships or not branch_relationship.relationships:
@@ -153,7 +146,7 @@ class ConflictsEnricher:
                 base_element=base_element,
                 branch_element=branch_element,
                 is_cardinality_one=is_cardinality_one,
-                is_managed=is_managed,
+                is_managed=branch_relationship.is_managed,
             )
             return
         base_peer_id_map = {element.peer_id: element for element in base_relationship.relationships}
@@ -168,7 +161,7 @@ class ConflictsEnricher:
                 base_element=base_element,
                 branch_element=branch_element,
                 is_cardinality_one=is_cardinality_one,
-                is_managed=is_managed,
+                is_managed=branch_relationship.is_managed,
             )
 
     def _add_relationship_conflicts_for_one_peer(

--- a/backend/infrahub/core/diff/conflicts_enricher.py
+++ b/backend/infrahub/core/diff/conflicts_enricher.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 from infrahub.core.constants import DiffAction, RelationshipCardinality
 from infrahub.core.constants.database import DatabaseEdgeType
 
+from .managed_relationship_checker import ManagedRelationshipChecker
 from .model.path import (
     EnrichedDiffAttribute,
     EnrichedDiffConflict,
@@ -15,7 +16,8 @@ from .model.path import (
 
 
 class ConflictsEnricher:
-    def __init__(self) -> None:
+    def __init__(self, managed_relationship_checker: ManagedRelationshipChecker) -> None:
+        self.managed_relationship_checker = managed_relationship_checker
         self._base_branch_name: str | None = None
         self._diff_branch_name: str | None = None
 
@@ -36,6 +38,7 @@ class ConflictsEnricher:
     ) -> None:
         self._base_branch_name = branch_diff_root.base_branch_name
         self._diff_branch_name = branch_diff_root.diff_branch_name
+        self.managed_relationship_checker.reset()
 
         base_node_map = {n.uuid: n for n in base_diff_root.nodes}
         branch_node_map = {n.uuid: n for n in branch_diff_root.nodes}
@@ -79,6 +82,7 @@ class ConflictsEnricher:
                 self._add_relationship_conflicts(
                     base_relationship=base_relationship,
                     branch_relationship=branch_relationship,
+                    node_kind=branch_node.kind,
                 )
             else:
                 branch_relationship.clear_conflicts()
@@ -133,10 +137,11 @@ class ConflictsEnricher:
             )
 
     def _add_relationship_conflicts(
-        self,
-        base_relationship: EnrichedDiffRelationship,
-        branch_relationship: EnrichedDiffRelationship,
+        self, base_relationship: EnrichedDiffRelationship, branch_relationship: EnrichedDiffRelationship, node_kind: str
     ) -> None:
+        is_managed = self.managed_relationship_checker.check(
+            node_kind=node_kind, relationship_name=branch_relationship.name
+        )
         is_cardinality_one = branch_relationship.cardinality is RelationshipCardinality.ONE
         if is_cardinality_one:
             if not base_relationship.relationships or not branch_relationship.relationships:
@@ -148,6 +153,7 @@ class ConflictsEnricher:
                 base_element=base_element,
                 branch_element=branch_element,
                 is_cardinality_one=is_cardinality_one,
+                is_managed=is_managed,
             )
             return
         base_peer_id_map = {element.peer_id: element for element in base_relationship.relationships}
@@ -162,6 +168,7 @@ class ConflictsEnricher:
                 base_element=base_element,
                 branch_element=branch_element,
                 is_cardinality_one=is_cardinality_one,
+                is_managed=is_managed,
             )
 
     def _add_relationship_conflicts_for_one_peer(
@@ -169,6 +176,7 @@ class ConflictsEnricher:
         base_element: EnrichedDiffSingleRelationship,
         branch_element: EnrichedDiffSingleRelationship,
         is_cardinality_one: bool,
+        is_managed: bool,
     ) -> None:
         base_properties_by_type = {p.property_type: p for p in base_element.properties}
         branch_properties_by_type = {p.property_type: p for p in branch_element.properties}
@@ -180,9 +188,10 @@ class ConflictsEnricher:
             base_property = base_properties_by_type[branch_property.property_type]
             includes_unchanged = DiffAction.UNCHANGED in {branch_property.action, base_property.action}
             same_value = self._have_same_value(base_property=base_property, branch_property=branch_property)
+            conflicts_ignored = branch_property.property_type is DatabaseEdgeType.IS_RELATED and is_managed
             # special handling for cardinality-one peer ID conflict
             if branch_property.property_type is DatabaseEdgeType.IS_RELATED and is_cardinality_one:
-                if same_value or includes_unchanged:
+                if same_value or includes_unchanged or conflicts_ignored:
                     branch_element.conflict = None
                     branch_property.conflict = None
                     continue
@@ -204,7 +213,7 @@ class ConflictsEnricher:
                 )
                 branch_element.conflict = conflict
                 continue
-            if same_value or includes_unchanged:
+            if same_value or includes_unchanged or conflicts_ignored:
                 branch_property.conflict = None
                 continue
             if branch_property.conflict:

--- a/backend/infrahub/core/diff/ipam_diff_parser.py
+++ b/backend/infrahub/core/diff/ipam_diff_parser.py
@@ -36,10 +36,10 @@ class IpamDiffParser:
     async def get_changed_ipam_node_details(
         self, source_branch_name: str, target_branch_name: str
     ) -> list[IpamNodeDetails]:
-        ip_address_kinds = await self.ip_kinds_getter.get_ipam_address_kinds(
+        ip_address_kinds = self.ip_kinds_getter.get_ipam_address_kinds(
             branch_names=[source_branch_name, target_branch_name]
         )
-        ip_prefix_kinds = await self.ip_kinds_getter.get_ipam_prefix_kinds(
+        ip_prefix_kinds = self.ip_kinds_getter.get_ipam_prefix_kinds(
             branch_names=[source_branch_name, target_branch_name]
         )
         if not ip_address_kinds and not ip_prefix_kinds:

--- a/backend/infrahub/core/diff/managed_relationship_checker.py
+++ b/backend/infrahub/core/diff/managed_relationship_checker.py
@@ -1,0 +1,38 @@
+from infrahub.core import registry
+from infrahub.core.branch.models import Branch
+from infrahub.core.ipam.kinds_getter import IpamKindsGetter
+
+
+class ManagedRelationshipChecker:
+    def __init__(
+        self,
+        ipam_kinds_getter: IpamKindsGetter,
+        branch: Branch,
+    ) -> None:
+        self.ipam_kinds_getter = ipam_kinds_getter
+        self.branch = branch
+        self._ip_address_kinds: set[str] = set()
+        self._ip_prefix_kinds: set[str] = set()
+        self._ip_address_managed_rel_names: set[str] = set()
+        self._ip_prefix_managed_rel_names: set[str] = set()
+
+    def reset(self) -> None:
+        self._ip_address_kinds = self.ipam_kinds_getter.get_ipam_address_kinds(
+            branch_names=[registry.default_branch, self.branch.name]
+        )
+        self._ip_prefix_kinds = self.ipam_kinds_getter.get_ipam_prefix_kinds(
+            branch_names=[registry.default_branch, self.branch.name]
+        )
+        self._ip_address_managed_rel_names = self.ipam_kinds_getter.get_address_managed_relationship_names()
+        self._ip_prefix_managed_rel_names = self.ipam_kinds_getter.get_prefix_managed_relationship_names()
+
+    def check(self, node_kind: str, relationship_name: str) -> bool:
+        is_prefix_kind = node_kind in self._ip_prefix_kinds
+        is_address_kind = node_kind in self._ip_address_kinds
+        if not is_prefix_kind and not is_address_kind:
+            return False
+        if is_prefix_kind:
+            return relationship_name in self._ip_prefix_managed_rel_names
+        if is_address_kind:
+            return relationship_name in self._ip_address_managed_rel_names
+        return False

--- a/backend/infrahub/core/diff/merger/serializer.py
+++ b/backend/infrahub/core/diff/merger/serializer.py
@@ -181,6 +181,8 @@ class DiffMergeSerializer:
                 serialized_property_diffs.append(attribute_property_diff)
             relationship_diffs: list[RelationshipMergeDict] = []
             for rel_diff in node.relationships:
+                if rel_diff.is_managed:
+                    continue
                 relationship_identifier = self._get_relationship_identifier(
                     schema_kind=node.kind, relationship_name=rel_diff.name
                 )

--- a/backend/infrahub/core/diff/model/path.py
+++ b/backend/infrahub/core/diff/model/path.py
@@ -243,6 +243,7 @@ class EnrichedDiffRelationship(BaseSummary):
     path_identifier: str = field(default="", kw_only=True)
     changed_at: Timestamp | None = field(default=None, kw_only=True)
     action: DiffAction
+    is_managed: bool = field(default=False)
     relationships: set[EnrichedDiffSingleRelationship] = field(default_factory=set)
     nodes: set[EnrichedDiffNode] = field(default_factory=set)
 
@@ -273,6 +274,7 @@ class EnrichedDiffRelationship(BaseSummary):
             cardinality=calculated_relationship.cardinality,
             changed_at=calculated_relationship.changed_at,
             action=calculated_relationship.action,
+            is_managed=calculated_relationship.is_managed,
             relationships={
                 EnrichedDiffSingleRelationship.from_calculated_element(calculated_element=element)
                 for element in calculated_relationship.relationships
@@ -564,6 +566,7 @@ class DiffRelationship:
     cardinality: RelationshipCardinality
     changed_at: Timestamp
     action: DiffAction
+    is_managed: bool
     relationships: list[DiffSingleRelationship] = field(default_factory=list)
 
 

--- a/backend/infrahub/core/diff/query/save.py
+++ b/backend/infrahub/core/diff/query/save.py
@@ -267,6 +267,7 @@ CALL {
                 if enriched_relationship.changed_at
                 else None,
                 "action": enriched_relationship.action,
+                "is_managed": enriched_relationship.is_managed,
                 "path_identifier": enriched_relationship.path_identifier,
                 "num_added": enriched_relationship.num_added,
                 "num_updated": enriched_relationship.num_updated,

--- a/backend/infrahub/core/diff/query_parser.py
+++ b/backend/infrahub/core/diff/query_parser.py
@@ -558,10 +558,7 @@ class DiffQueryParser:
     def _parse_path(self, database_path: DatabasePath) -> None:
         diff_root = self._get_diff_root(database_path=database_path)
         diff_node = self._get_diff_node(database_path=database_path, diff_root=diff_root)
-        is_base_branch = False
-        if self.base_branch_name != self.diff_branch_name and diff_root.branch == self.base_branch_name:
-            is_base_branch = True
-        self._update_attribute_level(database_path=database_path, diff_node=diff_node, is_base_branch=is_base_branch)
+        self._update_attribute_level(database_path=database_path, diff_node=diff_node)
 
     def _get_diff_root(self, database_path: DatabasePath) -> DiffRootIntermediate:
         branch = database_path.deepest_branch
@@ -595,9 +592,7 @@ class DiffQueryParser:
                 return rel_schema
         return None
 
-    def _update_attribute_level(
-        self, database_path: DatabasePath, diff_node: DiffNodeIntermediate, is_base_branch: bool
-    ) -> None:
+    def _update_attribute_level(self, database_path: DatabasePath, diff_node: DiffNodeIntermediate) -> None:
         node_schema = self.db.schema.get(
             name=database_path.node_kind, branch=database_path.deepest_branch, duplicate=False
         )
@@ -608,9 +603,7 @@ class DiffQueryParser:
         relationship_schema = self._get_relationship_schema(database_path=database_path, node_schema=node_schema)
         if not relationship_schema:
             return
-        diff_relationship = self._get_diff_relationship(
-            diff_node=diff_node, relationship_schema=relationship_schema, is_base_branch=is_base_branch
-        )
+        diff_relationship = self._get_diff_relationship(diff_node=diff_node, relationship_schema=relationship_schema)
         diff_relationship.add_path(
             database_path=database_path, diff_from_time=self.from_time, diff_to_time=self.to_time
         )
@@ -647,15 +640,13 @@ class DiffQueryParser:
         )
 
     def _get_diff_relationship(
-        self, diff_node: DiffNodeIntermediate, relationship_schema: RelationshipSchema, is_base_branch: bool
+        self, diff_node: DiffNodeIntermediate, relationship_schema: RelationshipSchema
     ) -> DiffRelationshipIntermediate:
         diff_relationship = diff_node.relationships_by_name.get(relationship_schema.name)
         if not diff_relationship:
-            is_managed = False
-            if is_base_branch and self.managed_relationship_checker.check(
+            is_managed = self.managed_relationship_checker.check(
                 node_kind=diff_node.kind, relationship_name=relationship_schema.name
-            ):
-                is_managed = True
+            )
             diff_relationship = DiffRelationshipIntermediate(
                 name=relationship_schema.name,
                 cardinality=relationship_schema.cardinality,

--- a/backend/infrahub/core/diff/query_parser.py
+++ b/backend/infrahub/core/diff/query_parser.py
@@ -23,8 +23,10 @@ if TYPE_CHECKING:
     from infrahub.core.branch import Branch
     from infrahub.core.query import QueryResult
     from infrahub.core.schema import MainSchemaTypes
-    from infrahub.core.schema.manager import SchemaManager
     from infrahub.core.schema.relationship_schema import RelationshipSchema
+    from infrahub.database import InfrahubDatabase
+
+    from .managed_relationship_checker import ManagedRelationshipChecker
 
 
 class DiffNoChildPathError(Exception): ...
@@ -308,6 +310,7 @@ class DiffRelationshipIntermediate:
     name: str
     identifier: str
     cardinality: RelationshipCardinality
+    is_managed: bool
     properties_by_db_id: dict[str, set[DiffRelationshipPropertyIntermediate]] = field(default_factory=dict)
     _single_relationship_list: list[DiffSingleRelationshipIntermediate] = field(default_factory=list)
 
@@ -354,6 +357,21 @@ class DiffRelationshipIntermediate:
             for single_relationship_properties in self.properties_by_db_id.values()
         ]
 
+    def _get_action(
+        self, from_time: Timestamp, last_changed_at: Timestamp, single_relationships: list[DiffSingleRelationship]
+    ) -> DiffAction:
+        if self.is_managed or all(sr.action is DiffAction.UNCHANGED for sr in single_relationships):
+            return DiffAction.UNCHANGED
+        if last_changed_at < from_time:
+            return DiffAction.UNCHANGED
+        if (
+            self.cardinality is RelationshipCardinality.ONE
+            and len(single_relationships) == 1
+            and single_relationships[0].action in (DiffAction.ADDED, DiffAction.REMOVED)
+        ):
+            return single_relationships[0].action
+        return DiffAction.UPDATED
+
     def to_diff_relationship(self, from_time: Timestamp, include_unchanged: bool) -> DiffRelationship:
         self._index_relationships()
         single_relationships = [
@@ -362,15 +380,9 @@ class DiffRelationshipIntermediate:
         ]
         last_changed_relationship = max(single_relationships, key=lambda r: r.changed_at)
         last_changed_at = last_changed_relationship.changed_at
-        action = DiffAction.UPDATED
-        if last_changed_at < from_time or all(sr.action is DiffAction.UNCHANGED for sr in single_relationships):
-            action = DiffAction.UNCHANGED
-        if (
-            self.cardinality is RelationshipCardinality.ONE
-            and len(single_relationships) == 1
-            and single_relationships[0].action in (DiffAction.ADDED, DiffAction.REMOVED)
-        ):
-            action = single_relationships[0].action
+        action = self._get_action(
+            from_time=from_time, last_changed_at=last_changed_at, single_relationships=single_relationships
+        )
         return DiffRelationship(
             name=self.name,
             changed_at=last_changed_at,
@@ -442,24 +454,68 @@ class DiffRootIntermediate:
 class DiffQueryParser:
     def __init__(
         self,
-        base_branch: Branch,
-        diff_branch: Branch,
-        schema_manager: SchemaManager,
-        from_time: Timestamp,
-        to_time: Optional[Timestamp] = None,
+        db: InfrahubDatabase,
+        managed_relationship_checker: ManagedRelationshipChecker,
     ) -> None:
-        self.base_branch_name = base_branch.name
-        self.diff_branch_name = diff_branch.name
-        self.schema_manager = schema_manager
-        self.from_time = from_time
-        self.to_time = to_time or Timestamp()
-        # if this diff is for the base branch, use from_time b/c create_time would be too much
-        if diff_branch.name == base_branch.name:
-            self.diff_branched_from_time = from_time
-        else:
-            self.diff_branched_from_time = Timestamp(diff_branch.get_branched_from())
+        self.db = db
+        self.managed_relationship_checker = managed_relationship_checker
+        self._base_branch_name: str | None = None
+        self._diff_branch_name: str | None = None
+        self._from_time: Timestamp | None = None
+        self._to_time: Timestamp | None = None
+        self._diff_branched_from_time: Timestamp | None = None
         self._diff_root_by_branch: dict[str, DiffRootIntermediate] = {}
         self._final_diff_root_by_branch: dict[str, DiffRoot] = {}
+
+    def initialize(
+        self,
+        base_branch: Branch,
+        diff_branch: Branch,
+        from_time: Timestamp,
+        to_time: Timestamp | None = None,
+    ) -> None:
+        self._base_branch_name = base_branch.name
+        self._diff_branch_name = diff_branch.name
+        self.managed_relationship_checker.reset()
+        self._from_time = from_time
+        self._to_time = to_time or Timestamp()
+        # if this diff is for the base branch, use from_time b/c create_time would be too much
+        if diff_branch.name == base_branch.name:
+            self._diff_branched_from_time = from_time
+        else:
+            self._diff_branched_from_time = Timestamp(diff_branch.get_branched_from())
+        self._diff_root_by_branch = {}
+        self._final_diff_root_by_branch = {}
+
+    @property
+    def base_branch_name(self) -> str:
+        if not self._base_branch_name:
+            raise RuntimeError("DiffQueryParser is not initialized")
+        return self._base_branch_name
+
+    @property
+    def diff_branch_name(self) -> str:
+        if not self._diff_branch_name:
+            raise RuntimeError("DiffQueryParser is not initialized")
+        return self._diff_branch_name
+
+    @property
+    def from_time(self) -> Timestamp:
+        if not self._from_time:
+            raise RuntimeError("DiffQueryParser is not initialized")
+        return self._from_time
+
+    @property
+    def to_time(self) -> Timestamp:
+        if not self._to_time:
+            raise RuntimeError("DiffQueryParser is not initialized")
+        return self._to_time
+
+    @property
+    def diff_branched_from_time(self) -> Timestamp:
+        if not self._diff_branched_from_time:
+            raise RuntimeError("DiffQueryParser is not initialized")
+        return self._diff_branched_from_time
 
     def get_branches(self) -> set[str]:
         return set(self._final_diff_root_by_branch.keys())
@@ -501,7 +557,10 @@ class DiffQueryParser:
     def _parse_path(self, database_path: DatabasePath) -> None:
         diff_root = self._get_diff_root(database_path=database_path)
         diff_node = self._get_diff_node(database_path=database_path, diff_root=diff_root)
-        self._update_attribute_level(database_path=database_path, diff_node=diff_node)
+        is_base_branch = False
+        if self.base_branch_name != self.diff_branch_name and diff_root.branch == self.base_branch_name:
+            is_base_branch = True
+        self._update_attribute_level(database_path=database_path, diff_node=diff_node, is_base_branch=is_base_branch)
 
     def _get_diff_root(self, database_path: DatabasePath) -> DiffRootIntermediate:
         branch = database_path.deepest_branch
@@ -535,8 +594,10 @@ class DiffQueryParser:
                 return rel_schema
         return None
 
-    def _update_attribute_level(self, database_path: DatabasePath, diff_node: DiffNodeIntermediate) -> None:
-        node_schema = self.schema_manager.get(
+    def _update_attribute_level(
+        self, database_path: DatabasePath, diff_node: DiffNodeIntermediate, is_base_branch: bool
+    ) -> None:
+        node_schema = self.db.schema.get(
             name=database_path.node_kind, branch=database_path.deepest_branch, duplicate=False
         )
         if "Attribute" in database_path.attribute_node.labels:
@@ -546,7 +607,9 @@ class DiffQueryParser:
         relationship_schema = self._get_relationship_schema(database_path=database_path, node_schema=node_schema)
         if not relationship_schema:
             return
-        diff_relationship = self._get_diff_relationship(diff_node=diff_node, relationship_schema=relationship_schema)
+        diff_relationship = self._get_diff_relationship(
+            diff_node=diff_node, relationship_schema=relationship_schema, is_base_branch=is_base_branch
+        )
         diff_relationship.add_path(
             database_path=database_path, diff_from_time=self.from_time, diff_to_time=self.to_time
         )
@@ -583,14 +646,20 @@ class DiffQueryParser:
         )
 
     def _get_diff_relationship(
-        self, diff_node: DiffNodeIntermediate, relationship_schema: RelationshipSchema
+        self, diff_node: DiffNodeIntermediate, relationship_schema: RelationshipSchema, is_base_branch: bool
     ) -> DiffRelationshipIntermediate:
         diff_relationship = diff_node.relationships_by_name.get(relationship_schema.name)
         if not diff_relationship:
+            is_managed = False
+            if is_base_branch and self.managed_relationship_checker.check(
+                node_kind=diff_node.kind, relationship_name=relationship_schema.name
+            ):
+                is_managed = True
             diff_relationship = DiffRelationshipIntermediate(
                 name=relationship_schema.name,
                 cardinality=relationship_schema.cardinality,
                 identifier=relationship_schema.get_identifier(),
+                is_managed=is_managed,
             )
             diff_node.relationships_by_name[relationship_schema.name] = diff_relationship
         return diff_relationship

--- a/backend/infrahub/core/diff/query_parser.py
+++ b/backend/infrahub/core/diff/query_parser.py
@@ -389,6 +389,7 @@ class DiffRelationshipIntermediate:
             action=action,
             relationships=single_relationships,
             cardinality=self.cardinality,
+            is_managed=self.is_managed,
         )
 
 

--- a/backend/infrahub/core/diff/repository/deserializer.py
+++ b/backend/infrahub/core/diff/repository/deserializer.py
@@ -238,6 +238,7 @@ class EnrichedDiffDeserializer:
             cardinality=RelationshipCardinality(relationship_group_node.get("cardinality")),
             changed_at=Timestamp(timestamp_str) if timestamp_str else None,
             action=DiffAction(str(relationship_group_node.get("action"))),
+            is_managed=str(relationship_group_node.get("is_managed")).lower() == "true",
             path_identifier=str(relationship_group_node.get("path_identifier")),
             num_added=int(relationship_group_node.get("num_added")),
             num_conflicts=int(relationship_group_node.get("num_conflicts")),

--- a/backend/infrahub/core/ipam/kinds_getter.py
+++ b/backend/infrahub/core/ipam/kinds_getter.py
@@ -2,21 +2,28 @@ from typing import Iterable
 
 from infrahub.core.constants import InfrahubKind
 from infrahub.database import InfrahubDatabase
+from infrahub.exceptions import SchemaNotFoundError
 
 
 class IpamKindsGetter:
     def __init__(self, db: InfrahubDatabase) -> None:
         self.db = db
 
-    async def get_ipam_address_kinds(self, branch_names: Iterable[str]) -> set[str]:
+    def get_ipam_address_kinds(self, branch_names: Iterable[str]) -> set[str]:
         ip_address_kinds: set[str] = set()
         for branch_name in branch_names:
-            address_generic_schema_source = self.db.schema.get(
-                InfrahubKind.IPADDRESS, branch=branch_name, duplicate=False
-            )
-            address_generic_schema_target = self.db.schema.get(
-                InfrahubKind.IPADDRESS, branch=branch_name, duplicate=False
-            )
+            try:
+                address_generic_schema_source = self.db.schema.get(
+                    InfrahubKind.IPADDRESS, branch=branch_name, duplicate=False
+                )
+            except SchemaNotFoundError:
+                address_generic_schema_source = None
+            try:
+                address_generic_schema_target = self.db.schema.get(
+                    InfrahubKind.IPADDRESS, branch=branch_name, duplicate=False
+                )
+            except SchemaNotFoundError:
+                address_generic_schema_target = None
 
             ip_address_kinds.update(
                 set(
@@ -26,15 +33,21 @@ class IpamKindsGetter:
             )
         return ip_address_kinds
 
-    async def get_ipam_prefix_kinds(self, branch_names: Iterable[str]) -> set[str]:
+    def get_ipam_prefix_kinds(self, branch_names: Iterable[str]) -> set[str]:
         ip_prefix_kinds: set[str] = set()
         for branch_name in branch_names:
-            prefix_generic_schema_source = self.db.schema.get(
-                InfrahubKind.IPPREFIX, branch=branch_name, duplicate=False
-            )
-            prefix_generic_schema_target = self.db.schema.get(
-                InfrahubKind.IPPREFIX, branch=branch_name, duplicate=False
-            )
+            try:
+                prefix_generic_schema_source = self.db.schema.get(
+                    InfrahubKind.IPPREFIX, branch=branch_name, duplicate=False
+                )
+            except SchemaNotFoundError:
+                prefix_generic_schema_source = None
+            try:
+                prefix_generic_schema_target = self.db.schema.get(
+                    InfrahubKind.IPPREFIX, branch=branch_name, duplicate=False
+                )
+            except SchemaNotFoundError:
+                prefix_generic_schema_target = None
 
             ip_prefix_kinds.update(
                 set(
@@ -43,3 +56,9 @@ class IpamKindsGetter:
                 )
             )
         return ip_prefix_kinds
+
+    def get_prefix_managed_relationship_names(self) -> set[str]:
+        return {"parent", "children", "ip_addresses"}
+
+    def get_address_managed_relationship_names(self) -> set[str]:
+        return {"ip_prefix"}

--- a/backend/infrahub/dependencies/builder/diff/calculator.py
+++ b/backend/infrahub/dependencies/builder/diff/calculator.py
@@ -1,8 +1,10 @@
 from infrahub.core.diff.calculator import DiffCalculator
 from infrahub.dependencies.interface import DependencyBuilder, DependencyBuilderContext
 
+from .query_parser import DiffQueryParserDependency
+
 
 class DiffCalculatorDependency(DependencyBuilder[DiffCalculator]):
     @classmethod
     def build(cls, context: DependencyBuilderContext) -> DiffCalculator:
-        return DiffCalculator(db=context.db)
+        return DiffCalculator(db=context.db, diff_query_parser=DiffQueryParserDependency.build(context=context))

--- a/backend/infrahub/dependencies/builder/diff/conflicts_enricher.py
+++ b/backend/infrahub/dependencies/builder/diff/conflicts_enricher.py
@@ -1,12 +1,8 @@
 from infrahub.core.diff.conflicts_enricher import ConflictsEnricher
 from infrahub.dependencies.interface import DependencyBuilder, DependencyBuilderContext
 
-from .managed_relationship_checker import ManagedRelationshipCheckerDependency
-
 
 class DiffConflictsEnricherDependency(DependencyBuilder[ConflictsEnricher]):
     @classmethod
     def build(cls, context: DependencyBuilderContext) -> ConflictsEnricher:
-        return ConflictsEnricher(
-            managed_relationship_checker=ManagedRelationshipCheckerDependency.build(context=context)
-        )
+        return ConflictsEnricher()

--- a/backend/infrahub/dependencies/builder/diff/conflicts_enricher.py
+++ b/backend/infrahub/dependencies/builder/diff/conflicts_enricher.py
@@ -1,8 +1,12 @@
 from infrahub.core.diff.conflicts_enricher import ConflictsEnricher
 from infrahub.dependencies.interface import DependencyBuilder, DependencyBuilderContext
 
+from .managed_relationship_checker import ManagedRelationshipCheckerDependency
+
 
 class DiffConflictsEnricherDependency(DependencyBuilder[ConflictsEnricher]):
     @classmethod
     def build(cls, context: DependencyBuilderContext) -> ConflictsEnricher:
-        return ConflictsEnricher()
+        return ConflictsEnricher(
+            managed_relationship_checker=ManagedRelationshipCheckerDependency.build(context=context)
+        )

--- a/backend/infrahub/dependencies/builder/diff/managed_relationship_checker.py
+++ b/backend/infrahub/dependencies/builder/diff/managed_relationship_checker.py
@@ -1,0 +1,13 @@
+from infrahub.core.diff.managed_relationship_checker import ManagedRelationshipChecker
+from infrahub.dependencies.interface import DependencyBuilder, DependencyBuilderContext
+
+from ..ip.kinds_getter import IpamKindsGetterDependency
+
+
+class ManagedRelationshipCheckerDependency(DependencyBuilder[ManagedRelationshipChecker]):
+    @classmethod
+    def build(cls, context: DependencyBuilderContext) -> ManagedRelationshipChecker:
+        return ManagedRelationshipChecker(
+            branch=context.branch,
+            ipam_kinds_getter=IpamKindsGetterDependency.build(context=context),
+        )

--- a/backend/infrahub/dependencies/builder/diff/query_parser.py
+++ b/backend/infrahub/dependencies/builder/diff/query_parser.py
@@ -1,0 +1,12 @@
+from infrahub.core.diff.query_parser import DiffQueryParser
+from infrahub.dependencies.interface import DependencyBuilder, DependencyBuilderContext
+
+from .managed_relationship_checker import ManagedRelationshipCheckerDependency
+
+
+class DiffQueryParserDependency(DependencyBuilder[DiffQueryParser]):
+    @classmethod
+    def build(cls, context: DependencyBuilderContext) -> DiffQueryParser:
+        return DiffQueryParser(
+            db=context.db, managed_relationship_checker=ManagedRelationshipCheckerDependency.build(context=context)
+        )

--- a/backend/infrahub/dependencies/registry.py
+++ b/backend/infrahub/dependencies/registry.py
@@ -19,6 +19,7 @@ from .builder.diff.enricher.aggregated import DiffAggregatedEnricherDependency
 from .builder.diff.enricher.cardinality_one import DiffCardinalityOneEnricherDependency
 from .builder.diff.enricher.hierarchy import DiffHierarchyEnricherDependency
 from .builder.diff.ipam_diff_parser import IpamDiffParserDependency
+from .builder.diff.managed_relationship_checker import ManagedRelationshipCheckerDependency
 from .builder.diff.repository import DiffRepositoryDependency
 from .builder.ip.kinds_getter import IpamKindsGetterDependency
 from .builder.node.delete_validator import NodeDeleteValidatorDependency
@@ -41,6 +42,7 @@ def build_component_registry() -> ComponentDependencyRegistry:
     component_registry.track_dependency(NodeDeleteValidatorDependency)
     component_registry.track_dependency(IpamKindsGetterDependency)
     component_registry.track_dependency(IpamDiffParserDependency)
+    component_registry.track_dependency(ManagedRelationshipCheckerDependency)
     component_registry.track_dependency(DiffCardinalityOneEnricherDependency)
     component_registry.track_dependency(DiffHierarchyEnricherDependency)
     component_registry.track_dependency(DiffAggregatedEnricherDependency)

--- a/backend/tests/integration/ipam/test_ipam_rebase_reconcile.py
+++ b/backend/tests/integration/ipam/test_ipam_rebase_reconcile.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 from infrahub.core import registry
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
@@ -81,7 +79,6 @@ class TestIpamRebaseReconcile(TestIpamReconcileBase):
         assert len(parent_rels) == 1
         assert parent_rels[0].peer_id == initial_dataset["net140"].id
 
-    @pytest.mark.skip(reason="broken for now, will be fixed in #4922")
     async def test_step02_add_delete_prefix(
         self,
         db: InfrahubDatabase,

--- a/backend/tests/integration/ipam/test_ipam_rebase_reconcile.py
+++ b/backend/tests/integration/ipam/test_ipam_rebase_reconcile.py
@@ -16,6 +16,21 @@ if TYPE_CHECKING:
 
     from infrahub.database import InfrahubDatabase
 
+
+BRANCH_CREATE = """
+    mutation($branch: String!) {
+        BranchCreate(data: {
+                name: $branch
+            }) {
+            ok
+            object {
+                id
+                name
+            }
+        }
+    }
+"""
+
 CREATE_IPPREFIX = """
 mutation CreatePrefix($prefix: String!, $namespace_id: String!) {
     IpamIPPrefixCreate(
@@ -85,7 +100,15 @@ class TestIpamRebaseReconcile(TestIpamReconcileBase):
         initial_dataset,
         client: InfrahubClient,
     ) -> None:
-        branch = await create_branch(db=db, branch_name="delete_prefix")
+        gql_params = prepare_graphql_params(db=db, include_subscription=False, branch=registry.default_branch)
+        result = await graphql(
+            schema=gql_params.schema,
+            source=BRANCH_CREATE,
+            context_value=gql_params.context,
+            variable_values={"branch": "delete_prefix"},
+        )
+        assert not result.errors
+        branch = await registry.get_branch(db=db, branch="delete_prefix")
 
         gql_params = prepare_graphql_params(db=db, include_subscription=False, branch=registry.default_branch)
         result = await graphql(

--- a/backend/tests/integration/ipam/test_proposed_change_reconcile.py
+++ b/backend/tests/integration/ipam/test_proposed_change_reconcile.py
@@ -3,36 +3,67 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
+from graphql import graphql
 
-from infrahub import config
 from infrahub.core import registry
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
-from infrahub.services.adapters.cache.redis import RedisCache
+from infrahub.graphql.initialization import prepare_graphql_params
 
 from .base import TestIpamReconcileBase
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from infrahub_sdk import InfrahubClient
 
     from infrahub.database import InfrahubDatabase
 
 
+CREATE_IPPREFIX = """
+mutation CreatePrefix($prefix: String!, $namespace_id: String!) {
+    IpamIPPrefixCreate(
+        data: {
+            prefix: {
+                value: $prefix
+            }
+            ip_namespace: {
+                id: $namespace_id
+            }
+        }
+    ) {
+        ok
+        object {
+            id
+        }
+    }
+}
+"""
+
+DELETE_IPPREFIX = """
+mutation DeletePrefix($id: String!) {
+    IpamIPPrefixDelete(
+        data: {
+            id: $id
+        }
+    ) {
+        ok
+    }
+}
+"""
+
+
 class TestProposedChangeReconcile(TestIpamReconcileBase):
-    @pytest.fixture(scope="class", autouse=True)
-    def enable_broker_settings(self):
-        config.SETTINGS.broker.enable = True
+    # @pytest.fixture(scope="class", autouse=True)
+    # def enable_broker_settings(self):
+    #     config.SETTINGS.broker.enable = True
 
-    @pytest.fixture(scope="class", autouse=True)
-    def bus_simulator_cache(self, bus_simulator):
-        bus_simulator.service.cache = RedisCache()
+    # @pytest.fixture(scope="class", autouse=True)
+    # def bus_simulator_cache(self, bus_simulator):
+    #     bus_simulator.service.cache = RedisCache()
 
-    @pytest.fixture(scope="class", autouse=True)
-    def git_repos_dir(self, git_repos_source_dir_module_scope: Path): ...
+    # @pytest.fixture(scope="class", autouse=True)
+    # def git_repos_dir(self, git_repos_source_dir_module_scope: Path): ...
 
     @pytest.fixture(scope="class")
     async def branch_1(self, db: InfrahubDatabase):
@@ -71,7 +102,7 @@ class TestProposedChangeReconcile(TestIpamReconcileBase):
         assert len(parent_rels) == 1
         assert parent_rels[0].peer_id == initial_dataset["net140"].id
 
-    @pytest.mark.skip(reason="broken for now, will be fixed in #4922")
+    # @pytest.mark.skip(reason="broken for now, will be fixed in #4922")
     async def test_step02_add_delete_prefix(
         self,
         db: InfrahubDatabase,
@@ -85,10 +116,21 @@ class TestProposedChangeReconcile(TestIpamReconcileBase):
             data={"source_branch": branch_2.name, "destination_branch": "main", "name": "delete_prefix_pc"},
         )
         await proposed_change_create.save()
-        prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=branch_2)
-        new_prefix = await Node.init(schema=prefix_schema, db=db, branch=registry.default_branch)
-        await new_prefix.new(db=db, prefix="10.10.0.0/17", ip_namespace=initial_dataset["ns1"].id)
-        await new_prefix.save(db=db)
+
+        gql_params = prepare_graphql_params(db=db, include_subscription=False, branch=registry.default_branch)
+        result = await graphql(
+            schema=gql_params.schema,
+            source=CREATE_IPPREFIX,
+            context_value=gql_params.context,
+            variable_values={"prefix": "10.10.0.0/17", "namespace_id": initial_dataset["ns1"].id},
+        )
+        assert not result.errors
+        assert result.data
+        assert result.data["IpamIPPrefixCreate"]
+        assert result.data["IpamIPPrefixCreate"]["ok"]
+        assert result.data["IpamIPPrefixCreate"]["object"]["id"]
+        new_prefix_id = result.data["IpamIPPrefixCreate"]["object"]["id"]
+
         deleted_prefix_branch = await NodeManager.get_one(db=db, branch=branch_2, id=initial_dataset["net140"].id)
         assert deleted_prefix_branch
         await deleted_prefix_branch.delete(db=db)
@@ -98,7 +140,7 @@ class TestProposedChangeReconcile(TestIpamReconcileBase):
 
         deleted_prefix = await NodeManager.get_one(db=db, id=deleted_prefix_branch.id)
         assert deleted_prefix is None
-        new_prefix_branch = await NodeManager.get_one(db=db, id=new_prefix.id)
+        new_prefix_branch = await NodeManager.get_one(db=db, id=new_prefix_id)
         parent_rels = await new_prefix_branch.parent.get_relationships(db=db)  # type: ignore[union-attr]
         assert len(parent_rels) == 1
         assert parent_rels[0].peer_id == initial_dataset["net146"].id
@@ -112,3 +154,14 @@ class TestProposedChangeReconcile(TestIpamReconcileBase):
         address_rels = await new_prefix_branch.ip_addresses.get_relationships(db=db)  # type: ignore[union-attr]
         assert len(address_rels) == 2
         assert {ar.peer_id for ar in address_rels} == {new_address_1.id, initial_dataset["address10"].id}
+
+
+"""
+MATCH p1 = (av:AttributeValue)-[:HAS_VALUE]-(:Attribute {name: "prefix"})-[:HAS_ATTRIBUTE]-(n:BuiltinIPPrefix)
+WHERE av.value IN ["10.10.0.0/16", "10.10.0.0/17"]
+OPTIONAL MATCH p2 = (n)-[:IS_RELATED]-(r:Relationship)
+    -[:IS_RELATED]-(:BuiltinIPPrefix|BuiltinIPAddress)-[:HAS_ATTRIBUTE]-(a:Attribute)-[:HAS_VALUE]-(:AttributeValue)
+WHERE r.name in ["parent__child", "ip_prefix__ip_address"]
+AND a.name in ["prefix", "address"]
+RETURN p1, p2
+"""

--- a/backend/tests/integration/ipam/test_proposed_change_reconcile.py
+++ b/backend/tests/integration/ipam/test_proposed_change_reconcile.py
@@ -54,17 +54,6 @@ mutation DeletePrefix($id: String!) {
 
 
 class TestProposedChangeReconcile(TestIpamReconcileBase):
-    # @pytest.fixture(scope="class", autouse=True)
-    # def enable_broker_settings(self):
-    #     config.SETTINGS.broker.enable = True
-
-    # @pytest.fixture(scope="class", autouse=True)
-    # def bus_simulator_cache(self, bus_simulator):
-    #     bus_simulator.service.cache = RedisCache()
-
-    # @pytest.fixture(scope="class", autouse=True)
-    # def git_repos_dir(self, git_repos_source_dir_module_scope: Path): ...
-
     @pytest.fixture(scope="class")
     async def branch_1(self, db: InfrahubDatabase):
         return await create_branch(db=db, branch_name="new_address")
@@ -102,7 +91,6 @@ class TestProposedChangeReconcile(TestIpamReconcileBase):
         assert len(parent_rels) == 1
         assert parent_rels[0].peer_id == initial_dataset["net140"].id
 
-    # @pytest.mark.skip(reason="broken for now, will be fixed in #4922")
     async def test_step02_add_delete_prefix(
         self,
         db: InfrahubDatabase,

--- a/backend/tests/unit/core/diff/factories.py
+++ b/backend/tests/unit/core/diff/factories.py
@@ -48,6 +48,7 @@ class EnrichedRelationshipGroupFactory(DataclassFactory[EnrichedDiffRelationship
     num_conflicts = 0
     nodes = set()
     contains_conflict = False
+    is_managed = False
 
 
 class EnrichedRelationshipElementFactory(DataclassFactory[EnrichedDiffSingleRelationship]):

--- a/backend/tests/unit/core/diff/factories.py
+++ b/backend/tests/unit/core/diff/factories.py
@@ -48,7 +48,6 @@ class EnrichedRelationshipGroupFactory(DataclassFactory[EnrichedDiffRelationship
     num_conflicts = 0
     nodes = set()
     contains_conflict = False
-    is_managed = False
 
 
 class EnrichedRelationshipElementFactory(DataclassFactory[EnrichedDiffSingleRelationship]):

--- a/backend/tests/unit/core/diff/test_conflicts_enricher.py
+++ b/backend/tests/unit/core/diff/test_conflicts_enricher.py
@@ -1,4 +1,5 @@
 import random
+from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
@@ -7,6 +8,7 @@ from infrahub.core.branch import Branch
 from infrahub.core.constants import DiffAction, RelationshipCardinality
 from infrahub.core.constants.database import DatabaseEdgeType
 from infrahub.core.diff.conflicts_enricher import ConflictsEnricher
+from infrahub.core.diff.managed_relationship_checker import ManagedRelationshipChecker
 from infrahub.core.diff.model.path import EnrichedDiffConflict
 from infrahub.core.initialization import create_branch
 from infrahub.core.timestamp import Timestamp
@@ -31,7 +33,9 @@ class TestConflictsEnricher:
         self.to_time = Timestamp()
 
     async def __call_system_under_test(self, db: InfrahubDatabase, base_enriched_diff, branch_enriched_diff) -> None:
-        conflicts_enricher = ConflictsEnricher()
+        mock_rel_checker = AsyncMock(spec=ManagedRelationshipChecker)
+        mock_rel_checker.check.return_value = False
+        conflicts_enricher = ConflictsEnricher(managed_relationship_checker=mock_rel_checker)
         return await conflicts_enricher.add_conflicts_to_branch_diff(
             base_diff_root=base_enriched_diff, branch_diff_root=branch_enriched_diff
         )

--- a/backend/tests/unit/core/diff/test_conflicts_enricher.py
+++ b/backend/tests/unit/core/diff/test_conflicts_enricher.py
@@ -1,5 +1,4 @@
 import random
-from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
@@ -8,7 +7,6 @@ from infrahub.core.branch import Branch
 from infrahub.core.constants import DiffAction, RelationshipCardinality
 from infrahub.core.constants.database import DatabaseEdgeType
 from infrahub.core.diff.conflicts_enricher import ConflictsEnricher
-from infrahub.core.diff.managed_relationship_checker import ManagedRelationshipChecker
 from infrahub.core.diff.model.path import EnrichedDiffConflict
 from infrahub.core.initialization import create_branch
 from infrahub.core.timestamp import Timestamp
@@ -33,9 +31,7 @@ class TestConflictsEnricher:
         self.to_time = Timestamp()
 
     async def __call_system_under_test(self, db: InfrahubDatabase, base_enriched_diff, branch_enriched_diff) -> None:
-        mock_rel_checker = AsyncMock(spec=ManagedRelationshipChecker)
-        mock_rel_checker.check.return_value = False
-        conflicts_enricher = ConflictsEnricher(managed_relationship_checker=mock_rel_checker)
+        conflicts_enricher = ConflictsEnricher()
         return await conflicts_enricher.add_conflicts_to_branch_diff(
             base_diff_root=base_enriched_diff, branch_diff_root=branch_enriched_diff
         )
@@ -172,7 +168,8 @@ class TestConflictsEnricher:
                     else:
                         assert prop.conflict is None
 
-    async def test_cardinality_one_conflicts(self, db: InfrahubDatabase, car_person_schema):
+    @pytest.mark.parametrize("is_managed", [True, False])
+    async def test_cardinality_one_conflicts(self, db: InfrahubDatabase, car_person_schema, is_managed: bool):
         branch = await create_branch(db=db, branch_name="branch")
         property_type = DatabaseEdgeType.IS_RELATED
         relationship_name = "owner"
@@ -199,6 +196,7 @@ class TestConflictsEnricher:
                     )
                 },
                 cardinality=RelationshipCardinality.ONE,
+                is_managed=is_managed,
             )
         }
         base_nodes = {
@@ -227,6 +225,7 @@ class TestConflictsEnricher:
                     )
                 },
                 cardinality=RelationshipCardinality.ONE,
+                is_managed=is_managed,
             )
         }
         branch_nodes = {
@@ -253,6 +252,7 @@ class TestConflictsEnricher:
                         node.uuid == node_uuid
                         and rel.name == relationship_name
                         and rel_element.peer_id == previous_peer_id
+                        and not is_managed
                     ):
                         assert rel_element.conflict
                         assert rel_element.conflict == EnrichedDiffConflict(
@@ -265,6 +265,8 @@ class TestConflictsEnricher:
                             diff_branch_changed_at=branch_conflict_property.changed_at,
                             selected_branch=None,
                         )
+                    else:
+                        assert rel_element.conflict is None
 
     async def test_cardinality_many_conflicts(self, db: InfrahubDatabase, car_person_schema):
         branch = await create_branch(db=db, branch_name="branch")
@@ -309,6 +311,7 @@ class TestConflictsEnricher:
                     EnrichedRelationshipElementFactory.build(peer_id=peer_id_2, properties=base_properties_2),
                 },
                 cardinality=RelationshipCardinality.MANY,
+                is_managed=False,
             )
         }
         base_nodes = {
@@ -349,6 +352,7 @@ class TestConflictsEnricher:
                     EnrichedRelationshipElementFactory.build(peer_id=peer_id_2, properties=branch_properties_2),
                 },
                 cardinality=RelationshipCardinality.MANY,
+                is_managed=False,
             )
         }
         branch_nodes = {
@@ -564,6 +568,7 @@ class TestConflictsEnricher:
                     )
                 },
                 cardinality=RelationshipCardinality.ONE,
+                is_managed=False,
             )
         }
         base_nodes = {
@@ -596,6 +601,7 @@ class TestConflictsEnricher:
                     )
                 },
                 cardinality=RelationshipCardinality.ONE,
+                is_managed=False,
             )
         }
         branch_nodes = {
@@ -646,6 +652,7 @@ class TestConflictsEnricher:
                     )
                 },
                 cardinality=RelationshipCardinality.ONE,
+                is_managed=False,
             )
         }
         base_nodes = {
@@ -680,6 +687,7 @@ class TestConflictsEnricher:
                     )
                 },
                 cardinality=RelationshipCardinality.ONE,
+                is_managed=False,
             )
         }
         branch_nodes = {
@@ -747,6 +755,7 @@ class TestConflictsEnricher:
                     EnrichedRelationshipElementFactory.build(peer_id=peer_id_2, properties=base_properties_2),
                 },
                 cardinality=RelationshipCardinality.MANY,
+                is_managed=False,
             )
         }
         base_nodes = {
@@ -788,6 +797,7 @@ class TestConflictsEnricher:
                     EnrichedRelationshipElementFactory.build(peer_id=peer_id_2, properties=branch_properties_2),
                 },
                 cardinality=RelationshipCardinality.MANY,
+                is_managed=False,
             )
         }
         branch_nodes = {
@@ -861,3 +871,87 @@ class TestConflictsEnricher:
 
         for node in branch_root.nodes:
             assert node.conflict is None
+
+    async def test_managed_rel_cannot_create_conflict(self, db: InfrahubDatabase, car_person_schema):
+        base_action = DiffAction.UPDATED
+        branch_action = DiffAction.REMOVED
+        branch = await create_branch(db=db, branch_name="branch")
+        property_type = DatabaseEdgeType.IS_RELATED
+        relationship_name = "owner"
+        node_uuid = str(uuid4())
+        node_kind = "TestCar"
+        peer_id = str(uuid4())
+        base_properties = {
+            EnrichedPropertyFactory.build(property_type=DatabaseEdgeType.IS_VISIBLE),
+            EnrichedPropertyFactory.build(property_type=property_type, action=base_action),
+        }
+        base_relationships = {
+            EnrichedRelationshipGroupFactory.build(
+                name=relationship_name,
+                relationships={
+                    EnrichedRelationshipElementFactory.build(
+                        peer_id=peer_id, properties=base_properties, action=DiffAction.UPDATED
+                    )
+                },
+                cardinality=RelationshipCardinality.ONE,
+                is_managed=True,
+            )
+        }
+        base_nodes = {
+            EnrichedNodeFactory.build(
+                uuid=node_uuid,
+                kind=node_kind,
+                action=DiffAction.UPDATED,
+                relationships=base_relationships,
+            ),
+            EnrichedNodeFactory.build(relationships=set()),
+        }
+        base_root = EnrichedRootFactory.build(nodes=base_nodes)
+        branch_conflict_property = EnrichedPropertyFactory.build(
+            property_type=property_type,
+            previous_value=peer_id,
+            action=branch_action,
+            conflict=EnrichedConflictFactory.build(),
+        )
+        branch_properties = {
+            branch_conflict_property,
+            EnrichedPropertyFactory.build(property_type=DatabaseEdgeType.HAS_OWNER),
+        }
+        branch_relationships = {
+            EnrichedRelationshipGroupFactory.build(
+                name=relationship_name,
+                relationships={
+                    EnrichedRelationshipElementFactory.build(
+                        peer_id=peer_id,
+                        properties=branch_properties,
+                        action=DiffAction.REMOVED,
+                        conflict=EnrichedConflictFactory.build(),
+                    )
+                },
+                cardinality=RelationshipCardinality.ONE,
+                is_managed=True,
+            )
+        }
+        branch_nodes = {
+            EnrichedNodeFactory.build(
+                uuid=node_uuid,
+                kind=node_kind,
+                action=DiffAction.UPDATED,
+                relationships=branch_relationships,
+            ),
+            EnrichedNodeFactory.build(relationships=set()),
+        }
+        branch_root = EnrichedRootFactory.build(nodes=branch_nodes, diff_branch_name=branch.name)
+
+        await self.__call_system_under_test(db=db, base_enriched_diff=base_root, branch_enriched_diff=branch_root)
+
+        for node in branch_root.nodes:
+            assert node.conflict is None
+            for attribute in node.attributes:
+                for prop in attribute.properties:
+                    assert prop.conflict is None
+            for rel in node.relationships:
+                for rel_element in rel.relationships:
+                    assert rel_element.conflict is None
+                    for prop in rel_element.properties:
+                        assert prop.conflict is None

--- a/backend/tests/unit/core/diff/test_diff_calculator.py
+++ b/backend/tests/unit/core/diff/test_diff_calculator.py
@@ -2881,3 +2881,55 @@ async def test_diff_relationship_property_update_on_main(
     diff_rel = node_diff.relationships.pop()
     assert diff_rel.name == "owner"
     assert diff_rel.action is DiffAction.ADDED
+
+
+async def test_managed_relationship_identified(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    person_alfred_main: Node,
+    person_john_main: Node,
+    car_accord_main: Node,
+):
+    branch = await create_branch(db=db, branch_name="branch")
+    from_time = Timestamp()
+    car_branch = await NodeManager.get_one(db=db, branch=branch, id=car_accord_main.id)
+    await car_branch.owner.update(db=db, data=person_alfred_main)
+    await car_branch.save(db=db)
+
+    component_registry = get_component_registry()
+    diff_calculator = await component_registry.get_component(DiffCalculator, db=db, branch=branch)
+
+    class MockManagedRelChecker:
+        def reset(self): ...
+        def check(self, node_kind: str, relationship_name: str) -> bool:
+            return node_kind == "TestCar" and relationship_name == "owner"
+
+    diff_calculator.query_parser.managed_relationship_checker = MockManagedRelChecker()
+
+    calculated_diffs = await diff_calculator.calculate_diff(
+        base_branch=default_branch,
+        diff_branch=branch,
+        from_time=from_time,
+        to_time=Timestamp(),
+    )
+
+    base_branch_diff = calculated_diffs.base_branch_diff
+    assert len(base_branch_diff.nodes) == 0
+    diff_branch_diff = calculated_diffs.diff_branch_diff
+    nodes_by_id = {n.uuid: n for n in diff_branch_diff.nodes}
+    assert set(nodes_by_id.keys()) == {car_accord_main.id, person_john_main.id, person_alfred_main.id}
+
+    car_diff = nodes_by_id[car_accord_main.id]
+    assert len(car_diff.relationships) == 1
+    owner_rel_diff = car_diff.relationships.pop()
+    assert owner_rel_diff.is_managed is True
+
+    john_diff = nodes_by_id[person_john_main.id]
+    assert len(john_diff.relationships) == 1
+    cars_rel_diff = john_diff.relationships.pop()
+    assert cars_rel_diff.is_managed is False
+
+    alfred_diff = nodes_by_id[person_alfred_main.id]
+    assert len(alfred_diff.relationships) == 1
+    cars_rel_diff = alfred_diff.relationships.pop()
+    assert cars_rel_diff.is_managed is False

--- a/backend/tests/unit/core/diff/test_diff_calculator.py
+++ b/backend/tests/unit/core/diff/test_diff_calculator.py
@@ -12,6 +12,12 @@ from infrahub.core.node import Node
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
+from infrahub.dependencies.registry import get_component_registry
+
+
+async def _get_diff_calculator(db: InfrahubDatabase, branch: Branch) -> DiffCalculator:
+    component_registry = get_component_registry()
+    return await component_registry.get_component(DiffCalculator, db=db, branch=branch)
 
 
 async def test_diff_attribute_branch_update(
@@ -30,7 +36,7 @@ async def test_diff_attribute_branch_update(
     await alfred_branch.save(db=db)
     branch_after_change = Timestamp()
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
         diff_branch=branch,
@@ -88,7 +94,7 @@ async def test_attribute_property_main_update(
     await alfred_main.save(db=db)
     after_change = Timestamp()
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=default_branch)
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
         diff_branch=default_branch,
@@ -135,7 +141,7 @@ async def test_attribute_branch_set_null(db: InfrahubDatabase, default_branch: B
     await car_branch.save(db=db)
     after_change = Timestamp()
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
         diff_branch=branch,
@@ -176,7 +182,7 @@ async def test_node_delete(db: InfrahubDatabase, default_branch: Branch, car_acc
     car_branch = await NodeManager.get_one(db=db, branch=branch, id=car_accord_main.id)
     await car_branch.delete(db=db)
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
         diff_branch=branch,
@@ -246,7 +252,7 @@ async def test_node_base_delete_branch_update(
     car_branch.nbr_seats.value = 10
     await car_branch.save(db=db)
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
         diff_branch=branch,
@@ -293,7 +299,7 @@ async def test_node_branch_add(db: InfrahubDatabase, default_branch: Branch, car
     await new_person.save(db=db)
     after_change = Timestamp()
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
         diff_branch=branch,
@@ -339,7 +345,7 @@ async def test_attribute_property_multiple_branch_updates(
     await alfred_branch.save(db=db)
     after_last_change = Timestamp()
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
         diff_branch=branch,
@@ -390,7 +396,7 @@ async def test_relationship_one_peer_branch_and_main_update(
     await car_branch.save(db=db)
     after_branch_change = Timestamp()
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
         diff_branch=branch,
@@ -605,7 +611,7 @@ async def test_relationship_one_property_branch_update(
     await car_branch.save(db=db)
     after_branch_change = Timestamp()
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
         diff_branch=branch,
@@ -761,7 +767,7 @@ async def test_add_node_branch(
     await new_car.new(db=db, name="Batmobile", color="#000000", owner=person_jane_main)
     await new_car.save(db=db)
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
         diff_branch=branch,
@@ -847,7 +853,7 @@ async def test_many_relationship_property_update(
     await branch_car.owner.update(db=db, data={"id": person_john_main.id, "_relation__source": person_jane_main.id})
     await branch_car.save(db=db)
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
         diff_branch=branch,
@@ -925,7 +931,7 @@ async def test_cardinality_one_peer_conflicting_updates(
     await main_car.save(db=db)
     main_update_done = Timestamp()
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
         diff_branch=branch,
@@ -1153,7 +1159,7 @@ async def test_relationship_property_owner_conflicting_updates(
     await branch_john.cars.update(db=db, data={"id": car_accord_main.id, "_relation__owner": car_accord_main.id})
     await branch_john.save(db=db)
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
         diff_branch=branch,
@@ -1281,7 +1287,7 @@ async def test_agnostic_source_relationship_update(
     await branch_car.owner.update(db=db, data={"id": person_1.id, "_relation__source": person_1.id})
     await branch_car.save(db=db)
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
         diff_branch=branch,
@@ -1334,7 +1340,7 @@ async def test_agnostic_owner_relationship_added(
     await new_car.owner.update(db=db, data={"id": person_1.id, "_relation__owner": person_1.id})
     await new_car.save(db=db)
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
         diff_branch=branch,
@@ -1423,7 +1429,7 @@ async def test_update_attribute_under_agnostic_node(
     await fruit_1.new(db=db, name="blueberry", branch_aware_attr="branchval")
     await fruit_1.save(db=db)
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
         diff_branch=branch,
@@ -1480,7 +1486,7 @@ async def test_diff_attribute_branch_update_with_previous_base_update_ignored(
     await alfred_branch.save(db=db)
     branch_after_change = Timestamp()
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
         diff_branch=branch,
@@ -1533,7 +1539,7 @@ async def test_diff_attribute_branch_update_with_concurrent_base_update_captured
     await alfred_branch.save(db=db)
     branch_after_change = Timestamp()
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
         diff_branch=branch,
@@ -1601,7 +1607,7 @@ async def test_diff_attribute_branch_update_with_previous_base_update_captured(
     await alfred_branch.save(db=db)
     branch_after_change = Timestamp()
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
         diff_branch=branch,
@@ -1667,7 +1673,7 @@ async def test_diff_attribute_branch_update_with_separate_previous_base_update_c
     await alfred_branch.save(db=db)
     branch_after_change = Timestamp()
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
 
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
@@ -1750,7 +1756,7 @@ async def test_branch_node_delete_with_base_updates(
     await car_main.owner.update(db=db, data={"id": person_jane_main.id})
     await car_main.save(db=db)
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
         diff_branch=branch,
@@ -1920,7 +1926,7 @@ async def test_branch_relationship_delete_with_property_update(
     await dog_main.save(db=db)
     after_main_change = Timestamp()
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
         diff_branch=branch,
@@ -2026,7 +2032,7 @@ async def test_node_deleted_on_both(
     alfred_branch = await NodeManager.get_one(db=db, branch=branch, id=person_alfred_main.id)
     await alfred_branch.delete(db=db)
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
         diff_branch=branch,
@@ -2075,7 +2081,7 @@ async def test_relationship_updated_then_node_deleted(
     car_branch = await NodeManager.get_one(db=db, branch=branch, id=car_camry_main.id)
     await car_branch.delete(db=db)
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
         diff_branch=branch,
@@ -2252,7 +2258,7 @@ async def test_node_added_and_deleted_on_branch(
     retrieved_car = await NodeManager.get_one(db=db, branch=branch, id=new_car.id)
     await retrieved_car.delete(db=db)
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
         diff_branch=branch,
@@ -2285,7 +2291,7 @@ async def test_property_update_then_relationship_deleted(
     await car_branch.owner.update(db=db, data={"id": person_john_main.id})
     await car_branch.save(db=db)
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
         diff_branch=branch,
@@ -2426,7 +2432,7 @@ async def test_hierarchy_with_same_kind_parent_and_child(
     await bottom_branch.parent.update(db=db, data=mid_node.id)
     await bottom_branch.save(db=db)
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
         diff_branch=branch,
@@ -2567,7 +2573,7 @@ async def test_diff_unchanged_included_when_not_first_diff(
     alfred_main.name.value = "Alfred"
     await alfred_main.save(db=db)
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
 
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
@@ -2648,7 +2654,7 @@ async def test_create_local_and_aware_nodes_on_branch(
     await car.new(db=db, name="camry", owner=person.id)
     await car.save(db=db)
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch, diff_branch=branch, from_time=from_time, to_time=Timestamp()
     )
@@ -2682,7 +2688,7 @@ async def test_create_aware_and_agnostic_nodes_on_branch(
     await car.new(db=db, name="camry", nbr_seats=3, is_electric=True, owner=person.id)
     await car.save(db=db)
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch, diff_branch=branch, from_time=from_time, to_time=Timestamp()
     )
@@ -2728,7 +2734,7 @@ async def test_diff_relationship_update_includes_unchanged_properties(
     await car_branch.owner.update(db=db, data=person_alfred_main)
     await car_branch.save(db=db)
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
 
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
@@ -2849,7 +2855,7 @@ async def test_diff_relationship_property_update_on_main(
     car_schema = car_main.get_schema()
     owner_rel_schema = car_schema.get_relationship(name="owner")
 
-    diff_calculator = DiffCalculator(db=db)
+    diff_calculator = await _get_diff_calculator(db=db, branch=branch)
 
     calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,

--- a/backend/tests/unit/core/diff/test_diff_combiner.py
+++ b/backend/tests/unit/core/diff/test_diff_combiner.py
@@ -455,6 +455,7 @@ class TestDiffCombiner:
             action=DiffAction.ADDED,
             path_identifier=later_relationship.path_identifier,
             relationships={expected_relationship_element},
+            is_managed=later_relationship.is_managed,
         )
         expected_node = EnrichedDiffNode(
             uuid=later_node.uuid,
@@ -560,6 +561,7 @@ class TestDiffCombiner:
             cardinality=RelationshipCardinality.MANY,
             relationships={added_element_1, removed_element_1, updated_element_1, canceled_element_1},
             nodes=set(),
+            is_managed=True,
         )
         relationship_group_2 = EnrichedRelationshipGroupFactory.build(
             name=relationship_name,
@@ -568,6 +570,7 @@ class TestDiffCombiner:
             relationships={added_element_2, removed_element_2, updated_element_2, canceled_element_2},
             changed_at=Timestamp(),
             nodes=set(),
+            is_managed=True,
         )
         node_1 = EnrichedNodeFactory.build(
             kind="TestPerson", action=DiffAction.UPDATED, relationships={relationship_group_1}
@@ -623,6 +626,7 @@ class TestDiffCombiner:
             action=DiffAction.UPDATED,
             path_identifier=relationship_group_2.path_identifier,
             relationships={expected_added_element, expected_removed_element, expected_updated_element},
+            is_managed=True,
         )
         expected_node = EnrichedDiffNode(
             uuid=node_1.uuid,
@@ -688,6 +692,7 @@ class TestDiffCombiner:
             path_identifier=later_relationship.path_identifier,
             relationships={element_1},
             nodes={later_parent_node},
+            is_managed=later_relationship.is_managed,
         )
         expected_node = EnrichedDiffNode(
             uuid=later_node.uuid,
@@ -857,6 +862,7 @@ class TestDiffCombiner:
             action=DiffAction.UNCHANGED,
             relationships=set(),
             nodes={expected_parent_node},
+            is_managed=parent_rel_2.is_managed,
         )
         expected_child_node = EnrichedDiffNode(
             uuid=child_node_uuid,
@@ -929,6 +935,7 @@ class TestDiffCombiner:
             action=DiffAction.UPDATED,
             relationships={child_element_1},
             nodes={expected_parent_2},
+            is_managed=child_rel_2.is_managed,
         )
         expected_child_node = EnrichedDiffNode(
             uuid=child_node_uuid,
@@ -1088,6 +1095,7 @@ class TestDiffCombiner:
             action=DiffAction.UPDATED,
             path_identifier=later_relationship.path_identifier,
             relationships={expected_relationship_element},
+            is_managed=later_relationship.is_managed,
         )
         expected_node = EnrichedDiffNode(
             uuid=later_node.uuid,


### PR DESCRIPTION
IFC-986

we need some special handling in the diff and merge logic for certain IPAM relationships that we manage for the user. we should not allow conflicts on these managed relationships and we should not include them when merging b/c they are going to get updated by the IPAM reconcile logic after the merge completes anyway.

This is not ready for primetime yet. it definitely needs more unit tests and I need to review it all again