### PR TITLE
Switch to query_report for GraphQL Analyzer

### DIFF
--- a/backend/infrahub/api/query.py
+++ b/backend/infrahub/api/query.py
@@ -100,9 +100,7 @@ async def execute_query(
     GRAPHQL_QUERY_HEIGHT_METRICS.labels(**labels).observe(await analyzed_query.calculate_height())
     GRAPHQL_QUERY_VARS_METRICS.labels(**labels).observe(len(analyzed_query.variables))
     GRAPHQL_TOP_LEVEL_QUERIES_METRICS.labels(**labels).observe(analyzed_query.nbr_queries)
-    GRAPHQL_QUERY_OBJECTS_METRICS.labels(**labels).observe(
-        len(await analyzed_query.get_models_in_use(types=gql_params.context.types))
-    )
+    GRAPHQL_QUERY_OBJECTS_METRICS.labels(**labels).observe(len(analyzed_query.query_report.impacted_models))
 
     response_payload: dict[str, Any] = {"data": data}
 

--- a/backend/infrahub/graphql/analyzer.py
+++ b/backend/infrahub/graphql/analyzer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import deque
 from copy import deepcopy
 from dataclasses import dataclass, field
 from enum import Enum
@@ -22,7 +23,8 @@ from infrahub_sdk.analyzer import GraphQLQueryAnalyzer
 from infrahub_sdk.utils import extract_fields
 
 from infrahub.core.constants import RelationshipCardinality
-from infrahub.core.schema import GenericSchema, NodeSchema
+from infrahub.core.schema import GenericSchema
+from infrahub.exceptions import SchemaNotFoundError
 from infrahub.graphql.utils import extract_schema_models
 
 if TYPE_CHECKING:
@@ -119,7 +121,7 @@ class GraphQLQueryNode:
     parent: GraphQLQueryNode | None = field(default=None)
     children: list[GraphQLQueryNode] = field(default_factory=list)
     infrahub_model: MainSchemaTypes | None = field(default=None)
-    infrahub_node_models: list[NodeSchema] = field(default_factory=list)
+    infrahub_node_models: list[MainSchemaTypes] = field(default_factory=list)
     infrahub_attributes: set[str] = field(default_factory=set)
     infrahub_relationships: set[str] = field(default_factory=set)
     field_node: FieldNode | None = field(default=None)
@@ -262,6 +264,7 @@ class InfrahubGraphQLQueryAnalyzer(GraphQLQueryAnalyzer):
         self.operation_name = operation_name
         self.query_variables: dict[str, Any] = query_variables or {}
         self._named_fragments: dict[str, GraphQLQueryNode] = {}
+        self._fragment_dependencies: dict[str, set[str]] = {}
         super().__init__(query=query, schema=schema)
 
     @property
@@ -338,7 +341,7 @@ class InfrahubGraphQLQueryAnalyzer(GraphQLQueryAnalyzer):
 
             for field_node in selections.field_nodes:
                 schema_model: MainSchemaTypes
-                infrahub_node_models: list[NodeSchema] = []
+                infrahub_node_models: list[MainSchemaTypes] = []
                 model_name = self._get_model_name(node=field_node, operation_definition=operation_definition)
 
                 if model_name in self.schema_branch.node_names:
@@ -346,7 +349,7 @@ class InfrahubGraphQLQueryAnalyzer(GraphQLQueryAnalyzer):
                 elif model_name in self.schema_branch.generic_names:
                     schema_model = self.schema_branch.get_generic(name=model_name, duplicate=False)
                     infrahub_node_models = [
-                        self.schema_branch.get_node(name=used_by, duplicate=False) for used_by in schema_model.used_by
+                        self.schema_branch.get(name=used_by, duplicate=False) for used_by in schema_model.used_by
                     ]
                 elif model_name in self.schema_branch.profile_names:
                     schema_model = self.schema_branch.get_profile(name=model_name, duplicate=False)
@@ -385,14 +388,60 @@ class InfrahubGraphQLQueryAnalyzer(GraphQLQueryAnalyzer):
                 return node.name.value[:-6]
         return node.name.value
 
+    @property
+    def _sorted_fragment_definitions(self) -> list[FragmentDefinitionNode]:
+        """Sort fragments so that we start processing fragments that don't depend on other fragments"""
+        dependencies = deepcopy(self._fragment_dependencies)
+
+        independent_fragments = deque([frag for frag, deps in dependencies.items() if not deps])
+
+        sorted_fragments = []
+
+        while independent_fragments:
+            fragment_name = independent_fragments.popleft()
+            sorted_fragments.append(fragment_name)
+
+            for dependent, deps in dependencies.items():
+                if fragment_name in deps:
+                    deps.remove(fragment_name)
+                    if not deps:
+                        independent_fragments.append(dependent)
+
+        if len(sorted_fragments) != len(self._fragment_dependencies):
+            raise ValueError("Circular fragment dependency detected.")
+
+        fragment_name_to_definition = {frag.name.value: frag for frag in self._fragment_definitions}
+        return [fragment_name_to_definition[name] for name in sorted_fragments]
+
+    def _populate_fragment_dependency(self, name: str, selection_set: SelectionSetNode | None) -> None:
+        if selection_set:
+            for selection in selection_set.selections:
+                if isinstance(selection, FragmentSpreadNode):
+                    self._fragment_dependencies[name].add(selection.name.value)
+                elif isinstance(selection, FieldNode):
+                    self._populate_fragment_dependency(name=name, selection_set=selection.selection_set)
+                elif isinstance(selection, InlineFragmentNode):
+                    self._populate_fragment_dependency(name=name, selection_set=selection.selection_set)
+
+    def _populate_fragment_dependencies(self) -> None:
+        for fragment in self._fragment_definitions:
+            fragment_name = fragment.name.value
+            self._fragment_dependencies[fragment_name] = set()
+            self._populate_fragment_dependency(name=fragment_name, selection_set=fragment.selection_set)
+
     def _populate_named_fragments(self) -> None:
+        self._populate_fragment_dependencies()
         self._named_fragments = {}
-        for fragment_definition in self._fragment_definitions:
+
+        for fragment_definition in self._sorted_fragment_definitions:
             fragment_name = fragment_definition.name.value
             condition_name = fragment_definition.type_condition.name.value
             selections = self._get_selections(selection_set=fragment_definition.selection_set)
 
-            infrahub_model = self.schema_branch.get(name=condition_name, duplicate=False)
+            try:
+                infrahub_model = self.schema_branch.get(name=condition_name, duplicate=False)
+            except SchemaNotFoundError:
+                infrahub_model = None
 
             named_fragment = GraphQLQueryNode(
                 path=fragment_definition.type_condition.name.value,
@@ -411,7 +460,7 @@ class InfrahubGraphQLQueryAnalyzer(GraphQLQueryAnalyzer):
     def _populate_field_node(self, node: FieldNode, query_node: GraphQLQueryNode) -> GraphQLQueryNode:
         context_type = query_node.context_type
         infrahub_model = None
-        infrahub_node_models: list[NodeSchema] = []
+        infrahub_node_models: list[MainSchemaTypes] = []
         if query_node.in_property_level:
             if model := query_node.context_model():
                 if node.name.value in model.attribute_names:
@@ -422,7 +471,7 @@ class InfrahubGraphQLQueryAnalyzer(GraphQLQueryAnalyzer):
                         infrahub_model = self.schema_branch.get(name=rel.peer, duplicate=False)
                         if isinstance(infrahub_model, GenericSchema):
                             infrahub_node_models = [
-                                self.schema_branch.get_node(name=used_by, duplicate=False)
+                                self.schema_branch.get(name=used_by, duplicate=False)
                                 for used_by in infrahub_model.used_by
                             ]
 

--- a/backend/infrahub/graphql/app.py
+++ b/backend/infrahub/graphql/app.py
@@ -282,9 +282,7 @@ class InfrahubGraphQLApp:
         GRAPHQL_QUERY_HEIGHT_METRICS.labels(**labels).observe(await analyzed_query.calculate_height())
         # GRAPHQL_QUERY_VARS_METRICS.labels(**labels).observe(len(analyzed_query.variables))
         GRAPHQL_TOP_LEVEL_QUERIES_METRICS.labels(**labels).observe(analyzed_query.nbr_queries)
-        GRAPHQL_QUERY_OBJECTS_METRICS.labels(**labels).observe(
-            len(await analyzed_query.get_models_in_use(types=graphql_params.context.types))
-        )
+        GRAPHQL_QUERY_OBJECTS_METRICS.labels(**labels).observe(len(analyzed_query.query_report.impacted_models))
 
         _, errors = analyzed_query.is_valid
         if errors:

--- a/backend/infrahub/graphql/auth/query_permission_checker/object_permission_checker.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/object_permission_checker.py
@@ -36,7 +36,7 @@ class ObjectPermissionChecker(GraphQLQueryPermissionCheckerInterface):
             else PermissionDecisionFlag.ALLOW_OTHER
         )
 
-        kinds = await analyzed_query.get_models_in_use(types=query_parameters.context.types)
+        kinds = analyzed_query.query_report.impacted_models
 
         # Identify which operations are performed. As we don't have a mapping between kinds and the
         # operation we currently require permissions all defined permissions for all objects
@@ -95,7 +95,7 @@ class AccountManagerPermissionChecker(GraphQLQueryPermissionCheckerInterface):
         branch: Branch,
     ) -> CheckerResolution:
         is_account_operation = False
-        kinds = await analyzed_query.get_models_in_use(types=query_parameters.context.types)
+        kinds = analyzed_query.query_report.impacted_models
         operation_names = [operation.name for operation in analyzed_query.operations]
 
         for kind in kinds:
@@ -139,7 +139,7 @@ class PermissionManagerPermissionChecker(GraphQLQueryPermissionCheckerInterface)
         branch: Branch,
     ) -> CheckerResolution:
         is_permission_operation = False
-        kinds = await analyzed_query.get_models_in_use(types=query_parameters.context.types)
+        kinds = analyzed_query.query_report.impacted_models
 
         for kind in kinds:
             schema = get_schema(db=db, branch=branch, node_schema=kind)
@@ -180,7 +180,7 @@ class RepositoryManagerPermissionChecker(GraphQLQueryPermissionCheckerInterface)
         branch: Branch,
     ) -> CheckerResolution:
         is_repository_operation = False
-        kinds = await analyzed_query.get_models_in_use(types=query_parameters.context.types)
+        kinds = analyzed_query.query_report.impacted_models
 
         for kind in kinds:
             schema = get_schema(db=db, branch=branch, node_schema=kind)

--- a/backend/infrahub/graphql/mutations/graphql_query.py
+++ b/backend/infrahub/graphql/mutations/graphql_query.py
@@ -51,7 +51,7 @@ class InfrahubGraphQLQueryMutation(InfrahubMutationMixin, Mutation):
         if not valid:
             raise ValueError(f"Query is not valid, {str(errors)}")
 
-        query_info["models"] = {"value": sorted(await analyzer.get_models_in_use(types=info.context.types))}
+        query_info["models"] = {"value": analyzer.query_report.impacted_models}
         query_info["depth"] = {"value": await analyzer.calculate_depth()}
         query_info["height"] = {"value": await analyzer.calculate_height()}
         query_info["operations"] = {

--- a/changelog/4644.changed.md
+++ b/changelog/4644.changed.md
@@ -1,0 +1,1 @@
+Modified query analyzer to not list all potential meta data models when only querying for "source" or "owner" ID. The full models will still show up if a fragment is used under the meta data properties. This change makes it easier to setup fine grained permissions and also speeds up the permission lookup as it doesn't require as many checks.


### PR DESCRIPTION
Switch code from:

`await analyzed_query.get_models_in_use()`

to:

`analyzed_query.query_report.impacted_models`

While doing this I noticed that the introspection query stopped working. This was due to the fact that it used named fragments that depend on each other.

Like the below example where `FullType` depends on `InputValue`. In order to resolve this I had to modify the code so that fragments like this are processed in a specific order to ensure that the those fragments that others depend on are processed first.

```graphql

    fragment FullType on __Type {
      kind
      name
      description
      
      
      fields(includeDeprecated: true) {
        name
        description
        args {
          ...InputValue
        }
        type {
          ...TypeRef
        }
        isDeprecated
        deprecationReason
      }
      inputFields {
        ...InputValue
      }
      interfaces {
        ...TypeRef
      }
      enumValues(includeDeprecated: true) {
        name
        description
        isDeprecated
        deprecationReason
      }
      possibleTypes {
        ...TypeRef
      }
    }

    fragment InputValue on __InputValue {
      name
      description
      type { ...TypeRef }
      defaultValue
      
      
    }

```

Fixes #4644.

