### PR TITLE
IFC-1033 Fix IP addr being in IP pfx pool allocated nodes

### DIFF
--- a/backend/infrahub/core/ipam/utilization.py
+++ b/backend/infrahub/core/ipam/utilization.py
@@ -35,7 +35,12 @@ class PrefixUtilizationGetter:
 
     async def _run_and_parse_query(self) -> None:
         self._results_by_prefix_id = {}
-        query = await IPPrefixUtilization.init(db=self.db, at=self.at, ip_prefixes=self.ip_prefixes)
+        query = await IPPrefixUtilization.init(
+            db=self.db,
+            at=self.at,
+            ip_prefixes=self.ip_prefixes,
+            allocated_kinds=[InfrahubKind.IPPREFIX, InfrahubKind.IPADDRESS],
+        )
         await query.execute(db=self.db)
 
         for result in query.get_results():

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -248,11 +248,9 @@ class IPPrefixUtilization(Query):
     name = "ipprefix_utilization_prefix"
     type = QueryType.READ
 
-    def __init__(self, ip_prefixes: list[str], allocated_kinds: list[str] | None = None, **kwargs):
+    def __init__(self, ip_prefixes: list[str], allocated_kinds: list[str], **kwargs):
         self.ip_prefixes = ip_prefixes
-        self.allocated_kinds = [
-            f'"{kind}"' for kind in (allocated_kinds or [InfrahubKind.IPPREFIX, InfrahubKind.IPADDRESS])
-        ]
+        self.allocated_kinds = [f'"{kind}"' for kind in allocated_kinds]
         super().__init__(**kwargs)
 
     async def query_init(self, db: InfrahubDatabase, **kwargs) -> None:

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import ipaddress
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Iterable, Optional, Union
+from typing import TYPE_CHECKING, Iterable
 
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.ipam.constants import AllIPTypes, IPAddressType, IPNetworkType
@@ -38,7 +38,7 @@ class IPAddressData:
 
 
 def _get_namespace_id(
-    namespace: Optional[Union[Node, str]] = None,
+    namespace: Node | str | None = None,
 ) -> str:
     if namespace and isinstance(namespace, str):
         return namespace
@@ -54,7 +54,7 @@ class IPPrefixSubnetFetch(Query):
     def __init__(
         self,
         obj: IPNetworkType,
-        namespace: Optional[Union[Node, str]] = None,
+        namespace: Node | str | None = None,
         **kwargs,
     ):
         self.obj = obj
@@ -145,7 +145,7 @@ class IPPrefixIPAddressFetch(Query):
     def __init__(
         self,
         obj: IPNetworkType,
-        namespace: Optional[Union[Node, str]] = None,
+        namespace: Node | str | None = None,
         **kwargs,
     ):
         self.obj = obj
@@ -215,9 +215,9 @@ class IPPrefixIPAddressFetch(Query):
 async def get_subnets(
     db: InfrahubDatabase,
     ip_prefix: IPNetworkType,
-    namespace: Optional[Union[Node, str]] = None,
-    branch: Optional[Union[Branch, str]] = None,
-    at: Optional[Union[Timestamp, str]] = None,
+    namespace: Node | str | None = None,
+    branch: Branch | str | None = None,
+    at: Timestamp | str | None = None,
     branch_agnostic: bool = False,
 ) -> Iterable[IPPrefixData]:
     branch = await registry.get_branch(db=db, branch=branch)
@@ -231,9 +231,9 @@ async def get_subnets(
 async def get_ip_addresses(
     db: InfrahubDatabase,
     ip_prefix: IPNetworkType,
-    namespace: Optional[Union[Node, str]] = None,
-    branch: Optional[Union[Branch, str]] = None,
-    at=None,
+    namespace: Node | str | None = None,
+    branch: Branch | str | None = None,
+    at: Timestamp | str | None = None,
     branch_agnostic: bool = False,
 ) -> Iterable[IPAddressData]:
     branch = await registry.get_branch(db=db, branch=branch)
@@ -248,8 +248,11 @@ class IPPrefixUtilization(Query):
     name = "ipprefix_utilization_prefix"
     type = QueryType.READ
 
-    def __init__(self, ip_prefixes: list[str], **kwargs):
+    def __init__(self, ip_prefixes: list[str], allocated_kinds: list[str] | None = None, **kwargs):
         self.ip_prefixes = ip_prefixes
+        self.allocated_kinds = [
+            f'"{kind}"' for kind in (allocated_kinds or [InfrahubKind.IPPREFIX, InfrahubKind.IPADDRESS])
+        ]
         super().__init__(**kwargs)
 
     async def query_init(self, db: InfrahubDatabase, **kwargs) -> None:
@@ -266,7 +269,7 @@ class IPPrefixUtilization(Query):
             WITH pfx
             MATCH (pfx)-[r_rel1:IS_RELATED]-(rl:Relationship)<-[r_rel2:IS_RELATED]-(child:Node)
             WHERE rl.name IN ["parent__child", "ip_prefix__ip_address"]
-            AND any(l IN labels(child) WHERE l in ["{InfrahubKind.IPPREFIX}", "{InfrahubKind.IPADDRESS}"])
+            AND any(l IN labels(child) WHERE l IN [{", ".join(self.allocated_kinds)}])
             AND ({rel_filter("r_rel1")})
             AND ({rel_filter("r_rel2")})
             RETURN r_rel1, rl, r_rel2, child
@@ -318,8 +321,8 @@ class IPPrefixReconcileQuery(Query):
     def __init__(
         self,
         ip_value: AllIPTypes,
-        namespace: Optional[Union[Node, str]] = None,
-        node_uuid: Optional[str] = None,
+        namespace: Node | str | None = None,
+        node_uuid: str | None = None,
         **kwargs,
     ):
         self.ip_value = ip_value
@@ -583,7 +586,7 @@ class IPPrefixReconcileQuery(Query):
         self.add_to_query(get_new_children_query)
         self.return_labels = ["ip_node", "current_parent", "current_children", "new_parent", "new_children"]
 
-    def _get_uuid_from_query(self, node_name: str) -> Optional[str]:
+    def _get_uuid_from_query(self, node_name: str) -> str | None:
         results = list(self.get_results())
         if not results:
             return None
@@ -610,13 +613,13 @@ class IPPrefixReconcileQuery(Query):
                 element_uuids.append(str(element_uuid))
         return element_uuids
 
-    def get_ip_node_uuid(self) -> Optional[str]:
+    def get_ip_node_uuid(self) -> str | None:
         return self._get_uuid_from_query("ip_node")
 
-    def get_current_parent_uuid(self) -> Optional[str]:
+    def get_current_parent_uuid(self) -> str | None:
         return self._get_uuid_from_query("current_parent")
 
-    def get_calculated_parent_uuid(self) -> Optional[str]:
+    def get_calculated_parent_uuid(self) -> str | None:
         return self._get_uuid_from_query("new_parent")
 
     def get_current_children_uuids(self) -> list[str]:

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -250,7 +250,15 @@ class IPPrefixUtilization(Query):
 
     def __init__(self, ip_prefixes: list[str], allocated_kinds: list[str], **kwargs):
         self.ip_prefixes = ip_prefixes
-        self.allocated_kinds = [f'"{kind}"' for kind in allocated_kinds]
+        self.allocated_kinds: list[str] = []
+        self.allocated_kinds_rel: list[str] = []
+
+        for kind in sorted(allocated_kinds):
+            self.allocated_kinds.append(f'"{kind}"')
+            self.allocated_kinds_rel.append(
+                {InfrahubKind.IPADDRESS: '"ip_prefix__ip_address"', InfrahubKind.IPPREFIX: '"parent__child"'}[kind]
+            )
+
         super().__init__(**kwargs)
 
     async def query_init(self, db: InfrahubDatabase, **kwargs) -> None:
@@ -266,7 +274,7 @@ class IPPrefixUtilization(Query):
         CALL {{
             WITH pfx
             MATCH (pfx)-[r_rel1:IS_RELATED]-(rl:Relationship)<-[r_rel2:IS_RELATED]-(child:Node)
-            WHERE rl.name IN ["parent__child", "ip_prefix__ip_address"]
+            WHERE rl.name IN [{", ".join(self.allocated_kinds_rel)}]
             AND any(l IN labels(child) WHERE l IN [{", ".join(self.allocated_kinds)}])
             AND ({rel_filter("r_rel1")})
             AND ({rel_filter("r_rel2")})

--- a/backend/infrahub/graphql/mutations/resource_manager.py
+++ b/backend/infrahub/graphql/mutations/resource_manager.py
@@ -33,7 +33,7 @@ class IPPrefixPoolGetResourceInput(InputObjectType):
     hfid = InputField(String(required=False), description="HFID of the pool to allocate from")
     identifier = InputField(String(required=False), description="Identifier for the allocated resource")
     prefix_length = InputField(Int(required=False), description="Size of the prefix to allocate")
-    member_type = InputField(String(required=False), description="member_type of the newly created prefix")
+    member_type = InputField(String(required=False), description="Type of members for the newly created prefix")
     prefix_type = InputField(String(required=False), description="Kind of prefix to allocate")
     data = InputField(GenericScalar(required=False), description="Additional data to pass to the newly created prefix")
 
@@ -45,9 +45,9 @@ class IPAddressPoolGetResourceInput(InputObjectType):
     prefix_length = InputField(
         Int(required=False), description="Size of the prefix mask to allocate on the new IP address"
     )
-    address_type = InputField(String(required=False), description="Kind of ip address to allocate")
+    address_type = InputField(String(required=False), description="Kind of IP address to allocate")
     data = InputField(
-        GenericScalar(required=False), description="Additional data to pass to the newly created ip address"
+        GenericScalar(required=False), description="Additional data to pass to the newly created IP address"
     )
 
 

--- a/backend/infrahub/graphql/queries/resource_manager.py
+++ b/backend/infrahub/graphql/queries/resource_manager.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 from graphene import Field, Float, Int, List, ObjectType, String
 from infrahub_sdk.utils import extract_fields_first_node
@@ -57,7 +57,7 @@ class PoolAllocatedEdge(ObjectType):
     node = Field(PoolAllocatedNode, required=True)
 
 
-def _validate_pool_type(pool_id: str, pool: Optional[CoreNode] = None) -> CoreNode:
+def _validate_pool_type(pool_id: str, pool: CoreNode | None = None) -> CoreNode:
     if not pool or pool.get_kind() not in [
         InfrahubKind.IPADDRESSPOOL,
         InfrahubKind.IPPREFIXPOOL,
@@ -81,12 +81,12 @@ class PoolAllocated(ObjectType):
         limit: int = 10,
     ) -> dict:
         context: GraphqlContext = info.context
-        pool: Optional[CoreNode] = await NodeManager.get_one(id=pool_id, db=context.db, branch=context.branch)
+        pool: CoreNode | None = await NodeManager.get_one(id=pool_id, db=context.db, branch=context.branch)
 
         fields = await extract_fields_first_node(info=info)
 
         pool = _validate_pool_type(pool_id=pool_id, pool=pool)
-        if pool.get_kind() == "CoreNumberPool":
+        if pool.get_kind() == InfrahubKind.NUMBERPOOL:
             return await resolve_number_pool_allocation(
                 db=context.db, context=context, pool=pool, fields=fields, offset=offset, limit=limit
             )
@@ -99,14 +99,27 @@ class PoolAllocated(ObjectType):
 
         resource = resources[resource_id]
 
+        allocated_kinds = None
+        match pool.get_kind():
+            case InfrahubKind.IPPREFIXPOOL:
+                allocated_kinds = [InfrahubKind.IPPREFIX]
+            case InfrahubKind.IPADDRESSPOOL:
+                allocated_kinds = [InfrahubKind.IPADDRESS]
+
         query = await IPPrefixUtilization.init(
-            db=context.db, at=context.at, ip_prefixes=[resource], offset=offset, limit=limit
+            db=context.db,
+            at=context.at,
+            ip_prefixes=[resource],
+            allocated_kinds=allocated_kinds,
+            offset=offset,
+            limit=limit,
         )
         response: dict[str, Any] = {}
         if "count" in fields:
             response["count"] = await query.count(db=context.db)
 
         if edges := fields.get("edges"):
+            query.print(include_var=True)
             await query.execute(db=context.db)
 
             node_fields = edges.get("node", {})
@@ -170,7 +183,7 @@ class PoolUtilization(ObjectType):
     ) -> dict:
         context: GraphqlContext = info.context
         db: InfrahubDatabase = context.db
-        pool: Optional[CoreNode] = await NodeManager.get_one(id=pool_id, db=db, branch=context.branch)
+        pool: CoreNode | None = await NodeManager.get_one(id=pool_id, db=db, branch=context.branch)
         pool = _validate_pool_type(pool_id=pool_id, pool=pool)
         if pool.get_kind() == "CoreNumberPool":
             return await resolve_number_pool_utilization(db=db, context=context, pool=pool)
@@ -212,7 +225,7 @@ class PoolUtilization(ObjectType):
                 for resource_id, resource_node in resources_map.items():
                     resource_total = None
                     default_branch_total = None
-                    node_response: dict[str, Union[str, float, int]] = {}
+                    node_response: dict[str, str | float | int] = {}
                     if "id" in node_fields:
                         node_response["id"] = resource_id
                     if "kind" in node_fields:

--- a/backend/infrahub/graphql/queries/resource_manager.py
+++ b/backend/infrahub/graphql/queries/resource_manager.py
@@ -85,7 +85,7 @@ class PoolAllocated(ObjectType):
 
         fields = await extract_fields_first_node(info=info)
 
-        allocated_kinds = [InfrahubKind.IPPREFIX, InfrahubKind.IPADDRESS]
+        allocated_kinds: list[str] = []
         pool = _validate_pool_type(pool_id=pool_id, pool=pool)
         match pool.get_kind():
             case InfrahubKind.NUMBERPOOL:
@@ -93,9 +93,9 @@ class PoolAllocated(ObjectType):
                     db=context.db, context=context, pool=pool, fields=fields, offset=offset, limit=limit
                 )
             case InfrahubKind.IPPREFIXPOOL:
-                allocated_kinds = [InfrahubKind.IPPREFIX]
+                allocated_kinds.append(InfrahubKind.IPPREFIX)
             case InfrahubKind.IPADDRESSPOOL:
-                allocated_kinds = [InfrahubKind.IPADDRESS]
+                allocated_kinds.append(InfrahubKind.IPADDRESS)
 
         resources = await pool.resources.get_peers(db=context.db)  # type: ignore[attr-defined,union-attr]
         if resource_id not in resources:

--- a/backend/infrahub/graphql/queries/resource_manager.py
+++ b/backend/infrahub/graphql/queries/resource_manager.py
@@ -85,11 +85,17 @@ class PoolAllocated(ObjectType):
 
         fields = await extract_fields_first_node(info=info)
 
+        allocated_kinds = [InfrahubKind.IPPREFIX, InfrahubKind.IPADDRESS]
         pool = _validate_pool_type(pool_id=pool_id, pool=pool)
-        if pool.get_kind() == InfrahubKind.NUMBERPOOL:
-            return await resolve_number_pool_allocation(
-                db=context.db, context=context, pool=pool, fields=fields, offset=offset, limit=limit
-            )
+        match pool.get_kind():
+            case InfrahubKind.NUMBERPOOL:
+                return await resolve_number_pool_allocation(
+                    db=context.db, context=context, pool=pool, fields=fields, offset=offset, limit=limit
+                )
+            case InfrahubKind.IPPREFIXPOOL:
+                allocated_kinds = [InfrahubKind.IPPREFIX]
+            case InfrahubKind.IPADDRESSPOOL:
+                allocated_kinds = [InfrahubKind.IPADDRESS]
 
         resources = await pool.resources.get_peers(db=context.db)  # type: ignore[attr-defined,union-attr]
         if resource_id not in resources:
@@ -98,13 +104,6 @@ class PoolAllocated(ObjectType):
             )
 
         resource = resources[resource_id]
-
-        allocated_kinds = None
-        match pool.get_kind():
-            case InfrahubKind.IPPREFIXPOOL:
-                allocated_kinds = [InfrahubKind.IPPREFIX]
-            case InfrahubKind.IPADDRESSPOOL:
-                allocated_kinds = [InfrahubKind.IPADDRESS]
 
         query = await IPPrefixUtilization.init(
             db=context.db,

--- a/backend/infrahub/graphql/queries/resource_manager.py
+++ b/backend/infrahub/graphql/queries/resource_manager.py
@@ -118,7 +118,6 @@ class PoolAllocated(ObjectType):
             response["count"] = await query.count(db=context.db)
 
         if edges := fields.get("edges"):
-            query.print(include_var=True)
             await query.execute(db=context.db)
 
             node_fields = edges.get("node", {})

--- a/changelog/5316.fixed.md
+++ b/changelog/5316.fixed.md
@@ -1,0 +1,1 @@
+Fix IP address being displayed in IP prefix pool after deleting the allocated prefix it was part of


### PR DESCRIPTION
Fixes #5316

The fix consists of limiting the labels that we search for when fetching nodes for a given resource of an IP address/prefix pool. Since we use the prefix utilization query to find those nodes, we were always expecting both prefixes and addresses to be returned. However in the case of pools we only want either prefixes (for prefix pool) or addresses (for address pool).