### PR TITLE
fix artifacts diff

### DIFF
--- a/backend/infrahub/core/diff/query/artifact.py
+++ b/backend/infrahub/core/diff/query/artifact.py
@@ -23,22 +23,29 @@ class ArtifactDiffQuery(Query):
         self.definition_rel_identifier = definition_rel_identifier
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:
-        self.params = {
-            "source_branch_name": self.branch.name,
-            "target_branch_name": self.target_branch.name,
-            "target_rel_identifier": self.target_rel_identifier,
-            "definition_rel_identifier": self.definition_rel_identifier,
-        }
+        source_branch_filter, branch_params = self.branch.get_query_filter_path(at=self.at.to_string())
+        self.params.update(branch_params)
+
+        self.params.update(
+            {
+                "source_branch_name": self.branch.name,
+                "target_branch_name": self.target_branch.name,
+                "target_rel_identifier": self.target_rel_identifier,
+                "definition_rel_identifier": self.definition_rel_identifier,
+            }
+        )
         query = """
 // -----------------------
 // get the active artifacts on the source branch
 // -----------------------
-MATCH (source_artifact:%(artifact_kind)s)-[:IS_PART_OF {branch: $source_branch_name}]->(:Root)
+MATCH (source_artifact:%(artifact_kind)s)-[r:IS_PART_OF]->(:Root)
+WHERE r.branch IN [$source_branch_name, $target_branch_name]
 CALL {
     WITH source_artifact
-    MATCH (source_artifact)-[root_rel:IS_PART_OF {branch: $source_branch_name}]->(:Root)
-    RETURN root_rel
-    ORDER BY root_rel.from DESC
+    MATCH (source_artifact)-[r:IS_PART_OF]->(:Root)
+    WHERE %(source_branch_filter)s
+    RETURN r AS root_rel
+    ORDER BY r.branch_level DESC, r.from DESC
     LIMIT 1
 }
 WITH source_artifact, root_rel
@@ -52,10 +59,12 @@ CALL {
         WITH source_artifact
         OPTIONAL MATCH (source_artifact)-[rrel1:IS_RELATED]-(rel_node:Relationship)-[rrel2:IS_RELATED]-(target_node:Node)
         WHERE rel_node.name = $target_rel_identifier
-        AND rrel1.branch = $source_branch_name
-        AND rrel2.branch = $source_branch_name
-        RETURN target_node, (rrel1.status = "active" AND rrel2.status = "active") AS target_is_active
-        ORDER BY rrel1.from DESC, rrel2.from DESC
+        AND all(r IN [rrel1, rrel2] WHERE ( %(source_branch_filter)s ))
+        RETURN
+            target_node,
+            (rrel1.status = "active" AND rrel2.status = "active") AS target_is_active,
+            $source_branch_name IN [rrel1.branch, rrel2.branch] AS target_on_source_branch
+        ORDER BY rrel1.branch_level DESC, rrel1.branch_level DESC, rrel1.from DESC, rrel2.from DESC
         LIMIT 1
     }
     // -----------------------
@@ -65,10 +74,12 @@ CALL {
         WITH source_artifact
         OPTIONAL MATCH (source_artifact)-[rrel1:IS_RELATED]-(rel_node:Relationship)-[rrel2:IS_RELATED]-(definition_node:Node)
         WHERE rel_node.name = $definition_rel_identifier
-        AND rrel1.branch = $source_branch_name
-        AND rrel2.branch = $source_branch_name
-        RETURN definition_node, (rrel1.status = "active" AND rrel2.status = "active") AS definition_is_active
-        ORDER BY rrel1.from DESC, rrel2.from DESC
+        AND all(r IN [rrel1, rrel2] WHERE ( %(source_branch_filter)s ))
+        RETURN
+            definition_node,
+            (rrel1.status = "active" AND rrel2.status = "active") AS definition_is_active,
+            $source_branch_name IN [rrel1.branch, rrel2.branch] AS definition_on_source_branch
+        ORDER BY rrel1.branch_level DESC, rrel1.branch_level DESC, rrel1.from DESC, rrel2.from DESC
         LIMIT 1
     }
     // -----------------------
@@ -78,10 +89,12 @@ CALL {
         WITH source_artifact
         OPTIONAL MATCH (source_artifact)-[attr_rel:HAS_ATTRIBUTE]->(attr:Attribute)-[value_rel:HAS_VALUE]->(attr_val:AttributeValue)
         WHERE attr.name = "checksum"
-        AND attr_rel.branch = $source_branch_name
-        AND value_rel.branch = $source_branch_name
-        RETURN attr_val.value AS checksum, (attr_rel.status = "active" AND value_rel.status = "active") AS checksum_is_active
-        ORDER BY value_rel.from DESC, attr_rel.from DESC
+        AND all(r IN [attr_rel, value_rel] WHERE ( %(source_branch_filter)s ))
+        RETURN
+            attr_val.value AS checksum,
+            (attr_rel.status = "active" AND value_rel.status = "active") AS checksum_is_active,
+            $source_branch_name IN [attr_rel.branch, value_rel.branch] AS checksum_on_source_branch
+        ORDER BY value_rel.branch_level DESC, attr_rel.branch_level DESC, value_rel.from DESC, attr_rel.from DESC
         LIMIT 1
     }
     // -----------------------
@@ -91,12 +104,22 @@ CALL {
         WITH source_artifact
         OPTIONAL MATCH (source_artifact)-[attr_rel:HAS_ATTRIBUTE]->(attr:Attribute)-[value_rel:HAS_VALUE]->(attr_val:AttributeValue)
         WHERE attr.name = "storage_id"
-        AND attr_rel.branch = $source_branch_name
-        AND value_rel.branch = $source_branch_name
-        RETURN attr_val.value AS storage_id, (attr_rel.status = "active" AND value_rel.status = "active") AS storage_id_is_active
-        ORDER BY value_rel.from DESC, attr_rel.from DESC
+        AND all(r IN [attr_rel, value_rel] WHERE ( %(source_branch_filter)s ))
+        RETURN
+            attr_val.value AS storage_id,
+            (attr_rel.status = "active" AND value_rel.status = "active") AS storage_id_is_active,
+            $source_branch_name IN [attr_rel.branch, value_rel.branch] AS storage_id_on_source_branch
+        ORDER BY value_rel.branch_level DESC, attr_rel.branch_level DESC, value_rel.from DESC, attr_rel.from DESC
         LIMIT 1
     }
+    WITH target_node, target_is_active, target_on_source_branch,
+        definition_node, definition_is_active, definition_on_source_branch,
+        checksum, checksum_is_active, checksum_on_source_branch,
+        storage_id, storage_id_is_active, storage_id_on_source_branch
+    WHERE (target_is_active AND target_on_source_branch)
+    OR (definition_is_active AND definition_on_source_branch)
+    OR (checksum_is_active AND checksum_on_source_branch)
+    OR (storage_id_is_active AND storage_id_on_source_branch)
     RETURN CASE
         WHEN target_is_active = TRUE THEN target_node
         ELSE NULL
@@ -175,7 +198,7 @@ CALL {
         ELSE NULL
     END AS target_storage_id
 }
-        """ % {"artifact_kind": InfrahubKind.ARTIFACT}
+        """ % {"artifact_kind": InfrahubKind.ARTIFACT, "source_branch_filter": source_branch_filter}
         self.return_labels = [
             "source_artifact",
             "target_node",

--- a/backend/tests/integration/git/test_readonly_repository.py
+++ b/backend/tests/integration/git/test_readonly_repository.py
@@ -5,7 +5,10 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from infrahub.core.constants import InfrahubKind
+from infrahub.core import registry
+from infrahub.core.constants import DiffAction, InfrahubKind
+from infrahub.core.diff.artifacts.calculator import ArtifactDiffCalculator
+from infrahub.core.diff.model.diff import ArtifactTarget, BranchDiffArtifact, BranchDiffArtifactStorage
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.git.models import RequestArtifactDefinitionGenerate
@@ -22,6 +25,7 @@ if TYPE_CHECKING:
 
     from infrahub_sdk import InfrahubClient
 
+    from infrahub.core.branch.models import Branch
     from infrahub.core.protocols import CoreCheckDefinition, CoreReadOnlyRepository
     from infrahub.database import InfrahubDatabase
     from tests.conftest import TestHelper
@@ -37,20 +41,29 @@ class TestCreateReadOnlyRepository(TestInfrahubApp):
         patch.stopall()
 
     @pytest.fixture(scope="class")
+    async def load_car_schema(self, db: InfrahubDatabase) -> None:
+        await load_schema(db=db, schema=CAR_SCHEMA)
+
+    @pytest.fixture(scope="class")
+    async def person_john(self, db: InfrahubDatabase, load_car_schema) -> Node:
+        john = await Node.init(schema=TestKind.PERSON, db=db)
+        await john.new(db=db, name="John", height=175, age=25)
+        await john.save(db=db)
+        return john
+
+    @pytest.fixture(scope="class")
     async def initial_dataset(
         self,
         db: InfrahubDatabase,
         initialize_registry: None,
         git_repos_dir_module_scope: Path,
         git_repos_source_dir_module_scope: Path,
+        load_car_schema,
+        person_john: Node,
     ) -> None:
-        await load_schema(db, schema=CAR_SCHEMA)
         FileRepo(name="car-dealership", sources_directory=git_repos_source_dir_module_scope)
-        john = await Node.init(schema=TestKind.PERSON, db=db)
-        await john.new(db=db, name="John", height=175, age=25)
-        await john.save(db=db)
         people = await Node.init(schema=InfrahubKind.STANDARDGROUP, db=db)
-        await people.new(db=db, name="people", members=[john])
+        await people.new(db=db, name="people", members=[person_john])
         await people.save(db=db)
 
     async def test_step01_create_repository(
@@ -85,13 +98,28 @@ class TestCreateReadOnlyRepository(TestInfrahubApp):
         assert check_definition.file_path.value == "checks/car_overview.py"
 
     async def test_step02_validate_generated_artifacts(
-        self,
-        db: InfrahubDatabase,
-        client: InfrahubClient,
+        self, db: InfrahubDatabase, default_branch: Branch, client: InfrahubClient, person_john: Node
     ):
         artifacts = await client.all(kind=InfrahubKind.ARTIFACT, branch="ro_repository")
         assert artifacts
         assert artifacts[0].name.value == "Ownership report"
+        john_display_label = await person_john.render_display_label(db=db)
+
+        artifact_diff_calculator = ArtifactDiffCalculator(db=db)
+        branch = await registry.get_branch(db=db, branch="ro_repository")
+        diffs = await artifact_diff_calculator.calculate(source_branch=branch, target_branch=default_branch)
+        assert len(diffs) == 1
+        assert diffs[0] == BranchDiffArtifact(
+            branch="ro_repository",
+            id=artifacts[0].id,
+            display_label=f"{john_display_label} - Ownership report",
+            action=DiffAction.ADDED,
+            target=ArtifactTarget(id=person_john.id, kind="TestingPerson", display_label=john_display_label),
+            item_new=BranchDiffArtifactStorage(
+                storage_id=artifacts[0].storage_id.value, checksum=artifacts[0].checksum.value
+            ),
+            item_previous=None,
+        )
 
     async def test_step03_merge_branch(
         self,
@@ -117,3 +145,55 @@ class TestCreateReadOnlyRepository(TestInfrahubApp):
         artifacts = await client.all(kind=InfrahubKind.ARTIFACT)
         assert artifacts
         assert artifacts[0].name.value == "Ownership report"
+
+    async def test_step04_new_branch_with_artifact(
+        self,
+        db: InfrahubDatabase,
+        default_branch,
+        client: InfrahubClient,
+        helper: TestHelper,
+        person_john: Node,
+    ):
+        from infrahub.core import registry
+        from infrahub.core.diff.artifacts.calculator import ArtifactDiffCalculator
+
+        await client.branch.create(branch_name="branch", sync_with_git=False)
+        branch = await registry.get_branch(db=db, branch="branch")
+
+        manufacturer = await Node.init(schema=TestKind.MANUFACTURER, db=db, branch=branch)
+        await manufacturer.new(db=db, name="Car builder")
+        await manufacturer.save(db=db)
+        john_branch = await NodeManager.get_one(db=db, branch=branch, id=person_john.id)
+        john_branch.name.value = "John2"
+        await john_branch.save(db=db)
+        john_display_label = await john_branch.render_display_label(db=db)
+
+        artifact_definitions = await client.all(kind=InfrahubKind.ARTIFACTDEFINITION)
+
+        for artifact_definition in artifact_definitions:
+            model = RequestArtifactDefinitionGenerate(artifact_definition=artifact_definition.id, branch="branch")
+            await services.service.workflow.submit_workflow(
+                REQUEST_ARTIFACT_DEFINITION_GENERATE, parameters={"model": model}
+            )
+
+        artifacts = await client.all(kind=InfrahubKind.ARTIFACT, branch="branch")
+        assert artifacts
+        assert artifacts[0].name.value == "Ownership report"
+        artifact_main = await NodeManager.get_one(db=db, id=artifacts[0].id)
+
+        artifact_diff_calculator = ArtifactDiffCalculator(db=db)
+        diffs = await artifact_diff_calculator.calculate(source_branch=branch, target_branch=default_branch)
+        assert len(diffs) == 1
+        assert diffs[0] == BranchDiffArtifact(
+            branch="branch",
+            id=artifacts[0].id,
+            display_label=f"{john_display_label} - Ownership report",
+            action=DiffAction.UPDATED,
+            target=ArtifactTarget(id=person_john.id, kind="TestingPerson", display_label=john_display_label),
+            item_new=BranchDiffArtifactStorage(
+                storage_id=artifacts[0].storage_id.value, checksum=artifacts[0].checksum.value
+            ),
+            item_previous=BranchDiffArtifactStorage(
+                storage_id=artifact_main.storage_id.value, checksum=artifact_main.checksum.value
+            ),
+        )

--- a/backend/tests/unit/core/diff/test_calculate_artifact_diff.py
+++ b/backend/tests/unit/core/diff/test_calculate_artifact_diff.py
@@ -43,10 +43,11 @@ async def car_person_data_artifact_diff(
     )
     await ad1.save(db=db)
 
+    # artifact on main and branch with updates
     art1 = await Node.init(db=db, schema=InfrahubKind.ARTIFACT)
     await art1.new(
         db=db,
-        name="myyartifact",
+        name="art_1_main",
         definition=ad1,
         status="Ready",
         object=car_person_data_generic["c1"],
@@ -55,13 +56,26 @@ async def car_person_data_artifact_diff(
         content_type="application/json",
     )
     await art1.save(db=db)
+    # artifact on main, same node updated on branch
+    art6_main = await Node.init(db=db, schema=InfrahubKind.ARTIFACT, branch=default_branch)
+    await art6_main.new(
+        db=db,
+        name="art_6_main",
+        definition=ad1,
+        status="Ready",
+        object=car_person_data_generic["p2"],
+        storage_id=str(uuid4()),
+        checksum=str(uuid4()),
+        content_type="application/json",
+    )
+    await art6_main.save(db=db)
 
     branch3 = await create_branch(branch_name="branch3", db=db)
 
     art1_branch = await Node.init(db=db, branch=branch3, schema=InfrahubKind.ARTIFACT)
     await art1_branch.new(
         db=db,
-        name="myyartifact",
+        name="art_1_branch",
         definition=ad1,
         status="Ready",
         object=car_person_data_generic["c1"],
@@ -73,15 +87,16 @@ async def car_person_data_artifact_diff(
     art1_branch = await NodeManager.get_one(db=db, branch=branch3, id=art1_branch.id)
     art1_branch.storage_id.value = "azertyui-073f-4173-aa4b-f50e1309f03c"
     await art1_branch.save(db=db)
-    art1_main = await NodeManager.get_one(db=db, branch=branch3, id=art1.id)
+    art1_main = await NodeManager.get_one(db=db, id=art1.id)
     art1_main.storage_id.value = str(uuid4())
     art1_main.checksum.value = str(uuid4())
     await art1_main.save(db=db)
 
+    # artifact only on branch
     art2 = await Node.init(db=db, schema=InfrahubKind.ARTIFACT, branch=branch3)
     await art2.new(
         db=db,
-        name="myyartifact",
+        name="art_2_branch",
         definition=ad1,
         status="Ready",
         object=car_person_data_generic["c2"],
@@ -91,10 +106,11 @@ async def car_person_data_artifact_diff(
     )
     await art2.save(db=db)
 
+    # artifact on both branches
     art3_main = await Node.init(db=db, schema=InfrahubKind.ARTIFACT, branch=default_branch)
     await art3_main.new(
         db=db,
-        name="myyartifact",
+        name="art_3_main",
         definition=ad1,
         status="Ready",
         object=car_person_data_generic["c3"],
@@ -107,7 +123,7 @@ async def car_person_data_artifact_diff(
     art3_branch = await Node.init(db=db, schema=InfrahubKind.ARTIFACT, branch=branch3)
     await art3_branch.new(
         db=db,
-        name="myyartifact",
+        name="art_3_branch",
         definition=ad1,
         status="Ready",
         object=car_person_data_generic["c3"],
@@ -117,10 +133,11 @@ async def car_person_data_artifact_diff(
     )
     await art3_branch.save(db=db)
 
+    # deleted artifact
     art4_main = await Node.init(db=db, schema=InfrahubKind.ARTIFACT, branch=default_branch)
     await art4_main.new(
         db=db,
-        name="myyartifact",
+        name="art_4_main",
         definition=ad1,
         status="Ready",
         object=car_person_data_generic["c4"],
@@ -133,7 +150,7 @@ async def car_person_data_artifact_diff(
     art4_branch = await Node.init(db=db, schema=InfrahubKind.ARTIFACT, branch=branch3)
     await art4_branch.new(
         db=db,
-        name="myyartifact",
+        name="art_4_branch",
         definition=ad1,
         status="Ready",
         object=car_person_data_generic["c4"],
@@ -144,12 +161,32 @@ async def car_person_data_artifact_diff(
     await art4_branch.save(db=db)
     await art4_branch.delete(db=db)
 
+    # artifact only on main
+    art5_main = await Node.init(db=db, schema=InfrahubKind.ARTIFACT, branch=default_branch)
+    await art5_main.new(
+        db=db,
+        name="art_5_main",
+        definition=ad1,
+        status="Ready",
+        object=car_person_data_generic["p1"],
+        storage_id=str(uuid4()),
+        checksum=str(uuid4()),
+        content_type="application/json",
+    )
+    await art5_main.save(db=db)
+
+    art6_branch = await NodeManager.get_one(db=db, branch=branch3, id=art6_main.id)
+    art6_branch.storage_id.value = str(uuid4())
+    await art6_branch.save(db=db)
+
     car_person_data_generic["branch3"] = branch3
-    car_person_data_generic["art1"] = art1
+    car_person_data_generic["art1"] = art1_main
     car_person_data_generic["art1_branch"] = art1_branch
     car_person_data_generic["art2_branch"] = art2
     car_person_data_generic["art3"] = art3_main
     car_person_data_generic["art3_branch"] = art3_branch
+    car_person_data_generic["art6"] = art6_main
+    car_person_data_generic["art6_branch"] = art6_branch
 
     return car_person_data_generic
 
@@ -158,13 +195,17 @@ async def test_calculate_artifact_diff(
     db: InfrahubDatabase, default_branch: Branch, car_person_data_artifact_diff: dict[str, Node]
 ):
     source_branch = car_person_data_artifact_diff["branch3"]
+    art1_main = car_person_data_artifact_diff["art1"]
     art1_branch = car_person_data_artifact_diff["art1_branch"]
     art2_branch = car_person_data_artifact_diff["art2_branch"]
     art3_branch = car_person_data_artifact_diff["art3_branch"]
+    art6_main = car_person_data_artifact_diff["art6"]
+    art6_branch = car_person_data_artifact_diff["art6_branch"]
+    # art 1
     expected_artifact_diff_1 = BranchDiffArtifact(
         branch=source_branch.name,
         id=art1_branch.id,
-        display_label="volt #444444 - myyartifact",
+        display_label="volt #444444 - art_1_branch",
         action=DiffAction.UPDATED,
         target=ArtifactTarget(
             id=car_person_data_artifact_diff["c1"].id,
@@ -176,14 +217,15 @@ async def test_calculate_artifact_diff(
             checksum="zxcv9063c26263353de24e1b911z1x2c3v",
         ),
         item_previous=BranchDiffArtifactStorage(
-            storage_id="8caf6f89-073f-4173-aa4b-f50e1309f03c",
-            checksum="60d39063c26263353de24e1b913e1e1c",
+            storage_id=art1_main.storage_id.value,
+            checksum=art1_main.checksum.value,
         ),
     )
+    # art 2
     expected_artifact_diff_2 = BranchDiffArtifact(
         branch=source_branch.name,
         id=art2_branch.id,
-        display_label="bolt #444444 - myyartifact",
+        display_label="bolt #444444 - art_2_branch",
         action=DiffAction.ADDED,
         target=ArtifactTarget(
             id=car_person_data_artifact_diff["c2"].id,
@@ -196,10 +238,11 @@ async def test_calculate_artifact_diff(
         ),
         item_previous=None,
     )
+    # art 3
     expected_artifact_diff_3 = BranchDiffArtifact(
         branch=source_branch.name,
         id=art3_branch.id,
-        display_label="nolt #444444 - myyartifact",
+        display_label="nolt #444444 - art_3_branch",
         action=DiffAction.UPDATED,
         target=ArtifactTarget(
             id=car_person_data_artifact_diff["c3"].id,
@@ -215,13 +258,34 @@ async def test_calculate_artifact_diff(
             checksum="poiuytrewq9063c26263353de24e1b913e1e1c",
         ),
     )
+    # art 6
+    expected_artifact_diff_6 = BranchDiffArtifact(
+        branch=source_branch.name,
+        id=art6_branch.id,
+        display_label="Jane - art_6_main",
+        action=DiffAction.UPDATED,
+        target=ArtifactTarget(
+            id=car_person_data_artifact_diff["p2"].id,
+            kind="TestPerson",
+            display_label="Jane",
+        ),
+        item_new=BranchDiffArtifactStorage(
+            storage_id=art6_branch.storage_id.value,
+            checksum=art6_branch.checksum.value,
+        ),
+        item_previous=BranchDiffArtifactStorage(
+            storage_id=art6_main.storage_id.value,
+            checksum=art6_main.checksum.value,
+        ),
+    )
 
     artifact_diff_calculator = ArtifactDiffCalculator(db=db)
     artifact_diffs = await artifact_diff_calculator.calculate(source_branch=source_branch, target_branch=default_branch)
 
-    assert len(artifact_diffs) == 3
+    assert len(artifact_diffs) == 4
     diffs_by_id = {d.id: d for d in artifact_diffs}
-    assert set(diffs_by_id.keys()) == {art1_branch.id, art2_branch.id, art3_branch.id}
+    assert set(diffs_by_id.keys()) == {art1_branch.id, art2_branch.id, art3_branch.id, art6_branch.id}
     assert diffs_by_id[art1_branch.id] == expected_artifact_diff_1
     assert diffs_by_id[art2_branch.id] == expected_artifact_diff_2
     assert diffs_by_id[art3_branch.id] == expected_artifact_diff_3
+    assert diffs_by_id[art6_branch.id] == expected_artifact_diff_6


### PR DESCRIPTION
IFC-1020
no changelog b/c this new artifact query was introduced after 1.0 and never ported back, so we only need this update in 1.1

fixes a bug in the new query for getting artifact diffs. the bug was that the query only looked for CoreArtifacts created on the `source_branch`, but the `CoreArtifact` could have been created on the `target_branch` (always `main` for now) and then updated on the `source_branch`. I thought this kind of handling would not be necessary because `CoreArtifact`s are `branch=local`, but I did not consider the following case for `branch=local` schema
1. an artifact is created on `main`
2. we create a new branch `branch2`
3. the artifact generation logic makes an update to the existing artifact on `branch2`
in this case, the `CoreArtifact` node is on the `main` branch, but it has updates to its attributes/relationships on the `branch2` branch

added some unit tests and integration tests to cover this