### PR TITLE
Validate uniqueness_constraint using NodeGetList

### DIFF
--- a/backend/infrahub/core/node/constraints/grouped_uniqueness.py
+++ b/backend/infrahub/core/node/constraints/grouped_uniqueness.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Iterable, Optional
 
 from infrahub.core import registry
+from infrahub.core.query.node import NodeGetListQuery
 from infrahub.core.schema import (
     MainSchemaTypes,
     SchemaAttributePath,
@@ -151,16 +152,44 @@ class NodeGroupedUniquenessConstraint(NodeConstraintInterface):
     ) -> None:
         schema_branch = self.db.schema.get_schema_branch(name=self.branch.name)
         path_groups = node_schema.get_unique_constraint_schema_attribute_paths(schema_branch=schema_branch)
-        query_request = self._build_query_request(
-            updated_node=node, node_schema=node_schema, path_groups=path_groups, filters=filters
-        )
-        if not query_request:
-            return
-        query = await NodeUniqueAttributeConstraintQuery.init(
-            db=self.db, branch=self.branch, at=at, query_request=query_request, min_count_required=0
-        )
-        await query.execute(db=self.db)
-        await self._check_results(updated_node=node, path_groups=path_groups, query_results=query.get_results())
+
+        for path_group in path_groups:
+            query_request = self._build_query_request(
+                updated_node=node, node_schema=node_schema, path_groups=[path_group], filters=filters
+            )
+
+            if not query_request:
+                continue
+
+            if query_request.has_attributes_only:
+                query_filters: dict[str, str] = {
+                    f"{attr.attribute_name}__{attr.property_name}": attr.value
+                    for attr in query_request.unique_attribute_paths
+                    if attr.value
+                }
+                get_node_query = await NodeGetListQuery.init(
+                    db=self.db,
+                    schema=node_schema,
+                    branch=self.branch,
+                    filters=query_filters,
+                    at=at,
+                    partial_match=False,
+                    branch_agnostic=False,
+                )
+                await get_node_query.execute(db=self.db)
+                node_ids = get_node_query.get_node_ids()
+
+                if (node.id in node_ids and len(node_ids) > 1) or (node.id not in node_ids and len(node_ids) > 0):
+                    raise ValidationError(query_request.get_error_message())
+
+            else:
+                query = await NodeUniqueAttributeConstraintQuery.init(
+                    db=self.db, branch=self.branch, at=at, query_request=query_request, min_count_required=0
+                )
+                await query.execute(db=self.db)
+                await self._check_results(
+                    updated_node=node, path_groups=[path_group], query_results=query.get_results()
+                )
 
     async def check(self, node: Node, at: Optional[Timestamp] = None, filters: Optional[list[str]] = None) -> None:
         node_schema = node.get_schema()

--- a/backend/infrahub/core/node/constraints/grouped_uniqueness.py
+++ b/backend/infrahub/core/node/constraints/grouped_uniqueness.py
@@ -150,6 +150,11 @@ class NodeGroupedUniquenessConstraint(NodeConstraintInterface):
         at: Optional[Timestamp] = None,
         filters: Optional[list[str]] = None,
     ) -> None:
+        """
+        Raises a `ValidationError` if database contains at least one node having same `uniqueness_constraint` attributes
+        than input `node` ones.
+        """
+
         schema_branch = self.db.schema.get_schema_branch(name=self.branch.name)
         path_groups = node_schema.get_unique_constraint_schema_attribute_paths(schema_branch=schema_branch)
 
@@ -158,7 +163,7 @@ class NodeGroupedUniquenessConstraint(NodeConstraintInterface):
                 updated_node=node, node_schema=node_schema, path_groups=[path_group], filters=filters
             )
 
-            if not query_request:
+            if query_request.is_empty():
                 continue
 
             if query_request.has_attributes_only:
@@ -179,6 +184,7 @@ class NodeGroupedUniquenessConstraint(NodeConstraintInterface):
                 await get_node_query.execute(db=self.db)
                 node_ids = get_node_query.get_node_ids()
 
+                # Node may or may not already exist in the database.
                 if (node.id in node_ids and len(node_ids) > 1) or (node.id not in node_ids and len(node_ids) > 0):
                     raise ValidationError(query_request.get_error_message())
 

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -804,12 +804,18 @@ class NodeGetListQuery(Query):
     type = QueryType.READ
 
     def __init__(
-        self, schema: NodeSchema, filters: Optional[dict] = None, partial_match: bool = False, **kwargs: Any
+        self,
+        schema: NodeSchema,
+        filters: Optional[dict] = None,
+        partial_match: bool = False,
+        ordering: bool = True,
+        **kwargs: Any,
     ) -> None:
         self.schema = schema
         self.filters = filters
         self.partial_match = partial_match
         self._variables_to_track = ["n", "rb"]
+        self.ordering = ordering
         self._validate_filters()
 
         super().__init__(**kwargs)
@@ -1176,7 +1182,7 @@ class NodeGetListQuery(Query):
                         types=[FieldAttributeRequirementType.FILTER],
                     )
                     index += 1
-        if not self.schema.order_by:
+        if not self.schema.order_by or not self.ordering:
             return list(field_requirements_map.values())
 
         for order_by_path in self.schema.order_by:

--- a/backend/infrahub/core/validators/uniqueness/checker.py
+++ b/backend/infrahub/core/validators/uniqueness/checker.py
@@ -112,7 +112,7 @@ class UniquenessChecker(ConstraintCheckerInterface):
     ) -> list[NonUniqueNode]:
         query_request = await self.build_query_request(schema)
 
-        if not query_request:
+        if query_request.is_empty():
             return []
 
         query = await NodeUniqueAttributeConstraintQuery.init(

--- a/backend/infrahub/core/validators/uniqueness/model.py
+++ b/backend/infrahub/core/validators/uniqueness/model.py
@@ -58,6 +58,16 @@ class NodeUniquenessQueryRequest(BaseModel):
             )
         )
 
+    @property
+    def has_attributes_only(self) -> bool:
+        if self.relationship_attribute_paths:
+            return False
+        return True
+
+    def get_error_message(self) -> str:
+        uniqueness_constaints = [f"{attr.attribute_name}__{attr.property_name}" for attr in self.unique_attribute_paths]
+        return f"Violates uniqueness constraint '{uniqueness_constaints}'"
+
 
 class NonUniqueRelatedAttribute(BaseModel):
     relationship: RelationshipSchema

--- a/backend/infrahub/core/validators/uniqueness/model.py
+++ b/backend/infrahub/core/validators/uniqueness/model.py
@@ -39,10 +39,8 @@ class NodeUniquenessQueryRequest(BaseModel):
     unique_attribute_paths: set[QueryAttributePath] = Field(default_factory=set)
     relationship_attribute_paths: set[QueryRelationshipAttributePath] = Field(default_factory=set)
 
-    def __bool__(self) -> bool:
-        if self.unique_attribute_paths or self.relationship_attribute_paths:
-            return True
-        return False
+    def is_empty(self) -> bool:
+        return not self.unique_attribute_paths and not self.relationship_attribute_paths
 
     def __str__(self) -> str:
         return (
@@ -65,7 +63,9 @@ class NodeUniquenessQueryRequest(BaseModel):
         return True
 
     def get_error_message(self) -> str:
-        uniqueness_constaints = [f"{attr.attribute_name}__{attr.property_name}" for attr in self.unique_attribute_paths]
+        uniqueness_constaints = sorted(
+            [f"{attr.attribute_name}__{attr.property_name}" for attr in self.unique_attribute_paths]
+        )
         return f"Violates uniqueness constraint '{uniqueness_constaints}'"
 
 

--- a/backend/infrahub/dependencies/builder/constraint/grouped/node_runner.py
+++ b/backend/infrahub/dependencies/builder/constraint/grouped/node_runner.py
@@ -15,7 +15,7 @@ class NodeConstraintRunnerDependency(DependencyBuilder[NodeConstraintRunner]):
             db=context.db,
             branch=context.branch,
             node_constraints=[
-                NodeAttributeUniquenessConstraintDependency.build(context=context),
+                NodeAttributeUniquenessConstraintDependency.build(context=context), # NOTE we probably don't need this Checker, it's redundant with NodeGroupedUniquenessConstraintDependency
                 NodeGroupedUniquenessConstraintDependency.build(context=context),
             ],
             relationship_manager_constraints=[

--- a/backend/infrahub/dependencies/builder/constraint/grouped/node_runner.py
+++ b/backend/infrahub/dependencies/builder/constraint/grouped/node_runner.py
@@ -2,7 +2,6 @@ from infrahub.core.constraint.node.runner import NodeConstraintRunner
 from infrahub.dependencies.interface import DependencyBuilder, DependencyBuilderContext
 
 from ..node.grouped_uniqueness import NodeGroupedUniquenessConstraintDependency
-from ..node.uniqueness import NodeAttributeUniquenessConstraintDependency
 from ..relationship_manager.count import RelationshipCountConstraintDependency
 from ..relationship_manager.peer_kind import RelationshipPeerKindConstraintDependency
 from ..relationship_manager.profiles_kind import RelationshipProfilesKindConstraintDependency
@@ -15,7 +14,6 @@ class NodeConstraintRunnerDependency(DependencyBuilder[NodeConstraintRunner]):
             db=context.db,
             branch=context.branch,
             node_constraints=[
-                NodeAttributeUniquenessConstraintDependency.build(context=context), # NOTE we probably don't need this Checker, it's redundant with NodeGroupedUniquenessConstraintDependency
                 NodeGroupedUniquenessConstraintDependency.build(context=context),
             ],
             relationship_manager_constraints=[

--- a/backend/tests/helpers/query_benchmark/db_query_profiler.py
+++ b/backend/tests/helpers/query_benchmark/db_query_profiler.py
@@ -134,6 +134,7 @@ class InfrahubDatabaseProfiler(InfrahubDatabase):
 
         # Do the query and measure duration
         time_start = time.time()
+        print(f"{query=}")
         response, metadata = await super().execute_query_with_metadata(query=query, params=params, name=name, type=type)
         duration_time = time.time() - time_start
 

--- a/backend/tests/query_benchmark/conftest.py
+++ b/backend/tests/query_benchmark/conftest.py
@@ -21,6 +21,7 @@ async def car_person_schema_root() -> SchemaRoot:
                 "default_filter": "name__value",
                 "display_labels": ["name__value", "color__value"],
                 "uniqueness_constraints": [["name__value"]],
+                "order_by": ["name__value"],
                 "branch": BranchSupportType.AWARE.value,
                 "attributes": [
                     {"name": "name", "kind": "Text", "unique": True},
@@ -58,6 +59,7 @@ async def car_person_schema_root() -> SchemaRoot:
                 "display_labels": ["name__value"],
                 "branch": BranchSupportType.AWARE.value,
                 "uniqueness_constraints": [["name__value"]],
+                "order_by": ["name__value"],
                 "attributes": [
                     {"name": "name", "kind": "Text", "unique": True},
                     {"name": "height", "kind": "Number", "optional": True},
@@ -82,6 +84,7 @@ async def car_person_schema_root() -> SchemaRoot:
                 "namespace": "Test",
                 "default_filter": "name__value",
                 "display_labels": ["name__value"],
+                "order_by": ["name__value"],
                 "branch": BranchSupportType.AWARE.value,
                 "uniqueness_constraints": [["name__value"]],
                 "attributes": [

--- a/backend/tests/query_benchmark/test_node_get_list.py
+++ b/backend/tests/query_benchmark/test_node_get_list.py
@@ -1,21 +1,18 @@
 import inspect
 from pathlib import Path
-from pickle import FALSE
 
 import pytest
 
 from infrahub.core import registry
-from infrahub.core.initialization import create_branch
-from infrahub.core.manager import NodeManager
-from infrahub.core.query.diff import DiffAllPathsQuery
 from infrahub.core.query.node import NodeGetListQuery
-from infrahub.core.timestamp import Timestamp
+from infrahub.core.validators.uniqueness.model import NodeUniquenessQueryRequest, QueryAttributePath
+from infrahub.core.validators.uniqueness.query import NodeUniqueAttributeConstraintQuery
 from infrahub.database.constants import Neo4jRuntime
 from infrahub.log import get_logger
-from tests.helpers.constants import NEO4J_COMMUNITY_IMAGE, NEO4J_ENTERPRISE_IMAGE
+from tests.helpers.constants import NEO4J_ENTERPRISE_IMAGE
 from tests.helpers.query_benchmark.benchmark_config import BenchmarkConfig
 from tests.helpers.query_benchmark.car_person_generators import (
-    CarWithDiffInSecondBranchGenerator, CarGenerator,
+    CarGenerator,
 )
 from tests.helpers.query_benchmark.data_generator import load_data_and_profile
 from tests.query_benchmark.conftest import RESULTS_FOLDER
@@ -30,17 +27,35 @@ log = get_logger()
 @pytest.mark.parametrize(
     "benchmark_config, ordering",
     [
-        (BenchmarkConfig(neo4j_runtime=Neo4jRuntime.PARALLEL, neo4j_image=NEO4J_ENTERPRISE_IMAGE, load_db_indexes=False), False),
-        (BenchmarkConfig(neo4j_runtime=Neo4jRuntime.PARALLEL, neo4j_image=NEO4J_ENTERPRISE_IMAGE, load_db_indexes=False), True),
+        # (BenchmarkConfig(neo4j_runtime=Neo4jRuntime.PARALLEL, neo4j_image=NEO4J_ENTERPRISE_IMAGE, load_db_indexes=False), False),
+        (
+            BenchmarkConfig(
+                neo4j_runtime=Neo4jRuntime.PARALLEL, neo4j_image=NEO4J_ENTERPRISE_IMAGE, load_db_indexes=False
+            ),
+            True,
+        ),
     ],
 )
-async def test_node_get_list_ordering(benchmark_config, car_person_schema_root, graph_generator, increase_query_size_limit, ordering):
+async def test_node_get_list_ordering_vs_uniqueness(
+    benchmark_config, car_person_schema_root, graph_generator, increase_query_size_limit, ordering
+):
     # Initialization
     db_profiling_queries, default_branch = await start_db_and_create_default_branch(
         neo4j_image=benchmark_config.neo4j_image,
         load_indexes=benchmark_config.load_db_indexes,
     )
     registry.schema.register_schema(schema=car_person_schema_root, branch=default_branch.name)
+
+    query_request = NodeUniquenessQueryRequest(
+        kind="TestCar",
+        unique_attribute_paths={
+            QueryAttributePath(attribute_name="name", property_name="value"),
+            # QueryAttributePath(attribute_name="nbr_seats", property_name="value"),
+        },
+        # relationship_attribute_paths={
+        #     QueryRelationshipAttributePath(identifier="testcar__testperson", attribute_name="name")
+        # },
+    )
 
     # Build function to profile
     async def init_and_execute():
@@ -50,13 +65,20 @@ async def test_node_get_list_ordering(benchmark_config, car_person_schema_root, 
             schema=car_node_schema,
             branch=default_branch,
             ordering=ordering,
+            filters={"name": "aaaa"},
         )
-        res = await query.execute(db=db_profiling_queries)
-        print(f"{len(res.get_node_ids())=}")
-        return res
+        res_node_get_list = await query.execute(db=db_profiling_queries)
+        print(f"{len(res_node_get_list.get_node_ids())=}")
 
+        query_uniqueness = await NodeUniqueAttributeConstraintQuery.init(
+            db=db_profiling_queries,
+            branch=default_branch,
+            query_request=query_request,
+        )
+        await query_uniqueness.execute(db=db_profiling_queries)
+        print(f"{query_uniqueness.results=}")
 
-    nb_cars = 10_000
+    nb_cars = 5_000
     cars_generator = CarGenerator(db=db_profiling_queries)
     test_name = inspect.currentframe().f_code.co_name
     module_name = Path(__file__).stem
@@ -67,7 +89,7 @@ async def test_node_get_list_ordering(benchmark_config, car_person_schema_root, 
     await load_data_and_profile(
         data_generator=cars_generator,
         func_call=init_and_execute,
-        profile_frequency=1_000,
+        profile_frequency=500,
         nb_elements=nb_cars,
         graphs_output_location=graph_output_location,
         test_label=test_label,

--- a/backend/tests/query_benchmark/test_node_get_list.py
+++ b/backend/tests/query_benchmark/test_node_get_list.py
@@ -1,0 +1,75 @@
+import inspect
+from pathlib import Path
+from pickle import FALSE
+
+import pytest
+
+from infrahub.core import registry
+from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.query.diff import DiffAllPathsQuery
+from infrahub.core.query.node import NodeGetListQuery
+from infrahub.core.timestamp import Timestamp
+from infrahub.database.constants import Neo4jRuntime
+from infrahub.log import get_logger
+from tests.helpers.constants import NEO4J_COMMUNITY_IMAGE, NEO4J_ENTERPRISE_IMAGE
+from tests.helpers.query_benchmark.benchmark_config import BenchmarkConfig
+from tests.helpers.query_benchmark.car_person_generators import (
+    CarWithDiffInSecondBranchGenerator, CarGenerator,
+)
+from tests.helpers.query_benchmark.data_generator import load_data_and_profile
+from tests.query_benchmark.conftest import RESULTS_FOLDER
+from tests.query_benchmark.utils import start_db_and_create_default_branch
+
+log = get_logger()
+
+# pytestmark = pytest.mark.skip("Not relevant to test this currently.")
+
+
+@pytest.mark.timeout(36000)  # 10 hours
+@pytest.mark.parametrize(
+    "benchmark_config, ordering",
+    [
+        (BenchmarkConfig(neo4j_runtime=Neo4jRuntime.PARALLEL, neo4j_image=NEO4J_ENTERPRISE_IMAGE, load_db_indexes=False), False),
+        (BenchmarkConfig(neo4j_runtime=Neo4jRuntime.PARALLEL, neo4j_image=NEO4J_ENTERPRISE_IMAGE, load_db_indexes=False), True),
+    ],
+)
+async def test_node_get_list_ordering(benchmark_config, car_person_schema_root, graph_generator, increase_query_size_limit, ordering):
+    # Initialization
+    db_profiling_queries, default_branch = await start_db_and_create_default_branch(
+        neo4j_image=benchmark_config.neo4j_image,
+        load_indexes=benchmark_config.load_db_indexes,
+    )
+    registry.schema.register_schema(schema=car_person_schema_root, branch=default_branch.name)
+
+    # Build function to profile
+    async def init_and_execute():
+        car_node_schema = registry.get_node_schema(name="TestCar", branch=default_branch.name)
+        query = await NodeGetListQuery.init(
+            db=db_profiling_queries,
+            schema=car_node_schema,
+            branch=default_branch,
+            ordering=ordering,
+        )
+        res = await query.execute(db=db_profiling_queries)
+        print(f"{len(res.get_node_ids())=}")
+        return res
+
+
+    nb_cars = 10_000
+    cars_generator = CarGenerator(db=db_profiling_queries)
+    test_name = inspect.currentframe().f_code.co_name
+    module_name = Path(__file__).stem
+    graph_output_location = RESULTS_FOLDER / module_name / test_name
+
+    test_label = str(benchmark_config) + "_ordering_" + str(ordering)
+
+    await load_data_and_profile(
+        data_generator=cars_generator,
+        func_call=init_and_execute,
+        profile_frequency=1_000,
+        nb_elements=nb_cars,
+        graphs_output_location=graph_output_location,
+        test_label=test_label,
+        graph_generator=graph_generator,
+    )

--- a/backend/tests/unit/core/constraint_validators/test_node_grouped_uniqueness.py
+++ b/backend/tests/unit/core/constraint_validators/test_node_grouped_uniqueness.py
@@ -67,6 +67,7 @@ class TestNodeGroupedUniquenessConstraint:
         car_volt_main: Node,
     ):
         car_accord_main.name.value = "camry"
+        car_accord_main.color.value = "#123456"
         car_accord_main.get_schema().uniqueness_constraints = [
             ["name__value", "color__value"],
             ["nbr_seats__value", "name__value"],

--- a/backend/tests/unit/core/constraint_validators/test_node_grouped_uniqueness.py
+++ b/backend/tests/unit/core/constraint_validators/test_node_grouped_uniqueness.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from infrahub.core import registry
@@ -31,7 +33,7 @@ class TestNodeGroupedUniquenessConstraint:
         car_accord_main.name.value = "camry"
         car_accord_main.get_schema().uniqueness_constraints = [["name__value"]]
 
-        with pytest.raises(ValidationError, match="Violates uniqueness constraint 'name'"):
+        with pytest.raises(ValidationError, match=re.escape("Violates uniqueness constraint '['name__value']'")):
             await self.__call_system_under_test(db=db, branch=default_branch, node=car_accord_main)
 
     async def test_uniqueness_constraint_filters(
@@ -66,14 +68,34 @@ class TestNodeGroupedUniquenessConstraint:
         car_camry_main: Node,
         car_volt_main: Node,
     ):
-        car_accord_main.name.value = "camry"
-        car_accord_main.color.value = "#123456"
+        car_accord_main.name.value = car_camry_main.name.value
         car_accord_main.get_schema().uniqueness_constraints = [
             ["name__value", "color__value"],
-            ["nbr_seats__value", "name__value"],
         ]
 
-        with pytest.raises(ValidationError, match="Violates uniqueness constraint 'name-color'"):
+        with pytest.raises(
+            ValidationError, match=re.escape("Violates uniqueness constraint '['color__value', 'name__value']'")
+        ):
+            await self.__call_system_under_test(db=db, branch=default_branch, node=car_accord_main)
+
+    async def test_uniqueness_constraint_conflict_multiple_constraints(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        car_accord_main: Node,
+        car_camry_main: Node,
+        car_volt_main: Node,
+    ):
+        car_accord_main.nbr_seats.value = car_camry_main.nbr_seats.value
+        car_accord_main.color.value = car_camry_main.color.value
+        car_accord_main.get_schema().uniqueness_constraints = [
+            ["name__value", "color__value"],
+            ["nbr_seats__value", "color__value"],
+        ]
+
+        with pytest.raises(
+            ValidationError, match=re.escape("Violates uniqueness constraint '['color__value', 'nbr_seats__value']'")
+        ):
             await self.__call_system_under_test(db=db, branch=default_branch, node=car_accord_main)
 
     async def test_uniqueness_constraint_no_conflict_attribute_enum(
@@ -108,7 +130,7 @@ class TestNodeGroupedUniquenessConstraint:
         car_accord_main.name.value = "camry"
         car_accord_main.get_schema().uniqueness_constraints = [["nbr_seats__value", "name__value"]]
 
-        with pytest.raises(ValidationError, match="Violates uniqueness constraint 'nbr_seats-name'"):
+        with pytest.raises(ValidationError, match="Violates uniqueness constraint ['name__value', 'nbr_seats__value']"):
             await self.__call_system_under_test(db=db, branch=default_branch, node=car_accord_main)
 
     async def test_uniqueness_constraint_no_conflict_one_relationship(

--- a/backend/tests/unit/core/test_node_get_list_query.py
+++ b/backend/tests/unit/core/test_node_get_list_query.py
@@ -374,6 +374,22 @@ async def test_query_NodeGetListQuery_order_by(
     assert query.get_node_ids() == [car_camry_main.id, car_yaris_main.id, car_accord_main.id, car_volt_main.id]
 
 
+async def test_query_NodeGetListQuery_order_by_disabled(
+    db: InfrahubDatabase, car_accord_main, car_camry_main, car_volt_main, car_yaris_main, branch: Branch
+):
+    schema = registry.schema.get(name="TestCar", branch=branch)
+    schema.order_by = ["owner__name__value", "name__value"]
+
+    query = await NodeGetListQuery.init(
+        db=db,
+        branch=branch,
+        schema=schema,
+        ordering=False,
+    )
+    await query.execute(db=db)
+    assert query.get_node_ids() == sorted([car_camry_main.id, car_yaris_main.id, car_accord_main.id, car_volt_main.id])
+
+
 async def test_query_NodeGetListQuery_order_by_optional_relationship_nulls(
     db: InfrahubDatabase, car_accord_main, car_camry_main, car_volt_main, car_yaris_main, branch: Branch
 ):

--- a/backend/tests/unit/graphql/test_mutation_create.py
+++ b/backend/tests/unit/graphql/test_mutation_create.py
@@ -140,7 +140,7 @@ async def test_create_check_unique(db: InfrahubDatabase, default_branch, car_per
 
     assert result.errors
     assert len(result.errors) == 1
-    assert "An object already exist" in result.errors[0].message
+    assert "Violates uniqueness constraint '['name__value']'" in result.errors[0].message
 
 
 async def test_create_check_unique_across_branch(db: InfrahubDatabase, default_branch, car_person_schema):
@@ -172,7 +172,7 @@ async def test_create_check_unique_across_branch(db: InfrahubDatabase, default_b
 
     assert result.errors
     assert len(result.errors) == 1
-    assert "An object already exist" in result.errors[0].message
+    assert "Violates uniqueness constraint '['name__value']'" in result.errors[0].message
 
 
 async def test_create_check_unique_in_branch(db: InfrahubDatabase, default_branch, car_person_schema):
@@ -203,7 +203,7 @@ async def test_create_check_unique_in_branch(db: InfrahubDatabase, default_branc
 
     assert result.errors
     assert len(result.errors) == 1
-    assert "An object already exist" in result.errors[0].message
+    assert "Violates uniqueness constraint '['name__value']'" in result.errors[0].message
 
 
 async def test_all_attributes(db: InfrahubDatabase, default_branch, all_attribute_types_schema):

--- a/backend/tests/unit/graphql/test_mutation_update.py
+++ b/backend/tests/unit/graphql/test_mutation_update.py
@@ -174,7 +174,7 @@ async def test_update_check_unique(db: InfrahubDatabase, person_john_main: Node,
 
     assert result.errors
     assert len(result.errors) == 1
-    assert "An object already exist" in result.errors[0].message
+    assert "Violates uniqueness constraint '['name__value']'" in result.errors[0].message
 
 
 async def test_update_object_with_flag_property(db: InfrahubDatabase, person_john_main: Node, branch: Branch):

--- a/backend/tests/unit/graphql/test_mutation_upsert.py
+++ b/backend/tests/unit/graphql/test_mutation_upsert.py
@@ -204,7 +204,7 @@ async def test_update_by_id_to_nonunique_value_raises_error(
         variable_values={},
     )
 
-    expected_error = "An object already exist with this value: name: Jim at name"
+    expected_error = "Violates uniqueness constraint '['name__value']'"
     assert any(expected_error in error.message for error in result.errors)
 
 


### PR DESCRIPTION
This PR uses `NodeGetListQuery` instead of `NodeUniquenessAttributeConstraintQuery` to validate `uniqueness_constraint` during object mutation. This should be more efficient as `NodeUniquenessAttributeConstraintQuery` needs to find violations between all nodes in db, while only nodes violating created/update node matter.