### PR TITLE
Rename context to graphql_context

### DIFF
--- a/backend/infrahub/core/diff/model/path.py
+++ b/backend/infrahub/core/diff/model/path.py
@@ -314,18 +314,18 @@ class EnrichedDiffNode(BaseSummary):
             rel.clear_conflicts()
         self.conflict = None
 
-    def get_parent_info(self, context: GraphqlContext | None = None) -> ParentNodeInfo | None:
+    def get_parent_info(self, graphql_context: GraphqlContext | None = None) -> ParentNodeInfo | None:
         for r in self.relationships:
             for n in r.nodes:
                 relationship_name: str = "undefined"
 
-                if not context:
+                if not graphql_context:
                     return ParentNodeInfo(node=n, relationship_name=relationship_name)
 
-                node_schema = context.db.schema.get(name=self.kind)
+                node_schema = graphql_context.db.schema.get(name=self.kind)
                 rel_schema = node_schema.get_relationship(name=r.name)
 
-                parent_schema = context.db.schema.get(name=n.kind)
+                parent_schema = graphql_context.db.schema.get(name=n.kind)
                 rels_parent = parent_schema.get_relationships_by_identifier(id=rel_schema.get_identifier())
 
                 if rels_parent and len(rels_parent) == 1:

--- a/backend/infrahub/core/task/user_task.py
+++ b/backend/infrahub/core/task/user_task.py
@@ -80,14 +80,16 @@ class UserTask:
 
     @classmethod
     def from_graphql_context(
-        cls, title: str, context: GraphqlContext, logger: Optional[Union[BoundLogger, InfrahubLogger]] = None
+        cls, title: str, graphql_context: GraphqlContext, logger: Optional[Union[BoundLogger, InfrahubLogger]] = None
     ) -> Self:
-        if not context.db or not context.account_session:
+        if not graphql_context.db or not graphql_context.account_session:
             raise ValueError("db and account_session must be provided to initialize a GraphQLTaskReport")
 
-        if not logger and context.service and context.service.log:
-            logger = context.service.log
-        return cls(title=title, account_id=context.account_session.account_id, db=context.db, logger=logger)
+        if not logger and graphql_context.service and graphql_context.service.log:
+            logger = graphql_context.service.log
+        return cls(
+            title=title, account_id=graphql_context.account_session.account_id, db=graphql_context.db, logger=logger
+        )
 
     async def __aenter__(self) -> Self:
         await self.create_task()

--- a/backend/infrahub/graphql/mutations/account.py
+++ b/backend/infrahub/graphql/mutations/account.py
@@ -53,19 +53,21 @@ class AccountMixin:
         info: GraphQLResolveInfo,
         data: dict[str, Any],
     ) -> Self:
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
 
-        if not context.account_session:
+        if not graphql_context.account_session:
             raise ValueError("An account_session is mandatory to execute this mutation")
 
-        if context.account_session.auth_type != AuthType.JWT:
+        if graphql_context.account_session.auth_type != AuthType.JWT:
             raise PermissionDeniedError("This operation requires authentication with a JWT token")
 
         results = await NodeManager.query(
-            schema=CoreAccount, filters={"ids": [context.account_session.account_id]}, db=context.db
+            schema=CoreAccount, filters={"ids": [graphql_context.account_session.account_id]}, db=graphql_context.db
         )
         if not results:
-            raise NodeNotFoundError(node_type=InfrahubKind.ACCOUNT, identifier=context.account_session.account_id)
+            raise NodeNotFoundError(
+                node_type=InfrahubKind.ACCOUNT, identifier=graphql_context.account_session.account_id
+            )
 
         account = results[0]
 
@@ -74,10 +76,10 @@ class AccountMixin:
             "InfrahubAccountTokenDelete": cls.delete_token,
             "InfrahubAccountSelfUpdate": cls.update_self,
         }
-        response = await mutation_map[cls.__name__](db=context.db, account=account, data=data, info=info)
+        response = await mutation_map[cls.__name__](db=graphql_context.db, account=account, data=data, info=info)
 
         # Reset the time of the query to guarantee that all resolvers executed after this point will account for the changes
-        context.at = Timestamp()
+        graphql_context.at = Timestamp()
 
         return response
 

--- a/backend/infrahub/graphql/mutations/artifact_definition.py
+++ b/backend/infrahub/graphql/mutations/artifact_definition.py
@@ -50,17 +50,17 @@ class InfrahubArtifactDefinitionMutation(InfrahubMutationMixin, Mutation):
         branch: Branch,
         database: Optional[InfrahubDatabase] = None,  # noqa: ARG003
     ) -> tuple[Node, Self]:
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
 
         artifact_definition, result = await super().mutate_create(info=info, data=data, branch=branch)
 
-        if context.service:
+        if graphql_context.service:
             model = RequestArtifactDefinitionGenerate(
                 branch=branch.name,
                 artifact_definition_id=artifact_definition.id,
                 artifact_definition_name=artifact_definition.name.value,  # type: ignore[attr-defined]
             )
-            await context.service.workflow.submit_workflow(
+            await graphql_context.service.workflow.submit_workflow(
                 workflow=REQUEST_ARTIFACT_DEFINITION_GENERATE, parameters={"model": model}
             )
 
@@ -75,17 +75,17 @@ class InfrahubArtifactDefinitionMutation(InfrahubMutationMixin, Mutation):
         database: Optional[InfrahubDatabase] = None,  # noqa: ARG003
         node: Optional[Node] = None,  # noqa: ARG003
     ) -> tuple[Node, Self]:
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
 
         artifact_definition, result = await super().mutate_update(info=info, data=data, branch=branch)
 
-        if context.service:
+        if graphql_context.service:
             model = RequestArtifactDefinitionGenerate(
                 branch=branch.name,
                 artifact_definition_id=artifact_definition.id,
                 artifact_definition_name=artifact_definition.name.value,  # type: ignore[attr-defined]
             )
-            await context.service.workflow.submit_workflow(
+            await graphql_context.service.workflow.submit_workflow(
                 workflow=REQUEST_ARTIFACT_DEFINITION_GENERATE, parameters={"model": model}
             )
 

--- a/backend/infrahub/graphql/mutations/branch.py
+++ b/backend/infrahub/graphql/mutations/branch.py
@@ -61,22 +61,24 @@ class BranchCreate(Mutation):
         background_execution: bool = False,
         wait_until_completion: bool = True,
     ) -> Self:
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
         task: dict | None = None
 
         model = BranchCreateModel(**data)
 
         if background_execution or not wait_until_completion:
-            workflow = await context.active_service.workflow.submit_workflow(
+            workflow = await graphql_context.active_service.workflow.submit_workflow(
                 workflow=BRANCH_CREATE, parameters={"model": model}
             )
             task = {"id": workflow.id}
             return cls(ok=True, task=task)
 
-        await context.active_service.workflow.execute_workflow(workflow=BRANCH_CREATE, parameters={"model": model})
+        await graphql_context.active_service.workflow.execute_workflow(
+            workflow=BRANCH_CREATE, parameters={"model": model}
+        )
 
         # Retrieve created branch
-        obj = await Branch.get_by_name(db=context.db, name=model.name)
+        obj = await Branch.get_by_name(db=graphql_context.db, name=model.name)
         fields = await extract_fields(info.field_nodes[0].selection_set)
         return cls(object=await obj.to_graphql(fields=fields.get("object", {})), ok=True, task=task)
 
@@ -107,16 +109,16 @@ class BranchDelete(Mutation):
         data: BranchNameInput,
         wait_until_completion: bool = True,
     ) -> Self:
-        context: GraphqlContext = info.context
-        obj = await Branch.get_by_name(db=context.db, name=str(data.name))
+        graphql_context: GraphqlContext = info.context
+        obj = await Branch.get_by_name(db=graphql_context.db, name=str(data.name))
 
         if wait_until_completion:
-            await context.active_service.workflow.execute_workflow(
+            await graphql_context.active_service.workflow.execute_workflow(
                 workflow=BRANCH_DELETE, parameters={"branch": obj.name}
             )
             return cls(ok=True)
 
-        workflow = await context.active_service.workflow.submit_workflow(
+        workflow = await graphql_context.active_service.workflow.submit_workflow(
             workflow=BRANCH_DELETE, parameters={"branch": obj.name}
         )
         return cls(ok=True, task={"id": str(workflow.id)})
@@ -131,16 +133,16 @@ class BranchUpdate(Mutation):
     @classmethod
     @retry_db_transaction(name="branch_update")
     async def mutate(cls, root: dict, info: GraphQLResolveInfo, data: BranchNameInput) -> Self:  # noqa: ARG003
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
 
-        obj = await Branch.get_by_name(db=context.db, name=data["name"])
+        obj = await Branch.get_by_name(db=graphql_context.db, name=data["name"])
 
         to_extract = ["description"]
         for field_name in to_extract:
             if field_name in data and data.get(field_name) is not None:
                 setattr(obj, field_name, data[field_name])
 
-        async with context.db.start_transaction() as db:
+        async with graphql_context.db.start_transaction() as db:
             await obj.save(db=db)
 
         return cls(ok=True)
@@ -163,20 +165,20 @@ class BranchRebase(Mutation):
         data: BranchNameInput,
         wait_until_completion: bool = True,
     ) -> Self:
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
 
-        obj = await Branch.get_by_name(db=context.db, name=str(data.name))
+        obj = await Branch.get_by_name(db=graphql_context.db, name=str(data.name))
         task: dict | None = None
 
         if wait_until_completion:
-            await context.active_service.workflow.execute_workflow(
+            await graphql_context.active_service.workflow.execute_workflow(
                 workflow=BRANCH_REBASE, parameters={"branch": obj.name}
             )
 
             # Pull the latest information about the branch from the database directly
-            obj = await Branch.get_by_name(db=context.db, name=str(data.name))
+            obj = await Branch.get_by_name(db=graphql_context.db, name=str(data.name))
         else:
-            workflow = await context.active_service.workflow.submit_workflow(
+            workflow = await graphql_context.active_service.workflow.submit_workflow(
                 workflow=BRANCH_REBASE, parameters={"branch": obj.name}
             )
             task = {"id": workflow.id}
@@ -205,18 +207,18 @@ class BranchValidate(Mutation):
         data: BranchNameInput,
         wait_until_completion: bool = True,
     ) -> Self:
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
 
-        obj = await Branch.get_by_name(db=context.db, name=str(data.name))
+        obj = await Branch.get_by_name(db=graphql_context.db, name=str(data.name))
         task: dict | None = None
         ok = True
 
         if wait_until_completion:
-            await context.active_service.workflow.execute_workflow(
+            await graphql_context.active_service.workflow.execute_workflow(
                 workflow=BRANCH_VALIDATE, parameters={"branch": obj.name}
             )
         else:
-            workflow = await context.active_service.workflow.submit_workflow(
+            workflow = await graphql_context.active_service.workflow.submit_workflow(
                 workflow=BRANCH_VALIDATE, parameters={"branch": obj.name}
             )
             task = {"id": workflow.id}
@@ -245,19 +247,20 @@ class BranchMerge(Mutation):
     ) -> Self:
         branch_name = data["name"]
         task: dict | None = None
+        graphql_context: GraphqlContext = info.context
 
         if wait_until_completion:
-            await info.context.active_service.workflow.execute_workflow(
+            await graphql_context.active_service.workflow.execute_workflow(
                 workflow=BRANCH_MERGE_MUTATION, parameters={"branch": branch_name}
             )
         else:
-            workflow = await info.context.active_service.workflow.submit_workflow(
+            workflow = await graphql_context.active_service.workflow.submit_workflow(
                 workflow=BRANCH_MERGE_MUTATION, parameters={"branch": branch_name}
             )
             task = {"id": workflow.id}
 
         # Pull the latest information about the branch from the database directly
-        obj = await Branch.get_by_name(db=info.context.db, name=branch_name)
+        obj = await Branch.get_by_name(db=graphql_context.db, name=branch_name)
 
         fields = await extract_fields(info.field_nodes[0].selection_set)
         ok = True

--- a/backend/infrahub/graphql/mutations/computed_attribute.py
+++ b/backend/infrahub/graphql/mutations/computed_attribute.py
@@ -10,7 +10,7 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.registry import registry
 from infrahub.database import retry_db_transaction
 from infrahub.events import EventMeta
-from infrahub.events.node_action import NodeUpdatedEvent
+from infrahub.events.node_action import NodeMutatedEvent
 from infrahub.exceptions import NodeNotFoundError, ValidationError
 from infrahub.log import get_log_data
 from infrahub.worker import WORKER_IDENTITY
@@ -42,8 +42,10 @@ class UpdateComputedAttribute(Mutation):
         info: GraphQLResolveInfo,
         data: InfrahubComputedAttributeUpdateInput,
     ) -> UpdateComputedAttribute:
-        context: GraphqlContext = info.context
-        node_schema = registry.schema.get_node_schema(name=str(data.kind), branch=context.branch.name, duplicate=False)
+        graphql_context: GraphqlContext = info.context
+        node_schema = registry.schema.get_node_schema(
+            name=str(data.kind), branch=graphql_context.branch.name, duplicate=False
+        )
         target_attribute = node_schema.get_attribute(name=str(data.attribute))
         if (
             not target_attribute.computed_attribute
@@ -51,20 +53,20 @@ class UpdateComputedAttribute(Mutation):
         ):
             raise ValidationError(input_value=f"{node_schema.kind}.{target_attribute.name} is not a computed attribute")
 
-        context.active_permissions.raise_for_permission(
+        graphql_context.active_permissions.raise_for_permission(
             permission=ObjectPermission(
                 namespace=node_schema.namespace,
                 name=node_schema.name,
                 action=PermissionAction.UPDATE.value,
                 decision=PermissionDecision.ALLOW_DEFAULT.value
-                if context.branch.name == registry.default_branch
+                if graphql_context.branch.name == registry.default_branch
                 else PermissionDecision.ALLOW_OTHER.value,
             )
         )
 
         if not (
             target_node := await NodeManager.get_one(
-                db=context.db, kind=node_schema.kind, id=str(data.id), branch=context.branch
+                db=graphql_context.db, kind=node_schema.kind, id=str(data.id), branch=graphql_context.branch
             )
         ):
             raise NodeNotFoundError(
@@ -82,15 +84,15 @@ class UpdateComputedAttribute(Mutation):
             )
         if attribute_field.value != str(data.value):
             attribute_field.value = str(data.value)
-            async with context.db.start_transaction() as dbt:
+            async with graphql_context.db.start_transaction() as dbt:
                 await target_node.save(db=dbt, fields=[str(data.attribute)])
 
             log_data = get_log_data()
             request_id = log_data.get("request_id", "")
 
-            graphql_payload = await target_node.to_graphql(db=context.db, filter_sensitive=True)
+            graphql_payload = await target_node.to_graphql(db=graphql_context.db, filter_sensitive=True)
 
-            event = NodeUpdatedEvent(
+            event = NodeMutatedEvent(
                 kind=node_schema.kind,
                 node_id=target_node.get_id(),
                 data=graphql_payload,
@@ -99,11 +101,11 @@ class UpdateComputedAttribute(Mutation):
                 meta=EventMeta(
                     initiator_id=WORKER_IDENTITY,
                     request_id=request_id,
-                    account_id=context.active_account_session.account_id,
-                    branch=context.branch.name,
+                    account_id=graphql_context.active_account_session.account_id,
+                    branch=graphql_context.branch.name,
                 ),
             )
-            await context.active_service.event.send(event=event)
+            await graphql_context.active_service.event.send(event=event)
 
         result: dict[str, Any] = {"ok": True}
 

--- a/backend/infrahub/graphql/mutations/diff.py
+++ b/backend/infrahub/graphql/mutations/diff.py
@@ -36,17 +36,17 @@ class DiffUpdateMutation(Mutation):
         info: GraphQLResolveInfo,
         data: DiffUpdateInput,
     ) -> dict[str, bool]:
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
 
         from_timestamp_str = DateTime.serialize(data.from_time) if data.from_time else None
         to_timestamp_str = DateTime.serialize(data.to_time) if data.to_time else None
         if data.wait_for_completion is True:
             component_registry = get_component_registry()
-            base_branch = await registry.get_branch(db=context.db, branch=registry.default_branch)
-            diff_branch = await registry.get_branch(db=context.db, branch=data.branch)
+            base_branch = await registry.get_branch(db=graphql_context.db, branch=registry.default_branch)
+            diff_branch = await registry.get_branch(db=graphql_context.db, branch=data.branch)
 
             diff_coordinator = await component_registry.get_component(
-                DiffCoordinator, db=context.db, branch=diff_branch
+                DiffCoordinator, db=graphql_context.db, branch=diff_branch
             )
             await diff_coordinator.run_update(
                 base_branch=base_branch,
@@ -64,7 +64,7 @@ class DiffUpdateMutation(Mutation):
             from_time=from_timestamp_str,
             to_time=to_timestamp_str,
         )
-        if context.service:
-            await context.service.workflow.submit_workflow(workflow=DIFF_UPDATE, parameters={"model": model})
+        if graphql_context.service:
+            await graphql_context.service.workflow.submit_workflow(workflow=DIFF_UPDATE, parameters={"model": model})
 
         return {"ok": True}

--- a/backend/infrahub/graphql/mutations/diff_conflict.py
+++ b/backend/infrahub/graphql/mutations/diff_conflict.py
@@ -40,10 +40,12 @@ class ResolveDiffConflict(Mutation):
         info: GraphQLResolveInfo,
         data: ResolveDiffConflictInput,
     ) -> ResolveDiffConflict:
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
 
         component_registry = get_component_registry()
-        diff_repo = await component_registry.get_component(DiffRepository, db=context.db, branch=context.branch)
+        diff_repo = await component_registry.get_component(
+            DiffRepository, db=graphql_context.db, branch=graphql_context.branch
+        )
 
         selection = ConflictSelection(data.selected_branch.value) if data.selected_branch else None
         conflict = await diff_repo.get_conflict_by_id(conflict_id=data.conflict_id)
@@ -52,7 +54,9 @@ class ResolveDiffConflict(Mutation):
         await diff_repo.update_conflict_by_id(conflict_id=data.conflict_id, selection=selection)
 
         core_data_checks = await NodeManager.query(
-            db=context.db, schema=InfrahubKind.DATACHECK, filters={"enriched_conflict_id__value": data.conflict_id}
+            db=graphql_context.db,
+            schema=InfrahubKind.DATACHECK,
+            filters={"enriched_conflict_id__value": data.conflict_id},
         )
         if not core_data_checks:
             return cls(ok=True)
@@ -64,5 +68,5 @@ class ResolveDiffConflict(Mutation):
             keep_branch = None
         for cdc in core_data_checks:
             cdc.keep_branch.value = keep_branch
-            await cdc.save(db=context.db)
+            await cdc.save(db=graphql_context.db)
         return cls(ok=True)

--- a/backend/infrahub/graphql/mutations/graphql_query.py
+++ b/backend/infrahub/graphql/mutations/graphql_query.py
@@ -69,9 +69,11 @@ class InfrahubGraphQLQueryMutation(InfrahubMutationMixin, Mutation):
         branch: Branch,
         database: Optional[InfrahubDatabase] = None,  # noqa: ARG003
     ) -> tuple[Node, Self]:
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
 
-        data.update(await cls.extract_query_info(info=info, data=data, branch=context.branch, db=context.db))
+        data.update(
+            await cls.extract_query_info(info=info, data=data, branch=graphql_context.branch, db=graphql_context.db)
+        )
 
         obj, result = await super().mutate_create(info=info, data=data, branch=branch)
 
@@ -86,9 +88,11 @@ class InfrahubGraphQLQueryMutation(InfrahubMutationMixin, Mutation):
         database: Optional[InfrahubDatabase] = None,  # noqa: ARG003
         node: Optional[Node] = None,  # noqa: ARG003
     ) -> tuple[Node, Self]:
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
 
-        data.update(await cls.extract_query_info(info=info, data=data, branch=context.branch, db=context.db))
+        data.update(
+            await cls.extract_query_info(info=info, data=data, branch=graphql_context.branch, db=graphql_context.db)
+        )
 
         obj, result = await super().mutate_update(info=info, data=data, branch=branch)
 

--- a/backend/infrahub/graphql/mutations/ipam.py
+++ b/backend/infrahub/graphql/mutations/ipam.py
@@ -132,8 +132,8 @@ class InfrahubIPAddressMutation(InfrahubMutationMixin, Mutation):
         branch: Branch,
         database: Optional[InfrahubDatabase] = None,
     ) -> tuple[Node, Self]:
-        context: GraphqlContext = info.context
-        db = database or context.db
+        graphql_context: GraphqlContext = info.context
+        db = database or graphql_context.db
         ip_address = ipaddress.ip_interface(data["address"]["value"])
         namespace_id = await validate_namespace(db=db, branch=branch, data=data)
 
@@ -179,8 +179,8 @@ class InfrahubIPAddressMutation(InfrahubMutationMixin, Mutation):
         database: Optional[InfrahubDatabase] = None,
         node: Optional[Node] = None,
     ) -> tuple[Node, Self]:
-        context: GraphqlContext = info.context
-        db = database or context.db
+        graphql_context: GraphqlContext = info.context
+        db = database or graphql_context.db
 
         address = node or await NodeManager.get_one_by_id_or_default_filter(
             db=db,
@@ -219,8 +219,8 @@ class InfrahubIPAddressMutation(InfrahubMutationMixin, Mutation):
         node_getters: list[MutationNodeGetterInterface],
         database: Optional[InfrahubDatabase] = None,
     ) -> tuple[Node, Self, bool]:
-        context: GraphqlContext = info.context
-        db = database or context.db
+        graphql_context: GraphqlContext = info.context
+        db = database or graphql_context.db
 
         await validate_namespace(db=db, branch=branch, data=data)
         prefix, result, created = await super().mutate_upsert(
@@ -286,8 +286,8 @@ class InfrahubIPPrefixMutation(InfrahubMutationMixin, Mutation):
         branch: Branch,
         database: Optional[InfrahubDatabase] = None,
     ) -> tuple[Node, Self]:
-        context: GraphqlContext = info.context
-        db = database or context.db
+        graphql_context: GraphqlContext = info.context
+        db = database or graphql_context.db
         namespace_id = await validate_namespace(db=db, branch=branch, data=data)
 
         async with db.start_transaction() as dbt:
@@ -330,8 +330,8 @@ class InfrahubIPPrefixMutation(InfrahubMutationMixin, Mutation):
         database: Optional[InfrahubDatabase] = None,
         node: Optional[Node] = None,
     ) -> tuple[Node, Self]:
-        context: GraphqlContext = info.context
-        db = database or context.db
+        graphql_context: GraphqlContext = info.context
+        db = database or graphql_context.db
 
         prefix = node or await NodeManager.get_one_by_id_or_default_filter(
             db=db,
@@ -369,8 +369,8 @@ class InfrahubIPPrefixMutation(InfrahubMutationMixin, Mutation):
         node_getters: list[MutationNodeGetterInterface],
         database: Optional[InfrahubDatabase] = None,
     ):
-        context: GraphqlContext = info.context
-        db = database or context.db
+        graphql_context: GraphqlContext = info.context
+        db = database or graphql_context.db
 
         await validate_namespace(db=db, branch=branch, data=data)
         prefix, result, created = await super().mutate_upsert(
@@ -403,17 +403,19 @@ class InfrahubIPPrefixMutation(InfrahubMutationMixin, Mutation):
         data: InputObjectType,
         branch: Branch,
     ) -> tuple[Node, Self]:
-        context: GraphqlContext = info.context
-        db = context.db
+        graphql_context: GraphqlContext = info.context
+        db = graphql_context.db
 
-        prefix = await NodeManager.get_one(data.get("id"), context.db, branch=branch, prefetch_relationships=True)
+        prefix = await NodeManager.get_one(
+            data.get("id"), graphql_context.db, branch=branch, prefetch_relationships=True
+        )
         if not prefix:
             raise NodeNotFoundError(branch, cls._meta.schema.kind, data.get("id"))
 
         namespace_rels = await prefix.ip_namespace.get_relationships(db=db)
         namespace_id = namespace_rels[0].peer_id
         try:
-            async with context.db.start_transaction() as dbt:
+            async with graphql_context.db.start_transaction() as dbt:
                 if lock_name := cls._get_lock_name(namespace_id, branch):
                     async with InfrahubMultiLock(lock_registry=lock.registry, locks=[lock_name]):
                         reconciled_prefix = await cls._reconcile_prefix(

--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -55,34 +55,34 @@ class InfrahubMutationOptions(MutationOptions):
 class InfrahubMutationMixin:
     @classmethod
     async def mutate(cls, root: dict, info: GraphQLResolveInfo, data: InputObjectType, *args: Any, **kwargs):  # noqa: ARG003
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
 
         obj = None
         mutation = None
         action = MutationAction.UNDEFINED
 
         if "Create" in cls.__name__:
-            obj, mutation = await cls.mutate_create(info=info, branch=context.branch, data=data, **kwargs)
+            obj, mutation = await cls.mutate_create(info=info, branch=graphql_context.branch, data=data, **kwargs)
             action = MutationAction.CREATED
         elif "Update" in cls.__name__:
-            obj, mutation = await cls.mutate_update(info=info, branch=context.branch, data=data, **kwargs)
+            obj, mutation = await cls.mutate_update(info=info, branch=graphql_context.branch, data=data, **kwargs)
             action = MutationAction.UPDATED
         elif "Upsert" in cls.__name__:
             node_manager = NodeManager()
             node_getters = [
-                MutationNodeGetterById(db=context.db, node_manager=node_manager),
-                MutationNodeGetterByHfid(db=context.db, node_manager=node_manager),
-                MutationNodeGetterByDefaultFilter(db=context.db, node_manager=node_manager),
+                MutationNodeGetterById(db=graphql_context.db, node_manager=node_manager),
+                MutationNodeGetterByHfid(db=graphql_context.db, node_manager=node_manager),
+                MutationNodeGetterByDefaultFilter(db=graphql_context.db, node_manager=node_manager),
             ]
             obj, mutation, created = await cls.mutate_upsert(
-                info=info, branch=context.branch, data=data, node_getters=node_getters, **kwargs
+                info=info, branch=graphql_context.branch, data=data, node_getters=node_getters, **kwargs
             )
             if created:
                 action = MutationAction.CREATED
             else:
                 action = MutationAction.UPDATED
         elif "Delete" in cls.__name__:
-            obj, mutation = await cls.mutate_delete(info=info, branch=context.branch, data=data, **kwargs)
+            obj, mutation = await cls.mutate_delete(info=info, branch=graphql_context.branch, data=data, **kwargs)
             action = MutationAction.DELETED
         else:
             raise ValueError(
@@ -90,23 +90,23 @@ class InfrahubMutationMixin:
             )
 
         # Reset the time of the query to guarantee that all resolvers executed after this point will account for the changes
-        context.at = Timestamp()
+        graphql_context.at = Timestamp()
 
-        if config.SETTINGS.broker.enable and context.background:
+        if config.SETTINGS.broker.enable and graphql_context.background:
             log_data = get_log_data()
             request_id = log_data.get("request_id", "")
 
-            graphql_payload = await obj.to_graphql(db=context.db, filter_sensitive=True)
+            graphql_payload = await obj.to_graphql(db=graphql_context.db, filter_sensitive=True)
             event = NodeMutatedEvent(
                 kind=obj._schema.kind,
                 node_id=obj.id,
                 data=graphql_payload,
                 action=action,
                 fields=_get_data_fields(data),
-                meta=EventMeta(initiator_id=WORKER_IDENTITY, request_id=request_id, branch=context.branch.name),
+                meta=EventMeta(initiator_id=WORKER_IDENTITY, request_id=request_id, branch=graphql_context.branch.name),
             )
 
-            context.background.add_task(context.active_service.event.send, event)
+            graphql_context.background.add_task(graphql_context.active_service.event.send, event)
 
         return mutation
 
@@ -158,8 +158,8 @@ class InfrahubMutationMixin:
         branch: Branch,
         database: Optional[InfrahubDatabase] = None,
     ) -> tuple[Node, Self]:
-        context: GraphqlContext = info.context
-        db = database or context.db
+        graphql_context: GraphqlContext = info.context
+        db = database or graphql_context.db
         obj = await cls._call_mutate_create_object(data=data, db=db, branch=branch)
         result = await cls.mutate_create_to_graphql(info=info, db=db, obj=obj)
         return obj, result
@@ -251,8 +251,8 @@ class InfrahubMutationMixin:
         database: Optional[InfrahubDatabase] = None,
         node: Optional[Node] = None,
     ) -> tuple[Node, Self]:
-        context: GraphqlContext = info.context
-        db = database or context.db
+        graphql_context: GraphqlContext = info.context
+        db = database or graphql_context.db
 
         obj = node or await NodeManager.find_object(
             db=db, kind=cls._meta.schema.kind, id=data.get("id"), hfid=data.get("hfid"), branch=branch
@@ -319,8 +319,8 @@ class InfrahubMutationMixin:
     ) -> tuple[Node, Self, bool]:
         schema_name = cls._meta.schema.kind
 
-        context: GraphqlContext = info.context
-        db = database or context.db
+        graphql_context: GraphqlContext = info.context
+        db = database or graphql_context.db
 
         node_schema = db.schema.get(name=schema_name, branch=branch)
 
@@ -348,14 +348,14 @@ class InfrahubMutationMixin:
         data: InputObjectType,
         branch: Branch,
     ) -> tuple[Node, Self]:
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
 
         obj = await NodeManager.find_object(
-            db=context.db, kind=cls._meta.schema.kind, id=data.get("id"), hfid=data.get("hfid"), branch=branch
+            db=graphql_context.db, kind=cls._meta.schema.kind, id=data.get("id"), hfid=data.get("hfid"), branch=branch
         )
 
         try:
-            async with context.db.start_transaction() as db:
+            async with graphql_context.db.start_transaction() as db:
                 deleted = await NodeManager.delete(db=db, branch=branch, nodes=[obj])
         except ValidationError as exc:
             raise ValueError(str(exc)) from exc

--- a/backend/infrahub/graphql/mutations/menu.py
+++ b/backend/infrahub/graphql/mutations/menu.py
@@ -70,10 +70,10 @@ class InfrahubCoreMenuMutation(InfrahubMutationMixin, Mutation):
         database: Optional[InfrahubDatabase] = None,  # noqa: ARG003
         node: Optional[Node] = None,  # noqa: ARG003
     ) -> tuple[Node, Self]:
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
 
         obj = await NodeManager.find_object(
-            db=context.db, kind=CoreMenuItem, id=data.get("id"), hfid=data.get("hfid"), branch=branch
+            db=graphql_context.db, kind=CoreMenuItem, id=data.get("id"), hfid=data.get("hfid"), branch=branch
         )
         validate_namespace(data=data)
 
@@ -90,9 +90,9 @@ class InfrahubCoreMenuMutation(InfrahubMutationMixin, Mutation):
         data: InputObjectType,
         branch: Branch,
     ) -> tuple[Node, Self]:
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
         obj = await NodeManager.find_object(
-            db=context.db, kind=CoreMenuItem, id=data.get("id"), hfid=data.get("hfid"), branch=branch
+            db=graphql_context.db, kind=CoreMenuItem, id=data.get("id"), hfid=data.get("hfid"), branch=branch
         )
         if obj.protected.value:
             raise ValidationError(input_value="This object is protected, it can't be deleted.")

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -51,10 +51,9 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
         branch: Branch,
         database: Optional[InfrahubDatabase] = None,  # noqa: ARG003
     ):
-        context: GraphqlContext = info.context
-        db: InfrahubDatabase = info.context.db
+        graphql_context: GraphqlContext = info.context
 
-        async with db.start_transaction() as dbt:
+        async with graphql_context.db.start_transaction() as dbt:
             proposed_change, result = await super().mutate_create(info=info, data=data, branch=branch, database=dbt)
             destination_branch = proposed_change.destination_branch.value
             source_branch = await _get_source_branch(db=dbt, name=proposed_change.source_branch.value)
@@ -65,7 +64,7 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
                     input_value="Currently only the 'main' branch is supported as a destination for a proposed change"
                 )
 
-        if context.service:
+        if graphql_context.service:
             message_list = [
                 messages.RequestProposedChangePipeline(
                     proposed_change=proposed_change.id,
@@ -76,7 +75,7 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
             ]
 
             for message in message_list:
-                await context.service.message_bus.send(message=message)
+                await graphql_context.service.message_bus.send(message=message)
 
         return proposed_change, result
 
@@ -89,10 +88,10 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
         database: Optional[InfrahubDatabase] = None,  # noqa: ARG003
         node: Optional[Node] = None,  # noqa: ARG003
     ):
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
 
         obj = await NodeManager.get_one_by_id_or_default_filter(
-            db=context.db,
+            db=graphql_context.db,
             kind=cls._meta.schema.kind,
             id=data.get("id"),
             branch=branch,
@@ -108,9 +107,9 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
             state.validate_state_transition(updated_state)
 
         # Check before starting a transaction, stopping in the middle of the transaction seems to break with memgraph
-        if updated_state == ProposedChangeState.MERGED and context.account_session:
+        if updated_state == ProposedChangeState.MERGED and graphql_context.account_session:
             try:
-                context.active_permissions.raise_for_permission(
+                graphql_context.active_permissions.raise_for_permission(
                     permission=GlobalPermission(
                         action=GlobalPermissions.MERGE_PROPOSED_CHANGE.value,
                         decision=PermissionDecision.ALLOW_ALL.value,
@@ -123,11 +122,11 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
             data["state"]["value"] = ProposedChangeState.MERGING.value
 
         proposed_change, result = await super().mutate_update(
-            info=info, data=data, branch=branch, database=context.db, node=obj
+            info=info, data=data, branch=branch, database=graphql_context.db, node=obj
         )
 
         if updated_state == ProposedChangeState.MERGED:
-            await context.service.workflow.execute_workflow(
+            await graphql_context.service.workflow.execute_workflow(
                 workflow=PROPOSED_CHANGE_MERGE,
                 parameters={
                     "proposed_change_id": proposed_change.id,
@@ -156,19 +155,19 @@ class ProposedChangeRequestRunCheck(Mutation):
         info: GraphQLResolveInfo,
         data: dict[str, Any],
     ) -> dict[str, bool]:
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
 
         check_type = data.get("check_type") or CheckType.ALL
 
         identifier = data.get("id", "")
         proposed_change = await NodeManager.get_one_by_id_or_default_filter(
-            id=identifier, kind=InfrahubKind.PROPOSEDCHANGE, db=context.db
+            id=identifier, kind=InfrahubKind.PROPOSEDCHANGE, db=graphql_context.db
         )
         state = ProposedChangeState(proposed_change.state.value.value)
         state.validate_state_check_run()
 
         destination_branch = proposed_change.destination_branch.value
-        source_branch = await _get_source_branch(db=context.db, name=proposed_change.source_branch.value)
+        source_branch = await _get_source_branch(db=graphql_context.db, name=proposed_change.source_branch.value)
 
         message = messages.RequestProposedChangePipeline(
             proposed_change=proposed_change.id,
@@ -177,8 +176,8 @@ class ProposedChangeRequestRunCheck(Mutation):
             destination_branch=destination_branch,
             check_type=check_type,
         )
-        if context.service:
-            await context.service.message_bus.send(message=message)
+        if graphql_context.service:
+            await graphql_context.service.message_bus.send(message=message)
 
         return {"ok": True}
 
@@ -203,23 +202,23 @@ class ProposedChangeMerge(Mutation):
         data: dict[str, Any],
         wait_until_completion: bool = True,
     ) -> dict[str, bool]:
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
         task: dict | None = None
 
         identifier = data.get("id", "")
         proposed_change = await NodeManager.get_one(
-            id=identifier, kind=InfrahubKind.PROPOSEDCHANGE, db=context.db, raise_on_error=True
+            id=identifier, kind=InfrahubKind.PROPOSEDCHANGE, db=graphql_context.db, raise_on_error=True
         )
         state = ProposedChangeState(proposed_change.state.value.value)
         if state != ProposedChangeState.OPEN:
             raise ValidationError("Only proposed change in OPEN state can be merged")
 
-        async with context.db.start_session() as db:
+        async with graphql_context.db.start_session() as db:
             proposed_change.state.value = ProposedChangeState.MERGING.value
             proposed_change.save(db=db)
 
         if wait_until_completion:
-            await context.service.workflow.execute_workflow(
+            await graphql_context.service.workflow.execute_workflow(
                 workflow=PROPOSED_CHANGE_MERGE,
                 parameters={
                     "proposed_change_id": proposed_change.id,
@@ -227,7 +226,7 @@ class ProposedChangeMerge(Mutation):
                 },
             )
         else:
-            workflow = await context.service.workflow.submit_workflow(
+            workflow = await graphql_context.service.workflow.submit_workflow(
                 workflow=PROPOSED_CHANGE_MERGE,
                 parameters={
                     "proposed_change_id": proposed_change.id,

--- a/backend/infrahub/graphql/mutations/relationship.py
+++ b/backend/infrahub/graphql/mutations/relationship.py
@@ -44,19 +44,19 @@ class RelationshipMixin:
         info: GraphQLResolveInfo,
         data: RelationshipNodesInput,
     ):
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
         input_id = str(data.id)
 
         if not (
             source := await NodeManager.get_one(
-                db=context.db,
+                db=graphql_context.db,
                 id=input_id,
-                branch=context.branch,
+                branch=graphql_context.branch,
                 include_owner=True,
                 include_source=True,
             )
         ):
-            raise NodeNotFoundError(context.branch, None, input_id)
+            raise NodeNotFoundError(graphql_context.branch, None, input_id)
 
         # Check if the name of the relationship provided exist for this node and is of cardinality Many
         if data.get("name") not in source._schema.relationship_names:
@@ -71,7 +71,7 @@ class RelationshipMixin:
         # Query the node in the database and validate that all of them exist and are if the correct kind
         node_ids: list[str] = [node_data["id"] for node_data in data.get("nodes") if "id" in node_data]
         nodes = await NodeManager.get_many(
-            db=context.db, ids=node_ids, fields={"display_label": None}, branch=context.branch
+            db=graphql_context.db, ids=node_ids, fields={"display_label": None}, branch=graphql_context.branch
         )
 
         _, _, in_list2 = compare_lists(list1=list(nodes.keys()), list2=node_ids)
@@ -92,7 +92,7 @@ class RelationshipMixin:
                 and peer_relationships[0].cardinality == RelationshipCardinality.ONE
             ):
                 peer_relationship: RelationshipManager = getattr(node, peer_relationships[0].name)
-                if peer := await peer_relationship.get_peer(db=context.db):
+                if peer := await peer_relationship.get_peer(db=graphql_context.db):
                     if peer.id != input_id:
                         raise ValidationError(
                             f"{node_id!r} {node.get_kind()!r} is already related to another peer on '{peer_relationships[0].name}'"
@@ -100,19 +100,19 @@ class RelationshipMixin:
 
         # The nodes that are already present in the db
         query = await RelationshipGetPeerQuery.init(
-            db=context.db,
+            db=graphql_context.db,
             source=source,
-            rel=Relationship(schema=rel_schema, branch=context.branch, node=source),
+            rel=Relationship(schema=rel_schema, branch=graphql_context.branch, node=source),
         )
-        await query.execute(db=context.db)
+        await query.execute(db=graphql_context.db)
         existing_peers: dict[str, RelationshipPeerData] = {peer.peer_id: peer for peer in query.get_peers()}
 
-        async with context.db.start_transaction() as db:
+        async with graphql_context.db.start_transaction() as db:
             if cls.__name__ == "RelationshipAdd":
                 for node_data in data.get("nodes"):
                     # Instantiate and resolve a relationship
                     # This will take care of allocating a node from a pool if needed
-                    rel = Relationship(schema=rel_schema, branch=context.branch, node=source)
+                    rel = Relationship(schema=rel_schema, branch=graphql_context.branch, node=source)
                     await rel.new(db=db, data=node_data)
                     await rel.resolve(db=db)
                     # Save it only if it does not exist
@@ -125,7 +125,7 @@ class RelationshipMixin:
                         # TODO once https://github.com/opsmill/infrahub/issues/792 has been fixed
                         # we should use RelationshipDataDeleteQuery to delete the relationship
                         # it would be more query efficient
-                        rel = Relationship(schema=rel_schema, branch=context.branch, node=source)
+                        rel = Relationship(schema=rel_schema, branch=graphql_context.branch, node=source)
                         await rel.load(db=db, data=existing_peers[node_data.get("id")])
                         await rel.delete(db=db)
 

--- a/backend/infrahub/graphql/mutations/repository.py
+++ b/backend/infrahub/graphql/mutations/repository.py
@@ -65,7 +65,7 @@ class InfrahubRepositoryMutation(InfrahubMutationMixin, Mutation):
         branch: Branch,
         database: Optional[InfrahubDatabase] = None,  # noqa: ARG003
     ):
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
 
         cleanup_payload(data)
         # Create the object in the database
@@ -74,17 +74,17 @@ class InfrahubRepositoryMutation(InfrahubMutationMixin, Mutation):
 
         # First check the connectivity to the remote repository
         # If the connectivity is not good, we remove the repository to allow the user to add a new one
-        if context.service:
+        if graphql_context.service:
             message = messages.GitRepositoryConnectivity(
                 repository_name=obj.name.value,
                 repository_location=obj.location.value,
             )
-            response = await context.service.message_bus.rpc(
+            response = await graphql_context.service.message_bus.rpc(
                 message=message, response_class=GitRepositoryConnectivityResponse
             )
 
             if response.data.success is False:
-                await obj.delete(db=context.db)
+                await obj.delete(db=graphql_context.db)
                 raise ValidationError(response.data.message)
 
         # If we are in the default branch, we set the sync status to Active
@@ -93,13 +93,13 @@ class InfrahubRepositoryMutation(InfrahubMutationMixin, Mutation):
             obj.internal_status.value = RepositoryInternalStatus.ACTIVE.value
         else:
             obj.internal_status.value = RepositoryInternalStatus.STAGING.value
-        await obj.save(db=context.db)
+        await obj.save(db=graphql_context.db)
 
         # Create the new repository in the filesystem.
         log.info("create_repository", name=obj.name.value)
         authenticated_user = None
-        if context.account_session and context.account_session.authenticated:
-            authenticated_user = context.account_session.account_id
+        if graphql_context.account_session and graphql_context.account_session.authenticated:
+            authenticated_user = graphql_context.account_session.account_id
         if obj.get_kind() == InfrahubKind.READONLYREPOSITORY:
             obj = cast(CoreReadOnlyRepository, obj)
             model = GitRepositoryAddReadOnly(
@@ -112,8 +112,8 @@ class InfrahubRepositoryMutation(InfrahubMutationMixin, Mutation):
                 internal_status=obj.internal_status.value,
                 created_by=authenticated_user,
             )
-            if context.service:
-                await context.service.workflow.submit_workflow(
+            if graphql_context.service:
+                await graphql_context.service.workflow.submit_workflow(
                     workflow=GIT_REPOSITORY_ADD_READ_ONLY, parameters={"model": model}
                 )
 
@@ -130,8 +130,8 @@ class InfrahubRepositoryMutation(InfrahubMutationMixin, Mutation):
                 created_by=authenticated_user,
             )
 
-            if context.service:
-                await context.service.workflow.submit_workflow(
+            if graphql_context.service:
+                await graphql_context.service.workflow.submit_workflow(
                     workflow=GIT_REPOSITORY_ADD, parameters={"model": git_repo_add_model}
                 )
 
@@ -148,12 +148,12 @@ class InfrahubRepositoryMutation(InfrahubMutationMixin, Mutation):
         database: Optional[InfrahubDatabase] = None,  # noqa: ARG003
         node: Optional[Node] = None,
     ):
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
 
         cleanup_payload(data)
         if not node:
             node: CoreReadOnlyRepository | CoreRepository = await NodeManager.get_one_by_id_or_default_filter(
-                db=context.db,
+                db=graphql_context.db,
                 kind=cls._meta.schema.kind,
                 id=data.get("id"),
                 branch=branch,
@@ -161,7 +161,7 @@ class InfrahubRepositoryMutation(InfrahubMutationMixin, Mutation):
                 include_source=True,
             )
         if node.get_kind() != InfrahubKind.READONLYREPOSITORY:
-            return await super().mutate_update(info, data, branch, database=context.db, node=node)
+            return await super().mutate_update(info, data, branch, database=graphql_context.db, node=node)
 
         node = cast(CoreReadOnlyRepository, node)
         current_commit = node.commit.value
@@ -173,7 +173,7 @@ class InfrahubRepositoryMutation(InfrahubMutationMixin, Mutation):
         if data.ref and data.ref.value:
             new_ref = data.ref.value
 
-        obj, result = await super().mutate_update(info, data, branch, database=context.db, node=node)
+        obj, result = await super().mutate_update(info, data, branch, database=graphql_context.db, node=node)
         obj = cast(CoreReadOnlyRepository, obj)
 
         send_update_message = (new_commit and new_commit != current_commit) or (new_ref and new_ref != current_ref)
@@ -196,8 +196,8 @@ class InfrahubRepositoryMutation(InfrahubMutationMixin, Mutation):
             infrahub_branch_name=branch.name,
             infrahub_branch_id=str(branch.get_uuid()),
         )
-        if context.service:
-            await context.service.workflow.submit_workflow(
+        if graphql_context.service:
+            await graphql_context.service.workflow.submit_workflow(
                 workflow=GIT_REPOSITORIES_PULL_READ_ONLY, parameters={"model": model}
             )
         return obj, result
@@ -230,11 +230,11 @@ class ProcessRepository(Mutation):
         info: GraphQLResolveInfo,
         data: IdentifierInput,
     ) -> dict[str, bool]:
-        context: GraphqlContext = info.context
-        branch = context.branch
+        graphql_context: GraphqlContext = info.context
+        branch = graphql_context.branch
         repository_id = str(data.id)
         repo: CoreReadOnlyRepository | CoreRepository = await NodeManager.get_one_by_id_or_default_filter(
-            db=context.db,
+            db=graphql_context.db,
             kind=InfrahubKind.GENERICREPOSITORY,
             id=str(data.id),
             branch=branch,
@@ -247,7 +247,7 @@ class ProcessRepository(Mutation):
             commit=str(repo.commit.value),
             infrahub_branch_name=branch.name,
         )
-        workflow = await context.active_service.workflow.submit_workflow(
+        workflow = await graphql_context.active_service.workflow.submit_workflow(
             workflow=GIT_REPOSITORIES_IMPORT_OBJECTS, parameters={"model": model}
         )
         task = {"id": workflow.id}
@@ -268,11 +268,11 @@ class ValidateRepositoryConnectivity(Mutation):
         info: GraphQLResolveInfo,
         data: IdentifierInput,
     ) -> dict[str, Any]:
-        context: GraphqlContext = info.context
-        branch = context.branch
+        graphql_context: GraphqlContext = info.context
+        branch = graphql_context.branch
         repository_id = str(data.id)
         repo: CoreReadOnlyRepository | CoreRepository = await NodeManager.get_one_by_id_or_default_filter(
-            db=context.db,
+            db=graphql_context.db,
             kind=InfrahubKind.GENERICREPOSITORY,
             id=repository_id,
             branch=branch,
@@ -282,8 +282,8 @@ class ValidateRepositoryConnectivity(Mutation):
             repository_name=str(repo.name.value),
             repository_location=str(repo.location.value),
         )
-        if context.service:
-            response = await context.service.message_bus.rpc(
+        if graphql_context.service:
+            response = await graphql_context.service.message_bus.rpc(
                 message=message, response_class=GitRepositoryConnectivityResponse
             )
 

--- a/backend/infrahub/graphql/mutations/resource_manager.py
+++ b/backend/infrahub/graphql/mutations/resource_manager.py
@@ -65,7 +65,7 @@ class IPPrefixPoolGetResource(Mutation):
         info: GraphQLResolveInfo,
         data: InputObjectType,
     ) -> Self:
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
 
         member_type = data.get("member_type", None)
         allowed_member_types = [t.value for t in PrefixMemberType]
@@ -73,15 +73,15 @@ class IPPrefixPoolGetResource(Mutation):
             raise QueryValidationError(f"Invalid member_type value, allowed values are {allowed_member_types}")
 
         obj: CoreIPPrefixPool = await registry.manager.find_object(  # type: ignore[assignment]
-            db=context.db,
+            db=graphql_context.db,
             kind=InfrahubKind.IPPREFIXPOOL,
             id=data.get("id"),
             hfid=data.get("hfid"),
-            branch=context.branch,
+            branch=graphql_context.branch,
         )
         resource = await obj.get_resource(
-            db=context.db,
-            branch=context.branch,
+            db=graphql_context.db,
+            branch=graphql_context.branch,
             identifier=data.get("identifier", None),
             prefixlen=data.get("prefix_length", None),
             member_type=member_type,
@@ -95,8 +95,8 @@ class IPPrefixPoolGetResource(Mutation):
                 "id": resource.id,
                 "kind": resource.get_kind(),
                 "identifier": data.get("identifier", None),
-                "display_label": await resource.render_display_label(db=context.db),
-                "branch": context.branch.name,
+                "display_label": await resource.render_display_label(db=graphql_context.db),
+                "branch": graphql_context.branch.name,
             },
         }
 
@@ -117,18 +117,18 @@ class IPAddressPoolGetResource(Mutation):
         info: GraphQLResolveInfo,
         data: dict[str, Any],
     ) -> Self:
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
 
         obj: CoreIPAddressPool = await registry.manager.find_object(
-            db=context.db,
+            db=graphql_context.db,
             kind=InfrahubKind.IPADDRESSPOOL,
             id=data.get("id"),
             hfid=data.get("hfid"),
-            branch=context.branch,
+            branch=graphql_context.branch,
         )
         resource = await obj.get_resource(
-            db=context.db,
-            branch=context.branch,
+            db=graphql_context.db,
+            branch=graphql_context.branch,
             identifier=data.get("identifier"),
             prefixlen=data.get("prefix_length"),
             address_type=data.get("address_type"),
@@ -141,8 +141,8 @@ class IPAddressPoolGetResource(Mutation):
                 "id": resource.id,
                 "kind": resource.get_kind(),
                 "identifier": data.get("identifier"),
-                "display_label": await resource.render_display_label(db=context.db),
-                "branch": context.branch.name,
+                "display_label": await resource.render_display_label(db=graphql_context.db),
+                "branch": graphql_context.branch.name,
             },
         }
 
@@ -211,9 +211,9 @@ class InfrahubNumberPoolMutation(InfrahubMutationMixin, Mutation):
             data.get("node_attribute") and data.get("node_attribute").value
         ):
             raise ValidationError(input_value="The fields 'node' or 'node_attribute' can't be changed.")
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
 
-        async with context.db.start_transaction() as dbt:
+        async with graphql_context.db.start_transaction() as dbt:
             number_pool, result = await super().mutate_update(
                 info=info, data=data, branch=branch, database=dbt, node=node
             )

--- a/backend/infrahub/graphql/mutations/schema.py
+++ b/backend/infrahub/graphql/mutations/schema.py
@@ -62,9 +62,9 @@ class SchemaDropdownAdd(Mutation):
         info: GraphQLResolveInfo,
         data: SchemaDropdownAddInput,
     ) -> Self:
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
 
-        kind = context.db.schema.get(name=str(data.kind), branch=context.branch.name)
+        kind = graphql_context.db.schema.get(name=str(data.kind), branch=graphql_context.branch.name)
         attribute = str(data.attribute)
         validate_kind_dropdown(kind=kind, attribute=attribute)
         dropdown = str(data.dropdown)
@@ -80,13 +80,13 @@ class SchemaDropdownAdd(Mutation):
 
         await update_registry(
             kind=kind,
-            branch=context.branch,
-            db=context.db,
-            account_id=context.active_account_session.account_id,
-            service=context.active_service,
+            branch=graphql_context.branch,
+            db=graphql_context.db,
+            account_id=graphql_context.active_account_session.account_id,
+            service=graphql_context.active_service,
         )
 
-        kind = context.db.schema.get(name=str(data.kind), branch=context.branch.name)
+        kind = graphql_context.db.schema.get(name=str(data.kind), branch=graphql_context.branch.name)
         attrib = kind.get_attribute(attribute)
         dropdown_entry = {}
         success = False
@@ -118,15 +118,18 @@ class SchemaDropdownRemove(Mutation):
         info: GraphQLResolveInfo,
         data: SchemaDropdownRemoveInput,
     ) -> dict[str, bool]:
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
 
-        kind = context.db.schema.get(name=str(data.kind), branch=context.branch.name)
+        kind = graphql_context.db.schema.get(name=str(data.kind), branch=graphql_context.branch.name)
 
         attribute = str(data.attribute)
         validate_kind_dropdown(kind=kind, attribute=attribute)
         dropdown = str(data.dropdown)
         nodes_with_dropdown = await NodeManager.query(
-            db=context.db, schema=kind.kind, filters={f"{attribute}__value": dropdown}, branch=context.branch
+            db=graphql_context.db,
+            schema=kind.kind,
+            filters={f"{attribute}__value": dropdown},
+            branch=graphql_context.branch,
         )
         if nodes_with_dropdown:
             raise ValidationError(f"There are still {kind.kind} objects using this dropdown")
@@ -143,10 +146,10 @@ class SchemaDropdownRemove(Mutation):
 
         await update_registry(
             kind=kind,
-            branch=context.branch,
-            db=context.db,
-            account_id=context.active_account_session.account_id,
-            service=context.active_service,
+            branch=graphql_context.branch,
+            db=graphql_context.db,
+            account_id=graphql_context.active_account_session.account_id,
+            service=graphql_context.active_service,
         )
 
         return {"ok": True}
@@ -166,9 +169,9 @@ class SchemaEnumAdd(Mutation):
         info: GraphQLResolveInfo,
         data: SchemaEnumInput,
     ) -> dict[str, bool]:
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
 
-        kind = context.db.schema.get(name=str(data.kind), branch=context.branch.name)
+        kind = graphql_context.db.schema.get(name=str(data.kind), branch=graphql_context.branch.name)
 
         attribute = str(data.attribute)
         enum = str(data.enum)
@@ -184,10 +187,10 @@ class SchemaEnumAdd(Mutation):
 
         await update_registry(
             kind=kind,
-            branch=context.branch,
-            db=context.db,
-            account_id=context.active_account_session.account_id,
-            service=context.active_service,
+            branch=graphql_context.branch,
+            db=graphql_context.db,
+            account_id=graphql_context.active_account_session.account_id,
+            service=graphql_context.active_service,
         )
 
         return {"ok": True}
@@ -207,15 +210,18 @@ class SchemaEnumRemove(Mutation):
         info: GraphQLResolveInfo,
         data: SchemaEnumInput,
     ) -> dict[str, bool]:
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
 
-        kind = context.db.schema.get(name=str(data.kind), branch=context.branch.name)
+        kind = graphql_context.db.schema.get(name=str(data.kind), branch=graphql_context.branch.name)
 
         attribute = str(data.attribute)
         enum = str(data.enum)
         validate_kind_enum(kind=kind, attribute=attribute)
         nodes_with_enum = await NodeManager.query(
-            db=context.db, schema=kind.kind, filters={f"{attribute}__value": enum}, branch=context.branch
+            db=graphql_context.db,
+            schema=kind.kind,
+            filters={f"{attribute}__value": enum},
+            branch=graphql_context.branch,
         )
         if nodes_with_enum:
             raise ValidationError(f"There are still {kind.kind} objects using this enum")
@@ -232,10 +238,10 @@ class SchemaEnumRemove(Mutation):
 
         await update_registry(
             kind=kind,
-            branch=context.branch,
-            db=context.db,
-            account_id=context.active_account_session.account_id,
-            service=context.active_service,
+            branch=graphql_context.branch,
+            db=graphql_context.db,
+            account_id=graphql_context.active_account_session.account_id,
+            service=graphql_context.active_service,
         )
 
         return {"ok": True}

--- a/backend/infrahub/graphql/permissions.py
+++ b/backend/infrahub/graphql/permissions.py
@@ -11,23 +11,25 @@ if TYPE_CHECKING:
     from infrahub.graphql.initialization import GraphqlContext
 
 
-async def get_permissions(schema: MainSchemaTypes, context: GraphqlContext) -> dict[str, Any]:
+async def get_permissions(schema: MainSchemaTypes, graphql_context: GraphqlContext) -> dict[str, Any]:
     schema_objects = [schema]
     if isinstance(schema, GenericSchema):
         for node_name in schema.used_by:
             schema_object: MainSchemaTypes
             try:
-                schema_object = registry.schema.get_node_schema(name=node_name, branch=context.branch, duplicate=False)
+                schema_object = registry.schema.get_node_schema(
+                    name=node_name, branch=graphql_context.branch, duplicate=False
+                )
             except ValueError:
                 schema_object = registry.schema.get_profile_schema(
-                    name=node_name, branch=context.branch, duplicate=False
+                    name=node_name, branch=graphql_context.branch, duplicate=False
                 )
             schema_objects.append(schema_object)
 
     response: dict[str, Any] = {"count": len(schema_objects), "edges": []}
 
     nodes = await report_schema_permissions(
-        branch=context.branch, permission_manager=context.active_permissions, schemas=schema_objects
+        branch=graphql_context.branch, permission_manager=graphql_context.active_permissions, schemas=schema_objects
     )
     response["edges"] = [{"node": node} for node in nodes]
 

--- a/backend/infrahub/graphql/queries/account.py
+++ b/backend/infrahub/graphql/queries/account.py
@@ -36,23 +36,23 @@ async def resolve_account_tokens(
     limit: int = 10,
     offset: int = 0,
 ) -> dict:
-    context: GraphqlContext = info.context
+    graphql_context: GraphqlContext = info.context
 
-    if not context.account_session:
+    if not graphql_context.account_session:
         raise ValueError("An account_session is mandatory to execute this query")
 
-    if not context.account_session.authenticated_by_jwt:
+    if not graphql_context.account_session.authenticated_by_jwt:
         raise PermissionDeniedError("This operation requires authentication with a JWT token")
 
     fields = await extract_fields_first_node(info)
 
-    filters = {"account__ids": [context.account_session.account_id]}
+    filters = {"account__ids": [graphql_context.account_session.account_id]}
     response: dict[str, Any] = {}
     if "count" in fields:
-        response["count"] = await NodeManager.count(db=context.db, schema=InternalAccountToken, filters=filters)
+        response["count"] = await NodeManager.count(db=graphql_context.db, schema=InternalAccountToken, filters=filters)
     if "edges" in fields:
         objs = await NodeManager.query(
-            db=context.db, schema=InternalAccountToken, filters=filters, limit=limit, offset=offset
+            db=graphql_context.db, schema=InternalAccountToken, filters=filters, limit=limit, offset=offset
         )
         response["edges"] = [
             {"node": {"id": obj.id, "name": obj.name.value, "expiration": obj.expiration.value}} for obj in objs
@@ -116,16 +116,16 @@ async def resolve_account_permissions(
     root: dict,  # noqa: ARG001
     info: GraphQLResolveInfo,
 ) -> dict:
-    context: GraphqlContext = info.context
+    graphql_context: GraphqlContext = info.context
 
-    if not context.account_session:
+    if not graphql_context.account_session:
         raise ValueError("An account_session is mandatory to execute this query")
 
     fields = await extract_fields_first_node(info)
 
     response: dict[str, dict[str, Any]] = {}
     if "global_permissions" in fields:
-        global_list = context.active_permissions.permissions["global_permissions"]
+        global_list = graphql_context.active_permissions.permissions["global_permissions"]
         response["global_permissions"] = {"count": len(global_list)}
         response["global_permissions"]["edges"] = [
             {
@@ -140,7 +140,7 @@ async def resolve_account_permissions(
             for obj in global_list
         ]
     if "object_permissions" in fields:
-        object_list = context.active_permissions.permissions["object_permissions"]
+        object_list = graphql_context.active_permissions.permissions["object_permissions"]
         response["object_permissions"] = {"count": len(object_list)}
         response["object_permissions"]["edges"] = [
             {

--- a/backend/infrahub/graphql/queries/branch.py
+++ b/backend/infrahub/graphql/queries/branch.py
@@ -17,7 +17,7 @@ async def branch_resolver(
     **kwargs: Any,
 ) -> list[dict[str, Any]]:
     fields = await extract_fields_first_node(info)
-    return await BranchType.get_list(context=info.context, fields=fields, **kwargs)
+    return await BranchType.get_list(graphql_context=info.context, fields=fields, **kwargs)
 
 
 BranchQueryList = Field(

--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -145,10 +145,10 @@ class DiffTreeSummary(DiffSummaryCounts):
 
 class DiffTreeResolver:
     async def to_diff_tree(
-        self, enriched_diff_root: EnrichedDiffRoot, context: GraphqlContext | None = None
+        self, enriched_diff_root: EnrichedDiffRoot, graphql_context: GraphqlContext | None = None
     ) -> DiffTree:
         all_nodes = list(enriched_diff_root.nodes)
-        tree_nodes = [self.to_diff_node(enriched_node=e_node, context=context) for e_node in all_nodes]
+        tree_nodes = [self.to_diff_node(enriched_node=e_node, graphql_context=graphql_context) for e_node in all_nodes]
         name = None
         if enriched_diff_root.tracking_id and isinstance(enriched_diff_root.tracking_id, NameTrackingId):
             name = enriched_diff_root.tracking_id.name
@@ -165,21 +165,22 @@ class DiffTreeResolver:
             num_conflicts=enriched_diff_root.num_conflicts,
         )
 
-    def to_diff_node(self, enriched_node: EnrichedDiffNode, context: GraphqlContext | None = None) -> DiffNode:
+    def to_diff_node(self, enriched_node: EnrichedDiffNode, graphql_context: GraphqlContext | None = None) -> DiffNode:
         diff_attributes = [
-            self.to_diff_attribute(enriched_attribute=e_attr, context=context) for e_attr in enriched_node.attributes
+            self.to_diff_attribute(enriched_attribute=e_attr, graphql_context=graphql_context)
+            for e_attr in enriched_node.attributes
         ]
         diff_relationships = [
-            self.to_diff_relationship(enriched_relationship=e_rel, context=context)
+            self.to_diff_relationship(enriched_relationship=e_rel, graphql_context=graphql_context)
             for e_rel in enriched_node.relationships
             if e_rel.include_in_response
         ]
         conflict = None
         if enriched_node.conflict:
-            conflict = self.to_diff_conflict(enriched_conflict=enriched_node.conflict, context=context)
+            conflict = self.to_diff_conflict(enriched_conflict=enriched_node.conflict, graphql_context=graphql_context)
 
         parent = None
-        if parent_info := enriched_node.get_parent_info(context=context):
+        if parent_info := enriched_node.get_parent_info(graphql_context=graphql_context):
             parent = DiffNodeParent(
                 uuid=parent_info.node.uuid,
                 kind=parent_info.node.kind,
@@ -205,10 +206,11 @@ class DiffTreeResolver:
         )
 
     def to_diff_attribute(
-        self, enriched_attribute: EnrichedDiffAttribute, context: GraphqlContext | None = None
+        self, enriched_attribute: EnrichedDiffAttribute, graphql_context: GraphqlContext | None = None
     ) -> DiffAttribute:
         diff_properties = [
-            self.to_diff_property(enriched_property=e_prop, context=context) for e_prop in enriched_attribute.properties
+            self.to_diff_property(enriched_property=e_prop, graphql_context=graphql_context)
+            for e_prop in enriched_attribute.properties
         ]
         conflict = None
         for diff_prop in diff_properties:
@@ -230,10 +232,10 @@ class DiffTreeResolver:
         )
 
     def to_diff_relationship(
-        self, enriched_relationship: EnrichedDiffRelationship, context: GraphqlContext | None = None
+        self, enriched_relationship: EnrichedDiffRelationship, graphql_context: GraphqlContext | None = None
     ) -> DiffRelationship:
         diff_elements = [
-            self.to_diff_relationship_element(enriched_element=element, context=context)
+            self.to_diff_relationship_element(enriched_element=element, graphql_context=graphql_context)
             for element in enriched_relationship.relationships
         ]
         return DiffRelationship(
@@ -252,12 +254,14 @@ class DiffTreeResolver:
         )
 
     def to_diff_relationship_element(
-        self, enriched_element: EnrichedDiffSingleRelationship, context: GraphqlContext | None = None
+        self, enriched_element: EnrichedDiffSingleRelationship, graphql_context: GraphqlContext | None = None
     ) -> DiffSingleRelationship:
         diff_properties = [self.to_diff_property(e_prop) for e_prop in enriched_element.properties]
         conflict = None
         if enriched_element.conflict:
-            conflict = self.to_diff_conflict(enriched_conflict=enriched_element.conflict, context=context)
+            conflict = self.to_diff_conflict(
+                enriched_conflict=enriched_element.conflict, graphql_context=graphql_context
+            )
         return DiffSingleRelationship(
             last_changed_at=enriched_element.changed_at.obj,
             status=enriched_element.action,
@@ -274,11 +278,13 @@ class DiffTreeResolver:
         )
 
     def to_diff_property(
-        self, enriched_property: EnrichedDiffProperty, context: GraphqlContext | None = None
+        self, enriched_property: EnrichedDiffProperty, graphql_context: GraphqlContext | None = None
     ) -> DiffProperty:
         conflict = None
         if enriched_property.conflict:
-            conflict = self.to_diff_conflict(enriched_conflict=enriched_property.conflict, context=context)
+            conflict = self.to_diff_conflict(
+                enriched_conflict=enriched_property.conflict, graphql_context=graphql_context
+            )
         return DiffProperty(
             property_type=enriched_property.property_type.value,
             last_changed_at=enriched_property.changed_at.obj,
@@ -294,7 +300,7 @@ class DiffTreeResolver:
     def to_diff_conflict(
         self,
         enriched_conflict: EnrichedDiffConflict,
-        context: GraphqlContext | None = None,  # noqa: ARG002
+        graphql_context: GraphqlContext | None = None,  # noqa: ARG002
     ) -> ConflictDetails:
         return ConflictDetails(
             uuid=enriched_conflict.uuid,
@@ -381,10 +387,10 @@ class DiffTreeResolver:
         offset: int | None = None,
     ) -> Optional[Union[list[dict[str, Any]], dict[str, Any]]]:
         component_registry = get_component_registry()
-        context: GraphqlContext = info.context
-        base_branch = await registry.get_branch(db=context.db, branch=registry.default_branch)
-        diff_branch = await registry.get_branch(db=context.db, branch=branch)
-        diff_repo = await component_registry.get_component(DiffRepository, db=context.db, branch=diff_branch)
+        graphql_context: GraphqlContext = info.context
+        base_branch = await registry.get_branch(db=graphql_context.db, branch=registry.default_branch)
+        diff_branch = await registry.get_branch(db=graphql_context.db, branch=branch)
+        diff_repo = await component_registry.get_component(DiffRepository, db=graphql_context.db, branch=diff_branch)
         branch_start_timestamp = Timestamp(diff_branch.get_branched_from())
         if from_time:
             from_timestamp = Timestamp(from_time.isoformat())
@@ -393,7 +399,7 @@ class DiffTreeResolver:
         if to_time:
             to_timestamp = Timestamp(to_time.isoformat())
         else:
-            to_timestamp = context.at or Timestamp()
+            to_timestamp = graphql_context.at or Timestamp()
 
         # Convert filters to dict and merge root_node_uuids for compatibility
         filters_dict = dict(filters or {})
@@ -427,12 +433,12 @@ class DiffTreeResolver:
             enriched_diff = enriched_diffs[0]
 
         full_fields = await extract_fields(info.field_nodes[0].selection_set)
-        diff_tree = await self.to_diff_tree(enriched_diff_root=enriched_diff, context=context)
+        diff_tree = await self.to_diff_tree(enriched_diff_root=enriched_diff, graphql_context=graphql_context)
         need_base_changes = "num_untracked_base_changes" in full_fields
         need_branch_changes = "num_untracked_diff_changes" in full_fields
         if need_base_changes or need_branch_changes:
             await self._add_untracked_fields(
-                db=context.db,
+                db=graphql_context.db,
                 diff_response=diff_tree,
                 from_time=enriched_diff.to_time,
                 base_branch_name=base_branch.name if need_base_changes else None,
@@ -450,10 +456,10 @@ class DiffTreeResolver:
         filters: dict | None = None,
     ) -> Optional[Union[list[dict[str, Any]], dict[str, Any]]]:
         component_registry = get_component_registry()
-        context: GraphqlContext = info.context
-        base_branch = await registry.get_branch(db=context.db, branch=registry.default_branch)
-        diff_branch = await registry.get_branch(db=context.db, branch=branch)
-        diff_repo = await component_registry.get_component(DiffRepository, db=context.db, branch=diff_branch)
+        graphql_context: GraphqlContext = info.context
+        base_branch = await registry.get_branch(db=graphql_context.db, branch=registry.default_branch)
+        diff_branch = await registry.get_branch(db=graphql_context.db, branch=branch)
+        diff_repo = await component_registry.get_component(DiffRepository, db=graphql_context.db, branch=diff_branch)
         branch_start_timestamp = Timestamp(diff_branch.get_branched_from())
         if from_time:
             from_timestamp = Timestamp(from_time.isoformat())
@@ -462,7 +468,7 @@ class DiffTreeResolver:
         if to_time:
             to_timestamp = Timestamp(to_time.isoformat())
         else:
-            to_timestamp = context.at or Timestamp()
+            to_timestamp = graphql_context.at or Timestamp()
 
         filters_dict = dict(filters or {})
 
@@ -488,7 +494,7 @@ class DiffTreeResolver:
         need_branch_changes = "num_untracked_diff_changes" in full_fields
         if need_base_changes or need_branch_changes:
             await self._add_untracked_fields(
-                db=context.db,
+                db=graphql_context.db,
                 diff_response=diff_tree_summary,
                 from_time=summary.to_time,
                 base_branch_name=base_branch.name if need_base_changes else None,

--- a/backend/infrahub/graphql/queries/ipam.py
+++ b/backend/infrahub/graphql/queries/ipam.py
@@ -29,13 +29,13 @@ class IPAddressGetNextAvailable(ObjectType):
         prefix_id: str,
         prefix_length: Optional[int] = None,
     ) -> dict[str, str]:
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
 
-        prefix = await NodeManager.get_one(id=prefix_id, db=context.db, branch=context.branch)
+        prefix = await NodeManager.get_one(id=prefix_id, db=graphql_context.db, branch=graphql_context.branch)
 
         if not prefix:
             raise NodeNotFoundError(
-                branch_name=context.branch.name, node_type=InfrahubKind.IPPREFIX, identifier=prefix_id
+                branch_name=graphql_context.branch.name, node_type=InfrahubKind.IPPREFIX, identifier=prefix_id
             )
 
         ip_prefix = ipaddress.ip_network(prefix.prefix.value)  # type: ignore[attr-defined]
@@ -44,12 +44,12 @@ class IPAddressGetNextAvailable(ObjectType):
         if not ip_prefix.prefixlen <= prefix_length <= ip_prefix.max_prefixlen:
             raise ValidationError(input_value="Invalid prefix length for current selected prefix")
 
-        namespace = await prefix.ip_namespace.get_peer(db=context.db)  # type: ignore[attr-defined]
+        namespace = await prefix.ip_namespace.get_peer(db=graphql_context.db)  # type: ignore[attr-defined]
         addresses = await get_ip_addresses(
-            db=context.db,
+            db=graphql_context.db,
             ip_prefix=ip_prefix,
             namespace=namespace,
-            branch=context.branch,
+            branch=graphql_context.branch,
         )
 
         available = get_available(
@@ -76,21 +76,21 @@ class IPPrefixGetNextAvailable(ObjectType):
         prefix_id: str,
         prefix_length: int,
     ) -> dict[str, str]:
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
 
-        prefix = await NodeManager.get_one(id=prefix_id, db=context.db, branch=context.branch)
+        prefix = await NodeManager.get_one(id=prefix_id, db=graphql_context.db, branch=graphql_context.branch)
 
         if not prefix:
             raise NodeNotFoundError(
-                branch_name=context.branch.name, node_type=InfrahubKind.IPPREFIX, identifier=prefix_id
+                branch_name=graphql_context.branch.name, node_type=InfrahubKind.IPPREFIX, identifier=prefix_id
             )
 
-        namespace = await prefix.ip_namespace.get_peer(db=context.db)  # type: ignore[attr-defined]
+        namespace = await prefix.ip_namespace.get_peer(db=graphql_context.db)  # type: ignore[attr-defined]
         subnets = await get_subnets(
-            db=context.db,
+            db=graphql_context.db,
             ip_prefix=ipaddress.ip_network(prefix.prefix.value),  # type: ignore[attr-defined]
             namespace=namespace,
-            branch=context.branch,
+            branch=graphql_context.branch,
         )
 
         pool = IPSet([prefix.prefix.value])

--- a/backend/infrahub/graphql/queries/relationship.py
+++ b/backend/infrahub/graphql/queries/relationship.py
@@ -27,18 +27,18 @@ class Relationships(ObjectType):
         offset: int = 0,
         excluded_namespaces: Optional[list[str]] = None,
     ) -> dict[str, Any]:
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
 
         fields = await extract_fields_first_node(info)
         excluded_namespaces = excluded_namespaces or []
 
         response: dict[str, Any] = {"edges": [], "count": None}
 
-        async with context.db.start_session() as db:
+        async with graphql_context.db.start_session() as db:
             query = await RelationshipGetByIdentifierQuery.init(
                 db=db,
-                branch=context.branch,
-                at=context.at,
+                branch=graphql_context.branch,
+                at=graphql_context.at,
                 identifiers=ids,
                 excluded_namespaces=excluded_namespaces,
                 limit=limit,

--- a/backend/infrahub/graphql/queries/resource_manager.py
+++ b/backend/infrahub/graphql/queries/resource_manager.py
@@ -80,8 +80,10 @@ class PoolAllocated(ObjectType):
         offset: int = 0,
         limit: int = 10,
     ) -> dict:
-        context: GraphqlContext = info.context
-        pool: CoreNode | None = await NodeManager.get_one(id=pool_id, db=context.db, branch=context.branch)
+        graphql_context: GraphqlContext = info.context
+        pool: CoreNode | None = await NodeManager.get_one(
+            id=pool_id, db=graphql_context.db, branch=graphql_context.branch
+        )
 
         fields = await extract_fields_first_node(info=info)
 
@@ -90,14 +92,19 @@ class PoolAllocated(ObjectType):
         match pool.get_kind():
             case InfrahubKind.NUMBERPOOL:
                 return await resolve_number_pool_allocation(
-                    db=context.db, context=context, pool=pool, fields=fields, offset=offset, limit=limit
+                    db=graphql_context.db,
+                    graphql_context=graphql_context,
+                    pool=pool,
+                    fields=fields,
+                    offset=offset,
+                    limit=limit,
                 )
             case InfrahubKind.IPPREFIXPOOL:
                 allocated_kinds.append(InfrahubKind.IPPREFIX)
             case InfrahubKind.IPADDRESSPOOL:
                 allocated_kinds.append(InfrahubKind.IPADDRESS)
 
-        resources = await pool.resources.get_peers(db=context.db)  # type: ignore[attr-defined,union-attr]
+        resources = await pool.resources.get_peers(db=graphql_context.db)  # type: ignore[attr-defined,union-attr]
         if resource_id not in resources:
             raise ValidationError(
                 input_value=f"The selected pool_id={pool_id} doesn't contain the requested resource_id={resource_id}"
@@ -106,8 +113,8 @@ class PoolAllocated(ObjectType):
         resource = resources[resource_id]
 
         query = await IPPrefixUtilization.init(
-            db=context.db,
-            at=context.at,
+            db=graphql_context.db,
+            at=graphql_context.at,
             ip_prefixes=[resource],
             allocated_kinds=allocated_kinds,
             offset=offset,
@@ -115,10 +122,10 @@ class PoolAllocated(ObjectType):
         )
         response: dict[str, Any] = {}
         if "count" in fields:
-            response["count"] = await query.count(db=context.db)
+            response["count"] = await query.count(db=graphql_context.db)
 
         if edges := fields.get("edges"):
-            await query.execute(db=context.db)
+            await query.execute(db=graphql_context.db)
 
             node_fields = edges.get("node", {})
 
@@ -146,9 +153,9 @@ class PoolAllocated(ObjectType):
                 if not identifier_query_class:
                     raise ValidationError(input_value=f"This query doesn't get support {pool.get_kind()}")
                 identifier_query = await identifier_query_class.init(
-                    db=context.db, at=context.at, pool_id=pool_id, allocated=allocated_ids
+                    db=graphql_context.db, at=graphql_context.at, pool_id=pool_id, allocated=allocated_ids
                 )
-                await identifier_query.execute(db=context.db)
+                await identifier_query.execute(db=graphql_context.db)
 
                 reservations = {}
                 for result in identifier_query.get_results():
@@ -179,12 +186,12 @@ class PoolUtilization(ObjectType):
         info: GraphQLResolveInfo,
         pool_id: str,
     ) -> dict:
-        context: GraphqlContext = info.context
-        db: InfrahubDatabase = context.db
-        pool: CoreNode | None = await NodeManager.get_one(id=pool_id, db=db, branch=context.branch)
+        graphql_context: GraphqlContext = info.context
+        db: InfrahubDatabase = graphql_context.db
+        pool: CoreNode | None = await NodeManager.get_one(id=pool_id, db=db, branch=graphql_context.branch)
         pool = _validate_pool_type(pool_id=pool_id, pool=pool)
         if pool.get_kind() == "CoreNumberPool":
-            return await resolve_number_pool_utilization(db=db, context=context, pool=pool)
+            return await resolve_number_pool_utilization(db=db, graphql_context=graphql_context, pool=pool)
 
         resources_map: dict[str, Node] = {}
 
@@ -193,7 +200,9 @@ class PoolUtilization(ObjectType):
         except SchemaNotFoundError:
             pass
 
-        utilization_getter = PrefixUtilizationGetter(db=db, ip_prefixes=list(resources_map.values()), at=context.at)
+        utilization_getter = PrefixUtilizationGetter(
+            db=db, ip_prefixes=list(resources_map.values()), at=graphql_context.at
+        )
         fields = await extract_fields_first_node(info=info)
         response: dict[str, Any] = {}
         total_utilization = None
@@ -262,11 +271,11 @@ class PoolUtilization(ObjectType):
 
 
 async def resolve_number_pool_allocation(
-    db: InfrahubDatabase, context: GraphqlContext, pool: CoreNode, fields: dict, offset: int, limit: int
+    db: InfrahubDatabase, graphql_context: GraphqlContext, pool: CoreNode, fields: dict, offset: int, limit: int
 ) -> dict:
     response: dict[str, Any] = {}
     query = await NumberPoolGetAllocated.init(
-        db=db, pool=pool, offset=offset, limit=limit, branch=context.branch, branch_agnostic=True
+        db=db, pool=pool, offset=offset, limit=limit, branch=graphql_context.branch, branch_agnostic=True
     )
 
     if "count" in fields:
@@ -290,8 +299,10 @@ async def resolve_number_pool_allocation(
     return response
 
 
-async def resolve_number_pool_utilization(db: InfrahubDatabase, context: GraphqlContext, pool: CoreNode) -> dict:
-    number_pool = NumberUtilizationGetter(db=db, pool=pool, at=context.at, branch=context.branch)
+async def resolve_number_pool_utilization(
+    db: InfrahubDatabase, graphql_context: GraphqlContext, pool: CoreNode
+) -> dict:
+    number_pool = NumberUtilizationGetter(db=db, pool=pool, at=graphql_context.at, branch=graphql_context.branch)
     await number_pool.load_data()
 
     return {

--- a/backend/infrahub/graphql/queries/search.py
+++ b/backend/infrahub/graphql/queries/search.py
@@ -103,7 +103,7 @@ async def search_resolver(
     limit: int = 10,
     partial_match: bool = True,
 ) -> dict[str, Any]:
-    context: GraphqlContext = info.context
+    graphql_context: GraphqlContext = info.context
     response: dict[str, Any] = {}
     results: list[CoreNode] = []
 
@@ -111,7 +111,7 @@ async def search_resolver(
 
     if is_valid_uuid(q):
         matching: Optional[CoreNode] = await NodeManager.get_one(
-            db=context.db, branch=context.branch, at=context.at, id=q
+            db=graphql_context.db, branch=graphql_context.branch, at=graphql_context.at, id=q
         )
         if matching:
             results.append(matching)
@@ -124,8 +124,8 @@ async def search_resolver(
 
         for kind in [InfrahubKind.NODE, InfrahubKind.GENERICGROUP]:
             objs = await NodeManager.query(
-                db=context.db,
-                branch=context.branch,
+                db=graphql_context.db,
+                branch=graphql_context.branch,
                 schema=kind,
                 filters={"any__value": q},
                 limit=limit,

--- a/backend/infrahub/graphql/queries/status.py
+++ b/backend/infrahub/graphql/queries/status.py
@@ -40,15 +40,15 @@ async def resolve_status(
     root: dict,  # noqa: ARG001
     info: GraphQLResolveInfo,
 ) -> dict:
-    context: GraphqlContext = info.context
-    service = context.service
+    graphql_context: GraphqlContext = info.context
+    service = graphql_context.service
     if service is None:
         raise ValueError("GraphqlContext.service is None")
 
     fields = await extract_fields_first_node(info)
     response: dict[str, Any] = {}
     workers = await service.component.list_workers(
-        branch=str(context.branch.uuid) or context.branch.name, schema_hash=True
+        branch=str(graphql_context.branch.uuid) or graphql_context.branch.name, schema_hash=True
     )
 
     if summary := fields.get("summary"):

--- a/backend/infrahub/graphql/queries/task.py
+++ b/backend/infrahub/graphql/queries/task.py
@@ -72,11 +72,11 @@ class Tasks(ObjectType):
         limit: int | None = None,
         offset: int | None = None,
     ) -> dict[str, Any]:
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
         fields = await extract_fields_first_node(info)
 
         prefect_tasks = await PrefectTask.query(
-            db=context.db,
+            db=graphql_context.db,
             fields=fields,
             q=q,
             ids=ids,

--- a/backend/infrahub/graphql/resolvers/resolver.py
+++ b/backend/infrahub/graphql/resolvers/resolver.py
@@ -27,12 +27,12 @@ async def account_resolver(
     info: GraphQLResolveInfo,
 ) -> dict:
     fields = await extract_fields(info.field_nodes[0].selection_set)
-    context: GraphqlContext = info.context
+    graphql_context: GraphqlContext = info.context
 
-    async with context.db.start_session() as db:
+    async with graphql_context.db.start_session() as db:
         results = await NodeManager.query(
             schema=InfrahubKind.GENERICACCOUNT,
-            filters={"ids": [context.account_session.account_id]},
+            filters={"ids": [graphql_context.account_session.account_id]},
             fields=fields,
             db=db,
             order=OrderModel(disable=True),
@@ -41,7 +41,9 @@ async def account_resolver(
             account_profile = await results[0].to_graphql(db=db, fields=fields)
             return account_profile
 
-        raise NodeNotFoundError(node_type=InfrahubKind.GENERICACCOUNT, identifier=context.account_session.account_id)
+        raise NodeNotFoundError(
+            node_type=InfrahubKind.GENERICACCOUNT, identifier=graphql_context.account_session.account_id
+        )
 
 
 async def default_resolver(*args: Any, **kwargs) -> dict | list[dict] | None:
@@ -84,7 +86,7 @@ async def default_resolver(*args: Any, **kwargs) -> dict | list[dict] | None:
         return parent.get(field_name, None)
 
     # Extract the contextual information from the request context
-    context: GraphqlContext = info.context
+    graphql_context: GraphqlContext = info.context
 
     # Extract the name of the fields in the GQL query
     fields = await extract_fields(info.field_nodes[0].selection_set)
@@ -99,7 +101,7 @@ async def default_resolver(*args: Any, **kwargs) -> dict | list[dict] | None:
         if "__" in key and value or key in ["id", "ids"]
     }
 
-    async with context.db.start_session() as db:
+    async with graphql_context.db.start_session() as db:
         objs = await NodeManager.query_peers(
             db=db,
             ids=[parent["id"]],
@@ -107,22 +109,23 @@ async def default_resolver(*args: Any, **kwargs) -> dict | list[dict] | None:
             schema=node_rel,
             filters=filters,
             fields=fields,
-            at=context.at,
-            branch=context.branch,
+            at=graphql_context.at,
+            branch=graphql_context.branch,
             branch_agnostic=node_rel.branch is BranchSupportType.AGNOSTIC,
             fetch_peers=True,
         )
 
         if node_rel.cardinality == "many":
             return [
-                await obj.to_graphql(db=db, fields=fields, related_node_ids=context.related_node_ids) for obj in objs
+                await obj.to_graphql(db=db, fields=fields, related_node_ids=graphql_context.related_node_ids)
+                for obj in objs
             ]
 
         # If cardinality is one
         if not objs:
             return None
 
-        return await objs[0].to_graphql(db=db, fields=fields, related_node_ids=context.related_node_ids)
+        return await objs[0].to_graphql(db=db, fields=fields, related_node_ids=graphql_context.related_node_ids)
 
 
 async def parent_field_name_resolver(parent: dict[str, dict], info: GraphQLResolveInfo) -> dict:
@@ -151,8 +154,8 @@ async def default_paginated_list_resolver(
 
     fields = await extract_selection(info.field_nodes[0], schema=schema)
 
-    context: GraphqlContext = info.context
-    async with context.db.start_session() as db:
+    graphql_context: GraphqlContext = info.context
+    async with graphql_context.db.start_session() as db:
         response: dict[str, Any] = {"edges": []}
         filters = {
             key: value for key, value in kwargs.items() if ("__" in key and value is not None) or key in ("ids", "hfid")
@@ -162,7 +165,11 @@ async def default_paginated_list_resolver(
         node_fields = edges.get("node", {})
 
         permission_set: Optional[dict[str, Any]] = None
-        permissions = await get_permissions(schema=schema, context=context) if context.permissions else None
+        permissions = (
+            await get_permissions(schema=schema, graphql_context=graphql_context)
+            if graphql_context.permissions
+            else None
+        )
         if fields.get("permissions"):
             response["permissions"] = permissions
 
@@ -178,11 +185,11 @@ async def default_paginated_list_resolver(
                 schema=schema,
                 filters=filters or None,
                 fields=node_fields,
-                at=context.at,
-                branch=context.branch,
+                at=graphql_context.at,
+                branch=graphql_context.branch,
                 limit=limit,
                 offset=offset,
-                account=context.account_session,
+                account=graphql_context.account_session,
                 include_source=True,
                 include_owner=True,
                 partial_match=partial_match,
@@ -197,8 +204,8 @@ async def default_paginated_list_resolver(
                     db=db,
                     schema=schema,
                     filters=filters,
-                    at=context.at,
-                    branch=context.branch,
+                    at=graphql_context.at,
+                    branch=graphql_context.branch,
                     partial_match=partial_match,
                 )
 
@@ -209,7 +216,7 @@ async def default_paginated_list_resolver(
                     "node": await obj.to_graphql(
                         db=db,
                         fields=node_fields,
-                        related_node_ids=context.related_node_ids,
+                        related_node_ids=graphql_context.related_node_ids,
                         permissions=permission_set,
                     )
                 }
@@ -221,8 +228,8 @@ async def default_paginated_list_resolver(
 
 
 async def single_relationship_resolver(parent: dict, info: GraphQLResolveInfo, **kwargs: Any) -> dict[str, Any]:
-    context: GraphqlContext = info.context
-    resolver = context.single_relationship_resolver
+    graphql_context: GraphqlContext = info.context
+    resolver = graphql_context.single_relationship_resolver
     return await resolver.resolve(parent=parent, info=info, **kwargs)
 
 
@@ -241,7 +248,7 @@ async def many_relationship_resolver(
         else info.parent_type.graphene_type._meta.schema
     )
 
-    context: GraphqlContext = info.context
+    graphql_context: GraphqlContext = info.context
 
     # Extract the name of the fields in the GQL query
     fields = await extract_fields(info.field_nodes[0].selection_set)
@@ -269,7 +276,7 @@ async def many_relationship_resolver(
 
     source_kind = node_schema.kind
 
-    async with context.db.start_session() as db:
+    async with graphql_context.db.start_session() as db:
         ids = [parent["id"]]
         if include_descendants:
             query = await NodeGetHierarchyQuery.init(
@@ -277,8 +284,8 @@ async def many_relationship_resolver(
                 direction=RelationshipHierarchyDirection.DESCENDANTS,
                 node_id=parent["id"],
                 node_schema=node_schema,
-                at=context.at,
-                branch=context.branch,
+                at=graphql_context.at,
+                branch=graphql_context.branch,
             )
             if node_schema.hierarchy:
                 source_kind = node_schema.hierarchy
@@ -293,8 +300,8 @@ async def many_relationship_resolver(
                 source_kind=source_kind,
                 schema=node_rel,
                 filters=filters,
-                at=context.at,
-                branch=context.branch,
+                at=graphql_context.at,
+                branch=graphql_context.branch,
                 branch_agnostic=node_rel.branch is BranchSupportType.AGNOSTIC,
             )
 
@@ -310,8 +317,8 @@ async def many_relationship_resolver(
             fields=node_fields,
             offset=offset,
             limit=limit,
-            at=context.at,
-            branch=context.branch,
+            at=graphql_context.at,
+            branch=graphql_context.branch,
             branch_agnostic=node_rel.branch is BranchSupportType.AGNOSTIC,
             fetch_peers=True,
         )
@@ -319,7 +326,8 @@ async def many_relationship_resolver(
         if not objs:
             return response
         node_graph = [
-            await obj.to_graphql(db=db, fields=node_fields, related_node_ids=context.related_node_ids) for obj in objs
+            await obj.to_graphql(db=db, fields=node_fields, related_node_ids=graphql_context.related_node_ids)
+            for obj in objs
         ]
 
         entries = []
@@ -363,7 +371,7 @@ async def hierarchy_resolver(
         else info.parent_type.graphene_type._meta.schema
     )
 
-    context: GraphqlContext = info.context
+    graphql_context: GraphqlContext = info.context
 
     # Extract the name of the fields in the GQL query
     fields = await extract_fields(info.field_nodes[0].selection_set)
@@ -382,7 +390,7 @@ async def hierarchy_resolver(
 
     response: dict[str, Any] = {"edges": [], "count": None}
 
-    async with context.db.start_session() as db:
+    async with graphql_context.db.start_session() as db:
         if "count" in fields:
             response["count"] = await NodeManager.count_hierarchy(
                 db=db,
@@ -390,8 +398,8 @@ async def hierarchy_resolver(
                 direction=direction,
                 node_schema=node_schema,
                 filters=filters,
-                at=context.at,
-                branch=context.branch,
+                at=graphql_context.at,
+                branch=graphql_context.branch,
             )
 
         if not node_fields:
@@ -406,8 +414,8 @@ async def hierarchy_resolver(
             fields=node_fields,
             offset=offset,
             limit=limit,
-            at=context.at,
-            branch=context.branch,
+            at=graphql_context.at,
+            branch=graphql_context.branch,
         )
 
         if not objs:

--- a/backend/infrahub/graphql/resolvers/single_relationship.py
+++ b/backend/infrahub/graphql/resolvers/single_relationship.py
@@ -39,7 +39,7 @@ class SingleRelationshipResolver:
             else info.parent_type.graphene_type._meta.schema  # type: ignore[attr-defined]
         )
 
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
 
         # Extract the name of the fields in the GQL query
         fields = await extract_fields(info.field_nodes[0].selection_set)
@@ -59,10 +59,10 @@ class SingleRelationshipResolver:
 
         if requires_relationship_metadata:
             node_graph = await self._get_entities_simple(
-                db=context.db,
-                branch=context.branch,
-                at=context.at,
-                related_node_ids=context.related_node_ids,
+                db=graphql_context.db,
+                branch=graphql_context.branch,
+                at=graphql_context.at,
+                related_node_ids=graphql_context.related_node_ids,
                 field_name=info.field_name,
                 parent_id=parent["id"],
                 source_kind=node_schema.kind,
@@ -72,10 +72,10 @@ class SingleRelationshipResolver:
             )
         else:
             node_graph = await self._get_entities_with_data_loader(
-                db=context.db,
-                branch=context.branch,
-                at=context.at,
-                related_node_ids=context.related_node_ids,
+                db=graphql_context.db,
+                branch=graphql_context.branch,
+                at=graphql_context.at,
+                related_node_ids=graphql_context.related_node_ids,
                 rel_schema=node_rel,
                 parent=parent,
                 node_fields=node_fields,

--- a/backend/infrahub/graphql/subscription/graphql_query.py
+++ b/backend/infrahub/graphql/subscription/graphql_query.py
@@ -25,28 +25,28 @@ async def resolver_graphql_query(
     params: dict[str, Any] | None = None,
     interval: int = 10,
 ) -> AsyncGenerator[dict[str, Any], None]:
-    context: GraphqlContext = info.context
+    graphql_context: GraphqlContext = info.context
     at = Timestamp()
 
-    async with context.db.start_session() as db:
+    async with graphql_context.db.start_session() as db:
         # Find the GraphQLQuery and the GraphQL Schema
         graphql_query = await NodeManager.get_one_by_default_filter(
-            db=db, id=name, kind=CoreGraphQLQuery, branch=context.branch, at=at
+            db=db, id=name, kind=CoreGraphQLQuery, branch=graphql_context.branch, at=at
         )
         if not graphql_query:
             raise ValueError(f"Unable to find the {InfrahubKind.GRAPHQLQUERY} {name}")
 
     while True:
-        async with context.db.start_session() as db:
+        async with graphql_context.db.start_session() as db:
             result = await graphql(
                 schema=graphql_schema,
                 source=graphql_query.query.value,
-                context_value=context.__class__(
+                context_value=graphql_context.__class__(
                     db=db,
-                    branch=context.branch,
+                    branch=graphql_context.branch,
                     at=Timestamp(),
                     related_node_ids=set(),
-                    types=context.types,
+                    types=graphql_context.types,
                     single_relationship_resolver=SingleRelationshipResolver(),
                 ),
                 root_value=None,

--- a/backend/infrahub/graphql/types/branch.py
+++ b/backend/infrahub/graphql/types/branch.py
@@ -34,10 +34,10 @@ class BranchType(InfrahubObjectType):
     async def get_list(
         cls,
         fields: dict,
-        context: GraphqlContext,
+        graphql_context: GraphqlContext,
         **kwargs: Any,
     ) -> list[dict[str, Any]]:
-        async with context.db.start_session() as db:
+        async with graphql_context.db.start_session() as db:
             objs = await Branch.get_list(db=db, **kwargs)
 
             if not objs:

--- a/backend/infrahub/graphql/types/interface.py
+++ b/backend/infrahub/graphql/types/interface.py
@@ -21,8 +21,8 @@ class InfrahubInterfaceOptions(InterfaceOptions):
 class InfrahubInterface(Interface):
     @classmethod
     def resolve_type(cls, instance: dict[str, Any], info: GraphQLResolveInfo) -> InfrahubObject:
-        context: GraphqlContext = info.context
+        graphql_context: GraphqlContext = info.context
         if KIND_GRAPHQL_FIELD_NAME in instance:
-            return context.types[instance[KIND_GRAPHQL_FIELD_NAME]]
+            return graphql_context.types[instance[KIND_GRAPHQL_FIELD_NAME]]
 
         raise ValueError("Unable to identify the type of the instance.")

--- a/backend/infrahub/graphql/types/standard_node.py
+++ b/backend/infrahub/graphql/types/standard_node.py
@@ -26,24 +26,24 @@ class InfrahubObjectType(ObjectType):
         super().__init_subclass_with_meta__(_meta=_meta, interfaces=interfaces, **options)
 
     @classmethod
-    async def get_list(cls, fields: dict[str, Any], context: GraphqlContext, **kwargs) -> list[dict[str, Any]]:
-        async with context.db.session(database=config.SETTINGS.database.database_name) as db:
+    async def get_list(cls, fields: dict[str, Any], graphql_context: GraphqlContext, **kwargs) -> list[dict[str, Any]]:
+        async with graphql_context.db.session(database=config.SETTINGS.database.database_name) as db:
             filters = {key: value for key, value in kwargs.items() if "__" in key and value}
 
             if filters:
                 objs = await cls._meta.model.get_list(
                     filters=filters,
-                    at=context.at,
-                    branch=context.branch,
-                    account=context.account_session,
+                    at=graphql_context.at,
+                    branch=graphql_context.branch,
+                    account=graphql_context.account_session,
                     include_source=True,
                     db=db,
                 )
             else:
                 objs = await cls._meta.model.get_list(
-                    at=context.at,
-                    branch=context.branch,
-                    account=context.account_session,
+                    at=graphql_context.at,
+                    branch=graphql_context.branch,
+                    account=graphql_context.account_session,
                     include_source=True,
                     db=db,
                 )


### PR DESCRIPTION
In preparation for #5578

This PR renames the variable for `GraphqlContext` to `graphql_context` instead of `context` to avoid confusion once we introduce another type of  context
