### PR TITLE
Prevent double tab navigation with a button is inside a link

### DIFF
--- a/frontend/app/src/screens/layout/menu-navigation/components/menu-section-internal.tsx
+++ b/frontend/app/src/screens/layout/menu-navigation/components/menu-section-internal.tsx
@@ -43,7 +43,7 @@ const RecursiveInternalMenuItem: React.FC<{ item: MenuItem }> = ({ item }) => {
 };
 
 const CollapsedMenuItemLink: React.FC<{ item: MenuItem }> = ({ item }) => (
-  <Link to={constructPath(item.path)}>
+  <Link to={constructPath(item.path)} tabIndex={-1}>
     <CollapsedButton icon={item.icon} tooltipContent={item.label} />
   </Link>
 );

--- a/frontend/app/src/screens/layout/tasks-status.tsx
+++ b/frontend/app/src/screens/layout/tasks-status.tsx
@@ -1,6 +1,7 @@
-import { ButtonWithTooltip } from "@/components/buttons/button-primitive";
+import { LinkButton } from "@/components/buttons/button-primitive";
 import { Pulse } from "@/components/ui/pulse";
 import { Spinner } from "@/components/ui/spinner";
+import { Tooltip } from "@/components/ui/tooltip";
 import { TASKS_STATUS_OBJECT } from "@/config/constants";
 import { QSP } from "@/config/qsp";
 import { TASKS_STATUS } from "@/graphql/queries/tasks/getTasksStatus";
@@ -10,7 +11,6 @@ import { currentBranchAtom } from "@/state/atoms/branches.atom";
 import { constructPath } from "@/utils/fetch";
 import { Icon } from "@iconify-icon/react";
 import { useAtomValue } from "jotai";
-import { Link } from "react-router-dom";
 
 export function TaskStatus() {
   const branch = useAtomValue(currentBranchAtom);
@@ -18,7 +18,7 @@ export function TaskStatus() {
   const { error, loading, data } = useQuery(TASKS_STATUS, {
     variables: { branch: branch?.name },
     skip: !branch?.name,
-    pollInterval: 1000,
+    pollInterval: 10_000,
   });
 
   if (error) {
@@ -33,20 +33,19 @@ export function TaskStatus() {
   };
 
   return (
-    <Link to={constructPath("/tasks", [{ name: QSP.FILTER, value: JSON.stringify([filter]) }])}>
-      <ButtonWithTooltip
+    <Tooltip enabled content="Task">
+      <LinkButton
         size="square"
         variant="ghost"
         className="h-8 w-8 bg-neutral-50 border border-neutral-200 rounded-lg relative"
-        tooltipEnabled
-        tooltipContent={"Tasks"}
+        to={constructPath("/tasks", [{ name: QSP.FILTER, value: JSON.stringify([filter]) }])}
       >
         {loading && <Spinner />}
 
         {!loading && <TasksStatusIcon />}
 
         {!loading && count > 0 && <Pulse className="right-[6.5px] bottom-[6.5px]" />}
-      </ButtonWithTooltip>
-    </Link>
+      </LinkButton>
+    </Tooltip>
   );
 }


### PR DESCRIPTION
When navigating using tab on a button which is inside a link, tab focus twice on it.

FIX:
make sure it focus only once.

BONUS:
Increased task pooling time, which might be too quick on slow network.