### PR TITLE
allow updating a diff when saving instead of forcing a create

### DIFF
--- a/backend/infrahub/core/diff/query/save.py
+++ b/backend/infrahub/core/diff/query/save.py
@@ -134,9 +134,12 @@ CALL {
         // add properties for this attribute
         // -------------------------
         WITH diff_attribute, node_attribute
-        CALL {
+            // -------------------------
+            // remove stale properties for this attribute
+            // -------------------------
+            CALL {
             WITH diff_attribute, node_attribute
-            WITH diff_attribute, [i IN node_attribute.properties | i.node_properties.property_type] AS prop_types
+            WITH diff_attribute, %(attr_props_list_comp)s AS prop_types
             OPTIONAL MATCH (diff_attribute)-[:DIFF_HAS_PROPERTY]->(prop_to_delete:DiffProperty)
             WHERE NOT (prop_to_delete.property_type IN prop_types)
             OPTIONAL MATCH (prop_to_delete)-[*..4]->(next_to_delete)
@@ -161,48 +164,115 @@ CALL {
         )
     }
     // -------------------------
+    // remove stale relationships for this node
+    // -------------------------
+    WITH diff_node, node_map
+    CALL {
+        WITH diff_node, node_map
+        WITH diff_node, %(rel_name_list_comp)s AS rel_names
+        OPTIONAL MATCH (diff_node)-[:DIFF_HAS_RELATIONSHIP]->(rel_to_delete:DiffRelationship)
+        WHERE NOT (rel_to_delete.name IN rel_names)
+        OPTIONAL MATCH (rel_to_delete)-[*..8]->(next_to_delete)
+        DETACH DELETE next_to_delete
+        DETACH DELETE rel_to_delete
+    }
+    // -------------------------
     // add relationships for this node
     // -------------------------
     WITH diff_node, node_map
     CALL {
         WITH diff_node, node_map
         UNWIND node_map.relationships as node_relationship
-        CREATE (diff_node)-[:DIFF_HAS_RELATIONSHIP]->(diff_relationship:DiffRelationship)
+        MERGE (diff_node)-[:DIFF_HAS_RELATIONSHIP]->(diff_relationship:DiffRelationship {name: node_relationship.node_properties.name})
         SET diff_relationship = node_relationship.node_properties
+        // -------------------------
+        // remove stale elements for this relationship group
+        // -------------------------
+        WITH diff_relationship, node_relationship
+        CALL {
+            WITH diff_relationship, node_relationship
+            WITH diff_relationship, %(rel_peers_list_comp)s AS rel_peers
+            OPTIONAL MATCH (diff_relationship)-[:DIFF_HAS_ELEMENT]->(element_to_delete:DiffRelationshipElement)
+            WHERE NOT (element_to_delete.peer_id IN rel_peers)
+            OPTIONAL MATCH (element_to_delete)-[*..6]->(next_to_delete)
+            DETACH DELETE next_to_delete
+            DETACH DELETE element_to_delete
+        }
         // -------------------------
         // add elements for this relationship group
         // -------------------------
         WITH diff_relationship, node_relationship
         UNWIND node_relationship.relationships as node_single_relationship
-        CREATE (diff_relationship)-[:DIFF_HAS_ELEMENT]->(diff_relationship_element:DiffRelationshipElement)
+        MERGE (diff_relationship)-[:DIFF_HAS_ELEMENT]
+            ->(diff_relationship_element:DiffRelationshipElement {peer_id: node_single_relationship.node_properties.peer_id})
         SET diff_relationship_element = node_single_relationship.node_properties
         // -------------------------
-        // add conflict for this relationship element
+        // add/remove conflict for this relationship element
         // -------------------------
-        FOREACH (i in CASE WHEN node_single_relationship.conflict_params IS NOT NULL THEN [1] ELSE [] END |
-            CREATE (diff_relationship_element)-[:DIFF_HAS_CONFLICT]->(diff_relationship_conflict:DiffConflict)
-            SET diff_relationship_conflict = node_single_relationship.conflict_params
+        WITH diff_relationship_element, node_single_relationship
+        OPTIONAL MATCH (diff_relationship_element)-[:DIFF_HAS_CONFLICT]->(current_element_conflict:DiffConflict)
+        WITH diff_relationship_element, node_single_relationship, current_element_conflict,
+            (node_single_relationship.conflict_params IS NOT NULL) AS has_element_conflict
+        FOREACH (i in CASE WHEN has_element_conflict = FALSE THEN [1] ELSE [] END |
+            DETACH DELETE current_element_conflict
         )
+        FOREACH (i in CASE WHEN has_element_conflict = TRUE THEN [1] ELSE [] END |
+            MERGE (diff_relationship_element)-[:DIFF_HAS_CONFLICT]->(element_conflict:DiffConflict)
+            SET element_conflict = node_single_relationship.conflict_params
+        )
+        // -------------------------
+        // remove stale properties for this relationship element
+        // -------------------------
+        WITH diff_relationship_element, node_single_relationship
+        CALL {
+            WITH diff_relationship_element, node_single_relationship
+            WITH diff_relationship_element, %(element_props_list_comp)s AS element_props
+            OPTIONAL MATCH (diff_relationship_element)-[:DIFF_HAS_PROPERTY]->(property_to_delete:DiffProperty)
+            WHERE NOT (property_to_delete.property_type IN element_props)
+            OPTIONAL MATCH (property_to_delete)-[*..4]->(next_to_delete)
+            DETACH DELETE next_to_delete
+            DETACH DELETE property_to_delete
+        }
         // -------------------------
         // add properties for this relationship element
         // -------------------------
         WITH diff_relationship_element, node_single_relationship
         UNWIND node_single_relationship.properties as node_relationship_property
-        CREATE (diff_relationship_element)-[:DIFF_HAS_PROPERTY]->(diff_relationship_property:DiffProperty)
+        MERGE (diff_relationship_element)-[:DIFF_HAS_PROPERTY]
+            ->(diff_relationship_property:DiffProperty {property_type: node_relationship_property.node_properties.property_type})
         SET diff_relationship_property = node_relationship_property.node_properties
         // -------------------------
         // add conflict for this relationship element
         // -------------------------
-        FOREACH (i in CASE WHEN node_relationship_property.conflict_params IS NOT NULL THEN [1] ELSE [] END |
-            CREATE (diff_relationship_property)-[:DIFF_HAS_CONFLICT]->(diff_relationship_property_conflict:DiffConflict)
-            SET diff_relationship_property_conflict = node_relationship_property.conflict_params
+        WITH diff_relationship_property, node_relationship_property
+        OPTIONAL MATCH (diff_relationship_property)-[:DIFF_HAS_CONFLICT]->(diff_relationship_property_conflict:DiffConflict)
+        WITH diff_relationship_property, node_relationship_property, diff_relationship_property_conflict,
+            (node_relationship_property.conflict_params IS NOT NULL) AS has_property_conflict
+        FOREACH (i in CASE WHEN has_property_conflict = FALSE THEN [1] ELSE [] END |
+            DETACH DELETE diff_relationship_property_conflict
+        )
+        FOREACH (i in CASE WHEN has_property_conflict = TRUE THEN [1] ELSE [] END |
+            MERGE (diff_relationship_property)-[:DIFF_HAS_CONFLICT]->(property_conflict:DiffConflict)
+            SET property_conflict = node_relationship_property.conflict_params
         )
     }
 }
         """ % {
             "attr_name_list_comp": db.render_list_comprehension(
                 items="node_map.attributes", item_name="node_properties.name"
-            )
+            ),
+            "attr_props_list_comp": db.render_list_comprehension(
+                items="node_attribute.properties", item_name="node_properties.property_type"
+            ),
+            "rel_name_list_comp": db.render_list_comprehension(
+                items="node_map.relationships", item_name="node_properties.name"
+            ),
+            "rel_peers_list_comp": db.render_list_comprehension(
+                items="node_relationship.relationships", item_name="node_properties.peer_id"
+            ),
+            "element_props_list_comp": db.render_list_comprehension(
+                items="node_single_relationship.properties", item_name="node_properties.property_type"
+            ),
         }
         self.add_to_query(query)
 

--- a/backend/infrahub/core/diff/query/save.py
+++ b/backend/infrahub/core/diff/query/save.py
@@ -31,18 +31,16 @@ UNWIND $diff_root_list AS diff_root_map
 WITH diff_root_map
 CALL {
     WITH diff_root_map
-    MERGE (diff_root:DiffRoot {
-        base_branch: diff_root_map.base_branch,
-        diff_branch: diff_root_map.diff_branch,
-        from_time: diff_root_map.from_time,
-        to_time: diff_root_map.to_time,
-        uuid: diff_root_map.uuid,
-        num_added: diff_root_map.num_added,
-        num_updated: diff_root_map.num_updated,
-        num_removed: diff_root_map.num_removed,
-        num_conflicts: diff_root_map.num_conflicts,
-        contains_conflict: diff_root_map.contains_conflict
-    })
+    MERGE (diff_root:DiffRoot {uuid: diff_root_map.uuid})
+    SET diff_root.base_branch = diff_root_map.base_branch
+    SET diff_root.diff_branch = diff_root_map.diff_branch
+    SET diff_root.from_time = diff_root_map.from_time
+    SET diff_root.to_time = diff_root_map.to_time
+    SET diff_root.num_added = diff_root_map.num_added
+    SET diff_root.num_updated = diff_root_map.num_updated
+    SET diff_root.num_removed = diff_root_map.num_removed
+    SET diff_root.num_conflicts = diff_root_map.num_conflicts
+    SET diff_root.contains_conflict = diff_root_map.contains_conflict
     SET diff_root.tracking_id = diff_root_map.tracking_id
     RETURN diff_root
 }
@@ -96,37 +94,70 @@ WITH node_details.root_uuid AS root_uuid, node_details.node_map AS node_map
 CALL {
     WITH root_uuid, node_map
     MATCH (diff_root {uuid: root_uuid})
-    CREATE (diff_root)-[:DIFF_HAS_NODE]->(diff_node:DiffNode)
+    MERGE (diff_root)-[:DIFF_HAS_NODE]->(diff_node:DiffNode {uuid: node_map.node_properties.uuid})
     SET diff_node = node_map.node_properties
     // -------------------------
-    // add node-level conflict
+    // add/remove node-level conflict
     // -------------------------
-    FOREACH (i in CASE WHEN node_map.conflict_params IS NOT NULL THEN [1] ELSE [] END |
-        CREATE (diff_node)-[:DIFF_HAS_CONFLICT]->(diff_node_conflict:DiffConflict)
+    WITH diff_node, node_map
+    OPTIONAL MATCH (diff_node)-[:DIFF_HAS_CONFLICT]->(current_diff_node_conflict:DiffConflict)
+    WITH diff_node, node_map, current_diff_node_conflict, (node_map.conflict_params IS NOT NULL) AS has_node_conflict
+    FOREACH (i in CASE WHEN has_node_conflict = FALSE THEN [1] ELSE [] END |
+        DETACH DELETE current_diff_node_conflict
+    )
+    FOREACH (i in CASE WHEN has_node_conflict = TRUE THEN [1] ELSE [] END |
+        MERGE (diff_node)-[:DIFF_HAS_CONFLICT]->(diff_node_conflict:DiffConflict)
         SET diff_node_conflict = node_map.conflict_params
     )
     // -------------------------
-    // add attributes for this node
+    // remove stale attributes for this node
     // -------------------------
     WITH diff_node, node_map
     CALL {
         WITH diff_node, node_map
+        WITH diff_node, %(attr_name_list_comp)s AS attr_names
+        OPTIONAL MATCH (diff_node)-[:DIFF_HAS_ATTRIBUTE]->(attr_to_delete:DiffAttribute)
+        WHERE NOT (attr_to_delete.name IN attr_names)
+        OPTIONAL MATCH (attr_to_delete)-[*..6]->(next_to_delete)
+        DETACH DELETE next_to_delete
+        DETACH DELETE attr_to_delete
+    }
+    // -------------------------
+    // add attributes for this node
+    // -------------------------
+    CALL {
+        WITH diff_node, node_map
         UNWIND node_map.attributes AS node_attribute
-        CREATE (diff_node)-[:DIFF_HAS_ATTRIBUTE]->(diff_attribute:DiffAttribute)
+        MERGE (diff_node)-[:DIFF_HAS_ATTRIBUTE]->(diff_attribute:DiffAttribute {name: node_attribute.node_properties.name})
         SET diff_attribute = node_attribute.node_properties
         // -------------------------
         // add properties for this attribute
         // -------------------------
         WITH diff_attribute, node_attribute
+        CALL {
+            WITH diff_attribute, node_attribute
+            WITH diff_attribute, [i IN node_attribute.properties | i.node_properties.property_type] AS prop_types
+            OPTIONAL MATCH (diff_attribute)-[:DIFF_HAS_PROPERTY]->(prop_to_delete:DiffProperty)
+            WHERE NOT (prop_to_delete.property_type IN prop_types)
+            OPTIONAL MATCH (prop_to_delete)-[*..4]->(next_to_delete)
+            DETACH DELETE next_to_delete
+            DETACH DELETE prop_to_delete
+        }
         UNWIND node_attribute.properties AS attr_property
-        CREATE (diff_attribute)-[:DIFF_HAS_PROPERTY]->(diff_attr_prop:DiffProperty)
+        MERGE (diff_attribute)-[:DIFF_HAS_PROPERTY]->(diff_attr_prop:DiffProperty {property_type: attr_property.node_properties.property_type})
         SET diff_attr_prop = attr_property.node_properties
         // -------------------------
-        // add conflict for this property
+        // add/remove conflict for this property
         // -------------------------
-        FOREACH (i in CASE WHEN attr_property.conflict_params IS NOT NULL THEN [1] ELSE [] END |
-            CREATE (diff_attr_prop)-[:DIFF_HAS_CONFLICT]->(diff_attribute_property_conflict:DiffConflict)
-            SET diff_attribute_property_conflict = attr_property.conflict_params
+        WITH diff_attr_prop, attr_property
+        OPTIONAL MATCH (diff_attr_prop)-[:DIFF_HAS_CONFLICT]->(current_attr_prop_conflict:DiffConflict)
+        WITH diff_attr_prop, attr_property, current_attr_prop_conflict, (attr_property.conflict_params IS NOT NULL) AS has_prop_conflict
+        FOREACH (i in CASE WHEN has_prop_conflict = FALSE THEN [1] ELSE [] END |
+            DETACH DELETE current_attr_prop_conflict
+        )
+        FOREACH (i in CASE WHEN has_prop_conflict = TRUE THEN [1] ELSE [] END |
+            MERGE (diff_attr_prop)-[:DIFF_HAS_CONFLICT]->(diff_attr_prop_conflict:DiffConflict)
+            SET diff_attr_prop_conflict = attr_property.conflict_params
         )
     }
     // -------------------------
@@ -168,7 +199,11 @@ CALL {
         )
     }
 }
-        """
+        """ % {
+            "attr_name_list_comp": db.render_list_comprehension(
+                items="node_map.attributes", item_name="node_properties.name"
+            )
+        }
         self.add_to_query(query)
 
     def _build_conflict_params(self, enriched_conflict: EnrichedDiffConflict) -> dict[str, Any]:

--- a/backend/tests/unit/core/diff/test_diff_repository.py
+++ b/backend/tests/unit/core/diff/test_diff_repository.py
@@ -28,6 +28,7 @@ from infrahub.exceptions import ResourceNotFoundError
 
 from .factories import (
     EnrichedAttributeFactory,
+    EnrichedConflictFactory,
     EnrichedNodeFactory,
     EnrichedPropertyFactory,
     EnrichedRelationshipElementFactory,
@@ -750,3 +751,274 @@ class TestDiffRepositorySaveAndLoad:
         assert {n.uuid for n in retrieved_diff.nodes} == {
             n.uuid for n in sorted(nodes_by_kind["KindOne"], key=lambda x: x.uuid)[7:]
         }
+
+    async def test_update_existing(self, db: InfrahubDatabase, diff_repository: DiffRepository, reset_database):
+        node_with_removes = self.build_diff_node(no_recurse=True, num_sub_fields=3)
+        node_with_updates = self.build_diff_node(no_recurse=True, num_sub_fields=3)
+        # there are no conflicts by default
+        node_with_adds = self.build_diff_node(no_recurse=True, num_sub_fields=3)
+        # set conflicts on every node/rel/prop in update and remove nodes
+        for node in (node_with_removes, node_with_updates):
+            node.conflict = EnrichedConflictFactory.build()
+            for attr in node.attributes:
+                for prop in attr.properties:
+                    prop.conflict = EnrichedConflictFactory.build()
+            for rel_group in node.relationships:
+                for rel_elem in rel_group.relationships:
+                    rel_elem.conflict = EnrichedConflictFactory.build()
+                    for prop in rel_elem.properties:
+                        prop.conflict = EnrichedConflictFactory.build()
+        enriched_diff = EnrichedRootFactory.build(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.diff_branch_name,
+            from_time=Timestamp(self.diff_from_time),
+            to_time=Timestamp(self.diff_to_time),
+            nodes={node_with_removes, node_with_updates, node_with_adds},
+            tracking_id=NameTrackingId(name="the-best-diff"),
+        )
+        base_diff = EnrichedRootFactory.build(
+            base_branch_name=enriched_diff.base_branch_name,
+            diff_branch_name=enriched_diff.base_branch_name,
+            from_time=enriched_diff.from_time,
+            to_time=enriched_diff.to_time,
+            nodes=set(),
+            tracking_id=enriched_diff.tracking_id,
+            partner_uuid=enriched_diff.uuid,
+        )
+        enriched_diff.partner_uuid = base_diff.uuid
+        enriched_diffs = EnrichedDiffs(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.diff_branch_name,
+            diff_branch_diff=enriched_diff,
+            base_branch_diff=base_diff,
+        )
+        await diff_repository.save(enriched_diffs=enriched_diffs)
+
+        # removed node conflict
+        node_with_removes.conflict = None
+        # add node conflict
+        node_with_adds.conflict = EnrichedConflictFactory.build()
+
+        # remove attribute
+        removed_attr = node_with_removes.attributes.pop()
+        # remove attribute property
+        attr_with_removed_prop = next(iter(node_with_removes.attributes))
+        removed_prop_from_attr = attr_with_removed_prop.properties.pop()
+        # remove attribute property conflict
+        attr_prop_with_removed_conflict = next(iter(attr_with_removed_prop.properties))
+        attr_prop_with_removed_conflict.conflict = None
+        # add attribute
+        added_attr = EnrichedAttributeFactory.build()
+        node_with_adds.attributes.add(added_attr)
+        # add attribute property conflict
+        attr_with_added_prop = next(iter(node_with_adds.attributes))
+        attr_prop_with_added_conflict = next(iter(attr_with_added_prop.properties))
+        attr_prop_with_added_conflict.conflict = EnrichedConflictFactory.build()
+        # add attribute property
+        added_prop_type = [
+            d for d in DatabaseEdgeType if d not in [p.property_type for p in attr_with_added_prop.properties]
+        ][0]
+        added_prop_to_attr = EnrichedPropertyFactory.build(property_type=added_prop_type)
+        attr_with_added_prop.properties.add(added_prop_to_attr)
+        # update attribute and property
+        attr_to_update = node_with_updates.attributes.pop()
+        attr_with_property_updates = next(iter(node_with_updates.attributes))
+        updated_attr = EnrichedAttributeFactory.build(name=attr_to_update.name)
+        node_with_updates.attributes.add(updated_attr)
+        attr_prop_to_update = attr_with_property_updates.properties.pop()
+        updated_attr_prop = EnrichedPropertyFactory.build(property_type=attr_prop_to_update.property_type)
+        attr_with_property_updates.properties.add(updated_attr_prop)
+
+        # remove relationship
+        removed_relationship = node_with_removes.relationships.pop()
+        # remove relationship element
+        relationship_with_removes = next(iter(node_with_removes.relationships))
+        removed_element = relationship_with_removes.relationships.pop()
+        # remove relationship element conflict
+        element_with_removes = next(iter(relationship_with_removes.relationships))
+        element_with_removes.conflict = None
+        # remove relationship element property
+        removed_element_property = element_with_removes.properties.pop()
+        # remove relationship element property conflict
+        element_property_with_removes = next(iter(element_with_removes.properties))
+        element_property_with_removes.conflict = None
+        # add relationship
+        relationship_with_adds = next(iter(node_with_adds.relationships))
+        added_relationship = EnrichedRelationshipGroupFactory.build()
+        node_with_adds.relationships.add(added_relationship)
+        # add relationship element
+        element_with_adds = next(iter(relationship_with_adds.relationships))
+        added_element = EnrichedRelationshipElementFactory.build()
+        relationship_with_adds.relationships.add(added_element)
+        # add relationship element conflict
+        added_element_conflict = EnrichedConflictFactory.build()
+        element_with_adds.conflict = added_element_conflict
+        # add relationship element property
+        element_property_with_adds = next(iter(element_with_adds.properties))
+        added_prop_type = [
+            d for d in DatabaseEdgeType if d not in [p.property_type for p in element_with_adds.properties]
+        ][0]
+        added_element_property = EnrichedPropertyFactory.build(property_type=added_prop_type)
+        element_with_adds.properties.add(added_element_property)
+        # add relationship element property conflict
+        added_element_property_conflict = EnrichedConflictFactory.build()
+        element_property_with_adds.conflict = added_element_property_conflict
+        # update relationship
+        updated_relationship = next(iter(node_with_updates.relationships))
+        updated_relationship.label += "_new"
+        # update relationship element
+        updated_relationship_element = next(iter(updated_relationship.relationships))
+        updated_relationship_element.peer_label = "fresh_label"
+        # update relationship element conflict
+        updated_relationship_element.conflict.base_branch_value = "BASE SOMETHING"
+        # update relationship element property
+        updated_element_property = next(iter(updated_relationship_element.properties))
+        updated_element_property.previous_value = "PREVIOUS SOMETHING"
+        # update relationship element property conflict
+        updated_element_property.conflict.diff_branch_value = "DIFF SOMETHING"
+
+        await diff_repository.save(enriched_diffs=enriched_diffs)
+
+        retrieved = await diff_repository.get(
+            base_branch_name=self.base_branch_name,
+            diff_branch_names=[self.diff_branch_name],
+            from_time=Timestamp(self.diff_from_time),
+            to_time=Timestamp(self.diff_to_time),
+        )
+        assert len(retrieved) == 1
+        retrieved_diff_root = retrieved[0]
+        assert len(retrieved_diff_root.nodes) == 3
+        nodes_by_uuid = {n.uuid: n for n in retrieved_diff_root.nodes}
+        # verify removed conflict
+        retrieved_node_with_removes = nodes_by_uuid[node_with_removes.uuid]
+        assert retrieved_node_with_removes.conflict is None
+        # verify added conflict
+        retrieved_node_with_adds = nodes_by_uuid[node_with_adds.uuid]
+        assert retrieved_node_with_adds.conflict == node_with_adds.conflict
+
+        # verify removed attribute
+        assert len(retrieved_node_with_removes.attributes) == 2
+        attrs_by_name = {a.name: a for a in retrieved_node_with_removes.attributes}
+        assert removed_attr.name not in attrs_by_name
+        # verify removed attribute property
+        retrieved_attr_with_removed_prop = attrs_by_name[attr_with_removed_prop.name]
+        props_by_type = {p.property_type: p for p in retrieved_attr_with_removed_prop.properties}
+        assert removed_prop_from_attr.property_type not in props_by_type
+        # verify removed attribute property conflict
+        attr_prop_with_removed_conflict = props_by_type[attr_prop_with_removed_conflict.property_type]
+        assert attr_prop_with_removed_conflict.conflict is None
+        # verify added attr
+        assert len(retrieved_node_with_adds.attributes) == 4
+        attrs_by_name = {a.name: a for a in retrieved_node_with_adds.attributes}
+        assert added_attr.name in attrs_by_name
+        assert added_attr == attrs_by_name[added_attr.name]
+        # verify added property to attribute
+        retrieved_attr_with_added_prop = attrs_by_name[attr_with_added_prop.name]
+        props_by_type = {p.property_type: p for p in retrieved_attr_with_added_prop.properties}
+        retrieved_added_prop_to_attr = props_by_type[added_prop_to_attr.property_type]
+        assert retrieved_added_prop_to_attr == added_prop_to_attr
+        # verify added conflict to attribute property
+        retrieved_attr_prop_with_added_conflict = props_by_type[attr_prop_with_added_conflict.property_type]
+        assert retrieved_attr_prop_with_added_conflict.conflict == attr_prop_with_added_conflict.conflict
+        # verify updated attr
+        retrieved_node_with_updates = nodes_by_uuid[node_with_updates.uuid]
+        assert len(retrieved_node_with_updates.attributes) == 3
+        attrs_by_name = {a.name: a for a in retrieved_node_with_updates.attributes}
+        assert updated_attr.name in attrs_by_name
+        assert updated_attr == attrs_by_name[updated_attr.name]
+        # verify updated attr property
+        retrieved_attr_with_property_update = attrs_by_name[attr_with_property_updates.name]
+        props_by_type = {p.property_type: p for p in retrieved_attr_with_property_update.properties}
+        assert updated_attr_prop == props_by_type[updated_attr_prop.property_type]
+
+        # verify relationship removed
+        rels_by_name = {r.name: r for r in retrieved_node_with_removes.relationships}
+        assert removed_relationship.name not in rels_by_name
+        # verify relationship element removed
+        retrieved_rel_with_removes = rels_by_name[relationship_with_removes.name]
+        elements_by_peer_id = {e.peer_id: e for e in retrieved_rel_with_removes.relationships}
+        assert removed_element.peer_id not in elements_by_peer_id
+        # verify relationship element conflict removed
+        retrieved_element_with_removes = elements_by_peer_id[element_with_removes.peer_id]
+        assert retrieved_element_with_removes.conflict is None
+        # verify relationship element property removed
+        props_by_type = {p.property_type: p for p in retrieved_element_with_removes.properties}
+        assert removed_element_property.property_type not in props_by_type
+        # verify relationship element property conflict removed
+        retrieved_element_property_with_removes = props_by_type[element_property_with_removes.property_type]
+        assert retrieved_element_property_with_removes.conflict is None
+        # verify relationship added
+        rels_by_name = {r.name: r for r in retrieved_node_with_adds.relationships}
+        assert added_relationship == rels_by_name[added_relationship.name]
+        # verify relationship element added
+        retrieved_rel_with_adds = rels_by_name[relationship_with_adds.name]
+        elements_by_peer_id = {e.peer_id: e for e in retrieved_rel_with_adds.relationships}
+        assert added_element == elements_by_peer_id[added_element.peer_id]
+        # verify relationship element conflict added
+        retrieved_element_with_adds = elements_by_peer_id[element_with_adds.peer_id]
+        assert retrieved_element_with_adds.conflict == added_element_conflict
+        # verify relationship element property added
+        props_by_type = {p.property_type: p for p in retrieved_element_with_adds.properties}
+        assert added_element_property == props_by_type[added_element_property.property_type]
+        # verify relationship element property conflict added
+        retrieved_element_property_with_adds = props_by_type[element_property_with_adds.property_type]
+        assert retrieved_element_property_with_adds.conflict == element_property_with_adds.conflict
+        # verify relationship updated
+        rels_by_name = {r.name: r for r in retrieved_node_with_updates.relationships}
+        retrieved_updated_relationship = rels_by_name[updated_relationship.name]
+        assert retrieved_updated_relationship == updated_relationship
+        # verify relationship element updated
+        elements_by_peer_id = {e.peer_id: e for e in retrieved_updated_relationship.relationships}
+        retrieved_updated_element = elements_by_peer_id[updated_relationship_element.peer_id]
+        assert retrieved_updated_element == updated_relationship_element
+        # verify relationship element conflict updated
+        assert retrieved_updated_element.conflict == updated_relationship_element.conflict
+        # verify relationship element property updated
+        props_by_type = {p.property_type: p for p in retrieved_updated_element.properties}
+        retrieved_updated_element_property = props_by_type[updated_element_property.property_type]
+        assert retrieved_updated_element_property == updated_element_property
+        # verify relationship element property conflict updated
+        assert retrieved_updated_element_property.conflict == updated_element_property.conflict
+
+        assert retrieved_diff_root == enriched_diff
+        await verify_no_orphaned_nodes(db=db)
+
+
+async def verify_no_orphaned_nodes(db: InfrahubDatabase) -> None:
+    """Verify that no diff elements have been orphaned"""
+    query = """
+CALL {
+    MATCH (d:DiffNode)
+    WHERE not exists((:DiffRoot)-[]->(d))
+    RETURN d
+    UNION
+    MATCH (d:DiffAttribute)
+    WHERE not exists((:DiffNode)-[]->(d))
+    RETURN d
+    UNION
+    MATCH (d:DiffRelationship)
+    WHERE not exists((:DiffNode)-[]->(d))
+    RETURN d
+    UNION
+    MATCH (d:DiffRelationshipElement)
+    WHERE not exists((:DiffRelationship)-[]->(d))
+    RETURN d
+    UNION
+    MATCH (d:DiffProperty)
+    WHERE not exists(()-[]->(d))
+    RETURN d
+    UNION
+    MATCH (d:DiffConflict)
+    WHERE not exists(()-[]->(d))
+    RETURN d
+}
+RETURN labels(d)[0] AS node_label, %(id_func)s(d) AS database_id
+    """ % {"id_func": db.get_id_function_name()}
+    records = await db.execute_query(query=query)
+    orphaned_nodes = []
+    for record in records:
+        node_label = record.get("node_label")
+        database_id = record.get("database_id")
+        orphaned_nodes.append(f"{node_label}({database_id})")
+    if orphaned_nodes:
+        raise ValueError(f"The following nodes are orphaned: {orphaned_nodes}")


### PR DESCRIPTION
IFC-580

the current approach for saving a diff requires always saving the entire thing. if a diff is very big, this will take a long time.

this PR updates the cypher query that saves a diff to allow for updating a diff in place instead of only creating one. more changes are necessary, but this will soon allow us to only save the changed parts of a diff instead of the whole thing.