### PR TITLE
Improvement and fixes on data diff view

### DIFF
--- a/changelog/+data-diff.added.md
+++ b/changelog/+data-diff.added.md
@@ -1,0 +1,2 @@
+- Data diffs are loaded in sequential batches for faster performance with large changes.
+- The diff tree and diff list can now be scrolled independently.

--- a/frontend/app/src/entities/diff/domain/get-diff-tree.ts
+++ b/frontend/app/src/entities/diff/domain/get-diff-tree.ts
@@ -2,7 +2,7 @@ import { getDiffTreeFromApi } from "@/entities/diff/api/get-diff-tree-from-api";
 import { DiffTree, DiffTreeQueryFilters } from "@/shared/api/graphql/generated/graphql";
 import { infiniteQueryOptions, useInfiniteQuery } from "@tanstack/react-query";
 
-export const DIFF_TREE_PER_PAGE = 30;
+export const DIFF_TREE_PER_PAGE = 300;
 
 export type GetDiffTreeParams = {
   branchName: string;

--- a/frontend/app/src/entities/diff/node-diff/index.tsx
+++ b/frontend/app/src/entities/diff/node-diff/index.tsx
@@ -13,7 +13,6 @@ import { proposedChangedState } from "@/entities/proposed-changes/stores/propose
 import { DateDisplay } from "@/shared/components/display/date-display";
 import ErrorScreen from "@/shared/components/errors/error-screen";
 import LoadingScreen from "@/shared/components/loading-screen";
-import { Spinner } from "@/shared/components/ui/spinner";
 import { useAtomValue } from "jotai";
 import { createContext, useEffect } from "react";
 import { StringParam, useQueryParam } from "use-query-params";
@@ -110,8 +109,6 @@ export const NodeDiff = ({ branchName, filters }: NodeDiffProps) => {
           ) : (
             <DiffNoFound diffStatus={qspStatus as string} />
           )}
-
-          {isFetchingNextPage && <Spinner className="flex justify-center" />}
         </main>
       </div>
     </div>

--- a/frontend/app/src/entities/diff/node-diff/index.tsx
+++ b/frontend/app/src/entities/diff/node-diff/index.tsx
@@ -81,7 +81,7 @@ export const NodeDiff = ({ branchName, filters }: NodeDiffProps) => {
       }) ?? [];
 
   return (
-    <div className="h-full overflow-hidden flex flex-col">
+    <div className="h-[calc(100vh-14rem)] overflow-hidden flex flex-col">
       <header className="flex items-center px-4 py-2 border-b gap-2">
         <ProposedChangeDiffFilter branch={branch} filters={filters} />
         <span className="text-xs inline-flex gap-1 ml-auto">


### PR DESCRIPTION
- Increase to number of diff per page to 300
- Fixed the scrollbar flickering when diff was loading  on a narrow window
- tree and diff list are scrollable independently 