### PR TITLE
Fix configuration for HTTP adapter

### DIFF
--- a/backend/infrahub/services/adapters/http/__init__.py
+++ b/backend/infrahub/services/adapters/http/__init__.py
@@ -7,9 +7,6 @@ if TYPE_CHECKING:
 
 
 class InfrahubHTTP:
-    async def initialize(self) -> None:
-        """Initialize the HTTP adapter"""
-
     async def get(
         self,
         url: str,

--- a/backend/infrahub/services/adapters/http/httpx.py
+++ b/backend/infrahub/services/adapters/http/httpx.py
@@ -15,15 +15,15 @@ log = get_logger()
 
 
 class HttpxAdapter(InfrahubHTTP):
-    settings: config.HTTPSettings
+    _settings: config.HTTPSettings | None = None
 
-    async def initialize(self) -> None:
-        """Initialize the HTTP adapter"""
-        self.settings = config.SETTINGS.http
+    @property
+    def settings(self) -> config.HTTPSettings:
+        if self._settings:
+            return self._settings
 
-        # Cache the context during init, this is to avoid issue when a CA bundle might be accessible
-        # when Infrahub initializes but then removed before the first external HTTP call is made.
-        _ = self.tls_context
+        self._settings = config.SETTINGS.http
+        return self._settings
 
     @cached_property
     def tls_context(self) -> ssl.SSLContext:


### PR DESCRIPTION
When we removed the service.initialize() method the HTTP adapter stopped working because HttpxAdapter.initialize() was never executed. I noticed this by accident while working on #5551. I haven't included any news fragments as this is just during changes for the 1.2 release.

I did open #5553 as a follow up issue so that we have proper tests for the HTTP adapter (currently used by SSO, Webhooks and telemetry.