### PR TITLE
IFC-993 Fix uniqueness constraint with enum attributes

### DIFF
--- a/backend/infrahub/core/node/constraints/grouped_uniqueness.py
+++ b/backend/infrahub/core/node/constraints/grouped_uniqueness.py
@@ -97,7 +97,10 @@ class NodeGroupedUniquenessConstraint(NodeConstraintInterface):
                 attribute_field = getattr(updated_node, attribute_name)
                 attribute_value = getattr(attribute_field, schema_attribute_path.attribute_property_name or "value")
                 node_value_combination.append(
-                    SchemaAttributePathValue.from_schema_attribute_path(schema_attribute_path, value=attribute_value)
+                    SchemaAttributePathValue.from_schema_attribute_path(
+                        schema_attribute_path,
+                        value=attribute_value.value if attribute_field.is_enum else attribute_value,
+                    )
                 )
         return node_value_combination
 

--- a/backend/tests/unit/core/constraint_validators/test_node_grouped_uniqueness.py
+++ b/backend/tests/unit/core/constraint_validators/test_node_grouped_uniqueness.py
@@ -75,6 +75,41 @@ class TestNodeGroupedUniquenessConstraint:
         with pytest.raises(ValidationError, match="Violates uniqueness constraint 'name-color'"):
             await self.__call_system_under_test(db=db, branch=default_branch, node=car_accord_main)
 
+    async def test_uniqueness_constraint_no_conflict_attribute_enum(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        car_accord_main: Node,
+        car_camry_main: Node,
+        car_volt_main: Node,
+    ):
+        car_schema = registry.schema.get("TestCar", branch=default_branch, duplicate=False)
+        car_schema.uniqueness_constraints = [["nbr_seats__value", "name__value"]]
+        attr = car_schema.get_attribute("nbr_seats")
+        attr.optional = False
+        attr.enum = [2, 4, 5, 7]
+
+        await self.__call_system_under_test(db=db, branch=default_branch, node=car_accord_main)
+
+    async def test_uniqueness_constraint_conflict_attribute_enum(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        car_accord_main: Node,
+        car_camry_main: Node,
+        car_volt_main: Node,
+    ):
+        car_schema = registry.schema.get("TestCar", branch=default_branch, duplicate=False)
+        attr = car_schema.get_attribute("nbr_seats")
+        attr.optional = False
+        attr.enum = [2, 4, 5, 7]
+
+        car_accord_main.name.value = "camry"
+        car_accord_main.get_schema().uniqueness_constraints = [["nbr_seats__value", "name__value"]]
+
+        with pytest.raises(ValidationError, match="Violates uniqueness constraint 'nbr_seats-name'"):
+            await self.__call_system_under_test(db=db, branch=default_branch, node=car_accord_main)
+
     async def test_uniqueness_constraint_no_conflict_one_relationship(
         self, db: InfrahubDatabase, default_branch: Branch, car_person_generics_data_simple
     ):

--- a/changelog/5132.fixed.md
+++ b/changelog/5132.fixed.md
@@ -1,0 +1,1 @@
+Fix uniqueness constraint check with enum based attributes


### PR DESCRIPTION
The actual value of the enum member was not checked. Instead a string representation of the member was used, which was causing the database query to never match any nodes.

Cherry pick of 101bfbe4c0ef4737040d446f4d646f41b078bec6