### PR TITLE
Lock CoreGroup kinds on any branch

### DIFF
--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -53,7 +53,6 @@ from infrahub.types import ATTRIBUTE_TYPES
 from infrahub.utils import format_label
 from infrahub.visuals import select_color
 
-from ...lock import build_object_lock_name
 from .constants import INTERNAL_SCHEMA_NODE_KINDS, SchemaNamespace
 from .schema_branch_computed import ComputedAttributes
 
@@ -62,7 +61,6 @@ log = get_logger()
 if TYPE_CHECKING:
     from pydantic import ValidationInfo
 
-    from ..branch import Branch
 
 # pylint: disable=redefined-builtin,too-many-public-methods,too-many-lines
 
@@ -1739,44 +1737,3 @@ class SchemaBranch:
             profile.attributes.append(attr)
 
         return profile
-
-    def _get_kinds_to_lock_on_object_mutation(self, kind: str) -> list[str]:
-        """
-        Return kinds for which we want to lock during creating / updating an object of a given schema node.
-        Lock should be performed on schema kind and its generics having a uniqueness_constraint defined.
-        If a generic uniqueness constraint is the same as the node schema one,
-        it means node schema overrided this constraint, in which case we only need to lock on the generic.
-        """
-
-        node_schema = self.get(name=kind)
-
-        schema_uc = None
-        kinds = []
-        if node_schema.uniqueness_constraints:
-            kinds.append(node_schema.kind)
-            schema_uc = node_schema.uniqueness_constraints
-
-        if node_schema.is_generic_schema:
-            return kinds
-
-        generics_kinds = node_schema.inherit_from
-
-        node_schema_kind_removed = False
-        for generic_kind in generics_kinds:
-            generic_uc = self.get(name=generic_kind).uniqueness_constraints
-            if generic_uc:
-                kinds.append(generic_kind)
-                if not node_schema_kind_removed and generic_uc == schema_uc:
-                    # Check whether we should remove original schema kind as it simply overrides uniqueness_constraint
-                    # of a generic
-                    kinds.pop(0)
-                    node_schema_kind_removed = True
-        return kinds
-
-    def get_kind_lock_names_on_object_mutation(self, kind: str, branch: Branch) -> list[str]:
-        if not branch.is_default:
-            # Do not lock on other branches as objects validations will be performed at least when merging in main branch.
-            return []
-        lock_kinds = self._get_kinds_to_lock_on_object_mutation(kind)
-        lock_names = [build_object_lock_name(kind) for kind in lock_kinds]
-        return lock_names

--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -10,7 +10,7 @@ from typing_extensions import Self
 from infrahub import config, lock
 from infrahub.auth import validate_mutation_permissions_update_node
 from infrahub.core import registry
-from infrahub.core.constants import MutationAction
+from infrahub.core.constants import InfrahubKind, MutationAction
 from infrahub.core.constraint.node.runner import NodeConstraintRunner
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
@@ -22,10 +22,10 @@ from infrahub.database import retry_db_transaction
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.events import EventMeta, NodeMutatedEvent
 from infrahub.exceptions import ValidationError
+from infrahub.lock import InfrahubMultiLock, build_object_lock_name
 from infrahub.log import get_log_data, get_logger
 from infrahub.worker import WORKER_IDENTITY
 
-from ...lock import InfrahubMultiLock
 from .node_getter.by_default_filter import MutationNodeGetterByDefaultFilter
 from .node_getter.by_hfid import MutationNodeGetterByHfid
 from .node_getter.by_id import MutationNodeGetterById
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     from graphql import GraphQLResolveInfo
 
     from infrahub.core.branch import Branch
+    from infrahub.core.schema.schema_branch import SchemaBranch
     from infrahub.database import InfrahubDatabase
 
     from ..initialization import GraphqlContext
@@ -42,6 +43,8 @@ if TYPE_CHECKING:
 # pylint: disable=unused-argument
 
 log = get_logger()
+
+KINDS_CONCURRENT_MUTATIONS_NOT_ALLOWED = [InfrahubKind.GENERICGROUP]
 
 
 # ------------------------------------------
@@ -140,8 +143,9 @@ class InfrahubMutationMixin:
         """
         Wrapper around mutate_create_object to potentially activate locking.
         """
-        lock_names = db.schema.get_schema_branch(name=branch.name).get_kind_lock_names_on_object_mutation(
-            kind=cls._meta.schema.kind, branch=branch
+        schema_branch = db.schema.get_schema_branch(name=branch.name)
+        lock_names = _get_kind_lock_names_on_object_mutation(
+            kind=cls._meta.schema.kind, branch=branch, schema_branch=schema_branch
         )
         if lock_names:
             async with InfrahubMultiLock(lock_registry=lock.registry, locks=lock_names):
@@ -217,8 +221,9 @@ class InfrahubMutationMixin:
         Wrapper around mutate_update to potentially activate locking and call it within a database transaction.
         """
 
-        lock_names = db.schema.get_schema_branch(name=branch.name).get_kind_lock_names_on_object_mutation(
-            kind=cls._meta.schema.kind, branch=branch
+        schema_branch = db.schema.get_schema_branch(name=branch.name)
+        lock_names = _get_kind_lock_names_on_object_mutation(
+            kind=cls._meta.schema.kind, branch=branch, schema_branch=schema_branch
         )
 
         if db.is_transaction:
@@ -386,3 +391,69 @@ class InfrahubMutation(InfrahubMutationMixin, Mutation):
         _meta.schema = schema
 
         super().__init_subclass_with_meta__(_meta=_meta, **options)
+
+
+def _get_kinds_to_lock_on_object_mutation(kind: str, schema_branch: SchemaBranch) -> list[str]:
+    """
+    Return kinds for which we want to lock during creating / updating an object of a given schema node.
+    Lock should be performed on schema kind and its generics having a uniqueness_constraint defined.
+    If a generic uniqueness constraint is the same as the node schema one,
+    it means node schema overrided this constraint, in which case we only need to lock on the generic.
+    """
+
+    node_schema = schema_branch.get(name=kind)
+
+    schema_uc = None
+    kinds = []
+    if node_schema.uniqueness_constraints:
+        kinds.append(node_schema.kind)
+        schema_uc = node_schema.uniqueness_constraints
+
+    if node_schema.is_generic_schema:
+        return kinds
+
+    generics_kinds = node_schema.inherit_from
+
+    node_schema_kind_removed = False
+    for generic_kind in generics_kinds:
+        generic_uc = schema_branch.get(name=generic_kind).uniqueness_constraints
+        if generic_uc:
+            kinds.append(generic_kind)
+            if not node_schema_kind_removed and generic_uc == schema_uc:
+                # Check whether we should remove original schema kind as it simply overrides uniqueness_constraint
+                # of a generic
+                kinds.pop(0)
+                node_schema_kind_removed = True
+    return kinds
+
+
+def _should_kind_be_locked_on_any_branch(kind: str, schema_branch: SchemaBranch) -> bool:
+    """
+    Check whether kind or any kind generic is in KINDS_TO_LOCK_ON_ANY_BRANCH.
+    """
+
+    if kind in KINDS_CONCURRENT_MUTATIONS_NOT_ALLOWED:
+        return True
+
+    node_schema = schema_branch.get(name=kind)
+    if node_schema.is_generic_schema:
+        return False
+
+    for generic_kind in node_schema.inherit_from:
+        if generic_kind in KINDS_CONCURRENT_MUTATIONS_NOT_ALLOWED:
+            return True
+    return False
+
+
+def _get_kind_lock_names_on_object_mutation(kind: str, branch: Branch, schema_branch: SchemaBranch) -> list[str]:
+    """
+    Return objects kind for which we want to avoid concurrent mutation (create/update). Except for some specific kinds,
+    concurrent mutations are only allowed on non-main branch as objects validations will be performed at least when merging in main branch.
+    """
+
+    if not branch.is_default and not _should_kind_be_locked_on_any_branch(kind, schema_branch):
+        return []
+
+    lock_kinds = _get_kinds_to_lock_on_object_mutation(kind, schema_branch)
+    lock_names = [build_object_lock_name(kind) for kind in lock_kinds]
+    return lock_names

--- a/backend/tests/unit/core/test_get_kinds_lock.py
+++ b/backend/tests/unit/core/test_get_kinds_lock.py
@@ -1,5 +1,10 @@
 from infrahub.core import registry
+from infrahub.core.initialization import create_branch
 from infrahub.database import InfrahubDatabase
+from infrahub.graphql.mutations.main import (
+    _get_kind_lock_names_on_object_mutation,
+    _get_kinds_to_lock_on_object_mutation,
+)
 from tests.helpers.test_app import TestInfrahubApp
 
 
@@ -13,12 +18,29 @@ class TestGetKindsLock(TestInfrahubApp):
     ):
         # CoreCredential has no uniqueness_constraint, but generic CorePasswordCredential has one
         schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
-        assert schema_branch._get_kinds_to_lock_on_object_mutation("CorePasswordCredential") == ["CoreCredential"]
+        assert _get_kinds_to_lock_on_object_mutation(kind="CorePasswordCredential", schema_branch=schema_branch) == [
+            "CoreCredential"
+        ]
 
         # 3 generics but only GenericAccount has a uniqueness_constraint
         schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
-        assert schema_branch._get_kinds_to_lock_on_object_mutation("CoreAccount") == ["CoreGenericAccount"]
+        assert _get_kinds_to_lock_on_object_mutation(kind="CoreAccount", schema_branch=schema_branch) == [
+            "CoreGenericAccount"
+        ]
 
         # No uniqueness_constraint, no generic
         schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
-        assert schema_branch._get_kinds_to_lock_on_object_mutation("BuiltinIPPrefix") == []
+        assert _get_kinds_to_lock_on_object_mutation(kind="BuiltinIPPrefix", schema_branch=schema_branch) == []
+
+    async def test_lock_graphql_query_group_other_branch(
+        self,
+        db: InfrahubDatabase,
+        default_branch,
+        register_core_models_schema,
+        client,
+    ):
+        other_branch = await create_branch(branch_name="other_branch", db=db)
+        schema_branch = registry.schema.get_schema_branch(name=other_branch.name)
+        assert _get_kind_lock_names_on_object_mutation(
+            kind="CoreGraphQLQueryGroup", branch=other_branch, schema_branch=schema_branch
+        ) == ["global.object.CoreGroup"]


### PR DESCRIPTION
This PR adds a lock on `CoreGroup` in order to not have duplicated `CoreGraphQLQueryGroup`.
Currently, we have a lock during object mutations on non-main branch. This PR adds a lock on nodes inheriting from `CoreGroup` on any branch. Logic of computing kinds to lock has been moved outside of `SchemaBranch` class. This fix has been validated manually by @BeArchiTek.