### PR TITLE
skip profile schemas when checking for schema migrations

### DIFF
--- a/backend/infrahub/core/validators/models/violation.py
+++ b/backend/infrahub/core/validators/models/violation.py
@@ -1,17 +1,4 @@
-from typing import Union
-
-from pydantic import BaseModel, Field
-
-from infrahub.core.branch import Branch
-from infrahub.core.path import SchemaPath
-from infrahub.core.schema import GenericSchema, NodeSchema
-
-
-class SchemaConstraintValidatorRequest(BaseModel):
-    branch: Branch = Field(..., description="The name of the branch to target")
-    constraint_name: str = Field(..., description="The name of the constraint to validate")
-    node_schema: Union[NodeSchema, GenericSchema] = Field(..., description="Schema of Node or Generic to validate")
-    schema_path: SchemaPath = Field(..., description="SchemaPath to the element of the schema to validate")
+from pydantic import BaseModel
 
 
 class SchemaViolation(BaseModel):

--- a/backend/infrahub/core/validators/tasks.py
+++ b/backend/infrahub/core/validators/tasks.py
@@ -7,7 +7,7 @@ from prefect.logging import get_run_logger
 
 from infrahub.core.branch import Branch  # noqa: TC001
 from infrahub.core.path import SchemaPath  # noqa: TC001
-from infrahub.core.schema import GenericSchema, NodeSchema  # noqa: TC001
+from infrahub.core.schema import GenericSchema, NodeSchema, ProfileSchema  # noqa: TC001
 from infrahub.core.validators.aggregated_checker import AggregatedConstraintChecker
 from infrahub.core.validators.model import (
     SchemaConstraintValidatorRequest,
@@ -32,11 +32,14 @@ async def schema_validate_migrations(message: SchemaValidateMigrationData) -> li
     log.info(f"{len(message.constraints)} constraint(s) to validate")
     # NOTE this task is a good candidate to add a progress bar
     for constraint in message.constraints:
+        schema = message.schema_branch.get(name=constraint.path.schema_kind)
+        if isinstance(schema, ProfileSchema):
+            continue
         batch.add(
             task=schema_path_validate,
             branch=message.branch,
             constraint_name=constraint.constraint_name,
-            node_schema=message.schema_branch.get(name=constraint.path.schema_kind),
+            node_schema=schema,
             schema_path=constraint.path,
         )
 

--- a/backend/infrahub/core/validators/tasks.py
+++ b/backend/infrahub/core/validators/tasks.py
@@ -7,7 +7,7 @@ from prefect.logging import get_run_logger
 
 from infrahub.core.branch import Branch  # noqa: TC001
 from infrahub.core.path import SchemaPath  # noqa: TC001
-from infrahub.core.schema import GenericSchema, NodeSchema, ProfileSchema  # noqa: TC001
+from infrahub.core.schema import GenericSchema, NodeSchema  # noqa: TC001
 from infrahub.core.validators.aggregated_checker import AggregatedConstraintChecker
 from infrahub.core.validators.model import (
     SchemaConstraintValidatorRequest,
@@ -33,7 +33,7 @@ async def schema_validate_migrations(message: SchemaValidateMigrationData) -> li
     # NOTE this task is a good candidate to add a progress bar
     for constraint in message.constraints:
         schema = message.schema_branch.get(name=constraint.path.schema_kind)
-        if isinstance(schema, ProfileSchema):
+        if not isinstance(schema, (GenericSchema, NodeSchema)):
             continue
         batch.add(
             task=schema_path_validate,


### PR DESCRIPTION
found this issue while doing some diff workflow testing locally

`SchemaConstraintValidatorRequest.node_schema` only accepts `NodeSchema` or `GenericSchema`, not `ProfileSchema`
if a branch includes a new/updated profile instance (say `backbone_profile` or `upstream_profile` from the `infrastructure_edge.py` script), then `SchemaValidateMigrationData.constraints` that is passed to `schema_validate_migrations` will include profile schema, which will raise a validation error and break the pipeline

I think the typing on `SchemaConstraintValidatorRequest` is correct b/c a profile will not require a migration. We have complete control over those schema, so there should be nothing to validate