### PR TITLE
skip loading a diff when we just need the conflicts from it

### DIFF
--- a/backend/infrahub/core/diff/query/all_conflicts.py
+++ b/backend/infrahub/core/diff/query/all_conflicts.py
@@ -1,0 +1,58 @@
+from typing import Any, Generator
+
+from neo4j.graph import Node as Neo4jNode
+
+from infrahub.core.query import Query, QueryType
+from infrahub.database import InfrahubDatabase
+
+from ..model.path import TrackingId
+
+
+class EnrichedDiffAllConflictsQuery(Query):
+    name = "enriched_diff_all_conflicts"
+    type = QueryType.READ
+
+    def __init__(
+        self, diff_branch_name: str, tracking_id: TrackingId | None = None, diff_id: str | None = None, **kwargs: Any
+    ) -> None:
+        super().__init__(**kwargs)
+        self.diff_branch_name = diff_branch_name
+        self.tracking_id = tracking_id
+        self.diff_id = diff_id
+        if self.tracking_id is None and self.diff_id is None:
+            raise RuntimeError("tracking_id or diff_id is required")
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:
+        self.params = {
+            "diff_branch_name": self.diff_branch_name,
+            "diff_id": self.diff_id,
+            "tracking_id": self.tracking_id.serialize() if self.tracking_id else None,
+        }
+        query = """
+MATCH (root:DiffRoot)
+WHERE root.diff_branch = $diff_branch_name
+AND (root.tracking_id = $tracking_id OR $tracking_id IS NULL)
+AND (root.uuid = $diff_id OR $diff_id IS NULL)
+MATCH (root)-[:DIFF_HAS_NODE]->(node:DiffNode)-[:DIFF_HAS_CONFLICT]->(node_conflict:DiffConflict)
+RETURN node.path_identifier AS path_identifier, node_conflict AS conflict
+UNION
+MATCH (root)-[:DIFF_HAS_NODE]->(node:DiffNode)-[:DIFF_HAS_ATTRIBUTE]->(:DiffAttribute)
+    -[:DIFF_HAS_PROPERTY]->(property:DiffProperty)-[:DIFF_HAS_CONFLICT]->(attr_property_conflict:DiffConflict)
+RETURN property.path_identifier AS path_identifier, attr_property_conflict AS conflict
+UNION
+MATCH (root)-[:DIFF_HAS_NODE]->(node:DiffNode)-[:DIFF_HAS_RELATIONSHIP]->(:DiffRelationship)
+    -[:DIFF_HAS_ELEMENT]->(element:DiffRelationshipElement)-[:DIFF_HAS_CONFLICT]->(rel_element_conflict:DiffConflict)
+RETURN element.path_identifier AS path_identifier, rel_element_conflict AS conflict
+UNION
+UNION
+MATCH (root)-[:DIFF_HAS_NODE]->(node:DiffNode)-[:DIFF_HAS_RELATIONSHIP]->(:DiffRelationship)
+    -[:DIFF_HAS_ELEMENT]->(:DiffRelationshipElement)-[:DIFF_HAS_PROPERTY]->(property:DiffProperty)
+    -[:DIFF_HAS_CONFLICT]->(rel_property_conflict:DiffConflict)
+RETURN property.path_identifier AS path_identifier, rel_property_conflict AS conflict
+"""
+        self.return_labels = ["path_identifier", "conflict"]
+        self.add_to_query(query=query)
+
+    def get_conflict_paths_and_nodes(self) -> Generator[tuple[str, Neo4jNode], None, None]:
+        for result in self.get_results():
+            yield (result.get_as_type("path_identifier", str), result.get_node("conflict"))

--- a/backend/infrahub/core/diff/query/all_conflicts.py
+++ b/backend/infrahub/core/diff/query/all_conflicts.py
@@ -11,11 +11,14 @@ from ..model.path import TrackingId
 class EnrichedDiffAllConflictsQuery(Query):
     name = "enriched_diff_all_conflicts"
     type = QueryType.READ
+    insert_return = False
 
     def __init__(
         self, diff_branch_name: str, tracking_id: TrackingId | None = None, diff_id: str | None = None, **kwargs: Any
     ) -> None:
         super().__init__(**kwargs)
+        if (diff_id is None and tracking_id is None) or (diff_id and tracking_id):
+            raise ValueError("EnrichedDiffAllConflictsQuery requires one and only one of `tracking_id` or `diff_id`")
         self.diff_branch_name = diff_branch_name
         self.tracking_id = tracking_id
         self.diff_id = diff_id
@@ -43,7 +46,6 @@ UNION
 MATCH (root)-[:DIFF_HAS_NODE]->(node:DiffNode)-[:DIFF_HAS_RELATIONSHIP]->(:DiffRelationship)
     -[:DIFF_HAS_ELEMENT]->(element:DiffRelationshipElement)-[:DIFF_HAS_CONFLICT]->(rel_element_conflict:DiffConflict)
 RETURN element.path_identifier AS path_identifier, rel_element_conflict AS conflict
-UNION
 UNION
 MATCH (root)-[:DIFF_HAS_NODE]->(node:DiffNode)-[:DIFF_HAS_RELATIONSHIP]->(:DiffRelationship)
     -[:DIFF_HAS_ELEMENT]->(:DiffRelationshipElement)-[:DIFF_HAS_PROPERTY]->(property:DiffProperty)

--- a/backend/infrahub/core/diff/query/all_conflicts.py
+++ b/backend/infrahub/core/diff/query/all_conflicts.py
@@ -11,7 +11,6 @@ from ..model.path import TrackingId
 class EnrichedDiffAllConflictsQuery(Query):
     name = "enriched_diff_all_conflicts"
     type = QueryType.READ
-    insert_return = False
 
     def __init__(
         self, diff_branch_name: str, tracking_id: TrackingId | None = None, diff_id: str | None = None, **kwargs: Any
@@ -33,24 +32,29 @@ class EnrichedDiffAllConflictsQuery(Query):
         }
         query = """
 MATCH (root:DiffRoot)
-WHERE root.diff_branch = $diff_branch_name
-AND (root.tracking_id = $tracking_id OR $tracking_id IS NULL)
-AND (root.uuid = $diff_id OR $diff_id IS NULL)
-MATCH (root)-[:DIFF_HAS_NODE]->(node:DiffNode)-[:DIFF_HAS_CONFLICT]->(node_conflict:DiffConflict)
-RETURN node.path_identifier AS path_identifier, node_conflict AS conflict
-UNION
-MATCH (root)-[:DIFF_HAS_NODE]->(node:DiffNode)-[:DIFF_HAS_ATTRIBUTE]->(:DiffAttribute)
-    -[:DIFF_HAS_PROPERTY]->(property:DiffProperty)-[:DIFF_HAS_CONFLICT]->(attr_property_conflict:DiffConflict)
-RETURN property.path_identifier AS path_identifier, attr_property_conflict AS conflict
-UNION
-MATCH (root)-[:DIFF_HAS_NODE]->(node:DiffNode)-[:DIFF_HAS_RELATIONSHIP]->(:DiffRelationship)
-    -[:DIFF_HAS_ELEMENT]->(element:DiffRelationshipElement)-[:DIFF_HAS_CONFLICT]->(rel_element_conflict:DiffConflict)
-RETURN element.path_identifier AS path_identifier, rel_element_conflict AS conflict
-UNION
-MATCH (root)-[:DIFF_HAS_NODE]->(node:DiffNode)-[:DIFF_HAS_RELATIONSHIP]->(:DiffRelationship)
-    -[:DIFF_HAS_ELEMENT]->(:DiffRelationshipElement)-[:DIFF_HAS_PROPERTY]->(property:DiffProperty)
-    -[:DIFF_HAS_CONFLICT]->(rel_property_conflict:DiffConflict)
-RETURN property.path_identifier AS path_identifier, rel_property_conflict AS conflict
+WHERE ($diff_id IS NOT NULL AND root.uuid = $diff_id)
+OR ($tracking_id IS NOT NULL AND root.tracking_id = $tracking_id AND root.diff_branch = $diff_branch_name)
+CALL {
+    WITH root
+    MATCH (root)-[:DIFF_HAS_NODE]->(node:DiffNode)-[:DIFF_HAS_CONFLICT]->(node_conflict:DiffConflict)
+    RETURN node.path_identifier AS path_identifier, node_conflict AS conflict
+    UNION
+    WITH root
+    MATCH (root)-[:DIFF_HAS_NODE]->(node:DiffNode)-[:DIFF_HAS_ATTRIBUTE]->(:DiffAttribute)
+        -[:DIFF_HAS_PROPERTY]->(property:DiffProperty)-[:DIFF_HAS_CONFLICT]->(attr_property_conflict:DiffConflict)
+    RETURN property.path_identifier AS path_identifier, attr_property_conflict AS conflict
+    UNION
+    WITH root
+    MATCH (root)-[:DIFF_HAS_NODE]->(node:DiffNode)-[:DIFF_HAS_RELATIONSHIP]->(:DiffRelationship)
+        -[:DIFF_HAS_ELEMENT]->(element:DiffRelationshipElement)-[:DIFF_HAS_CONFLICT]->(rel_element_conflict:DiffConflict)
+    RETURN element.path_identifier AS path_identifier, rel_element_conflict AS conflict
+    UNION
+    WITH root
+    MATCH (root)-[:DIFF_HAS_NODE]->(node:DiffNode)-[:DIFF_HAS_RELATIONSHIP]->(:DiffRelationship)
+        -[:DIFF_HAS_ELEMENT]->(:DiffRelationshipElement)-[:DIFF_HAS_PROPERTY]->(property:DiffProperty)
+        -[:DIFF_HAS_CONFLICT]->(rel_property_conflict:DiffConflict)
+    RETURN property.path_identifier AS path_identifier, rel_property_conflict AS conflict
+}
 """
         self.return_labels = ["path_identifier", "conflict"]
         self.add_to_query(query=query)

--- a/backend/infrahub/core/diff/repository/repository.py
+++ b/backend/infrahub/core/diff/repository/repository.py
@@ -1,4 +1,4 @@
-from typing import Generator
+from typing import AsyncGenerator, Generator
 
 from infrahub import config
 from infrahub.core import registry
@@ -22,6 +22,7 @@ from ..model.path import (
     TimeRange,
     TrackingId,
 )
+from ..query.all_conflicts import EnrichedDiffAllConflictsQuery
 from ..query.delete_query import EnrichedDiffDeleteQuery
 from ..query.diff_get import EnrichedDiffGetQuery
 from ..query.diff_summary import DiffSummaryCounters, DiffSummaryQuery
@@ -317,6 +318,19 @@ class DiffRepository:
         if not conflict_node:
             raise ResourceNotFoundError(f"No conflict with id {conflict_id}")
         return self.deserializer.deserialize_conflict(diff_conflict_node=conflict_node)
+
+    async def get_all_conflicts_for_diff(
+        self,
+        diff_branch_name: str,
+        tracking_id: TrackingId | None = None,
+        diff_id: str | None = None,
+    ) -> AsyncGenerator[tuple[str, EnrichedDiffConflict], None]:
+        query = await EnrichedDiffAllConflictsQuery.init(
+            db=self.db, diff_branch_name=diff_branch_name, tracking_id=tracking_id, diff_id=diff_id
+        )
+        await query.execute(db=self.db)
+        for conflict_path, conflict_node in query.get_conflict_paths_and_nodes():
+            yield (conflict_path, self.deserializer.deserialize_conflict(diff_conflict_node=conflict_node))
 
     async def get_node_field_summaries(
         self, diff_branch_name: str, tracking_id: TrackingId | None = None, diff_id: str | None = None

--- a/backend/infrahub/core/merge.py
+++ b/backend/infrahub/core/merge.py
@@ -177,14 +177,16 @@ class BranchMerger:
         if self.source_branch.name == registry.default_branch:
             raise ValidationError(f"Unable to merge the branch '{self.source_branch.name}' into itself")
 
-        log.debug("Updating diff for merge")
-        enriched_diff = await self.diff_coordinator.update_branch_diff_and_return(
+        log.info("Updating diff for merge")
+        await self.diff_coordinator.update_branch_diff(
             base_branch=self.destination_branch, diff_branch=self.source_branch
         )
-        log.debug("Diff updated for merge")
-        conflict_map = enriched_diff.get_all_conflicts()
+        log.info("Diff updated for merge")
+
         errors: list[str] = []
-        for conflict_path, conflict in conflict_map.items():
+        async for conflict_path, conflict in self.diff_repository.get_all_conflicts_for_diff(
+            diff_branch_name=self.source_branch.name, tracking_id=BranchTrackingId(name=self.source_branch.name)
+        ):
             if conflict.selected_branch is None or conflict.resolvable is False:
                 errors.append(conflict_path)
 

--- a/backend/tests/unit/core/diff/test_diff_get_all_conflicts.py
+++ b/backend/tests/unit/core/diff/test_diff_get_all_conflicts.py
@@ -1,0 +1,188 @@
+import pytest
+
+from infrahub.core.branch.models import Branch
+from infrahub.core.diff.model.path import (
+    BranchTrackingId,
+    EnrichedDiffs,
+)
+from infrahub.core.diff.repository.deserializer import EnrichedDiffDeserializer
+from infrahub.core.diff.repository.repository import DiffRepository
+from infrahub.core.utils import delete_all_nodes
+from infrahub.database import InfrahubDatabase
+
+from .factories import (
+    EnrichedAttributeFactory,
+    EnrichedConflictFactory,
+    EnrichedNodeFactory,
+    EnrichedPropertyFactory,
+    EnrichedRelationshipElementFactory,
+    EnrichedRelationshipGroupFactory,
+    EnrichedRootFactory,
+)
+
+
+class TestDiffGetAllConflicts:
+    @pytest.fixture(autouse=True, scope="function")
+    async def reset_database(self, db: InfrahubDatabase, default_branch: Branch):
+        await delete_all_nodes(db=db)
+
+    @pytest.fixture
+    def diff_repository(self, db: InfrahubDatabase) -> DiffRepository:
+        return DiffRepository(db=db, deserializer=EnrichedDiffDeserializer())
+
+    def _get_enriched_diffs(self) -> EnrichedDiffs:
+        branch_diff_root = EnrichedRootFactory.build(
+            base_branch_name="main", nodes={EnrichedNodeFactory.build() for _ in range(3)}
+        )
+        tracking_id = BranchTrackingId(name=branch_diff_root.diff_branch_name)
+        branch_diff_root.tracking_id = tracking_id
+        base_diff_root = EnrichedRootFactory.build(
+            base_branch_name="main",
+            diff_branch_name="main",
+            partner_uuid=branch_diff_root.partner_uuid,
+            tracking_id=tracking_id,
+        )
+        return EnrichedDiffs(
+            base_branch_name="main",
+            diff_branch_name=branch_diff_root.diff_branch_name,
+            diff_branch_diff=branch_diff_root,
+            base_branch_diff=base_diff_root,
+        )
+
+    async def test_query_initialization_failure(self, diff_repository: DiffRepository):
+        with pytest.raises(ValueError, match=r"requires one and only one of `tracking_id` or `diff_id`"):
+            [_ async for _ in diff_repository.get_all_conflicts_for_diff(diff_branch_name="a")]
+
+        with pytest.raises(ValueError, match=r"requires one and only one of `tracking_id` or `diff_id`"):
+            [
+                _
+                async for _ in diff_repository.get_all_conflicts_for_diff(
+                    diff_branch_name="a", tracking_id=BranchTrackingId(name="abc"), diff_id="123"
+                )
+            ]
+
+    async def test_no_conflicts(self, diff_repository: DiffRepository):
+        enriched_diffs = self._get_enriched_diffs()
+        await diff_repository.save(enriched_diffs=enriched_diffs)
+
+        conflicts = {
+            x: y
+            async for x, y in diff_repository.get_all_conflicts_for_diff(
+                diff_branch_name=enriched_diffs.diff_branch_name,
+                tracking_id=BranchTrackingId(name=enriched_diffs.diff_branch_name),
+            )
+        }
+        assert conflicts == {}
+
+    async def test_get_node_level_conflict(self, diff_repository: DiffRepository):
+        enriched_diffs = self._get_enriched_diffs()
+        node = enriched_diffs.diff_branch_diff.nodes.pop()
+        node.conflict = EnrichedConflictFactory.build()
+        enriched_diffs.diff_branch_diff.nodes.add(node)
+        await diff_repository.save(enriched_diffs=enriched_diffs)
+
+        conflicts_map = {
+            path_str: conflict
+            async for path_str, conflict in diff_repository.get_all_conflicts_for_diff(
+                diff_branch_name=enriched_diffs.diff_branch_name,
+                tracking_id=BranchTrackingId(name=enriched_diffs.diff_branch_name),
+            )
+        }
+        assert len(conflicts_map) == 1
+        assert conflicts_map == {node.path_identifier: node.conflict}
+
+        conflicts_map = {
+            path_str: conflict
+            async for path_str, conflict in diff_repository.get_all_conflicts_for_diff(
+                diff_branch_name=enriched_diffs.diff_branch_name, diff_id=enriched_diffs.diff_branch_diff.uuid
+            )
+        }
+        assert len(conflicts_map) == 1
+        assert conflicts_map == {node.path_identifier: node.conflict}
+
+    async def test_get_attribute_level_conflict(self, diff_repository: DiffRepository):
+        enriched_diffs = self._get_enriched_diffs()
+        node = enriched_diffs.diff_branch_diff.nodes.pop()
+        diff_prop = EnrichedPropertyFactory.build(conflict=EnrichedConflictFactory.build())
+        diff_attr = EnrichedAttributeFactory.build(properties={diff_prop})
+        node.attributes.add(diff_attr)
+        enriched_diffs.diff_branch_diff.nodes.add(node)
+        await diff_repository.save(enriched_diffs=enriched_diffs)
+
+        conflicts_map = {
+            path_str: conflict
+            async for path_str, conflict in diff_repository.get_all_conflicts_for_diff(
+                diff_branch_name=enriched_diffs.diff_branch_name,
+                tracking_id=BranchTrackingId(name=enriched_diffs.diff_branch_name),
+            )
+        }
+        assert len(conflicts_map) == 1
+        assert conflicts_map == {diff_prop.path_identifier: diff_prop.conflict}
+
+        conflicts_map = {
+            path_str: conflict
+            async for path_str, conflict in diff_repository.get_all_conflicts_for_diff(
+                diff_branch_name=enriched_diffs.diff_branch_name, diff_id=enriched_diffs.diff_branch_diff.uuid
+            )
+        }
+        assert len(conflicts_map) == 1
+        assert conflicts_map == {diff_prop.path_identifier: diff_prop.conflict}
+
+    async def test_get_relationship_level_conflicts(self, diff_repository: DiffRepository):
+        enriched_diffs = self._get_enriched_diffs()
+        node = enriched_diffs.diff_branch_diff.nodes.pop()
+        diff_rel_element = EnrichedRelationshipElementFactory.build(conflict=EnrichedConflictFactory.build())
+        diff_rel = EnrichedRelationshipGroupFactory.build(relationships={diff_rel_element})
+        node.relationships.add(diff_rel)
+        enriched_diffs.diff_branch_diff.nodes.add(node)
+        await diff_repository.save(enriched_diffs=enriched_diffs)
+
+        conflicts_map = {
+            path_str: conflict
+            async for path_str, conflict in diff_repository.get_all_conflicts_for_diff(
+                diff_branch_name=enriched_diffs.diff_branch_name,
+                tracking_id=BranchTrackingId(name=enriched_diffs.diff_branch_name),
+            )
+        }
+        assert len(conflicts_map) == 1
+        assert conflicts_map == {diff_rel_element.path_identifier: diff_rel_element.conflict}
+
+        conflicts_map = {
+            path_str: conflict
+            async for path_str, conflict in diff_repository.get_all_conflicts_for_diff(
+                diff_branch_name=enriched_diffs.diff_branch_name, diff_id=enriched_diffs.diff_branch_diff.uuid
+            )
+        }
+        assert len(conflicts_map) == 1
+        assert conflicts_map == {diff_rel_element.path_identifier: diff_rel_element.conflict}
+
+    async def test_get_relationship_property_level_conflicts(self, diff_repository: DiffRepository):
+        enriched_diffs = self._get_enriched_diffs()
+        node = enriched_diffs.diff_branch_diff.nodes.pop()
+        diff_prop = EnrichedPropertyFactory.build(conflict=EnrichedConflictFactory.build())
+        node.relationships.add(
+            EnrichedRelationshipGroupFactory.build(
+                relationships={EnrichedRelationshipElementFactory.build(properties={diff_prop})}
+            )
+        )
+        enriched_diffs.diff_branch_diff.nodes.add(node)
+        await diff_repository.save(enriched_diffs=enriched_diffs)
+
+        conflicts_map = {
+            path_str: conflict
+            async for path_str, conflict in diff_repository.get_all_conflicts_for_diff(
+                diff_branch_name=enriched_diffs.diff_branch_name,
+                tracking_id=BranchTrackingId(name=enriched_diffs.diff_branch_name),
+            )
+        }
+        assert len(conflicts_map) == 1
+        assert conflicts_map == {diff_prop.path_identifier: diff_prop.conflict}
+
+        conflicts_map = {
+            path_str: conflict
+            async for path_str, conflict in diff_repository.get_all_conflicts_for_diff(
+                diff_branch_name=enriched_diffs.diff_branch_name, diff_id=enriched_diffs.diff_branch_diff.uuid
+            )
+        }
+        assert len(conflicts_map) == 1
+        assert conflicts_map == {diff_prop.path_identifier: diff_prop.conflict}

--- a/backend/tests/unit/core/diff/test_diff_get_all_conflicts.py
+++ b/backend/tests/unit/core/diff/test_diff_get_all_conflicts.py
@@ -1,13 +1,11 @@
 import pytest
 
-from infrahub.core.branch.models import Branch
 from infrahub.core.diff.model.path import (
     BranchTrackingId,
     EnrichedDiffs,
 )
 from infrahub.core.diff.repository.deserializer import EnrichedDiffDeserializer
 from infrahub.core.diff.repository.repository import DiffRepository
-from infrahub.core.utils import delete_all_nodes
 from infrahub.database import InfrahubDatabase
 
 from .factories import (
@@ -22,10 +20,6 @@ from .factories import (
 
 
 class TestDiffGetAllConflicts:
-    @pytest.fixture(autouse=True, scope="function")
-    async def reset_database(self, db: InfrahubDatabase, default_branch: Branch):
-        await delete_all_nodes(db=db)
-
     @pytest.fixture
     def diff_repository(self, db: InfrahubDatabase) -> DiffRepository:
         return DiffRepository(db=db, deserializer=EnrichedDiffDeserializer())


### PR DESCRIPTION
should help performance when merging a branch b/c it allows us to skip loading the whole diff to check if there are any conflicts. for a small diff, this does not really matter, but for a huge diff, skipping loading the whole diff makes a big difference