### PR TITLE
Update RabbitMQ image to use 3.13.6 instead of 3.13.7

### DIFF
--- a/backend/infrahub/testing/docker-compose.test.yml
+++ b/backend/infrahub/testing/docker-compose.test.yml
@@ -5,7 +5,7 @@
 # https://docs.infrahub.app/reference/configuration
 services:
   message-queue:
-    image: ${MESSAGE_QUEUE_DOCKER_IMAGE:-rabbitmq:3.13.7-management}
+    image: ${MESSAGE_QUEUE_DOCKER_IMAGE:-rabbitmq:3.13.6-management}
     restart: unless-stopped
     environment:
       RABBITMQ_DEFAULT_USER: infrahub

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,7 +128,7 @@ x-task-manager-config:
 
 services:
   message-queue:
-    image: ${MESSAGE_QUEUE_DOCKER_IMAGE:-rabbitmq:3.13.7-management}
+    image: ${MESSAGE_QUEUE_DOCKER_IMAGE:-rabbitmq:3.13.6-management}
     restart: unless-stopped
     environment:
       RABBITMQ_DEFAULT_USER: *broker_username

--- a/tasks/shared.py
+++ b/tasks/shared.py
@@ -40,7 +40,7 @@ MEMGRAPH_DOCKER_IMAGE = os.getenv("MEMGRAPH_DOCKER_IMAGE", "memgraph/memgraph-ma
 NEO4J_DOCKER_IMAGE = os.getenv("NEO4J_DOCKER_IMAGE", "neo4j:5.20.0-enterprise")
 MESSAGE_QUEUE_DOCKER_IMAGE = os.getenv(
     "MESSAGE_QUEUE_DOCKER_IMAGE",
-    "rabbitmq:3.13.7-management" if not INFRAHUB_USE_NATS else "nats:2.10.14-alpine",
+    "rabbitmq:3.13.6-management" if not INFRAHUB_USE_NATS else "nats:2.10.14-alpine",
 )
 CACHE_DOCKER_IMAGE = os.getenv(
     "CACHE_DOCKER_IMAGE",


### PR DESCRIPTION
The current image we are using for RabbitMQ is not available right now from dockerhub which makes it impossible to start Infrahub

the workaround is to use a slightly old image that is still available : 3.13.6 

More information here https://github.com/docker-library/rabbitmq/issues/747