### PR TITLE
Slight fix for GraphQL app typing

### DIFF
--- a/backend/infrahub/graphql/app.py
+++ b/backend/infrahub/graphql/app.py
@@ -276,8 +276,8 @@ class InfrahubGraphQLApp:
             len(await analyzed_query.get_models_in_use(types=graphql_params.context.types))
         )
 
-        valid, errors = analyzed_query.is_valid
-        if not valid:
+        _, errors = analyzed_query.is_valid
+        if errors:
             GRAPHQL_QUERY_ERRORS_METRICS.labels(**labels).observe(len(errors))
 
         return json_response


### PR DESCRIPTION
Small fix for typing, would have been an issue later when we add `py.typed` to the SDK.

```diff
-        valid, errors = analyzed_query.is_valid
-        if not valid:
+        _, errors = analyzed_query.is_valid
+        if errors:
             GRAPHQL_QUERY_ERRORS_METRICS.labels(**labels).observe(len(errors))
```

This is what the is_valid property looks like:

```python
    @property
    def is_valid(self) -> tuple[bool, list[GraphQLError] | None]:
        if self.schema is None:
            return False, [GraphQLError("Schema is not provided")]

        errors = validate(schema=self.schema, document_ast=self.document)
        if errors:
            return False, errors

        return True, None
```

The problem is that based on the signature we don't know if "errors" would be `None` even if the query was not valid so I've changed this to only look at the errors since `len(None)` would raise an exception.