### PR TITLE
Fix parent query in relationship to ensure to get the parent of the current node

### DIFF
--- a/changelog/5035.fixed.md
+++ b/changelog/5035.fixed.md
@@ -1,0 +1,1 @@
+Update the parent relationship query to populate the dropdown options when editing an object, ensuring the current parent is correctly selected for the current node.

--- a/frontend/app/src/components/form/fields/relationship.field.tsx
+++ b/frontend/app/src/components/form/fields/relationship.field.tsx
@@ -21,16 +21,6 @@ import { gql } from "@apollo/client";
 import { useAtomValue } from "jotai";
 import { useState } from "react";
 
-const getGenericParentRelationship = (kind?: string) => {
-  if (!kind) return;
-
-  const nodes = store.get(schemaState);
-  const schemaData = nodes.find((schema) => schema.kind === kind);
-  const parentRelationship = schemaData?.relationships?.find((rel) => rel.kind === "Parent");
-
-  return parentRelationship;
-};
-
 const getParentRelationship = (peer?: string) => {
   if (!peer) return;
 
@@ -68,37 +58,43 @@ const RelationshipField = ({
   const generic = generics.find((generic) => generic.kind === relationship.peer);
 
   const parentRelationship = generic
-    ? getGenericParentRelationship(selectedGeneric?.id)
+    ? getParentRelationship(selectedGeneric?.id)
     : getParentRelationship(relationship?.peer);
 
   const kind = parentRelationship?.peer;
-  const parentSchema = schemaList.find((schema) => schema.kind === kind);
-  const attribute = parentSchema?.relationships?.find((relationship) => {
-    if (parentRelationship?.direction === "bidirectional") {
-      return relationship.identifier === parentRelationship?.identifier;
-    }
+  const parentRelationshipSchema = schemaList.find((schema) => schema.kind === kind);
+  const parentRelationshipAttribute = parentRelationshipSchema?.relationships?.find(
+    (relationship) => {
+      if (parentRelationship?.direction === "bidirectional") {
+        return relationship.identifier === parentRelationship?.identifier;
+      }
 
-    if (parentRelationship?.direction === "inbound") {
-      return (
-        relationship.direction === "outbound" &&
-        relationship.identifier === parentRelationship?.identifier
-      );
-    }
+      if (parentRelationship?.direction === "inbound") {
+        return (
+          relationship.direction === "outbound" &&
+          relationship.identifier === parentRelationship?.identifier
+        );
+      }
 
-    if (parentRelationship?.direction === "outbound") {
-      return (
-        relationship.direction === "inbound" &&
-        relationship.identifier === parentRelationship?.identifier
-      );
-    }
+      if (parentRelationship?.direction === "outbound") {
+        return (
+          relationship.direction === "inbound" &&
+          relationship.identifier === parentRelationship?.identifier
+        );
+      }
 
-    return false;
-  });
+      return false;
+    }
+  );
   const id = defaultValue?.value?.id;
-  const queryString = getRelationshipParent({ kind, attribute: `${attribute?.name}__ids`, id });
+  const queryString = getRelationshipParent({
+    kind,
+    attribute: `${parentRelationshipAttribute?.name}__ids`,
+    id,
+  });
 
   const query =
-    kind && attribute?.name && id
+    kind && parentRelationshipAttribute?.name && id
       ? gql`
           ${queryString}
         `
@@ -108,7 +104,7 @@ const RelationshipField = ({
           }
         `;
 
-  const { data } = useQuery(query, { skip: !parentSchema?.kind || !id });
+  const { data } = useQuery(query, { skip: !parentRelationshipSchema?.kind || !id });
 
   const currentParent = data && kind && data[kind]?.edges[0]?.node;
 

--- a/frontend/app/src/components/form/fields/relationship.field.tsx
+++ b/frontend/app/src/components/form/fields/relationship.field.tsx
@@ -26,15 +26,19 @@ const getGenericParentRelationship = (kind?: string) => {
 
   const nodes = store.get(schemaState);
   const schemaData = nodes.find((schema) => schema.kind === kind);
-  return schemaData?.relationships?.find((rel) => rel.kind === "Parent");
+  const parentRelationship = schemaData?.relationships?.find((rel) => rel.kind === "Parent");
+
+  return parentRelationship;
 };
 
 const getParentRelationship = (peer?: string) => {
   if (!peer) return;
 
-  const schemaList = useAtomValue(schemaState);
-  const schemaData = schemaList.find((schema) => schema.kind === peer);
-  return schemaData?.relationships?.find((rel) => rel.kind === "Parent");
+  const nodes = store.get(schemaState);
+  const peerSchema = nodes.find((schema) => schema.kind === peer);
+  const parentRelationship = peerSchema?.relationships?.find((rel) => rel.kind === "Parent");
+
+  return parentRelationship;
 };
 
 export interface RelationshipFieldProps extends DynamicRelationshipFieldProps {}
@@ -68,13 +72,33 @@ const RelationshipField = ({
     : getParentRelationship(relationship?.peer);
 
   const kind = parentRelationship?.peer;
-  const attribute = parentRelationship?.identifier?.split("__")[1];
-  const id = defaultValue?.value?.id;
+  const parentSchema = schemaList.find((schema) => schema.kind === kind);
+  const attribute = parentSchema?.relationships?.find((relationship) => {
+    if (parentRelationship?.direction === "bidirectional") {
+      return relationship.identifier === parentRelationship?.identifier;
+    }
 
-  const queryString = getRelationshipParent({ kind, attribute: `${attribute}s__ids`, id });
+    if (parentRelationship?.direction === "inbound") {
+      return (
+        relationship.direction === "outbound" &&
+        relationship.identifier === parentRelationship?.identifier
+      );
+    }
+
+    if (parentRelationship?.direction === "outbound") {
+      return (
+        relationship.direction === "inbound" &&
+        relationship.identifier === parentRelationship?.identifier
+      );
+    }
+
+    return false;
+  });
+  const id = defaultValue?.value?.id;
+  const queryString = getRelationshipParent({ kind, attribute: `${attribute?.name}__ids`, id });
 
   const query =
-    kind && attribute && id
+    kind && attribute?.name && id
       ? gql`
           ${queryString}
         `
@@ -84,7 +108,7 @@ const RelationshipField = ({
           }
         `;
 
-  const { data } = useQuery(query, { skip: !parentRelationship?.kind || !id });
+  const { data } = useQuery(query, { skip: !parentSchema?.kind || !id });
 
   const currentParent = data && kind && data[kind]?.edges[0]?.node;
 

--- a/frontend/app/src/components/form/utils/getFormFieldsFromSchema.ts
+++ b/frontend/app/src/components/form/utils/getFormFieldsFromSchema.ts
@@ -18,8 +18,7 @@ import { isRequired } from "@/components/form/utils/validation";
 import { SCHEMA_ATTRIBUTE_KIND } from "@/config/constants";
 import { AuthContextType } from "@/hooks/useAuth";
 import { SchemaAttributeType } from "@/screens/edit-form-hook/dynamic-control-types";
-import { store } from "@/state";
-import { IModelSchema, genericsState, schemaState } from "@/state/atoms/schema.atom";
+import { IModelSchema } from "@/state/atoms/schema.atom";
 import { sortByOrderWeight } from "@/utils/common";
 import { AttributeType, RelationshipType } from "@/utils/getObjectItemDisplayValue";
 
@@ -84,9 +83,6 @@ export const getFormFieldsFromSchema = ({
     };
 
     if ("peer" in attribute) {
-      const nodes = store.get(schemaState);
-      const generics = store.get(genericsState);
-
       const currentRelationshipData = initialObject?.[attribute.name] as
         | RelationshipType
         | undefined;


### PR DESCRIPTION
Issue: https://github.com/opsmill/infrahub/issues/5035

Update the parent relationship query to populate the dropdown options when editing an object, ensuring the current parent is correctly selected for the current node.