### PR TITLE
Cleanup graphql-query tasks

### DIFF
--- a/backend/infrahub/api/query.py
+++ b/backend/infrahub/api/query.py
@@ -26,7 +26,7 @@ from infrahub.graphql.metrics import (
 from infrahub.graphql.utils import extract_data
 from infrahub.groups.models import RequestGraphQLQueryGroupUpdate
 from infrahub.log import get_logger
-from infrahub.workflows.catalogue import UPDATE_GRAPHQL_QUERY_GROUP
+from infrahub.workflows.catalogue import GRAPHQL_QUERY_GROUP_UPDATE
 
 if TYPE_CHECKING:
     from infrahub.auth import AccountSession
@@ -115,7 +115,7 @@ async def execute_query(
             subscribers=sorted(subscribers),
             params=params,
         )
-        await service.workflow.submit_workflow(workflow=UPDATE_GRAPHQL_QUERY_GROUP, parameters={"model": model})
+        await service.workflow.submit_workflow(workflow=GRAPHQL_QUERY_GROUP_UPDATE, parameters={"model": model})
 
     return response_payload
 

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -279,10 +279,10 @@ async def generate_artifact(model: RequestArtifactGenerate) -> None:
         await artifact.save()
 
 
-@flow(name="request_artifact_definitions_generate", flow_run_name="Generate artifacts")
+@flow(name="request_artifact_definitions_generate", flow_run_name="Trigger Generation of Artifacts for ")
 async def generate_request_artifact_definition(model: RequestArtifactDefinitionGenerate) -> None:
     service = services.service
-    await add_branch_tag(branch_name=model.branch)
+    await add_tags(branches=[model.branch])
 
     artifact_definition = await service.client.get(
         kind=InfrahubKind.ARTIFACTDEFINITION, id=model.artifact_definition, branch=model.branch

--- a/backend/infrahub/groups/tasks.py
+++ b/backend/infrahub/groups/tasks.py
@@ -5,14 +5,20 @@ from prefect import flow
 from infrahub.core.constants import InfrahubKind
 from infrahub.groups.models import RequestGraphQLQueryGroupUpdate
 from infrahub.services import services
-from infrahub.workflows.utils import add_branch_tag
+from infrahub.workflows.utils import add_tags
 
 
-@flow(name="update_graphql_query_group", flow_run_name="Update GraphQLQuery Group {model.query_name}")
+@flow(name="graphql-query-group-update", flow_run_name="Update GraphQLQuery Group '{model.query_name}'")
 async def update_graphql_query_group(model: RequestGraphQLQueryGroupUpdate) -> None:
     """Create or Update a GraphQLQueryGroup."""
 
-    await add_branch_tag(branch_name=model.branch)
+    # If there is only one subscriber, associate the task to it
+    # If there are more than one, for now we can't associate all of them
+    related_nodes = []
+    if len(model.subscribers) == 1:
+        related_nodes.append(model.subscribers[0])
+
+    await add_tags(branches=[model.branch], nodes=related_nodes)
     service = services.service
 
     params_hash = dict_hash(model.params)

--- a/backend/infrahub/workflows/catalogue.py
+++ b/backend/infrahub/workflows/catalogue.py
@@ -231,8 +231,8 @@ PROPOSED_CHANGE_MERGE = WorkflowDefinition(
     tags=[WorkflowTag.DATABASE_CHANGE],
 )
 
-UPDATE_GRAPHQL_QUERY_GROUP = WorkflowDefinition(
-    name="update_graphql_query_group",
+GRAPHQL_QUERY_GROUP_UPDATE = WorkflowDefinition(
+    name="graphql-query-group-update",
     type=WorkflowType.CORE,
     module="infrahub.groups.tasks",
     function="update_graphql_query_group",
@@ -419,6 +419,7 @@ workflows = [
     GIT_REPOSITORIES_SYNC,
     GIT_REPOSITORY_ADD,
     GIT_REPOSITORY_ADD_READ_ONLY,
+    GRAPHQL_QUERY_GROUP_UPDATE,
     IPAM_RECONCILIATION,
     PROCESS_COMPUTED_MACRO,
     PROPOSED_CHANGE_MERGE,
@@ -441,7 +442,6 @@ workflows = [
     TRIGGER_UPDATE_JINJA_COMPUTED_ATTRIBUTES,
     TRIGGER_UPDATE_PYTHON_COMPUTED_ATTRIBUTES,
     UPDATE_COMPUTED_ATTRIBUTE_TRANSFORM,
-    UPDATE_GRAPHQL_QUERY_GROUP,
     WEBHOOK_CONFIGURE,
     WEBHOOK_SEND,
     WEBHOOK_TRIGGER,

--- a/backend/tests/unit/api/test_05_query_api.py
+++ b/backend/tests/unit/api/test_05_query_api.py
@@ -7,7 +7,7 @@ import pytest
 
 from infrahub.core.initialization import create_branch
 from infrahub.groups.models import RequestGraphQLQueryGroupUpdate
-from infrahub.workflows.catalogue import UPDATE_GRAPHQL_QUERY_GROUP
+from infrahub.workflows.catalogue import GRAPHQL_QUERY_GROUP_UPDATE
 
 if TYPE_CHECKING:
     from fastapi.testclient import TestClient
@@ -72,7 +72,7 @@ async def test_query_endpoint_group_no_params(
 
         expected_calls = [
             call(
-                workflow=UPDATE_GRAPHQL_QUERY_GROUP,
+                workflow=GRAPHQL_QUERY_GROUP_UPDATE,
                 parameters={"model": model},
             ),
         ]
@@ -113,7 +113,7 @@ async def test_query_endpoint_group_params(
 
         expected_calls = [
             call(
-                workflow=UPDATE_GRAPHQL_QUERY_GROUP,
+                workflow=GRAPHQL_QUERY_GROUP_UPDATE,
                 parameters={"model": model},
             ),
         ]

--- a/backend/tests/unit/message_bus/operations/requests/test_graphql_query_group.py
+++ b/backend/tests/unit/message_bus/operations/requests/test_graphql_query_group.py
@@ -45,7 +45,7 @@ async def test_graphql_group_update(db: InfrahubDatabase, httpx_mock: HTTPXMock,
     )
     service = InfrahubServices(client=client, workflow=WorkflowLocalExecution())
 
-    with init_global_service(service), patch("infrahub.groups.tasks.add_branch_tag"):
+    with init_global_service(service), patch("infrahub.groups.tasks.add_tags"):
         # add_branch_tag requires a prefect client, ie it does not work with WorkflowLocal
         response1 = {
             "data": {


### PR DESCRIPTION
- Add subscriber as related node (if there is only one for now)
- Update the name of the workflow in the catalogue
- Update the name of the flow to use `-` for consistency