### PR TITLE
Switch Prefect to 3.0.9

### DIFF
--- a/backend/infrahub/testing/docker-compose.test.yml
+++ b/backend/infrahub/testing/docker-compose.test.yml
@@ -49,7 +49,7 @@ services:
       - 0:6362
 
   task-manager:
-    image: "${TASK_MANAGER_DOCKER_IMAGE:-prefecthq/prefect:3.1.5-python3.12}"
+    image: "${TASK_MANAGER_DOCKER_IMAGE:-prefecthq/prefect:3.0.9-python3.12}"
     command: prefect server start --host 0.0.0.0 --ui
     depends_on:
       task-manager-db:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -371,7 +371,7 @@ def prefect_container(request: pytest.FixtureRequest, load_settings_before_sessi
         return None
 
     container = (
-        DockerContainer(image="prefecthq/prefect:3.1.5-python3.12")
+        DockerContainer(image="prefecthq/prefect:3.0.9-python3.12")
         .with_command("prefect server start --host 0.0.0.0 --ui")
         .with_exposed_ports(PORT_PREFECT)
     )

--- a/backend/tests/helpers/test_worker.py
+++ b/backend/tests/helpers/test_worker.py
@@ -69,7 +69,7 @@ class TestWorkerInfrahubAsync(TestInfrahubApp):
             return None
 
         container = (
-            DockerContainer(image="prefecthq/prefect:3.1.5-python3.12")
+            DockerContainer(image="prefecthq/prefect:3.0.9-python3.12")
             .with_command("prefect server start --host 0.0.0.0 --ui")
             .with_exposed_ports(PORT_PREFECT)
         )

--- a/development/docker-compose-deps-nats.yml
+++ b/development/docker-compose-deps-nats.yml
@@ -24,7 +24,7 @@ services:
       start_period: 10s
   task-manager:
     profiles: [demo, dev]
-    image: "${TASK_MANAGER_DOCKER_IMAGE:-prefecthq/prefect:3.1.5-python3.12}"
+    image: "${TASK_MANAGER_DOCKER_IMAGE:-prefecthq/prefect:3.0.9-python3.12}"
     command: prefect server start --host 0.0.0.0 --ui
     environment:
       PREFECT_API_DATABASE_CONNECTION_URL: postgresql+asyncpg://postgres:postgres@task-manager-db:5432/prefect

--- a/development/docker-compose-deps.yml
+++ b/development/docker-compose-deps.yml
@@ -23,7 +23,7 @@ services:
       retries: 3
   task-manager:
     profiles: [demo, dev]
-    image: "${TASK_MANAGER_DOCKER_IMAGE:-prefecthq/prefect:3.1.5-python3.12}"
+    image: "${TASK_MANAGER_DOCKER_IMAGE:-prefecthq/prefect:3.0.9-python3.12}"
     command: prefect server start --host 0.0.0.0 --ui
     environment:
       PREFECT_API_DATABASE_CONNECTION_URL: postgresql+asyncpg://postgres:postgres@task-manager-db:5432/prefect

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,7 +172,7 @@ services:
       - 6362:6362
 
   task-manager:
-    image: "${TASK_MANAGER_DOCKER_IMAGE:-prefecthq/prefect:3.1.5-python3.12}"
+    image: "${TASK_MANAGER_DOCKER_IMAGE:-prefecthq/prefect:3.0.9-python3.12}"
     command: prefect server start --host 0.0.0.0 --ui
     restart: unless-stopped
     depends_on:

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -44,6 +44,6 @@ dependencies:
     repository: "https://nats-io.github.io/k8s/helm/charts/"
     condition: nats.enabled
   - name: prefect-server
-    version: "2024.12.5195120"
+    version: "2024.10.15184517"
     repository: "https://prefecthq.github.io/prefect-helm"
     condition: prefect-server.enabled

--- a/poetry.lock
+++ b/poetry.lock
@@ -3480,13 +3480,13 @@ virtualenv = ">=20.10.0"
 
 [[package]]
 name = "prefect"
-version = "3.1.5"
+version = "3.0.9"
 description = "Workflow orchestration and management."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "prefect-3.1.5-py3-none-any.whl", hash = "sha256:c0f50328060a3b5d530ad5f16381c65984ba4e16c0cb7a2da7fda79f78f62310"},
-    {file = "prefect-3.1.5.tar.gz", hash = "sha256:3872a6a8441c62ebb56d2cf209480317a692d22f879e921a7bca2d93ec68d444"},
+    {file = "prefect-3.0.9-py3-none-any.whl", hash = "sha256:f0238d40b791c95e431b5647b2adddc4a43c323f88cc9016308580ece2d517ea"},
+    {file = "prefect-3.0.9.tar.gz", hash = "sha256:f96f3ae601e0be1ea6b6c61f345b66723940b3947ebda14e2125737742f84472"},
 ]
 
 [package.dependencies]
@@ -3500,7 +3500,7 @@ cachetools = ">=5.3,<6.0"
 click = ">=8.0,<8.2"
 cloudpickle = ">=2.0,<4.0"
 coolname = ">=1.0.4,<3.0.0"
-croniter = ">=1.0.12,<6.0.0"
+croniter = ">=1.0.12,<4.0.0"
 cryptography = ">=36.0.1"
 dateparser = ">=1.1.1,<2.0.0"
 docker = ">=4.0,<8.0"
@@ -3516,17 +3516,16 @@ jinja2 = ">=3.0.0,<4.0.0"
 jinja2-humanize-extension = ">=0.4.0"
 jsonpatch = ">=1.32,<2.0"
 jsonschema = ">=4.0.0,<5.0.0"
-opentelemetry-api = ">=1.27.0,<2.0.0"
 orjson = ">=3.7,<4.0"
 packaging = ">=21.3,<24.3"
 pathspec = ">=0.8.0"
 pendulum = ">=3.0.0,<4"
 prometheus-client = ">=0.20.0"
-pydantic = ">=2.7,<2.10.0 || >2.10.0,<3.0.0"
-pydantic_core = ">=2.12.0,<3.0.0"
-pydantic_extra_types = ">=2.8.2,<3.0.0"
-pydantic_settings = ">2.2.1"
-python_dateutil = ">=2.8.2,<3.0.0"
+pydantic = ">=2.7,<3.0.0"
+pydantic-core = ">=2.12.0,<3.0.0"
+pydantic-extra-types = ">=2.8.2,<3.0.0"
+pydantic-settings = "*"
+python-dateutil = ">=2.8.2,<3.0.0"
 python-slugify = ">=5.0,<9.0"
 pytz = ">=2021.1,<2025"
 pyyaml = ">=5.4.1,<7.0.0"
@@ -3537,33 +3536,32 @@ rich = ">=11.0,<14.0"
 sniffio = ">=1.3.0,<2.0.0"
 sqlalchemy = {version = ">=2.0,<3.0.0", extras = ["asyncio"]}
 toml = ">=0.10.0"
-typer = ">=0.12.0,<0.12.2 || >0.12.2,<0.14.0"
-typing_extensions = ">=4.5.0,<5.0.0"
+typer = ">=0.12.0,<0.12.2 || >0.12.2,<0.13.0"
+typing-extensions = ">=4.5.0,<5.0.0"
 ujson = ">=5.8.0,<6.0.0"
 uvicorn = ">=0.14.0,<0.29.0 || >0.29.0"
 websockets = ">=10.4,<14.0"
 
 [package.extras]
-aws = ["prefect-aws (>=0.5.0)"]
-azure = ["prefect-azure (>=0.4.0)"]
-bitbucket = ["prefect-bitbucket (>=0.3.0)"]
-dask = ["prefect-dask (>=0.3.0)"]
-databricks = ["prefect-databricks (>=0.3.0)"]
-dbt = ["prefect-dbt (>=0.6.0)"]
-dev = ["cairosvg", "codespell (>=2.2.6)", "ipython", "jinja2", "mkdocs", "mkdocs-gen-files", "mkdocs-material", "mkdocstrings[python]", "moto (>=5)", "mypy (>=1.9.0)", "numpy", "opentelemetry-distro (>=0.48b0,<1.0.0)", "opentelemetry-exporter-otlp (>=1.27.0,<2.0.0)", "opentelemetry-instrumentation (>=0.48b0,<1.0.0)", "opentelemetry-instrumentation-logging (>=0.48b0,<1.0.0)", "opentelemetry-test-utils (>=0.48b0,<1.0.0)", "pillow", "pluggy (>=1.4.0)", "pre-commit", "pytest (>=8.3)", "pytest-asyncio (>=0.24)", "pytest-benchmark", "pytest-cov", "pytest-env", "pytest-flakefinder", "pytest-timeout", "pytest-xdist (>=3.6.1)", "pyyaml", "redis (>=5.0.1)", "respx", "ruff", "setuptools", "types-PyYAML", "types-cachetools", "uv (>=0.4.5)", "vale", "vermin", "virtualenv", "watchfiles"]
-docker = ["prefect-docker (>=0.6.0)"]
-email = ["prefect-email (>=0.4.0)"]
-gcp = ["prefect-gcp (>=0.6.0)"]
-github = ["prefect-github (>=0.3.0)"]
-gitlab = ["prefect-gitlab (>=0.3.0)"]
-kubernetes = ["prefect-kubernetes (>=0.4.0)"]
-otel = ["opentelemetry-distro (>=0.48b0,<1.0.0)", "opentelemetry-exporter-otlp (>=1.27.0,<2.0.0)", "opentelemetry-instrumentation (>=0.48b0,<1.0.0)", "opentelemetry-instrumentation-logging (>=0.48b0,<1.0.0)"]
-ray = ["prefect-ray (>=0.4.0)"]
+aws = ["prefect-aws (>=0.5.0rc1)"]
+azure = ["prefect-azure (>=0.4.0rc1)"]
+bitbucket = ["prefect-bitbucket (>=0.3.0rc1)"]
+dask = ["prefect-dask (>=0.3.0rc1)"]
+databricks = ["prefect-databricks (>=0.3.0rc1)"]
+dbt = ["prefect-dbt (>=0.6.0rc1)"]
+dev = ["cairosvg", "codespell (>=2.2.6)", "ipython", "jinja2", "mkdocs", "mkdocs-gen-files", "mkdocs-material", "mkdocstrings[python]", "moto (>=5)", "mypy (>=1.9.0)", "numpy", "pillow", "pluggy (>=1.4.0)", "pre-commit", "pytest (>=8.3)", "pytest-asyncio (>=0.24)", "pytest-benchmark", "pytest-codspeed", "pytest-cov", "pytest-env", "pytest-flakefinder", "pytest-timeout", "pytest-xdist (>=3.6.1)", "pyyaml", "redis (>=5.0.1)", "respx", "ruff", "setuptools", "types-PyYAML", "types-cachetools", "uv (>=0.4.5)", "vale", "vermin", "virtualenv", "watchfiles"]
+docker = ["prefect-docker (>=0.6.0rc1)"]
+email = ["prefect-email (>=0.4.0rc1)"]
+gcp = ["prefect-gcp (>=0.6.0rc1)"]
+github = ["prefect-github (>=0.3.0rc1)"]
+gitlab = ["prefect-gitlab (>=0.3.0rc1)"]
+kubernetes = ["prefect-kubernetes (>=0.4.0rc1)"]
+ray = ["prefect-ray (>=0.4.0rc1)"]
 redis = ["prefect-redis (>=0.2.0)"]
-shell = ["prefect-shell (>=0.3.0)"]
-slack = ["prefect-slack (>=0.3.0)"]
-snowflake = ["prefect-snowflake (>=0.28.0)"]
-sqlalchemy = ["prefect-sqlalchemy (>=0.5.0)"]
+shell = ["prefect-shell (>=0.3.0rc1)"]
+slack = ["prefect-slack (>=0.3.0rc1)"]
+snowflake = ["prefect-snowflake (>=0.28.0rc1)"]
+sqlalchemy = ["prefect-sqlalchemy (>=0.5.0rc1)"]
 
 [[package]]
 name = "prometheus-client"
@@ -5802,4 +5800,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10, < 3.13"
-content-hash = "a3ea935d7914a7cc5bd6d96dc379cab7d78ce85df19228cd5d9c469cdcdb5f28"
+content-hash = "c7064984fb0690bfbd8a13a27a5b18cce550202a12b97df6ba16f10990bc6579"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ boto3 = "1.34.129"
 email-validator = "~2.1"
 redis = { version = "^5.0.0", extras = ["hiredis"] }
 typer = "0.12.5"
-prefect = "3.1.5"
+prefect = "3.0.9"
 ujson = "^5"
 Jinja2 = "^3"
 gitpython = "^3"

--- a/tasks/shared.py
+++ b/tasks/shared.py
@@ -48,7 +48,7 @@ CACHE_DOCKER_IMAGE = os.getenv(
     "redis:7.2.4" if not INFRAHUB_USE_NATS else "nats:2.10.14-alpine",
 )
 
-TASK_MANAGER_DOCKER_IMAGE = os.getenv("TASK_MANAGER_DOCKER_IMAGE", "prefecthq/prefect:3.1.5-python3.12")
+TASK_MANAGER_DOCKER_IMAGE = os.getenv("TASK_MANAGER_DOCKER_IMAGE", "prefecthq/prefect:3.0.9-python3.12")
 
 here = Path(__file__).parent.resolve()
 TOP_DIRECTORY_NAME = here.parent.name


### PR DESCRIPTION
Trying to downgrade Prefect to see if it helps with the flaky ephemeral server in CI 

The latest version in 3.0.x is 3.0.11 but the latest helm chart only support 3.0.9 so I settled on 3.0.9 for now