### PR TITLE
fix(backend): randomize telemetry workflow schedule

### DIFF
--- a/backend/infrahub/workflows/catalogue.py
+++ b/backend/infrahub/workflows/catalogue.py
@@ -1,3 +1,5 @@
+import random
+
 from .constants import WorkflowTag, WorkflowType
 from .models import WorkerPoolDefinition, WorkflowDefinition
 
@@ -27,7 +29,7 @@ TRANSFORM_PYTHON_RENDER = WorkflowDefinition(
 ANONYMOUS_TELEMETRY_SEND = WorkflowDefinition(
     name="anonymous_telemetry_send",
     type=WorkflowType.INTERNAL,
-    cron="0 2 * * *",
+    cron=f"{random.randint(0, 59)} 2 * * *",
     module="infrahub.tasks.telemetry",
     function="send_telemetry_push",
 )


### PR DESCRIPTION
Having all Infrahub instances send telemetry at the exact same time would stress the telemetry backend and make it error prone due to the rate limiting (if multiple instances are behind the same address).

Randomize the cron schedule to workaround that issue. The cron schedule would be changed everytime infrahub-server restarts but I think this is the most straightforward way.