### PR TITLE
Use `artifact_name` instead of `name` from ArtifactDefinition to generate artifacts

### DIFF
--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -37,7 +37,7 @@ from pydantic import BaseModel, Field
 from pydantic import ValidationError as PydanticValidationError
 from typing_extensions import Self
 
-from infrahub.core.constants import InfrahubKind, RepositorySyncStatus
+from infrahub.core.constants import ArtifactStatus, ContentType, InfrahubKind, RepositorySyncStatus
 from infrahub.events.repository_action import CommitUpdatedEvent
 from infrahub.exceptions import CheckError, RepositoryInvalidFileSystemError, TransformError
 from infrahub.git.base import InfrahubRepositoryBase, extract_repo_file_information
@@ -1210,6 +1210,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):  # pylint: disable=t
         transformation: CoreTransformation,
         query: CoreGraphQLQuery,
     ) -> ArtifactGenerateResult:
+        """It doesn't look like this is used anywhere today ... we should either remove it or refactor render_artifact below to use this."""
         variables = target.extract(params=definition.parameters.value)
         response = await self.sdk.query_gql_query(
             name=query.name.value,
@@ -1237,9 +1238,9 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):  # pylint: disable=t
                 client=self.sdk,
             )
 
-        if definition.content_type.value == "application/json":
+        if definition.content_type.value == ContentType.APPLICATION_JSON.value:
             artifact_content_str = ujson.dumps(artifact_content, indent=2)
-        elif definition.content_type.value == "text/plain":
+        elif definition.content_type.value == ContentType.TEXT_PLAIN.value:
             artifact_content_str = artifact_content
 
         checksum = hashlib.md5(bytes(artifact_content_str, encoding="utf-8"), usedforsecurity=False).hexdigest()
@@ -1254,7 +1255,9 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):  # pylint: disable=t
 
         artifact.checksum.value = checksum
         artifact.storage_id.value = storage_id
-        artifact.status.value = "Ready"
+        artifact.status.value = ArtifactStatus.READY.value
+        if artifact.name.value != definition.artifact_name.value:
+            artifact.name.value = definition.artifact_name.value
         await artifact.save()
 
         return ArtifactGenerateResult(changed=True, checksum=checksum, storage_id=storage_id, artifact_id=artifact.id)
@@ -1285,9 +1288,9 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):  # pylint: disable=t
                 client=self.sdk,
             )
 
-        if message.content_type == "application/json":
+        if message.content_type == ContentType.APPLICATION_JSON.value:
             artifact_content_str = ujson.dumps(artifact_content, indent=2)
-        elif message.content_type == "text/plain":
+        elif message.content_type == ContentType.TEXT_PLAIN.value:
             artifact_content_str = artifact_content
 
         checksum = hashlib.md5(bytes(artifact_content_str, encoding="utf-8"), usedforsecurity=False).hexdigest()
@@ -1303,6 +1306,8 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):  # pylint: disable=t
         artifact.content_type.value = message.content_type
         artifact.checksum.value = checksum
         artifact.storage_id.value = storage_id
-        artifact.status.value = "Ready"
+        artifact.status.value = ArtifactStatus.READY.value
+        if artifact.name.value != message.artifact_name:
+            artifact.name.value = message.artifact_name
         await artifact.save()
         return ArtifactGenerateResult(changed=True, checksum=checksum, storage_id=storage_id, artifact_id=artifact.id)

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
 from infrahub_sdk import InfrahubClient
-from infrahub_sdk.protocols import CoreArtifactDefinition, CoreRepository
+from infrahub_sdk.protocols import CoreArtifact, CoreArtifactDefinition, CoreRepository
 from prefect import flow, task
 from prefect.automations import AutomationCore
 from prefect.cache_policies import NONE
@@ -293,7 +293,7 @@ async def generate_request_artifact_definition(model: RequestArtifactDefinitionG
     await add_tags(branches=[model.branch], nodes=[model.artifact_definition_id])
 
     artifact_definition = await service.client.get(
-        kind=InfrahubKind.ARTIFACTDEFINITION, id=model.artifact_definition_id, branch=model.branch
+        kind=CoreArtifactDefinition, id=model.artifact_definition_id, branch=model.branch
     )
 
     await artifact_definition.targets.fetch()
@@ -302,7 +302,7 @@ async def generate_request_artifact_definition(model: RequestArtifactDefinitionG
     current_members = [member.id for member in group.members.peers]
 
     existing_artifacts = await service.client.filters(
-        kind=InfrahubKind.ARTIFACT,
+        kind=CoreArtifact,
         definition__ids=[model.artifact_definition_id],
         include=["object"],
         branch=model.branch,
@@ -340,12 +340,12 @@ async def generate_request_artifact_definition(model: RequestArtifactDefinitionG
             continue
 
         request_artifact_generate_model = RequestArtifactGenerate(
-            artifact_name=artifact_definition.name.value,
+            artifact_name=artifact_definition.artifact_name.value,
             artifact_id=artifact_id,
             artifact_definition=model.artifact_definition_id,
             commit=repository.commit.value,
             content_type=artifact_definition.content_type.value,
-            transform_type=transform.typename,
+            transform_type=str(transform.typename),
             transform_location=transform_location,
             repository_id=repository.id,
             repository_name=repository.name.value,

--- a/backend/infrahub/message_bus/operations/requests/artifact_definition.py
+++ b/backend/infrahub/message_bus/operations/requests/artifact_definition.py
@@ -91,7 +91,7 @@ async def check(message: messages.RequestArtifactDefinitionCheck, service: Infra
             log.info(f"Trigger Artifact processing for {member.display_label}")
             events.append(
                 messages.CheckArtifactCreate(
-                    artifact_name=message.artifact_definition.definition_name,
+                    artifact_name=message.artifact_definition.artifact_name,
                     artifact_id=artifact_id,
                     artifact_definition=message.artifact_definition.definition_id,
                     commit=repository.source_commit,

--- a/backend/infrahub/message_bus/operations/requests/proposed_change.py
+++ b/backend/infrahub/message_bus/operations/requests/proposed_change.py
@@ -254,6 +254,9 @@ query GatherArtifactDefinitions {
         name {
           value
         }
+        artifact_name {
+          value
+        }
         content_type {
             value
         }
@@ -479,6 +482,7 @@ def _parse_artifact_definitions(definitions: list[dict]) -> list[ProposedChangeA
         artifact_definition = ProposedChangeArtifactDefinition(
             definition_id=definition["node"]["id"],
             definition_name=definition["node"]["name"]["value"],
+            artifact_name=definition["node"]["artifact_name"]["value"],
             content_type=definition["node"]["content_type"]["value"],
             timeout=definition["node"]["transformation"]["node"]["timeout"]["value"],
             query_name=definition["node"]["transformation"]["node"]["query"]["node"]["name"]["value"],

--- a/backend/infrahub/message_bus/types.py
+++ b/backend/infrahub/message_bus/types.py
@@ -87,6 +87,7 @@ class ProposedChangeSubscriber(BaseModel):
 class ProposedChangeArtifactDefinition(BaseModel):
     definition_id: str
     definition_name: str
+    artifact_name: str
     query_name: str
     query_models: list[str]
     repository_id: str

--- a/backend/tests/integration/git/test_readonly_repository.py
+++ b/backend/tests/integration/git/test_readonly_repository.py
@@ -103,23 +103,23 @@ class TestCreateReadOnlyRepository(TestInfrahubApp):
     ):
         artifacts = await client.all(kind=CoreArtifact, branch="ro_repository")
         artifacts_dict = {item.name.value: item for item in artifacts}
-        assert sorted(artifacts_dict.keys()) == ["Ownership report", "name report"]
+        assert sorted(artifacts_dict.keys()) == ["car-name", "car-owner"]
         john_display_label = await person_john.render_display_label(db=db)
 
         artifact_diff_calculator = ArtifactDiffCalculator(db=db)
         branch = await registry.get_branch(db=db, branch="ro_repository")
         diffs = await artifact_diff_calculator.calculate(source_branch=branch, target_branch=default_branch)
         diffs_dict = {str(item.display_label): item for item in diffs}
-        assert sorted(diffs_dict.keys()) == ["John - Ownership report", "John - name report"]
-        assert diffs_dict["John - Ownership report"] == BranchDiffArtifact(
+        assert sorted(diffs_dict.keys()) == ["John - car-name", "John - car-owner"]
+        assert diffs_dict["John - car-owner"] == BranchDiffArtifact(
             branch="ro_repository",
-            id=artifacts_dict["Ownership report"].id,
-            display_label=f"{john_display_label} - Ownership report",
+            id=artifacts_dict["car-owner"].id,
+            display_label=f"{john_display_label} - car-owner",
             action=DiffAction.ADDED,
             target=ArtifactTarget(id=person_john.id, kind="TestingPerson", display_label=john_display_label),
             item_new=BranchDiffArtifactStorage(
-                storage_id=str(artifacts_dict["Ownership report"].storage_id.value),
-                checksum=str(artifacts_dict["Ownership report"].checksum.value),
+                storage_id=str(artifacts_dict["car-owner"].storage_id.value),
+                checksum=str(artifacts_dict["car-owner"].checksum.value),
             ),
             item_previous=None,
         )
@@ -149,9 +149,8 @@ class TestCreateReadOnlyRepository(TestInfrahubApp):
                 REQUEST_ARTIFACT_DEFINITION_GENERATE, parameters={"model": model}
             )
 
-        artifacts = await client.all(kind=InfrahubKind.ARTIFACT)
-        assert artifacts
-        assert artifacts[0].name.value == "Ownership report"
+        artifacts = await client.all(kind=CoreArtifact)
+        assert sorted([artifact.name.value for artifact in artifacts]) == ["car-name", "car-owner"]
 
     async def test_step04_new_branch_with_artifact(
         self,
@@ -189,22 +188,22 @@ class TestCreateReadOnlyRepository(TestInfrahubApp):
 
         artifacts = await client.all(kind=CoreArtifact, branch="branch")
         artifacts_dict = {item.name.value: item for item in artifacts}
-        assert sorted(artifacts_dict.keys()) == ["Ownership report", "name report"]
-        artifact_main = await NodeManager.get_one(db=db, id=artifacts[0].id)
+        assert sorted(artifacts_dict.keys()) == ["car-name", "car-owner"]
+        artifact_main = await NodeManager.get_one(db=db, id=artifacts_dict["car-owner"].id)
 
         artifact_diff_calculator = ArtifactDiffCalculator(db=db)
         diffs = await artifact_diff_calculator.calculate(source_branch=branch, target_branch=default_branch)
         diffs_dict = {str(item.display_label): item for item in diffs}
-        assert sorted(diffs_dict.keys()) == ["John2 - Ownership report", "John2 - name report"]
-        assert diffs_dict["John2 - Ownership report"] == BranchDiffArtifact(
+        assert sorted(diffs_dict.keys()) == ["John2 - car-name", "John2 - car-owner"]
+        assert diffs_dict["John2 - car-owner"] == BranchDiffArtifact(
             branch="branch",
-            id=artifacts_dict["Ownership report"].id,
-            display_label=f"{john_display_label} - Ownership report",
+            id=artifacts_dict["car-owner"].id,
+            display_label=f"{john_display_label} - car-owner",
             action=DiffAction.UPDATED,
             target=ArtifactTarget(id=person_john.id, kind="TestingPerson", display_label=john_display_label),
             item_new=BranchDiffArtifactStorage(
-                storage_id=str(artifacts_dict["Ownership report"].storage_id.value),
-                checksum=str(artifacts_dict["Ownership report"].checksum.value),
+                storage_id=str(artifacts_dict["car-owner"].storage_id.value),
+                checksum=str(artifacts_dict["car-owner"].checksum.value),
             ),
             item_previous=BranchDiffArtifactStorage(
                 storage_id=artifact_main.storage_id.value, checksum=artifact_main.checksum.value

--- a/changelog/5484.fixed.md
+++ b/changelog/5484.fixed.md
@@ -1,0 +1,1 @@
+The name of generated artifacts is now using `artifact_name`, from the artifact definition, instead of the name of the definition itself. Existing artifacts will be renamed the next time they are generated.

--- a/frontend/app/tests/e2e/objects/artifact.spec.ts
+++ b/frontend/app/tests/e2e/objects/artifact.spec.ts
@@ -15,18 +15,16 @@ test.describe("/objects/CoreArtifact - Artifact page", () => {
 
   test("should generate artifacts successfully", async ({ page }) => {
     await page.goto(
-      '/objects/CoreArtifact?filters=[{"name":"name__value","value":"Startup Config for Edge devices"}]'
+      '/objects/CoreArtifact?filters=[{"name":"name__value","value":"startup-config"}]'
     );
 
     // reload page until we have artifacts defined
-    while (
-      await page.getByRole("link", { name: "startup Config for Edge devices" }).first().isHidden()
-    ) {
+    while (await page.getByRole("link", { name: "startup-config" }).first().isHidden()) {
       await page.reload();
       await expect(page.getByText("Previous")).toBeVisible();
     }
 
-    await page.getByRole("link", { name: "startup Config for Edge devices" }).first().click();
+    await page.getByRole("link", { name: "startup-config" }).first().click();
     await expect(page.getByText("no aaa root").first()).toBeVisible();
   });
 
@@ -42,9 +40,9 @@ test.describe("/objects/CoreArtifact - Artifact page", () => {
     test("should add generated artifact to a group", async ({ page }) => {
       await page.goto(
         // eslint-disable-next-line quotes
-        '/objects/CoreArtifact?filters=[{"name":"name__value","value":"Startup Config for Edge devices"}]'
+        '/objects/CoreArtifact?filters=[{"name":"name__value","value":"startup-config"}]'
       );
-      await page.getByRole("link", { name: "startup Config for Edge devices" }).first().click();
+      await page.getByRole("link", { name: "startup-config" }).first().click();
 
       await test.step("add artifact to a group", async () => {
         await page.getByRole("button", { name: "Manage groups" }).click();


### PR DESCRIPTION
Fixes #5484 

Update artifact name to be generated based on `artifact_name` from the artifact definition instead of using the name of the artifact definition itself

Existing artifacts will be updated the next time they are regenerated