### PR TITLE
IFC-1128 Fix account with perm not able to update accounts

### DIFF
--- a/backend/infrahub/auth.py
+++ b/backend/infrahub/auth.py
@@ -258,7 +258,7 @@ def _validate_update_account(
 def validate_mutation_permissions_update_node(
     operation: str, node_id: str, account_session: AccountSession, fields: list[str], context: GraphqlContext
 ) -> None:
-    validation_map: dict[str, Callable[[AccountSession, str, list[str]], None]] = {
+    validation_map: dict[str, Callable[[AccountSession, str, list[str], GraphqlContext], None]] = {
         f"{InfrahubKind.ACCOUNT}Update": _validate_update_account,
         f"{InfrahubKind.ACCOUNT}Upsert": _validate_update_account,
     }

--- a/backend/infrahub/auth.py
+++ b/backend/infrahub/auth.py
@@ -3,15 +3,15 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timedelta, timezone
 from enum import Enum
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 import bcrypt
 import jwt
 from pydantic import BaseModel
 
 from infrahub import config, models
-from infrahub.core.account import GlobalPermission, validate_token
-from infrahub.core.constants import AccountStatus, GlobalPermissions, InfrahubKind, PermissionDecision
+from infrahub.core.account import validate_token
+from infrahub.core.constants import AccountStatus, InfrahubKind
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.protocols import CoreAccount, CoreAccountGroup
@@ -21,7 +21,6 @@ from infrahub.exceptions import AuthorizationError, NodeNotFoundError
 if TYPE_CHECKING:
     from infrahub.core.protocols import CoreGenericAccount
     from infrahub.database import InfrahubDatabase
-    from infrahub.graphql.initialization import GraphqlContext
 
 
 class AuthType(str, Enum):
@@ -232,39 +231,6 @@ async def validate_api_key(db: InfrahubDatabase, token: str) -> AccountSession:
     await validate_active_account(db=db, account_id=str(account_id))
 
     return AccountSession(account_id=account_id, auth_type=AuthType.API)
-
-
-def _validate_update_account(
-    account_session: AccountSession, node_id: str, fields: list[str], context: GraphqlContext
-) -> None:
-    # Account with permissions can change anything on accounts
-    if context.active_permissions.has_permission(
-        permission=GlobalPermission(
-            action=GlobalPermissions.MANAGE_ACCOUNTS.value, decision=PermissionDecision.ALLOW_ALL.value
-        )
-    ):
-        return
-
-    # Account without permissions can only update its own account for a limited subset of fields
-    if account_session.account_id != node_id:
-        raise PermissionError("You cannot someone else's account")
-
-    allowed_fields = ["description", "label", "password"]
-    for field in fields:
-        if field not in allowed_fields:
-            raise PermissionError(f"You cannot modify account's {field} value")
-
-
-def validate_mutation_permissions_update_node(
-    operation: str, node_id: str, account_session: AccountSession, fields: list[str], context: GraphqlContext
-) -> None:
-    validation_map: dict[str, Callable[[AccountSession, str, list[str], GraphqlContext], None]] = {
-        f"{InfrahubKind.ACCOUNT}Update": _validate_update_account,
-        f"{InfrahubKind.ACCOUNT}Upsert": _validate_update_account,
-    }
-
-    if validator := validation_map.get(operation):
-        validator(account_session, node_id, fields, context)
 
 
 async def invalidate_refresh_token(db: InfrahubDatabase, token_id: str) -> None:

--- a/backend/infrahub/auth.py
+++ b/backend/infrahub/auth.py
@@ -10,8 +10,8 @@ import jwt
 from pydantic import BaseModel
 
 from infrahub import config, models
-from infrahub.core.account import validate_token
-from infrahub.core.constants import AccountStatus, InfrahubKind
+from infrahub.core.account import GlobalPermission, validate_token
+from infrahub.core.constants import AccountStatus, GlobalPermissions, InfrahubKind, PermissionDecision
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.protocols import CoreAccount, CoreAccountGroup
@@ -21,6 +21,7 @@ from infrahub.exceptions import AuthorizationError, NodeNotFoundError
 if TYPE_CHECKING:
     from infrahub.core.protocols import CoreGenericAccount
     from infrahub.database import InfrahubDatabase
+    from infrahub.graphql.initialization import GraphqlContext
 
 
 class AuthType(str, Enum):
@@ -233,19 +234,29 @@ async def validate_api_key(db: InfrahubDatabase, token: str) -> AccountSession:
     return AccountSession(account_id=account_id, auth_type=AuthType.API)
 
 
-def _validate_update_account(account_session: AccountSession, node_id: str, fields: list[str]) -> None:
+def _validate_update_account(
+    account_session: AccountSession, node_id: str, fields: list[str], context: GraphqlContext
+) -> None:
+    # Account with permissions can change anything on accounts
+    if context.active_permissions.has_permission(
+        permission=GlobalPermission(
+            action=GlobalPermissions.MANAGE_ACCOUNTS.value, decision=PermissionDecision.ALLOW_ALL.value
+        )
+    ):
+        return
+
+    # Account without permissions can only update its own account for a limited subset of fields
     if account_session.account_id != node_id:
-        # A regular account is not allowed to modify another account
-        raise PermissionError("You are not allowed to modify this account")
+        raise PermissionError("You cannot someone else's account")
 
     allowed_fields = ["description", "label", "password"]
     for field in fields:
         if field not in allowed_fields:
-            raise PermissionError(f"You are not allowed to modify '{field}'")
+            raise PermissionError(f"You cannot modify account's {field} value")
 
 
 def validate_mutation_permissions_update_node(
-    operation: str, node_id: str, account_session: AccountSession, fields: list[str]
+    operation: str, node_id: str, account_session: AccountSession, fields: list[str], context: GraphqlContext
 ) -> None:
     validation_map: dict[str, Callable[[AccountSession, str, list[str]], None]] = {
         f"{InfrahubKind.ACCOUNT}Update": _validate_update_account,
@@ -253,7 +264,7 @@ def validate_mutation_permissions_update_node(
     }
 
     if validator := validation_map.get(operation):
-        validator(account_session, node_id, fields)
+        validator(account_session, node_id, fields, context)
 
 
 async def invalidate_refresh_token(db: InfrahubDatabase, token_id: str) -> None:

--- a/backend/infrahub/graphql/mutations/account.py
+++ b/backend/infrahub/graphql/mutations/account.py
@@ -35,8 +35,9 @@ class InfrahubAccountTokenDeleteInput(InputObjectType):
 
 
 class InfrahubAccountUpdateSelfInput(InputObjectType):
-    password = InputField(String(required=False), description="The new password")
-    description = InputField(String(required=False), description="The new description")
+    password = InputField(String(required=False), description="Password to use instead of the current one")
+    label = InputField(String(required=False), description="Label to use instead of the current one")
+    description = InputField(String(required=False), description="Description to use instead of the current one")
 
 
 class ValueType(InfrahubObjectType):
@@ -123,7 +124,7 @@ class AccountMixin:
             raise NodeNotFoundError(node_type="AccountToken", identifier=token_id)
 
         async with db.start_transaction() as dbt:
-            await results[0].delete(db=dbt)  # type: ignore[arg-type]
+            await results[0].delete(db=dbt)
 
         return cls(ok=True)  # type: ignore[call-arg]
 
@@ -132,12 +133,12 @@ class AccountMixin:
     async def update_self(
         cls, db: InfrahubDatabase, account: CoreNode, data: dict[str, Any], info: GraphQLResolveInfo
     ) -> Self:
-        for field in ("password", "description"):
+        for field in ("password", "label", "description"):
             if value := data.get(field):
                 getattr(account, field).value = value
 
         async with db.start_transaction() as dbt:
-            await account.save(db=dbt)  # type: ignore[arg-type]
+            await account.save(db=dbt)
 
         return cls(ok=True)  # type: ignore[call-arg]
 

--- a/backend/infrahub/graphql/mutations/account.py
+++ b/backend/infrahub/graphql/mutations/account.py
@@ -36,7 +36,6 @@ class InfrahubAccountTokenDeleteInput(InputObjectType):
 
 class InfrahubAccountUpdateSelfInput(InputObjectType):
     password = InputField(String(required=False), description="Password to use instead of the current one")
-    label = InputField(String(required=False), description="Label to use instead of the current one")
     description = InputField(String(required=False), description="Description to use instead of the current one")
 
 
@@ -133,7 +132,7 @@ class AccountMixin:
     async def update_self(
         cls, db: InfrahubDatabase, account: CoreNode, data: dict[str, Any], info: GraphQLResolveInfo
     ) -> Self:
-        for field in ("password", "label", "description"):
+        for field in ("password", "description"):
             if value := data.get(field):
                 getattr(account, field).value = value
 

--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -292,7 +292,11 @@ class InfrahubMutationMixin:
         if "hfid" in fields:
             fields.remove("hfid")
         validate_mutation_permissions_update_node(
-            operation=cls.__name__, node_id=node_id, account_session=context.account_session, fields=fields
+            operation=cls.__name__,
+            node_id=node_id,
+            account_session=context.account_session,
+            fields=fields,
+            context=context,
         )
 
         await obj.save(db=db, fields=fields)

--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -8,7 +8,6 @@ from infrahub_sdk.utils import extract_fields
 from typing_extensions import Self
 
 from infrahub import config, lock
-from infrahub.auth import validate_mutation_permissions_update_node
 from infrahub.core import registry
 from infrahub.core.constants import InfrahubKind, MutationAction
 from infrahub.core.constraint.node.runner import NodeConstraintRunner
@@ -270,14 +269,8 @@ class InfrahubMutationMixin:
 
     @classmethod
     async def mutate_update_object(
-        cls,
-        db: InfrahubDatabase,
-        info: GraphQLResolveInfo,
-        data: InputObjectType,
-        branch: Branch,
-        obj: Node,
+        cls, db: InfrahubDatabase, info: GraphQLResolveInfo, data: InputObjectType, branch: Branch, obj: Node
     ) -> Node:
-        context: GraphqlContext = info.context
         component_registry = get_component_registry()
         node_constraint_runner = await component_registry.get_component(NodeConstraintRunner, db=db, branch=branch)
 
@@ -285,19 +278,11 @@ class InfrahubMutationMixin:
         await obj.from_graphql(db=db, data=data)
         fields_to_validate = list(data)
         await node_constraint_runner.check(node=obj, field_filters=fields_to_validate)
-        node_id = data.get("id", obj.id)
+
         fields = list(data.keys())
-        if "id" in fields:
-            fields.remove("id")
-        if "hfid" in fields:
-            fields.remove("hfid")
-        validate_mutation_permissions_update_node(
-            operation=cls.__name__,
-            node_id=node_id,
-            account_session=context.account_session,
-            fields=fields,
-            context=context,
-        )
+        for field in ("id", "hfid"):
+            if field in fields:
+                fields.remove(field)
 
         await obj.save(db=db, fields=fields)
         obj = await cls._refresh_for_profile_update(

--- a/changelog/5455.fixed.md
+++ b/changelog/5455.fixed.md
@@ -1,0 +1,1 @@
+Allow to change any attributes and relationships when using a mutation on `CoreAccount`


### PR DESCRIPTION
Fixes #5455 

This PR removes the old mutation permission validation for accounts which was used to limit what a user could update when using the `CoreAccountUpdate` (or upsert) mutation while only allowing it for his/her own account.

Users should now only use the `InfrahubAccountUpdate` mutation to change details for their own accounts. This mutation will limit the scope of what can be changed by its possible inputs.

Mutations to change account related nodes will now only be checked through the permission system like any other kind of nodes (in addition to the global permission specially dedicated for account management).