### PR TITLE
refactor Search Anywhere component

### DIFF
--- a/frontend/app/package-lock.json
+++ b/frontend/app/package-lock.json
@@ -33,6 +33,8 @@
         "@radix-ui/react-tooltip": "^1.0.7",
         "@svgr/rollup": "^8.1.0",
         "@tailwindcss/forms": "^0.5.7",
+        "@tanstack/react-query": "^5.62.3",
+        "@tanstack/react-query-devtools": "^5.62.3",
         "@uiw/react-color": "^2.1.1",
         "@vitejs/plugin-react": "^4.2.1",
         "autoprefixer": "^10.4.19",
@@ -5734,6 +5736,59 @@
         "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.62.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.62.3.tgz",
+      "integrity": "sha512-Jp/nYoz8cnO7kqhOlSv8ke/0MJRJVGuZ0P/JO9KQ+f45mpN90hrerzavyTKeSoT/pOzeoOUkv1Xd0wPsxAWXfg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.61.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.61.4.tgz",
+      "integrity": "sha512-21Tw+u8E3IJJj4A/Bct4H0uBaDTEu7zBrR79FeSyY+mS2gx5/m316oDtJiKkILc819VSTYt+sFzODoJNcpPqZQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.62.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.62.3.tgz",
+      "integrity": "sha512-y2zDNKuhgiuMgsKkqd4AcsLIBiCfEO8U11AdrtAUihmLbRNztPrlcZqx2lH1GacZsx+y1qRRbCcJLYTtF1vKsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.62.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.62.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.62.3.tgz",
+      "integrity": "sha512-4iaQap/iP5ErS094u1WehFntHtjRo6g5HJMvyHovBVbsxnvgPc6AtKAw7qxPPoKy6Wj5Bew0045eYP5phiiBmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.61.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.62.3",
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@tanstack/react-virtual": {
       "version": "3.10.8",
       "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.10.8.tgz",
@@ -6876,9 +6931,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.13.0.tgz",
-      "integrity": "sha512-8zSiw54Oxrdym50NlZ9sUusyO1Z1ZchgRLWRaK6c86XJFClyCgFKetdowBg5bKxyp/u+CDBJG4Mpp0m3HLZl9w==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -53,6 +53,8 @@
     "@radix-ui/react-tooltip": "^1.0.7",
     "@svgr/rollup": "^8.1.0",
     "@tailwindcss/forms": "^0.5.7",
+    "@tanstack/react-query": "^5.62.3",
+    "@tanstack/react-query-devtools": "^5.62.3",
     "@uiw/react-color": "^2.1.1",
     "@vitejs/plugin-react": "^4.2.1",
     "autoprefixer": "^10.4.19",

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -11,9 +11,12 @@ import { store } from "@/state";
 import { ApolloProvider } from "@apollo/client";
 import { addCollection } from "@iconify-icon/react";
 import mdiIcons from "@iconify-json/mdi/icons.json";
+import { QueryClientProvider } from "@tanstack/react-query";
 
 import "./styles/index.css";
 import "react-toastify/dist/ReactToastify.css";
+import { queryClient } from "@/api/client";
+import { TanStackQueryDevtools } from "@/devtools";
 
 addCollection(mdiIcons);
 
@@ -22,17 +25,20 @@ export function App() {
     <ErrorBoundary FallbackComponent={ErrorFallback}>
       <Provider store={store}>
         <AuthProvider>
-          <ApolloProvider client={graphqlClient}>
-            <ToastContainer
-              hideProgressBar={true}
-              transition={Slide}
-              autoClose={5000}
-              closeOnClick={false}
-              newestOnTop
-              position="bottom-right"
-            />
-            <RouterProvider router={router} />
-          </ApolloProvider>
+          <QueryClientProvider client={queryClient}>
+            <ApolloProvider client={graphqlClient}>
+              <ToastContainer
+                hideProgressBar={true}
+                transition={Slide}
+                autoClose={5000}
+                closeOnClick={false}
+                newestOnTop
+                position="bottom-right"
+              />
+              <RouterProvider router={router} />
+            </ApolloProvider>
+            <TanStackQueryDevtools />
+          </QueryClientProvider>
         </AuthProvider>
       </Provider>
     </ErrorBoundary>

--- a/frontend/app/src/api/client.ts
+++ b/frontend/app/src/api/client.ts
@@ -1,0 +1,9 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});

--- a/frontend/app/src/components/search/queries/get-doc-results.ts
+++ b/frontend/app/src/components/search/queries/get-doc-results.ts
@@ -1,0 +1,19 @@
+import { CONFIG } from "@/config/config";
+import { fetchUrl } from "@/utils/fetch";
+import { queryOptions } from "@tanstack/react-query";
+
+export type DocResult = {
+  title: string;
+  url: string;
+  breadcrumb: string[];
+};
+
+export const searchDocsQueryOptions = ({ query, limit = 3 }: { query: string; limit?: number }) => {
+  return queryOptions<DocResult[]>({
+    queryKey: ["search-docs", query, limit],
+    queryFn: async () => {
+      return await fetchUrl(CONFIG.SEARCH_URL(query, limit));
+    },
+    enabled: !!query,
+  });
+};

--- a/frontend/app/src/components/search/search-actions.tsx
+++ b/frontend/app/src/components/search/search-actions.tsx
@@ -1,20 +1,22 @@
+import { SearchAnywhereGroup } from "@/components/search/search-anywhere-group";
+import { SearchAnywhereItem } from "@/components/search/search-anywhere-item";
 import { Badge } from "@/components/ui/badge";
 import { MenuItem } from "@/screens/layout/menu-navigation/types";
 import { IModelSchema, genericsState, menuFlatAtom, schemaState } from "@/state/atoms/schema.atom";
 import { constructPath } from "@/utils/fetch";
 import { Icon } from "@iconify-icon/react";
+import { useCommandState } from "cmdk";
 import { useAtomValue } from "jotai";
-import { SearchGroup, SearchGroupTitle, SearchResultItem } from "./search-anywhere";
 
-type SearchProps = {
-  query: string;
-};
-export const SearchActions = ({ query }: SearchProps) => {
+export const SearchActions = () => {
+  const query = useCommandState((state) => state.search);
   const nodes = useAtomValue(schemaState);
   const generics = useAtomValue(genericsState);
   const models: IModelSchema[] = [...nodes, ...generics];
 
   const menuItems = useAtomValue(menuFlatAtom);
+
+  if (query === "") return null;
 
   const queryLowerCased = query.toLowerCase();
   const resultsMenu = menuItems.filter(({ label }) =>
@@ -32,17 +34,15 @@ export const SearchActions = ({ query }: SearchProps) => {
 
   const firstThreeMatches = results.slice(0, 3);
   return (
-    <SearchGroup>
-      <SearchGroupTitle>Go to</SearchGroupTitle>
-
+    <SearchAnywhereGroup heading="Go to">
       {firstThreeMatches.map((result) => {
         return "namespace" in result ? (
-          <ActionOnSchema key={result.kind} model={result} />
+          <ActionOnSchema key={result.id} model={result} />
         ) : (
-          <ActionOnMenu key={result.path} menuItem={result} />
+          <ActionOnMenu key={result.identifier} menuItem={result} />
         );
       })}
-    </SearchGroup>
+    </SearchAnywhereGroup>
   );
 };
 
@@ -51,20 +51,23 @@ type ActionOnMenuProps = {
 };
 
 const ActionOnMenu = ({ menuItem }: ActionOnMenuProps) => {
+  const url = constructPath(menuItem.path);
+
   return (
-    <SearchResultItem to={constructPath(menuItem.path)}>
+    <SearchAnywhereItem to={url} value={menuItem.identifier}>
       <span className="font-medium">Menu</span>
       <Icon icon="mdi:chevron-right" />
       <span className="font-semibold">{menuItem.label}</span>
-    </SearchResultItem>
+    </SearchAnywhereItem>
   );
 };
 
 const ActionOnSchema = ({ model }: { model: IModelSchema }) => {
   const { kind, label, name } = model;
+  const url = constructPath("/schema", [{ name: "kind", value: kind }]);
 
   return (
-    <SearchResultItem to={constructPath("/schema", [{ name: "kind", value: kind }])}>
+    <SearchAnywhereItem to={url} value={model.id!}>
       <span className="font-medium">Schema</span>
       <Icon icon="mdi:chevron-right" />
       <span className="font-semibold">
@@ -73,6 +76,6 @@ const ActionOnSchema = ({ model }: { model: IModelSchema }) => {
         </Badge>
         {label || name || kind}
       </span>
-    </SearchResultItem>
+    </SearchAnywhereItem>
   );
 };

--- a/frontend/app/src/components/search/search-anywhere-context.ts
+++ b/frontend/app/src/components/search/search-anywhere-context.ts
@@ -1,0 +1,23 @@
+import React from "react";
+
+export interface SearchAnywhereContextProps {
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+  closeDialog: () => void;
+  openDialog: () => void;
+}
+
+export const SearchAnywhereContext = React.createContext<SearchAnywhereContextProps>({
+  isOpen: false,
+  closeDialog: () => {},
+  openDialog: () => {},
+  setIsOpen: () => {},
+});
+
+export const useSearchAnywhereContext = () => {
+  const context = React.useContext(SearchAnywhereContext);
+  if (context === undefined) {
+    throw new Error("useSearchAnywhereContext must be used within a SearchAnywhereContext");
+  }
+  return context;
+};

--- a/frontend/app/src/components/search/search-anywhere-dialog.tsx
+++ b/frontend/app/src/components/search/search-anywhere-dialog.tsx
@@ -1,0 +1,34 @@
+import { useSearchAnywhereContext } from "@/components/search/search-anywhere-context";
+import { classNames } from "@/utils/common";
+import { Command } from "cmdk";
+import React from "react";
+
+export function SearchAnywhereDialog({
+  children,
+  ...props
+}: React.ComponentProps<typeof Command.Dialog>) {
+  const { isOpen, setIsOpen } = useSearchAnywhereContext();
+
+  return (
+    <Command.Dialog
+      {...props}
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      overlayClassName={classNames(
+        "fixed inset-0 z-50 bg-gray-600/25",
+        "data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        "data-[state=closed]:animate-out data-[state=closed]:fade-out-0"
+      )}
+      contentClassName={classNames(
+        "fixed top-1 left-[50%] translate-x-[-50%] z-50 grid w-full max-w-screen-md gap-4 border bg-stone-100 p-2 shadow-lg rounded-xl duration-200",
+        "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
+        "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%]"
+      )}
+      data-testid="search-anywhere"
+      shouldFilter={false}
+      label="Search anywhere"
+    >
+      {children}
+    </Command.Dialog>
+  );
+}

--- a/frontend/app/src/components/search/search-anywhere-empty.tsx
+++ b/frontend/app/src/components/search/search-anywhere-empty.tsx
@@ -1,0 +1,21 @@
+import { SearchAnywhereGroup } from "@/components/search/search-anywhere-group";
+import { SearchAnywhereItem } from "@/components/search/search-anywhere-item";
+import { INFRAHUB_API_SERVER_URL } from "@/config/config";
+import { Icon } from "@iconify-icon/react";
+import { useCommandState } from "cmdk";
+
+export function SearchAnywhereEmpty() {
+  const count = useCommandState((state) => state.filtered.count);
+  const query = useCommandState((state) => state.search);
+
+  if (query === "" || count !== 0) return null;
+
+  return (
+    <SearchAnywhereGroup>
+      <SearchAnywhereItem forceMount to={`${INFRAHUB_API_SERVER_URL}/docs/search?q=${query}`}>
+        <Icon icon="mdi:book-open-blank-variant-outline" className="text-lg" />
+        Search in docs: <span className="font-semibold">{query}</span>
+      </SearchAnywhereItem>
+    </SearchAnywhereGroup>
+  );
+}

--- a/frontend/app/src/components/search/search-anywhere-group.tsx
+++ b/frontend/app/src/components/search/search-anywhere-group.tsx
@@ -1,0 +1,19 @@
+import { classNames } from "@/utils/common";
+import { Command } from "cmdk";
+import React from "react";
+
+export function SearchAnywhereGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof Command.Group>) {
+  return (
+    <Command.Group
+      className={classNames(
+        "bg-custom-white rounded-lg border p-2",
+        "[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-neutral-600",
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/frontend/app/src/components/search/search-anywhere-input.tsx
+++ b/frontend/app/src/components/search/search-anywhere-input.tsx
@@ -1,0 +1,25 @@
+import { inputStyle } from "@/components/ui/style";
+import { classNames } from "@/utils/common";
+import { Icon } from "@iconify-icon/react";
+import { Command, Command as CommandPrimitive } from "cmdk";
+import * as React from "react";
+
+export function SearchAnywhereInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div className="relative">
+      <div className="absolute top-2.5 pl-2.5">
+        <Icon icon="mdi:magnify" className="text-xl text-custom-blue-600" />
+      </div>
+
+      <Command.Input
+        placeholder="Search for objects, attributes, schemas, documentations ..."
+        className={classNames(inputStyle, "px-9", className)}
+        data-testid="search-anywhere-input"
+        {...props}
+      />
+    </div>
+  );
+}

--- a/frontend/app/src/components/search/search-anywhere-item.tsx
+++ b/frontend/app/src/components/search/search-anywhere-item.tsx
@@ -1,0 +1,28 @@
+import { useSearchAnywhereContext } from "@/components/search/search-anywhere-context";
+import { CommandItem } from "@/components/ui/command";
+import React from "react";
+import { useNavigate } from "react-router-dom";
+
+export interface SearchAnywhereItemProps extends React.ComponentProps<typeof CommandItem> {
+  to: string;
+}
+
+export function SearchAnywhereItem({ to, ...props }: SearchAnywhereItemProps) {
+  const { closeDialog } = useSearchAnywhereContext();
+  const navigate = useNavigate();
+
+  return (
+    <CommandItem
+      {...props}
+      onSelect={() => {
+        if (to.startsWith("http")) {
+          window.open(to, "_blank", "rel=noopener noreferrer, popup=false");
+        } else {
+          navigate(to);
+        }
+
+        closeDialog();
+      }}
+    />
+  );
+}

--- a/frontend/app/src/components/search/search-anywhere-trigger.tsx
+++ b/frontend/app/src/components/search/search-anywhere-trigger.tsx
@@ -1,0 +1,49 @@
+import { Button, ButtonProps } from "@/components/buttons/button-primitive";
+import Kbd from "@/components/ui/kbd";
+import { CollapsedButton } from "@/screens/layout/menu-navigation/components/collapsed-button";
+import { classNames } from "@/utils/common";
+import { Icon } from "@iconify-icon/react";
+
+export interface SearchAnywhereTriggerButtonProps extends ButtonProps {
+  isCollapsed?: boolean;
+}
+
+export function SearchAnywhereTrigger({
+  className,
+  isCollapsed,
+  ...props
+}: SearchAnywhereTriggerButtonProps) {
+  if (isCollapsed) {
+    return (
+      <CollapsedButton
+        tooltipContent="Search anywhere"
+        icon="mdi:search"
+        data-testid="search-anywhere-trigger"
+        {...props}
+      />
+    );
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      className={classNames(
+        "px-3 py-2 gap-3 bg-neutral-100 shadow-none text-neutral-800 justify-between",
+        className
+      )}
+      data-testid="search-anywhere-trigger"
+      {...props}
+    >
+      <div className="flex items-center gap-2 overflow-hidden">
+        <Icon icon="mdi:magnify" aria-hidden="true" className="text-xl" />
+        <span className="text-neutral-700 text-sm group-data-[collapsed=true]/sidebar:hidden transition-all truncate">
+          Search
+        </span>
+      </div>
+
+      <Kbd keys="command" className="group-data-[collapsed=true]/sidebar:hidden transition-all">
+        K
+      </Kbd>
+    </Button>
+  );
+}

--- a/frontend/app/src/components/search/search-anywhere.tsx
+++ b/frontend/app/src/components/search/search-anywhere.tsx
@@ -1,47 +1,13 @@
-import { Button, ButtonProps } from "@/components/buttons/button-primitive";
-import Kbd from "@/components/ui/kbd";
-import { CollapsedButton } from "@/screens/layout/menu-navigation/components/collapsed-button";
-import { classNames } from "@/utils/common";
-import { Icon } from "@iconify-icon/react";
+import { SearchAnywhereDialog } from "@/components/search/search-anywhere-dialog";
+import { SearchAnywhereEmpty } from "@/components/search/search-anywhere-empty";
+import { SearchAnywhereInput } from "@/components/search/search-anywhere-input";
+import { SearchAnywhereTrigger } from "@/components/search/search-anywhere-trigger";
 import { Command } from "cmdk";
-import React, { ReactNode, useContext, useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { CommandItem } from "../ui/command";
-import { Input } from "../ui/input";
+import { useEffect, useState } from "react";
 import { SearchActions } from "./search-actions";
+import { SearchAnywhereContext } from "./search-anywhere-context";
 import { SearchDocs } from "./search-docs";
 import { SearchNodes } from "./search-nodes";
-
-const SearchAnywhereTriggerButton = ({ className, ...props }: ButtonProps) => {
-  return (
-    <Button
-      variant="ghost"
-      className={classNames(
-        "px-3 py-2 gap-3 bg-neutral-100 shadow-none text-neutral-800 justify-between",
-        className
-      )}
-      data-testid="search-anywhere-trigger"
-      {...props}
-    >
-      <div className="flex items-center gap-2 overflow-hidden">
-        <Icon icon="mdi:magnify" aria-hidden="true" className="text-xl" />
-        <span className="text-neutral-700 text-sm group-data-[collapsed=true]/sidebar:hidden transition-all truncate">
-          Search
-        </span>
-      </div>
-
-      <Kbd keys="command" className="group-data-[collapsed=true]/sidebar:hidden transition-all">
-        K
-      </Kbd>
-    </Button>
-  );
-};
-
-interface SearchAnywhereContextProps {
-  closeDrawer?: () => void;
-}
-
-export const SearchAnywhereContext = React.createContext<SearchAnywhereContextProps>({});
 
 type SearchModalProps = {
   isCollapsed?: boolean;
@@ -50,18 +16,19 @@ type SearchModalProps = {
 export function SearchAnywhere({ isCollapsed }: SearchModalProps) {
   let [isOpen, setIsOpen] = useState(false);
 
-  function closeDrawer() {
+  function closeDialog() {
     setIsOpen(false);
   }
 
-  function openModal() {
+  function openDialog() {
     setIsOpen(true);
   }
 
   useEffect(() => {
     const onSearchAnywhereShortcut = (event: KeyboardEvent) => {
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
-        openModal();
+        event.preventDefault();
+        openDialog();
       }
     };
 
@@ -70,142 +37,26 @@ export function SearchAnywhere({ isCollapsed }: SearchModalProps) {
   }, []);
 
   return (
-    <>
-      {isCollapsed ? (
-        <CollapsedButton
-          tooltipContent="Search anywhere"
-          icon="mdi:search"
-          onClick={openModal}
-          onChange={openModal}
-        />
-      ) : (
-        <SearchAnywhereTriggerButton onClick={openModal} />
-      )}
-
-      <Command.Dialog
-        open={isOpen}
-        onOpenChange={setIsOpen}
-        data-testid="search-anywhere"
-        shouldFilter={false}
-        className="fixed inset-0"
-      >
-        <div
-          className="fixed inset-0 flex flex-col items-center bg-gray-600/25 animate-in fade-in"
-          onClick={closeDrawer}
-        >
-          <SearchAnywhereContext.Provider value={{ closeDrawer }}>
-            <SearchAnywhereDialog className="mt-1 animate-in fade-in" />
-          </SearchAnywhereContext.Provider>
-        </div>
-      </Command.Dialog>
-    </>
-  );
-}
-
-type SearchAnywhereProps = {
-  className?: string;
-};
-
-const SearchAnywhereDialog = ({ className }: SearchAnywhereProps) => {
-  const [query, setQuery] = useState("");
-
-  return (
-    <div
-      className={classNames(
-        "p-2 w-full max-w-screen-md rounded-xl bg-stone-100 shadow-xl",
-        className
-      )}
-      onClick={(event) => event.stopPropagation()}
-    >
-      <div className="relative">
-        <div className="absolute top-2.5 pl-2.5">
-          <Icon icon="mdi:magnify" className="text-xl text-custom-blue-600" />
-        </div>
-
-        <Input
-          placeholder="Search anywhere"
-          value={query}
-          onChange={(event) => {
-            setQuery(event.target.value);
-          }}
-          className="px-9 py-2"
-        />
-      </div>
-
-      {query && (
-        <Command.List className="pt-2">
-          <div className="overflow-x-hidden overflow-y-auto space-y-2">
-            <SearchActions query={query} />
-
-            <SearchNodes query={query} />
-
-            <SearchDocs query={query} />
-          </div>
-        </Command.List>
-      )}
-    </div>
-  );
-};
-
-type SearchGroupProps = {
-  children: ReactNode;
-};
-
-export const SearchGroup = ({ children }: SearchGroupProps) => {
-  return (
-    <Command.Group className="bg-custom-white rounded-lg border p-2">{children}</Command.Group>
-  );
-};
-
-export const SearchGroupTitle = ({ children }: SearchGroupProps) => {
-  return (
-    <div className="text-xs mb-0.5 pl-1.5 font-semibold text-neutral-600 flex items-center">
-      {children}
-    </div>
-  );
-};
-
-type SearchResultItemProps = {
-  children: ReactNode;
-  className?: string;
-  to: string;
-};
-
-export const SearchResultItem = ({
-  className = "",
-  children,
-  to,
-  ...props
-}: SearchResultItemProps) => {
-  const navigate = useNavigate();
-  const { closeDrawer } = useContext(SearchAnywhereContext);
-
-  return (
-    <CommandItem
-      {...props}
-      onSelect={() => {
-        if (to.length === 0) return;
-
-        if (to.startsWith("http")) {
-          window.open(to, "_blank", "rel=noopener noreferrer, popup=false");
-        } else {
-          navigate(to);
-        }
-
-        if (closeDrawer) {
-          closeDrawer();
-        }
+    <SearchAnywhereContext.Provider
+      value={{
+        isOpen,
+        setIsOpen,
+        closeDialog,
+        openDialog,
       }}
     >
-      <Button
-        variant={"ghost"}
-        className={classNames(
-          "flex justify-start w-full h-min gap-1 text-xs p-2 m-0 rounded text-wrap text-left hover:bg-gray-100",
-          className
-        )}
-      >
-        {children}
-      </Button>
-    </CommandItem>
+      <SearchAnywhereTrigger isCollapsed={isCollapsed} onClick={openDialog} />
+
+      <SearchAnywhereDialog>
+        <SearchAnywhereInput />
+
+        <Command.List className="[&_[cmdk-group]]:mt-2">
+          <SearchAnywhereEmpty />
+          <SearchActions />
+          <SearchNodes />
+          <SearchDocs />
+        </Command.List>
+      </SearchAnywhereDialog>
+    </SearchAnywhereContext.Provider>
   );
-};
+}

--- a/frontend/app/src/components/search/search-docs.tsx
+++ b/frontend/app/src/components/search/search-docs.tsx
@@ -1,79 +1,51 @@
-import { CONFIG, INFRAHUB_API_SERVER_URL } from "@/config/config";
+import { searchDocsQueryOptions } from "@/components/search/queries/get-doc-results";
+import { SearchAnywhereGroup } from "@/components/search/search-anywhere-group";
+import { SearchAnywhereItem } from "@/components/search/search-anywhere-item";
+import { INFRAHUB_API_SERVER_URL } from "@/config/config";
 import { useDebounce } from "@/hooks/useDebounce";
-import { fetchUrl } from "@/utils/fetch";
-import { Icon } from "@iconify-icon/react";
-import { Fragment, useEffect, useState } from "react";
-import { SearchGroup, SearchGroupTitle, SearchResultItem } from "./search-anywhere";
+import { useQuery } from "@tanstack/react-query";
+import { useCommandState } from "cmdk";
 
-type SearchProps = {
-  query: string;
-};
-export const SearchDocs = ({ query }: SearchProps) => {
+export const SearchDocs = () => {
+  const query = useCommandState((state) => state.search);
   const queryDebounced = useDebounce(query, 300);
-  const [results, setResults] = useState([]);
-  const [error, setError] = useState(null);
+  const {
+    data: results,
+    error,
+    isPending,
+  } = useQuery(searchDocsQueryOptions({ query: queryDebounced }));
 
-  useEffect(() => {
-    let ignore = false;
-    const cleanedValue = queryDebounced.trim();
+  if (query === "") {
+    return null;
+  }
 
-    fetchUrl(CONFIG.SEARCH_URL(cleanedValue))
-      .then((data) => {
-        if (ignore) return;
-        setResults(data);
-        setError(null);
-      })
-      .catch((error) => {
-        setError(error);
-      });
-
-    return () => {
-      ignore = true;
-    };
-  }, [queryDebounced]);
-
-  if (error || !results.length || results.length === 0)
+  if (isPending) {
     return (
-      <SearchGroup>
-        <SearchResultItem to={`${INFRAHUB_API_SERVER_URL}/docs/search?q=${query}`} target="_blank">
-          <Icon icon="mdi:book-open-blank-variant-outline" className="text-lg" />
-          Search in docs: <span className="font-semibold">{query}</span>
-        </SearchResultItem>
-      </SearchGroup>
+      <SearchAnywhereGroup heading="Documentation">
+        <SearchAnywhereItem to="" disabled>
+          Loading...
+        </SearchAnywhereItem>
+      </SearchAnywhereGroup>
     );
+  }
+
+  if (error || results.length === 0) return null;
 
   return (
-    <SearchGroup>
-      <SearchGroupTitle>Documentation</SearchGroupTitle>
-
-      {results.map((doc: SearchDocsResultProps) => (
-        <DocsResults
+    <SearchAnywhereGroup heading="Documentation">
+      {results.map((doc) => (
+        <SearchAnywhereItem
           key={doc.title + doc.url}
-          breadcrumb={doc.breadcrumb}
-          title={doc.title}
-          url={doc.url}
-        />
+          value={doc.url}
+          to={INFRAHUB_API_SERVER_URL + doc.url}
+          className="flex-col gap-0 items-start"
+        >
+          <div className="text-sm font-medium">{doc.title}</div>
+          <div className="text-xs truncate text-neutral-500">
+            {doc.breadcrumb.slice(1).join(" > ")}
+          </div>
+        </SearchAnywhereItem>
       ))}
-    </SearchGroup>
-  );
-};
-
-type SearchDocsResultProps = {
-  breadcrumb: string[];
-  title: string;
-  url: string;
-};
-
-const DocsResults = ({ breadcrumb, title, url }: SearchDocsResultProps) => {
-  return (
-    <SearchResultItem to={INFRAHUB_API_SERVER_URL + url} target="_blank">
-      {breadcrumb.slice(1).map((b) => (
-        <Fragment key={b}>
-          <span>{b}</span>
-          <Icon icon="mdi:chevron-right" />
-        </Fragment>
-      ))}
-      <strong className="font-semibold">{title}</strong>
-    </SearchResultItem>
+    </SearchAnywhereGroup>
   );
 };

--- a/frontend/app/src/components/search/search-nodes.tsx
+++ b/frontend/app/src/components/search/search-nodes.tsx
@@ -1,52 +1,56 @@
+import { SearchAnywhereGroup } from "@/components/search/search-anywhere-group";
+import { SearchAnywhereItem } from "@/components/search/search-anywhere-item";
 import { Skeleton } from "@/components/skeleton";
 import { Badge } from "@/components/ui/badge";
 import { SCHEMA_ATTRIBUTE_KIND, SEARCH_QUERY_NAME } from "@/config/constants";
 import { SEARCH } from "@/graphql/queries/objects/search";
 import { useDebounce } from "@/hooks/useDebounce";
 import { useObjectDetails } from "@/hooks/useObjectDetails";
-import { useLazyQuery } from "@/hooks/useQuery";
+import useQuery from "@/hooks/useQuery";
 import { useSchema } from "@/hooks/useSchema";
 import { constructPath } from "@/utils/fetch";
 import { getSchemaObjectColumns } from "@/utils/getSchemaObjectColumns";
 import { getObjectDetailsUrl } from "@/utils/objects";
 import { Icon } from "@iconify-icon/react";
+import { Command, useCommandState } from "cmdk";
 import { format } from "date-fns";
-import { ReactElement, useEffect } from "react";
-import { SearchGroup, SearchGroupTitle, SearchResultItem } from "./search-anywhere";
+import { ReactElement } from "react";
 
-type SearchProps = {
-  query: string;
-};
-export const SearchNodes = ({ query }: SearchProps) => {
-  const queryDebounced = useDebounce(query, 300);
-  const [fetchSearchNodes, { data, previousData, error }] = useLazyQuery(SEARCH);
+export const SearchNodes = () => {
+  const query = useCommandState((state) => state.search);
+  const queryDebounced = useDebounce(query.trim(), 300);
 
-  useEffect(() => {
-    const cleanedValue = queryDebounced.trim();
-    fetchSearchNodes({ variables: { search: cleanedValue } });
-  }, [queryDebounced]);
+  const { data, error, loading } = useQuery(SEARCH, {
+    skip: !queryDebounced,
+    variables: { search: queryDebounced },
+  });
 
-  if (error) {
+  if (query === "") {
+    return null;
+  }
+
+  if (loading) {
     return (
-      <div className="flex flex-col items-center justify-center">
-        <Icon icon="mdi:error" className="text-2xl px-2 py-0.5" />
-        <p className="text-sm">{error.message}</p>
-      </div>
+      <SearchAnywhereGroup heading="Objects">
+        <SearchAnywhereItem to="" disabled>
+          Loading...
+        </SearchAnywhereItem>
+      </SearchAnywhereGroup>
     );
   }
 
-  const results = (data || previousData)?.[SEARCH_QUERY_NAME];
+  if (error) return null;
+
+  const results = data?.[SEARCH_QUERY_NAME];
 
   if (!results || results?.count === 0) return null;
 
   return (
-    <SearchGroup>
-      <SearchGroupTitle>Search results for &quot;{query}&quot;</SearchGroupTitle>
-
+    <SearchAnywhereGroup heading="Objects">
       {results.edges.map(({ node }: NodesOptionsProps) => (
         <NodesOptions key={node.id} node={node} />
       ))}
-    </SearchGroup>
+    </SearchAnywhereGroup>
   );
 };
 
@@ -82,10 +86,10 @@ const NodesOptions = ({ node }: NodesOptionsProps) => {
   );
 
   return (
-    <SearchResultItem to={url} className="!items-start">
+    <SearchAnywhereItem to={url} value={url}>
       <Icon
         icon={schema.icon || "mdi:code-braces-box"}
-        className="text-lg pr-2 py-0.5 text-custom-blue-700"
+        className="text-lg px-2 py-0.5 text-custom-blue-700"
       />
 
       <div className="flex-grow text-sm">
@@ -98,7 +102,7 @@ const NodesOptions = ({ node }: NodesOptionsProps) => {
             <Badge variant="blue" className="text-xxs py-0">
               {schema.namespace}
             </Badge>
-            <span className="text-xxs font-medium">{schema.label}</span>
+            <span className="text-xxs font-medium mr-2">{schema.label}</span>
           </div>
         </div>
 
@@ -115,7 +119,7 @@ const NodesOptions = ({ node }: NodesOptionsProps) => {
             ))}
         </div>
       </div>
-    </SearchResultItem>
+    </SearchAnywhereItem>
   );
 };
 
@@ -177,7 +181,7 @@ const NodeAttribute = ({ title, kind, value }: NodeAttributeProps) => {
 
 export const SearchResultNodeSkeleton = () => {
   return (
-    <div className="flex py-2 w-full">
+    <Command.Item disabled className="flex py-2 w-full">
       <Skeleton className="h-6 w-6 rounded mx-1 mr-2" />
 
       <div className="space-y-2 flex-grow">
@@ -190,6 +194,6 @@ export const SearchResultNodeSkeleton = () => {
           <Skeleton className="h-3 max-w-xl" />
         </div>
       </div>
-    </div>
+    </Command.Item>
   );
 };

--- a/frontend/app/src/devtools.tsx
+++ b/frontend/app/src/devtools.tsx
@@ -1,0 +1,9 @@
+import * as React from "react";
+
+export const TanStackQueryDevtools = import.meta.env.PROD
+  ? () => null
+  : React.lazy(() =>
+      import("@tanstack/react-query-devtools").then((module) => ({
+        default: module.ReactQueryDevtools,
+      }))
+    );

--- a/frontend/app/tests/e2e/search.spec.ts
+++ b/frontend/app/tests/e2e/search.spec.ts
@@ -37,7 +37,7 @@ test.describe("when searching an object", () => {
     });
 
     await test.step("find a matching result", async () => {
-      await page.getByTestId("search-anywhere").getByPlaceholder("Search anywhere").fill("devi");
+      await page.getByTestId("search-anywhere-input").fill("devi");
       await expect(page.getByTestId("search-anywhere")).toContainText("Go to");
       await page.getByRole("option", { name: "Menu Device" }).click();
       await expect(page.getByRole("heading", { name: "Device" })).toBeVisible();
@@ -55,7 +55,7 @@ test.describe("when searching an object", () => {
 
     const searchAnywhere = page.getByTestId("search-anywhere");
     await test.step("open search anywhere modal when typing on header input", async () => {
-      await searchAnywhere.getByPlaceholder("Search anywhere").fill("no_results_query_for_test");
+      await searchAnywhere.getByTestId("search-anywhere-input").fill("no_results_query_for_test");
       await expect(searchAnywhere.getByRole("option")).toContainText(
         "Search in docs: no_results_query_for_test"
       );
@@ -71,7 +71,7 @@ test.describe("when searching an object", () => {
     });
 
     await test.step("find a matching result", async () => {
-      await page.getByTestId("search-anywhere").getByPlaceholder("Search anywhere").fill("atl1");
+      await page.getByTestId("search-anywhere-input").fill("atl1");
       await expect(
         page.getByTestId("search-anywhere").getByRole("option", { name: "atl1 Location Site" })
       ).toBeVisible();
@@ -89,7 +89,7 @@ test.describe("when searching an object", () => {
       await expect(page.getByTestId("search-anywhere")).toBeVisible();
     });
 
-    await page.getByTestId("search-anywhere").getByPlaceholder("Search anywhere").fill(uuid);
+    await page.getByTestId("search-anywhere-input").fill(uuid);
     await expect(
       page.getByRole("option", { name: "AS174 174 Infra Autonomous System" })
     ).toBeVisible();

--- a/frontend/app/tests/e2e/search.spec.ts
+++ b/frontend/app/tests/e2e/search.spec.ts
@@ -53,12 +53,13 @@ test.describe("when searching an object", () => {
       await expect(page.getByTestId("search-anywhere")).toBeVisible();
     });
 
-    const searchAnywhere = page.getByTestId("search-anywhere");
     await test.step("open search anywhere modal when typing on header input", async () => {
-      await searchAnywhere.getByTestId("search-anywhere-input").fill("no_results_query_for_test");
-      await expect(searchAnywhere.getByRole("option")).toContainText(
-        "Search in docs: no_results_query_for_test"
-      );
+      await page.getByTestId("search-anywhere-input").fill("no_results_query_for_test");
+      await expect(
+        page
+          .getByTestId("search-anywhere")
+          .getByRole("option", { name: "Search in docs: no_results_query_for_test" })
+      ).toBeVisible();
     });
   });
 


### PR DESCRIPTION
- Used cmdk everywhere
- split initial big component into smaller well-scoped components
- introduce @tanstack/query for fetching
- improved search anywhere context and how to consume it
- better navigation
- Better variable naming
- some fixes
  - FIX: open search anywhere with shortcut in firefox
  - FIX: broken keyboard navigation when 2 search results have the same kind
  - FIX: conflicting style when navigating with keyboard + hovering with mouse