### PR TITLE
Add CoreProfile to database

### DIFF
--- a/backend/infrahub/core/schema/manager.py
+++ b/backend/infrahub/core/schema/manager.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from infrahub import lock
-from infrahub.core.constants import (
-    InfrahubKind,
-)
 from infrahub.core.manager import NodeManager
 from infrahub.core.models import (
     HashableModelDiff,
@@ -234,8 +231,6 @@ class SchemaManager(NodeManager):
         branch = await registry.get_branch(branch=branch, db=db)
 
         for item_kind in schema.node_names + schema.generic_names:
-            if item_kind == InfrahubKind.PROFILE:
-                continue
             if limit and item_kind not in limit:
                 continue
             item = schema.get(name=item_kind, duplicate=False)

--- a/changelog/+f91354a0.fixed.md
+++ b/changelog/+f91354a0.fixed.md
@@ -1,0 +1,1 @@
+Store CoreProfile in database to ensure consistent initial schema hash. Prior to this the schema was reported as being out of sync when starting the application for the first time. This error wouldn't have hade any impact but was confusing. The workaround would be to load a schema or restart the application at least once after first time initialization.


### PR DESCRIPTION
This PR fixes the issue of the workers being out of sync after the initial startup. It seems unclear if there was a reason why we didn't store the CoreProfile schema node in the database, my guess is that this was something that just happened when we removed the other profiles from the database.

As `CoreProfile` wasn't loaded to the database, we'd have a different instance on the first gunicorn worker compared to the three where `CoreProfile` gets generated automatically during initialization. There might be additional cleanups that could be done around this object but I'm guessing that would require changes to other tests and this is something we can look at later.