### PR TITLE
Add mutation reporting for InfrahubQueryAnalyzer.query_report

### DIFF
--- a/backend/infrahub/graphql/analyzer.py
+++ b/backend/infrahub/graphql/analyzer.py
@@ -33,6 +33,12 @@ if TYPE_CHECKING:
     from infrahub.core.schema.schema_branch import SchemaBranch
 
 
+class MutateAction(str, Enum):
+    CREATE = "create"
+    DELETE = "delete"
+    UPDATE = "update"
+
+
 class ContextType(str, Enum):
     EDGE = "edge"
     NODE = "node"
@@ -109,6 +115,7 @@ class GraphQLQueryModel:
     arguments: list[GraphQLArgument]
     attributes: set[str]
     relationships: set[str]
+    mutate_actions: list[MutateAction] = field(default_factory=list)
 
 
 @dataclass
@@ -125,6 +132,7 @@ class GraphQLQueryNode:
     infrahub_attributes: set[str] = field(default_factory=set)
     infrahub_relationships: set[str] = field(default_factory=set)
     field_node: FieldNode | None = field(default=None)
+    mutate_actions: list[MutateAction] = field(default_factory=list)
 
     def context_model(self) -> MainSchemaTypes | None:
         """Return the closest Infrahub object by going up in the tree"""
@@ -169,8 +177,8 @@ class GraphQLQueryNode:
     @property
     def at_root(self) -> bool:
         if self.parent:
-            return True
-        return False
+            return False
+        return True
 
     @property
     def in_property_level(self) -> bool:
@@ -202,6 +210,7 @@ class GraphQLQueryNode:
                     arguments=self.arguments,
                     attributes=self.infrahub_attributes,
                     relationships=self.infrahub_relationships,
+                    mutate_actions=self.mutate_actions,
                 )
             )
             for used_by in self.infrahub_node_models:
@@ -212,6 +221,7 @@ class GraphQLQueryNode:
                         arguments=self.arguments,
                         attributes=self.infrahub_attributes,
                         relationships=self.infrahub_relationships,
+                        mutate_actions=self.mutate_actions,
                     )
                 )
 
@@ -234,7 +244,7 @@ class GraphQLQueryReport:
 
         return sorted(models)
 
-    @property
+    @cached_property
     def requested_read(self) -> dict[str, ObjectAccess]:
         """Return Infrahub objects and the fields (attributes and relationships) that this query would attempt to read"""
         access: dict[str, ObjectAccess] = {}
@@ -245,6 +255,34 @@ class GraphQLQueryReport:
                     access[query_model.model.kind] = ObjectAccess()
                 access[query_model.model.kind].attributes.update(query_model.attributes)
                 access[query_model.model.kind].relationships.update(query_model.relationships)
+
+        return access
+
+    @cached_property
+    def kind_action_map(self) -> dict[str, set[MutateAction]]:
+        access: dict[str, set[MutateAction]] = {}
+        root_models: set[str] = set()
+        includes_mutations: bool = False
+        for query in self.queries:
+            query_models = query.get_models()
+            for query_model in query_models:
+                if query_model.mutate_actions:
+                    includes_mutations = True
+                if includes_mutations:
+                    if query_model.model.kind not in access:
+                        access[query_model.model.kind] = set()
+                    if query_model.root:
+                        root_models.add(query_model.model.kind)
+                    access[query_model.model.kind].update(query_model.mutate_actions)
+
+        # Until we properly analyze the data payload it is assumed that the required permissions on non-root objects is update
+        # the idea around this is that at this point even if we only return data from a relationship without actually updating
+        # that relationship we'd still expect to have UPDATE permissions on that related object. However, this is still a step
+        # in the right direction as we'd previously require the same permissions as that of the base object so this is still
+        # more correct.
+        for node_kind, node_actions in access.items():
+            if node_kind not in root_models:
+                node_actions.add(MutateAction.UPDATE)
 
         return access
 
@@ -361,6 +399,9 @@ class InfrahubGraphQLQueryAnalyzer(GraphQLQueryAnalyzer):
                     path=schema_model.kind,
                     infrahub_model=schema_model,
                     infrahub_node_models=infrahub_node_models,
+                    mutate_actions=self._get_model_mutations(
+                        node=field_node, operation_definition=operation_definition
+                    ),
                     context_type=ContextType.from_operation(operation=operation_definition.operation),
                     arguments=self._parse_arguments(field_node=field_node),
                     variables=self._get_variables(operation=operation_definition),
@@ -377,16 +418,24 @@ class InfrahubGraphQLQueryAnalyzer(GraphQLQueryAnalyzer):
 
     @staticmethod
     def _get_model_name(node: FieldNode, operation_definition: OperationDefinitionNode) -> str:
+        if operation_definition.operation == OperationType.MUTATION and node.name.value.endswith(
+            ("Create", "Delete", "Update", "Upsert")
+        ):
+            return node.name.value[:-6]
+        return node.name.value
+
+    @staticmethod
+    def _get_model_mutations(node: FieldNode, operation_definition: OperationDefinitionNode) -> list[MutateAction]:
         if operation_definition.operation == OperationType.MUTATION:
             if node.name.value.endswith("Create"):
-                return node.name.value[:-6]
+                return [MutateAction.CREATE]
             if node.name.value.endswith("Delete"):
-                return node.name.value[:-6]
+                return [MutateAction.DELETE]
             if node.name.value.endswith("Update"):
-                return node.name.value[:-6]
+                return [MutateAction.UPDATE]
             if node.name.value.endswith("Upsert"):
-                return node.name.value[:-6]
-        return node.name.value
+                return [MutateAction.CREATE, MutateAction.UPDATE]
+        return []
 
     @property
     def _sorted_fragment_definitions(self) -> list[FragmentDefinitionNode]:
@@ -463,7 +512,7 @@ class InfrahubGraphQLQueryAnalyzer(GraphQLQueryAnalyzer):
         infrahub_node_models: list[MainSchemaTypes] = []
         if query_node.in_property_level:
             if model := query_node.context_model():
-                if node.name.value in model.attribute_names:
+                if node.name.value in model.attribute_names or node.name.value == "display_label":
                     query_node.append_attribute(attribute=node.name.value)
                 elif node.name.value in model.relationship_names:
                     rel = model.get_relationship_or_none(name=node.name.value)

--- a/backend/infrahub/graphql/auth/query_permission_checker/object_permission_checker.py
+++ b/backend/infrahub/graphql/auth/query_permission_checker/object_permission_checker.py
@@ -36,34 +36,27 @@ class ObjectPermissionChecker(GraphQLQueryPermissionCheckerInterface):
             else PermissionDecisionFlag.ALLOW_OTHER
         )
 
-        kinds = analyzed_query.query_report.impacted_models
-
-        # Identify which operations are performed. As we don't have a mapping between kinds and the
-        # operation we currently require permissions all defined permissions for all objects
-        # within the GraphQL query / mutation
-        actions: set[str] = set()
-        for operation in analyzed_query.operations:
-            for kind in kinds:
-                if operation.name and operation.name.startswith(kind):
-                    # An empty string after prefix removal means a query to "view"
-                    query_action = operation.name[len(kind) :].lower() or "view"
-                    if query_action == "upsert":
-                        # Require both create and update for Upsert mutations
-                        actions.add("create")
-                        actions.add("update")
-                    else:
-                        actions.add(query_action)
-
-        # Infer required permissions from the kind/operation map
         permissions: list[ObjectPermission] = []
-        for action in actions:
-            for kind in kinds:
+        for kind, object_access in analyzed_query.query_report.requested_read.items():
+            if object_access.attributes or object_access.relationships:
                 extracted_words = extract_camelcase_words(kind)
                 permissions.append(
                     ObjectPermission(
                         namespace=extracted_words[0],
                         name="".join(extracted_words[1:]),
-                        action=action.lower(),
+                        action="view",
+                        decision=required_decision,
+                    )
+                )
+
+        for kind, requested_permissions in analyzed_query.query_report.kind_action_map.items():
+            for requested_permission in requested_permissions:
+                extracted_words = extract_camelcase_words(kind)
+                permissions.append(
+                    ObjectPermission(
+                        namespace=extracted_words[0],
+                        name="".join(extracted_words[1:]),
+                        action=requested_permission.value,
                         decision=required_decision,
                     )
                 )

--- a/backend/tests/unit/graphql/test_query_analyzer.py
+++ b/backend/tests/unit/graphql/test_query_analyzer.py
@@ -4,7 +4,7 @@ from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.registry import registry
 from infrahub.database import InfrahubDatabase
-from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
+from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer, MutateAction
 from infrahub.graphql.initialization import prepare_graphql_params
 
 
@@ -205,7 +205,7 @@ async def test_query_report(db: InfrahubDatabase, default_branch: Branch, car_pe
 
     mutation_query_with_return_data = """
     mutation {
-        TestElectricCar(
+        TestElectricCarCreate(
             data: {
                 name: { value: "Accord" }
                 nbr_seats: { value: 5 }
@@ -247,6 +247,50 @@ async def test_query_report(db: InfrahubDatabase, default_branch: Branch, car_pe
     assert gqa.query_report.requested_read["TestElectricCar"].relationships == {"owner"}
     assert gqa.query_report.requested_read["TestPerson"].attributes == {"name"}
     assert gqa.query_report.requested_read["TestPerson"].relationships == set()
+    assert len(gqa.query_report.kind_action_map.keys()) == 2
+    assert gqa.query_report.kind_action_map["TestElectricCar"] == {MutateAction.CREATE}
+    assert gqa.query_report.kind_action_map["TestPerson"] == {MutateAction.UPDATE}
+
+    mutation_query_with_simple_return_data = """
+    mutation {
+        TestElectricCarCreate(
+            data: {
+                name: { value: "Accord" }
+                nbr_seats: { value: 5 }
+                is_electric: { value: true }
+                owner: { id: "John" }
+            }
+        ) {
+            ok
+            object {
+                id
+                name {
+                    value
+                }
+                nbr_seats {
+                    value
+                }
+            }
+        }
+    }
+    """
+    gqa = InfrahubGraphQLQueryAnalyzer(
+        query=mutation_query_with_simple_return_data,
+        schema=gql_params.schema,
+        branch=default_branch,
+        schema_branch=schema_branch,
+    )
+
+    # As we only return data from the object we created and also from a related object
+    # we'd need read access from both TestElectricCar and TestPerson
+    assert len(gqa.query_report.requested_read.keys()) == 1
+    assert gqa.query_report.requested_read["TestElectricCar"].attributes == {"name", "nbr_seats"}
+    assert gqa.query_report.requested_read["TestElectricCar"].relationships == set()
+    # Unlike the test case above this one doesn't return data for the owner and as such we don't currently
+    # need the update permission on the test person. This is something that we will want to change in the
+    # future
+    assert len(gqa.query_report.kind_action_map.keys()) == 1
+    assert gqa.query_report.kind_action_map["TestElectricCar"] == {MutateAction.CREATE}
 
     query_with_source_only_id = """
     query {


### PR DESCRIPTION
This PR adds support to report requested mutation permissions on objects. For now it only deals with object level permissions. In an upcoming PR we'll expand this to list attribute level permissions and the correct reporting of updating related nodes.

* I've fixed a small bug for the .at_root property where the order was switched around.
* Added "display_label" as an attribute for now. I don't know if we want to threat this in some other way instead such as parsing the value of the display_label and finding the actual attribute
* Update the permission checker to use the query_analyzer report for mutations
* Add to tests

Fixes #5539