### PR TITLE
Fixes issue when retrieving files from S3 buckets 

### DIFF
--- a/backend/infrahub/storage.py
+++ b/backend/infrahub/storage.py
@@ -1,3 +1,4 @@
+import io
 import tempfile
 from typing import Any, BinaryIO
 
@@ -17,11 +18,11 @@ class InfrahubS3ObjectStorage(fastapi_storages.S3Storage):
         super().__init__()
 
     def open(self, name: str) -> BinaryIO:
-        with tempfile.NamedTemporaryFile() as f:
-            self._bucket.download_fileobj(name, f)
-            f.flush()
-            f.seek(0)
-            return f  # type: ignore
+        f = io.BytesIO()
+        self._bucket.download_fileobj(name, f)
+        f.flush()
+        f.seek(0)
+        return f  # type: ignore
 
 
 fastapi_storages.InfrahubS3ObjectStorage = InfrahubS3ObjectStorage

--- a/changelog/5573.fixed.md
+++ b/changelog/5573.fixed.md
@@ -1,0 +1,1 @@
+Fixes an issue with retrieving object from S3 storage backend


### PR DESCRIPTION
fixes #5573 

In #5033  a context manager was introduced to handle the creation of a NamedTempFile, to be compliant with rule SIM115 for ruff.
This created an issue as the context manager would close the file object that we returned from the function.

In this PR we take another approach by using a BytesIO object instead of a tempfile.