### PR TITLE
Fix name dropdown selection for object permissions form

### DIFF
--- a/changelog/5100.fixed.md
+++ b/changelog/5100.fixed.md
@@ -1,0 +1,1 @@
+On the object permission form, fix the name option selection when changing the namespace to get the latest options and to be able to choose a name option

--- a/frontend/app/src/components/inputs/dropdown.tsx
+++ b/frontend/app/src/components/inputs/dropdown.tsx
@@ -22,7 +22,7 @@ import { AttributeSchema } from "@/screens/schema/types";
 import { IModelSchema } from "@/state/atoms/schema.atom";
 import { classNames, getTextColor } from "@/utils/common";
 import { Icon } from "@iconify-icon/react";
-import React, { forwardRef, HTMLAttributes, useState } from "react";
+import React, { forwardRef, HTMLAttributes, useEffect, useState } from "react";
 
 export type DropdownOption = {
   value: string;
@@ -237,6 +237,10 @@ export const Dropdown = forwardRef<HTMLButtonElement, DropdownProps>(
     };
 
     const selectItem = localItems.find((item) => item.value === value);
+
+    useEffect(() => {
+      setLocalItems(items);
+    }, [items?.length]);
 
     return (
       <Combobox open={open} onOpenChange={setOpen}>

--- a/frontend/app/src/components/inputs/dropdown.tsx
+++ b/frontend/app/src/components/inputs/dropdown.tsx
@@ -238,10 +238,6 @@ export const Dropdown = forwardRef<HTMLButtonElement, DropdownProps>(
 
     const selectItem = localItems.find((item) => item.value === value);
 
-    // useEffect(() => {
-    //   setLocalItems(items);
-    // }, [items?.length]);
-
     return (
       <Combobox open={open} onOpenChange={setOpen}>
         <ComboboxTrigger ref={ref} style={getDropdownStyle(selectItem?.color)} {...props}>

--- a/frontend/app/src/components/inputs/dropdown.tsx
+++ b/frontend/app/src/components/inputs/dropdown.tsx
@@ -22,7 +22,7 @@ import { AttributeSchema } from "@/screens/schema/types";
 import { IModelSchema } from "@/state/atoms/schema.atom";
 import { classNames, getTextColor } from "@/utils/common";
 import { Icon } from "@iconify-icon/react";
-import React, { forwardRef, HTMLAttributes, useEffect, useState } from "react";
+import React, { forwardRef, HTMLAttributes, useState } from "react";
 
 export type DropdownOption = {
   value: string;
@@ -238,9 +238,9 @@ export const Dropdown = forwardRef<HTMLButtonElement, DropdownProps>(
 
     const selectItem = localItems.find((item) => item.value === value);
 
-    useEffect(() => {
-      setLocalItems(items);
-    }, [items?.length]);
+    // useEffect(() => {
+    //   setLocalItems(items);
+    // }, [items?.length]);
 
     return (
       <Combobox open={open} onOpenChange={setOpen}>

--- a/frontend/app/src/screens/role-management/object-permissions-form.tsx
+++ b/frontend/app/src/screens/role-management/object-permissions-form.tsx
@@ -261,7 +261,6 @@ const NodeSelect = () => {
       />
 
       <DropdownField
-        key={nameOptions.length} // Re render optons depending on namespace selected
         name={"name"}
         label="Name"
         defaultValue={DEFAULT_FORM_FIELD_VALUE}

--- a/frontend/app/src/screens/role-management/object-permissions-form.tsx
+++ b/frontend/app/src/screens/role-management/object-permissions-form.tsx
@@ -261,6 +261,7 @@ const NodeSelect = () => {
       />
 
       <DropdownField
+        key={selectedNamespaceField?.value}
         name={"name"}
         label="Name"
         defaultValue={DEFAULT_FORM_FIELD_VALUE}


### PR DESCRIPTION
Issue: https://github.com/opsmill/infrahub/issues/5100

On the object permission form, fix the name option selection when changing the namespace to get the latest options and to be able to choose a name option