### PR TITLE
Add log group around the building of the docker container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -691,7 +691,10 @@ jobs:
         run: docker compose -p $INFRAHUB_BUILD_NAME down -v --remove-orphans --rmi local
 
       - name: Build Demo
-        run: invoke dev.build
+        run: |
+          echo "::group::Build infrahub container"
+          invoke dev.build
+          echo "::endgroup::"
 
       - name: Initialize Demo
         id: init-demo


### PR DESCRIPTION
This PR changes the log behaviour of the docker build so that it isn't as verbose by default and instead lets you expand the section if you want to see details.

It uses this:
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#grouping-log-lines