### PR TITLE
Refactor InfrahubEvent query

### DIFF
--- a/backend/infrahub/api/schema.py
+++ b/backend/infrahub/api/schema.py
@@ -379,7 +379,7 @@ async def load_schema(
             initiator_id=WORKER_IDENTITY,
             request_id=request_id,
             account_id=account_session.account_id,
-            branch=branch.name,
+            branch=branch,
         ),
     )
     await service.event.send(event=event)

--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -147,7 +147,7 @@ async def rebase_branch(branch: str, service: InfrahubServices) -> None:
     # -------------------------------------------------------------
     # TODO Add account information
     await service.event.send(
-        event=BranchRebasedEvent(branch_name=obj.name, branch_id=str(obj.uuid), meta=EventMeta(branch=obj.name))
+        event=BranchRebasedEvent(branch_name=obj.name, branch_id=str(obj.uuid), meta=EventMeta(branch=obj))
     )
 
 
@@ -241,7 +241,7 @@ async def delete_branch(branch: str, service: InfrahubServices) -> None:
         await obj.delete(db=db)
 
         event = BranchDeletedEvent(
-            branch_name=branch, branch_id=str(obj.uuid), sync_with_git=obj.sync_with_git, meta=EventMeta(branch=branch)
+            branch_name=branch, branch_id=str(obj.uuid), sync_with_git=obj.sync_with_git, meta=EventMeta(branch=obj)
         )
 
         await service.workflow.submit_workflow(
@@ -309,7 +309,7 @@ async def create_branch(model: BranchCreateModel, service: InfrahubServices) -> 
             branch_name=obj.name,
             branch_id=str(obj.uuid),
             sync_with_git=obj.sync_with_git,
-            meta=EventMeta(branch=obj.name),
+            meta=EventMeta(branch=obj),
         )
         await service.event.send(event=event)
 

--- a/backend/infrahub/events/branch_action.py
+++ b/backend/infrahub/events/branch_action.py
@@ -1,4 +1,4 @@
-from pydantic import Field
+from pydantic import Field, computed_field
 
 from infrahub.message_bus import InfrahubMessage
 from infrahub.message_bus.messages.refresh_registry_branches import RefreshRegistryBranches
@@ -10,8 +10,6 @@ from .models import InfrahubEvent
 
 class BranchDeletedEvent(InfrahubEvent):
     """Event generated when a branch has been deleted"""
-
-    event_name: str = f"{EVENT_NAMESPACE}.branch.deleted"
 
     branch_name: str = Field(..., description="The name of the branch")
     branch_id: str = Field(..., description="The ID of the mutated node")
@@ -36,11 +34,13 @@ class BranchDeletedEvent(InfrahubEvent):
         ]
         return events
 
+    @computed_field
+    def event_name(self) -> str:
+        return f"{EVENT_NAMESPACE}.branch.deleted"
+
 
 class BranchCreatedEvent(InfrahubEvent):
     """Event generated when a branch has been created"""
-
-    event_name: str = f"{EVENT_NAMESPACE}.branch.created"
 
     branch_name: str = Field(..., description="The name of the branch")
     branch_id: str = Field(..., description="The ID of the branch")
@@ -65,11 +65,13 @@ class BranchCreatedEvent(InfrahubEvent):
         ]
         return events
 
+    @computed_field
+    def event_name(self) -> str:
+        return f"{EVENT_NAMESPACE}.branch.created"
+
 
 class BranchRebasedEvent(InfrahubEvent):
     """Event generated when a branch has been rebased"""
-
-    event_name: str = f"{EVENT_NAMESPACE}.branch.rebased"
 
     branch_id: str = Field(..., description="The ID of the mutated node")
     branch_name: str = Field(..., description="The name of the branch")
@@ -89,3 +91,7 @@ class BranchRebasedEvent(InfrahubEvent):
             RefreshRegistryRebasedBranch(branch=self.branch_name),
         ]
         return events
+
+    @computed_field
+    def event_name(self) -> str:
+        return f"{EVENT_NAMESPACE}.branch.rebased"

--- a/backend/infrahub/events/models.py
+++ b/backend/infrahub/events/models.py
@@ -1,17 +1,20 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import Any, cast
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, computed_field
 
+from infrahub.core.branch import Branch  # noqa: TC001
 from infrahub.message_bus import InfrahubMessage, Meta
 
 from .constants import EVENT_NAMESPACE
 
 
 class EventMeta(BaseModel):
-    branch: str = ""
+    branch: Branch | None = Field(default=None)
     request_id: str = ""
-    account_id: str = ""
+    account_id: str | None = Field(default=None, description="The ID of the account triggering this event")
     initiator_id: str | None = Field(
         default=None, description="The worker identity of the initial sender of this message"
     )
@@ -23,17 +26,18 @@ class EventMeta(BaseModel):
             related.append(
                 {
                     "prefect.resource.id": f"infrahub.account.{self.account_id}",
+                    "prefect.resource.role": "infrahub.account",
                     "infrahub.resource.id": self.account_id,
-                    "prefect.resource.role": "account",
                 }
             )
 
         if self.branch:
             related.append(
                 {
-                    "prefect.resource.id": "infrahub.branch",
-                    "prefect.resource.name": self.branch,
-                    "prefect.resource.role": "branch",
+                    "prefect.resource.id": f"infrahub.branch.{self.branch.get_uuid()}",
+                    "prefect.resource.role": "infrahub.branch",
+                    "infrahub.resource.id": str(self.branch.get_uuid()),
+                    "infrahub.resource.label": self.branch.name,
                 }
             )
 
@@ -48,8 +52,6 @@ class InfrahubEvent(BaseModel):
         description="UUID of the event",
     )
 
-    event_name: str
-
     def get_id(self) -> str:
         return str(self.id)
 
@@ -57,7 +59,8 @@ class InfrahubEvent(BaseModel):
         return EVENT_NAMESPACE
 
     def get_name(self) -> str:
-        return self.event_name
+        # Convince linters that @computed_field is a property and not a method...
+        return cast(str, self.event_name)
 
     def get_resource(self) -> dict[str, str]:
         raise NotImplementedError
@@ -84,3 +87,7 @@ class InfrahubEvent(BaseModel):
             meta.initiator_id = self.meta.request_id
 
         return meta
+
+    @computed_field
+    def event_name(self) -> str:
+        raise NotImplementedError("The event name has not been defined")

--- a/backend/infrahub/events/node_action.py
+++ b/backend/infrahub/events/node_action.py
@@ -1,7 +1,8 @@
 from typing import Any
 
-from pydantic import Field, ValidationInfo, field_validator
+from pydantic import Field, computed_field
 
+from infrahub.core.changelog.models import NodeChangelog
 from infrahub.core.constants import MutationAction
 from infrahub.message_bus import InfrahubMessage
 
@@ -12,19 +13,35 @@ from .models import InfrahubEvent
 class NodeMutatedEvent(InfrahubEvent):
     """Event generated when a node has been mutated"""
 
-    event_name: str = Field(default="infrahub.node.unknown", description="The name of the event")
-
     kind: str = Field(..., description="The type of object modified")
     node_id: str = Field(..., description="The ID of the mutated node")
     action: MutationAction = Field(..., description="The action taken on the node")
-    data: dict[str, Any] = Field(..., description="Data on modified object")
+    data: NodeChangelog = Field(..., description="Data on modified object")
     fields: list[str] = Field(default_factory=list, description="Fields provided in the mutation")
 
-    @field_validator("event_name", mode="after")
-    @classmethod
-    def updaate_event_name(cls, value: str, info: ValidationInfo) -> str:  # noqa: ARG003
-        action: MutationAction = info.data["action"]
-        return f"{EVENT_NAMESPACE}.node.{action.value}"
+    def get_related(self) -> list[dict[str, str]]:
+        related = super().get_related()
+        for attribute in self.data.attributes.values():
+            related.append(
+                {
+                    "prefect.resource.id": f"infrahub.node.{self.node_id}",
+                    "prefect.resource.role": "infrahub.node.field_update",
+                    "infrahub.attribute.name": attribute.name,
+                    "infrahub.attribute.value": "NULL" if attribute.value is None else str(attribute.value),
+                    "infrahub.attribute.kind": attribute.kind,
+                    "infrahub.attribute.value_previous": "NULL"
+                    if attribute.value_previous is None
+                    else str(attribute.value_previous),
+                    # Mypy doesn't understand that .value_update_status is a @computed_attribute
+                    "infrahub.attribute.action": attribute.value_update_status.value,  # type: ignore[attr-defined]
+                }
+            )
+
+        return related
+
+    @computed_field
+    def event_name(self) -> str:
+        return f"{EVENT_NAMESPACE}.node.{self.action.value}"
 
     def get_resource(self) -> dict[str, str]:
         return {
@@ -35,7 +52,7 @@ class NodeMutatedEvent(InfrahubEvent):
         }
 
     def get_payload(self) -> dict[str, Any]:
-        return {"data": self.data, "fields": self.fields}
+        return {"data": self.data.model_dump(), "fields": self.fields}
 
     def get_messages(self) -> list[InfrahubMessage]:
         return [

--- a/backend/infrahub/events/repository_action.py
+++ b/backend/infrahub/events/repository_action.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from pydantic import Field
+from pydantic import Field, computed_field
 
 from infrahub.message_bus import InfrahubMessage
 
@@ -10,8 +10,6 @@ from .models import InfrahubEvent
 
 class CommitUpdatedEvent(InfrahubEvent):
     """Event generated when the the commit within a repository has been updated."""
-
-    event_name: str = f"{EVENT_NAMESPACE}.repository.update_commit"
 
     commit: str = Field(..., description="The commit the repository was updated to")
     repository_id: str = Field(..., description="The ID of the repository")
@@ -33,3 +31,7 @@ class CommitUpdatedEvent(InfrahubEvent):
 
     def get_messages(self) -> list[InfrahubMessage]:
         return []
+
+    @computed_field
+    def event_name(self) -> str:
+        return f"{EVENT_NAMESPACE}.repository.update_commit"

--- a/backend/infrahub/events/schema_action.py
+++ b/backend/infrahub/events/schema_action.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from pydantic import Field
+from pydantic import Field, computed_field
 
 from infrahub.message_bus import InfrahubMessage
 from infrahub.message_bus.messages.refresh_registry_branches import RefreshRegistryBranches
@@ -11,8 +11,6 @@ from .models import InfrahubEvent
 
 class SchemaUpdatedEvent(InfrahubEvent):
     """Event generated when the schema within a branch has been updated."""
-
-    event_name: str = f"{EVENT_NAMESPACE}.schema.update"
 
     branch_name: str = Field(..., description="The name of the branch")
     schema_hash: str = Field(..., description="Schema hash after the update")
@@ -45,3 +43,7 @@ class SchemaUpdatedEvent(InfrahubEvent):
             #     meta=self.get_message_meta(),
             # )
         ]
+
+    @computed_field
+    def event_name(self) -> str:
+        return f"{EVENT_NAMESPACE}.schema.update"

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -38,6 +38,7 @@ from pydantic import ValidationError as PydanticValidationError
 from typing_extensions import Self
 
 from infrahub.core.constants import ArtifactStatus, ContentType, InfrahubKind, RepositorySyncStatus
+from infrahub.core.registry import registry
 from infrahub.events.models import EventMeta
 from infrahub.events.repository_action import CommitUpdatedEvent
 from infrahub.exceptions import CheckError, RepositoryInvalidFileSystemError, TransformError
@@ -200,12 +201,13 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         if error:
             raise error
 
+        infrahub_branch = registry.get_branch_from_registry(branch=infrahub_branch_name)
         await self.service.event.send(
             CommitUpdatedEvent(
                 commit=commit,
                 repository_name=self.name,
                 repository_id=str(self.id),
-                meta=EventMeta(branch=infrahub_branch_name),
+                meta=EventMeta(branch=infrahub_branch),
             )
         )
 

--- a/backend/infrahub/graphql/mutations/computed_attribute.py
+++ b/backend/infrahub/graphql/mutations/computed_attribute.py
@@ -100,7 +100,7 @@ class UpdateComputedAttribute(Mutation):
                     initiator_id=WORKER_IDENTITY,
                     request_id=request_id,
                     account_id=graphql_context.active_account_session.account_id,
-                    branch=graphql_context.branch.name,
+                    branch=graphql_context.branch,
                 ),
             )
             await graphql_context.active_service.event.send(event=event)

--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -96,13 +96,22 @@ class InfrahubMutationMixin:
             log_data = get_log_data()
             request_id = log_data.get("request_id", "")
 
+            account_id: str | None = None
+            if graphql_context.account_session:
+                account_id = graphql_context.account_session.account_id
+
             event = NodeMutatedEvent(
                 kind=obj._schema.kind,
                 node_id=obj.id,
-                data=obj.node_changelog.model_dump(),
+                data=obj.node_changelog,
                 action=action,
                 fields=_get_data_fields(data),
-                meta=EventMeta(initiator_id=WORKER_IDENTITY, request_id=request_id, branch=graphql_context.branch.name),
+                meta=EventMeta(
+                    account_id=account_id,
+                    initiator_id=WORKER_IDENTITY,
+                    request_id=request_id,
+                    branch=graphql_context.branch,
+                ),
             )
 
             graphql_context.background.add_task(graphql_context.active_service.event.send, event)

--- a/backend/infrahub/graphql/mutations/schema.py
+++ b/backend/infrahub/graphql/mutations/schema.py
@@ -305,7 +305,7 @@ async def update_registry(
                 branch_name=branch.name,
                 schema_hash=branch.active_schema_hash.main,
                 meta=EventMeta(
-                    initiator_id=WORKER_IDENTITY, request_id=request_id, account_id=account_id, branch=branch.name
+                    initiator_id=WORKER_IDENTITY, request_id=request_id, account_id=account_id, branch=branch
                 ),
             )
             await service.event.send(event=event)

--- a/backend/infrahub/graphql/queries/event.py
+++ b/backend/infrahub/graphql/queries/event.py
@@ -22,17 +22,20 @@ class Events(ObjectType):
         info: GraphQLResolveInfo,
         limit: int = 10,
         offset: int = 0,
+        account: str | None = None,
         ids: list[str] | None = None,
         branch: str | None = None,
         q: str | None = None,
+        related_node__ids: list[str] | None = None,
     ) -> dict[str, Any]:
-        # related_nodes = related_node__ids or []
         ids = ids or []
         return await Events.query(
             info=info,
             branch=branch,
+            account=account,
             limit=limit,
             offset=offset,
+            related_node__ids=related_node__ids,
             q=q,
             ids=ids,
         )
@@ -43,7 +46,9 @@ class Events(ObjectType):
         info: GraphQLResolveInfo,
         q: str | None = None,
         ids: list[str] | None = None,
+        related_node__ids: list[str] | None = None,
         branch: str | None = None,
+        account: str | None = None,
         limit: int | None = None,
         offset: int | None = None,
     ) -> dict[str, Any]:
@@ -53,7 +58,9 @@ class Events(ObjectType):
             fields=fields,
             q=q,
             ids=ids,
+            related_node__ids=related_node__ids,
             branch=branch,
+            account=account,
             limit=limit,
             offset=offset,
         )
@@ -69,6 +76,7 @@ Event = Field(
     offset=Int(required=False),
     related_node__ids=List(String),
     branch=String(required=False),
+    account=String(required=False),
     ids=List(String),
     q=String(required=False),
     resolver=Events.resolve,

--- a/backend/infrahub/graphql/types/enums.py
+++ b/backend/infrahub/graphql/types/enums.py
@@ -5,6 +5,8 @@ from infrahub.permissions import constants as permission_constants
 
 CheckType = Enum.from_enum(constants.CheckType)
 
+DiffAction = Enum.from_enum(constants.DiffAction)
+
 Severity = Enum.from_enum(constants.Severity)
 
 BranchRelativePermissionDecision = Enum.from_enum(permission_constants.BranchRelativePermissionDecision)

--- a/backend/infrahub/graphql/types/event.py
+++ b/backend/infrahub/graphql/types/event.py
@@ -2,20 +2,36 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from graphene import Field, Interface, ObjectType, String
+from graphene import Field, Interface, List, NonNull, ObjectType, String
 from graphene.types.generic import GenericScalar
+
+from .enums import DiffAction
 
 if TYPE_CHECKING:
     from graphql import GraphQLResolveInfo
+
+
+class InfrahubMutatedAttribute(ObjectType):
+    name = String(required=True)
+    action = DiffAction(required=True)
+    value = String(required=False)
+    kind = String(required=True)
+    value_previous = String(required=False)
 
 
 class EventNodeInterface(Interface):
     id = String(required=True)
     event = String(required=True)
     branch = String(required=False)
+    account_id = String(required=False)
+    occurred_at = String(required=True)
 
     @classmethod
-    def resolve_type(cls, instance: dict[str, Any], info: GraphQLResolveInfo) -> ObjectType:  # noqa: ARG003
+    def resolve_type(
+        cls,
+        instance: dict[str, Any],
+        info: GraphQLResolveInfo,  # noqa: ARG003
+    ) -> type[ObjectType]:
         if "event" in instance:
             return EVENT_TYPES.get(instance["event"], StandardEvent)
         return StandardEvent
@@ -52,11 +68,12 @@ class BranchDeletedEvent(ObjectType):
 # ---------------------------------------
 # Node/Object events
 # ---------------------------------------
-class NodeAddedEvent(ObjectType):
+class NodeMutatedEvent(ObjectType):
     class Meta:
         interfaces = (EventNodeInterface,)
 
     payload = Field(GenericScalar, required=True)
+    attributes = Field(List(of_type=NonNull(InfrahubMutatedAttribute), required=True), required=True)
 
 
 class StandardEvent(ObjectType):
@@ -67,7 +84,9 @@ class StandardEvent(ObjectType):
 
 
 EVENT_TYPES: dict[str, type[ObjectType]] = {
-    "infrahub.node.added": NodeAddedEvent,
+    "infrahub.node.created": NodeMutatedEvent,
+    "infrahub.node.updated": NodeMutatedEvent,
+    "infrahub.node.deleted": NodeMutatedEvent,
     "infrahub.branch.created": BranchCreatedEvent,
     "infrahub.branch.rebased": BranchRebasedEvent,
     "infrahub.branch.deleted": BranchDeletedEvent,

--- a/backend/infrahub/task_manager/event.py
+++ b/backend/infrahub/task_manager/event.py
@@ -2,10 +2,10 @@ import uuid
 from typing import Any
 
 from prefect.client.orchestration import PrefectClient, get_client
-from prefect.events.filters import EventFilter, EventIDFilter, EventNameFilter, EventRelatedFilter
+from prefect.events.filters import EventFilter, EventIDFilter, EventNameFilter, EventRelatedFilter, EventResourceFilter
 from prefect.events.schemas.events import Event as PrefectEventModel
 from prefect.events.schemas.events import ResourceSpecification
-from pydantic import TypeAdapter
+from pydantic import BaseModel, Field, TypeAdapter
 
 from infrahub.log import get_logger
 from infrahub.utils import get_nested_dict
@@ -16,43 +16,117 @@ log = get_logger()
 class PrefectEventData(PrefectEventModel):
     def get_branch(self) -> str | None:
         for resource in self.related:
-            if resource.get("prefect.resource.id") != "infrahub.branch":
+            if resource.get("prefect.resource.role") != "infrahub.branch":
                 continue
-            if "prefect.resource.name" not in resource:
+            if "infrahub.resource.label" not in resource:
                 continue
-            return resource.get("prefect.resource.name")
+            return resource.get("infrahub.resource.label")
         return None
+
+    def get_account_id(self) -> str | None:
+        for resource in self.related:
+            if resource.get("prefect.resource.role") != "infrahub.account":
+                continue
+            return resource.get("infrahub.resource.id")
+        return None
+
+    def _return_node_mutation(self) -> dict[str, Any]:
+        attributes = []
+
+        for resource in self.related:
+            if resource.get("prefect.resource.role") == "infrahub.node.field_update" and resource.get(
+                "infrahub.attribute.name"
+            ):
+                attributes.append(
+                    {
+                        "name": resource.get("infrahub.attribute.name", ""),
+                        "kind": resource.get("infrahub.attribute.kind", ""),
+                        "value": None
+                        if resource.get("infrahub.attribute.value") == "NULL"
+                        else resource.get("infrahub.attribute.value"),
+                        "value_previous": None
+                        if resource.get("infrahub.attribute.value_previous") == "NULL"
+                        else resource.get("infrahub.attribute.value_previous"),
+                        "action": resource.get("infrahub.attribute.action", "unchanged"),
+                    }
+                )
+
+        return {"attributes": attributes}
+
+    def _return_event_specifics(self) -> dict[str, Any]:
+        match self.event:
+            case "infrahub.node.created" | "infrahub.node.updated" | "infrahub.node.deleted":
+                return self._return_node_mutation()
+
+        return {}
+
+    def to_graphql(self) -> dict[str, Any]:
+        response = {
+            "id": str(self.id),
+            "event": self.event,
+            "branch": self.get_branch(),
+            "account_id": self.get_account_id(),
+            "occurred_at": self.occurred.to_iso8601_string(),
+            "payload": self.payload,
+        }
+        response.update(self._return_event_specifics())
+        return response
+
+
+class PrefectEventResponse(BaseModel):
+    count: int = Field(..., description="Number of matching events")
+    events: list[PrefectEventData] = Field(..., description="Returned events")
 
 
 class PrefectEvent:
     @classmethod
-    async def query_events(cls, client: PrefectClient, filters: EventFilter | None = None) -> list[PrefectEventData]:
-        body = {}
+    async def query_events(
+        cls, client: PrefectClient, filters: EventFilter | None = None, limit: int | None = None
+    ) -> PrefectEventResponse:
+        body: dict[str, Any] = {}
         if filters:
             body["filter"] = filters.model_dump(mode="json", exclude_unset=True)
+
+        if limit is not None:
+            body["limit"] = limit
 
         response = await client._client.post("/events/filter", json=body)
         response.raise_for_status()
         # TODO need to implement pagination :(
-        # total_nbr_results = response.json().get("total")
-        return TypeAdapter(list[PrefectEventData]).validate_python(response.json().get("events"))
+        return PrefectEventResponse(
+            count=response.json().get("total", 0),
+            events=TypeAdapter(list[PrefectEventData]).validate_python(response.json().get("events")),
+        )
 
     @classmethod
     def _generate_filters(
         cls,
         ids: list[str] | None = None,
-        related_nodes: list[str] | None = None,  # noqa: ARG003
+        account: str | None = None,
+        related_node__ids: list[str] | None = None,
         branch: str | None = None,
     ) -> EventFilter:
-        filters = EventFilter(event=EventNameFilter(prefix=["infrahub."], name=[]))  # type: ignore[call-arg]
+        filters = EventFilter(event=EventNameFilter(prefix=["infrahub."], name=[]))
 
         if ids:
             filters.id = EventIDFilter(id=[uuid.UUID(id) for id in ids])
 
+        if related_node__ids:
+            filters.resource = EventResourceFilter(
+                labels=ResourceSpecification({"infrahub.node.id": related_node__ids})
+            )
+
         if branch:
-            filters.related = EventRelatedFilter(  # type: ignore[call-arg]
+            filters.related = EventRelatedFilter(
                 labels=ResourceSpecification(
-                    {"prefect.resource.id": "infrahub.branch", "prefect.resource.name": branch}
+                    {"prefect.resource.role": "infrahub.branch", "infrahub.resource.label": branch}
+                )
+            )
+
+        if account:
+            filters.related = EventRelatedFilter(
+                labels=ResourceSpecification(
+                    {"prefect.resource.role": "infrahub.account", "infrahub.resource.id": account}
                 )
             )
 
@@ -65,27 +139,23 @@ class PrefectEvent:
         q: str | None = None,  # noqa: ARG003
         ids: list[str] | None = None,
         branch: str | None = None,
-        limit: int | None = None,  # noqa: ARG003
+        account: str | None = None,
+        limit: int | None = None,
+        related_node__ids: list[str] | None = None,
         offset: int | None = None,  # noqa: ARG003
     ) -> dict[str, Any]:
         nodes: list[dict] = []
 
         node_fields = get_nested_dict(nested_dict=fields, keys=["edges", "node"])
-        filters = cls._generate_filters(ids=ids, branch=branch)
+        filters = cls._generate_filters(ids=ids, branch=branch, account=account, related_node__ids=related_node__ids)
+
+        if not node_fields:
+            # This means that it's purely a count query and as such we can override the limit to avoid
+            # returning data that will only be discarded
+            limit = 1
 
         async with get_client(sync_client=False) as client:
-            if node_fields:
-                events = await cls.query_events(client=client, filters=filters)
+            response = await cls.query_events(client=client, filters=filters, limit=limit)
+            nodes = [{"node": event.to_graphql()} for event in response.events]
 
-                for event in events:
-                    nodes.append(
-                        {
-                            "node": {
-                                "id": str(event.id),
-                                "event": event.event,
-                                "branch": event.get_branch(),
-                            }
-                        }
-                    )
-
-        return {"count": len(nodes), "edges": nodes}
+        return {"count": response.count, "edges": nodes}

--- a/backend/tests/unit/git/test_git_repository.py
+++ b/backend/tests/unit/git/test_git_repository.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from uuid import uuid4
 
 import anyio
 import pytest
@@ -9,7 +10,9 @@ from infrahub_sdk.node import InfrahubNode
 from infrahub_sdk.uuidt import UUIDT
 from pytest_httpx._httpx_mock import HTTPXMock
 
+from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind
+from infrahub.core.registry import registry
 from infrahub.exceptions import (
     CheckError,
     CommitNotFoundError,
@@ -457,7 +460,9 @@ async def test_sync_new_branch(
 
     await repo.fetch()
     # Mock update_commit_value query
-    commit = repo.get_commit_value(branch_name="branch01", remote=True)
+    branch = Branch(name="branch01", uuid=uuid4())
+    registry.branch[branch.name] = branch
+    commit = repo.get_commit_value(branch_name=branch.name, remote=True)
 
     commit_response = {"data": {"repository_update": {"ok": True, "object": {"commit": {"value": str(commit)}}}}}
     httpx_mock.add_response(
@@ -474,12 +479,15 @@ async def test_sync_new_branch(
     await repo.sync()
     worktrees = repo.get_worktrees()
 
-    assert repo.get_commit_value(branch_name="branch01") == "92700512b5b16c0144f7fd2869669273577f1bd8"
+    assert repo.get_commit_value(branch_name=branch.name) == "92700512b5b16c0144f7fd2869669273577f1bd8"
     assert len(worktrees) == 4
 
 
 async def test_sync_updated_branch(prefect_test_fixture, git_repo_04: InfrahubRepository):
     repo = git_repo_04
+
+    branch = Branch(name="branch01", uuid=uuid4())
+    registry.branch[branch.name] = branch
 
     # Mock update_commit_value query
     commit = repo.get_commit_value(branch_name="branch01", remote=True)

--- a/backend/tests/unit/graphql/queries/test_event.py
+++ b/backend/tests/unit/graphql/queries/test_event.py
@@ -6,16 +6,20 @@ from graphql import ExecutionResult
 from prefect.client.orchestration import PrefectClient, get_client
 
 from infrahub.core.branch import Branch
+from infrahub.core.constants import MutationAction
+from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
 from infrahub.events.branch_action import BranchCreatedEvent, BranchRebasedEvent
-from infrahub.events.models import InfrahubEvent
+from infrahub.events.models import EventMeta, InfrahubEvent
+from infrahub.events.node_action import NodeMutatedEvent
 from infrahub.graphql.initialization import prepare_graphql_params
 from tests.helpers.events import send_events
 from tests.helpers.graphql import graphql
 
 QUERY_EVENT = """
-query {
-  InfrahubEvent {
+query($branch: String) {
+  InfrahubEvent(branch: $branch) {
     count
     edges {
       node {
@@ -28,38 +32,119 @@ query {
 }
 """
 
+QUERY_SIMPLE_COUNT_EVENT = """
+query($branch: String) {
+  InfrahubEvent(branch: $branch) {
+    count
+  }
+}
+"""
 
-@pytest.fixture(scope="module")
-async def branch1_id() -> str:
-    return str(uuid.uuid4())
+QUERY_MUTATED_NODES = """
+query MutatedNodes($id: [String]) {
+  InfrahubEvent(related_node__ids: $id) {
+    count
+    edges {
+      node {
+        id
+        ... on NodeMutatedEvent {
+          __typename
+          branch
+          event
+          payload
+          attributes {
+            action
+            kind
+            name
+            value
+            value_previous
+          }
+        }
+      }
+    }
+  }
+}
+"""
 
 
-@pytest.fixture(scope="module")
-async def branch2_id() -> str:
-    return str(uuid.uuid4())
+@pytest.fixture
+async def branch1_id() -> uuid.UUID:
+    return uuid.uuid4()
 
 
-@pytest.fixture(scope="module")
-async def events_data(prefect_client: PrefectClient, branch1_id, branch2_id) -> dict[str, InfrahubEvent]:
+@pytest.fixture
+async def branch2_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+@pytest.fixture
+async def events_data(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: None,
+    prefect_client: PrefectClient,
+    branch1_id,
+    branch2_id,
+) -> dict[str, InfrahubEvent]:
+    tag1 = await Node.init(db=db, schema="BuiltinTag", branch=default_branch)
+    await tag1.new(db=db, name="red", description="The red tag")
+    await tag1.save(db=db)
+
+    tag1_update = await NodeManager.get_one(id=tag1.id, db=db, branch=default_branch)
+    tag1_update.description.value = "This is an important tag"
+    await tag1_update.save(db=db)
+
     items: dict[str, InfrahubEvent] = {
-        "branch1_created": BranchCreatedEvent(branch_name="branch1", branch_id=branch1_id, sync_with_git=True),
-        "branch1_rebased": BranchRebasedEvent(branch_name="branch1", branch_id=branch1_id),
-        "branch2_created": BranchCreatedEvent(branch_name="branch2", branch_id=branch2_id, sync_with_git=False),
-        "branch2_rebased": BranchRebasedEvent(branch_name="branch2", branch_id=branch2_id),
+        "branch1_created": BranchCreatedEvent(
+            branch_name="branch1",
+            branch_id=str(branch1_id),
+            sync_with_git=True,
+            meta=EventMeta(branch=Branch(uuid=branch1_id, name="branch1")),
+        ),
+        "branch1_rebased": BranchRebasedEvent(
+            branch_name="branch1",
+            branch_id=str(branch1_id),
+            meta=EventMeta(branch=Branch(uuid=branch1_id, name="branch1")),
+        ),
+        "branch2_created": BranchCreatedEvent(
+            branch_name="branch2",
+            branch_id=str(branch2_id),
+            sync_with_git=False,
+            meta=EventMeta(branch=Branch(uuid=branch2_id, name="branch2")),
+        ),
+        "branch2_rebased": BranchRebasedEvent(
+            branch_name="branch2",
+            branch_id=str(branch2_id),
+            meta=EventMeta(branch=Branch(uuid=branch2_id, name="branch2")),
+        ),
+        "branch1_mutated1": NodeMutatedEvent(
+            kind="BuiltinTag",
+            node_id=tag1.get_id(),
+            action=MutationAction.CREATED,
+            data=tag1.node_changelog,
+            meta=EventMeta(branch=Branch(uuid=branch1_id, name="branch1")),
+        ),
+        "branch1_mutated2": NodeMutatedEvent(
+            kind="BuiltinTag",
+            node_id=tag1_update.get_id(),
+            action=MutationAction.UPDATED,
+            data=tag1_update.node_changelog,
+            meta=EventMeta(branch=Branch(uuid=branch1_id, name="branch1")),
+        ),
     }
 
     await send_events(client=prefect_client, events=items.values())
     return items
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 async def event_ids_inscope(events_data: dict[str, InfrahubEvent]) -> list[str]:
     return [str(event.id) for event in events_data.values()]
 
 
 def filter_outofscope_events(result_data: dict, in_scope_ids: list[str]):
     """
-    Because we can't garantee that Prefect is empty at the start of the test easily
+    Because we can't guarantee that Prefect is empty at the start of the test easily
     we need to exclude all events not created by this test suite.
     """
     filtered_events = [event for event in result_data["InfrahubEvent"]["edges"] if event["node"]["id"] in in_scope_ids]
@@ -84,7 +169,11 @@ async def run_query(db: InfrahubDatabase, branch: Branch, query: str, variables:
 
 
 async def test_event_query_prefect(
-    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None, events_data, event_ids_inscope
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: None,
+    events_data,
+    event_ids_inscope,
 ):
     result = await run_query(
         db=db,
@@ -96,4 +185,63 @@ async def test_event_query_prefect(
     assert result.data
 
     clean_result = filter_outofscope_events(result.data, event_ids_inscope)
+    assert clean_result["InfrahubEvent"]["count"] == 6
+
+    result_branch1 = await run_query(
+        db=db,
+        branch=default_branch,
+        query=QUERY_EVENT,
+        variables={"branch": "branch1"},
+    )
+    assert result_branch1.errors is None
+    assert result_branch1.data
+
+    clean_result = filter_outofscope_events(result_branch1.data, event_ids_inscope)
     assert clean_result["InfrahubEvent"]["count"] == 4
+
+    result_count_branch1 = await run_query(
+        db=db,
+        branch=default_branch,
+        query=QUERY_SIMPLE_COUNT_EVENT,
+        variables={"branch": "branch1"},
+    )
+    assert result_count_branch1.errors is None
+    assert result_count_branch1.data
+
+    # Validate that the count query works even if there are no edges requested
+    # Due to the workings of `filter_outofscope_events()` we can't use that here
+    # we just want to ensure that the query itself is valid.
+    assert result_count_branch1.data["InfrahubEvent"]["count"] > 0
+
+    mutated_nodes = await run_query(
+        db=db,
+        branch=default_branch,
+        query=QUERY_MUTATED_NODES,
+        variables={"id": events_data["branch1_mutated1"].node_id},
+    )
+    assert mutated_nodes.errors is None
+    assert mutated_nodes.data
+    clean_result = filter_outofscope_events(mutated_nodes.data, event_ids_inscope)
+
+    assert len(clean_result["InfrahubEvent"]["edges"]) == 2
+    created = [
+        entry for entry in clean_result["InfrahubEvent"]["edges"] if entry["node"]["event"] == "infrahub.node.created"
+    ][0]
+    updated = [
+        entry for entry in clean_result["InfrahubEvent"]["edges"] if entry["node"]["event"] == "infrahub.node.updated"
+    ][0]
+
+    assert created["node"]["attributes"] == [
+        {"action": "ADDED", "kind": "Text", "name": "name", "value": "red", "value_previous": None},
+        {"action": "ADDED", "kind": "Text", "name": "description", "value": "The red tag", "value_previous": None},
+    ]
+
+    assert updated["node"]["attributes"] == [
+        {
+            "action": "UPDATED",
+            "kind": "Text",
+            "name": "description",
+            "value": "This is an important tag",
+            "value_previous": "The red tag",
+        }
+    ]

--- a/backend/tests/unit/graphql/test_mutation_update.py
+++ b/backend/tests/unit/graphql/test_mutation_update.py
@@ -3,6 +3,7 @@ import pytest
 from infrahub import config
 from infrahub.core import registry
 from infrahub.core.branch import Branch
+from infrahub.core.changelog.models import RelationshipCardinalityOneChangelog
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
@@ -293,9 +294,9 @@ async def test_update_all_attributes(
     assert len(memory_event.events) == 1
     event = memory_event.events[0]
     assert isinstance(event, NodeMutatedEvent)
-    assert sorted(event.data["attributes"].keys()) == ["ipaddress", "mybool", "myint", "mylist", "mystring", "prefix"]
-    assert event.data["attributes"]["ipaddress"]["value"] == "10.3.4.254/24"
-    assert event.data["attributes"]["ipaddress"]["value_previous"] == "10.5.0.1/27"
+    assert sorted(event.data.attributes.keys()) == ["ipaddress", "mybool", "myint", "mylist", "mystring", "prefix"]
+    assert event.data.attributes["ipaddress"].value == "10.3.4.254/24"
+    assert event.data.attributes["ipaddress"].value_previous == "10.5.0.1/27"
 
 
 @pytest.fixture
@@ -456,8 +457,9 @@ async def test_update_single_relationship(
     assert len(memory_event.events) == 1
     event = memory_event.events[0]
     assert isinstance(event, NodeMutatedEvent)
-    assert event.data["relationships"]["owner"]["peer_id"] == person_jim_main.id
-    assert event.data["relationships"]["owner"]["peer_kind"] == "TestPerson"
+    assert isinstance(event.data.relationships["owner"], RelationshipCardinalityOneChangelog)
+    assert event.data.relationships["owner"].peer_id == person_jim_main.id
+    assert event.data.relationships["owner"].peer_kind == "TestPerson"
 
 
 async def test_update_default_value(


### PR DESCRIPTION
* Add proper support for "count" to indicate the number of events found
* Refactor how the names of the events are managed
* Add ability to query for specific fields under the node mutation events to see which attributes have changed

The queries in general will need more work specifically around the filtering of related nodes and restricting combinations of branches, accounts and node_ids etc. But it would be nice to have to have this in develop and also avoid the PR growing even more.