### PR TITLE
Add CoreProfile to diff

### DIFF
--- a/backend/infrahub/core/models.py
+++ b/backend/infrahub/core/models.py
@@ -529,9 +529,12 @@ class HashableModel(BaseModel):
 
         return attr_other
 
+    def _get_field_names_for_diff(self) -> list[str]:
+        return list(self.model_fields.keys())
+
     def diff(self, other: Self) -> HashableModelDiff:
         in_both, local_only, other_only = compare_lists(
-            list1=list(self.model_fields.keys()), list2=list(other.model_fields.keys())
+            list1=self._get_field_names_for_diff(), list2=other._get_field_names_for_diff()
         )
         diff_result = HashableModelDiff(added=dict.fromkeys(local_only), removed=dict.fromkeys(other_only))
 

--- a/backend/infrahub/core/schema/generic_schema.py
+++ b/backend/infrahub/core/schema/generic_schema.py
@@ -33,3 +33,8 @@ class GenericSchema(GeneratedGenericSchema):
     def get_labels(self) -> list[str]:
         """Return the labels for this object"""
         return [self.kind]
+
+    def _get_field_names_for_diff(self) -> list[str]:
+        """Exclude used_by from the diff for generic nodes"""
+        fields = super()._get_field_names_for_diff()
+        return [field for field in fields if field not in ["used_by"]]

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -101,7 +101,7 @@ class SchemaBranch:
     def get_all_kind_id_map(self, exclude_profiles: bool = False) -> dict[str, str]:
         kind_id_map = {}
         if exclude_profiles:
-            names = self.node_names + [gn for gn in self.generic_names if gn != InfrahubKind.PROFILE]
+            names = self.node_names + self.generic_names
         else:
             names = self.all_names
         for name in names:

--- a/backend/tests/integration/schema_lifecycle/test_migration_hierarchy_change.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_hierarchy_change.py
@@ -153,7 +153,6 @@ class TestSchemaLifecycleBase(TestInfrahubApp):
                             },
                         },
                     },
-                    "LocationGeneric": {"added": {}, "changed": {"used_by": None}, "removed": {}},
                 },
             },
         }

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -596,8 +596,26 @@ async def test_schema_branch_add_profile_schema(schema_all_in_one):
     }
 
 
+async def test_schema_branch_diff_core_profile(schema_all_in_one):
+    core_profile_schema = _get_schema_by_kind(core_models, kind=InfrahubKind.PROFILE)
+    schema_all_in_one["generics"].append(core_profile_schema)
+
+    schema = SchemaBranch(cache={}, name="test")
+    schema.load_schema(schema=SchemaRoot(**schema_all_in_one))
+    schema.process_inheritance()
+    schema.manage_profile_schemas()
+
+    new_schema = schema.duplicate()
+    profile_schema = new_schema.get(name=InfrahubKind.PROFILE, duplicate=True)
+    profile_schema.description = "New description"
+    new_schema.set(name=InfrahubKind.PROFILE, schema=profile_schema)
+
+    diff = new_schema.diff(other=schema)
+    assert diff.all == ["CoreProfile"]
+
+
 async def test_schema_branch_add_profile_schema_respects_flag(schema_all_in_one):
-    core_profile_schema = _get_schema_by_kind(core_models, kind="CoreProfile")
+    core_profile_schema = _get_schema_by_kind(core_models, kind=InfrahubKind.PROFILE)
     schema_all_in_one["generics"].append(core_profile_schema)
     builtin_tag_schema = _get_schema_by_kind(schema_all_in_one, kind="BuiltinTag")
     builtin_tag_schema["generate_profile"] = False


### PR DESCRIPTION
Follow up to #5170

I noticed that CoreProfile is currently excluded from the diff

As part of this change,  I've excluded `used_by` from for Diff for `GenericSchema` to avoid having CoreProfile showing up in the diff every time someone add a new node.
