### PR TITLE
Change path strings to pathlib.Path objects

### DIFF
--- a/backend/infrahub/api/internal.py
+++ b/backend/infrahub/api/internal.py
@@ -1,5 +1,4 @@
 import re
-from pathlib import Path
 from typing import Optional
 
 import ujson
@@ -84,7 +83,7 @@ class SearchDocs:
         """
 
         try:
-            with Path(config.SETTINGS.main.docs_index_path).open(encoding="utf-8") as f:
+            with config.SETTINGS.main.docs_index_path.open(encoding="utf-8") as f:
                 search_index = ujson.loads(f.read())
                 self._title_documents = search_index[0]["documents"]
                 heading_json = search_index[1]

--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import os.path
 import ssl
 import sys
 from dataclasses import dataclass
@@ -11,7 +10,16 @@ from typing import TYPE_CHECKING, Any, Optional
 
 import toml
 from infrahub_sdk.utils import generate_uuid
-from pydantic import AliasChoices, BaseModel, Field, PrivateAttr, ValidationError, computed_field, model_validator
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    Field,
+    PrivateAttr,
+    ValidationError,
+    computed_field,
+    field_validator,
+    model_validator,
+)
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing_extensions import Self
 
@@ -117,7 +125,7 @@ class WorkflowDriver(str, Enum):
 class MainSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="INFRAHUB_")
     docs_index_path: Path = Field(
-        default="/opt/infrahub/docs/build/search-index.json",
+        default=Path("/opt/infrahub/docs/build/search-index.json"),
         description="Full path of saved json containing pre-indexed documentation",
     )
     internal_address: Optional[str] = Field(default=None)
@@ -134,15 +142,23 @@ class MainSettings(BaseSettings):
         description="List of modules to handle permissions, they will be run in the given order",
     )
 
+    @field_validator("docs_index_path", mode="before")
+    def convert_to_path(cls, value: Path | str) -> Path:  # pylint: disable=no-self-argument  # noqa: N805
+        return Path(value) if isinstance(value, str) else value
+
 
 class FileSystemStorageSettings(BaseSettings):
     # Make variable lookup case-sensitive to avoid fetching $PATH value
     model_config = SettingsConfigDict(case_sensitive=True)
     path_: Path = Field(
-        default="/opt/infrahub/storage",
+        default=Path("/opt/infrahub/storage"),
         alias="path",
         validation_alias=AliasChoices("INFRAHUB_STORAGE_LOCAL_PATH", "infrahub_storage_local_path", "path"),
     )
+
+    @field_validator("path_", mode="before")
+    def convert_to_path(cls, value: Path | str) -> Path:  # pylint: disable=no-self-argument  # noqa: N805
+        return Path(value) if isinstance(value, str) else value
 
 
 class S3StorageSettings(BaseSettings):
@@ -803,15 +819,13 @@ def load(config_file_name: Path | str = "infrahub.toml", config_data: Optional[d
     Configuration is loaded from a config file in toml format that contains the settings,
     or from a dictionary of those settings passed in as "config_data"
     """
+    config_file = Path(config_file_name)
 
     if config_data:
         return Settings(**config_data)
 
-    if isinstance(config_file_name, str):
-        config_file_name = Path(config_file_name)
-
-    if config_file_name.exists():
-        config_string = config_file_name.read_text(encoding="utf-8")
+    if config_file.exists():
+        config_string = config_file.read_text(encoding="utf-8")
         config_tmp = toml.loads(config_string)
 
         return Settings(**config_tmp)

--- a/backend/infrahub/serve/worker.py
+++ b/backend/infrahub/serve/worker.py
@@ -35,6 +35,6 @@ class InfrahubUvicorn(UvicornWorker):
         super().__init__(*args, **kwargs)
         self.config.log_config = log_config
         self.config.configure_logging()
-        if "PROMETHEUS_MULTIPROC_DIR" in os.environ:
-            for file in os.scandir(os.environ["PROMETHEUS_MULTIPROC_DIR"]):
-                Path(file.path).unlink()
+        if os.getenv("PROMETHEUS_MULTIPROC_DIR", None):
+            for file_path in Path(os.environ["PROMETHEUS_MULTIPROC_DIR"]).iterdir():
+                file_path.unlink()

--- a/backend/infrahub/server.py
+++ b/backend/infrahub/server.py
@@ -123,12 +123,12 @@ def server_request_hook(span: Span, scope: dict) -> None:  # pylint: disable=unu
 
 FastAPIInstrumentor().instrument_app(app, excluded_urls=".*/metrics", server_request_hook=server_request_hook)
 
-FRONTEND_DIRECTORY = os.environ.get("INFRAHUB_FRONTEND_DIRECTORY", Path("frontend/app").resolve())
-FRONTEND_ASSET_DIRECTORY = f"{FRONTEND_DIRECTORY}/dist/assets"
-FRONTEND_FAVICONS_DIRECTORY = f"{FRONTEND_DIRECTORY}/dist/favicons"
+FRONTEND_DIRECTORY = Path(os.environ.get("INFRAHUB_FRONTEND_DIRECTORY", "frontend/app")).resolve()
+FRONTEND_ASSET_DIRECTORY = FRONTEND_DIRECTORY / "dist" / "assets"
+FRONTEND_FAVICONS_DIRECTORY = FRONTEND_DIRECTORY / "dist" / "favicons"
 
-DOCS_DIRECTORY = os.environ.get("INFRAHUB_DOCS_DIRECTORY", Path("docs").resolve())
-DOCS_BUILD_DIRECTORY = f"{DOCS_DIRECTORY}/build"
+DOCS_DIRECTORY = Path(os.environ.get("INFRAHUB_DOCS_DIRECTORY", Path("docs").resolve()))
+DOCS_BUILD_DIRECTORY = DOCS_DIRECTORY / "build"
 
 log = get_logger()
 gunicorn_logger = logging.getLogger("gunicorn.error")
@@ -136,7 +136,7 @@ logger.handlers = gunicorn_logger.handlers
 
 app.include_router(api)
 
-templates = Jinja2Templates(directory=f"{FRONTEND_DIRECTORY}/dist")
+templates = Jinja2Templates(directory=FRONTEND_DIRECTORY / "dist")
 
 
 @app.middleware("http")
@@ -195,17 +195,17 @@ app.add_exception_handler(ValidationError, partial(generic_api_exception_handler
 app.add_route(path="/metrics", route=handle_metrics)
 app.include_router(graphql_router)
 
-app.mount("/api-static", StaticFiles(directory=f"{CURRENT_DIRECTORY}/api/static"), name="static")
+app.mount("/api-static", StaticFiles(directory=CURRENT_DIRECTORY / "api" / "static"), name="static")
 
-if Path(FRONTEND_ASSET_DIRECTORY).exists() and Path(FRONTEND_ASSET_DIRECTORY).is_dir():
+if FRONTEND_ASSET_DIRECTORY.exists() and FRONTEND_ASSET_DIRECTORY.is_dir():
     app.mount("/assets", StaticFiles(directory=FRONTEND_ASSET_DIRECTORY), "assets")
 
 
-if Path(FRONTEND_FAVICONS_DIRECTORY).exists() and Path(FRONTEND_FAVICONS_DIRECTORY).is_dir():
+if FRONTEND_FAVICONS_DIRECTORY.exists() and FRONTEND_FAVICONS_DIRECTORY.is_dir():
     app.mount("/favicons", StaticFiles(directory=FRONTEND_FAVICONS_DIRECTORY), "favicons")
 
 
-if Path(DOCS_BUILD_DIRECTORY).exists() and Path(DOCS_BUILD_DIRECTORY).is_dir():
+if DOCS_BUILD_DIRECTORY.exists() and DOCS_BUILD_DIRECTORY.is_dir():
     app.mount("/docs", StaticFiles(directory=DOCS_BUILD_DIRECTORY, html=True, check_dir=True), name="infrahub-docs")
 
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -396,7 +396,7 @@ def reload_settings_before_each_module(tmpdir_factory):
     config.SETTINGS.workflow.driver = config.WorkflowDriver.LOCAL
 
     storage_dir = tmpdir_factory.mktemp("storage")
-    config.SETTINGS.storage.local.path_ = str(storage_dir)
+    config.SETTINGS.storage.local.path_ = storage_dir
 
     config.SETTINGS.broker.enable = False
     config.SETTINGS.cache.enable = True

--- a/backend/tests/helpers/file_repo.py
+++ b/backend/tests/helpers/file_repo.py
@@ -66,4 +66,4 @@ class FileRepo:
 
     @property
     def path(self) -> str:
-        return str(Path(self.sources_directory, self.name))
+        return str(self.sources_directory / self.name)

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -34,9 +34,8 @@ from .test_client import InfrahubTestClient
 class TestInfrahub:
     @pytest.fixture(scope="class")
     def local_storage_dir(self, tmpdir_factory: pytest.TempdirFactory) -> Path:
-        storage_dir = Path(tmpdir_factory.getbasetemp().strpath, "storage")
-        if not storage_dir.exists():
-            storage_dir.mkdir()
+        storage_dir = Path(tmpdir_factory.getbasetemp().strpath) / "storage"
+        storage_dir.mkdir(parents=True, exist_ok=True)
 
         config.SETTINGS.storage.driver = config.StorageDriver.FileSystemStorage
         config.SETTINGS.storage.local.path_ = storage_dir

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -49,11 +49,11 @@ async def load_infrastructure_schema(db: InfrahubDatabase):
     branch_schema = registry.schema.get_schema_branch(name=default_branch_name)
     tmp_schema = branch_schema.duplicate()
 
-    for file_name in os.listdir(base_dir):
-        file_path = Path(base_dir, file_name)
+    for file_name in base_dir.iterdir():
+        file_path = base_dir / file_name
 
         if file_path.suffix in (".yml", ".yaml"):
-            schema_txt = Path(file_path).read_text(encoding="utf-8")
+            schema_txt = file_path.read_text(encoding="utf-8")
             loaded_schema = yaml.safe_load(schema_txt)
             tmp_schema.load_schema(schema=SchemaRoot(**loaded_schema))
     tmp_schema.process()

--- a/backend/tests/integration/git/test_git_repository.py
+++ b/backend/tests/integration/git/test_git_repository.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from typing import AsyncGenerator
 
@@ -34,14 +33,13 @@ async def load_infrastructure_schema(db: InfrahubDatabase):
     branch_schema = registry.schema.get_schema_branch(name=default_branch_name)
     tmp_schema = branch_schema.duplicate()
 
-    for file_name in os.listdir(base_dir):
+    for file_name in base_dir.iterdir():
         file_path = base_dir / file_name
-        if file_path.suffix not in (".yml", ".yaml"):
-            continue
-        schema_txt = file_path.read_text(encoding="utf-8")
-        loaded_schema = yaml.safe_load(schema_txt)
-        tmp_schema.load_schema(schema=SchemaRoot(**loaded_schema))
 
+        if file_path.suffix in (".yml", ".yaml"):
+            schema_txt = file_path.read_text(encoding="utf-8")
+            loaded_schema = yaml.safe_load(schema_txt)
+            tmp_schema.load_schema(schema=SchemaRoot(**loaded_schema))
     tmp_schema.process()
 
     await registry.schema.update_schema_branch(schema=tmp_schema, db=db, branch=default_branch_name, update_db=True)

--- a/backend/tests/unit/api/test_internal.py
+++ b/backend/tests/unit/api/test_internal.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import pytest
 
 from infrahub import config
@@ -11,7 +9,7 @@ from tests.helpers.fixtures import get_fixtures_dir
 def override_search_index_path():
     old_search_index_path = config.SETTINGS.main.docs_index_path
     old_search_docs_loader = internal.search_docs_loader
-    config.SETTINGS.main.docs_index_path = Path(get_fixtures_dir(), "docs/search-index.json")
+    config.SETTINGS.main.docs_index_path = get_fixtures_dir() / "docs" / "search-index.json"
     internal.search_docs_loader = internal.SearchDocs()
     yield
     config.SETTINGS.main.docs_index_path = old_search_index_path
@@ -22,7 +20,7 @@ def override_search_index_path():
 def no_search_index_path():
     old_search_index_path = config.SETTINGS.main.docs_index_path
     old_search_docs_loader = internal.search_docs_loader
-    config.SETTINGS.main.docs_index_path = Path(get_fixtures_dir(), "docs/no-index.json")
+    config.SETTINGS.main.docs_index_path = get_fixtures_dir() / "docs" / "no-index.json"
     internal.search_docs_loader = internal.SearchDocs()
     yield
     config.SETTINGS.main.docs_index_path = old_search_index_path

--- a/backend/tests/unit/git/conftest.py
+++ b/backend/tests/unit/git/conftest.py
@@ -658,8 +658,7 @@ async def gql_query_data_02() -> dict:
 
 @pytest.fixture
 async def mock_schema_query_01(helper, httpx_mock: HTTPXMock) -> HTTPXMock:
-    schema_file: Path = helper.get_fixtures_dir() / "schemas" / "schema_01.json"
-    response_text = schema_file.read_text(encoding="UTF-8")
+    response_text = (helper.get_fixtures_dir() / "schemas" / "schema_01.json").read_text(encoding="UTF-8")
 
     httpx_mock.add_response(
         method="GET", url=re.compile(r"^http://mock/api/schema\?branch=(main|cr1234)"), json=ujson.loads(response_text)
@@ -669,8 +668,7 @@ async def mock_schema_query_01(helper, httpx_mock: HTTPXMock) -> HTTPXMock:
 
 @pytest.fixture
 async def mock_schema_query_02(helper, httpx_mock: HTTPXMock) -> HTTPXMock:
-    schema_file: Path = helper.get_fixtures_dir() / "schemas" / "schema_02.json"
-    response_text = schema_file.read_text(encoding="UTF-8")
+    response_text = (helper.get_fixtures_dir() / "schemas" / "schema_02.json").read_text(encoding="UTF-8")
 
     httpx_mock.add_response(method="GET", url="http://mock/api/schema?branch=main", json=ujson.loads(response_text))
     return httpx_mock
@@ -853,7 +851,7 @@ async def gql_query_data_03():
 
 @pytest.fixture
 async def schema_02(client, helper, car_data_01) -> ClientSchemaRoot:
-    full_schema = ujson.loads(Path(helper.get_fixtures_dir(), "schemas", "schema_02.json").read_text(encoding="UTF-8"))
+    full_schema = ujson.loads((helper.get_fixtures_dir() / "schemas" / "schema_02.json").read_text(encoding="UTF-8"))
 
     return ClientSchemaRoot(**full_schema)
 

--- a/backend/tests/unit/git/test_git_repository.py
+++ b/backend/tests/unit/git/test_git_repository.py
@@ -760,11 +760,11 @@ async def test_calculate_diff_between_commits(
 
     # Add a file
     new_file = "mynewfile.txt"
-    Path(worktree.directory, new_file).write_text("this is a new file\n", encoding="utf-8")
+    (worktree.directory / new_file).write_text("this is a new file\n", encoding="utf-8")
 
     # Remove a file
     file_to_remove = "pyproject.toml"
-    Path(worktree.directory, file_to_remove).unlink()
+    (worktree.directory / file_to_remove).unlink()
 
     git_repo.index.add([new_file])
     git_repo.index.remove([file_to_remove])
@@ -777,7 +777,7 @@ async def test_calculate_diff_between_commits(
     #     worktree = repo.get_worktree(identifier=branch)
     #     git_repo = repo.get_git_repo_worktree(identifier=branch)
 
-    #     sports_file = os.path.join(worktree.directory, "test_files/sports.yml")
+    #     sports_file = worktree.directory / "test_files" / "sports.yml"
 
     #     with open(sports_file, 'r') as file:
     #         data = file.readlines()
@@ -818,11 +818,11 @@ async def test_list_all_files(git_repo_01: InfrahubRepository, branch01: BranchD
 
     # Add a file
     new_file = "mynewfile.txt"
-    Path(worktree.directory, new_file).write_text("this is a new file\n", encoding="utf-8")
+    (worktree.directory / new_file).write_text("this is a new file\n", encoding="utf-8")
 
     # Remove a file
     file_to_remove = "pyproject.toml"
-    Path(worktree.directory, file_to_remove).unlink()
+    (worktree.directory / file_to_remove).unlink()
 
     git_repo.index.add([new_file])
     git_repo.index.remove([file_to_remove])

--- a/backend/tests/unit/message_bus/operations/requests/test_graphql_query_group.py
+++ b/backend/tests/unit/message_bus/operations/requests/test_graphql_query_group.py
@@ -1,5 +1,4 @@
 import uuid
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -17,7 +16,7 @@ from tests.helpers.utils import init_global_service
 
 @pytest.fixture
 async def mock_schema_query_02(helper, httpx_mock: HTTPXMock) -> HTTPXMock:
-    response_text = Path(helper.get_fixtures_dir(), "schemas", "schema_02.json").read_text(encoding="UTF-8")
+    response_text = (helper.get_fixtures_dir() / "schemas" / "schema_02.json").read_text(encoding="UTF-8")
 
     httpx_mock.add_response(method="GET", url="http://mock/api/schema?branch=main", json=ujson.loads(response_text))
     return httpx_mock

--- a/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
+++ b/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import pytest
 import ujson
 from infrahub_sdk import Config, InfrahubClient
@@ -40,7 +38,7 @@ DST_BRANCH_A = "main"
 
 @pytest.fixture
 async def mock_schema_query_02(helper: TestHelper, httpx_mock: HTTPXMock) -> HTTPXMock:
-    response_text = Path(helper.get_fixtures_dir(), "schemas", "schema_02.json").read_text(encoding="UTF-8")
+    response_text = (helper.get_fixtures_dir() / "schemas" / "schema_02.json").read_text(encoding="UTF-8")
 
     httpx_mock.add_response(method="GET", url="http://mock/api/schema?branch=main", json=ujson.loads(response_text))
     return httpx_mock

--- a/backend/tests/unit/storage/test_local_storage.py
+++ b/backend/tests/unit/storage/test_local_storage.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 import fastapi_storages
@@ -38,10 +37,10 @@ async def test_store_file(helper, local_storage_dir: Path):
     storage = await InfrahubObjectStorage.init(settings=config.SETTINGS.storage)
 
     fixture_dir = helper.get_fixtures_dir()
-    files_dir = Path(fixture_dir, "schemas")
-    filenames = [item.name for item in os.scandir(files_dir) if item.is_file()]
+    files_dir = fixture_dir / "schemas"
+    filenames = [item.name for item in files_dir.iterdir() if item.is_file()]
 
-    content_file1 = Path(files_dir, filenames[0]).read_bytes()
+    content_file1 = (files_dir / filenames[0]).read_bytes()
     identifier = str(UUIDT())
     storage.store(identifier=identifier, content=content_file1)
 

--- a/backend/tests/unit/test_utils.py
+++ b/backend/tests/unit/test_utils.py
@@ -1,7 +1,5 @@
-from pathlib import Path
-
 from infrahub.utils import get_fixtures_dir
 
 
 def test_get_fixtures_dir():
-    assert Path.exists(get_fixtures_dir())
+    assert get_fixtures_dir().exists()

--- a/changelog/3545.changed.md
+++ b/changelog/3545.changed.md
@@ -1,0 +1,1 @@
+Change strings referring to file system paths to pathlib.Path objects

--- a/tasks/docs.py
+++ b/tasks/docs.py
@@ -206,20 +206,20 @@ def _generate_infrahub_schema_documentation() -> None:
     }
     print(" - Generate Infrahub schema documentation")
     for schema_name, schema in schemas_to_generate.items():
-        template_file = f"{DOCUMENTATION_DIRECTORY}/_templates/schema/{schema_name}.j2"
-        output_file = f"{DOCUMENTATION_DIRECTORY}/docs/reference/schema/{schema_name}.mdx"
+        template_file = Path(f"{DOCUMENTATION_DIRECTORY}/_templates/schema/{schema_name}.j2")
+        output_file = Path(f"{DOCUMENTATION_DIRECTORY}/docs/reference/schema/{schema_name}.mdx")
         output_label = f"docs/docs/reference/schema/{schema_name}.mdx"
-        if not Path(template_file).exists():
+        if not template_file.exists():
             print(f"Unable to find the template file at {template_file}")
             sys.exit(-1)
 
-        template_text = Path(template_file).read_text(encoding="utf-8")
+        template_text = template_file.read_text(encoding="utf-8")
 
         environment = jinja2.Environment()
         template = environment.from_string(template_text)
         rendered_file = template.render(schema=schema)
 
-        Path(output_file).write_text(rendered_file, encoding="utf-8")
+        output_file.write_text(rendered_file, encoding="utf-8")
         print(f"Docs saved to: {output_label}")
 
 
@@ -270,21 +270,21 @@ def _generate_infrahub_sdk_configuration_documentation() -> None:
 
     print(" - Generate Infrahub SDK configuration documentation")
 
-    template_file = f"{DOCUMENTATION_DIRECTORY}/_templates/sdk_config.j2"
-    output_file = f"{DOCUMENTATION_DIRECTORY}/docs/python-sdk/reference/config.mdx"
+    template_file = Path(f"{DOCUMENTATION_DIRECTORY}/_templates/sdk_config.j2")
+    output_file = Path(f"{DOCUMENTATION_DIRECTORY}/docs/python-sdk/reference/config.mdx")
     output_label = "docs/docs/python-sdk/reference/config.mdx"
 
-    if not Path(template_file).exists():
+    if not template_file.exists():
         print(f"Unable to find the template file at {template_file}")
         sys.exit(-1)
 
-    template_text = Path(template_file).read_text(encoding="utf-8")
+    template_text = template_file.read_text(encoding="utf-8")
 
     environment = jinja2.Environment(trim_blocks=True)
     template = environment.from_string(template_text)
     rendered_file = template.render(properties=properties)
 
-    Path(output_file).write_text(rendered_file, encoding="utf-8")
+    output_file.write_text(rendered_file, encoding="utf-8")
     print(f"Docs saved to: {output_label}")
 
 
@@ -322,20 +322,20 @@ def _generate_infrahub_repository_configuration_documentation() -> None:
 
     print(" - Generate Infrahub repository configuration documentation")
 
-    template_file = f"{DOCUMENTATION_DIRECTORY}/_templates/dotinfrahub.j2"
-    output_file = f"{DOCUMENTATION_DIRECTORY}/docs/reference/dotinfrahub.mdx"
+    template_file = Path(f"{DOCUMENTATION_DIRECTORY}/_templates/dotinfrahub.j2")
+    output_file = Path(f"{DOCUMENTATION_DIRECTORY}/docs/reference/dotinfrahub.mdx")
     output_label = "docs/docs/reference/dotinfrahub.mdx"
-    if not Path(template_file).exists():
+    if not template_file.exists():
         print(f"Unable to find the template file at {template_file}")
         sys.exit(-1)
 
-    template_text = Path(template_file).read_text(encoding="utf-8")
+    template_text = template_file.read_text(encoding="utf-8")
 
     environment = jinja2.Environment()
     template = environment.from_string(template_text)
     rendered_file = template.render(properties=properties, definitions=definitions)
 
-    Path(output_file).write_text(rendered_file, encoding="utf-8")
+    output_file.write_text(rendered_file, encoding="utf-8")
     print(f"Docs saved to: {output_label}")
 
 
@@ -385,7 +385,7 @@ def _generate_infrahub_events_documentation() -> None:
 
     print(" - Generate Infrahub Bus Events documentation")
 
-    if not Path(template_file).exists():
+    if not template_file.exists():
         print(f"Unable to find the template file at {template_file}")
         sys.exit(-1)
 

--- a/tasks/docs.py
+++ b/tasks/docs.py
@@ -206,8 +206,8 @@ def _generate_infrahub_schema_documentation() -> None:
     }
     print(" - Generate Infrahub schema documentation")
     for schema_name, schema in schemas_to_generate.items():
-        template_file = Path(f"{DOCUMENTATION_DIRECTORY}/_templates/schema/{schema_name}.j2")
-        output_file = Path(f"{DOCUMENTATION_DIRECTORY}/docs/reference/schema/{schema_name}.mdx")
+        template_file = Path(DOCUMENTATION_DIRECTORY) / "_templates" / "schema" / f"{schema_name}.j2"
+        output_file = Path(DOCUMENTATION_DIRECTORY) / "docs" / "reference" / "schema" / f"{schema_name}.mdx"
         output_label = f"docs/docs/reference/schema/{schema_name}.mdx"
         if not template_file.exists():
             print(f"Unable to find the template file at {template_file}")
@@ -270,8 +270,8 @@ def _generate_infrahub_sdk_configuration_documentation() -> None:
 
     print(" - Generate Infrahub SDK configuration documentation")
 
-    template_file = Path(f"{DOCUMENTATION_DIRECTORY}/_templates/sdk_config.j2")
-    output_file = Path(f"{DOCUMENTATION_DIRECTORY}/docs/python-sdk/reference/config.mdx")
+    template_file = Path(DOCUMENTATION_DIRECTORY) / "_templates" / "sdk_config.j2"
+    output_file = Path(DOCUMENTATION_DIRECTORY) / "docs" / "python-sdk" / "reference" / "config.mdx"
     output_label = "docs/docs/python-sdk/reference/config.mdx"
 
     if not template_file.exists():
@@ -322,8 +322,8 @@ def _generate_infrahub_repository_configuration_documentation() -> None:
 
     print(" - Generate Infrahub repository configuration documentation")
 
-    template_file = Path(f"{DOCUMENTATION_DIRECTORY}/_templates/dotinfrahub.j2")
-    output_file = Path(f"{DOCUMENTATION_DIRECTORY}/docs/reference/dotinfrahub.mdx")
+    template_file = Path(DOCUMENTATION_DIRECTORY) / "_templates" / "dotinfrahub.j2"
+    output_file = Path(DOCUMENTATION_DIRECTORY) / "docs" / "reference" / "dotinfrahub.mdx"
     output_label = "docs/docs/reference/dotinfrahub.mdx"
     if not template_file.exists():
         print(f"Unable to find the template file at {template_file}")

--- a/tasks/main.py
+++ b/tasks/main.py
@@ -1,8 +1,10 @@
+from pathlib import Path
+
 from invoke import Context, task
 
 from .utils import ESCAPED_REPO_PATH, REPO_BASE
 
-MAIN_DIRECTORY = "tasks"
+MAIN_DIRECTORY = Path("tasks")
 NAMESPACE = "MAIN"
 
 
@@ -15,8 +17,8 @@ def _format_ruff(context: Context) -> None:
     """Run ruff to format all Python files."""
 
     print(f" - [{NAMESPACE}] Format code with ruff")
-    exec_cmd = f"ruff format {MAIN_DIRECTORY} models utilities --config {REPO_BASE}/pyproject.toml && "
-    exec_cmd += f"ruff check --fix {MAIN_DIRECTORY} models utilities --config {REPO_BASE}/pyproject.toml"
+    exec_cmd = f"ruff format {MAIN_DIRECTORY} models utilities --config {REPO_BASE / 'pyproject.toml'} && "
+    exec_cmd += f"ruff check --fix {MAIN_DIRECTORY} models utilities --config {REPO_BASE / 'pyproject.toml'}"
     with context.cd(ESCAPED_REPO_PATH):
         context.run(exec_cmd)
 

--- a/tasks/schema.py
+++ b/tasks/schema.py
@@ -6,8 +6,8 @@ from invoke.tasks import task
 
 from .utils import REPO_BASE
 
-SDK_DIRECTORY = f"{REPO_BASE}/generated/python-sdk"
-INFRAHUB_DIRECTORY = f"{REPO_BASE}/generated/infrahub"
+SDK_DIRECTORY = REPO_BASE / "generated" / "python-sdk"
+INFRAHUB_DIRECTORY = REPO_BASE / "generated" / "infrahub"
 
 
 @task
@@ -21,7 +21,7 @@ def generate_jsonschema(context: Context) -> None:
 def generate_infrahub_node_schema() -> None:
     from infrahub.api.schema import SchemaLoadAPI
 
-    schema_dir = Path(f"{INFRAHUB_DIRECTORY}/schema")
+    schema_dir = INFRAHUB_DIRECTORY / "schema"
     schema_dir.mkdir(parents=True, exist_ok=True)
 
     schema = SchemaLoadAPI.model_json_schema()
@@ -36,7 +36,7 @@ def generate_infrahub_node_schema() -> None:
 def generate_sdk_repository_config() -> None:
     from infrahub_sdk.schema import InfrahubRepositoryConfig
 
-    repository_dir = Path(f"{SDK_DIRECTORY}/repository-config")
+    repository_dir = SDK_DIRECTORY / "repository-config"
     repository_dir.mkdir(parents=True, exist_ok=True)
     schema = json.dumps(InfrahubRepositoryConfig.model_json_schema(), indent=4)
 

--- a/tasks/sdk.py
+++ b/tasks/sdk.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Optional
 
 from invoke import Context, task
@@ -8,11 +7,11 @@ from .shared import (
     INFRAHUB_DATABASE,
     NBR_WORKERS,
 )
-from .utils import ESCAPED_REPO_PATH
+from .utils import ESCAPED_REPO_PATH, REPO_BASE
 
 MAIN_DIRECTORY = "python_sdk"
 NAMESPACE = "SDK"
-MAIN_DIRECTORY_PATH = Path(ESCAPED_REPO_PATH, MAIN_DIRECTORY)
+MAIN_DIRECTORY_PATH = REPO_BASE / MAIN_DIRECTORY
 
 
 # ----------------------------------------------------------------------------
@@ -24,8 +23,8 @@ def _format_ruff(context: Context) -> None:
     """Run ruff to format all Python files."""
 
     print(f" - [{NAMESPACE}] Format code with ruff")
-    exec_cmd = f"ruff format {MAIN_DIRECTORY}/ --config {MAIN_DIRECTORY}/pyproject.toml && "
-    exec_cmd += f"ruff check --fix {MAIN_DIRECTORY}/ --config {MAIN_DIRECTORY}/pyproject.toml"
+    exec_cmd = f"ruff format {MAIN_DIRECTORY}/ --config {MAIN_DIRECTORY / 'pyproject.toml'} && "
+    exec_cmd += f"ruff check --fix {MAIN_DIRECTORY}/ --config {MAIN_DIRECTORY / 'pyproject.toml'}"
     with context.cd(ESCAPED_REPO_PATH):
         context.run(exec_cmd)
 
@@ -48,7 +47,7 @@ def ruff(context: Context) -> None:
 
     print(f" - [{NAMESPACE}] Check code with ruff")
     exec_directory = MAIN_DIRECTORY_PATH
-    exec_cmd = f"ruff check --diff {exec_directory} --config {exec_directory}/pyproject.toml"
+    exec_cmd = f"ruff check --diff {exec_directory} --config {exec_directory / 'pyproject.toml'}"
 
     with context.cd(exec_directory):
         context.run(exec_cmd)
@@ -92,7 +91,7 @@ def lint(context: Context) -> Optional[Result]:
 def test_unit(context: Context) -> Optional[Result]:
     """Run unit tests for the Python SDK."""
     with context.cd(ESCAPED_REPO_PATH):
-        exec_cmd = f"pytest -n {NBR_WORKERS} -v --cov=infrahub_sdk {MAIN_DIRECTORY}/tests/unit"
+        exec_cmd = f"pytest -n {NBR_WORKERS} -v --cov=infrahub_sdk {MAIN_DIRECTORY / 'tests' / 'unit'}"
         return context.run(exec_cmd)
 
 
@@ -100,7 +99,7 @@ def test_unit(context: Context) -> Optional[Result]:
 def test_integration(context: Context, database: str = INFRAHUB_DATABASE) -> Optional[Result]:
     """Run integration tests for the Python SDK."""
     with context.cd(ESCAPED_REPO_PATH):
-        exec_cmd = f"pytest -n {NBR_WORKERS} -v --cov=infrahub_sdk {MAIN_DIRECTORY}/tests/integration"
+        exec_cmd = f"pytest -n {NBR_WORKERS} -v --cov=infrahub_sdk {MAIN_DIRECTORY / 'tests' / 'integration'}"
         return context.run(exec_cmd)
 
 

--- a/tasks/shared.py
+++ b/tasks/shared.py
@@ -57,37 +57,40 @@ AVAILABLE_SERVICES = [SERVICE_SERVER_NAME, SERVICE_WORKER_NAME, "database", "mes
 
 SUPPORTED_DATABASES = [DatabaseType.MEMGRAPH.value, DatabaseType.NEO4J.value]
 
-COMPOSE_FILES_DEPS = {False: "development/docker-compose-deps.yml", True: "development/docker-compose-deps-nats.yml"}
+COMPOSE_FILES_DEPS = {
+    False: Path("development/docker-compose-deps.yml"),
+    True: Path("development/docker-compose-deps-nats.yml"),
+}
 
 IMAGE_NAME = os.getenv("INFRAHUB_IMAGE_NAME", "registry.opsmill.io/opsmill/infrahub")
 REQUESTED_IMAGE_VER = os.getenv("INFRAHUB_IMAGE_VER")
 IMAGE_VER = REQUESTED_IMAGE_VER or "latest"
 
-OVERRIDE_FILE_NAME = "development/docker-compose.override.yml"
-DEFAULT_FILE_NAME = "development/docker-compose.default.yml"
-LOCAL_FILE_NAME = "development/docker-compose.local-build.yml"
+OVERRIDE_FILE = Path("development/docker-compose.override.yml")
+DEFAULT_FILE = Path("development/docker-compose.default.yml")
+LOCAL_FILE = Path("development/docker-compose.local-build.yml")
 COMPOSE_FILES_MEMGRAPH = [
     COMPOSE_FILES_DEPS[INFRAHUB_USE_NATS],
-    "development/docker-compose-database-memgraph.yml",
-    "development/docker-compose.yml",
+    Path("development/docker-compose-database-memgraph.yml"),
+    Path("development/docker-compose.yml"),
 ]
 COMPOSE_FILES_NEO4J = [
     COMPOSE_FILES_DEPS[INFRAHUB_USE_NATS],
-    "development/docker-compose-database-neo4j.yml",
-    "development/docker-compose.yml",
+    Path("development/docker-compose-database-neo4j.yml"),
+    Path("development/docker-compose.yml"),
 ]
 
 DEV_COMPOSE_FILES_MEMGRAPH = [
     COMPOSE_FILES_DEPS[INFRAHUB_USE_NATS],
-    "development/docker-compose-database-memgraph.yml",
+    Path("development/docker-compose-database-memgraph.yml"),
 ]
 DEV_COMPOSE_FILES_NEO4J = [
     COMPOSE_FILES_DEPS[INFRAHUB_USE_NATS],
-    "development/docker-compose-database-neo4j.yml",
+    Path("development/docker-compose-database-neo4j.yml"),
 ]
-DEV_OVERRIDE_FILE_NAME = "development/docker-compose.dev-override.yml"
+DEV_OVERRIDE_FILE = Path("development/docker-compose.dev-override.yml")
 
-TEST_METRICS_OVERRIDE_FILE_NAME = "development/docker-compose-test-metrics.yml"
+TEST_METRICS_OVERRIDE_FILE = Path("development/docker-compose-test-metrics.yml")
 
 
 PLATFORMS_PTY_ENABLE = ["Linux", "Darwin"]
@@ -229,19 +232,19 @@ def build_compose_files_cmd(database: str, namespace: Namespace = Namespace.DEFA
     elif database == DatabaseType.NEO4J.value:
         COMPOSE_FILES = COMPOSE_FILES_NEO4J.copy()
 
-    if Path(OVERRIDE_FILE_NAME).exists():
+    if OVERRIDE_FILE.exists():
         print("!! Found an override file for docker-compose !!")
-        COMPOSE_FILES.append(OVERRIDE_FILE_NAME)
+        COMPOSE_FILES.append(OVERRIDE_FILE)
     else:
-        COMPOSE_FILES.append(DEFAULT_FILE_NAME)
+        COMPOSE_FILES.append(DEFAULT_FILE)
 
     if "local" in IMAGE_VER or (namespace == Namespace.DEV and not REQUESTED_IMAGE_VER):
-        COMPOSE_FILES.append(LOCAL_FILE_NAME)
+        COMPOSE_FILES.append(LOCAL_FILE)
 
     if os.getenv("CI") is not None:
-        COMPOSE_FILES.append(TEST_METRICS_OVERRIDE_FILE_NAME)
+        COMPOSE_FILES.append(TEST_METRICS_OVERRIDE_FILE)
 
-    return f"-f {' -f '.join(COMPOSE_FILES)}"
+    return f"-f {' -f '.join(map(str, COMPOSE_FILES))}"
 
 
 def build_dev_compose_files_cmd(database: str) -> str:
@@ -253,8 +256,8 @@ def build_dev_compose_files_cmd(database: str) -> str:
     elif database == DatabaseType.NEO4J.value:
         DEV_COMPOSE_FILES = DEV_COMPOSE_FILES_NEO4J.copy()
 
-    if Path(DEV_OVERRIDE_FILE_NAME).exists():
+    if DEV_OVERRIDE_FILE.exists():
         print("!! Found a dev override file for docker-compose !!")
-        DEV_COMPOSE_FILES.append(DEV_OVERRIDE_FILE_NAME)
+        DEV_COMPOSE_FILES.append(DEV_OVERRIDE_FILE)
 
-    return f"-f {' -f '.join(DEV_COMPOSE_FILES)}"
+    return f"-f {' -f '.join(map(str, DEV_COMPOSE_FILES))}"

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -47,7 +47,7 @@ ESCAPED_REPO_PATH = escape_path(REPO_BASE)
 def project_ver() -> str:
     """Find version from pyproject.toml to use for docker image tagging."""
 
-    with Path(f"{REPO_BASE}/pyproject.toml").open(encoding="utf-8") as file:
+    with (REPO_BASE / "pyproject.toml").open(encoding="utf-8") as file:
         return toml.load(file)["tool"]["poetry"].get("version", "latest")
 
 


### PR DESCRIPTION
This PR touches a fair bit of code, so it may be hard to keep up to date if left in the open state for a long time.

The config object takes a `config_file_name` attribute currently. I believe it would be best to convert this to a more appropriate name of `config_file` with a type of `PathLike[str]` -- this way a path object or a string can be passed in. I didn't do this because config is used in a lot of places in the code, and may also be used in a lot of places external to the code base -- so I wanted to get feedback on if this is worth doing at some point, if we should create another issue...etc.

Fixes #3545 