### PR TITLE
fix diff limit/offset logic

### DIFF
--- a/backend/infrahub/core/diff/repository/repository.py
+++ b/backend/infrahub/core/diff/repository/repository.py
@@ -51,7 +51,8 @@ class DiffRepository:
         self,
         base_branch_name: str,
         diff_branch_names: list[str],
-        limit: int,
+        batch_size_limit: int,
+        limit: int | None = None,
         from_time: Timestamp | None = None,
         to_time: Timestamp | None = None,
         filters: EnrichedDiffQueryFilters | None = None,
@@ -62,8 +63,13 @@ class DiffRepository:
         diff_ids: list[str] | None = None,
     ) -> list[EnrichedDiffRoot]:
         self.deserializer.initialize()
+        final_row_number = None
+        if limit:
+            final_row_number = offset + limit
         has_more_data = True
-        while has_more_data:
+        while has_more_data and (final_row_number is None or offset < final_row_number):
+            if final_row_number is not None and offset + batch_size_limit > final_row_number:
+                batch_size_limit = final_row_number - offset
             get_query = await EnrichedDiffGetQuery.init(
                 db=self.db,
                 base_branch_name=base_branch_name,
@@ -72,12 +78,12 @@ class DiffRepository:
                 to_time=to_time,
                 filters=filters,
                 max_depth=max_depth,
-                limit=limit,
+                limit=batch_size_limit,
                 offset=offset,
                 tracking_id=tracking_id,
                 diff_ids=diff_ids,
             )
-            log.info(f"Beginning enriched diff get query {limit=}, {offset=}")
+            log.info(f"Beginning enriched diff get query {batch_size_limit=}, {offset=}")
             await get_query.execute(db=self.db)
             log.info("Enriched diff get query complete")
             last_result = None
@@ -87,7 +93,7 @@ class DiffRepository:
             has_more_data = False
             if last_result:
                 has_more_data = last_result.get_as_type("has_more_data", bool)
-            offset += limit
+            offset += batch_size_limit
         return await self.deserializer.deserialize()
 
     async def get(
@@ -105,16 +111,17 @@ class DiffRepository:
         include_empty: bool = False,
     ) -> list[EnrichedDiffRoot]:
         final_max_depth = config.SETTINGS.database.max_depth_search_hierarchy
-        limit = limit or int(config.SETTINGS.database.query_size_limit / 10)
+        batch_size_limit = int(config.SETTINGS.database.query_size_limit / 10)
         diff_roots = await self._run_get_diff_query(
             base_branch_name=base_branch_name,
             diff_branch_names=diff_branch_names,
+            batch_size_limit=batch_size_limit,
+            limit=limit,
             from_time=from_time,
             to_time=to_time,
             filters=EnrichedDiffQueryFilters(**dict(filters or {})),
             include_parents=include_parents,
             max_depth=final_max_depth,
-            limit=limit,
             offset=offset or 0,
             tracking_id=tracking_id,
             diff_ids=diff_ids,
@@ -131,21 +138,21 @@ class DiffRepository:
         to_time: Timestamp,
     ) -> list[EnrichedDiffs]:
         max_depth = config.SETTINGS.database.max_depth_search_hierarchy
-        limit = int(config.SETTINGS.database.query_size_limit / 10)
+        batch_size_limit = int(config.SETTINGS.database.query_size_limit / 10)
         diff_branch_roots = await self._run_get_diff_query(
             base_branch_name=base_branch_name,
             diff_branch_names=[diff_branch_name],
             from_time=from_time,
             to_time=to_time,
             max_depth=max_depth,
-            limit=limit,
+            batch_size_limit=batch_size_limit,
         )
         diffs_by_uuid = {dbr.uuid: dbr for dbr in diff_branch_roots}
         base_branch_roots = await self._run_get_diff_query(
             base_branch_name=base_branch_name,
             diff_branch_names=[base_branch_name],
             max_depth=max_depth,
-            limit=limit,
+            batch_size_limit=batch_size_limit,
             diff_ids=[d.partner_uuid for d in diffs_by_uuid.values()],
         )
         diffs_by_uuid.update({bbr.uuid: bbr for bbr in base_branch_roots})

--- a/backend/tests/unit/core/diff/test_diff_repository.py
+++ b/backend/tests/unit/core/diff/test_diff_repository.py
@@ -1,4 +1,5 @@
 import random
+from collections import defaultdict
 from dataclasses import replace
 from datetime import UTC
 from typing import Generator
@@ -46,7 +47,9 @@ class TestDiffRepositorySaveAndLoad:
         original_size = config.SETTINGS.database.query_size_limit
         config.SETTINGS.database.max_depth_search_hierarchy = 10
         config.SETTINGS.database.query_size_limit = 50
-        yield DiffRepository(db=db, deserializer=EnrichedDiffDeserializer())
+        diff_repository = DiffRepository(db=db, deserializer=EnrichedDiffDeserializer())
+        diff_repository.MAX_SAVE_BATCH_SIZE = 3
+        yield diff_repository
         config.SETTINGS.database.max_depth_search_hierarchy = original_depth
         config.SETTINGS.database.query_size_limit = original_size
 
@@ -651,3 +654,99 @@ class TestDiffRepositorySaveAndLoad:
             diff_branch_name=tracking_id_diff_1.diff_branch_name, diff_id=tracking_id_diff_1.uuid
         )
         assert diff_1.tracking_id is None
+
+    async def test_limit_and_offset(self, diff_repository: DiffRepository, reset_database):
+        nodes_by_kind = defaultdict(list)
+        all_nodes = set()
+        for kind in ("KindOne", "KindTwo", "KindThree"):
+            for _ in range(8):
+                node = EnrichedNodeFactory.build(kind=kind, relationships=set())
+                nodes_by_kind[kind].append(node)
+                all_nodes.add(node)
+        sorted_uuids = sorted(all_nodes, key=lambda i: i.uuid)
+        enriched_branch_diff = EnrichedRootFactory.build(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.diff_branch_name,
+            from_time=Timestamp(self.diff_from_time),
+            to_time=Timestamp(self.diff_to_time),
+            nodes=all_nodes,
+            tracking_id=NameTrackingId(name="the-best-diff"),
+        )
+        enriched_base_diff = EnrichedRootFactory.build(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.base_branch_name,
+            from_time=Timestamp(self.diff_from_time),
+            to_time=Timestamp(self.diff_to_time),
+            nodes=set(),
+            tracking_id=NameTrackingId(name="the-best-diff"),
+        )
+        enriched_base_diff.partner_uuid = enriched_branch_diff.uuid
+        enriched_branch_diff.partner_uuid = enriched_base_diff.uuid
+        enriched_diffs = EnrichedDiffs(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.diff_branch_name,
+            base_branch_diff=enriched_base_diff,
+            diff_branch_diff=enriched_branch_diff,
+        )
+
+        await diff_repository.save(enriched_diffs=enriched_diffs)
+
+        # validate limit
+        retrieved = await diff_repository.get(
+            base_branch_name=self.base_branch_name,
+            diff_branch_names=[self.diff_branch_name],
+            from_time=Timestamp(self.diff_from_time),
+            to_time=Timestamp(self.diff_to_time),
+            limit=7,
+        )
+        assert len(retrieved) == 1
+        retrieved_diff = retrieved[0]
+        assert len(retrieved_diff.nodes) == 7
+        assert {n.uuid for n in retrieved_diff.nodes} == {n.uuid for n in sorted_uuids[:7]}
+
+        # validate limit with offset
+        retrieved = await diff_repository.get(
+            base_branch_name=self.base_branch_name,
+            diff_branch_names=[self.diff_branch_name],
+            from_time=Timestamp(self.diff_from_time),
+            to_time=Timestamp(self.diff_to_time),
+            limit=7,
+            offset=7,
+        )
+        assert len(retrieved) == 1
+        retrieved_diff = retrieved[0]
+        assert len(retrieved_diff.nodes) == 7
+        assert {n.uuid for n in retrieved_diff.nodes} == {n.uuid for n in sorted_uuids[7:14]}
+
+        # validate limit with filter
+        retrieved = await diff_repository.get(
+            base_branch_name=self.base_branch_name,
+            diff_branch_names=[self.diff_branch_name],
+            from_time=Timestamp(self.diff_from_time),
+            to_time=Timestamp(self.diff_to_time),
+            limit=7,
+            filters={"kind": {"includes": ["KindOne"]}},
+        )
+        assert len(retrieved) == 1
+        retrieved_diff = retrieved[0]
+        assert len(retrieved_diff.nodes) == 7
+        assert {n.uuid for n in retrieved_diff.nodes} == {
+            n.uuid for n in sorted(nodes_by_kind["KindOne"], key=lambda x: x.uuid)[:7]
+        }
+
+        # validate limit with offset and filter
+        retrieved = await diff_repository.get(
+            base_branch_name=self.base_branch_name,
+            diff_branch_names=[self.diff_branch_name],
+            from_time=Timestamp(self.diff_from_time),
+            to_time=Timestamp(self.diff_to_time),
+            limit=7,
+            offset=7,
+            filters={"kind": {"includes": ["KindOne"]}},
+        )
+        assert len(retrieved) == 1
+        retrieved_diff = retrieved[0]
+        assert len(retrieved_diff.nodes) == 1
+        assert {n.uuid for n in retrieved_diff.nodes} == {
+            n.uuid for n in sorted(nodes_by_kind["KindOne"], key=lambda x: x.uuid)[7:]
+        }


### PR DESCRIPTION
the logic of limiting/offsetting nodes when retrieving a diff from the database was not working correctly

the problem was that the query to retrieve a diff has an internal limit that we enforce to prevent crashing the database when retrieving too much data and this was interacting with the limit/offset requested by the user incorrectly