### PR TITLE
Capture additional loggers during task execution

### DIFF
--- a/backend/infrahub/cli/tasks.py
+++ b/backend/infrahub/cli/tasks.py
@@ -44,7 +44,9 @@ async def execute(
 
     async with get_client(sync_client=False) as client:
         worker = WorkflowWorkerExecution()
-        await DUMMY_FLOW.save(client=client, work_pool=WorkerPoolDefinition(name="testing", worker_type="process"))
+        await DUMMY_FLOW.save(
+            client=client, work_pool=WorkerPoolDefinition(name="infrahub-worker", worker_type="infrahubasync")
+        )
 
         result = await worker.execute_workflow(
             workflow=DUMMY_FLOW, parameters={"data": DummyInput(firstname="John", lastname="Doe")}

--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -126,6 +126,14 @@ class WorkflowDriver(str, Enum):
     WORKER = "worker"
 
 
+class ExtraLogLevel(str, Enum):
+    CRITICAL = "CRITICAL"
+    ERROR = "ERROR"
+    WARNING = "WARNING"
+    INFO = "INFO"
+    DEBUG = "DEBUG"
+
+
 class MainSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="INFRAHUB_")
     docs_index_path: Path = Field(
@@ -318,6 +326,12 @@ class WorkflowSettings(BaseSettings):
     tls_enabled: bool = Field(default=False, description="Indicates if TLS is enabled for the connection")
     driver: WorkflowDriver = WorkflowDriver.WORKER
     default_worker_type: str = "infrahubasync"
+    extra_loggers: list[str] = Field(
+        default_factory=list, description="A list of additional logger that will be captured during task execution."
+    )
+    extra_log_level: ExtraLogLevel = Field(
+        default=ExtraLogLevel.INFO, description="Log level applied to all extra loggers."
+    )
     worker_polling_interval: int = Field(
         default=2, ge=1, le=30, description="Specify how often the worker should poll the server for tasks (sec)"
     )

--- a/backend/infrahub/log.py
+++ b/backend/infrahub/log.py
@@ -22,6 +22,10 @@ def get_logger(name: str = "infrahub") -> structlog.stdlib.BoundLogger:
     return structlog.stdlib.get_logger(name)
 
 
+def get_run_logger(name: str = "infrahub.tasks") -> logging.Logger:
+    return logging.getLogger(name)
+
+
 def get_log_data() -> dict[str, Any]:
     return structlog.contextvars.get_contextvars()
 

--- a/backend/infrahub/message_bus/operations/check/generator.py
+++ b/backend/infrahub/message_bus/operations/check/generator.py
@@ -59,8 +59,8 @@ async def run(message: messages.CheckGeneratorRun, service: InfrahubServices) ->
 
     check_message = "Instance successfully generated"
     try:
-        log.info(f"repo information {file_info}")
-        log.info(f"Root directory : {repository.directory_root}")
+        log.debug(f"repo information {file_info}")
+        log.debug(f"Root directory : {repository.directory_root}")
         generator_class = generator_definition.load_class(
             import_root=repository.directory_root, relative_path=file_info.relative_repo_path_dir
         )
@@ -87,7 +87,7 @@ async def run(message: messages.CheckGeneratorRun, service: InfrahubServices) ->
         check_message = f"Failed to execute generator: {str(exc)}"
         log.exception(check_message, exc_info=exc)
 
-    log.debug("Generator run completed, starting update")
+    log.info("Generator run completed, starting update")
     await generator_instance.update(do_full_update=True)
 
     check = None

--- a/backend/infrahub/tasks/dummy.py
+++ b/backend/infrahub/tasks/dummy.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 from prefect import flow, task
 from pydantic import BaseModel
 
@@ -35,6 +37,7 @@ async def aggregate_name(firstname: str, lastname: str) -> str:
 
 @flow(name="dummy-flow", persist_result=True)
 async def dummy_flow(data: DummyInput) -> DummyOutput:
+    logging.getLogger("infrahub.tasks").info("Log in the flow")
     return DummyOutput(full_name=await aggregate_name(firstname=data.firstname, lastname=data.lastname))
 
 

--- a/backend/infrahub/workers/infrahub_async.py
+++ b/backend/infrahub/workers/infrahub_async.py
@@ -10,6 +10,7 @@ from infrahub_sdk.exceptions import Error as SdkError
 from prefect import settings as prefect_settings
 from prefect.client.schemas.objects import FlowRun
 from prefect.flow_engine import run_flow_async
+from prefect.logging.handlers import APILogHandler
 from prefect.workers.base import BaseJobConfiguration, BaseVariables, BaseWorker, BaseWorkerResult
 from prometheus_client import start_http_server
 
@@ -36,6 +37,7 @@ from infrahub.workflows.models import TASK_RESULT_STORAGE_NAME
 
 WORKER_QUERY_SECONDS = "2"
 WORKER_DEFAULT_RESULT_STORAGE_BLOCK = f"redisstoragecontainer/{TASK_RESULT_STORAGE_NAME}"
+DEFAULT_TASK_LOGGERS = ["infrahub.tasks"]
 
 
 class InfrahubWorkerAsyncConfiguration(BaseJobConfiguration):
@@ -84,6 +86,8 @@ class InfrahubWorkerAsync(BaseWorker):
         if not config.SETTINGS.settings:
             config_file = os.environ.get("INFRAHUB_CONFIG", "infrahub.toml")
             config.load_and_exit(config_file_name=config_file)
+
+        self._init_logger()
 
         # Start metric endpoint
         if metric_port is None or metric_port != 0:
@@ -147,6 +151,15 @@ class InfrahubWorkerAsync(BaseWorker):
             status_code=0,
             identifier=str(flow_run.id),
         )
+
+    def _init_logger(self) -> None:
+        """Initialize loggers to use the API handle provided by Prefect."""
+        api_handler = APILogHandler()
+
+        for logger_name in config.SETTINGS.workflow.extra_loggers + DEFAULT_TASK_LOGGERS:
+            logger = logging.getLogger(logger_name)
+            logger.setLevel(config.SETTINGS.workflow.extra_log_level.value)
+            logger.addHandler(api_handler)
 
     async def _init_infrahub_client(self, client: InfrahubClient | None = None) -> InfrahubClient:
         if not client:

--- a/docs/docs/topics/developer-guide.mdx
+++ b/docs/docs/topics/developer-guide.mdx
@@ -1,0 +1,133 @@
+---
+title: Developer Guide
+---
+
+# Developer Guide
+
+Infrahub support various form of extensibility that rely on users providing their own code that then will be executed by Infrahub.
+This guide provides best practices to help you develop robust, efficient, and maintainable extensions.
+
+The following features in Infrahub are based on user provided code :
+
+- [**Transforms** (Python and Jinja2)](./transformation.mdx): Used to generate [Artifacts](./artifact.mdx) and define [Computed Attributes](./computed-attributes.mdx).
+- [**Generators**](./generator.mdx): Automate complex tasks by generating outputs dynamically.
+- [**Checks**](./check.mdx): Validate your infrastructure with custom rules.
+
+## Development Lifecycle
+
+### Development
+
+#### Execute your code locally
+
+During development, you can use the `infrahubctl` CLI to execute your code locally. This provides an environment similar to Infrahub's execution environment, enabling quick testing without deploying your code.
+
+Key points:
+
+- Your code can be executed locally without needing to be checked into Git or pushed to the server.
+- GraphQL queries, if required, will be discovered and executed locally.
+- The branch to use in Infrahub can be auto-detected from Git or specified explicitly in the CLI.
+
+Refer to the command documentation for details:
+
+| Command                        | Description                                                  |
+|--------------------------------|--------------------------------------------------------------|
+| [`infrahubctl transform`](../infrahubctl/infrahubctl-transform.mdx) | Execute Python transforms locally.                          |
+| [`infrahubctl render`](../infrahubctl/infrahubctl-render.mdx)       | Render Jinja2 transforms locally.                           |
+| [`infrahubctl generator`](../infrahubctl/infrahubctl-generator.mdx) | Test custom generators.                                     |
+| [`infrahubctl check`](../infrahubctl/infrahubctl-check.mdx)         | Run local checks                                            |
+
+#### Typing & Protocols (Python)
+
+Infrahub supports Python Typing and Protocols to improve the developer experience by providing static analysis and detecting issues early.
+
+:::info What are Protocols?
+
+Protocols are a way to define structural subtyping in Python, allowing you to specify expected behavior without requiring inheritance. Infrahub leverages this to enforce typing for flexible schemas.
+
+:::
+
+##### Generating Protocols
+
+You can generate Protocols for your schema with the `infrahubctl protocols` command. The schema can be provided locally or pulled from a running Infrahub instance.
+
+```shell
+infrahubctl protocols --schema my-schema.yaml --output protocols.py
+```
+
+> If you don’t have a Python module, save the protocols in a protocols.py file in the same directory as your script.
+
+##### Using Protocols in Code
+
+The python SDK natively support Protocol in place of `kind` for most functions that interact with objects (`all`, `filters`, `get`, `create`)
+
+```python
+# With Protocols
+from infrahub_sdk.protocols import BuiltinTag
+
+tags = await client.all(kind=BuiltinTag)
+for tag in tags:
+    print(tag.name.value)  # Type-safe access to the 'name' attribute
+```
+
+Same code without Protocols
+
+```python
+# Without Protocols
+tags = await client.all(kind="BuiltinTag")
+for tag in tags:
+    print(tag.name.value)  # May raise type errors as attributes are not checked
+```
+
+:::info Protocol for Infrahub Schema
+
+Protocols for all objects natively provided by Infrahub are available within the SDK in `infrahub_sdk.protocols`
+
+:::
+
+##### Learn More about Python Protocols
+
+- [Python Protocols: Leveraging Structural Subtyping - Real Python](https://realpython.com/python-protocol/)
+- [What are "Protocols" In Python? - Youtube](https://www.youtube.com/watch?v=2jN11lyKvfA)
+
+#### Git integration
+
+Infrahub integrates seamlessly with Git, allowing you to use your current branch name as the default branch. To enable this feature, set the environment variable:
+
+```shell
+export INFRAHUB_DEFAULT_BRANCH_FROM_GIT=true
+```
+
+### Testing
+
+Testing is crucial for maintaining high-quality code. Infrahub provides a testing framework based on Pytest to simplify unit and integration tests.
+
+Refer to the [Testing Framework Documentation](./resources-testing-framework.mdx) for details.
+
+:::warning Under Construction
+
+This section is still under development. Contact the team via Discord for additional resources.
+
+:::
+
+## Logging (Python)
+
+You can use Python’s standard logging library to gain insights into the execution of your code. Infrahub captures logs from the `infrahub.tasks` logger by default.
+
+The logger `infrahub.tasks` is configure by default and it's possible to configure additional loggers using the settings (see below)
+
+```python
+import logging
+
+log = logging.getLogger("infrahub.tasks")
+log.info("This log will be captured within the task")
+```
+
+### Configuring Additional Loggers
+
+To capture logs from additional loggers, configure them using the environment variable `INFRAHUB_WORKFLOW_EXTRA_LOGGERS`.
+The level of the extra loggers can be controled with the environment variable `INFRAHUB_WORKFLOW_EXTRA_LOG_LEVEL`.
+
+```shell
+export INFRAHUB_WORKFLOW_EXTRA_LOGGERS = '["mylogger", "otherlogger"]'
+export INFRAHUB_WORKFLOW_EXTRA_LOG_LEVEL = "DEBUG"
+```

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -98,6 +98,7 @@ const sidebars: SidebarsConfig = {
         'topics/check',
         'topics/metadata',
         'topics/database-backup',
+        'topics/developer-guide',
         'topics/local-demo-environment',
         'topics/generator',
         'topics/graphql',


### PR DESCRIPTION
This PR extend the logging capabilities in during the execution of a task in the task-worker to capture logs from any loggers from standard python logging library.

And in order to add this feature to the doc, I started a new page under `Topic` called `Developer Guide`. it's not complete but it already covers a couple of features and best practices that we didn't have in the doc yet ... 

# Capture additional logs 

The logger `infrahub.tasks` is configure by default and it's possible to configure additional loggers using the settings (see below)
```python
logging.getLogger("infrahub.tasks").info("Log in the flow")
```

Configure additional loggers using the environment variable `INFRAHUB_WORKFLOW_EXTRA_LOGGERS`
```
export INFRAHUB_WORKFLOW_EXTRA_LOGGERS = '["mylogger", "otherlogger"]'
```