### PR TITLE
Adjust the pagination style on small screens

### DIFF
--- a/frontend/app/src/components/ui/pagination.tsx
+++ b/frontend/app/src/components/ui/pagination.tsx
@@ -90,7 +90,7 @@ export const Pagination = (props: tPaginationType) => {
         className
       )}
     >
-      <div className="hidden sm:flex sm:flex-1 sm:items-center sm:justify-between">
+      <div className="flex flex-wrap flex-1 gap-2 justify-between">
         <div className="flex items-center">
           <div className="text-sm text-gray-700">{paginationText}</div>
 


### PR DESCRIPTION
Issue: https://github.com/opsmill/infrahub/issues/5096

Adjust the pagination style on small screens to ensure it remains usable

<img width="933" alt="image" src="https://github.com/user-attachments/assets/a450922d-ac39-4cab-9559-4043e0fcaa6a" />

<img width="388" alt="image" src="https://github.com/user-attachments/assets/9d88b8b6-2475-4ab2-994c-f05f7a96261c" />
