### PR TITLE
Clean up around TestInfrahubDockerClient

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,19 +404,21 @@ jobs:
               git config --global credential.helper /usr/local/bin/infrahub-git-credential"
       - name: "Set environment variables"
         run: echo INFRAHUB_BUILD_NAME=infrahub-${{ runner.name }}>> $GITHUB_ENV
-      - name: "Set environment variables"
+      - name: "Set environment variables prior dev.build"
         run: |
           RUNNER_NAME=$(echo "${{ runner.name }}" | grep -o 'ghrunner[0-9]\+' | sed 's/ghrunner\([0-9]\+\)/ghrunner_\1/')
           echo "PYTEST_DEBUG_TEMPROOT=/var/lib/github/${RUNNER_NAME}/_temp" >> $GITHUB_ENV
           echo INFRAHUB_IMAGE_VER=local-${{ runner.name }}-${{ github.sha }} >> $GITHUB_ENV
-          echo INFRAHUB_TESTING_IMAGE_VER=local-${{ runner.name }}-${{ github.sha }} >> $GITHUB_ENV
-          echo INFRAHUB_TESTING_DOCKER_IMAGE="opsmill/infrahub" >> $GITHUB_ENV
       - name: "Build container"
         run: "inv dev.build"
       - name: "Setup Python environment"
         run: |
           poetry config virtualenvs.create true --local
           poetry env use 3.12
+      - name: "Set environment variables for python_testcontainers"
+        run: |
+          echo INFRAHUB_TESTING_IMAGE_TAG=$INFRAHUB_IMAGE_VER >> $GITHUB_ENV
+          echo INFRAHUB_TESTING_IMAGE_NAME=$INFRAHUB_IMAGE_NAME >> $GITHUB_ENV
       - name: "Run tests"
         run: "poetry run pytest backend/tests/integration_docker/"
 

--- a/backend/tests/integration_docker/classes.py
+++ b/backend/tests/integration_docker/classes.py
@@ -1,0 +1,14 @@
+import os
+
+from infrahub_sdk.testing.docker import TestInfrahubDockerClient
+
+
+class TestDockerIntegration(TestInfrahubDockerClient):
+    """
+    Perform a test against an Infrahub image. Typically, a prior `dev.build` should be executed before running
+    a test inheriting from this class, in order to build the local image.
+    """
+
+    @staticmethod
+    def infrahub_version() -> str:
+        return os.getenv("INFRAHUB_TESTING_IMAGE_TAG", "local")

--- a/backend/tests/integration_docker/test_propose_change_repository.py
+++ b/backend/tests/integration_docker/test_propose_change_repository.py
@@ -4,7 +4,6 @@ import pytest
 from infrahub_sdk import InfrahubClient
 from infrahub_sdk.protocols import CoreGenericRepository, CoreProposedChange
 from infrahub_sdk.schema import NodeSchema, SchemaRoot
-from infrahub_sdk.testing.docker import TestInfrahubDockerClient
 from infrahub_sdk.testing.repository import GitRepo
 from infrahub_sdk.testing.schemas.car_person import (
     TESTING_PERSON,
@@ -13,15 +12,12 @@ from infrahub_sdk.testing.schemas.car_person import (
 
 from infrahub.core.constants import InfrahubKind
 from tests.helpers.fixtures import get_fixtures_dir
+from tests.integration_docker.classes import TestDockerIntegration
 
 CURRENT_DIRECTORY = Path(__file__).parent.resolve()
 
 
-class TestProposeChangeRepository(TestInfrahubDockerClient, SchemaCarPerson):
-    @pytest.fixture(scope="class")
-    def infrahub_version(self) -> str:
-        return "local"
-
+class TestProposeChangeRepository(TestDockerIntegration, SchemaCarPerson):
     @pytest.fixture(scope="class")
     def schema_person_artifact(self, schema_person_base: NodeSchema) -> NodeSchema:
         person_schema = schema_person_base.model_copy(deep=True)

--- a/backend/tests/integration_docker/test_schema_migration.py
+++ b/backend/tests/integration_docker/test_schema_migration.py
@@ -4,21 +4,18 @@ import pytest
 import yaml
 from infrahub_sdk import InfrahubClient
 from infrahub_sdk.schema.main import AttributeKind, AttributeSchema, NodeSchema, SchemaRoot
-from infrahub_sdk.testing.docker import TestInfrahubDockerClient
 from infrahub_sdk.testing.schemas.car_person import (
     NAMESPACE,
     TESTING_PERSON,
     SchemaCarPerson,
 )
 
+from tests.integration_docker.classes import TestDockerIntegration
+
 CURRENT_DIRECTORY = Path(__file__).parent.resolve()
 
 
-class TestSchemaMigrations(TestInfrahubDockerClient, SchemaCarPerson):
-    @pytest.fixture(scope="class")
-    def infrahub_version(self) -> str:
-        return "local"
-
+class TestSchemaMigrations(TestDockerIntegration, SchemaCarPerson):
     @pytest.fixture(scope="class")
     def schema_person_mandatory_age(self, schema_person_base: NodeSchema) -> NodeSchema:
         schema_person = schema_person_base.model_copy(deep=True)

--- a/python_testcontainers/infrahub_testcontainers/__init__.py
+++ b/python_testcontainers/infrahub_testcontainers/__init__.py
@@ -1,6 +1,0 @@
-import importlib.metadata
-
-try:
-    __version__ = importlib.metadata.version("infrahub-testcontainers")
-except importlib.metadata.PackageNotFoundError:
-    __version__ = importlib.metadata.version("infrahub-server")

--- a/python_testcontainers/infrahub_testcontainers/container.py
+++ b/python_testcontainers/infrahub_testcontainers/container.py
@@ -8,8 +8,6 @@ from typing import Optional
 from testcontainers.compose import DockerCompose
 from typing_extensions import Self
 
-from infrahub_testcontainers import __version__ as infrahub_version
-
 
 @dataclass
 class ContainerService:
@@ -22,9 +20,8 @@ INFRAHUB_SERVICES: dict[str, ContainerService] = {
     "task-manager": ContainerService(container="task-manager", port=4200),
 }
 
-PROJECT_ENV_VARIABLES: dict[str, str] = {
-    "INFRAHUB_TESTING_DOCKER_IMAGE": "registry.opsmill.io/opsmill/infrahub",
-    "INFRAHUB_TESTING_IMAGE_VERSION": infrahub_version,
+ENV_VAR_DEFAULT_VALUES: dict[str, str] = {
+    "INFRAHUB_TESTING_IMAGE_NAME": "registry.opsmill.io/opsmill/infrahub",
     "INFRAHUB_TESTING_PRODUCTION": "false",
     "INFRAHUB_TESTING_DB_ADDRESS": "database",
     "INFRAHUB_TESTING_LOG_LEVEL": "DEBUG",
@@ -51,19 +48,9 @@ class InfrahubDockerCompose(DockerCompose):
     project_name: Optional[str] = None
 
     @classmethod
-    def init(cls, directory: Optional[Path] = None, version: Optional[str] = None) -> Self:
-        if not directory:
-            directory = Path.cwd()
-
-        if not version:
-            version = infrahub_version
-
-        infrahub_image_version = os.environ.get("INFRAHUB_TESTING_IMAGE_VER", None)
-        if version == "local" and infrahub_image_version:
-            version = infrahub_image_version
-
+    def init(cls, directory: Path, image_tag: str) -> Self:
         cls.create_docker_file(directory=directory)
-        cls.create_env_file(directory=directory, version=version)
+        cls.create_env_file(directory=directory, image_tag=image_tag)
 
         return cls(project_name=cls.generate_project_name(), context=directory)
 
@@ -83,15 +70,16 @@ class InfrahubDockerCompose(DockerCompose):
         return test_compose_file
 
     @classmethod
-    def create_env_file(cls, directory: Path, version: str) -> Path:
+    def create_env_file(cls, directory: Path, image_tag: str) -> Path:
         env_file = directory / ".env"
 
-        PROJECT_ENV_VARIABLES.update({"INFRAHUB_TESTING_IMAGE_VERSION": version})
-
         with env_file.open(mode="w", encoding="utf-8") as file:
-            for key, value in PROJECT_ENV_VARIABLES.items():
+            for key, value in ENV_VAR_DEFAULT_VALUES.items():
                 env_var_value = os.environ.get(key, value)
                 file.write(f"{key}={env_var_value}\n")
+
+            file.write(f"INFRAHUB_TESTING_IMAGE_TAG={image_tag}\n")
+
         return env_file.absolute()
 
     # TODO would be good to the support for project_name upstream

--- a/python_testcontainers/infrahub_testcontainers/docker-compose.test.yml
+++ b/python_testcontainers/infrahub_testcontainers/docker-compose.test.yml
@@ -80,7 +80,7 @@ services:
       retries: 5
 
   infrahub-server:
-    image: "${INFRAHUB_TESTING_DOCKER_IMAGE}:${INFRAHUB_TESTING_IMAGE_VERSION}"
+    image: "${INFRAHUB_TESTING_IMAGE_NAME}:${INFRAHUB_TESTING_IMAGE_TAG}"
     command: >
       gunicorn --config backend/infrahub/serve/gunicorn_config.py
       -w ${INFRAHUB_TESTING_WEB_CONCURRENCY}
@@ -122,7 +122,7 @@ services:
     deploy:
       mode: replicated
       replicas: 2
-    image: "${INFRAHUB_TESTING_DOCKER_IMAGE}:${INFRAHUB_TESTING_IMAGE_VERSION}"
+    image: "${INFRAHUB_TESTING_IMAGE_NAME}:${INFRAHUB_TESTING_IMAGE_TAG}"
     command: prefect worker start --type infrahubasync --pool infrahub-worker --with-healthcheck
     environment:
       INFRAHUB_PRODUCTION: ${INFRAHUB_TESTING_PRODUCTION}

--- a/python_testcontainers/infrahub_testcontainers/helpers.py
+++ b/python_testcontainers/infrahub_testcontainers/helpers.py
@@ -1,23 +1,61 @@
 import os
 import subprocess  # noqa: S404
 from pathlib import Path
+from typing import Optional
 
 import pytest
+from packaging.version import InvalidVersion, Version
 
-from infrahub_testcontainers import __version__ as infrahub_version
+from .container import ENV_VAR_DEFAULT_VALUES, InfrahubDockerCompose
 
-from .container import PROJECT_ENV_VARIABLES, InfrahubDockerCompose
+DEFAULT_INFRAHUB_SERVER_VERSION = "latest"
 
 
 class TestInfrahubDocker:
-    @pytest.fixture(scope="class")
-    def infrahub_version(self) -> str:
-        return infrahub_version
+    @staticmethod
+    def infrahub_version() -> str:
+        """Required (for now) to define the version of infrahub to use.
+        This fixture is meant to be overriden by subclasses."""
+
+        # Note that when this method is not overriden, it might also return an image tag, like "local" or "latest".
+
+        return os.getenv("INFRAHUB_TESTING_IMAGE_TAG", DEFAULT_INFRAHUB_SERVER_VERSION)
+
+    def check_skip(self, min_infrahub_version: Optional[str], max_infrahub_version: Optional[str]) -> None:
+        """
+        Check if a test should be skipped depending on infrahub version. This method is meant to be called
+        at the start of any test that should be skipped depending on infrahub version.
+        """
+
+        # Ideally, we would use `skipIf` or a fixture instead of calling a method to skip a test. The fact
+        # we support both `infrahub_version` as a convenient way to declare version and `INFRAHUB_TESTING_IMAGE_TAG`
+        # for internal development purposes (CI) makes it trickier to do.
+
+        infrahub_version = self.infrahub_version()
+
+        try:
+            version = Version(infrahub_version)
+        except InvalidVersion:
+            # We would typically end up here for development purpose while running a CI test against
+            # unreleased versions of infrahub, like `stable` or `develop` branch.
+            # For now, we consider this means we are testing against the most recent version of infrahub,
+            # so we skip if the test should not be ran against a maximum version.
+            if max_infrahub_version is None:
+                pytest.skip(
+                    f"A local version is used ({infrahub_version}) while a maximum version is specified ({max_infrahub_version}"
+                )
+            return
+
+        if min_infrahub_version is not None and version <= Version(min_infrahub_version):
+            pytest.skip(f"Infrahub version should be higher than {min_infrahub_version}, found {infrahub_version}")
+
+        if max_infrahub_version is not None and version <= Version(max_infrahub_version):
+            pytest.skip(f"Infrahub version should be less than {max_infrahub_version}, found {infrahub_version}")
 
     def execute_ctl_run(self, address: str, script: str) -> str:
         env = os.environ.copy()
         env["INFRAHUB_ADDRESS"] = address
-        env["INFRAHUB_API_TOKEN"] = PROJECT_ENV_VARIABLES["INFRAHUB_TESTING_INITIAL_ADMIN_TOKEN"]
+        env["INFRAHUB_API_TOKEN"] = ENV_VAR_DEFAULT_VALUES["INFRAHUB_TESTING_INITIAL_ADMIN_TOKEN"]
         env["INFRAHUB_MAX_CONCURRENT_EXECUTION"] = "1"
         result = subprocess.run(  # noqa: S602
             f"infrahubctl run {script}", shell=True, capture_output=True, text=True, env=env, check=False
@@ -31,7 +69,7 @@ class TestInfrahubDocker:
 
     @pytest.fixture(scope="class")
     def remote_repos_dir(self, tmp_directory: Path) -> Path:
-        directory = tmp_directory / PROJECT_ENV_VARIABLES["INFRAHUB_TESTING_LOCAL_REMOTE_GIT_DIRECTORY"]
+        directory = tmp_directory / ENV_VAR_DEFAULT_VALUES["INFRAHUB_TESTING_LOCAL_REMOTE_GIT_DIRECTORY"]
         directory.mkdir(exist_ok=True)
 
         return directory
@@ -41,8 +79,8 @@ class TestInfrahubDocker:
         return "main"
 
     @pytest.fixture(scope="class")
-    def infrahub_compose(self, tmp_directory: Path, infrahub_version: str) -> InfrahubDockerCompose:
-        return InfrahubDockerCompose.init(directory=tmp_directory, version=infrahub_version)
+    def infrahub_compose(self, tmp_directory: Path) -> InfrahubDockerCompose:
+        return InfrahubDockerCompose.init(directory=tmp_directory, image_tag=self.infrahub_version())
 
     @pytest.fixture(scope="class")
     def infrahub_app(self, request: pytest.FixtureRequest, infrahub_compose: InfrahubDockerCompose) -> dict[str, int]:

--- a/tasks/shared.py
+++ b/tasks/shared.py
@@ -28,6 +28,9 @@ class Namespace(str, Enum):
     TEST = "test"
 
 
+LOCAL_BUILD_DEFAULT_IMAGE_NAME = "local.build/opsmill/infrahub"
+LOCAL_BUILD_DEFAULT_IMAGE_TAG = "local"
+
 INVOKE_SUDO = os.getenv("INVOKE_SUDO", None)
 INVOKE_PTY = os.getenv("INVOKE_PTY", None)
 DEBUG = os.environ.get("DEBUG", "").lower() in ("true", "1", "yes")
@@ -80,7 +83,7 @@ COMPOSE_FILES_DEPS = {
     True: Path("development/docker-compose-deps-nats.yml"),
 }
 
-IMAGE_NAME = os.getenv("INFRAHUB_IMAGE_NAME", "registry.opsmill.io/opsmill/infrahub")
+IMAGE_NAME = os.getenv("INFRAHUB_IMAGE_NAME", LOCAL_BUILD_DEFAULT_IMAGE_NAME)
 REQUESTED_IMAGE_VER = os.getenv("INFRAHUB_IMAGE_VER")
 IMAGE_VER = REQUESTED_IMAGE_VER or "latest"
 
@@ -234,7 +237,7 @@ def get_env_vars(context: Context, namespace: Namespace = Namespace.DEFAULT) -> 
     }
 
     if namespace == Namespace.DEV and not REQUESTED_IMAGE_VER:
-        ENV_VARS_DICT["IMAGE_VER"] = "local"
+        ENV_VARS_DICT["IMAGE_VER"] = LOCAL_BUILD_DEFAULT_IMAGE_TAG
 
     if DATABASE_DOCKER_IMAGE:
         ENV_VARS_DICT["DATABASE_DOCKER_IMAGE"] = DATABASE_DOCKER_IMAGE


### PR DESCRIPTION
Prior PR before sdk changes allowing sdk tests to run against multiple versions of infrahub. It contains some cleanup and should simplify / make explicit which version / image-tag we use while using `TestInfrahubDockerClient`. So:
- A user writing some SDK tests can still specify `infrahub_version` of a given test.
- We will still use `INFRAHUB_TESTING_IMAGE_TAG` (former `INFRAHUB_TESTING_IMAGE_VER`) to specify which version to use from CI.

It also adds a `check_skip` so we can specify for specific tests whether they should be skipped depending on tested infrahub version.