### PR TITLE
Display tasks in the proposed changes view only if needed - IFC-1010

### DIFF
--- a/changelog/+tasks-display.fixed.md
+++ b/changelog/+tasks-display.fixed.md
@@ -1,3 +1,3 @@
 * Verify the tasks related to the proposed changes view to show or hide the tasks accordion in the details view
 * Disable the merge button if there is an ongoing merge
-* Add poll-interval to the proposed changes query to be up to date on the state and disbale the merge button if the proposed change is already merged
+* Add poll-interval to the proposed changes query to be up to date on the state and disable the merge button if the proposed change is already merged

--- a/changelog/+tasks-display.fixed.md
+++ b/changelog/+tasks-display.fixed.md
@@ -1,1 +1,2 @@
-Verify the tasks related to the proposed changes view to show or hide the tasks accordion in the details view
+* Verify the tasks related to the proposed changes view to show or hide the tasks accordion in the details view
+* Disable the merge button if there is an ongoing merge

--- a/changelog/+tasks-display.fixed.md
+++ b/changelog/+tasks-display.fixed.md
@@ -1,2 +1,3 @@
 * Verify the tasks related to the proposed changes view to show or hide the tasks accordion in the details view
 * Disable the merge button if there is an ongoing merge
+* Add pollinterval to the proposed changes query to be up to date on the state and ddisbale the merge button if the proposed change is already merged

--- a/changelog/+tasks-display.fixed.md
+++ b/changelog/+tasks-display.fixed.md
@@ -1,0 +1,1 @@
+Verify the tasks related to the proposed changes view to show or hide the tasks accordion in the details view

--- a/changelog/+tasks-display.fixed.md
+++ b/changelog/+tasks-display.fixed.md
@@ -1,3 +1,3 @@
 * Verify the tasks related to the proposed changes view to show or hide the tasks accordion in the details view
 * Disable the merge button if there is an ongoing merge
-* Add pollinterval to the proposed changes query to be up to date on the state and ddisbale the merge button if the proposed change is already merged
+* Add poll-interval to the proposed changes query to be up to date on the state and disbale the merge button if the proposed change is already merged

--- a/frontend/app/src/graphql/queries/tasks/checkTasksItemDetails.ts
+++ b/frontend/app/src/graphql/queries/tasks/checkTasksItemDetails.ts
@@ -1,0 +1,9 @@
+import { gql } from "@apollo/client";
+
+export const TASK_DETAILS_CHECK = gql`
+query TASK_DETAILS_CHECK($ids: [String], $branch: String, $workflow: [String], $relatedNodes: [String]) {
+  InfrahubTask(ids: $ids, branch: $branch, workflow: $workflow, related_node__ids: $relatedNodes) {
+    count
+  }
+}
+`;

--- a/frontend/app/src/screens/branches/task-display.tsx
+++ b/frontend/app/src/screens/branches/task-display.tsx
@@ -109,13 +109,13 @@ export function TaskDisplay({ branch, workflow, relatedNode }: TaskDisplayProps)
 
 function Log({ message, severity, timestamp }: tLog) {
   return (
-    <div className="flex flex-col bg-white rounded-md p-4 gap-2">
+    <div className="flex flex-col bg-white rounded-md p-2 gap-2">
       <div className="flex items-center justify-between">
         {getSeverityBadge[severity]}
         <DateDisplay date={timestamp} />
       </div>
 
-      <pre className="text-xs">{message}</pre>
+      <pre className="text-xs whitespace-pre-wrap">{message}</pre>
     </div>
   );
 }

--- a/frontend/app/src/screens/proposed-changes/proposed-change-details.tsx
+++ b/frontend/app/src/screens/proposed-changes/proposed-change-details.tsx
@@ -35,7 +35,9 @@ export const ProposedChangeDetails = ({ className, ...props }: HTMLAttributes<HT
 
   const navigate = useNavigate();
 
-  const { data } = useQuery(gql(getObjectPermissionsQuery(PROPOSED_CHANGES_OBJECT)));
+  const { data } = useQuery(gql(getObjectPermissionsQuery(PROPOSED_CHANGES_OBJECT)), {
+    pollInterval: 2000,
+  });
 
   const { loading: loadingCheck, data: checkData } = useQuery(TASK_DETAILS_CHECK, {
     variables: {

--- a/frontend/app/src/screens/proposed-changes/proposed-change-details.tsx
+++ b/frontend/app/src/screens/proposed-changes/proposed-change-details.tsx
@@ -6,7 +6,8 @@ import { Property, PropertyList } from "@/components/table/property-list";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardWithBorder } from "@/components/ui/card";
 import { Tooltip } from "@/components/ui/tooltip";
-import { PROPOSED_CHANGES_OBJECT } from "@/config/constants";
+import { PROPOSED_CHANGES_OBJECT, TASK_OBJECT } from "@/config/constants";
+import { TASK_DETAILS_CHECK } from "@/graphql/queries/tasks/checkTasksItemDetails";
 import useQuery from "@/hooks/useQuery";
 import { PcApproveButton } from "@/screens/proposed-changes/action-button/pc-approve-button";
 import { PcCloseButton } from "@/screens/proposed-changes/action-button/pc-close-button";
@@ -23,6 +24,7 @@ import { useAtom } from "jotai";
 import { HTMLAttributes } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { TaskDisplay } from "../branches/task-display";
+import LoadingScreen from "../loading-screen/loading-screen";
 import { getObjectPermissionsQuery } from "../permission/queries/getObjectPermissions";
 import { getPermission } from "../permission/utils";
 import {
@@ -37,9 +39,15 @@ export const ProposedChangeDetails = ({ className, ...props }: HTMLAttributes<HT
 
   const navigate = useNavigate();
 
-  const { loading, data, error } = useQuery(
-    gql(getObjectPermissionsQuery(PROPOSED_CHANGES_OBJECT))
-  );
+  const { data } = useQuery(gql(getObjectPermissionsQuery(PROPOSED_CHANGES_OBJECT)));
+
+  const { loading: loadingCheck, data: checkData } = useQuery(TASK_DETAILS_CHECK, {
+    variables: {
+      workflow: [BRANCH_VALIDATE_WORKFLOW, BRANCH_MERGE_WORKFLOW, BRANCH_REBASE_WORKFLOW],
+      relatedNodes: proposedChangeId ? [proposedChangeId] : undefined,
+    },
+    pollInterval: 5000,
+  });
 
   const permission = getPermission(data?.[PROPOSED_CHANGES_OBJECT]?.permissions?.edges);
 
@@ -136,16 +144,20 @@ export const ProposedChangeDetails = ({ className, ...props }: HTMLAttributes<HT
 
   return (
     <div className="bg-stone-50 p-2.5 flex flex-col flex-grow gap-2.5">
-      <Card>
-        <Accordion title={<div className="font-normal text-xs">Tasks</div>}>
-          <div className="mt-2">
-            <TaskDisplay
-              relatedNode={proposedChangeId}
-              workflow={[BRANCH_VALIDATE_WORKFLOW, BRANCH_MERGE_WORKFLOW, BRANCH_REBASE_WORKFLOW]}
-            />
-          </div>
-        </Accordion>
-      </Card>
+      {loadingCheck && <LoadingScreen hideText />}
+
+      {!loadingCheck && !!checkData[TASK_OBJECT].count && (
+        <Card>
+          <Accordion title={<div className="font-normal text-xs">Actions in progress</div>}>
+            <div className="mt-2">
+              <TaskDisplay
+                relatedNode={proposedChangeId}
+                workflow={[BRANCH_VALIDATE_WORKFLOW, BRANCH_MERGE_WORKFLOW, BRANCH_REBASE_WORKFLOW]}
+              />
+            </div>
+          </Accordion>
+        </Card>
+      )}
 
       <div className={classNames("grid grid-cols-3 gap-2", className)} {...props}>
         <div className="col-start-1 col-end-3 space-y-4">

--- a/frontend/app/src/screens/proposed-changes/proposed-change-details.tsx
+++ b/frontend/app/src/screens/proposed-changes/proposed-change-details.tsx
@@ -42,7 +42,7 @@ export const ProposedChangeDetails = ({ className, ...props }: HTMLAttributes<HT
       workflow: [PROPOSED_CHANGE_MERGE_WORKFLOW],
       relatedNodes: proposedChangeId ? [proposedChangeId] : undefined,
     },
-    pollInterval: 5000,
+    pollInterval: 2000,
   });
 
   const permission = getPermission(data?.[PROPOSED_CHANGES_OBJECT]?.permissions?.edges);

--- a/frontend/app/src/screens/proposed-changes/proposed-change-details.tsx
+++ b/frontend/app/src/screens/proposed-changes/proposed-change-details.tsx
@@ -126,7 +126,7 @@ export const ProposedChangeDetails = ({ className, ...props }: HTMLAttributes<HT
             proposedChangeId={proposedChangeId!}
             state={state}
             sourceBranch={proposedChangesDetails?.source_branch?.value}
-            disabled={!permission.update.isAllowed || checkData[TASK_OBJECT].count}
+            disabled={!permission.update.isAllowed || (checkData && checkData[TASK_OBJECT].count)}
           />
           <PcCloseButton
             proposedChangeId={proposedChangeId!}
@@ -142,7 +142,7 @@ export const ProposedChangeDetails = ({ className, ...props }: HTMLAttributes<HT
     <div className="bg-stone-50 p-2.5 flex flex-col flex-grow gap-2.5">
       {loadingCheck && <LoadingScreen hideText />}
 
-      {!loadingCheck && !!checkData[TASK_OBJECT].count && (
+      {!loadingCheck && checkData && !!checkData[TASK_OBJECT].count && (
         <Card>
           <Accordion title={<div className="font-normal text-xs">Actions in progress</div>}>
             <div className="mt-2">

--- a/frontend/app/src/screens/proposed-changes/proposed-change-details.tsx
+++ b/frontend/app/src/screens/proposed-changes/proposed-change-details.tsx
@@ -126,7 +126,7 @@ export const ProposedChangeDetails = ({ className, ...props }: HTMLAttributes<HT
             proposedChangeId={proposedChangeId!}
             state={state}
             sourceBranch={proposedChangesDetails?.source_branch?.value}
-            disabled={!permission.update.isAllowed}
+            disabled={!permission.update.isAllowed || checkData[TASK_OBJECT].count}
           />
           <PcCloseButton
             proposedChangeId={proposedChangeId!}

--- a/frontend/app/src/screens/proposed-changes/proposed-change-details.tsx
+++ b/frontend/app/src/screens/proposed-changes/proposed-change-details.tsx
@@ -27,11 +27,7 @@ import { TaskDisplay } from "../branches/task-display";
 import LoadingScreen from "../loading-screen/loading-screen";
 import { getObjectPermissionsQuery } from "../permission/queries/getObjectPermissions";
 import { getPermission } from "../permission/utils";
-import {
-  BRANCH_MERGE_WORKFLOW,
-  BRANCH_REBASE_WORKFLOW,
-  BRANCH_VALIDATE_WORKFLOW,
-} from "../tasks/constants";
+import { PROPOSED_CHANGE_MERGE_WORKFLOW } from "../tasks/constants";
 
 export const ProposedChangeDetails = ({ className, ...props }: HTMLAttributes<HTMLDivElement>) => {
   const { proposedChangeId } = useParams();
@@ -43,7 +39,7 @@ export const ProposedChangeDetails = ({ className, ...props }: HTMLAttributes<HT
 
   const { loading: loadingCheck, data: checkData } = useQuery(TASK_DETAILS_CHECK, {
     variables: {
-      workflow: [BRANCH_VALIDATE_WORKFLOW, BRANCH_MERGE_WORKFLOW, BRANCH_REBASE_WORKFLOW],
+      workflow: [PROPOSED_CHANGE_MERGE_WORKFLOW],
       relatedNodes: proposedChangeId ? [proposedChangeId] : undefined,
     },
     pollInterval: 5000,
@@ -152,7 +148,7 @@ export const ProposedChangeDetails = ({ className, ...props }: HTMLAttributes<HT
             <div className="mt-2">
               <TaskDisplay
                 relatedNode={proposedChangeId}
-                workflow={[BRANCH_VALIDATE_WORKFLOW, BRANCH_MERGE_WORKFLOW, BRANCH_REBASE_WORKFLOW]}
+                workflow={[PROPOSED_CHANGE_MERGE_WORKFLOW]}
               />
             </div>
           </Accordion>

--- a/frontend/app/src/screens/tasks/constants.ts
+++ b/frontend/app/src/screens/tasks/constants.ts
@@ -12,3 +12,4 @@ export const TASK_STATES = [
 export const BRANCH_VALIDATE_WORKFLOW = "branch-validate";
 export const BRANCH_REBASE_WORKFLOW = "branch-rebase";
 export const BRANCH_MERGE_WORKFLOW = "merge-branch-mutation";
+export const PROPOSED_CHANGE_MERGE_WORKFLOW = "proposed-change-merge";


### PR DESCRIPTION
* Verify the tasks related to the proposed changes view to show or hide the tasks accordion in the details view
* Disable the merge button if there is some ongoing tasks related to the merge
* Refresh the view with a pollinterval to disable the merge button if the proposed change is already merged
* Update some style for the tasks logs
* Rename the accordion title

<img width="1465" alt="image" src="https://github.com/user-attachments/assets/7d7d5c72-926f-42a5-be7b-4143281d558c" />

<img width="1465" alt="Capture d’écran 2024-12-18 à 12 21 40" src="https://github.com/user-attachments/assets/178ab2ef-dc5f-49d4-90d2-7f5af059757e" />
