### PR TITLE
Add option to define default Neo4j runtime and improve support for Parallel runtime

### DIFF
--- a/backend/infrahub/core/account.py
+++ b/backend/infrahub/core/account.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 from typing_extensions import Self
 
 from infrahub.core.constants import InfrahubKind, PermissionDecision
-from infrahub.core.query import Query
+from infrahub.core.query import Query, QueryType
 from infrahub.core.registry import registry
 
 if TYPE_CHECKING:
@@ -62,6 +62,7 @@ class ObjectPermission:
 
 class AccountGlobalPermissionQuery(Query):
     name: str = "account_global_permissions"
+    type: QueryType = QueryType.READ
 
     def __init__(self, account_id: str, **kwargs: Any):
         self.account_id = account_id
@@ -176,6 +177,7 @@ class AccountGlobalPermissionQuery(Query):
 
 class AccountObjectPermissionQuery(Query):
     name: str = "account_object_permissions"
+    type: QueryType = QueryType.READ
 
     def __init__(self, account_id: str, **kwargs: Any):
         self.account_id = account_id
@@ -327,6 +329,7 @@ async def fetch_permissions(account_id: str, db: InfrahubDatabase, branch: Branc
 
 class AccountRoleGlobalPermissionQuery(Query):
     name: str = "account_role_global_permissions"
+    type: QueryType = QueryType.READ
 
     def __init__(self, role_id: str, **kwargs: Any):
         self.role_id = role_id
@@ -416,6 +419,7 @@ class AccountRoleGlobalPermissionQuery(Query):
 
 class AccountRoleObjectPermissionQuery(Query):
     name: str = "account_role_object_permissions"
+    type: QueryType = QueryType.READ
 
     def __init__(self, role_id: str, **kwargs: Any):
         self.role_id = role_id
@@ -542,6 +546,7 @@ async def fetch_role_permissions(role_id: str, db: InfrahubDatabase, branch: Bra
 
 class AccountTokenValidateQuery(Query):
     name: str = "account_token_validate"
+    type: QueryType = QueryType.READ
 
     def __init__(self, token: str, **kwargs: Any):
         self.token = token

--- a/backend/infrahub/core/branch/models.py
+++ b/backend/infrahub/core/branch/models.py
@@ -10,6 +10,7 @@ from infrahub.core.constants import (
 )
 from infrahub.core.models import SchemaBranchHash  # noqa: TCH001
 from infrahub.core.node.standard import StandardNode
+from infrahub.core.query import QueryType
 from infrahub.core.query.branch import (
     DeleteBranchRelationshipsQuery,
     GetAllBranchInternalRelationshipQuery,
@@ -139,7 +140,7 @@ class Branch(StandardNode):  # pylint: disable=too-many-public-methods
 
         params = {"name": name}
 
-        results = await db.execute_query(query=query, params=params, name="branch_get_by_name")
+        results = await db.execute_query(query=query, params=params, name="branch_get_by_name", type=QueryType.READ)
 
         if len(results) == 0:
             raise BranchNotFoundError(identifier=name)

--- a/backend/infrahub/core/constraint/node/runner.py
+++ b/backend/infrahub/core/constraint/node/runner.py
@@ -24,15 +24,16 @@ class NodeConstraintRunner:
         self.relationship_manager_constraints = relationship_manager_constraints
 
     async def check(self, node: Node, field_filters: Optional[list[str]] = None) -> None:
-        await node.resolve_relationships(db=self.db)
+        async with self.db.start_session() as db:
+            await node.resolve_relationships(db=db)
 
-        for node_constraint in self.node_constraints:
-            await node_constraint.check(node, filters=field_filters)
+            for node_constraint in self.node_constraints:
+                await node_constraint.check(node, filters=field_filters)
 
-        for relationship_name in node.get_schema().relationship_names:
-            if field_filters and relationship_name not in field_filters:
-                continue
-            relationship_manager: RelationshipManager = getattr(node, relationship_name)
-            await relationship_manager.fetch_relationship_ids(db=self.db, force_refresh=True)
-            for relationship_constraint in self.relationship_manager_constraints:
-                await relationship_constraint.check(relm=relationship_manager, node_schema=node.get_schema())
+            for relationship_name in node.get_schema().relationship_names:
+                if field_filters and relationship_name not in field_filters:
+                    continue
+                relationship_manager: RelationshipManager = getattr(node, relationship_name)
+                await relationship_manager.fetch_relationship_ids(db=db, force_refresh=True)
+                for relationship_constraint in self.relationship_manager_constraints:
+                    await relationship_constraint.check(relm=relationship_manager, node_schema=node.get_schema())

--- a/backend/infrahub/core/diff/query/artifact.py
+++ b/backend/infrahub/core/diff/query/artifact.py
@@ -2,12 +2,13 @@ from typing import Any
 
 from infrahub.core.branch.models import Branch
 from infrahub.core.constants import InfrahubKind
-from infrahub.core.query import Query
+from infrahub.core.query import Query, QueryType
 from infrahub.database import InfrahubDatabase
 
 
 class ArtifactDiffQuery(Query):
     name = "get_artifact_diff"
+    type = QueryType.READ
 
     def __init__(
         self,

--- a/backend/infrahub/core/graph/constraints.py
+++ b/backend/infrahub/core/graph/constraints.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING, ForwardRef, Optional, Union, get_origin
 from pydantic import BaseModel
 from typing_extensions import Self
 
+from infrahub.core.query import QueryType
+
 if TYPE_CHECKING:
     from infrahub.database import InfrahubDatabase
 
@@ -255,7 +257,7 @@ class ConstraintManagerNeo4j(ConstraintManagerBase):
 
     async def list(self) -> list[ConstraintInfo]:
         query = "SHOW CONSTRAINTS"
-        records = await self.db.execute_query(query=query, params={}, name="constraint_show")
+        records = await self.db.execute_query(query=query, params={}, name="constraint_show", type=QueryType.READ)
         results = []
         for record in records:
             results.append(
@@ -285,7 +287,7 @@ class ConstraintManagerMemgraph(ConstraintManagerBase):
 
     async def list(self) -> list[ConstraintInfo]:
         query = "SHOW CONSTRAINT INFO"
-        records = await self.db.execute_query(query=query, params={}, name="constraint_show")
+        records = await self.db.execute_query(query=query, params={}, name="constraint_show", type=QueryType.READ)
         results = []
         for record in records:
             results.append(ConstraintInfo(item_name="n_a", item_label=record["label"], property=record["properties"]))

--- a/backend/infrahub/core/migrations/graph/m012_convert_account_generic.py
+++ b/backend/infrahub/core/migrations/graph/m012_convert_account_generic.py
@@ -40,6 +40,7 @@ default_branch = Branch(
 
 class Migration012RenameTypeAttributeData(AttributeRenameQuery):
     name = "migration_012_rename_attr_type"
+    type = QueryType.WRITE
 
     def __init__(self, **kwargs: Any):
         new_attr = AttributeInfo(
@@ -80,6 +81,7 @@ class Migration012RenameTypeAttributeData(AttributeRenameQuery):
 
 class Migration012AddLabelData(NodeDuplicateQuery):
     name = "migration_012_add_labels"
+    type = QueryType.WRITE
 
     def __init__(self, **kwargs: Any):
         new_node = SchemaNodeInfo(
@@ -128,7 +130,7 @@ class Migration012AddLabelData(NodeDuplicateQuery):
 
 class Migration012RenameTypeAttributeSchema(SchemaAttributeUpdateQuery):
     name = "migration_012_rename_type_attr_schema"
-    type: QueryType = QueryType.WRITE
+    type = QueryType.WRITE
     insert_return = False
 
     def __init__(self, **kwargs: Any):
@@ -147,6 +149,7 @@ class Migration012RenameTypeAttributeSchema(SchemaAttributeUpdateQuery):
 
 class Migration012RenameRelationshipAccountTokenData(RelationshipDuplicateQuery):
     name = "migration_012_rename_rel_account_token_data"
+    type = QueryType.WRITE
 
     def __init__(self, **kwargs: Any):
         new_rel = SchemaRelationshipInfo(
@@ -170,6 +173,7 @@ class Migration012RenameRelationshipAccountTokenData(RelationshipDuplicateQuery)
 
 class Migration012RenameRelationshipRefreshTokenData(RelationshipDuplicateQuery):
     name = "migration_012_rename_rel_refresh_token_data"
+    type = QueryType.WRITE
 
     def __init__(self, **kwargs: Any):
         new_rel = SchemaRelationshipInfo(
@@ -193,6 +197,7 @@ class Migration012RenameRelationshipRefreshTokenData(RelationshipDuplicateQuery)
 
 class Migration012RenameRelationshipThreadData(RelationshipDuplicateQuery):
     name = "migration_012_rename_rel_thread_data"
+    type = QueryType.WRITE
 
     def __init__(self, **kwargs: Any):
         new_rel = SchemaRelationshipInfo(
@@ -216,6 +221,7 @@ class Migration012RenameRelationshipThreadData(RelationshipDuplicateQuery):
 
 class Migration012RenameRelationshipCommentData(RelationshipDuplicateQuery):
     name = "migration_012_rename_rel_comment_data"
+    type = QueryType.WRITE
 
     def __init__(self, **kwargs: Any):
         new_rel = SchemaRelationshipInfo(
@@ -239,7 +245,7 @@ class Migration012RenameRelationshipCommentData(RelationshipDuplicateQuery):
 
 class Migration012DeleteOldElementsSchema(DeleteElementInSchemaQuery):
     name = "migration_012_delete_old_elements_schema"
-    type: QueryType = QueryType.WRITE
+    type = QueryType.WRITE
     insert_return = False
 
     def __init__(self, **kwargs: Any):
@@ -257,7 +263,7 @@ class Migration012DeleteOldElementsSchema(DeleteElementInSchemaQuery):
 
 class Migration012UpdateDisplayLabels(SchemaAttributeUpdateQuery):
     name = "migration_012_display_labels"
-    type: QueryType = QueryType.WRITE
+    type = QueryType.WRITE
     insert_return = False
 
     def __init__(self, **kwargs: Any):
@@ -275,7 +281,7 @@ class Migration012UpdateDisplayLabels(SchemaAttributeUpdateQuery):
 
 class Migration012UpdateOrderBy(SchemaAttributeUpdateQuery):
     name = "migration_012_order_by"
-    type: QueryType = QueryType.WRITE
+    type = QueryType.WRITE
     insert_return = False
 
     def __init__(self, **kwargs: Any):
@@ -293,7 +299,7 @@ class Migration012UpdateOrderBy(SchemaAttributeUpdateQuery):
 
 class Migration012UpdateDefaultFilter(SchemaAttributeUpdateQuery):
     name = "migration_012_reset_default_filter"
-    type: QueryType = QueryType.WRITE
+    type = QueryType.WRITE
     insert_return = False
 
     def __init__(self, **kwargs: Any):
@@ -311,7 +317,7 @@ class Migration012UpdateDefaultFilter(SchemaAttributeUpdateQuery):
 
 class Migration012UpdateHFID(SchemaAttributeUpdateQuery):
     name = "migration_012_reset_hfid"
-    type: QueryType = QueryType.WRITE
+    type = QueryType.WRITE
     insert_return = False
 
     def __init__(self, **kwargs: Any):

--- a/backend/infrahub/core/migrations/graph/m013_convert_git_password_credential.py
+++ b/backend/infrahub/core/migrations/graph/m013_convert_git_password_credential.py
@@ -34,7 +34,7 @@ default_branch = Branch(
 
 class Migration013ConvertCoreRepositoryWithCred(Query):
     name = "migration_013_convert_repository_with_cred"
-    type: QueryType = QueryType.WRITE
+    type = QueryType.WRITE
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:
         at = Timestamp()
@@ -170,7 +170,7 @@ class Migration013ConvertCoreRepositoryWithCred(Query):
 
 class Migration013ConvertCoreRepositoryWithoutCred(Query):
     name = "migration_013_convert_repository_without_cred"
-    type: QueryType = QueryType.WRITE
+    type = QueryType.WRITE
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:
         at = Timestamp()
@@ -233,7 +233,7 @@ class Migration013ConvertCoreRepositoryWithoutCred(Query):
 
 class Migration013DeleteUsernamePasswordGenericSchema(DeleteElementInSchemaQuery):
     name = "migration_013_delete_username_password_schema"
-    type: QueryType = QueryType.WRITE
+    type = QueryType.WRITE
     insert_return = False
 
     def __init__(self, **kwargs: Any):
@@ -251,7 +251,7 @@ class Migration013DeleteUsernamePasswordGenericSchema(DeleteElementInSchemaQuery
 
 class Migration013DeleteUsernamePasswordReadWriteSchema(DeleteElementInSchemaQuery):
     name = "migration_013_delete_username_password_schema"
-    type: QueryType = QueryType.WRITE
+    type = QueryType.WRITE
     insert_return = False
 
     def __init__(self, **kwargs: Any):
@@ -269,7 +269,7 @@ class Migration013DeleteUsernamePasswordReadWriteSchema(DeleteElementInSchemaQue
 
 class Migration013DeleteUsernamePasswordReadOnlySchema(DeleteElementInSchemaQuery):
     name = "migration_013_delete_username_password_schema"
-    type: QueryType = QueryType.WRITE
+    type = QueryType.WRITE
     insert_return = False
 
     def __init__(self, **kwargs: Any):

--- a/backend/infrahub/core/migrations/query/attribute_add.py
+++ b/backend/infrahub/core/migrations/query/attribute_add.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Optional
 
 from infrahub.core.constants import NULL_VALUE, RelationshipStatus
-from infrahub.core.query import Query
+from infrahub.core.query import Query, QueryType
 
 if TYPE_CHECKING:
     from infrahub.database import InfrahubDatabase
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 
 class AttributeAddQuery(Query):
     name = "attribute_add"
+    type = QueryType.WRITE
 
     def __init__(
         self,

--- a/backend/infrahub/core/migrations/query/delete_element_in_schema.py
+++ b/backend/infrahub/core/migrations/query/delete_element_in_schema.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from infrahub.core.constants import RelationshipStatus
 from infrahub.core.graph.schema import GraphNodeRelationships, GraphRelDirection
-from infrahub.core.query import Query
+from infrahub.core.query import Query, QueryType
 from infrahub.core.timestamp import Timestamp
 
 if TYPE_CHECKING:
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 
 class DeleteElementInSchemaQuery(Query):
     name = "delete_element_in_schema"
+    type = QueryType.WRITE
     insert_return: bool = False
 
     def __init__(

--- a/backend/infrahub/core/migrations/query/node_duplicate.py
+++ b/backend/infrahub/core/migrations/query/node_duplicate.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 
 from infrahub.core.constants import BranchSupportType, RelationshipStatus
 from infrahub.core.graph.schema import GraphNodeRelationships, GraphRelDirection
-from infrahub.core.query import Query
+from infrahub.core.query import Query, QueryType
 
 if TYPE_CHECKING:
     from pydantic.fields import FieldInfo
@@ -24,6 +24,7 @@ class SchemaNodeInfo(BaseModel):
 
 class NodeDuplicateQuery(Query):
     name = "node_duplicate"
+    type = QueryType.WRITE
     insert_return: bool = False
 
     def __init__(

--- a/backend/infrahub/core/migrations/query/relationship_duplicate.py
+++ b/backend/infrahub/core/migrations/query/relationship_duplicate.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 
 from infrahub.core.constants import BranchSupportType, RelationshipStatus
 from infrahub.core.graph.schema import GraphRelationshipRelationships, GraphRelDirection
-from infrahub.core.query import Query
+from infrahub.core.query import Query, QueryType
 
 if TYPE_CHECKING:
     from infrahub.database import InfrahubDatabase
@@ -21,6 +21,7 @@ class SchemaRelationshipInfo(BaseModel):
 
 class RelationshipDuplicateQuery(Query):
     name = "relationship_duplicate"
+    type = QueryType.WRITE
     insert_return: bool = False
 
     def __init__(

--- a/backend/infrahub/core/migrations/query/schema_attribute_update.py
+++ b/backend/infrahub/core/migrations/query/schema_attribute_update.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 class SchemaAttributeUpdateQuery(Query):
     name = "schema_attribute_update"
-    type: QueryType = QueryType.WRITE
+    type = QueryType.WRITE
     insert_return = True
 
     def __init__(

--- a/backend/infrahub/core/query/__init__.py
+++ b/backend/infrahub/core/query/__init__.py
@@ -337,7 +337,7 @@ class QueryStat:
 
 class Query(ABC):
     name: str = "base-query"
-    type: QueryType = QueryType.READ
+    type: QueryType
 
     raise_error_if_empty: bool = False
     insert_return: bool = True
@@ -535,14 +535,14 @@ class Query(ABC):
         if self.type == QueryType.READ:
             if self.limit or self.offset:
                 results = await db.execute_query(
-                    query=query_str, params=self.params, name=self.name, context=self.get_context()
+                    query=query_str, params=self.params, name=self.name, context=self.get_context(), type=self.type
                 )
             else:
                 results = await self.query_with_size_limit(db=db)
 
         elif self.type == QueryType.WRITE:
             results, metadata = await db.execute_query_with_metadata(
-                query=query_str, params=self.params, name=self.name, context=self.get_context()
+                query=query_str, params=self.params, name=self.name, context=self.get_context(), type=self.type
             )
             if "stats" in metadata:
                 self.stats.add(metadata.get("stats"))
@@ -568,6 +568,7 @@ class Query(ABC):
                 params=self.params,
                 name=self.name,
                 context=self.get_context(),
+                type=self.type,
             )
             if "stats" in metadata:
                 self.stats.add(metadata.get("stats"))
@@ -589,7 +590,9 @@ class Query(ABC):
         if self.type != QueryType.READ:
             raise ValueError(f"unknown value for {self.type}")
 
-        results = await db.execute_query(query=self.get_count_query(), params=self.params, name=f"{self.name}_count")
+        results = await db.execute_query(
+            query=self.get_count_query(), params=self.params, name=f"{self.name}_count", type=QueryType.READ
+        )
 
         if not results and self.raise_error_if_empty:
             raise QueryError(query=self.get_count_query(), params=self.params)

--- a/backend/infrahub/core/query/diff.py
+++ b/backend/infrahub/core/query/diff.py
@@ -47,7 +47,8 @@ class DiffQuery(Query):
 
 
 class DiffNodeQuery(DiffQuery):
-    name: str = "diff_node"
+    name = "diff_node"
+    type = QueryType.READ
 
     def __init__(
         self,
@@ -113,7 +114,8 @@ class DiffNodeQuery(DiffQuery):
 
 
 class DiffAttributeQuery(DiffQuery):
-    name: str = "diff_attribute"
+    name = "diff_attribute"
+    type = QueryType.READ
 
     def __init__(
         self,
@@ -175,8 +177,8 @@ class DiffAttributeQuery(DiffQuery):
 
 
 class DiffRelationshipQuery(DiffQuery):
-    name: str = "diff_relationship"
-    type: QueryType = QueryType.READ
+    name = "diff_relationship"
+    type = QueryType.READ
 
     def __init__(
         self,
@@ -260,8 +262,8 @@ class DiffRelationshipQuery(DiffQuery):
 
 
 class DiffRelationshipPropertyQuery(DiffQuery):
-    name: str = "diff_relationship_property"
-    type: QueryType = QueryType.READ
+    name = "diff_relationship_property"
+    type = QueryType.READ
 
     async def query_init(self, db: InfrahubDatabase, **kwargs) -> None:
         rels_filter, rels_params = self.branch.get_query_filter_relationships_range(
@@ -317,7 +319,8 @@ class DiffRelationshipPropertyQuery(DiffQuery):
 
 
 class DiffNodePropertiesByIDSRangeQuery(Query):
-    name: str = "diff_node_properties_range_ids"
+    name = "diff_node_properties_range_ids"
+    type = QueryType.READ
 
     def __init__(self, ids: list[str], diff_from: str, diff_to: str, account=None, **kwargs):
         self.account = account
@@ -362,7 +365,8 @@ class DiffNodePropertiesByIDSRangeQuery(Query):
 
 
 class DiffNodePropertiesByIDSQuery(Query):
-    name: str = "diff_node_properties_ids"
+    name = "diff_node_properties_ids"
+    type = QueryType.READ
     order_by: list[str] = ["a.name"]
 
     def __init__(
@@ -414,8 +418,7 @@ class DiffNodePropertiesByIDSQuery(Query):
 
 class DiffRelationshipPropertiesByIDSRangeQuery(Query):
     name = "diff_relationship_properties_range_ids"
-
-    type: QueryType = QueryType.READ
+    type = QueryType.READ
 
     def __init__(
         self,
@@ -469,8 +472,8 @@ class DiffRelationshipPropertiesByIDSRangeQuery(Query):
 
 
 class DiffCountChanges(Query):
-    name: str = "diff_count_changes"
-    type: QueryType = QueryType.READ
+    name = "diff_count_changes"
+    type = QueryType.READ
 
     def __init__(
         self,
@@ -522,7 +525,8 @@ class DiffCountChanges(Query):
 class DiffAllPathsQuery(DiffQuery):
     """Gets the required Cypher paths for a diff"""
 
-    name: str = "diff_node"
+    name = "diff_node"
+    type = QueryType.READ
 
     def __init__(
         self,

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Iterable, Optional, Union
 
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.ipam.constants import AllIPTypes, IPAddressType, IPNetworkType
+from infrahub.core.query import QueryType
 from infrahub.core.registry import registry
 from infrahub.core.utils import convert_ip_to_binary_str
 
@@ -47,7 +48,8 @@ def _get_namespace_id(
 
 
 class IPPrefixSubnetFetch(Query):
-    name: str = "ipprefix_subnet_fetch"
+    name = "ipprefix_subnet_fetch"
+    type = QueryType.READ
 
     def __init__(
         self,
@@ -138,7 +140,8 @@ class IPPrefixSubnetFetch(Query):
 
 
 class IPPrefixIPAddressFetch(Query):
-    name: str = "ipprefix_ipaddress_fetch"
+    name = "ipprefix_ipaddress_fetch"
+    type = QueryType.READ
 
     def __init__(
         self,
@@ -243,7 +246,8 @@ async def get_ip_addresses(
 
 
 class IPPrefixUtilization(Query):
-    name: str = "ipprefix_utilization_prefix"
+    name = "ipprefix_utilization_prefix"
+    type = QueryType.READ
 
     def __init__(self, ip_prefixes: list[str], **kwargs):
         self.ip_prefixes = ip_prefixes
@@ -309,7 +313,8 @@ class IPPrefixUtilization(Query):
 
 
 class IPPrefixReconcileQuery(Query):
-    name: str = "ip_prefix_reconcile"
+    name = "ip_prefix_reconcile"
+    type = QueryType.READ
 
     def __init__(
         self,

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -117,8 +117,7 @@ class NodeQuery(Query):
 
 class NodeCreateAllQuery(NodeQuery):
     name = "node_create_all"
-
-    type: QueryType = QueryType.WRITE
+    type = QueryType.WRITE
 
     raise_error_if_empty: bool = True
 
@@ -397,7 +396,8 @@ class NodeCheckIDQuery(Query):
 
 
 class NodeListGetAttributeQuery(Query):
-    name: str = "node_list_get_attribute"
+    name = "node_list_get_attribute"
+    type = QueryType.READ
 
     property_type_mapping = {
         "HAS_VALUE": ("r2", "av"),
@@ -556,7 +556,8 @@ class NodeListGetAttributeQuery(Query):
 
 
 class NodeListGetRelationshipsQuery(Query):
-    name: str = "node_list_get_relationship"
+    name = "node_list_get_relationship"
+    type = QueryType.READ
 
     def __init__(self, ids: list[str], **kwargs):
         self.ids = ids
@@ -596,7 +597,7 @@ class NodeListGetRelationshipsQuery(Query):
 
 
 class NodeGetKindQuery(Query):
-    name: str = "node_get_kind_query"
+    name = "node_get_kind_query"
     type = QueryType.READ
 
     def __init__(self, ids: list[str], **kwargs: Any) -> None:
@@ -621,7 +622,8 @@ class NodeGetKindQuery(Query):
 
 
 class NodeListGetInfoQuery(Query):
-    name: str = "node_list_get_info"
+    name = "node_list_get_info"
+    type = QueryType.READ
 
     def __init__(self, ids: list[str], account=None, **kwargs: Any) -> None:
         self.account = account
@@ -752,6 +754,7 @@ class FieldAttributeRequirement:
 
 class NodeGetListQuery(Query):
     name = "node_get_list"
+    type = QueryType.READ
 
     def __init__(
         self, schema: NodeSchema, filters: Optional[dict] = None, partial_match: bool = False, **kwargs: Any
@@ -1156,8 +1159,7 @@ class NodeGetListQuery(Query):
 
 class NodeGetHierarchyQuery(Query):
     name = "node_get_hierarchy"
-
-    type: QueryType = QueryType.READ
+    type = QueryType.READ
 
     def __init__(
         self,

--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -276,8 +276,7 @@ class RelationshipCreateQuery(RelationshipQuery):
 
 class RelationshipUpdatePropertyQuery(RelationshipQuery):
     name = "relationship_property_update"
-
-    type: QueryType = QueryType.WRITE
+    type = QueryType.WRITE
 
     def __init__(
         self,
@@ -358,8 +357,7 @@ class RelationshipUpdatePropertyQuery(RelationshipQuery):
 
 class RelationshipDataDeleteQuery(RelationshipQuery):
     name = "relationship_data_delete"
-
-    type: QueryType = QueryType.WRITE
+    type = QueryType.WRITE
 
     def __init__(
         self,
@@ -425,8 +423,7 @@ class RelationshipDataDeleteQuery(RelationshipQuery):
 
 class RelationshipDeleteQuery(RelationshipQuery):
     name = "relationship_delete"
-
-    type: QueryType = QueryType.WRITE
+    type = QueryType.WRITE
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -513,8 +510,7 @@ class RelationshipDeleteQuery(RelationshipQuery):
 
 class RelationshipGetPeerQuery(Query):
     name = "relationship_get_peer"
-
-    type: QueryType = QueryType.READ
+    type = QueryType.READ
 
     def __init__(
         self,
@@ -797,8 +793,7 @@ class RelationshipGetQuery(RelationshipQuery):
 
 class RelationshipGetByIdentifierQuery(Query):
     name = "relationship_get_identifier"
-
-    type: QueryType = QueryType.READ
+    type = QueryType.READ
 
     def __init__(
         self,

--- a/backend/infrahub/core/query/resource_manager.py
+++ b/backend/infrahub/core/query/resource_manager.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from infrahub.core import registry
 from infrahub.core.constants import InfrahubKind, RelationshipStatus
-from infrahub.core.query import Query
+from infrahub.core.query import Query, QueryType
 
 if TYPE_CHECKING:
     from infrahub.core.protocols import CoreNumberPool
@@ -12,7 +12,8 @@ if TYPE_CHECKING:
 
 
 class IPAddressPoolGetIdentifiers(Query):
-    name: str = "ipaddresspool_get_identifiers"
+    name = "ipaddresspool_get_identifiers"
+    type = QueryType.READ
 
     def __init__(
         self,
@@ -38,7 +39,8 @@ class IPAddressPoolGetIdentifiers(Query):
 
 
 class IPAddressPoolGetReserved(Query):
-    name: str = "ipaddresspool_get_reserved"
+    name = "ipaddresspool_get_reserved"
+    type = QueryType.READ
 
     def __init__(
         self,
@@ -64,7 +66,8 @@ class IPAddressPoolGetReserved(Query):
 
 
 class IPAddressPoolSetReserved(Query):
-    name: str = "ipaddresspool_set_reserved"
+    name = "ipaddresspool_set_reserved"
+    type = QueryType.WRITE
 
     def __init__(
         self,
@@ -104,7 +107,8 @@ class IPAddressPoolSetReserved(Query):
 
 
 class NumberPoolGetAllocated(Query):
-    name: str = "numberpool_get_allocated"
+    name = "numberpool_get_allocated"
+    type = QueryType.READ
 
     def __init__(
         self,
@@ -146,7 +150,8 @@ class NumberPoolGetAllocated(Query):
 
 
 class NumberPoolGetReserved(Query):
-    name: str = "numberpool_get_reserved"
+    name = "numberpool_get_reserved"
+    type = QueryType.READ
 
     def __init__(
         self,
@@ -187,7 +192,8 @@ class NumberPoolGetReserved(Query):
 
 
 class NumberPoolGetUsed(Query):
-    name: str = "number_pool_get_used"
+    name = "number_pool_get_used"
+    type = QueryType.READ
 
     def __init__(
         self,
@@ -235,7 +241,8 @@ class NumberPoolGetUsed(Query):
 
 
 class NumberPoolSetReserved(Query):
-    name: str = "numberpool_set_reserved"
+    name = "numberpool_set_reserved"
+    type = QueryType.WRITE
 
     def __init__(
         self,
@@ -275,7 +282,8 @@ class NumberPoolSetReserved(Query):
 
 
 class PrefixPoolGetIdentifiers(Query):
-    name: str = "prefixpool_get_identifiers"
+    name = "prefixpool_get_identifiers"
+    type = QueryType.READ
 
     def __init__(
         self,
@@ -301,7 +309,8 @@ class PrefixPoolGetIdentifiers(Query):
 
 
 class PrefixPoolGetReserved(Query):
-    name: str = "prefixpool_get_reserved"
+    name = "prefixpool_get_reserved"
+    type = QueryType.READ
 
     def __init__(
         self,
@@ -327,7 +336,8 @@ class PrefixPoolGetReserved(Query):
 
 
 class PrefixPoolSetReserved(Query):
-    name: str = "prefixpool_set_reserved"
+    name = "prefixpool_set_reserved"
+    type = QueryType.WRITE
 
     def __init__(
         self,

--- a/backend/infrahub/core/query/standard_node.py
+++ b/backend/infrahub/core/query/standard_node.py
@@ -27,9 +27,8 @@ class StandardNodeQuery(Query):
 
 
 class RootNodeCreateQuery(StandardNodeQuery):
-    name: str = "standard_node_create"
-
-    type: QueryType = QueryType.WRITE
+    name = "standard_node_create"
+    type = QueryType.WRITE
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:
         node_type = self.node.get_type()
@@ -44,9 +43,8 @@ class RootNodeCreateQuery(StandardNodeQuery):
 
 
 class StandardNodeCreateQuery(StandardNodeQuery):
-    name: str = "standard_node_create"
-
-    type: QueryType = QueryType.WRITE
+    name = "standard_node_create"
+    type = QueryType.WRITE
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:
         node_type = self.node.get_type()
@@ -62,9 +60,8 @@ class StandardNodeCreateQuery(StandardNodeQuery):
 
 
 class StandardNodeUpdateQuery(StandardNodeQuery):
-    name: str = "standard_node_update"
-
-    type: QueryType = QueryType.WRITE
+    name = "standard_node_update"
+    type = QueryType.WRITE
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:
         self.node.get_type()
@@ -82,10 +79,9 @@ class StandardNodeUpdateQuery(StandardNodeQuery):
 
 
 class StandardNodeDeleteQuery(StandardNodeQuery):
-    name: str = "standard_node_delete"
-    insert_return: bool = False
-
-    type: QueryType = QueryType.WRITE
+    name = "standard_node_delete"
+    insert_return = False
+    type = QueryType.WRITE
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:
         query = """
@@ -98,9 +94,8 @@ class StandardNodeDeleteQuery(StandardNodeQuery):
 
 
 class StandardNodeGetItemQuery(Query):
-    name: str = "standard_node_get"
-
-    type: QueryType = QueryType.WRITE
+    name = "standard_node_get"
+    type = QueryType.READ
 
     def __init__(self, node_id: str, node_type: str, **kwargs: Any) -> None:
         self.node_id = node_id
@@ -121,9 +116,8 @@ class StandardNodeGetItemQuery(Query):
 
 
 class StandardNodeGetListQuery(Query):
-    name: str = "standard_node_list"
-
-    type: QueryType = QueryType.WRITE
+    name = "standard_node_list"
+    type = QueryType.READ
 
     def __init__(
         self, node_class: StandardNode, ids: Optional[list[str]] = None, node_name: Optional[str] = None, **kwargs: Any

--- a/backend/infrahub/core/utils.py
+++ b/backend/infrahub/core/utils.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 
 from infrahub.core.constants import RelationshipStatus
 from infrahub.core.models import NodeKind
+from infrahub.core.query import QueryType
 from infrahub.core.registry import registry
 from infrahub.core.timestamp import Timestamp
 
@@ -110,7 +111,7 @@ async def get_paths_between_nodes(
         "destination_id": db.to_database_id(destination_id),
     }
 
-    return await db.execute_query(query=query, params=params, name="get_paths_between_nodes")
+    return await db.execute_query(query=query, params=params, name="get_paths_between_nodes", type=QueryType.READ)
 
 
 async def count_relationships(db: InfrahubDatabase, label: Optional[str] = None) -> int:
@@ -125,7 +126,7 @@ async def count_relationships(db: InfrahubDatabase, label: Optional[str] = None)
 
     params: dict = {}
 
-    result = await db.execute_query(query=query, params=params, name="count_relationships")
+    result = await db.execute_query(query=query, params=params, name="count_relationships", type=QueryType.READ)
     return result[0][0]
 
 
@@ -135,7 +136,7 @@ async def get_nodes(db: InfrahubDatabase, label: str) -> list[Neo4jNode]:
     MATCH (node:%(node_kind)s)
     RETURN node
     """ % {"node_kind": label}
-    results = await db.execute_query(query=query, name="get_nodes")
+    results = await db.execute_query(query=query, name="get_nodes", type=QueryType.READ)
     return [result[0] for result in results]
 
 
@@ -149,7 +150,7 @@ async def count_nodes(db: InfrahubDatabase, label: Optional[str] = None) -> int:
     RETURN count(node) as count
     """
     params: dict = {"label": label}
-    result = await db.execute_query(query=query, params=params, name="count_nodes")
+    result = await db.execute_query(query=query, params=params, name="count_nodes", type=QueryType.READ)
     return result[0][0]
 
 

--- a/backend/infrahub/core/validators/uniqueness/query.py
+++ b/backend/infrahub/core/validators/uniqueness/query.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from infrahub.core.constants.relationship_label import RELATIONSHIP_TO_VALUE_LABEL
-from infrahub.core.query import Query
+from infrahub.core.query import Query, QueryType
 
 if TYPE_CHECKING:
     from infrahub.database import InfrahubDatabase
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 class NodeUniqueAttributeConstraintQuery(Query):
     name = "node_constraints_uniqueness"
     insert_return = False
+    type = QueryType.READ
     attribute_property_map = {"value": RELATIONSHIP_TO_VALUE_LABEL}
 
     def __init__(

--- a/backend/infrahub/database/__init__.py
+++ b/backend/infrahub/database/__init__.py
@@ -27,6 +27,7 @@ from typing_extensions import Self
 
 from infrahub import config, lock
 from infrahub.core import registry
+from infrahub.core.query import QueryType
 from infrahub.exceptions import DatabaseError
 from infrahub.log import get_logger
 from infrahub.utils import InfrahubStringEnum
@@ -135,20 +136,22 @@ class InfrahubDatabase:
         self,
         driver: AsyncDriver,
         mode: InfrahubDatabaseMode = InfrahubDatabaseMode.DRIVER,
-        db_type: Optional[DatabaseType] = None,
-        db_manager: Optional[DatabaseManager] = None,
-        schemas: Optional[list[SchemaBranch]] = None,
-        session: Optional[AsyncSession] = None,
+        db_type: DatabaseType | None = None,
+        default_neo4j_runtime: Neo4jRuntime = Neo4jRuntime.DEFAULT,
+        db_manager: DatabaseManager | None = None,
+        schemas: list[SchemaBranch] | None = None,
+        session: AsyncSession | None = None,
         session_mode: InfrahubDatabaseSessionMode = InfrahubDatabaseSessionMode.WRITE,
-        transaction: Optional[AsyncTransaction] = None,
-        queries_names_to_config: Optional[dict[str, QueryConfig]] = None,
+        transaction: AsyncTransaction | None = None,
+        queries_names_to_config: dict[str, QueryConfig] | None = None,
     ):
         self._mode: InfrahubDatabaseMode = mode
         self._driver: AsyncDriver = driver
-        self._session: Optional[AsyncSession] = session
+        self._session: AsyncSession | None = session
         self._session_mode: InfrahubDatabaseSessionMode = session_mode
         self._is_session_local: bool = False
-        self._transaction: Optional[AsyncTransaction] = transaction
+        self._transaction: AsyncTransaction | None = transaction
+        self.default_neo4j_runtime = default_neo4j_runtime
         self.queries_names_to_config = queries_names_to_config if queries_names_to_config is not None else {}
 
         if schemas:
@@ -204,6 +207,7 @@ class InfrahubDatabase:
         return self.__class__(
             mode=InfrahubDatabaseMode.SESSION,
             db_type=self.db_type,
+            default_neo4j_runtime=self.default_neo4j_runtime,
             schemas=schemas or self._schemas.values(),
             db_manager=self.manager,
             driver=self._driver,
@@ -218,6 +222,7 @@ class InfrahubDatabase:
         return self.__class__(
             mode=InfrahubDatabaseMode.TRANSACTION,
             db_type=self.db_type,
+            default_neo4j_runtime=self.default_neo4j_runtime,
             schemas=schemas or self._schemas.values(),
             db_manager=self.manager,
             driver=self._driver,
@@ -302,8 +307,11 @@ class InfrahubDatabase:
         params: dict[str, Any] | None = None,
         name: str = "undefined",
         context: dict[str, str] | None = None,
+        type: QueryType | None = None,  # pylint: disable=redefined-builtin
     ) -> list[Record]:
-        results, _ = await self.execute_query_with_metadata(query=query, params=params, name=name, context=context)
+        results, _ = await self.execute_query_with_metadata(
+            query=query, params=params, name=name, context=context, type=type
+        )
         return results
 
     async def execute_query_with_metadata(
@@ -312,27 +320,36 @@ class InfrahubDatabase:
         params: dict[str, Any] | None = None,
         name: str = "undefined",
         context: dict[str, str] | None = None,
+        type: QueryType | None = None,  # pylint: disable=redefined-builtin
     ) -> tuple[list[Record], dict[str, Any]]:
         with trace.get_tracer(__name__).start_as_current_span("execute_db_query_with_metadata") as span:
             span.set_attribute("query", query)
             if name:
                 span.set_attribute("query_name", name)
 
-            runtime = Neo4jRuntime.UNDEFINED
+            runtime = self.default_neo4j_runtime
 
-            try:
-                query_config = self.queries_names_to_config[name]
-                if self.db_type == DatabaseType.NEO4J:
-                    runtime = self.queries_names_to_config[name].neo4j_runtime
-                    if runtime not in [Neo4jRuntime.DEFAULT, Neo4jRuntime.UNDEFINED]:
-                        query = f"CYPHER runtime = {runtime.value}\n" + query
-                if query_config.profile_memory:
+            if self.db_type == DatabaseType.NEO4J:
+                query_config = self.queries_names_to_config.get(name, None)
+
+                if query_config and query_config.neo4j_runtime not in [Neo4jRuntime.DEFAULT, Neo4jRuntime.UNDEFINED]:
+                    runtime = query_config.neo4j_runtime
+
+                if (
+                    type
+                    and type == QueryType.READ
+                    and runtime not in [Neo4jRuntime.DEFAULT, Neo4jRuntime.UNDEFINED]
+                    and not (self.is_transaction and runtime in [Neo4jRuntime.PARALLEL])
+                ):
+                    query = f"CYPHER runtime = {runtime.value}\n" + query
+                else:
+                    runtime = Neo4jRuntime.DEFAULT
+
+                if query_config and query_config.profile_memory:
                     query = "PROFILE\n" + query
-            except KeyError:
-                pass  # No specific config for this query
 
             labels = {
-                "type": self._session_mode.value,
+                "type": type.value if type else self._session_mode.value,
                 "query": name,
                 "runtime": runtime.value,
                 "context1": "",

--- a/backend/infrahub/database/neo4j.py
+++ b/backend/infrahub/database/neo4j.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from infrahub.core.query import QueryType
+
 from .constants import EntityType, IndexType
 from .index import IndexInfo, IndexItem, IndexManagerBase
 from .manager import DatabaseManager
@@ -50,7 +52,7 @@ class IndexManagerNeo4j(IndexManagerBase):
 
     async def list(self) -> list[IndexInfo]:
         query = "SHOW INDEXES"
-        records = await self.db.execute_query(query=query, params={}, name="index_show")
+        records = await self.db.execute_query(query=query, params={}, name="index_show", type=QueryType.READ)
         results = []
         for record in records:
             if not record["labelsOrTypes"]:

--- a/backend/tests/helpers/query_benchmark/db_query_profiler.py
+++ b/backend/tests/helpers/query_benchmark/db_query_profiler.py
@@ -9,6 +9,7 @@ import pandas as pd
 from neo4j import Record
 
 from infrahub.config import SETTINGS
+from infrahub.core.query import QueryType
 
 # pylint: skip-file
 from infrahub.database import InfrahubDatabase
@@ -115,10 +116,11 @@ class InfrahubDatabaseProfiler(InfrahubDatabase):
         params: dict[str, Any] | None = None,
         name: str = "undefined",
         context: dict[str, str] | None = None,
+        type: QueryType | None = None,
     ) -> tuple[list[Record], dict[str, Any]]:
         if not self.profiling_enabled:
             # Profiling might be disabled to avoid capturing queries while loading data
-            return await super().execute_query_with_metadata(query, params, name)
+            return await super().execute_query_with_metadata(query=query, params=params, name=name, type=type)
 
         # We don't want to memory profile all queries
         if self.profile_memory and name in self.queries_names_to_config:
@@ -132,7 +134,7 @@ class InfrahubDatabaseProfiler(InfrahubDatabase):
 
         # Do the query and measure duration
         time_start = time.time()
-        response, metadata = await super().execute_query_with_metadata(query, params, name)
+        response, metadata = await super().execute_query_with_metadata(query=query, params=params, name=name, type=type)
         duration_time = time.time() - time_start
 
         assert len(response) < SETTINGS.database.query_size_limit // 2, "make sure data return is small"

--- a/backend/tests/unit/core/test_query.py
+++ b/backend/tests/unit/core/test_query.py
@@ -15,6 +15,8 @@ from infrahub.database import InfrahubDatabase
 
 
 class Query01(Query):
+    type = QueryType.READ
+
     async def query_init(self, db: InfrahubDatabase, *args, **kwargs):
         self.order_by = ["at.name", "r2.from"]
 
@@ -30,7 +32,7 @@ class Query01(Query):
 
 
 class Query02(Query):
-    type: QueryType = QueryType.WRITE
+    type = QueryType.WRITE
 
     async def query_init(self, db: InfrahubDatabase, *args, **kwargs):
         query = """


### PR DESCRIPTION
This PR add an option to define a default runtime for Neo4j and it also ensures that if the Parallel runtime is selected, it will only be used on READ query and not on Write query.

In order to know if the query is READ or WRITE, The method `execute_query` has been updated to accept the type of the query (READ or WRITE) and the default behavior for all queries has been changed to WRITE.
Changing the default type ensure that all READ queries (eligible to be used with the parallel runtime) have to be explicitly marked at READ