### PR TITLE
Format schema converge time

### DIFF
--- a/backend/infrahub/workflows/utils.py
+++ b/backend/infrahub/workflows/utils.py
@@ -76,4 +76,4 @@ async def wait_for_schema_to_converge(
 
         iteration += 1
 
-    log.info(f"Schema converged after {delay * iteration} seconds")
+    log.info(f"Schema converged after {delay * iteration:.2f} seconds")


### PR DESCRIPTION
Format the schema converge time to avoid log entries like this:

```shell
Schema converged after 2.8000000000000003 seconds | info | 3 minutes ago
processing InfraDevice_computed_description | info | 3 minutes ago
InfraDevice_computed_description Created

```