### PR TITLE
Add branch support to transform based computed attributes

### DIFF
--- a/backend/infrahub/computed_attribute/constants.py
+++ b/backend/infrahub/computed_attribute/constants.py
@@ -4,7 +4,7 @@ PROCESS_PYTHON_AUTOMATION_NAME_PREFIX = "Computed-attribute-process-python"
 PROCESS_AUTOMATION_NAME_PREFIX = "Computed-attribute-process"
 QUERY_AUTOMATION_NAME_PREFIX = "Computed-attribute-query"
 
-PROCESS_AUTOMATION_NAME = "{prefix}::{identifier}::{scope}"
-QUERY_AUTOMATION_NAME = QUERY_AUTOMATION_NAME_PREFIX + "::{identifier}::{scope}"
+PROCESS_AUTOMATION_NAME = "{prefix}::{scope}::{identifier}"
+QUERY_AUTOMATION_NAME = QUERY_AUTOMATION_NAME_PREFIX + "::{scope}::{identifier}"
 
 VALID_KINDS = ["Text", "URL"]

--- a/backend/infrahub/computed_attribute/models.py
+++ b/backend/infrahub/computed_attribute/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from prefect.events.schemas.automations import Automation  # noqa: TCH002
@@ -10,6 +10,8 @@ from typing_extensions import Self
 
 if TYPE_CHECKING:
     from uuid import UUID
+
+    from infrahub_sdk.data import RepositoryData
 
     from infrahub.core.schema.schema_branch_computed import PythonDefinition
 
@@ -28,8 +30,8 @@ class ComputedAttributeAutomations(BaseModel):
             if len(name_split) != 3:
                 continue
 
-            identifier = name_split[1]
-            scope = name_split[2]
+            scope = name_split[1]
+            identifier = name_split[2]
 
             obj.data[identifier][scope] = automation
 
@@ -46,12 +48,15 @@ class ComputedAttributeAutomations(BaseModel):
         return False
 
     def return_obsolete(self, keep: list[UUID]) -> list[UUID]:
-        remove = []
+        return [automation_id for automation_id in self.all_automation_ids if automation_id not in keep]
+
+    @property
+    def all_automation_ids(self) -> list[UUID]:
+        automation_ids: list[UUID] = []
         for identifier in self.data.values():
             for automation in identifier.values():
-                if automation.id not in keep:
-                    remove.append(automation.id)
-        return remove
+                automation_ids.append(automation.id)
+        return automation_ids
 
 
 @dataclass
@@ -63,6 +68,13 @@ class PythonTransformComputedAttribute:
     query_name: str
     query_models: list[str]
     computed_attribute: PythonDefinition
+    default_schema: bool
+    branch_commit: dict[str, str] = field(default_factory=dict)
+
+    def populate_branch_commit(self, repository_data: RepositoryData | None = None) -> None:
+        if repository_data:
+            for branch, commit in repository_data.branches.items():
+                self.branch_commit[branch] = commit
 
 
 @dataclass

--- a/backend/infrahub/computed_attribute/tasks.py
+++ b/backend/infrahub/computed_attribute/tasks.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
-from infrahub_sdk.protocols import CoreNode
+from infrahub_sdk.protocols import CoreNode  # noqa: TCH002
 from prefect import flow
 from prefect.automations import AutomationCore
 from prefect.client.orchestration import get_client
@@ -37,7 +39,10 @@ from .constants import (
 from .models import ComputedAttributeAutomations, PythonTransformComputedAttribute, PythonTransformTarget
 
 if TYPE_CHECKING:
+    import logging
+
     from infrahub.core.schema.computed_attribute import ComputedAttribute
+    from infrahub.services import InfrahubServices
 
 UPDATE_ATTRIBUTE = """
 mutation UpdateAttribute(
@@ -108,6 +113,7 @@ async def process_transform(
 
         data = await service.client.query_gql_query(
             name=transform.query.peer.name.value,
+            branch_name=branch_name,
             variables={"id": object_id},
             update_group=True,
             subscribers=[object_id],
@@ -464,51 +470,20 @@ async def computed_attribute_setup(branch_name: str | None = None) -> None:  # p
     flow_run_name="Setup computed attributes for Python transforms in task-manager",
 )
 async def computed_attribute_setup_python(
-    branch_name: str | None = None,  # pylint: disable=unused-argument
+    branch_name: str | None = None,
+    commit: str | None = None,  # pylint: disable=unused-argument
+    trigger_updates: bool = True,
 ) -> None:
     log = get_run_logger()
     service = services.service
 
-    if branch_name:
-        await add_tags(branches=[branch_name])
+    branch_name = branch_name or registry.default_branch
 
-    await wait_for_schema_to_converge(branch_name=registry.default_branch, service=service, log=log)
+    await add_tags(branches=[branch_name])
 
-    schema_branch = registry.schema.get_schema_branch(name=registry.default_branch)
+    await wait_for_schema_to_converge(branch_name=branch_name, service=service, log=log)
 
-    transform_attributes = schema_branch.computed_attributes.python_attributes_by_transform
-
-    transform_names = list(transform_attributes.keys())
-
-    transforms = await service.client.filters(
-        kind="CoreTransformPython",
-        branch=registry.default_branch,
-        prefetch_relationships=True,
-        populate_store=True,
-        name__values=transform_names,
-    )
-
-    found_transforms_names = [transform.name.value for transform in transforms]
-    for transform_name in transform_names:
-        if transform_name not in found_transforms_names:
-            log.warning(
-                msg=f"The transform {transform_name} is assigned to a computed attribute but the transform could not be found in the database."
-            )
-
-    computed_attributes: list[PythonTransformComputedAttribute] = []
-    for transform in transforms:
-        for attribute in transform_attributes[transform.name.value]:
-            computed_attributes.append(
-                PythonTransformComputedAttribute(
-                    name=transform.name.value,
-                    repository_id=transform.repository.peer.id,
-                    repository_name=transform.repository.peer.name.value,
-                    repository_kind=transform.repository.peer.typename,
-                    query_name=transform.query.peer.name.value,
-                    query_models=transform.query.peer.models.value,
-                    computed_attribute=attribute,
-                )
-            )
+    computed_attributes = await _gather_python_transform_attributes(branch_name=branch_name, service=service, log=log)
 
     async with get_client(sync_client=False) as client:
         deployments = {
@@ -531,15 +506,16 @@ async def computed_attribute_setup_python(
 
         automations = await client.read_automations()
         existing_computed_attr_process_automations = ComputedAttributeAutomations.from_prefect(
-            automations=automations, prefix=PROCESS_PYTHON_AUTOMATION_NAME_PREFIX
+            automations=automations, prefix=f"{PROCESS_PYTHON_AUTOMATION_NAME_PREFIX}::{branch_name}::"
         )
         existing_computed_attr_query_automations = ComputedAttributeAutomations.from_prefect(
-            automations=automations, prefix=QUERY_AUTOMATION_NAME_PREFIX
+            automations=automations, prefix=f"{QUERY_AUTOMATION_NAME_PREFIX}::{branch_name}::"
         )
 
+        automations_to_keep = []
         for computed_attribute in computed_attributes:
             log.info(f"processing {computed_attribute.computed_attribute.key_name}")
-            scope = "default"
+            scope = branch_name
 
             automation = AutomationCore(
                 name=PROCESS_AUTOMATION_NAME.format(
@@ -553,7 +529,12 @@ async def computed_attribute_setup_python(
                     posture=Posture.Reactive,
                     expect={"infrahub.node.*"},
                     within=timedelta(0),
-                    match=ResourceSpecification({"infrahub.node.kind": [computed_attribute.computed_attribute.kind]}),
+                    match=ResourceSpecification(
+                        {
+                            "infrahub.node.kind": [computed_attribute.computed_attribute.kind],
+                            "infrahub.branch.name": branch_name,
+                        }
+                    ),
                     threshold=1,
                 ),
                 actions=[
@@ -580,8 +561,10 @@ async def computed_attribute_setup_python(
                 )
                 await client.update_automation(automation_id=existing.id, automation=automation)
                 log.info(f"Process {computed_attribute.computed_attribute.key_name} Updated")
+                automations_to_keep.append(existing.id)
             else:
-                await client.create_automation(automation=automation)
+                automation_id = await client.create_automation(automation=automation)
+                automations_to_keep.append(automation_id)
                 log.info(f"Process {computed_attribute.computed_attribute.key_name} Created")
 
             automation = AutomationCore(
@@ -596,7 +579,12 @@ async def computed_attribute_setup_python(
                     posture=Posture.Reactive,
                     expect={"infrahub.node.*"},
                     within=timedelta(0),
-                    match=ResourceSpecification({"infrahub.node.kind": computed_attribute.query_models}),
+                    match=ResourceSpecification(
+                        {
+                            "infrahub.node.kind": computed_attribute.query_models,
+                            "infrahub.branch.name": branch_name,
+                        }
+                    ),
                     threshold=1,
                 ),
                 actions=[
@@ -620,19 +608,53 @@ async def computed_attribute_setup_python(
                     identifier=computed_attribute.computed_attribute.key_name, scope=scope
                 )
                 await client.update_automation(automation_id=existing.id, automation=automation)
+                automations_to_keep.append(existing.id)
                 log.info(f"Query {computed_attribute.computed_attribute.key_name} Updated")
             else:
-                await client.create_automation(automation=automation)
+                automation_id = await client.create_automation(automation=automation)
+                automations_to_keep.append(automation_id)
                 log.info(f"Query {computed_attribute.computed_attribute.key_name} Created")
 
-            await service.workflow.submit_workflow(
-                workflow=TRIGGER_UPDATE_PYTHON_COMPUTED_ATTRIBUTES,
-                parameters={
-                    "branch_name": registry.default_branch,
-                    "computed_attribute_name": computed_attribute.computed_attribute.attribute.name,
-                    "computed_attribute_kind": computed_attribute.computed_attribute.kind,
-                },
-            )
+            if trigger_updates:
+                await service.workflow.submit_workflow(
+                    workflow=TRIGGER_UPDATE_PYTHON_COMPUTED_ATTRIBUTES,
+                    parameters={
+                        "branch_name": branch_name,
+                        "computed_attribute_name": computed_attribute.computed_attribute.attribute.name,
+                        "computed_attribute_kind": computed_attribute.computed_attribute.kind,
+                    },
+                )
+
+        automations_to_remove = existing_computed_attr_process_automations.return_obsolete(keep=automations_to_keep)
+        for automation_to_remove in automations_to_remove:
+            await client.delete_automation(automation_id=automation_to_remove)
+
+        automations_to_remove = existing_computed_attr_query_automations.return_obsolete(keep=automations_to_keep)
+        for automation_to_remove in automations_to_remove:
+            await client.delete_automation(automation_id=automation_to_remove)
+
+
+@flow(
+    name="computed-attribute-remove-python",
+    flow_run_name="Remove Python based computed attributes on branch={branch_name}",
+)
+async def computed_attribute_remove_python(
+    branch_name: str,
+) -> None:
+    async with get_client(sync_client=False) as client:
+        automations = await client.read_automations()
+        existing_computed_attr_process_automations = ComputedAttributeAutomations.from_prefect(
+            automations=automations, prefix=f"{PROCESS_PYTHON_AUTOMATION_NAME_PREFIX}::{branch_name}::"
+        )
+        existing_computed_attr_query_automations = ComputedAttributeAutomations.from_prefect(
+            automations=automations, prefix=f"{QUERY_AUTOMATION_NAME_PREFIX}::{branch_name}::"
+        )
+
+        for automation_id in existing_computed_attr_process_automations.all_automation_ids:
+            await client.delete_automation(automation_id=automation_id)
+
+        for automation_id in existing_computed_attr_query_automations.all_automation_ids:
+            await client.delete_automation(automation_id=automation_id)
 
 
 @flow(
@@ -648,7 +670,7 @@ async def query_transform_targets(
     service = services.service
     schema_branch = registry.schema.get_schema_branch(name=branch_name)
     targets = await service.client.execute_graphql(
-        query=GATHER_GRAPHQL_QUERY_SUBSCRIBERS, variables={"members": [object_id]}
+        query=GATHER_GRAPHQL_QUERY_SUBSCRIBERS, variables={"members": [object_id]}, branch_name=branch_name
     )
 
     subscribers: list[PythonTransformTarget] = []
@@ -673,6 +695,55 @@ async def query_transform_targets(
                         "computed_attribute_kind": subscriber.kind,
                     },
                 )
+
+
+async def _gather_python_transform_attributes(
+    branch_name: str, service: InfrahubServices, log: logging.Logger | logging.LoggerAdapter
+) -> list[PythonTransformComputedAttribute]:
+    schema_branch = registry.schema.get_schema_branch(name=branch_name)
+    branches_with_diff_from_main = registry.get_altered_schema_branches()
+
+    transform_attributes = schema_branch.computed_attributes.python_attributes_by_transform
+
+    transform_names = list(transform_attributes.keys())
+    if not transform_names:
+        return []
+
+    transforms = await service.client.filters(
+        kind="CoreTransformPython",
+        branch=branch_name,
+        prefetch_relationships=True,
+        populate_store=True,
+        name__values=transform_names,
+    )
+
+    found_transforms_names = [transform.name.value for transform in transforms]
+    for transform_name in transform_names:
+        if transform_name not in found_transforms_names:
+            log.warning(
+                msg=f"The transform {transform_name} is assigned to a computed attribute but the transform could not be found in the database."
+            )
+
+    repositories = await service.client.get_list_repositories()
+    computed_attributes: list[PythonTransformComputedAttribute] = []
+    for transform in transforms:
+        for attribute in transform_attributes[transform.name.value]:
+            python_transform_computed_attribute = PythonTransformComputedAttribute(
+                name=transform.name.value,
+                repository_id=transform.repository.peer.id,
+                repository_name=transform.repository.peer.name.value,
+                repository_kind=transform.repository.peer.typename,
+                query_name=transform.query.peer.name.value,
+                query_models=transform.query.peer.models.value,
+                computed_attribute=attribute,
+                default_schema=branch_name not in branches_with_diff_from_main,
+            )
+            python_transform_computed_attribute.populate_branch_commit(
+                repository_data=repositories.get(transform.repository.peer.name.value)
+            )
+            computed_attributes.append(python_transform_computed_attribute)
+
+    return computed_attributes
 
 
 GATHER_GRAPHQL_QUERY_SUBSCRIBERS = """

--- a/backend/infrahub/core/branch/constants.py
+++ b/backend/infrahub/core/branch/constants.py
@@ -1,0 +1,2 @@
+AUTOMATION_NAME_CREATE = "Trigger-branch-create-events"
+AUTOMATION_NAME_REMOVE = "Trigger-branch-remove-events"

--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+from datetime import timedelta
 from typing import Any
 
 import pydantic
 from prefect import flow, get_run_logger
+from prefect.automations import AutomationCore
+from prefect.client.orchestration import get_client
+from prefect.client.schemas.filters import DeploymentFilter, DeploymentFilterName
 from prefect.client.schemas.objects import State  # noqa: TCH002
+from prefect.events.actions import RunDeployment
+from prefect.events.schemas.automations import EventTrigger, Posture
 from prefect.states import Completed, Failed
 
 from infrahub import lock
@@ -31,11 +37,15 @@ from infrahub.services import services
 from infrahub.worker import WORKER_IDENTITY
 from infrahub.workflows.catalogue import (
     BRANCH_CANCEL_PROPOSED_CHANGES,
+    COMPUTED_ATTRIBUTE_REMOVE_PYTHON,
+    COMPUTED_ATTRIBUTE_SETUP_PYTHON,
     DIFF_REFRESH_ALL,
     GIT_REPOSITORIES_CREATE_BRANCH,
     IPAM_RECONCILIATION,
 )
 from infrahub.workflows.utils import add_branch_tag
+
+from .constants import AUTOMATION_NAME_CREATE, AUTOMATION_NAME_REMOVE
 
 
 @flow(name="branch-rebase", flow_run_name="Rebase branch {branch}")
@@ -303,3 +313,85 @@ async def create_branch(model: BranchCreateModel) -> None:
             workflow=GIT_REPOSITORIES_CREATE_BRANCH,
             parameters={"branch": obj.name, "branch_id": str(obj.id)},
         )
+
+
+@flow(name="branch-actions-setup", flow_run_name="Setup branch action events in task-manager")
+async def branch_actions_setup() -> None:
+    log = get_run_logger()
+
+    async with get_client(sync_client=False) as client:
+        deployments = {
+            item.name: item
+            for item in await client.read_deployments(
+                deployment_filter=DeploymentFilter(
+                    name=DeploymentFilterName(
+                        any_=[COMPUTED_ATTRIBUTE_SETUP_PYTHON.name, COMPUTED_ATTRIBUTE_REMOVE_PYTHON.name]
+                    )
+                )
+            )
+        }
+        deployment_id_computed_attribute_setup_python = deployments[COMPUTED_ATTRIBUTE_SETUP_PYTHON.name].id
+        deployment_id_computed_attribute_remove_python = deployments[COMPUTED_ATTRIBUTE_REMOVE_PYTHON.name].id
+
+        branch_create_automation = await client.find_automation(id_or_name=AUTOMATION_NAME_CREATE)
+
+        automation = AutomationCore(
+            name=AUTOMATION_NAME_CREATE,
+            description="Trigger actions on branch create event",
+            enabled=True,
+            trigger=EventTrigger(
+                posture=Posture.Reactive,
+                expect={"infrahub.branch.created"},
+                within=timedelta(0),
+                threshold=1,
+            ),
+            actions=[
+                RunDeployment(
+                    source="selected",
+                    deployment_id=deployment_id_computed_attribute_setup_python,
+                    parameters={
+                        "branch_name": "{{ event.resource['infrahub.branch.name'] }}",
+                        "trigger_updates": False,
+                    },
+                    job_variables={},
+                ),
+            ],
+        )
+
+        if branch_create_automation:
+            await client.update_automation(automation_id=branch_create_automation.id, automation=automation)
+            log.info(f"{AUTOMATION_NAME_CREATE} Updated")
+        else:
+            await client.create_automation(automation=automation)
+            log.info(f"{AUTOMATION_NAME_CREATE} Created")
+
+        branch_remove_automation = await client.find_automation(id_or_name=AUTOMATION_NAME_REMOVE)
+
+        automation = AutomationCore(
+            name=AUTOMATION_NAME_REMOVE,
+            description="Trigger actions on branch delete event",
+            enabled=True,
+            trigger=EventTrigger(
+                posture=Posture.Reactive,
+                expect={"infrahub.branch.deleted"},
+                within=timedelta(0),
+                threshold=1,
+            ),
+            actions=[
+                RunDeployment(
+                    source="selected",
+                    deployment_id=deployment_id_computed_attribute_remove_python,
+                    parameters={
+                        "branch_name": "{{ event.resource['infrahub.branch.name'] }}",
+                    },
+                    job_variables={},
+                ),
+            ],
+        )
+
+        if branch_remove_automation:
+            await client.update_automation(automation_id=branch_remove_automation.id, automation=automation)
+            log.info(f"{AUTOMATION_NAME_REMOVE} Updated")
+        else:
+            await client.create_automation(automation=automation)
+            log.info(f"{AUTOMATION_NAME_REMOVE} Created")

--- a/backend/infrahub/core/registry.py
+++ b/backend/infrahub/core/registry.py
@@ -216,7 +216,6 @@ class Registry:
 
     def get_altered_schema_branches(self) -> list[str]:
         """Return a list of branch names that has a different hash than the default branch"""
-        # altered_branches = []
         default_branch = self.branch[registry.default_branch]
         return [
             name

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -68,13 +68,19 @@ if TYPE_CHECKING:
 
 
 class SchemaBranch:
-    def __init__(self, cache: dict, name: str | None = None, data: dict[str, dict[str, str]] | None = None):
+    def __init__(
+        self,
+        cache: dict,
+        name: str | None = None,
+        data: dict[str, dict[str, str]] | None = None,
+        computed_attributes: ComputedAttributes | None = None,
+    ):
         self._cache: dict[str, Union[NodeSchema, GenericSchema]] = cache
         self.name: str | None = name
         self.nodes: dict[str, str] = {}
         self.generics: dict[str, str] = {}
         self.profiles: dict[str, str] = {}
-        self.computed_attributes = ComputedAttributes()
+        self.computed_attributes = computed_attributes or ComputedAttributes()
 
         if data:
             self.nodes = data.get("nodes", {})
@@ -254,7 +260,12 @@ class SchemaBranch:
 
     def duplicate(self, name: Optional[str] = None) -> SchemaBranch:
         """Duplicate the current object but conserve the same cache."""
-        return self.__class__(name=name, data=copy.deepcopy(self.to_dict()), cache=self._cache)
+        return self.__class__(
+            name=name,
+            data=copy.deepcopy(self.to_dict()),
+            cache=self._cache,
+            computed_attributes=self.computed_attributes.duplicate(),
+        )
 
     def set(self, name: str, schema: MainSchemaTypes) -> str:
         """Store a NodeSchema or GenericSchema associated with a specific name.

--- a/backend/infrahub/core/schema/schema_branch_computed.py
+++ b/backend/infrahub/core/schema/schema_branch_computed.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -71,9 +72,19 @@ class RegisteredNodeComputedAttribute(BaseModel):
 
 
 class ComputedAttributes:
-    def __init__(self) -> None:
-        self._computed_python_transform_attribute_map: dict[str, list[AttributeSchema]] = {}
-        self._computed_jinja2_attribute_map: dict[str, RegisteredNodeComputedAttribute] = {}
+    def __init__(
+        self,
+        transform_attribute_map: dict[str, list[AttributeSchema]] | None = None,
+        jinja2_attribute_map: dict[str, RegisteredNodeComputedAttribute] | None = None,
+    ) -> None:
+        self._computed_python_transform_attribute_map: dict[str, list[AttributeSchema]] = transform_attribute_map or {}
+        self._computed_jinja2_attribute_map: dict[str, RegisteredNodeComputedAttribute] = jinja2_attribute_map or {}
+
+    def duplicate(self) -> ComputedAttributes:
+        return self.__class__(
+            transform_attribute_map=deepcopy(self._computed_python_transform_attribute_map),
+            jinja2_attribute_map=deepcopy(self._computed_jinja2_attribute_map),
+        )
 
     def add_python_attribute(self, node: NodeSchema, attribute: AttributeSchema) -> None:
         if node.kind not in self._computed_python_transform_attribute_map:

--- a/backend/infrahub/events/branch_action.py
+++ b/backend/infrahub/events/branch_action.py
@@ -20,6 +20,7 @@ class BranchDeleteEvent(InfrahubBranchEvent):
         return {
             "prefect.resource.id": f"infrahub.branch.{self.branch}",
             "infrahub.branch.id": self.branch_id,
+            "infrahub.branch.name": self.branch,
         }
 
     def get_messages(self) -> list[InfrahubMessage]:
@@ -48,6 +49,7 @@ class BranchCreateEvent(InfrahubBranchEvent):
         return {
             "prefect.resource.id": f"infrahub.branch.{self.branch}",
             "infrahub.branch.id": self.branch_id,
+            "infrahub.branch.name": self.branch,
         }
 
     def get_messages(self) -> list[InfrahubMessage]:

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -468,7 +468,10 @@ async def setup_commit_automation() -> None:
                 RunDeployment(
                     source="selected",
                     deployment_id=deployment_id_computed_attribute_setup_python,
-                    parameters={},
+                    parameters={
+                        "branch_name": "{{ event.resource['infrahub.branch.name'] }}",
+                        "commit": "{{ event.payload['commit'] }}",
+                    },
                     job_variables={},
                 ),
             ],

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -46,7 +46,7 @@ from infrahub.proposed_change.models import (
 )
 from infrahub.pytest_plugin import InfrahubBackendPlugin
 from infrahub.services import services
-from infrahub.workflows.catalogue import REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS
+from infrahub.workflows.catalogue import COMPUTED_ATTRIBUTE_SETUP_PYTHON, REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS
 from infrahub.workflows.utils import add_tags
 
 if TYPE_CHECKING:
@@ -136,6 +136,7 @@ async def merge_proposed_change(proposed_change_id: str, proposed_change_name: s
         log.info(f"Branch {source_branch.name} has been merged successfully")
 
         await _proposed_change_transition_state(proposed_change=proposed_change, state=ProposedChangeState.MERGED)
+        await service.workflow.submit_workflow(workflow=COMPUTED_ATTRIBUTE_SETUP_PYTHON)
         return Completed(message="proposed change merged successfully")
 
 

--- a/backend/infrahub/server.py
+++ b/backend/infrahub/server.py
@@ -46,7 +46,7 @@ from infrahub.worker import WORKER_IDENTITY
 CURRENT_DIRECTORY = Path(__file__).parent.resolve()
 
 
-async def app_initialization(application: FastAPI) -> None:
+async def app_initialization(application: FastAPI, enable_scheduler: bool = True) -> None:
     config.SETTINGS.initialize_and_exit()
 
     # Initialize trace
@@ -92,6 +92,8 @@ async def app_initialization(application: FastAPI) -> None:
     services.prepare(service=service)
     application.state.service = service
     application.state.response_delay = config.SETTINGS.miscellaneous.response_delay
+    if enable_scheduler:
+        await service.scheduler.start_schedule()
 
 
 async def shutdown(application: FastAPI) -> None:

--- a/backend/infrahub/services/scheduler.py
+++ b/backend/infrahub/services/scheduler.py
@@ -33,7 +33,7 @@ class InfrahubScheduler:
 
         self.running = config.SETTINGS.miscellaneous.start_background_runner
         # Add some randomness to the interval to avoid having all workers pulling the latest update at the same time
-        random_number = random.randint(30, 60)
+        random_number = random.randint(0, 5)
         if self.service.component_type == ComponentType.API_SERVER:
             schedules = [
                 Schedule(name="refresh_api_components", interval=10, function=refresh_heartbeat, start_delay=0),
@@ -51,8 +51,6 @@ class InfrahubScheduler:
                 ),
             ]
             self.schedules.extend(schedules)
-
-        await self.start_schedule()
 
     async def start_schedule(self) -> None:
         for schedule in self.schedules:

--- a/backend/infrahub/workers/infrahub_async.py
+++ b/backend/infrahub/workers/infrahub_async.py
@@ -116,6 +116,7 @@ class InfrahubWorkerAsync(BaseWorker):
 
         initialize_repositories_directory()
         build_component_registry()
+        await service.scheduler.start_schedule()
         self._logger.info("Worker initialization completed .. ")
 
     async def run(

--- a/backend/infrahub/workflows/catalogue.py
+++ b/backend/infrahub/workflows/catalogue.py
@@ -274,6 +274,13 @@ COMPUTED_ATTRIBUTE_SETUP_PYTHON = WorkflowDefinition(
     function="computed_attribute_setup_python",
 )
 
+COMPUTED_ATTRIBUTE_REMOVE_PYTHON = WorkflowDefinition(
+    name="computed-attribute-remove-python",
+    type=WorkflowType.CORE,
+    module="infrahub.computed_attribute.tasks",
+    function="computed_attribute_remove_python",
+)
+
 UPDATE_COMPUTED_ATTRIBUTE_TRANSFORM = WorkflowDefinition(
     name="process_computed_attribute_transform",
     type=WorkflowType.USER,
@@ -308,6 +315,13 @@ REQUEST_PROPOSED_CHANGE_USER_TESTS = WorkflowDefinition(
     type=WorkflowType.USER,
     module="infrahub.proposed_change.tasks",
     function="run_proposed_change_user_tests",
+)
+
+AUTOMATION_BRANCH_ACTIONS = WorkflowDefinition(
+    name="branch-actions-setup",
+    type=WorkflowType.CORE,
+    module="infrahub.core.branch.tasks",
+    function="branch_actions_setup",
 )
 
 AUTOMATION_SCHEMA_UPDATED = WorkflowDefinition(
@@ -380,6 +394,7 @@ worker_pools = [INFRAHUB_WORKER_POOL]
 
 workflows = [
     ANONYMOUS_TELEMETRY_SEND,
+    AUTOMATION_BRANCH_ACTIONS,
     AUTOMATION_GIT_UPDATED,
     AUTOMATION_SCHEMA_UPDATED,
     AUTOMATION_SETUP_WEBHOOK_CONFIGURATION_TRIGGER,
@@ -390,6 +405,7 @@ workflows = [
     BRANCH_MERGE_MUTATION,
     BRANCH_REBASE,
     BRANCH_VALIDATE,
+    COMPUTED_ATTRIBUTE_REMOVE_PYTHON,
     COMPUTED_ATTRIBUTE_SETUP,
     COMPUTED_ATTRIBUTE_SETUP_PYTHON,
     DIFF_REFRESH,
@@ -432,6 +448,7 @@ workflows = [
 ]
 
 automation_setup_workflows = [
+    AUTOMATION_BRANCH_ACTIONS,
     AUTOMATION_GIT_UPDATED,
     AUTOMATION_SCHEMA_UPDATED,
     AUTOMATION_SETUP_WEBHOOK_CONFIGURATION_TRIGGER,

--- a/backend/tests/functional/ipam/test_proposed_change_reconcile.py
+++ b/backend/tests/functional/ipam/test_proposed_change_reconcile.py
@@ -5,12 +5,17 @@ from typing import TYPE_CHECKING
 import pytest
 
 from infrahub import config
+from infrahub.components import ComponentType
 from infrahub.core import registry
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
+from infrahub.core.timestamp import Timestamp
+from infrahub.message_bus.types import KVTTL
+from infrahub.services import services
 from infrahub.services.adapters.cache.redis import RedisCache
+from infrahub.worker import WORKER_IDENTITY
 
 from .base import TestIpamReconcileBase
 
@@ -58,12 +63,18 @@ class TestProposedChangeReconcile(TestIpamReconcileBase):
         branch_1,
         new_address_1,
     ) -> None:
+        await services.service.component.refresh_heartbeat()
         proposed_change_create = await client.create(
             kind=InfrahubKind.PROPOSEDCHANGE,
             data={"source_branch": branch_1.name, "destination_branch": "main", "name": "add_address_pc"},
         )
         await proposed_change_create.save()
         proposed_change_create.state.value = "merged"  # type: ignore[attr-defined]
+        await services.service.cache.set(
+            key=f"workers:active:{ComponentType.API_SERVER}:worker:{WORKER_IDENTITY}",
+            value=Timestamp().to_string(),
+            expires=KVTTL.FIFTEEN,
+        )
         await proposed_change_create.save()
 
         updated_address = await NodeManager.get_one(db=db, id=new_address_1.id)

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -100,7 +100,7 @@ class TestInfrahubApp(TestInfrahub):
         # This call emits an ERROR because it calls registry-webhook-config-refresh flow within a local worker
         # while services.service.client is not set. There might be a design issue here: a client is needed while
         # the app is being initialized.
-        await app_initialization(app)
+        await app_initialization(app, enable_scheduler=False)
         return InfrahubTestClient(app=app, base_url="http://testserver")
 
     @pytest.fixture(scope="class")

--- a/backend/tests/unit/graphql/mutations/test_proposed_change.py
+++ b/backend/tests/unit/graphql/mutations/test_proposed_change.py
@@ -1,17 +1,24 @@
 from uuid import uuid4
 
+from prefect.client.orchestration import get_client
+
 from infrahub.auth import AccountSession
 from infrahub.core.branch import Branch
 from infrahub.core.constants import CheckType, InfrahubKind
 from infrahub.core.initialization import create_branch
 from infrahub.core.node import Node
 from infrahub.core.registry import registry
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.message_bus import messages
+from infrahub.message_bus.types import KVTTL
 from infrahub.permissions.local_backend import LocalPermissionBackend
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
+from infrahub.worker import WORKER_IDENTITY
+from infrahub.workflows.initialization import setup_deployments, setup_worker_pools
+from tests.adapters.cache import MemoryCache
 from tests.adapters.message_bus import BusRecorder
 from tests.helpers.graphql import graphql, graphql_mutation
 from tests.helpers.utils import init_global_service
@@ -202,12 +209,30 @@ async def test_merge_proposed_change_permission_failure(
     session_first_account: AccountSession,
     session_admin: AccountSession,
 ):
-    service = InfrahubServices(database=db, message_bus=BusRecorder(), workflow=WorkflowLocalExecution())
+    service = InfrahubServices(
+        database=db, message_bus=BusRecorder(), workflow=WorkflowLocalExecution(), cache=MemoryCache()
+    )
+    await service.component.initialize(service=service)
+    async with get_client(sync_client=False) as client:
+        await setup_worker_pools(client=client)
+        await setup_deployments(client)
+
     with init_global_service(service):
         registry.permission_backends = [LocalPermissionBackend()]
 
         branch_name = "merge-proposed-change-perm"
-        await create_branch(branch_name=branch_name, db=db)
+        branch = await create_branch(branch_name=branch_name, db=db)
+        await service.cache.set(
+            key=f"workers:schema_hash:branch:{str(branch.get_uuid)}:{service.component_type.value}:worker:{WORKER_IDENTITY}",
+            value=branch.active_schema_hash.main,
+            expires=KVTTL.TWO_HOURS,
+        )
+        await service.cache.set(
+            key=f"workers:active:{service.component_type.value}:worker:{WORKER_IDENTITY}",
+            value=Timestamp().to_string(),
+            expires=KVTTL.FIFTEEN,
+        )
+        await service.component.refresh_heartbeat()
 
         proposed_change = await Node.init(db=db, schema=InfrahubKind.PROPOSEDCHANGE)
         await proposed_change.new(


### PR DESCRIPTION
This PR adds branch support for the transform based computed attributes. Within this iteration this is done by setting up the automations on a per branch basis. At a later point it would be better to limit the number of automations we setup. For now the approach is different compared to what we do for the Jinja2 based computed attributes, a reason for this is that there are more dimensions to consider in this case where with Jinja2 we need to consider the hash of the schema in each branch and for the computed transforms we have the branch, schema_hash and the commit of each repository within each branch. I did some limited tests around this having an approach more similar to Jinja2 but it turned out quite ugly, I think we'll want to refactor how the automations are setup as a whole before revisiting that part.

Changes in this PR:

* Revert the order of the automation names 

```diff
-PROCESS_AUTOMATION_NAME = "{prefix}::{identifier}::{scope}"
+PROCESS_AUTOMATION_NAME = "{prefix}::{scope}::{identifier}"
```
The reason for this is to allow for easier filtering based on branch name when we want to tear down the automations when they are no longer in use.

* General fixes by adding `branch_name` as parameters to various SDK calls to enable proper branch support
* Add automations to events when branches are created and deleted so that the computed attribute automations are executed on branch create and delete
* Add automation when merging a proposed change so that computed attribute automations are refreshed and triggered (in order to populate GraphQL query groups that might have changed in the branch)
* Changes to the SchemaBranch.duplicate() method so that any parsed computed attributes are carried over to the cloned SchemaBranch
* Prepared to send a git `commit` id to be able to limit which computed attributes are regenerated when updating a repository
* Changed the `app_initialization` so that the scheduler isn't automatically started before the application is initialized, here I also added an optional parameter so that we can control if the scheduler is enabled when testing.
* Lowered the start time for the scheduled tasks to refresh branches in the background
* Changes to tests to reflect new background events

We also need a good way to test the automations and that they are working properly. Starting out this will probably be some new E2E tests.