### PR TITLE
Add node_changelog for deleted nodes & cardinaly many relationships

### DIFF
--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -327,9 +327,9 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin):
 
         return await self._update(at=save_at, db=db)
 
-    async def delete(self, db: InfrahubDatabase, at: Optional[Timestamp] = None) -> bool:
+    async def delete(self, db: InfrahubDatabase, at: Optional[Timestamp] = None) -> AttributeChangelog | None:
         if not self.db_id:
-            return False
+            return None
 
         delete_at = Timestamp(at)
 
@@ -338,7 +338,14 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin):
         results = query.get_results()
 
         if not results:
-            return False
+            return None
+
+        changelog = AttributeChangelog(
+            name=self.name,
+            value=None,
+            value_previous=None,
+            kind=self.schema.kind,
+        )
 
         properties_to_delete = []
         branch = self.get_branch_based_on_support_type()
@@ -346,6 +353,8 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin):
         # Check all the relationship and update the one that are in the same branch
         rel_ids_to_update = set()
         for result in results:
+            if result.get_rel("r2").type == "HAS_VALUE":
+                changelog.value_previous = result.get_node("ap").get("value")
             properties_to_delete.append((result.get_rel("r2").type, result.get_node("ap").element_id))
 
             await add_relationship(
@@ -377,7 +386,7 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin):
             db=db,
         )
 
-        return True
+        return changelog
 
     async def _update(self, db: InfrahubDatabase, at: Optional[Timestamp] = None) -> AttributeChangelog | None:
         """Update the attribute in the database.

--- a/backend/infrahub/core/changelog/models.py
+++ b/backend/infrahub/core/changelog/models.py
@@ -165,6 +165,15 @@ class RelationshipCardinalityManyChangelog(BaseModel):
             )
         )
 
+    def remove_peer(self, peer_id: str, peer_kind: str) -> None:
+        self.peers.append(
+            RelationshipPeerChangelog(
+                peer_id=peer_id,
+                peer_kind=peer_kind,
+                peer_status=DiffAction.REMOVED,
+            )
+        )
+
     @property
     def is_empty(self) -> bool:
         return not self.peers
@@ -259,6 +268,10 @@ class ChangelogRelationshipMapper:
         if self.schema.cardinality == RelationshipCardinality.ONE:
             self.cardinality_one_relationship.peer_id_previous = str(peer_data.peer_id)
             self.cardinality_one_relationship.peer_kind_previous = peer_data.peer_kind
+        elif self.schema.cardinality == RelationshipCardinality.MANY:
+            self.cardinality_many_relationship.remove_peer(
+                peer_id=str(peer_data.peer_id), peer_kind=peer_data.peer_kind
+            )
 
     def _set_cardinality_one_peer(self, relationship: Relationship) -> None:
         self.cardinality_one_relationship.peer_id = relationship.peer_id
@@ -267,6 +280,8 @@ class ChangelogRelationshipMapper:
     def add_peer_from_relationship(self, relationship: Relationship) -> None:
         if self.schema.cardinality == RelationshipCardinality.ONE:
             self._set_cardinality_one_peer(relationship=relationship)
+        elif self.schema.cardinality == RelationshipCardinality.MANY:
+            self.cardinality_many_relationship.add_new_peer(relationship=relationship)
 
     def add_updated_relationship(
         self, relationship: Relationship, old_data: RelationshipPeerData, properties_to_update: list[str]
@@ -291,6 +306,15 @@ class ChangelogRelationshipMapper:
                     value_current=getattr(relationship, property_name),
                     value_previous=previous_value,
                 )
+
+    def delete_relationship(self, relationship: Relationship) -> None:
+        if self.schema.cardinality == RelationshipCardinality.ONE:
+            self.cardinality_one_relationship.peer_id_previous = relationship.get_peer_id()
+            self.cardinality_one_relationship.peer_kind_previous = relationship.get_peer_kind()
+        elif self.schema.cardinality == RelationshipCardinality.MANY:
+            self.cardinality_many_relationship.remove_peer(
+                peer_id=relationship.get_peer_id(), peer_kind=relationship.get_peer_kind()
+            )
 
     @property
     def changelog(self) -> RelationshipCardinalityOneChangelog | RelationshipCardinalityManyChangelog:

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -607,16 +607,21 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
 
         delete_at = Timestamp(at)
 
-        changelog = NodeChangelog(node_id=self.get_id(), node_kind=self.get_kind(), display_label="")
+        node_changelog = NodeChangelog(
+            node_id=self.get_id(), node_kind=self.get_kind(), display_label=await self.render_display_label(db=db)
+        )
         # Go over the list of Attribute and update them one by one
         for name in self._attributes:
             attr: BaseAttribute = getattr(self, name)
-            await attr.delete(at=delete_at, db=db)
+            deleted_attribute = await attr.delete(at=delete_at, db=db)
+            if deleted_attribute:
+                node_changelog.add_attribute(attribute=deleted_attribute)
 
         # Go over the list of relationships and update them one by one
         for name in self._relationships:
             rel: RelationshipManager = getattr(self, name)
-            await rel.delete(at=delete_at, db=db)
+            updated_relationship = await rel.delete(at=delete_at, db=db)
+            node_changelog.add_relationship(relationship=updated_relationship)
 
         # Need to check if there are some unidirectional relationship as well
         # For example, if we delete a tag, we must check the permissions and update all the relationships pointing at it
@@ -639,7 +644,7 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
 
         query = await NodeDeleteQuery.init(db=db, node=self, at=delete_at)
         await query.execute(db=db)
-        self._node_changelog = changelog
+        self._node_changelog = node_changelog
 
     async def to_graphql(
         self,

--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -1182,15 +1182,21 @@ class RelationshipManager:
 
         return relationship_mapper.changelog
 
-    async def delete(self, db: InfrahubDatabase, at: Optional[Timestamp] = None) -> None:
+    async def delete(
+        self, db: InfrahubDatabase, at: Optional[Timestamp] = None
+    ) -> RelationshipCardinalityManyChangelog | RelationshipCardinalityOneChangelog:
         """Delete all the relationships."""
 
         delete_at = Timestamp(at)
+        relationship_mapper = ChangelogRelationshipMapper(schema=self.schema)
 
         await self._fetch_relationships(at=delete_at, db=db, force_refresh=True)
 
         for rel in await self.get_relationships(db=db):
+            relationship_mapper.delete_relationship(relationship=rel)
             await rel.delete(at=delete_at, db=db)
+
+        return relationship_mapper.changelog
 
     async def to_graphql(
         self, db: InfrahubDatabase, fields: Optional[dict] = None, related_node_ids: Optional[set] = None

--- a/backend/tests/unit/core/test_changelog.py
+++ b/backend/tests/unit/core/test_changelog.py
@@ -228,3 +228,50 @@ async def test_node_changelog_update_with_cardinality_many_relationship(
         )
         in group1.node_changelog.relationships["members"].peers
     )
+
+
+async def test_node_changelog_delete_with_cardinality_one_relationship(
+    db: InfrahubDatabase, default_branch, animal_person_schema
+):
+    person_schema = animal_person_schema.get(name="TestPerson")
+    dog_schema = animal_person_schema.get(name="TestDog")
+
+    person1 = await Node.init(db=db, schema=person_schema, branch=default_branch)
+    await person1.new(db=db, name="Jack")
+    await person1.save(db=db)
+
+    dog1 = await Node.init(db=db, schema=dog_schema, branch=default_branch)
+    await dog1.new(db=db, name={"value": "Rocky", "owner": person1.id}, breed="Labrador", owner=person1)
+    await dog1.save(db=db)
+
+    dog1_update = await NodeManager.get_one(id=dog1.id, db=db)
+    await dog1_update.delete(db=db)
+    assert dog1_update.node_changelog.attributes["breed"].value_update_status == DiffAction.REMOVED
+    assert list(dog1_update.node_changelog.relationships.keys()) == ["owner"]
+    assert dog1_update.node_changelog.relationships["owner"].peer_status == DiffAction.REMOVED
+
+
+async def test_node_changelog_delete_with_cardinality_many_relationship(
+    db: InfrahubDatabase, default_branch, animal_person_schema
+):
+    person_schema = animal_person_schema.get(name="TestPerson")
+    dog_schema = animal_person_schema.get(name="TestDog")
+
+    person1 = await Node.init(db=db, schema=person_schema, branch=default_branch)
+    await person1.new(db=db, name="Jack")
+    await person1.save(db=db)
+
+    dog1 = await Node.init(db=db, schema=dog_schema, branch=default_branch)
+    await dog1.new(db=db, name={"value": "Rocky", "owner": person1.id}, breed="Labrador", owner=person1)
+    await dog1.save(db=db)
+
+    dog2 = await Node.init(db=db, schema=dog_schema, branch=default_branch)
+    await dog2.new(db=db, name={"value": "Lassie", "owner": person1.id}, breed="Collie", owner=person1)
+    await dog2.save(db=db)
+
+    person1_update = await NodeManager.get_one(id=person1.id, db=db)
+    await person1_update.delete(db=db)
+
+    animals = person1_update.node_changelog.relationships["animals"].peers
+    assert RelationshipPeerChangelog(peer_id=dog1.id, peer_kind="TestAnimal", peer_status=DiffAction.REMOVED) in animals
+    assert RelationshipPeerChangelog(peer_id=dog2.id, peer_kind="TestAnimal", peer_status=DiffAction.REMOVED) in animals


### PR DESCRIPTION
This PR adds deleted attributes and relationships to the node_changelog for deleted nodes as well as cardinality=many relationships.

The missing remaining part for the node_changelog is updates to properties when modifying cardinality=many relationships. I'll open a separate issue for that as it shouldn't be critical for now.