### PR TITLE
raise better error for invalid HFID relationship

### DIFF
--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -432,10 +432,14 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin):
                 else self.schema.peer
             )
             peer = await registry.manager.get_one_by_hfid(
-                db=db, hfid=self.peer_hfid, branch=self.branch, kind=kind, fields={"display_label": None}
+                db=db,
+                hfid=self.peer_hfid,
+                branch=self.branch,
+                kind=kind,
+                fields={"display_label": None},
+                raise_on_error=True,
             )
-            if peer:
-                await self.set_peer(value=peer)
+            await self.set_peer(value=peer)
 
         if not self.peer_id and self.from_pool and "id" in self.from_pool:
             pool_id = str(self.from_pool.get("id"))

--- a/backend/tests/unit/graphql/test_mutation_create.py
+++ b/backend/tests/unit/graphql/test_mutation_create.py
@@ -499,6 +499,37 @@ async def test_create_object_with_single_relationship(db: InfrahubDatabase, defa
     assert len(result.data["TestCarCreate"]["object"]["id"]) == 36  # length of an UUID
 
 
+async def test_create_object_with_invalid_single_relationship_fails(
+    db: InfrahubDatabase, default_branch, hierarchical_location_schema
+):
+    query = """
+    mutation {
+        LocationSiteCreate(
+            data: {
+                name: { value: "NewSite" },
+                parent: { hfid: ["pretend region"] }
+            }
+        ) {
+            ok
+            object {
+                id
+            }
+        }
+    }
+    """
+    gql_params = prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
+    assert len(result.errors) == 1
+    gql_error = result.errors[0]
+    assert "Unable to find the node pretend region / LocationRegion in the database." in gql_error.message
+
+
 async def test_create_object_with_single_relationship_flag_property(
     db: InfrahubDatabase, default_branch, car_person_schema
 ):

--- a/changelog/5360.fixed.md
+++ b/changelog/5360.fixed.md
@@ -1,0 +1,1 @@
+Raise a better error when trying to resolve an invalid HFID for a relationship


### PR DESCRIPTION
IFC-1056
fixes #5360

raises a better error when an `hfid` is invalid instead of silently failing

frankly, I am a little surprised all the tests passed for this change, but I think it is the right change to make. If we are trying to resolve a relationship that does not exist, we should fail