### PR TITLE
Docs: Fix formatting of a :::warning in topics/schema.

### DIFF
--- a/docs/docs/topics/schema.mdx
+++ b/docs/docs/topics/schema.mdx
@@ -239,7 +239,7 @@ nodes:
 
 </details>
 
-::: warning
+:::warning
 
 When you create a relationship of kind Component, automatically the `on_delete` property of the relationship will get set to the value `cascade`. This means that when you delete a node, all the related nodes of that relationship will also be deleted.
 


### PR DESCRIPTION
Remove the space in notification block to have it properly rendered.

Current view:

![image](https://github.com/user-attachments/assets/e8ccc9a8-fbaf-4ef3-8cc8-09626be63bc6)

Fixed view:

![image](https://github.com/user-attachments/assets/db12fa81-fc27-44c3-ae60-d2bf5119160c)
