### PR TITLE
Refactor GraphQLQueryAnalyzer

### DIFF
--- a/backend/infrahub/api/query.py
+++ b/backend/infrahub/api/query.py
@@ -60,9 +60,12 @@ async def execute_query(
     gql_params = await prepare_graphql_params(
         db=db, branch=branch_params.branch, at=branch_params.at, account_session=account_session
     )
+    schema_branch = db.schema.get_schema_branch(name=branch_params.branch.name)
+
     analyzed_query = InfrahubGraphQLQueryAnalyzer(
         query=gql_query.query.value,
         schema=gql_params.schema,
+        schema_branch=schema_branch,
         branch=branch_params.branch,
     )
     await permission_checker.check(

--- a/backend/infrahub/graphql/analyzer.py
+++ b/backend/infrahub/graphql/analyzer.py
@@ -1,38 +1,303 @@
-from typing import Any, Optional
+from __future__ import annotations
 
-from graphql import GraphQLSchema, OperationType
+from copy import deepcopy
+from dataclasses import dataclass, field
+from enum import Enum
+from functools import cached_property
+from typing import TYPE_CHECKING, Any
+
+from graphql import (
+    FieldNode,
+    FragmentDefinitionNode,
+    FragmentSpreadNode,
+    GraphQLSchema,
+    InlineFragmentNode,
+    NamedTypeNode,
+    NonNullTypeNode,
+    OperationDefinitionNode,
+    OperationType,
+    SelectionSetNode,
+)
 from infrahub_sdk.analyzer import GraphQLQueryAnalyzer
 from infrahub_sdk.utils import extract_fields
 
-from infrahub.core.branch import Branch
+from infrahub.core.constants import RelationshipCardinality
+from infrahub.core.schema import GenericSchema, NodeSchema
 from infrahub.graphql.utils import extract_schema_models
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.core.schema import MainSchemaTypes
+    from infrahub.core.schema.schema_branch import SchemaBranch
+
+
+class ContextType(str, Enum):
+    EDGE = "edge"
+    NODE = "node"
+    DIRECT = "direct"
+    OBJECT = "object"
+
+    @classmethod
+    def from_operation(cls, operation: OperationType) -> ContextType:
+        match operation:
+            case OperationType.QUERY:
+                return cls.EDGE
+            case OperationType.MUTATION:
+                return cls.OBJECT
+            case OperationType.SUBSCRIPTION:
+                return cls.EDGE
+
+    @classmethod
+    def from_relationship_cardinality(cls, cardinality: RelationshipCardinality) -> ContextType:
+        match cardinality:
+            case RelationshipCardinality.MANY:
+                return cls.EDGE
+            case RelationshipCardinality.ONE:
+                return cls.NODE
+
+
+class GraphQLOperation(str, Enum):
+    QUERY = "query"
+    MUTATION = "mutation"
+    SUBSCRIPTION = "subscription"
+    UNDEFINED = "undefined"
+
+    @classmethod
+    def from_operation(cls, operation: OperationType) -> GraphQLOperation:
+        match operation:
+            case OperationType.QUERY:
+                return cls.QUERY
+            case OperationType.MUTATION:
+                return cls.MUTATION
+            case OperationType.SUBSCRIPTION:
+                return cls.SUBSCRIPTION
+
+
+@dataclass
+class GraphQLSelectionSet:
+    field_nodes: list[FieldNode]
+    fragment_spread_nodes: list[FragmentSpreadNode]
+    inline_fragment_nodes: list[InlineFragmentNode]
+
+
+@dataclass
+class GraphQLArgument:
+    name: str
+    value: str
+    kind: str
+
+
+@dataclass
+class ObjectAccess:
+    attributes: set[str] = field(default_factory=set)
+    relationships: set[str] = field(default_factory=set)
+
+
+@dataclass
+class GraphQLVariable:
+    name: str
+    type: str
+    required: bool
+
+
+@dataclass
+class GraphQLQueryModel:
+    model: MainSchemaTypes
+    root: bool
+    arguments: list[GraphQLArgument]
+    attributes: set[str]
+    relationships: set[str]
+
+
+@dataclass
+class GraphQLQueryNode:
+    path: str
+    operation: GraphQLOperation = field(default=GraphQLOperation.UNDEFINED)
+    arguments: list[GraphQLArgument] = field(default_factory=list)
+    variables: list[GraphQLVariable] = field(default_factory=list)
+    context_type: ContextType = field(default=ContextType.EDGE)
+    parent: GraphQLQueryNode | None = field(default=None)
+    children: list[GraphQLQueryNode] = field(default_factory=list)
+    infrahub_model: MainSchemaTypes | None = field(default=None)
+    infrahub_node_models: list[NodeSchema] = field(default_factory=list)
+    infrahub_attributes: set[str] = field(default_factory=set)
+    infrahub_relationships: set[str] = field(default_factory=set)
+    field_node: FieldNode | None = field(default=None)
+
+    def context_model(self) -> MainSchemaTypes | None:
+        """Return the closest Infrahub object by going up in the tree"""
+        if self.infrahub_model:
+            return self.infrahub_model
+        if self.parent:
+            return self.parent.context_model()
+
+        return None
+
+    def context_path(self) -> str:
+        """Return the relative path for the current context with the closest Infrahub object as the root"""
+        if self.infrahub_model:
+            return f"/{self.path}"
+        if self.parent:
+            return f"{self.parent.context_path()}/{self.path}"
+        return self.path
+
+    def properties_path(self) -> str:
+        """Indicate the expected path to where Infrahub attributes and relationships would be defined."""
+        if self.infrahub_model:
+            match self.context_type:
+                case ContextType.DIRECT:
+                    return f"/{self.path}"
+                case ContextType.EDGE:
+                    return f"/{self.path}/edges/node"
+                case ContextType.NODE:
+                    return f"/{self.path}/node"
+                case ContextType.OBJECT:
+                    return f"/{self.path}/object"
+        if self.parent:
+            return self.parent.properties_path()
+
+        return self.path
+
+    def full_path(self) -> str:
+        """Return the full path within the tree for the current context."""
+        if self.parent:
+            return f"{self.parent.full_path()}/{self.path}"
+        return self.path
+
+    @property
+    def at_root(self) -> bool:
+        if self.parent:
+            return True
+        return False
+
+    @property
+    def in_property_level(self) -> bool:
+        """Indicate if properties, i.e., attributes and relationships could exist at this level."""
+        return self.context_path() == self.properties_path()
+
+    def append_attribute(self, attribute: str) -> None:
+        """Add attributes to the closes parent Infrahub object."""
+        if self.infrahub_model:
+            self.infrahub_attributes.add(attribute)
+        elif self.parent:
+            self.parent.append_attribute(attribute=attribute)
+
+    def append_relationship(self, relationship: str) -> None:
+        """Add relationships to the closes parent Infrahub object."""
+        if self.infrahub_model:
+            self.infrahub_relationships.add(relationship)
+        elif self.parent:
+            self.parent.append_relationship(relationship=relationship)
+
+    def get_models(self) -> list[GraphQLQueryModel]:
+        """Return all models defined on this node along with child nodes"""
+        models: list[GraphQLQueryModel] = []
+        if self.infrahub_model:
+            models.append(
+                GraphQLQueryModel(
+                    model=self.infrahub_model,
+                    root=self.at_root,
+                    arguments=self.arguments,
+                    attributes=self.infrahub_attributes,
+                    relationships=self.infrahub_relationships,
+                )
+            )
+            for used_by in self.infrahub_node_models:
+                models.append(
+                    GraphQLQueryModel(
+                        model=used_by,
+                        root=self.at_root,
+                        arguments=self.arguments,
+                        attributes=self.infrahub_attributes,
+                        relationships=self.infrahub_relationships,
+                    )
+                )
+
+        for child in self.children:
+            models.extend(child.get_models())
+        return models
+
+
+@dataclass
+class GraphQLQueryReport:
+    queries: list[GraphQLQueryNode]
+
+    @property
+    def impacted_models(self) -> list[str]:
+        """Return a list of all Infrahub objects that are impacted by queries within the request"""
+        models: set[str] = set()
+        for query in self.queries:
+            query_models = query.get_models()
+            models.update([query_model.model.kind for query_model in query_models])
+
+        return sorted(models)
+
+    @property
+    def requested_read(self) -> dict[str, ObjectAccess]:
+        """Return Infrahub objects and the fields (attributes and relationships) that this query would attempt to read"""
+        access: dict[str, ObjectAccess] = {}
+        for query in self.queries:
+            query_models = query.get_models()
+            for query_model in query_models:
+                if query_model.model.kind not in access:
+                    access[query_model.model.kind] = ObjectAccess()
+                access[query_model.model.kind].attributes.update(query_model.attributes)
+                access[query_model.model.kind].relationships.update(query_model.relationships)
+
+        return access
 
 
 class InfrahubGraphQLQueryAnalyzer(GraphQLQueryAnalyzer):
     def __init__(
         self,
         query: str,
-        query_variables: Optional[dict[str, Any]] = None,
-        schema: Optional[GraphQLSchema] = None,
-        operation_name: Optional[str] = None,
-        branch: Optional[Branch] = None,
+        branch: Branch,
+        schema_branch: SchemaBranch,
+        schema: GraphQLSchema | None = None,
+        query_variables: dict[str, Any] | None = None,
+        operation_name: str | None = None,
     ) -> None:
-        self.branch: Optional[Branch] = branch
-        self.operation_name: Optional[str] = operation_name
+        self.branch = branch
+        self.schema_branch = schema_branch
+        self.operation_name = operation_name
         self.query_variables: dict[str, Any] = query_variables or {}
+        self._named_fragments: dict[str, GraphQLQueryNode] = {}
         super().__init__(query=query, schema=schema)
 
     @property
     def operation_names(self) -> list[str]:
         return [operation.name for operation in self.operations if operation.name is not None]
 
+    @cached_property
+    def _fragment_definitions(self) -> list[FragmentDefinitionNode]:
+        return [
+            definition for definition in self.document.definitions if isinstance(definition, FragmentDefinitionNode)
+        ]
+
+    @cached_property
+    def _operation_definitions(self) -> list[OperationDefinitionNode]:
+        return [
+            definition for definition in self.document.definitions if isinstance(definition, OperationDefinitionNode)
+        ]
+
+    def get_named_fragment_with_parent(self, name: str, parent: GraphQLQueryNode) -> GraphQLQueryNode:
+        """Return a copy of the named fragment and attach it to a parent.
+
+        We return a copy of the object as a named fragment could be used by multiple queries and as we're
+        generally working with references to objects we wouldn't want to override the parent of a previously
+        assigned object
+        """
+        named_fragment = deepcopy(self._named_fragments[name])
+        named_fragment.parent = parent
+        return named_fragment
+
     async def get_models_in_use(self, types: dict[str, Any]) -> set[str]:
         """List of Infrahub models that are referenced in the query."""
         graphql_types = set()
         models = set()
 
-        if not (self.schema and self.branch):
-            raise ValueError("Schema and Branch must be provided to extract the models in use.")
+        if not self.schema:
+            raise ValueError("Schema must be provided to extract the models in use.")
 
         for definition in self.document.definitions:
             fields = await extract_fields(definition.selection_set)
@@ -58,3 +323,201 @@ class InfrahubGraphQLQueryAnalyzer(GraphQLQueryAnalyzer):
                 continue
 
         return models
+
+    @cached_property
+    def query_report(self) -> GraphQLQueryReport:
+        self._populate_named_fragments()
+        operations = self._get_operations()
+
+        return GraphQLQueryReport(queries=operations)
+
+    def _get_operations(self) -> list[GraphQLQueryNode]:
+        operations: list[GraphQLQueryNode] = []
+        for operation_definition in self._operation_definitions:
+            selections = self._get_selections(selection_set=operation_definition.selection_set)
+
+            for field_node in selections.field_nodes:
+                schema_model: MainSchemaTypes
+                infrahub_node_models: list[NodeSchema] = []
+                model_name = self._get_model_name(node=field_node, operation_definition=operation_definition)
+
+                if model_name in self.schema_branch.node_names:
+                    schema_model = self.schema_branch.get_node(name=model_name, duplicate=False)
+                elif model_name in self.schema_branch.generic_names:
+                    schema_model = self.schema_branch.get_generic(name=model_name, duplicate=False)
+                    infrahub_node_models = [
+                        self.schema_branch.get_node(name=used_by, duplicate=False) for used_by in schema_model.used_by
+                    ]
+                elif model_name in self.schema_branch.profile_names:
+                    schema_model = self.schema_branch.get_profile(name=model_name, duplicate=False)
+                else:
+                    continue
+
+                operational_node = GraphQLQueryNode(
+                    operation=GraphQLOperation.from_operation(operation=operation_definition.operation),
+                    path=schema_model.kind,
+                    infrahub_model=schema_model,
+                    infrahub_node_models=infrahub_node_models,
+                    context_type=ContextType.from_operation(operation=operation_definition.operation),
+                    arguments=self._parse_arguments(field_node=field_node),
+                    variables=self._get_variables(operation=operation_definition),
+                )
+
+                if field_node.selection_set:
+                    selections = self._get_selections(selection_set=field_node.selection_set)
+                    for selection_field_node in selections.field_nodes:
+                        operational_node.children.append(
+                            self._populate_field_node(node=selection_field_node, query_node=operational_node)
+                        )
+                operations.append(operational_node)
+        return operations
+
+    @staticmethod
+    def _get_model_name(node: FieldNode, operation_definition: OperationDefinitionNode) -> str:
+        if operation_definition.operation == OperationType.MUTATION:
+            if node.name.value.endswith("Create"):
+                return node.name.value[:-6]
+            if node.name.value.endswith("Delete"):
+                return node.name.value[:-6]
+            if node.name.value.endswith("Update"):
+                return node.name.value[:-6]
+            if node.name.value.endswith("Upsert"):
+                return node.name.value[:-6]
+        return node.name.value
+
+    def _populate_named_fragments(self) -> None:
+        self._named_fragments = {}
+        for fragment_definition in self._fragment_definitions:
+            fragment_name = fragment_definition.name.value
+            condition_name = fragment_definition.type_condition.name.value
+            selections = self._get_selections(selection_set=fragment_definition.selection_set)
+
+            infrahub_model = self.schema_branch.get(name=condition_name, duplicate=False)
+
+            named_fragment = GraphQLQueryNode(
+                path=fragment_definition.type_condition.name.value,
+                context_type=ContextType.DIRECT,
+                infrahub_model=infrahub_model,
+            )
+            for field_node in selections.field_nodes:
+                named_fragment.children.append(self._populate_field_node(node=field_node, query_node=named_fragment))
+            for inline_fragment_node in selections.inline_fragment_nodes:
+                named_fragment.children.append(
+                    self._populate_inline_fragment_node(node=inline_fragment_node, query_node=named_fragment)
+                )
+
+            self._named_fragments[fragment_name] = named_fragment
+
+    def _populate_field_node(self, node: FieldNode, query_node: GraphQLQueryNode) -> GraphQLQueryNode:
+        context_type = query_node.context_type
+        infrahub_model = None
+        infrahub_node_models: list[NodeSchema] = []
+        if query_node.in_property_level:
+            if model := query_node.context_model():
+                if node.name.value in model.attribute_names:
+                    query_node.append_attribute(attribute=node.name.value)
+                elif node.name.value in model.relationship_names:
+                    rel = model.get_relationship_or_none(name=node.name.value)
+                    if rel:
+                        infrahub_model = self.schema_branch.get(name=rel.peer, duplicate=False)
+                        if isinstance(infrahub_model, GenericSchema):
+                            infrahub_node_models = [
+                                self.schema_branch.get_node(name=used_by, duplicate=False)
+                                for used_by in infrahub_model.used_by
+                            ]
+
+                        context_type = ContextType.from_relationship_cardinality(cardinality=rel.cardinality)
+                    query_node.append_relationship(relationship=node.name.value)
+
+        current_node = GraphQLQueryNode(
+            parent=query_node,
+            path=node.name.value,
+            context_type=context_type,
+            infrahub_model=infrahub_model,
+            infrahub_node_models=infrahub_node_models,
+            arguments=self._parse_arguments(field_node=node),
+        )
+
+        if node.selection_set:
+            selections = self._get_selections(selection_set=node.selection_set)
+            for field_node in selections.field_nodes:
+                current_node.children.append(self._populate_field_node(node=field_node, query_node=current_node))
+            for inline_fragment_node in selections.inline_fragment_nodes:
+                current_node.children.append(
+                    self._populate_inline_fragment_node(node=inline_fragment_node, query_node=current_node)
+                )
+            for fragment_spread_node in selections.fragment_spread_nodes:
+                current_node.children.append(
+                    self._populate_fragment_spread_node(node=fragment_spread_node, query_node=current_node)
+                )
+
+        return current_node
+
+    def _populate_inline_fragment_node(
+        self, node: InlineFragmentNode, query_node: GraphQLQueryNode
+    ) -> GraphQLQueryNode:
+        context_type = query_node.context_type
+        infrahub_model = self.schema_branch.get(name=node.type_condition.name.value)
+        context_type = ContextType.DIRECT
+        current_node = GraphQLQueryNode(
+            parent=query_node,
+            path=node.type_condition.name.value,
+            context_type=context_type,
+            infrahub_model=infrahub_model,
+        )
+        if node.selection_set:
+            selections = self._get_selections(selection_set=node.selection_set)
+            for field_node in selections.field_nodes:
+                current_node.children.append(self._populate_field_node(node=field_node, query_node=current_node))
+            for inline_fragment_node in selections.inline_fragment_nodes:
+                current_node.children.append(
+                    self._populate_inline_fragment_node(node=inline_fragment_node, query_node=current_node)
+                )
+
+        return current_node
+
+    def _populate_fragment_spread_node(
+        self, node: FragmentSpreadNode, query_node: GraphQLQueryNode
+    ) -> GraphQLQueryNode:
+        return self.get_named_fragment_with_parent(name=node.name.value, parent=query_node)
+
+    @staticmethod
+    def _get_selections(selection_set: SelectionSetNode) -> GraphQLSelectionSet:
+        return GraphQLSelectionSet(
+            field_nodes=[selection for selection in selection_set.selections if isinstance(selection, FieldNode)],
+            fragment_spread_nodes=[
+                selection for selection in selection_set.selections if isinstance(selection, FragmentSpreadNode)
+            ],
+            inline_fragment_nodes=[
+                selection for selection in selection_set.selections if isinstance(selection, InlineFragmentNode)
+            ],
+        )
+
+    @staticmethod
+    def _get_variables(operation: OperationDefinitionNode) -> list[GraphQLVariable]:
+        variables = []
+        for variable in operation.variable_definitions:
+            if isinstance(variable.type, NamedTypeNode):
+                variables.append(
+                    GraphQLVariable(name=variable.variable.name.value, type=variable.type.name.value, required=False)
+                )
+            elif isinstance(variable.type, NonNullTypeNode):
+                if isinstance(variable.type.type, NamedTypeNode):
+                    variables.append(
+                        GraphQLVariable(
+                            name=variable.variable.name.value, type=variable.type.type.name.value, required=True
+                        )
+                    )
+
+        return variables
+
+    @staticmethod
+    def _parse_arguments(field_node: FieldNode) -> list[GraphQLArgument]:
+        return [
+            GraphQLArgument(
+                name=argument.name.value,
+                value=getattr(argument.value, "value", ""),
+                kind=argument.value.kind,
+            )
+            for argument in field_node.arguments
+        ]

--- a/backend/infrahub/graphql/app.py
+++ b/backend/infrahub/graphql/app.py
@@ -206,19 +206,14 @@ class InfrahubGraphQLApp:
         graphql_params = await prepare_graphql_params(
             db=db, branch=branch, at=at, account_session=account_session, request=request
         )
+        schema_branch = db.schema.get_schema_branch(name=branch.name)
+
         analyzed_query = InfrahubGraphQLQueryAnalyzer(
             query=query,
+            schema_branch=schema_branch,
             query_variables=variable_values,
             schema=graphql_params.schema,
             operation_name=operation_name,
-            branch=branch,
-        )
-        await self._evaluate_permissions(
-            db=db,
-            request=request,
-            query=analyzed_query,
-            query_parameters=graphql_params,
-            account_session=account_session,
             branch=branch,
         )
 
@@ -228,6 +223,23 @@ class InfrahubGraphQLApp:
         elif at and branch.schema_changed_at and Timestamp(branch.schema_changed_at) > Timestamp(at):
             schema_branch = await registry.schema.load_schema_from_db(db=db, branch=branch, at=Timestamp(at))
             db.add_schema(name=branch.name, schema=schema_branch)
+            analyzed_query = InfrahubGraphQLQueryAnalyzer(
+                query=query,
+                schema_branch=schema_branch,
+                query_variables=variable_values,
+                schema=graphql_params.schema,
+                operation_name=operation_name,
+                branch=branch,
+            )
+
+        await self._evaluate_permissions(
+            db=db,
+            request=request,
+            query=analyzed_query,
+            query_parameters=graphql_params,
+            account_session=account_session,
+            branch=branch,
+        )
 
         if operation_name == "IntrospectionQuery":
             nbr_object_in_schema = len(graphql_params.schema.type_map)

--- a/backend/infrahub/graphql/mutations/graphql_query.py
+++ b/backend/infrahub/graphql/mutations/graphql_query.py
@@ -34,14 +34,18 @@ class InfrahubGraphQLQueryMutation(InfrahubMutationMixin, Mutation):
 
     @classmethod
     async def extract_query_info(
-        cls, info: GraphQLResolveInfo, data: InputObjectType, branch: Branch
+        cls, info: GraphQLResolveInfo, data: InputObjectType, branch: Branch, db: InfrahubDatabase
     ) -> dict[str, Any]:
         query_value = data.get("query", {}).get("value", None)
         if query_value is None:
             return {}
 
         query_info = {}
-        analyzer = InfrahubGraphQLQueryAnalyzer(query=query_value, schema=info.schema, branch=branch)
+        schema_branch = db.schema.get_schema_branch(name=branch.name)
+
+        analyzer = InfrahubGraphQLQueryAnalyzer(
+            query=query_value, schema=info.schema, branch=branch, schema_branch=schema_branch
+        )
 
         valid, errors = analyzer.is_valid
         if not valid:
@@ -67,7 +71,7 @@ class InfrahubGraphQLQueryMutation(InfrahubMutationMixin, Mutation):
     ) -> tuple[Node, Self]:
         context: GraphqlContext = info.context
 
-        data.update(await cls.extract_query_info(info=info, data=data, branch=context.branch))
+        data.update(await cls.extract_query_info(info=info, data=data, branch=context.branch, db=context.db))
 
         obj, result = await super().mutate_create(info=info, data=data, branch=branch)
 
@@ -84,7 +88,7 @@ class InfrahubGraphQLQueryMutation(InfrahubMutationMixin, Mutation):
     ) -> tuple[Node, Self]:
         context: GraphqlContext = info.context
 
-        data.update(await cls.extract_query_info(info=info, data=data, branch=context.branch))
+        data.update(await cls.extract_query_info(info=info, data=data, branch=context.branch, db=context.db))
 
         obj, result = await super().mutate_update(info=info, data=data, branch=branch)
 

--- a/backend/tests/unit/graphql/auth/query_permission_checker/test_object_permission_checker.py
+++ b/backend/tests/unit/graphql/auth/query_permission_checker/test_object_permission_checker.py
@@ -272,8 +272,12 @@ class TestObjectPermissions:
         gql_params = await prepare_graphql_params(
             db=db, include_mutation=True, branch=permissions_helper.default_branch, account_session=session
         )
+        schema_branch = registry.schema.get_schema_branch(name=permissions_helper.default_branch.name)
         analyzed_query = InfrahubGraphQLQueryAnalyzer(
-            query=QUERY_TAGS, schema=gql_params.schema, branch=permissions_helper.default_branch
+            query=QUERY_TAGS,
+            schema=gql_params.schema,
+            branch=permissions_helper.default_branch,
+            schema_branch=schema_branch,
         )
 
         await checker.check(
@@ -293,8 +297,12 @@ class TestObjectPermissions:
         gql_params = await prepare_graphql_params(
             db=db, include_mutation=True, branch=permissions_helper.default_branch, account_session=session
         )
+        schema_branch = registry.schema.get_schema_branch(name=permissions_helper.default_branch.name)
         analyzed_query = InfrahubGraphQLQueryAnalyzer(
-            query=QUERY_REPOS, schema=gql_params.schema, branch=permissions_helper.default_branch
+            query=QUERY_REPOS,
+            schema=gql_params.schema,
+            branch=permissions_helper.default_branch,
+            schema_branch=schema_branch,
         )
 
         with pytest.raises(PermissionDeniedError, match=r":Repository:view:"):
@@ -316,8 +324,12 @@ class TestObjectPermissions:
         gql_params = await prepare_graphql_params(
             db=db, include_mutation=True, branch=permissions_helper.default_branch, account_session=session
         )
+        schema_branch = registry.schema.get_schema_branch(name=permissions_helper.default_branch.name)
         analyzed_query = InfrahubGraphQLQueryAnalyzer(
-            query=QUERY_GRAPHQL, schema=gql_params.schema, branch=permissions_helper.default_branch
+            query=QUERY_GRAPHQL,
+            schema=gql_params.schema,
+            branch=permissions_helper.default_branch,
+            schema_branch=schema_branch,
         )
 
         await checker.check(
@@ -340,8 +352,12 @@ class TestObjectPermissions:
         gql_params = await prepare_graphql_params(
             db=db, include_mutation=True, branch=permissions_helper.default_branch, account_session=session
         )
+        schema_branch = registry.schema.get_schema_branch(name=permissions_helper.default_branch.name)
         analyzed_query = InfrahubGraphQLQueryAnalyzer(
-            query=QUERY_GRAPHQL_AND_REPO, schema=gql_params.schema, branch=permissions_helper.default_branch
+            query=QUERY_GRAPHQL_AND_REPO,
+            schema=gql_params.schema,
+            branch=permissions_helper.default_branch,
+            schema_branch=schema_branch,
         )
 
         with pytest.raises(PermissionDeniedError, match=r"Repository:view:"):
@@ -414,8 +430,12 @@ class TestAccountManagerPermissions:
         gql_params = await prepare_graphql_params(
             db=db, include_mutation=True, branch=permissions_helper.default_branch, account_session=session
         )
+        schema_branch = registry.schema.get_schema_branch(name=permissions_helper.default_branch.name)
         analyzed_query = InfrahubGraphQLQueryAnalyzer(
-            query=operation, schema=gql_params.schema, branch=permissions_helper.default_branch
+            query=operation,
+            schema=gql_params.schema,
+            branch=permissions_helper.default_branch,
+            schema_branch=schema_branch,
         )
 
         resolution = await checker.check(
@@ -448,8 +468,12 @@ class TestAccountManagerPermissions:
         gql_params = await prepare_graphql_params(
             db=db, include_mutation=True, branch=permissions_helper.default_branch, account_session=session
         )
+        schema_branch = registry.schema.get_schema_branch(name=permissions_helper.default_branch.name)
         analyzed_query = InfrahubGraphQLQueryAnalyzer(
-            query=operation, schema=gql_params.schema, branch=permissions_helper.default_branch
+            query=operation,
+            schema=gql_params.schema,
+            branch=permissions_helper.default_branch,
+            schema_branch=schema_branch,
         )
 
         if not must_raise:
@@ -536,8 +560,12 @@ class TestPermissionManagerPermissions:
         gql_params = await prepare_graphql_params(
             db=db, include_mutation=True, branch=permissions_helper.default_branch, account_session=session
         )
+        schema_branch = registry.schema.get_schema_branch(name=permissions_helper.default_branch.name)
         analyzed_query = InfrahubGraphQLQueryAnalyzer(
-            query=operation, schema=gql_params.schema, branch=permissions_helper.default_branch
+            query=operation,
+            schema=gql_params.schema,
+            branch=permissions_helper.default_branch,
+            schema_branch=schema_branch,
         )
 
         resolution = await checker.check(
@@ -569,8 +597,12 @@ class TestPermissionManagerPermissions:
         gql_params = await prepare_graphql_params(
             db=db, include_mutation=True, branch=permissions_helper.default_branch, account_session=session
         )
+        schema_branch = registry.schema.get_schema_branch(name=permissions_helper.default_branch.name)
         analyzed_query = InfrahubGraphQLQueryAnalyzer(
-            query=operation, schema=gql_params.schema, branch=permissions_helper.default_branch
+            query=operation,
+            schema=gql_params.schema,
+            branch=permissions_helper.default_branch,
+            schema_branch=schema_branch,
         )
 
         if not must_raise:
@@ -655,8 +687,12 @@ class TestRepositoryManagerPermissions:
         gql_params = await prepare_graphql_params(
             db=db, include_mutation=True, branch=permissions_helper.default_branch, account_session=session
         )
+        schema_branch = registry.schema.get_schema_branch(name=permissions_helper.default_branch.name)
         analyzed_query = InfrahubGraphQLQueryAnalyzer(
-            query=operation, schema=gql_params.schema, branch=permissions_helper.default_branch
+            query=operation,
+            schema=gql_params.schema,
+            branch=permissions_helper.default_branch,
+            schema_branch=schema_branch,
         )
 
         resolution = await checker.check(
@@ -688,8 +724,12 @@ class TestRepositoryManagerPermissions:
         gql_params = await prepare_graphql_params(
             db=db, include_mutation=True, branch=permissions_helper.default_branch, account_session=session
         )
+        schema_branch = registry.schema.get_schema_branch(name=permissions_helper.default_branch.name)
         analyzed_query = InfrahubGraphQLQueryAnalyzer(
-            query=operation, schema=gql_params.schema, branch=permissions_helper.default_branch
+            query=operation,
+            schema=gql_params.schema,
+            branch=permissions_helper.default_branch,
+            schema_branch=schema_branch,
         )
 
         if not must_raise:

--- a/backend/tests/unit/graphql/test_query_analyzer.py
+++ b/backend/tests/unit/graphql/test_query_analyzer.py
@@ -2,6 +2,7 @@ from graphql import DocumentNode, GraphQLSchema
 
 from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind
+from infrahub.core.registry import registry
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 from infrahub.graphql.initialization import prepare_graphql_params
@@ -10,8 +11,11 @@ from infrahub.graphql.initialization import prepare_graphql_params
 async def test_analyzer_init_with_schema(
     db: InfrahubDatabase, default_branch: Branch, car_person_schema_generics, query_01: str, bad_query_01: str
 ):
+    schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
     gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
-    gqa = InfrahubGraphQLQueryAnalyzer(query=query_01, schema=gql_params.schema, branch=default_branch)
+    gqa = InfrahubGraphQLQueryAnalyzer(
+        query=query_01, schema=gql_params.schema, branch=default_branch, schema_branch=schema_branch
+    )
     assert isinstance(gqa.document, DocumentNode)
     assert isinstance(gqa.schema, GraphQLSchema)
 
@@ -26,28 +30,39 @@ async def test_is_valid_simple_schema(
     query_introspection: str,
     car_person_schema_generics,
 ):
+    schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
     gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
-    gqa = InfrahubGraphQLQueryAnalyzer(query=query_01, schema=gql_params.schema, branch=default_branch)
+    gqa = InfrahubGraphQLQueryAnalyzer(
+        query=query_01, schema=gql_params.schema, branch=default_branch, schema_branch=schema_branch
+    )
     is_valid, errors = gqa.is_valid
     assert errors is None
     assert is_valid is True
 
-    gqa = InfrahubGraphQLQueryAnalyzer(query=query_03, schema=gql_params.schema, branch=default_branch)
+    gqa = InfrahubGraphQLQueryAnalyzer(
+        query=query_03, schema=gql_params.schema, branch=default_branch, schema_branch=schema_branch
+    )
     is_valid, errors = gqa.is_valid
     assert errors is None
     assert is_valid is True
 
-    gqa = InfrahubGraphQLQueryAnalyzer(query=query_02, schema=gql_params.schema, branch=default_branch)
+    gqa = InfrahubGraphQLQueryAnalyzer(
+        query=query_02, schema=gql_params.schema, branch=default_branch, schema_branch=schema_branch
+    )
     is_valid, errors = gqa.is_valid
     assert errors is None
     assert is_valid is True
 
-    gqa = InfrahubGraphQLQueryAnalyzer(query=query_04, schema=gql_params.schema, branch=default_branch)
+    gqa = InfrahubGraphQLQueryAnalyzer(
+        query=query_04, schema=gql_params.schema, branch=default_branch, schema_branch=schema_branch
+    )
     is_valid, errors = gqa.is_valid
     assert errors is None
     assert is_valid is True
 
-    gqa = InfrahubGraphQLQueryAnalyzer(query=query_introspection, schema=gql_params.schema, branch=default_branch)
+    gqa = InfrahubGraphQLQueryAnalyzer(
+        query=query_introspection, schema=gql_params.schema, branch=default_branch, schema_branch=schema_branch
+    )
     is_valid, errors = gqa.is_valid
     assert errors is None
     assert is_valid is True
@@ -59,9 +74,12 @@ async def test_is_valid_core_schema(
     query_05: str,
     register_core_models_schema,
 ):
+    schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
     gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
 
-    gqa = InfrahubGraphQLQueryAnalyzer(query=query_05, schema=gql_params.schema, branch=default_branch)
+    gqa = InfrahubGraphQLQueryAnalyzer(
+        query=query_05, schema=gql_params.schema, branch=default_branch, schema_branch=schema_branch
+    )
     is_valid, errors = gqa.is_valid
     assert errors is None
     assert is_valid is True
@@ -75,24 +93,51 @@ async def test_get_models_in_use(
     query_03: str,
     car_person_schema_generics,
 ):
+    schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
     gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
-    gqa = InfrahubGraphQLQueryAnalyzer(query=query_01, schema=gql_params.schema, branch=default_branch)
+    gqa = InfrahubGraphQLQueryAnalyzer(
+        query=query_01, schema=gql_params.schema, branch=default_branch, schema_branch=schema_branch
+    )
     assert await gqa.get_models_in_use(types=gql_params.context.types) == {
         "TestCar",
         "TestElectricCar",
         "TestGazCar",
         "TestPerson",
     }
+    assert gqa.query_report.impacted_models == [
+        "TestCar",
+        "TestElectricCar",
+        "TestGazCar",
+        "TestPerson",
+    ]
+    assert gqa.query_report.requested_read["TestPerson"].attributes == {"name"}
+    assert gqa.query_report.requested_read["TestPerson"].relationships == {"cars"}
+    assert gqa.query_report.requested_read["TestCar"].attributes == {"name"}
+    assert gqa.query_report.requested_read["TestCar"].relationships == set()
+    assert gqa.query_report.requested_read["TestElectricCar"].attributes == {"name"}
+    assert gqa.query_report.requested_read["TestElectricCar"].relationships == set()
+    assert gqa.query_report.requested_read["TestGazCar"].attributes == {"name"}
+    assert gqa.query_report.requested_read["TestGazCar"].relationships == set()
 
-    gqa = InfrahubGraphQLQueryAnalyzer(query=query_03, schema=gql_params.schema, branch=default_branch)
+    gqa = InfrahubGraphQLQueryAnalyzer(
+        query=query_03, schema=gql_params.schema, branch=default_branch, schema_branch=schema_branch
+    )
     assert await gqa.get_models_in_use(types=gql_params.context.types) == {
         "TestCar",
         "TestElectricCar",
         "TestGazCar",
         "TestPerson",
     }
+    assert gqa.query_report.impacted_models == [
+        "TestCar",
+        "TestElectricCar",
+        "TestGazCar",
+        "TestPerson",
+    ]
 
-    gqa = InfrahubGraphQLQueryAnalyzer(query=query_02, schema=gql_params.schema, branch=default_branch)
+    gqa = InfrahubGraphQLQueryAnalyzer(
+        query=query_02, schema=gql_params.schema, branch=default_branch, schema_branch=schema_branch
+    )
     assert await gqa.get_models_in_use(types=gql_params.context.types) == {
         InfrahubKind.GENERATORGROUP,
         InfrahubKind.GRAPHQLQUERYGROUP,
@@ -104,3 +149,168 @@ async def test_get_models_in_use(
         "TestGazCar",
         "TestPerson",
     }
+    assert gqa.query_report.impacted_models == [
+        InfrahubKind.ACCOUNTGROUP,
+        InfrahubKind.GENERATORGROUP,
+        InfrahubKind.GRAPHQLQUERYGROUP,
+        InfrahubKind.GENERICGROUP,
+        InfrahubKind.STANDARDGROUP,
+        "TestCar",
+        "TestElectricCar",
+        "TestGazCar",
+        "TestPerson",
+    ]
+    assert gqa.query_report.requested_read["TestPerson"].attributes == {"name"}
+    assert gqa.query_report.requested_read["TestPerson"].relationships == {"cars"}
+    assert gqa.query_report.requested_read["TestCar"].attributes == {"name"}
+    assert gqa.query_report.requested_read["TestCar"].relationships == set()
+    assert gqa.query_report.requested_read["TestElectricCar"].attributes == {"name", "nbr_engine"}
+    assert gqa.query_report.requested_read["TestElectricCar"].relationships == {"member_of_groups"}
+    assert gqa.query_report.requested_read["TestGazCar"].attributes == {"name", "mpg"}
+    assert gqa.query_report.requested_read["TestGazCar"].relationships == set()
+    assert gqa.query_report.requested_read[InfrahubKind.GENERICGROUP].attributes == set()
+    assert gqa.query_report.requested_read[InfrahubKind.GENERICGROUP].relationships == set()
+
+
+async def test_query_report(db: InfrahubDatabase, default_branch: Branch, car_person_schema_generics):
+    schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+
+    mutation_query_no_return_data = """
+    mutation {
+        TestElectricCar(
+            data: {
+                name: { value: "Accord" }
+                nbr_seats: { value: 5 }
+                is_electric: { value: true }
+                owner: { id: "John" }
+            }
+        ) {
+            ok
+        }
+    }
+    """
+    gqa = InfrahubGraphQLQueryAnalyzer(
+        query=mutation_query_no_return_data,
+        schema=gql_params.schema,
+        branch=default_branch,
+        schema_branch=schema_branch,
+    )
+
+    # As we only return 'ok' and no data we don't expect to have to read attributes or
+    # relationships from the object we created
+    assert len(gqa.query_report.requested_read.keys()) == 1
+    assert gqa.query_report.requested_read["TestElectricCar"].attributes == set()
+    assert gqa.query_report.requested_read["TestElectricCar"].relationships == set()
+
+    mutation_query_with_return_data = """
+    mutation {
+        TestElectricCar(
+            data: {
+                name: { value: "Accord" }
+                nbr_seats: { value: 5 }
+                is_electric: { value: true }
+                owner: { id: "John" }
+            }
+        ) {
+            ok
+            object {
+                id
+                name {
+                    value
+                }
+                nbr_seats {
+                    value
+                }
+                owner {
+                    node {
+                        name {
+                            value
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+    gqa = InfrahubGraphQLQueryAnalyzer(
+        query=mutation_query_with_return_data,
+        schema=gql_params.schema,
+        branch=default_branch,
+        schema_branch=schema_branch,
+    )
+
+    # As we only return data from the object we created and also from a related object
+    # we'd need read access from both TestElectricCar and TestPerson
+    assert len(gqa.query_report.requested_read.keys()) == 2
+    assert gqa.query_report.requested_read["TestElectricCar"].attributes == {"name", "nbr_seats"}
+    assert gqa.query_report.requested_read["TestElectricCar"].relationships == {"owner"}
+    assert gqa.query_report.requested_read["TestPerson"].attributes == {"name"}
+    assert gqa.query_report.requested_read["TestPerson"].relationships == set()
+
+    query_with_source_only_id = """
+    query {
+        TestElectricCar {
+            edges {
+                node {
+                    name {
+                        value
+                        source {
+                            id
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+    gqa = InfrahubGraphQLQueryAnalyzer(
+        query=query_with_source_only_id,
+        schema=gql_params.schema,
+        branch=default_branch,
+        schema_branch=schema_branch,
+    )
+    # If we only lookup the 'source' property id but not objects themselves
+    # we don't expect to need generic read access to all potential objects
+    assert len(gqa.query_report.requested_read.keys()) == 1
+    assert gqa.query_report.requested_read["TestElectricCar"].attributes == {"name"}
+    assert gqa.query_report.requested_read["TestElectricCar"].relationships == set()
+
+    query_with_source_object_lookup = """
+    query {
+        TestElectricCar {
+            edges {
+                node {
+                    name {
+                        value
+                        source {
+                            id
+                            ... on TestPerson {
+                                name {
+                                    value
+                                }
+                                height {
+                                    value
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+    gqa = InfrahubGraphQLQueryAnalyzer(
+        query=query_with_source_object_lookup,
+        schema=gql_params.schema,
+        branch=default_branch,
+        schema_branch=schema_branch,
+    )
+    # If we lookup the 'source' property id and request information about an object
+    # attached to the 'source' we require read access to those
+    # we don't expect to need generic read access to all potential objects
+    assert len(gqa.query_report.requested_read.keys()) == 2
+    assert gqa.query_report.requested_read["TestElectricCar"].attributes == {"name"}
+    assert gqa.query_report.requested_read["TestElectricCar"].relationships == set()
+    assert gqa.query_report.requested_read["TestPerson"].attributes == {"name", "height"}
+    assert gqa.query_report.requested_read["TestPerson"].relationships == set()


### PR DESCRIPTION
Related to #5351 but doesn't fix everything mentioned in that issue.

In this PR I've modified the `InfrahubGraphQLQueryAnalyzer` class so that it requires a `SchemaBranch` object when we create it.

This allows us to inspect GraphQL queries using the information within the schema branch instead of only relying on potential matches from within the GraphQL schema. Additionally it lets us separate out what an attribute or what a relationship is.

In the current state what this PR provides is:

* Include information about the attributes / relationships that are being access for each node
* Include more precise information about the generic, only include the generic is some attributes / relationship from that generics is being accessed
* When we query for the metadata properties "source" and "owner" we no longer map all possible object types to the query as most node types could possibly be sources or owners. This is highlighted in the tests in this way:

```python
    query_with_source_only_id = """
    query {
        TestElectricCar {
            edges {
                node {
                    name {
                        value
                        source {
                            id
                        }
                    }
                }
            }
        }
    }
    """
    gqa = InfrahubGraphQLQueryAnalyzer(
        query=query_with_source_only_id,
        schema=gql_params.schema,
        branch=default_branch,
        schema_branch=schema_branch,
    )
    # If we only lookup the 'source' property id but not objects themselves
    # we don't expect to need generic read access to all potential objects
    assert len(gqa.query_report.requested_read.keys()) == 1
    assert gqa.query_report.requested_read["TestElectricCar"].attributes == {"name"}
    assert gqa.query_report.requested_read["TestElectricCar"].relationships == set()

    query_with_source_object_lookup = """
    query {
        TestElectricCar {
            edges {
                node {
                    name {
                        value
                        source {
                            id
                            ... on TestPerson {
                                name {
                                    value
                                }
                                height {
                                    value
                                }
                            }
                        }
                    }
                }
            }
        }
    }
    """
    gqa = InfrahubGraphQLQueryAnalyzer(
        query=query_with_source_object_lookup,
        schema=gql_params.schema,
        branch=default_branch,
        schema_branch=schema_branch,
    )
    # If we lookup the 'source' property id and request information about an object
    # attached to the 'source' we require read access to those
    # we don't expect to need generic read access to all potential objects
    assert len(gqa.query_report.requested_read.keys()) == 2
    assert gqa.query_report.requested_read["TestElectricCar"].attributes == {"name"}
    assert gqa.query_report.requested_read["TestElectricCar"].relationships == set()
    assert gqa.query_report.requested_read["TestPerson"].attributes == {"name", "height"}
    assert gqa.query_report.requested_read["TestPerson"].relationships == set()
```

With the previous model the `query_with_source_only_id` query would still require read access to most object types.

I've also added the query_report output to some of the existing tests to validate that they produce the same kind of output for similar queries.

What is missing:

* For now I haven't yet activated to `.query_report` property within the code permission code etc. Though that part should be easy to switch over later
* We capture required read permissions for both queries and mutations, however I want to add a `.requested_write` property to the query_report for mutations where we can see if the query includes create and or update mutations etc for each object type.
* Include information about filtering, especially if the filter is using an ID or an HFID to understand if the query is targeting a single object or multiple nodes. (Some argument parsing and filtering has been added but it needs some additional work to capture arguments of all supported types and also to do lookups with regards to figuring out if a single node has been requested)

If approved I'd like to get this merged and iterate on it with the next parts. Does anyone have any thoughts about the format and name of the properties on the query report `impacted_models` and `requested_read`?

