### PR TITLE
fix missing branch param in computed attributes logic

### DIFF
--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -399,7 +399,7 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
                     peer = await relationship_attribute.get_peer(db=db, raise_on_error=True)
 
                     related_node = await registry.manager.get_one_by_id_or_default_filter(
-                        db=db, id=peer.id, kind=attribute_path.active_relationship_schema.peer
+                        db=db, id=peer.id, kind=attribute_path.active_relationship_schema.peer, branch=self._branch.name
                     )
 
                     attribute: BaseAttribute = getattr(

--- a/backend/tests/unit/graphql/test_mutation_create_jinja2_attributes.py
+++ b/backend/tests/unit/graphql/test_mutation_create_jinja2_attributes.py
@@ -16,15 +16,15 @@ if TYPE_CHECKING:
 
 
 async def test_create_with_jinja2_computed_attributes_on_related_node(
-    db: InfrahubDatabase, default_branch: Branch, node_group_schema: None, data_schema: None
+    db: InfrahubDatabase, default_branch: Branch, node_group_schema: None, data_schema: None, branch: Branch
 ) -> None:
     schema = SchemaRoot(**internal_schema)
-    registry.schema.register_schema(schema=schema, branch=default_branch.name)
-    default_branch.update_schema_hash()
-    await default_branch.save(db=db)
-    await load_schema(db, schema=SchemaRoot(nodes=[CHILD, THING]))
+    registry.schema.register_schema(schema=schema, branch=branch.name)
+    branch.update_schema_hash()
+    await branch.save(db=db)
+    await load_schema(db, branch_name=branch.name, schema=SchemaRoot(nodes=[CHILD, THING]))
 
-    fred = await Node.init(schema=TestKind.CHILD, db=db)
+    fred = await Node.init(schema=TestKind.CHILD, db=db, branch=branch)
     await fred.new(db=db, name="Fred", height=110)
     await fred.save(db=db)
 
@@ -45,7 +45,7 @@ async def test_create_with_jinja2_computed_attributes_on_related_node(
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -61,19 +61,19 @@ async def test_create_with_jinja2_computed_attributes_on_related_node(
 
 
 async def test_create_with_jinja2_computed_attributes_on_hierarchial_node(
-    db: InfrahubDatabase, default_branch: Branch, node_group_schema: None, data_schema: None
+    db: InfrahubDatabase, default_branch: Branch, node_group_schema: None, data_schema: None, branch: Branch
 ) -> None:
     schema = SchemaRoot(**internal_schema)
-    registry.schema.register_schema(schema=schema, branch=default_branch.name)
-    default_branch.update_schema_hash()
-    await default_branch.save(db=db)
-    await load_schema(db, schema=LOCATION_SCHEMA)
+    registry.schema.register_schema(schema=schema, branch=branch.name)
+    branch.update_schema_hash()
+    await branch.save(db=db)
+    await load_schema(db, branch_name=branch.name, schema=LOCATION_SCHEMA)
 
-    continent = await Node.init(schema=TestKind.CONTINENT, db=db)
+    continent = await Node.init(schema=TestKind.CONTINENT, db=db, branch=branch)
     await continent.new(db=db, name="Europe", shortname="eu")
     await continent.save(db=db)
 
-    country = await Node.init(schema=TestKind.COUNTRY, db=db)
+    country = await Node.init(schema=TestKind.COUNTRY, db=db, branch=branch)
     await country.new(db=db, name="Sweden", shortname="se", parent=continent)
     await country.save(db=db)
 
@@ -94,7 +94,7 @@ async def test_create_with_jinja2_computed_attributes_on_hierarchial_node(
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,

--- a/changelog/5385.fixed.md
+++ b/changelog/5385.fixed.md
@@ -1,0 +1,1 @@
+Fix an issue that would prevent creating a node on a branch with a computed attribute that referenced another node on that branch


### PR DESCRIPTION
fixes #5385

the problem was a missing `branch` param in the logic that handles computed attributes. it was not related to the node being hierarchical. the node in the issue just happened to be hierarchical