### PR TITLE
Remove extra kind print

### DIFF
--- a/backend/infrahub/core/schema/manager.py
+++ b/backend/infrahub/core/schema/manager.py
@@ -672,7 +672,6 @@ class SchemaManager(NodeManager):
                 db=db,
             ):
                 kind = f"{schema_node.namespace.value}{schema_node.name.value}"
-                print(f"{kind=}")
                 schema.set(
                     name=kind,
                     schema=await self.convert_generic_schema_to_schema(schema_node=schema_node, db=db),


### PR DESCRIPTION
Actually initial motivation for this PR (`InitializationError` on `registry.schema`) only happens on `release-1.1`. This will be fixed when cherry picking this commit into `release-1.1`. Still keeping this PR to remove the extra print though.