### PR TITLE
Bugfix: PC Close Button Fix

### DIFF
--- a/frontend/app/src/screens/proposed-changes/action-button/pc-close-button.tsx
+++ b/frontend/app/src/screens/proposed-changes/action-button/pc-close-button.tsx
@@ -80,7 +80,7 @@ export const PcCloseButton = ({
       variant="danger"
       onClick={handleClose}
       isLoading={isLoadingClose}
-      disabled={!disabled || state === "merged"}
+      disabled={disabled || state === "merged"}
       {...props}
     >
       {state === "closed" ? "Re-open" : "Close"}

--- a/frontend/app/tests/e2e/proposed-changes/proposed-changes.spec.ts
+++ b/frontend/app/tests/e2e/proposed-changes/proposed-changes.spec.ts
@@ -86,6 +86,10 @@ test.describe("/proposed-changes", () => {
           await page.getByText(pcName, { exact: true }).click();
           await expect(page.getByText("Source branch" + pcBranchName)).toBeVisible();
           await expect(page.getByText("Stateopen")).toBeVisible();
+          // Validate the buttons are showing as intended
+          await expect(page.getByRole("button", { name: "Approve" })).not.toBeDisabled();
+          await expect(page.getByRole("button", { name: "Merge" })).not.toBeDisabled();
+          await expect(page.getByRole("button", { name: "Close" })).not.toBeDisabled();
         });
 
         await test.step("edit proposed change reviewers", async () => {


### PR DESCRIPTION
Fixes #4800 

Flip disabled button logic for the ``Close`` button on PC, as the logic was disabling the button when it was falsey.

I will cherry-pick this into `develop` and `release-1.1` once merged in.