### PR TITLE
Change S3 storage default_acl setting to a default value `private`

### DIFF
--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -198,7 +198,7 @@ class S3StorageSettings(BaseSettings):
         validation_alias=AliasChoices("INFRAHUB_STORAGE_USE_SSL", "AWS_S3_USE_SSL"),
     )
     default_acl: str = Field(
-        default="",
+        default="private",
         alias="AWS_DEFAULT_ACL",
         validation_alias=AliasChoices("INFRAHUB_STORAGE_DEFAULT_ACL", "AWS_DEFAULT_ACL"),
     )

--- a/changelog/s3-storage-default-acl.changed.md
+++ b/changelog/s3-storage-default-acl.changed.md
@@ -1,0 +1,1 @@
+Changed the default value for the s3.default_acl configuration setting to `private`


### PR DESCRIPTION
Since fastapi-storages v0.3.0 it requires that you set a value`AWS_DEFAULT_ACL`. 
In its documentation however, it is specified that it is optional setting and that the default value is `private`.

https://github.com/aminalaee/fastapi-storages/blob/edc624fb647e128e82669f19b195e670a4714dfd/fastapi_storages/s3.py#L39 

This creates a problem if an Infrahub user does not explicitly provide a value for this setting.

In this PR we set the default value for this setting to private, which is also the default value that boto3 uses.