### PR TITLE
merge stable to release 1.1

### DIFF
--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -666,6 +666,21 @@ class Integer(BaseAttribute):
     value: int
     from_pool: Optional[str] = None
 
+    @classmethod
+    def validate_format(cls, value: Any, name: str, schema: AttributeSchema) -> None:
+        """
+        Make sure boolean objects are not accepted as value. Need to override `validate_format`
+        as `isinstance(True, int)` is True.
+        """
+
+        value_to_check = value
+        if schema.enum and isinstance(value, Enum):
+            value_to_check = value.value
+
+        # Note that we might want to do this check directly in parent function.
+        if value_to_check.__class__ != cls.type:
+            raise ValidationError({name: f"{value} is not a valid {schema.kind}"})
+
 
 class IntegerOptional(Integer):
     value: Optional[int]

--- a/backend/infrahub/core/diff/calculator.py
+++ b/backend/infrahub/core/diff/calculator.py
@@ -31,6 +31,7 @@ class DiffCalculator:
             schema_manager=registry.schema,
             from_time=from_time,
             to_time=to_time,
+            previous_node_field_specifiers=previous_node_specifiers,
         )
         branch_diff_query = await DiffAllPathsQuery.init(
             db=self.db,
@@ -45,9 +46,9 @@ class DiffCalculator:
             diff_parser.read_result(query_result=query_result)
 
         if base_branch.name != diff_branch.name:
-            branch_node_specifiers = diff_parser.get_node_field_specifiers_for_branch(branch_name=diff_branch.name)
-            new_node_field_specifiers = branch_node_specifiers - (previous_node_specifiers or set())
-            current_node_field_specifiers = (previous_node_specifiers or set()) - new_node_field_specifiers
+            new_node_field_specifiers = diff_parser.get_new_node_field_specifiers()
+            current_node_field_specifiers = diff_parser.get_current_node_field_specifiers()
+
             base_diff_query = await DiffAllPathsQuery.init(
                 db=self.db,
                 branch=base_branch,

--- a/backend/infrahub/core/diff/coordinator.py
+++ b/backend/infrahub/core/diff/coordinator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterable
 
 from infrahub import lock
 from infrahub.core import registry
@@ -14,7 +14,6 @@ from .model.path import (
     EnrichedDiffs,
     NameTrackingId,
     NodeFieldSpecifier,
-    TimeRange,
     TrackingId,
 )
 
@@ -219,6 +218,30 @@ class DiffCoordinator:
             log.debug(f"Diff recalculation complete for {base_branch.name} - {diff_branch.name}")
         return enriched_diffs.diff_branch_diff
 
+    def _get_ordered_diff_pairs(
+        self, diff_pairs: Iterable[EnrichedDiffs], allow_overlap: bool = False
+    ) -> list[EnrichedDiffs]:
+        ordered_diffs = sorted(diff_pairs, key=lambda d: d.diff_branch_diff.from_time)
+        if allow_overlap:
+            return ordered_diffs
+        ordered_diffs_no_overlaps: list[EnrichedDiffs] = []
+        for candidate_diff_pair in ordered_diffs:
+            if not ordered_diffs_no_overlaps:
+                ordered_diffs_no_overlaps.append(candidate_diff_pair)
+                continue
+            # no time overlap
+            previous_diff = ordered_diffs_no_overlaps[-1].diff_branch_diff
+            candidate_diff = candidate_diff_pair.diff_branch_diff
+            if previous_diff.to_time <= candidate_diff.from_time:
+                ordered_diffs_no_overlaps.append(candidate_diff_pair)
+                continue
+            previous_interval = previous_diff.time_range
+            candidate_interval = candidate_diff.time_range
+            # keep the diff that covers the larger time frame
+            if candidate_interval > previous_interval:
+                ordered_diffs_no_overlaps[-1] = candidate_diff_pair
+        return ordered_diffs_no_overlaps
+
     async def _update_diffs(
         self,
         base_branch: Branch,
@@ -272,15 +295,17 @@ class DiffCoordinator:
         if not partial_enriched_diffs:
             return await self._get_enriched_diff(diff_request=diff_request)
 
-        remaining_diffs = sorted(partial_enriched_diffs, key=lambda d: d.diff_branch_diff.from_time)
+        ordered_diffs = self._get_ordered_diff_pairs(diff_pairs=partial_enriched_diffs, allow_overlap=False)
+        ordered_diff_reprs = [repr(d) for d in ordered_diffs]
+        log.debug(f"Ordered diffs for aggregation: {ordered_diff_reprs}")
         current_time = diff_request.from_time
         previous_diffs: EnrichedDiffs | None = None
         while current_time < diff_request.to_time:
-            if remaining_diffs and remaining_diffs[0].diff_branch_diff.from_time == current_time:
-                current_diffs = remaining_diffs.pop(0)
+            if ordered_diffs and ordered_diffs[0].diff_branch_diff.from_time == current_time:
+                current_diffs = ordered_diffs.pop(0)
             else:
-                if remaining_diffs:
-                    end_time = remaining_diffs[0].diff_branch_diff.from_time
+                if ordered_diffs:
+                    end_time = ordered_diffs[0].diff_branch_diff.from_time
                 else:
                     end_time = diff_request.to_time
                 if previous_diffs is None:
@@ -321,26 +346,6 @@ class DiffCoordinator:
         )
         enriched_diff_pair = await self.diff_enricher.enrich(calculated_diffs=calculated_diff_pair)
         return enriched_diff_pair
-
-    def _get_missing_time_ranges(
-        self, time_ranges: list[TimeRange], from_time: Timestamp, to_time: Timestamp
-    ) -> list[TimeRange]:
-        if not time_ranges:
-            return [TimeRange(from_time=from_time, to_time=to_time)]
-        sorted_time_ranges = sorted(time_ranges, key=lambda tr: tr.from_time)
-        missing_time_ranges = []
-        if sorted_time_ranges[0].from_time > from_time:
-            missing_time_ranges.append(TimeRange(from_time=from_time, to_time=sorted_time_ranges[0].from_time))
-        index = 0
-        while index < len(sorted_time_ranges) - 1:
-            this_diff = sorted_time_ranges[index]
-            next_diff = sorted_time_ranges[index + 1]
-            if this_diff.to_time < next_diff.from_time:
-                missing_time_ranges.append(TimeRange(from_time=this_diff.to_time, to_time=next_diff.from_time))
-            index += 1
-        if sorted_time_ranges[-1].to_time < to_time:
-            missing_time_ranges.append(TimeRange(from_time=sorted_time_ranges[-1].to_time, to_time=to_time))
-        return missing_time_ranges
 
     def _get_node_field_specifiers(self, enriched_diff: EnrichedDiffRoot) -> set[NodeFieldSpecifier]:
         specifiers: set[NodeFieldSpecifier] = set()

--- a/backend/infrahub/core/diff/model/path.py
+++ b/backend/infrahub/core/diff/model/path.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from neo4j.graph import Node as Neo4jNode
     from neo4j.graph import Path as Neo4jPath
     from neo4j.graph import Relationship as Neo4jRelationship
+    from pendulum import Interval
 
     from infrahub.graphql.initialization import GraphqlContext
 
@@ -394,6 +395,10 @@ class EnrichedDiffRoot(BaseSummary):
     def __hash__(self) -> int:
         return hash(self.uuid)
 
+    @property
+    def time_range(self) -> Interval:
+        return self.to_time.obj - self.from_time.obj
+
     def get_nodes_without_parents(self) -> set[EnrichedDiffNode]:
         nodes_with_parent_uuids = set()
         for n in self.nodes:
@@ -482,6 +487,17 @@ class EnrichedDiffs:
     diff_branch_name: str
     base_branch_diff: EnrichedDiffRoot
     diff_branch_diff: EnrichedDiffRoot
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"branch_uuid={self.diff_branch_diff.uuid},"
+            f"base_uuid={self.base_branch_diff.uuid},"
+            f"branch_name={self.diff_branch_name},"
+            f"base_name={self.base_branch_name},"
+            f"from_time={self.diff_branch_diff.from_time},"
+            f"to_time={self.diff_branch_diff.to_time})"
+        )
 
     @classmethod
     def from_calculated_diffs(cls, calculated_diffs: CalculatedDiffs) -> EnrichedDiffs:

--- a/backend/infrahub/core/diff/query_parser.py
+++ b/backend/infrahub/core/diff/query_parser.py
@@ -153,6 +153,7 @@ class DiffPropertyIntermediate:
 class DiffAttributeIntermediate(TrackedStatusUpdates):
     uuid: str
     name: str
+    from_time: Timestamp
     properties_by_type: dict[DatabaseEdgeType, DiffPropertyIntermediate] = field(default_factory=dict)
 
     def track_database_path(self, database_path: DatabasePath) -> None:
@@ -160,13 +161,13 @@ class DiffAttributeIntermediate(TrackedStatusUpdates):
             return
         self.timestamp_status_map[database_path.attribute_changed_at] = database_path.attribute_status
 
-    def to_diff_attribute(self, from_time: Timestamp, include_unchanged: bool) -> DiffAttribute:
+    def to_diff_attribute(self, include_unchanged: bool) -> DiffAttribute:
         properties = []
         for prop in self.properties_by_type.values():
-            diff_prop = prop.to_diff_property(from_time=from_time)
+            diff_prop = prop.to_diff_property(from_time=self.from_time)
             if include_unchanged or diff_prop.action is not DiffAction.UNCHANGED:
                 properties.append(diff_prop)
-        action, changed_at = self.get_action_and_timestamp(from_time=from_time)
+        action, changed_at = self.get_action_and_timestamp(from_time=self.from_time)
         if not properties or all(p.action is DiffAction.UNCHANGED for p in properties):
             action = DiffAction.UNCHANGED
         return DiffAttribute(
@@ -308,6 +309,7 @@ class DiffRelationshipIntermediate:
     name: str
     identifier: str
     cardinality: RelationshipCardinality
+    from_time: Timestamp
     properties_by_db_id: dict[str, set[DiffRelationshipPropertyIntermediate]] = field(default_factory=dict)
     _single_relationship_list: list[DiffSingleRelationshipIntermediate] = field(default_factory=list)
 
@@ -354,22 +356,26 @@ class DiffRelationshipIntermediate:
             for single_relationship_properties in self.properties_by_db_id.values()
         ]
 
-    def to_diff_relationship(self, from_time: Timestamp, include_unchanged: bool) -> DiffRelationship:
+    def to_diff_relationship(self, include_unchanged: bool) -> DiffRelationship:
         self._index_relationships()
         single_relationships = [
-            sr.get_final_single_relationship(from_time=from_time, include_unchanged=include_unchanged)
+            sr.get_final_single_relationship(from_time=self.from_time, include_unchanged=include_unchanged)
             for sr in self._single_relationship_list
         ]
         last_changed_relationship = max(single_relationships, key=lambda r: r.changed_at)
         last_changed_at = last_changed_relationship.changed_at
         action = DiffAction.UPDATED
-        if last_changed_at < from_time or all(sr.action is DiffAction.UNCHANGED for sr in single_relationships):
+        if last_changed_at < self.from_time or all(sr.action is DiffAction.UNCHANGED for sr in single_relationships):
             action = DiffAction.UNCHANGED
         # bubble up action, excluding UNCHANGED
         if self.cardinality is RelationshipCardinality.ONE:
             actions = {sr.action for sr in single_relationships if sr.action is not DiffAction.UNCHANGED}
             if len(actions) == 1:
                 action = actions.pop()
+
+            # if action is DiffAction.REMOVED:
+            #     breakpoint()
+
         return DiffRelationship(
             name=self.name,
             changed_at=last_changed_at,
@@ -390,13 +396,13 @@ class DiffNodeIntermediate(TrackedStatusUpdates):
     def to_diff_node(self, from_time: Timestamp, include_unchanged: bool) -> DiffNode:
         attributes = []
         for attr in self.attributes_by_name.values():
-            diff_attr = attr.to_diff_attribute(from_time=from_time, include_unchanged=include_unchanged)
+            diff_attr = attr.to_diff_attribute(include_unchanged=include_unchanged)
             if include_unchanged or diff_attr.action is not DiffAction.UNCHANGED:
                 attributes.append(diff_attr)
         action, changed_at = self.get_action_and_timestamp(from_time=from_time)
         relationships = []
         for rel in self.relationships_by_name.values():
-            diff_rel = rel.to_diff_relationship(from_time=from_time, include_unchanged=include_unchanged)
+            diff_rel = rel.to_diff_relationship(include_unchanged=include_unchanged)
             if include_unchanged or diff_rel.action is not DiffAction.UNCHANGED:
                 relationships.append(diff_rel)
         if not attributes and not relationships:
@@ -446,6 +452,7 @@ class DiffQueryParser:
         schema_manager: SchemaManager,
         from_time: Timestamp,
         to_time: Optional[Timestamp] = None,
+        previous_node_field_specifiers: set[NodeFieldSpecifier] | None = None,
     ) -> None:
         self.base_branch_name = base_branch.name
         self.diff_branch_name = diff_branch.name
@@ -459,6 +466,10 @@ class DiffQueryParser:
             self.diff_branched_from_time = Timestamp(diff_branch.get_branched_from())
         self._diff_root_by_branch: dict[str, DiffRootIntermediate] = {}
         self._final_diff_root_by_branch: dict[str, DiffRoot] = {}
+        self._previous_node_field_specifiers = previous_node_field_specifiers or set()
+        # self._diff_branch_node_field_specifiers: set[NodeFieldSpecifier] | None = None
+        # self._new_node_field_specifiers: set[NodeFieldSpecifier] | None = None
+        # self._current_node_field_specifiers: set[NodeFieldSpecifier] | None = None
 
     def get_branches(self) -> set[str]:
         return set(self._final_diff_root_by_branch.keys())
@@ -470,11 +481,11 @@ class DiffQueryParser:
             return self._final_diff_root_by_branch[branch]
         return DiffRoot(from_time=self.from_time, to_time=self.to_time, uuid=str(uuid4()), branch=branch, nodes=[])
 
-    def get_node_field_specifiers_for_branch(self, branch_name: str) -> set[NodeFieldSpecifier]:
-        if branch_name not in self._diff_root_by_branch:
+    def get_diff_node_field_specifiers(self) -> set[NodeFieldSpecifier]:
+        if self.diff_branch_name not in self._diff_root_by_branch:
             return set()
         node_field_specifiers: set[NodeFieldSpecifier] = set()
-        diff_root = self._diff_root_by_branch[branch_name]
+        diff_root = self._diff_root_by_branch[self.diff_branch_name]
         for node in diff_root.nodes_by_id.values():
             node_field_specifiers.update(
                 NodeFieldSpecifier(node_uuid=node.uuid, field_name=attribute_name)
@@ -485,6 +496,16 @@ class DiffQueryParser:
                 for relationship_diff in node.relationships_by_name.values()
             )
         return node_field_specifiers
+
+    def get_new_node_field_specifiers(self) -> set[NodeFieldSpecifier]:
+        branch_node_specifiers = self.get_diff_node_field_specifiers()
+        new_node_field_specifiers = branch_node_specifiers - self._previous_node_field_specifiers
+        return new_node_field_specifiers
+
+    def get_current_node_field_specifiers(self) -> set[NodeFieldSpecifier]:
+        new_node_field_specifiers = self.get_new_node_field_specifiers()
+        current_node_field_specifiers = self._previous_node_field_specifiers - new_node_field_specifiers
+        return current_node_field_specifiers
 
     def read_result(self, query_result: QueryResult) -> None:
         path = query_result.get_path(label="diff_path")
@@ -545,7 +566,9 @@ class DiffQueryParser:
         relationship_schema = self._get_relationship_schema(database_path=database_path, node_schema=node_schema)
         if not relationship_schema:
             return
-        diff_relationship = self._get_diff_relationship(diff_node=diff_node, relationship_schema=relationship_schema)
+        diff_relationship = self._get_diff_relationship(
+            diff_node=diff_node, relationship_schema=relationship_schema, database_path=database_path
+        )
         diff_relationship.add_path(
             database_path=database_path, diff_from_time=self.from_time, diff_to_time=self.to_time
         )
@@ -554,10 +577,16 @@ class DiffQueryParser:
         self, database_path: DatabasePath, diff_node: DiffNodeIntermediate
     ) -> DiffAttributeIntermediate:
         attribute_name = database_path.attribute_name
+        node_field_specifier = NodeFieldSpecifier(node_uuid=diff_node.uuid, field_name=attribute_name)
+        branch_name = database_path.deepest_branch
+        from_time = self.from_time
+        if branch_name == self.base_branch_name and node_field_specifier in self.get_new_node_field_specifiers():
+            from_time = self.diff_branched_from_time
         if attribute_name not in diff_node.attributes_by_name:
             diff_node.attributes_by_name[attribute_name] = DiffAttributeIntermediate(
                 uuid=database_path.attribute_id,
                 name=attribute_name,
+                from_time=from_time,
             )
         diff_attribute = diff_node.attributes_by_name[attribute_name]
         diff_attribute.track_database_path(database_path=database_path)
@@ -582,14 +611,25 @@ class DiffQueryParser:
         )
 
     def _get_diff_relationship(
-        self, diff_node: DiffNodeIntermediate, relationship_schema: RelationshipSchema
+        self,
+        diff_node: DiffNodeIntermediate,
+        relationship_schema: RelationshipSchema,
+        database_path: DatabasePath,
     ) -> DiffRelationshipIntermediate:
         diff_relationship = diff_node.relationships_by_name.get(relationship_schema.name)
         if not diff_relationship:
+            node_field_specifier = NodeFieldSpecifier(
+                node_uuid=diff_node.uuid, field_name=relationship_schema.get_identifier()
+            )
+            branch_name = database_path.deepest_branch
+            from_time = self.from_time
+            if branch_name == self.base_branch_name and node_field_specifier in self.get_new_node_field_specifiers():
+                from_time = self.diff_branched_from_time
             diff_relationship = DiffRelationshipIntermediate(
                 name=relationship_schema.name,
                 cardinality=relationship_schema.cardinality,
                 identifier=relationship_schema.get_identifier(),
+                from_time=from_time,
             )
             diff_node.relationships_by_name[relationship_schema.name] = diff_relationship
         return diff_relationship

--- a/backend/infrahub/core/diff/query_parser.py
+++ b/backend/infrahub/core/diff/query_parser.py
@@ -372,10 +372,6 @@ class DiffRelationshipIntermediate:
             actions = {sr.action for sr in single_relationships if sr.action is not DiffAction.UNCHANGED}
             if len(actions) == 1:
                 action = actions.pop()
-
-            # if action is DiffAction.REMOVED:
-            #     breakpoint()
-
         return DiffRelationship(
             name=self.name,
             changed_at=last_changed_at,
@@ -467,9 +463,6 @@ class DiffQueryParser:
         self._diff_root_by_branch: dict[str, DiffRootIntermediate] = {}
         self._final_diff_root_by_branch: dict[str, DiffRoot] = {}
         self._previous_node_field_specifiers = previous_node_field_specifiers or set()
-        # self._diff_branch_node_field_specifiers: set[NodeFieldSpecifier] | None = None
-        # self._new_node_field_specifiers: set[NodeFieldSpecifier] | None = None
-        # self._current_node_field_specifiers: set[NodeFieldSpecifier] | None = None
 
     def get_branches(self) -> set[str]:
         return set(self._final_diff_root_by_branch.keys())

--- a/backend/infrahub/core/diff/query_parser.py
+++ b/backend/infrahub/core/diff/query_parser.py
@@ -365,12 +365,11 @@ class DiffRelationshipIntermediate:
         action = DiffAction.UPDATED
         if last_changed_at < from_time or all(sr.action is DiffAction.UNCHANGED for sr in single_relationships):
             action = DiffAction.UNCHANGED
-        if (
-            self.cardinality is RelationshipCardinality.ONE
-            and len(single_relationships) == 1
-            and single_relationships[0].action in (DiffAction.ADDED, DiffAction.REMOVED)
-        ):
-            action = single_relationships[0].action
+        # bubble up action, excluding UNCHANGED
+        if self.cardinality is RelationshipCardinality.ONE:
+            actions = {sr.action for sr in single_relationships if sr.action is not DiffAction.UNCHANGED}
+            if len(actions) == 1:
+                action = actions.pop()
         return DiffRelationship(
             name=self.name,
             changed_at=last_changed_at,

--- a/backend/infrahub/core/query/diff.py
+++ b/backend/infrahub/core/query/diff.py
@@ -767,8 +767,10 @@ CALL {
         // -------------------------------------
         MATCH diff_rel_path = (root:Root)<-[r_root:IS_PART_OF]-(n:Node)-[r_node]-(p)-[diff_rel {branch: $branch_name}]->(q)
         WHERE (node_field_specifiers_list IS NULL OR [n.uuid, p.name] IN node_field_specifiers_list)
-        AND (from_time <= diff_rel.from < $to_time)
-        AND (diff_rel.to IS NULL OR (from_time <= diff_rel.to < $to_time))
+        AND (
+            (from_time <= diff_rel.from < $to_time)
+            OR (from_time <= diff_rel.to < $to_time)
+        )
         // exclude attributes and relationships under added/removed nodes, attrs, and rels b/c they are covered above
         AND ALL(
             r in [r_root, r_node]

--- a/backend/infrahub/core/query/diff.py
+++ b/backend/infrahub/core/query/diff.py
@@ -668,7 +668,7 @@ CALL {
             AND (from_time <= diff_rel.from < $to_time)
             AND (diff_rel.to IS NULL OR (from_time <= diff_rel.to < $to_time))
             AND r_root.from <= diff_rel.from
-            AND (r_root.to IS NULL OR r_root.to >= diff_rel.from)
+            AND (r_root.to IS NULL OR diff_rel.branch <> r_root.branch OR r_root.to >= diff_rel.from)
             RETURN root, r_root, p, diff_rel, q
             UNION ALL
             WITH node_field_specifiers_list, from_time
@@ -683,7 +683,7 @@ CALL {
             AND (from_time <= diff_rel.from < $to_time)
             AND (diff_rel.to IS NULL OR (from_time <= diff_rel.to < $to_time))
             AND r_root.from <= diff_rel.from
-            AND (r_root.to IS NULL OR r_root.to >= diff_rel.from)
+            AND (r_root.to IS NULL OR diff_rel.branch <> r_root.branch OR r_root.to >= diff_rel.from)
             RETURN root, r_root, p, diff_rel, q
         }
         WITH root, r_root, p, diff_rel, q, from_time

--- a/backend/tests/integration/diff/test_diff_merge.py
+++ b/backend/tests/integration/diff/test_diff_merge.py
@@ -146,11 +146,11 @@ class TestDiffMerge(TestInfrahubApp):
         await new_person.save(db=db)
         diff_branch = await create_branch(db=db, branch_name="branch2")
         if delete_on_branch:
-            delete_branch = default_branch
-            update_branch = diff_branch
-        else:
             delete_branch = diff_branch
             update_branch = default_branch
+        else:
+            delete_branch = default_branch
+            update_branch = diff_branch
         person_deleted = await NodeManager.get_one(db=db, id=new_person.id, branch=delete_branch)
         await person_deleted.delete(db=db)
 
@@ -174,11 +174,11 @@ class TestDiffMerge(TestInfrahubApp):
         assert set(conflicts_map.keys()) == {f"data/{person_updated.id}"}
         conflict = conflicts_map[f"data/{person_updated.id}"]
         if delete_on_branch:
-            assert conflict.base_branch_action is DiffAction.REMOVED
-            assert conflict.diff_branch_action is DiffAction.UPDATED
-        else:
             assert conflict.base_branch_action is DiffAction.UPDATED
             assert conflict.diff_branch_action is DiffAction.REMOVED
+        else:
+            assert conflict.base_branch_action is DiffAction.REMOVED
+            assert conflict.diff_branch_action is DiffAction.UPDATED
         assert conflict.resolvable is False
 
         # manually undo updates on branch to resolve conflict

--- a/backend/tests/unit/core/diff/test_coordinator.py
+++ b/backend/tests/unit/core/diff/test_coordinator.py
@@ -2,9 +2,12 @@ from infrahub.core.branch import Branch
 from infrahub.core.constants import DiffAction
 from infrahub.core.constants.database import DatabaseEdgeType
 from infrahub.core.diff.coordinator import DiffCoordinator
+from infrahub.core.diff.model.path import BranchTrackingId
+from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.dependencies.registry import get_component_registry
 
@@ -44,3 +47,65 @@ class TestDiffCoordinator:
                 assert prop_diff.action is DiffAction.REMOVED
                 assert prop_diff.conflict is None
                 assert prop_diff.new_value is None
+
+    async def test_overlapping_diffs(self, db: InfrahubDatabase, default_branch: Branch, person_john_main: Node):
+        branch = await create_branch(db=db, branch_name="branch")
+        component_registry = get_component_registry()
+        diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch)
+        diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=branch)
+        original_height = person_john_main.height.value
+        person_john_branch = await NodeManager.get_one(db=db, branch=branch, id=person_john_main.id)
+
+        # t0
+        t0 = Timestamp()
+        person_john_branch.height.value = 1
+        await person_john_branch.save(db=db)
+        # t1
+        t1 = Timestamp()
+        person_john_branch.height.value = 2
+        await person_john_branch.save(db=db)
+        # t2
+        # diff from t0 - t2
+        await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch)
+        person_john_branch.height.value = 3
+        await person_john_branch.save(db=db)
+        # t3
+        t3 = Timestamp()
+        # overlapping diff from t1 to t3
+        arbitrary_diff = await diff_coordinator.create_or_update_arbitrary_timeframe_diff(
+            base_branch=default_branch, diff_branch=branch, from_time=t1, to_time=t3
+        )
+
+        full_diff = await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch)
+
+        # check that only one branch-tracking diff exists for this branch
+        tracking_diff = await diff_repository.get_one(
+            diff_branch_name=branch.name, tracking_id=BranchTrackingId(name=branch.name)
+        )
+        assert tracking_diff == full_diff
+        # test that arbitrary diff still exists
+        retrieved_arbitrary_diff = await diff_repository.get_one(
+            diff_branch_name=branch.name, diff_id=arbitrary_diff.uuid
+        )
+        assert retrieved_arbitrary_diff == arbitrary_diff
+
+        # validate content of the diff
+        assert full_diff.base_branch_name == default_branch.name
+        assert full_diff.diff_branch_name == branch.name
+        assert full_diff.from_time < t0
+        assert full_diff.to_time > t3
+        assert len(full_diff.nodes) == 1
+        diff_node = full_diff.nodes.pop()
+        assert diff_node.uuid == person_john_main.id
+        assert diff_node.action is DiffAction.UPDATED
+        assert not diff_node.relationships
+        assert len(diff_node.attributes) == 1
+        diff_attribute = diff_node.attributes.pop()
+        assert diff_attribute.name == "height"
+        assert diff_attribute.action is DiffAction.UPDATED
+        assert len(diff_attribute.properties) == 1
+        diff_property = diff_attribute.properties.pop()
+        assert diff_property.property_type is DatabaseEdgeType.HAS_VALUE
+        assert diff_property.action is DiffAction.UPDATED
+        assert diff_property.previous_value == str(original_height)
+        assert diff_property.new_value == "3"

--- a/backend/tests/unit/core/diff/test_diff_calculator.py
+++ b/backend/tests/unit/core/diff/test_diff_calculator.py
@@ -2880,4 +2880,5 @@ async def test_diff_relationship_property_update_on_main(
     assert len(node_diff.relationships) == 1
     diff_rel = node_diff.relationships.pop()
     assert diff_rel.name == "owner"
-    assert diff_rel.action is DiffAction.ADDED
+    assert diff_rel.action is DiffAction.UPDATED
+    assert {elem.action for elem in diff_rel.relationships} == {DiffAction.ADDED, DiffAction.REMOVED}

--- a/backend/tests/unit/core/diff/test_diff_calculator.py
+++ b/backend/tests/unit/core/diff/test_diff_calculator.py
@@ -694,7 +694,7 @@ async def test_relationship_one_property_branch_update(
     single_relationship = single_relationships_by_peer_id[person_john_main.id]
     assert single_relationship.peer_id == person_john_main.id
     assert single_relationship.action is DiffAction.REMOVED
-    assert len(single_relationship.properties) == 2
+    assert len(single_relationship.properties) == 3
     assert before_main_change < single_relationship.changed_at < after_main_change
     property_diff_by_type = {p.property_type: p for p in single_relationship.properties}
     property_diff = property_diff_by_type[DatabaseEdgeType.IS_RELATED]
@@ -706,6 +706,12 @@ async def test_relationship_one_property_branch_update(
     property_diff = property_diff_by_type[DatabaseEdgeType.IS_VISIBLE]
     assert property_diff.property_type == DatabaseEdgeType.IS_VISIBLE
     assert property_diff.previous_value is True
+    assert property_diff.new_value is None
+    assert property_diff.action is DiffAction.REMOVED
+    assert before_main_change < property_diff.changed_at < after_main_change
+    property_diff = property_diff_by_type[DatabaseEdgeType.IS_PROTECTED]
+    assert property_diff.property_type == DatabaseEdgeType.IS_PROTECTED
+    assert property_diff.previous_value is False
     assert property_diff.new_value is None
     assert property_diff.action is DiffAction.REMOVED
     assert before_main_change < property_diff.changed_at < after_main_change

--- a/backend/tests/unit/core/schema/schema_branch/test_number_attribute_default_value.py
+++ b/backend/tests/unit/core/schema/schema_branch/test_number_attribute_default_value.py
@@ -1,0 +1,32 @@
+import pytest
+
+from infrahub.core import registry
+from infrahub.core.schema import SchemaRoot
+from infrahub.database import InfrahubDatabase
+from infrahub.exceptions import ValidationError
+from tests.helpers.test_app import TestInfrahubApp
+
+
+class TestNumberAttrForbidsBool(TestInfrahubApp):
+    async def test_number_attr_forbids_bool(
+        self,
+        db: InfrahubDatabase,
+        default_branch,
+        client,
+    ):
+        schema = {
+            "version": "1.0",
+            "nodes": [
+                {
+                    "name": "Node",
+                    "namespace": "Testing",
+                    "attributes": [{"name": "number", "kind": "Number", "default_value": True, "optional": False}],
+                }
+            ],
+        }
+
+        schema_root = SchemaRoot(**schema)  # type: ignore
+        schema_branch = registry.schema.get_schema_branch(default_branch.name)
+        schema_branch.load_schema(schema=schema_root)
+        with pytest.raises(ValidationError, match="TestingNode: default value True is not a valid Number"):
+            schema_branch.process()


### PR DESCRIPTION
had to make a separate branch to address how some diff query changes on `stable` interact with other diff changes on `release-1.1`

had to make more changes than expected to the diff calculation logic to interact correctly with a bug that I fixed in `stable`. fortunately, we have a lot of tests that cover the diff pretty well