### PR TITLE
Clickable link for URL kind in the details view

### DIFF
--- a/changelog/5005.added.md
+++ b/changelog/5005.added.md
@@ -1,1 +1,1 @@
-Include a clickable link for URL type in the details view
+Make URL fields clickable in the details view

--- a/changelog/5005.added.md
+++ b/changelog/5005.added.md
@@ -1,0 +1,1 @@
+Include a clickable link for URL type in the details view

--- a/frontend/app/src/components/ui/link.tsx
+++ b/frontend/app/src/components/ui/link.tsx
@@ -5,6 +5,7 @@ type LinkProps = {
   to: string;
   children?: any;
   target?: string;
+  rel?: string;
   className?: string;
 };
 

--- a/frontend/app/src/components/ui/link.tsx
+++ b/frontend/app/src/components/ui/link.tsx
@@ -1,13 +1,5 @@
 import { classNames } from "@/utils/common";
-import { Link as RouterLink } from "react-router-dom";
-
-type LinkProps = {
-  to: string;
-  children?: any;
-  target?: string;
-  rel?: string;
-  className?: string;
-};
+import { LinkProps, Link as RouterLink } from "react-router-dom";
 
 export const Link = (props: LinkProps) => {
   const { children, className, ...propsToPass } = props;

--- a/frontend/app/src/utils/getObjectItemDisplayValue.tsx
+++ b/frontend/app/src/utils/getObjectItemDisplayValue.tsx
@@ -5,6 +5,7 @@ import { PasswordDisplay } from "@/components/display/password-display";
 import { TextDisplay } from "@/components/display/text-display";
 import { CodeEditor } from "@/components/editor/code-editor";
 import { MarkdownViewer } from "@/components/editor/markdown-viewer";
+import { Link } from "@/components/ui/link";
 import { MAX_VALUE_LENGTH_DISPLAY, SCHEMA_ATTRIBUTE_KIND } from "@/config/constants";
 import {
   AnyAttribute,
@@ -197,13 +198,18 @@ export const ObjectAttributeValue = ({
     case SCHEMA_ATTRIBUTE_KIND.NUMBER:
     case SCHEMA_ATTRIBUTE_KIND.BANDWIDTH:
     case SCHEMA_ATTRIBUTE_KIND.EMAIL:
-    case SCHEMA_ATTRIBUTE_KIND.URL:
     case SCHEMA_ATTRIBUTE_KIND.MAC_ADDRESS:
     case SCHEMA_ATTRIBUTE_KIND.FILE:
     case SCHEMA_ATTRIBUTE_KIND.IP_HOST:
     case SCHEMA_ATTRIBUTE_KIND.IP_NETWORK:
     case SCHEMA_ATTRIBUTE_KIND.ANY:
       return <TextDisplay>{getTextValue(attributeValue).toString()}</TextDisplay>;
+    case SCHEMA_ATTRIBUTE_KIND.URL:
+      return (
+        <Link to={getTextValue(attributeValue).toString()} target="_blank" rel="noreferrer">
+          {getTextValue(attributeValue).toString()}
+        </Link>
+      );
     case SCHEMA_ATTRIBUTE_KIND.BOOLEAN:
     case SCHEMA_ATTRIBUTE_KIND.CHECKBOX:
       return attributeValue ? <CheckIcon className="h-4 w-4" /> : <XMarkIcon className="h-4 w-4" />;


### PR DESCRIPTION
Issue: https://github.com/opsmill/infrahub/issues/5005

Include a clickable link for URL type in the details view