### PR TITLE
limit attributes/relationship diffs

### DIFF
--- a/backend/infrahub/core/diff/calculator.py
+++ b/backend/infrahub/core/diff/calculator.py
@@ -7,7 +7,7 @@ from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.log import get_logger
 
-from .model.path import CalculatedDiffs, NodeFieldSpecifier
+from .model.path import CalculatedDiffs
 
 log = get_logger()
 
@@ -23,7 +23,7 @@ class DiffCalculator:
         from_time: Timestamp,
         to_time: Timestamp,
         include_unchanged: bool = True,
-        previous_node_specifiers: set[NodeFieldSpecifier] | None = None,
+        previous_node_specifiers: dict[str, set[str]] | None = None,
     ) -> CalculatedDiffs:
         if diff_branch.name == registry.default_branch:
             diff_branch_from_time = from_time
@@ -124,10 +124,8 @@ class DiffCalculator:
                     diff_branch_from_time=diff_branch_from_time,
                     diff_from=from_time,
                     diff_to=to_time,
-                    current_node_field_specifiers=[
-                        (nfs.node_uuid, nfs.field_name) for nfs in current_node_field_specifiers
-                    ],
-                    new_node_field_specifiers=[(nfs.node_uuid, nfs.field_name) for nfs in new_node_field_specifiers],
+                    current_node_field_specifiers=current_node_field_specifiers,
+                    new_node_field_specifiers=new_node_field_specifiers,
                     limit=node_limit,
                     offset=offset,
                 )
@@ -155,10 +153,8 @@ class DiffCalculator:
                     diff_branch_from_time=diff_branch_from_time,
                     diff_from=from_time,
                     diff_to=to_time,
-                    current_node_field_specifiers=[
-                        (nfs.node_uuid, nfs.field_name) for nfs in current_node_field_specifiers
-                    ],
-                    new_node_field_specifiers=[(nfs.node_uuid, nfs.field_name) for nfs in new_node_field_specifiers],
+                    current_node_field_specifiers=current_node_field_specifiers,
+                    new_node_field_specifiers=new_node_field_specifiers,
                     limit=fields_limit,
                     offset=offset,
                 )
@@ -176,6 +172,14 @@ class DiffCalculator:
                     has_more_data = query_result.get_as_type("has_more_data", bool)
                 offset += node_limit
 
+            # Temporary until next change
+            current_node_field_specifier_tuples: list[tuple[str, str]] = []
+            new_node_field_specifier_tuples: list[tuple[str, str]] = []
+            for node_uuid, field_names in current_node_field_specifiers.items():
+                current_node_field_specifier_tuples.extend((node_uuid, field_name) for field_name in field_names)
+            for node_uuid, field_names in new_node_field_specifiers.items():
+                new_node_field_specifier_tuples.extend((node_uuid, field_name) for field_name in field_names)
+
             base_diff_query = await DiffAllPathsQuery.init(
                 db=self.db,
                 branch=base_branch,
@@ -183,10 +187,8 @@ class DiffCalculator:
                 diff_branch_from_time=diff_branch_from_time,
                 diff_from=from_time,
                 diff_to=to_time,
-                current_node_field_specifiers=[
-                    (nfs.node_uuid, nfs.field_name) for nfs in current_node_field_specifiers
-                ],
-                new_node_field_specifiers=[(nfs.node_uuid, nfs.field_name) for nfs in new_node_field_specifiers],
+                current_node_field_specifiers=current_node_field_specifier_tuples,
+                new_node_field_specifiers=new_node_field_specifier_tuples,
             )
 
             log.info("Beginning diff calculation query for base")

--- a/backend/infrahub/core/diff/calculator.py
+++ b/backend/infrahub/core/diff/calculator.py
@@ -1,8 +1,10 @@
+from dataclasses import dataclass, field
+
 from infrahub import config
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.diff.query_parser import DiffQueryParser
-from infrahub.core.query.diff import DiffAllPathsQuery, DiffFieldPathsQuery, DiffNodePathsQuery
+from infrahub.core.query.diff import DiffAllPathsQuery, DiffCalculationQuery, DiffFieldPathsQuery, DiffNodePathsQuery
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.log import get_logger
@@ -12,9 +14,54 @@ from .model.path import CalculatedDiffs
 log = get_logger()
 
 
+@dataclass
+class DiffCalculationRequest:
+    base_branch: Branch
+    diff_branch: Branch
+    branch_from_time: Timestamp
+    from_time: Timestamp
+    to_time: Timestamp
+    current_node_field_specifiers: dict[str, set[str]] | None = field(default=None)
+    new_node_field_specifiers: dict[str, set[str]] | None = field(default=None)
+
+
 class DiffCalculator:
     def __init__(self, db: InfrahubDatabase) -> None:
         self.db = db
+
+    async def _run_diff_calculation_query(
+        self,
+        diff_parser: DiffQueryParser,
+        query_class: type[DiffCalculationQuery],
+        calculation_request: DiffCalculationRequest,
+        limit: int,
+    ) -> None:
+        has_more_data = True
+        offset = 0
+        while has_more_data:
+            diff_query = await query_class.init(
+                db=self.db,
+                branch=calculation_request.diff_branch,
+                base_branch=calculation_request.base_branch,
+                diff_branch_from_time=calculation_request.branch_from_time,
+                diff_from=calculation_request.from_time,
+                diff_to=calculation_request.to_time,
+                current_node_field_specifiers=calculation_request.current_node_field_specifiers,
+                new_node_field_specifiers=calculation_request.new_node_field_specifiers,
+                limit=limit,
+                offset=offset,
+            )
+            log.info(f"Beginning one diff calculation query {limit=}, {offset=}")
+            await diff_query.execute(db=self.db)
+            log.info("Diff calculation query complete")
+            last_result = None
+            for query_result in diff_query.get_results():
+                diff_parser.read_result(query_result=query_result)
+                last_result = query_result
+            has_more_data = False
+            if last_result:
+                has_more_data = last_result.get_as_type("has_more_data", bool)
+            offset += limit
 
     async def calculate_diff(
         self,
@@ -40,59 +87,31 @@ class DiffCalculator:
         node_limit = int(config.SETTINGS.database.query_size_limit / 10)
         fields_limit = int(config.SETTINGS.database.query_size_limit / 3)
 
-        has_more_data = True
-        offset = 0
-        while has_more_data:
-            branch_diff_nodes_query = await DiffNodePathsQuery.init(
-                db=self.db,
-                branch=diff_branch,
-                base_branch=base_branch,
-                diff_branch_from_time=diff_branch_from_time,
-                diff_from=from_time,
-                diff_to=to_time,
-                limit=node_limit,
-                offset=offset,
-            )
-            log.info(f"Beginning diff node-level calculation query for branch {node_limit=}, {offset=}")
-            await branch_diff_nodes_query.execute(db=self.db)
-            log.info("Diff node-level calculation query for branch complete")
-            last_result = None
-            log.info("Reading node-level results of query for branch")
-            for query_result in branch_diff_nodes_query.get_results():
-                diff_parser.read_result(query_result=query_result)
-                last_result = query_result
-            log.info("Results of node-level query for branch read")
-            has_more_data = False
-            if last_result:
-                has_more_data = last_result.get_as_type("has_more_data", bool)
-            offset += node_limit
+        calculation_request = DiffCalculationRequest(
+            base_branch=base_branch,
+            diff_branch=diff_branch,
+            branch_from_time=diff_branch_from_time,
+            from_time=from_time,
+            to_time=to_time,
+        )
 
-        has_more_data = True
-        offset = 0
-        while has_more_data:
-            branch_diff_fields_query = await DiffFieldPathsQuery.init(
-                db=self.db,
-                branch=diff_branch,
-                base_branch=base_branch,
-                diff_branch_from_time=diff_branch_from_time,
-                diff_from=from_time,
-                diff_to=to_time,
-                limit=fields_limit,
-                offset=offset,
-            )
-            log.info(f"Beginning diff field-level calculation query for branch {fields_limit=}, {offset=}")
-            await branch_diff_fields_query.execute(db=self.db)
-            log.info("Diff field-level calculation query for branch complete")
-            last_result = None
-            log.info("Reading field-level results of query for branch")
-            for query_result in branch_diff_fields_query.get_results():
-                diff_parser.read_result(query_result=query_result)
-                last_result = query_result
-            log.info("Results of field-level query for branch read")
-            has_more_data = False
-            if last_result:
-                has_more_data = last_result.get_as_type("has_more_data", bool)
-            offset += node_limit
+        log.info("Beginning diff node-level calculation queries for branch")
+        await self._run_diff_calculation_query(
+            diff_parser=diff_parser,
+            query_class=DiffNodePathsQuery,
+            calculation_request=calculation_request,
+            limit=node_limit,
+        )
+        log.info("Diff node-level calculation queries for branch complete")
+
+        log.info("Beginning diff field-level calculation queries for branch")
+        await self._run_diff_calculation_query(
+            diff_parser=diff_parser,
+            query_class=DiffFieldPathsQuery,
+            calculation_request=calculation_request,
+            limit=fields_limit,
+        )
+        log.info("Diff field-level calculation queries for branch complete")
 
         branch_diff_query = await DiffAllPathsQuery.init(
             db=self.db,
@@ -111,66 +130,35 @@ class DiffCalculator:
         log.info("Results of query for branch read")
 
         if base_branch.name != diff_branch.name:
-            new_node_field_specifiers = diff_parser.get_new_node_field_specifiers()
             current_node_field_specifiers = diff_parser.get_current_node_field_specifiers()
+            new_node_field_specifiers = diff_parser.get_new_node_field_specifiers()
+            calculation_request = DiffCalculationRequest(
+                base_branch=base_branch,
+                diff_branch=base_branch,
+                branch_from_time=diff_branch_from_time,
+                from_time=from_time,
+                to_time=to_time,
+                current_node_field_specifiers=current_node_field_specifiers,
+                new_node_field_specifiers=new_node_field_specifiers,
+            )
 
-            has_more_data = True
-            offset = 0
-            while has_more_data:
-                base_diff_nodes_query = await DiffNodePathsQuery.init(
-                    db=self.db,
-                    branch=base_branch,
-                    base_branch=base_branch,
-                    diff_branch_from_time=diff_branch_from_time,
-                    diff_from=from_time,
-                    diff_to=to_time,
-                    current_node_field_specifiers=current_node_field_specifiers,
-                    new_node_field_specifiers=new_node_field_specifiers,
-                    limit=node_limit,
-                    offset=offset,
-                )
-                log.info(f"Beginning diff node-level calculation query for base {node_limit=}, {offset=}")
-                await base_diff_nodes_query.execute(db=self.db)
-                log.info("Diff node-level calculation query for base complete")
-                last_result = None
-                log.info("Reading field-level results of query for base")
-                for query_result in base_diff_nodes_query.get_results():
-                    diff_parser.read_result(query_result=query_result)
-                    last_result = query_result
-                log.info("Results of node-level query for base read")
-                has_more_data = False
-                if last_result:
-                    has_more_data = query_result.get_as_type("has_more_data", bool)
-                offset += node_limit
+            log.info("Beginning diff node-level calculation queries for base")
+            await self._run_diff_calculation_query(
+                diff_parser=diff_parser,
+                query_class=DiffNodePathsQuery,
+                calculation_request=calculation_request,
+                limit=node_limit,
+            )
+            log.info("Diff node-level calculation queries for base complete")
 
-            has_more_data = True
-            offset = 0
-            while has_more_data:
-                base_diff_fields_query = await DiffFieldPathsQuery.init(
-                    db=self.db,
-                    branch=base_branch,
-                    base_branch=base_branch,
-                    diff_branch_from_time=diff_branch_from_time,
-                    diff_from=from_time,
-                    diff_to=to_time,
-                    current_node_field_specifiers=current_node_field_specifiers,
-                    new_node_field_specifiers=new_node_field_specifiers,
-                    limit=fields_limit,
-                    offset=offset,
-                )
-                log.info(f"Beginning diff field-level calculation query for base {fields_limit=}, {offset=}")
-                await base_diff_fields_query.execute(db=self.db)
-                log.info("Diff field-level calculation query for base complete")
-                last_result = None
-                log.info("Reading field-level results of query for base")
-                for query_result in base_diff_fields_query.get_results():
-                    diff_parser.read_result(query_result=query_result)
-                    last_result = query_result
-                log.info("Results of field-level query for base read")
-                has_more_data = False
-                if last_result:
-                    has_more_data = query_result.get_as_type("has_more_data", bool)
-                offset += node_limit
+            log.info("Beginning diff field-level calculation queries for base")
+            await self._run_diff_calculation_query(
+                diff_parser=diff_parser,
+                query_class=DiffFieldPathsQuery,
+                calculation_request=calculation_request,
+                limit=fields_limit,
+            )
+            log.info("Diff field-level calculation queries for base complete")
 
             # Temporary until next change
             current_node_field_specifier_tuples: list[tuple[str, str]] = []

--- a/backend/infrahub/core/diff/calculator.py
+++ b/backend/infrahub/core/diff/calculator.py
@@ -2,7 +2,7 @@ from infrahub import config
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.diff.query_parser import DiffQueryParser
-from infrahub.core.query.diff import DiffAllPathsQuery, DiffNodePathsQuery
+from infrahub.core.query.diff import DiffAllPathsQuery, DiffFieldPathsQuery, DiffNodePathsQuery
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.log import get_logger
@@ -38,6 +38,7 @@ class DiffCalculator:
             previous_node_field_specifiers=previous_node_specifiers,
         )
         node_limit = int(config.SETTINGS.database.query_size_limit / 10)
+        fields_limit = int(config.SETTINGS.database.query_size_limit / 3)
 
         has_more_data = True
         offset = 0
@@ -55,6 +56,29 @@ class DiffCalculator:
             await branch_diff_nodes_query.execute(db=self.db)
             last_result = None
             for query_result in branch_diff_nodes_query.get_results():
+                diff_parser.read_result(query_result=query_result)
+                last_result = query_result
+            has_more_data = False
+            if last_result:
+                has_more_data = last_result.get_as_type("has_more_data", bool)
+            offset += node_limit
+
+        has_more_data = True
+        offset = 0
+        while has_more_data:
+            branch_diff_fields_query = await DiffFieldPathsQuery.init(
+                db=self.db,
+                branch=diff_branch,
+                base_branch=base_branch,
+                diff_branch_from_time=diff_branch_from_time,
+                diff_from=from_time,
+                diff_to=to_time,
+                limit=fields_limit,
+                offset=offset,
+            )
+            await branch_diff_fields_query.execute(db=self.db)
+            last_result = None
+            for query_result in branch_diff_fields_query.get_results():
                 diff_parser.read_result(query_result=query_result)
                 last_result = query_result
             has_more_data = False
@@ -102,6 +126,33 @@ class DiffCalculator:
                 await base_diff_nodes_query.execute(db=self.db)
                 last_result = None
                 for query_result in base_diff_nodes_query.get_results():
+                    diff_parser.read_result(query_result=query_result)
+                    last_result = query_result
+                has_more_data = False
+                if last_result:
+                    has_more_data = query_result.get_as_type("has_more_data", bool)
+                offset += node_limit
+
+            has_more_data = True
+            offset = 0
+            while has_more_data:
+                base_diff_fields_query = await DiffFieldPathsQuery.init(
+                    db=self.db,
+                    branch=base_branch,
+                    base_branch=base_branch,
+                    diff_branch_from_time=diff_branch_from_time,
+                    diff_from=from_time,
+                    diff_to=to_time,
+                    current_node_field_specifiers=[
+                        (nfs.node_uuid, nfs.field_name) for nfs in current_node_field_specifiers
+                    ],
+                    new_node_field_specifiers=[(nfs.node_uuid, nfs.field_name) for nfs in new_node_field_specifiers],
+                    limit=fields_limit,
+                    offset=offset,
+                )
+                await base_diff_fields_query.execute(db=self.db)
+                last_result = None
+                for query_result in base_diff_fields_query.get_results():
                     diff_parser.read_result(query_result=query_result)
                     last_result = query_result
                 has_more_data = False

--- a/backend/infrahub/core/diff/calculator.py
+++ b/backend/infrahub/core/diff/calculator.py
@@ -53,11 +53,15 @@ class DiffCalculator:
                 limit=node_limit,
                 offset=offset,
             )
+            log.info(f"Beginning diff node-level calculation query for branch {node_limit=}, {offset=}")
             await branch_diff_nodes_query.execute(db=self.db)
+            log.info("Diff node-level calculation query for branch complete")
             last_result = None
+            log.info("Reading node-level results of query for branch")
             for query_result in branch_diff_nodes_query.get_results():
                 diff_parser.read_result(query_result=query_result)
                 last_result = query_result
+            log.info("Results of node-level query for branch read")
             has_more_data = False
             if last_result:
                 has_more_data = last_result.get_as_type("has_more_data", bool)
@@ -76,11 +80,15 @@ class DiffCalculator:
                 limit=fields_limit,
                 offset=offset,
             )
+            log.info(f"Beginning diff field-level calculation query for branch {fields_limit=}, {offset=}")
             await branch_diff_fields_query.execute(db=self.db)
+            log.info("Diff field-level calculation query for branch complete")
             last_result = None
+            log.info("Reading field-level results of query for branch")
             for query_result in branch_diff_fields_query.get_results():
                 diff_parser.read_result(query_result=query_result)
                 last_result = query_result
+            log.info("Results of field-level query for branch read")
             has_more_data = False
             if last_result:
                 has_more_data = last_result.get_as_type("has_more_data", bool)
@@ -123,11 +131,15 @@ class DiffCalculator:
                     limit=node_limit,
                     offset=offset,
                 )
+                log.info(f"Beginning diff node-level calculation query for base {node_limit=}, {offset=}")
                 await base_diff_nodes_query.execute(db=self.db)
+                log.info("Diff node-level calculation query for base complete")
                 last_result = None
+                log.info("Reading field-level results of query for base")
                 for query_result in base_diff_nodes_query.get_results():
                     diff_parser.read_result(query_result=query_result)
                     last_result = query_result
+                log.info("Results of node-level query for base read")
                 has_more_data = False
                 if last_result:
                     has_more_data = query_result.get_as_type("has_more_data", bool)
@@ -150,11 +162,15 @@ class DiffCalculator:
                     limit=fields_limit,
                     offset=offset,
                 )
+                log.info(f"Beginning diff field-level calculation query for base {fields_limit=}, {offset=}")
                 await base_diff_fields_query.execute(db=self.db)
+                log.info("Diff field-level calculation query for base complete")
                 last_result = None
+                log.info("Reading field-level results of query for base")
                 for query_result in base_diff_fields_query.get_results():
                     diff_parser.read_result(query_result=query_result)
                     last_result = query_result
+                log.info("Results of field-level query for base read")
                 has_more_data = False
                 if last_result:
                     has_more_data = query_result.get_as_type("has_more_data", bool)

--- a/backend/infrahub/core/diff/coordinator.py
+++ b/backend/infrahub/core/diff/coordinator.py
@@ -15,7 +15,6 @@ from .model.path import (
     EnrichedDiffs,
     EnrichedDiffsMetadata,
     NameTrackingId,
-    NodeFieldSpecifier,
     TrackingId,
 )
 
@@ -44,7 +43,7 @@ class EnrichedDiffRequest:
     from_time: Timestamp
     to_time: Timestamp
     tracking_id: TrackingId | None = field(default=None)
-    node_field_specifiers: set[NodeFieldSpecifier] = field(default_factory=set)
+    node_field_specifiers: dict[str, set[str]] = field(default_factory=dict)
 
     def __repr__(self) -> str:
         return (

--- a/backend/infrahub/core/diff/model/path.py
+++ b/backend/infrahub/core/diff/model/path.py
@@ -83,15 +83,6 @@ def deserialize_tracking_id(tracking_id_str: str) -> TrackingId:
 
 
 @dataclass
-class NodeFieldSpecifier:
-    node_uuid: str
-    field_name: str
-
-    def __hash__(self) -> int:
-        return hash(f"{self.node_uuid}:{self.field_name}")
-
-
-@dataclass
 class NodeDiffFieldSummary:
     kind: str
     attribute_names: set[str] = field(default_factory=set)

--- a/backend/infrahub/core/diff/query_parser.py
+++ b/backend/infrahub/core/diff/query_parser.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Optional
 from uuid import uuid4
@@ -22,7 +23,6 @@ from .model.path import (
     DiffRelationship,
     DiffRoot,
     DiffSingleRelationship,
-    NodeFieldSpecifier,
 )
 
 if TYPE_CHECKING:
@@ -459,7 +459,7 @@ class DiffQueryParser:
         schema_manager: SchemaManager,
         from_time: Timestamp,
         to_time: Optional[Timestamp] = None,
-        previous_node_field_specifiers: set[NodeFieldSpecifier] | None = None,
+        previous_node_field_specifiers: dict[str, set[str]] | None = None,
     ) -> None:
         self.base_branch_name = base_branch.name
         self.diff_branch_name = diff_branch.name
@@ -473,7 +473,9 @@ class DiffQueryParser:
             self.diff_branched_from_time = Timestamp(diff_branch.get_branched_from())
         self._diff_root_by_branch: dict[str, DiffRootIntermediate] = {}
         self._final_diff_root_by_branch: dict[str, DiffRoot] = {}
-        self._previous_node_field_specifiers = previous_node_field_specifiers or set()
+        self._previous_node_field_specifiers = previous_node_field_specifiers or {}
+        self._new_node_field_specifiers: dict[str, set[str]] | None = None
+        self._current_node_field_specifiers: dict[str, set[str]] | None = None
 
     def get_branches(self) -> set[str]:
         return set(self._final_diff_root_by_branch.keys())
@@ -485,38 +487,59 @@ class DiffQueryParser:
             return self._final_diff_root_by_branch[branch]
         return DiffRoot(from_time=self.from_time, to_time=self.to_time, uuid=str(uuid4()), branch=branch, nodes=[])
 
-    def get_diff_node_field_specifiers(self) -> set[NodeFieldSpecifier]:
+    def get_diff_node_field_specifiers(self) -> dict[str, set[str]]:
         if self.diff_branch_name not in self._diff_root_by_branch:
-            return set()
-        node_field_specifiers: set[NodeFieldSpecifier] = set()
+            return {}
+        node_field_specifiers_map: dict[str, set[str]] = defaultdict(set)
         diff_root = self._diff_root_by_branch[self.diff_branch_name]
         for node in diff_root.nodes_by_id.values():
-            node_field_specifiers.update(
-                NodeFieldSpecifier(node_uuid=node.uuid, field_name=attribute_name)
-                for attribute_name in node.attributes_by_name
-            )
-            node_field_specifiers.update(
-                NodeFieldSpecifier(node_uuid=node.uuid, field_name=relationship_diff.identifier)
-                for relationship_diff in node.relationships_by_name.values()
-            )
-        return node_field_specifiers
+            for attribute_name in node.attributes_by_name:
+                node_field_specifiers_map[node.uuid].add(attribute_name)
+            for relationship_diff in node.relationships_by_name.values():
+                node_field_specifiers_map[node.uuid].add(relationship_diff.identifier)
+        return node_field_specifiers_map
 
-    def get_new_node_field_specifiers(self) -> set[NodeFieldSpecifier]:
+    def _remove_node_specifiers(
+        self, node_specifiers: dict[str, set[str]], node_specifiers_to_remove: dict[str, set[str]]
+    ) -> dict[str, set[str]]:
+        final_node_specifiers: dict[str, set[str]] = defaultdict(set)
+        for node_uuid, field_names_set in node_specifiers.items():
+            specifiers_to_remove = node_specifiers_to_remove.get(node_uuid, set())
+            final_specifiers = field_names_set - specifiers_to_remove
+            if final_specifiers:
+                final_node_specifiers[node_uuid] = final_specifiers
+        return final_node_specifiers
+
+    def get_new_node_field_specifiers(self) -> dict[str, set[str]]:
+        if self._new_node_field_specifiers is not None:
+            return self._new_node_field_specifiers
         branch_node_specifiers = self.get_diff_node_field_specifiers()
-        new_node_field_specifiers = branch_node_specifiers - self._previous_node_field_specifiers
+        new_node_field_specifiers = self._remove_node_specifiers(
+            branch_node_specifiers, self._previous_node_field_specifiers
+        )
+        self._new_node_field_specifiers = new_node_field_specifiers
         return new_node_field_specifiers
 
-    def get_current_node_field_specifiers(self) -> set[NodeFieldSpecifier]:
+    def get_current_node_field_specifiers(self) -> dict[str, set[str]]:
+        if self._current_node_field_specifiers is not None:
+            return self._current_node_field_specifiers
         new_node_field_specifiers = self.get_new_node_field_specifiers()
-        current_node_field_specifiers = self._previous_node_field_specifiers - new_node_field_specifiers
+        current_node_field_specifiers = self._remove_node_specifiers(
+            self._previous_node_field_specifiers, new_node_field_specifiers
+        )
+        self._current_node_field_specifiers = current_node_field_specifiers
         return current_node_field_specifiers
 
     def read_result(self, query_result: QueryResult) -> None:
         path = query_result.get_path(label="diff_path")
         database_path = DatabasePath.from_cypher_path(cypher_path=path)
         self._parse_path(database_path=database_path)
+        self._current_node_field_specifiers = None
+        self._new_node_field_specifiers = None
 
     def parse(self, include_unchanged: bool = False) -> None:
+        self._new_node_field_specifiers = None
+        self._current_node_field_specifiers = None
         if len(self._diff_root_by_branch) > 1:
             self._apply_base_branch_previous_values()
             self._remove_empty_base_diff_root()
@@ -586,11 +609,12 @@ class DiffQueryParser:
         self, database_path: DatabasePath, diff_node: DiffNodeIntermediate
     ) -> DiffAttributeIntermediate:
         attribute_name = database_path.attribute_name
-        node_field_specifier = NodeFieldSpecifier(node_uuid=diff_node.uuid, field_name=attribute_name)
         branch_name = database_path.deepest_branch
         from_time = self.from_time
-        if branch_name == self.base_branch_name and node_field_specifier in self.get_new_node_field_specifiers():
-            from_time = self.diff_branched_from_time
+        if branch_name == self.base_branch_name:
+            new_node_field_specifiers = self.get_new_node_field_specifiers()
+            if attribute_name in new_node_field_specifiers.get(diff_node.uuid, set()):
+                from_time = self.diff_branched_from_time
         if attribute_name not in diff_node.attributes_by_name:
             diff_node.attributes_by_name[attribute_name] = DiffAttributeIntermediate(
                 uuid=database_path.attribute_id,
@@ -627,13 +651,12 @@ class DiffQueryParser:
     ) -> DiffRelationshipIntermediate:
         diff_relationship = diff_node.relationships_by_name.get(relationship_schema.name)
         if not diff_relationship:
-            node_field_specifier = NodeFieldSpecifier(
-                node_uuid=diff_node.uuid, field_name=relationship_schema.get_identifier()
-            )
             branch_name = database_path.deepest_branch
             from_time = self.from_time
-            if branch_name == self.base_branch_name and node_field_specifier in self.get_new_node_field_specifiers():
-                from_time = self.diff_branched_from_time
+            if branch_name == self.base_branch_name:
+                new_node_field_specifiers = self.get_new_node_field_specifiers()
+                if relationship_schema.get_identifier() in new_node_field_specifiers.get(diff_node.uuid, set()):
+                    from_time = self.diff_branched_from_time
             diff_relationship = DiffRelationshipIntermediate(
                 name=relationship_schema.name,
                 cardinality=relationship_schema.cardinality,

--- a/backend/infrahub/core/diff/repository/repository.py
+++ b/backend/infrahub/core/diff/repository/repository.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from typing import AsyncGenerator, Generator
 
 from infrahub import config
@@ -18,7 +19,6 @@ from ..model.path import (
     EnrichedDiffsMetadata,
     EnrichedNodeCreateRequest,
     NodeDiffFieldSummary,
-    NodeFieldSpecifier,
     TimeRange,
     TrackingId,
 )
@@ -352,23 +352,18 @@ class DiffRepository:
         await query.execute(db=self.db)
         return query.get_num_changes_by_branch()
 
-    async def get_node_field_specifiers(self, diff_id: str) -> set[NodeFieldSpecifier]:
+    async def get_node_field_specifiers(self, diff_id: str) -> dict[str, set[str]]:
         limit = config.SETTINGS.database.query_size_limit
         offset = 0
-        specifiers: set[NodeFieldSpecifier] = set()
+        specifiers: dict[str, set[str]] = defaultdict(set)
         while True:
             query = await EnrichedDiffFieldSpecifiersQuery.init(db=self.db, diff_id=diff_id, offset=offset, limit=limit)
             await query.execute(db=self.db)
-
-            new_specifiers = {
-                NodeFieldSpecifier(
-                    node_uuid=field_specifier_tuple[0],
-                    field_name=field_specifier_tuple[1],
-                )
-                for field_specifier_tuple in query.get_node_field_specifier_tuples()
-            }
-            if not new_specifiers:
+            has_data = False
+            for field_specifier_tuple in query.get_node_field_specifier_tuples():
+                specifiers[field_specifier_tuple[0]].add(field_specifier_tuple[1])
+                has_data = True
+            if not has_data:
                 break
-            specifiers |= new_specifiers
             offset += limit
         return specifiers

--- a/backend/infrahub/core/query/diff.py
+++ b/backend/infrahub/core/query/diff.py
@@ -160,124 +160,6 @@ CALL {
     CALL {
         WITH node_field_specifiers_list, node_ids_list, field_names_list, from_time
         // -------------------------------------
-        // Identify attributes/relationships added/removed on branch
-        // -------------------------------------
-        CALL {
-            WITH node_field_specifiers_list, node_ids_list, field_names_list, from_time
-            MATCH (root:Root)<-[r_root:IS_PART_OF]-(p:Node)-[diff_rel:HAS_ATTRIBUTE {branch: $branch_name}]->(q:Attribute)
-            // exclude attributes and relationships under added/removed nodes b/c they are covered above
-            WHERE r_root.branch IN [$branch_name, $base_branch_name, $global_branch_name]
-            AND q.branch_support = $branch_aware
-            AND (size(node_ids_list) = 0 OR p.uuid IN node_ids_list)
-            AND (size(field_names_list) = 0 OR q.name IN field_names_list)
-            // if p has a different type of branch support and was addded within our timeframe
-            AND (r_root.from < from_time OR p.branch_support = $branch_agnostic)
-            AND r_root.status = "active"
-            // get attributes and relationships added on the branch during the timeframe
-            AND (from_time <= diff_rel.from < $to_time)
-            AND (diff_rel.to IS NULL OR (from_time <= diff_rel.to < $to_time))
-            AND r_root.from <= diff_rel.from
-            AND (r_root.to IS NULL OR diff_rel.branch <> r_root.branch OR r_root.to >= diff_rel.from)
-            AND (node_field_specifiers_list IS NULL OR [p.uuid, q.name] IN node_field_specifiers_list)
-            RETURN root, r_root, p, diff_rel, q
-            UNION ALL
-            WITH node_field_specifiers_list, node_ids_list, field_names_list, from_time
-            MATCH (root:Root)<-[r_root:IS_PART_OF]-(p:Node)-[diff_rel:IS_RELATED {branch: $branch_name}]-(q:Relationship)
-            // exclude attributes and relationships under added/removed nodes b/c they are covered above
-            WHERE r_root.branch IN [$branch_name, $base_branch_name, $global_branch_name]
-            AND q.branch_support = $branch_aware
-            AND (size(node_ids_list) = 0 OR p.uuid IN node_ids_list)
-            AND (size(field_names_list) = 0 OR q.name IN field_names_list)
-            // if p has a different type of branch support and was addded within our timeframe
-            AND (r_root.from < from_time OR p.branch_support = $branch_agnostic)
-            // get attributes and relationships added on the branch during the timeframe
-            AND (from_time <= diff_rel.from < $to_time)
-            AND (diff_rel.to IS NULL OR (from_time <= diff_rel.to < $to_time))
-            AND r_root.from <= diff_rel.from
-            AND (r_root.to IS NULL OR diff_rel.branch <> r_root.branch OR r_root.to >= diff_rel.from)
-            AND (node_field_specifiers_list IS NULL OR [p.uuid, q.name] IN node_field_specifiers_list)
-            RETURN root, r_root, p, diff_rel, q
-        }
-        WITH root, r_root, p, diff_rel, q, from_time
-        // -------------------------------------
-        // Exclude attributes/relationship under nodes deleted on this branch in the timeframe
-        // because those were all handled above at the node level
-        // -------------------------------------
-        CALL {
-            WITH root, p, from_time
-            OPTIONAL MATCH (root)<-[r_root_deleted:IS_PART_OF {branch: $branch_name}]-(p)
-            WHERE from_time <= r_root_deleted.from < $to_time
-            WITH r_root_deleted
-            ORDER BY r_root_deleted.status DESC
-            LIMIT 1
-            RETURN COALESCE(r_root_deleted.status = "deleted", FALSE) AS node_deleted
-        }
-        WITH root, r_root, p, diff_rel, q, from_time, node_deleted
-        WHERE node_deleted = FALSE
-        // -------------------------------------
-        // Exclude relationships added and deleted within the timeframe
-        // -------------------------------------
-        WITH root, r_root, p, diff_rel, q, from_time, type(diff_rel) AS rel_type
-        CALL {
-            WITH p, rel_type, q, from_time
-            OPTIONAL MATCH (p)-[rel_to_check {branch: $branch_name}]-(q)
-            WHERE from_time <= rel_to_check.from < $to_time
-            AND type(rel_to_check) = rel_type
-            WITH DISTINCT rel_to_check.status AS rel_status
-            WITH collect(rel_status) AS rel_statuses
-            RETURN ("active" IN rel_statuses AND "deleted" IN rel_statuses) AS intra_branch_update
-        }
-        WITH root, r_root, p, diff_rel, q, from_time, intra_branch_update
-        WHERE intra_branch_update = FALSE
-        // -------------------------------------
-        // Get every path on this branch under each attribute/relationship
-        // -------------------------------------
-        CALL {
-            WITH root, r_root, p, diff_rel, q
-            OPTIONAL MATCH path = (
-                (root:Root)<-[mid_r_root:IS_PART_OF]-(p)-[mid_diff_rel]-(q)-[r_prop]-(prop)
-            )
-            WHERE %(id_func)s(mid_r_root) =  %(id_func)s(r_root)
-            AND %(id_func)s(mid_diff_rel) =  %(id_func)s(diff_rel)
-            AND type(r_prop) IN ["IS_VISIBLE", "IS_PROTECTED", "HAS_SOURCE", "HAS_OWNER", "HAS_VALUE", "IS_RELATED"]
-            AND any(l in labels(prop) WHERE l in ["Boolean", "Node", "AttributeValue"])
-            AND r_prop.from < $to_time AND r_prop.branch = mid_diff_rel.branch
-            AND (mid_diff_rel.to IS NULL OR mid_diff_rel.to >= r_prop.from)
-            AND [%(id_func)s(p), type(mid_diff_rel)] <> [%(id_func)s(prop), type(r_prop)]
-            // exclude paths where an active edge is below a deleted edge
-            AND (mid_diff_rel.status = "active" OR r_prop.status = "deleted")
-            WITH path, prop, r_prop, mid_r_root
-            ORDER BY
-                type(r_prop),
-                mid_r_root.branch = mid_diff_rel.branch DESC,
-                r_prop.from DESC,
-                mid_r_root.from DESC
-            WITH prop, type(r_prop) AS type_r_prop, head(collect(path)) AS latest_prop_path
-            RETURN latest_prop_path
-        }
-        // -------------------------------------
-        // Exclude properties within the timeframe
-        // -------------------------------------
-        WITH q, nodes(latest_prop_path)[3] AS prop, type(relationships(latest_prop_path)[2]) AS rel_type, latest_prop_path, from_time
-        CALL {
-            WITH q, rel_type, prop, from_time
-            OPTIONAL MATCH (q)-[rel_to_check {branch: $branch_name}]-(prop)
-            WHERE from_time <= rel_to_check.from < $to_time
-            AND type(rel_to_check) = rel_type
-            WITH DISTINCT rel_to_check.status AS rel_status
-            WITH collect(rel_status) AS rel_statuses
-            RETURN ("active" IN rel_statuses AND "deleted" IN rel_statuses) AS intra_branch_update
-        }
-        WITH latest_prop_path, intra_branch_update
-        WHERE intra_branch_update = FALSE
-        RETURN latest_prop_path AS mid_diff_path
-    }
-    RETURN mid_diff_path AS diff_path
-    UNION
-    WITH node_field_specifiers_list, node_ids_list, field_names_list, from_time
-    CALL {
-        WITH node_field_specifiers_list, node_ids_list, field_names_list, from_time
-        // -------------------------------------
         // Identify properties added/removed on branch
         // -------------------------------------
         MATCH diff_rel_path = (root:Root)<-[r_root:IS_PART_OF]-(n:Node)-[r_node]-(p)-[diff_rel {branch: $branch_name}]->(q)
@@ -538,12 +420,6 @@ WITH reduce(
             "branch_local": BranchSupportType.LOCAL.value,
             "branch_aware": BranchSupportType.AWARE.value,
             "branch_agnostic": BranchSupportType.AGNOSTIC.value,
-            "new_node_ids_list": [nfs[0] for nfs in self.new_node_field_specifiers]
-            if self.new_node_field_specifiers
-            else None,
-            "current_node_ids_list": [nfs[0] for nfs in self.current_node_field_specifiers]
-            if self.current_node_field_specifiers
-            else None,
             "limit": self.limit or config.SETTINGS.database.query_size_limit,
             "offset": self.offset or 0,
         }
@@ -555,6 +431,16 @@ class DiffNodePathsQuery(DiffCalculationQuery):
     async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:
         params_dict = self.get_params()
         self.params.update(params_dict)
+        self.params.update(
+            {
+                "new_node_ids_list": [nfs[0] for nfs in self.new_node_field_specifiers]
+                if self.new_node_field_specifiers
+                else None,
+                "current_node_ids_list": [nfs[0] for nfs in self.current_node_field_specifiers]
+                if self.current_node_field_specifiers
+                else None,
+            }
+        )
         nodes_path_query = """
 // -------------------------------------
 // Identify nodes added/removed on branch
@@ -665,6 +551,238 @@ CALL {
 }
 """ % {"id_func": db.get_id_function_name()}
         self.add_to_query(nodes_path_query)
+        self.add_to_query(self.get_previous_base_path_query(db=db))
+        self.add_to_query(self.get_relationship_peer_side_query(db=db))
+        self.add_to_query("UNWIND diff_rel_paths AS diff_path")
+        self.return_labels = ["DISTINCT diff_path AS diff_path", "has_more_data"]
+
+
+class DiffFieldPathsQuery(DiffCalculationQuery):
+    name = "diff_field_paths"
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:
+        params_dict = self.get_params()
+        self.params.update(params_dict)
+        current_node_ids: set[str] | None = None
+        new_node_ids: set[str] | None = None
+        current_field_names: set[str] | None = None
+        new_field_names: set[str] | None = None
+        if self.current_node_field_specifiers:
+            current_node_ids, current_field_names = set(), set()
+            for nfs in self.current_node_field_specifiers:
+                current_node_ids.add(nfs[0])
+                current_field_names.add(nfs[1])
+        if self.new_node_field_specifiers:
+            new_node_ids, new_field_names = set(), set()
+            for nfs in self.new_node_field_specifiers:
+                new_node_ids.add(nfs[0])
+                new_field_names.add(nfs[1])
+
+        self.params.update(
+            {
+                "current_node_ids_list": list(current_node_ids) if current_node_ids is not None else None,
+                "new_node_ids_list": list(new_node_ids) if new_node_ids is not None else None,
+                "current_field_names_list": list(current_field_names) if current_field_names is not None else None,
+                "new_field_names_list": list(new_field_names) if new_field_names is not None else None,
+                "current_node_field_specifiers_list": self.current_node_field_specifiers,
+                "new_node_field_specifiers_list": self.new_node_field_specifiers,
+            }
+        )
+        fields_path_query = """
+// -------------------------------------
+// Identify attributes/relationships added/removed on branch
+// -------------------------------------
+CALL {
+    MATCH (root:Root)<-[r_root:IS_PART_OF]-(p:Node)-[diff_rel:HAS_ATTRIBUTE {branch: $branch_name}]->(q:Attribute)
+    // simple filters to start
+    WHERE r_root.branch IN [$branch_name, $base_branch_name, $global_branch_name]
+    AND q.branch_support = $branch_aware
+    AND r_root.status = "active"
+    AND r_root.from <= diff_rel.from
+    AND (r_root.to IS NULL OR diff_rel.branch <> r_root.branch OR r_root.to >= diff_rel.from)
+    // node ID and field name filtering first pass
+    AND (
+        (
+            $current_node_ids_list IS NOT NULL
+            AND p.uuid IN $current_node_ids_list
+            AND $current_field_names_list IS NOT NULL
+            AND q.name IN $current_field_names_list
+        ) OR (
+            $new_node_ids_list IS NOT NULL
+            AND p.uuid IN $new_node_ids_list
+            AND $new_field_names_list IS NOT NULL
+            AND q.name IN $new_field_names_list
+        ) OR (
+            $current_node_ids_list IS NULL
+            AND $current_field_names_list IS NULL
+            AND $new_node_ids_list IS NULL
+            AND $new_field_names_list IS NULL
+        )
+    )
+    // node ID and field name filtering second pass
+    AND (
+        // time-based filters for nodes already included in the diff
+        (
+            ($current_node_field_specifiers_list IS NOT NULL AND [p.uuid, q.name] IN $current_node_field_specifiers_list)
+            AND (r_root.from < $from_time OR p.branch_support = $branch_agnostic)
+            AND ($from_time <= diff_rel.from < $to_time)
+            AND (diff_rel.to IS NULL OR ($from_time <= diff_rel.to < $to_time))
+        )
+        // time-based filters for new nodes
+        OR (
+            (
+                ($new_node_field_specifiers_list IS NOT NULL AND [p.uuid, q.name] IN $new_node_field_specifiers_list)
+                OR ($current_node_field_specifiers_list IS NULL AND $new_node_field_specifiers_list IS NULL)
+            )
+            AND (r_root.from < $branch_from_time OR p.branch_support = $branch_agnostic)
+            AND ($branch_from_time <= diff_rel.from < $to_time)
+            AND (diff_rel.to IS NULL OR ($branch_from_time <= diff_rel.to < $to_time))
+        )
+    )
+    RETURN root, r_root, p, diff_rel, q
+    UNION ALL
+    MATCH (root:Root)<-[r_root:IS_PART_OF]-(p:Node)-[diff_rel:IS_RELATED {branch: $branch_name}]-(q:Relationship)
+    // simple filters to start
+    WHERE r_root.branch IN [$branch_name, $base_branch_name, $global_branch_name]
+    AND q.branch_support = $branch_aware
+    AND r_root.status = "active"
+    AND r_root.from <= diff_rel.from
+    AND (r_root.to IS NULL OR diff_rel.branch <> r_root.branch OR r_root.to >= diff_rel.from)
+    // node ID and field name filtering first pass
+    AND (
+        (
+            $current_node_ids_list IS NOT NULL
+            AND p.uuid IN $current_node_ids_list
+            AND $current_field_names_list IS NOT NULL
+            AND q.name IN $current_field_names_list
+        ) OR (
+            $new_node_ids_list IS NOT NULL
+            AND p.uuid IN $new_node_ids_list
+            AND $new_field_names_list IS NOT NULL
+            AND q.name IN $new_field_names_list
+        ) OR (
+            $current_node_ids_list IS NULL
+            AND $current_field_names_list IS NULL
+            AND $new_node_ids_list IS NULL
+            AND $new_field_names_list IS NULL
+        )
+    )
+    // node ID and field name filtering second pass
+    AND (
+        // time-based filters for nodes already included in the diff
+        (
+            ($current_node_field_specifiers_list IS NOT NULL AND [p.uuid, q.name] IN $current_node_field_specifiers_list)
+            AND (r_root.from < $from_time OR p.branch_support = $branch_agnostic)
+            AND ($from_time <= diff_rel.from < $to_time)
+            AND (diff_rel.to IS NULL OR ($from_time <= diff_rel.to < $to_time))
+        )
+        // time-based filters for new nodes
+        OR (
+            (
+                ($new_node_field_specifiers_list IS NOT NULL AND [p.uuid, q.name] IN $new_node_field_specifiers_list)
+                OR ($current_node_field_specifiers_list IS NULL AND $new_node_field_specifiers_list IS NULL)
+            )
+            AND (r_root.from < $branch_from_time OR p.branch_support = $branch_agnostic)
+            AND ($branch_from_time <= diff_rel.from < $to_time)
+            AND (diff_rel.to IS NULL OR ($branch_from_time <= diff_rel.to < $to_time))
+        )
+    )
+    RETURN root, r_root, p, diff_rel, q
+}
+// -------------------------------------
+// Limit the number of paths
+// -------------------------------------
+WITH root, r_root, p, diff_rel, q
+ORDER BY p.uuid, q.uuid, diff_rel.branch, diff_rel.from
+SKIP $offset
+LIMIT $limit
+// -------------------------------------
+// Add flag to indicate if there is more data after this
+// -------------------------------------
+WITH collect([root, r_root, p, diff_rel, q]) AS limited_results
+WITH limited_results, size(limited_results) = $limit AS has_more_data
+UNWIND limited_results AS one_result
+WITH one_result[0] AS root, one_result[1] AS r_root, one_result[2] AS p, one_result[3] AS diff_rel, one_result[4] AS q, has_more_data
+// -------------------------------------
+// Add correct from_time for row
+// -------------------------------------
+WITH root, r_root, p, diff_rel, q, has_more_data, CASE
+    WHEN $new_node_field_specifiers_list IS NOT NULL AND [p.uuid, q.name] IN $new_node_field_specifiers_list THEN $branch_from_time
+    ELSE $from_time
+END AS row_from_time
+// -------------------------------------
+// Exclude attributes/relationship under nodes deleted on this branch in the timeframe
+// because those were all handled above at the node level
+// -------------------------------------
+CALL {
+    WITH root, p, row_from_time
+    OPTIONAL MATCH (root)<-[r_root_deleted:IS_PART_OF {branch: $branch_name}]-(p)
+    WHERE row_from_time <= r_root_deleted.from < $to_time
+    WITH r_root_deleted
+    ORDER BY r_root_deleted.status DESC
+    LIMIT 1
+    RETURN COALESCE(r_root_deleted.status = "deleted", FALSE) AS node_deleted
+}
+WITH root, r_root, p, diff_rel, q, has_more_data, row_from_time, node_deleted
+WHERE node_deleted = FALSE
+// -------------------------------------
+// Exclude relationships added and deleted within the timeframe
+// -------------------------------------
+WITH root, r_root, p, diff_rel, q, has_more_data, row_from_time, type(diff_rel) AS rel_type
+CALL {
+    WITH p, rel_type, q, row_from_time
+    OPTIONAL MATCH (p)-[rel_to_check {branch: $branch_name}]-(q)
+    WHERE row_from_time <= rel_to_check.from < $to_time
+    AND type(rel_to_check) = rel_type
+    WITH DISTINCT rel_to_check.status AS rel_status
+    WITH collect(rel_status) AS rel_statuses
+    RETURN ("active" IN rel_statuses AND "deleted" IN rel_statuses) AS intra_branch_update
+}
+WITH root, r_root, p, diff_rel, q, has_more_data, row_from_time, intra_branch_update
+WHERE intra_branch_update = FALSE
+// -------------------------------------
+// Get every path on this branch under each attribute/relationship
+// -------------------------------------
+CALL {
+    WITH root, r_root, p, diff_rel, q
+    OPTIONAL MATCH path = (
+        (root:Root)<-[mid_r_root:IS_PART_OF]-(p)-[mid_diff_rel]-(q)-[r_prop]-(prop)
+    )
+    WHERE %(id_func)s(mid_r_root) =  %(id_func)s(r_root)
+    AND %(id_func)s(mid_diff_rel) =  %(id_func)s(diff_rel)
+    AND type(r_prop) IN ["IS_VISIBLE", "IS_PROTECTED", "HAS_SOURCE", "HAS_OWNER", "HAS_VALUE", "IS_RELATED"]
+    AND any(l in labels(prop) WHERE l in ["Boolean", "Node", "AttributeValue"])
+    AND r_prop.from < $to_time AND r_prop.branch = mid_diff_rel.branch
+    AND (mid_diff_rel.to IS NULL OR mid_diff_rel.to >= r_prop.from)
+    AND [%(id_func)s(p), type(mid_diff_rel)] <> [%(id_func)s(prop), type(r_prop)]
+    // exclude paths where an active edge is below a deleted edge
+    AND (mid_diff_rel.status = "active" OR r_prop.status = "deleted")
+    WITH path, prop, r_prop, mid_r_root
+    ORDER BY
+        type(r_prop),
+        mid_r_root.branch = mid_diff_rel.branch DESC,
+        r_prop.from DESC,
+        mid_r_root.from DESC
+    WITH prop, type(r_prop) AS type_r_prop, head(collect(path)) AS latest_prop_path
+    RETURN latest_prop_path
+}
+// -------------------------------------
+// Exclude properties within the timeframe
+// -------------------------------------
+WITH q, nodes(latest_prop_path)[3] AS prop, type(relationships(latest_prop_path)[2]) AS rel_type, latest_prop_path, has_more_data, row_from_time
+CALL {
+    WITH q, rel_type, prop, row_from_time
+    OPTIONAL MATCH (q)-[rel_to_check {branch: $branch_name}]-(prop)
+    WHERE row_from_time <= rel_to_check.from < $to_time
+    AND type(rel_to_check) = rel_type
+    WITH DISTINCT rel_to_check.status AS rel_status
+    WITH collect(rel_status) AS rel_statuses
+    RETURN ("active" IN rel_statuses AND "deleted" IN rel_statuses) AS intra_branch_update
+}
+WITH latest_prop_path AS diff_path, has_more_data, intra_branch_update
+WHERE intra_branch_update = FALSE
+        """ % {"id_func": db.get_id_function_name()}
+        self.add_to_query(fields_path_query)
         self.add_to_query(self.get_previous_base_path_query(db=db))
         self.add_to_query(self.get_relationship_peer_side_query(db=db))
         self.add_to_query("UNWIND diff_rel_paths AS diff_path")

--- a/backend/infrahub/core/query/diff.py
+++ b/backend/infrahub/core/query/diff.py
@@ -321,8 +321,8 @@ class DiffCalculationQuery(DiffQuery):
         self,
         base_branch: Branch,
         diff_branch_from_time: Timestamp,
-        current_node_field_specifiers: list[tuple[str, str]] | None = None,
-        new_node_field_specifiers: list[tuple[str, str]] | None = None,
+        current_node_field_specifiers: dict[str, set[str]] | None = None,
+        new_node_field_specifiers: dict[str, set[str]] | None = None,
         **kwargs: Any,
     ):
         self.base_branch = base_branch
@@ -433,10 +433,10 @@ class DiffNodePathsQuery(DiffCalculationQuery):
         self.params.update(params_dict)
         self.params.update(
             {
-                "new_node_ids_list": [nfs[0] for nfs in self.new_node_field_specifiers]
+                "new_node_ids_list": list(self.new_node_field_specifiers.keys())
                 if self.new_node_field_specifiers
                 else None,
-                "current_node_ids_list": [nfs[0] for nfs in self.current_node_field_specifiers]
+                "current_node_ids_list": list(self.current_node_field_specifiers.keys())
                 if self.current_node_field_specifiers
                 else None,
             }
@@ -563,132 +563,70 @@ class DiffFieldPathsQuery(DiffCalculationQuery):
     async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:
         params_dict = self.get_params()
         self.params.update(params_dict)
-        current_node_ids: set[str] | None = None
-        new_node_ids: set[str] | None = None
-        current_field_names: set[str] | None = None
-        new_field_names: set[str] | None = None
-        if self.current_node_field_specifiers:
-            current_node_ids, current_field_names = set(), set()
-            for nfs in self.current_node_field_specifiers:
-                current_node_ids.add(nfs[0])
-                current_field_names.add(nfs[1])
-        if self.new_node_field_specifiers:
-            new_node_ids, new_field_names = set(), set()
-            for nfs in self.new_node_field_specifiers:
-                new_node_ids.add(nfs[0])
-                new_field_names.add(nfs[1])
 
         self.params.update(
             {
-                "current_node_ids_list": list(current_node_ids) if current_node_ids is not None else None,
-                "new_node_ids_list": list(new_node_ids) if new_node_ids is not None else None,
-                "current_field_names_list": list(current_field_names) if current_field_names is not None else None,
-                "new_field_names_list": list(new_field_names) if new_field_names is not None else None,
-                "current_node_field_specifiers_list": self.current_node_field_specifiers,
-                "new_node_field_specifiers_list": self.new_node_field_specifiers,
+                "current_node_field_specifiers_map": {
+                    node_uuid: list(field_names)
+                    for node_uuid, field_names in self.current_node_field_specifiers.items()
+                }
+                if self.current_node_field_specifiers
+                else None,
+                "new_node_field_specifiers_map": {
+                    node_uuid: list(field_names) for node_uuid, field_names in self.new_node_field_specifiers.items()
+                }
+                if self.new_node_field_specifiers
+                else None,
             }
         )
         fields_path_query = """
 // -------------------------------------
 // Identify attributes/relationships added/removed on branch
 // -------------------------------------
-CALL {
-    MATCH (root:Root)<-[r_root:IS_PART_OF]-(p:Node)-[diff_rel:HAS_ATTRIBUTE {branch: $branch_name}]->(q:Attribute)
-    // simple filters to start
-    WHERE r_root.branch IN [$branch_name, $base_branch_name, $global_branch_name]
-    AND q.branch_support = $branch_aware
-    AND r_root.status = "active"
-    AND r_root.from <= diff_rel.from
-    AND (r_root.to IS NULL OR diff_rel.branch <> r_root.branch OR r_root.to >= diff_rel.from)
-    // node ID and field name filtering first pass
-    AND (
-        (
-            $current_node_ids_list IS NOT NULL
-            AND p.uuid IN $current_node_ids_list
-            AND $current_field_names_list IS NOT NULL
-            AND q.name IN $current_field_names_list
-        ) OR (
-            $new_node_ids_list IS NOT NULL
-            AND p.uuid IN $new_node_ids_list
-            AND $new_field_names_list IS NOT NULL
-            AND q.name IN $new_field_names_list
-        ) OR (
-            $current_node_ids_list IS NULL
-            AND $current_field_names_list IS NULL
-            AND $new_node_ids_list IS NULL
-            AND $new_field_names_list IS NULL
-        )
+MATCH (root:Root)<-[r_root:IS_PART_OF]-(p:Node)-[diff_rel {branch: $branch_name}]-(q)
+// simple filters to start
+WHERE type(diff_rel) IN ["HAS_ATTRIBUTE", "IS_RELATED"]
+AND ("Attribute" IN labels(q) OR "Relationship" IN labels(q))
+AND r_root.branch IN [$branch_name, $base_branch_name, $global_branch_name]
+AND q.branch_support = $branch_aware
+AND r_root.status = "active"
+AND r_root.from <= diff_rel.from
+AND (r_root.to IS NULL OR diff_rel.branch <> r_root.branch OR r_root.to >= diff_rel.from)
+// node ID and field name filtering first pass
+AND (
+    (
+        $current_node_field_specifiers_map IS NOT NULL
+        AND $current_node_field_specifiers_map[p.uuid] IS NOT NULL
+        AND q.name IN $current_node_field_specifiers_map[p.uuid]
+    ) OR (
+        $new_node_field_specifiers_map IS NOT NULL
+        AND $new_node_field_specifiers_map[p.uuid] IS NOT NULL
+        AND q.name IN $new_node_field_specifiers_map[p.uuid]
+    ) OR (
+        $current_node_field_specifiers_map IS NULL
+        AND $new_node_field_specifiers_map IS NULL
     )
-    // node ID and field name filtering second pass
-    AND (
-        // time-based filters for nodes already included in the diff
-        (
-            ($current_node_field_specifiers_list IS NOT NULL AND [p.uuid, q.name] IN $current_node_field_specifiers_list)
-            AND (r_root.from < $from_time OR p.branch_support = $branch_agnostic)
-            AND ($from_time <= diff_rel.from < $to_time)
-            AND (diff_rel.to IS NULL OR ($from_time <= diff_rel.to < $to_time))
-        )
-        // time-based filters for new nodes
-        OR (
-            (
-                ($new_node_field_specifiers_list IS NOT NULL AND [p.uuid, q.name] IN $new_node_field_specifiers_list)
-                OR ($current_node_field_specifiers_list IS NULL AND $new_node_field_specifiers_list IS NULL)
-            )
-            AND (r_root.from < $branch_from_time OR p.branch_support = $branch_agnostic)
-            AND ($branch_from_time <= diff_rel.from < $to_time)
-            AND (diff_rel.to IS NULL OR ($branch_from_time <= diff_rel.to < $to_time))
-        )
+)
+// node ID and field name filtering second pass
+AND (
+    // time-based filters for nodes already included in the diff
+    (
+        ($current_node_field_specifiers_map IS NOT NULL AND q.name IN $current_node_field_specifiers_map[p.uuid])
+        AND (r_root.from < $from_time OR p.branch_support = $branch_agnostic)
+        AND ($from_time <= diff_rel.from < $to_time)
+        AND (diff_rel.to IS NULL OR ($from_time <= diff_rel.to < $to_time))
     )
-    RETURN root, r_root, p, diff_rel, q
-    UNION ALL
-    MATCH (root:Root)<-[r_root:IS_PART_OF]-(p:Node)-[diff_rel:IS_RELATED {branch: $branch_name}]-(q:Relationship)
-    // simple filters to start
-    WHERE r_root.branch IN [$branch_name, $base_branch_name, $global_branch_name]
-    AND q.branch_support = $branch_aware
-    AND r_root.status = "active"
-    AND r_root.from <= diff_rel.from
-    AND (r_root.to IS NULL OR diff_rel.branch <> r_root.branch OR r_root.to >= diff_rel.from)
-    // node ID and field name filtering first pass
-    AND (
+    // time-based filters for new nodes
+    OR (
         (
-            $current_node_ids_list IS NOT NULL
-            AND p.uuid IN $current_node_ids_list
-            AND $current_field_names_list IS NOT NULL
-            AND q.name IN $current_field_names_list
-        ) OR (
-            $new_node_ids_list IS NOT NULL
-            AND p.uuid IN $new_node_ids_list
-            AND $new_field_names_list IS NOT NULL
-            AND q.name IN $new_field_names_list
-        ) OR (
-            $current_node_ids_list IS NULL
-            AND $current_field_names_list IS NULL
-            AND $new_node_ids_list IS NULL
-            AND $new_field_names_list IS NULL
+            (q.name IN $new_node_field_specifiers_map[p.uuid])
+            OR ($current_node_field_specifiers_map IS NULL AND $new_node_field_specifiers_map IS NULL)
         )
+        AND (r_root.from < $branch_from_time OR p.branch_support = $branch_agnostic)
+        AND ($branch_from_time <= diff_rel.from < $to_time)
+        AND (diff_rel.to IS NULL OR ($branch_from_time <= diff_rel.to < $to_time))
     )
-    // node ID and field name filtering second pass
-    AND (
-        // time-based filters for nodes already included in the diff
-        (
-            ($current_node_field_specifiers_list IS NOT NULL AND [p.uuid, q.name] IN $current_node_field_specifiers_list)
-            AND (r_root.from < $from_time OR p.branch_support = $branch_agnostic)
-            AND ($from_time <= diff_rel.from < $to_time)
-            AND (diff_rel.to IS NULL OR ($from_time <= diff_rel.to < $to_time))
-        )
-        // time-based filters for new nodes
-        OR (
-            (
-                ($new_node_field_specifiers_list IS NOT NULL AND [p.uuid, q.name] IN $new_node_field_specifiers_list)
-                OR ($current_node_field_specifiers_list IS NULL AND $new_node_field_specifiers_list IS NULL)
-            )
-            AND (r_root.from < $branch_from_time OR p.branch_support = $branch_agnostic)
-            AND ($branch_from_time <= diff_rel.from < $to_time)
-            AND (diff_rel.to IS NULL OR ($branch_from_time <= diff_rel.to < $to_time))
-        )
-    )
-    RETURN root, r_root, p, diff_rel, q
-}
+)
 // -------------------------------------
 // Limit the number of paths
 // -------------------------------------
@@ -707,7 +645,7 @@ WITH one_result[0] AS root, one_result[1] AS r_root, one_result[2] AS p, one_res
 // Add correct from_time for row
 // -------------------------------------
 WITH root, r_root, p, diff_rel, q, has_more_data, CASE
-    WHEN $new_node_field_specifiers_list IS NOT NULL AND [p.uuid, q.name] IN $new_node_field_specifiers_list THEN $branch_from_time
+    WHEN $new_node_field_specifiers_map IS NOT NULL AND q.name IN $new_node_field_specifiers_map[p.uuid] THEN $branch_from_time
     ELSE $from_time
 END AS row_from_time
 // -------------------------------------

--- a/backend/infrahub/core/query/diff.py
+++ b/backend/infrahub/core/query/diff.py
@@ -570,12 +570,12 @@ class DiffFieldPathsQuery(DiffCalculationQuery):
                     node_uuid: list(field_names)
                     for node_uuid, field_names in self.current_node_field_specifiers.items()
                 }
-                if self.current_node_field_specifiers
+                if self.current_node_field_specifiers is not None
                 else None,
                 "new_node_field_specifiers_map": {
                     node_uuid: list(field_names) for node_uuid, field_names in self.new_node_field_specifiers.items()
                 }
-                if self.new_node_field_specifiers
+                if self.new_node_field_specifiers is not None
                 else None,
             }
         )
@@ -609,19 +609,19 @@ AND (
 )
 // node ID and field name filtering second pass
 AND (
-    // time-based filters for nodes already included in the diff
+    // time-based filters for nodes already included in the diff or fresh changes
     (
-        ($current_node_field_specifiers_map IS NOT NULL AND q.name IN $current_node_field_specifiers_map[p.uuid])
+        (
+            ($current_node_field_specifiers_map IS NOT NULL AND q.name IN $current_node_field_specifiers_map[p.uuid])
+            OR ($current_node_field_specifiers_map IS NULL AND $new_node_field_specifiers_map IS NULL)
+        )
         AND (r_root.from < $from_time OR p.branch_support = $branch_agnostic)
         AND ($from_time <= diff_rel.from < $to_time)
         AND (diff_rel.to IS NULL OR ($from_time <= diff_rel.to < $to_time))
     )
     // time-based filters for new nodes
     OR (
-        (
-            (q.name IN $new_node_field_specifiers_map[p.uuid])
-            OR ($current_node_field_specifiers_map IS NULL AND $new_node_field_specifiers_map IS NULL)
-        )
+        ($new_node_field_specifiers_map IS NOT NULL AND q.name IN $new_node_field_specifiers_map[p.uuid])
         AND (r_root.from < $branch_from_time OR p.branch_support = $branch_agnostic)
         AND ($branch_from_time <= diff_rel.from < $to_time)
         AND (diff_rel.to IS NULL OR ($branch_from_time <= diff_rel.to < $to_time))

--- a/backend/tests/unit/core/diff/test_coordinator.py
+++ b/backend/tests/unit/core/diff/test_coordinator.py
@@ -214,7 +214,7 @@ class TestDiffCoordinator:
                     from_time=Timestamp(branch.get_branched_from()),
                     to_time=diff_with_data.from_time,
                     include_unchanged=False,
-                    previous_node_specifiers=set(),
+                    previous_node_specifiers={},
                 ),
                 call(
                     base_branch=default_branch,
@@ -222,7 +222,7 @@ class TestDiffCoordinator:
                     from_time=diff_with_data.to_time,
                     to_time=no_changes_diff.to_time,
                     include_unchanged=True,
-                    previous_node_specifiers={person_john_branch.id: {"height"}},
+                    previous_node_specifiers={person_john_main.id: {"height"}},
                 ),
             ]
         )

--- a/backend/tests/unit/core/diff/test_coordinator.py
+++ b/backend/tests/unit/core/diff/test_coordinator.py
@@ -7,7 +7,7 @@ from infrahub.core.constants.database import DatabaseEdgeType
 from infrahub.core.diff.calculator import DiffCalculator
 from infrahub.core.diff.combiner import DiffCombiner
 from infrahub.core.diff.coordinator import DiffCoordinator
-from infrahub.core.diff.model.path import BranchTrackingId, EnrichedDiffRootMetadata, NodeFieldSpecifier
+from infrahub.core.diff.model.path import BranchTrackingId, EnrichedDiffRootMetadata
 from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
@@ -222,7 +222,7 @@ class TestDiffCoordinator:
                     from_time=diff_with_data.to_time,
                     to_time=no_changes_diff.to_time,
                     include_unchanged=True,
-                    previous_node_specifiers={NodeFieldSpecifier(node_uuid=person_john_branch.id, field_name="height")},
+                    previous_node_specifiers={person_john_branch.id: {"height"}},
                 ),
             ]
         )

--- a/backend/tests/unit/core/diff/test_diff_calculator.py
+++ b/backend/tests/unit/core/diff/test_diff_calculator.py
@@ -6,7 +6,6 @@ from infrahub.core.branch import Branch
 from infrahub.core.constants import DiffAction, InfrahubKind, RelationshipCardinality
 from infrahub.core.constants.database import DatabaseEdgeType
 from infrahub.core.diff.calculator import DiffCalculator
-from infrahub.core.diff.model.path import NodeFieldSpecifier
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
@@ -1630,7 +1629,7 @@ async def test_diff_attribute_branch_update_with_previous_base_update_ignored(
         diff_branch=branch,
         from_time=from_time,
         to_time=Timestamp(),
-        previous_node_specifiers={NodeFieldSpecifier(node_uuid=alfred_main.id, field_name="name")},
+        previous_node_specifiers={alfred_main.id: {"name"}},
         include_unchanged=True,
     )
 
@@ -1683,7 +1682,7 @@ async def test_diff_attribute_branch_update_with_concurrent_base_update_captured
         diff_branch=branch,
         from_time=from_time,
         to_time=Timestamp(),
-        previous_node_specifiers={NodeFieldSpecifier(node_uuid=alfred_main.id, field_name="name")},
+        previous_node_specifiers={alfred_main.id: {"name"}},
         include_unchanged=True,
     )
 
@@ -1819,8 +1818,8 @@ async def test_diff_attribute_branch_update_with_separate_previous_base_update_c
         from_time=from_time,
         to_time=Timestamp(),
         previous_node_specifiers={
-            NodeFieldSpecifier(node_uuid=car_accord_main.id, field_name="color"),
-            NodeFieldSpecifier(node_uuid=person_alfred_main.id, field_name="name"),
+            car_accord_main.id: {"color"},
+            person_alfred_main.id: {"name"},
         },
         include_unchanged=True,
     )
@@ -2777,8 +2776,8 @@ async def test_diff_unchanged_included_when_not_first_diff(
         from_time=from_time,
         to_time=Timestamp(),
         previous_node_specifiers={
-            NodeFieldSpecifier(node_uuid=car_accord_main.id, field_name="color"),
-            NodeFieldSpecifier(node_uuid=person_alfred_main.id, field_name="name"),
+            car_accord_main.id: {"color"},
+            person_alfred_main.id: {"name"},
         },
         include_unchanged=True,
     )
@@ -3059,7 +3058,7 @@ async def test_diff_relationship_property_update_on_main(
         from_time=from_time,
         to_time=Timestamp(),
         previous_node_specifiers={
-            NodeFieldSpecifier(node_uuid=car_accord_main.id, field_name=owner_rel_schema.get_identifier()),
+            car_accord_main.id: {owner_rel_schema.get_identifier()},
         },
         include_unchanged=True,
     )


### PR DESCRIPTION
IFC-1141

changes to increase performance of diff calculations for attribute and relationship-level changes
- previous PR broke the `DiffNodePathsQuery` out of the `DiffAllPathsQuery`. this PR does the same for the new `DiffFieldPathsQuery`.
- changes to how we pass node UUID and attribute names/relationship identifiers into the diff calculation queries. used to use a big list of tuples: one for each node-attribute/relationship combination, which would be a lot of tuples for a large diff (>100,000). new approach is to use a dict/map b/c I figured out how to use one in the cypher query in place of the tuples list. testing indicates this did not affect performance, but it does make things easier to read and uses much less memory in Python

still need to do this one more time for the remaining `DiffAllPathsQuery`, but that should be a pretty significant performance improvement once get the query updated. will include the changelog with that final PR