### PR TITLE
Split apart old pylint ignore rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -434,10 +434,8 @@ ignore = [
     "PLR0912", # Too many branches
     "PLR0913", # Too many arguments in function definition
     "PLR0914", # Too many local variables
-    "PLR0915", # Too many statements
     "PLR0916", # Too many Boolean expressions
     "PLR0917", # Too many positional arguments
-    "PLR1702", # Too many nested blocks
     "PLR2004", # Magic value used in comparison this could possibly be fine in the tests folders
     "PLR6201", # Use a `set` literal when testing for membership
     "PLR6301", # Method could be a function, class method, or static method
@@ -516,8 +514,54 @@ allow-dunder-method-names = [
     "UP007",  # Use X | Y for type annotations
 ]
 
+"backend/infrahub/cli/db.py" = [
+    ##################################################################################################
+    # Refactor code and remove the ignore rule
+    ##################################################################################################
+    "PLR1702", # Too many nested blocks
+    "PLR0915", # Too many statements
+]
+
 "backend/infrahub/config.py" = [
     "S323", # Allow users to create an SSL context that doesn't validate certificates
+]
+
+
+"backend/infrahub/core/models.py" = [
+    ##################################################################################################
+    # Refactor code and remove the ignore rule
+    ##################################################################################################
+    "PLR1702", # Too many nested blocks
+]
+
+
+"backend/infrahub/core/query/attribute.py" = [
+    ##################################################################################################
+    # Refactor code and remove the ignore rule
+    ##################################################################################################
+    "PLR0915", # Too many statements
+]
+
+
+"backend/infrahub/core/query/relationship.py" = [
+    ##################################################################################################
+    # Refactor code and remove the ignore rule
+    ##################################################################################################
+    "PLR0915", # Too many statements
+]
+
+"backend/infrahub/core/schema/manager.py" = [
+    ##################################################################################################
+    # Refactor code and remove the ignore rule
+    ##################################################################################################
+    "PLR0915", # Too many statements
+]
+
+"backend/infrahub/graphql/manager.py" = [
+    ##################################################################################################
+    # Refactor code and remove the ignore rule
+    ##################################################################################################
+    "PLR0915", # Too many statements
 ]
 
 "backend/infrahub/graphql/mutations/**.py" = [
@@ -525,6 +569,13 @@ allow-dunder-method-names = [
     # Review and change the below later                                                              #
     ##################################################################################################
     "ANN206", # Missing return type annotation for classmethod
+]
+
+"backend/infrahub/menu/generator.py" = [
+    ##################################################################################################
+    # Refactor code and remove the ignore rule
+    ##################################################################################################
+    "PLR0915", # Too many statements
 ]
 
 "backend/tests/**.py" = [
@@ -540,7 +591,7 @@ allow-dunder-method-names = [
     "ANN201", # Missing return type annotation for public function
     "ANN202", # Missing return type annotation for private function
     "ANN401", # Dynamically typed expressions (typing.Any) are disallowed
-
+    "PLR0915", # Too many statements
 ]
 
 "backend/tests/integration_docker/test_schema_migration.py" = [
@@ -560,7 +611,16 @@ allow-dunder-method-names = [
     ##################################################################################################
     "C901",   # `generate_site` is too complex (34 > 33)"
     "E501",   # Line too long
+    "PLR0915", # Too many statements
 ]
+
+"tasks/release.py" = [
+    ##################################################################################################
+    # Refactor code and remove the ignore rule
+    ##################################################################################################
+    "PLR0915", # Too many statements
+]
+
 
 "utilities/**.py" = [
     ##################################################################################################


### PR DESCRIPTION
Splitting apart some of the pylint ignore rules for ruff so that we don't introduce new violations and it's easier to fix them in smaller chunks.