### PR TITLE
Use plain instead of enriched stack traceback

### DIFF
--- a/backend/infrahub/log.py
+++ b/backend/infrahub/log.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any
 
 import structlog
 from pydantic import TypeAdapter
+from structlog.dev import plain_traceback
 
 if TYPE_CHECKING:
     from structlog.types import Processor
@@ -57,7 +58,7 @@ def configure_logging(production: bool, log_level: str) -> None:
     if production:
         log_renderer = structlog.processors.JSONRenderer()
     else:
-        log_renderer = structlog.dev.ConsoleRenderer()
+        log_renderer = structlog.dev.ConsoleRenderer(exception_formatter=plain_traceback)
 
     formatter = structlog.stdlib.ProcessorFormatter(
         foreign_pre_chain=shared_processors,


### PR DESCRIPTION
Since https://github.com/opsmill/infrahub/pull/5034, CI error stack traces are enriched and look too verbose, see for instance on https://github.com/opsmill/infrahub/actions/runs/12088516424/job/33712200947?pr=5102. This PR restores stracktraces to their default format in non-production environment. This can still be controlled through an environment variable if we want to have a different verbosity while developing locally though.