### PR TITLE
Set target-version for ruff to Python 3.10

### DIFF
--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -524,7 +524,7 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin):
                     field = field.value
             if isinstance(field, str):
                 response[field_name] = self._filter_sensitive(value=field, filter_sensitive=filter_sensitive)
-            elif isinstance(field, (int, bool, dict, list)):
+            elif isinstance(field, int | bool | dict | list):
                 response[field_name] = field
 
             if related_node_ids and self.is_from_profile and self.source_id:
@@ -1155,7 +1155,7 @@ class ListAttribute(BaseAttribute):
 
     def deserialize_value(self, data: AttributeFromDB) -> Any:
         """Deserialize the value (potentially) coming from the database."""
-        if isinstance(data.value, (str, bytes)):
+        if isinstance(data.value, str | bytes):
             return ujson.loads(data.value)
         return data.value
 
@@ -1191,7 +1191,7 @@ class JSONAttribute(BaseAttribute):
 
     def deserialize_value(self, data: AttributeFromDB) -> Any:
         """Deserialize the value (potentially) coming from the database."""
-        if data.value and isinstance(data.value, (str, bytes)):
+        if data.value and isinstance(data.value, str | bytes):
             return ujson.loads(data.value)
         return data.value
 

--- a/backend/infrahub/core/diff/repository/deserializer.py
+++ b/backend/infrahub/core/diff/repository/deserializer.py
@@ -129,7 +129,7 @@ class EnrichedDiffDeserializer:
 
         # TODO Ensure the list is even
         current_node_uuid = node_uuid
-        for rel, parent in zip(parents_path[::2], parents_path[1::2]):
+        for rel, parent in zip(parents_path[::2], parents_path[1::2], strict=False):
             enriched_root.add_parent(
                 node_id=current_node_uuid,
                 parent_id=parent.get("uuid"),

--- a/backend/infrahub/core/ipam/reconciler.py
+++ b/backend/infrahub/core/ipam/reconciler.py
@@ -104,7 +104,7 @@ class IpamReconciler:
         ip_node_uuid = query.get_ip_node_uuid()
         if not ip_node_uuid:
             node_type = InfrahubKind.IPPREFIX
-            if isinstance(ip_value, (ipaddress.IPv6Interface, ipaddress.IPv4Interface)):
+            if isinstance(ip_value, ipaddress.IPv6Interface | ipaddress.IPv4Interface):
                 node_type = InfrahubKind.IPADDRESS
             raise NodeNotFoundError(node_type=node_type, identifier=str(ip_value))
         current_parent_uuid = query.get_current_parent_uuid()

--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -800,7 +800,7 @@ class NodeManager:
             raise NodeNotFoundError(branch_name=branch.name, node_type=kind_str, identifier=hfid_str)
 
         filters = {}
-        for key, item in zip(node_schema.human_friendly_id, hfid):
+        for key, item in zip(node_schema.human_friendly_id, hfid, strict=False):
             path = node_schema.parse_schema_path(path=key, schema=registry.schema.get_schema_branch(name=branch.name))
 
             if path.is_type_relationship:

--- a/backend/infrahub/core/migrations/graph/m018_uniqueness_nulls.py
+++ b/backend/infrahub/core/migrations/graph/m018_uniqueness_nulls.py
@@ -52,7 +52,7 @@ class Migration018(InternalSchemaMigration):
 
         for schema_kind in schema_branch.node_names + schema_branch.generic_names:
             schema = schema_branch.get(name=schema_kind, duplicate=False)
-            if not isinstance(schema, (NodeSchema, GenericSchema)):
+            if not isinstance(schema, NodeSchema | GenericSchema):
                 continue
 
             schema_constraint_path_groups = schema.get_unique_constraint_schema_attribute_paths(

--- a/backend/infrahub/core/models.py
+++ b/backend/infrahub/core/models.py
@@ -535,7 +535,7 @@ class HashableModel(BaseModel):
             if attr_other is None or attr_local == attr_other:
                 continue
 
-            if attr_local is None or isinstance(attr_other, (int, str, bool, float)):
+            if attr_local is None or isinstance(attr_other, int | str | bool | float):
                 setattr(self, field_name, attr_other)
                 continue
 

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -200,7 +200,7 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
 
         branch = await registry.get_branch(branch=branch, db=db)
 
-        if isinstance(schema, (NodeSchema, ProfileSchema)):
+        if isinstance(schema, NodeSchema | ProfileSchema):
             attrs["schema"] = schema
         elif isinstance(schema, str):
             # TODO need to raise a proper exception for this, right now it will raise a generic ValueError

--- a/backend/infrahub/core/node/standard.py
+++ b/backend/infrahub/core/node/standard.py
@@ -171,9 +171,9 @@ class StandardNode(BaseModel):
 
             if value == NULL_VALUE:
                 attrs[key] = None
-            elif issubclass(field_type, (int, float, bool, str, UUID)):
+            elif issubclass(field_type, int | float | bool | str | UUID):
                 attrs[key] = value
-            elif isinstance(value, (str, bytes)):
+            elif isinstance(value, str | bytes):
                 attrs[key] = ujson.loads(value)
 
         return cls(**attrs)
@@ -201,7 +201,7 @@ class StandardNode(BaseModel):
                     data[attr_name] = ujson.dumps(clean_value)
                 else:
                     data[attr_name] = attr_value.model_dump_json()
-            elif issubclass(field_type, (int, float, bool, str, UUID)):
+            elif issubclass(field_type, int | float | bool | str | UUID):
                 data[attr_name] = attr_value
             else:
                 data[attr_name] = ujson.dumps(attr_value)

--- a/backend/infrahub/core/property.py
+++ b/backend/infrahub/core/property.py
@@ -123,7 +123,7 @@ class NodePropertyMixin:
         If the value is a Node, we save the node and we extract the ID
         if the value is None, we just initialize the 2 variables."""
 
-        if isinstance(value, (str, UUID)):
+        if isinstance(value, str | UUID):
             setattr(self, f"{name}_id", value)
             setattr(self, f"_{name}", None)
         elif isinstance(value, dict) and "id" in value:

--- a/backend/infrahub/core/query/__init__.py
+++ b/backend/infrahub/core/query/__init__.py
@@ -479,7 +479,7 @@ class Query(ABC):
         """Search for all the variables in a Query string and replace each variable with its value."""
 
         def prep_value(v: Any) -> str:
-            if isinstance(v, (int, list)):
+            if isinstance(v, int | list):
                 return str(v)
             return f'"{v}"'
 
@@ -517,7 +517,7 @@ class Query(ABC):
         params = []
 
         for key, value in self.params.items():
-            if isinstance(value, (int, list)):
+            if isinstance(value, int | list):
                 params.append(f"{key}: {str(value)}")
             else:
                 params.append(f'{key}: "{value}"')

--- a/backend/infrahub/core/query/attribute.py
+++ b/backend/infrahub/core/query/attribute.py
@@ -201,10 +201,10 @@ async def default_attribute_query_filter(
     query_params: dict[str, Any] = {}
     query_where: list[str] = []
 
-    if filter_value and not isinstance(filter_value, (str, bool, int, list)):
+    if filter_value and not isinstance(filter_value, str | bool | int | list):
         raise TypeError(f"filter {filter_name}: {filter_value} ({type(filter_value)}) is not supported.")
 
-    if isinstance(filter_value, list) and not all(isinstance(value, (str, bool, int)) for value in filter_value):
+    if isinstance(filter_value, list) and not all(isinstance(value, str | bool | int) for value in filter_value):
         raise TypeError(f"filter {filter_name}: {filter_value} (list) contains unsupported item")
 
     param_prefix = param_prefix or f"attr_{name}"

--- a/backend/infrahub/core/query/utils.py
+++ b/backend/infrahub/core/query/utils.py
@@ -17,7 +17,7 @@ def find_node_schema(
     for label in node.labels:
         if db.schema.has(name=label, branch=branch):
             schema = db.schema.get(name=label, branch=branch, duplicate=duplicate)
-            if isinstance(schema, (NodeSchema, ProfileSchema)):
+            if isinstance(schema, NodeSchema | ProfileSchema):
                 return schema
 
     return None

--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -744,7 +744,7 @@ class RelationshipManager:
         await rm._validate_hierarchy()
 
         for item in data:
-            if not isinstance(item, (rm.rel_class, str, dict)) and not hasattr(item, "_schema"):
+            if not isinstance(item, rm.rel_class | str | dict) and not hasattr(item, "_schema"):
                 raise ValidationError({rm.name: f"Invalid data provided to form a relationship {item}"})
 
             rel = rm.rel_class(schema=rm.schema, branch=rm.branch, at=rm.at, node=rm.node)
@@ -991,7 +991,7 @@ class RelationshipManager:
         changed = False
 
         for item in list_data:
-            if not isinstance(item, (self.rel_class, str, dict, type(None))) and not hasattr(item, "_schema"):
+            if not isinstance(item, self.rel_class | str | dict | type(None)) and not hasattr(item, "_schema"):
                 raise ValidationError({self.name: f"Invalid data provided to form a relationship {item}"})
 
             if hasattr(item, "_schema"):
@@ -1039,7 +1039,7 @@ class RelationshipManager:
 
     async def add(self, data: Union[dict[str, Any], Node], db: InfrahubDatabase) -> bool:
         """Add a new relationship to the list of existing ones, avoid duplication."""
-        if not isinstance(data, (self.rel_class, dict)) and not hasattr(data, "_schema"):
+        if not isinstance(data, self.rel_class | dict) and not hasattr(data, "_schema"):
             raise ValidationError({self.name: f"Invalid data provided to form a relationship {data}"})
 
         await self._validate_hierarchy()

--- a/backend/infrahub/core/schema/manager.py
+++ b/backend/infrahub/core/schema/manager.py
@@ -286,7 +286,7 @@ class SchemaManager(NodeManager):
         new_node.id = obj.id
 
         # Then create the Attributes and the relationships
-        if isinstance(node, (NodeSchema, GenericSchema)):
+        if isinstance(node, NodeSchema | GenericSchema):
             new_node.relationships = []
             new_node.attributes = []
 

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -428,7 +428,7 @@ class SchemaBranch:
 
     def generate_fields_for_display_label(self, name: str) -> Optional[dict]:
         node = self.get(name=name, duplicate=False)
-        if isinstance(node, (NodeSchema, ProfileSchema)):
+        if isinstance(node, NodeSchema | ProfileSchema):
             return node.generate_fields_for_display_label()
 
         fields: dict[str, Union[str, None, dict[str, None]]] = {}

--- a/backend/infrahub/core/utils.py
+++ b/backend/infrahub/core/utils.py
@@ -184,7 +184,7 @@ def parse_node_kind(kind: str) -> NodeKind:
 def convert_ip_to_binary_str(
     obj: Union[ipaddress.IPv6Network, ipaddress.IPv4Network, ipaddress.IPv4Interface, ipaddress.IPv6Interface],
 ) -> str:
-    if isinstance(obj, (ipaddress.IPv6Network, ipaddress.IPv4Network)):
+    if isinstance(obj, ipaddress.IPv6Network | ipaddress.IPv4Network):
         prefix_bin = f"{int(obj.network_address):b}"
         return prefix_bin.zfill(obj.max_prefixlen)
 
@@ -204,7 +204,7 @@ def build_regex_attr(value: str | int | bool) -> str:
     """
     if isinstance(value, str):
         return f'"{value}"'
-    if isinstance(value, (bool, int)):
+    if isinstance(value, bool | int):
         value_str = str(value).lower()
         return rf'(?<=[^\w"\d]){value_str}(?=[^\w"\d])'
 

--- a/backend/infrahub/core/validators/tasks.py
+++ b/backend/infrahub/core/validators/tasks.py
@@ -35,7 +35,7 @@ async def schema_validate_migrations(
     # NOTE this task is a good candidate to add a progress bar
     for constraint in message.constraints:
         schema = message.schema_branch.get(name=constraint.path.schema_kind)
-        if not isinstance(schema, (GenericSchema, NodeSchema)):
+        if not isinstance(schema, GenericSchema | NodeSchema):
             continue
         batch.add(
             task=schema_path_validate,

--- a/backend/infrahub/graphql/app.py
+++ b/backend/infrahub/graphql/app.py
@@ -499,7 +499,7 @@ async def _get_operation_from_multipart(request: Request) -> Union[dict[str, Any
         operations = ujson.loads(operations_data)
     except (TypeError, ValueError) as err:
         raise ValueError("'operations' must be a valid JSON") from err
-    if not isinstance(operations, (dict, list)):
+    if not isinstance(operations, dict | list):
         raise ValueError("'operations' field must be an Object or an Array")
 
     try:

--- a/backend/infrahub/graphql/loaders/node.py
+++ b/backend/infrahub/graphql/loaders/node.py
@@ -75,7 +75,7 @@ def to_frozen_set(to_freeze: dict[str, Any]) -> frozenset:
     for k, v in to_freeze.items():
         if isinstance(v, dict):
             freezing_dict[k] = to_frozen_set(v)
-        elif isinstance(v, (list, set)):
+        elif isinstance(v, list | set):
             freezing_dict[k] = frozenset(v)
         else:
             freezing_dict[k] = v

--- a/backend/infrahub/graphql/manager.py
+++ b/backend/infrahub/graphql/manager.py
@@ -251,7 +251,7 @@ class GraphQLSchemaManager:
 
     def get_type(self, name: str) -> type[InfrahubObject]:
         if name in self._graphql_types and issubclass(
-            self._graphql_types[name], (BaseAttributeType, graphene.Interface, graphene.ObjectType)
+            self._graphql_types[name], BaseAttributeType | graphene.Interface | graphene.ObjectType
         ):
             return self._graphql_types[name]
         raise ValueError(f"Unable to find {name!r}")
@@ -390,7 +390,7 @@ class GraphQLSchemaManager:
 
         # Generate all GraphQL ObjectType, Nested, Paginated & NestedPaginated and store them in the registry
         for node_schema in full_schema.values():
-            if isinstance(node_schema, (NodeSchema, ProfileSchema)):
+            if isinstance(node_schema, NodeSchema | ProfileSchema):
                 node_type = self.generate_graphql_object(schema=node_schema, populate_cache=True)
                 node_type_edged = self.generate_graphql_edged_object(
                     schema=node_schema, node=node_type, populate_cache=True
@@ -520,7 +520,7 @@ class GraphQLSchemaManager:
             else:
                 base_class = mutation_map.get(node_schema.kind, InfrahubMutation)
 
-            if isinstance(node_schema, (NodeSchema, ProfileSchema)):
+            if isinstance(node_schema, NodeSchema | ProfileSchema):
                 mutations = self.generate_graphql_mutations(schema=node_schema, base_class=base_class)
 
                 class_attrs[f"{node_schema.kind}Create"] = mutations.create.Field()
@@ -546,7 +546,7 @@ class GraphQLSchemaManager:
 
         interfaces: set[type[InfrahubObject]] = set()
 
-        if isinstance(schema, (NodeSchema, ProfileSchema)) and schema.inherit_from:
+        if isinstance(schema, NodeSchema | ProfileSchema) and schema.inherit_from:
             for generic_name in schema.inherit_from:
                 generic = self.get_type(name=generic_name)
                 interfaces.add(generic)
@@ -983,7 +983,7 @@ class GraphQLSchemaManager:
             "Meta": type("Meta", (object,), meta_attrs),
         }
 
-        if isinstance(schema, (NodeSchema, GenericSchema)):
+        if isinstance(schema, NodeSchema | GenericSchema):
             main_attrs["permissions"] = graphene.Field(
                 PaginatedObjectPermission, required=True, resolver=parent_field_name_resolver
             )

--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -370,7 +370,7 @@ class InfrahubMutation(InfrahubMutationMixin, Mutation):
         cls, schema: Optional[Union[NodeSchema, GenericSchema, ProfileSchema]] = None, _meta=None, **options
     ) -> None:
         # Make sure schema is a valid NodeSchema Node Class
-        if not isinstance(schema, (NodeSchema, GenericSchema, ProfileSchema)):
+        if not isinstance(schema, NodeSchema | GenericSchema | ProfileSchema):
             raise ValueError(f"You need to pass a valid NodeSchema in '{cls.__name__}.Meta', received '{schema}'")
 
         if not _meta:

--- a/backend/infrahub/graphql/types/node.py
+++ b/backend/infrahub/graphql/types/node.py
@@ -21,7 +21,7 @@ class InfrahubObject(ObjectType):
         _meta: InfrahubObjectOptions | None = None,
         **options: Any,
     ) -> None:
-        if not isinstance(schema, (NodeSchema, GenericSchema, ProfileSchema)):
+        if not isinstance(schema, NodeSchema | GenericSchema | ProfileSchema):
             raise ValueError(f"You need to pass a valid NodeSchema in '{cls.__name__}.Meta', received '{schema}'")
 
         if not _meta:

--- a/backend/infrahub/menu/models.py
+++ b/backend/infrahub/menu/models.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 
 def get_full_name(obj: CoreMenuItem | NodeSchema | GenericSchema | ProfileSchema) -> str:
-    if isinstance(obj, (NodeSchema, GenericSchema, ProfileSchema)):
+    if isinstance(obj, NodeSchema | GenericSchema | ProfileSchema):
         return _get_full_name_schema(obj)
     return _get_full_name_node(obj)
 

--- a/backend/infrahub/services/component.py
+++ b/backend/infrahub/services/component.py
@@ -69,7 +69,7 @@ class InfrahubComponent:
             schema_hash_keys = [key for key in keys if f":schema_hash:branch:{branch}" in key]
             response = await self.cache.get_values(keys=schema_hash_keys)
 
-        for key, value in zip(schema_hash_keys, response):
+        for key, value in zip(schema_hash_keys, response, strict=False):
             if match := WORKER_MATCH.search(key):
                 identity = match.group(1)
                 workers[identity].add_value(key=key, value=value)

--- a/backend/tests/adapters/cache.py
+++ b/backend/tests/adapters/cache.py
@@ -1,5 +1,4 @@
 import re
-from typing import Optional
 
 from infrahub.services.adapters.cache import InfrahubCache
 
@@ -11,10 +10,10 @@ class MemoryCache(InfrahubCache):
     async def delete(self, key: str) -> None:
         self.storage.pop(key, None)
 
-    async def get(self, key: str) -> Optional[str]:
+    async def get(self, key: str) -> str | None:
         return self.storage.get(key)
 
-    async def get_values(self, keys: list[str]) -> list[Optional[str]]:
+    async def get_values(self, keys: list[str]) -> list[str | None]:
         return [await self.get(key) for key in keys]
 
     async def list_keys(self, filter_pattern: str) -> list[str]:
@@ -22,8 +21,6 @@ class MemoryCache(InfrahubCache):
         compiled_pattern = re.compile(regex_pattern)
         return [key for key in self.storage.keys() if compiled_pattern.match(key)]
 
-    async def set(
-        self, key: str, value: str, expires: Optional[int] = None, not_exists: bool = False
-    ) -> Optional[bool]:
+    async def set(self, key: str, value: str, expires: int | None = None, not_exists: bool = False) -> bool | None:
         self.storage[key] = value
         return True

--- a/backend/tests/adapters/log.py
+++ b/backend/tests/adapters/log.py
@@ -1,26 +1,26 @@
-from typing import Any, Optional
+from typing import Any
 
 
 class FakeLogger:
     def __init__(self) -> None:
-        self.info_logs: list[Optional[str]] = []
-        self.error_logs: list[Optional[str]] = []
+        self.info_logs: list[str | None] = []
+        self.error_logs: list[str | None] = []
 
-    def debug(self, event: Optional[str] = None, *args: Any, **kw: Any) -> Any:
+    def debug(self, event: str | None = None, *args: Any, **kw: Any) -> Any:
         """Send a debug event"""
 
-    def info(self, event: Optional[str] = None, *args: Any, **kw: Any) -> Any:
+    def info(self, event: str | None = None, *args: Any, **kw: Any) -> Any:
         self.info_logs.append(event)
 
-    def warning(self, event: Optional[str] = None, *args: Any, **kw: Any) -> Any:
+    def warning(self, event: str | None = None, *args: Any, **kw: Any) -> Any:
         """Send a warning event"""
 
-    def error(self, event: Optional[str] = None, *args: Any, **kw: Any) -> Any:
+    def error(self, event: str | None = None, *args: Any, **kw: Any) -> Any:
         """Send an error event."""
         self.error_logs.append(event)
 
-    def critical(self, event: Optional[str] = None, *args: Any, **kw: Any) -> Any:
+    def critical(self, event: str | None = None, *args: Any, **kw: Any) -> Any:
         """Send a critical event."""
 
-    def exception(self, event: Optional[str] = None, *args: Any, **kw: Any) -> Any:
+    def exception(self, event: str | None = None, *args: Any, **kw: Any) -> Any:
         """Send an exception event."""

--- a/backend/tests/adapters/message_bus.py
+++ b/backend/tests/adapters/message_bus.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import TYPE_CHECKING, Optional, TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 import ujson
 from infrahub_sdk.uuidt import UUIDT
@@ -23,7 +23,7 @@ class BusRecorder(InfrahubMessageBus):
         self.messages_per_routing_key: dict[str, list[InfrahubMessage]] = {}
 
     async def publish(
-        self, message: InfrahubMessage, routing_key: str, delay: Optional[MessageTTL] = None, is_retry: bool = False
+        self, message: InfrahubMessage, routing_key: str, delay: MessageTTL | None = None, is_retry: bool = False
     ) -> None:
         self.messages.append(message)
         if routing_key not in self.messages_per_routing_key:
@@ -52,7 +52,7 @@ class BusSimulator(InfrahubMessageBus):
         self.service: InfrahubServices
 
     async def publish(
-        self, message: InfrahubMessage, routing_key: str, delay: Optional[MessageTTL] = None, is_retry: bool = False
+        self, message: InfrahubMessage, routing_key: str, delay: MessageTTL | None = None, is_retry: bool = False
     ) -> None:
         self.messages.append(message)
         if routing_key not in self.messages_per_routing_key:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,7 +7,7 @@ import time
 from contextlib import ExitStack
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, AsyncGenerator, Generator, Optional, TypeVar
+from typing import Any, AsyncGenerator, Generator, TypeVar
 
 import pytest
 import ujson
@@ -104,7 +104,7 @@ def event_loop():
 
 @pytest.fixture(scope="module")
 async def db(
-    neo4j: Optional[dict[int, int]], memgraph: Optional[dict[int, int]], reload_settings_before_each_module
+    neo4j: dict[int, int] | None, memgraph: dict[int, int] | None, reload_settings_before_each_module
 ) -> AsyncGenerator[InfrahubDatabase, None]:
     if INFRAHUB_USE_TEST_CONTAINERS:
         config.SETTINGS.database.address = "localhost"
@@ -153,7 +153,7 @@ async def do_default_branch(db: InfrahubDatabase) -> Branch:
 
 
 @pytest.fixture
-async def default_ipnamespace(db: InfrahubDatabase, register_core_models_schema) -> Optional[Node]:
+async def default_ipnamespace(db: InfrahubDatabase, register_core_models_schema) -> Node | None:
     if not registry._default_ipnamespace:
         ip_namespace = await create_ipam_namespace(db=db)
         registry.default_ipnamespace = ip_namespace.id
@@ -201,7 +201,7 @@ async def do_register_core_models_schema(branch: Branch) -> SchemaBranch:
 
 
 @pytest.fixture(scope="session")
-def neo4j(request: pytest.FixtureRequest, load_settings_before_session) -> Optional[dict[int, int]]:
+def neo4j(request: pytest.FixtureRequest, load_settings_before_session) -> dict[int, int] | None:
     if not INFRAHUB_USE_TEST_CONTAINERS or config.SETTINGS.database.db_type == "memgraph":
         return None
 
@@ -297,7 +297,7 @@ def wait_for_memgraph_ready(host, port, timeout=15):
 
 
 @pytest.fixture(scope="session")
-def memgraph(request: pytest.FixtureRequest, load_settings_before_session) -> Optional[dict[int, int]]:
+def memgraph(request: pytest.FixtureRequest, load_settings_before_session) -> dict[int, int] | None:
     if not INFRAHUB_USE_TEST_CONTAINERS or config.SETTINGS.database.db_type != "memgraph":
         return None
 
@@ -323,7 +323,7 @@ def memgraph(request: pytest.FixtureRequest, load_settings_before_session) -> Op
 
 
 @pytest.fixture(scope="session")
-def nats_container(request: pytest.FixtureRequest, load_settings_before_session) -> Optional[dict[int, int]]:
+def nats_container(request: pytest.FixtureRequest, load_settings_before_session) -> dict[int, int] | None:
     if not INFRAHUB_USE_TEST_CONTAINERS or config.SETTINGS.cache.driver != config.CacheDriver.NATS:
         return None
 
@@ -352,7 +352,7 @@ def nats(nats_container: dict[int, int] | None, reload_settings_before_each_modu
 
 
 @pytest.fixture(scope="session")
-def prefect_container(request: pytest.FixtureRequest, load_settings_before_session) -> Optional[dict[int, int]]:
+def prefect_container(request: pytest.FixtureRequest, load_settings_before_session) -> dict[int, int] | None:
     return start_prefect_server_container(request)
 
 
@@ -867,7 +867,7 @@ class BusRPCMock(InfrahubMessageBus):
         self.messages: list[InfrahubMessage] = []
 
     async def publish(
-        self, message: InfrahubMessage, routing_key: str, delay: Optional[MessageTTL] = None, is_retry: bool = False
+        self, message: InfrahubMessage, routing_key: str, delay: MessageTTL | None = None, is_retry: bool = False
     ) -> None:
         self.messages.append(message)
 
@@ -913,7 +913,7 @@ class TestHelper:
         return BusRecorder()
 
     @staticmethod
-    async def get_message_bus_simulator(db: Optional[InfrahubDatabase] = None) -> BusSimulator:
+    async def get_message_bus_simulator(db: InfrahubDatabase | None = None) -> BusSimulator:
         service = await InfrahubServices.new(database=db, message_bus=BusSimulator())
         message_bus = service.message_bus
         assert isinstance(message_bus, BusSimulator)

--- a/backend/tests/helpers/file_repo.py
+++ b/backend/tests/helpers/file_repo.py
@@ -1,7 +1,6 @@
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
 
 from git.repo import Repo
 
@@ -20,8 +19,8 @@ class FileRepo:
     # when https://github.com/opsmill/infrahub/issues/4296 is fixed.
     local_repo_base_path: Path = get_fixtures_dir() / "repos"
 
-    _repo: Optional[Repo] = None
-    _initial_branch: Optional[str] = None
+    _repo: Repo | None = None
+    _initial_branch: str | None = None
     _branches: list[str] = field(default_factory=list)
 
     @property

--- a/backend/tests/helpers/query_benchmark/car_person_generators.py
+++ b/backend/tests/helpers/query_benchmark/car_person_generators.py
@@ -1,6 +1,6 @@
 import random
 import uuid
-from typing import Any, Optional
+from typing import Any
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
@@ -59,7 +59,7 @@ class EngineGenerator(DataGenerator):
 
 
 class CarWithDiffInSecondBranchGenerator(CarGenerator):
-    persons: Optional[dict[str, Node]]  # mapping of existing cars names -> node
+    persons: dict[str, Node] | None  # mapping of existing cars names -> node
     nb_persons: int
     diff_ratio: float  # 0.1 means 10% of added nodes, 10% of deleted nodes, 10% of modified nodes
     main_branch: Branch
@@ -157,7 +157,7 @@ class PersonGenerator(DataGenerator):
     async def load_persons(
         self,
         nb_persons: int,
-        cars: Optional[dict[str, Node]] = None,
+        cars: dict[str, Node] | None = None,
     ) -> dict[str, Node]:
         """
         Load persons and return a mapping person_name -> person_node.

--- a/backend/tests/helpers/query_benchmark/data_generator.py
+++ b/backend/tests/helpers/query_benchmark/data_generator.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Callable
 
 from rich.console import Console
 from rich.progress import Progress
@@ -37,7 +37,7 @@ async def load_data_and_profile(
     graphs_output_location: Path,
     test_label: str,
     graph_generator: GraphProfileGenerator,
-    memory_profiling_rate: Optional[int] = None,
+    memory_profiling_rate: int | None = None,
 ) -> None:
     """
     Loads data using the provided data generator, profiles the execution at specified loading intervals,

--- a/backend/tests/helpers/query_benchmark/db_query_profiler.py
+++ b/backend/tests/helpers/query_benchmark/db_query_profiler.py
@@ -2,7 +2,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 from types import TracebackType
-from typing import Any, Optional, Self
+from typing import Any, Self
 
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -33,8 +33,8 @@ class QueryMeasurement:
     duration: float
     query_name: str
     start_time: float
-    nb_elements_loaded: Optional[int] = None
-    memory: Optional[float] = None
+    nb_elements_loaded: int | None = None
+    memory: float | None = None
 
 
 class GraphProfileGenerator:
@@ -89,7 +89,7 @@ class InfrahubDatabaseProfiler(InfrahubDatabase):
         self,
         profiling_enabled: bool = False,
         profile_memory: bool = False,
-        measurements: Optional[list[QueryMeasurement]] = None,
+        measurements: list[QueryMeasurement] | None = None,
         nb_elements_loaded: int = 0,
         **kwargs: Any,
     ) -> None:  # todo args in constructor only because of __class__ pattern
@@ -166,7 +166,7 @@ class InfrahubDatabaseProfiler(InfrahubDatabase):
         self.profile_memory = self.profile_memory
 
     def __exit__(
-        self, exc_type: Optional[type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]
+        self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None
     ) -> None:
         self.profiling_enabled = False
         self.profile_memory = False

--- a/backend/tests/helpers/test_client.py
+++ b/backend/tests/helpers/test_client.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, Optional
+from typing import Any
 
 import httpx
 import ujson
@@ -8,7 +8,7 @@ from infrahub_sdk.types import HTTPMethod
 
 
 async def dummy_async_request(
-    url: str, method: HTTPMethod, headers: dict[str, Any], timeout: int, payload: Optional[dict] = None
+    url: str, method: HTTPMethod, headers: dict[str, Any], timeout: int, payload: dict | None = None
 ) -> httpx.Response:
     """Return an empty response and to pretend that the git commit was updated successfully"""
     return httpx.Response(status_code=200, json={"data": {}}, request=httpx.Request(method="POST", url="http://mock"))
@@ -20,7 +20,7 @@ class InfrahubTestClient(httpx.AsyncClient):
         super().__init__(app=app, base_url=base_url)
 
     async def _request(
-        self, url: str, method: HTTPMethod, headers: dict[str, Any], timeout: int, payload: Optional[dict] = None
+        self, url: str, method: HTTPMethod, headers: dict[str, Any], timeout: int, payload: dict | None = None
     ) -> httpx.Response:
         content = None
         if payload:
@@ -28,12 +28,12 @@ class InfrahubTestClient(httpx.AsyncClient):
         return await self.request(method=method.value, url=url, headers=headers, timeout=timeout, content=content)
 
     async def async_request(
-        self, url: str, method: HTTPMethod, headers: dict[str, Any], timeout: int, payload: Optional[dict] = None
+        self, url: str, method: HTTPMethod, headers: dict[str, Any], timeout: int, payload: dict | None = None
     ) -> httpx.Response:
         return await self._request(url=url, method=method, headers=headers, timeout=timeout, payload=payload)
 
     def sync_request(
-        self, url: str, method: HTTPMethod, headers: dict[str, Any], timeout: int, payload: Optional[dict] = None
+        self, url: str, method: HTTPMethod, headers: dict[str, Any], timeout: int, payload: dict | None = None
     ) -> httpx.Response:
         future = asyncio.run_coroutine_threadsafe(
             self._request(url=url, method=method, headers=headers, timeout=timeout, payload=payload), self.loop

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 import yaml
@@ -81,7 +81,7 @@ class IntegrationHelper:
             self._admin_headers = {"X-INFRAHUB-KEY": await self.create_token()}
         return self._admin_headers
 
-    async def create_token(self, account_name: Optional[str] = None) -> str:
+    async def create_token(self, account_name: str | None = None) -> str:
         token = str(UUIDT())
         account_name = account_name or "admin"
         response = await NodeManager.query(

--- a/backend/tests/integration/schema_lifecycle/test_migration_attribute_branch.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_attribute_branch.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 from infrahub_sdk import InfrahubClient
@@ -24,7 +24,7 @@ from .shared import (
 
 class BranchState:
     def __init__(self) -> None:
-        self._branch: Optional[Branch] = None
+        self._branch: Branch | None = None
 
     @property
     def branch(self) -> Branch:

--- a/backend/tests/integration/schema_lifecycle/test_migration_relationship_branch.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_relationship_branch.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 from infrahub_sdk import InfrahubClient
@@ -18,7 +18,7 @@ from .shared import CAR_KIND, MANUFACTURER_KIND_01, PERSON_KIND, TAG_KIND, TestS
 
 class BranchState:
     def __init__(self) -> None:
-        self._branch: Optional[Branch] = None
+        self._branch: Branch | None = None
 
     @property
     def branch(self) -> Branch:

--- a/backend/tests/integration/schema_lifecycle/test_schema_attribute_remove_add.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_attribute_remove_add.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 from infrahub_sdk import InfrahubClient
@@ -21,7 +21,7 @@ from .shared import (
 
 class BranchState:
     def __init__(self) -> None:
-        self._branch: Optional[Branch] = None
+        self._branch: Branch | None = None
 
     @property
     def branch(self) -> Branch:

--- a/backend/tests/integration/schema_lifecycle/test_schema_migration_branch.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_migration_branch.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import pytest
 from infrahub_sdk import InfrahubClient
 
@@ -26,7 +24,7 @@ from .shared import (
 
 class BranchState:
     def __init__(self) -> None:
-        self._branch: Optional[Branch] = None
+        self._branch: Branch | None = None
 
     @property
     def branch(self) -> Branch:

--- a/backend/tests/query_benchmark/utils.py
+++ b/backend/tests/query_benchmark/utils.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from infrahub import config
 from infrahub.core import registry
 from infrahub.core.branch import Branch
@@ -13,7 +11,7 @@ from tests.helpers.utils import start_neo4j_container
 
 
 async def start_db_and_create_default_branch(
-    neo4j_image: str, load_indexes: bool, queries_names_to_config: Optional[dict[str, QueryConfig]] = None
+    neo4j_image: str, load_indexes: bool, queries_names_to_config: dict[str, QueryConfig] | None = None
 ) -> tuple[InfrahubDatabaseProfiler, Branch]:
     # Start database and create db profiler
     neo4j_container = start_neo4j_container(neo4j_image)

--- a/backend/tests/scale/common/stagers.py
+++ b/backend/tests/scale/common/stagers.py
@@ -1,6 +1,5 @@
 from functools import partial
 from pathlib import Path
-from typing import Optional
 
 import yaml
 from infrahub_sdk import InfrahubClientSync
@@ -12,9 +11,9 @@ from .utils import prepare_node_attributes
 def load_schema(
     client: InfrahubClientSync,
     schema: Path,
-    branch: Optional[str] = None,
-    attributes: Optional[list[dict]] = None,
-    relationships: Optional[list[dict]] = None,
+    branch: str | None = None,
+    attributes: list[dict] | None = None,
+    relationships: list[dict] | None = None,
 ):
     attributes = attributes or []
     relationships = relationships or []

--- a/backend/tests/unit/api/test_api_exception_handler.py
+++ b/backend/tests/unit/api/test_api_exception_handler.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from pydantic import BaseModel, ValidationError, field_validator
 from ujson import loads
 
@@ -8,17 +6,17 @@ from infrahub.exceptions import Error
 
 
 class ModelForTesting(BaseModel):
-    field_1: Optional[str] = None
+    field_1: str | None = None
     field_2: str
 
     @field_validator("field_1", mode="before")
     @classmethod
-    def always_fail(cls, value: Optional[str] = None) -> str:
+    def always_fail(cls, value: str | None = None) -> str:
         raise ValueError("this is the error message")
 
     @field_validator("field_2", mode="before")
     @classmethod
-    def always_fail_more(cls, value: Optional[str] = None) -> str:
+    def always_fail_more(cls, value: str | None = None) -> str:
         raise ValueError("another error message")
 
 
@@ -26,7 +24,7 @@ class MockError(Error):
     HTTP_CODE = 418
     DESCRIPTION = "the teapot error"
 
-    def __init__(self, message: Optional[str]) -> None:
+    def __init__(self, message: str | None) -> None:
         self.message = message or ""
 
 

--- a/backend/tests/unit/core/diff/test_diff_repository.py
+++ b/backend/tests/unit/core/diff/test_diff_repository.py
@@ -578,12 +578,12 @@ class TestDiffRepositorySaveAndLoad:
             same_kind_diff_node = self.build_diff_node(num_sub_fields=3, no_recurse=True)
             same_kind_diff_node.kind = diff_node.kind
             same_attr_names = random.sample([a.name for a in diff_node.attributes], k=min(len(diff_node.attributes), 2))
-            for attr_diff, attr_name in zip(list(same_kind_diff_node.attributes)[:2], same_attr_names):
+            for attr_diff, attr_name in zip(list(same_kind_diff_node.attributes)[:2], same_attr_names, strict=False):
                 attr_diff.name = attr_name
             same_rel_names = random.sample(
                 [r.name for r in diff_node.relationships], k=min(len(diff_node.relationships), 2)
             )
-            for rel_diff, rel_name in zip(list(same_kind_diff_node.relationships)[:2], same_rel_names):
+            for rel_diff, rel_name in zip(list(same_kind_diff_node.relationships)[:2], same_rel_names, strict=False):
                 rel_diff.name = rel_name
             diff_nodes.add(same_kind_diff_node)
         diff_root = EnrichedRootFactory.build(nodes=diff_nodes)

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -517,7 +517,7 @@ async def test_schema_branch_generate_weight(schema_all_in_one):
     def extract_weights(schema: SchemaBranch):
         weights = []
         for node in schema.get_all().values():
-            if not isinstance(node, (NodeSchema, GenericSchema)):
+            if not isinstance(node, NodeSchema | GenericSchema):
                 continue
             for item in node.attributes + node.relationships:
                 weights.append(f"{node.name}__{item.name}__{item.order_weight}")

--- a/backend/tests/unit/core/test_model_hashable.py
+++ b/backend/tests/unit/core/test_model_hashable.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from deepdiff import DeepDiff
 
 from infrahub.core.constants import HashableModelState
@@ -59,7 +57,7 @@ def test_hashing_dict():
     class MySubElement(HashableModel):
         _sort_by: list[str] = ["name"]
         name: str
-        value1: Optional[dict] = None
+        value1: dict | None = None
 
     class MyTopElement(HashableModel):
         _sort_by: list[str] = ["name"]
@@ -80,14 +78,14 @@ def test_update():
     class MySubElement(HashableModel):
         _sort_by: list[str] = ["name"]
         name: str
-        value1: Optional[str] = None
-        value2: Optional[int] = None
+        value1: str | None = None
+        value2: int | None = None
 
     class MyTopElement(HashableModel):
         _sort_by: list[str] = ["name"]
         name: str
-        value1: Optional[str] = None
-        value2: Optional[int] = None
+        value1: str | None = None
+        value2: int | None = None
         value3: list[str]
         subs: list[MySubElement]
 
@@ -126,14 +124,14 @@ def test_update_element_absent():
     class MySubElement(HashableModel):
         _sort_by: list[str] = ["name"]
         name: str
-        value1: Optional[str] = None
-        value2: Optional[int] = None
+        value1: str | None = None
+        value2: int | None = None
 
     class MyTopElement(HashableModel):
         _sort_by: list[str] = ["name"]
         name: str
-        value1: Optional[str] = None
-        value2: Optional[int] = None
+        value1: str | None = None
+        value2: int | None = None
         value3: list[str]
         subs: list[MySubElement]
 
@@ -174,14 +172,14 @@ def test_update_rename():
     class MySubElement(HashableModel):
         _sort_by: list[str] = ["name"]
         name: str
-        value1: Optional[str] = None
-        value2: Optional[int] = None
+        value1: str | None = None
+        value2: int | None = None
 
     class MyTopElement(HashableModel):
         _sort_by: list[str] = ["name"]
         name: str
-        value1: Optional[str] = None
-        value2: Optional[int] = None
+        value1: str | None = None
+        value2: int | None = None
         value3: list[str]
         subs: list[MySubElement]
 
@@ -259,14 +257,14 @@ def test_diff_nested_objects():
     class MySubElement(HashableModel):
         _sort_by: list[str] = ["name"]
         name: str
-        value1: Optional[str] = None
-        value2: Optional[int] = None
+        value1: str | None = None
+        value2: int | None = None
 
     class MyTopElement(HashableModel):
         _sort_by: list[str] = ["name"]
         name: str
-        value1: Optional[str] = None
-        value2: Optional[int] = None
+        value1: str | None = None
+        value2: int | None = None
         value3: list[str]
         value4: MySubElement
         subs: list[MySubElement]
@@ -297,14 +295,14 @@ def test_update_nested_objects():
     class MySubElement(HashableModel):
         _sort_by: list[str] = ["name"]
         name: str
-        value1: Optional[str] = None
-        value2: Optional[int] = None
+        value1: str | None = None
+        value2: int | None = None
 
     class MyTopElement(HashableModel):
         _sort_by: list[str] = ["name"]
         name: str
-        value1: Optional[str] = None
-        value2: Optional[int] = None
+        value1: str | None = None
+        value2: int | None = None
         value3: list[str]
         value4: MySubElement
         subs: list[MySubElement]

--- a/backend/tests/unit/core/test_node_standard.py
+++ b/backend/tests/unit/core/test_node_standard.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -9,7 +9,7 @@ from infrahub.database import InfrahubDatabase
 class MyStdNode(StandardNode):
     attr1_str: str
     attr2_int: int
-    attr3_int: Optional[int] = None
+    attr3_int: int | None = None
     attr4_bool: bool = False
     attr5_dict: dict
 

--- a/models/infrastructure_edge.py
+++ b/models/infrastructure_edge.py
@@ -5,7 +5,7 @@ import uuid
 from collections import defaultdict
 from enum import Enum
 from ipaddress import IPv4Network, IPv6Network
-from typing import Optional, cast
+from typing import cast
 
 from infrahub_sdk import InfrahubClient
 from infrahub_sdk.batch import InfrahubBatch
@@ -184,7 +184,7 @@ class BgpPeerGroup(BaseModel):
     import_policies: str
     export_policies: str
     local_as: str
-    remote_as: Optional[str] = Field(default=None)
+    remote_as: str | None = Field(default=None)
 
 
 class Device(BaseModel):
@@ -261,7 +261,7 @@ class P2pNetwork(BaseModel):
     site2: str
     edge: int
     circuit: str
-    pool: Optional[IpamIPPrefix] = None
+    pool: IpamIPPrefix | None = None
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -351,6 +351,7 @@ ignore_errors = true
 
 [tool.ruff]
 line-length = 120
+target-version = "py310"
 
 exclude = [
     ".git",

--- a/python_testcontainers/infrahub_testcontainers/container.py
+++ b/python_testcontainers/infrahub_testcontainers/container.py
@@ -3,7 +3,6 @@ import uuid
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
-from typing import Optional
 
 from testcontainers.compose import DockerCompose
 from typing_extensions import Self
@@ -48,10 +47,10 @@ PROJECT_ENV_VARIABLES: dict[str, str] = {
 
 @dataclass
 class InfrahubDockerCompose(DockerCompose):
-    project_name: Optional[str] = None
+    project_name: str | None = None
 
     @classmethod
-    def init(cls, directory: Optional[Path] = None, version: Optional[str] = None) -> Self:
+    def init(cls, directory: Path | None = None, version: str | None = None) -> Self:
         if not directory:
             directory = Path.cwd()
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -34,6 +34,7 @@ def format_all(context: Context) -> None:
 @task(name="lint")
 def lint_all(context: Context) -> None:
     yamllint(context)
+    main.lint(context)
     backend.lint(context)
 
 

--- a/tasks/backend.py
+++ b/tasks/backend.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 from invoke import Context, task
 from invoke.runners import Result
@@ -75,7 +75,7 @@ def lint(context: Context) -> None:
 
 
 @task(optional=["database"])
-def test_unit(context: Context, database: str = INFRAHUB_DATABASE) -> Optional[Result]:
+def test_unit(context: Context, database: str = INFRAHUB_DATABASE) -> Result | None:
     with context.cd(ESCAPED_REPO_PATH):
         exec_cmd = f"poetry run pytest -n {NBR_WORKERS} -v --cov=infrahub {MAIN_DIRECTORY}/tests/unit"
         if database == "neo4j":
@@ -85,7 +85,7 @@ def test_unit(context: Context, database: str = INFRAHUB_DATABASE) -> Optional[R
 
 
 @task(optional=["database"])
-def test_core(context: Context, database: str = INFRAHUB_DATABASE) -> Optional[Result]:
+def test_core(context: Context, database: str = INFRAHUB_DATABASE) -> Result | None:
     with context.cd(ESCAPED_REPO_PATH):
         exec_cmd = f"poetry run pytest -n {NBR_WORKERS} -v --cov=infrahub {MAIN_DIRECTORY}/tests/unit/core"
         if database == "neo4j":
@@ -95,7 +95,7 @@ def test_core(context: Context, database: str = INFRAHUB_DATABASE) -> Optional[R
 
 
 @task(optional=["database"])
-def test_integration(context: Context, database: str = INFRAHUB_DATABASE) -> Optional[Result]:
+def test_integration(context: Context, database: str = INFRAHUB_DATABASE) -> Result | None:
     with context.cd(ESCAPED_REPO_PATH):
         exec_cmd = f"poetry run pytest -n {NBR_WORKERS} -v --cov=infrahub {MAIN_DIRECTORY}/tests/integration"
         if database == "neo4j":
@@ -105,7 +105,7 @@ def test_integration(context: Context, database: str = INFRAHUB_DATABASE) -> Opt
 
 
 @task(optional=["database"])
-def test_functional(context: Context, database: str = INFRAHUB_DATABASE) -> Optional[Result]:
+def test_functional(context: Context, database: str = INFRAHUB_DATABASE) -> Result | None:
     with context.cd(ESCAPED_REPO_PATH):
         exec_cmd = f"poetry run pytest -n {NBR_WORKERS} -v --cov=infrahub {MAIN_DIRECTORY}/tests/functional"
         if database == "neo4j":
@@ -118,13 +118,13 @@ def test_functional(context: Context, database: str = INFRAHUB_DATABASE) -> Opti
 def test_scale(
     context: Context,
     schema: Path = f"{ESCAPED_REPO_PATH}/backend/tests/scale/schema.yml",
-    stager: Optional[str] = None,
-    amount: Optional[int] = None,
-    test: Optional[str] = None,
-    attrs: Optional[int] = None,
-    rels: Optional[int] = None,
-    changes: Optional[int] = None,
-) -> Optional[Result]:
+    stager: str | None = None,
+    amount: int | None = None,
+    test: str | None = None,
+    attrs: int | None = None,
+    rels: int | None = None,
+    changes: int | None = None,
+) -> Result | None:
     args = []
     if stager:
         args.extend(["--stager", stager])
@@ -263,7 +263,7 @@ def _jinja2_filter_render_attribute(value: dict[str, Any], use_python_primitive:
 
 
 def _sort_and_filter_models(
-    models: list[dict[str, Any]], filters: Optional[list[tuple[str, str]]] = None
+    models: list[dict[str, Any]], filters: list[tuple[str, str]] | None = None
 ) -> list[dict[str, Any]]:
     if filters is None:
         filters = [("Core", "Node")]

--- a/tasks/docs.py
+++ b/tasks/docs.py
@@ -345,13 +345,12 @@ def _generate_infrahub_events_documentation() -> None:
     using a Jinja2 template. Accessible via `invoke generate_infrahub_events_documentation`.
     """
     from collections import defaultdict
-    from typing import Optional, Union
 
     from infrahub.message_bus import InfrahubMessage, InfrahubResponse
 
     def group_classes_by_category(
-        classes: dict[str, type[Union[InfrahubMessage, InfrahubResponse]]],
-        priority_map: Optional[dict[str, int]] = None,
+        classes: dict[str, type[InfrahubMessage | InfrahubResponse]],
+        priority_map: dict[str, int] | None = None,
     ) -> dict[str, dict[str, list[dict[str, any]]]]:
         """
         Group classes into a nested dictionary by primary and secondary categories, including priority.

--- a/tasks/main.py
+++ b/tasks/main.py
@@ -8,6 +8,8 @@ MAIN_DIRECTORY = Path("tasks")
 NAMESPACE = "MAIN"
 
 
+DIRECTORIES = [str(MAIN_DIRECTORY), "models", "utilities", "python_testcontainers"]
+
 # ----------------------------------------------------------------------------
 # Formatting tasks
 # ----------------------------------------------------------------------------
@@ -17,8 +19,8 @@ def _format_ruff(context: Context) -> None:
     """Run ruff to format all Python files."""
 
     print(f" - [{NAMESPACE}] Format code with ruff")
-    exec_cmd = f"ruff format {MAIN_DIRECTORY} models utilities --config {REPO_BASE / 'pyproject.toml'} && "
-    exec_cmd += f"ruff check --fix {MAIN_DIRECTORY} models utilities --config {REPO_BASE / 'pyproject.toml'}"
+    exec_cmd = f"poetry run ruff format {' '.join(DIRECTORIES)} --config {REPO_BASE / 'pyproject.toml'} && "
+    exec_cmd += f"poetry run ruff check --fix {' '.join(DIRECTORIES)} --config {REPO_BASE / 'pyproject.toml'}"
     with context.cd(ESCAPED_REPO_PATH):
         context.run(exec_cmd)
 
@@ -30,3 +32,22 @@ def format_all(context: Context) -> None:
     _format_ruff(context)
 
     print(f" - [{NAMESPACE}] All formatters have been executed!")
+
+
+def _lint_ruff(context: Context) -> None:
+    """Run ruff to check that Python files adherence to standards."""
+
+    print(f" - [{NAMESPACE}] Check code with ruff")
+    exec_cmd = f"poetry run ruff check --diff {' '.join(DIRECTORIES)} --config {REPO_BASE}/pyproject.toml"
+
+    with context.cd(ESCAPED_REPO_PATH):
+        context.run(exec_cmd)
+
+
+@task
+def lint(context: Context) -> None:
+    """This will run all linters."""
+
+    _lint_ruff(context)
+
+    print(f" - [{NAMESPACE}] All linters have been executed!")

--- a/tasks/sdk.py
+++ b/tasks/sdk.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from invoke import Context, task
 from invoke.runners import Result
 
@@ -66,7 +64,7 @@ def mypy(context: Context) -> None:
 
 
 @task
-def lint(context: Context) -> Optional[Result]:
+def lint(context: Context) -> Result | None:
     """This will run all linter."""
     ruff(context)
     mypy(context)
@@ -75,7 +73,7 @@ def lint(context: Context) -> Optional[Result]:
 
 
 @task
-def test_unit(context: Context) -> Optional[Result]:
+def test_unit(context: Context) -> Result | None:
     """Run unit tests for the Python SDK."""
     with context.cd(ESCAPED_REPO_PATH):
         exec_cmd = f"pytest -n {NBR_WORKERS} -v --cov=infrahub_sdk {MAIN_DIRECTORY / 'tests' / 'unit'}"
@@ -83,7 +81,7 @@ def test_unit(context: Context) -> Optional[Result]:
 
 
 @task(optional=["database"])
-def test_integration(context: Context, database: str = INFRAHUB_DATABASE) -> Optional[Result]:
+def test_integration(context: Context, database: str = INFRAHUB_DATABASE) -> Result | None:
     """Run integration tests for the Python SDK."""
     with context.cd(ESCAPED_REPO_PATH):
         exec_cmd = f"pytest -n {NBR_WORKERS} -v --cov=infrahub_sdk {MAIN_DIRECTORY / 'tests' / 'integration'}"

--- a/utilities/db_backup/__main__.py
+++ b/utilities/db_backup/__main__.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Generator, Optional
+from typing import Any, Generator
 
 import docker
 from docker.models.containers import Container
@@ -133,7 +133,7 @@ class Neo4jBackupRestoreBase:
 
     @contextmanager
     def _print_task_status(
-        self, start: str, completion_message: Optional[str] = None, with_timestamp: bool = True
+        self, start: str, completion_message: str | None = None, with_timestamp: bool = True
     ) -> Generator[None, None, None]:
         end = "" if completion_message else "\n"
         to_print = start
@@ -150,8 +150,8 @@ class Neo4jBackupRestoreBase:
         self,
         container: Container,
         command: list[str],
-        environment: Optional[dict[str, str]] = None,
-        failure_message: Optional[str] = None,
+        environment: dict[str, str] | None = None,
+        failure_message: str | None = None,
         display_error: bool = True,
         continue_on_error: bool = False,
     ) -> bool:
@@ -168,7 +168,7 @@ class Neo4jBackupRestoreBase:
             sys.exit(exit_code)
         return False
 
-    def _get_database_container_details(self, raise_error_on_fail: bool = True) -> Optional[ContainerDetails]:
+    def _get_database_container_details(self, raise_error_on_fail: bool = True) -> ContainerDetails | None:
         containers = self.docker_client.containers.list(filters={"label": "infrahub_role=database"})
         if len(containers) == 0:
             if raise_error_on_fail:
@@ -189,8 +189,8 @@ class Neo4jBackupRestoreBase:
     def _create_helper_container(
         self,
         local_backup_directory: Path,
-        local_docker_networks: Optional[list[Network]],
-        volumes_from_container_names: Optional[list[str]] = None,
+        local_docker_networks: list[Network] | None,
+        volumes_from_container_names: list[str] | None = None,
     ) -> Container:
         try:
             existing_exporter_container = self.docker_client.containers.get(self.backup_helper_container_name)
@@ -278,7 +278,7 @@ class Neo4jBackupRunner(Neo4jBackupRestoreBase):
     def backup(
         self,
         local_backup_directory: Path,
-        database_url: Optional[str],
+        database_url: str | None,
         database_backup_port: int,
         do_aggregate_backups: bool = True,
     ) -> None:


### PR DESCRIPTION
Set target-version for ruff to Python 3.10

Ruff automatically fixed a lot of files after setting the `target-version` to Python 3.10
the main changes are related to 
- Using a union (`|`) instead of a tuple in `isinstance`
- Setting strict=False when using zip
- Replacing `Optional` with `| None`