### PR TITLE
fix SchemaNotFoundError for renamed schema during diff enrichment

### DIFF
--- a/backend/infrahub/core/diff/payload_builder.py
+++ b/backend/infrahub/core/diff/payload_builder.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Optional, Union
 from infrahub.core.constants import DiffAction, RelationshipCardinality
 from infrahub.core.manager import NodeManager
 from infrahub.core.registry import registry
+from infrahub.exceptions import SchemaNotFoundError
 from infrahub.log import get_logger
 
 from .model.diff import (
@@ -42,12 +43,17 @@ log = get_logger(__name__)
 
 
 async def get_display_labels_per_kind(
-    kind: str, ids: list[str], branch_name: str, db: InfrahubDatabase
+    kind: str, ids: list[str], branch_name: str, db: InfrahubDatabase, skip_missing_schema: bool = False
 ) -> dict[str, str]:
     """Return the display_labels of a list of nodes of a specific kind."""
     branch = await registry.get_branch(branch=branch_name, db=db)
     schema_branch = db.schema.get_schema_branch(name=branch.name)
-    fields = schema_branch.generate_fields_for_display_label(name=kind)
+    try:
+        fields = schema_branch.generate_fields_for_display_label(name=kind)
+    except SchemaNotFoundError:
+        if skip_missing_schema:
+            return {}
+        raise
     nodes = await NodeManager.get_many(ids=ids, fields=fields, db=db, branch=branch)
     return {node_id: await node.render_display_label(db=db) for node_id, node in nodes.items()}
 
@@ -59,7 +65,9 @@ async def get_display_labels(nodes: dict[str, dict[str, list[str]]], db: Infrahu
         if branch_name not in response:
             response[branch_name] = {}
         for kind, ids in items.items():
-            labels = await get_display_labels_per_kind(kind=kind, ids=ids, db=db, branch_name=branch_name)
+            labels = await get_display_labels_per_kind(
+                kind=kind, ids=ids, db=db, branch_name=branch_name, skip_missing_schema=True
+            )
             response[branch_name].update(labels)
 
     return response

--- a/changelog/+schema-rename-diff.fixed.md
+++ b/changelog/+schema-rename-diff.fixed.md
@@ -1,0 +1,1 @@
+Fix issue that could cause diff generation to crash if a schema was renamed


### PR DESCRIPTION
the logic to enrich a diff with display labels would crash if a schema had its kind changed on the branch. this fix prevents the crash, but we could do a better fix that would require more changes to the diff. this is documented in a new Jira issue: IFC-990