### PR TITLE
add AttributeKindChecker to aggregated constraints

### DIFF
--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -1163,6 +1163,17 @@ class ListAttribute(BaseAttribute):
             return ujson.loads(data.value)
         return data.value
 
+    @classmethod
+    def validate_format(cls, value: Any, name: str, schema: AttributeSchema) -> None:
+        value_to_check = value
+
+        if isinstance(value, str):
+            try:
+                value_to_check = cls.deserialize_from_string(value_as_string=value)
+            except ujson.JSONDecodeError as exc:
+                raise ValidationError({name: f"{value} is not a valid JSON list"}) from exc
+        super().validate_format(value=value_to_check, name=name, schema=schema)
+
 
 class ListAttributeOptional(ListAttribute):
     value: Optional[list[Any]]
@@ -1187,6 +1198,17 @@ class JSONAttribute(BaseAttribute):
         if data.value and isinstance(data.value, (str, bytes)):
             return ujson.loads(data.value)
         return data.value
+
+    @classmethod
+    def validate_format(cls, value: Any, name: str, schema: AttributeSchema) -> None:
+        value_to_check = value
+
+        if isinstance(value, str):
+            try:
+                value_to_check = cls.deserialize_from_string(value_as_string=value)
+            except ujson.JSONDecodeError as exc:
+                raise ValidationError({name: f"{value} is not valid JSON"}) from exc
+        super().validate_format(value=value_to_check, name=name, schema=schema)
 
 
 class JSONAttributeOptional(JSONAttribute):

--- a/backend/infrahub/core/validators/attribute/kind.py
+++ b/backend/infrahub/core/validators/attribute/kind.py
@@ -67,7 +67,7 @@ class AttributeKindUpdateValidatorQuery(AttributeSchemaValidatorQuery):
             if value in (None, NULL_VALUE):
                 continue
             try:
-                infrahub_attribute_class.validate(
+                infrahub_attribute_class.validate_format(
                     value=result.get("attribute_value"), name=self.attribute_schema.name, schema=self.attribute_schema
                 )
             except ValidationError:

--- a/backend/infrahub/dependencies/builder/constraint/schema/aggregated.py
+++ b/backend/infrahub/dependencies/builder/constraint/schema/aggregated.py
@@ -3,6 +3,7 @@ from infrahub.dependencies.interface import DependencyBuilder, DependencyBuilder
 
 from .attribute_choices import SchemaAttributeChoicesConstraintDependency
 from .attribute_enum import SchemaAttributeEnumConstraintDependency
+from .attribute_kind import SchemaAttributeKindConstraintDependency
 from .attribute_length import SchemaAttributLengthConstraintDependency
 from .attribute_optional import SchemaAttributeOptionalConstraintDependency
 from .attribute_regex import SchemaAttributeRegexConstraintDependency
@@ -32,6 +33,7 @@ class AggregatedSchemaConstraintsDependency(DependencyBuilder[AggregatedConstrai
                 SchemaAttributeChoicesConstraintDependency.build(context=context),
                 SchemaAttributeEnumConstraintDependency.build(context=context),
                 SchemaAttributLengthConstraintDependency.build(context=context),
+                SchemaAttributeKindConstraintDependency.build(context=context),
                 SchemaNodeAttributeAddConstraintDependency.build(context=context),
                 SchemaNodeRelationshipAddConstraintDependency.build(context=context),
             ],

--- a/backend/infrahub/dependencies/builder/constraint/schema/attribute_kind.py
+++ b/backend/infrahub/dependencies/builder/constraint/schema/attribute_kind.py
@@ -1,0 +1,8 @@
+from infrahub.core.validators.attribute.kind import AttributeKindChecker
+from infrahub.dependencies.interface import DependencyBuilder, DependencyBuilderContext
+
+
+class SchemaAttributeKindConstraintDependency(DependencyBuilder[AttributeKindChecker]):
+    @classmethod
+    def build(cls, context: DependencyBuilderContext) -> AttributeKindChecker:
+        return AttributeKindChecker(db=context.db, branch=context.branch)

--- a/changelog/5460.fixed.md
+++ b/changelog/5460.fixed.md
@@ -1,0 +1,1 @@
+Validate updates to an attribute's `kind` when loading a new schema


### PR DESCRIPTION
#5059 
IFC-959

the `AttributeKindChecker` class, which is used to determine if an attribute's kind can be updated, was not included in the `AggregatedConstraintRunner` class, which is the class that we call during a schema update to make sure the changes to the schema are legal.

this PR adds the `AttributeKindChecker` to `AggregatedConstraintRunner` and adds the `validate_format` method to `JSONAttribute` and `ListAttribute` classes that were missing it before.

it also changes the call of `BaseAttribute.validate` to `BaseAttribute.validate_format` within `AttributeKindValidatorQuery` b/c `.validate` includes some logic that resulted in duplicate errors being raised that will be captured by other attribute-related constraint validators (regex, min/max length)

this approach to fixing the error means that a change from `Number` to `Text` as described in the linked issue will be prevented b/c  an integer/decimal will fail validation when checking if it is a string. if we really want to support this type of `kind` change completely, then we need to add a migration that would support updating all the appropriate attribute values from one kind to another (such as `99` - > `"99"`, or even vice versa)