### PR TITLE
add test and changes for a relationship identifier migration

### DIFF
--- a/backend/infrahub/core/diff/enricher/labels.py
+++ b/backend/infrahub/core/diff/enricher/labels.py
@@ -157,7 +157,9 @@ class DiffLabelsEnricher(DiffEnricherInterface):
 
             node_schema = self.db.schema.get(name=node.kind, branch=enriched_diff.diff_branch_name, duplicate=False)
             alternate_node_schema = None
-            if enriched_diff.diff_branch_name != enriched_diff.base_branch_name:
+            if enriched_diff.diff_branch_name != enriched_diff.base_branch_name and self.db.schema.has(
+                name=node.kind, branch=enriched_diff.base_branch_name
+            ):
                 alternate_node_schema = self.db.schema.get(
                     name=node.kind, branch=enriched_diff.base_branch_name, duplicate=False
                 )

--- a/backend/infrahub/core/diff/enricher/labels.py
+++ b/backend/infrahub/core/diff/enricher/labels.py
@@ -154,10 +154,18 @@ class DiffLabelsEnricher(DiffEnricherInterface):
         for node in enriched_diff.nodes:
             if not node.relationships:
                 continue
-            node_schema = self.db.schema.get(name=node.kind, branch=self.diff_branch_name, duplicate=False)
+
+            node_schema = self.db.schema.get(name=node.kind, branch=enriched_diff.diff_branch_name, duplicate=False)
+            alternate_node_schema = None
+            if enriched_diff.diff_branch_name != enriched_diff.base_branch_name:
+                alternate_node_schema = self.db.schema.get(
+                    name=node.kind, branch=enriched_diff.base_branch_name, duplicate=False
+                )
             for relationship_diff in node.relationships:
-                relationship_schema = node_schema.get_relationship(name=relationship_diff.name)
-                relationship_diff.label = relationship_schema.label or ""
+                relationship_schema = node_schema.get_relationship_or_none(name=relationship_diff.name)
+                if not relationship_schema and alternate_node_schema:
+                    relationship_schema = alternate_node_schema.get_relationship_or_none(name=relationship_diff.name)
+                relationship_diff.label = relationship_schema.label or "" if relationship_schema else ""
 
     async def _get_display_label_map(
         self, display_label_requests: set[DisplayLabelRequest]

--- a/backend/infrahub/core/diff/enricher/path_identifier.py
+++ b/backend/infrahub/core/diff/enricher/path_identifier.py
@@ -44,12 +44,10 @@ class DiffPathIdentifierEnricher(DiffEnricherInterface):
                     attribute_property.path_identifier = property_path.get_path()
             if not node.relationships:
                 continue
-            node_schema = self.db.schema.get(name=node.kind, branch=self.diff_branch_name, duplicate=False)
             for relationship in node.relationships:
-                relationship_schema = node_schema.get_relationship(name=relationship.name)
                 path_type = (
                     PathType.RELATIONSHIP_ONE
-                    if relationship_schema.cardinality is RelationshipCardinality.ONE
+                    if relationship.cardinality is RelationshipCardinality.ONE
                     else PathType.RELATIONSHIP_MANY
                 )
                 relationship_path = DataPath(

--- a/backend/infrahub/core/diff/enricher/path_identifier.py
+++ b/backend/infrahub/core/diff/enricher/path_identifier.py
@@ -1,4 +1,4 @@
-from infrahub.core.constants import PathType, RelationshipCardinality
+from infrahub.core.constants import PathType
 from infrahub.core.path import DataPath
 from infrahub.database import InfrahubDatabase
 
@@ -45,11 +45,7 @@ class DiffPathIdentifierEnricher(DiffEnricherInterface):
             if not node.relationships:
                 continue
             for relationship in node.relationships:
-                path_type = (
-                    PathType.RELATIONSHIP_ONE
-                    if relationship.cardinality is RelationshipCardinality.ONE
-                    else PathType.RELATIONSHIP_MANY
-                )
+                path_type = PathType.from_relationship(relationship.cardinality)
                 relationship_path = DataPath(
                     branch=enriched_diff_root.diff_branch_name,
                     path_type=path_type,

--- a/backend/infrahub/core/diff/query_parser.py
+++ b/backend/infrahub/core/diff/query_parser.py
@@ -400,7 +400,8 @@ class DiffNodeIntermediate(TrackedStatusUpdates):
     from_time: Timestamp
     status: RelationshipStatus
     attributes_by_name: dict[str, DiffAttributeIntermediate] = field(default_factory=dict)
-    relationships_by_identifier: dict[str, DiffRelationshipIntermediate] = field(default_factory=dict)
+    # {(name, identifier): DiffRelationshipIntermediate}
+    relationships_by_identifier: dict[tuple[str, str], DiffRelationshipIntermediate] = field(default_factory=dict)
 
     def to_diff_node(self, from_time: Timestamp, include_unchanged: bool) -> DiffNode:
         attributes = []
@@ -669,7 +670,9 @@ class DiffQueryParser:
         relationship_schema: RelationshipSchema,
         database_path: DatabasePath,
     ) -> DiffRelationshipIntermediate:
-        diff_relationship = diff_node.relationships_by_identifier.get(relationship_schema.get_identifier())
+        diff_relationship = diff_node.relationships_by_identifier.get(
+            (relationship_schema.name, relationship_schema.get_identifier())
+        )
         if not diff_relationship:
             branch_name = database_path.deepest_branch
             from_time = self.from_time
@@ -683,7 +686,9 @@ class DiffQueryParser:
                 identifier=relationship_schema.get_identifier(),
                 from_time=from_time,
             )
-            diff_node.relationships_by_identifier[relationship_schema.get_identifier()] = diff_relationship
+            diff_node.relationships_by_identifier[relationship_schema.name, relationship_schema.get_identifier()] = (
+                diff_relationship
+            )
         return diff_relationship
 
     def _apply_base_branch_previous_values(self) -> None:
@@ -720,8 +725,8 @@ class DiffQueryParser:
     def _apply_relationship_previous_values(
         self, diff_node: DiffNodeIntermediate, base_diff_node: DiffNodeIntermediate
     ) -> None:
-        for relationship_identifier, diff_relationship in diff_node.relationships_by_identifier.items():
-            base_diff_relationship = base_diff_node.relationships_by_identifier.get(relationship_identifier)
+        for relationship_key, diff_relationship in diff_node.relationships_by_identifier.items():
+            base_diff_relationship = base_diff_node.relationships_by_identifier.get(relationship_key)
             if not base_diff_relationship:
                 continue
             for db_id, property_set in diff_relationship.properties_by_db_id.items():

--- a/backend/infrahub/core/diff/query_parser.py
+++ b/backend/infrahub/core/diff/query_parser.py
@@ -28,7 +28,6 @@ from .model.path import (
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
     from infrahub.core.query import QueryResult
-    from infrahub.core.schema import MainSchemaTypes
     from infrahub.core.schema.manager import SchemaManager
     from infrahub.core.schema.relationship_schema import RelationshipSchema
 
@@ -401,7 +400,7 @@ class DiffNodeIntermediate(TrackedStatusUpdates):
     from_time: Timestamp
     status: RelationshipStatus
     attributes_by_name: dict[str, DiffAttributeIntermediate] = field(default_factory=dict)
-    relationships_by_name: dict[str, DiffRelationshipIntermediate] = field(default_factory=dict)
+    relationships_by_identifier: dict[str, DiffRelationshipIntermediate] = field(default_factory=dict)
 
     def to_diff_node(self, from_time: Timestamp, include_unchanged: bool) -> DiffNode:
         attributes = []
@@ -411,7 +410,7 @@ class DiffNodeIntermediate(TrackedStatusUpdates):
                 attributes.append(diff_attr)
         action, changed_at = self.get_action_and_timestamp(from_time=from_time)
         relationships = []
-        for rel in self.relationships_by_name.values():
+        for rel in self.relationships_by_identifier.values():
             diff_rel = rel.to_diff_relationship(include_unchanged=include_unchanged)
             if include_unchanged or diff_rel.action is not DiffAction.UNCHANGED:
                 relationships.append(diff_rel)
@@ -434,7 +433,7 @@ class DiffNodeIntermediate(TrackedStatusUpdates):
 
     @property
     def is_empty(self) -> bool:
-        return len(self.attributes_by_name) == 0 and len(self.relationships_by_name) == 0
+        return len(self.attributes_by_name) == 0 and len(self.relationships_by_identifier) == 0
 
 
 @dataclass
@@ -498,7 +497,7 @@ class DiffQueryParser:
         for node in diff_root.nodes_by_id.values():
             for attribute_name in node.attributes_by_name:
                 node_field_specifiers_map[node.uuid].add(attribute_name)
-            for relationship_diff in node.relationships_by_name.values():
+            for relationship_diff in node.relationships_by_identifier.values():
                 node_field_specifiers_map[node.uuid].add(relationship_diff.identifier)
         return node_field_specifiers_map
 
@@ -594,27 +593,29 @@ class DiffQueryParser:
         diff_node.track_database_path(database_path=database_path)
         return diff_node
 
-    def _get_relationship_schema(
-        self, database_path: DatabasePath, node_schema: MainSchemaTypes
-    ) -> RelationshipSchema | None:
-        relationship_schemas = node_schema.get_relationships_by_identifier(id=database_path.attribute_name)
-        if len(relationship_schemas) == 1:
-            return relationship_schemas[0]
-        possible_path_directions = database_path.possible_relationship_directions
-        for rel_schema in relationship_schemas:
-            if rel_schema.direction in possible_path_directions:
-                return rel_schema
+    def _get_relationship_schema(self, database_path: DatabasePath) -> RelationshipSchema | None:
+        branches_to_check = [database_path.deepest_branch]
+        if database_path.deepest_branch == self.diff_branch_name:
+            branches_to_check.append(self.base_branch_name)
+        for schema_branch_name in branches_to_check:
+            node_schema = self.schema_manager.get(
+                name=database_path.node_kind, branch=schema_branch_name, duplicate=False
+            )
+            relationship_schemas = node_schema.get_relationships_by_identifier(id=database_path.attribute_name)
+            if len(relationship_schemas) == 1:
+                return relationship_schemas[0]
+            possible_path_directions = database_path.possible_relationship_directions
+            for rel_schema in relationship_schemas:
+                if rel_schema.direction in possible_path_directions:
+                    return rel_schema
         return None
 
     def _update_attribute_level(self, database_path: DatabasePath, diff_node: DiffNodeIntermediate) -> None:
-        node_schema = self.schema_manager.get(
-            name=database_path.node_kind, branch=database_path.deepest_branch, duplicate=False
-        )
         if "Attribute" in database_path.attribute_node.labels:
             diff_attribute = self._get_diff_attribute(database_path=database_path, diff_node=diff_node)
             self._update_attribute_property(database_path=database_path, diff_attribute=diff_attribute)
             return
-        relationship_schema = self._get_relationship_schema(database_path=database_path, node_schema=node_schema)
+        relationship_schema = self._get_relationship_schema(database_path=database_path)
         if not relationship_schema:
             return
         diff_relationship = self._get_diff_relationship(
@@ -668,7 +669,7 @@ class DiffQueryParser:
         relationship_schema: RelationshipSchema,
         database_path: DatabasePath,
     ) -> DiffRelationshipIntermediate:
-        diff_relationship = diff_node.relationships_by_name.get(relationship_schema.name)
+        diff_relationship = diff_node.relationships_by_identifier.get(relationship_schema.get_identifier())
         if not diff_relationship:
             branch_name = database_path.deepest_branch
             from_time = self.from_time
@@ -682,7 +683,7 @@ class DiffQueryParser:
                 identifier=relationship_schema.get_identifier(),
                 from_time=from_time,
             )
-            diff_node.relationships_by_name[relationship_schema.name] = diff_relationship
+            diff_node.relationships_by_identifier[relationship_schema.identifier] = diff_relationship
         return diff_relationship
 
     def _apply_base_branch_previous_values(self) -> None:
@@ -719,8 +720,8 @@ class DiffQueryParser:
     def _apply_relationship_previous_values(
         self, diff_node: DiffNodeIntermediate, base_diff_node: DiffNodeIntermediate
     ) -> None:
-        for relationship_name, diff_relationship in diff_node.relationships_by_name.items():
-            base_diff_relationship = base_diff_node.relationships_by_name.get(relationship_name)
+        for relationship_identifier, diff_relationship in diff_node.relationships_by_identifier.items():
+            base_diff_relationship = base_diff_node.relationships_by_identifier.get(relationship_identifier)
             if not base_diff_relationship:
                 continue
             for db_id, property_set in diff_relationship.properties_by_db_id.items():
@@ -773,7 +774,7 @@ class DiffQueryParser:
                         continue
                     if ordered_diff_values[-1].changed_at >= self.diff_branched_from_time:
                         return
-            for relationship_diff in node_diff.relationships_by_name.values():
+            for relationship_diff in node_diff.relationships_by_identifier.values():
                 for diff_relationship_property_list in relationship_diff.properties_by_db_id.values():
                     for diff_relationship_property in diff_relationship_property_list:
                         if diff_relationship_property.changed_at >= self.diff_branched_from_time:

--- a/backend/infrahub/core/diff/query_parser.py
+++ b/backend/infrahub/core/diff/query_parser.py
@@ -683,7 +683,7 @@ class DiffQueryParser:
                 identifier=relationship_schema.get_identifier(),
                 from_time=from_time,
             )
-            diff_node.relationships_by_identifier[relationship_schema.identifier] = diff_relationship
+            diff_node.relationships_by_identifier[relationship_schema.get_identifier()] = diff_relationship
         return diff_relationship
 
     def _apply_base_branch_previous_values(self) -> None:

--- a/backend/tests/unit/core/diff/test_diff_calculator.py
+++ b/backend/tests/unit/core/diff/test_diff_calculator.py
@@ -1,13 +1,17 @@
+from uuid import uuid4
+
 import pytest
 
 from infrahub import config
 from infrahub.core import registry
 from infrahub.core.branch import Branch
-from infrahub.core.constants import DiffAction, InfrahubKind, RelationshipCardinality, SchemaPathType
+from infrahub.core.constants import BranchSupportType, DiffAction, InfrahubKind, RelationshipCardinality, SchemaPathType
 from infrahub.core.constants.database import DatabaseEdgeType
 from infrahub.core.diff.calculator import DiffCalculator
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
+from infrahub.core.migrations.query.relationship_duplicate import RelationshipDuplicateQuery, SchemaRelationshipInfo
+from infrahub.core.migrations.schema.attribute_name_update import AttributeNameUpdateMigration
 from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
@@ -3144,6 +3148,252 @@ async def test_calculate_with_migrated_kind_node(
         assert property_diff.action is DiffAction.ADDED
         assert property_diff.new_value == value
         assert property_diff.previous_value is None
+
+    base_diff = calculated_diffs.base_branch_diff
+    assert len(base_diff.nodes) == 0
+
+
+async def test_calculate_with_migrated_attr_name(
+    db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main, person_john_main, person_jane_main
+):
+    """Test that the diff can correctly handle an attribute name migration"""
+    branch = await create_branch(db=db, branch_name="branch")
+    schema = registry.schema.get_schema_branch(name=default_branch.name)
+    prev_car_schema = schema.get(name="TestCar")
+    prev_attr = prev_car_schema.get_attribute(name="color")
+    prev_attr.id = str(uuid4())
+    candidate_schema = schema.duplicate()
+    new_car_schema = candidate_schema.get(name="TestCar")
+    new_attr = new_car_schema.get_attribute(name="color")
+    new_attr.name = "new-color"
+    new_attr.id = prev_attr.id
+    registry.schema.set(name=new_car_schema.kind, schema=new_car_schema, branch=branch.name)
+
+    migration = AttributeNameUpdateMigration(
+        previous_node_schema=prev_car_schema,
+        new_node_schema=new_car_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="new-color"),
+    )
+
+    execution_result = await migration.execute(db=db, branch=branch)
+    assert not execution_result.errors
+
+    diff_calculator = DiffCalculator(db=db)
+
+    calculated_diffs = await diff_calculator.calculate_diff(
+        base_branch=default_branch,
+        diff_branch=branch,
+        from_time=Timestamp(branch.get_branched_from()),
+        to_time=Timestamp(),
+        previous_node_specifiers=None,
+        include_unchanged=True,
+    )
+
+    branch_diff = calculated_diffs.diff_branch_diff
+    assert len(branch_diff.nodes) == 2
+    nodes_by_id = {n.uuid: n for n in branch_diff.nodes}
+    assert set(nodes_by_id.keys()) == {car_accord_main.id, car_camry_main.id}
+    for diff_node in branch_diff.nodes:
+        assert diff_node.action is DiffAction.UPDATED
+        assert len(diff_node.relationships) == 0
+        attrs_by_name = {a.name: a for a in diff_node.attributes}
+        assert set(attrs_by_name.keys()) == {"color", "new-color"}
+        old_attr_diff = attrs_by_name["color"]
+        assert old_attr_diff.action is DiffAction.REMOVED
+        props_by_type = {p.property_type: p for p in old_attr_diff.properties}
+        assert set(props_by_type.keys()) == {
+            DatabaseEdgeType.HAS_VALUE,
+            DatabaseEdgeType.IS_VISIBLE,
+            DatabaseEdgeType.IS_PROTECTED,
+        }
+        for property_type, value in (
+            (DatabaseEdgeType.HAS_VALUE, car_accord_main.color.value),
+            (DatabaseEdgeType.IS_VISIBLE, True),
+            (DatabaseEdgeType.IS_PROTECTED, False),
+        ):
+            diff_prop = props_by_type[property_type]
+            assert diff_prop.action is DiffAction.REMOVED
+            assert diff_prop.new_value is None
+            assert diff_prop.previous_value == value
+
+        new_attr_diff = attrs_by_name["new-color"]
+        assert new_attr_diff.action is DiffAction.ADDED
+        props_by_type = {p.property_type: p for p in new_attr_diff.properties}
+        assert set(props_by_type.keys()) == {
+            DatabaseEdgeType.HAS_VALUE,
+            DatabaseEdgeType.IS_VISIBLE,
+            DatabaseEdgeType.IS_PROTECTED,
+        }
+        for property_type, value in (
+            (DatabaseEdgeType.HAS_VALUE, car_accord_main.color.value),
+            (DatabaseEdgeType.IS_VISIBLE, True),
+            (DatabaseEdgeType.IS_PROTECTED, False),
+        ):
+            diff_prop = props_by_type[property_type]
+            assert diff_prop.action is DiffAction.ADDED
+            assert diff_prop.new_value == value
+            assert diff_prop.previous_value is None
+
+    base_diff = calculated_diffs.base_branch_diff
+    assert len(base_diff.nodes) == 0
+
+
+async def test_calculate_with_renamed_relationships(
+    db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main, person_john_main, person_jane_main
+):
+    """Test that the diff can correctly handle an attribute name migration"""
+    branch = await create_branch(db=db, branch_name="branch")
+    new_rel_identifier = "brand_new_identifier"
+    schema = registry.schema.get_schema_branch(name=default_branch.name)
+    candidate_schema = schema.duplicate()
+    new_car_schema = candidate_schema.get(name="TestCar")
+    new_owner_rel = new_car_schema.get_relationship(name="owner")
+    previous_rel_identifier = new_owner_rel.identifier
+    new_owner_rel.identifier = new_rel_identifier
+    new_person_schema = candidate_schema.get(name="TestPerson")
+    new_cars_rel = new_person_schema.get_relationship(name="cars")
+    new_cars_rel.identifier = new_rel_identifier
+    registry.schema.set(name=new_car_schema.kind, schema=new_car_schema, branch=branch.name)
+    registry.schema.set(name=new_person_schema.kind, schema=new_person_schema, branch=branch.name)
+
+    migration_query = await RelationshipDuplicateQuery.init(
+        db=db,
+        branch=branch,
+        previous_rel=SchemaRelationshipInfo(
+            name=previous_rel_identifier,
+            branch_support=BranchSupportType.AWARE.value,
+            src_peer="TestCar",
+            dst_peer="TestPerson",
+        ),
+        new_rel=SchemaRelationshipInfo(
+            name=new_rel_identifier,
+            branch_support=BranchSupportType.AWARE.value,
+            src_peer="TestCar",
+            dst_peer="TestPerson",
+        ),
+    )
+    await migration_query.execute(db=db)
+
+    diff_calculator = DiffCalculator(db=db)
+
+    calculated_diffs = await diff_calculator.calculate_diff(
+        base_branch=default_branch,
+        diff_branch=branch,
+        from_time=Timestamp(branch.get_branched_from()),
+        to_time=Timestamp(),
+        previous_node_specifiers=None,
+        include_unchanged=True,
+    )
+
+    branch_diff = calculated_diffs.diff_branch_diff
+    assert len(branch_diff.nodes) == 4
+    nodes_by_id = {n.uuid: n for n in branch_diff.nodes}
+    assert set(nodes_by_id.keys()) == {car_accord_main.id, car_camry_main.id, person_jane_main.id, person_john_main.id}
+    for car_id, peer_id in ((car_accord_main.id, person_john_main.id), (car_camry_main.id, person_jane_main.id)):
+        car_diff = nodes_by_id[car_id]
+        assert car_diff.action is DiffAction.UPDATED
+        assert len(car_diff.attributes) == 0
+        rels_by_identifier = {r.identifier: r for r in car_diff.relationships}
+        assert set(rels_by_identifier.keys()) == {previous_rel_identifier, new_rel_identifier}
+        # validate removed relationship
+        removed_rel = rels_by_identifier[previous_rel_identifier]
+        assert removed_rel.name == "owner"
+        assert removed_rel.action is DiffAction.REMOVED
+        elements_by_peer_id = {e.peer_id: e for e in removed_rel.relationships}
+        assert set(elements_by_peer_id.keys()) == {peer_id}
+        element_diff = elements_by_peer_id[peer_id]
+        assert element_diff.action is DiffAction.REMOVED
+        props_by_type = {p.property_type: p for p in element_diff.properties}
+        assert set(props_by_type.keys()) == {
+            DatabaseEdgeType.IS_RELATED,
+            DatabaseEdgeType.IS_VISIBLE,
+            DatabaseEdgeType.IS_PROTECTED,
+        }
+        for property_type, value in (
+            (DatabaseEdgeType.IS_RELATED, peer_id),
+            (DatabaseEdgeType.IS_VISIBLE, True),
+            (DatabaseEdgeType.IS_PROTECTED, False),
+        ):
+            diff_prop = props_by_type[property_type]
+            assert diff_prop.action is DiffAction.REMOVED
+            assert diff_prop.new_value is None
+            assert diff_prop.previous_value == value
+        # validate added relationship
+        added_rel = rels_by_identifier[new_rel_identifier]
+        assert added_rel.name == "owner"
+        assert added_rel.action is DiffAction.ADDED
+        elements_by_peer_id = {e.peer_id: e for e in added_rel.relationships}
+        assert set(elements_by_peer_id.keys()) == {peer_id}
+        element_diff = elements_by_peer_id[peer_id]
+        assert element_diff.action is DiffAction.ADDED
+        props_by_type = {p.property_type: p for p in element_diff.properties}
+        assert set(props_by_type.keys()) == {
+            DatabaseEdgeType.IS_RELATED,
+            DatabaseEdgeType.IS_VISIBLE,
+            DatabaseEdgeType.IS_PROTECTED,
+        }
+        for property_type, value in (
+            (DatabaseEdgeType.IS_RELATED, peer_id),
+            (DatabaseEdgeType.IS_VISIBLE, True),
+            (DatabaseEdgeType.IS_PROTECTED, False),
+        ):
+            diff_prop = props_by_type[property_type]
+            assert diff_prop.action is DiffAction.ADDED
+            assert diff_prop.new_value == value
+            assert diff_prop.previous_value is None
+
+    for person_id, peer_id in ((person_john_main.id, car_accord_main.id), (person_jane_main.id, car_camry_main.id)):
+        person_diff = nodes_by_id[person_id]
+        assert person_diff.action is DiffAction.UPDATED
+        assert len(person_diff.attributes) == 0
+        rels_by_identifier = {r.identifier: r for r in person_diff.relationships}
+        assert set(rels_by_identifier.keys()) == {previous_rel_identifier, new_rel_identifier}
+        # validate removed relationship
+        removed_rel = rels_by_identifier[previous_rel_identifier]
+        assert removed_rel.name == "cars"
+        assert removed_rel.action is DiffAction.UPDATED
+        elements_by_peer_id = {e.peer_id: e for e in removed_rel.relationships}
+        assert set(elements_by_peer_id.keys()) == {peer_id}
+        element_diff = elements_by_peer_id[peer_id]
+        assert element_diff.action is DiffAction.REMOVED
+        props_by_type = {p.property_type: p for p in element_diff.properties}
+        assert set(props_by_type.keys()) == {
+            DatabaseEdgeType.IS_RELATED,
+            DatabaseEdgeType.IS_VISIBLE,
+            DatabaseEdgeType.IS_PROTECTED,
+        }
+        for property_type, value in (
+            (DatabaseEdgeType.IS_RELATED, peer_id),
+            (DatabaseEdgeType.IS_VISIBLE, True),
+            (DatabaseEdgeType.IS_PROTECTED, False),
+        ):
+            diff_prop = props_by_type[property_type]
+            assert diff_prop.action is DiffAction.REMOVED
+            assert diff_prop.new_value is None
+            assert diff_prop.previous_value == value
+        # validate added relationship
+        added_rel = rels_by_identifier[new_rel_identifier]
+        assert added_rel.name == "cars"
+        assert added_rel.action is DiffAction.UPDATED
+        elements_by_peer_id = {e.peer_id: e for e in added_rel.relationships}
+        assert set(elements_by_peer_id.keys()) == {peer_id}
+        element_diff = elements_by_peer_id[peer_id]
+        assert element_diff.action is DiffAction.ADDED
+        props_by_type = {p.property_type: p for p in element_diff.properties}
+        assert set(props_by_type.keys()) == {
+            DatabaseEdgeType.IS_RELATED,
+            DatabaseEdgeType.IS_VISIBLE,
+            DatabaseEdgeType.IS_PROTECTED,
+        }
+        for property_type, value in (
+            (DatabaseEdgeType.IS_RELATED, peer_id),
+            (DatabaseEdgeType.IS_VISIBLE, True),
+            (DatabaseEdgeType.IS_PROTECTED, False),
+        ):
+            diff_prop = props_by_type[property_type]
+            assert diff_prop.action is DiffAction.ADDED
+            assert diff_prop.new_value == value
+            assert diff_prop.previous_value is None
 
     base_diff = calculated_diffs.base_branch_diff
     assert len(base_diff.nodes) == 0

--- a/backend/tests/unit/core/diff/test_path_identifier_enricher.py
+++ b/backend/tests/unit/core/diff/test_path_identifier_enricher.py
@@ -1,3 +1,4 @@
+from infrahub.core.constants import RelationshipCardinality
 from infrahub.core.constants.database import DatabaseEdgeType
 from infrahub.core.diff.enricher.path_identifier import DiffPathIdentifierEnricher
 from infrahub.core.diff.model.diff import ModifiedPathType
@@ -28,7 +29,7 @@ class TestPathIdentifierEnricher:
             properties={diff_relationship_property, diff_relationship_value_property}
         )
         diff_relationship = EnrichedRelationshipGroupFactory.build(
-            relationships={diff_relationship_element}, name="cars"
+            relationships={diff_relationship_element}, name="cars", cardinality=RelationshipCardinality.MANY
         )
         diff_node = EnrichedNodeFactory.build(
             relationships={diff_relationship}, attributes={diff_attribute}, kind="TestPerson"


### PR DESCRIPTION
IFC-1202

add tests for the diff calculation logic when handling an attribute name migration or a relationship identifier migration.

update the diff calculation logic to correctly handle a relationship identifier migration. this required using the relationship's identifier instead of its name for determining uniqueness
