### PR TITLE
Improve NodeGetListQuery on default branch

### DIFF
--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any, AsyncIterator, Generator, Optional, Union
 from infrahub import config
 from infrahub.core.constants import (
     AttributeDBNodeType,
-    BranchSupportType,
     RelationshipDirection,
     RelationshipHierarchyDirection,
 )
@@ -868,7 +867,10 @@ class NodeGetListQuery(Query):
         )
         self.params.update(branch_params)
 
-        if (not self.branch.is_default and not self.has_filters) or self.schema.branch == BranchSupportType.AGNOSTIC:
+        # The initial subquery is used to filter out deleted nodes because we can have multiple valid results per branch
+        #   and we need to filter out the one that have been deleted in the branch.
+        # If we are on the default branch, the subquery is not required because only one valid result is expected at a given time
+        if not self.branch.is_default:
             topquery = """
             MATCH (n:%(node_kind)s)
             CALL {

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -7,7 +7,12 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, AsyncIterator, Generator, Optional, Union
 
 from infrahub import config
-from infrahub.core.constants import AttributeDBNodeType, RelationshipDirection, RelationshipHierarchyDirection
+from infrahub.core.constants import (
+    AttributeDBNodeType,
+    BranchSupportType,
+    RelationshipDirection,
+    RelationshipHierarchyDirection,
+)
 from infrahub.core.query import Query, QueryResult, QueryType
 from infrahub.core.query.subquery import build_subquery_filter, build_subquery_order
 from infrahub.core.query.utils import find_node_schema
@@ -814,6 +819,18 @@ class NodeGetListQuery(Query):
 
         super().__init__(**kwargs)
 
+    @property
+    def has_filters(self) -> bool:
+        if not self.filters or self.has_filter_by_id:
+            return False
+        return True
+
+    @property
+    def has_filter_by_id(self) -> bool:
+        if self.filters and "id" in self.filters:
+            return True
+        return False
+
     def _validate_filters(self) -> None:
         if not self.filters:
             return
@@ -851,28 +868,39 @@ class NodeGetListQuery(Query):
         )
         self.params.update(branch_params)
 
-        query = """
-        MATCH (n:%(node_kind)s)
-        CALL {
-            WITH n
-            MATCH (root:Root)<-[r:IS_PART_OF]-(n)
+        if (not self.branch.is_default and not self.has_filters) or self.schema.branch == BranchSupportType.AGNOSTIC:
+            topquery = """
+            MATCH (n:%(node_kind)s)
+            CALL {
+                WITH n
+                MATCH (root:Root)<-[r:IS_PART_OF]-(n)
+                WHERE %(branch_filter)s
+                RETURN r
+                ORDER BY r.branch_level DESC, r.from DESC
+                LIMIT 1
+            }
+            WITH n, r as rb
+            WHERE rb.status = "active"
+            """ % {"branch_filter": branch_filter, "node_kind": self.schema.kind}
+            self.add_to_query(topquery)
+        else:
+            topquery = """
+            MATCH (root:Root)<-[r:IS_PART_OF]-(n:%(node_kind)s)
             WHERE %(branch_filter)s
-            RETURN r
-            ORDER BY r.branch_level DESC, r.from DESC
-            LIMIT 1
-        }
-        WITH n, r as rb
-        WHERE rb.status = "active"
-        """ % {"branch_filter": branch_filter, "node_kind": self.schema.kind}
-        self.add_to_query(query)
+            WITH n, r as rb
+            WHERE rb.status = "active"
+            """ % {"branch_filter": branch_filter, "node_kind": self.schema.kind}
+            self.add_to_query(topquery)
+
         use_simple = False
-        if self.filters and "id" in self.filters:
+        if self.has_filter_by_id and self.filters:
             use_simple = True
             where_clause_elements.append("n.uuid = $uuid")
             self.params["uuid"] = self.filters["id"]
-        if not self.filters and not self.schema.order_by:
+        elif not self.has_filters and not self.schema.order_by:
             use_simple = True
             self.order_by = ["n.uuid"]
+
         if use_simple:
             if where_clause_elements:
                 self.add_to_query(" AND " + " AND ".join(where_clause_elements))

--- a/backend/tests/unit/core/test_node_get_list_query.py
+++ b/backend/tests/unit/core/test_node_get_list_query.py
@@ -263,6 +263,20 @@ async def test_query_NodeGetListQuery_deleted_node(
     assert len(query.get_node_ids()) == 2
 
 
+async def test_query_NodeGetListQuery_deleted_node_no_filter(
+    db: InfrahubDatabase, car_accord_main, car_camry_main: Node, car_volt_main, car_yaris_main, branch: Branch
+):
+    node_to_delete = await NodeManager.get_one(id=car_camry_main.id, db=db, branch=branch)
+    await node_to_delete.delete(db=db)
+
+    schema = registry.schema.get(name="TestCar", branch=branch)
+    schema.order_by = ["owner__name__value"]
+
+    query = await NodeGetListQuery.init(db=db, branch=branch, schema=schema)
+    await query.execute(db=db)
+    assert len(query.get_node_ids()) == 3
+
+
 async def test_query_NodeGetListQuery_filter_relationship(
     db: InfrahubDatabase, car_accord_main, car_camry_main, car_volt_main, car_yaris_main, branch: Branch
 ):

--- a/backend/tests/unit/core/test_node_get_list_query.py
+++ b/backend/tests/unit/core/test_node_get_list_query.py
@@ -41,6 +41,9 @@ async def test_query_NodeGetListQuery_filter_id(
 async def test_query_NodeGetListQuery_filter_ids(
     db: InfrahubDatabase, person_john_main, person_jim_main, person_albert_main, person_alfred_main, branch: Branch
 ):
+    node_to_delete = await NodeManager.get_one(id=person_jim_main.id, db=db, branch=branch)
+    await node_to_delete.delete(db=db)
+
     person_schema = registry.schema.get(name="TestPerson", branch=branch)
     person_schema.order_by = ["height__value"]
     query = await NodeGetListQuery.init(
@@ -50,7 +53,7 @@ async def test_query_NodeGetListQuery_filter_ids(
         filters={"ids": [person_jim_main.id, person_john_main.id, person_albert_main.id]},
     )
     await query.execute(db=db)
-    assert query.get_node_ids() == [person_albert_main.id, person_jim_main.id, person_john_main.id]
+    assert set(query.get_node_ids()) == {person_albert_main.id, person_john_main.id}
 
 
 async def test_query_NodeGetListQuery_filter_attribute_isnull(


### PR DESCRIPTION
Improve the response time of the query `NodeGetListQuery` by removing the top level subquery when we are on the default branch or when we are using filters


