### PR TITLE
Models for node mutation events

### DIFF
--- a/backend/infrahub/events/models.py
+++ b/backend/infrahub/events/models.py
@@ -1,7 +1,8 @@
+from enum import Enum
 from typing import Any
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, computed_field
 
 from infrahub.message_bus import InfrahubMessage, Meta
 
@@ -100,3 +101,233 @@ class InfrahubBranchEvent(InfrahubEvent):
             }
         )
         return related
+
+
+class UpdateStatus(str, Enum):
+    UNMODIFIED = "unmodified"
+    ADDED = "added"
+    UPDATED = "updated"
+    REMOVED = "removed"
+
+
+###############################################################################
+# Properties
+###############################################################################
+
+
+class Property(BaseModel):
+    name: str = Field(..., description="The name of the property")
+    value: str | bool = Field(
+        ...,
+        description="The value of the property, the type of value will be determined based on what kind of property it is",
+    )
+
+    @computed_field
+    def value_type(self) -> str:
+        """The value_type of the property, used to help external systems
+
+        Would be Boolean for the is_visible, is_protected type properties or Text for owner and source
+        """
+        if isinstance(self.value, str):
+            return "Text"
+
+        return "Boolean"
+
+
+class UpdatedProperty(BaseModel):
+    name: str = Field(..., description="The name of the property")
+    value_current: str | bool = Field(..., description="The updated value of the property")
+    value_previous: str | bool | None = Field(
+        ...,
+        description="The previous value of the property, a `null` value indicates that the property didn't previously have a value",
+    )
+
+    @computed_field
+    def value_type(self) -> str:
+        """The value_type of the property, used to help external systems"""
+        if isinstance(self.value_current, str):
+            return "Text"
+
+        return "Boolean"
+
+    @computed_field
+    def value_update_status(self) -> UpdateStatus:
+        """Indicate how the value was changed during this update"""
+        if self.value_current == self.value_previous:
+            return UpdateStatus.UNMODIFIED
+        if self.value_previous is not None and self.value_current is None:
+            return UpdateStatus.REMOVED
+        if self.value_previous is None and self.value_current is not None:
+            return UpdateStatus.ADDED
+
+        return UpdateStatus.UPDATED
+
+
+###############################################################################
+# Attributes
+###############################################################################
+
+
+class CreatedAttribute(BaseModel):
+    name: str = Field(..., description="The name of the attribute")
+    value: Any = Field(..., description="The value used during creation of this attribute")
+    properties: list[Property] = Field(
+        default_factory=list, description="Properties defined for the attribute during creation"
+    )
+
+    @computed_field
+    def value_type(self) -> str:
+        """The value_type of the attribute, used to help external systems"""
+
+        # Add more types
+        if isinstance(self.value, str):
+            return "Text"
+
+        return "Boolean"
+
+
+class UpdatedAttribute(BaseModel):
+    name: str = Field(..., description="The name of the attribute")
+    value_current: Any = Field(..., description="The current value of the attribute")
+    value_previous: Any = Field(..., description="The previous value of the attribute")
+    updated_properties: list[UpdatedProperty] = Field(
+        default_factory=list, description="The properties that were updated during this update"
+    )
+
+    @computed_field
+    def value_update_status(self) -> UpdateStatus:
+        """Indicate how the peer was changed during this update"""
+        if self.value_current == self.value_previous:
+            return UpdateStatus.UNMODIFIED
+        if self.value_previous is not None and self.value_current is None:
+            return UpdateStatus.REMOVED
+        if self.value_previous is None and self.value_current is not None:
+            return UpdateStatus.ADDED
+
+        return UpdateStatus.UPDATED
+
+    @computed_field
+    def value_type(self) -> str:
+        """The value_type of the attribute, used to help external systems
+
+        The value_type will be based on the current or previous value of this attribute
+        """
+
+        # Add more types
+        if isinstance(self.value_current, str):
+            return "Text"
+
+        return "Boolean"
+
+
+###############################################################################
+# Relationships
+###############################################################################
+
+
+class Relationship(BaseModel):
+    peer_id: str = Field(..., description="The ID of the peer on the remote end of this relationship")
+    peer_kind: str = Field(..., description="The node kind of the remote peer")
+    properties: list[Property] = Field(default_factory=list, description="The properties of this relationship")
+
+
+class CreatedRelationshipCardinalityOne(Relationship):
+    name: str = Field(..., description="The name of the relationship")
+
+    @computed_field
+    def cardinality(self) -> str:
+        return "one"
+
+
+class CreatedRelationshipCardinalityMany(BaseModel):
+    name: str = Field(..., description="The name of the relationship")
+    peers: list[Relationship] = Field(
+        default_factory=list, description="The peers defined during the creation of this relationship"
+    )
+
+    @computed_field
+    def cardinality(self) -> str:
+        return "many"
+
+
+class UpdatedRelationshipCardinalityOne(BaseModel):
+    name: str = Field(..., description="The name of the relationship")
+    peer_id_previous: str | None = Field(..., description="The previous peer of this relationship")
+    peer_kind_previous: str | None = Field(..., description="The node kind of the previous peer")
+    peer_id_current: str | None = Field(..., description="The current peer of this relationship")
+    peer_kind_current: str | None = Field(..., description="The node kind of the current peer")
+    properties: list[UpdatedProperty] = Field(
+        default_factory=list, description="Changes to properties of this relationship if any were made"
+    )
+
+    @computed_field
+    def cardinality(self) -> str:
+        return "one"
+
+    @computed_field
+    def peer_status(self) -> UpdateStatus:
+        """Indicate how the peer was changed during this update"""
+        if self.peer_id_previous == self.peer_id_current:
+            return UpdateStatus.UNMODIFIED
+        if self.peer_id_previous and not self.peer_id_current:
+            return UpdateStatus.REMOVED
+        if self.peer_id_current and not self.peer_id_previous:
+            return UpdateStatus.ADDED
+
+        return UpdateStatus.UPDATED
+
+
+class UpdatedRelationshipPeer(BaseModel):
+    peer_id: str = Field(..., description="The ID of the peer")
+    peer_kind: str = Field(..., description="The node kind of the peer")
+    peer_status: UpdateStatus = Field(
+        ..., description="Indicate how the relationship to this peer was changed in this update"
+    )
+    properties: list[UpdatedProperty] = Field(
+        default_factory=list, description="Changes to properties of this relationship if any were made"
+    )
+
+
+class UpdatedRelationshipCardinalityMany(BaseModel):
+    name: str
+    peers: list[UpdatedRelationshipPeer] = Field(default_factory=list)
+
+    @computed_field
+    def cardinality(self) -> str:
+        return "many"
+
+
+###############################################################################
+# Nodes
+###############################################################################
+
+
+class MutatedNode(BaseModel):
+    node_id: str
+    node_kind: str
+    display_label: str
+
+
+class CreatedNode(MutatedNode):
+    """Emitted when a node is created"""
+
+    attributes: list[CreatedAttribute] = Field(default_factory=list)
+    relationships: list[CreatedRelationshipCardinalityOne | CreatedRelationshipCardinalityMany] = Field(
+        default_factory=list
+    )
+
+
+class DeletedNode(MutatedNode):
+    """Emitted when a node is deleted
+
+    It is assumed that all attributes and relationships are deleted during this event
+    """
+
+
+class UpdatedNode(MutatedNode):
+    """Emitted when a node is updated"""
+
+    attributes: list[UpdatedAttribute] = Field(default_factory=list)
+    relationships: list[UpdatedRelationshipCardinalityOne | UpdatedRelationshipCardinalityMany] = Field(
+        default_factory=list
+    )


### PR DESCRIPTION
I'm not sure where this code should live but I've been looking at the payload we can use for the updated node mutation events and what information we need to have in them. The goals have been to include information that could be useable but also to avoid having to do extensive lookups for every event type so the focus is on the information that gets updated in each mutation.

It would be great to have any feedback if we are missing something or if there are any thoughts for a different implementation.

Some examples of what the payload would look like during mutations can be found below. The output (after the print statements) would be for the payload of the events, a receiver such as webhook would also get information about the branch where the event occured and the type of event (node update / create / delete).

**Note** For now the `attributes` and `relationships`, in the example output payloads below are defined as lists/arrays, those will probably change to dicts/objects instead.

```python
from rich import print

from infrahub.events.models import (
    CreatedAttribute,
    CreatedNode,
    CreatedRelationshipCardinalityOne,
    DeletedNode,
    Property,
    UpdatedAttribute,
    UpdatedNode,
    UpdatedProperty,
    UpdatedRelationshipCardinalityMany,
    UpdatedRelationshipCardinalityOne,
    UpdatedRelationshipPeer,
    UpdateStatus,
)

created_tag = CreatedNode(
    node_id="125671ae-e655-4bf0-8f75-eed297c4699a",
    node_kind="BuiltinTag",
    display_label="red",
    attributes=[CreatedAttribute(name="name", value="red")],
)

print(created_tag.model_dump(by_alias=True))
```
```python
{'node_id': '125671ae-e655-4bf0-8f75-eed297c4699a', 'node_kind': 'BuiltinTag', 'display_label': 'red', 'attributes': [{'name': 'name', 'value': 'red', 'properties': [], 'value_type': 'Text'}], 'relationships': []}
```

```python
updated_tag = UpdatedNode(
    node_id="125671ae-e655-4bf0-8f75-eed297c4699a",
    node_kind="BuiltinTag",
    display_label="red",
    attributes=[
        UpdatedAttribute(
            name="name",
            value_previous="red",
            value_current="red",
            updated_properties=[
                UpdatedProperty(name="owner", value_previous=None, value_current="56f32951-9b19-45ff-99fa-971982d7d608")
            ],
        ),
        UpdatedAttribute(
            name="description",
            value_previous=None,
            value_current="My red tag",
            updated_properties=[
                UpdatedProperty(name="owner", value_previous=None, value_current="56f32951-9b19-45ff-99fa-971982d7d608")
            ],
        ),
    ],
)


print(updated_tag.model_dump(by_alias=True))
```

```python
{
    'node_id': '125671ae-e655-4bf0-8f75-eed297c4699a',
    'node_kind': 'BuiltinTag',
    'display_label': 'red',
    'attributes': [
        {
            'name': 'name',
            'value_current': 'red',
            'value_previous': 'red',
            'updated_properties': [{'name': 'owner', 'value_current': '56f32951-9b19-45ff-99fa-971982d7d608', 'value_previous': None, 'value_type': 'Text', 'value_update_status': <UpdateStatus.UPDATED: 'updated'>}],
            'value_update_status': <UpdateStatus.UNMODIFIED: 'unmodified'>,
            'value_type': 'Text'
        },
        {
            'name': 'description',
            'value_current': 'My red tag',
            'value_previous': None,
            'updated_properties': [{'name': 'owner', 'value_current': '56f32951-9b19-45ff-99fa-971982d7d608', 'value_previous': None, 'value_type': 'Text', 'value_update_status': <UpdateStatus.UPDATED: 'updated'>}],
            'value_update_status': <UpdateStatus.UPDATED: 'updated'>,
            'value_type': 'Text'
        }
    ],
    'relationships': []
}
```

```python
deleted_tag = DeletedNode(
    node_id="125671ae-e655-4bf0-8f75-eed297c4699a",
    node_kind="BuiltinTag",
    display_label="red",
)

print(deleted_tag.model_dump(by_alias=True))
```

```python
{'node_id': '125671ae-e655-4bf0-8f75-eed297c4699a', 'node_kind': 'BuiltinTag', 'display_label': 'red'}
```

```python
created_device = CreatedNode(
    node_id="5f3e85cf-f7f1-483a-a09c-66654a156ebc",
    node_kind="InfraDevice",
    display_label="router-1",
    attributes=[CreatedAttribute(name="name", value="router-1")],
    relationships=[
        CreatedRelationshipCardinalityOne(
            name="site",
            peer_id="1cecdd91-6851-43ff-8a88-1858d7b1c5bd",
            peer_kind="InfraSite",
            properties=[
                Property(name="is_protected", value=True),
                Property(name="owner", value="c8c26901-f74f-4465-8a68-30322fc9747f"),
            ],
        )
    ],
)


print(created_device.model_dump(by_alias=True))
```

```python
{
    'node_id': '5f3e85cf-f7f1-483a-a09c-66654a156ebc',
    'node_kind': 'InfraDevice',
    'display_label': 'router-1',
    'attributes': [{'name': 'name', 'value': 'router-1', 'properties': [], 'value_type': 'Text'}],
    'relationships': [
        {
            'peer_id': '1cecdd91-6851-43ff-8a88-1858d7b1c5bd',
            'peer_kind': 'InfraSite',
            'properties': [{'name': 'is_protected', 'value': True, 'value_type': 'Boolean'}, {'name': 'owner', 'value': 'c8c26901-f74f-4465-8a68-30322fc9747f', 'value_type': 'Text'}],
            'name': 'site',
            'cardinality': 'one'
        }
    ]
}
```


```python
updated_device = UpdatedNode(
    node_id="5f3e85cf-f7f1-483a-a09c-66654a156ebc",
    node_kind="InfraDevice",
    display_label="router-01",
    attributes=[
        UpdatedAttribute(
            name="name",
            value_previous="router-1",
            value_current="router-01",
            updated_properties=[
                UpdatedProperty(name="owner", value_previous=None, value_current="56f32951-9b19-45ff-99fa-971982d7d608")
            ],
        )
    ],
    relationships=[
        UpdatedRelationshipCardinalityOne(
            name="site",
            peer_id_current="1cecdd91-6851-43ff-8a88-1858d7b1c5bd",
            peer_kind_current="InfraSite",
            peer_id_previous="1cecdd91-6851-43ff-8a88-1858d7b1c5bd",
            peer_kind_previous="InfraSite",
            properties=[
                UpdatedProperty(
                    name="owner",
                    value_previous="c8c26901-f74f-4465-8a68-30322fc9747f",
                    value_current="56f32951-9b19-45ff-99fa-971982d7d608",
                )
            ],
        ),
        UpdatedRelationshipCardinalityMany(
            name="interfaces",
            peers=[
                UpdatedRelationshipPeer(
                    peer_id="1739e502-6a3d-4f39-ac84-5418a22f82de",
                    peer_kind="InfraInterfaceL3",
                    peer_status=UpdateStatus.ADDED,
                    properties=[
                        UpdatedProperty(
                            name="owner",
                            value_previous=None,
                            value_current="56f32951-9b19-45ff-99fa-971982d7d608",
                        )
                    ],
                ),
                UpdatedRelationshipPeer(
                    peer_id="d8046a5a-9287-4be4-9788-9fc2e683861a",
                    peer_kind="InfraInterfaceL3",
                    peer_status=UpdateStatus.ADDED,
                    properties=[
                        UpdatedProperty(
                            name="owner",
                            value_previous=None,
                            value_current="56f32951-9b19-45ff-99fa-971982d7d608",
                        )
                    ],
                ),
            ],
        ),
    ],
)


print(updated_device.model_dump(by_alias=True))
```

```python
{
    'node_id': '5f3e85cf-f7f1-483a-a09c-66654a156ebc',
    'node_kind': 'InfraDevice',
    'display_label': 'router-01',
    'attributes': [
        {
            'name': 'name',
            'value_current': 'router-01',
            'value_previous': 'router-1',
            'updated_properties': [{'name': 'owner', 'value_current': '56f32951-9b19-45ff-99fa-971982d7d608', 'value_previous': None, 'value_type': 'Text', 'value_update_status': <UpdateStatus.UPDATED: 'updated'>}],
            'value_update_status': <UpdateStatus.UPDATED: 'updated'>,
            'value_type': 'Text'
        }
    ],
    'relationships': [
        {
            'name': 'site',
            'peer_id_previous': '1cecdd91-6851-43ff-8a88-1858d7b1c5bd',
            'peer_kind_previous': 'InfraSite',
            'peer_id_current': '1cecdd91-6851-43ff-8a88-1858d7b1c5bd',
            'peer_kind_current': 'InfraSite',
            'properties': [
                {'name': 'owner', 'value_current': '56f32951-9b19-45ff-99fa-971982d7d608', 'value_previous': 'c8c26901-f74f-4465-8a68-30322fc9747f', 'value_type': 'Text', 'value_update_status': <UpdateStatus.UPDATED: 'updated'>}
            ],
            'cardinality': 'one',
            'peer_status': <UpdateStatus.UNMODIFIED: 'unmodified'>
        },
        {
            'name': 'interfaces',
            'peers': [
                {
                    'peer_id': '1739e502-6a3d-4f39-ac84-5418a22f82de',
                    'peer_kind': 'InfraInterfaceL3',
                    'peer_status': <UpdateStatus.ADDED: 'added'>,
                    'properties': [{'name': 'owner', 'value_current': '56f32951-9b19-45ff-99fa-971982d7d608', 'value_previous': None, 'value_type': 'Text', 'value_update_status': <UpdateStatus.UPDATED: 'updated'>}]
                },
                {
                    'peer_id': 'd8046a5a-9287-4be4-9788-9fc2e683861a',
                    'peer_kind': 'InfraInterfaceL3',
                    'peer_status': <UpdateStatus.ADDED: 'added'>,
                    'properties': [{'name': 'owner', 'value_current': '56f32951-9b19-45ff-99fa-971982d7d608', 'value_previous': None, 'value_type': 'Text', 'value_update_status': <UpdateStatus.UPDATED: 'updated'>}]
                }
            ],
            'cardinality': 'many'
        }
    ]
}
```

