### PR TITLE
Consider updated fields for Jinja2 based computed attributes

### DIFF
--- a/backend/infrahub/computed_attribute/tasks.py
+++ b/backend/infrahub/computed_attribute/tasks.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
+import ujson
 from infrahub_sdk.protocols import CoreNode  # noqa: TCH002
 from prefect import flow
 from prefect.automations import AutomationCore
@@ -227,12 +228,15 @@ async def process_jinja2(
     object_id: str,
     computed_attribute_name: str,
     computed_attribute_kind: str,
-    updated_fields: list[str] | None = None,
+    updated_fields: str | None = None,
 ) -> None:
     log = get_run_logger()
     service = services.service
 
     await add_tags(branches=[branch_name])
+    updates: list[str] = []
+    if isinstance(updated_fields, str):
+        updates = ujson.loads(updated_fields)
 
     target_branch_schema = (
         branch_name if branch_name in registry.get_altered_schema_branches() else registry.default_branch
@@ -242,9 +246,7 @@ async def process_jinja2(
 
     computed_macros = [
         attrib
-        for attrib in schema_branch.computed_attributes.get_impacted_jinja2_targets(
-            kind=node_kind, updates=updated_fields
-        )
+        for attrib in schema_branch.computed_attributes.get_impacted_jinja2_targets(kind=node_kind, updates=updates)
         if attrib.kind == computed_attribute_kind and attrib.attribute.name == computed_attribute_name
     ]
     for computed_macro in computed_macros:
@@ -369,6 +371,7 @@ async def computed_attribute_setup(branch_name: str | None = None) -> None:  # p
                             "object_id": "{{ event.resource['infrahub.node.id'] }}",
                             "computed_attribute_name": computed_attribute.attribute.name,
                             "computed_attribute_kind": computed_attribute.kind,
+                            "updated_fields": "{{ event.payload['fields'] | tojson }}",
                         },
                         job_variables={},
                     )
@@ -432,6 +435,7 @@ async def computed_attribute_setup(branch_name: str | None = None) -> None:  # p
                                 "object_id": "{{ event.resource['infrahub.node.id'] }}",
                                 "computed_attribute_name": computed_attribute.attribute.name,
                                 "computed_attribute_kind": computed_attribute.kind,
+                                "updated_fields": "{{ event.payload['fields'] | tojson }}",
                             },
                             job_variables={},
                         )

--- a/backend/infrahub/events/node_action.py
+++ b/backend/infrahub/events/node_action.py
@@ -15,6 +15,7 @@ class NodeMutatedEvent(InfrahubBranchEvent):
     node_id: str = Field(..., description="The ID of the mutated node")
     action: MutationAction = Field(..., description="The action taken on the node")
     data: dict[str, Any] = Field(..., description="Data on modified object")
+    fields: list[str] = Field(default_factory=list, description="Fields provided in the mutation")
 
     def get_name(self) -> str:
         return f"{self.get_event_namespace()}.node.{self.action.value}"
@@ -29,7 +30,7 @@ class NodeMutatedEvent(InfrahubBranchEvent):
         }
 
     def get_payload(self) -> dict[str, Any]:
-        return self.data
+        return {"data": self.data, "fields": self.fields}
 
     def get_messages(self) -> list[InfrahubMessage]:
         return [

--- a/backend/infrahub/graphql/mutations/computed_attribute.py
+++ b/backend/infrahub/graphql/mutations/computed_attribute.py
@@ -92,7 +92,8 @@ class UpdateComputedAttribute(Mutation):
             )
         if attribute_field.value != str(data.value):
             attribute_field.value = str(data.value)
-            await target_node.save(db=context.db, fields=[str(data.attribute)])
+            async with context.db.start_transaction() as dbt:
+                await target_node.save(db=dbt, fields=[str(data.attribute)])
 
             log_data = get_log_data()
             request_id = log_data.get("request_id", "")
@@ -104,6 +105,7 @@ class UpdateComputedAttribute(Mutation):
                 kind=node_schema.kind,
                 node_id=target_node.get_id(),
                 data=graphql_payload,
+                fields=[str(data.attribute)],
                 action=MutationAction.UPDATED,
                 meta=EventMeta(initiator_id=WORKER_IDENTITY, request_id=request_id),
             )

--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -99,17 +99,17 @@ class InfrahubMutationMixin:
             request_id = log_data.get("request_id", "")
 
             graphql_payload = await obj.to_graphql(db=context.db, filter_sensitive=True)
-
             event = NodeMutatedEvent(
                 branch=context.branch.name,
                 kind=obj._schema.kind,
                 node_id=obj.id,
                 data=graphql_payload,
                 action=action,
+                fields=_get_data_fields(data),
                 meta=EventMeta(initiator_id=WORKER_IDENTITY, request_id=request_id),
             )
 
-            context.background.add_task(context.service.event.send, event)
+            context.background.add_task(context.active_service.event.send, event)
 
         return mutation
 
@@ -457,3 +457,7 @@ def _get_kind_lock_names_on_object_mutation(kind: str, branch: Branch, schema_br
     lock_kinds = _get_kinds_to_lock_on_object_mutation(kind, schema_branch)
     lock_names = [build_object_lock_name(kind) for kind in lock_kinds]
     return lock_names
+
+
+def _get_data_fields(data: InputObjectType) -> list[str]:
+    return [field for field in data.keys() if field not in ["id", "hfid"]]

--- a/backend/infrahub/webhook/tasks.py
+++ b/backend/infrahub/webhook/tasks.py
@@ -163,7 +163,7 @@ async def configure_webhooks() -> None:
                     deployment_id=deployment_id_webhook_trigger,
                     parameters={
                         "event_type": "{{ event.resource['infrahub.node.kind'] }}.{{ event.resource['infrahub.node.action'] }}",
-                        "event_data": "{{ event.payload | tojson }}",
+                        "event_data": "{{ event.payload['data'] | tojson }}",
                     },
                     job_variables={},
                 ),

--- a/backend/tests/functional/computed_attributes/test_computed_attribute.py
+++ b/backend/tests/functional/computed_attributes/test_computed_attribute.py
@@ -91,7 +91,7 @@ class TestComputedAttribute(TestInfrahubApp):
             object_id=tshirt_1.id,
             computed_attribute_kind="TestingTShirt",
             computed_attribute_name="description",
-            updated_fields=["color"],
+            updated_fields='"color"',
         )
 
         tshirt_updated = await client.get(kind="TestingTShirt", id=data["t1"].id)


### PR DESCRIPTION
Changes in this PR

* The computed attribute mutation didn't manage the update in a transaction so I've wrapped the save() method within a new transaction
* Changed the node mutated event to include a "fields" key in the payload (due to this I also had to modify the webhook as it gained an extra level of "indentation", we'll probably refactor the webhook completely in a not to distant future regardless)
* Use these updated fields as part of the lookup to find computed attributes in the schema. The goal is to only run the computed attribute calculation if a relevant attribute/relationship has been updated.

Note in this iteration I've only isolated the change to when we are actually running the Computed Attributes, it will save us from querying the backend with the SDK when we know that it isn't strictly required.

I view this as an initial step to improve the performance a bit. The next iteration of this would be to modify the event automations so that the triggers themselves have these fields built in. I think it would be nice to refactor the automations in general as we'll end up with potentially quite a few additional automations when this is in place. Most of the code for this was already in place since before we started using it as automations in Prefect but the filtering was ignored as we always sent in an empty list for "updated_fields".

Also I really dislike that I did with the "update_fields" parameter and the use of ujson, we have this with the webhooks too. Would like a cleaner solution.

Final note: To improve things in a similar way for the Transforms I think we really have to spend time to rewrite and enhance the GraphQLQueryAnalyzer.