### PR TITLE
Pin version of Poetry to 1.8.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,7 +447,7 @@ jobs:
           python-version: 3.12
       - name: "Setup environment"
         run: |
-          pipx install poetry
+          pipx install poetry==1.8.5
           poetry config virtualenvs.prefer-active-python true
           pip install invoke toml
       - name: "Install Package"
@@ -556,7 +556,7 @@ jobs:
           python-version: "3.12"
       - name: "Setup Python environment"
         run: |
-          pipx install poetry
+          pipx install poetry==1.8.5
           poetry config virtualenvs.create true --local
           poetry env use 3.12
       - name: "Install dependencies"

--- a/.github/workflows/poetry-check.yml
+++ b/.github/workflows/poetry-check.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: "3.12"
       - name: "Setup environment"
         run: |
-          pipx install poetry
+          pipx install poetry==1.8.5
       - name: "Validate pyproject.toml and consistency with poetry.lock"
         run: |
           poetry check

--- a/.github/workflows/update-compose-file-and-chart.yml
+++ b/.github/workflows/update-compose-file-and-chart.yml
@@ -38,7 +38,7 @@ jobs:
           python-version: 3.12
       - name: "Setup environment"
         run: |
-          pipx install poetry
+          pipx install poetry==1.8.5
           poetry config virtualenvs.prefer-active-python true
       - name: "Install Package"
         run: "poetry install --all-extras"

--- a/.github/workflows/version-upgrade.yml
+++ b/.github/workflows/version-upgrade.yml
@@ -51,7 +51,7 @@ jobs:
           python-version: 3.12
       - name: "Setup python environment"
         run: |
-          pipx install poetry
+          pipx install poetry==1.8.5
           poetry config virtualenvs.prefer-active-python true
           pip install invoke toml
       - name: "Install Package"


### PR DESCRIPTION
A new major release of Poetry has been published earlier today (2.0)
it looks like it includes some breaking changes that are breaking the CI pipeline for now

This PR fixes the issue by pinning the version of Poetry in CI to the latest know working release (1.8.5)