### PR TITLE
Use 3.0.11-python3.12 in docker-compose oneliner

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,7 +172,7 @@ services:
       - 6362:6362
 
   task-manager:
-    image: "${TASK_MANAGER_DOCKER_IMAGE:-prefecthq/prefect:3.0.9-python3.12}"
+    image: "${TASK_MANAGER_DOCKER_IMAGE:-prefecthq/prefect:3.0.11-python3.12}"
     command: prefect server start --host 0.0.0.0 --ui
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
We are using 3.0.11-python3.12 in the other docker-compose file but the oneliner is not up to date for 1.1.0