### PR TITLE
fix(ci): run invoke demo start test only on stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -907,7 +907,7 @@ jobs:
       always() && !cancelled() &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
-      github.base_ref == 'develop'
+      github.base_ref == 'stable'
     runs-on:
       group: huge-runners
     steps:


### PR DESCRIPTION
We changed the github default branch to stable.