### PR TITLE
Initial query interfaces for events

### DIFF
--- a/backend/infrahub/events/models.py
+++ b/backend/infrahub/events/models.py
@@ -1,4 +1,5 @@
 from typing import Any
+from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field
 
@@ -17,6 +18,14 @@ class EventMeta(BaseModel):
 
 class InfrahubEvent(BaseModel):
     meta: EventMeta | None = None
+
+    id: UUID = Field(
+        default_factory=uuid4,
+        description="UUID of the event",
+    )
+
+    def get_id(self) -> str:
+        return str(self.id)
 
     def get_event_namespace(self) -> str:
         return EVENT_NAMESPACE

--- a/backend/infrahub/graphql/manager.py
+++ b/backend/infrahub/graphql/manager.py
@@ -59,6 +59,7 @@ from .types import (
 )
 from .types.attribute import BaseAttribute as BaseAttributeType
 from .types.attribute import TextAttributeType
+from .types.event import EVENT_TYPES
 
 if TYPE_CHECKING:
     from graphql import GraphQLSchema
@@ -159,6 +160,7 @@ class GraphQLSchemaManager:
         self._graphql_types: dict[str, GraphQLTypes] = {}
 
         self._load_attribute_types()
+        self._load_event_types()
         if config.SETTINGS.experimental_features.graphql_enums:
             self._load_all_enum_types(node_schemas=self.schema.get_all().values())
         self._load_node_interface()
@@ -270,6 +272,10 @@ class GraphQLSchemaManager:
     def _load_attribute_types(self) -> None:
         for data_type in ATTRIBUTE_TYPES.values():
             self.set_type(name=data_type.get_graphql_type_name(), graphql_type=data_type.get_graphql_type())
+
+    def _load_event_types(self) -> None:
+        for event in EVENT_TYPES.values():
+            self.set_type(name=event._meta.name, graphql_type=event)
 
     def _load_node_interface(self) -> None:
         node_interface_schema = GenericSchema(

--- a/backend/infrahub/graphql/queries/event.py
+++ b/backend/infrahub/graphql/queries/event.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from graphene import Field, Int, List, NonNull, ObjectType, String
+from infrahub_sdk.utils import extract_fields_first_node
+
+from infrahub.graphql.types.event import EventNodes
+from infrahub.task_manager.event import PrefectEvent
+
+if TYPE_CHECKING:
+    from graphql import GraphQLResolveInfo
+
+
+class Events(ObjectType):
+    edges = List(NonNull(EventNodes), required=True)
+    count = Int(required=True)
+
+    @staticmethod
+    async def resolve(
+        root: dict,
+        info: GraphQLResolveInfo,
+        limit: int = 10,
+        offset: int = 0,
+        ids: list[str] | None = None,
+        branch: str | None = None,
+        q: str | None = None,
+    ) -> dict[str, Any]:
+        # related_nodes = related_node__ids or []
+        ids = ids or []
+        return await Events.query(
+            info=info,
+            branch=branch,
+            limit=limit,
+            offset=offset,
+            q=q,
+            ids=ids,
+        )
+
+    @classmethod
+    async def query(
+        cls,
+        info: GraphQLResolveInfo,
+        q: str | None = None,
+        ids: list[str] | None = None,
+        branch: str | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> dict[str, Any]:
+        fields = await extract_fields_first_node(info)
+
+        prefect_tasks = await PrefectEvent.query(
+            fields=fields,
+            q=q,
+            ids=ids,
+            branch=branch,
+            limit=limit,
+            offset=offset,
+        )
+        return {
+            "count": prefect_tasks.get("count", 0),
+            "edges": prefect_tasks.get("edges", []),
+        }
+
+
+Event = Field(
+    Events,
+    limit=Int(required=False),
+    offset=Int(required=False),
+    related_node__ids=List(String),
+    branch=String(required=False),
+    ids=List(String),
+    q=String(required=False),
+    resolver=Events.resolve,
+    required=True,
+)

--- a/backend/infrahub/graphql/schema.py
+++ b/backend/infrahub/graphql/schema.py
@@ -48,6 +48,7 @@ from .queries import (
     Relationship,
 )
 from .queries.diff.tree import DiffTreeQuery, DiffTreeSummaryQuery
+from .queries.event import Event
 from .queries.task import Task, TaskBranchStatus
 
 
@@ -67,6 +68,7 @@ class InfrahubBaseQuery(ObjectType):
     InfrahubSearchAnywhere = InfrahubSearchAnywhere
 
     InfrahubTask = Task
+    InfrahubEvent = Event
     InfrahubTaskBranchStatus = TaskBranchStatus
 
     IPAddressGetNextAvailable = InfrahubIPAddressGetNextAvailable

--- a/backend/infrahub/graphql/types/event.py
+++ b/backend/infrahub/graphql/types/event.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from graphene import Field, Interface, ObjectType, String
+from graphene.types.generic import GenericScalar
+
+if TYPE_CHECKING:
+    from graphql import GraphQLResolveInfo
+
+
+class EventNodeInterface(Interface):
+    id = String(required=True)
+    event = String(required=True)
+    branch = String(required=False)
+
+    @classmethod
+    def resolve_type(cls, instance: dict[str, Any], info: GraphQLResolveInfo) -> ObjectType:
+        if "event" in instance:
+            return EVENT_TYPES.get(instance["event"], StandardEvent)
+        return StandardEvent
+
+
+class EventNodes(ObjectType):
+    node = Field(EventNodeInterface)
+
+
+# ---------------------------------------
+# Branch events
+# ---------------------------------------
+class BranchCreateEvent(ObjectType):
+    class Meta:
+        interfaces = (EventNodeInterface,)
+
+    payload = Field(GenericScalar, required=True)
+
+
+class BranchRebaseEvent(ObjectType):
+    class Meta:
+        interfaces = (EventNodeInterface,)
+
+    payload = Field(GenericScalar, required=True)
+
+
+class BranchDeleteEvent(ObjectType):
+    class Meta:
+        interfaces = (EventNodeInterface,)
+
+    payload = Field(GenericScalar, required=True)
+
+
+# ---------------------------------------
+# Node/Object events
+# ---------------------------------------
+class NodeAddedEvent(ObjectType):
+    class Meta:
+        interfaces = (EventNodeInterface,)
+
+    payload = Field(GenericScalar, required=True)
+
+
+class StandardEvent(ObjectType):
+    class Meta:
+        interfaces = (EventNodeInterface,)
+
+    payload = Field(GenericScalar, required=True)
+
+
+EVENT_TYPES: dict[str, type[ObjectType]] = {
+    "infrahub.node.added": NodeAddedEvent,
+    "infrahub.branch.created": BranchCreateEvent,
+    "infrahub.branch.rebased": BranchRebaseEvent,
+    "infrahub.branch.deleted": BranchDeleteEvent,
+    "undefined": StandardEvent,
+}

--- a/backend/infrahub/task_manager/event.py
+++ b/backend/infrahub/task_manager/event.py
@@ -1,0 +1,91 @@
+import uuid
+from typing import Any
+
+from prefect.client.orchestration import PrefectClient, get_client
+from prefect.events.filters import EventFilter, EventIDFilter, EventNameFilter, EventRelatedFilter
+from prefect.events.schemas.events import Event as PrefectEventModel
+from prefect.events.schemas.events import ResourceSpecification
+from pydantic import TypeAdapter
+
+from infrahub.log import get_logger
+from infrahub.utils import get_nested_dict
+
+log = get_logger()
+
+
+class PrefectEventData(PrefectEventModel):
+    def get_branch(self) -> str | None:
+        for resource in self.related:
+            if resource.get("prefect.resource.id") != "infrahub.branch":
+                continue
+            if "prefect.resource.name" not in resource:
+                continue
+            return resource.get("prefect.resource.name")
+        return None
+
+
+class PrefectEvent:
+    @classmethod
+    async def query_events(cls, client: PrefectClient, filters: EventFilter | None = None) -> list[PrefectEventData]:
+        body = {}
+        if filters:
+            body["filter"] = filters.model_dump(mode="json", exclude_unset=True)
+
+        response = await client._client.post("/events/filter", json=body)
+        response.raise_for_status()
+        # TODO need to implement pagination :(
+        # total_nbr_results = response.json().get("total")
+        return TypeAdapter(list[PrefectEventData]).validate_python(response.json().get("events"))
+
+    @classmethod
+    def _generate_filters(
+        cls,
+        ids: list[str] | None = None,
+        related_nodes: list[str] | None = None,
+        branch: str | None = None,
+    ) -> EventFilter:
+        filters = EventFilter(event=EventNameFilter(prefix=["infrahub."], name=[]))  # type: ignore[call-arg]
+
+        if ids:
+            filters.id = EventIDFilter(id=[uuid.UUID(id) for id in ids])
+
+        if branch:
+            filters.related = EventRelatedFilter(  # type: ignore[call-arg]
+                labels=ResourceSpecification(
+                    {"prefect.resource.id": "infrahub.branch", "prefect.resource.name": branch}
+                )
+            )
+
+        return filters
+
+    @classmethod
+    async def query(
+        cls,
+        fields: dict[str, Any],
+        q: str | None = None,
+        ids: list[str] | None = None,
+        branch: str | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> dict[str, Any]:
+        nodes: list[dict] = []
+
+        node_fields = get_nested_dict(nested_dict=fields, keys=["edges", "node"])
+        filters = cls._generate_filters(ids=ids, branch=branch)
+
+        async with get_client(sync_client=False) as client:
+            if node_fields:
+                events = await cls.query_events(client=client, filters=filters)
+
+                for event in events:
+                    nodes.append(
+                        {
+                            "node": {
+                                "id": str(event.id),
+                                "event": event.event,
+                                "branch": event.get_branch(),
+                            }
+                        }
+                    )
+
+        return {"count": len(nodes), "edges": nodes}

--- a/backend/tests/helpers/events.py
+++ b/backend/tests/helpers/events.py
@@ -1,0 +1,57 @@
+import asyncio
+from uuid import UUID
+
+from prefect.client.orchestration import PrefectClient
+from prefect.events.filters import EventFilter, EventIDFilter
+from prefect.events.schemas.events import Event, RelatedResource, Resource
+from pydantic import TypeAdapter
+
+from infrahub.events.models import InfrahubEvent
+
+
+async def send_events(client: PrefectClient, events: list[InfrahubEvent]) -> list[Event]:
+    events_data = [
+        Event(
+            id=event.id,
+            event=event.get_name(),
+            payload=event.get_payload(),
+            related=[RelatedResource(item) for item in event.get_related()],
+            resource=Resource(event.get_resource()),
+        )
+        for event in events
+    ]
+    await client._client.post("/events", json=[event.model_dump(mode="json") for event in events_data])
+
+    # Ensure the events are available in the API, not sure why but we have to wait for them to be available
+    last_event_id = events_data[-1].id
+    for _ in range(10):
+        if await has_event(client=client, event_id=last_event_id):
+            return events_data
+        await asyncio.sleep(1)
+    raise Exception(f"Event {last_event_id} not found")
+
+
+async def has_event(client: PrefectClient, event_id: UUID) -> bool:
+    try:
+        await query_event(client=client, event_id=event_id)
+        return True
+    except Exception:
+        return False
+
+
+async def query_event(client: PrefectClient, event_id: UUID) -> Event:
+    filters = EventFilter(id=EventIDFilter(id=[event_id]))  # type: ignore[call-arg]
+    body = {"filter": filters.model_dump(mode="json", exclude_unset=True)}
+
+    response = await client._client.post("/events/filter", json=body)
+    response.raise_for_status()
+    events = TypeAdapter(list[Event]).validate_python(response.json().get("events"))
+
+    if events and len(events) == 1:
+        return events[0]
+
+    raise Exception(f"No event found for id {event_id}")
+
+
+def extract_expected_ids(data: dict[str, InfrahubEvent], expected_events: list[str]) -> list[str]:
+    return sorted([event.get_id() for name, event in data.items() if name in expected_events])

--- a/backend/tests/unit/graphql/queries/test_event.py
+++ b/backend/tests/unit/graphql/queries/test_event.py
@@ -1,0 +1,99 @@
+import uuid
+from typing import Any
+
+import pytest
+from graphql import ExecutionResult
+from prefect.client.orchestration import PrefectClient, get_client
+
+from infrahub.core.branch import Branch
+from infrahub.database import InfrahubDatabase
+from infrahub.events.branch_action import BranchCreateEvent, BranchRebaseEvent
+from infrahub.events.models import InfrahubEvent
+from infrahub.graphql.initialization import prepare_graphql_params
+from tests.helpers.events import send_events
+from tests.helpers.graphql import graphql
+
+QUERY_EVENT = """
+query {
+  InfrahubEvent {
+    count
+    edges {
+      node {
+        id
+        event
+        branch
+      }
+    }
+  }
+}
+"""
+
+
+@pytest.fixture(scope="module")
+async def branch1_id() -> str:
+    return str(uuid.uuid4())
+
+
+@pytest.fixture(scope="module")
+async def branch2_id() -> str:
+    return str(uuid.uuid4())
+
+
+@pytest.fixture(scope="module")
+async def events_data(prefect_client: PrefectClient, branch1_id, branch2_id) -> dict[str, InfrahubEvent]:
+    items: dict[str, InfrahubEvent] = {
+        "branch1_created": BranchCreateEvent(branch="branch1", branch_id=branch1_id, sync_with_git=True),
+        "branch1_rebased": BranchRebaseEvent(branch="branch1", branch_id=branch1_id),
+        "branch2_created": BranchCreateEvent(branch="branch2", branch_id=branch2_id, sync_with_git=False),
+        "branch2_rebased": BranchRebaseEvent(branch="branch2", branch_id=branch2_id),
+    }
+
+    await send_events(client=prefect_client, events=items.values())
+    return items
+
+
+@pytest.fixture(scope="module")
+async def event_ids_inscope(events_data: dict[str, InfrahubEvent]) -> list[str]:
+    return [str(event.id) for event in events_data.values()]
+
+
+def filter_outofscope_events(result_data: dict, in_scope_ids: list[str]):
+    """
+    Because we can't garantee that Prefect is empty at the start of the test easily
+    we need to exclude all events not created by this test suite.
+    """
+    filtered_events = [event for event in result_data["InfrahubEvent"]["edges"] if event["node"]["id"] in in_scope_ids]
+    return {"InfrahubEvent": {"count": len(filtered_events), "edges": filtered_events}}
+
+
+@pytest.fixture(scope="module")
+async def prefect_client(prefect_test_fixture):
+    async with get_client(sync_client=False) as client:
+        yield client
+
+
+async def run_query(db: InfrahubDatabase, branch: Branch, query: str, variables: dict[str, Any]) -> ExecutionResult:
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    return await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values=variables,
+    )
+
+
+async def test_event_query_prefect(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None, events_data, event_ids_inscope
+):
+    result = await run_query(
+        db=db,
+        branch=default_branch,
+        query=QUERY_EVENT,
+        variables={},
+    )
+    assert result.errors is None
+    assert result.data
+
+    clean_result = filter_outofscope_events(result.data, event_ids_inscope)
+    assert clean_result["InfrahubEvent"]["count"] == 4

--- a/backend/tests/unit/task_manager/test_event.py
+++ b/backend/tests/unit/task_manager/test_event.py
@@ -1,0 +1,97 @@
+import uuid
+
+import pytest
+from prefect.client.orchestration import PrefectClient, get_client
+from tests.helpers.events import extract_expected_ids, send_events
+
+from infrahub.events.branch_action import BranchCreateEvent, BranchRebaseEvent
+from infrahub.events.models import InfrahubEvent
+from infrahub.task_manager.event import PrefectEvent
+
+QUERY_EVENT = """
+query {
+  InfrahubEvent {
+    count
+    edges {
+      node {
+        id
+        event
+        branch
+      }
+    }
+  }
+}
+"""
+
+
+def filter_outofscope_events(events: dict, in_scope_ids: list[str]):
+    """
+    Because we can't garantee that Prefect is empty at the start of the test easily
+    we need to exclude all events not created by this test suite.
+    """
+    filtered_events = [event for event in events["edges"] if event["node"]["id"] in in_scope_ids]
+    return {"count": len(filtered_events), "edges": filtered_events}
+
+
+@pytest.fixture(scope="module")
+async def prefect_client(prefect_test_fixture):
+    async with get_client(sync_client=False) as client:
+        yield client
+
+
+@pytest.fixture(scope="module")
+async def branch1_id() -> str:
+    return str(uuid.uuid4())
+
+
+@pytest.fixture(scope="module")
+async def branch2_id() -> str:
+    return str(uuid.uuid4())
+
+
+@pytest.fixture(scope="module")
+async def events_data(prefect_client: PrefectClient, branch1_id, branch2_id) -> dict[str, InfrahubEvent]:
+    items: dict[str, InfrahubEvent] = {
+        "branch1_created": BranchCreateEvent(branch="branch1", branch_id=branch1_id, sync_with_git=True),
+        "branch1_rebased": BranchRebaseEvent(branch="branch1", branch_id=branch1_id),
+        "branch2_created": BranchCreateEvent(branch="branch2", branch_id=branch2_id, sync_with_git=False),
+        "branch2_rebased": BranchRebaseEvent(branch="branch2", branch_id=branch2_id),
+    }
+
+    await send_events(client=prefect_client, events=items.values())
+    return items
+
+
+@pytest.fixture(scope="module")
+async def event_ids_inscope(events_data: dict[str, InfrahubEvent]) -> list[str]:
+    return [str(event.id) for event in events_data.values()]
+
+
+async def test_query_no_filters(event_ids_inscope):
+    fields = {"count": None, "edges": {"node": {"event": None, "branch": None}}}
+    events = await PrefectEvent.query(fields=fields)
+    clean_events = filter_outofscope_events(events, event_ids_inscope)
+    assert clean_events["count"] == 4
+
+
+@pytest.mark.xfail(reason="Was working with Prefect 3.1 but is failing with Prefect 3.0, need to investigate")
+async def test_query_branch_filter(events_data, event_ids_inscope):
+    expected_ids = extract_expected_ids(expected_events=["branch1_created", "branch1_rebased"], data=events_data)
+    fields = {"count": None, "edges": {"node": {"event": None, "branch": None}}}
+
+    events = await PrefectEvent.query(fields=fields, branch="branch1")
+    clean_events = filter_outofscope_events(events, event_ids_inscope)
+
+    received_ids = sorted([event["node"]["id"] for event in clean_events["edges"]])
+    assert received_ids == expected_ids
+
+
+async def test_query_ids_filter(events_data, event_ids_inscope):
+    expected_ids = extract_expected_ids(expected_events=["branch1_created", "branch2_created"], data=events_data)
+    fields = {"count": None, "edges": {"node": {"event": None, "branch": None}}}
+
+    events = await PrefectEvent.query(fields=fields, ids=expected_ids)
+    clean_events = filter_outofscope_events(events, event_ids_inscope)
+
+    received_ids = sorted([event["node"]["id"] for event in clean_events["edges"]])
+    assert received_ids == expected_ids


### PR DESCRIPTION
This PR introduces the foundation to query events from Prefect, within Infrahub and via GraphQL.

For now the implementation is basic but it's been designed to evolve easily. In GraphQL, each type of event is defined as it's own ObjectType and all of them are inheriting from a common interface.
