### PR TITLE
Add Support for S3 Signature Version

### DIFF
--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -197,6 +197,11 @@ class S3StorageSettings(BaseSettings):
         alias="AWS_S3_USE_SSL",
         validation_alias=AliasChoices("INFRAHUB_STORAGE_USE_SSL", "AWS_S3_USE_SSL"),
     )
+    signature_version: str = Field(
+        default="s3v4",
+        alias="AWS_SIGNATURE_VERSION",
+        validation_alias=AliasChoices("INFRAHUB_STORAGE_S3_SIGNATURE_VERSION", "AWS_SIGNATURE_VERSION"),
+    )
     default_acl: str = Field(
         default="",
         alias="AWS_DEFAULT_ACL",

--- a/docs/docs/reference/configuration.mdx
+++ b/docs/docs/reference/configuration.mdx
@@ -97,6 +97,7 @@ Here are a few common methods of setting environmental variables:
 | INFRAHUB_PRODUCTION | "Enable or disable the production mode, in production mode the logs are generated in JSON format" | FALSE |  |  |
 | INFRAHUB_SECURITY_ACCESS_TOKEN_LIFETIME | Lifetime of access token in seconds |  |  |  |
 | INFRAHUB_SECURITY_REFRESH_TOKEN_LIFETIME | Lifetime of refresh token in seconds |  |  |  |
+| INFRAHUB_STORAGE_S3_SIGNATURE_VERSION |  | "s3" | AWS_SIGNATURE_VERSION |  |
 | INFRAHUB_STORAGE_BUCKET_NAME |  | infrahub-data | AWS_S3_BUCKET_NAME |  |
 | INFRAHUB_STORAGE_CUSTOM_DOMAIN |  |  | AWS_S3_CUSTOM_DOMAIN |  |
 | INFRAHUB_STORAGE_DEFAULT_ACL |  |  | AWS_DEFAULT_ACL |  |


### PR DESCRIPTION
This PR will have to wait until fastapi_storages PR is approved https://github.com/aminalaee/fastapi-storages/pull/57

Currently fastapi_storages has no support for older S3 signature versions(Ie Version 2) but the upstream [Boto python SDK does. ](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html)

This will allow old signature versions to be supported with S3 storage. 

Examples: 

- EMC ECS
- Vast Object Store