### PR TITLE
more verbose schema integrity error message

### DIFF
--- a/backend/infrahub/core/validators/aggregated_checker.py
+++ b/backend/infrahub/core/validators/aggregated_checker.py
@@ -65,7 +65,7 @@ class AggregatedConstraintChecker:
                     full_display_label=display_label,
                 )
                 violation.message = await self.render_error_request(
-                    violation=violation, constraint_name=constraint_name, request=request, data_path=path
+                    violation=violation, constraint_name=constraint_name, data_path=path
                 )
                 violations.append(violation)
         return violations
@@ -74,18 +74,33 @@ class AggregatedConstraintChecker:
         self,
         violation: SchemaViolation,
         constraint_name: str,
-        request: SchemaConstraintValidatorRequest,
         data_path: DataPath,
     ) -> str:
-        error_str = (
-            f"{violation.full_display_label} is not compatible with the constraint {constraint_name!r}"
-            f" at {request.schema_path.get_path()!r}"
-        )
-        error_detail_props = []
-        error_detail_props += [f"field_name={data_path.field_name}"] if data_path.field_name else []
-        error_detail_props += [f"property_name={data_path.property_name}"] if data_path.property_name else []
-        error_detail_props += [f"peer_id={data_path.peer_id}"] if data_path.peer_id else []
-        error_detail_props += [f"value={data_path.value}"] if data_path.value else []
-        if error_detail_props:
-            error_str += " (" + ",".join(error_detail_props) + ")"
+        constraint_name_str = constraint_name
+        if constraint_name.count(".") == 2:
+            constraint_level, constraint_name_str, _ = constraint_name.split(".", maxsplit=2)
+            error_str = f"{constraint_level.title()}-level '{constraint_name_str}'"
+        else:
+            error_str = f"'{constraint_name_str}'"
+        error_str += f" constraint violation on schema '{violation.node_kind}'."
+        if violation.display_label.startswith("Node"):
+            error_str += f" {violation.display_label}"
+        else:
+            error_str += f" Node ({violation.display_label})"
+        error_str += " is not compliant."
+        error_detail_str_list = []
+        if data_path.field_name:
+            if data_path.value:
+                error_detail_str = data_path.field_name
+                if data_path.property_name:
+                    error_detail_str += f".{data_path.property_name}"
+                error_detail_str += f"={data_path.value!r}"
+                error_detail_str_list.append(error_detail_str)
+            if data_path.peer_id:
+                error_detail_str += f"{data_path.field_name}.id={data_path.peer_id}"
+                error_detail_str_list.append(error_detail_str)
+            if error_detail_str:
+                error_str += " The error relates to field "
+                error_str += ",".join(error_detail_str_list)
+                error_str += "."
         return error_str

--- a/backend/infrahub/core/validators/aggregated_checker.py
+++ b/backend/infrahub/core/validators/aggregated_checker.py
@@ -10,7 +10,7 @@ from .model import SchemaViolation
 
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
-    from infrahub.core.path import GroupedDataPaths
+    from infrahub.core.path import DataPath, GroupedDataPaths
     from infrahub.database import InfrahubDatabase
 
     from .interface import ConstraintCheckerInterface
@@ -65,12 +65,27 @@ class AggregatedConstraintChecker:
                     full_display_label=display_label,
                 )
                 violation.message = await self.render_error_request(
-                    violation=violation, constraint_name=constraint_name, request=request
+                    violation=violation, constraint_name=constraint_name, request=request, data_path=path
                 )
                 violations.append(violation)
         return violations
 
     async def render_error_request(
-        self, violation: SchemaViolation, constraint_name: str, request: SchemaConstraintValidatorRequest
+        self,
+        violation: SchemaViolation,
+        constraint_name: str,
+        request: SchemaConstraintValidatorRequest,
+        data_path: DataPath,
     ) -> str:
-        return f"{violation.full_display_label} is not compatible with the constraint {constraint_name!r} at {request.schema_path.get_path()!r}"
+        error_str = (
+            f"{violation.full_display_label} is not compatible with the constraint {constraint_name!r}"
+            f" at {request.schema_path.get_path()!r}"
+        )
+        error_detail_props = []
+        error_detail_props += [f"field_name={data_path.field_name}"] if data_path.field_name else []
+        error_detail_props += [f"property_name={data_path.property_name}"] if data_path.property_name else []
+        error_detail_props += [f"peer_id={data_path.peer_id}"] if data_path.peer_id else []
+        error_detail_props += [f"value={data_path.value}"] if data_path.value else []
+        if error_detail_props:
+            error_str += " (" + ",".join(error_detail_props) + ")"
+        return error_str

--- a/backend/infrahub/core/validators/node/hierarchy.py
+++ b/backend/infrahub/core/validators/node/hierarchy.py
@@ -133,7 +133,7 @@ class NodeHierarchyUpdateValidatorQuery(SchemaValidatorQuery):
                     branch=str(result.get("branch_name")),
                     path_type=PathType.NODE,
                     node_id=str(result.get("start_node.uuid")),
-                    property_name="children" if self.check_children else "parent",
+                    field_name="children" if self.check_children else "parent",
                     peer_id=str(result.get("current_peer.uuid")),
                     kind=self.node_schema.kind,
                 )

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_add_mandatory_attr_rel.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_add_mandatory_attr_rel.py
@@ -257,7 +257,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         assert len(response["errors"]) == 1
         err_msg = response["errors"][0]["message"]
 
-        assert "Node-level 'relationship' constraint violation" in err_msg
+        assert "Node-level 'attribute' constraint violation" in err_msg
 
     async def test_check_mandatory_relationship_failure(
         self, client: InfrahubClient, initial_dataset, schema_with_person_mandatory_rel
@@ -269,7 +269,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         assert len(response["errors"]) == 1
         err_msg = response["errors"][0]["message"]
 
-        assert "Node-level 'attribute' constraint violation" in err_msg
+        assert "Node-level 'relationship' constraint violation" in err_msg
 
     async def test_check_mandatory_attribute_after_deleting_nodes(
         self, client: InfrahubClient, db: InfrahubDatabase, initial_dataset, schema_with_person_mandatory_attr

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_add_mandatory_attr_rel.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_add_mandatory_attr_rel.py
@@ -269,7 +269,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         assert len(response["errors"]) == 1
         err_msg = response["errors"][0]["message"]
 
-        assert "Node-level 'relationship' constraint violation" in err_msg
+        assert "Node-level 'attribute' constraint violation" in err_msg
 
     async def test_check_mandatory_attribute_after_deleting_nodes(
         self, client: InfrahubClient, db: InfrahubDatabase, initial_dataset, schema_with_person_mandatory_attr

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_add_mandatory_attr_rel.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_add_mandatory_attr_rel.py
@@ -257,7 +257,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         assert len(response["errors"]) == 1
         err_msg = response["errors"][0]["message"]
 
-        assert "is not compatible with the constraint 'node.attribute.add'" in err_msg
+        assert "Node-level 'relationship' constraint violation" in err_msg
 
     async def test_check_mandatory_relationship_failure(
         self, client: InfrahubClient, initial_dataset, schema_with_person_mandatory_rel
@@ -269,7 +269,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         assert len(response["errors"]) == 1
         err_msg = response["errors"][0]["message"]
 
-        assert "is not compatible with the constraint 'node.relationship.add'" in err_msg
+        assert "Node-level 'relationship' constraint violation" in err_msg
 
     async def test_check_mandatory_attribute_after_deleting_nodes(
         self, client: InfrahubClient, db: InfrahubDatabase, initial_dataset, schema_with_person_mandatory_attr

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_generic_uniqueness.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_generic_uniqueness.py
@@ -276,7 +276,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         err_msg = response["errors"][0]["message"]
         assert initial_dataset["boomer"] in err_msg
         assert initial_dataset["athena"] in err_msg
-        assert "node.uniqueness_constraints.update" in err_msg
+        assert "Node-level 'uniqueness_constraints'" in err_msg
 
     async def test_step_02_check_generic_uniqueness_constraint_rebase_failure(
         self,
@@ -305,7 +305,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
 
         assert initial_dataset["boomer"] in exc.value.message
         assert initial_dataset["athena"] in exc.value.message
-        assert "node.uniqueness_constraints.update" in exc.value.message
+        assert "Node-level 'uniqueness_constraints'" in exc.value.message
 
     async def test_step_03_check_generic_and_node_uniqueness_constraint_failure(
         self,
@@ -336,7 +336,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         assert initial_dataset["starbuck"] in err_msg
         assert initial_dataset["president"] in err_msg
         assert initial_dataset["gaius"] not in err_msg
-        assert "node.uniqueness_constraints.update" in err_msg
+        assert "Node-level 'uniqueness_constraints'" in err_msg
 
     async def test_step_03_reset(self, db: InfrahubDatabase, initial_dataset):
         boomer_main = await NodeManager.get_one_by_id_or_default_filter(
@@ -389,17 +389,42 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
 
         assert initial_dataset["gaius"] not in exc.value.message
         assert initial_dataset["caprica"] not in exc.value.message
-        for display_label, kind in [
-            (await boomer_main.render_display_label(db=db), "TestingHumanoid"),
-            (await athena_branch.render_display_label(db=db), "TestingHumanoid"),
-            (await boomer_main.render_display_label(db=db), "TestingCylon"),
-            (await athena_branch.render_display_label(db=db), "TestingCylon"),
-            (await starbuck_main.render_display_label(db=db), "TestingPerson"),
-            (await president_branch.render_display_label(db=db), "TestingPerson"),
-        ]:
-            expected_error_msg = (
-                f"Node {display_label} is not compatible with the constraint 'node.uniqueness_constraints.update'"
-                f" at 'schema/{kind}/uniqueness_constraints'"
-            )
+        for node in [boomer_main, athena_branch]:
+            # boomer_main,
+            # athena_branch,
+            # starbuck_main,
+            # president_branch,
+            display_label = await node.render_display_label(db=db)
+            kind = "TestingHumanoid"
+            for field in ("name", "favorite_color"):
+                value = getattr(node, field).value
+                expected_error_msg = (
+                    f"Node-level 'uniqueness_constraints' constraint violation on schema '{kind}'."
+                    f" Node ({display_label}) is not compliant."
+                    f" The error relates to field {field}.value='{value}'"
+                )
+                assert expected_error_msg in exc.value.errors[0]["message"]
 
-            assert expected_error_msg in exc.value.errors[0]["message"]
+        for node in [boomer_main, athena_branch]:
+            display_label = await node.render_display_label(db=db)
+            kind = "TestingCylon"
+            for field in ("model_number", "favorite_color"):
+                value = getattr(node, field).value
+                expected_error_msg = (
+                    f"Node-level 'uniqueness_constraints' constraint violation on schema '{kind}'."
+                    f" Node ({display_label}) is not compliant."
+                    f" The error relates to field {field}.value='{value}'"
+                )
+                assert expected_error_msg in exc.value.errors[0]["message"]
+
+        for node in [starbuck_main, president_branch]:
+            display_label = await node.render_display_label(db=db)
+            kind = "TestingHuman"
+            for field in ("homeworld", "favorite_color"):
+                value = getattr(node, field).value
+                expected_error_msg = (
+                    f"Node-level 'uniqueness_constraints' constraint violation on schema '{kind}'."
+                    f" Node ({display_label}) is not compliant."
+                    f" The error relates to field {field}.value='{value}'"
+                )
+                assert expected_error_msg in exc.value.errors[0]["message"]

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_generic_uniqueness.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_generic_uniqueness.py
@@ -419,7 +419,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
 
         for node in [starbuck_main, president_branch]:
             display_label = await node.render_display_label(db=db)
-            kind = "TestingHuman"
+            kind = "TestingPerson"
             for field in ("homeworld", "favorite_color"):
                 value = getattr(node, field).value
                 expected_error_msg = (

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_inherit_from.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_inherit_from.py
@@ -204,4 +204,5 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         assert success is False
         assert len(response["errors"]) == 1
         error = response["errors"][0]
-        assert "is not compatible with the constraint 'node.inherit_from.update'" in error["message"]
+        assert "Node-level 'inherit_from' constraint violation on schema 'SchemaNode'" in error["message"]
+        assert "The error relates to field inherit_from=['TestingHumanoid']." in error["message"]

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_main.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_main.py
@@ -261,7 +261,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         err_msg = response["errors"][0]["message"]
         assert initial_dataset["john"] in err_msg
         assert initial_dataset["jane"] in err_msg
-        assert "attribute.regex.update" in err_msg
+        assert "Attribute-level 'regex' constraint violation" in err_msg
 
     async def test_step_02_check_attr_regex_add_success(
         self, client: InfrahubClient, initial_dataset, schema_02_attr_regex
@@ -303,7 +303,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         assert len(response["errors"]) == 1
         err_msg = response["errors"][0]["message"]
         assert initial_dataset["blue"] in err_msg
-        assert "relationship.count.update" in err_msg
+        assert "Relationship-level 'count' constraint violation" in err_msg
 
     async def test_step_04_check_relationship_cardinality_change_success(
         self, client: InfrahubClient, initial_dataset, schema_04_relationship_cardinality
@@ -356,7 +356,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         err_msg = response["errors"][0]["message"]
         assert pinto.id in err_msg
         assert initial_dataset["accord"] in err_msg
-        assert "attribute.unique.update" in err_msg
+        assert "Attribute-level 'unique' constraint violation" in err_msg
 
     async def test_step_06_check_attribute_unique_change_success(
         self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_05_attribute_unique
@@ -408,7 +408,7 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         err_msg = response["errors"][0]["message"]
 
         assert car_profile.id in err_msg
-        assert "node.generate_profile.update" in err_msg
+        assert "Node-level 'generate_profile' constraint violation" in err_msg
 
     async def test_step_08_check_generate_profile_failure(
         self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_07_generate_profile_false
@@ -467,4 +467,4 @@ class TestSchemaLifecycleValidatorMain(TestSchemaLifecycleBase):
         err_msg = response["errors"][0]["message"]
 
         assert generic_profile.id in err_msg
-        assert "node.generate_profile.update" in err_msg
+        assert "Node-level 'generate_profile' constraint violation" in err_msg

--- a/backend/tests/integration/schema_lifecycle/test_schema_validator_rebase.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_validator_rebase.py
@@ -139,7 +139,7 @@ class TestSchemaLifecycleValidatorRebase(TestSchemaLifecycleBase):
             await client.branch.rebase(branch_name=branch_2.name)
 
         assert little_john.id in exc.value.message
-        assert "attribute.regex.update" in exc.value.message
+        assert "Attribute-level 'regex' constraint violation" in exc.value.message
 
     async def test_step_02_node_unique_rebase_failure(
         self, client: InfrahubClient, db: InfrahubDatabase, initial_dataset, schema_02_node_unique, branch_2

--- a/backend/tests/unit/api/test_40_schema.py
+++ b/backend/tests/unit/api/test_40_schema.py
@@ -379,7 +379,10 @@ async def test_schema_load_endpoint_constraints_not_valid(
             json={"schemas": [{"version": "1.0", "nodes": [person_schema]}]},
         )
 
-    error_message = f"Node John (TestPerson: {person_john_main.id}) is not compatible with the constraint 'attribute.regex.update' at 'schema/TestPerson/name/regex'"  # noqa: E501
+    error_message = (
+        f"Node John (TestPerson: {person_john_main.id}) is not compatible with the constraint 'attribute.regex.update'"
+        " at 'schema/TestPerson/name/regex' (field_name=name,value=John)"
+    )
     assert response.json() == {
         "data": None,
         "errors": [{"extensions": {"code": 422}, "message": error_message}],

--- a/backend/tests/unit/api/test_40_schema.py
+++ b/backend/tests/unit/api/test_40_schema.py
@@ -380,8 +380,9 @@ async def test_schema_load_endpoint_constraints_not_valid(
         )
 
     error_message = (
-        f"Node John (TestPerson: {person_john_main.id}) is not compatible with the constraint 'attribute.regex.update'"
-        " at 'schema/TestPerson/name/regex' (field_name=name,value=John)"
+        "Attribute-level 'regex' constraint violation on schema 'TestPerson'."
+        f" Node (John) is not compliant."
+        f" The error relates to field name='{person_john_main.name.value}'."
     )
     assert response.json() == {
         "data": None,

--- a/backend/tests/unit/core/constraint_validators/test_node_hierarchy_update.py
+++ b/backend/tests/unit/core/constraint_validators/test_node_hierarchy_update.py
@@ -115,7 +115,7 @@ async def test_query_children_failure(
             path_type=PathType.NODE,
             node_id=hldsas["s1r1"].id,
             kind="LocationSite",
-            property_name="children",
+            field_name="children",
             peer_id=hldsas["s1r1_rack"].id,
         )
         in all_data_paths
@@ -126,7 +126,7 @@ async def test_query_children_failure(
             path_type=PathType.NODE,
             node_id=hldsas["s2r2"].id,
             kind="LocationSite",
-            property_name="children",
+            field_name="children",
             peer_id=hldsas["s2r2_rack"].id,
         )
         in all_data_paths
@@ -137,7 +137,7 @@ async def test_query_children_failure(
             path_type=PathType.NODE,
             node_id=hldsas["s1r2"].id,
             kind="LocationSite",
-            property_name="children",
+            field_name="children",
             peer_id=hldsas["s1r2_rack"].id,
         )
         in all_data_paths
@@ -148,7 +148,7 @@ async def test_query_children_failure(
             path_type=PathType.NODE,
             node_id=hldsas["s2r1"].id,
             kind="LocationSite",
-            property_name="children",
+            field_name="children",
             peer_id=hldsas["s2r1_rack"].id,
         )
         in all_data_paths
@@ -179,7 +179,7 @@ async def test_query_parent_failure(
             path_type=PathType.NODE,
             node_id=hldsas["s1r1"].id,
             kind="LocationSite",
-            property_name="parent",
+            field_name="parent",
             peer_id=hldsas["r1"].id,
         )
         in all_data_paths
@@ -190,7 +190,7 @@ async def test_query_parent_failure(
             path_type=PathType.NODE,
             node_id=hldsas["s2r2"].id,
             kind="LocationSite",
-            property_name="parent",
+            field_name="parent",
             peer_id=hldsas["r2"].id,
         )
         in all_data_paths
@@ -201,7 +201,7 @@ async def test_query_parent_failure(
             path_type=PathType.NODE,
             node_id=hldsas["s1r2"].id,
             kind="LocationSite",
-            property_name="parent",
+            field_name="parent",
             peer_id=hldsas["r2"].id,
         )
         in all_data_paths
@@ -212,7 +212,7 @@ async def test_query_parent_failure(
             path_type=PathType.NODE,
             node_id=hldsas["s2r1"].id,
             kind="LocationSite",
-            property_name="parent",
+            field_name="parent",
             peer_id=hldsas["r1"].id,
         )
         in all_data_paths
@@ -247,7 +247,7 @@ async def test_query_update_on_branch_failure(
             path_type=PathType.NODE,
             node_id=hldsas["s1r1"].id,
             kind="LocationSite",
-            property_name="children",
+            field_name="children",
             peer_id=hldsas["s1r1_rack"].id,
         )
         in all_data_paths
@@ -258,7 +258,7 @@ async def test_query_update_on_branch_failure(
             path_type=PathType.NODE,
             node_id=hldsas["s1r1"].id,
             kind="LocationSite",
-            property_name="children",
+            field_name="children",
             peer_id=s1r1_rack2.id,
         )
         in all_data_paths
@@ -269,7 +269,7 @@ async def test_query_update_on_branch_failure(
             path_type=PathType.NODE,
             node_id=hldsas["s2r2"].id,
             kind="LocationSite",
-            property_name="children",
+            field_name="children",
             peer_id=hldsas["s2r2_rack"].id,
         )
         in all_data_paths
@@ -280,7 +280,7 @@ async def test_query_update_on_branch_failure(
             path_type=PathType.NODE,
             node_id=hldsas["s1r2"].id,
             kind="LocationSite",
-            property_name="children",
+            field_name="children",
             peer_id=hldsas["s1r2_rack"].id,
         )
         in all_data_paths
@@ -291,7 +291,7 @@ async def test_query_update_on_branch_failure(
             path_type=PathType.NODE,
             node_id=hldsas["s2r1"].id,
             kind="LocationSite",
-            property_name="children",
+            field_name="children",
             peer_id=hldsas["s2r1_rack"].id,
         )
         in all_data_paths
@@ -326,7 +326,7 @@ async def test_query_delete_on_branch_failure(
             path_type=PathType.NODE,
             node_id=hldsas["s2r2"].id,
             kind="LocationSite",
-            property_name="children",
+            field_name="children",
             peer_id=hldsas["s2r2_rack"].id,
         )
         in all_data_paths
@@ -337,7 +337,7 @@ async def test_query_delete_on_branch_failure(
             path_type=PathType.NODE,
             node_id=hldsas["s1r2"].id,
             kind="LocationSite",
-            property_name="children",
+            field_name="children",
             peer_id=hldsas["s1r2_rack"].id,
         )
         in all_data_paths
@@ -348,7 +348,7 @@ async def test_query_delete_on_branch_failure(
             path_type=PathType.NODE,
             node_id=hldsas["s2r1"].id,
             kind="LocationSite",
-            property_name="children",
+            field_name="children",
             peer_id=hldsas["s2r1_rack"].id,
         )
         in all_data_paths

--- a/backend/tests/unit/core/constraint_validators/test_task_schema_validate_migrations.py
+++ b/backend/tests/unit/core/constraint_validators/test_task_schema_validate_migrations.py
@@ -47,4 +47,5 @@ async def test_schema_validate_migrations(
 
     assert len(responses) == 1
     assert len(responses[0].violations) == 1
-    assert "is not compatible with the constraint 'attribute.regex.update'" in responses[0].violations[0].message
+    assert "Attribute-level 'regex' constraint violation" in responses[0].violations[0].message
+    assert f"name='{person_john_main.name.value}'" in responses[0].violations[0].message

--- a/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
+++ b/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
@@ -300,6 +300,6 @@ async def test_schema_integrity(
                 "path": "schema/TestPerson/name/regex",
                 "type": "attribute.regex.update",
                 # ruff: noqa: E501
-                "value": f"Node (TestPerson: {person_john_main.id}) is not compatible with the constraint 'attribute.regex.update' at 'schema/TestPerson/name/regex'",
+                "value": f"Node (TestPerson: {person_john_main.id}) is not compatible with the constraint 'attribute.regex.update' at 'schema/TestPerson/name/regex' (field_name=name,value=John)",
             }
         ]

--- a/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
+++ b/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
@@ -300,6 +300,6 @@ async def test_schema_integrity(
                 "path": "schema/TestPerson/name/regex",
                 "type": "attribute.regex.update",
                 # ruff: noqa: E501
-                "value": f"Node (TestPerson: {person_john_main.id}) is not compatible with the constraint 'attribute.regex.update' at 'schema/TestPerson/name/regex' (field_name=name,value=John)",
+                "value": f"Attribute-level 'regex' constraint violation on schema 'TestPerson'. Node (TestPerson: {person_john_main.id}) is not compliant. The error relates to field name='{person_john_main.name.value}'.",
             }
         ]

--- a/changelog/+constraint-error-messages.fixed.md
+++ b/changelog/+constraint-error-messages.fixed.md
@@ -1,0 +1,1 @@
+Improved format of data and schema integrity error messages on a Proposed Change to include more information


### PR DESCRIPTION
the error we display to the end user for a uniqueness_constraint schema violation is not always the most helpful. I've heard this complaint a few times before and heard it again today.

for example, `Node (TestCar: 1234) is not compatible with the constraint 'node.uniqueness_constraints.update' at 'schema/TestCar/uniqueness_constraints'"`

this tells the user which node is breaking the constraint, but does not convey which attributes or relationships are involved.

this PR adds a little more detail to the error messages for constraint violations to include the field name (attribute name or relationship name), property name, value, and peer ID, if any/all of these are defined on the error being serialized. with this change, the previous error message example looks like this
`Node-level 'uniqueness_constraints' constraint violation on schema 'TestCar'. Node (TestCar: 1234) is not compliant. The error relates to field name.value='Accord'`
