### PR TITLE
Remove static ports for Neo4j container in dev environment

### DIFF
--- a/development/docker-compose-database-neo4j.yml
+++ b/development/docker-compose-database-neo4j.yml
@@ -29,8 +29,6 @@ services:
       com.github.job: "${JOB_NAME:-unknown}"
     ports:
       - "${INFRAHUB_DB_BACKUP_PORT:-6362}:6362"
-      - "7687:7687"
-      - "7474:7474"
 
 
 volumes:


### PR DESCRIPTION
Revert a change introduced in https://github.com/opsmill/infrahub/pull/5355 that is causing some issues in CI