### PR TITLE
fix(ci): remove chromium netlink workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -808,14 +808,6 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install chromium
 
-      # Make chromium ignore netlink messages by returning HandleMessage early
-      - name: Chrome path
-        run: echo CHROME_BIN_PATH="$(npx playwright install chromium --dry-run | grep Install | grep chromium- | awk '{print $3}')/chrome-linux/chrome" >> $GITHUB_ENV
-      - name: Chrome func offset
-        run: echo FUNC_OFFSET="$(objdump -C --file-offsets --disassemble='net::internal::AddressTrackerLinux::HandleMessage(char const*, int, bool*, bool*, bool*)' $CHROME_BIN_PATH | grep 'File Offset' | sed -n 1p | sed -E 's/.*File Offset. (.*)\).*/\1/')" >> $GITHUB_ENV
-      - name: Patch chromium
-        run: printf '\xc3' | dd of=$CHROME_BIN_PATH bs=1 seek=$(($FUNC_OFFSET)) conv=notrunc
-
       - name: Wait for artifacts to be generated before restarting infrahub
         if: needs.files-changed.outputs.e2e_tests == 'true'
         run: npx playwright test artifact


### PR DESCRIPTION
Starting 1.49, Playwright now uses chromium headless shell.