### PR TITLE
Search shortcuts show 'Cmd' on macOS and 'Ctrl' on other systems.

### DIFF
--- a/changelog/4861.fixed.md
+++ b/changelog/4861.fixed.md
@@ -1,1 +1,1 @@
-Search shortcuts show 'Cmd' on macOS and 'Ctrl' on other systems.
+Search shortcuts show `Cmd` on macOS and `Ctrl` on other systems.

--- a/changelog/4861.fixed.md
+++ b/changelog/4861.fixed.md
@@ -1,0 +1,1 @@
+Search shortcuts show 'Cmd' on macOS and 'Ctrl' on other systems.

--- a/frontend/app/src/components/search/search-anywhere-trigger.tsx
+++ b/frontend/app/src/components/search/search-anywhere-trigger.tsx
@@ -24,6 +24,8 @@ export function SearchAnywhereTrigger({
     );
   }
 
+  const command = navigator.userAgent.includes("Macintosh") ? "command" : "ctrl";
+
   return (
     <Button
       variant="ghost"
@@ -41,7 +43,7 @@ export function SearchAnywhereTrigger({
         </span>
       </div>
 
-      <Kbd keys="command" className="group-data-[collapsed=true]/sidebar:hidden transition-all">
+      <Kbd keys={command} className="group-data-[collapsed=true]/sidebar:hidden transition-all">
         K
       </Kbd>
     </Button>


### PR DESCRIPTION
related to:
- https://github.com/opsmill/infrahub/issues/4861

Based on:
- https://github.com/opsmill/infrahub/pull/5025