### PR TITLE
Update infrahub-testcontainers to 1.1.0

### DIFF
--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
-name = "infrahub-testing"
-version = "1.1.0b2"
+name = "infrahub-testcontainers"
+version = "1.1.0"
 requires-python = ">=3.9"
 
 [tool.poetry]
 name = "infrahub-testcontainers"
-version = "1.1.0b2"
+version = "1.1.0"
 description = "Testcontainers instance for Infrahub to easily build integration tests"
 authors = ["OpsMill <info@opsmill.com>"]
 readme = "README.md"


### PR DESCRIPTION
We need to implement some check in CI to ensure that the version of `infrahub-testcontainers` always matches the version of infrahub
