### PR TITLE
Add support for Context in backend

### DIFF
--- a/backend/infrahub/api/artifact.py
+++ b/backend/infrahub/api/artifact.py
@@ -5,7 +5,14 @@ from typing import TYPE_CHECKING
 from fastapi import APIRouter, Body, Depends, Request, Response
 from pydantic import BaseModel, Field
 
-from infrahub.api.dependencies import BranchParams, get_branch_params, get_current_user, get_db, get_permission_manager
+from infrahub.api.dependencies import (
+    BranchParams,
+    get_branch_params,
+    get_context,
+    get_current_user,
+    get_db,
+    get_permission_manager,
+)
 from infrahub.core import registry
 from infrahub.core.account import ObjectPermission
 from infrahub.core.constants import GLOBAL_BRANCH_NAME, InfrahubKind, PermissionAction
@@ -19,7 +26,9 @@ from infrahub.workflows.catalogue import REQUEST_ARTIFACT_DEFINITION_GENERATE
 
 if TYPE_CHECKING:
     from infrahub.auth import AccountSession
+    from infrahub.context import InfrahubContext
     from infrahub.permissions import PermissionManager
+    from infrahub.services import InfrahubServices
 
 log = get_logger()
 router = APIRouter(prefix="/artifact")
@@ -63,6 +72,7 @@ async def generate_artifact(
     db: InfrahubDatabase = Depends(get_db),
     branch_params: BranchParams = Depends(get_branch_params),
     permission_manager: PermissionManager = Depends(get_permission_manager),
+    context: InfrahubContext = Depends(get_context),
 ) -> None:
     permission_decision = (
         PermissionDecisionFlag.ALLOW_DEFAULT
@@ -83,7 +93,7 @@ async def generate_artifact(
         branch=branch_params.branch,
     )
 
-    service = request.app.state.service
+    service: InfrahubServices = request.app.state.service
     model = RequestArtifactDefinitionGenerate(
         artifact_definition_id=artifact_definition.id,
         artifact_definition_name=artifact_definition.name.value,
@@ -91,4 +101,6 @@ async def generate_artifact(
         limit=payload.nodes,
     )
 
-    await service.workflow.submit_workflow(workflow=REQUEST_ARTIFACT_DEFINITION_GENERATE, parameters={"model": model})
+    await service.workflow.submit_workflow(
+        workflow=REQUEST_ARTIFACT_DEFINITION_GENERATE, context=context, parameters={"model": model}
+    )

--- a/backend/infrahub/api/dependencies.py
+++ b/backend/infrahub/api/dependencies.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, ConfigDict
 
 from infrahub import config
 from infrahub.auth import AccountSession, authentication_token, validate_jwt_access_token, validate_jwt_refresh_token
+from infrahub.context import InfrahubContext
 from infrahub.core.branch import Branch  # noqa: TC001
 from infrahub.core.registry import registry
 from infrahub.core.timestamp import Timestamp
@@ -133,3 +134,10 @@ async def get_permission_manager(
     await permission_manager.load_permissions(db=db, branch=branch_params.branch)
 
     return permission_manager
+
+
+async def get_context(
+    branch: Branch = Depends(get_branch_dep),
+    account_session: AccountSession = Depends(get_current_user),
+) -> InfrahubContext:
+    return InfrahubContext.init(branch=branch, account=account_session)

--- a/backend/infrahub/api/query.py
+++ b/backend/infrahub/api/query.py
@@ -7,6 +7,7 @@ from graphql import graphql
 from pydantic import BaseModel, Field
 
 from infrahub.api.dependencies import BranchParams, get_branch_params, get_current_user, get_db
+from infrahub.context import InfrahubContext
 from infrahub.core import registry
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.protocols import CoreGraphQLQuery
@@ -56,6 +57,8 @@ async def execute_query(
     gql_query = await registry.manager.get_one_by_id_or_default_filter(
         db=db, id=query_id, kind=CoreGraphQLQuery, branch=branch_params.branch, at=branch_params.at
     )
+
+    context = InfrahubContext.init(branch=branch_params.branch, account=account_session)
 
     gql_params = await prepare_graphql_params(
         db=db,
@@ -120,7 +123,9 @@ async def execute_query(
             subscribers=sorted(subscribers),
             params=params,
         )
-        await service.workflow.submit_workflow(workflow=GRAPHQL_QUERY_GROUP_UPDATE, parameters={"model": model})
+        await service.workflow.submit_workflow(
+            workflow=GRAPHQL_QUERY_GROUP_UPDATE, context=context, parameters={"model": model}
+        )
 
     return response_payload
 

--- a/backend/infrahub/api/schema.py
+++ b/backend/infrahub/api/schema.py
@@ -13,7 +13,7 @@ from pydantic import (
 from starlette.responses import JSONResponse
 
 from infrahub import lock
-from infrahub.api.dependencies import get_branch_dep, get_current_user, get_db, get_permission_manager
+from infrahub.api.dependencies import get_branch_dep, get_context, get_current_user, get_db, get_permission_manager
 from infrahub.api.exceptions import SchemaNotValidError
 from infrahub.core import registry
 from infrahub.core.account import GlobalPermission
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from infrahub.auth import AccountSession
+    from infrahub.context import InfrahubContext
     from infrahub.core.schema.schema_branch import SchemaBranch
     from infrahub.permissions import PermissionManager
     from infrahub.services import InfrahubServices
@@ -269,6 +270,7 @@ async def load_schema(
     branch: Branch = Depends(get_branch_dep),
     account_session: AccountSession = Depends(get_current_user),
     permission_manager: PermissionManager = Depends(get_permission_manager),
+    context: InfrahubContext = Depends(get_context),
 ) -> SchemaUpdate:
     permission_manager.raise_for_permission(
         permission=GlobalPermission(
@@ -317,6 +319,7 @@ async def load_schema(
         )
         responses = await service.workflow.execute_workflow(
             workflow=SCHEMA_VALIDATE_MIGRATION,
+            context=context,
             expected_return=list[SchemaValidatorPathResponseData],
             parameters={"message": validate_migration_data},
         )
@@ -361,6 +364,7 @@ async def load_schema(
         )
         migration_error_msgs = await service.workflow.execute_workflow(
             workflow=SCHEMA_APPLY_MIGRATION,
+            context=context,
             expected_return=list[str],
             parameters={"message": apply_migration_data},
         )
@@ -392,6 +396,7 @@ async def check_schema(
     request: Request,
     schemas: SchemasLoadAPI,
     branch: Branch = Depends(get_branch_dep),
+    context: InfrahubContext = Depends(get_context),
     _: AccountSession = Depends(get_current_user),
 ) -> JSONResponse:
     service: InfrahubServices = request.app.state.service
@@ -418,6 +423,7 @@ async def check_schema(
     )
     responses = await service.workflow.execute_workflow(
         workflow=SCHEMA_VALIDATE_MIGRATION,
+        context=context,
         expected_return=list[SchemaValidatorPathResponseData],
         parameters={"message": validate_migration_data},
     )

--- a/backend/infrahub/api/transformation.py
+++ b/backend/infrahub/api/transformation.py
@@ -9,6 +9,7 @@ from starlette.responses import JSONResponse, PlainTextResponse
 from infrahub.api.dependencies import (
     BranchParams,
     get_branch_params,
+    get_context,
     get_current_user,
     get_db,
 )
@@ -28,8 +29,8 @@ from infrahub.workflows.catalogue import TRANSFORM_JINJA2_RENDER, TRANSFORM_PYTH
 
 if TYPE_CHECKING:
     from infrahub.auth import AccountSession
+    from infrahub.context import InfrahubContext
     from infrahub.services import InfrahubServices
-
 router = APIRouter()
 
 
@@ -38,6 +39,7 @@ async def transform_python(
     request: Request,
     transform_id: str,
     db: InfrahubDatabase = Depends(get_db),
+    context: InfrahubContext = Depends(get_context),
     branch_params: BranchParams = Depends(get_branch_params),
     _: AccountSession = Depends(get_current_user),
 ) -> JSONResponse:
@@ -90,7 +92,7 @@ async def transform_python(
     )
 
     response = await service.workflow.execute_workflow(
-        workflow=TRANSFORM_PYTHON_RENDER, parameters={"message": message}
+        workflow=TRANSFORM_PYTHON_RENDER, context=context, parameters={"message": message}
     )
     return JSONResponse(content=response)
 
@@ -101,6 +103,7 @@ async def transform_jinja2(
     transform_id: str = Path(description="ID or Name of the Jinja2 Transform to render"),
     db: InfrahubDatabase = Depends(get_db),
     branch_params: BranchParams = Depends(get_branch_params),
+    context: InfrahubContext = Depends(get_context),
     _: AccountSession = Depends(get_current_user),
 ) -> PlainTextResponse:
     params = {key: value for key, value in request.query_params.items() if key not in ["branch", "at"]}
@@ -152,6 +155,6 @@ async def transform_jinja2(
     service: InfrahubServices = request.app.state.service
 
     response = await service.workflow.execute_workflow(
-        workflow=TRANSFORM_JINJA2_RENDER, expected_return=str, parameters={"message": message}
+        workflow=TRANSFORM_JINJA2_RENDER, context=context, expected_return=str, parameters={"message": message}
     )
     return PlainTextResponse(content=response)

--- a/backend/infrahub/computed_attribute/tasks.py
+++ b/backend/infrahub/computed_attribute/tasks.py
@@ -19,6 +19,7 @@ from prefect.events.schemas.automations import EventTrigger, Posture
 from prefect.events.schemas.events import ResourceSpecification
 from prefect.logging import get_run_logger
 
+from infrahub.context import InfrahubContext  # noqa: TC001  needed for prefect flow
 from infrahub.core.constants import ComputedAttributeKind, InfrahubKind
 from infrahub.core.registry import registry
 from infrahub.git.repository import get_initialized_repo
@@ -73,6 +74,7 @@ async def process_transform(
     object_id: str,
     computed_attribute_name: str,  # noqa: ARG001
     computed_attribute_kind: str,  # noqa: ARG001
+    context: InfrahubContext,  # noqa: ARG001
     service: InfrahubServices,
     updated_fields: list[str] | None = None,  # noqa: ARG001
 ) -> None:
@@ -151,6 +153,7 @@ async def trigger_update_python_computed_attributes(
     branch_name: str,
     computed_attribute_name: str,
     computed_attribute_kind: str,
+    context: InfrahubContext,
     service: InfrahubServices,
 ) -> None:
     await add_tags(branches=[branch_name])
@@ -160,6 +163,7 @@ async def trigger_update_python_computed_attributes(
     for node in nodes:
         await service.workflow.submit_workflow(
             workflow=UPDATE_COMPUTED_ATTRIBUTE_TRANSFORM,
+            context=context,
             parameters={
                 "branch_name": branch_name,
                 "node_kind": computed_attribute_kind,
@@ -230,6 +234,7 @@ async def process_jinja2(
     object_id: str,
     computed_attribute_name: str,
     computed_attribute_kind: str,
+    context: InfrahubContext,  # noqa: ARG001
     service: InfrahubServices,
     updated_fields: str | None = None,
 ) -> None:
@@ -293,6 +298,7 @@ async def trigger_update_jinja2_computed_attributes(
     branch_name: str,
     computed_attribute_name: str,
     computed_attribute_kind: str,
+    context: InfrahubContext,
     service: InfrahubServices,
 ) -> None:
     await add_tags(branches=[branch_name])
@@ -302,6 +308,7 @@ async def trigger_update_jinja2_computed_attributes(
     for node in nodes:
         await service.workflow.submit_workflow(
             workflow=PROCESS_COMPUTED_MACRO,
+            context=context,
             parameters={
                 "branch_name": branch_name,
                 "computed_attribute_name": computed_attribute_name,
@@ -313,7 +320,9 @@ async def trigger_update_jinja2_computed_attributes(
 
 
 @flow(name="computed-attribute-setup", flow_run_name="Setup computed attributes in task-manager")
-async def computed_attribute_setup(service: InfrahubServices, branch_name: str | None = None) -> None:
+async def computed_attribute_setup(
+    service: InfrahubServices, context: InfrahubContext, branch_name: str | None = None
+) -> None:
     branch_name = branch_name or registry.default_branch
 
     await add_tags(branches=[branch_name])
@@ -393,6 +402,7 @@ async def computed_attribute_setup(service: InfrahubServices, branch_name: str |
             if branch_name == registry.default_branch:
                 await service.workflow.submit_workflow(
                     workflow=TRIGGER_UPDATE_JINJA_COMPUTED_ATTRIBUTES,
+                    context=context,
                     parameters={
                         "branch_name": registry.default_branch,
                         "computed_attribute_name": computed_attribute.attribute.name,
@@ -459,6 +469,7 @@ async def computed_attribute_setup(service: InfrahubServices, branch_name: str |
                 if branch_name == diff_branch:
                     await service.workflow.submit_workflow(
                         workflow=TRIGGER_UPDATE_JINJA_COMPUTED_ATTRIBUTES,
+                        context=context,
                         parameters={
                             "branch_name": branch_name,
                             "computed_attribute_name": computed_attribute.attribute.name,
@@ -477,6 +488,7 @@ async def computed_attribute_setup(service: InfrahubServices, branch_name: str |
 )
 async def computed_attribute_setup_python(
     service: InfrahubServices,
+    context: InfrahubContext,
     branch_name: str | None = None,
     commit: str | None = None,  # noqa: ARG001
     trigger_updates: bool = True,
@@ -624,6 +636,7 @@ async def computed_attribute_setup_python(
             if trigger_updates:
                 await service.workflow.submit_workflow(
                     workflow=TRIGGER_UPDATE_PYTHON_COMPUTED_ATTRIBUTES,
+                    context=context,
                     parameters={
                         "branch_name": branch_name,
                         "computed_attribute_name": computed_attribute.computed_attribute.attribute.name,
@@ -671,6 +684,7 @@ async def query_transform_targets(
     branch_name: str,
     node_kind: str,  # noqa: ARG001
     object_id: str,
+    context: InfrahubContext,
     service: InfrahubServices,
 ) -> None:
     await add_tags(branches=[branch_name])
@@ -693,6 +707,7 @@ async def query_transform_targets(
             for computed_attribute in nodes_with_computed_attributes[subscriber.kind]:
                 await service.workflow.submit_workflow(
                     workflow=UPDATE_COMPUTED_ATTRIBUTE_TRANSFORM,
+                    context=context,
                     parameters={
                         "branch_name": branch_name,
                         "node_kind": subscriber.kind,

--- a/backend/infrahub/context.py
+++ b/backend/infrahub/context.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel, Field
+from typing_extensions import Self
+
+from infrahub.auth import AccountSession
+from infrahub.core.branch import Branch
+
+
+class EventContext(BaseModel):
+    name: str
+
+
+class BranchContext(BaseModel):
+    name: str
+    id: str | None = None
+
+
+class InfrahubContext(BaseModel):
+    branch: BranchContext
+    account: AccountSession
+    events: list[EventContext] = Field(default_factory=list)
+
+    @classmethod
+    def init(cls, branch: Branch, account: AccountSession) -> Self:
+        return cls(branch=BranchContext(name=branch.name, id=str(branch.uuid)), account=account)

--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -8,6 +8,7 @@ from prefect.client.schemas.objects import State  # noqa: TC002
 from prefect.states import Completed, Failed
 
 from infrahub import lock
+from infrahub.context import InfrahubContext  # noqa: TC001  needed for prefect flow
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.diff.coordinator import DiffCoordinator
@@ -36,14 +37,14 @@ from infrahub.workflows.catalogue import (
     GIT_REPOSITORIES_CREATE_BRANCH,
     IPAM_RECONCILIATION,
 )
-from infrahub.workflows.utils import add_branch_tag
+from infrahub.workflows.utils import add_tags
 
 
 @flow(name="branch-rebase", flow_run_name="Rebase branch {branch}")
-async def rebase_branch(branch: str, service: InfrahubServices) -> None:
+async def rebase_branch(branch: str, context: InfrahubContext, service: InfrahubServices) -> None:
     async with service.database.start_session() as db:
         log = get_run_logger()
-        await add_branch_tag(branch_name=branch)
+        await add_tags(branches=[branch])
         obj = await Branch.get_by_name(db=db, name=branch)
         base_branch = await Branch.get_by_name(db=db, name=registry.default_branch)
         component_registry = get_component_registry()
@@ -137,10 +138,14 @@ async def rebase_branch(branch: str, service: InfrahubServices) -> None:
         )
         if ipam_node_details:
             await service.workflow.submit_workflow(
-                workflow=IPAM_RECONCILIATION, parameters={"branch": obj.name, "ipam_node_details": ipam_node_details}
+                workflow=IPAM_RECONCILIATION,
+                context=context,
+                parameters={"branch": obj.name, "ipam_node_details": ipam_node_details},
             )
 
-    await service.workflow.submit_workflow(workflow=DIFF_REFRESH_ALL, parameters={"branch_name": obj.name})
+    await service.workflow.submit_workflow(
+        workflow=DIFF_REFRESH_ALL, context=context, parameters={"branch_name": obj.name}
+    )
 
     # -------------------------------------------------------------
     # Generate an event to indicate that a branch has been rebased
@@ -152,12 +157,11 @@ async def rebase_branch(branch: str, service: InfrahubServices) -> None:
 
 
 @flow(name="branch-merge", flow_run_name="Merge branch {branch} into main")
-async def merge_branch(branch: str, service: InfrahubServices) -> None:
+async def merge_branch(branch: str, context: InfrahubContext, service: InfrahubServices) -> None:
     async with service.database.start_session() as db:
         log = get_run_logger()
 
-        await add_branch_tag(branch_name=branch)
-        await add_branch_tag(branch_name=registry.default_branch)
+        await add_tags(branches=[branch, registry.default_branch])
 
         obj = await Branch.get_by_name(db=db, name=branch)
         component_registry = get_component_registry()
@@ -209,6 +213,7 @@ async def merge_branch(branch: str, service: InfrahubServices) -> None:
         if ipam_node_details:
             await service.workflow.submit_workflow(
                 workflow=IPAM_RECONCILIATION,
+                context=context,
                 parameters={"branch": registry.default_branch, "ipam_node_details": ipam_node_details},
             )
         # -------------------------------------------------------------
@@ -227,14 +232,15 @@ async def merge_branch(branch: str, service: InfrahubServices) -> None:
         message = messages.EventBranchMerge(
             source_branch=obj.name,
             target_branch=registry.default_branch,
+            context=context,
             meta=Meta(initiator_id=WORKER_IDENTITY, request_id=request_id),
         )
         await service.message_bus.send(message=message)
 
 
 @flow(name="branch-delete", flow_run_name="Delete branch {branch}")
-async def delete_branch(branch: str, service: InfrahubServices) -> None:
-    await add_branch_tag(branch_name=branch)
+async def delete_branch(branch: str, context: InfrahubContext, service: InfrahubServices) -> None:
+    await add_tags(branches=[branch])
 
     async with service.database.start_session() as db:
         obj = await Branch.get_by_name(db=db, name=str(branch))
@@ -245,7 +251,7 @@ async def delete_branch(branch: str, service: InfrahubServices) -> None:
         )
 
         await service.workflow.submit_workflow(
-            workflow=BRANCH_CANCEL_PROPOSED_CHANGES, parameters={"branch_name": branch}
+            workflow=BRANCH_CANCEL_PROPOSED_CHANGES, context=context, parameters={"branch_name": branch}
         )
 
         await service.event.send(event=event)
@@ -258,7 +264,7 @@ async def delete_branch(branch: str, service: InfrahubServices) -> None:
     persist_result=True,
 )
 async def validate_branch(branch: str, service: InfrahubServices) -> State:
-    await add_branch_tag(branch_name=branch)
+    await add_tags(branches=[branch])
 
     async with service.database.start_session() as db:
         obj = await Branch.get_by_name(db=db, name=branch)
@@ -274,8 +280,8 @@ async def validate_branch(branch: str, service: InfrahubServices) -> State:
 
 
 @flow(name="create-branch", flow_run_name="Create branch {model.name}")
-async def create_branch(model: BranchCreateModel, service: InfrahubServices) -> None:
-    await add_branch_tag(model.name)
+async def create_branch(model: BranchCreateModel, context: InfrahubContext, service: InfrahubServices) -> None:
+    await add_tags(branches=[model.name])
 
     async with service.database.start_session() as db:
         try:
@@ -309,12 +315,13 @@ async def create_branch(model: BranchCreateModel, service: InfrahubServices) -> 
             branch_name=obj.name,
             branch_id=str(obj.uuid),
             sync_with_git=obj.sync_with_git,
-            meta=EventMeta(branch=obj),
+            meta=EventMeta(branch=obj, account_id=context.account.account_id, initiator_id=WORKER_IDENTITY),
         )
         await service.event.send(event=event)
 
         if obj.sync_with_git:
             await service.workflow.submit_workflow(
                 workflow=GIT_REPOSITORIES_CREATE_BRANCH,
+                context=context,
                 parameters={"branch": obj.name, "branch_id": str(obj.uuid)},
             )

--- a/backend/infrahub/core/diff/tasks.py
+++ b/backend/infrahub/core/diff/tasks.py
@@ -1,21 +1,17 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from prefect import flow
 
 from infrahub.context import InfrahubContext  # noqa: TC001  needed for prefect flow
 from infrahub.core import registry
 from infrahub.core.diff.coordinator import DiffCoordinator
+from infrahub.core.diff.models import RequestDiffUpdate  # noqa: TC001  needed for prefect flow
 from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.log import get_logger
 from infrahub.services import InfrahubServices  # noqa: TC001  needed for prefect flow
 from infrahub.workflows.catalogue import DIFF_REFRESH
 from infrahub.workflows.utils import add_branch_tag
-
-if TYPE_CHECKING:
-    from infrahub.core.diff.models import RequestDiffUpdate
 
 log = get_logger()
 

--- a/backend/infrahub/core/diff/tasks.py
+++ b/backend/infrahub/core/diff/tasks.py
@@ -1,14 +1,21 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from prefect import flow
 
+from infrahub.context import InfrahubContext  # noqa: TC001  needed for prefect flow
 from infrahub.core import registry
 from infrahub.core.diff.coordinator import DiffCoordinator
-from infrahub.core.diff.models import RequestDiffUpdate
 from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.log import get_logger
-from infrahub.services import InfrahubServices
+from infrahub.services import InfrahubServices  # noqa: TC001  needed for prefect flow
 from infrahub.workflows.catalogue import DIFF_REFRESH
 from infrahub.workflows.utils import add_branch_tag
+
+if TYPE_CHECKING:
+    from infrahub.core.diff.models import RequestDiffUpdate
 
 log = get_logger()
 
@@ -47,7 +54,7 @@ async def refresh_diff(branch_name: str, diff_id: str, service: InfrahubServices
 
 
 @flow(name="diff-refresh-all", flow_run_name="Recreate all diffs for branch {branch_name}")
-async def refresh_diff_all(branch_name: str, service: InfrahubServices) -> None:
+async def refresh_diff_all(branch_name: str, context: InfrahubContext, service: InfrahubServices) -> None:
     await add_branch_tag(branch_name=branch_name)
 
     async with service.database.start_session() as db:
@@ -60,5 +67,6 @@ async def refresh_diff_all(branch_name: str, service: InfrahubServices) -> None:
             if diff_root.base_branch_name != diff_root.diff_branch_name:
                 await service.workflow.submit_workflow(
                     workflow=DIFF_REFRESH,
+                    context=context,
                     parameters={"branch_name": diff_root.diff_branch_name, "diff_id": diff_root.uuid},
                 )

--- a/backend/infrahub/generators/tasks.py
+++ b/backend/infrahub/generators/tasks.py
@@ -8,6 +8,7 @@ from prefect import flow, task
 from prefect.cache_policies import NONE
 
 from infrahub import lock
+from infrahub.context import InfrahubContext  # noqa: TC001 needed for prefect flow
 from infrahub.core.constants import GeneratorInstanceStatus, InfrahubKind
 from infrahub.generators.models import (
     ProposedChangeGeneratorDefinition,
@@ -117,7 +118,7 @@ async def _define_instance(model: RequestGeneratorRun, service: InfrahubServices
 
 
 @flow(name="generator-definition-run", flow_run_name="Run all generators")
-async def run_generator_definition(branch: str, service: InfrahubServices) -> None:
+async def run_generator_definition(branch: str, context: InfrahubContext, service: InfrahubServices) -> None:
     await add_tags(branches=[branch])
 
     generators = await service.client.filters(
@@ -142,14 +143,18 @@ async def run_generator_definition(branch: str, service: InfrahubServices) -> No
 
     for generator_definition in generator_definitions:
         model = RequestGeneratorDefinitionRun(branch=branch, generator_definition=generator_definition)
-        await service.workflow.submit_workflow(workflow=REQUEST_GENERATOR_DEFINITION_RUN, parameters={"model": model})
+        await service.workflow.submit_workflow(
+            workflow=REQUEST_GENERATOR_DEFINITION_RUN, context=context, parameters={"model": model}
+        )
 
 
 @flow(
     name="request-generator-definition-run",
     flow_run_name="Execute generator {model.generator_definition.definition_name}",
 )
-async def request_generator_definition_run(model: RequestGeneratorDefinitionRun, service: InfrahubServices) -> None:
+async def request_generator_definition_run(
+    model: RequestGeneratorDefinitionRun, context: InfrahubContext, service: InfrahubServices
+) -> None:
     await add_tags(branches=[model.branch], nodes=[model.generator_definition.definition_id])
 
     group = await service.client.get(
@@ -202,5 +207,5 @@ async def request_generator_definition_run(model: RequestGeneratorDefinitionRun,
             target_name=member.display_label,
         )
         await service.workflow.submit_workflow(
-            workflow=REQUEST_GENERATOR_RUN, parameters={"model": request_generator_run_model}
+            workflow=REQUEST_GENERATOR_RUN, context=context, parameters={"model": request_generator_run_model}
         )

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -5,6 +5,7 @@ from prefect.cache_policies import NONE
 from prefect.logging import get_run_logger
 
 from infrahub import lock
+from infrahub.context import InfrahubContext
 from infrahub.core.constants import InfrahubKind, RepositoryInternalStatus
 from infrahub.core.registry import registry
 from infrahub.exceptions import RepositoryError
@@ -228,7 +229,7 @@ async def git_branch_create(
 
 
 @flow(name="artifact-definition-generate", flow_run_name="Generate all artifacts")
-async def generate_artifact_definition(branch: str, service: InfrahubServices) -> None:
+async def generate_artifact_definition(branch: str, context: InfrahubContext, service: InfrahubServices) -> None:
     await add_branch_tag(branch_name=branch)
 
     artifact_definitions = await service.client.all(kind=CoreArtifactDefinition, branch=branch, include=["id"])
@@ -240,7 +241,7 @@ async def generate_artifact_definition(branch: str, service: InfrahubServices) -
             artifact_definition_name=artifact_definition.name.value,
         )
         await service.workflow.submit_workflow(
-            workflow=REQUEST_ARTIFACT_DEFINITION_GENERATE, parameters={"model": model}
+            workflow=REQUEST_ARTIFACT_DEFINITION_GENERATE, context=context, parameters={"model": model}
         )
 
 
@@ -275,7 +276,7 @@ async def generate_artifact(model: RequestArtifactGenerate, service: InfrahubSer
     flow_run_name="Trigger Generation of Artifacts for {model.artifact_definition_name}",
 )
 async def generate_request_artifact_definition(
-    model: RequestArtifactDefinitionGenerate, service: InfrahubServices
+    model: RequestArtifactDefinitionGenerate, context: InfrahubContext, service: InfrahubServices
 ) -> None:
     await add_tags(branches=[model.branch])
 
@@ -346,7 +347,7 @@ async def generate_request_artifact_definition(
         )
 
         await service.workflow.submit_workflow(
-            workflow=REQUEST_ARTIFACT_GENERATE, parameters={"model": request_artifact_generate_model}
+            workflow=REQUEST_ARTIFACT_GENERATE, context=context, parameters={"model": request_artifact_generate_model}
         )
 
 

--- a/backend/infrahub/graphql/initialization.py
+++ b/backend/infrahub/graphql/initialization.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 from starlette.background import BackgroundTasks
 
+from infrahub.context import InfrahubContext
 from infrahub.core import registry
 from infrahub.core.timestamp import Timestamp
 from infrahub.exceptions import InitializationError
@@ -69,6 +70,9 @@ class GraphqlContext:
         if self.service:
             return self.service
         raise InitializationError("GraphQLContext doesn't contain a service")
+
+    def get_context(self) -> InfrahubContext:
+        return InfrahubContext.init(branch=self.branch, account=self.active_account_session)
 
 
 async def prepare_graphql_params(

--- a/backend/infrahub/graphql/mutations/artifact_definition.py
+++ b/backend/infrahub/graphql/mutations/artifact_definition.py
@@ -61,7 +61,9 @@ class InfrahubArtifactDefinitionMutation(InfrahubMutationMixin, Mutation):
                 artifact_definition_name=artifact_definition.name.value,  # type: ignore[attr-defined]
             )
             await graphql_context.service.workflow.submit_workflow(
-                workflow=REQUEST_ARTIFACT_DEFINITION_GENERATE, parameters={"model": model}
+                workflow=REQUEST_ARTIFACT_DEFINITION_GENERATE,
+                context=graphql_context.get_context(),
+                parameters={"model": model},
             )
 
         return artifact_definition, result
@@ -86,7 +88,9 @@ class InfrahubArtifactDefinitionMutation(InfrahubMutationMixin, Mutation):
                 artifact_definition_name=artifact_definition.name.value,  # type: ignore[attr-defined]
             )
             await graphql_context.service.workflow.submit_workflow(
-                workflow=REQUEST_ARTIFACT_DEFINITION_GENERATE, parameters={"model": model}
+                workflow=REQUEST_ARTIFACT_DEFINITION_GENERATE,
+                context=graphql_context.get_context(),
+                parameters={"model": model},
             )
 
         return artifact_definition, result

--- a/backend/infrahub/graphql/mutations/branch.py
+++ b/backend/infrahub/graphql/mutations/branch.py
@@ -74,7 +74,7 @@ class BranchCreate(Mutation):
             return cls(ok=True, task=task)
 
         await graphql_context.active_service.workflow.execute_workflow(
-            workflow=BRANCH_CREATE, parameters={"model": model}
+            workflow=BRANCH_CREATE, context=graphql_context.get_context(), parameters={"model": model}
         )
 
         # Retrieve created branch
@@ -114,12 +114,12 @@ class BranchDelete(Mutation):
 
         if wait_until_completion:
             await graphql_context.active_service.workflow.execute_workflow(
-                workflow=BRANCH_DELETE, parameters={"branch": obj.name}
+                workflow=BRANCH_DELETE, context=graphql_context.get_context(), parameters={"branch": obj.name}
             )
             return cls(ok=True)
 
         workflow = await graphql_context.active_service.workflow.submit_workflow(
-            workflow=BRANCH_DELETE, parameters={"branch": obj.name}
+            workflow=BRANCH_DELETE, context=graphql_context.get_context(), parameters={"branch": obj.name}
         )
         return cls(ok=True, task={"id": str(workflow.id)})
 
@@ -172,14 +172,14 @@ class BranchRebase(Mutation):
 
         if wait_until_completion:
             await graphql_context.active_service.workflow.execute_workflow(
-                workflow=BRANCH_REBASE, parameters={"branch": obj.name}
+                workflow=BRANCH_REBASE, context=graphql_context.get_context(), parameters={"branch": obj.name}
             )
 
             # Pull the latest information about the branch from the database directly
             obj = await Branch.get_by_name(db=graphql_context.db, name=str(data.name))
         else:
             workflow = await graphql_context.active_service.workflow.submit_workflow(
-                workflow=BRANCH_REBASE, parameters={"branch": obj.name}
+                workflow=BRANCH_REBASE, context=graphql_context.get_context(), parameters={"branch": obj.name}
             )
             task = {"id": workflow.id}
 
@@ -215,11 +215,11 @@ class BranchValidate(Mutation):
 
         if wait_until_completion:
             await graphql_context.active_service.workflow.execute_workflow(
-                workflow=BRANCH_VALIDATE, parameters={"branch": obj.name}
+                workflow=BRANCH_VALIDATE, context=graphql_context.get_context(), parameters={"branch": obj.name}
             )
         else:
             workflow = await graphql_context.active_service.workflow.submit_workflow(
-                workflow=BRANCH_VALIDATE, parameters={"branch": obj.name}
+                workflow=BRANCH_VALIDATE, context=graphql_context.get_context(), parameters={"branch": obj.name}
             )
             task = {"id": workflow.id}
 
@@ -251,11 +251,15 @@ class BranchMerge(Mutation):
 
         if wait_until_completion:
             await graphql_context.active_service.workflow.execute_workflow(
-                workflow=BRANCH_MERGE_MUTATION, parameters={"branch": branch_name}
+                workflow=BRANCH_MERGE_MUTATION,
+                context=graphql_context.get_context(),
+                parameters={"branch": branch_name},
             )
         else:
             workflow = await graphql_context.active_service.workflow.submit_workflow(
-                workflow=BRANCH_MERGE_MUTATION, parameters={"branch": branch_name}
+                workflow=BRANCH_MERGE_MUTATION,
+                context=graphql_context.get_context(),
+                parameters={"branch": branch_name},
             )
             task = {"id": workflow.id}
 

--- a/backend/infrahub/graphql/mutations/branch.py
+++ b/backend/infrahub/graphql/mutations/branch.py
@@ -68,7 +68,7 @@ class BranchCreate(Mutation):
 
         if background_execution or not wait_until_completion:
             workflow = await graphql_context.active_service.workflow.submit_workflow(
-                workflow=BRANCH_CREATE, parameters={"model": model}
+                workflow=BRANCH_CREATE, context=graphql_context.get_context(), parameters={"model": model}
             )
             task = {"id": workflow.id}
             return cls(ok=True, task=task)

--- a/backend/infrahub/graphql/mutations/diff.py
+++ b/backend/infrahub/graphql/mutations/diff.py
@@ -65,6 +65,8 @@ class DiffUpdateMutation(Mutation):
             to_time=to_timestamp_str,
         )
         if graphql_context.service:
-            await graphql_context.service.workflow.submit_workflow(workflow=DIFF_UPDATE, parameters={"model": model})
+            await graphql_context.service.workflow.submit_workflow(
+                workflow=DIFF_UPDATE, context=graphql_context.get_context(), parameters={"model": model}
+            )
 
         return {"ok": True}

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -71,6 +71,7 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
                     source_branch=source_branch.name,
                     source_branch_sync_with_git=source_branch.sync_with_git,
                     destination_branch=destination_branch,
+                    context=graphql_context.get_context(),
                 ),
             ]
 
@@ -176,6 +177,7 @@ class ProposedChangeRequestRunCheck(Mutation):
             source_branch_sync_with_git=source_branch.sync_with_git,
             destination_branch=destination_branch,
             check_type=check_type,
+            context=graphql_context.get_context(),
         )
         if graphql_context.service:
             await graphql_context.service.message_bus.send(message=message)

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -128,6 +128,7 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
         if updated_state == ProposedChangeState.MERGED:
             await graphql_context.service.workflow.execute_workflow(
                 workflow=PROPOSED_CHANGE_MERGE,
+                context=graphql_context.get_context(),
                 parameters={
                     "proposed_change_id": proposed_change.id,
                     "proposed_change_name": proposed_change.name.value,
@@ -220,6 +221,7 @@ class ProposedChangeMerge(Mutation):
         if wait_until_completion:
             await graphql_context.service.workflow.execute_workflow(
                 workflow=PROPOSED_CHANGE_MERGE,
+                context=graphql_context.get_context(),
                 parameters={
                     "proposed_change_id": proposed_change.id,
                     "proposed_change_name": proposed_change.name.value,
@@ -228,6 +230,7 @@ class ProposedChangeMerge(Mutation):
         else:
             workflow = await graphql_context.service.workflow.submit_workflow(
                 workflow=PROPOSED_CHANGE_MERGE,
+                context=graphql_context.get_context(),
                 parameters={
                     "proposed_change_id": proposed_change.id,
                     "proposed_change_name": proposed_change.name.value,

--- a/backend/infrahub/graphql/mutations/repository.py
+++ b/backend/infrahub/graphql/mutations/repository.py
@@ -114,7 +114,9 @@ class InfrahubRepositoryMutation(InfrahubMutationMixin, Mutation):
             )
             if graphql_context.service:
                 await graphql_context.service.workflow.submit_workflow(
-                    workflow=GIT_REPOSITORY_ADD_READ_ONLY, parameters={"model": model}
+                    workflow=GIT_REPOSITORY_ADD_READ_ONLY,
+                    context=graphql_context.get_context(),
+                    parameters={"model": model},
                 )
 
         else:
@@ -132,7 +134,9 @@ class InfrahubRepositoryMutation(InfrahubMutationMixin, Mutation):
 
             if graphql_context.service:
                 await graphql_context.service.workflow.submit_workflow(
-                    workflow=GIT_REPOSITORY_ADD, parameters={"model": git_repo_add_model}
+                    workflow=GIT_REPOSITORY_ADD,
+                    context=graphql_context.get_context(),
+                    parameters={"model": git_repo_add_model},
                 )
 
         # TODO Validate that the creation of the repository went as expected
@@ -198,7 +202,9 @@ class InfrahubRepositoryMutation(InfrahubMutationMixin, Mutation):
         )
         if graphql_context.service:
             await graphql_context.service.workflow.submit_workflow(
-                workflow=GIT_REPOSITORIES_PULL_READ_ONLY, parameters={"model": model}
+                workflow=GIT_REPOSITORIES_PULL_READ_ONLY,
+                context=graphql_context.get_context(),
+                parameters={"model": model},
             )
         return obj, result
 
@@ -248,7 +254,7 @@ class ProcessRepository(Mutation):
             infrahub_branch_name=branch.name,
         )
         workflow = await graphql_context.active_service.workflow.submit_workflow(
-            workflow=GIT_REPOSITORIES_IMPORT_OBJECTS, parameters={"model": model}
+            workflow=GIT_REPOSITORIES_IMPORT_OBJECTS, context=graphql_context.get_context(), parameters={"model": model}
         )
         task = {"id": workflow.id}
         return cls(ok=True, task=task)

--- a/backend/infrahub/graphql/mutations/tasks.py
+++ b/backend/infrahub/graphql/mutations/tasks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from prefect import flow
 
+from infrahub.context import InfrahubContext  # noqa: TC001  needed for prefect flow
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.diff.coordinator import DiffCoordinator
@@ -15,12 +16,12 @@ from infrahub.dependencies.registry import get_component_registry
 from infrahub.exceptions import ValidationError
 from infrahub.services import InfrahubServices  # noqa: TC001  needed for prefect flow
 from infrahub.workflows.catalogue import BRANCH_MERGE
-from infrahub.workflows.utils import add_branch_tag
+from infrahub.workflows.utils import add_tags
 
 
 @flow(name="merge-branch-mutation", flow_run_name="Merge branch graphQL mutation")
-async def merge_branch_mutation(branch: str, service: InfrahubServices) -> None:
-    await add_branch_tag(branch_name=branch)
+async def merge_branch_mutation(branch: str, context: InfrahubContext, service: InfrahubServices) -> None:
+    await add_tags(branches=[branch])
 
     async with service.database.start_session() as db:
         obj = await Branch.get_by_name(db=db, name=branch)
@@ -65,4 +66,4 @@ async def merge_branch_mutation(branch: str, service: InfrahubServices) -> None:
             if error_messages:
                 raise ValidationError(",\n".join(error_messages))
 
-        await service.workflow.execute_workflow(workflow=BRANCH_MERGE, parameters={"branch": obj.name})
+        await service.workflow.execute_workflow(workflow=BRANCH_MERGE, context=context, parameters={"branch": obj.name})

--- a/backend/infrahub/message_bus/messages/event_branch_merge.py
+++ b/backend/infrahub/message_bus/messages/event_branch_merge.py
@@ -1,5 +1,6 @@
 from pydantic import Field
 
+from infrahub.context import InfrahubContext
 from infrahub.message_bus import InfrahubMessage
 
 
@@ -8,3 +9,5 @@ class EventBranchMerge(InfrahubMessage):
 
     source_branch: str = Field(..., description="The source branch")
     target_branch: str = Field(..., description="The target branch")
+
+    context: InfrahubContext = Field(..., description="The context of the event")

--- a/backend/infrahub/message_bus/messages/request_proposedchange_pipeline.py
+++ b/backend/infrahub/message_bus/messages/request_proposedchange_pipeline.py
@@ -1,5 +1,6 @@
 from pydantic import Field
 
+from infrahub.context import InfrahubContext
 from infrahub.core.constants import CheckType
 from infrahub.message_bus import InfrahubMessage
 
@@ -14,3 +15,4 @@ class RequestProposedChangePipeline(InfrahubMessage):
     check_type: CheckType = Field(
         default=CheckType.ALL, description="Can be used to restrict the pipeline to a specific type of job"
     )
+    context: InfrahubContext = Field(..., description="The context of the task")

--- a/backend/infrahub/message_bus/operations/event/branch.py
+++ b/backend/infrahub/message_bus/operations/event/branch.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from prefect import flow
 
 from infrahub.core import registry
@@ -7,7 +9,7 @@ from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.log import get_logger
 from infrahub.message_bus import InfrahubMessage, messages
-from infrahub.services import InfrahubServices
+from infrahub.services import InfrahubServices  # noqa: TC001  needed for prefect flow
 from infrahub.workflows.catalogue import (
     DIFF_UPDATE,
     TRIGGER_ARTIFACT_DEFINITION_GENERATE,
@@ -33,11 +35,13 @@ async def merge(message: messages.EventBranchMerge, service: InfrahubServices) -
 
         await service.workflow.submit_workflow(
             workflow=TRIGGER_ARTIFACT_DEFINITION_GENERATE,
+            context=message.context,
             parameters={"branch": message.target_branch},
         )
 
         await service.workflow.submit_workflow(
             workflow=TRIGGER_GENERATOR_DEFINITION_RUN,
+            context=message.context,
             parameters={"branch": message.target_branch},
         )
 
@@ -49,7 +53,7 @@ async def merge(message: messages.EventBranchMerge, service: InfrahubServices) -
             ):
                 request_diff_update_model = RequestDiffUpdate(branch_name=diff_root.diff_branch_name)
                 await service.workflow.submit_workflow(
-                    workflow=DIFF_UPDATE, parameters={"model": request_diff_update_model}
+                    workflow=DIFF_UPDATE, context=message.context, parameters={"model": request_diff_update_model}
                 )
 
         for event in events:

--- a/backend/infrahub/message_bus/operations/requests/proposed_change.py
+++ b/backend/infrahub/message_bus/operations/requests/proposed_change.py
@@ -122,7 +122,9 @@ async def pipeline(message: messages.RequestProposedChangePipeline, service: Inf
             do_repository_checks=message.check_type is CheckType.ALL,
         )
         await service.workflow.submit_workflow(
-            workflow=REQUEST_PROPOSED_CHANGE_RUN_GENERATORS, parameters={"model": model_proposed_change_run_generator}
+            workflow=REQUEST_PROPOSED_CHANGE_RUN_GENERATORS,
+            context=message.context,
+            parameters={"model": model_proposed_change_run_generator},
         )
 
     if message.check_type in [CheckType.ALL, CheckType.DATA] and branch_diff.has_node_changes(
@@ -136,7 +138,9 @@ async def pipeline(message: messages.RequestProposedChangePipeline, service: Inf
             branch_diff=branch_diff,
         )
         await service.workflow.submit_workflow(
-            workflow=REQUEST_PROPOSED_CHANGE_DATA_INTEGRITY, parameters={"model": model_proposed_change_data_integrity}
+            workflow=REQUEST_PROPOSED_CHANGE_DATA_INTEGRITY,
+            context=message.context,
+            parameters={"model": model_proposed_change_data_integrity},
         )
 
     if message.check_type in [CheckType.REPOSITORY, CheckType.USER]:
@@ -148,7 +152,9 @@ async def pipeline(message: messages.RequestProposedChangePipeline, service: Inf
             branch_diff=branch_diff,
         )
         await service.workflow.submit_workflow(
-            workflow=REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS, parameters={"model": model_proposed_change_repo_checks}
+            workflow=REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS,
+            context=message.context,
+            parameters={"model": model_proposed_change_repo_checks},
         )
 
     if message.check_type in [CheckType.ALL, CheckType.SCHEMA] and branch_diff.has_data_changes(
@@ -156,6 +162,7 @@ async def pipeline(message: messages.RequestProposedChangePipeline, service: Inf
     ):
         await service.workflow.submit_workflow(
             workflow=REQUEST_PROPOSED_CHANGE_SCHEMA_INTEGRITY,
+            context=message.context,
             parameters={
                 "model": RequestProposedChangeSchemaIntegrity(
                     proposed_change=message.proposed_change,
@@ -170,6 +177,7 @@ async def pipeline(message: messages.RequestProposedChangePipeline, service: Inf
     if message.check_type in [CheckType.ALL, CheckType.TEST]:
         await service.workflow.submit_workflow(
             workflow=REQUEST_PROPOSED_CHANGE_USER_TESTS,
+            context=message.context,
             parameters={
                 "model": RequestProposedChangeUserTests(
                     proposed_change=message.proposed_change,

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -152,7 +152,7 @@ async def merge_proposed_change(
         await _proposed_change_transition_state(
             proposed_change=proposed_change, state=ProposedChangeState.MERGED, service=service
         )
-        await service.workflow.submit_workflow(workflow=COMPUTED_ATTRIBUTE_SETUP_PYTHON)
+        await service.workflow.submit_workflow(workflow=COMPUTED_ATTRIBUTE_SETUP_PYTHON, context=context)
         return Completed(message="proposed change merged successfully")
 
 

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -17,6 +17,7 @@ from prefect.logging import get_run_logger
 from prefect.states import Completed, Failed
 
 from infrahub import config
+from infrahub.context import InfrahubContext  # noqa: TC001  needed for prefect flow
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.branch.tasks import merge_branch
@@ -96,7 +97,12 @@ async def _proposed_change_transition_state(
     # on_crashed=[proposed_change_transition_open],  # type: ignore
     # on_cancellation=[proposed_change_transition_open],  # type: ignore
 )
-async def merge_proposed_change(proposed_change_id: str, proposed_change_name: str, service: InfrahubServices) -> State:  # noqa: ARG001
+async def merge_proposed_change(
+    proposed_change_id: str,
+    proposed_change_name: str,  # noqa: ARG001
+    context: InfrahubContext,
+    service: InfrahubServices,
+) -> State:
     log = get_run_logger()
 
     await add_tags(nodes=[proposed_change_id])
@@ -134,7 +140,7 @@ async def merge_proposed_change(proposed_change_id: str, proposed_change_name: s
 
         log.info("Proposed change is eligible to be merged")
         try:
-            await merge_branch(branch=source_branch.name, service=service)
+            await merge_branch(branch=source_branch.name, context=context, service=service)
         except MergeFailedError as exc:
             await _proposed_change_transition_state(
                 proposed_change=proposed_change, state=ProposedChangeState.OPEN, service=service
@@ -209,7 +215,9 @@ async def run_proposed_change_data_integrity_check(
     name="proposed-changed-run-generator",
     flow_run_name="Run generators",
 )
-async def run_generators(model: RequestProposedChangeRunGenerators, service: InfrahubServices) -> None:
+async def run_generators(
+    model: RequestProposedChangeRunGenerators, context: InfrahubContext, service: InfrahubServices
+) -> None:
     await add_tags(branches=[model.source_branch], nodes=[model.proposed_change], db_change=True)
 
     generators = await service.client.filters(
@@ -288,7 +296,9 @@ async def run_generators(model: RequestProposedChangeRunGenerators, service: Inf
             branch_diff=model.branch_diff,
         )
         await service.workflow.submit_workflow(
-            workflow=REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS, parameters={"model": model_proposed_change_repo_checks}
+            workflow=REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS,
+            context=context,
+            parameters={"model": model_proposed_change_repo_checks},
         )
 
     for next_msg in next_messages:

--- a/backend/infrahub/services/adapters/workflow/__init__.py
+++ b/backend/infrahub/services/adapters/workflow/__init__.py
@@ -4,8 +4,8 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Callable, ParamSpec, TypeVar, overload
 
 if TYPE_CHECKING:
+    from infrahub.context import InfrahubContext
     from infrahub.workflows.models import WorkflowDefinition, WorkflowInfo
-
 Return = TypeVar("Return")
 Params = ParamSpec("Params")
 
@@ -18,6 +18,7 @@ class InfrahubWorkflow(ABC):
         self,
         workflow: WorkflowDefinition,
         expected_return: type[Return],
+        context: InfrahubContext | None = ...,
         parameters: dict[str, Any] | None = ...,
         tags: list[str] | None = ...,
     ) -> Return: ...
@@ -27,6 +28,7 @@ class InfrahubWorkflow(ABC):
         self,
         workflow: WorkflowDefinition,
         expected_return: None = ...,
+        context: InfrahubContext | None = ...,
         parameters: dict[str, Any] | None = ...,
         tags: list[str] | None = ...,
     ) -> Any: ...
@@ -36,6 +38,7 @@ class InfrahubWorkflow(ABC):
         self,
         workflow: WorkflowDefinition,
         expected_return: type[Return] | None = None,
+        context: InfrahubContext | None = None,
         parameters: dict[str, Any] | None = None,
         tags: list[str] | None = None,
     ) -> Any:
@@ -45,6 +48,7 @@ class InfrahubWorkflow(ABC):
     async def submit_workflow(
         self,
         workflow: WorkflowDefinition,
+        context: InfrahubContext | None = None,
         parameters: dict[str, Any] | None = None,
         tags: list[str] | None = None,
     ) -> WorkflowInfo:

--- a/backend/infrahub/services/adapters/workflow/local.py
+++ b/backend/infrahub/services/adapters/workflow/local.py
@@ -32,8 +32,7 @@ class WorkflowLocalExecution(InfrahubWorkflow):
         flow_func = workflow.load_function()
         parameters = dict(parameters) if parameters is not None else {}  # avoid mutating input parameters
         inject_service_parameter(func=flow_func, parameters=parameters, service=self.service)
-        if context:
-            inject_context_parameter(func=flow_func, parameters=parameters, context=context)
+        inject_context_parameter(func=flow_func, parameters=parameters, context=context)
 
         parameters = flow_func.validate_parameters(parameters=parameters)
 

--- a/backend/infrahub/services/adapters/workflow/local.py
+++ b/backend/infrahub/services/adapters/workflow/local.py
@@ -35,7 +35,6 @@ class WorkflowLocalExecution(InfrahubWorkflow):
         inject_context_parameter(func=flow_func, parameters=parameters, context=context)
 
         parameters = flow_func.validate_parameters(parameters=parameters)
-
         return await flow_func(**parameters)
 
     async def submit_workflow(

--- a/backend/infrahub/services/adapters/workflow/local.py
+++ b/backend/infrahub/services/adapters/workflow/local.py
@@ -5,12 +5,13 @@ from typing import Any, Optional
 
 from typing_extensions import TYPE_CHECKING
 
-from infrahub.workers.utils import inject_service_parameter
+from infrahub.workers.utils import inject_context_parameter, inject_service_parameter
 from infrahub.workflows.models import WorkflowDefinition, WorkflowInfo
 
 from . import InfrahubWorkflow, Return
 
 if TYPE_CHECKING:
+    from infrahub.context import InfrahubContext
     from infrahub.services import InfrahubServices
 
 
@@ -21,6 +22,7 @@ class WorkflowLocalExecution(InfrahubWorkflow):
         self,
         workflow: WorkflowDefinition,
         expected_return: type[Return] | None = None,  # noqa: ARG002
+        context: InfrahubContext | None = None,
         parameters: dict[str, Any] | None = None,
         tags: list[str] | None = None,  # noqa: ARG002
     ) -> Any:
@@ -30,6 +32,9 @@ class WorkflowLocalExecution(InfrahubWorkflow):
         flow_func = workflow.load_function()
         parameters = dict(parameters) if parameters is not None else {}  # avoid mutating input parameters
         inject_service_parameter(func=flow_func, parameters=parameters, service=self.service)
+        if context:
+            inject_context_parameter(func=flow_func, parameters=parameters, context=context)
+
         parameters = flow_func.validate_parameters(parameters=parameters)
 
         return await flow_func(**parameters)
@@ -37,8 +42,9 @@ class WorkflowLocalExecution(InfrahubWorkflow):
     async def submit_workflow(
         self,
         workflow: WorkflowDefinition,
+        context: InfrahubContext | None = None,
         parameters: dict[str, Any] | None = None,
         tags: list[str] | None = None,  # noqa: ARG002
     ) -> WorkflowInfo:
-        await self.execute_workflow(workflow=workflow, parameters=parameters)
+        await self.execute_workflow(workflow=workflow, context=context, parameters=parameters)
         return WorkflowInfo(id=uuid.uuid4())

--- a/backend/infrahub/services/adapters/workflow/worker.py
+++ b/backend/infrahub/services/adapters/workflow/worker.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, overload
 from prefect.client.schemas.objects import StateType
 from prefect.deployments import run_deployment
 
+from infrahub.workers.utils import inject_context_parameter
 from infrahub.workflows.initialization import setup_task_manager
 from infrahub.workflows.models import WorkflowInfo
 
@@ -13,6 +14,7 @@ from . import InfrahubWorkflow, Return
 if TYPE_CHECKING:
     from prefect.client.schemas.objects import FlowRun
 
+    from infrahub.context import InfrahubContext
     from infrahub.workflows.models import WorkflowDefinition
 
 
@@ -27,6 +29,7 @@ class WorkflowWorkerExecution(InfrahubWorkflow):
         self,
         workflow: WorkflowDefinition,
         expected_return: type[Return],
+        context: InfrahubContext | None = None,
         parameters: dict[str, Any] | None = ...,
         tags: list[str] | None = ...,
     ) -> Return: ...
@@ -36,6 +39,7 @@ class WorkflowWorkerExecution(InfrahubWorkflow):
         self,
         workflow: WorkflowDefinition,
         expected_return: None = ...,
+        context: InfrahubContext | None = ...,
         parameters: dict[str, Any] | None = ...,
         tags: list[str] | None = ...,
     ) -> Any: ...
@@ -45,9 +49,15 @@ class WorkflowWorkerExecution(InfrahubWorkflow):
         self,
         workflow: WorkflowDefinition,
         expected_return: type[Return] | None = None,  # noqa: ARG002
+        context: InfrahubContext | None = None,
         parameters: dict[str, Any] | None = None,
         tags: list[str] | None = None,
     ) -> Any:
+        if context:
+            flow_func = workflow.load_function()
+            parameters = dict(parameters) if parameters is not None else {}
+            inject_context_parameter(func=flow_func, parameters=parameters, context=context)
+
         response: FlowRun = await run_deployment(
             name=workflow.full_name, poll_interval=1, parameters=parameters or {}, tags=tags
         )  # type: ignore[return-value, misc]
@@ -60,7 +70,16 @@ class WorkflowWorkerExecution(InfrahubWorkflow):
         return await response.state.result(raise_on_failure=True, fetch=True)  # type: ignore[call-overload]
 
     async def submit_workflow(
-        self, workflow: WorkflowDefinition, parameters: dict[str, Any] | None = None, tags: list[str] | None = None
+        self,
+        workflow: WorkflowDefinition,
+        context: InfrahubContext | None = None,
+        parameters: dict[str, Any] | None = None,
+        tags: list[str] | None = None,
     ) -> WorkflowInfo:
+        if context:
+            flow_func = workflow.load_function()
+            parameters = dict(parameters) if parameters is not None else {}
+            inject_context_parameter(func=flow_func, parameters=parameters, context=context)
+
         flow_run = await run_deployment(name=workflow.full_name, timeout=0, parameters=parameters or {}, tags=tags)  # type: ignore[return-value, misc]
         return WorkflowInfo.from_flow(flow_run=flow_run)

--- a/backend/infrahub/services/adapters/workflow/worker.py
+++ b/backend/infrahub/services/adapters/workflow/worker.py
@@ -53,10 +53,9 @@ class WorkflowWorkerExecution(InfrahubWorkflow):
         parameters: dict[str, Any] | None = None,
         tags: list[str] | None = None,
     ) -> Any:
-        if context:
-            flow_func = workflow.load_function()
-            parameters = dict(parameters) if parameters is not None else {}
-            inject_context_parameter(func=flow_func, parameters=parameters, context=context)
+        flow_func = workflow.load_function()
+        parameters = dict(parameters) if parameters is not None else {}
+        inject_context_parameter(func=flow_func, parameters=parameters, context=context)
 
         response: FlowRun = await run_deployment(
             name=workflow.full_name, poll_interval=1, parameters=parameters or {}, tags=tags
@@ -76,10 +75,9 @@ class WorkflowWorkerExecution(InfrahubWorkflow):
         parameters: dict[str, Any] | None = None,
         tags: list[str] | None = None,
     ) -> WorkflowInfo:
-        if context:
-            flow_func = workflow.load_function()
-            parameters = dict(parameters) if parameters is not None else {}
-            inject_context_parameter(func=flow_func, parameters=parameters, context=context)
+        flow_func = workflow.load_function()
+        parameters = dict(parameters) if parameters is not None else {}
+        inject_context_parameter(func=flow_func, parameters=parameters, context=context)
 
         flow_run = await run_deployment(name=workflow.full_name, timeout=0, parameters=parameters or {}, tags=tags)  # type: ignore[return-value, misc]
         return WorkflowInfo.from_flow(flow_run=flow_run)

--- a/backend/infrahub/workers/utils.py
+++ b/backend/infrahub/workers/utils.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING, Any
 
 from prefect import Flow
 
+from infrahub.context import InfrahubContext
+
 if TYPE_CHECKING:
     from infrahub.services import InfrahubServices
 
@@ -20,13 +22,19 @@ def inject_service_parameter(func: Flow, parameters: dict[str, Any], service: In
     # avoid circular imports
     from infrahub.services import InfrahubServices  # pylint: disable=C0415
 
-    sig = inspect.signature(func)
-    for sig_param in sig.parameters.values():
-        if sig_param.annotation in [InfrahubServices.__name__, InfrahubServices]:  # why it can be both?
-            if any(isinstance(param_value, InfrahubServices) for param_value in parameters):
-                raise ValueError(f"{func} parameters contains an InfrahubServices object while it should be injected")
-            parameters[sig_param.name] = service
-            return
+    if service_parameter_name := get_parameter_name(func=func, types=[InfrahubServices.__name__, InfrahubServices]):
+        if any(isinstance(param_value, InfrahubServices) for param_value in parameters):
+            raise ValueError(f"{func} parameters contains an InfrahubServices object while it should be injected")
+        parameters[service_parameter_name] = service
+        return
+
+
+def inject_context_parameter(func: Flow, parameters: dict[str, Any], context: InfrahubContext) -> None:
+    if service_parameter_name := get_parameter_name(func=func, types=[InfrahubContext]):
+        # if any(isinstance(param_value, InfrahubServices) for param_value in parameters):
+        #     raise ValueError(f"{func} parameters contains an InfrahubServices object while it should be injected")
+        parameters[service_parameter_name] = context
+        return
 
 
 def load_flow_function(module_path: str, flow_name: str) -> Flow:
@@ -37,3 +45,15 @@ def load_flow_function(module_path: str, flow_name: str) -> Flow:
             f"Function loaded at {module_path=} with {flow_name=} has type {type(flow_func)}, expected {Flow}"
         )
     return flow_func
+
+
+def get_parameter_name(func: Flow, types: list[Any]) -> str | None:
+    sig = inspect.signature(func)
+    for sig_param in sig.parameters.values():
+        if sig_param.annotation in types:
+            return sig_param.name
+    return None
+
+
+def has_parameter(func: Flow, types: list[Any]) -> bool:
+    return get_parameter_name(func=func, types=types) is not None

--- a/backend/infrahub/workers/utils.py
+++ b/backend/infrahub/workers/utils.py
@@ -30,7 +30,7 @@ def inject_service_parameter(func: Flow, parameters: dict[str, Any], service: In
 
 
 def inject_context_parameter(func: Flow, parameters: dict[str, Any], context: InfrahubContext | None = None) -> None:
-    service_parameter_name = get_parameter_name(func=func, types=[InfrahubContext])
+    service_parameter_name = get_parameter_name(func=func, types=[InfrahubContext.__name__, InfrahubContext])
     if service_parameter_name and context:
         parameters[service_parameter_name] = context
         return

--- a/backend/infrahub/workers/utils.py
+++ b/backend/infrahub/workers/utils.py
@@ -29,12 +29,16 @@ def inject_service_parameter(func: Flow, parameters: dict[str, Any], service: In
         return
 
 
-def inject_context_parameter(func: Flow, parameters: dict[str, Any], context: InfrahubContext) -> None:
-    if service_parameter_name := get_parameter_name(func=func, types=[InfrahubContext]):
-        # if any(isinstance(param_value, InfrahubServices) for param_value in parameters):
-        #     raise ValueError(f"{func} parameters contains an InfrahubServices object while it should be injected")
+def inject_context_parameter(func: Flow, parameters: dict[str, Any], context: InfrahubContext | None = None) -> None:
+    service_parameter_name = get_parameter_name(func=func, types=[InfrahubContext])
+    if service_parameter_name and context:
         parameters[service_parameter_name] = context
         return
+
+    if service_parameter_name and not context:
+        raise ValueError(
+            f"{func} has a {service_parameter_name} parameter of type InfrahubContext, while context is not provided"
+        )
 
 
 def load_flow_function(module_path: str, flow_name: str) -> Flow:

--- a/backend/tests/functional/computed_attributes/test_computed_attribute.py
+++ b/backend/tests/functional/computed_attributes/test_computed_attribute.py
@@ -107,6 +107,7 @@ class TestComputedAttribute(TestInfrahubApp):
             computed_attribute_kind="TestingTShirt",
             computed_attribute_name="description",
             updated_fields='"color"',
+            context=context,
             service=service,
         )
 
@@ -137,6 +138,7 @@ class TestComputedAttribute(TestInfrahubApp):
             node_kind="TestingTShirt",
             computed_attribute_name="pitch",
             computed_attribute_kind="TestingTShirt",
+            context=context,
             service=service,
         )
 

--- a/backend/tests/functional/computed_attributes/test_computed_attribute.py
+++ b/backend/tests/functional/computed_attributes/test_computed_attribute.py
@@ -4,7 +4,9 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from infrahub.auth import AccountSession, AuthType
 from infrahub.computed_attribute.tasks import process_jinja2, process_transform, query_transform_targets
+from infrahub.context import BranchContext, InfrahubContext
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.node import Node
 from infrahub.core.schema import SchemaRoot
@@ -24,6 +26,14 @@ if TYPE_CHECKING:
 
 
 class TestComputedAttribute(TestInfrahubApp):
+    @pytest.fixture(scope="class")
+    async def context(self, client: InfrahubClient, default_branch: Branch) -> InfrahubContext:
+        """Placeholder context for now, would be good to implement some auth and permissions here"""
+        return InfrahubContext(
+            account=AccountSession(authenticated=False, account_id="placeholder", auth_type=AuthType.NONE),
+            branch=BranchContext(name=default_branch.name, id=str(default_branch.uuid)),
+        )
+
     @pytest.fixture(scope="class")
     async def data(
         self,
@@ -72,7 +82,12 @@ class TestComputedAttribute(TestInfrahubApp):
         return {"c1": c1, "c2": c2, "c3": c3, "t1": t1, "t2": t2}
 
     async def test_description_after_color_change_jinja2(
-        self, data: dict[str, Node], client: InfrahubClient, default_branch: Branch, service: InfrahubServices
+        self,
+        data: dict[str, Node],
+        client: InfrahubClient,
+        default_branch: Branch,
+        context: InfrahubContext,
+        service: InfrahubServices,
     ) -> None:
         tshirt_1 = await client.get(kind="TestingTShirt", id=data["t1"].id)
         assert (
@@ -106,6 +121,7 @@ class TestComputedAttribute(TestInfrahubApp):
         data: dict[str, Node],
         client: InfrahubClient,
         default_branch: Branch,
+        context: InfrahubContext,
         service: InfrahubServices,
     ) -> None:
         # As we currently don't have a way to trigger on events within these tests we fire the automated workflow
@@ -131,7 +147,11 @@ class TestComputedAttribute(TestInfrahubApp):
         await color.save()
 
         await query_transform_targets(
-            branch_name=default_branch.name, node_kind="TestingColor", object_id=color_obj.id, service=service
+            branch_name=default_branch.name,
+            node_kind="TestingColor",
+            object_id=color_obj.id,
+            context=context,
+            service=service,
         )
 
         tshirt_altered_pitch_allocation = await client.get(kind="TestingTShirt", id=tshirt_obj.id)

--- a/backend/tests/integration/git/test_readonly_repository.py
+++ b/backend/tests/integration/git/test_readonly_repository.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from infrahub_sdk.protocols import CoreArtifact, CoreArtifactDefinition
 
+from infrahub.auth import AccountSession, AuthType
+from infrahub.context import BranchContext, InfrahubContext
 from infrahub.core import registry
 from infrahub.core.constants import DiffAction, InfrahubKind
 from infrahub.core.diff.artifacts.calculator import ArtifactDiffCalculator
@@ -44,6 +46,14 @@ class TestCreateReadOnlyRepository(TestInfrahubApp):
     @pytest.fixture(scope="class")
     async def load_car_schema(self, db: InfrahubDatabase) -> None:
         await load_schema(db=db, schema=CAR_SCHEMA)
+
+    @pytest.fixture(scope="class")
+    async def context(self) -> None:
+        """Placeholder context for now, would be good to implement some auth and permissions here"""
+        return InfrahubContext(
+            account=AccountSession(authenticated=False, account_id="placeholder", auth_type=AuthType.NONE),
+            branch=BranchContext(name="main", id="d18808fe-70c8-4782-bd55-144d6980036f"),
+        )
 
     @pytest.fixture(scope="class")
     async def person_john(self, db: InfrahubDatabase, load_car_schema) -> Node:
@@ -134,6 +144,7 @@ class TestCreateReadOnlyRepository(TestInfrahubApp):
         db: InfrahubDatabase,
         client: InfrahubClient,
         helper: TestHelper,
+        context: InfrahubContext,
         service: InfrahubServices,
     ):
         await client.branch.merge(branch_name="ro_repository")
@@ -151,7 +162,9 @@ class TestCreateReadOnlyRepository(TestInfrahubApp):
                 artifact_definition_id=artifact_definition.id,
                 artifact_definition_name=artifact_definition.name.value,
             )
-            await service.workflow.submit_workflow(REQUEST_ARTIFACT_DEFINITION_GENERATE, parameters={"model": model})
+            await service.workflow.submit_workflow(
+                REQUEST_ARTIFACT_DEFINITION_GENERATE, context=context, parameters={"model": model}
+            )
 
         artifacts = await client.all(kind=CoreArtifact)
         assert sorted([artifact.name.value for artifact in artifacts]) == [
@@ -168,6 +181,7 @@ class TestCreateReadOnlyRepository(TestInfrahubApp):
         client: InfrahubClient,
         helper: TestHelper,
         person_john: Node,
+        context: InfrahubContext,
         service: InfrahubServices,
     ):
         from infrahub.core import registry
@@ -192,7 +206,9 @@ class TestCreateReadOnlyRepository(TestInfrahubApp):
                 artifact_definition_name=artifact_definition.name.value,
                 branch="branch",
             )
-            await service.workflow.submit_workflow(REQUEST_ARTIFACT_DEFINITION_GENERATE, parameters={"model": model})
+            await service.workflow.submit_workflow(
+                REQUEST_ARTIFACT_DEFINITION_GENERATE, context=context, parameters={"model": model}
+            )
 
         artifacts = await client.all(kind=CoreArtifact, branch="branch")
         artifacts_dict = {item.name.value: item for item in artifacts}

--- a/backend/tests/integration/git/test_readonly_repository.py
+++ b/backend/tests/integration/git/test_readonly_repository.py
@@ -48,7 +48,7 @@ class TestCreateReadOnlyRepository(TestInfrahubApp):
         await load_schema(db=db, schema=CAR_SCHEMA)
 
     @pytest.fixture(scope="class")
-    async def context(self) -> None:
+    async def context(self) -> InfrahubContext:
         """Placeholder context for now, would be good to implement some auth and permissions here"""
         return InfrahubContext(
             account=AccountSession(authenticated=False, account_id="placeholder", auth_type=AuthType.NONE),

--- a/backend/tests/integration/message_bus/operations/request/test_proposed_change.py
+++ b/backend/tests/integration/message_bus/operations/request/test_proposed_change.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from infrahub.auth import AccountSession, AuthType
+from infrahub.context import BranchContext, InfrahubContext
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.node import Node
 from infrahub.git import InfrahubRepository
@@ -66,6 +68,14 @@ mutation ProposedChange(
 
 class TestProposedChange(TestInfrahubApp):
     @pytest.fixture(scope="class")
+    async def context(self) -> InfrahubContext:
+        """Placeholder context for now, would be good to implement some auth and permissions here"""
+        return InfrahubContext(
+            account=AccountSession(authenticated=False, account_id="placeholder", auth_type=AuthType.NONE),
+            branch=BranchContext(name="main", id="placeholder"),
+        )
+
+    @pytest.fixture(scope="class")
     async def prepare_proposed_change(
         self,
         db: InfrahubDatabase,
@@ -116,12 +126,14 @@ class TestProposedChange(TestInfrahubApp):
         db: InfrahubDatabase,
         test_client: InfrahubTestClient,
         client: InfrahubClient,
+        context: InfrahubContext,
     ):
         message = messages.RequestProposedChangePipeline(
             source_branch="change1",
             source_branch_sync_with_git=True,
             destination_branch="main",
             proposed_change=prepare_proposed_change,
+            context=context,
         )
         bus_pre_data_changes = BusRecorder()
         fake_log = FakeLogger()
@@ -161,6 +173,7 @@ class TestProposedChange(TestInfrahubApp):
         db: InfrahubDatabase,
         test_client: InfrahubTestClient,
         client: InfrahubClient,
+        context: InfrahubContext,
     ):
         model = RequestProposedChangeRunGenerators(
             source_branch="change1",
@@ -178,7 +191,7 @@ class TestProposedChange(TestInfrahubApp):
             log=FakeLogger(),
             workflow=WorkflowLocalExecution(),
         )
-        await run_generators(model=model, service=service)
+        await run_generators(model=model, context=context, service=service)
 
         assert sorted(bus.seen_routing_keys) == [
             "request.proposed_change.refresh_artifacts",

--- a/backend/tests/integration/message_bus/operations/request/test_proposed_change.py
+++ b/backend/tests/integration/message_bus/operations/request/test_proposed_change.py
@@ -84,6 +84,7 @@ class TestProposedChange(TestInfrahubApp):
         init_db_base,
         client: InfrahubClient,
         redis,
+        context: InfrahubContext,
     ) -> str:
         source_dir = tmp_path_module_scope / "sources"
         source_dir.mkdir()
@@ -115,6 +116,7 @@ class TestProposedChange(TestInfrahubApp):
             variables={"name": "first", "source_branch": "change1", "destination_branch": "main"},
             db=db,
             service=service,
+            account_session=context.account,
         )
         assert not result.errors
         assert result.data

--- a/backend/tests/unit/api/test_10_query.py
+++ b/backend/tests/unit/api/test_10_query.py
@@ -6,6 +6,8 @@ from unittest.mock import call, patch
 import pytest
 
 from infrahub import config
+from infrahub.auth import AccountSession, AuthType
+from infrahub.context import BranchContext, InfrahubContext
 from infrahub.core.initialization import create_branch
 from infrahub.groups.models import RequestGraphQLQueryGroupUpdate
 from infrahub.workflows.catalogue import GRAPHQL_QUERY_GROUP_UPDATE
@@ -29,10 +31,10 @@ async def test_query_endpoint_group_no_params(
     db: InfrahubDatabase,
     client: TestClient,
     admin_headers,
-    create_test_admin,
-    default_branch,
+    create_test_admin: Node,
+    default_branch: Branch,
     car_person_data,
-):
+) -> None:
     # Must execute in a with block to execute the startup/shutdown events
     with (
         client,
@@ -42,6 +44,13 @@ async def test_query_endpoint_group_no_params(
     ):
         response = client.get(
             "/api/query/query01?update_group=true&subscribers=AAAAAA&subscribers=BBBBBB", headers=admin_headers
+        )
+
+        context = InfrahubContext(
+            branch=BranchContext(name=default_branch.name, id=str(default_branch.get_uuid())),
+            account=AccountSession(
+                authenticated=True, account_id=create_test_admin.id, session_id=None, auth_type=AuthType.API
+            ),
         )
 
         assert "errors" not in response.json()
@@ -71,17 +80,19 @@ async def test_query_endpoint_group_no_params(
         )
 
         expected_calls = [
-            call(
-                workflow=GRAPHQL_QUERY_GROUP_UPDATE,
-                parameters={"model": model},
-            ),
+            call(workflow=GRAPHQL_QUERY_GROUP_UPDATE, parameters={"model": model}, context=context),
         ]
         mock_submit_workflow.assert_has_calls(expected_calls)
 
 
 async def test_query_endpoint_group_params(
-    db: InfrahubDatabase, client: TestClient, admin_headers, default_branch, create_test_admin, car_person_data
-):
+    db: InfrahubDatabase,
+    client: TestClient,
+    admin_headers,
+    default_branch: Branch,
+    create_test_admin: Node,
+    car_person_data,
+) -> None:
     # Must execute in a with block to execute the startup/shutdown events
     with (
         client,
@@ -111,11 +122,14 @@ async def test_query_endpoint_group_params(
             params={"person": "John"},
         )
 
-        expected_calls = [
-            call(
-                workflow=GRAPHQL_QUERY_GROUP_UPDATE,
-                parameters={"model": model},
+        context = InfrahubContext(
+            branch=BranchContext(name=default_branch.name, id=str(default_branch.get_uuid())),
+            account=AccountSession(
+                authenticated=True, account_id=create_test_admin.id, session_id=None, auth_type=AuthType.API
             ),
+        )
+        expected_calls = [
+            call(workflow=GRAPHQL_QUERY_GROUP_UPDATE, parameters={"model": model}, context=context),
         ]
         mock_submit_workflow.assert_has_calls(expected_calls)
 

--- a/backend/tests/unit/api/test_11_artifact.py
+++ b/backend/tests/unit/api/test_11_artifact.py
@@ -4,7 +4,10 @@ import pytest
 from starlette.testclient import TestClient
 
 from infrahub import config
+from infrahub.auth import AccountSession, AuthType
+from infrahub.context import BranchContext, InfrahubContext
 from infrahub.core import registry
+from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
@@ -78,11 +81,11 @@ class TestArtifact11(TestInfrahubApp):
         self,
         db: InfrahubDatabase,
         admin_headers,
-        default_branch,
+        default_branch: Branch,
         register_core_models_schema,
         register_builtin_models_schema,
         car_person_data_generic,
-        authentication_base,
+        authentication_base: Node,
         client,
     ):
         _, _, definition = await self.setup_artifact_definition(
@@ -107,6 +110,14 @@ class TestArtifact11(TestInfrahubApp):
             )
 
             assert response.status_code == 200
+
+            context = InfrahubContext(
+                branch=BranchContext(name=default_branch.name, id=str(default_branch.get_uuid())),
+                account=AccountSession(
+                    authenticated=True, account_id=authentication_base.id, session_id=None, auth_type=AuthType.API
+                ),
+            )
+
             expected_calls = [
                 call(
                     workflow=REQUEST_ARTIFACT_DEFINITION_GENERATE,
@@ -118,6 +129,7 @@ class TestArtifact11(TestInfrahubApp):
                             limit=[],
                         )
                     },
+                    context=context,
                 ),
             ]
             mock_submit_workflow.assert_has_calls(expected_calls)

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -2616,8 +2616,8 @@ async def authentication_base(
     register_core_models_schema,
     register_builtin_models_schema,
     register_organization_schema,
-):
-    pass
+) -> Node:
+    return create_test_admin
 
 
 @pytest.fixture

--- a/backend/tests/unit/core/test_branch_rebase.py
+++ b/backend/tests/unit/core/test_branch_rebase.py
@@ -1,5 +1,9 @@
+from uuid import uuid4
+
 import pytest
 
+from infrahub.auth import AccountSession, AuthType
+from infrahub.context import InfrahubContext
 from infrahub.core.branch import Branch
 from infrahub.core.branch.tasks import rebase_branch
 from infrahub.core.constants import InfrahubKind
@@ -104,4 +108,11 @@ async def test_branch_rebase_diff_conflict(
     service = await InfrahubServices.new(database=db, workflow=WorkflowLocalExecution())
 
     with pytest.raises(ValidationError, match="contains conflicts with the default branch that must be addressed"):
-        await rebase_branch(branch=branch2.name, service=service)
+        await rebase_branch(
+            branch=branch2.name,
+            service=service,
+            context=InfrahubContext.init(
+                branch=default_branch,
+                account=AccountSession(account_id=str(uuid4()), auth_type=AuthType.NONE),
+            ),
+        )

--- a/backend/tests/unit/git/test_git_rpc.py
+++ b/backend/tests/unit/git/test_git_rpc.py
@@ -8,6 +8,8 @@ from infrahub_sdk import Config, InfrahubClient
 from infrahub_sdk.uuidt import UUIDT
 from typing_extensions import Self
 
+from infrahub.auth import AccountSession, AuthType
+from infrahub.context import BranchContext, InfrahubContext
 from infrahub.core.constants import InfrahubKind, RepositoryInternalStatus
 from infrahub.exceptions import RepositoryError
 from infrahub.git import InfrahubRepository
@@ -33,7 +35,7 @@ if TYPE_CHECKING:
 
     from infrahub_sdk.branch import BranchData
 
-    from infrahub.context import InfrahubContext
+    from infrahub.core.node import Node
     from tests.conftest import TestHelper
 
 
@@ -119,8 +121,8 @@ async def test_git_rpc_merge(
     prefect_test_fixture,
     git_repo_01: InfrahubRepository,
     branch01: BranchData,
-    context: InfrahubContext,
     helper: TestHelper,
+    create_test_admin: Node,
 ):
     repo = git_repo_01
 
@@ -143,7 +145,12 @@ async def test_git_rpc_merge(
     service = await InfrahubServices.new(
         client=InfrahubClient(config=client_config), message_bus=bus_simulator, workflow=WorkflowLocalExecution()
     )
-
+    context = InfrahubContext(
+        branch=BranchContext(name=branch01.name, id=branch01.id),
+        account=AccountSession(
+            authenticated=True, account_id=create_test_admin.id, session_id=None, auth_type=AuthType.API
+        ),
+    )
     await service.workflow.submit_workflow(
         workflow=GIT_REPOSITORIES_MERGE, context=context, parameters={"model": model}
     )

--- a/backend/tests/unit/git/test_git_rpc.py
+++ b/backend/tests/unit/git/test_git_rpc.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
 
     from infrahub_sdk.branch import BranchData
 
+    from infrahub.context import InfrahubContext
     from tests.conftest import TestHelper
 
 
@@ -115,7 +116,11 @@ class TestAddRepository:
 
 
 async def test_git_rpc_merge(
-    prefect_test_fixture, git_repo_01: InfrahubRepository, branch01: BranchData, helper: TestHelper
+    prefect_test_fixture,
+    git_repo_01: InfrahubRepository,
+    branch01: BranchData,
+    context: InfrahubContext,
+    helper: TestHelper,
 ):
     repo = git_repo_01
 
@@ -139,7 +144,9 @@ async def test_git_rpc_merge(
         client=InfrahubClient(config=client_config), message_bus=bus_simulator, workflow=WorkflowLocalExecution()
     )
 
-    await service.workflow.submit_workflow(workflow=GIT_REPOSITORIES_MERGE, parameters={"model": model})
+    await service.workflow.submit_workflow(
+        workflow=GIT_REPOSITORIES_MERGE, context=context, parameters={"model": model}
+    )
 
     commit_main_after = repo.get_commit_value(branch_name="main")
 

--- a/backend/tests/unit/graphql/mutations/test_proposed_change.py
+++ b/backend/tests/unit/graphql/mutations/test_proposed_change.py
@@ -2,7 +2,7 @@ from uuid import uuid4
 
 from prefect.client.orchestration import get_client
 
-from infrahub.auth import AccountSession
+from infrahub.auth import AccountSession, AuthType
 from infrahub.core.branch import Branch
 from infrahub.core.constants import CheckType, InfrahubKind
 from infrahub.core.initialization import create_branch
@@ -127,7 +127,9 @@ async def test_create_invalid_branch_combinations(db: InfrahubDatabase, default_
     )
 
 
-async def test_trigger_proposed_change(db: InfrahubDatabase, register_core_models_schema: None):
+async def test_trigger_proposed_change(
+    db: InfrahubDatabase, register_core_models_schema: None, create_test_admin: Node
+) -> None:
     branch_name = "triggered-proposed-change"
     source_branch = Branch(name=branch_name)
     await source_branch.save(db=db)
@@ -137,8 +139,15 @@ async def test_trigger_proposed_change(db: InfrahubDatabase, register_core_model
     await proposed_change.save(db=db)
     all_recorder = BusRecorder()
     service = await InfrahubServices.new(database=db, message_bus=all_recorder)
+    account_session = AccountSession(
+        authenticated=True, account_id=create_test_admin.id, session_id=None, auth_type=AuthType.API
+    )
     all_result = await graphql_mutation(
-        query=RUN_CHECK, db=db, variables={"proposed_change": proposed_change.id}, service=service
+        query=RUN_CHECK,
+        db=db,
+        variables={"proposed_change": proposed_change.id},
+        service=service,
+        account_session=account_session,
     )
     assert all_result.data
     assert not all_result.errors
@@ -150,6 +159,7 @@ async def test_trigger_proposed_change(db: InfrahubDatabase, register_core_model
         db=db,
         variables={"proposed_change": proposed_change.id, "check_type": "ARTIFACT"},
         service=service,
+        account_session=account_session,
     )
 
     update_status = await graphql_mutation(
@@ -157,6 +167,7 @@ async def test_trigger_proposed_change(db: InfrahubDatabase, register_core_model
         db=db,
         variables={"proposed_change": proposed_change.id, "state": "canceled"},
         service=service,
+        account_session=account_session,
     )
 
     cancelled_recorder = BusRecorder()
@@ -166,6 +177,7 @@ async def test_trigger_proposed_change(db: InfrahubDatabase, register_core_model
         db=db,
         variables={"proposed_change": proposed_change.id, "check_type": "DATA"},
         service=service,
+        account_session=account_session,
     )
 
     assert len(all_recorder.messages) == 1

--- a/backend/tests/unit/graphql/mutations/test_repository.py
+++ b/backend/tests/unit/graphql/mutations/test_repository.py
@@ -5,6 +5,8 @@ from unittest.mock import call, patch
 
 import pytest
 
+from infrahub.auth import AccountSession, AuthType
+from infrahub.context import BranchContext, InfrahubContext
 from infrahub.core import registry
 from infrahub.core.constants import InfrahubKind, RepositoryInternalStatus
 from infrahub.core.initialization import create_branch
@@ -24,12 +26,14 @@ if TYPE_CHECKING:
 
 
 async def test_trigger_repository_import(
-    db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch
-):
+    db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch, create_test_admin: Node
+) -> None:
     repository_model = registry.schema.get_node_schema(name=InfrahubKind.REPOSITORY, branch=default_branch)
     recorder = BusRecorder()
     service = await InfrahubServices.new(database=db, message_bus=recorder, workflow=WorkflowLocalExecution())
-
+    account_session = AccountSession(
+        authenticated=True, account_id=create_test_admin.id, session_id=None, auth_type=AuthType.API
+    )
     # TODO: Removing this mock triggers issue: `Invalid file system for test-edge-demo, local directory ... missing`
     with (
         patch(
@@ -49,15 +53,17 @@ async def test_trigger_repository_import(
         await repo.new(db=db, name="test-edge-demo", location="/tmp/edge", commit=commit_id)
         await repo.save(db=db)
         result = await graphql_mutation(
-            query=RUN_REIMPORT,
-            db=db,
-            variables={"id": repo.id},
-            service=service,
+            query=RUN_REIMPORT, db=db, variables={"id": repo.id}, service=service, account_session=account_session
         )
 
         assert not result.errors
         assert result.data
-
+        context = InfrahubContext(
+            branch=BranchContext(name=default_branch.name, id=str(default_branch.get_uuid())),
+            account=AccountSession(
+                authenticated=True, account_id=create_test_admin.id, session_id=None, auth_type=AuthType.API
+            ),
+        )
         expected_calls = [
             call(
                 workflow=GIT_REPOSITORIES_IMPORT_OBJECTS,
@@ -70,6 +76,7 @@ async def test_trigger_repository_import(
                         infrahub_branch_name=default_branch.name,
                     )
                 },
+                context=context,
             ),
         ]
         mock_submit_workflow.assert_has_calls(expected_calls)

--- a/backend/tests/unit/graphql/test_mutation_artifact_definition.py
+++ b/backend/tests/unit/graphql/test_mutation_artifact_definition.py
@@ -2,6 +2,8 @@ from unittest.mock import call, patch
 
 import pytest
 
+from infrahub.auth import AccountSession, AuthType
+from infrahub.context import InfrahubContext
 from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.manager import NodeManager
@@ -68,6 +70,7 @@ async def test_create_artifact_definition(
     default_branch: Branch,
     register_core_models_schema,
     car_person_data_generic,
+    create_test_admin: Node,
     group1: Node,
     transformation1: Node,
     branch: Branch,
@@ -95,7 +98,12 @@ async def test_create_artifact_definition(
     recorder = BusRecorder()
     service = await InfrahubServices.new(message_bus=recorder, workflow=WorkflowLocalExecution())
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch, service=service)
+    account_session = AccountSession(
+        authenticated=True, account_id=create_test_admin.id, session_id=None, auth_type=AuthType.API
+    )
+    gql_params = await prepare_graphql_params(
+        db=db, include_subscription=False, branch=branch, service=service, account_session=account_session
+    )
 
     with patch(
         "infrahub.services.adapters.workflow.local.WorkflowLocalExecution.submit_workflow"
@@ -109,12 +117,18 @@ async def test_create_artifact_definition(
         )
 
         assert result.errors is None
+        assert result.data
         assert result.data["CoreArtifactDefinitionCreate"]["ok"] is True
         ad_id = result.data["CoreArtifactDefinitionCreate"]["object"]["id"]
 
         ad1 = await NodeManager.get_one(db=db, id=ad_id, include_owner=True, include_source=True, branch=branch)
 
         assert ad1.name.value == "Artifact 01"
+
+        context = InfrahubContext.init(
+            branch=branch,
+            account=account_session,
+        )
 
         expected_calls = [
             call(
@@ -127,6 +141,7 @@ async def test_create_artifact_definition(
                         limit=[],
                     )
                 },
+                context=context,
             ),
         ]
         mock_submit_workflow.assert_has_calls(expected_calls)
@@ -137,6 +152,7 @@ async def test_update_artifact_definition(
     default_branch: Branch,
     register_core_models_schema,
     car_person_data_generic,
+    create_test_admin: Node,
     definition1: Node,
     branch: Branch,
 ):
@@ -156,8 +172,12 @@ async def test_update_artifact_definition(
 
     recorder = BusRecorder()
     service = await InfrahubServices.new(message_bus=recorder, workflow=WorkflowLocalExecution())
-
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch, service=service)
+    account_session = AccountSession(
+        authenticated=True, account_id=create_test_admin.id, session_id=None, auth_type=AuthType.API
+    )
+    gql_params = await prepare_graphql_params(
+        db=db, include_subscription=False, branch=branch, service=service, account_session=account_session
+    )
     with patch(
         "infrahub.services.adapters.workflow.local.WorkflowLocalExecution.submit_workflow"
     ) as mock_submit_workflow:
@@ -170,6 +190,7 @@ async def test_update_artifact_definition(
         )
 
         assert result.errors is None
+        assert result.data
         assert result.data["CoreArtifactDefinitionUpdate"]["ok"] is True
 
         ad1_post = await NodeManager.get_one(
@@ -177,6 +198,11 @@ async def test_update_artifact_definition(
         )
 
         assert ad1_post.artifact_name.value == "myartifact2"
+
+        context = InfrahubContext.init(
+            branch=branch,
+            account=account_session,
+        )
 
         expected_calls = [
             call(
@@ -189,6 +215,7 @@ async def test_update_artifact_definition(
                         limit=[],
                     )
                 },
+                context=context,
             ),
         ]
         mock_submit_workflow.assert_has_calls(expected_calls)

--- a/backend/tests/unit/message_bus/operations/event/test_branch.py
+++ b/backend/tests/unit/message_bus/operations/event/test_branch.py
@@ -91,18 +91,25 @@ async def test_merged(default_branch: Branch, prefect_test_fixture, context: Inf
         await merge.fn(message=message, service=init_service)
 
         expected_calls = [
-            call(workflow=TRIGGER_ARTIFACT_DEFINITION_GENERATE, parameters={"branch": message.target_branch}),
+            call(
+                workflow=TRIGGER_ARTIFACT_DEFINITION_GENERATE,
+                parameters={"branch": message.target_branch},
+                context=context,
+            ),
             call(
                 workflow=TRIGGER_GENERATOR_DEFINITION_RUN,
                 parameters={"branch": target_branch_name},
+                context=context,
             ),
             call(
                 workflow=DIFF_UPDATE,
                 parameters={"model": RequestDiffUpdate(branch_name=tracked_diff_roots[0].diff_branch_name)},
+                context=context,
             ),
             call(
                 workflow=DIFF_UPDATE,
                 parameters={"model": RequestDiffUpdate(branch_name=tracked_diff_roots[1].diff_branch_name)},
+                context=context,
             ),
         ]
         mock_submit_workflow.assert_has_calls(expected_calls)

--- a/backend/tests/unit/message_bus/operations/event/test_branch.py
+++ b/backend/tests/unit/message_bus/operations/event/test_branch.py
@@ -3,6 +3,8 @@ from uuid import uuid4
 
 import pytest
 
+from infrahub.auth import AccountSession, AuthType
+from infrahub.context import BranchContext, InfrahubContext
 from infrahub.core.branch import Branch
 from infrahub.core.diff.model.path import BranchTrackingId, EnrichedDiffRoot
 from infrahub.core.diff.models import RequestDiffUpdate
@@ -30,7 +32,15 @@ async def init_service():
     return service
 
 
-async def test_merged(default_branch: Branch, prefect_test_fixture, init_service):
+@pytest.fixture
+def context():
+    return InfrahubContext(
+        account=AccountSession(account_id="123", auth_type=AuthType.NONE),
+        branch=BranchContext(name="main", id="placeholder"),
+    )
+
+
+async def test_merged(default_branch: Branch, prefect_test_fixture, context: InfrahubContext, init_service):
     """
     Test that merge flow triggers corrects events/workflows. It does not actually test these events/workflows behaviors
     as they are mocked.
@@ -40,7 +50,7 @@ async def test_merged(default_branch: Branch, prefect_test_fixture, init_service
     target_branch_name = "main"
     right_now = Timestamp()
     message = messages.EventBranchMerge(
-        source_branch=source_branch_name, target_branch=target_branch_name, ipam_node_details=[]
+        source_branch=source_branch_name, target_branch=target_branch_name, context=context, ipam_node_details=[]
     )
 
     tracked_diff_roots = [

--- a/docs/docs/reference/message-bus-events.mdx
+++ b/docs/docs/reference/message-bus-events.mdx
@@ -207,6 +207,7 @@ For more detailed explanations on how to use these events within Infrahub, see t
 | **meta** | Meta properties for the message | N/A | None |
 | **source_branch** | The source branch | string | None |
 | **target_branch** | The target branch | string | None |
+| **context** | The context of the event | N/A | None |
 <!-- vale on -->
 <!-- vale off -->
 #### Event event.branch.rebased
@@ -478,6 +479,7 @@ For more detailed explanations on how to use these events within Infrahub, see t
 | **source_branch_sync_with_git** | Indicates if the source branch should sync with git | boolean | None |
 | **destination_branch** | The destination branch of the proposed change | string | None |
 | **check_type** | Can be used to restrict the pipeline to a specific type of job | N/A | all |
+| **context** | The context of the task | N/A | None |
 <!-- vale on -->
 <!-- vale off -->
 #### Event request.proposed_change.refresh_artifacts
@@ -766,6 +768,7 @@ For more detailed explanations on how to use these events within Infrahub, see t
 | **meta** | Meta properties for the message | N/A | None |
 | **source_branch** | The source branch | string | None |
 | **target_branch** | The target branch | string | None |
+| **context** | The context of the event | N/A | None |
 <!-- vale on -->
 <!-- vale off -->
 #### Event event.branch.rebased
@@ -1050,6 +1053,7 @@ For more detailed explanations on how to use these events within Infrahub, see t
 | **source_branch_sync_with_git** | Indicates if the source branch should sync with git | boolean | None |
 | **destination_branch** | The destination branch of the proposed change | string | None |
 | **check_type** | Can be used to restrict the pipeline to a specific type of job | N/A | all |
+| **context** | The context of the task | N/A | None |
 <!-- vale on -->
 <!-- vale off -->
 #### Event request.proposed_change.refresh_artifacts


### PR DESCRIPTION
Related to IFC-1044

This PR introduces the concept of `context` as a mean to capture additional information about who is executing a specific task and in which context. 
The context is meant to be passed along when executing tasks. 

For now `InfrahubContext` mainly stores the information about the account_session and the branch but later the goal is to add more information like the related events etc ...
 