### PR TITLE
Add setting for public url

### DIFF
--- a/backend/infrahub/api/oauth2.py
+++ b/backend/infrahub/api/oauth2.py
@@ -25,8 +25,8 @@ router = APIRouter(prefix="/oauth2")
 
 
 def _get_redirect_url(request: Request, provider_name: str) -> str:
-    """This function is mostly to support local development when the frontend runs on different ports compared to the API."""
-    base_url = config.SETTINGS.dev.frontend_url or str(request.base_url)
+    """Return public redirect URL."""
+    base_url = config.SETTINGS.main.public_url or str(request.base_url)
     return urljoin(base_url, f"auth/oauth2/{provider_name}/callback")
 
 
@@ -40,7 +40,7 @@ async def authorize(request: Request, provider_name: str, final_url: str | None 
     )
 
     redirect_uri = _get_redirect_url(request=request, provider_name=provider_name)
-    final_url = final_url or config.SETTINGS.dev.frontend_url or str(request.base_url)
+    final_url = final_url or config.SETTINGS.main.public_url or str(request.base_url)
 
     authorization_uri, state = client.create_authorization_url(
         url=provider.authorization_url, redirect_uri=redirect_uri, scope=provider.scopes, final_url=final_url

--- a/backend/infrahub/api/oidc.py
+++ b/backend/infrahub/api/oidc.py
@@ -54,8 +54,8 @@ class OIDCDiscoveryConfig(BaseModel):
 
 
 def _get_redirect_url(request: Request, provider_name: str) -> str:
-    """This function is mostly to support local development when the frontend runs on different ports compared to the API."""
-    base_url = config.SETTINGS.dev.frontend_url or str(request.base_url)
+    """Return public redirect URL."""
+    base_url = config.SETTINGS.main.public_url or str(request.base_url)
     return urljoin(base_url, f"auth/oidc/{provider_name}/callback")
 
 
@@ -75,7 +75,7 @@ async def authorize(request: Request, provider_name: str, final_url: str | None 
     )
 
     redirect_uri = _get_redirect_url(request=request, provider_name=provider_name)
-    final_url = final_url or config.SETTINGS.dev.frontend_url or str(request.base_url)
+    final_url = final_url or config.SETTINGS.main.public_url or str(request.base_url)
 
     authorization_uri, state = client.create_authorization_url(
         url=str(oidc_config.authorization_endpoint), redirect_uri=redirect_uri, scope=provider.scopes

--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -153,6 +153,10 @@ class MainSettings(BaseSettings):
         default=["infrahub.permissions.LocalPermissionBackend"],
         description="List of modules to handle permissions, they will be run in the given order",
     )
+    public_url: Optional[str] = Field(
+        default=None,
+        description="Define the public URL of the Infrahub, might be required for OAuth2 and OIDC depending on your infrastructure.",
+    )
 
     @field_validator("docs_index_path", mode="before")
     @classmethod
@@ -256,10 +260,6 @@ class DevelopmentSettings(BaseSettings):
 
     model_config = SettingsConfigDict(env_prefix="INFRAHUB_DEV_")
 
-    frontend_url: Optional[str] = Field(
-        default=None,
-        description="Define the URL of the frontend, useful for OAuth2 development when the frontend and backend use different ports.",
-    )
     frontend_redirect_sso: bool = Field(
         default=False,
         description="Indicates of the frontend should be responsible for the SSO redirection",

--- a/changelog/5306.added.md
+++ b/changelog/5306.added.md
@@ -1,0 +1,1 @@
+Added a configuration option for INFRAHUB_PUBLIC_URL, which could be required for SSO depending on how Infrahub is published and accessed within your organization.


### PR DESCRIPTION
This PR just renames a setting that was previously used for local development because Infrahub would be exposed on a different port compared to the frontend app. It turns out that it can be required for SSO depending on how the infrastructure is configured and accessed. The PR only promotes a development setting and makes it public.

Fixes #5306