### PR TITLE
Use the branch uuid instead of the internal database id to track the hash of the schema in the cache

### DIFF
--- a/backend/infrahub/graphql/queries/status.py
+++ b/backend/infrahub/graphql/queries/status.py
@@ -46,7 +46,9 @@ async def resolve_status(
     service = context.service or services.service
     fields = await extract_fields_first_node(info)
     response: dict[str, Any] = {}
-    workers = await service.component.list_workers(branch=context.branch.id or context.branch.name, schema_hash=True)
+    workers = await service.component.list_workers(
+        branch=str(context.branch.uuid) or context.branch.name, schema_hash=True
+    )
 
     if summary := fields.get("summary"):
         response["summary"] = {}

--- a/backend/infrahub/services/component.py
+++ b/backend/infrahub/services/component.py
@@ -4,6 +4,7 @@ import re
 from typing import TYPE_CHECKING, Any, Optional
 
 from infrahub.components import ComponentType
+from infrahub.core.constants import GLOBAL_BRANCH_NAME
 from infrahub.core.registry import registry
 from infrahub.core.timestamp import Timestamp
 from infrahub.exceptions import InitializationError
@@ -71,16 +72,18 @@ class InfrahubComponent:
                 workers[identity].add_value(key=key, value=value)
         return list(workers.values())
 
-    async def refresh_schema_hash(self, branches: Optional[list[str]] = None) -> None:
+    async def refresh_schema_hash(self, branches: list[str] | None = None) -> None:
         branches = branches or list(registry.branch.keys())
         for branch in branches:
+            if branch == GLOBAL_BRANCH_NAME:
+                continue
             schema_branch = registry.schema.get_schema_branch(name=branch)
             hash_value = schema_branch.get_hash()
 
             # Use branch name if we cannot find branch id in cache
             branch_id: Optional[str] = None
             if branch_obj := await registry.get_branch(branch=branch, db=self.service.database):
-                branch_id = branch_obj.id
+                branch_id = str(branch_obj.uuid)
 
             if not branch_id:
                 branch_id = branch

--- a/changelog/+branch-hash-id.fixed.md
+++ b/changelog/+branch-hash-id.fixed.md
@@ -1,0 +1,1 @@
+Use the branch uuid instead of the internal database id to track the hash of the schema in the cache


### PR DESCRIPTION
While investigating another issue I noticed that we are currently using the internal database id to track the schema hash in the code and that we are also tracking the schema hash for the global branch which we shouldn't do

This PR is a quick fix for both