### PR TITLE
diff calculation performance improvement

### DIFF
--- a/backend/infrahub/core/diff/repository/repository.py
+++ b/backend/infrahub/core/diff/repository/repository.py
@@ -61,7 +61,6 @@ class DiffRepository:
         include_empty: bool = False,
     ) -> list[EnrichedDiffRoot]:
         final_max_depth = config.SETTINGS.database.max_depth_search_hierarchy
-        final_limit = limit or config.SETTINGS.database.query_size_limit
         query = await EnrichedDiffGetQuery.init(
             db=self.db,
             base_branch_name=base_branch_name,
@@ -70,7 +69,7 @@ class DiffRepository:
             to_time=to_time,
             filters=EnrichedDiffQueryFilters(**dict(filters or {})),
             max_depth=final_max_depth,
-            limit=final_limit,
+            limit=limit,
             offset=offset,
             tracking_id=tracking_id,
             diff_ids=diff_ids,

--- a/backend/infrahub/core/query/diff.py
+++ b/backend/infrahub/core/query/diff.py
@@ -568,17 +568,26 @@ WITH CASE
     ELSE [[$new_node_field_specifiers, $branch_from_time], [$current_node_field_specifiers, $from_time]]
 END AS diff_filter_params_list
 UNWIND diff_filter_params_list AS diff_filter_params
+WITH diff_filter_params[0] AS node_field_specifiers_list, diff_filter_params[1] AS from_time
 CALL {
-    WITH diff_filter_params
-    WITH diff_filter_params[0] AS node_field_specifiers_list, diff_filter_params[1] AS from_time
+    // -------------------------------------
+    // These lists contain duplicate data, but vastly improve querying speed below
+    // -------------------------------------
+    WITH node_field_specifiers_list
+    UNWIND node_field_specifiers_list AS nfs
+    WITH nfs[0] AS uuid, nfs[1] AS field_name
+    WITH collect(DISTINCT uuid) as uuids, collect(DISTINCT field_name) AS field_names
+    RETURN uuids AS node_ids_list, field_names AS field_names_list
+}
+CALL {
+    WITH node_field_specifiers_list, node_ids_list, from_time
     CALL {
-        WITH node_field_specifiers_list, from_time
-        WITH reduce(node_ids = [], nfs IN node_field_specifiers_list | node_ids + [nfs[0]]) AS node_ids_list, from_time
+        WITH node_field_specifiers_list, from_time, node_ids_list
         // -------------------------------------
         // Identify nodes added/removed on branch
         // -------------------------------------
         MATCH (q:Root)<-[diff_rel:IS_PART_OF {branch: $branch_name}]-(p:Node)
-        WHERE (node_ids_list IS NULL OR p.uuid IN node_ids_list)
+        WHERE (size(node_ids_list) = 0 OR p.uuid IN node_ids_list)
         AND (from_time <= diff_rel.from < $to_time)
         AND (diff_rel.to IS NULL OR (from_time <= diff_rel.to < $to_time))
         AND p.branch_support = $branch_aware
@@ -647,18 +656,19 @@ CALL {
     }
     RETURN diff_path
     UNION
-    WITH diff_filter_params
-    WITH diff_filter_params[0] AS node_field_specifiers_list, diff_filter_params[1] AS from_time
+    WITH node_field_specifiers_list, node_ids_list, field_names_list, from_time
     CALL {
-        WITH node_field_specifiers_list, from_time
+        WITH node_field_specifiers_list, node_ids_list, field_names_list, from_time
         // -------------------------------------
         // Identify attributes/relationships added/removed on branch
         // -------------------------------------
         CALL {
-            WITH node_field_specifiers_list, from_time
+            WITH node_field_specifiers_list, node_ids_list, field_names_list, from_time
             MATCH (root:Root)<-[r_root:IS_PART_OF]-(p:Node)-[diff_rel:HAS_ATTRIBUTE {branch: $branch_name}]->(q:Attribute)
             // exclude attributes and relationships under added/removed nodes b/c they are covered above
-            WHERE (node_field_specifiers_list IS NULL OR [p.uuid, q.name] IN node_field_specifiers_list)
+            WHERE (size(node_ids_list) = 0 OR p.uuid IN node_ids_list)
+            AND (size(field_names_list) = 0 OR q.name IN field_names_list)
+            AND (node_field_specifiers_list IS NULL OR [p.uuid, q.name] IN node_field_specifiers_list)
             AND r_root.branch IN [$branch_name, $base_branch_name, $global_branch_name]
             AND q.branch_support = $branch_aware
             // if p has a different type of branch support and was addded within our timeframe
@@ -671,10 +681,12 @@ CALL {
             AND (r_root.to IS NULL OR diff_rel.branch <> r_root.branch OR r_root.to >= diff_rel.from)
             RETURN root, r_root, p, diff_rel, q
             UNION ALL
-            WITH node_field_specifiers_list, from_time
+            WITH node_field_specifiers_list, node_ids_list, field_names_list, from_time
             MATCH (root:Root)<-[r_root:IS_PART_OF]-(p:Node)-[diff_rel:IS_RELATED {branch: $branch_name}]-(q:Relationship)
             // exclude attributes and relationships under added/removed nodes b/c they are covered above
-            WHERE (node_field_specifiers_list IS NULL OR [p.uuid, q.name] IN node_field_specifiers_list)
+            WHERE (size(node_ids_list) = 0 OR p.uuid IN node_ids_list)
+            AND (size(field_names_list) = 0 OR q.name IN field_names_list)
+            AND (node_field_specifiers_list IS NULL OR [p.uuid, q.name] IN node_field_specifiers_list)
             AND r_root.branch IN [$branch_name, $base_branch_name, $global_branch_name]
             AND q.branch_support = $branch_aware
             // if p has a different type of branch support and was addded within our timeframe
@@ -762,15 +774,16 @@ CALL {
     }
     RETURN mid_diff_path AS diff_path
     UNION
-    WITH diff_filter_params
-    WITH diff_filter_params[0] AS node_field_specifiers_list, diff_filter_params[1] AS from_time
+    WITH node_field_specifiers_list, node_ids_list, field_names_list, from_time
     CALL {
-        WITH node_field_specifiers_list, from_time
+        WITH node_field_specifiers_list, node_ids_list, field_names_list, from_time
         // -------------------------------------
         // Identify properties added/removed on branch
         // -------------------------------------
         MATCH diff_rel_path = (root:Root)<-[r_root:IS_PART_OF]-(n:Node)-[r_node]-(p)-[diff_rel {branch: $branch_name}]->(q)
-        WHERE (node_field_specifiers_list IS NULL OR [n.uuid, p.name] IN node_field_specifiers_list)
+        WHERE (size(node_ids_list) = 0 OR n.uuid IN node_ids_list)
+        AND (size(field_names_list) = 0 OR p.name IN field_names_list)
+        AND (node_field_specifiers_list IS NULL OR [n.uuid, p.name] IN node_field_specifiers_list)
         AND (
             (from_time <= diff_rel.from < $to_time)
             OR (from_time <= diff_rel.to < $to_time)

--- a/backend/infrahub/core/query/diff.py
+++ b/backend/infrahub/core/query/diff.py
@@ -666,11 +666,10 @@ CALL {
             WITH node_field_specifiers_list, node_ids_list, field_names_list, from_time
             MATCH (root:Root)<-[r_root:IS_PART_OF]-(p:Node)-[diff_rel:HAS_ATTRIBUTE {branch: $branch_name}]->(q:Attribute)
             // exclude attributes and relationships under added/removed nodes b/c they are covered above
-            WHERE (size(node_ids_list) = 0 OR p.uuid IN node_ids_list)
-            AND (size(field_names_list) = 0 OR q.name IN field_names_list)
-            AND (node_field_specifiers_list IS NULL OR [p.uuid, q.name] IN node_field_specifiers_list)
-            AND r_root.branch IN [$branch_name, $base_branch_name, $global_branch_name]
+            WHERE r_root.branch IN [$branch_name, $base_branch_name, $global_branch_name]
             AND q.branch_support = $branch_aware
+            AND (size(node_ids_list) = 0 OR p.uuid IN node_ids_list)
+            AND (size(field_names_list) = 0 OR q.name IN field_names_list)
             // if p has a different type of branch support and was addded within our timeframe
             AND (r_root.from < from_time OR p.branch_support = $branch_agnostic)
             AND r_root.status = "active"
@@ -679,16 +678,16 @@ CALL {
             AND (diff_rel.to IS NULL OR (from_time <= diff_rel.to < $to_time))
             AND r_root.from <= diff_rel.from
             AND (r_root.to IS NULL OR diff_rel.branch <> r_root.branch OR r_root.to >= diff_rel.from)
+            AND (node_field_specifiers_list IS NULL OR [p.uuid, q.name] IN node_field_specifiers_list)
             RETURN root, r_root, p, diff_rel, q
             UNION ALL
             WITH node_field_specifiers_list, node_ids_list, field_names_list, from_time
             MATCH (root:Root)<-[r_root:IS_PART_OF]-(p:Node)-[diff_rel:IS_RELATED {branch: $branch_name}]-(q:Relationship)
             // exclude attributes and relationships under added/removed nodes b/c they are covered above
-            WHERE (size(node_ids_list) = 0 OR p.uuid IN node_ids_list)
-            AND (size(field_names_list) = 0 OR q.name IN field_names_list)
-            AND (node_field_specifiers_list IS NULL OR [p.uuid, q.name] IN node_field_specifiers_list)
-            AND r_root.branch IN [$branch_name, $base_branch_name, $global_branch_name]
+            WHERE r_root.branch IN [$branch_name, $base_branch_name, $global_branch_name]
             AND q.branch_support = $branch_aware
+            AND (size(node_ids_list) = 0 OR p.uuid IN node_ids_list)
+            AND (size(field_names_list) = 0 OR q.name IN field_names_list)
             // if p has a different type of branch support and was addded within our timeframe
             AND (r_root.from < from_time OR p.branch_support = $branch_agnostic)
             // get attributes and relationships added on the branch during the timeframe
@@ -696,6 +695,7 @@ CALL {
             AND (diff_rel.to IS NULL OR (from_time <= diff_rel.to < $to_time))
             AND r_root.from <= diff_rel.from
             AND (r_root.to IS NULL OR diff_rel.branch <> r_root.branch OR r_root.to >= diff_rel.from)
+            AND (node_field_specifiers_list IS NULL OR [p.uuid, q.name] IN node_field_specifiers_list)
             RETURN root, r_root, p, diff_rel, q
         }
         WITH root, r_root, p, diff_rel, q, from_time
@@ -781,13 +781,12 @@ CALL {
         // Identify properties added/removed on branch
         // -------------------------------------
         MATCH diff_rel_path = (root:Root)<-[r_root:IS_PART_OF]-(n:Node)-[r_node]-(p)-[diff_rel {branch: $branch_name}]->(q)
-        WHERE (size(node_ids_list) = 0 OR n.uuid IN node_ids_list)
-        AND (size(field_names_list) = 0 OR p.name IN field_names_list)
-        AND (node_field_specifiers_list IS NULL OR [n.uuid, p.name] IN node_field_specifiers_list)
-        AND (
+        WHERE (
             (from_time <= diff_rel.from < $to_time)
             OR (from_time <= diff_rel.to < $to_time)
         )
+        AND (size(node_ids_list) = 0 OR n.uuid IN node_ids_list)
+        AND (size(field_names_list) = 0 OR p.name IN field_names_list)
         // exclude attributes and relationships under added/removed nodes, attrs, and rels b/c they are covered above
         AND ALL(
             r in [r_root, r_node]
@@ -798,6 +797,7 @@ CALL {
         AND type(diff_rel) IN ["IS_VISIBLE", "IS_PROTECTED", "HAS_SOURCE", "HAS_OWNER", "HAS_VALUE"]
         AND any(l in labels(q) WHERE l in ["Boolean", "Node", "AttributeValue"])
         AND type(r_node) IN ["HAS_ATTRIBUTE", "IS_RELATED"]
+        AND (node_field_specifiers_list IS NULL OR [n.uuid, p.name] IN node_field_specifiers_list)
         AND ALL(
             r_pair IN [[r_root, r_node], [r_node, diff_rel]]
             // filter out paths where a base branch edge follows a branch edge


### PR DESCRIPTION
IFC-1129

updates the `DiffAllPathsQuery` to speed up calculating an incremental diff on the base branch (`main`) portion of the diff. my tests for calculating/updating very large diffs indicate that this is a bottleneck that slows down updating a diff even when there are very few or no changes on the `main` branch.

my local testing indicates that this change speeds up calculating a diff on `main` when there are no/very few changes on `main` by a factor of 4, which is pretty good, but I think there is still more that we can do