### PR TITLE
Exclude node properties from node events

### DIFF
--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -470,6 +470,7 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin):
         related_node_ids: Optional[set] = None,
         filter_sensitive: bool = False,
         permissions: Optional[dict] = None,
+        include_properties: bool = True,
     ) -> dict:
         """Generate GraphQL Payload for this attribute."""
         # pylint: disable=too-many-branches
@@ -480,7 +481,9 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin):
             field_names = fields.keys()
         else:
             # REMOVED updated_at for now, need to investigate further how it's being used today
-            field_names = ["__typename", "value"] + self._node_properties + self._flag_properties
+            field_names = ["__typename", "value"]
+            if include_properties:
+                field_names += self._node_properties + self._flag_properties
 
         for field_name in field_names:
             if field_name == "updated_at":

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -633,6 +633,7 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
         related_node_ids: set | None = None,
         filter_sensitive: bool = False,
         permissions: dict | None = None,
+        include_properties: bool = True,
     ) -> dict:
         """Generate GraphQL Payload for all attributes
 
@@ -686,10 +687,14 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
                     related_node_ids=related_node_ids,
                     filter_sensitive=filter_sensitive,
                     permissions=permissions,
+                    include_properties=include_properties,
                 )
             else:
                 response[field_name] = await field.to_graphql(
-                    db=db, filter_sensitive=filter_sensitive, permissions=permissions
+                    db=db,
+                    filter_sensitive=filter_sensitive,
+                    permissions=permissions,
+                    include_properties=include_properties,
                 )
 
         for relationship_schema in self.get_schema().relationships:

--- a/backend/infrahub/core/node/ipam.py
+++ b/backend/infrahub/core/node/ipam.py
@@ -20,9 +20,14 @@ class BuiltinIPPrefix(Node):
         related_node_ids: Optional[set] = None,
         filter_sensitive: bool = False,
         permissions: Optional[dict] = None,
+        include_properties: bool = True,
     ) -> dict:
         response = await super().to_graphql(
-            db, fields=fields, related_node_ids=related_node_ids, filter_sensitive=filter_sensitive
+            db,
+            fields=fields,
+            related_node_ids=related_node_ids,
+            filter_sensitive=filter_sensitive,
+            include_properties=include_properties,
         )
 
         if fields:

--- a/backend/infrahub/core/node/permissions.py
+++ b/backend/infrahub/core/node/permissions.py
@@ -18,6 +18,7 @@ class CoreGlobalPermission(Node):
         related_node_ids: Optional[set] = None,
         filter_sensitive: bool = False,
         permissions: Optional[dict] = None,
+        include_properties: bool = True,
     ) -> dict:
         response = await super().to_graphql(
             db,
@@ -25,6 +26,7 @@ class CoreGlobalPermission(Node):
             related_node_ids=related_node_ids,
             filter_sensitive=filter_sensitive,
             permissions=permissions,
+            include_properties=include_properties,
         )
 
         if fields:
@@ -43,6 +45,7 @@ class CoreObjectPermission(Node):
         related_node_ids: Optional[set] = None,
         filter_sensitive: bool = False,
         permissions: Optional[dict] = None,
+        include_properties: bool = True,
     ) -> dict:
         response = await super().to_graphql(
             db,
@@ -50,6 +53,7 @@ class CoreObjectPermission(Node):
             related_node_ids=related_node_ids,
             filter_sensitive=filter_sensitive,
             permissions=permissions,
+            include_properties=include_properties,
         )
 
         if fields:

--- a/backend/infrahub/graphql/mutations/computed_attribute.py
+++ b/backend/infrahub/graphql/mutations/computed_attribute.py
@@ -87,7 +87,9 @@ class UpdateComputedAttribute(Mutation):
             log_data = get_log_data()
             request_id = log_data.get("request_id", "")
 
-            graphql_payload = await target_node.to_graphql(db=context.db, filter_sensitive=True)
+            graphql_payload = await target_node.to_graphql(
+                db=context.db, filter_sensitive=True, include_properties=False
+            )
 
             event = NodeMutatedEvent(
                 branch=context.branch.name,

--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -97,7 +97,7 @@ class InfrahubMutationMixin:
             log_data = get_log_data()
             request_id = log_data.get("request_id", "")
 
-            graphql_payload = await obj.to_graphql(db=context.db, filter_sensitive=True)
+            graphql_payload = await obj.to_graphql(db=context.db, filter_sensitive=True, include_properties=False)
             event = NodeMutatedEvent(
                 branch=context.branch.name,
                 kind=obj._schema.kind,

--- a/backend/tests/unit/core/test_node.py
+++ b/backend/tests/unit/core/test_node.py
@@ -420,6 +420,46 @@ async def test_to_graphql_no_fields(db: InfrahubDatabase, default_branch: Branch
     assert await c1.to_graphql(db=db) == expected_data
 
 
+async def test_to_graphql_without_properties(db: InfrahubDatabase, default_branch: Branch, car_person_schema):
+    car = registry.schema.get(name="TestCar")
+    person = registry.schema.get(name="TestPerson")
+
+    p1 = await Node.init(db=db, schema=person)
+    await p1.new(db=db, name="John", height=180)
+    await p1.save(db=db)
+
+    c1 = await Node.init(db=db, schema=car)
+    await c1.new(db=db, name="volt", nbr_seats=4, is_electric=True, owner=p1)
+    await c1.save(db=db)
+
+    graphql_data_properties = await c1.to_graphql(db=db, include_properties=True)
+    graphql_data_no_properties = await c1.to_graphql(db=db, include_properties=False)
+    top_level_keys = [
+        "__kind__",
+        "__typename",
+        "color",
+        "display_label",
+        "id",
+        "is_electric",
+        "name",
+        "nbr_seats",
+        "transmission",
+    ]
+
+    assert sorted(graphql_data_properties.keys()) == top_level_keys
+    assert sorted(graphql_data_no_properties.keys()) == top_level_keys
+    assert sorted(graphql_data_properties["name"].keys()) == [
+        "__typename",
+        "id",
+        "is_protected",
+        "is_visible",
+        "owner",
+        "source",
+        "value",
+    ]
+    assert sorted(graphql_data_no_properties["name"].keys()) == ["__typename", "id", "value"]
+
+
 # --------------------------------------------------------------------------
 # Create
 # --------------------------------------------------------------------------

--- a/changelog/5664.changed.md
+++ b/changelog/5664.changed.md
@@ -1,0 +1,1 @@
+Modified node mutation events to not send metadata properties as part of the mutation payload. The reason is that the property lookup was time consuming. This information will return again in Infrahub 1.2 with a completely updated format.


### PR DESCRIPTION
Changes:

* Introduce an include_properties parameter to node.to_graphql to optionally remove the properties lookup
* Update node mutation & computed attributes events to exclude properties
