### PR TITLE
Add validator when adding a new attribute / relationship to the schema

### DIFF
--- a/backend/infrahub/core/models.py
+++ b/backend/infrahub/core/models.py
@@ -192,6 +192,15 @@ class SchemaUpdateValidationResult(BaseModel):
                         migration_name="node.attribute.add",
                     )
                 )
+            elif path_type == SchemaPathType.RELATIONSHIP:
+                self.constraints.append(
+                    SchemaUpdateConstraintInfo(
+                        path=SchemaPath(  # type: ignore[call-arg]
+                            schema_kind=schema.kind, path_type=path_type, field_name=field_name
+                        ),
+                        constraint_name="node.relationship.add",
+                    )
+                )
 
         for field_name in node_field_diff.removed.keys():
             self.migrations.append(
@@ -272,6 +281,7 @@ class SchemaUpdateValidationResult(BaseModel):
     def validate_all(self, migration_map: dict[str, Any], validator_map: dict[str, Any]) -> None:
         self.validate_migrations(migration_map=migration_map)
         self.validate_constraints(validator_map=validator_map)
+        self.add_validator_for_migration(validator_map=validator_map)
 
     def validate_migrations(self, migration_map: dict[str, Any]) -> None:
         for migration in self.migrations:
@@ -292,6 +302,16 @@ class SchemaUpdateValidationResult(BaseModel):
                         path=constraint.path,
                         error=UpdateValidationErrorType.VALIDATOR_NOT_AVAILABLE,
                         message=f"Validator {constraint.constraint_name!r} is not available yet",
+                    )
+                )
+
+    def add_validator_for_migration(self, validator_map: dict[str, Any]) -> None:
+        for migration in self.migrations:
+            if validator_map.get(migration.migration_name, None):
+                self.constraints.append(
+                    SchemaUpdateConstraintInfo(
+                        path=migration.path,
+                        constraint_name=migration.migration_name,
                     )
                 )
 

--- a/backend/infrahub/core/validators/__init__.py
+++ b/backend/infrahub/core/validators/__init__.py
@@ -8,9 +8,11 @@ from .attribute.optional import AttributeOptionalChecker
 from .attribute.regex import AttributeRegexChecker
 from .attribute.unique import AttributeUniquenessChecker
 from .interface import ConstraintCheckerInterface
+from .node.attribute import NodeAttributeAddChecker
 from .node.generate_profile import NodeGenerateProfileChecker
 from .node.hierarchy import NodeHierarchyChecker
 from .node.inherit_from import NodeInheritFromChecker
+from .node.relationship import NodeRelationshipAddChecker
 from .relationship.count import RelationshipCountChecker
 from .relationship.optional import RelationshipOptionalChecker
 from .relationship.peer import RelationshipPeerChecker
@@ -35,4 +37,6 @@ CONSTRAINT_VALIDATOR_MAP: dict[str, Optional[type[ConstraintCheckerInterface]]] 
     "node.parent.update": NodeHierarchyChecker,
     "node.children.update": NodeHierarchyChecker,
     "node.generate_profile.update": NodeGenerateProfileChecker,
+    "node.attribute.add": NodeAttributeAddChecker,
+    "node.relationship.add": NodeRelationshipAddChecker,
 }

--- a/backend/infrahub/core/validators/attribute/choices.py
+++ b/backend/infrahub/core/validators/attribute/choices.py
@@ -75,7 +75,7 @@ class AttributeChoicesUpdateValidatorQuery(AttributeSchemaValidatorQuery):
 class AttributeChoicesChecker(ConstraintCheckerInterface):
     query_classes = [AttributeChoicesUpdateValidatorQuery]
 
-    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch]):
+    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch] = None):
         self.db = db
         self.branch = branch
 

--- a/backend/infrahub/core/validators/attribute/enum.py
+++ b/backend/infrahub/core/validators/attribute/enum.py
@@ -74,7 +74,7 @@ class AttributeEnumUpdateValidatorQuery(AttributeSchemaValidatorQuery):
 class AttributeEnumChecker(ConstraintCheckerInterface):
     query_classes = [AttributeEnumUpdateValidatorQuery]
 
-    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch]):
+    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch] = None):
         self.db = db
         self.branch = branch
 

--- a/backend/infrahub/core/validators/attribute/kind.py
+++ b/backend/infrahub/core/validators/attribute/kind.py
@@ -87,7 +87,7 @@ class AttributeKindUpdateValidatorQuery(AttributeSchemaValidatorQuery):
 class AttributeKindChecker(ConstraintCheckerInterface):
     query_classes = [AttributeKindUpdateValidatorQuery]
 
-    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch]):
+    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch] = None):
         self.db = db
         self.branch = branch
 

--- a/backend/infrahub/core/validators/attribute/length.py
+++ b/backend/infrahub/core/validators/attribute/length.py
@@ -70,7 +70,7 @@ class AttributeLengthUpdateValidatorQuery(AttributeSchemaValidatorQuery):
 class AttributeLengthChecker(ConstraintCheckerInterface):
     query_classes = [AttributeLengthUpdateValidatorQuery]
 
-    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch]):
+    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch] = None):
         self.db = db
         self.branch = branch
 

--- a/backend/infrahub/core/validators/attribute/optional.py
+++ b/backend/infrahub/core/validators/attribute/optional.py
@@ -66,7 +66,7 @@ class AttributeOptionalUpdateValidatorQuery(AttributeSchemaValidatorQuery):
 class AttributeOptionalChecker(ConstraintCheckerInterface):
     query_classes = [AttributeOptionalUpdateValidatorQuery]
 
-    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch]):
+    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch] = None):
         self.db = db
         self.branch = branch
 
@@ -75,7 +75,7 @@ class AttributeOptionalChecker(ConstraintCheckerInterface):
         return "attribute.optional.update"
 
     def supports(self, request: SchemaConstraintValidatorRequest) -> bool:
-        return request.constraint_name == "attribute.optional.update"
+        return request.constraint_name == self.name
 
     async def check(self, request: SchemaConstraintValidatorRequest) -> list[GroupedDataPaths]:
         grouped_data_paths_list: list[GroupedDataPaths] = []

--- a/backend/infrahub/core/validators/attribute/regex.py
+++ b/backend/infrahub/core/validators/attribute/regex.py
@@ -70,7 +70,7 @@ class AttributeRegexUpdateValidatorQuery(AttributeSchemaValidatorQuery):
 class AttributeRegexChecker(ConstraintCheckerInterface):
     query_classes = [AttributeRegexUpdateValidatorQuery]
 
-    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch]):
+    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch] = None):
         self.db = db
         self.branch = branch
 

--- a/backend/infrahub/core/validators/attribute/unique.py
+++ b/backend/infrahub/core/validators/attribute/unique.py
@@ -91,7 +91,7 @@ class AttributeUniqueUpdateValidatorQuery(AttributeSchemaValidatorQuery):
 class AttributeUniquenessChecker(ConstraintCheckerInterface):
     query_classes = [AttributeUniqueUpdateValidatorQuery]
 
-    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch]) -> None:
+    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch] = None) -> None:
         self.db = db
         self.branch = branch
 

--- a/backend/infrahub/core/validators/node/attribute.py
+++ b/backend/infrahub/core/validators/node/attribute.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+from ..interface import ConstraintCheckerInterface
+from ..query import NodeNotPresentValidatorQuery
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.core.path import GroupedDataPaths
+    from infrahub.database import InfrahubDatabase
+
+    from ..model import SchemaConstraintValidatorRequest
+
+
+class NodeAttributeAddChecker(ConstraintCheckerInterface):
+    query_classes = [NodeNotPresentValidatorQuery]
+
+    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch] = None):
+        self.db = db
+        self.branch = branch
+
+    @property
+    def name(self) -> str:
+        return "node.attribute.add"
+
+    def supports(self, request: SchemaConstraintValidatorRequest) -> bool:
+        return request.constraint_name == self.name
+
+    async def check(self, request: SchemaConstraintValidatorRequest) -> list[GroupedDataPaths]:
+        grouped_data_paths_list: list[GroupedDataPaths] = []
+        if not request.schema_path.field_name:
+            raise ValueError("field_name is not defined")
+        attribute_schema = request.node_schema.get_attribute(name=request.schema_path.field_name)
+        if attribute_schema.optional is True or attribute_schema.default_value is not None:
+            return grouped_data_paths_list
+
+        for query_class in self.query_classes:
+            # TODO add exception handling
+            query = await query_class.init(
+                db=self.db, branch=self.branch, node_schema=request.node_schema, schema_path=request.schema_path
+            )
+            await query.execute(db=self.db)
+            grouped_data_paths_list.append(await query.get_paths())
+        return grouped_data_paths_list

--- a/backend/infrahub/core/validators/node/generate_profile.py
+++ b/backend/infrahub/core/validators/node/generate_profile.py
@@ -61,7 +61,7 @@ class NodeGenerateProfileValidatorQuery(SchemaValidatorQuery):
 class NodeGenerateProfileChecker(ConstraintCheckerInterface):
     query_classes = [NodeGenerateProfileValidatorQuery]
 
-    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch]) -> None:
+    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch] = None) -> None:
         self.db = db
         self.branch = branch
 

--- a/backend/infrahub/core/validators/node/hierarchy.py
+++ b/backend/infrahub/core/validators/node/hierarchy.py
@@ -145,7 +145,7 @@ class NodeHierarchyUpdateValidatorQuery(SchemaValidatorQuery):
 class NodeHierarchyChecker(ConstraintCheckerInterface):
     query_classes = [NodeHierarchyUpdateValidatorQuery]
 
-    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch]) -> None:
+    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch] = None) -> None:
         self.db = db
         self.branch = branch
 

--- a/backend/infrahub/core/validators/node/inherit_from.py
+++ b/backend/infrahub/core/validators/node/inherit_from.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 
 class NodeInheritFromChecker(ConstraintCheckerInterface):
-    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch]) -> None:
+    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch] = None) -> None:
         self.db = db
         self.branch = branch
 

--- a/backend/infrahub/core/validators/node/relationship.py
+++ b/backend/infrahub/core/validators/node/relationship.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+from ..interface import ConstraintCheckerInterface
+from ..query import NodeNotPresentValidatorQuery
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.core.path import GroupedDataPaths
+    from infrahub.database import InfrahubDatabase
+
+    from ..model import SchemaConstraintValidatorRequest
+
+
+class NodeRelationshipAddChecker(ConstraintCheckerInterface):
+    query_classes = [NodeNotPresentValidatorQuery]
+
+    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch] = None):
+        self.db = db
+        self.branch = branch
+
+    @property
+    def name(self) -> str:
+        return "node.relationship.add"
+
+    def supports(self, request: SchemaConstraintValidatorRequest) -> bool:
+        return request.constraint_name == self.name
+
+    async def check(self, request: SchemaConstraintValidatorRequest) -> list[GroupedDataPaths]:
+        grouped_data_paths_list: list[GroupedDataPaths] = []
+        if not request.schema_path.field_name:
+            raise ValueError("field_name is not defined")
+        rel_schema = request.node_schema.get_relationship(name=request.schema_path.field_name)
+        if rel_schema.optional is True:
+            return grouped_data_paths_list
+
+        for query_class in self.query_classes:
+            # TODO add exception handling
+            query = await query_class.init(
+                db=self.db, branch=self.branch, node_schema=request.node_schema, schema_path=request.schema_path
+            )
+            await query.execute(db=self.db)
+            grouped_data_paths_list.append(await query.get_paths())
+        return grouped_data_paths_list

--- a/backend/infrahub/core/validators/query.py
+++ b/backend/infrahub/core/validators/query.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from infrahub.core.constants import PathType
+from infrahub.core.path import DataPath, GroupedDataPaths
+
+from .shared import SchemaValidatorQuery
+
+if TYPE_CHECKING:
+    from infrahub.database import InfrahubDatabase
+
+
+class NodeNotPresentValidatorQuery(SchemaValidatorQuery):
+    name: str = "node_not_present_validator"
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:
+        branch_filter, branch_params = self.branch.get_query_filter_path(at=self.at.to_string())
+        self.params.update(branch_params)
+
+        query = """
+        MATCH (n:%(node_kind)s)
+        CALL {
+            WITH n
+            MATCH path = (root:Root)<-[rr:IS_PART_OF]-(n)
+            WHERE all(
+                r in relationships(path)
+                WHERE %(branch_filter)s
+            )
+            RETURN path as full_path, n as node, rr as root_relationship
+            ORDER BY rr.branch_level DESC, rr.from DESC
+            LIMIT 1
+        }
+        WITH full_path, node, root_relationship
+        WITH full_path, node, root_relationship
+        WHERE all(r in relationships(full_path) WHERE r.status = "active")
+        """ % {"branch_filter": branch_filter, "node_kind": self.node_schema.kind}
+
+        self.add_to_query(query)
+        self.return_labels = ["node.uuid", "root_relationship"]
+
+    async def get_paths(self) -> GroupedDataPaths:
+        grouped_data_paths = GroupedDataPaths()
+        for result in self.results:
+            grouped_data_paths.add_data_path(
+                DataPath(
+                    branch=str(result.get("root_relationship").get("branch")),
+                    path_type=PathType.NODE,
+                    node_id=str(result.get("node.uuid")),
+                    kind=self.node_schema.kind,
+                ),
+            )
+
+        return grouped_data_paths

--- a/backend/infrahub/core/validators/relationship/count.py
+++ b/backend/infrahub/core/validators/relationship/count.py
@@ -150,7 +150,7 @@ class RelationshipCountUpdateValidatorQuery(RelationshipSchemaValidatorQuery):
 class RelationshipCountChecker(ConstraintCheckerInterface):
     query_classes = [RelationshipCountUpdateValidatorQuery]
 
-    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch]) -> None:
+    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch] = None) -> None:
         self.db = db
         self.branch = branch
 

--- a/backend/infrahub/core/validators/relationship/optional.py
+++ b/backend/infrahub/core/validators/relationship/optional.py
@@ -82,7 +82,7 @@ class RelationshipOptionalUpdateValidatorQuery(RelationshipSchemaValidatorQuery)
 class RelationshipOptionalChecker(ConstraintCheckerInterface):
     query_classes = [RelationshipOptionalUpdateValidatorQuery]
 
-    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch]) -> None:
+    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch] = None) -> None:
         self.db = db
         self.branch = branch
 

--- a/backend/infrahub/core/validators/relationship/peer.py
+++ b/backend/infrahub/core/validators/relationship/peer.py
@@ -108,7 +108,7 @@ class RelationshipPeerUpdateValidatorQuery(RelationshipSchemaValidatorQuery):
 class RelationshipPeerChecker(ConstraintCheckerInterface):
     query_classes = [RelationshipPeerUpdateValidatorQuery]
 
-    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch]) -> None:
+    def __init__(self, db: InfrahubDatabase, branch: Optional[Branch] = None) -> None:
         self.db = db
         self.branch = branch
 

--- a/backend/infrahub/dependencies/builder/constraint/schema/aggregated.py
+++ b/backend/infrahub/dependencies/builder/constraint/schema/aggregated.py
@@ -9,6 +9,8 @@ from .attribute_regex import SchemaAttributeRegexConstraintDependency
 from .attribute_uniqueness import SchemaAttributeUniqueConstraintDependency
 from .generate_profile import SchemaGenerateProfileConstraintDependency
 from .inherit_from import SchemaInheritFromConstraintDependency
+from .node_attribute import SchemaNodeAttributeAddConstraintDependency
+from .node_relationship import SchemaNodeRelationshipAddConstraintDependency
 from .relationship_count import SchemaRelationshipCountConstraintDependency
 from .relationship_optional import SchemaRelationshipOptionalConstraintDependency
 from .uniqueness import SchemaUniquenessConstraintDependency
@@ -30,6 +32,8 @@ class AggregatedSchemaConstraintsDependency(DependencyBuilder[AggregatedConstrai
                 SchemaAttributeChoicesConstraintDependency.build(context=context),
                 SchemaAttributeEnumConstraintDependency.build(context=context),
                 SchemaAttributLengthConstraintDependency.build(context=context),
+                SchemaNodeAttributeAddConstraintDependency.build(context=context),
+                SchemaNodeRelationshipAddConstraintDependency.build(context=context),
             ],
             db=context.db,
             branch=context.branch,

--- a/backend/infrahub/dependencies/builder/constraint/schema/node_attribute.py
+++ b/backend/infrahub/dependencies/builder/constraint/schema/node_attribute.py
@@ -1,0 +1,8 @@
+from infrahub.core.validators.node.attribute import NodeAttributeAddChecker
+from infrahub.dependencies.interface import DependencyBuilder, DependencyBuilderContext
+
+
+class SchemaNodeAttributeAddConstraintDependency(DependencyBuilder[NodeAttributeAddChecker]):
+    @classmethod
+    def build(cls, context: DependencyBuilderContext) -> NodeAttributeAddChecker:
+        return NodeAttributeAddChecker(db=context.db, branch=context.branch)

--- a/backend/infrahub/dependencies/builder/constraint/schema/node_relationship.py
+++ b/backend/infrahub/dependencies/builder/constraint/schema/node_relationship.py
@@ -1,0 +1,8 @@
+from infrahub.core.validators.node.relationship import NodeRelationshipAddChecker
+from infrahub.dependencies.interface import DependencyBuilder, DependencyBuilderContext
+
+
+class SchemaNodeRelationshipAddConstraintDependency(DependencyBuilder[NodeRelationshipAddChecker]):
+    @classmethod
+    def build(cls, context: DependencyBuilderContext) -> NodeRelationshipAddChecker:
+        return NodeRelationshipAddChecker(db=context.db, branch=context.branch)

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_add_mandatory_attr_rel.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_add_mandatory_attr_rel.py
@@ -1,0 +1,334 @@
+import copy
+from typing import Any
+
+import pytest
+from infrahub_sdk import InfrahubClient
+
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
+from infrahub.database import InfrahubDatabase
+
+from ..shared import load_schema
+from .shared import (
+    TestSchemaLifecycleBase,
+)
+
+PERSON_KIND = "TestingPerson"
+CYLON_KIND = "TestingCylon"
+CAR_KIND = "TestingCar"
+
+# pylint: disable=unused-argument
+
+
+class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
+    @pytest.fixture(scope="class")
+    def schema_car_base(self) -> dict[str, Any]:
+        return {
+            "name": "Car",
+            "namespace": "Testing",
+            "include_in_menu": True,
+            "default_filter": "name__value",
+            "label": "Car",
+            "attributes": [
+                {"name": "name", "kind": "Text"},
+                {"name": "description", "kind": "Text", "optional": True},
+                {"name": "color", "kind": "Text"},
+            ],
+            "relationships": [
+                {
+                    "name": "owner",
+                    "kind": "Attribute",
+                    "optional": False,
+                    "peer": "TestingHumanoid",
+                    "cardinality": "one",
+                },
+            ],
+        }
+
+    @pytest.fixture(scope="class")
+    def schema_humanoid_base(self) -> dict[str, Any]:
+        return {
+            "name": "Humanoid",
+            "namespace": "Testing",
+            "include_in_menu": True,
+            "label": "Humanoid",
+            "attributes": [
+                {"name": "name", "kind": "Text"},
+                {"name": "description", "kind": "Text", "optional": True},
+                {"name": "height", "kind": "Number", "optional": True},
+                {"name": "favorite_color", "kind": "Text", "optional": True},
+            ],
+            "relationships": [
+                {"name": "cars", "kind": "Generic", "optional": True, "peer": "TestingCar", "cardinality": "many"}
+            ],
+        }
+
+    @pytest.fixture(scope="class")
+    def schema_person_base(self) -> dict[str, Any]:
+        return {
+            "name": "Person",
+            "namespace": "Testing",
+            "include_in_menu": True,
+            "label": "Person",
+            "inherit_from": ["TestingHumanoid"],
+            "attributes": [
+                {"name": "homeworld", "kind": "Text", "optional": False},
+            ],
+            "relationships": [],
+        }
+
+    @pytest.fixture(scope="class")
+    def schema_person_mandatory_attr_no_default(self, schema_person_base) -> dict[str, Any]:
+        schema_person = copy.deepcopy(schema_person_base)
+        schema_person["attributes"].append({"name": "age", "kind": "Number", "optional": False})
+        return schema_person
+
+    @pytest.fixture(scope="class")
+    def schema_person_mandatory_rel(self, schema_person_base) -> dict[str, Any]:
+        schema_person = copy.deepcopy(schema_person_base)
+        schema_person["relationships"].append(
+            {"name": "favorite_cars", "peer": CAR_KIND, "optional": False, "cardinality": "many"}
+        )
+        return schema_person
+
+    @pytest.fixture(scope="class")
+    def schema_person_mandatory_attr_default(self, schema_person_base) -> dict[str, Any]:
+        schema_person = copy.deepcopy(schema_person_base)
+        schema_person["attributes"].append({"name": "age", "kind": "Number", "optional": False, "default_value": 99})
+        return schema_person
+
+    @pytest.fixture(scope="class")
+    def schema_person_optional_attr(self, schema_person_base) -> dict[str, Any]:
+        schema_person = copy.deepcopy(schema_person_base)
+        schema_person["attributes"].append({"name": "hair_color", "kind": "Text", "optional": True})
+        return schema_person
+
+    @pytest.fixture(scope="class")
+    def schema_car_mandatory_attr_no_default(self, schema_car_base) -> dict[str, Any]:
+        schema_car = copy.deepcopy(schema_car_base)
+        schema_car["attributes"].append({"name": "nbr_wheels", "kind": "Number", "optional": False})
+        return schema_car
+
+    @pytest.fixture(scope="class")
+    def schema_car_mandatory_attr_default(self, schema_car_base) -> dict[str, Any]:
+        schema_car = copy.deepcopy(schema_car_base)
+        schema_car["attributes"].append({"name": "nbr_wheels", "kind": "Number", "optional": False, "default_value": 4})
+        return schema_car
+
+    @pytest.fixture(scope="class")
+    def schema_cylon_base(self) -> dict[str, Any]:
+        return {
+            "name": "Cylon",
+            "namespace": "Testing",
+            "include_in_menu": True,
+            "label": "Cylon",
+            "inherit_from": ["TestingHumanoid"],
+            "attributes": [
+                {"name": "model_number", "kind": "Number", "optional": False},
+            ],
+        }
+
+    @pytest.fixture(scope="class")
+    async def branch_2(self, db: InfrahubDatabase) -> Branch:
+        return await create_branch(db=db, branch_name="branch_2")
+
+    @pytest.fixture(scope="class")
+    async def initial_dataset(self, db: InfrahubDatabase, initialize_registry, schema_step_01):
+        await load_schema(db=db, schema=schema_step_01)
+
+        starbuck = await Node.init(schema=PERSON_KIND, db=db)
+        await starbuck.new(db=db, name="Kara", height=175, description="Starbuck", homeworld="Caprica")
+        await starbuck.save(db=db)
+
+        president = await Node.init(schema=PERSON_KIND, db=db)
+        await president.new(db=db, name="Laura", height=175, description="President", homeworld="Caprica")
+        await president.save(db=db)
+
+        gaius = await Node.init(schema=PERSON_KIND, db=db)
+        await gaius.new(db=db, name="Gaius", height=155, description="'Scientist'", homeworld="Aerilon")
+        await gaius.save(db=db)
+
+        boomer = await Node.init(schema=CYLON_KIND, db=db)
+        await boomer.new(db=db, name="Sharon", height=165, model_number=8, description="8 (Boomer)")
+        await boomer.save(db=db)
+
+        athena = await Node.init(schema=CYLON_KIND, db=db)
+        await athena.new(db=db, name="Sharon", height=165, model_number=8, description="8 (Athena)")
+        await athena.save(db=db)
+
+        caprica = await Node.init(schema=CYLON_KIND, db=db)
+        await caprica.new(db=db, name="Caprica", height=185, model_number=6, description="6 (Caprica)")
+        await caprica.save(db=db)
+
+        objs = {
+            "starbuck": starbuck.id,
+            "president": president.id,
+            "gaius": gaius.id,
+            "boomer": boomer.id,
+            "athena": athena.id,
+            "caprica": caprica.id,
+        }
+
+        return objs
+
+    @pytest.fixture(scope="class")
+    def schema_step_01(
+        self, schema_humanoid_base, schema_car_base, schema_person_base, schema_cylon_base
+    ) -> dict[str, Any]:
+        return {
+            "version": "1.0",
+            "generics": [schema_humanoid_base],
+            "nodes": [schema_car_base, schema_person_base, schema_cylon_base],
+        }
+
+    @pytest.fixture(scope="class")
+    def schema_with_person_mandatory_attr(
+        self,
+        schema_person_mandatory_attr_no_default,
+        schema_humanoid_base,
+        schema_car_base,
+        schema_person_base,
+        schema_cylon_base,
+    ) -> dict[str, Any]:
+        return {
+            "version": "1.0",
+            "generics": [schema_humanoid_base],
+            "nodes": [schema_person_mandatory_attr_no_default, schema_car_base, schema_cylon_base],
+        }
+
+    @pytest.fixture(scope="class")
+    def schema_with_person_mandatory_rel(
+        self,
+        schema_person_mandatory_rel,
+        schema_humanoid_base,
+        schema_car_base,
+        schema_person_base,
+        schema_cylon_base,
+    ) -> dict[str, Any]:
+        return {
+            "version": "1.0",
+            "generics": [schema_humanoid_base],
+            "nodes": [schema_person_mandatory_rel, schema_car_base, schema_cylon_base],
+        }
+
+    @pytest.fixture(scope="class")
+    def schema_with_person_default_value(
+        self,
+        schema_person_mandatory_attr_default,
+        schema_humanoid_base,
+        schema_car_base,
+        schema_person_base,
+        schema_cylon_base,
+    ) -> dict[str, Any]:
+        return {
+            "version": "1.0",
+            "generics": [schema_humanoid_base],
+            "nodes": [schema_person_mandatory_attr_default, schema_car_base, schema_cylon_base],
+        }
+
+    @pytest.fixture(scope="class")
+    def schema_with_car_mandatory(
+        self, schema_person_base, schema_humanoid_base, schema_car_mandatory_attr_no_default, schema_cylon_base
+    ) -> dict[str, Any]:
+        return {
+            "version": "1.0",
+            "generics": [schema_humanoid_base],
+            "nodes": [schema_person_base, schema_car_mandatory_attr_no_default, schema_cylon_base],
+        }
+
+    async def test_baseline_backend(self, db: InfrahubDatabase, initial_dataset):
+        persons = await registry.manager.query(db=db, schema=PERSON_KIND)
+        cylons = await registry.manager.query(db=db, schema=CYLON_KIND)
+        cars = await registry.manager.query(db=db, schema=CAR_KIND)
+        assert len(persons) == 3
+        assert len(cylons) == 3
+        assert len(cars) == 0
+
+    async def test_check_mandatory_attribute_failure(
+        self, client: InfrahubClient, initial_dataset, schema_with_person_mandatory_attr
+    ):
+        success, response = await client.schema.check(schemas=[schema_with_person_mandatory_attr])
+
+        assert success is False
+        assert "errors" in response
+        assert len(response["errors"]) == 1
+        err_msg = response["errors"][0]["message"]
+
+        assert "is not compatible with the constraint 'node.attribute.add'" in err_msg
+
+    async def test_check_mandatory_relationship_failure(
+        self, client: InfrahubClient, initial_dataset, schema_with_person_mandatory_rel
+    ):
+        success, response = await client.schema.check(schemas=[schema_with_person_mandatory_rel])
+
+        assert success is False
+        assert "errors" in response
+        assert len(response["errors"]) == 1
+        err_msg = response["errors"][0]["message"]
+
+        assert "is not compatible with the constraint 'node.relationship.add'" in err_msg
+
+    async def test_check_mandatory_attribute_after_deleting_nodes(
+        self, client: InfrahubClient, db: InfrahubDatabase, initial_dataset, schema_with_person_mandatory_attr
+    ):
+        """Validate that it's possible to add a new mandatory attribute after deleting all the nodes in scope."""
+        branch = await client.branch.create(branch_name="add-attr-delete-nodes")
+
+        for name in ["starbuck", "president", "gaius"]:
+            node_id = initial_dataset[name]
+            node: Node = await NodeManager.get_one(db=db, id=node_id, branch=branch.name, raise_on_error=True)
+            await node.delete(db=db)
+
+        success, response = await client.schema.check(schemas=[schema_with_person_mandatory_attr], branch=branch.name)
+        assert success is True
+
+        response = await client.schema.load(schemas=[schema_with_person_mandatory_attr], branch=branch.name)
+        assert response.errors == {}
+
+    async def test_check_mandatory_rel_after_deleting_nodes(
+        self, client: InfrahubClient, db: InfrahubDatabase, initial_dataset, schema_with_person_mandatory_rel
+    ):
+        """Validate that it's possible to add a new mandatory attribute after deleting all the nodes in scope."""
+        branch = await client.branch.create(branch_name="add-rel-delete-nodes")
+
+        for name in ["starbuck", "president", "gaius"]:
+            node_id = initial_dataset[name]
+            node: Node = await NodeManager.get_one(db=db, id=node_id, branch=branch.name, raise_on_error=True)
+            await node.delete(db=db)
+
+        success, response = await client.schema.check(schemas=[schema_with_person_mandatory_rel], branch=branch.name)
+        assert success is True
+
+        response = await client.schema.load(schemas=[schema_with_person_mandatory_rel], branch=branch.name)
+        assert response.errors == {}
+
+    async def test_check_mandatory_attribute_success_no_data(
+        self, client: InfrahubClient, initial_dataset, schema_with_car_mandatory
+    ):
+        """Validate that it's possible to add a new mandatory attribute when there is no data in the database."""
+        success, _ = await client.schema.check(schemas=[schema_with_car_mandatory])
+        assert success is True
+
+    async def test_load_mandatory_attribute_success_no_data(
+        self, client: InfrahubClient, initial_dataset, schema_with_car_mandatory
+    ):
+        branch = await client.branch.create(branch_name="add-no-prior-data")
+        response = await client.schema.load(schemas=[schema_with_car_mandatory], branch=branch.name)
+        assert response.errors == {}
+
+    async def test_check_mandatory_attribute_success_default_value(
+        self, client: InfrahubClient, initial_dataset, schema_with_person_default_value
+    ):
+        """Validate that it's possible to add a new mandatory attribute with a default value."""
+        success, _ = await client.schema.check(schemas=[schema_with_person_default_value])
+        assert success is True
+
+    async def test_load_mandatory_attribute_success_default_value(
+        self, client: InfrahubClient, initial_dataset, schema_with_person_default_value
+    ):
+        branch = await client.branch.create(branch_name="add-default-value")
+        response = await client.schema.load(schemas=[schema_with_person_default_value], branch=branch.name)
+        assert response.errors == {}

--- a/backend/tests/unit/core/constraint_validators/test_query_node_not_present.py
+++ b/backend/tests/unit/core/constraint_validators/test_query_node_not_present.py
@@ -1,0 +1,57 @@
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.constants import SchemaPathType
+from infrahub.core.path import SchemaPath
+from infrahub.core.validators.query import NodeNotPresentValidatorQuery
+from infrahub.database import InfrahubDatabase
+
+
+async def test_query_node_present_with_data(
+    db: InfrahubDatabase, default_branch: Branch, person_john_main, person_jane_main
+):
+    person_schema = registry.schema.get(name="TestPerson")
+
+    schema_path = SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="name")
+    query = await NodeNotPresentValidatorQuery.init(
+        db=db, branch=default_branch, node_schema=person_schema, schema_path=schema_path
+    )
+
+    await query.execute(db=db)
+
+    grouped_paths = await query.get_paths()
+    all_data_paths = grouped_paths.get_all_data_paths()
+    assert len(all_data_paths) == 2
+
+
+async def test_query_node_present_with_data_rel(
+    db: InfrahubDatabase, default_branch: Branch, person_john_main, person_jane_main
+):
+    person_schema = registry.schema.get(name="TestPerson")
+
+    schema_path = SchemaPath(path_type=SchemaPathType.RELATIONSHIP, schema_kind="TestPerson", field_name="cars")
+    query = await NodeNotPresentValidatorQuery.init(
+        db=db, branch=default_branch, node_schema=person_schema, schema_path=schema_path
+    )
+
+    await query.execute(db=db)
+
+    grouped_paths = await query.get_paths()
+    all_data_paths = grouped_paths.get_all_data_paths()
+    assert len(all_data_paths) == 2
+
+
+async def test_query_node_present_no_data(
+    db: InfrahubDatabase, default_branch: Branch, person_john_main, person_jane_main
+):
+    car_schema = registry.schema.get(name="TestCar")
+
+    schema_path = SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestCar")
+    query = await NodeNotPresentValidatorQuery.init(
+        db=db, branch=default_branch, node_schema=car_schema, schema_path=schema_path
+    )
+
+    await query.execute(db=db)
+
+    grouped_paths = await query.get_paths()
+    all_data_paths = grouped_paths.get_all_data_paths()
+    assert len(all_data_paths) == 0

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -2092,7 +2092,28 @@ async def test_schema_branch_validate_add_node_relationships(
     diff = schema_branch.diff(other=new_schema)
     result = schema_branch.validate_update(other=new_schema, diff=diff)
     assert result.model_dump(exclude=["diff"]) == {
-        "constraints": [],
+        "constraints": [
+            {
+                "constraint_name": "node.relationship.add",
+                "path": {
+                    "field_name": "primary_tag",
+                    "path_type": SchemaPathType.RELATIONSHIP,
+                    "property_name": None,
+                    "schema_id": None,
+                    "schema_kind": "BuiltinCriticality",
+                },
+            },
+            {
+                "constraint_name": "node.relationship.add",
+                "path": {
+                    "field_name": "tags",
+                    "path_type": SchemaPathType.RELATIONSHIP,
+                    "property_name": None,
+                    "schema_id": None,
+                    "schema_kind": "BuiltinCriticality",
+                },
+            },
+        ],
         "enforce_update_support": True,
         "errors": [],
         "migrations": [],

--- a/changelog/5106.fixed.md
+++ b/changelog/5106.fixed.md
@@ -1,0 +1,1 @@
+Prevent adding a new mandatory attribute or relationship to the schema if some nodes are already present in the database.


### PR DESCRIPTION
Fixes #5122

This PR adds validators for `node.attribute.add` & `node.relationship.add` to ensure that the database is empty if we are trying to add a new mandatory attribute / relationship.

Currently each change in the schema can have either a validator or a migration, this PR changes that by making it possible to have both for operations that requires a migration (MIGRATION_REQUIRED)