### PR TITLE
IFC-592 Merge schemas when loading them from files

### DIFF
--- a/backend/infrahub/api/schema.py
+++ b/backend/infrahub/api/schema.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Sequence
 
 from fastapi import APIRouter, Depends, Query, Request
 from pydantic import (
@@ -128,13 +128,26 @@ class SchemaUpdate(BaseModel):
         return self.hash != self.previous_hash
 
 
+def _merge_candidate_schemas(schemas: Sequence[SchemaRoot]) -> SchemaRoot:
+    """Merge multiple schemas into one suitable to be loaded."""
+    if not schemas:
+        raise ValueError("Cannot merge an empty list of schemas")
+
+    merged = schemas[0]
+    for schema in schemas[1:]:
+        merged = merged.merge(schema=schema)
+
+    return merged
+
+
 def evaluate_candidate_schemas(
     branch_schema: SchemaBranch, schemas_to_evaluate: SchemasLoadAPI
 ) -> tuple[SchemaBranch, SchemaUpdateValidationResult]:
     candidate_schema = branch_schema.duplicate()
+    schema = _merge_candidate_schemas(schemas=schemas_to_evaluate.schemas)
+
     try:
-        for schema in schemas_to_evaluate.schemas:
-            candidate_schema.load_schema(schema=schema)
+        candidate_schema.load_schema(schema=schema)
         candidate_schema.process()
 
         schema_diff = branch_schema.diff(other=candidate_schema)

--- a/backend/infrahub/core/schema/__init__.py
+++ b/backend/infrahub/core/schema/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import uuid
 from typing import Any, Optional, TypeAlias, Union
 
+from infrahub_sdk.utils import deep_merge_dict
 from pydantic import BaseModel, ConfigDict, Field
 
 from infrahub.core.constants import RESTRICTED_NAMESPACES
@@ -85,6 +86,10 @@ class SchemaRoot(BaseModel):
             for item in node.relationships + node.attributes:
                 if not item.id:
                     item.id = str(uuid.uuid4())
+
+    def merge(self, schema: SchemaRoot) -> SchemaRoot:
+        """Return a new `SchemaRoot` after merging `self` with `schema`."""
+        return SchemaRoot.model_validate(deep_merge_dict(dicta=self.model_dump(), dictb=schema.model_dump()))
 
 
 internal_schema = internal.to_dict()

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -1468,7 +1468,7 @@ async def test_schema_branch_from_dict_schema_object():
 
     exported = schema_branch.to_dict_schema_object()
 
-    exported_json = json.dumps(exported, default=lambda x: x.dict())
+    exported_json = json.dumps(exported, default=lambda x: x.model_dump())
 
     exported_dict = json.loads(exported_json)
     schema_branch_after = SchemaBranch.from_dict_schema_object(data=exported_dict)
@@ -2534,6 +2534,85 @@ async def test_load_schema(
     assert schema11.get(name="TestCriticality").get_hash() == schema2.get(name="TestCriticality").get_hash()
     assert schema11.get(name=InfrahubKind.TAG).get_hash() == schema2.get(name=InfrahubKind.TAG).get_hash()
     assert schema11.get(name="TestGenericInterface").get_hash() == schema2.get(name="TestGenericInterface").get_hash()
+
+
+async def test_load_schemas(
+    db: InfrahubDatabase, reset_registry, default_branch: Branch, register_internal_models_schema
+):
+    part1 = SchemaRoot(
+        extensions={
+            "nodes": [
+                {
+                    "kind": "RandomOrganization",
+                    "relationships": [
+                        {
+                            "cardinality": "many",
+                            "identifier": "organization__model",
+                            "kind": "Component",
+                            "label": "Device Models",
+                            "name": "models",
+                            "optional": True,
+                            "peer": "RandomModel",
+                        }
+                    ],
+                }
+            ]
+        },
+        nodes=[
+            {
+                "attributes": [
+                    {"kind": "Text", "name": "name", "unique": True},
+                    {"kind": "Text", "name": "description", "optional": True},
+                ],
+                "default_filter": "name__value",
+                "display_labels": ["name__value"],
+                "human_friendly_id": ["name__value"],
+                "name": "Model",
+                "namespace": "Random",
+                "order_by": ["name__value"],
+                "relationships": [
+                    {
+                        "cardinality": "one",
+                        "identifier": "organization__model",
+                        "kind": "Attribute",
+                        "name": "organization",
+                        "peer": "RandomOrganization",
+                    }
+                ],
+            }
+        ],
+        version="1.0",
+    )
+    part2 = SchemaRoot(
+        nodes=[
+            {
+                "attributes": [
+                    {"kind": "Text", "name": "name", "unique": True},
+                    {"kind": "Text", "name": "description", "optional": True},
+                ],
+                "name": "Organization",
+                "namespace": "Random",
+            }
+        ],
+        version="1.0",
+    )
+    merged = part1.merge(schema=part2)
+
+    assert len(merged.nodes) == 2
+    assert merged.extensions == part1.extensions
+
+    schema_branch = SchemaBranch(cache={}, name="test")
+    schema_branch.load_schema(schema=merged)
+
+    random_org_schema = schema_branch.get(name="RandomOrganization", duplicate=False)
+    try:
+        random_org_schema.get_attribute("name")
+    except ValueError:
+        pytest.fail(reason="Attribute 'name' must be present in 'RandomOrganization'")
+    try:
+        random_org_schema.get_relationship("models")
+    except ValueError:
+        pytest.fail(reason="Relationship 'models' must be present in 'RandomOrganization'")
 
 
 def test_schema_branch_load_schema_append_to_list(schema_all_in_one):

--- a/changelog/4188.fixed.md
+++ b/changelog/4188.fixed.md
@@ -1,0 +1,1 @@
+Fix issue when loading multiple schema files due to load order, schemas are now merged into a single one before importing


### PR DESCRIPTION
Fixes #4188 

When loading multiple schemas files, they used to be imported one by one. With this change, the files are now parsed as schemas and then merged together in order to produce a single schema to load. The merge is performed one by one in the order of the files. This means that the schema coming last will overwrite the previous one if they refer to the same nodes.