### PR TITLE
Cleanup around InfrahubServices

### DIFF
--- a/backend/infrahub/cli/db.py
+++ b/backend/infrahub/cli/db.py
@@ -216,10 +216,10 @@ async def update_core_schema(  # pylint: disable=too-many-statements
             # ----------------------------------------------------------
             # Initialize Schema and Registry
             # ----------------------------------------------------------
-            service = InfrahubServices(
-                database=db, message_bus=BusSimulator(database=db), workflow=WorkflowLocalExecution()
+            service = await InfrahubServices.new(
+                database=db, message_bus=BusSimulator(), workflow=WorkflowLocalExecution()
             )
-            services.prepare(service)
+            services.service = service
             await initialize_registry(db=db)
 
             default_branch = registry.get_branch_from_registry(branch=registry.default_branch)

--- a/backend/infrahub/cli/events.py
+++ b/backend/infrahub/cli/events.py
@@ -26,7 +26,7 @@ async def listen(
     """Listen to event in the Events bus and print them."""
     config.load_and_exit(config_file)
 
-    # TODO below code seems to be a duplicate of `RabbitMQMessageBus._initialize_api_server`.
+    # Below code seems to be a duplicate of `RabbitMQMessageBus._initialize_api_server`.
     #  Also, here we are using ComponentType.NONE so RabbitMQMessageBus will NOT instantiate connection.
     #  We might want to factorize here and use ComponentType.GitAgent so broker instantiates connection correctly.
     component_type = ComponentType.NONE

--- a/backend/infrahub/cli/events.py
+++ b/backend/infrahub/cli/events.py
@@ -7,6 +7,7 @@ from infrahub_sdk.async_typer import AsyncTyper
 from rich import print as rprint
 
 from infrahub import config
+from infrahub.components import ComponentType
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.message_bus.rabbitmq import RabbitMQMessageBus
 
@@ -24,9 +25,13 @@ async def listen(
 ) -> None:
     """Listen to event in the Events bus and print them."""
     config.load_and_exit(config_file)
-    broker = RabbitMQMessageBus()
-    service = InfrahubServices()
-    await broker.initialize(service=service)
+
+    # TODO below code seems to be a duplicate of `RabbitMQMessageBus._initialize_api_server`.
+    #  Also, here we are using ComponentType.NONE so RabbitMQMessageBus will NOT instantiate connection.
+    #  We might want to factorize here and use ComponentType.GitAgent so broker instantiates connection correctly.
+    component_type = ComponentType.NONE
+    broker = await RabbitMQMessageBus.new(component_type=component_type)
+    _ = await InfrahubServices.new(message_bus=broker, component_type=component_type)
 
     queue = await broker.channel.declare_queue(exclusive=True)
     exchange_name = f"{config.SETTINGS.broker.namespace}.events"

--- a/backend/infrahub/cli/git_agent.py
+++ b/backend/infrahub/cli/git_agent.py
@@ -119,20 +119,23 @@ async def start(
         else WorkflowLocalExecution()
     )
 
+    component_type = ComponentType.GIT_AGENT
     message_bus = config.OVERRIDE.message_bus or (
-        NATSMessageBus() if config.SETTINGS.broker.driver == config.BrokerDriver.NATS else RabbitMQMessageBus()
+        await NATSMessageBus.new(component_type=component_type)
+        if config.SETTINGS.broker.driver == config.BrokerDriver.NATS
+        else await RabbitMQMessageBus.new(component_type=component_type)
     )
     cache = config.OVERRIDE.cache or (
-        NATSCache() if config.SETTINGS.cache.driver == config.CacheDriver.NATS else RedisCache()
+        await NATSCache.new() if config.SETTINGS.cache.driver == config.CacheDriver.NATS else RedisCache()
     )
 
-    service = await InfrahubServices.init_and_initialize(
+    service = await InfrahubServices.new(
         cache=cache,
         client=client,
         database=database,
         workflow=workflow,
         message_bus=message_bus,
-        component_type=ComponentType.GIT_AGENT,
+        component_type=component_type,
     )
 
     # Initialize the lock

--- a/backend/infrahub/cli/git_agent.py
+++ b/backend/infrahub/cli/git_agent.py
@@ -126,7 +126,7 @@ async def start(
         NATSCache() if config.SETTINGS.cache.driver == config.CacheDriver.NATS else RedisCache()
     )
 
-    service = InfrahubServices(
+    service = await InfrahubServices.init_and_initialize(
         cache=cache,
         client=client,
         database=database,
@@ -134,7 +134,6 @@ async def start(
         message_bus=message_bus,
         component_type=ComponentType.GIT_AGENT,
     )
-    await service.initialize()
 
     # Initialize the lock
     initialize_lock(service=service)

--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -233,7 +233,7 @@ async def merge_branch(branch: str) -> None:
             target_branch=registry.default_branch,
             meta=Meta(initiator_id=WORKER_IDENTITY, request_id=request_id),
         )
-        await service.send(message=message)
+        await service.message_bus.send(message=message)
 
 
 @flow(name="branch-delete", flow_run_name="Delete branch {branch}")

--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -394,9 +394,7 @@ class InfrahubRepositoryBase(BaseModel, ABC):  # pylint: disable=too-many-public
         return [Worktree.init(response) for response in responses]
 
     def get_client(self) -> InfrahubClient:
-        if self.client:
-            return self.client
-        return self.service.client
+        return self.sdk
 
     def get_location(self) -> str:
         if self.location:

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -41,7 +41,7 @@ from infrahub.core.constants import InfrahubKind, RepositorySyncStatus
 from infrahub.events.repository_action import CommitUpdatedEvent
 from infrahub.exceptions import CheckError, RepositoryInvalidFileSystemError, TransformError
 from infrahub.git.base import InfrahubRepositoryBase, extract_repo_file_information
-from infrahub.services import InfrahubServices
+from infrahub.log import get_logger
 from infrahub.workflows.utils import add_tags
 
 if TYPE_CHECKING:
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
 
     from infrahub.git.models import RequestArtifactGenerate
     from infrahub.message_bus import messages
+    from infrahub.services import InfrahubServices
 
 # pylint: disable=too-many-lines
 
@@ -130,20 +131,20 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):  # pylint: disable=t
     """
 
     @classmethod
-    async def init(cls, commit: str | None = None, service: InfrahubServices | None = None, **kwargs: Any) -> Self:
-        service = service or InfrahubServices()
+    async def init(cls, service: InfrahubServices, commit: str | None = None, **kwargs: Any) -> Self:
         self = cls(service=service, **kwargs)
+        log = get_logger()
         try:
             self.validate_local_directories()
         except RepositoryInvalidFileSystemError:
             await self.ensure_location_is_defined()
             await self.create_locally(infrahub_branch_name=self.infrahub_branch_name, update_commit_value=False)
-            service.log.info(f"Initialized the local directory for {self.name} because it was missing.")
+            log.info(f"Initialized the local directory for {self.name} because it was missing.")
 
         if commit:
             self.get_commit_worktree(commit=commit)
 
-        service.log.debug(
+        log.debug(
             f"Initiated the object on an existing directory for {self.name}",
         )
         return self

--- a/backend/infrahub/git/repository.py
+++ b/backend/infrahub/git/repository.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Union
+from typing import TYPE_CHECKING, Any, Union
 
 from git.exc import BadName, GitCommandError
 from infrahub_sdk.exceptions import GraphQLError
@@ -10,7 +10,9 @@ from infrahub.core.constants import InfrahubKind, RepositoryInternalStatus
 from infrahub.exceptions import RepositoryError
 from infrahub.git.integrator import InfrahubRepositoryIntegrator
 from infrahub.log import get_logger
-from infrahub.services import InfrahubServices
+
+if TYPE_CHECKING:
+    from infrahub.services import InfrahubServices
 
 log = get_logger()
 
@@ -24,9 +26,8 @@ class InfrahubRepository(InfrahubRepositoryIntegrator):
 
     @classmethod
     async def new(
-        cls, service: InfrahubServices | None = None, update_commit_value: bool = True, **kwargs: Any
+        cls, service: InfrahubServices, update_commit_value: bool = True, **kwargs: Any
     ) -> InfrahubRepository:
-        service = service or InfrahubServices()
         self = cls(service=service, **kwargs)
         await self.create_locally(
             infrahub_branch_name=self.infrahub_branch_name, update_commit_value=update_commit_value
@@ -208,9 +209,7 @@ class InfrahubReadOnlyRepository(InfrahubRepositoryIntegrator):
     ref: str | None = Field(None, description="Ref to track on the external repository")
 
     @classmethod
-    async def new(cls, service: InfrahubServices | None = None, **kwargs: Any) -> InfrahubReadOnlyRepository:
-        service = service or InfrahubServices()
-
+    async def new(cls, service: InfrahubServices, **kwargs: Any) -> InfrahubReadOnlyRepository:
         if "ref" not in kwargs or "infrahub_branch_name" not in kwargs:
             raise ValueError("ref and infrahub_branch_name are mandatory to initialize a new Read-Only repository")
 

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -56,6 +56,7 @@ async def add_git_repository(model: GitRepositoryAdd) -> None:
             infrahub_branch_name=model.infrahub_branch_name,
             internal_status=model.internal_status,
             default_branch_name=model.default_branch_name,
+            service=service,
         )
         await repo.import_objects_from_files(
             infrahub_branch_name=model.infrahub_branch_name, git_branch_name=model.default_branch_name
@@ -73,7 +74,7 @@ async def add_git_repository(model: GitRepositoryAdd) -> None:
                 infrahub_branch_name=model.infrahub_branch_name,
                 infrahub_branch_id=model.infrahub_branch_id,
             )
-            await service.send(message=notification)
+            await service.message_bus.send(message=notification)
 
 
 @flow(
@@ -92,6 +93,7 @@ async def add_git_repository_read_only(model: GitRepositoryAddReadOnly) -> None:
             client=service.client,
             ref=model.ref,
             infrahub_branch_name=model.infrahub_branch_name,
+            service=service,
         )
         await repo.import_objects_from_files(infrahub_branch_name=model.infrahub_branch_name)
         if model.internal_status == RepositoryInternalStatus.ACTIVE.value:
@@ -107,7 +109,7 @@ async def add_git_repository_read_only(model: GitRepositoryAddReadOnly) -> None:
                 infrahub_branch_name=model.infrahub_branch_name,
                 infrahub_branch_id=model.infrahub_branch_id,
             )
-            await service.send(message=notification)
+            await service.message_bus.send(message=notification)
 
 
 @flow(name="git-repositories-create-branch", flow_run_name="Create branch '{branch}' in Git Repositories")
@@ -197,7 +199,7 @@ async def sync_remote_repositories() -> None:
                     infrahub_branch_name=infrahub_branch,
                     infrahub_branch_id=branches[infrahub_branch].id,
                 )
-                await service.send(message=message)
+                await service.message_bus.send(message=message)
             except RepositoryError as exc:
                 log.info(exc.message)
 
@@ -218,7 +220,7 @@ async def git_branch_create(
     service = services.service
     log = get_run_logger()
     repo = await InfrahubRepository.init(
-        id=repository_id, name=repository_name, location=repository_location, client=client
+        id=repository_id, name=repository_name, location=repository_location, client=client, service=service
     )
 
     async with lock.registry.get(name=repository_name, namespace="repository"):
@@ -234,7 +236,7 @@ async def git_branch_create(
             infrahub_branch_name=branch,
             infrahub_branch_id=branch_id,
         )
-        await service.send(message=message)
+        await service.message_bus.send(message=message)
         log.debug("Sent message to all workers to fetch the latest version of the repository (RefreshGitFetch)")
 
 
@@ -375,6 +377,7 @@ async def pull_read_only(model: GitRepositoryPullReadOnly) -> None:
                 client=service.client,
                 ref=model.ref,
                 infrahub_branch_name=model.infrahub_branch_name,
+                service=service,
             )
         except RepositoryError:
             init_failed = True
@@ -387,6 +390,7 @@ async def pull_read_only(model: GitRepositoryPullReadOnly) -> None:
                 client=service.client,
                 ref=model.ref,
                 infrahub_branch_name=model.infrahub_branch_name,
+                service=service,
             )
 
         await repo.import_objects_from_files(infrahub_branch_name=model.infrahub_branch_name, commit=model.commit)
@@ -402,7 +406,7 @@ async def pull_read_only(model: GitRepositoryPullReadOnly) -> None:
             infrahub_branch_name=model.infrahub_branch_name,
             infrahub_branch_id=model.infrahub_branch_id,
         )
-        await service.send(message=message)
+        await service.message_bus.send(message=message)
 
 
 @flow(
@@ -419,6 +423,7 @@ async def merge_git_repository(model: GitRepositoryMerge) -> None:
         name=model.repository_name,
         client=service.client,
         default_branch_name=model.default_branch,
+        service=service,
     )
 
     if model.internal_status == RepositoryInternalStatus.STAGING.value:
@@ -447,7 +452,7 @@ async def merge_git_repository(model: GitRepositoryMerge) -> None:
                     infrahub_branch_name=model.destination_branch,
                     infrahub_branch_id=model.destination_branch_id,
                 )
-                await service.send(message=message)
+                await service.message_bus.send(message=message)
 
 
 @flow(name="git-commit-automation-setup", flow_run_name="Setup git commit updated event in task-manager")

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -76,7 +76,7 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
             ]
 
             for message in message_list:
-                await context.service.send(message=message)
+                await context.service.message_bus.send(message=message)
 
         return proposed_change, result
 
@@ -178,7 +178,7 @@ class ProposedChangeRequestRunCheck(Mutation):
             check_type=check_type,
         )
         if context.service:
-            await context.service.send(message=message)
+            await context.service.message_bus.send(message=message)
 
         return {"ok": True}
 

--- a/backend/infrahub/message_bus/operations/__init__.py
+++ b/backend/infrahub/message_bus/operations/__init__.py
@@ -57,12 +57,12 @@ async def execute_message(
     except Exception as exc:  # pylint: disable=broad-except
         if message.reply_requested:
             response = RPCErrorResponse(errors=[str(exc)], initial_message=message.model_dump())
-            await service.reply(message=response, initiator=message)
+            await service.message_bus.reply_if_initiator_meta(message=response, initiator=message)
             return None
         if message.reached_max_retries:
             service.log.exception("Message failed after maximum number of retries", error=exc)
             await set_check_status(message, conclusion="failure", service=service)
             return None
         message.increase_retry_count()
-        await service.send(message, delay=MessageTTL.FIVE, is_retry=True)
+        await service.message_bus.send(message, delay=MessageTTL.FIVE, is_retry=True)
         return MessageTTL.FIVE

--- a/backend/infrahub/message_bus/operations/check/artifact.py
+++ b/backend/infrahub/message_bus/operations/check/artifact.py
@@ -24,11 +24,17 @@ async def create(message: messages.CheckArtifactCreate, service: InfrahubService
 
     if InfrahubKind.READONLYREPOSITORY:
         repo = await InfrahubReadOnlyRepository.init(
-            id=message.repository_id, name=message.repository_name, client=service.client
+            id=message.repository_id,
+            name=message.repository_name,
+            client=service.client,
+            service=service,
         )
     else:
         repo = await InfrahubRepository.init(
-            id=message.repository_id, name=message.repository_name, client=service.client
+            id=message.repository_id,
+            name=message.repository_name,
+            client=service.client,
+            service=service,
         )
 
     artifact = await define_artifact(message=message, service=service)

--- a/backend/infrahub/message_bus/operations/check/repository.py
+++ b/backend/infrahub/message_bus/operations/check/repository.py
@@ -129,7 +129,7 @@ async def check_definition(message: messages.CheckRepositoryCheckDefinition, ser
 
     for event in events:
         event.assign_meta(parent=message)
-        await service.send(message=event)
+        await service.message_bus.send(message=event)
 
 
 @flow(

--- a/backend/infrahub/message_bus/operations/event/branch.py
+++ b/backend/infrahub/message_bus/operations/event/branch.py
@@ -54,4 +54,4 @@ async def merge(message: messages.EventBranchMerge, service: InfrahubServices) -
 
         for event in events:
             event.assign_meta(parent=message)
-            await service.send(message=event)
+            await service.message_bus.send(message=event)

--- a/backend/infrahub/message_bus/operations/event/schema.py
+++ b/backend/infrahub/message_bus/operations/event/schema.py
@@ -14,4 +14,4 @@ async def update(message: messages.EventSchemaUpdate, service: InfrahubServices)
     msg = messages.RefreshRegistryBranches()
 
     msg.assign_meta(parent=message)
-    await service.send(message=msg)
+    await service.message_bus.send(message=msg)

--- a/backend/infrahub/message_bus/operations/finalize/validator.py
+++ b/backend/infrahub/message_bus/operations/finalize/validator.py
@@ -67,7 +67,7 @@ async def execution(message: messages.FinalizeValidatorExecution, service: Infra
                 validator_id=message.validator_id,
                 validator_execution_id=message.validator_execution_id,
             )
-            await service.send(message=message, delay=MessageTTL.FIVE)
+            await service.message_bus.send(message=message, delay=MessageTTL.FIVE)
             return
 
         log.info(

--- a/backend/infrahub/message_bus/operations/git/file.py
+++ b/backend/infrahub/message_bus/operations/git/file.py
@@ -27,8 +27,8 @@ async def get(message: messages.GitFileGet, service: InfrahubServices) -> None:
     except (FileOutOfRepositoryError, RepositoryFileNotFoundError) as e:
         if message.reply_requested:
             response = GitFileGetResponse(data=GitFileGetResponseData(error_message=e.message, http_code=e.HTTP_CODE))
-            await service.reply(message=response, initiator=message)
+            await service.message_bus.reply_if_initiator_meta(message=response, initiator=message)
     else:
         if message.reply_requested:
             response = GitFileGetResponse(data=GitFileGetResponseData(content=content))
-            await service.reply(message=response, initiator=message)
+            await service.message_bus.reply_if_initiator_meta(message=response, initiator=message)

--- a/backend/infrahub/message_bus/operations/git/repository.py
+++ b/backend/infrahub/message_bus/operations/git/repository.py
@@ -28,7 +28,7 @@ async def connectivity(message: messages.GitRepositoryConnectivity, service: Inf
         response = GitRepositoryConnectivityResponse(
             data=response_data,
         )
-        await service.reply(message=response, initiator=message)
+        await service.message_bus.reply_if_initiator_meta(message=response, initiator=message)
 
 
 @flow(name="refresh-git-fetch", flow_run_name="Fetch git repository {message.repository_name} on " + WORKER_IDENTITY)

--- a/backend/infrahub/message_bus/operations/requests/artifact_definition.py
+++ b/backend/infrahub/message_bus/operations/requests/artifact_definition.py
@@ -128,7 +128,7 @@ async def check(message: messages.RequestArtifactDefinitionCheck, service: Infra
     )
     for event in events:
         event.assign_meta(parent=message)
-        await service.send(message=event)
+        await service.message_bus.send(message=event)
 
 
 def _render_artifact(artifact_id: Optional[str], managed_branch: bool, impacted_artifacts: list[str]) -> bool:  # pylint: disable=unused-argument

--- a/backend/infrahub/message_bus/operations/requests/generator_definition.py
+++ b/backend/infrahub/message_bus/operations/requests/generator_definition.py
@@ -125,7 +125,7 @@ async def check(message: messages.RequestGeneratorDefinitionCheck, service: Infr
     )
     for event in events:
         event.assign_meta(parent=message)
-        await service.send(message=event)
+        await service.message_bus.send(message=event)
 
 
 def _run_generator(instance_id: Optional[str], managed_branch: bool, impacted_instances: list[str]) -> bool:

--- a/backend/infrahub/message_bus/operations/requests/proposed_change.py
+++ b/backend/infrahub/message_bus/operations/requests/proposed_change.py
@@ -84,7 +84,7 @@ async def pipeline(message: messages.RequestProposedChangePipeline, service: Inf
                 )
         for event in events:
             event.assign_meta(parent=message)
-            await service.send(message=event)
+            await service.message_bus.send(message=event)
         return
 
     await _gather_repository_repository_diffs(repositories=repositories, service=service)
@@ -183,7 +183,7 @@ async def pipeline(message: messages.RequestProposedChangePipeline, service: Inf
 
     for event in events:
         event.assign_meta(parent=message)
-        await service.send(message=event)
+        await service.message_bus.send(message=event)
 
 
 @flow(
@@ -242,7 +242,7 @@ async def refresh_artifacts(message: messages.RequestProposedChangeRefreshArtifa
             )
 
             msg.assign_meta(parent=message)
-            await service.send(message=msg)
+            await service.message_bus.send(message=msg)
 
 
 GATHER_ARTIFACT_DEFINITIONS = """
@@ -525,7 +525,10 @@ async def _validate_repository_merge_conflicts(
     for repo in repositories:
         if repo.has_diff and not repo.is_staging:
             git_repo = await InfrahubRepository.init(
-                id=repo.repository_id, name=repo.repository_name, client=service.client
+                id=repo.repository_id,
+                name=repo.repository_name,
+                client=service.client,
+                service=service,
             )
             async with lock.registry.get(name=repo.repository_name, namespace="repository"):
                 repo.conflicts = await git_repo.get_conflicts(
@@ -547,7 +550,10 @@ async def _gather_repository_repository_diffs(
         if repo.has_diff and repo.source_commit and repo.destination_commit:
             # TODO we need to find a way to return all files in the repo if the repo is new
             git_repo = await InfrahubRepository.init(
-                id=repo.repository_id, name=repo.repository_name, client=service.client
+                id=repo.repository_id,
+                name=repo.repository_name,
+                client=service.client,
+                service=service,
             )
 
             files_changed: list[str] = []

--- a/backend/infrahub/message_bus/operations/requests/repository.py
+++ b/backend/infrahub/message_bus/operations/requests/repository.py
@@ -91,7 +91,7 @@ async def checks(message: messages.RequestRepositoryChecks, service: InfrahubSer
 
     for event in events:
         event.assign_meta(parent=message)
-        await service.send(message=event)
+        await service.message_bus.send(message=event)
 
 
 @flow(
@@ -130,4 +130,4 @@ async def user_checks(message: messages.RequestRepositoryUserChecks, service: In
 
     for event in events:
         event.assign_meta(parent=message)
-        await service.send(message=event)
+        await service.message_bus.send(message=event)

--- a/backend/infrahub/message_bus/operations/send/echo.py
+++ b/backend/infrahub/message_bus/operations/send/echo.py
@@ -10,4 +10,4 @@ async def request(message: messages.SendEchoRequest, service: InfrahubServices) 
     service.log.info(f"Received message: {message.message}")
     if message.reply_requested:
         response = SendEchoRequestResponse(data=SendEchoRequestResponseData(response=f"Reply to: {message.message}"))
-        await service.reply(message=response, initiator=message)
+        await service.message_bus.reply_if_initiator_meta(message=response, initiator=message)

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -45,7 +45,7 @@ from infrahub.proposed_change.models import (
     RequestProposedChangeUserTests,
 )
 from infrahub.pytest_plugin import InfrahubBackendPlugin
-from infrahub.services import InfrahubServices, services
+from infrahub.services import services
 from infrahub.workflows.catalogue import COMPUTED_ATTRIBUTE_SETUP_PYTHON, REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS
 from infrahub.workflows.utils import add_tags
 
@@ -202,7 +202,8 @@ async def run_proposed_change_data_integrity_check(model: RequestProposedChangeD
     name="proposed-changed-run-generator",
     flow_run_name="Run generators",
 )
-async def run_generators(model: RequestProposedChangeRunGenerators, service: InfrahubServices) -> None:
+async def run_generators(model: RequestProposedChangeRunGenerators) -> None:
+    service = services.service
     await add_tags(branches=[model.source_branch], nodes=[model.proposed_change], db_change=True)
 
     generators = await service.client.filters(
@@ -258,7 +259,7 @@ async def run_generators(model: RequestProposedChangeRunGenerators, service: Inf
                 destination_branch=model.destination_branch,
             )
             msg.assign_meta(parent=model)
-            await service.send(message=msg)
+            await service.message_bus.send(message=msg)
 
     next_messages: list[InfrahubMessage] = []
     if model.refresh_artifacts:
@@ -286,7 +287,7 @@ async def run_generators(model: RequestProposedChangeRunGenerators, service: Inf
 
     for next_msg in next_messages:
         next_msg.assign_meta(parent=model)
-        await service.send(message=next_msg)
+        await service.message_bus.send(message=next_msg)
 
 
 @flow(
@@ -387,7 +388,8 @@ async def _get_proposed_change_schema_integrity_constraints(
     name="proposed-changed-repository-checks",
     flow_run_name="Process user defined checks",
 )
-async def repository_checks(model: RequestProposedChangeRepositoryChecks, service: InfrahubServices) -> None:
+async def repository_checks(model: RequestProposedChangeRepositoryChecks) -> None:
+    service = services.service
     await add_tags(branches=[model.source_branch], nodes=[model.proposed_change])
 
     events: list[InfrahubMessage] = []
@@ -419,7 +421,7 @@ async def repository_checks(model: RequestProposedChangeRepositoryChecks, servic
         )
     for event in events:
         event.assign_meta(parent=model)
-        await service.send(message=event)
+        await service.message_bus.send(message=event)
 
 
 @flow(

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -45,7 +45,7 @@ from infrahub.proposed_change.models import (
     RequestProposedChangeUserTests,
 )
 from infrahub.pytest_plugin import InfrahubBackendPlugin
-from infrahub.services import services
+from infrahub.services import InfrahubServices, services
 from infrahub.workflows.catalogue import COMPUTED_ATTRIBUTE_SETUP_PYTHON, REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS
 from infrahub.workflows.utils import add_tags
 
@@ -202,8 +202,7 @@ async def run_proposed_change_data_integrity_check(model: RequestProposedChangeD
     name="proposed-changed-run-generator",
     flow_run_name="Run generators",
 )
-async def run_generators(model: RequestProposedChangeRunGenerators) -> None:
-    service = services.service
+async def run_generators(model: RequestProposedChangeRunGenerators, service: InfrahubServices) -> None:
     await add_tags(branches=[model.source_branch], nodes=[model.proposed_change], db_change=True)
 
     generators = await service.client.filters(
@@ -388,8 +387,7 @@ async def _get_proposed_change_schema_integrity_constraints(
     name="proposed-changed-repository-checks",
     flow_run_name="Process user defined checks",
 )
-async def repository_checks(model: RequestProposedChangeRepositoryChecks) -> None:
-    service = services.service
+async def repository_checks(model: RequestProposedChangeRepositoryChecks, service: InfrahubServices) -> None:
     await add_tags(branches=[model.source_branch], nodes=[model.proposed_change])
 
     events: list[InfrahubMessage] = []

--- a/backend/infrahub/server.py
+++ b/backend/infrahub/server.py
@@ -70,25 +70,27 @@ async def app_initialization(application: FastAPI, enable_scheduler: bool = True
         if config.SETTINGS.workflow.driver == config.WorkflowDriver.WORKER
         else WorkflowLocalExecution()
     )
-
+    component_type = ComponentType.API_SERVER
     message_bus = config.OVERRIDE.message_bus or (
-        NATSMessageBus() if config.SETTINGS.broker.driver == config.BrokerDriver.NATS else RabbitMQMessageBus()
+        await NATSMessageBus.new(component_type=component_type)
+        if config.SETTINGS.broker.driver == config.BrokerDriver.NATS
+        else await RabbitMQMessageBus.new(component_type=component_type)
     )
     cache = config.OVERRIDE.cache or (
-        NATSCache() if config.SETTINGS.cache.driver == config.CacheDriver.NATS else RedisCache()
+        await NATSCache.new() if config.SETTINGS.cache.driver == config.CacheDriver.NATS else RedisCache()
     )
-    service = await InfrahubServices.init_and_initialize(
+    service = await InfrahubServices.new(
         cache=cache,
         database=database,
         message_bus=message_bus,
         workflow=workflow,
-        component_type=ComponentType.API_SERVER,
+        component_type=component_type,
     )
     initialize_lock(service=service)
     # We must initialize DB after initialize lock and initialize lock depends on cache initialization
     async with application.state.db.start_session() as db:
         await initialization(db=db)
-    services.prepare(service=service)
+    services.service = service
     application.state.service = service
     application.state.response_delay = config.SETTINGS.miscellaneous.response_delay
     if enable_scheduler:

--- a/backend/infrahub/server.py
+++ b/backend/infrahub/server.py
@@ -77,14 +77,13 @@ async def app_initialization(application: FastAPI, enable_scheduler: bool = True
     cache = config.OVERRIDE.cache or (
         NATSCache() if config.SETTINGS.cache.driver == config.CacheDriver.NATS else RedisCache()
     )
-    service = InfrahubServices(
+    service = await InfrahubServices.init_and_initialize(
         cache=cache,
         database=database,
         message_bus=message_bus,
         workflow=workflow,
         component_type=ComponentType.API_SERVER,
     )
-    await service.initialize()
     initialize_lock(service=service)
     # We must initialize DB after initialize lock and initialize lock depends on cache initialization
     async with application.state.db.start_session() as db:

--- a/backend/infrahub/services/__init__.py
+++ b/backend/infrahub/services/__init__.py
@@ -10,6 +10,7 @@ from infrahub.message_bus.messages import ROUTING_KEY_MAP
 from .adapters.event import InfrahubEventService
 from .adapters.http.httpx import HttpxAdapter
 from .adapters.workflow.local import WorkflowLocalExecution
+from .adapters.workflow.worker import WorkflowWorkerExecution
 from .component import InfrahubComponent
 from .scheduler import InfrahubScheduler
 
@@ -17,7 +18,7 @@ if TYPE_CHECKING:
     from infrahub_sdk import InfrahubClient
 
     from infrahub.database import InfrahubDatabase
-    from infrahub.message_bus import InfrahubMessage, InfrahubResponse
+    from infrahub.message_bus import InfrahubMessage
     from infrahub.message_bus.types import MessageTTL
 
     from .adapters.cache import InfrahubCache
@@ -27,62 +28,115 @@ if TYPE_CHECKING:
 
 
 class InfrahubServices:
+    _cache: Optional[InfrahubCache]
+    _client: Optional[InfrahubClient]
+    _database: Optional[InfrahubDatabase]
+    _message_bus: Optional[InfrahubMessageBus]
+    _workflow: Optional[InfrahubWorkflow]
+    _component: Optional[InfrahubComponent]
+
+    log: InfrahubLogger
+    component_type: ComponentType
+    http: HttpxAdapter
+    event: InfrahubEventService
+    scheduler: InfrahubScheduler
+
     def __init__(
         self,
-        cache: Optional[InfrahubCache] = None,
-        client: Optional[InfrahubClient] = None,
-        database: Optional[InfrahubDatabase] = None,
-        message_bus: Optional[InfrahubMessageBus] = None,
-        workflow: Optional[InfrahubWorkflow] = None,
-        event: InfrahubEventService | None = None,
-        log: Optional[InfrahubLogger] = None,
-        component_type: Optional[ComponentType] = None,
-    ) -> None:
-        self._cache = cache
-        self._client = client
-        self._database = database
-        self._message_bus = message_bus
-        self.event = event or InfrahubEventService()
-        self.log = log or get_logger()
-        self.component_type = component_type or ComponentType.NONE
-        self.http = HttpxAdapter()
-        self.scheduler = InfrahubScheduler()
-        self.component = InfrahubComponent()
-        self._workflow = workflow
+        log: InfrahubLogger,
+        component_type: ComponentType,
+        http: HttpxAdapter,
+        event: InfrahubEventService,
+        scheduler: InfrahubScheduler,
+        _cache: Optional[InfrahubCache] = None,
+        _client: Optional[InfrahubClient] = None,
+        _database: Optional[InfrahubDatabase] = None,
+        _message_bus: Optional[InfrahubMessageBus] = None,
+        _workflow: Optional[InfrahubWorkflow] = None,
+        _component: Optional[InfrahubComponent] = None,
+    ):
+        """
+        This method should not be called directly, use `new` instead for a proper initialization.
+        """
 
-        # Hack for testing purposes. WorkflowLocalExecution needs a reference to services within execute_workflow
-        # and we don't want to call workflow.initialize within each of our tests.
-        if isinstance(self._workflow, WorkflowLocalExecution):
-            self._workflow.service = self
+        self._cache = _cache
+        self._client = _client
+        self._database = _database
+        self._message_bus = _message_bus
+        self._workflow = _workflow
+        self._component = _component
+        self.log = log
+        self.component_type = component_type
+        self.http = http
+        self.event = event
+        self.scheduler = scheduler
 
     @classmethod
-    async def init_and_initialize(
+    async def new(
         cls,
         cache: Optional[InfrahubCache] = None,
         client: Optional[InfrahubClient] = None,
         database: Optional[InfrahubDatabase] = None,
         message_bus: Optional[InfrahubMessageBus] = None,
         workflow: Optional[InfrahubWorkflow] = None,
-        event: InfrahubEventService | None = None,
         log: Optional[InfrahubLogger] = None,
         component_type: Optional[ComponentType] = None,
     ) -> InfrahubServices:
         """
-        Wrapper around `__init__` + `initialize`. We can't `initialize` within `__init__` because `__init__` can't be async.
+        Instantiate InfrahubServices object, and finalize initializations of underlying services having a circular
+        dependency with InfrahubServices.
         """
 
+        component_type = component_type or ComponentType.NONE
+
+        if cache is not None and database is not None and message_bus is not None:
+            component: Optional[InfrahubComponent] = await InfrahubComponent.new(
+                cache=cache, component_type=component_type, db=database, message_bus=message_bus
+            )
+        else:
+            component = None
+
+        scheduler = InfrahubScheduler(component_type)
         service = cls(
-            cache=cache,
-            client=client,
-            database=database,
-            message_bus=message_bus,
-            workflow=workflow,
-            event=event,
-            log=log,
+            _cache=cache,
+            _client=client,
+            _database=database,
+            _message_bus=message_bus,
+            _workflow=workflow,
+            _component=component,
+            log=log or get_logger(),
             component_type=component_type,
+            scheduler=scheduler,
+            event=InfrahubEventService(message_bus),
+            http=HttpxAdapter(),
         )
-        await service.initialize()
+
+        # This circular dependency could be removed if InfrahubScheduler only depends on what it needs.
+        scheduler.service = service
+
+        if message_bus is not None:
+            # need circular dependency for injecting `service`  within `execute_message`
+            message_bus.service = service
+
+        if workflow is not None:
+            if isinstance(workflow, WorkflowWorkerExecution):
+                assert component is not None
+                # Ideally `WorkflowWorkerExecution.initialize` would be directly part of WorkflowWorkerExecution
+                # constructor but this requires some redesign as it depends on InfrahubComponent which is instantiated
+                # after workflow instantiation.
+                await workflow.initialize(component_is_primary_server=await component.is_primary_gunicorn_worker())
+            elif isinstance(workflow, WorkflowLocalExecution):
+                # Circular dependency is only needed for injecting `service` within `execute_workflow` while testing.
+                workflow.service = service
+
         return service
+
+    @property
+    def component(self) -> InfrahubComponent:
+        if not self._component:
+            raise InitializationError("Service is not initialized with a component")
+
+        return self._component
 
     @property
     def message_bus(self) -> InfrahubMessageBus:
@@ -112,35 +166,12 @@ class InfrahubServices:
 
         return self._client
 
-    def set_client(self, client: InfrahubClient | None) -> None:
-        self._client = client
-
     @property
     def database(self) -> InfrahubDatabase:
         if not self._database:
             raise InitializationError("Service is not initialized with a database")
 
         return self._database
-
-    async def initialize(self) -> None:
-        # Each service has an extra reference to this InfrahubServices object for convenience.
-        # Note that it could simplify code that each service has a reference to only what it needs. It would
-        # at least avoid circular dependencies.
-
-        if self._message_bus is not None:
-            await self._message_bus.initialize(service=self)
-
-        if self._cache is not None:
-            await self._cache.initialize(service=self)
-
-        await self.http.initialize(service=self)
-        await self.component.initialize(service=self)
-        await self.scheduler.initialize(service=self)
-
-        if self._workflow is not None:
-            await self._workflow.initialize(service=self)
-
-        await self.event.initialize(service=self)
 
     async def shutdown(self) -> None:
         await self.scheduler.shutdown()
@@ -152,24 +183,24 @@ class InfrahubServices:
             raise ValueError("Unable to determine routing key")
         await self.message_bus.publish(message, routing_key=routing_key, delay=delay, is_retry=is_retry)
 
-    async def reply(self, message: InfrahubResponse, initiator: InfrahubMessage) -> None:
-        if initiator.meta:
-            message.meta.correlation_id = initiator.meta.correlation_id
-            routing_key = initiator.meta.reply_to or ""
-            await self.message_bus.reply(message, routing_key=routing_key)
-
-
-class ServiceManager:
-    def __init__(self) -> None:
-        self.service = InfrahubServices()
-        self.send = self.service.send
-
-    def prepare(self, service: InfrahubServices) -> None:
-        self.service = service
-        self.send = self.service.send
-
 
 ServiceFunction = Callable[[InfrahubServices], Awaitable[None]]
+
+
+# TODO Remove this code once services is no longer
+class ServiceManager:
+    # Optional because it is supposed to be really instantiated later
+    _service: Optional[InfrahubServices] = None
+
+    @property
+    def service(self) -> InfrahubServices:
+        if self._service is None:
+            raise ValueError("ServiceManager.service is not initialized")
+        return self._service
+
+    @service.setter
+    def service(self, _service: InfrahubServices) -> None:
+        self._service = _service
 
 
 services = ServiceManager()

--- a/backend/infrahub/services/__init__.py
+++ b/backend/infrahub/services/__init__.py
@@ -28,12 +28,12 @@ if TYPE_CHECKING:
 
 
 class InfrahubServices:
-    _cache: Optional[InfrahubCache]
-    _client: Optional[InfrahubClient]
-    _database: Optional[InfrahubDatabase]
-    _message_bus: Optional[InfrahubMessageBus]
-    _workflow: Optional[InfrahubWorkflow]
-    _component: Optional[InfrahubComponent]
+    _cache: InfrahubCache | None
+    _client: InfrahubClient | None
+    _database: InfrahubDatabase | None
+    _message_bus: InfrahubMessageBus | None
+    _workflow: InfrahubWorkflow | None
+    _component: InfrahubComponent | None
 
     log: InfrahubLogger
     component_type: ComponentType
@@ -48,23 +48,23 @@ class InfrahubServices:
         http: HttpxAdapter,
         event: InfrahubEventService,
         scheduler: InfrahubScheduler,
-        _cache: Optional[InfrahubCache] = None,
-        _client: Optional[InfrahubClient] = None,
-        _database: Optional[InfrahubDatabase] = None,
-        _message_bus: Optional[InfrahubMessageBus] = None,
-        _workflow: Optional[InfrahubWorkflow] = None,
-        _component: Optional[InfrahubComponent] = None,
+        cache: InfrahubCache | None = None,
+        client: InfrahubClient | None = None,
+        database: InfrahubDatabase | None = None,
+        message_bus: InfrahubMessageBus | None = None,
+        workflow: InfrahubWorkflow | None = None,
+        component: InfrahubComponent | None = None,
     ):
         """
         This method should not be called directly, use `new` instead for a proper initialization.
         """
 
-        self._cache = _cache
-        self._client = _client
-        self._database = _database
-        self._message_bus = _message_bus
-        self._workflow = _workflow
-        self._component = _component
+        self._cache = cache
+        self._client = client
+        self._database = database
+        self._message_bus = message_bus
+        self._workflow = workflow
+        self._component = component
         self.log = log
         self.component_type = component_type
         self.http = http
@@ -74,13 +74,13 @@ class InfrahubServices:
     @classmethod
     async def new(
         cls,
-        cache: Optional[InfrahubCache] = None,
-        client: Optional[InfrahubClient] = None,
-        database: Optional[InfrahubDatabase] = None,
-        message_bus: Optional[InfrahubMessageBus] = None,
-        workflow: Optional[InfrahubWorkflow] = None,
-        log: Optional[InfrahubLogger] = None,
-        component_type: Optional[ComponentType] = None,
+        cache: InfrahubCache | None = None,
+        client: InfrahubClient | None = None,
+        database: InfrahubDatabase | None = None,
+        message_bus: InfrahubMessageBus | None = None,
+        workflow: InfrahubWorkflow | None = None,
+        log: InfrahubLogger | None = None,
+        component_type: ComponentType | None = None,
     ) -> InfrahubServices:
         """
         Instantiate InfrahubServices object, and finalize initializations of underlying services having a circular
@@ -98,12 +98,12 @@ class InfrahubServices:
 
         scheduler = InfrahubScheduler(component_type)
         service = cls(
-            _cache=cache,
-            _client=client,
-            _database=database,
-            _message_bus=message_bus,
-            _workflow=workflow,
-            _component=component,
+            cache=cache,
+            client=client,
+            database=database,
+            message_bus=message_bus,
+            workflow=workflow,
+            component=component,
             log=log or get_logger(),
             component_type=component_type,
             scheduler=scheduler,
@@ -187,10 +187,9 @@ class InfrahubServices:
 ServiceFunction = Callable[[InfrahubServices], Awaitable[None]]
 
 
-# TODO Remove this code once services is no longer
 class ServiceManager:
     # Optional because it is supposed to be really instantiated later
-    _service: Optional[InfrahubServices] = None
+    _service: InfrahubServices | None = None
 
     @property
     def service(self) -> InfrahubServices:

--- a/backend/infrahub/services/__init__.py
+++ b/backend/infrahub/services/__init__.py
@@ -1,24 +1,29 @@
-from typing import Awaitable, Callable, Optional
+from __future__ import annotations
 
-from infrahub_sdk import InfrahubClient
+from typing import TYPE_CHECKING, Awaitable, Callable, Optional
 
 from infrahub.components import ComponentType
-from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import InitializationError
 from infrahub.log import get_logger
-from infrahub.message_bus import InfrahubMessage, InfrahubResponse
 from infrahub.message_bus.messages import ROUTING_KEY_MAP
-from infrahub.message_bus.types import MessageTTL
 
-from .adapters.cache import InfrahubCache
 from .adapters.event import InfrahubEventService
-from .adapters.http import InfrahubHTTP
 from .adapters.http.httpx import HttpxAdapter
-from .adapters.message_bus import InfrahubMessageBus
-from .adapters.workflow import InfrahubWorkflow
+from .adapters.workflow.local import WorkflowLocalExecution
 from .component import InfrahubComponent
-from .protocols import InfrahubLogger
 from .scheduler import InfrahubScheduler
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClient
+
+    from infrahub.database import InfrahubDatabase
+    from infrahub.message_bus import InfrahubMessage, InfrahubResponse
+    from infrahub.message_bus.types import MessageTTL
+
+    from .adapters.cache import InfrahubCache
+    from .adapters.message_bus import InfrahubMessageBus
+    from .adapters.workflow import InfrahubWorkflow
+    from .protocols import InfrahubLogger
 
 
 class InfrahubServices:
@@ -28,23 +33,77 @@ class InfrahubServices:
         client: Optional[InfrahubClient] = None,
         database: Optional[InfrahubDatabase] = None,
         message_bus: Optional[InfrahubMessageBus] = None,
-        http: InfrahubHTTP | None = None,
         workflow: Optional[InfrahubWorkflow] = None,
         event: InfrahubEventService | None = None,
         log: Optional[InfrahubLogger] = None,
         component_type: Optional[ComponentType] = None,
     ) -> None:
-        self.cache = cache or InfrahubCache()
+        self._cache = cache
         self._client = client
         self._database = database
-        self.message_bus = message_bus or InfrahubMessageBus()
-        self.workflow = workflow or InfrahubWorkflow()
+        self._message_bus = message_bus
         self.event = event or InfrahubEventService()
         self.log = log or get_logger()
         self.component_type = component_type or ComponentType.NONE
-        self.http = http or HttpxAdapter()
+        self.http = HttpxAdapter()
         self.scheduler = InfrahubScheduler()
         self.component = InfrahubComponent()
+        self._workflow = workflow
+
+        # Hack for testing purposes. WorkflowLocalExecution needs a reference to services within execute_workflow
+        # and we don't want to call workflow.initialize within each of our tests.
+        if isinstance(self._workflow, WorkflowLocalExecution):
+            self._workflow.service = self
+
+    @classmethod
+    async def init_and_initialize(
+        cls,
+        cache: Optional[InfrahubCache] = None,
+        client: Optional[InfrahubClient] = None,
+        database: Optional[InfrahubDatabase] = None,
+        message_bus: Optional[InfrahubMessageBus] = None,
+        workflow: Optional[InfrahubWorkflow] = None,
+        event: InfrahubEventService | None = None,
+        log: Optional[InfrahubLogger] = None,
+        component_type: Optional[ComponentType] = None,
+    ) -> InfrahubServices:
+        """
+        Wrapper around `__init__` + `initialize`. We can't `initialize` within `__init__` because `__init__` can't be async.
+        """
+
+        service = cls(
+            cache=cache,
+            client=client,
+            database=database,
+            message_bus=message_bus,
+            workflow=workflow,
+            event=event,
+            log=log,
+            component_type=component_type,
+        )
+        await service.initialize()
+        return service
+
+    @property
+    def message_bus(self) -> InfrahubMessageBus:
+        if not self._message_bus:
+            raise InitializationError("Service is not initialized with a message bus")
+
+        return self._message_bus
+
+    @property
+    def workflow(self) -> InfrahubWorkflow:
+        if not self._workflow:
+            raise InitializationError("Service is not initialized with a workflow")
+
+        return self._workflow
+
+    @property
+    def cache(self) -> InfrahubCache:
+        if not self._cache:
+            raise InitializationError("Service is not initialized with a cache")
+
+        return self._cache
 
     @property
     def client(self) -> InfrahubClient:
@@ -64,17 +123,26 @@ class InfrahubServices:
         return self._database
 
     async def initialize(self) -> None:
-        """Initialize the Services"""
-        await self.message_bus.initialize(service=self)
-        await self.cache.initialize(service=self)
+        # Each service has an extra reference to this InfrahubServices object for convenience.
+        # Note that it could simplify code that each service has a reference to only what it needs. It would
+        # at least avoid circular dependencies.
+
+        if self._message_bus is not None:
+            await self._message_bus.initialize(service=self)
+
+        if self._cache is not None:
+            await self._cache.initialize(service=self)
+
         await self.http.initialize(service=self)
         await self.component.initialize(service=self)
         await self.scheduler.initialize(service=self)
-        await self.workflow.initialize(service=self)
+
+        if self._workflow is not None:
+            await self._workflow.initialize(service=self)
+
         await self.event.initialize(service=self)
 
     async def shutdown(self) -> None:
-        """Initialize the Services"""
         await self.scheduler.shutdown()
         await self.message_bus.shutdown()
 

--- a/backend/infrahub/services/adapters/cache/__init__.py
+++ b/backend/infrahub/services/adapters/cache/__init__.py
@@ -5,15 +5,10 @@ from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from infrahub.message_bus.types import KVTTL
-    from infrahub.services import InfrahubServices
 
 
 class InfrahubCache(ABC):
     """Base class for caching services"""
-
-    @abstractmethod
-    async def initialize(self, service: InfrahubServices) -> None:
-        raise NotImplementedError()
 
     @abstractmethod
     async def delete(self, key: str) -> None:

--- a/backend/infrahub/services/adapters/cache/__init__.py
+++ b/backend/infrahub/services/adapters/cache/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
@@ -7,28 +8,34 @@ if TYPE_CHECKING:
     from infrahub.services import InfrahubServices
 
 
-class InfrahubCache:
+class InfrahubCache(ABC):
     """Base class for caching services"""
 
+    @abstractmethod
     async def initialize(self, service: InfrahubServices) -> None:
-        """Initialize the cache"""
+        raise NotImplementedError()
 
+    @abstractmethod
     async def delete(self, key: str) -> None:
         """Delete a key from the cache."""
         raise NotImplementedError()
 
+    @abstractmethod
     async def get(self, key: str) -> Optional[str]:
         """Retrieve a value from the cache."""
         raise NotImplementedError()
 
+    @abstractmethod
     async def get_values(self, keys: list[str]) -> list[Optional[str]]:
         """Return a list the values for requested keys."""
         raise NotImplementedError()
 
+    @abstractmethod
     async def list_keys(self, filter_pattern: str) -> list[str]:
         """Return a list of active keys that match the provided filter."""
         raise NotImplementedError()
 
+    @abstractmethod
     async def set(
         self, key: str, value: str, expires: Optional[KVTTL] = None, not_exists: bool = False
     ) -> Optional[bool]:

--- a/backend/infrahub/services/adapters/cache/nats.py
+++ b/backend/infrahub/services/adapters/cache/nats.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import ssl
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 import nats
 
@@ -9,26 +9,38 @@ from infrahub import config
 from infrahub.message_bus.types import KVTTL
 from infrahub.services.adapters.cache import InfrahubCache
 
-if TYPE_CHECKING:
-    from infrahub.services import InfrahubServices
+# Inherit from BaseModel to avoid implementing a `__init__` otherwise `cls(...)` fails.
 
 
 class NATSCache(InfrahubCache):
-    def __init__(self) -> None:
-        self.connection: nats.NATS
-        self.jetstream: nats.js.JetStreamContext
-        self.kv: dict[int, nats.js.kv.KeyValue]
+    connection: nats.NATS
+    jetstream: nats.js.JetStreamContext
+    kv: dict[int, nats.js.kv.KeyValue]
+    kv_buckets: dict[str, KVTTL]
 
+    def __init__(
+        self,
+        connection: nats.NATS,
+        jetstream: nats.js.JetStreamContext,
+        kv: dict[int, nats.js.kv.KeyValue],
+        kv_buckets: dict[str, KVTTL],
+    ):
+        self.connection = connection
+        self.jetstream = jetstream
+        self.kv = kv
+        self.kv_buckets = kv_buckets
+
+    @classmethod
+    async def new(cls) -> NATSCache:
         # FIXME: remove once NATS supports TTL for keys (2.11)
-        self.kv_buckets = {
-            self._tokenize_key_name("validator_execution_id:"): KVTTL.TWO_HOURS,
-            self._tokenize_key_name("workers:primary:"): KVTTL.FIFTEEN,
-            self._tokenize_key_name("workers:schema_hash:branch:"): KVTTL.TWO_HOURS,
-            self._tokenize_key_name("workers:active:"): KVTTL.FIFTEEN,
-            self._tokenize_key_name("workers:worker:"): KVTTL.TWO_HOURS,
+        kv_buckets = {
+            NATSCache._tokenize_key_name("validator_execution_id:"): KVTTL.TWO_HOURS,
+            NATSCache._tokenize_key_name("workers:primary:"): KVTTL.FIFTEEN,
+            NATSCache._tokenize_key_name("workers:schema_hash:branch:"): KVTTL.TWO_HOURS,
+            NATSCache._tokenize_key_name("workers:active:"): KVTTL.FIFTEEN,
+            NATSCache._tokenize_key_name("workers:worker:"): KVTTL.TWO_HOURS,
         }
 
-    async def initialize(self, service: InfrahubServices) -> None:
         tls_context = None
         if config.SETTINGS.cache.tls_enabled:
             tls_context = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
@@ -38,25 +50,27 @@ class NATSCache(InfrahubCache):
                 tls_context.check_hostname = False
                 tls_context.verify_mode = ssl.CERT_NONE
 
-        self.connection = await nats.connect(
+        connection = await nats.connect(
             f"nats://{config.SETTINGS.cache.address}:{config.SETTINGS.cache.service_port}",
             user=config.SETTINGS.cache.username,
             password=config.SETTINGS.cache.password,
             tls=tls_context,
         )
-
-        self.jetstream = self.connection.jetstream()
+        jetstream = connection.jetstream()
 
         kv_config = nats.js.api.KeyValueConfig(bucket=f"kv_{config.SETTINGS.cache.database}")
-        self.kv = {0: await self.jetstream.create_key_value(config=kv_config)}
+        kv = {0: await jetstream.create_key_value(config=kv_config)}
 
         # FIXME: remove once NATS supports TTL for keys (2.11)
         for ttl in KVTTL.variations():
             kv_config.bucket = f"kv_{config.SETTINGS.cache.database}_ttl_{ttl.name.lower()}"
             kv_config.ttl = ttl.value
-            self.kv[ttl.value] = await self.jetstream.create_key_value(config=kv_config)
+            kv[ttl.value] = await jetstream.create_key_value(config=kv_config)
 
-    def _tokenize_key_name(self, key: str) -> str:
+        return cls(kv_buckets=kv_buckets, kv=kv, connection=connection, jetstream=jetstream)
+
+    @staticmethod
+    def _tokenize_key_name(key: str) -> str:
         return key.replace(":", ".")
 
     # FIXME: remove once NATS supports TTL for keys (2.11)

--- a/backend/infrahub/services/adapters/cache/redis.py
+++ b/backend/infrahub/services/adapters/cache/redis.py
@@ -4,7 +4,6 @@ import redis.asyncio as redis
 
 from infrahub import config
 from infrahub.message_bus.types import KVTTL
-from infrahub.services import InfrahubServices
 from infrahub.services.adapters.cache import InfrahubCache
 
 
@@ -19,9 +18,6 @@ class RedisCache(InfrahubCache):
             ssl_check_hostname=not config.SETTINGS.cache.tls_insecure,
             ssl_ca_certs=config.SETTINGS.cache.tls_ca_file,
         )
-
-    async def initialize(self, service: InfrahubServices) -> None:
-        pass
 
     async def delete(self, key: str) -> None:
         await self.connection.delete(key)

--- a/backend/infrahub/services/adapters/database/__init__.py
+++ b/backend/infrahub/services/adapters/database/__init__.py
@@ -1,9 +1,0 @@
-from neo4j import AsyncSession
-
-
-class InfrahubDatabase:
-    """Base class for database access"""
-
-    @property
-    def session(self) -> AsyncSession:
-        raise NotImplementedError()

--- a/backend/infrahub/services/adapters/event/__init__.py
+++ b/backend/infrahub/services/adapters/event/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from prefect.events import emit_event
 
@@ -13,9 +13,9 @@ if TYPE_CHECKING:
 class InfrahubEventService:
     """Base class for infrahub event service"""
 
-    def __init__(self, message_bus: Optional[InfrahubMessageBus] = None) -> None:
-        # TODO message_bus should not be optional, we let it like this for existing tests that
-        #  pass without a bus as event send do not have bus messages
+    def __init__(self, message_bus: InfrahubMessageBus | None = None) -> None:
+        # Ideally message_bus should not be optional, we let it like this for existing tests that
+        #  pass without a bus as corresponding tested events do not send bus messages.
         self.message_bus = message_bus
 
     async def send(self, event: InfrahubEvent) -> None:

--- a/backend/infrahub/services/adapters/event/__init__.py
+++ b/backend/infrahub/services/adapters/event/__init__.py
@@ -1,33 +1,22 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from prefect.events import emit_event
 
-from infrahub.exceptions import InitializationError
-
 if TYPE_CHECKING:
     from infrahub.events import InfrahubEvent
-    from infrahub.services import InfrahubServices
+    from infrahub.services import InfrahubMessageBus
 
 
 class InfrahubEventService:
     """Base class for infrahub event service"""
 
-    def __init__(self) -> None:
-        self._service: InfrahubServices | None = None
-
-    @property
-    def service(self) -> InfrahubServices:
-        if not self._service:
-            raise InitializationError("Event is not initialized with a service")
-
-        return self._service
-
-    async def initialize(self, service: InfrahubServices) -> None:
-        """Initialize the event service"""
-        self._service = service
+    def __init__(self, message_bus: Optional[InfrahubMessageBus] = None) -> None:
+        # TODO message_bus should not be optional, we let it like this for existing tests that
+        #  pass without a bus as event send do not have bus messages
+        self.message_bus = message_bus
 
     async def send(self, event: InfrahubEvent) -> None:
         tasks = [self._send_bus(event=event), self._send_prefect(event=event)]
@@ -35,7 +24,9 @@ class InfrahubEventService:
 
     async def _send_bus(self, event: InfrahubEvent) -> None:
         for message in event.get_messages():
-            await self.service.send(message=message)
+            if self.message_bus is None:
+                raise ValueError("InfrahubEventService.message_bus is None.")
+            await self.message_bus.send(message=message)
 
     async def _send_prefect(self, event: InfrahubEvent) -> None:
         emit_event(

--- a/backend/infrahub/services/adapters/http/__init__.py
+++ b/backend/infrahub/services/adapters/http/__init__.py
@@ -5,11 +5,9 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     import httpx
 
-    from infrahub.services import InfrahubServices
-
 
 class InfrahubHTTP:
-    async def initialize(self, service: InfrahubServices) -> None:
+    async def initialize(self) -> None:
         """Initialize the HTTP adapter"""
 
     async def get(

--- a/backend/infrahub/services/adapters/http/httpx.py
+++ b/backend/infrahub/services/adapters/http/httpx.py
@@ -2,25 +2,23 @@ from __future__ import annotations
 
 import ssl
 from functools import cached_property
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import httpx
 
 from infrahub import config
 from infrahub.exceptions import HTTPServerError, HTTPServerSSLError, HTTPServerTimeoutError
+from infrahub.log import get_logger
 from infrahub.services.adapters.http import InfrahubHTTP
 
-if TYPE_CHECKING:
-    from infrahub.services import InfrahubServices
+log = get_logger()
 
 
 class HttpxAdapter(InfrahubHTTP):
     settings: config.HTTPSettings
-    service: InfrahubServices
 
-    async def initialize(self, service: InfrahubServices) -> None:
+    async def initialize(self) -> None:
         """Initialize the HTTP adapter"""
-        self.service = service
         self.settings = config.SETTINGS.http
 
         # Cache the context during init, this is to avoid issue when a CA bundle might be accessible
@@ -62,16 +60,16 @@ class HttpxAdapter(InfrahubHTTP):
                     **params,
                 )
             except ssl.SSLCertVerificationError as exc:
-                self.service.log.info(f"TLS verification failed for connection to {url}")
+                log.info(f"TLS verification failed for connection to {url}")
                 raise HTTPServerSSLError(message=f"Unable to validate TLS certificate for connection to {url}") from exc
             except httpx.ReadTimeout as exc:
-                self.service.log.info(f"Connection timed out when trying to reach {url}")
+                log.info(f"Connection timed out when trying to reach {url}")
                 raise HTTPServerTimeoutError(
                     message=f"Connection to {url} timed out after {self.settings.timeout}"
                 ) from exc
             except httpx.RequestError as exc:
                 # Catch all error from httpx
-                self.service.log.warning(f"Unhandled HTTP error for {url} ({exc})")
+                log.warning(f"Unhandled HTTP error for {url} ({exc})")
                 raise HTTPServerError(message=f"Unknown http error when connecting to {url}") from exc
 
         return response

--- a/backend/infrahub/services/adapters/message_bus/__init__.py
+++ b/backend/infrahub/services/adapters/message_bus/__init__.py
@@ -31,9 +31,8 @@ class InfrahubMessageBus(ABC):
     broadcasted_event_bindings: list[str] = ["refresh.git.*"]
     service: InfrahubServices
 
-    @abstractmethod
-    async def shutdown(self) -> None:
-        pass
+    async def shutdown(self) -> None:  # noqa: B027 We want a default empty behavior, so it's ok to have an empty non-abstract method.
+        """Shutdown the Message bus"""
 
     @abstractmethod
     async def publish(

--- a/backend/infrahub/services/adapters/message_bus/__init__.py
+++ b/backend/infrahub/services/adapters/message_bus/__init__.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Optional, TypeVar
 
+from infrahub.message_bus.messages import ROUTING_KEY_MAP
+
 ResponseClass = TypeVar("ResponseClass")
 
 if TYPE_CHECKING:
-    from infrahub.message_bus import InfrahubMessage
+    from infrahub.message_bus import InfrahubMessage, InfrahubResponse
     from infrahub.message_bus.types import MessageTTL
     from infrahub.services import InfrahubServices
 
@@ -27,10 +29,7 @@ class InfrahubMessageBus(ABC):
     ]
     event_bindings: list[str] = ["refresh.registry.*"]
     broadcasted_event_bindings: list[str] = ["refresh.git.*"]
-
-    @abstractmethod
-    async def initialize(self, service: InfrahubServices) -> None:
-        pass
+    service: InfrahubServices
 
     @abstractmethod
     async def shutdown(self) -> None:
@@ -49,3 +48,16 @@ class InfrahubMessageBus(ABC):
     @abstractmethod
     async def rpc(self, message: InfrahubMessage, response_class: type[ResponseClass]) -> ResponseClass:
         raise NotImplementedError()
+
+    async def send(self, message: InfrahubMessage, delay: Optional[MessageTTL] = None, is_retry: bool = False) -> None:
+        routing_key = ROUTING_KEY_MAP.get(type(message))
+        if not routing_key:
+            raise ValueError("Unable to determine routing key")
+        await self.publish(message, routing_key=routing_key, delay=delay, is_retry=is_retry)
+
+    # TODO rename it
+    async def reply_if_initiator_meta(self, message: InfrahubResponse, initiator: InfrahubMessage) -> None:
+        if initiator.meta:
+            message.meta.correlation_id = initiator.meta.correlation_id
+            routing_key = initiator.meta.reply_to or ""
+            await self.reply(message, routing_key=routing_key)

--- a/backend/infrahub/services/adapters/message_bus/__init__.py
+++ b/backend/infrahub/services/adapters/message_bus/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Optional, TypeVar
 
 ResponseClass = TypeVar("ResponseClass")
@@ -10,7 +11,7 @@ if TYPE_CHECKING:
     from infrahub.services import InfrahubServices
 
 
-class InfrahubMessageBus:
+class InfrahubMessageBus(ABC):
     DELIVER_TIMEOUT: int = 30 * 60  # 30 minutes
     worker_bindings: list[str] = [
         "check.*.*",
@@ -27,19 +28,24 @@ class InfrahubMessageBus:
     event_bindings: list[str] = ["refresh.registry.*"]
     broadcasted_event_bindings: list[str] = ["refresh.git.*"]
 
+    @abstractmethod
     async def initialize(self, service: InfrahubServices) -> None:
-        """Initialize the Message bus"""
+        pass
 
+    @abstractmethod
     async def shutdown(self) -> None:
-        """Shutdown the Message bus"""
+        pass
 
+    @abstractmethod
     async def publish(
         self, message: InfrahubMessage, routing_key: str, delay: Optional[MessageTTL] = None, is_retry: bool = False
     ) -> None:
         raise NotImplementedError()
 
+    @abstractmethod
     async def reply(self, message: InfrahubMessage, routing_key: str) -> None:
         raise NotImplementedError()
 
+    @abstractmethod
     async def rpc(self, message: InfrahubMessage, response_class: type[ResponseClass]) -> ResponseClass:
         raise NotImplementedError()

--- a/backend/infrahub/services/adapters/message_bus/local.py
+++ b/backend/infrahub/services/adapters/message_bus/local.py
@@ -55,6 +55,3 @@ class BusSimulator(InfrahubMessageBus):
     @property
     def seen_routing_keys(self) -> list[str]:
         return list(self.messages_per_routing_key.keys())
-
-    async def shutdown(self) -> None:
-        pass

--- a/backend/infrahub/services/adapters/message_bus/local.py
+++ b/backend/infrahub/services/adapters/message_bus/local.py
@@ -10,21 +10,18 @@ from infrahub.dependencies.registry import build_component_registry
 from infrahub.message_bus import InfrahubMessage, Meta
 from infrahub.message_bus.messages import ROUTING_KEY_MAP
 from infrahub.message_bus.operations import execute_message
-from infrahub.services import InfrahubServices
 from infrahub.services.adapters.message_bus import InfrahubMessageBus
 
 if TYPE_CHECKING:
-    from infrahub.database import InfrahubDatabase
     from infrahub.message_bus.types import MessageTTL
 
 ResponseClass = TypeVar("ResponseClass")
 
 
 class BusSimulator(InfrahubMessageBus):
-    def __init__(self, database: Optional[InfrahubDatabase] = None) -> None:
+    def __init__(self) -> None:
         self.messages: list[InfrahubMessage] = []
         self.messages_per_routing_key: dict[str, list[InfrahubMessage]] = {}
-        self.service: InfrahubServices = InfrahubServices(database=database, message_bus=self)
         self.replies: dict[str, list[InfrahubMessage]] = defaultdict(list)
         build_component_registry()
 
@@ -35,6 +32,7 @@ class BusSimulator(InfrahubMessageBus):
         if routing_key not in self.messages_per_routing_key:
             self.messages_per_routing_key[routing_key] = []
         self.messages_per_routing_key[routing_key].append(message)
+        assert self.service is not None
         await execute_message(routing_key=routing_key, message_body=message.body, service=self.service)
 
     async def reply(self, message: InfrahubMessage, routing_key: str) -> None:
@@ -57,9 +55,6 @@ class BusSimulator(InfrahubMessageBus):
     @property
     def seen_routing_keys(self) -> list[str]:
         return list(self.messages_per_routing_key.keys())
-
-    async def initialize(self, service: InfrahubServices) -> None:
-        pass
 
     async def shutdown(self) -> None:
         pass

--- a/backend/infrahub/services/adapters/message_bus/local.py
+++ b/backend/infrahub/services/adapters/message_bus/local.py
@@ -57,3 +57,9 @@ class BusSimulator(InfrahubMessageBus):
     @property
     def seen_routing_keys(self) -> list[str]:
         return list(self.messages_per_routing_key.keys())
+
+    async def initialize(self, service: InfrahubServices) -> None:
+        pass
+
+    async def shutdown(self) -> None:
+        pass

--- a/backend/infrahub/services/adapters/message_bus/nats.py
+++ b/backend/infrahub/services/adapters/message_bus/nats.py
@@ -33,7 +33,7 @@ async def _add_request_id(message: InfrahubMessage) -> None:
 
 
 class NATSMessageBus(InfrahubMessageBus):
-    def __init__(self, settings: Optional[BrokerSettings] = None) -> None:
+    def __init__(self, component_type: ComponentType, settings: Optional[BrokerSettings] = None) -> None:
         self.settings = settings or config.SETTINGS.broker
 
         self.service: InfrahubServices
@@ -46,9 +46,15 @@ class NATSMessageBus(InfrahubMessageBus):
         self.loop = asyncio.get_running_loop()
         self.futures: MutableMapping[str, asyncio.Future] = {}
 
-    async def initialize(self, service: InfrahubServices) -> None:
-        self.service = service
+        self.component_type: ComponentType = component_type
 
+    @classmethod
+    async def new(cls, component_type: ComponentType, settings: Optional[BrokerSettings] = None) -> NATSMessageBus:
+        message_bus = cls(component_type=component_type, settings=settings)
+        await message_bus._initialize()
+        return message_bus
+
+    async def _initialize(self) -> None:
         tls_context = None
         if self.settings.tls_enabled:
             tls_context = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
@@ -67,9 +73,9 @@ class NATSMessageBus(InfrahubMessageBus):
 
         self.jetstream = self.connection.jetstream()
 
-        if self.service.component_type == ComponentType.API_SERVER:
+        if self.component_type == ComponentType.API_SERVER:
             await self._initialize_api_server()
-        elif self.service.component_type == ComponentType.GIT_AGENT:
+        elif self.component_type == ComponentType.GIT_AGENT:
             await self._initialize_git_worker()
 
     async def shutdown(self) -> None:
@@ -282,7 +288,7 @@ class NATSMessageBus(InfrahubMessageBus):
             request_id=request_id, correlation_id=correlation_id, reply_to=self.callback_queue.config.name
         )
 
-        await self.service.send(message=message)
+        await self.service.message_bus.send(message=message)
 
         response: nats.aio.msg.Msg = await future
         data = ujson.loads(response.data)

--- a/backend/infrahub/services/adapters/message_bus/rabbitmq.py
+++ b/backend/infrahub/services/adapters/message_bus/rabbitmq.py
@@ -65,12 +65,14 @@ async def _add_request_id(message: InfrahubMessage) -> None:
 
 
 class RabbitMQMessageBus(InfrahubMessageBus):
-    def __init__(self, settings: Optional[BrokerSettings] = None) -> None:
+    def __init__(
+        self, component_type: ComponentType = ComponentType.NONE, settings: Optional[BrokerSettings] = None
+    ) -> None:
         self.settings = settings or config.SETTINGS.broker
         self.channel: AbstractChannel
         self.exchange: AbstractExchange
         self.delayed_exchange: AbstractExchange
-        self.service: InfrahubServices
+        self.service: InfrahubServices  # Needed because we inject `service` while sending messages.
         self.connection: AbstractRobustConnection
         self.callback_queue: AbstractQueue
         self.events_queue: AbstractQueue
@@ -80,10 +82,17 @@ class RabbitMQMessageBus(InfrahubMessageBus):
         self.loop = asyncio.get_running_loop()
         self.futures: MutableMapping[str, asyncio.Future] = {}
 
-    async def initialize(self, service: InfrahubServices) -> None:
+        self.component_type: ComponentType = component_type
+
+    @classmethod
+    async def new(cls, component_type: ComponentType, settings: Optional[BrokerSettings] = None) -> RabbitMQMessageBus:
+        message_bus = cls(component_type=component_type, settings=settings)
+        await message_bus._initialize()
+        return message_bus
+
+    async def _initialize(self) -> None:
         patch_spanbuilder_set_channel()
 
-        self.service = service
         self.connection = await aio_pika.connect_robust(
             host=self.settings.address,
             login=self.settings.username,
@@ -103,9 +112,9 @@ class RabbitMQMessageBus(InfrahubMessageBus):
     async def _initialize_connection(self) -> None:
         self.channel = await self.connection.channel()
 
-        if self.service.component_type == ComponentType.API_SERVER:
+        if self.component_type == ComponentType.API_SERVER:
             await self._initialize_api_server()
-        elif self.service.component_type == ComponentType.GIT_AGENT:
+        elif self.component_type == ComponentType.GIT_AGENT:
             await self._initialize_git_worker()
 
     async def shutdown(self) -> None:
@@ -233,7 +242,7 @@ class RabbitMQMessageBus(InfrahubMessageBus):
         request_id = log_data.get("request_id", "")
         message.meta = Meta(request_id=request_id, correlation_id=correlation_id, reply_to=self.callback_queue.name)
 
-        await self.service.send(message=message)
+        await self.service.message_bus.send(message=message)
 
         response: AbstractIncomingMessage = await future
         data = ujson.loads(response.body)

--- a/backend/infrahub/services/adapters/workflow/__init__.py
+++ b/backend/infrahub/services/adapters/workflow/__init__.py
@@ -4,7 +4,6 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Callable, ParamSpec, TypeVar, overload
 
 if TYPE_CHECKING:
-    from infrahub.services import InfrahubServices
     from infrahub.workflows.models import WorkflowDefinition, WorkflowInfo
 
 Return = TypeVar("Return")
@@ -14,10 +13,6 @@ FuncType = Callable[Params, Return]
 
 
 class InfrahubWorkflow(ABC):
-    @abstractmethod
-    async def initialize(self, service: InfrahubServices) -> None:
-        raise NotImplementedError()
-
     @overload
     async def execute_workflow(
         self,

--- a/backend/infrahub/services/adapters/workflow/__init__.py
+++ b/backend/infrahub/services/adapters/workflow/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Callable, ParamSpec, TypeVar, overload
 
 if TYPE_CHECKING:
@@ -12,9 +13,10 @@ Params = ParamSpec("Params")
 FuncType = Callable[Params, Return]
 
 
-class InfrahubWorkflow:
+class InfrahubWorkflow(ABC):
+    @abstractmethod
     async def initialize(self, service: InfrahubServices) -> None:
-        """Initialize the Workflow engine"""
+        raise NotImplementedError()
 
     @overload
     async def execute_workflow(
@@ -34,6 +36,7 @@ class InfrahubWorkflow:
         tags: list[str] | None = ...,
     ) -> Any: ...
 
+    @abstractmethod
     async def execute_workflow(
         self,
         workflow: WorkflowDefinition,
@@ -41,12 +44,13 @@ class InfrahubWorkflow:
         parameters: dict[str, Any] | None = None,
         tags: list[str] | None = None,
     ) -> Any:
-        raise NotImplementedError("InfrahubWorkflow.execute_workflow is an abstract method")
+        raise NotImplementedError()
 
+    @abstractmethod
     async def submit_workflow(
         self,
         workflow: WorkflowDefinition,
         parameters: dict[str, Any] | None = None,
         tags: list[str] | None = None,
     ) -> WorkflowInfo:
-        raise NotImplementedError("InfrahubWorkflow.submit_workflow is an abstract method")
+        raise NotImplementedError()

--- a/backend/infrahub/services/adapters/workflow/local.py
+++ b/backend/infrahub/services/adapters/workflow/local.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-import inspect
 import uuid
 from typing import Any, Optional
 
 from typing_extensions import TYPE_CHECKING
 
-from infrahub.workers.utils import inject_service_parameter, load_flow_function
 from infrahub.workflows.models import WorkflowDefinition, WorkflowInfo
 
 from . import InfrahubWorkflow, Return
@@ -16,10 +14,7 @@ if TYPE_CHECKING:
 
 
 class WorkflowLocalExecution(InfrahubWorkflow):
-    service: Optional[InfrahubServices] = None
-
-    async def initialize(self, service: InfrahubServices) -> None:
-        self.service = service
+    service: Optional[InfrahubServices] = None  # needed for local injections
 
     async def execute_workflow(
         self,
@@ -30,17 +25,8 @@ class WorkflowLocalExecution(InfrahubWorkflow):
     ) -> Any:
         assert self.service is not None, "service not initialized"
 
-        flow_func = load_flow_function(module_path=workflow.module, flow_name=workflow.function)
-        if parameters is not None:
-            params = dict(parameters)  # avoid mutating input parameters
-            sig = inspect.signature(flow_func)
-            if "service" in sig.parameters:
-                inject_service_parameter(service=self.service, parameters=params)
-            params = flow_func.validate_parameters(parameters=params)
-        else:
-            params = {}
-
-        return await flow_func(**params)
+        fn = workflow.load_function()
+        return await fn(**parameters or {})
 
     async def submit_workflow(
         self,

--- a/backend/infrahub/services/adapters/workflow/local.py
+++ b/backend/infrahub/services/adapters/workflow/local.py
@@ -1,12 +1,26 @@
-import uuid
-from typing import Any
+from __future__ import annotations
 
+import inspect
+import uuid
+from typing import Any, Optional
+
+from typing_extensions import TYPE_CHECKING
+
+from infrahub.workers.utils import inject_service_parameter, load_flow_function
 from infrahub.workflows.models import WorkflowDefinition, WorkflowInfo
 
 from . import InfrahubWorkflow, Return
 
+if TYPE_CHECKING:
+    from ... import InfrahubServices
+
 
 class WorkflowLocalExecution(InfrahubWorkflow):
+    service: Optional[InfrahubServices] = None
+
+    async def initialize(self, service: InfrahubServices) -> None:
+        self.service = service
+
     async def execute_workflow(
         self,
         workflow: WorkflowDefinition,
@@ -14,8 +28,19 @@ class WorkflowLocalExecution(InfrahubWorkflow):
         parameters: dict[str, Any] | None = None,
         tags: list[str] | None = None,
     ) -> Any:
-        fn = workflow.get_function()
-        return await fn(**parameters or {})
+        assert self.service is not None, "service not initialized"
+
+        flow_func = load_flow_function(module_path=workflow.module, flow_name=workflow.function)
+        if parameters is not None:
+            params = dict(parameters)  # avoid mutating input parameters
+            sig = inspect.signature(flow_func)
+            if "service" in sig.parameters:
+                inject_service_parameter(service=self.service, parameters=params)
+            params = flow_func.validate_parameters(parameters=params)
+        else:
+            params = {}
+
+        return await flow_func(**params)
 
     async def submit_workflow(
         self,

--- a/backend/infrahub/services/adapters/workflow/worker.py
+++ b/backend/infrahub/services/adapters/workflow/worker.py
@@ -42,6 +42,7 @@ class WorkflowWorkerExecution(InfrahubWorkflow):
         tags: list[str] | None = ...,
     ) -> Any: ...
 
+    # TODO Make expected_return mandatory and remove above overloads.
     async def execute_workflow(
         self,
         workflow: WorkflowDefinition,

--- a/backend/infrahub/services/adapters/workflow/worker.py
+++ b/backend/infrahub/services/adapters/workflow/worker.py
@@ -13,15 +13,13 @@ from . import InfrahubWorkflow, Return
 if TYPE_CHECKING:
     from prefect.client.schemas.objects import FlowRun
 
-    from infrahub.services import InfrahubServices
     from infrahub.workflows.models import WorkflowDefinition
 
 
 class WorkflowWorkerExecution(InfrahubWorkflow):
-    async def initialize(self, service: InfrahubServices) -> None:
-        """Initialize the Workflow engine"""
-
-        if await service.component.is_primary_api():
+    @staticmethod
+    async def initialize(component_is_primary_server: bool) -> None:
+        if component_is_primary_server:
             await setup_task_manager()
 
     @overload

--- a/backend/infrahub/services/component.py
+++ b/backend/infrahub/services/component.py
@@ -40,7 +40,6 @@ class InfrahubComponent:
         return names
 
     async def initialize(self, service: InfrahubServices) -> None:
-        """Initialize the Message bus"""
         self._service = service
 
         await self.refresh_heartbeat()

--- a/backend/infrahub/services/component.py
+++ b/backend/infrahub/services/component.py
@@ -3,53 +3,57 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, Optional
 
+from attr import dataclass
+
 from infrahub.components import ComponentType
 from infrahub.core.constants import GLOBAL_BRANCH_NAME
 from infrahub.core.registry import registry
 from infrahub.core.timestamp import Timestamp
-from infrahub.exceptions import InitializationError
+from infrahub.log import get_logger
 from infrahub.message_bus import messages
 from infrahub.message_bus.types import KVTTL
 from infrahub.worker import WORKER_IDENTITY
 
 if TYPE_CHECKING:
-    from infrahub.services import InfrahubServices
+    from infrahub.database import InfrahubDatabase
+    from infrahub.services import InfrahubCache, InfrahubMessageBus
 
 PRIMARY_API_SERVER = "workers:primary:api_server"
 WORKER_MATCH = re.compile(r":worker:([^:]+)")
 
+log = get_logger()
 
+
+@dataclass
 class InfrahubComponent:
-    def __init__(self) -> None:
-        self._service: Optional[InfrahubServices] = None
+    cache: InfrahubCache
+    db: InfrahubDatabase
+    message_bus: InfrahubMessageBus
+    component_type: ComponentType
 
-    @property
-    def service(self) -> InfrahubServices:
-        if not self._service:
-            raise InitializationError("Component has not been initialized")
-
-        return self._service
+    @classmethod
+    async def new(
+        cls, cache: InfrahubCache, db: InfrahubDatabase, message_bus: InfrahubMessageBus, component_type: ComponentType
+    ) -> InfrahubComponent:
+        component = cls(cache=cache, db=db, message_bus=message_bus, component_type=component_type)
+        await component.refresh_heartbeat()
+        return component
 
     @property
     def component_names(self) -> list[str]:
         names = []
-        if self.service.component_type == ComponentType.API_SERVER:
+        if self.component_type == ComponentType.API_SERVER:
             names.append("api_server")
-        elif self.service.component_type == ComponentType.GIT_AGENT:
+        elif self.component_type == ComponentType.GIT_AGENT:
             names.append("git_agent")
         return names
 
-    async def initialize(self, service: InfrahubServices) -> None:
-        self._service = service
-
-        await self.refresh_heartbeat()
-
-    async def is_primary_api(self) -> bool:
-        primary_identity = await self.service.cache.get(PRIMARY_API_SERVER)
+    async def is_primary_gunicorn_worker(self) -> bool:
+        primary_identity = await self.cache.get(PRIMARY_API_SERVER)
         return primary_identity == WORKER_IDENTITY
 
     async def list_workers(self, branch: str, schema_hash: bool) -> list[WorkerInfo]:
-        keys = await self.service.cache.list_keys(filter_pattern="workers:*")
+        keys = await self.cache.list_keys(filter_pattern="workers:*")
 
         workers: dict[str, WorkerInfo] = {}
         for key in keys:
@@ -63,7 +67,7 @@ class InfrahubComponent:
         schema_hash_keys = []
         if schema_hash:
             schema_hash_keys = [key for key in keys if f":schema_hash:branch:{branch}" in key]
-            response = await self.service.cache.get_values(keys=schema_hash_keys)
+            response = await self.cache.get_values(keys=schema_hash_keys)
 
         for key, value in zip(schema_hash_keys, response):
             if match := WORKER_MATCH.search(key):
@@ -81,14 +85,14 @@ class InfrahubComponent:
 
             # Use branch name if we cannot find branch id in cache
             branch_id: Optional[str] = None
-            if branch_obj := await registry.get_branch(branch=branch, db=self.service.database):
+            if branch_obj := await registry.get_branch(branch=branch, db=self.db):
                 branch_id = str(branch_obj.uuid)
 
             if not branch_id:
                 branch_id = branch
 
             for component in self.component_names:
-                await self.service.cache.set(
+                await self.cache.set(
                     key=f"workers:schema_hash:branch:{branch_id}:{component}:worker:{WORKER_IDENTITY}",
                     value=hash_value,
                     expires=KVTTL.TWO_HOURS,
@@ -96,29 +100,29 @@ class InfrahubComponent:
 
     async def refresh_heartbeat(self) -> None:
         for component in self.component_names:
-            await self.service.cache.set(
+            await self.cache.set(
                 key=f"workers:active:{component}:worker:{WORKER_IDENTITY}",
                 value=Timestamp().to_string(),
                 expires=KVTTL.FIFTEEN,
             )
-        if self.service.component_type == ComponentType.API_SERVER:
+        if self.component_type == ComponentType.API_SERVER:
             await self._set_primary_api_server()
-        await self.service.cache.set(
+        await self.cache.set(
             key=f"workers:worker:{WORKER_IDENTITY}", value=Timestamp().to_string(), expires=KVTTL.TWO_HOURS
         )
 
     async def _set_primary_api_server(self) -> None:
-        result = await self.service.cache.set(
+        result = await self.cache.set(
             key=PRIMARY_API_SERVER, value=WORKER_IDENTITY, expires=KVTTL.FIFTEEN, not_exists=True
         )
         if result:
-            await self.service.send(message=messages.EventWorkerNewPrimaryAPI(worker_id=WORKER_IDENTITY))
+            await self.message_bus.send(message=messages.EventWorkerNewPrimaryAPI(worker_id=WORKER_IDENTITY))
         else:
-            self.service.log.debug("Primary node already set")
-            primary_id = await self.service.cache.get(key=PRIMARY_API_SERVER)
+            log.debug("Primary node already set")
+            primary_id = await self.cache.get(key=PRIMARY_API_SERVER)
             if primary_id == WORKER_IDENTITY:
-                self.service.log.debug("Primary node set but same as ours, refreshing lifetime")
-                await self.service.cache.set(key=PRIMARY_API_SERVER, value=WORKER_IDENTITY, expires=KVTTL.FIFTEEN)
+                log.debug("Primary node set but same as ours, refreshing lifetime")
+                await self.cache.set(key=PRIMARY_API_SERVER, value=WORKER_IDENTITY, expires=KVTTL.FIFTEEN)
 
 
 class WorkerInfo:

--- a/backend/infrahub/services/scheduler.py
+++ b/backend/infrahub/services/scheduler.py
@@ -5,13 +5,18 @@ import random
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from typing_extensions import Optional
+
 from infrahub import config
 from infrahub.components import ComponentType
+from infrahub.log import get_logger
 from infrahub.tasks.keepalive import refresh_heartbeat
 from infrahub.tasks.recurring import trigger_branch_refresh
 
 if TYPE_CHECKING:
     from infrahub.services import InfrahubServices, ServiceFunction
+
+log = get_logger()
 
 
 @dataclass
@@ -23,18 +28,17 @@ class Schedule:
 
 
 class InfrahubScheduler:
-    def __init__(self) -> None:
-        self.service: InfrahubServices
+    # TODO we could remove service dependency by adding kwargs to Schedule instead of passing services
+    service: Optional[InfrahubServices]
+
+    def __init__(self, component_type: ComponentType) -> None:
         self.running: bool = False
         self.schedules: list[Schedule] = []
-
-    async def initialize(self, service: InfrahubServices) -> None:
-        self.service = service
 
         self.running = config.SETTINGS.miscellaneous.start_background_runner
         # Add some randomness to the interval to avoid having all workers pulling the latest update at the same time
         random_number = random.randint(0, 5)
-        if self.service.component_type == ComponentType.API_SERVER:
+        if component_type == ComponentType.API_SERVER:
             schedules = [
                 Schedule(name="refresh_api_components", interval=10, function=refresh_heartbeat, start_delay=0),
                 Schedule(
@@ -43,7 +47,7 @@ class InfrahubScheduler:
             ]
             self.schedules.extend(schedules)
 
-        if self.service.component_type == ComponentType.GIT_AGENT:
+        if component_type == ComponentType.GIT_AGENT:
             schedules = [
                 Schedule(name="refresh_components", interval=10, function=refresh_heartbeat),
                 Schedule(
@@ -54,32 +58,29 @@ class InfrahubScheduler:
 
     async def start_schedule(self) -> None:
         for schedule in self.schedules:
-            asyncio.create_task(
-                run_schedule(schedule=schedule, service=self.service), name=f"scheduled_task_{schedule.name}"
-            )
+            asyncio.create_task(self.run_schedule(schedule=schedule), name=f"scheduled_task_{schedule.name}")
 
     async def shutdown(self) -> None:
         self.running = False
 
+    async def run_schedule(self, schedule: Schedule) -> None:
+        """Execute the task provided in the schedule as per the defined interval
 
-async def run_schedule(schedule: Schedule, service: InfrahubServices) -> None:
-    """Execute the task provided in the schedule as per the defined interval
-
-    Once the service is marked to be shutdown the scheduler will stop executing tasks.
-    """
-    for _ in range(schedule.start_delay):
-        if not service.scheduler.running:
-            return
-        await asyncio.sleep(delay=1)
-
-    service.log.info("Started recurring task", task=schedule.name)
-
-    while service.scheduler.running:
-        try:
-            await schedule.function(service)
-        except Exception as exc:  # pylint: disable=broad-exception-caught
-            service.log.error(str(exc))
-        for _ in range(schedule.interval):
-            if not service.scheduler.running:
+        Once the service is marked to be shutdown the scheduler will stop executing tasks.
+        """
+        for _ in range(schedule.start_delay):
+            if not self.running:
                 return
             await asyncio.sleep(delay=1)
+
+        assert self.service is not None, "InfrahubScheduler.service is None"
+        self.service.log.info("Started recurring task", task=schedule.name)
+        while self.running:
+            try:
+                await schedule.function(self.service)
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                self.service.log.error(str(exc))
+            for _ in range(schedule.interval):
+                if not self.running:
+                    return
+                await asyncio.sleep(delay=1)

--- a/backend/infrahub/services/scheduler.py
+++ b/backend/infrahub/services/scheduler.py
@@ -73,7 +73,9 @@ class InfrahubScheduler:
                 return
             await asyncio.sleep(delay=1)
 
-        assert self.service is not None, "InfrahubScheduler.service is None"
+        if self.service is None:
+            raise ValueError("InfrahubScheduler.service is None")
+
         self.service.log.info("Started recurring task", task=schedule.name)
         while self.running:
             try:

--- a/backend/infrahub/webhook/models.py
+++ b/backend/infrahub/webhook/models.py
@@ -85,11 +85,17 @@ class TransformWebhook(Webhook):
         repo: Union[InfrahubReadOnlyRepository, InfrahubRepository]
         if self.repository_kind == InfrahubKind.READONLYREPOSITORY:
             repo = await InfrahubReadOnlyRepository.init(
-                id=self.repository_id, name=self.repository_name, client=self.service.client
+                id=self.repository_id,
+                name=self.repository_name,
+                client=self.service.client,
+                service=self.service,
             )
         else:
             repo = await InfrahubRepository.init(
-                id=self.repository_id, name=self.repository_name, client=self.service.client
+                id=self.repository_id,
+                name=self.repository_name,
+                client=self.service.client,
+                service=self.service,
             )
 
         default_branch = repo.default_branch

--- a/backend/infrahub/workers/infrahub_async.py
+++ b/backend/infrahub/workers/infrahub_async.py
@@ -1,4 +1,3 @@
-import inspect
 import logging
 import os
 from typing import Any, Optional
@@ -23,7 +22,7 @@ from infrahub.database import InfrahubDatabase, get_db
 from infrahub.dependencies.registry import build_component_registry
 from infrahub.git import initialize_repositories_directory
 from infrahub.lock import initialize_lock
-from infrahub.services import InfrahubServices
+from infrahub.services import InfrahubServices, services
 from infrahub.services.adapters.cache import InfrahubCache
 from infrahub.services.adapters.cache.nats import NATSCache
 from infrahub.services.adapters.cache.redis import RedisCache
@@ -33,7 +32,7 @@ from infrahub.services.adapters.message_bus.rabbitmq import RabbitMQMessageBus
 from infrahub.services.adapters.workflow import InfrahubWorkflow
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from infrahub.services.adapters.workflow.worker import WorkflowWorkerExecution
-from infrahub.workers.utils import inject_service_parameter, load_flow_function
+from infrahub.workers.utils import load_flow_function
 from infrahub.workflows.models import TASK_RESULT_STORAGE_NAME
 
 WORKER_QUERY_SECONDS = "2"
@@ -138,9 +137,6 @@ class InfrahubWorkerAsync(BaseWorker):
         file_path.replace("/", ".")
         module_path = file_path.replace("backend/", "").replace(".py", "").replace("/", ".")
         flow_func = load_flow_function(module_path=module_path, flow_name=flow_name)
-        sig = inspect.signature(flow_func)
-        if "service" in sig.parameters:
-            inject_service_parameter(service=self.service, parameters=flow_run.parameters)
 
         flow_run_logger.debug("Validating parameters")
         params = flow_func.validate_parameters(parameters=flow_run.parameters)
@@ -189,30 +185,36 @@ class InfrahubWorkerAsync(BaseWorker):
             else WorkflowLocalExecution()
         )
 
-    async def _init_message_bus(self) -> InfrahubMessageBus:
+    async def _init_message_bus(self, component_type: ComponentType) -> InfrahubMessageBus:
         return config.OVERRIDE.message_bus or (
-            NATSMessageBus() if config.SETTINGS.broker.driver == config.BrokerDriver.NATS else RabbitMQMessageBus()
+            await NATSMessageBus.new(component_type=component_type)
+            if config.SETTINGS.broker.driver == config.BrokerDriver.NATS
+            else await RabbitMQMessageBus.new(component_type=component_type)
         )
 
     async def _init_cache(self) -> InfrahubCache:
         return config.OVERRIDE.cache or (
-            NATSCache() if config.SETTINGS.cache.driver == config.CacheDriver.NATS else RedisCache()
+            await NATSCache.new() if config.SETTINGS.cache.driver == config.CacheDriver.NATS else RedisCache()
         )
 
     async def _init_services(self, client: InfrahubClient) -> None:
+        component_type = ComponentType.GIT_AGENT
         client = await self._init_infrahub_client(client=client)
         database = await self._init_database()
         workflow = await self._init_workflow()
-        message_bus = await self._init_message_bus()
+        message_bus = await self._init_message_bus(component_type=component_type)
         cache = await self._init_cache()
 
-        service = await InfrahubServices.init_and_initialize(
+        service = await InfrahubServices.new(
             cache=cache,
             client=client,
             database=database,
             message_bus=message_bus,
             workflow=workflow,
-            component_type=ComponentType.GIT_AGENT,
+            component_type=component_type,
         )
 
         self.service = service
+
+        # TODO This will be removed when all flows support `service` injection
+        services.service = service

--- a/backend/infrahub/workers/infrahub_async.py
+++ b/backend/infrahub/workers/infrahub_async.py
@@ -1,4 +1,4 @@
-import importlib
+import inspect
 import logging
 import os
 from typing import Any, Optional
@@ -23,7 +23,7 @@ from infrahub.database import InfrahubDatabase, get_db
 from infrahub.dependencies.registry import build_component_registry
 from infrahub.git import initialize_repositories_directory
 from infrahub.lock import initialize_lock
-from infrahub.services import InfrahubServices, services
+from infrahub.services import InfrahubServices
 from infrahub.services.adapters.cache import InfrahubCache
 from infrahub.services.adapters.cache.nats import NATSCache
 from infrahub.services.adapters.cache.redis import RedisCache
@@ -33,6 +33,7 @@ from infrahub.services.adapters.message_bus.rabbitmq import RabbitMQMessageBus
 from infrahub.services.adapters.workflow import InfrahubWorkflow
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from infrahub.services.adapters.workflow.worker import WorkflowWorkerExecution
+from infrahub.workers.utils import inject_service_parameter, load_flow_function
 from infrahub.workflows.models import TASK_RESULT_STORAGE_NAME
 
 WORKER_QUERY_SECONDS = "2"
@@ -65,6 +66,7 @@ class InfrahubWorkerAsync(BaseWorker):
     _documentation_url = "https://example.com/docs"
     _logo_url = "https://example.com/logo"
     _description = "Infrahub worker designed to run the flow in the main async loop."
+    service: InfrahubServices  # keep a reference to `service` so we can inject it within flows parameters.
 
     async def setup(
         self,
@@ -107,20 +109,19 @@ class InfrahubWorkerAsync(BaseWorker):
             )
         )
 
-        client = await self._init_infrahub_client(client=client)
-        service = await self._init_services(client=client)
+        await self._init_services(client=client)
 
         if not registry.schema_has_been_initialized():
-            initialize_lock(service=service)
+            initialize_lock(service=self.service)
 
-            async with service.database.start_session() as db:
+            async with self.service.database.start_session() as db:
                 await initialization(db=db)
 
-            await service.component.refresh_schema_hash()
+            await self.service.component.refresh_schema_hash()
 
         initialize_repositories_directory()
         build_component_registry()
-        await service.scheduler.start_schedule()
+        await self.service.scheduler.start_schedule()
         self._logger.info("Worker initialization completed .. ")
 
     async def run(
@@ -136,8 +137,10 @@ class InfrahubWorkerAsync(BaseWorker):
         file_path, flow_name = entrypoint.split(":")
         file_path.replace("/", ".")
         module_path = file_path.replace("backend/", "").replace(".py", "").replace("/", ".")
-        module = importlib.import_module(module_path)
-        flow_func = getattr(module, flow_name)
+        flow_func = load_flow_function(module_path=module_path, flow_name=flow_name)
+        sig = inspect.signature(flow_func)
+        if "service" in sig.parameters:
+            inject_service_parameter(service=self.service, parameters=flow_run.parameters)
 
         flow_run_logger.debug("Validating parameters")
         params = flow_func.validate_parameters(parameters=flow_run.parameters)
@@ -196,13 +199,14 @@ class InfrahubWorkerAsync(BaseWorker):
             NATSCache() if config.SETTINGS.cache.driver == config.CacheDriver.NATS else RedisCache()
         )
 
-    async def _init_services(self, client: InfrahubClient) -> InfrahubServices:
+    async def _init_services(self, client: InfrahubClient) -> None:
+        client = await self._init_infrahub_client(client=client)
         database = await self._init_database()
         workflow = await self._init_workflow()
         message_bus = await self._init_message_bus()
         cache = await self._init_cache()
 
-        service = InfrahubServices(
+        service = await InfrahubServices.init_and_initialize(
             cache=cache,
             client=client,
             database=database,
@@ -211,7 +215,4 @@ class InfrahubWorkerAsync(BaseWorker):
             component_type=ComponentType.GIT_AGENT,
         )
 
-        services.service = service
-        await service.initialize()
-
-        return service
+        self.service = service

--- a/backend/infrahub/workers/utils.py
+++ b/backend/infrahub/workers/utils.py
@@ -1,25 +1,8 @@
 from __future__ import annotations
 
 import importlib
-from typing import TYPE_CHECKING, Any
 
 from prefect import Flow
-
-if TYPE_CHECKING:
-    from infrahub.services import InfrahubServices
-
-# TODO solve this circular issue. we should have no ref to WorkflowLocalExec within InfrahubServices
-
-
-def inject_service_parameter(service: InfrahubServices, parameters: dict[str, Any]) -> None:
-    """
-    `service` object instantiates connections to various services (db, cache...) at worker startup,
-    # so it is not meant to be sent by the server payload. We inject it here to avoid relying on a global variable.
-    This mutates input `parameters`.
-    """
-
-    assert "service" not in parameters
-    parameters["service"] = service
 
 
 def load_flow_function(module_path: str, flow_name: str) -> Flow:

--- a/backend/infrahub/workers/utils.py
+++ b/backend/infrahub/workers/utils.py
@@ -8,5 +8,8 @@ from prefect import Flow
 def load_flow_function(module_path: str, flow_name: str) -> Flow:
     module = importlib.import_module(module_path)
     flow_func = getattr(module, flow_name)
-    assert isinstance(flow_func, Flow)
+    if not isinstance(flow_func, Flow):
+        raise ValueError(
+            f"Function loaded at {module_path=} with {flow_name=} has type {type(flow_func)}, expected {Flow}"
+        )
     return flow_func

--- a/backend/infrahub/workers/utils.py
+++ b/backend/infrahub/workers/utils.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING, Any
+
+from prefect import Flow
+
+if TYPE_CHECKING:
+    from infrahub.services import InfrahubServices
+
+# TODO solve this circular issue. we should have no ref to WorkflowLocalExec within InfrahubServices
+
+
+def inject_service_parameter(service: InfrahubServices, parameters: dict[str, Any]) -> None:
+    """
+    `service` object instantiates connections to various services (db, cache...) at worker startup,
+    # so it is not meant to be sent by the server payload. We inject it here to avoid relying on a global variable.
+    This mutates input `parameters`.
+    """
+
+    assert "service" not in parameters
+    parameters["service"] = service
+
+
+def load_flow_function(module_path: str, flow_name: str) -> Flow:
+    module = importlib.import_module(module_path)
+    flow_func = getattr(module, flow_name)
+    assert isinstance(flow_func, Flow)
+    return flow_func

--- a/backend/infrahub/workflows/initialization.py
+++ b/backend/infrahub/workflows/initialization.py
@@ -8,6 +8,7 @@ from prefect.logging import get_run_logger
 
 from infrahub import config
 
+from ..workers.utils import load_flow_function
 from .catalogue import automation_setup_workflows, worker_pools, workflows
 from .models import TASK_RESULT_STORAGE_NAME
 
@@ -39,8 +40,12 @@ async def setup_deployments(client: PrefectClient) -> None:
         log.info(f"Flow {workflow.name}, created successfully ... ")
 
     for automation_setup_workflow in automation_setup_workflows:
-        automation_setup = automation_setup_workflow.get_function()
-        await automation_setup()
+        # TODO we defined workflows for automations but we only use them to load functions here.
+        #  It seems like we should we delete corresponding workflows and call functions directly here.
+        automation_setup = load_flow_function(
+            module_path=automation_setup_workflow.module, flow_name=automation_setup_workflow.function
+        )
+        await automation_setup()  # type: ignore
 
 
 @task(name="task-manager-setup-blocks", task_run_name="Setup Blocks", cache_policy=NONE)

--- a/backend/infrahub/workflows/initialization.py
+++ b/backend/infrahub/workflows/initialization.py
@@ -8,7 +8,6 @@ from prefect.logging import get_run_logger
 
 from infrahub import config
 
-from ..workers.utils import load_flow_function
 from .catalogue import automation_setup_workflows, worker_pools, workflows
 from .models import TASK_RESULT_STORAGE_NAME
 
@@ -40,12 +39,8 @@ async def setup_deployments(client: PrefectClient) -> None:
         log.info(f"Flow {workflow.name}, created successfully ... ")
 
     for automation_setup_workflow in automation_setup_workflows:
-        # TODO we defined workflows for automations but we only use them to load functions here.
-        #  It seems like we should we delete corresponding workflows and call functions directly here.
-        automation_setup = load_flow_function(
-            module_path=automation_setup_workflow.module, flow_name=automation_setup_workflow.function
-        )
-        await automation_setup()  # type: ignore
+        automation_setup = automation_setup_workflow.load_function()
+        await automation_setup()
 
 
 @task(name="task-manager-setup-blocks", task_run_name="Setup Blocks", cache_policy=NONE)

--- a/backend/infrahub/workflows/models.py
+++ b/backend/infrahub/workflows/models.py
@@ -1,6 +1,8 @@
-from typing import Any, TypeVar
+import importlib
+from typing import Any, Awaitable, TypeVar
 from uuid import UUID
 
+from prefect import Flow
 from prefect.client.orchestration import PrefectClient
 from prefect.client.schemas.actions import DeploymentScheduleCreate
 from prefect.client.schemas.objects import FlowRun
@@ -70,3 +72,7 @@ class WorkflowDefinition(BaseModel):
         data = self.to_deployment()
         data["work_pool_name"] = work_pool.name
         return await client.create_deployment(flow_id=flow_id, **data)
+
+    def load_function(self) -> Flow[Any, Awaitable]:
+        module = importlib.import_module(self.module)
+        return getattr(module, self.function)

--- a/backend/infrahub/workflows/models.py
+++ b/backend/infrahub/workflows/models.py
@@ -1,5 +1,4 @@
-import importlib
-from typing import Any, Awaitable, Callable, TypeVar
+from typing import Any, TypeVar
 from uuid import UUID
 
 from prefect.client.orchestration import PrefectClient
@@ -71,10 +70,3 @@ class WorkflowDefinition(BaseModel):
         data = self.to_deployment()
         data["work_pool_name"] = work_pool.name
         return await client.create_deployment(flow_id=flow_id, **data)
-
-    def get_function(self) -> Callable[..., Awaitable[Any]]:
-        module = importlib.import_module(self.module)
-        return getattr(module, self.function)
-
-    def validate_workflow(self) -> None:
-        self.get_function()

--- a/backend/tests/adapters/message_bus.py
+++ b/backend/tests/adapters/message_bus.py
@@ -34,9 +34,6 @@ class BusRecorder(InfrahubMessageBus):
     def seen_routing_keys(self) -> list[str]:
         return list(self.messages_per_routing_key.keys())
 
-    async def shutdown(self) -> None:
-        pass
-
     async def reply(self, message: InfrahubMessage, routing_key: str) -> None:
         raise ValueError("BusRecorder.reply should not be called")
 
@@ -83,6 +80,3 @@ class BusSimulator(InfrahubMessageBus):
     @property
     def seen_routing_keys(self) -> list[str]:
         return list(self.messages_per_routing_key.keys())
-
-    async def shutdown(self) -> None:
-        pass

--- a/backend/tests/adapters/message_bus.py
+++ b/backend/tests/adapters/message_bus.py
@@ -1,25 +1,24 @@
 from collections import defaultdict
-from typing import Optional, TypeVar
+from typing import TYPE_CHECKING, Optional, TypeVar
 
 import ujson
 from infrahub_sdk.uuidt import UUIDT
 
-from infrahub.components import ComponentType
-from infrahub.database import InfrahubDatabase
 from infrahub.dependencies.registry import build_component_registry
 from infrahub.message_bus import InfrahubMessage, Meta
 from infrahub.message_bus.messages import ROUTING_KEY_MAP
 from infrahub.message_bus.operations import execute_message
 from infrahub.message_bus.types import MessageTTL
-from infrahub.services import InfrahubServices
 from infrahub.services.adapters.message_bus import InfrahubMessageBus
-from infrahub.services.adapters.workflow import InfrahubWorkflow
 
 ResponseClass = TypeVar("ResponseClass")
 
+if TYPE_CHECKING:
+    from infrahub.services import InfrahubServices
+
 
 class BusRecorder(InfrahubMessageBus):
-    def __init__(self, component_type: Optional[ComponentType] = None) -> None:
+    def __init__(self) -> None:
         self.messages: list[InfrahubMessage] = []
         self.messages_per_routing_key: dict[str, list[InfrahubMessage]] = {}
 
@@ -35,9 +34,6 @@ class BusRecorder(InfrahubMessageBus):
     def seen_routing_keys(self) -> list[str]:
         return list(self.messages_per_routing_key.keys())
 
-    async def initialize(self, service: InfrahubServices) -> None:
-        pass
-
     async def shutdown(self) -> None:
         pass
 
@@ -49,13 +45,14 @@ class BusRecorder(InfrahubMessageBus):
 
 
 class BusSimulator(InfrahubMessageBus):
-    def __init__(self, database: InfrahubDatabase | None = None, workflow: InfrahubWorkflow | None = None) -> None:
+    def __init__(self) -> None:
         self.messages: list[InfrahubMessage] = []
         self.messages_per_routing_key: dict[str, list[InfrahubMessage]] = {}
 
-        self.service: InfrahubServices = InfrahubServices(database=database, message_bus=self, workflow=workflow)
         self.replies: dict[str, list[InfrahubMessage]] = defaultdict(list)
         build_component_registry()
+
+        self.service: InfrahubServices
 
     async def publish(
         self, message: InfrahubMessage, routing_key: str, delay: Optional[MessageTTL] = None, is_retry: bool = False
@@ -86,9 +83,6 @@ class BusSimulator(InfrahubMessageBus):
     @property
     def seen_routing_keys(self) -> list[str]:
         return list(self.messages_per_routing_key.keys())
-
-    async def initialize(self, service: InfrahubServices) -> None:
-        self.service = service
 
     async def shutdown(self) -> None:
         pass

--- a/backend/tests/adapters/message_bus.py
+++ b/backend/tests/adapters/message_bus.py
@@ -35,6 +35,18 @@ class BusRecorder(InfrahubMessageBus):
     def seen_routing_keys(self) -> list[str]:
         return list(self.messages_per_routing_key.keys())
 
+    async def initialize(self, service: InfrahubServices) -> None:
+        pass
+
+    async def shutdown(self) -> None:
+        pass
+
+    async def reply(self, message: InfrahubMessage, routing_key: str) -> None:
+        raise ValueError("BusRecorder.reply should not be called")
+
+    async def rpc(self, message: InfrahubMessage, response_class: type[ResponseClass]) -> ResponseClass:
+        raise ValueError("BusRecorder.rpc should not be called")
+
 
 class BusSimulator(InfrahubMessageBus):
     def __init__(self, database: InfrahubDatabase | None = None, workflow: InfrahubWorkflow | None = None) -> None:
@@ -77,3 +89,6 @@ class BusSimulator(InfrahubMessageBus):
 
     async def initialize(self, service: InfrahubServices) -> None:
         self.service = service
+
+    async def shutdown(self) -> None:
+        pass

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -910,9 +910,6 @@ class BusRPCMock(InfrahubMessageBus):
         data = ujson.loads(response.body)
         return response_class(**data)
 
-    async def shutdown(self) -> None:
-        pass
-
     async def reply(self, message: InfrahubMessage, routing_key: str) -> None:
         raise ValueError("BusRPCMock.reply should not be called")
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -43,7 +43,7 @@ from infrahub.database import InfrahubDatabase, get_db
 from infrahub.lock import initialize_lock
 from infrahub.message_bus import InfrahubMessage, InfrahubResponse
 from infrahub.message_bus.types import MessageTTL
-from infrahub.services import InfrahubServices, services
+from infrahub.services import InfrahubServices
 from infrahub.services.adapters.message_bus import InfrahubMessageBus
 from tests.adapters.log import FakeLogger
 from tests.adapters.message_bus import BusRecorder, BusSimulator
@@ -910,9 +910,6 @@ class BusRPCMock(InfrahubMessageBus):
         data = ujson.loads(response.body)
         return response_class(**data)
 
-    async def initialize(self, service: InfrahubServices) -> None:
-        pass
-
     async def shutdown(self) -> None:
         pass
 
@@ -949,8 +946,11 @@ class TestHelper:
         return BusRecorder()
 
     @staticmethod
-    def get_message_bus_simulator(db: Optional[InfrahubDatabase] = None) -> BusSimulator:
-        return BusSimulator(database=db)
+    async def get_message_bus_simulator(db: Optional[InfrahubDatabase] = None) -> BusSimulator:
+        service = await InfrahubServices.new(database=db, message_bus=BusSimulator())
+        message_bus = service.message_bus
+        assert isinstance(message_bus, BusSimulator)
+        return message_bus
 
     @staticmethod
     def get_message_bus_rpc() -> BusRPCMock:
@@ -965,14 +965,3 @@ def fake_log() -> FakeLogger:
 @pytest.fixture()
 def helper() -> TestHelper:
     return TestHelper()
-
-
-@pytest.fixture
-def patch_services(helper):
-    original = services.service.message_bus
-    bus = helper.get_message_bus_rpc()
-    services.service.message_bus = bus
-    services.prepare(service=services.service)
-    yield bus
-    services.service.message_bus = original
-    services.prepare(service=services.service)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -43,7 +43,7 @@ from infrahub.database import InfrahubDatabase, get_db
 from infrahub.lock import initialize_lock
 from infrahub.message_bus import InfrahubMessage, InfrahubResponse
 from infrahub.message_bus.types import MessageTTL
-from infrahub.services import services
+from infrahub.services import InfrahubServices, services
 from infrahub.services.adapters.message_bus import InfrahubMessageBus
 from tests.adapters.log import FakeLogger
 from tests.adapters.message_bus import BusRecorder, BusSimulator
@@ -909,6 +909,15 @@ class BusRPCMock(InfrahubMessageBus):
         response = self.response.pop()
         data = ujson.loads(response.body)
         return response_class(**data)
+
+    async def initialize(self, service: InfrahubServices) -> None:
+        pass
+
+    async def shutdown(self) -> None:
+        pass
+
+    async def reply(self, message: InfrahubMessage, routing_key: str) -> None:
+        raise ValueError("BusRPCMock.reply should not be called")
 
 
 class TestHelper:

--- a/backend/tests/functional/branch/test_graphql_mutation.py
+++ b/backend/tests/functional/branch/test_graphql_mutation.py
@@ -81,7 +81,7 @@ class TestBranchMutations(TestInfrahubApp):
         )
         await jesko.save(db=db)
 
-        bus_simulator.service.cache = RedisCache()
+        bus_simulator.service._cache = RedisCache()
         FileRepo(name="car-dealership", sources_directory=git_repos_source_dir_module_scope)
         client_repository = await client.create(
             kind=InfrahubKind.REPOSITORY,

--- a/backend/tests/functional/ipam/test_proposed_change_reconcile.py
+++ b/backend/tests/functional/ipam/test_proposed_change_reconcile.py
@@ -34,7 +34,7 @@ class TestProposedChangeReconcile(TestIpamReconcileBase):
 
     @pytest.fixture(scope="class", autouse=True)
     def bus_simulator_cache(self, bus_simulator):
-        bus_simulator.service.cache = RedisCache()
+        bus_simulator.service._cache = RedisCache()
 
     @pytest.fixture(scope="class", autouse=True)
     def git_repos_dir(self, git_repos_source_dir_module_scope: Path): ...

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import AsyncGenerator, Generator
+from typing import AsyncGenerator
 
 import pytest
 from infrahub_sdk import Config, InfrahubClient
@@ -23,7 +23,7 @@ from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.utils import delete_all_nodes
 from infrahub.database import InfrahubDatabase
 from infrahub.server import app, lifespan
-from infrahub.services import services
+from infrahub.services import InfrahubServices, services
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from infrahub.workflows.initialization import setup_task_manager
 from tests.adapters.message_bus import BusSimulator
@@ -59,11 +59,14 @@ class TestInfrahubApp(TestInfrahub):
         return str(UUIDT())
 
     @pytest.fixture(scope="class")
-    def bus_simulator(self, db: InfrahubDatabase) -> Generator[BusSimulator, None, None]:
-        bus = BusSimulator(database=db, workflow=WorkflowLocalExecution())
+    async def bus_simulator(self, db: InfrahubDatabase) -> AsyncGenerator[BusSimulator, None]:
+        service = await InfrahubServices.new(database=db, workflow=WorkflowLocalExecution(), message_bus=BusSimulator())
+
         original = config.OVERRIDE.message_bus
-        config.OVERRIDE.message_bus = bus
-        yield bus
+        message_bus = service.message_bus
+        assert isinstance(message_bus, BusSimulator)
+        config.OVERRIDE.message_bus = message_bus
+        yield message_bus
         config.OVERRIDE.message_bus = original
 
     @pytest.fixture(scope="class", autouse=True)
@@ -96,7 +99,7 @@ class TestInfrahubApp(TestInfrahub):
     @pytest.fixture(scope="class")
     async def test_client(
         self, initialize_registry: None, redis: dict[int, int] | None, nats: dict[int, int] | None
-    ) -> AsyncGenerator[InfrahubTestClient]:
+    ) -> AsyncGenerator[InfrahubTestClient, None]:
         # NOTE 1: lifespan call emits an ERROR because it calls registry-webhook-config-refresh flow within a local worker
         # while services.service.client is not set. There might be a design issue here: a client is needed while
         # the app is being initialized.
@@ -129,9 +132,9 @@ class TestInfrahubApp(TestInfrahub):
             services.service.workflow, WorkflowLocalExecution
         ), "These tests are currently meant to run with a local worker"
         original_service_client = services.service._client
-        services.service.set_client(sdk_client)
+        services.service._client = sdk_client
         yield sdk_client
-        services.service.set_client(original_service_client)
+        services.service._client = original_service_client
 
     @pytest.fixture(scope="class")
     async def initialize_registry(

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -22,7 +22,7 @@ from infrahub.core.schema.manager import SchemaManager
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.utils import delete_all_nodes
 from infrahub.database import InfrahubDatabase
-from infrahub.server import app, app_initialization
+from infrahub.server import app, lifespan
 from infrahub.services import services
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from infrahub.workflows.initialization import setup_task_manager
@@ -96,12 +96,14 @@ class TestInfrahubApp(TestInfrahub):
     @pytest.fixture(scope="class")
     async def test_client(
         self, initialize_registry: None, redis: dict[int, int] | None, nats: dict[int, int] | None
-    ) -> InfrahubTestClient:
-        # This call emits an ERROR because it calls registry-webhook-config-refresh flow within a local worker
+    ) -> AsyncGenerator[InfrahubTestClient]:
+        # NOTE 1: lifespan call emits an ERROR because it calls registry-webhook-config-refresh flow within a local worker
         # while services.service.client is not set. There might be a design issue here: a client is needed while
         # the app is being initialized.
-        await app_initialization(app, enable_scheduler=False)
-        return InfrahubTestClient(app=app, base_url="http://testserver")
+        # NOTE 2: FastAPI does not have an asynchronous TestClient, thus we rely on httpx.AsyncClient which does not trigger
+        # lifespan events (see https://fastapi.tiangolo.com/advanced/async-tests/#in-detail).
+        async with lifespan(app):
+            yield InfrahubTestClient(app=app, base_url="http://testserver")
 
     @pytest.fixture(scope="class")
     async def client(
@@ -116,7 +118,8 @@ class TestInfrahubApp(TestInfrahub):
 
         sdk_client = InfrahubClient(config=config)
 
-        bus_simulator.service._client = sdk_client
+        assert app.state.service is bus_simulator.service
+        app.state.service._client = sdk_client
 
         # Some tests rely on infrahub worker which runs locally during testing. Thus, code supposed to run
         # on worker rely on server's `services.service`, which is not initialized with a client,

--- a/backend/tests/helpers/utils.py
+++ b/backend/tests/helpers/utils.py
@@ -42,9 +42,9 @@ def init_global_service(service: InfrahubServices) -> Generator:
     helps for restoring original `service` values so tests do no have side effects.
     """
 
-    original = services.service
-    services.service = service
+    original = services._service
+    services._service = service
     try:
         yield service
     finally:
-        services.service = original
+        services._service = original

--- a/backend/tests/integration/diff/test_diff_incremental_addition.py
+++ b/backend/tests/integration/diff/test_diff_incremental_addition.py
@@ -68,7 +68,7 @@ class TestDiffUpdateConflict(TestInfrahubApp):
         await delorean.previous_owner.update(db=db, data={"id": doc_brown.id, "_relation__is_protected": True})  # type: ignore[attr-defined]
         await delorean.save(db=db)
 
-        bus_simulator.service.cache = RedisCache()
+        bus_simulator.service._cache = RedisCache()
 
         return {
             "doc_brown": doc_brown,

--- a/backend/tests/integration/diff/test_diff_merge.py
+++ b/backend/tests/integration/diff/test_diff_merge.py
@@ -56,7 +56,7 @@ class TestDiffMerge(TestInfrahubApp):
         )
         await delorean.save(db=db)
 
-        bus_simulator.service.cache = RedisCache()
+        bus_simulator.service._cache = RedisCache()
 
         return {
             "doc_brown": doc_brown,

--- a/backend/tests/integration/diff/test_diff_rebase.py
+++ b/backend/tests/integration/diff/test_diff_rebase.py
@@ -132,7 +132,7 @@ class TestDiffRebase(TestInfrahubApp):
         )
         await ed_209.save(db=db)
 
-        bus_simulator.service.cache = RedisCache()
+        bus_simulator.service._cache = RedisCache()
 
         return {
             "john": john,

--- a/backend/tests/integration/diff/test_diff_update.py
+++ b/backend/tests/integration/diff/test_diff_update.py
@@ -169,7 +169,7 @@ class TestDiffUpdateConflict(TestInfrahubApp):
         )
         await ed_209.save(db=db)
 
-        bus_simulator.service.cache = RedisCache()
+        bus_simulator.service._cache = RedisCache()
 
         return {
             "john": john,

--- a/backend/tests/integration/diff/test_merge_rollback.py
+++ b/backend/tests/integration/diff/test_merge_rollback.py
@@ -55,7 +55,7 @@ class TestBranchMergeRollback(TestInfrahubApp):
     ) -> dict[str, Node]:
         await load_schema(db, schema=CAR_SCHEMA)
 
-        bus_simulator.service.cache = RedisCache()
+        bus_simulator.service._cache = RedisCache()
 
         john = await Node.init(schema=TestKind.PERSON, db=db)
         await john.new(db=db, name="John", height=175, description="The famous Joe Doe")

--- a/backend/tests/integration/git/test_git_repository.py
+++ b/backend/tests/integration/git/test_git_repository.py
@@ -17,7 +17,7 @@ from infrahub.core.utils import count_relationships, delete_all_nodes
 from infrahub.database import InfrahubDatabase
 from infrahub.git import InfrahubRepository
 from infrahub.server import app, app_initialization
-from infrahub.services import services
+from infrahub.services import InfrahubServices, services
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from infrahub.utils import get_models_dir
 from infrahub.workflows.initialization import setup_task_manager
@@ -79,9 +79,9 @@ class TestInfrahubClient:
         config = Config(api_token=admin_token, requester=test_client.async_request)
         sdk_client = InfrahubClient(config=config)
         original_service_client = services.service._client
-        services.service.set_client(sdk_client)
+        services.service._client = sdk_client
         yield sdk_client
-        services.service.set_client(original_service_client)
+        services.service._client = original_service_client
 
     @pytest.fixture(scope="class")
     async def query_99(self, db: InfrahubDatabase, test_client):
@@ -114,6 +114,7 @@ class TestInfrahubClient:
             name=git_repo_infrahub_demo_edge.name,
             location=git_repo_infrahub_demo_edge.path,
             client=client,
+            service=await InfrahubServices.new(database=db),
         )
 
         return repo
@@ -320,6 +321,7 @@ class TestGetMissingFile(TestInfrahubApp):
             name=git_repo_car_dealership.name,
             location=git_repo_car_dealership.path,
             client=client,
+            service=await InfrahubServices.new(database=db),
         )
 
         commit = repo.get_commit_value(branch_name="main")

--- a/backend/tests/integration/message_bus/operations/request/conftest.py
+++ b/backend/tests/integration/message_bus/operations/request/conftest.py
@@ -80,10 +80,12 @@ async def prepare_proposed_change(
     config = Config(api_token=admin_token, requester=test_client.async_request)
     client = InfrahubClient(config=config)
 
-    service = InfrahubServices(message_bus=bus, client=client)
-    services.prepare(service=service)
+    service = await InfrahubServices.new(message_bus=bus, client=client)
+    services.service = service
 
-    repo = await InfrahubRepository.new(id=obj.id, name=file_repo.name, location=file_repo.path, client=client)
+    repo = await InfrahubRepository.new(
+        id=obj.id, name=file_repo.name, location=file_repo.path, client=client, service=service
+    )
 
     await repo.sync()
 

--- a/backend/tests/integration/message_bus/operations/request/test_proposed_change.py
+++ b/backend/tests/integration/message_bus/operations/request/test_proposed_change.py
@@ -103,15 +103,14 @@ async def prepare_proposed_change(
     config = Config(api_token=admin_token, requester=test_client.async_request)
     client = InfrahubClient(config=config)
 
-    service = InfrahubServices(
+    service = await InfrahubServices.new(
         message_bus=bus, client=client, workflow=WorkflowLocalExecution(), database=db, cache=RedisCache()
     )
-    await service.event.initialize(service)
-    await service.component.initialize(service)
-    await service.workflow.initialize(service)
-    services.prepare(service=service)
+    services.service = service
 
-    repo = await InfrahubRepository.new(id=obj.id, name=file_repo.name, location=file_repo.path, client=client)
+    repo = await InfrahubRepository.new(
+        id=obj.id, name=file_repo.name, location=file_repo.path, client=client, service=service
+    )
     await repo.sync()
 
     result = await graphql_mutation(
@@ -141,7 +140,7 @@ async def test_run_pipeline_validate_requested_jobs(
     config = Config(api_token=admin_token, requester=test_client.async_request)
     client = InfrahubClient(config=config)
     fake_log = FakeLogger()
-    service = InfrahubServices(
+    service = await InfrahubServices.new(
         client=client,
         log=fake_log,
         message_bus=bus_pre_data_changes,
@@ -156,8 +155,9 @@ async def test_run_pipeline_validate_requested_jobs(
         await obj.new(db=db, name="ci-pipeline-01", description="for use within tests")
         await obj.save(db=db)
 
-        bus_post_data_changes = BusSimulator(database=services.service.database)
+        bus_post_data_changes = BusSimulator()
         services.service._message_bus = bus_post_data_changes
+        bus_post_data_changes.service = services.service
 
         await pipeline(message=message, service=services.service)
 
@@ -191,13 +191,14 @@ async def test_run_generators_validate_requested_jobs(
     admin_token = await integration_helper.create_token()
     config = Config(api_token=admin_token, requester=test_client.async_request)
     client = InfrahubClient(config=config)
-    service = InfrahubServices(
+    service = await InfrahubServices.new(
         client=client,
         message_bus=bus,
         log=FakeLogger(),
         workflow=WorkflowLocalExecution(),
     )
-    await run_generators(model=model, service=service)
+    with init_global_service(service):
+        await run_generators(model=model)
 
     assert sorted(bus.seen_routing_keys) == [
         "request.proposed_change.refresh_artifacts",

--- a/backend/tests/integration/message_bus/operations/request/test_proposed_change.py
+++ b/backend/tests/integration/message_bus/operations/request/test_proposed_change.py
@@ -108,6 +108,7 @@ async def prepare_proposed_change(
     )
     await service.event.initialize(service)
     await service.component.initialize(service)
+    await service.workflow.initialize(service)
     services.prepare(service=service)
 
     repo = await InfrahubRepository.new(id=obj.id, name=file_repo.name, location=file_repo.path, client=client)
@@ -156,7 +157,7 @@ async def test_run_pipeline_validate_requested_jobs(
         await obj.save(db=db)
 
         bus_post_data_changes = BusSimulator(database=services.service.database)
-        services.service.message_bus = bus_post_data_changes
+        services.service._message_bus = bus_post_data_changes
 
         await pipeline(message=message, service=services.service)
 
@@ -196,8 +197,7 @@ async def test_run_generators_validate_requested_jobs(
         log=FakeLogger(),
         workflow=WorkflowLocalExecution(),
     )
-    with init_global_service(service):
-        await run_generators(model=model)
+    await run_generators(model=model, service=service)
 
     assert sorted(bus.seen_routing_keys) == [
         "request.proposed_change.refresh_artifacts",

--- a/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
@@ -80,7 +80,7 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
         )
         await jesko.save(db=db)
 
-        bus_simulator.service.cache = RedisCache()
+        bus_simulator.service._cache = RedisCache()
         repo_path, repo_name = car_dealership_copy
         FileRepo(name=repo_name, local_repo_base_path=repo_path, sources_directory=git_repos_source_dir_module_scope)
         client_repository = await client.create(

--- a/backend/tests/integration/proposed_change/test_proposed_change_profile.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_profile.py
@@ -52,7 +52,7 @@ class TestProposedChangePipelineProfile(TestInfrahubApp):
         await jesko.new(db=db, name="Jesko", color="Red", owner=john, manufacturer=koenigsegg, profiles=[car_profile])
         await jesko.save(db=db)
 
-        bus_simulator.service.cache = RedisCache()
+        bus_simulator.service._cache = RedisCache()
 
     @pytest.fixture(scope="class")
     async def update_profile(self, db: InfrahubDatabase, initial_dataset: None, client: InfrahubClient) -> None:

--- a/backend/tests/integration/proposed_change/test_proposed_change_repository.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_repository.py
@@ -35,7 +35,7 @@ class TestProposedChangePipelineRepository(TestInfrahubApp):
     ) -> None:
         await load_schema(db, schema=CAR_SCHEMA)
 
-        bus_simulator.service.cache = RedisCache()
+        bus_simulator.service._cache = RedisCache()
 
         john = await Node.init(schema=TestKind.PERSON, db=db)
         await john.new(db=db, name="John", height=175, age=25, description="The famous Joe Doe")

--- a/backend/tests/integration/services/adapters/message_bus/test_rabbitmq.py
+++ b/backend/tests/integration/services/adapters/message_bus/test_rabbitmq.py
@@ -148,16 +148,16 @@ async def rabbitmq_api(rabbitmq) -> RabbitMQManager:
 async def test_rabbitmq_initial_setup(rabbitmq_api: RabbitMQManager) -> None:
     """Validates creation of exchanges, queues and bindings."""
 
-    bus = RabbitMQMessageBus(settings=rabbitmq_api.settings)
-    api_service = InfrahubServices(message_bus=bus, component_type=ComponentType.API_SERVER)
-    agent_service = InfrahubServices(message_bus=bus, component_type=ComponentType.GIT_AGENT)
-    await bus.initialize(service=api_service)
+    bus = await RabbitMQMessageBus.new(settings=rabbitmq_api.settings, component_type=ComponentType.API_SERVER)
+    _ = await InfrahubServices.new(message_bus=bus, component_type=ComponentType.API_SERVER)
+
     api_exchanges = await rabbitmq_api.get_exchanges(prefix="infrahub")
     api_queues = await rabbitmq_api.get_queues()
     api_bindings = await rabbitmq_api.get_bindings()
     await bus.shutdown()
 
-    await bus.initialize(service=agent_service)
+    bus = await RabbitMQMessageBus.new(settings=rabbitmq_api.settings, component_type=ComponentType.GIT_AGENT)
+    _ = await InfrahubServices.new(message_bus=bus, component_type=ComponentType.GIT_AGENT)
     agent_queues = await rabbitmq_api.get_queues()
     agent_bindings = await rabbitmq_api.get_bindings()
     await bus.shutdown()
@@ -341,15 +341,14 @@ async def test_rabbitmq_initial_setup(rabbitmq_api: RabbitMQManager) -> None:
 async def test_rabbitmq_publish(rabbitmq_api: RabbitMQManager) -> None:
     """Validate that the adapter publishes messages to the correct queue"""
 
-    bus = RabbitMQMessageBus(settings=rabbitmq_api.settings)
-    service = InfrahubServices(message_bus=bus, component_type=ComponentType.API_SERVER)
+    bus = await RabbitMQMessageBus.new(settings=rabbitmq_api.settings, component_type=ComponentType.API_SERVER)
+    service = await InfrahubServices.new(message_bus=bus, component_type=ComponentType.API_SERVER)
 
     normal_message = messages.EventBranchCreate(branch="normal", branch_id=str(uuid4()), sync_with_git=False)
     delayed_message = messages.EventBranchCreate(branch="delayed", branch_id=str(uuid4()), sync_with_git=False)
 
-    await bus.initialize(service=service)
-    await service.send(message=normal_message)
-    await service.send(message=delayed_message, delay=MessageTTL.FIVE)
+    await bus.send(message=normal_message)
+    await service.message_bus.send(message=delayed_message, delay=MessageTTL.FIVE)
 
     queue = await bus.channel.get_queue(name=f"{bus.settings.namespace}.rpcs")
     delayed_queue = await bus.channel.get_queue(name=f"{bus.settings.namespace}.delay.five_seconds")
@@ -376,17 +375,15 @@ async def test_rabbitmq_publish(rabbitmq_api: RabbitMQManager) -> None:
 async def test_rabbitmq_callback(rabbitmq_api: RabbitMQManager, fake_log: FakeLogger) -> None:
     """Validates that incoming messages gets parsed by the callback method."""
 
-    bus = RabbitMQMessageBus(settings=rabbitmq_api.settings)
-    service = InfrahubServices(message_bus=bus, component_type=ComponentType.API_SERVER, log=fake_log)
-
-    await bus.initialize(service=service)
+    bus = await RabbitMQMessageBus.new(settings=rabbitmq_api.settings, component_type=ComponentType.API_SERVER)
+    service = await InfrahubServices.new(message_bus=bus, component_type=ComponentType.API_SERVER, log=fake_log)
 
     queue = await bus.channel.get_queue(
         f"{bus.settings.namespace}.rpcs",
     )
     await queue.consume(bus.on_callback, no_ack=True)
 
-    await service.send(message=messages.SendEchoRequest(message="Hello there"))
+    await service.message_bus.send(message=messages.SendEchoRequest(message="Hello there"))
     await asyncio.sleep(delay=0.1)
 
     assert "Received message: Hello there" in fake_log.info_logs
@@ -396,10 +393,8 @@ async def test_rabbitmq_callback(rabbitmq_api: RabbitMQManager, fake_log: FakeLo
 async def test_rabbitmq_callback_with_invalid_routing_key(rabbitmq_api: RabbitMQManager, fake_log: FakeLogger) -> None:
     """Validate that messages with an invalid routing key is logged."""
 
-    bus = RabbitMQMessageBus(settings=rabbitmq_api.settings)
-    service = InfrahubServices(message_bus=bus, component_type=ComponentType.API_SERVER, log=fake_log)
-
-    await bus.initialize(service=service)
+    bus = await RabbitMQMessageBus.new(settings=rabbitmq_api.settings, component_type=ComponentType.API_SERVER)
+    service = await InfrahubServices.new(message_bus=bus, component_type=ComponentType.API_SERVER, log=fake_log)
 
     queue = await bus.channel.get_queue(
         f"{bus.settings.namespace}.rpcs",
@@ -415,10 +410,8 @@ async def test_rabbitmq_callback_with_invalid_routing_key(rabbitmq_api: RabbitMQ
 async def test_rabbitmq_rpc(rabbitmq_api: RabbitMQManager, fake_log: FakeLogger) -> None:
     """Validates that incoming messages gets parsed by the callback method."""
 
-    bus = RabbitMQMessageBus(settings=rabbitmq_api.settings)
-    service = InfrahubServices(message_bus=bus, component_type=ComponentType.API_SERVER, log=fake_log)
-
-    await bus.initialize(service=service)
+    bus = await RabbitMQMessageBus.new(settings=rabbitmq_api.settings, component_type=ComponentType.API_SERVER)
+    service = await InfrahubServices.new(message_bus=bus, component_type=ComponentType.API_SERVER, log=fake_log)
 
     queue = await bus.channel.get_queue(
         f"{bus.settings.namespace}.rpcs",
@@ -438,15 +431,14 @@ async def test_rabbitmq_rpc(rabbitmq_api: RabbitMQManager, fake_log: FakeLogger)
 async def test_rabbitmq_on_message(rabbitmq_api: RabbitMQManager, fake_log: FakeLogger) -> None:
     """Validates the on_message method."""
 
-    bus = RabbitMQMessageBus(settings=rabbitmq_api.settings)
-    api_service = InfrahubServices(message_bus=bus, component_type=ComponentType.API_SERVER)
-    agent_service = InfrahubServices(message_bus=bus, component_type=ComponentType.GIT_AGENT, log=fake_log)
-    await bus.initialize(service=api_service)
+    bus = await RabbitMQMessageBus.new(settings=rabbitmq_api.settings, component_type=ComponentType.API_SERVER)
+    _ = await InfrahubServices.new(message_bus=bus, component_type=ComponentType.API_SERVER)
     await bus.shutdown()
 
-    await bus.initialize(service=agent_service)
+    bus = await RabbitMQMessageBus.new(settings=rabbitmq_api.settings, component_type=ComponentType.GIT_AGENT)
+    _ = await InfrahubServices.new(message_bus=bus, component_type=ComponentType.GIT_AGENT, log=fake_log)
 
-    await agent_service.send(message=messages.SendEchoRequest(message="Hello there"))
+    await bus.send(message=messages.SendEchoRequest(message="Hello there"))
     await asyncio.sleep(delay=1)
     await bus.shutdown()
 
@@ -457,13 +449,12 @@ async def test_rabbitmq_on_message(rabbitmq_api: RabbitMQManager, fake_log: Fake
 async def test_rabbitmq_on_message_invalid_routing_key(rabbitmq_api: RabbitMQManager, fake_log: FakeLogger) -> None:
     """Validates logging of invalid routing key"""
 
-    bus = RabbitMQMessageBus(settings=rabbitmq_api.settings)
-    api_service = InfrahubServices(message_bus=bus, component_type=ComponentType.API_SERVER)
-    agent_service = InfrahubServices(message_bus=bus, component_type=ComponentType.GIT_AGENT, log=fake_log)
-    await bus.initialize(service=api_service)
+    bus = await RabbitMQMessageBus.new(settings=rabbitmq_api.settings, component_type=ComponentType.API_SERVER)
+    _ = await InfrahubServices.new(message_bus=bus, component_type=ComponentType.API_SERVER)
     await bus.shutdown()
 
-    await bus.initialize(service=agent_service)
+    bus = await RabbitMQMessageBus.new(settings=rabbitmq_api.settings, component_type=ComponentType.GIT_AGENT)
+    _ = await InfrahubServices.new(message_bus=bus, component_type=ComponentType.GIT_AGENT, log=fake_log)
 
     await bus.publish(routing_key="request.something.invalid", message=messages.SendEchoRequest(message="Hello there"))
     await asyncio.sleep(delay=1)

--- a/backend/tests/integration/transform/test_transform.py
+++ b/backend/tests/integration/transform/test_transform.py
@@ -11,7 +11,7 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.utils import delete_all_nodes
 from infrahub.git import InfrahubRepository
-from infrahub.server import app, app_initialization
+from infrahub.server import app, lifespan
 from infrahub.services import InfrahubServices, services
 from tests.constants import TestKind
 from tests.helpers.schema import CAR_SCHEMA, load_schema
@@ -19,6 +19,8 @@ from tests.helpers.test_app import TestInfrahubApp
 from tests.helpers.test_client import InfrahubTestClient
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
     from infrahub.database import InfrahubDatabase
     from tests.helpers.file_repo import FileRepo
 
@@ -85,15 +87,14 @@ class TestTransforms(TestInfrahubApp):
         base_dataset,
         redis: dict[int, int] | None,
         nats: dict[int, int] | None,
-    ) -> InfrahubTestClient:
-        await app_initialization(app)
-        return InfrahubTestClient(app=app)
+    ) -> AsyncGenerator[InfrahubTestClient]:
+        async with lifespan(app):
+            yield InfrahubTestClient(app=app)
 
     @pytest.fixture(scope="class")
     async def client(self, test_client: InfrahubTestClient, integration_helper):  # type: ignore[override]
         admin_token = await integration_helper.create_token()
         config = Config(api_token=admin_token, requester=test_client.async_request)
-
         return InfrahubClient(config=config)
 
     @pytest.fixture(scope="class")

--- a/backend/tests/integration/transform/test_transform.py
+++ b/backend/tests/integration/transform/test_transform.py
@@ -26,9 +26,9 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture
-def init_service():
-    original = services.service
-    service = InfrahubServices(client=InfrahubClient())
+async def init_service():
+    original = services._service
+    service = await InfrahubServices.new(client=InfrahubClient())
     services.service = service
     yield service
     services.service = original
@@ -87,7 +87,7 @@ class TestTransforms(TestInfrahubApp):
         base_dataset,
         redis: dict[int, int] | None,
         nats: dict[int, int] | None,
-    ) -> AsyncGenerator[InfrahubTestClient]:
+    ) -> AsyncGenerator[InfrahubTestClient, None]:
         async with lifespan(app):
             yield InfrahubTestClient(app=app)
 
@@ -115,6 +115,7 @@ class TestTransforms(TestInfrahubApp):
             name=git_repo_car_dealership.name,
             location=git_repo_car_dealership.path,
             client=client,
+            service=await InfrahubServices.new(database=db),
         )
 
         return repo

--- a/backend/tests/unit/api/conftest.py
+++ b/backend/tests/unit/api/conftest.py
@@ -46,15 +46,6 @@ def rpc_bus(helper):
     config.OVERRIDE.message_bus = original
 
 
-@pytest.fixture
-def rpc_bus_simulator(helper, db):
-    original = config.OVERRIDE.message_bus
-    bus = helper.get_message_bus_simulator(db=db)
-    config.OVERRIDE.message_bus = bus
-    yield bus
-    config.OVERRIDE.message_bus = original
-
-
 @pytest.fixture()
 async def workflow_local():
     original = config.OVERRIDE.workflow

--- a/backend/tests/unit/api/test_10_query.py
+++ b/backend/tests/unit/api/test_10_query.py
@@ -32,7 +32,6 @@ async def test_query_endpoint_group_no_params(
     create_test_admin,
     default_branch,
     car_person_data,
-    patch_services,
 ):
     # Must execute in a with block to execute the startup/shutdown events
     with (

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -113,6 +113,7 @@ async def git_fixture_repo(git_sources_dir: Path, git_repos_dir: Path) -> Infrah
         name="test_basename",
         location=str(git_sources_dir / "test_base"),
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
+        service=await InfrahubServices.new(),
     )
 
     await repo.create_branch_in_git(branch_name="main", branch_id="8808dcea-f7b4-4f5a-b5e9-a0605d4c11ba")
@@ -2944,11 +2945,11 @@ def workflow_local():
 
 
 @pytest.fixture
-def init_service(db: InfrahubDatabase):
-    original = services.service
-    services.service = InfrahubServices(database=db, workflow=WorkflowLocalExecution())
-    yield services.service
-    services.service = original
+async def init_service(db: InfrahubDatabase):
+    original = services._service
+    services._service = await InfrahubServices.new(database=db, workflow=WorkflowLocalExecution())
+    yield services._service
+    services._service = original
 
 
 @pytest.fixture

--- a/backend/tests/unit/core/constraint_validators/test_task_schema_validate_migrations.py
+++ b/backend/tests/unit/core/constraint_validators/test_task_schema_validate_migrations.py
@@ -36,8 +36,8 @@ async def test_schema_validate_migrations(
         )
     ]
 
-    services.service = InfrahubServices(
-        message_bus=BusSimulator(database=db), client=InfrahubClient(), workflow=WorkflowLocalExecution(), database=db
+    services.service = await InfrahubServices.new(
+        message_bus=BusSimulator(), client=InfrahubClient(), workflow=WorkflowLocalExecution(), database=db
     )
 
     message = SchemaValidateMigrationData(branch=default_branch, schema_branch=schema, constraints=constraints)

--- a/backend/tests/unit/core/test_branch_diff.py
+++ b/backend/tests/unit/core/test_branch_diff.py
@@ -124,7 +124,7 @@ async def test_diff_get_files_repository(db: InfrahubDatabase, repos_in_main, ba
         )
         return model
 
-    service = InfrahubServices(database=db, workflow=WorkflowLocalExecution())
+    service = await InfrahubServices.new(database=db, workflow=WorkflowLocalExecution())
     with (
         patch(
             "infrahub.services.adapters.workflow.local.WorkflowLocalExecution.execute_workflow",
@@ -167,7 +167,7 @@ async def test_diff_get_files_repositories_for_branch_case01(
         )
         return model
 
-    service = InfrahubServices(database=db, workflow=WorkflowLocalExecution())
+    service = await InfrahubServices.new(database=db, workflow=WorkflowLocalExecution())
     with (
         patch(
             "infrahub.services.adapters.workflow.local.WorkflowLocalExecution.execute_workflow",
@@ -218,7 +218,7 @@ async def test_diff_get_files_repositories_for_branch_case02(
             )
         raise ValueError(f"Should not reach here: {model}")
 
-    service = InfrahubServices(database=db, workflow=WorkflowLocalExecution())
+    service = await InfrahubServices.new(database=db, workflow=WorkflowLocalExecution())
     with init_global_service(service):
         branch2 = await create_branch(branch_name="branch2", db=db)
 
@@ -266,7 +266,7 @@ async def test_diff_get_files(db: InfrahubDatabase, default_branch: Branch, repo
             )
         raise ValueError(f"Should not reach here: {model}")
 
-    service = InfrahubServices(database=db, workflow=WorkflowLocalExecution())
+    service = await InfrahubServices.new(database=db, workflow=WorkflowLocalExecution())
     with init_global_service(service):
         branch2 = await create_branch(branch_name="branch2", db=db)
 

--- a/backend/tests/unit/git/conftest.py
+++ b/backend/tests/unit/git/conftest.py
@@ -18,6 +18,7 @@ from infrahub.core.constants import InfrahubKind
 from infrahub.core.schema import SchemaRoot, core_models
 from infrahub.git import InfrahubRepository
 from infrahub.git.repository import InfrahubReadOnlyRepository
+from infrahub.services import InfrahubServices
 from infrahub.utils import find_first_file_in_directory, get_fixtures_dir
 from tests.conftest import TestHelper
 from tests.helpers.test_client import dummy_async_request
@@ -137,6 +138,7 @@ async def git_repo_01(
         name=git_upstream_repo_01["name"],
         location=str(git_upstream_repo_01["path"]),
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
+        service=await InfrahubServices.new(),
     )
 
     return repo
@@ -155,6 +157,7 @@ async def git_repo_01_read_only(
         ref="branch01",
         infrahub_branch_name="main",
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
+        service=await InfrahubServices.new(),
     )
 
     return repo
@@ -176,6 +179,7 @@ async def git_repo_02(git_upstream_repo_02: dict[str, str | Path], git_repos_dir
         name=git_upstream_repo_02["name"],
         location=str(git_upstream_repo_02["path"]),
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
+        service=await InfrahubServices.new(),
     )
 
     return repo
@@ -200,6 +204,7 @@ async def git_repo_03(
         name=git_upstream_repo_03["name"],
         location=str(git_upstream_repo_03["path"]),
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
+        service=await InfrahubServices.new(),
     )
 
     return repo
@@ -228,6 +233,7 @@ async def git_repo_04(
         name=git_upstream_repo_03["name"],
         location=str(git_upstream_repo_03["path"]),
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
+        service=await InfrahubServices.new(),
     )
     await repo.create_branch_in_git(branch_name=branch01.name, branch_id=branch01.id)
 
@@ -265,6 +271,7 @@ async def git_repo_05(
         name=git_upstream_repo_01["name"],
         location=str(git_upstream_repo_01["path"]),
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
+        service=await InfrahubServices.new(),
     )
 
     # Update the first file at the top level and commit the change in the branch
@@ -296,6 +303,7 @@ async def git_repo_06(
         name=git_upstream_repo_01["name"],
         location=str(git_upstream_repo_01["path"]),
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
+        service=await InfrahubServices.new(),
     )
     await repo.create_branch_in_git(branch_name=branch01.name, branch_id=branch01.id)
 
@@ -391,6 +399,7 @@ async def git_repo_jinja(
         name=git_upstream_repo_02["name"],
         location=str(git_upstream_repo_02["path"]),
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
+        service=await InfrahubServices.new(),
     )
     await repo.create_branch_in_git(branch_name=branch01.name, branch_id=branch01.id)
 
@@ -429,6 +438,7 @@ async def git_repo_checks(
         name=git_upstream_repo_02["name"],
         location=str(git_upstream_repo_02["path"]),
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
+        service=await InfrahubServices.new(),
     )
     return repo
 
@@ -459,6 +469,7 @@ async def git_repo_transforms(
         name=git_upstream_repo_02["name"],
         location=str(git_upstream_repo_02["path"]),
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
+        service=await InfrahubServices.new(),
     )
     return repo
 
@@ -482,6 +493,7 @@ async def git_repo_10(
         name=git_upstream_repo_10["name"],
         location=str(git_upstream_repo_10["path"]),
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
+        service=await InfrahubServices.new(),
     )
 
     repo.client = client

--- a/backend/tests/unit/git/test_git_read_only_repository.py
+++ b/backend/tests/unit/git/test_git_read_only_repository.py
@@ -5,6 +5,7 @@ from infrahub_sdk.client import Config, InfrahubClient
 from infrahub_sdk.uuidt import UUIDT
 
 from infrahub.git.repository import InfrahubReadOnlyRepository
+from infrahub.services import InfrahubServices
 from tests.helpers.test_client import dummy_async_request
 
 
@@ -16,6 +17,7 @@ async def test_new_empty_dir(git_upstream_repo_01: dict[str, str | Path], git_re
         ref="branch01",
         infrahub_branch_name="main",
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
+        service=await InfrahubServices.new(),
     )
 
     assert repo.directory_root.is_dir()

--- a/backend/tests/unit/git/test_git_repository.py
+++ b/backend/tests/unit/git/test_git_repository.py
@@ -28,6 +28,7 @@ from infrahub.git.integrator import (
     CheckDefinitionInformation,
 )
 from infrahub.git.worktree import Worktree
+from infrahub.services import InfrahubServices
 from infrahub.utils import find_first_file_in_directory
 from tests.conftest import TestHelper
 from tests.helpers.test_client import dummy_async_request
@@ -45,6 +46,7 @@ async def test_directories_props(git_upstream_repo_01: dict[str, str | Path], gi
         name=git_upstream_repo_01["name"],
         location=str(git_upstream_repo_01["path"]),
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
+        service=await InfrahubServices.new(),
     )
 
     assert repo.directory_root == git_repos_dir / str(repo.id)
@@ -59,6 +61,7 @@ async def test_new_empty_dir(git_upstream_repo_01: dict[str, str | Path], git_re
         name=git_upstream_repo_01["name"],
         location=str(git_upstream_repo_01["path"]),
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
+        service=await InfrahubServices.new(),
     )
 
     # Check if all the directories are present
@@ -78,6 +81,7 @@ async def test_new_existing_directory(git_upstream_repo_01: dict[str, str | Path
         name=git_upstream_repo_01["name"],
         location=str(git_upstream_repo_01["path"]),
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
+        service=await InfrahubServices.new(),
     )
 
     # Check if all the directories are present
@@ -96,6 +100,7 @@ async def test_new_existing_file(git_upstream_repo_01: dict[str, str | Path], gi
         name=git_upstream_repo_01["name"],
         location=str(git_upstream_repo_01["path"]),
         client=InfrahubClient(config=Config(requester=dummy_async_request)),
+        service=await InfrahubServices.new(),
     )
 
     # Check if all the directories are present
@@ -107,7 +112,12 @@ async def test_new_existing_file(git_upstream_repo_01: dict[str, str | Path], gi
 
 async def test_new_wrong_location(git_upstream_repo_01: dict[str, str | Path], git_repos_dir: Path, tmp_path: Path):
     with pytest.raises(RepositoryError) as exc:
-        await InfrahubRepository.new(id=UUIDT.new(), name=git_upstream_repo_01["name"], location=str(tmp_path))
+        await InfrahubRepository.new(
+            id=UUIDT.new(),
+            name=git_upstream_repo_01["name"],
+            location=str(tmp_path),
+            service=await InfrahubServices.new(),
+        )
 
     assert f"fatal: repository '{tmp_path}' does not exist" in str(exc.value)
 
@@ -119,13 +129,14 @@ async def test_new_wrong_branch(git_upstream_repo_01: dict[str, str | Path], git
             name=git_upstream_repo_01["name"],
             location=str(git_upstream_repo_01["path"]),
             default_branch_name="notvalid",
+            service=await InfrahubServices.new(),
         )
 
     assert "isn't a valid branch" in str(exc.value)
 
 
 async def test_init_existing_repository(git_repo_01: InfrahubRepository):
-    repo = await InfrahubRepository.init(id=git_repo_01.id, name=git_repo_01.name)
+    repo = await InfrahubRepository.init(id=git_repo_01.id, name=git_repo_01.name, service=await InfrahubServices.new())
 
     # Check if all the directories are present
     assert repo.has_origin is True

--- a/backend/tests/unit/git/test_git_rpc.py
+++ b/backend/tests/unit/git/test_git_rpc.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from infrahub_sdk import Config, InfrahubClient
 from infrahub_sdk.uuidt import UUIDT
 from typing_extensions import Self
@@ -55,23 +56,25 @@ class AsyncContextManagerMock:
 
 
 class TestAddRepository:
-    def setup_method(self):
+    @pytest.fixture
+    async def setup(self):
         self.default_branch_name = "default-branch"
         self.client = AsyncMock(spec=InfrahubClient)
         self.original_services = services.service
         self.recorder = BusSimulator()
-        services.service = InfrahubServices(client=self.client, message_bus=self.recorder)
+        services.service = await InfrahubServices.new(client=self.client, message_bus=self.recorder)
 
         self.mock_repo = AsyncMock(spec=InfrahubRepository)
         self.mock_repo.default_branch = self.default_branch_name
         self.mock_repo.infrahub_branch_name = self.default_branch_name
         self.mock_repo.internal_status = "active"
 
-    def teardown_method(self):
+        yield
+
         patch.stopall()
         services.service = self.original_services
 
-    async def test_git_rpc_create_successful(self, prefect_test_fixture, git_upstream_repo_01: dict[str, str]):
+    async def test_git_rpc_create_successful(self, prefect_test_fixture, git_upstream_repo_01: dict[str, str], setup):
         repo_id = str(UUIDT())
         model = GitRepositoryAdd(
             repository_id=repo_id,
@@ -105,6 +108,7 @@ class TestAddRepository:
                 infrahub_branch_name=self.default_branch_name,
                 internal_status="active",
                 default_branch_name=self.default_branch_name,
+                service=services.service,
             )
             self.mock_repo.import_objects_from_files.assert_awaited_once_with(
                 infrahub_branch_name=self.default_branch_name, git_branch_name=self.default_branch_name
@@ -135,11 +139,10 @@ async def test_git_rpc_merge(
     )
 
     client_config = Config(requester=dummy_async_request)
-    bus_simulator = helper.get_message_bus_simulator()
-    service = InfrahubServices(
+    bus_simulator = await helper.get_message_bus_simulator()
+    service = await InfrahubServices.new(
         client=InfrahubClient(config=client_config), message_bus=bus_simulator, workflow=WorkflowLocalExecution()
     )
-    bus_simulator.service = service
 
     original_services = services.service
     services.service = service
@@ -178,9 +181,10 @@ async def test_git_rpc_diff(
         second_commit=commit_branch02,
     )
 
-    bus_simulator = helper.get_message_bus_simulator()
-    service = InfrahubServices(client=InfrahubClient(), message_bus=bus_simulator, workflow=WorkflowLocalExecution())
-    bus_simulator.service = service
+    bus_simulator = await helper.get_message_bus_simulator()
+    service = await InfrahubServices.new(
+        client=InfrahubClient(), message_bus=bus_simulator, workflow=WorkflowLocalExecution()
+    )
     with init_global_service(service):
         diff = await service.workflow.execute_workflow(
             workflow=GIT_REPOSITORIES_DIFF_NAMES_ONLY, parameters={"model": model}
@@ -201,11 +205,12 @@ async def test_git_rpc_diff(
 
 
 class TestAddReadOnly:
-    def setup_method(self):
+    @pytest.fixture
+    async def setup(self):
         self.client = AsyncMock(spec=InfrahubClient)
         self.original_services = services.service
         self.recorder = BusSimulator()
-        services.service = InfrahubServices(client=self.client, message_bus=self.recorder)
+        services.service = await InfrahubServices.new(client=self.client, message_bus=self.recorder)
 
         lock_patcher = patch("infrahub.git.tasks.lock")
         self.mock_infra_lock = lock_patcher.start()
@@ -215,11 +220,13 @@ class TestAddReadOnly:
         self.mock_repo = AsyncMock(spec=InfrahubReadOnlyRepository)
         self.mock_repo_class.new.return_value = self.mock_repo
 
-    def teardown_method(self):
+        yield
+
+        # teardown
         patch.stopall()
         services.service = self.original_services
 
-    async def test_git_rpc_add_read_only_success(self, git_upstream_repo_01: dict[str, str]):
+    async def test_git_rpc_add_read_only_success(self, git_upstream_repo_01: dict[str, str], setup):
         repo_id = str(UUIDT())
         model = GitRepositoryAddReadOnly(
             repository_id=repo_id,
@@ -243,6 +250,7 @@ class TestAddReadOnly:
             client=self.client,
             ref="branch01",
             infrahub_branch_name="read-only-branch",
+            service=services.service,
         )
         self.mock_repo.import_objects_from_files.assert_awaited_once_with(infrahub_branch_name="read-only-branch")
         self.mock_repo.sync_from_remote.assert_awaited_once_with()
@@ -252,11 +260,12 @@ class TestAddReadOnly:
 
 
 class TestPullReadOnly:
-    def setup_method(self):
+    @pytest.fixture
+    async def setup(self):
         self.client = AsyncMock(spec=InfrahubClient)
         self.original_services = services.service
         self.recorder = BusSimulator()
-        services.service = InfrahubServices(
+        services.service = await InfrahubServices.new(
             client=self.client, workflow=WorkflowLocalExecution(), message_bus=self.recorder
         )
 
@@ -286,11 +295,13 @@ class TestPullReadOnly:
         self.mock_repo_class.new.return_value = self.mock_repo
         self.mock_repo_class.init.return_value = self.mock_repo
 
-    def teardown_method(self):
+        yield
+
+        # teardown
         patch.stopall()
         services.service = self.original_services
 
-    async def test_improper_message(self):
+    async def test_improper_message(self, setup):
         self.model.ref = None
         self.model.commit = None
 
@@ -299,7 +310,7 @@ class TestPullReadOnly:
         self.mock_repo_class.new.assert_not_awaited()
         self.mock_repo_class.init.assert_not_awaited()
 
-    async def test_existing_repository(self):
+    async def test_existing_repository(self, setup):
         self.mock_repo.import_objects_from_files = AsyncMock()
 
         await pull_read_only(model=self.model)
@@ -312,6 +323,7 @@ class TestPullReadOnly:
             client=self.client,
             ref=self.ref,
             infrahub_branch_name=self.infrahub_branch_name,
+            service=services.service,
         )
         self.mock_repo.import_objects_from_files.assert_awaited_once_with(
             infrahub_branch_name=self.infrahub_branch_name, commit=self.commit
@@ -321,7 +333,7 @@ class TestPullReadOnly:
         assert len(self.recorder.messages) > 0
         assert isinstance(self.recorder.messages[0], RefreshGitFetch)
 
-    async def test_new_repository(self, prefect_test_fixture):
+    async def test_new_repository(self, setup, prefect_test_fixture):
         self.mock_repo_class.init.side_effect = RepositoryError(self.repo_name, "it is broken")
         self.mock_repo.import_objects_from_files = AsyncMock()
 
@@ -335,6 +347,7 @@ class TestPullReadOnly:
             client=self.client,
             ref=self.ref,
             infrahub_branch_name=self.infrahub_branch_name,
+            service=services.service,
         )
         self.mock_repo_class.new.assert_awaited_once_with(
             id=self.repo_id,
@@ -343,6 +356,7 @@ class TestPullReadOnly:
             client=self.client,
             ref=self.ref,
             infrahub_branch_name=self.infrahub_branch_name,
+            service=services.service,
         )
         self.mock_repo.import_objects_from_files.assert_awaited_once_with(
             infrahub_branch_name=self.infrahub_branch_name, commit=self.commit

--- a/backend/tests/unit/git/test_git_transform.py
+++ b/backend/tests/unit/git/test_git_transform.py
@@ -11,12 +11,12 @@ from infrahub.transformations.tasks import transform_python, transform_render_ji
 
 
 @pytest.fixture
-def init_service():
-    original = services.service
-    service = InfrahubServices(client=InfrahubClient(), workflow=WorkflowLocalExecution())
-    services.service = service
+async def init_service():
+    original = services._service
+    service = await InfrahubServices.new(client=InfrahubClient(), workflow=WorkflowLocalExecution())
+    services._service = service
     yield service
-    services.service = original
+    services._service = original
 
 
 async def test_git_transform_jinja2_success(git_repo_jinja: InfrahubRepository, prefect_test_fixture, helper):

--- a/backend/tests/unit/graphql/mutations/test_branch.py
+++ b/backend/tests/unit/graphql/mutations/test_branch.py
@@ -266,7 +266,7 @@ async def test_branch_rebase_wrong_branch(
     }
     """
     recorder = BusRecorder()
-    service = InfrahubServices(message_bus=recorder)
+    service = await InfrahubServices.new(message_bus=recorder)
     gql_params = await prepare_graphql_params(
         db=db, include_subscription=False, service=service, branch=default_branch, account_session=session_admin
     )
@@ -332,7 +332,7 @@ async def test_branch_merge_wrong_branch(
     }
     """
     recorder = BusRecorder()
-    service = InfrahubServices(message_bus=recorder, database=db, workflow=WorkflowLocalExecution())
+    service = await InfrahubServices.new(message_bus=recorder, database=db, workflow=WorkflowLocalExecution())
     with init_global_service(service):
         gql_params = await prepare_graphql_params(
             db=db, include_subscription=False, branch=branch1, account_session=session_admin, service=service
@@ -371,7 +371,7 @@ async def test_branch_merge_with_conflict_fails(db: InfrahubDatabase, car_person
     await car_branch.save(db=db)
 
     recorder = BusRecorder()
-    service = InfrahubServices(message_bus=recorder, database=db, workflow=WorkflowLocalExecution())
+    service = await InfrahubServices.new(message_bus=recorder, database=db, workflow=WorkflowLocalExecution())
     with init_global_service(service):
         gql_params = await prepare_graphql_params(
             db=db, include_subscription=False, branch=branch2, account_session=session_admin, service=service

--- a/backend/tests/unit/graphql/mutations/test_menu.py
+++ b/backend/tests/unit/graphql/mutations/test_menu.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 
 async def test_menu_create(db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch):
-    service = InfrahubServices(database=db)
+    service = await InfrahubServices.new(database=db)
 
     CREATE_MENU = """
     mutation CoreMenuItemCreate {
@@ -37,7 +37,7 @@ async def test_menu_create(db: InfrahubDatabase, register_core_models_schema: No
 
 
 async def test_menu_update_protected(db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch):
-    service = InfrahubServices(database=db)
+    service = await InfrahubServices.new(database=db)
 
     menu_item = MenuItemDefinition(
         namespace="Builtin",
@@ -77,7 +77,7 @@ async def test_menu_update_protected(db: InfrahubDatabase, register_core_models_
 
 
 async def test_menu_delete_protected(db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch):
-    service = InfrahubServices(database=db)
+    service = await InfrahubServices.new(database=db)
 
     menu_item = MenuItemDefinition(
         namespace="Builtin",

--- a/backend/tests/unit/graphql/mutations/test_proposed_change.py
+++ b/backend/tests/unit/graphql/mutations/test_proposed_change.py
@@ -137,7 +137,7 @@ async def test_trigger_proposed_change(db: InfrahubDatabase, register_core_model
     await proposed_change.new(db=db, name="change123", destination_branch="main", source_branch=branch_name)
     await proposed_change.save(db=db)
     all_recorder = BusRecorder()
-    service = InfrahubServices(database=db, message_bus=all_recorder)
+    service = await InfrahubServices.new(database=db, message_bus=all_recorder)
     all_result = await graphql_mutation(
         query=RUN_CHECK, db=db, variables={"proposed_change": proposed_change.id}, service=service
     )
@@ -145,7 +145,7 @@ async def test_trigger_proposed_change(db: InfrahubDatabase, register_core_model
     assert not all_result.errors
 
     artifact_recorder = BusRecorder()
-    service = InfrahubServices(database=db, message_bus=artifact_recorder)
+    service = await InfrahubServices.new(database=db, message_bus=artifact_recorder)
     artifact_result = await graphql_mutation(
         query=RUN_CHECK,
         db=db,
@@ -158,7 +158,7 @@ async def test_trigger_proposed_change(db: InfrahubDatabase, register_core_model
     )
 
     cancelled_recorder = BusRecorder()
-    service = InfrahubServices(database=db, message_bus=cancelled_recorder)
+    service = await InfrahubServices.new(database=db, message_bus=cancelled_recorder)
     canceled_result = await graphql_mutation(
         query=RUN_CHECK,
         db=db,
@@ -209,10 +209,9 @@ async def test_merge_proposed_change_permission_failure(
     session_first_account: AccountSession,
     session_admin: AccountSession,
 ):
-    service = InfrahubServices(
+    service = await InfrahubServices.new(
         database=db, message_bus=BusRecorder(), workflow=WorkflowLocalExecution(), cache=MemoryCache()
     )
-    await service.component.initialize(service=service)
     async with get_client(sync_client=False) as client:
         await setup_worker_pools(client=client)
         await setup_deployments(client)

--- a/backend/tests/unit/graphql/mutations/test_repository.py
+++ b/backend/tests/unit/graphql/mutations/test_repository.py
@@ -29,7 +29,7 @@ async def test_trigger_repository_import(
 ):
     repository_model = registry.schema.get_node_schema(name=InfrahubKind.REPOSITORY, branch=default_branch)
     recorder = BusRecorder()
-    service = InfrahubServices(database=db, message_bus=recorder, workflow=WorkflowLocalExecution())
+    service = await InfrahubServices.new(database=db, message_bus=recorder, workflow=WorkflowLocalExecution())
 
     # TODO: Removing this mock triggers issue: `Invalid file system for test-edge-demo, local directory ... missing`
     with (
@@ -81,7 +81,7 @@ async def test_repository_update(db: InfrahubDatabase, register_core_models_sche
     branch2 = await create_branch(branch_name="branch2", db=db)
     repository_model = registry.schema.get_node_schema(name=InfrahubKind.REPOSITORY, branch=default_branch)
     recorder = BusRecorder()
-    service = InfrahubServices(database=db, message_bus=recorder)
+    service = await InfrahubServices.new(database=db, message_bus=recorder)
 
     UPDATE_COMMIT = """
     mutation CoreRepositoryUpdate($id: String!, $commit_id: String!, $internal_status: String!) {

--- a/backend/tests/unit/graphql/queries/test_status.py
+++ b/backend/tests/unit/graphql/queries/test_status.py
@@ -18,9 +18,11 @@ if TYPE_CHECKING:
 async def test_status_query(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None):
     cache = MemoryCache()
     bus = BusRecorder()
-    service = InfrahubServices(cache=cache, database=db, component_type=ComponentType.API_SERVER, message_bus=bus)
+    service = await InfrahubServices.new(
+        cache=cache, database=db, component_type=ComponentType.API_SERVER, message_bus=bus
+    )
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
-    await service.component.initialize(service=service)
+
     await service.component.refresh_heartbeat()
     await service.component.refresh_schema_hash()
     response = await graphql_query(query=STATUS_QUERY, db=db, branch=default_branch, service=service)

--- a/backend/tests/unit/graphql/test_mutation_artifact_definition.py
+++ b/backend/tests/unit/graphql/test_mutation_artifact_definition.py
@@ -71,7 +71,6 @@ async def test_create_artifact_definition(
     group1: Node,
     transformation1: Node,
     branch: Branch,
-    patch_services,
 ):
     query = """
     mutation {
@@ -94,7 +93,7 @@ async def test_create_artifact_definition(
         transformation1.id,
     )
     recorder = BusRecorder()
-    service = InfrahubServices(message_bus=recorder, workflow=WorkflowLocalExecution())
+    service = await InfrahubServices.new(message_bus=recorder, workflow=WorkflowLocalExecution())
 
     gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch, service=service)
 
@@ -151,7 +150,7 @@ async def test_update_artifact_definition(
     """ % (definition1.id)
 
     recorder = BusRecorder()
-    service = InfrahubServices(message_bus=recorder, workflow=WorkflowLocalExecution())
+    service = await InfrahubServices.new(message_bus=recorder, workflow=WorkflowLocalExecution())
 
     gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch, service=service)
     with patch(

--- a/backend/tests/unit/message_bus/operations/event/test_branch.py
+++ b/backend/tests/unit/message_bus/operations/event/test_branch.py
@@ -22,15 +22,15 @@ from tests.adapters.message_bus import BusRecorder
 
 
 @pytest.fixture
-def init_service():
-    original = services.service
+async def init_service():
+    original = services._service
     recorder = BusRecorder()
     database = MagicMock()
     workflow = WorkflowLocalExecution()
-    service = InfrahubServices(message_bus=recorder, database=database, workflow=workflow)
-    services.service = service
+    service = await InfrahubServices.new(message_bus=recorder, database=database, workflow=workflow)
+    services._service = service
     yield service
-    services.service = original
+    services._service = original
 
 
 async def test_merged(default_branch: Branch, init_service: InfrahubServices, prefect_test_fixture):
@@ -82,7 +82,7 @@ async def test_merged(default_branch: Branch, init_service: InfrahubServices, pr
             "infrahub.services.adapters.workflow.local.WorkflowLocalExecution.submit_workflow"
         ) as mock_submit_workflow,
     ):
-        await merge(message=message, service=service)
+        await merge.fn(message=message, service=service)
 
         expected_calls = [
             call(workflow=TRIGGER_ARTIFACT_DEFINITION_GENERATE, parameters={"branch": message.target_branch}),

--- a/backend/tests/unit/message_bus/operations/git/test_file.py
+++ b/backend/tests/unit/message_bus/operations/git/test_file.py
@@ -17,9 +17,8 @@ async def test_file_get(git_fixture_repo: InfrahubRepository, helper):
         file="sample.txt",
     )
 
-    bus_simulator = helper.get_message_bus_simulator()
-    service = InfrahubServices(client=InfrahubClient(), message_bus=bus_simulator)
-    bus_simulator.service = service
+    bus_simulator = await helper.get_message_bus_simulator()
+    service = await InfrahubServices.new(client=InfrahubClient(), message_bus=bus_simulator)
 
     reply = await service.message_bus.rpc(message=message, response_class=messages.GitFileGetResponse)
     assert reply.passed

--- a/backend/tests/unit/message_bus/operations/requests/test_graphql_query_group.py
+++ b/backend/tests/unit/message_bus/operations/requests/test_graphql_query_group.py
@@ -43,7 +43,7 @@ async def test_graphql_group_update(db: InfrahubDatabase, httpx_mock: HTTPXMock,
     client = InfrahubClient(
         config=config,
     )
-    service = InfrahubServices(client=client, workflow=WorkflowLocalExecution())
+    service = await InfrahubServices.new(client=client, workflow=WorkflowLocalExecution())
 
     with init_global_service(service), patch("infrahub.groups.tasks.add_tags"):
         # add_branch_tag requires a prefect client, ie it does not work with WorkflowLocal

--- a/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
+++ b/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
@@ -22,11 +22,11 @@ from tests.helpers.utils import init_global_service
 
 
 @pytest.fixture
-def service_all(db: InfrahubDatabase, helper: TestHelper) -> InfrahubServices:
+async def service_all(db: InfrahubDatabase, helper: TestHelper) -> InfrahubServices:
     config = Config(address="http://mock", insert_tracker=True)
     client = InfrahubClient(config=config)
-    bus_simulator = helper.get_message_bus_simulator()
-    service = InfrahubServices(message_bus=bus_simulator, client=client, database=db)
+    bus_simulator = await helper.get_message_bus_simulator()
+    service = await InfrahubServices.new(message_bus=bus_simulator, client=client, database=db)
     bus_simulator.service = service
 
     return service

--- a/backend/tests/unit/services/test_scheduler.py
+++ b/backend/tests/unit/services/test_scheduler.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from infrahub.services import InfrahubServices
-from infrahub.services.scheduler import InfrahubScheduler, Schedule, run_schedule
+from infrahub.services.scheduler import Schedule
 
 if TYPE_CHECKING:
     from tests.adapters.log import FakeLogger
@@ -22,12 +22,9 @@ async def log_once_and_stop(service: InfrahubServices) -> None:
 
 async def test_scheduler_return_on_not_running(fake_log: FakeLogger):
     """The scheduler should return without writing entries to the log if it is not running."""
-    schedule_manager = InfrahubScheduler()
-    schedule_manager.running = False
-    service = InfrahubServices(log=fake_log)
-    service.scheduler = schedule_manager
+    service = await InfrahubServices.new(log=fake_log)
     schedule = Schedule(name="inactive", interval=10, start_delay=1, function=log_once_and_stop)
-    await run_schedule(schedule=schedule, service=service)
+    await service.scheduler.run_schedule(schedule=schedule)
 
     assert len(fake_log.info_logs) == 0
 
@@ -35,12 +32,10 @@ async def test_scheduler_return_on_not_running(fake_log: FakeLogger):
 async def test_scheduler_exit_after_first(fake_log: FakeLogger):
     """The scheduler should return without writing entries to the log if it is not running."""
 
-    schedule_manager = InfrahubScheduler()
-    schedule_manager.running = True
-    service = InfrahubServices(log=fake_log)
-    service.scheduler = schedule_manager
+    service = await InfrahubServices.new(log=fake_log)
     schedule = Schedule(name="inactive", interval=1, start_delay=1, function=log_once_and_stop)
-    await run_schedule(schedule=schedule, service=service)
+    service.scheduler.running = True
+    await service.scheduler.run_schedule(schedule=schedule)
 
     assert len(fake_log.info_logs) == 3
     assert fake_log.info_logs[0] == "Started recurring task"
@@ -50,12 +45,10 @@ async def test_scheduler_exit_after_first(fake_log: FakeLogger):
 
 async def test_scheduler_task_with_error(fake_log: FakeLogger):
     """The scheduler should return without writing entries to the log if it is not running."""
-    schedule_manager = InfrahubScheduler()
-    schedule_manager.running = True
-    service = InfrahubServices(log=fake_log)
-    service.scheduler = schedule_manager
+    service = await InfrahubServices.new(log=fake_log)
     schedule = Schedule(name="inactive", interval=1, start_delay=0, function=nothing_to_see)
-    await run_schedule(schedule=schedule, service=service)
+    service.scheduler.running = True
+    await service.scheduler.run_schedule(schedule=schedule)
 
     assert len(fake_log.info_logs) == 1
     assert len(fake_log.error_logs) == 1

--- a/backend/tests/unit/workflows/test_catalogue.py
+++ b/backend/tests/unit/workflows/test_catalogue.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from infrahub.workers.infrahub_async import load_flow_function
 from infrahub.workflows import catalogue
 from infrahub.workflows.catalogue import automation_setup_workflows, worker_pools, workflows
 
@@ -15,13 +16,13 @@ if TYPE_CHECKING:
 @pytest.mark.parametrize("workflow", [pytest.param(workflow, id=workflow.name) for workflow in workflows])
 def test_workflow_definition(workflow: WorkflowDefinition) -> None:
     """Validate that we can import the function for each workflow."""
-    workflow.validate_workflow()
+    load_flow_function(module_path=workflow.function, flow_name=workflow.function)
 
 
 @pytest.mark.parametrize("workflow", [pytest.param(workflow, id=workflow.name) for workflow in workflows])
 def test_workflow_definition_matches(workflow: WorkflowDefinition) -> None:
     """Validate that the name of the workflow matches the name of the flow"""
-    flow = workflow.get_function()
+    flow = load_flow_function(module_path=workflow.module, flow_name=workflow.function)
     assert hasattr(flow, "name")
     assert workflow.name == flow.name
 

--- a/backend/tests/unit/workflows/test_catalogue.py
+++ b/backend/tests/unit/workflows/test_catalogue.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from infrahub.workers.infrahub_async import load_flow_function
 from infrahub.workflows import catalogue
 from infrahub.workflows.catalogue import automation_setup_workflows, worker_pools, workflows
 
@@ -16,13 +15,13 @@ if TYPE_CHECKING:
 @pytest.mark.parametrize("workflow", [pytest.param(workflow, id=workflow.name) for workflow in workflows])
 def test_workflow_definition(workflow: WorkflowDefinition) -> None:
     """Validate that we can import the function for each workflow."""
-    load_flow_function(module_path=workflow.function, flow_name=workflow.function)
+    workflow.load_function()
 
 
 @pytest.mark.parametrize("workflow", [pytest.param(workflow, id=workflow.name) for workflow in workflows])
 def test_workflow_definition_matches(workflow: WorkflowDefinition) -> None:
     """Validate that the name of the workflow matches the name of the flow"""
-    flow = load_flow_function(module_path=workflow.module, flow_name=workflow.function)
+    flow = workflow.load_function()
     assert hasattr(flow, "name")
     assert workflow.name == flow.name
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,8 +185,8 @@ min-similarity-lines = 20
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-timeout = 9999999 # 5 minutes
-session_timeout = 9999999 # 20 minutes
+timeout = 300 # 5 minutes
+session_timeout = 1200 # 20 minutes
 testpaths = ["tests"]
 filterwarnings = [
     "ignore:Module already imported so cannot be rewritten",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,8 +185,8 @@ min-similarity-lines = 20
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-timeout = 300 # 5 minutes
-session_timeout = 1200 # 20 minutes
+timeout = 9999999 # 5 minutes
+session_timeout = 9999999 # 20 minutes
 testpaths = ["tests"]
 filterwarnings = [
     "ignore:Module already imported so cannot be rewritten",


### PR DESCRIPTION
PR initial purpose was to inject `InfrahubServices` within flows but it will actually be done in a second PR to avoid having a too big one here. So, this PR actually simplifies how `InfrahubServices` and related services are used in the following manners:

- Services objects (cache, message_bus, services, ...) should now instantiated with a single call to `new`, while currently a second call to `object.initialize(service)` is required. This avoids having objects in an intermediate state where they are instantiated but partially initialized, leading to confusion/errors. Some circular dependencies have been removed to make that possible, typically `InfrahubCache` does not depend anymore of `InfrahubServices` object. For information, the two main circular dependencies trickier to handle are:
     - `InfrahubServices` <-> `InfrahubMessageBus`, typically, a service holds a message bus, but a message bus requires a service to inject within `execute_message`.
     - `InfrahubServices` <-> `WorkflowLocalExecution`, same as above, local workflow needs a service for flow injection. Note this only applies during tests.
- Remove some abstract object initializations, like `InfrahubCache`, `InfrahubWorkflow`, ...
- `InfrahubRepository` related constructors service parameter is now mandatory to avoid instantiating extra `InfrahubServices` objects.

There are still some things to improve, but I believe this should make testing easier. At least, dependencies between different services will be more explicit and we should barely not be dealing with partially instantiated objects. I plan to remove global services.service once this PR is merged.