### PR TITLE
Do not send event messages that have been migrated already to RabbitMQ

### DIFF
--- a/backend/infrahub/events/branch_action.py
+++ b/backend/infrahub/events/branch_action.py
@@ -1,7 +1,6 @@
 from pydantic import Field
 
 from infrahub.message_bus import InfrahubMessage
-from infrahub.message_bus.messages.event_branch_delete import EventBranchDelete
 from infrahub.message_bus.messages.refresh_registry_branches import RefreshRegistryBranches
 from infrahub.message_bus.messages.refresh_registry_rebasedbranch import RefreshRegistryRebasedBranch
 
@@ -24,15 +23,13 @@ class BranchDeleteEvent(InfrahubBranchEvent):
         }
 
     def get_messages(self) -> list[InfrahubMessage]:
-        events = [
-            # TODO: Sending EventBranchDelete currently has no effect.
-            #  We should either consider handle it or remove it.
-            EventBranchDelete(
-                branch=self.branch,
-                branch_id=self.branch_id,
-                sync_with_git=self.sync_with_git,
-                meta=self.get_message_meta(),
-            ),
+        events: list[InfrahubMessage] = [
+            # EventBranchDelete(
+            #     branch=self.branch,
+            #     branch_id=self.branch_id,
+            #     sync_with_git=self.sync_with_git,
+            #     meta=self.get_message_meta(),
+            # ),
             RefreshRegistryBranches(),
         ]
         return events
@@ -54,7 +51,7 @@ class BranchCreateEvent(InfrahubBranchEvent):
         }
 
     def get_messages(self) -> list[InfrahubMessage]:
-        events = [
+        events: list[InfrahubMessage] = [
             # EventBranchCreate(
             #     branch=self.branch,
             #     branch_id=self.branch_id,
@@ -63,7 +60,7 @@ class BranchCreateEvent(InfrahubBranchEvent):
             # ),
             RefreshRegistryBranches(),
         ]
-        return events  # type: ignore
+        return events
 
 
 class BranchRebaseEvent(InfrahubBranchEvent):
@@ -81,11 +78,11 @@ class BranchRebaseEvent(InfrahubBranchEvent):
         }
 
     def get_messages(self) -> list[InfrahubMessage]:
-        events = [
+        events: list[InfrahubMessage] = [
             # EventBranchRebased(
             #     branch=self.branch,
             #     meta=self.get_message_meta(),
             # ),
             RefreshRegistryRebasedBranch(branch=self.branch),
         ]
-        return events  # type: ignore
+        return events

--- a/backend/infrahub/events/node_action.py
+++ b/backend/infrahub/events/node_action.py
@@ -4,7 +4,6 @@ from pydantic import Field
 
 from infrahub.core.constants import MutationAction
 from infrahub.message_bus import InfrahubMessage
-from infrahub.message_bus.messages.event_node_mutated import EventNodeMutated
 
 from .models import InfrahubBranchEvent
 
@@ -34,12 +33,12 @@ class NodeMutatedEvent(InfrahubBranchEvent):
 
     def get_messages(self) -> list[InfrahubMessage]:
         return [
-            EventNodeMutated(
-                branch=self.branch,
-                kind=self.kind,
-                node_id=self.node_id,
-                action=self.action.value,
-                data=self.data,
-                meta=self.get_message_meta(),
-            )
+            # EventNodeMutated(
+            #     branch=self.branch,
+            #     kind=self.kind,
+            #     node_id=self.node_id,
+            #     action=self.action.value,
+            #     data=self.data,
+            #     meta=self.get_message_meta(),
+            # )
         ]

--- a/backend/infrahub/events/schema_action.py
+++ b/backend/infrahub/events/schema_action.py
@@ -3,7 +3,7 @@ from typing import Any
 from pydantic import Field
 
 from infrahub.message_bus import InfrahubMessage
-from infrahub.message_bus.messages.event_schema_update import EventSchemaUpdate
+from infrahub.message_bus.messages.refresh_registry_branches import RefreshRegistryBranches
 
 from .models import InfrahubBranchEvent
 
@@ -28,8 +28,9 @@ class SchemaUpdatedEvent(InfrahubBranchEvent):
 
     def get_messages(self) -> list[InfrahubMessage]:
         return [
-            EventSchemaUpdate(
-                branch=self.branch,
-                meta=self.get_message_meta(),
-            )
+            RefreshRegistryBranches(),
+            # EventSchemaUpdate(
+            #     branch=self.branch,
+            #     meta=self.get_message_meta(),
+            # )
         ]


### PR DESCRIPTION
This PR disable sending some event messages that have been already migrated to the new system to RabbitMQ because currently they are not used in RabbitMQ

In the current configuration of the event queue in RabbitMQ, there is no point sending these messages. As part of the upcoming refactoring of the event systems, and once the configuration of the queue has been adjusted, we'll re-activate them.

messages impacted
- EventBranchDelete
- EventNodeMutated
- EventSchemaUpdate