### PR TITLE
update diff logic to handle schema kind migration

### DIFF
--- a/backend/infrahub/core/diff/model/path.py
+++ b/backend/infrahub/core/diff/model/path.py
@@ -740,6 +740,10 @@ class DatabasePath:  # pylint: disable=too-many-public-methods
         return str(self.node_node.get("uuid"))
 
     @property
+    def node_db_id(self) -> str:
+        return self.node_node.element_id
+
+    @property
     def node_kind(self) -> str:
         return str(self.node_node.get("kind"))
 

--- a/backend/infrahub/core/diff/query_parser.py
+++ b/backend/infrahub/core/diff/query_parser.py
@@ -397,6 +397,9 @@ class DiffNodeIntermediate(TrackedStatusUpdates):
     force_action: DiffAction | None
     uuid: str
     kind: str
+    db_id: str
+    from_time: Timestamp
+    status: RelationshipStatus
     attributes_by_name: dict[str, DiffAttributeIntermediate] = field(default_factory=dict)
     relationships_by_name: dict[str, DiffRelationshipIntermediate] = field(default_factory=dict)
 
@@ -567,11 +570,27 @@ class DiffQueryParser:
             diff_root.nodes_by_id[node_id] = DiffNodeIntermediate(
                 uuid=node_id,
                 kind=database_path.node_kind,
+                db_id=database_path.node_db_id,
+                from_time=database_path.node_changed_at,
+                status=database_path.node_status,
                 force_action=DiffAction.UPDATED
                 if database_path.node_branch_support is BranchSupportType.AGNOSTIC
                 else None,
             )
         diff_node = diff_root.nodes_by_id[node_id]
+        # special handling for nodes that have their kind updated, which results in 2 nodes with the same uuid
+        if diff_node.db_id != database_path.node_db_id and (
+            database_path.node_changed_at > diff_node.from_time
+            or (
+                database_path.node_changed_at >= diff_node.from_time
+                and (diff_node.status, database_path.node_status)
+                == (RelationshipStatus.DELETED, RelationshipStatus.ACTIVE)
+            )
+        ):
+            diff_node.kind = database_path.node_kind
+            diff_node.db_id = database_path.node_db_id
+            diff_node.from_time = database_path.node_changed_at
+            diff_node.status = database_path.node_status
         diff_node.track_database_path(database_path=database_path)
         return diff_node
 

--- a/backend/infrahub/core/query/diff.py
+++ b/backend/infrahub/core/query/diff.py
@@ -137,6 +137,14 @@ CALL {
         r in relationships(latest_base_path)
         WHERE r.from < $branch_from_time
     )
+    // ------------------------
+    // special handling for nodes that had their kind updated,
+    // the migration leaves two nodes with the same UUID linked to the same Relationship
+    // ------------------------
+    AND (
+        n.uuid IS NULL OR base_prop.uuid IS NULL OR n.uuid <> base_prop.uuid
+        OR type(base_r_node) <> "IS_RELATED" OR type(base_r_prop) <> "IS_RELATED"
+    )
     WITH latest_base_path, base_r_root, base_r_node, base_r_prop
     ORDER BY base_r_prop.from DESC, base_r_node.from DESC, base_r_root.from DESC
     LIMIT 1
@@ -175,8 +183,13 @@ CALL {
         OR peer_r_node.to IS NULL
         OR peer_r_node.to >= r_peer.from
     )
+    // ------------------------
+    // special handling for nodes that had their kind updated,
+    // the migration leaves two nodes with the same UUID linked to the same Relationship
+    // ------------------------
+    AND (n.uuid IS NULL OR peer.uuid IS NULL OR n.uuid <> peer.uuid)
     WITH peer_path, r_peer, r_prop
-    ORDER BY r_peer.branch = r_prop.branch DESC, r_peer.from DESC
+    ORDER BY r_peer.branch = r_prop.branch DESC, r_peer.from DESC, r_peer.status ASC
     LIMIT 1
     RETURN peer_path
 }
@@ -309,6 +322,14 @@ CALL {
     AND [%(id_func)s(p), type(r_node)] <> [%(id_func)s(prop), type(r_prop)]
     AND top_diff_rel.status = r_node.status
     AND top_diff_rel.status = r_prop.status
+    // ------------------------
+    // special handling for nodes that had their kind updated,
+    // the migration leaves two nodes with the same UUID linked to the same Relationship
+    // ------------------------
+    AND (
+        p.uuid IS NULL OR prop.uuid IS NULL OR p.uuid <> prop.uuid
+        OR type(r_node) <> "IS_RELATED" OR type(r_prop) <> "IS_RELATED"
+    )
     WITH path, p, node, prop, r_prop, r_node, type(r_node) AS rel_type, row_from_time
     // -------------------------------------
     // Exclude attributes/relationships added then removed on branch within timeframe
@@ -483,6 +504,14 @@ CALL {
     AND [%(id_func)s(p), type(mid_diff_rel)] <> [%(id_func)s(prop), type(r_prop)]
     // exclude paths where an active edge is below a deleted edge
     AND (mid_diff_rel.status = "active" OR r_prop.status = "deleted")
+    // ------------------------
+    // special handling for nodes that had their kind updated,
+    // the migration leaves two nodes with the same UUID linked to the same Relationship
+    // ------------------------
+    AND (
+        p.uuid IS NULL OR prop.uuid IS NULL OR p.uuid <> prop.uuid
+        OR type(mid_diff_rel) <> "IS_RELATED" OR type(r_prop) <> "IS_RELATED"
+    )
     WITH path, prop, r_prop, mid_r_root
     ORDER BY
         type(r_prop),
@@ -493,7 +522,7 @@ CALL {
     RETURN latest_prop_path
 }
 // -------------------------------------
-// Exclude properties within the timeframe
+// Exclude properties added and deleted within the timeframe
 // -------------------------------------
 WITH q, nodes(latest_prop_path)[3] AS prop, type(relationships(latest_prop_path)[2]) AS rel_type, latest_prop_path, has_more_data, row_from_time
 CALL {
@@ -593,6 +622,14 @@ AND (
             AND r_node.from <= $branch_from_time AND (r_node.to IS NULL OR r_node.branch <> diff_rel.branch OR r_node.to <= $branch_from_time)
         )
     )
+)
+// ------------------------
+// special handling for nodes that had their kind updated,
+// the migration leaves two nodes with the same UUID linked to the same Relationship
+// ------------------------
+AND (
+    n.uuid IS NULL OR q.uuid IS NULL OR n.uuid <> q.uuid
+    OR type(r_node) <> "IS_RELATED" OR type(diff_rel) <> "IS_RELATED"
 )
 AND ALL(
     r_pair IN [[r_root, r_node], [r_node, diff_rel]]

--- a/backend/tests/unit/core/diff/test_diff_calculator.py
+++ b/backend/tests/unit/core/diff/test_diff_calculator.py
@@ -3,12 +3,14 @@ import pytest
 from infrahub import config
 from infrahub.core import registry
 from infrahub.core.branch import Branch
-from infrahub.core.constants import DiffAction, InfrahubKind, RelationshipCardinality
+from infrahub.core.constants import DiffAction, InfrahubKind, RelationshipCardinality, SchemaPathType
 from infrahub.core.constants.database import DatabaseEdgeType
 from infrahub.core.diff.calculator import DiffCalculator
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
+from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration
 from infrahub.core.node import Node
+from infrahub.core.path import SchemaPath
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
@@ -1308,7 +1310,6 @@ async def test_relationship_property_owner_conflicting_updates(
     # check branch
     branch_root_path = calculated_diffs.diff_branch_diff
     assert branch_root_path.branch == branch.name
-    assert len(branch_root_path.nodes) == 2
     nodes_by_id = {n.uuid: n for n in branch_root_path.nodes}
     assert set(nodes_by_id.keys()) == {person_john_main.get_id(), car_accord_main.get_id()}
     # john node on branch
@@ -3077,3 +3078,72 @@ async def test_diff_relationship_property_update_on_main(
     assert diff_rel.name == "owner"
     assert diff_rel.action is DiffAction.UPDATED
     assert {elem.action for elem in diff_rel.relationships} == {DiffAction.ADDED, DiffAction.REMOVED}
+
+
+async def test_calculate_with_migrated_kind_node(
+    db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main, person_john_main, person_jane_main
+):
+    """Test that the diff can correctly handle a schema kind migration, which results in 2 nodes with the same UUID"""
+    branch = await create_branch(db=db, branch_name="branch")
+    branch_car = await Node.init(db=db, schema="TestCar", branch=branch)
+    await branch_car.new(db=db, name="nova", nbr_seats=2, is_electric=False, owner=person_jane_main.id)
+    await branch_car.save(db=db)
+    schema = registry.schema.get_schema_branch(name=default_branch.name)
+    car_schema = schema.get(name="TestCar")
+    car_schema.name = "NewCar"
+    car_schema.namespace = "Test2"
+    assert car_schema.kind == "Test2NewCar"
+    owner_rel_schema = car_schema.get_relationship(name="owner")
+    registry.schema.set(name="Test2NewCar", schema=car_schema, branch=branch.name)
+
+    migration = NodeKindUpdateMigration(
+        previous_node_schema=schema.get(name="TestCar"),
+        new_node_schema=car_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="Test2NewCar", field_name="namespace"),
+    )
+    execution_result = await migration.execute(db=db, branch=branch)
+    assert not execution_result.errors
+
+    diff_calculator = DiffCalculator(db=db)
+
+    calculated_diffs = await diff_calculator.calculate_diff(
+        base_branch=default_branch,
+        diff_branch=branch,
+        from_time=Timestamp(branch.get_branched_from()),
+        to_time=Timestamp(),
+        previous_node_specifiers={
+            car_accord_main.id: {owner_rel_schema.get_identifier()},
+            car_camry_main.id: {owner_rel_schema.get_identifier()},
+        },
+        include_unchanged=True,
+    )
+
+    branch_diff = calculated_diffs.diff_branch_diff
+    assert len(branch_diff.nodes) == 2
+    nodes_by_id = {n.uuid: n for n in branch_diff.nodes}
+    assert set(nodes_by_id.keys()) == {branch_car.id, person_jane_main.id}
+    # validate relationship on person is correct
+    jane_diff = nodes_by_id[person_jane_main.id]
+    assert jane_diff.action is DiffAction.UPDATED
+    assert len(jane_diff.attributes) == 0
+    rels_by_name = {r.name: r for r in jane_diff.relationships}
+    assert set(rels_by_name.keys()) == {"cars"}
+    cars_rel_diff = rels_by_name["cars"]
+    assert cars_rel_diff.action is DiffAction.UPDATED
+    elements_by_peer_id = {e.peer_id: e for e in cars_rel_diff.relationships}
+    assert set(elements_by_peer_id) == {branch_car.id}
+    element_diff = elements_by_peer_id[branch_car.id]
+    assert element_diff.action is DiffAction.ADDED
+    props_by_type = {p.property_type: p for p in element_diff.properties}
+    for property_type, value in (
+        (DatabaseEdgeType.IS_RELATED, branch_car.id),
+        (DatabaseEdgeType.IS_VISIBLE, True),
+        (DatabaseEdgeType.IS_PROTECTED, False),
+    ):
+        property_diff = props_by_type[property_type]
+        assert property_diff.action is DiffAction.ADDED
+        assert property_diff.new_value == value
+        assert property_diff.previous_value is None
+
+    base_diff = calculated_diffs.base_branch_diff
+    assert len(base_diff.nodes) == 0


### PR DESCRIPTION
IFC-990

updating a schema's kind puts the database into an unusual state that the diff was not capable of handling.
the green node has the updated kind and the red node has the old kind. they both have the same UUID and the red one has been deleted. this make sense logically, but the diff expected every UUID to link to one and only one node. it also expected that there would only ever be 2 nodes connected to a relationship, not 3
![image](https://github.com/user-attachments/assets/40d85765-3486-4a85-a695-714ce1ad5618)

I made some changes to the diff cypher queries and the `DiffQueryParser` that reads those cypher queries to allow them to handle this unusual database situation correctly