### PR TITLE
fix: use infrahub image to run prefect server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -931,7 +931,6 @@ jobs:
       - name: "Set environment variables"
         run: |
           echo INFRAHUB_BUILD_NAME=infrahub-${{ runner.name }} >> $GITHUB_ENV
-          echo TASK_MANAGER_DOCKER_IMAGE="prefecthq/prefect:3.0.11-python3.12" >> $GITHUB_ENV
       - name: "Clear docker environment"
         run: docker compose -p $INFRAHUB_BUILD_NAME down -v --remove-orphans --rmi local
 

--- a/.github/workflows/version-upgrade.yml
+++ b/.github/workflows/version-upgrade.yml
@@ -60,7 +60,6 @@ jobs:
         run: |
           echo INFRAHUB_BUILD_NAME=infrahub-${{ runner.name }} >> $GITHUB_ENV
           echo INFRAHUB_IMAGE_VER=${{ matrix.source_version }} >> $GITHUB_ENV
-          echo TASK_MANAGER_DOCKER_IMAGE="prefecthq/prefect:3.0.11-python3.12" >> $GITHUB_ENV
       - name: "Clear docker environment"
         run: docker compose -p $INFRAHUB_BUILD_NAME down -v --remove-orphans --rmi local
       - name: "Store start time"
@@ -83,7 +82,6 @@ jobs:
       - name: "Set environment variables"
         run: |
           echo INFRAHUB_IMAGE_VER=local-${{ runner.name }}-${{ github.sha }} >> $GITHUB_ENV
-          echo TASK_MANAGER_DOCKER_IMAGE="" >> $GITHUB_ENV
 
       - name: Build Demo
         run: invoke dev.build

--- a/development/docker-compose-deps-nats.yml
+++ b/development/docker-compose-deps-nats.yml
@@ -24,7 +24,7 @@ services:
       start_period: 10s
   task-manager:
     profiles: [demo, dev]
-    image: "${TASK_MANAGER_DOCKER_IMAGE:-prefecthq/prefect:3.1.13-python3.12}"
+    image: "${IMAGE_NAME}:${IMAGE_VER}"
     command: prefect server start --host 0.0.0.0 --ui
     environment:
       PREFECT_API_DATABASE_CONNECTION_URL: postgresql+asyncpg://postgres:postgres@task-manager-db:5432/prefect

--- a/development/docker-compose-deps.yml
+++ b/development/docker-compose-deps.yml
@@ -23,7 +23,7 @@ services:
       retries: 3
   task-manager:
     profiles: [demo, dev]
-    image: "${TASK_MANAGER_DOCKER_IMAGE:-prefecthq/prefect:3.1.13-python3.12}"
+    image: "${IMAGE_NAME}:${IMAGE_VER}"
     command: prefect server start --host 0.0.0.0 --ui
     environment:
       PREFECT_API_DATABASE_CONNECTION_URL: postgresql+asyncpg://postgres:postgres@task-manager-db:5432/prefect

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -174,7 +174,7 @@ services:
       - 6362:6362
 
   task-manager:
-    image: "${TASK_MANAGER_DOCKER_IMAGE:-prefecthq/prefect:3.1.13-python3.12}"
+    image: "${INFRAHUB_DOCKER_IMAGE:-registry.opsmill.io/opsmill/infrahub}:${VERSION:-1.1.4}"
     command: prefect server start --host 0.0.0.0 --ui
     restart: unless-stopped
     depends_on:

--- a/python_testcontainers/infrahub_testcontainers/docker-compose.test.yml
+++ b/python_testcontainers/infrahub_testcontainers/docker-compose.test.yml
@@ -49,7 +49,7 @@ services:
       - ${INFRAHUB_TESTING_DATABASE_UI_PORT:-0}:7474
 
   task-manager:
-    image: "${TASK_MANAGER_DOCKER_IMAGE:-prefecthq/prefect:3.1.13-python3.12}"
+    image: "${INFRAHUB_TESTING_DOCKER_IMAGE}:${INFRAHUB_TESTING_IMAGE_VERSION}"
     command: prefect server start --host 0.0.0.0 --ui
     depends_on:
       task-manager-db:

--- a/tasks/shared.py
+++ b/tasks/shared.py
@@ -51,8 +51,6 @@ CACHE_DOCKER_IMAGE = os.getenv(
     "redis:7.2.4" if not INFRAHUB_USE_NATS else "nats:2.10.14-alpine",
 )
 
-TASK_MANAGER_DOCKER_IMAGE = os.getenv("TASK_MANAGER_DOCKER_IMAGE", "prefecthq/prefect:3.1.13-python3.12")
-
 here = Path(__file__).parent.resolve()
 TOP_DIRECTORY_NAME = here.parent.name
 BUILD_NAME = os.getenv("INFRAHUB_BUILD_NAME", re.sub(r"[^a-zA-Z0-9_/.]", "", str(TOP_DIRECTORY_NAME)))
@@ -237,7 +235,6 @@ def get_env_vars(context: Context, namespace: Namespace = Namespace.DEFAULT) -> 
         "NBR_WORKERS": NBR_WORKERS,
         "CACHE_DOCKER_IMAGE": CACHE_DOCKER_IMAGE,
         "MESSAGE_QUEUE_DOCKER_IMAGE": MESSAGE_QUEUE_DOCKER_IMAGE,
-        "TASK_MANAGER_DOCKER_IMAGE": TASK_MANAGER_DOCKER_IMAGE,
         "INFRAHUB_DB_TYPE": INFRAHUB_DATABASE,
     }
 


### PR DESCRIPTION
This will avoid incompatibility issues between the Prefect client used by Infrahub and the Prefect server.
This also avoid dirty workarounds in CI to make jobs work when we have a mismatch between the Prefect version in docker compose and the client used.

Prefect's web UI is also working using this method.

Next step would be to have our own entrypoint to autoconfigure Prefect according to Infrahub's settings.