### PR TITLE
Refresh branch hash in cache for local worker on create

### DIFF
--- a/backend/infrahub/graphql/mutations/branch.py
+++ b/backend/infrahub/graphql/mutations/branch.py
@@ -105,6 +105,7 @@ class BranchCreate(Mutation):
 
             fields = await extract_fields(info.field_nodes[0].selection_set)
             if context.service:
+                await context.service.component.refresh_schema_hash(branches=[obj.name])
                 message = messages.EventBranchCreate(
                     branch=obj.name,
                     branch_id=str(obj.id),

--- a/backend/tests/unit/graphql/mutations/test_branch.py
+++ b/backend/tests/unit/graphql/mutations/test_branch.py
@@ -11,6 +11,7 @@ from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.message_bus import messages
 from infrahub.services import InfrahubServices
+from tests.adapters.cache import MemoryCache
 from tests.adapters.message_bus import BusRecorder
 from tests.helpers.graphql import graphql_mutation
 
@@ -71,7 +72,9 @@ async def test_branch_create(
     }
     """
     recorder = BusRecorder()
-    service = InfrahubServices(message_bus=recorder)
+    cache = MemoryCache()
+    service = InfrahubServices(message_bus=recorder, cache=cache, database=db)
+    await service.component.initialize(service=service)
 
     result = await graphql_mutation(
         query=query, db=db, service=service, branch=default_branch, account_session=session_admin
@@ -178,8 +181,9 @@ async def test_branch_delete(
         query=delete_query, db=db, branch=default_branch, account_session=session_admin
     )
     recorder = BusRecorder()
-    service = InfrahubServices(message_bus=recorder)
-
+    cache = MemoryCache()
+    service = InfrahubServices(message_bus=recorder, cache=cache, database=db)
+    await service.component.initialize(service=service)
     create = await graphql_mutation(
         query=create_query, db=db, branch=default_branch, service=service, account_session=session_admin
     )

--- a/changelog/5130.fixed.md
+++ b/changelog/5130.fixed.md
@@ -1,0 +1,1 @@
+Refresh branch hash on local worker during branch create


### PR DESCRIPTION
This issue specifically deals with the fact that the branch hash was reported as `null` on one of the workers after creating a new branch. There is still a separate issue related to the branch hash being out of sync from the start.

Fixes #5130