### PR TITLE
Do not display error message on search anywhere

### DIFF
--- a/frontend/app/src/components/search/search-nodes.tsx
+++ b/frontend/app/src/components/search/search-nodes.tsx
@@ -66,17 +66,12 @@ const NodesOptions = ({ node }: NodesOptionsProps) => {
   const { data, loading, error } = useObjectDetails(schema!, node.id);
 
   if (!schema) return null;
+
   const columns = getSchemaObjectColumns({ schema, forListView: true, limit: 7 });
 
   if (loading) return <SearchResultNodeSkeleton />;
 
-  if (error) {
-    return (
-      <div className="text-sm text-red-600">
-        Error loading object details for {node.kind} (id: {node.id})
-      </div>
-    );
-  }
+  if (error) return null;
 
   const objectDetailsData = schema && data?.[node.kind]?.edges[0]?.node;
   if (!objectDetailsData) return <div className="text-sm">No data found for this object</div>;


### PR DESCRIPTION
Search anywhere return id of resources that a user is not allow to view. I cause an error when we try to preview forbidden object data.

A quick workaround frontend-side is to not display error message in this case.
before:
<img width="800" alt="image" src="https://github.com/user-attachments/assets/066670b7-c221-4b47-b59a-9f84879bcacb" />
after:
<img width="800" alt="image" src="https://github.com/user-attachments/assets/3ca51f95-7d7f-429f-8a75-6bb485e011e2" />
