### PR TITLE
Fix combobox value for relationship many

### DIFF
--- a/frontend/app/src/components/inputs/relationship-many.tsx
+++ b/frontend/app/src/components/inputs/relationship-many.tsx
@@ -156,7 +156,7 @@ export const RelationshipManyInput = React.forwardRef<
             .map((relationship) => (
               <ComboboxItem
                 key={relationship.id}
-                value={relationship.display_label}
+                value={relationship.id}
                 onSelect={() => handleSelect(relationship)}
               >
                 <span className="truncate">


### PR DESCRIPTION
Fix combobox value for relationship many to correctly differentiate the options when dealing with hover and focus behaviour