### PR TITLE
Remove flows for webhooks and node mutated event

### DIFF
--- a/backend/infrahub/message_bus/operations/event/node.py
+++ b/backend/infrahub/message_bus/operations/event/node.py
@@ -1,7 +1,5 @@
 from typing import List
 
-from prefect import flow
-
 from infrahub.core.constants import InfrahubKind
 from infrahub.log import get_logger
 from infrahub.message_bus import InfrahubMessage, messages
@@ -10,7 +8,6 @@ from infrahub.services import InfrahubServices
 log = get_logger()
 
 
-@flow(name="event-node-mutated")
 async def mutated(
     message: messages.EventNodeMutated,
     service: InfrahubServices,

--- a/backend/infrahub/message_bus/operations/trigger/webhook.py
+++ b/backend/infrahub/message_bus/operations/trigger/webhook.py
@@ -1,14 +1,11 @@
 from typing import List
 
-from prefect import flow
-
 from infrahub.message_bus import InfrahubMessage, messages
 from infrahub.send.models import SendWebhookData
 from infrahub.services import InfrahubServices
 from infrahub.workflows.catalogue import WEBHOOK_SEND
 
 
-@flow(name="webhook-trigger-actions")
 async def actions(message: messages.TriggerWebhookActions, service: InfrahubServices) -> None:
     webhooks = await service.cache.list_keys(filter_pattern="webhook:active:*")
     events: List[InfrahubMessage] = []

--- a/backend/tests/unit/message_bus/test_mappings.py
+++ b/backend/tests/unit/message_bus/test_mappings.py
@@ -16,9 +16,17 @@ def test_message_command_overlap():
     assert messages == commands
 
 
+operations_without_flows = [
+    "event.node.mutated",
+    "refresh.registry.branches",
+    "refresh.registry.rebased_branch",
+    "trigger.webhook.actions",
+]
+
+
 @pytest.mark.parametrize(
     "operation",
-    [pytest.param(function, id=key) for key, function in COMMAND_MAP.items() if not key.startswith("refresh.registry")],
+    [pytest.param(function, id=key) for key, function in COMMAND_MAP.items() if key not in operations_without_flows],
 )
 def test_operations_decorated(operation: Callable):
     if callable(operation) and hasattr(operation, "__name__") and "Flow" not in type(operation).__name__:


### PR DESCRIPTION
This is a poor man's backport of #5029. I started to look at cherry picking that PR but when I began to resolve merge conflicts I realised that my #5029 also depended on other work from the release branch.

I think this PR would be a good compromise. It will also introduce a merge conflict when brought back but one that should be simple to resolve.