### PR TITLE
Fix git auth prompting and allow config of '.git' auto suffix

### DIFF
--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -36,6 +36,10 @@ def default_cors_allow_headers() -> list[str]:
     return ["accept", "authorization", "content-type", "user-agent", "x-csrftoken", "x-requested-with"]
 
 
+def default_append_git_suffix_domains() -> list[str]:
+    return ["github.com", "gitlab.com"]
+
+
 class UserInfoMethod(str, Enum):
     POST = "post"
     GET = "get"
@@ -336,6 +340,10 @@ class GitSettings(BaseSettings):
         ge=0,
         description="Time (in seconds) between git repositories synchronizations",
         deprecated="This setting is deprecated and not currently in use.",
+    )
+    append_git_suffix: list[str] = Field(
+        default_factory=default_append_git_suffix_domains,
+        description="Automatically append '.git' to HTTP URLs if for these domains.",
     )
 
 

--- a/backend/infrahub/graphql/mutations/repository.py
+++ b/backend/infrahub/graphql/mutations/repository.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, Optional, cast
 
+import httpx
 from graphene import Boolean, InputObjectType, Mutation, String
 
+from infrahub import config
 from infrahub.core.constants import InfrahubKind, RepositoryInternalStatus
 from infrahub.core.manager import NodeManager
 from infrahub.core.protocols import CoreGenericRepository, CoreReadOnlyRepository, CoreRepository
@@ -187,7 +189,9 @@ def cleanup_payload(data: InputObjectType | dict[str, Any]) -> None:
         and data["location"].get("value")
         and re.match(http_without_dotgit, data["location"]["value"])
     ):
-        data["location"]["value"] = f'{data["location"]["value"]}.git'
+        url = httpx.URL(data["location"]["value"])
+        if url.host in config.SETTINGS.git.append_git_suffix:
+            data["location"]["value"] = f'{data["location"]["value"]}.git'
 
 
 class ProcessRepository(Mutation):

--- a/backend/infrahub/workers/infrahub_async.py
+++ b/backend/infrahub/workers/infrahub_async.py
@@ -79,6 +79,9 @@ class InfrahubWorkerAsync(BaseWorker):
         logging.getLogger("aio_pika").setLevel(logging.ERROR)
         logging.getLogger("aiormq").setLevel(logging.ERROR)
         logging.getLogger("git").setLevel(logging.ERROR)
+        # Prevent git from interactively prompting the user for passwords if the credentials provided
+        # by the credential helper is failing.
+        os.environ["GIT_TERMINAL_PROMPT"] = "0"
 
         if not config.SETTINGS.settings:
             config_file = os.environ.get("INFRAHUB_CONFIG", "infrahub.toml")

--- a/backend/tests/unit/graphql/mutations/test_repository.py
+++ b/backend/tests/unit/graphql/mutations/test_repository.py
@@ -113,6 +113,14 @@ async def test_repository_update(db: InfrahubDatabase, register_core_models_sche
             {"name": "demo", "location": {"value": "http://github.com/opsmill/infrahub-demo-edge-develop.git"}},
         ),
         (
+            {"name": "demo", "location": {"value": "http://gitlab.com/opsmill/infrahub-demo-edge-develop"}},
+            {"name": "demo", "location": {"value": "http://gitlab.com/opsmill/infrahub-demo-edge-develop.git"}},
+        ),
+        (
+            {"name": "demo", "location": {"value": "http://example.com/opsmill/infrahub-demo-edge-develop"}},
+            {"name": "demo", "location": {"value": "http://example.com/opsmill/infrahub-demo-edge-develop"}},
+        ),
+        (
             {"name": "demo"},
             {"name": "demo"},
         ),

--- a/changelog/+ddd89dc2.fixed.md
+++ b/changelog/+ddd89dc2.fixed.md
@@ -1,0 +1,1 @@
+Corrected configuration for prefect worker to never prompt for Git credentials on the console

--- a/changelog/5077.added.md
+++ b/changelog/5077.added.md
@@ -1,0 +1,1 @@
+Added a 'append_git_suffix' configuration setting for Git repositories that allows you to define domains for auto appending '.git' to repositories defined with an HTTP URL


### PR DESCRIPTION
This PR ensures that we set the environment variable to Git so that we never prompt for credentials (in the console of the docker container), this change reflects the what we had with the old git agent.

It also adds a configuration option that lets users disable the automatic suffix of ".git" that Infrahub adds to HTTP repositories if this string wasn't appended to the URL.

Fixes #5077