### PR TITLE
Ensure git repository is initialized locally before accessing files

### DIFF
--- a/backend/infrahub/computed_attribute/tasks.py
+++ b/backend/infrahub/computed_attribute/tasks.py
@@ -103,6 +103,7 @@ async def process_transform(
             name=transform.repository.peer.name.value,
             service=service,
             repository_kind=transform.repository.peer.typename,
+            commit=repo_node.commit.value,
         )
 
         data = await service.client.query_gql_query(

--- a/backend/infrahub/exceptions.py
+++ b/backend/infrahub/exceptions.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Any, Optional, Union
 
 
@@ -60,16 +61,28 @@ class GraphQLQueryError(Error):
 
 
 class RepositoryError(Error):
-    def __init__(self, identifier: str, message: Optional[str] = None) -> None:
+    def __init__(self, identifier: str, message: str | None = None) -> None:
         self.identifier = identifier
         self.message = message or f"An error occurred with GitRepository '{identifier}'."
         super().__init__(self.message)
 
 
+class RepositoryInvalidFileSystemError(RepositoryError):
+    def __init__(
+        self,
+        identifier: str,
+        directory: Path,
+        message: str | None = None,
+    ) -> None:
+        super().__init__(identifier=identifier)
+        self.directory = directory
+        self.message = message or f"Invalid file system for {identifier}, Local directory {directory} missing."
+
+
 class CommitNotFoundError(Error):
     HTTP_CODE: int = 400
 
-    def __init__(self, identifier: str, commit: str, message: Optional[str] = None) -> None:
+    def __init__(self, identifier: str, commit: str, message: str | None = None) -> None:
         self.identifier = identifier
         self.commit = commit
         self.message = message or f"Commit {commit} not found with GitRepository '{identifier}'."
@@ -79,7 +92,7 @@ class CommitNotFoundError(Error):
 class DataTypeNotFoundError(Error):
     HTTP_CODE: int = 400
 
-    def __init__(self, name: str, message: Optional[str] = None) -> None:
+    def __init__(self, name: str, message: str | None = None) -> None:
         self.name = name
         self.message = message or f"Unable to find the DataType '{name}'."
         super().__init__(self.message)
@@ -88,7 +101,7 @@ class DataTypeNotFoundError(Error):
 class RepositoryFileNotFoundError(Error):
     HTTP_CODE: int = 404
 
-    def __init__(self, repository_name: str, location: str, commit: str, message: Optional[str] = None) -> None:
+    def __init__(self, repository_name: str, location: str, commit: str, message: str | None = None) -> None:
         self.repository_name = repository_name
         self.location = location
         self.commit = commit
@@ -99,7 +112,7 @@ class RepositoryFileNotFoundError(Error):
 class FileOutOfRepositoryError(Error):
     HTTP_CODE: int = 403
 
-    def __init__(self, repository_name: str, location: str, commit: str, message: Optional[str] = None) -> None:
+    def __init__(self, repository_name: str, location: str, commit: str, message: str | None = None) -> None:
         self.repository_name = repository_name
         self.location = location
         self.commit = commit
@@ -108,7 +121,7 @@ class FileOutOfRepositoryError(Error):
 
 
 class TransformError(Error):
-    def __init__(self, repository_name: str, location: str, commit: str, message: Optional[str] = None) -> None:
+    def __init__(self, repository_name: str, location: str, commit: str, message: str | None = None) -> None:
         self.repository_name = repository_name
         self.location = location
         self.commit = commit
@@ -120,7 +133,7 @@ class TransformError(Error):
 
 class CheckError(Error):
     def __init__(
-        self, repository_name: str, location: str, class_name: str, commit: str, message: Optional[str] = None
+        self, repository_name: str, location: str, class_name: str, commit: str, message: str | None = None
     ) -> None:
         self.repository_name = repository_name
         self.location = location
@@ -134,7 +147,7 @@ class CheckError(Error):
 
 
 class TransformNotFoundError(TransformError):
-    def __init__(self, repository_name: str, location: str, commit: str, message: Optional[str] = None) -> None:
+    def __init__(self, repository_name: str, location: str, commit: str, message: str | None = None) -> None:
         self.message = (
             message or f"Unable to locate the transform function at '{repository_name}::{commit}::{location}'."
         )
@@ -144,7 +157,7 @@ class TransformNotFoundError(TransformError):
 class BranchNotFoundError(Error):
     HTTP_CODE: int = 400
 
-    def __init__(self, identifier: str, message: Optional[str] = None) -> None:
+    def __init__(self, identifier: str, message: str | None = None) -> None:
         self.identifier = identifier
         self.message = message or f"Branch: {identifier} not found."
         super().__init__(self.message)
@@ -154,7 +167,7 @@ class NodeNotFoundError(Error):
     HTTP_CODE: int = 404
 
     def __init__(
-        self, node_type: str, identifier: str, branch_name: Optional[str] = None, message: Optional[str] = None
+        self, node_type: str, identifier: str, branch_name: str | None = None, message: str | None = None
     ) -> None:
         self.node_type = node_type
         self.identifier = identifier
@@ -172,7 +185,7 @@ class NodeNotFoundError(Error):
 class ResourceNotFoundError(Error):
     HTTP_CODE: int = 404
 
-    def __init__(self, message: Optional[str] = None) -> None:
+    def __init__(self, message: str | None = None) -> None:
         self.message = message or "The requested resource was not found"
         super().__init__(self.message)
 
@@ -181,7 +194,7 @@ class AuthorizationError(Error):
     HTTP_CODE: int = 401
     message: str = "Access to the requested resource was denied"
 
-    def __init__(self, message: Optional[str] = None) -> None:
+    def __init__(self, message: str | None = None) -> None:
         self.message = message or self.message
         super().__init__(self.message)
 
@@ -190,7 +203,7 @@ class PermissionDeniedError(Error):
     HTTP_CODE: int = 403
     message: str = "The requested operation was not authorized"
 
-    def __init__(self, message: Optional[str] = None) -> None:
+    def __init__(self, message: str | None = None) -> None:
         self.message = message or self.message
         super().__init__(self.message)
 
@@ -199,7 +212,7 @@ class ProcessingError(Error):
     HTTP_CODE: int = 400
     message: str = "Unable to process the request"
 
-    def __init__(self, message: Optional[str] = None) -> None:
+    def __init__(self, message: str | None = None) -> None:
         self.message = message or self.message
         super().__init__(self.message)
 
@@ -208,7 +221,7 @@ class PoolExhaustedError(Error):
     HTTP_CODE: int = 409
     message: str = "No more resources available in the pool"
 
-    def __init__(self, message: Optional[str] = None) -> None:
+    def __init__(self, message: str | None = None) -> None:
         self.message = message or self.message
         super().__init__(self.message)
 
@@ -216,7 +229,7 @@ class PoolExhaustedError(Error):
 class SchemaNotFoundError(Error):
     HTTP_CODE: int = 422
 
-    def __init__(self, branch_name: str, identifier: str, message: Optional[str] = None) -> None:
+    def __init__(self, branch_name: str, identifier: str, message: str | None = None) -> None:
         self.branch_name = branch_name
         self.identifier = identifier
         self.message = message or f"Unable to find the schema {identifier} in the database."

--- a/backend/infrahub/generators/tasks.py
+++ b/backend/infrahub/generators/tasks.py
@@ -33,6 +33,7 @@ async def run_generator(model: RequestGeneratorRun) -> None:
         name=model.repository_name,
         service=service,
         repository_kind=model.repository_kind,
+        commit=model.commit,
     )
 
     generator_definition = InfrahubGeneratorDefinitionConfig(

--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -23,6 +23,7 @@ from infrahub.exceptions import (
     FileOutOfRepositoryError,
     RepositoryError,
     RepositoryFileNotFoundError,
+    RepositoryInvalidFileSystemError,
 )
 from infrahub.git.constants import BRANCHES_DIRECTORY_NAME, COMMITS_DIRECTORY_NAME, TEMPORARY_DIRECTORY_NAME
 from infrahub.git.directory import get_repositories_directory, initialize_repositories_directory
@@ -106,7 +107,7 @@ class BranchInGraph(BaseModel):
     id: str
     name: str
     sync_with_git: bool
-    commit: Optional[str] = None
+    commit: str | None = None
 
 
 class BranchInRemote(BaseModel):
@@ -135,9 +136,9 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
 
     id: UUID = Field(..., description="Internal UUID of the repository")
     name: str = Field(..., description="Primary name of the repository")
-    default_branch_name: Optional[str] = Field(None, description="Default branch to use when pulling the repository")
-    type: Optional[str] = None
-    location: Optional[str] = Field(None, description="Location of the remote repository")
+    default_branch_name: str | None = Field(None, description="Default branch to use when pulling the repository")
+    type: str | None = None
+    location: str | None = Field(None, description="Location of the remote repository")
     has_origin: bool = Field(
         False, description="Flag to indicate if a remote repository (named origin) is present in the config."
     )
@@ -154,9 +155,7 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
     is_read_only: bool = Field(False, description="If true, changes will not be synced to remote")
 
     internal_status: str = Field("active", description="Internal status: Active, Inactive, Staging")
-    infrahub_branch_name: Optional[str] = Field(
-        None, description="Infrahub branch on which to sync the remote repository"
-    )
+    infrahub_branch_name: str | None = Field(None, description="Infrahub branch on which to sync the remote repository")
     model_config = ConfigDict(arbitrary_types_allowed=True, ignored_types=(Flow, Task))
 
     @property
@@ -274,9 +273,9 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
 
         for directory in directories_to_validate:
             if not directory.is_dir():
-                raise RepositoryError(
+                raise RepositoryInvalidFileSystemError(
                     identifier=self.name,
-                    message=f"Invalid file system for {self.name}, Local directory {directory} missing.",
+                    directory=directory,
                 )
 
         # Validate that a worktree for the commit in main is present
@@ -306,7 +305,7 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
         return True
 
     async def create_locally(
-        self, checkout_ref: Optional[str] = None, infrahub_branch_name: Optional[str] = None
+        self, checkout_ref: str | None = None, infrahub_branch_name: str | None = None, update_commit_value: bool = True
     ) -> bool:
         """Ensure the required directory already exist in the filesystem or create them if needed.
 
@@ -348,7 +347,8 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
         # TODO Need to handle the potential exceptions coming from repo.git.worktree
         commit = str(repo.head.commit)
         self.create_commit_worktree(commit=commit)
-        await self.update_commit_value(branch_name=infrahub_branch_name or self.default_branch, commit=commit)
+        if update_commit_value:
+            await self.update_commit_value(branch_name=infrahub_branch_name or self.default_branch, commit=commit)
 
         return True
 
@@ -392,6 +392,11 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
         responses = repo.git.worktree("list", "--porcelain").split("\n\n")
 
         return [Worktree.init(response) for response in responses]
+
+    def get_client(self) -> InfrahubClient:
+        if self.client:
+            return self.client
+        return self.service.client
 
     async def get_branches_from_graph(self) -> dict[str, BranchInGraph]:
         """Return a dict with all the branches present in the graph.
@@ -699,8 +704,8 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
     async def find_files(
         self,
         extension: Union[str, list[str]],
-        branch_name: Optional[str] = None,
-        commit: Optional[str] = None,
+        branch_name: str | None = None,
+        commit: str | None = None,
         directory: Optional[Path] = None,
     ) -> list[Path]:
         """Return the path of all files matching a specific extension in a given Branch or Commit."""

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -15,6 +15,7 @@ from infrahub_sdk.protocols import (
     CoreArtifactDefinition,
     CoreCheckDefinition,
     CoreGeneratorDefinition,
+    CoreGenericRepository,
     CoreGraphQLQuery,
     CoreTransformation,
     CoreTransformJinja2,
@@ -34,11 +35,13 @@ from prefect.cache_policies import NONE
 from prefect.logging import get_run_logger
 from pydantic import BaseModel, Field
 from pydantic import ValidationError as PydanticValidationError
+from typing_extensions import Self
 
 from infrahub.core.constants import InfrahubKind, RepositorySyncStatus
 from infrahub.events.repository_action import CommitUpdatedEvent
-from infrahub.exceptions import CheckError, TransformError
+from infrahub.exceptions import CheckError, RepositoryInvalidFileSystemError, TransformError
 from infrahub.git.base import InfrahubRepositoryBase, extract_repo_file_information
+from infrahub.services import InfrahubServices
 from infrahub.workflows.utils import add_tags
 
 if TYPE_CHECKING:
@@ -125,6 +128,33 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):  # pylint: disable=t
     This class will later be broken out from the "InfrahubRepository" based classes and instead be a separate
     class that uses an "InfrahubRepository" or "InfrahubReadOnlyRepository" as input
     """
+
+    @classmethod
+    async def init(cls, commit: str | None = None, service: InfrahubServices | None = None, **kwargs: Any) -> Self:
+        service = service or InfrahubServices()
+        self = cls(service=service, **kwargs)
+        try:
+            self.validate_local_directories()
+        except RepositoryInvalidFileSystemError:
+            await self.ensure_location_is_defined()
+            await self.create_locally(infrahub_branch_name=self.infrahub_branch_name, update_commit_value=False)
+            service.log.info(f"Initialized the local directory for {self.name} because it was missing.")
+            if commit:
+                self.get_commit_worktree(commit=commit)
+
+        service.log.debug(
+            f"Initiated the object on an existing directory for {self.name}",
+        )
+        return self
+
+    async def ensure_location_is_defined(self) -> None:
+        if self.location:
+            return
+        client = self.get_client()
+        repo = await client.get(
+            kind=CoreGenericRepository, name__value=self.name, exclude=["tags", "credential"], raise_when_missing=True
+        )
+        self.location = repo.location.value
 
     @flow(name="import-object-from-file", flow_run_name="Import objects")
     async def import_objects_from_files(

--- a/backend/infrahub/git/repository.py
+++ b/backend/infrahub/git/repository.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Optional, Union
+from typing import Any, Union
 
 from git.exc import BadName, GitCommandError
 from infrahub_sdk.exceptions import GraphQLError
@@ -23,18 +23,14 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
     """
 
     @classmethod
-    async def init(cls, service: Optional[InfrahubServices] = None, **kwargs: Any) -> InfrahubRepository:
+    async def new(
+        cls, service: InfrahubServices | None = None, update_commit_value: bool = True, **kwargs: Any
+    ) -> InfrahubRepository:
         service = service or InfrahubServices()
         self = cls(service=service, **kwargs)
-        self.validate_local_directories()
-        log.debug("Initiated the object on an existing directory.", repository=self.name)
-        return self
-
-    @classmethod
-    async def new(cls, service: Optional[InfrahubServices] = None, **kwargs: Any) -> InfrahubRepository:
-        service = service or InfrahubServices()
-        self = cls(service=service, **kwargs)
-        await self.create_locally(infrahub_branch_name=self.infrahub_branch_name)
+        await self.create_locally(
+            infrahub_branch_name=self.infrahub_branch_name, update_commit_value=update_commit_value
+        )
         log.info("Created new repository locally.", repository=self.name)
         return self
 
@@ -51,7 +47,7 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
         return str(branches[branch_name].commit)
 
     async def create_branch_in_git(
-        self, branch_name: str, branch_id: Optional[str] = None, push_origin: bool = True
+        self, branch_name: str, branch_id: str | None = None, push_origin: bool = True
     ) -> bool:
         """Create new branch in the repository, assuming the branch has been created in the graph already."""
 
@@ -245,18 +241,10 @@ class InfrahubReadOnlyRepository(InfrahubRepositoryIntegrator):
     """
 
     is_read_only: bool = True
-    ref: Optional[str] = Field(None, description="Ref to track on the external repository")
+    ref: str | None = Field(None, description="Ref to track on the external repository")
 
     @classmethod
-    async def init(cls, service: Optional[InfrahubServices] = None, **kwargs: Any) -> InfrahubReadOnlyRepository:
-        service = service or InfrahubServices()
-        self = cls(service=service, **kwargs)
-        self.validate_local_directories()
-        log.debug("Initiated the object on an existing directory.", repository=self.name)
-        return self
-
-    @classmethod
-    async def new(cls, service: Optional[InfrahubServices] = None, **kwargs: Any) -> InfrahubReadOnlyRepository:
+    async def new(cls, service: InfrahubServices | None = None, **kwargs: Any) -> InfrahubReadOnlyRepository:
         service = service or InfrahubServices()
 
         if "ref" not in kwargs or "infrahub_branch_name" not in kwargs:
@@ -286,7 +274,7 @@ class InfrahubReadOnlyRepository(InfrahubRepositoryIntegrator):
 
         return str(commit)
 
-    async def sync_from_remote(self, commit: Optional[str] = None) -> None:
+    async def sync_from_remote(self, commit: str | None = None) -> None:
         if not commit:
             commit = self.get_commit_value(branch_name=self.ref, remote=True)
         local_branches = self.get_branches_from_local()
@@ -298,14 +286,16 @@ class InfrahubReadOnlyRepository(InfrahubRepositoryIntegrator):
 
 
 async def get_initialized_repo(
-    repository_id: str, name: str, service: InfrahubServices, repository_kind: str
+    repository_id: str, name: str, service: InfrahubServices, repository_kind: str, commit: str | None = None
 ) -> Union[InfrahubReadOnlyRepository, InfrahubRepository]:
     if repository_kind == InfrahubKind.REPOSITORY:
-        return await InfrahubRepository.init(id=repository_id, name=name, client=service._client, service=service)
+        return await InfrahubRepository.init(
+            id=repository_id, name=name, commit=commit, client=service._client, service=service
+        )
 
     if repository_kind == InfrahubKind.READONLYREPOSITORY:
         return await InfrahubReadOnlyRepository.init(
-            id=repository_id, name=name, client=service._client, service=service
+            id=repository_id, name=name, commit=commit, client=service._client, service=service
         )
 
     raise NotImplementedError(f"The repository kind {repository_kind} has not been implemented")

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -249,6 +249,7 @@ async def generate_artifact(model: RequestArtifactGenerate) -> None:
         name=model.repository_name,
         service=service,
         repository_kind=model.repository_kind,
+        commit=model.commit,
     )
 
     artifact = await define_artifact(message=model, service=service)
@@ -489,6 +490,7 @@ async def import_objects_from_git_repository(model: GitRepositoryImportObjects) 
         name=model.repository_name,
         service=services.service,
         repository_kind=model.repository_kind,
+        commit=model.commit,
     )
     await repo.import_objects_from_files(infrahub_branch_name=model.infrahub_branch_name, commit=model.commit)
 

--- a/backend/infrahub/message_bus/operations/check/generator.py
+++ b/backend/infrahub/message_bus/operations/check/generator.py
@@ -22,6 +22,7 @@ async def run(message: messages.CheckGeneratorRun, service: InfrahubServices) ->
         name=message.repository_name,
         service=service,
         repository_kind=message.repository_kind,
+        commit=message.commit,
     )
 
     conclusion = ValidatorConclusion.SUCCESS

--- a/backend/infrahub/message_bus/operations/check/repository.py
+++ b/backend/infrahub/message_bus/operations/check/repository.py
@@ -146,7 +146,7 @@ async def merge_conflicts(message: messages.CheckRepositoryMergeConflicts, servi
     validator = await service.client.get(kind=InfrahubKind.REPOSITORYVALIDATOR, id=message.validator_id)
     await validator.checks.fetch()
 
-    repo = await InfrahubRepository.init(id=message.repository_id, name=message.repository_name)
+    repo = await InfrahubRepository.init(id=message.repository_id, name=message.repository_name, service=service)
     async with lock.registry.get(name=message.repository_name, namespace="repository"):
         conflicts = await repo.get_conflicts(source_branch=message.source_branch, dest_branch=message.target_branch)
 
@@ -224,7 +224,9 @@ async def user_check(message: messages.CheckRepositoryUserCheck, service: Infrah
     validator = await service.client.get(kind=InfrahubKind.USERVALIDATOR, id=message.validator_id)
     await validator.checks.fetch()
 
-    repo = await InfrahubRepository.init(id=message.repository_id, name=message.repository_name)
+    repo = await InfrahubRepository.init(
+        id=message.repository_id, name=message.repository_name, commit=message.commit, service=service
+    )
     conclusion = "failure"
     severity = "critical"
     log_entries = ""

--- a/backend/infrahub/message_bus/operations/git/file.py
+++ b/backend/infrahub/message_bus/operations/git/file.py
@@ -19,6 +19,7 @@ async def get(message: messages.GitFileGet, service: InfrahubServices) -> None:
         name=message.repository_name,
         service=service,
         repository_kind=message.repository_kind,
+        commit=message.commit,
     )
 
     try:

--- a/backend/infrahub/message_bus/operations/requests/proposed_change.py
+++ b/backend/infrahub/message_bus/operations/requests/proposed_change.py
@@ -69,7 +69,9 @@ async def pipeline(message: messages.RequestProposedChangePipeline, service: Inf
 
     repositories = await _get_proposed_change_repositories(message=message, service=service)
 
-    if message.source_branch_sync_with_git and await _validate_repository_merge_conflicts(repositories=repositories):
+    if message.source_branch_sync_with_git and await _validate_repository_merge_conflicts(
+        repositories=repositories, service=service
+    ):
         for repo in repositories:
             if not repo.read_only and repo.internal_status == RepositoryInternalStatus.ACTIVE.value:
                 events.append(
@@ -85,7 +87,7 @@ async def pipeline(message: messages.RequestProposedChangePipeline, service: Inf
             await service.send(message=event)
         return
 
-    await _gather_repository_repository_diffs(repositories=repositories)
+    await _gather_repository_repository_diffs(repositories=repositories, service=service)
 
     async with service.database.start_transaction() as dbt:
         destination_branch = await registry.get_branch(db=dbt, branch=message.destination_branch)
@@ -513,12 +515,16 @@ async def _get_proposed_change_repositories(
 
 
 @task(name="proposed-change-validate-repository-conflicts", task_run_name="Validate conflicts on repository")
-async def _validate_repository_merge_conflicts(repositories: list[ProposedChangeRepository]) -> bool:
+async def _validate_repository_merge_conflicts(
+    repositories: list[ProposedChangeRepository], service: InfrahubServices
+) -> bool:
     log = get_run_logger()
     conflicts = False
     for repo in repositories:
         if repo.has_diff and not repo.is_staging:
-            git_repo = await InfrahubRepository.init(id=repo.repository_id, name=repo.repository_name)
+            git_repo = await InfrahubRepository.init(
+                id=repo.repository_id, name=repo.repository_name, client=service.client
+            )
             async with lock.registry.get(name=repo.repository_name, namespace="repository"):
                 repo.conflicts = await git_repo.get_conflicts(
                     source_branch=repo.source_branch, dest_branch=repo.destination_branch
@@ -532,11 +538,15 @@ async def _validate_repository_merge_conflicts(repositories: list[ProposedChange
     return conflicts
 
 
-async def _gather_repository_repository_diffs(repositories: list[ProposedChangeRepository]) -> None:
+async def _gather_repository_repository_diffs(
+    repositories: list[ProposedChangeRepository], service: InfrahubServices
+) -> None:
     for repo in repositories:
         if repo.has_diff and repo.source_commit and repo.destination_commit:
             # TODO we need to find a way to return all files in the repo if the repo is new
-            git_repo = await InfrahubRepository.init(id=repo.repository_id, name=repo.repository_name)
+            git_repo = await InfrahubRepository.init(
+                id=repo.repository_id, name=repo.repository_name, client=service.client
+            )
 
             files_changed: list[str] = []
             files_added: list[str] = []

--- a/backend/infrahub/transformations/tasks.py
+++ b/backend/infrahub/transformations/tasks.py
@@ -22,6 +22,7 @@ async def transform_python(message: TransformPythonData) -> Any:
         name=message.repository_name,
         service=service,
         repository_kind=message.repository_kind,
+        commit=message.commit,
     )
 
     transformed_data = await repo.execute_python_transform(
@@ -45,6 +46,7 @@ async def transform_render_jinja2_template(message: TransformJinjaTemplateData) 
         name=message.repository_name,
         service=service,
         repository_kind=message.repository_kind,
+        commit=message.commit,
     )
 
     rendered_template = await repo.render_jinja2_template(

--- a/backend/infrahub/webhook/models.py
+++ b/backend/infrahub/webhook/models.py
@@ -84,9 +84,13 @@ class TransformWebhook(Webhook):
     async def _prepare_payload(self) -> None:
         repo: Union[InfrahubReadOnlyRepository, InfrahubRepository]
         if self.repository_kind == InfrahubKind.READONLYREPOSITORY:
-            repo = await InfrahubReadOnlyRepository.init(id=self.repository_id, name=self.repository_name)
+            repo = await InfrahubReadOnlyRepository.init(
+                id=self.repository_id, name=self.repository_name, client=self.service.client
+            )
         else:
-            repo = await InfrahubRepository.init(id=self.repository_id, name=self.repository_name)
+            repo = await InfrahubRepository.init(
+                id=self.repository_id, name=self.repository_name, client=self.service.client
+            )
 
         default_branch = repo.default_branch
         commit = repo.get_commit_value(branch_name=default_branch)


### PR DESCRIPTION
This PR ensure that the local directory containing a git repository is being initialized if it's not already present when we initialize a `InfrahubRepository` object with ``InfrahubRepository.init()`

For it to work, the `init` method must be initialized with a valid `client` or a valid `service` because it might be required to pull the location of the git repository from the server (often missing when we access a file in git)
(The other option would be to pass the location of the repository along with the name and the id for all requests)

the `init` method also access a commit to ensure that the worktree for this commit is properly initialized as well