### PR TITLE
Add uuid to spelling-exceptions

### DIFF
--- a/.vale/styles/spelling-exceptions.txt
+++ b/.vale/styles/spelling-exceptions.txt
@@ -116,6 +116,8 @@ validator
 upsert
 Upserting
 upserting
+uuid
+UUID
 validators
 Version Control
 Vitest


### PR DESCRIPTION
Need for the validate-release-notes-style  in the CI
Issue spotted in https://github.com/opsmill/infrahub/actions/runs/12252627366/job/34179659879