### PR TITLE
Fix CoreNumberPool utilization

### DIFF
--- a/backend/infrahub/core/query/resource_manager.py
+++ b/backend/infrahub/core/query/resource_manager.py
@@ -123,6 +123,7 @@ class NumberPoolGetAllocated(Query):
         self.params["node_attribute"] = self.pool.node_attribute.value
         self.params["start_range"] = self.pool.start_range.value
         self.params["end_range"] = self.pool.end_range.value
+        self.params["pool_id"] = self.pool.get_id()
 
         branch_filter, branch_params = self.branch.get_query_filter_path(
             at=self.at.to_string(), branch_agnostic=self.branch_agnostic
@@ -133,7 +134,8 @@ class NumberPoolGetAllocated(Query):
         MATCH (n:%(node)s)-[ha:HAS_ATTRIBUTE]-(a:Attribute {name: $node_attribute})-[hv:HAS_VALUE]-(av:AttributeValue)
         MATCH (a)-[hs:HAS_SOURCE]-(pool:%(number_pool_kind)s)
         WHERE
-            av.value >= $start_range and av.value <= $end_range
+            pool.uuid = $pool_id
+            AND av.value >= $start_range and av.value <= $end_range
             AND all(r in [ha, hv, hs] WHERE (%(branch_filter)s))
             AND ha.status = "active"
             AND hv.status = "active"

--- a/backend/infrahub/graphql/queries/resource_manager.py
+++ b/backend/infrahub/graphql/queries/resource_manager.py
@@ -21,8 +21,10 @@ from infrahub.pools.number import NumberUtilizationGetter
 if TYPE_CHECKING:
     from graphql import GraphQLResolveInfo
 
+    from infrahub.core.branch import Branch
     from infrahub.core.node import Node
     from infrahub.core.protocols import CoreNode
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
     from infrahub.graphql.initialization import GraphqlContext
 
@@ -184,7 +186,7 @@ class PoolUtilization(ObjectType):
         pool: CoreNode | None = await NodeManager.get_one(id=pool_id, db=db, branch=context.branch)
         pool = _validate_pool_type(pool_id=pool_id, pool=pool)
         if pool.get_kind() == "CoreNumberPool":
-            return await resolve_number_pool_utilization(db=db, context=context, pool=pool)
+            return await resolve_number_pool_utilization(db=db, at=context.at, pool=pool, branch=context.branch)
 
         resources_map: dict[str, Node] = {}
 
@@ -290,8 +292,10 @@ async def resolve_number_pool_allocation(
     return response
 
 
-async def resolve_number_pool_utilization(db: InfrahubDatabase, context: GraphqlContext, pool: CoreNode) -> dict:
-    number_pool = NumberUtilizationGetter(db=db, pool=pool, at=context.at, branch=context.branch)
+async def resolve_number_pool_utilization(
+    db: InfrahubDatabase, pool: CoreNode, at: Timestamp | str | None, branch: Branch
+) -> dict:
+    number_pool = NumberUtilizationGetter(db=db, pool=pool, at=at, branch=branch)
     await number_pool.load_data()
 
     return {

--- a/backend/tests/unit/core/resource_manager/test_number_pool.py
+++ b/backend/tests/unit/core/resource_manager/test_number_pool.py
@@ -2,7 +2,9 @@ from infrahub.core.branch import Branch
 from infrahub.core.initialization import initialize_registry
 from infrahub.core.node import Node
 from infrahub.core.schema import SchemaRoot
+from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
+from infrahub.graphql.queries.resource_manager import resolve_number_pool_utilization
 from tests.helpers.schema import TICKET, load_schema
 
 
@@ -31,3 +33,79 @@ async def test_allocate_from_number_pool(db: InfrahubDatabase, default_branch: B
     await recreated_ticket2.new(db=db, title="ticket2", ticket_id={"from_pool": {"id": np1.id}})
     await recreated_ticket2.save(db=db)
     assert recreated_ticket2.ticket_id.value == 2
+
+
+async def test_resource_utilization(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema):
+    """
+    Allocates:
+    - 1 ticket in first number pool
+    - 2 tickets in second number pool
+    and verifies resource pool utilization.
+    """
+
+    await load_schema(db=db, schema=SchemaRoot(nodes=[TICKET]))
+    await initialize_registry(db=db)
+
+    np1 = await Node.init(db=db, schema="CoreNumberPool")
+    await np1.new(db=db, name="pool1", node="TestingTicket", node_attribute="ticket_id", start_range=1, end_range=10)
+    await np1.save(db=db)
+
+    ticket1_np1 = await Node.init(db=db, schema=TICKET.kind)
+    await ticket1_np1.new(db=db, title="ticket1_np1", ticket_id={"from_pool": {"id": np1.id}})
+    await ticket1_np1.save(db=db)
+
+    np2 = await Node.init(db=db, schema="CoreNumberPool")
+    await np2.new(db=db, name="pool2", node="TestingTicket", node_attribute="ticket_id", start_range=1, end_range=10)
+    await np2.save(db=db)
+
+    ticket1_np2 = await Node.init(db=db, schema=TICKET.kind)
+    await ticket1_np2.new(db=db, title="ticket1_np2", ticket_id={"from_pool": {"id": np2.id}})
+    await ticket1_np2.save(db=db)
+
+    ticket2_np2 = await Node.init(db=db, schema=TICKET.kind)
+    await ticket2_np2.new(db=db, title="ticket2_np2", ticket_id={"from_pool": {"id": np2.id}})
+    await ticket2_np2.save(db=db)
+
+    utilization_np1 = await resolve_number_pool_utilization(db=db, pool=np1, at=Timestamp(), branch=default_branch)
+
+    assert utilization_np1 == {
+        "count": 1,
+        "utilization": 10,
+        "utilization_default_branch": 10,
+        "utilization_branches": 0,
+        "edges": [
+            {
+                "node": {
+                    "id": np1.get_id(),
+                    "kind": "CoreNumberPool",
+                    "display_label": "pool1",
+                    "weight": 1,
+                    "utilization": 10,
+                    "utilization_default_branch": 10,
+                    "utilization_branches": 0,
+                }
+            }
+        ],
+    }
+
+    utilization_np2 = await resolve_number_pool_utilization(db=db, pool=np2, at=Timestamp(), branch=default_branch)
+
+    assert utilization_np2 == {
+        "count": 1,
+        "utilization": 20,
+        "utilization_default_branch": 20,
+        "utilization_branches": 0,
+        "edges": [
+            {
+                "node": {
+                    "id": np2.get_id(),
+                    "kind": "CoreNumberPool",
+                    "display_label": "pool2",
+                    "weight": 1,
+                    "utilization": 20,
+                    "utilization_default_branch": 20,
+                    "utilization_branches": 0,
+                }
+            }
+        ],
+    }


### PR DESCRIPTION
Fixes #4756. Pool id was not used in `NumberPoolGetAllocated` query so computed utilization was wrong as any pool utilization was considered.