### PR TITLE
Fix bi-directional identifier for circuit

### DIFF
--- a/models/base/dcim.yml
+++ b/models/base/dcim.yml
@@ -536,12 +536,19 @@ nodes:
         optional: true
     relationships:
       - name: provider
-        label: "Provider (Organization)"
-        peer: OrganizationGeneric
+        identifier: circuit__provider
+        peer: OrganizationProvider
         optional: false
         cardinality: one
         kind: Attribute
         order_weight: 1
+      - name: tenant
+        identifier: circuit__tenant
+        peer: OrganizationTenant
+        optional: true
+        cardinality: one
+        kind: Attribute
+        order_weight: 2
       - name: endpoints
         peer: InfraCircuitEndpoint
         optional: true

--- a/models/base/organization.yml
+++ b/models/base/organization.yml
@@ -69,6 +69,7 @@ nodes:
         optional: true
       - name: circuit
         peer: InfraCircuit
+        identifier: circuit__provider
         cardinality: many
         optional: true
   - name: Tenant
@@ -89,5 +90,6 @@ nodes:
         optional: true
       - name: circuit
         peer: InfraCircuit
+        identifier: circuit__tenant
         cardinality: many
         optional: true


### PR DESCRIPTION
When using demo-edge, the circuit has a link to the Provider but the "return" is not properly set.
Looking at the schema, the identifiers on both sides were different.

Using this opportunity to split tenant and provider as it was split on the organization side.