### PR TITLE
Improved response time of menu api endpoint

### DIFF
--- a/backend/infrahub/api/menu.py
+++ b/backend/infrahub/api/menu.py
@@ -29,6 +29,6 @@ async def get_menu(
 ) -> Menu:
     log.info("menu_request", branch=branch.name)
 
-    menu_items = await registry.manager.query(db=db, schema=CoreMenuItem, branch=branch)
+    menu_items = await registry.manager.query(db=db, schema=CoreMenuItem, branch=branch, prefetch_relationships=True)
     menu = await generate_restricted_menu(db=db, branch=branch, account=account_session, menu_items=menu_items)
     return menu.to_rest()

--- a/changelog/+menu-api.changed.md
+++ b/changelog/+menu-api.changed.md
@@ -1,0 +1,1 @@
+Improved response time of menu endpoint


### PR DESCRIPTION
Now that #4672 has been merged we can enable `prefetch_relationships` when loading the schema to improve the response time.
