### PR TITLE
Fix issue with branch creation in Git

### DIFF
--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -305,13 +305,13 @@ async def create_branch(model: BranchCreateModel) -> None:
         registry.branch[obj.name] = obj
         await service.component.refresh_schema_hash(branches=[obj.name])
 
-    event = BranchCreateEvent(branch=obj.name, branch_id=str(obj.id), sync_with_git=obj.sync_with_git)
+    event = BranchCreateEvent(branch=obj.name, branch_id=str(obj.uuid), sync_with_git=obj.sync_with_git)
     await service.event.send(event=event)
 
     if obj.sync_with_git:
         await service.workflow.submit_workflow(
             workflow=GIT_REPOSITORIES_CREATE_BRANCH,
-            parameters={"branch": obj.name, "branch_id": str(obj.id)},
+            parameters={"branch": obj.name, "branch_id": str(obj.uuid)},
         )
 
 

--- a/backend/infrahub/core/merge.py
+++ b/backend/infrahub/core/merge.py
@@ -217,7 +217,8 @@ class BranchMerger:
                     repository_name=repo.name.value,
                     internal_status=repo.internal_status.value,
                     source_branch=self.source_branch.name,
-                    destination_branch=registry.default_branch,
+                    destination_branch=self.destination_branch.name,
+                    destination_branch_id=str(self.destination_branch.get_uuid()),
                     default_branch=repo.default_branch.value,
                 )
                 await self.service.workflow.submit_workflow(

--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -371,7 +371,7 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
             if worktree.identifier == identifier:
                 return worktree
 
-        raise RepositoryError(identifier=identifier, message="Unble to get worktree")
+        raise RepositoryError(identifier=identifier, message=f"Unable to get worktree : {identifier}")
 
     def get_commit_worktree(self, commit: str) -> Worktree:
         """Access a specific commit worktree."""
@@ -397,6 +397,11 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
         if self.client:
             return self.client
         return self.service.client
+
+    def get_location(self) -> str:
+        if self.location:
+            return self.location
+        raise ValueError(f"location hasn't been provided for this repository ({self.name})")
 
     async def get_branches_from_graph(self) -> dict[str, BranchInGraph]:
         """Return a dict with all the branches present in the graph.
@@ -504,6 +509,48 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
 
         log.debug(f"Branch {branch_name} created in the Graph", repository=self.name, branch=branch_name)
         return branch
+
+    async def create_branch_in_git(self, branch_name: str, branch_id: str | None = None) -> bool:
+        """Create new branch in the repository, assuming the branch has been created in the graph already."""
+
+        repo = self.get_git_repo_main()
+
+        # Check if the branch already exists locally, if it does do nothing
+        local_branches = self.get_branches_from_local(include_worktree=False)
+        if branch_name in local_branches:
+            return False
+
+        # TODO Catch potential exceptions coming from repo.git.branch & repo.git.worktree
+        repo.git.branch(branch_name)
+        self.create_branch_worktree(branch_name=branch_name, branch_id=branch_id or branch_name)
+
+        # If there is not remote configured, we are done
+        #  Since the branch is a match for the main branch we don't need to create a commit worktree
+        # If there is a remote, Check if there is an existing remote branch with the same name and if so track it.
+        if not self.has_origin:
+            log.debug(
+                f"Branch {branch_name} created in Git without tracking a remote branch.",
+                repository=self.name,
+                branch=branch_name,
+            )
+            return True
+
+        remote_branch = [br for br in repo.remotes.origin.refs if br.name == f"origin/{branch_name}"]
+
+        if remote_branch:
+            br_repo = self.get_git_repo_worktree(identifier=branch_name)
+            br_repo.head.reference.set_tracking_branch(remote_branch[0])
+            br_repo.remotes.origin.pull(branch_name)
+            self.create_commit_worktree(str(br_repo.head.reference.commit))
+            log.debug(
+                f"Branch {branch_name} created in Git, tracking remote branch {remote_branch[0]}.",
+                repository=self.name,
+                branch=branch_name,
+            )
+        else:
+            log.debug(f"Branch {branch_name} created in Git without tracking a remote branch.", repository=self.name)
+
+        return True
 
     def create_commit_worktree(self, commit: str) -> Union[bool, Worktree]:
         """Create a new worktree for a given commit."""
@@ -651,7 +698,13 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
 
         return True
 
-    async def pull(self, branch_name: str) -> Union[bool, str]:
+    async def pull(
+        self,
+        branch_name: str,
+        branch_id: str | None = None,
+        create_if_missing: bool = False,
+        update_commit_value: bool = True,
+    ) -> Union[bool, str]:
         """Pull the latest update from the remote repository on a given branch."""
 
         if not self.has_origin:
@@ -660,24 +713,40 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
         if branch_name == self.default_branch and branch_name != registry.default_branch:
             identifier = "main"
 
-        repo = self.get_git_repo_worktree(identifier=identifier)
-        if not repo:
-            raise ValueError(f"Unable to identify the worktree for the branch : {branch_name}")
-
+        repo: Repo | None = None
         try:
-            commit_before = str(repo.head.commit)
-            repo.remotes.origin.pull(branch_name)
-        except GitCommandError as exc:
-            self._raise_enriched_error(error=exc, branch_name=branch_name)
+            repo = self.get_git_repo_worktree(identifier=identifier)
+        except RepositoryError as exc:
+            if not create_if_missing:
+                raise ValueError(f"Unable to identify the worktree for the branch : {branch_name}") from exc
 
-        commit_after = str(repo.head.commit)
+        if repo:
+            try:
+                commit_before = str(repo.head.commit)
+                repo.remotes.origin.pull(branch_name)
+            except GitCommandError as exc:
+                self._raise_enriched_error(error=exc, branch_name=branch_name)
 
-        if commit_after == commit_before:
-            return True
+            commit_after = str(repo.head.commit)
 
-        self.create_commit_worktree(commit=commit_after)
-        infrahub_branch = self._get_mapped_target_branch(branch_name=branch_name)
-        await self.update_commit_value(branch_name=infrahub_branch, commit=commit_after)
+            if commit_after == commit_before:
+                return True
+
+            self.create_commit_worktree(commit=commit_after)
+            infrahub_branch = self._get_mapped_target_branch(branch_name=branch_name)
+
+        elif branch_id:
+            await self.create_branch_in_git(branch_name=branch_name, branch_id=branch_id)
+            repo = self.get_git_repo_worktree(identifier=branch_name)
+            commit_after = str(repo.head.commit)
+        else:
+            raise ValueError(
+                f"Unable to identify the worktree for the branch : {branch_name} "
+                "and unable to pull the branch because the branch)id is missing"
+            )
+
+        if update_commit_value:
+            await self.update_commit_value(branch_name=infrahub_branch, commit=commit_after)
 
         return commit_after
 

--- a/backend/infrahub/git/models.py
+++ b/backend/infrahub/git/models.py
@@ -44,6 +44,7 @@ class GitRepositoryAdd(BaseModel):
     created_by: Optional[str] = Field(default=None, description="The user ID of the user that created the repository")
     default_branch_name: Optional[str] = Field(None, description="Default branch for this repository")
     infrahub_branch_name: str = Field(..., description="Infrahub branch on which to sync the remote repository")
+    infrahub_branch_id: str = Field(..., description="Id of the Infrahub branch on which to sync the remote repository")
     internal_status: str = Field(..., description="Administrative status of the repository")
 
 
@@ -56,6 +57,7 @@ class GitRepositoryAddReadOnly(BaseModel):
     ref: str = Field(..., description="Ref to track on the external repository")
     created_by: Optional[str] = Field(default=None, description="The user ID of the user that created the repository")
     infrahub_branch_name: str = Field(..., description="Infrahub branch on which to sync the remote repository")
+    infrahub_branch_id: str = Field(..., description="Id of the Infrahub branch on which to sync the remote repository")
     internal_status: str = Field(..., description="Internal status of the repository")
 
 
@@ -68,6 +70,7 @@ class GitRepositoryPullReadOnly(BaseModel):
     ref: Optional[str] = Field(None, description="Ref to track on the external repository")
     commit: Optional[str] = Field(None, description="Specific commit to pull")
     infrahub_branch_name: str = Field(..., description="Infrahub branch on which to sync the remote repository")
+    infrahub_branch_id: str = Field(..., description="Infrahub branch on which to sync the remote repository")
 
 
 class GitRepositoryMerge(BaseModel):
@@ -77,7 +80,8 @@ class GitRepositoryMerge(BaseModel):
     repository_name: str = Field(..., description="The name of the repository")
     internal_status: str = Field(..., description="Administrative status of the repository")
     source_branch: str = Field(..., description="The source branch")
-    destination_branch: str = Field(..., description="The source branch")
+    destination_branch: str = Field(..., description="The destination branch")
+    destination_branch_id: str = Field(..., description="The ID of the destination branch")
     default_branch: str = Field(..., description="The default branch in Git")
 
 

--- a/backend/infrahub/git/repository.py
+++ b/backend/infrahub/git/repository.py
@@ -51,47 +51,11 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
     ) -> bool:
         """Create new branch in the repository, assuming the branch has been created in the graph already."""
 
-        repo = self.get_git_repo_main()
-
-        # Check if the branch already exists locally, if it does do nothing
-        local_branches = self.get_branches_from_local(include_worktree=False)
-        if branch_name in local_branches:
-            return False
-
-        # TODO Catch potential exceptions coming from repo.git.branch & repo.git.worktree
-        repo.git.branch(branch_name)
-        self.create_branch_worktree(branch_name=branch_name, branch_id=branch_id or branch_name)
-
-        # If there is not remote configured, we are done
-        #  Since the branch is a match for the main branch we don't need to create a commit worktree
-        # If there is a remote, Check if there is an existing remote branch with the same name and if so track it.
-        if not self.has_origin:
-            log.debug(
-                f"Branch {branch_name} created in Git without tracking a remote branch.",
-                repository=self.name,
-                branch=branch_name,
-            )
-            return True
-
-        remote_branch = [br for br in repo.remotes.origin.refs if br.name == f"origin/{branch_name}"]
-
-        if remote_branch:
-            br_repo = self.get_git_repo_worktree(identifier=branch_name)
-            br_repo.head.reference.set_tracking_branch(remote_branch[0])
-            br_repo.remotes.origin.pull(branch_name)
-            self.create_commit_worktree(str(br_repo.head.reference.commit))
-            log.debug(
-                f"Branch {branch_name} created in Git, tracking remote branch {remote_branch[0]}.",
-                repository=self.name,
-                branch=branch_name,
-            )
-        else:
-            log.debug(f"Branch {branch_name} created in Git without tracking a remote branch.", repository=self.name)
-
+        response = await super().create_branch_in_git(branch_name=branch_name, branch_id=branch_id)
         if push_origin:
             await self.push(branch_name)
 
-        return True
+        return response
 
     async def sync(self, staging_branch: str | None = None) -> None:
         """Synchronize the repository with its remote origin and with the database.
@@ -125,7 +89,7 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
                         raise
                     branch = await self.sdk.branch.get(branch_name=infrahub_branch)
 
-                await self.create_branch_in_git(branch_name=branch.name, branch_id=branch.id)
+                await self.create_branch_in_git(branch_name=branch.name, branch_id=branch.id, push_origin=True)
 
                 commit = self.get_commit_value(branch_name=branch_name, remote=False)
                 self.create_commit_worktree(commit=commit)

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -71,6 +71,7 @@ async def add_git_repository(model: GitRepositoryAdd) -> None:
                 repository_name=model.repository_name,
                 repository_kind=InfrahubKind.REPOSITORY,
                 infrahub_branch_name=model.infrahub_branch_name,
+                infrahub_branch_id=model.infrahub_branch_id,
             )
             await service.send(message=notification)
 
@@ -104,15 +105,16 @@ async def add_git_repository_read_only(model: GitRepositoryAddReadOnly) -> None:
                 repository_name=model.repository_name,
                 repository_kind=InfrahubKind.REPOSITORY,
                 infrahub_branch_name=model.infrahub_branch_name,
+                infrahub_branch_id=model.infrahub_branch_id,
             )
             await service.send(message=notification)
 
 
-@flow(name="git_repositories_create_branch", flow_run_name="Create branch in Git Repositories")
+@flow(name="git-repositories-create-branch", flow_run_name="Create branch '{branch}' in Git Repositories")
 async def create_branch(branch: str, branch_id: str) -> None:
     """Request to the creation of git branches in available repositories."""
     service = services.service
-    await add_branch_tag(branch_name=branch)
+    await add_tags(branches=[branch])
     repositories: list[CoreRepository] = await service.client.filters(kind=CoreRepository)
     batch = await service.client.create_batch()
     for repository in repositories:
@@ -123,6 +125,7 @@ async def create_branch(branch: str, branch_id: str) -> None:
             branch_id=branch_id,
             repository_name=repository.name.value,
             repository_id=repository.id,
+            repository_location=repository.location.value,
         )
 
     async for _, _ in batch.execute():
@@ -192,6 +195,7 @@ async def sync_remote_repositories() -> None:
                     repository_name=repository_data.repository.name.value,
                     repository_kind=repository_data.repository.get_kind(),
                     infrahub_branch_name=infrahub_branch,
+                    infrahub_branch_id=branches[infrahub_branch].id,
                 )
                 await service.send(message=message)
             except RepositoryError as exc:
@@ -199,29 +203,39 @@ async def sync_remote_repositories() -> None:
 
 
 @task(
-    name="git-branch-create", task_run_name="Create Branch {branch} in repository {repository_name}", cache_policy=NONE
+    name="git-branch-create",
+    task_run_name="Create branch '{branch}' in repository {repository_name}",
+    cache_policy=NONE,
 )
 async def git_branch_create(
-    client: InfrahubClient, branch: str, branch_id: str, repository_id: str, repository_name: str
+    client: InfrahubClient,
+    branch: str,
+    branch_id: str,
+    repository_id: str,
+    repository_name: str,
+    repository_location: str,
 ) -> None:
     service = services.service
-
-    repo = await InfrahubRepository.init(id=repository_id, name=repository_name, client=client)
+    log = get_run_logger()
+    repo = await InfrahubRepository.init(
+        id=repository_id, name=repository_name, location=repository_location, client=client
+    )
 
     async with lock.registry.get(name=repository_name, namespace="repository"):
-        await repo.create_branch_in_git(branch_name=branch, branch_id=branch_id)
+        await repo.create_branch_in_git(branch_name=branch, branch_id=branch_id, push_origin=True)
 
-        if repo.location:
-            # New branch has been pushed remotely, tell workers to fetch it
-            message = messages.RefreshGitFetch(
-                meta=Meta(initiator_id=WORKER_IDENTITY, request_id=get_log_data().get("request_id", "")),
-                location=repo.location,
-                repository_id=str(repo.id),
-                repository_name=repo.name,
-                repository_kind=InfrahubKind.REPOSITORY,
-                infrahub_branch_name=branch,
-            )
-            await service.send(message=message)
+        # New branch has been pushed remotely, tell workers to fetch it
+        message = messages.RefreshGitFetch(
+            meta=Meta(initiator_id=WORKER_IDENTITY, request_id=get_log_data().get("request_id", "")),
+            location=repo.get_location(),
+            repository_id=str(repo.id),
+            repository_name=repo.name,
+            repository_kind=InfrahubKind.REPOSITORY,
+            infrahub_branch_name=branch,
+            infrahub_branch_id=branch_id,
+        )
+        await service.send(message=message)
+        log.debug("Sent message to all workers to fetch the latest version of the repository (RefreshGitFetch)")
 
 
 @flow(name="artifact-definition-generate", flow_run_name="Generate all artifacts")
@@ -386,6 +400,7 @@ async def pull_read_only(model: GitRepositoryPullReadOnly) -> None:
             repository_name=model.repository_name,
             repository_kind=InfrahubKind.READONLYREPOSITORY,
             infrahub_branch_name=model.infrahub_branch_name,
+            infrahub_branch_id=model.infrahub_branch_id,
         )
         await service.send(message=message)
 
@@ -430,6 +445,7 @@ async def merge_git_repository(model: GitRepositoryMerge) -> None:
                     repository_name=repo.name,
                     repository_kind=InfrahubKind.REPOSITORY,
                     infrahub_branch_name=model.destination_branch,
+                    infrahub_branch_id=model.destination_branch_id,
                 )
                 await service.send(message=message)
 

--- a/backend/infrahub/graphql/mutations/branch.py
+++ b/backend/infrahub/graphql/mutations/branch.py
@@ -54,7 +54,6 @@ class BranchCreate(Mutation):
     task = Field(TaskInfo, required=False)
 
     @classmethod
-    @retry_db_transaction(name="branch_create")
     @trace.get_tracer(__name__).start_as_current_span("branch_create")
     async def mutate(
         cls,
@@ -103,7 +102,6 @@ class BranchDelete(Mutation):
     task = Field(TaskInfo, required=False)
 
     @classmethod
-    @retry_db_transaction(name="branch_delete")
     async def mutate(
         cls, root: dict, info: GraphQLResolveInfo, data: BranchNameInput, wait_until_completion: bool = True
     ) -> Self:

--- a/backend/infrahub/graphql/mutations/repository.py
+++ b/backend/infrahub/graphql/mutations/repository.py
@@ -108,6 +108,7 @@ class InfrahubRepositoryMutation(InfrahubMutationMixin, Mutation):
                 location=obj.location.value,
                 ref=obj.ref.value,
                 infrahub_branch_name=branch.name,
+                infrahub_branch_id=str(branch.get_uuid()),
                 internal_status=obj.internal_status.value,
                 created_by=authenticated_user,
             )
@@ -124,6 +125,7 @@ class InfrahubRepositoryMutation(InfrahubMutationMixin, Mutation):
                 location=obj.location.value,
                 default_branch_name=obj.default_branch.value,
                 infrahub_branch_name=branch.name,
+                infrahub_branch_id=str(branch.get_uuid()),
                 internal_status=obj.internal_status.value,
                 created_by=authenticated_user,
             )
@@ -192,6 +194,7 @@ class InfrahubRepositoryMutation(InfrahubMutationMixin, Mutation):
             ref=obj.ref.value,
             commit=new_commit,
             infrahub_branch_name=branch.name,
+            infrahub_branch_id=str(branch.get_uuid()),
         )
         if context.service:
             await context.service.workflow.submit_workflow(

--- a/backend/infrahub/message_bus/messages/refresh_git_fetch.py
+++ b/backend/infrahub/message_bus/messages/refresh_git_fetch.py
@@ -11,3 +11,4 @@ class RefreshGitFetch(InfrahubMessage):
     repository_name: str = Field(..., description="The name of the repository")
     repository_kind: str = Field(..., description="The type of repository")
     infrahub_branch_name: str = Field(..., description="Infrahub branch on which to sync the remote repository")
+    infrahub_branch_id: str = Field(..., description="Id of the Infrahub branch on which to sync the remote repository")

--- a/backend/infrahub/message_bus/operations/git/repository.py
+++ b/backend/infrahub/message_bus/operations/git/repository.py
@@ -54,4 +54,9 @@ async def fetch(message: messages.RefreshGitFetch, service: InfrahubServices) ->
         )
 
     await repo.fetch()
-    await repo.pull(branch_name=message.infrahub_branch_name)
+    await repo.pull(
+        branch_name=message.infrahub_branch_name,
+        branch_id=message.infrahub_branch_id,
+        create_if_missing=True,
+        update_commit_value=False,
+    )

--- a/backend/infrahub/workflows/catalogue.py
+++ b/backend/infrahub/workflows/catalogue.py
@@ -132,7 +132,7 @@ GIT_REPOSITORIES_SYNC = WorkflowDefinition(
 )
 
 GIT_REPOSITORIES_CREATE_BRANCH = WorkflowDefinition(
-    name="git_repositories_create_branch",
+    name="git-repositories-create-branch",
     type=WorkflowType.CORE,
     module="infrahub.git.tasks",
     function="create_branch",

--- a/backend/tests/functional/branch/test_graphql_mutation.py
+++ b/backend/tests/functional/branch/test_graphql_mutation.py
@@ -94,7 +94,7 @@ class TestBranchMutations(TestInfrahubApp):
         from infrahub.core import registry
 
         branch = await client.branch.create(branch_name="branch_to_delete")
-        branch_server_id = registry.branch[branch.name].id
+        branch_server_id = registry.branch[branch.name].uuid
 
         query = Mutation(
             mutation="BranchDelete",
@@ -113,7 +113,7 @@ class TestBranchMutations(TestInfrahubApp):
 
     async def test_branch_delete(self, initial_dataset: str, client: InfrahubClient) -> None:
         branch = await client.branch.create(branch_name="branch_to_delete_sync")
-        branch_server_id = registry.branch[branch.name].id
+        branch_server_id = registry.branch[branch.name].uuid
         query = Mutation(
             mutation="BranchDelete",
             input_data={"data": {"name": branch.name}},

--- a/backend/tests/unit/git/conftest.py
+++ b/backend/tests/unit/git/conftest.py
@@ -217,7 +217,7 @@ async def git_repo_03_w_client(git_repo_03: InfrahubRepository, client: Infrahub
 async def git_repo_04(
     client: InfrahubClient, git_upstream_repo_03: dict[str, str | Path], git_repos_dir: Path, branch01: BranchData
 ) -> InfrahubRepository:
-    """Git Repository with git_upstream_repo_01 as remote
+    """Git Repository with git_upstream_repo_03 as remote
     The repo has 2 local branches : main and branch01
     The content of the branch branch01 has been  updated after the repo has been initialized
     to generate a diff between the local and the remote branch branch01.

--- a/backend/tests/unit/git/test_git_repository.py
+++ b/backend/tests/unit/git/test_git_repository.py
@@ -316,6 +316,34 @@ async def test_pull_branch(git_repo_04: InfrahubRepository):
     assert response is True
 
 
+async def test_pull_new_branch(git_repo_01: InfrahubRepository):
+    repo = git_repo_01
+    await repo.fetch()
+
+    branch_name = "branch02"
+
+    response = await repo.pull(
+        branch_name=branch_name,
+        branch_id="469cd407-0a8f-4d4e-9629-84fa435cf5ad",
+        create_if_missing=True,
+        update_commit_value=False,
+    )
+    assert response
+
+    commit1 = repo.get_commit_value(branch_name=branch_name, remote=False)
+    commit2 = repo.get_commit_value(branch_name=branch_name, remote=True)
+
+    assert commit1 == commit2 == response
+
+    response = await repo.pull(
+        branch_name=branch_name,
+        branch_id="469cd407-0a8f-4d4e-9629-84fa435cf5ad",
+        create_if_missing=True,
+        update_commit_value=False,
+    )
+    assert response is True
+
+
 async def test_pull_branch_conflict(git_repo_06: InfrahubRepository):
     repo = git_repo_06
     await repo.fetch()

--- a/backend/tests/unit/git/test_git_rpc.py
+++ b/backend/tests/unit/git/test_git_rpc.py
@@ -79,6 +79,7 @@ class TestAddRepository:
             location=str(git_upstream_repo_01["path"]),
             default_branch_name=self.default_branch_name,
             infrahub_branch_name=self.default_branch_name,
+            infrahub_branch_id="469cd407-0a8f-4d4e-9629-84fa435cf5ad",
             internal_status="active",
         )
 
@@ -128,6 +129,7 @@ async def test_git_rpc_merge(
         repository_name=repo.name,
         source_branch="branch01",
         destination_branch="main",
+        destination_branch_id="469cd407-0a8f-4d4e-9629-84fa435cf5ad",
         internal_status=RepositoryInternalStatus.ACTIVE.value,
         default_branch="main",
     )
@@ -225,6 +227,7 @@ class TestAddReadOnly:
             location=str(git_upstream_repo_01["path"]),
             ref="branch01",
             infrahub_branch_name="read-only-branch",
+            infrahub_branch_id="469cd407-0a8f-4d4e-9629-84fa435cf5ad",
             internal_status="active",
         )
 
@@ -271,6 +274,7 @@ class TestPullReadOnly:
             ref=self.ref,
             commit=self.commit,
             infrahub_branch_name=self.infrahub_branch_name,
+            infrahub_branch_id="469cd407-0a8f-4d4e-9629-84fa435cf5ad",
         )
 
         lock_patcher = patch("infrahub.git.tasks.lock")

--- a/docs/docs/reference/message-bus-events.mdx
+++ b/docs/docs/reference/message-bus-events.mdx
@@ -372,6 +372,7 @@ For more detailed explanations on how to use these events within Infrahub, see t
 | **repository_name** | The name of the repository | string | None |
 | **repository_kind** | The type of repository | string | None |
 | **infrahub_branch_name** | Infrahub branch on which to sync the remote repository | string | None |
+| **infrahub_branch_id** | Id of the Infrahub branch on which to sync the remote repository | string | None |
 <!-- vale on -->
 
 <!-- vale off -->
@@ -937,6 +938,7 @@ For more detailed explanations on how to use these events within Infrahub, see t
 | **repository_name** | The name of the repository | string | None |
 | **repository_kind** | The type of repository | string | None |
 | **infrahub_branch_name** | Infrahub branch on which to sync the remote repository | string | None |
+| **infrahub_branch_id** | Id of the Infrahub branch on which to sync the remote repository | string | None |
 <!-- vale on -->
 
 <!-- vale off -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,7 @@ disable = """,
     unnecessary-comprehension,
     multiple-statements,
     self-assigning-variable,
+    no-else-return,
     """
 
 [tool.pylint.miscellaneous]


### PR DESCRIPTION
This PR fixes a few issues related to the creation of a new branch that will be synced with Git
- The worker that create the branch in the first place was using the internal id of the branch instead of the UUID
- All other workers where not able to pull the update or the new branch because the branch doesn't exist yet in Git

This PR mainly update the repo.pull method to allow the creation of the branch if it doesn't exist and it ensure that each worker that pull a new branch will not try to update the commit in the database.

In order to create the branch, it was required to pass the branch id as part of some messages, including `RefreshGitFetch`

