### PR TITLE
IFC-1032 Fix IP pool allocation with deleted nodes

### DIFF
--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -97,8 +97,7 @@ class IPPrefixSubnetFetch(Query):
             AND av.binary_address STARTS WITH $prefix_binary
             AND av.prefixlen > $maxprefixlen
             AND av.version = $ip_version
-            AND all(r IN relationships(path2) WHERE (%(branch_filter)s))
-        // TODO Need to check for delete nodes
+            AND all(r IN relationships(path2) WHERE (%(branch_filter)s) and r.status = "active")
         WITH
             collect([pfx, av]) as all_prefixes_and_value,
             collect(pfx) as all_prefixes
@@ -189,7 +188,7 @@ class IPPrefixIPAddressFetch(Query):
             AND av.binary_address STARTS WITH $prefix_binary
             AND av.prefixlen >= $maxprefixlen
             AND av.version = $ip_version
-            AND all(r IN relationships(path2) WHERE (%(branch_filter)s))
+            AND all(r IN relationships(path2) WHERE (%(branch_filter)s) and r.status = "active")
         """ % {
             "ns_label": InfrahubKind.IPNAMESPACE,
             "node_label": InfrahubKind.IPADDRESS,

--- a/changelog/5315.fixed.md
+++ b/changelog/5315.fixed.md
@@ -1,0 +1,1 @@
+Fix pool exhaustion error for IP resource pools when some allocated nodes were deleted


### PR DESCRIPTION
Fixes #5315

The queries in charge of fetching prefixes or addresses within a prefix were not excluding deleted nodes from the possible results. This was causing issues when trying to allocate nodes from a pool when some previous nodes were deleted. The new allocation was considering that the deleted nodes were still allocated thus causing false pool exhaustion errors.