### PR TITLE
Block the merge button only if there is ongoing tasks for the proposed change

### DIFF
--- a/changelog/5565.fixed.md
+++ b/changelog/5565.fixed.md
@@ -1,0 +1,1 @@
+Modify the query for the current tasks, ensuring the correct determination of the merge button state.

--- a/frontend/app/src/entities/diff/node-diff/conflict.tsx
+++ b/frontend/app/src/entities/diff/node-diff/conflict.tsx
@@ -44,7 +44,9 @@ export const Conflict = ({ conflict }: any) => {
         },
       });
 
-      await graphqlClient.refetchQueries({ include: ["GET_PROPOSED_CHANGES_DIFF_TREE"] });
+      await graphqlClient.refetchQueries({
+        include: ["GET_PROPOSED_CHANGES_DIFF_TREE", "TASK_DETAILS_CHECK"],
+      });
 
       const message = newValue ? "Conflict marked as resolved" : "Conflict marked as not resolved";
 

--- a/frontend/app/src/entities/diff/node-diff/conflict.tsx
+++ b/frontend/app/src/entities/diff/node-diff/conflict.tsx
@@ -3,6 +3,7 @@ import { currentBranchAtom } from "@/entities/branches/stores";
 import { resolveConflict } from "@/entities/diff/api/resolveConflict";
 import { proposedChangedState } from "@/entities/proposed-changes/stores/proposedChanges.atom";
 import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
+import { queryClient } from "@/shared/api/rest/client";
 import { Checkbox } from "@/shared/components/inputs/checkbox";
 import LoadingScreen from "@/shared/components/loading-screen";
 import { ALERT_TYPES, Alert } from "@/shared/components/ui/alert";
@@ -44,8 +45,9 @@ export const Conflict = ({ conflict }: any) => {
         },
       });
 
+      await queryClient.invalidateQueries({ queryKey: ["diff-tree"] });
       await graphqlClient.refetchQueries({
-        include: ["GET_PROPOSED_CHANGES_DIFF_TREE", "TASK_DETAILS_CHECK"],
+        include: ["TASK_DETAILS_CHECK"],
       });
 
       const message = newValue ? "Conflict marked as resolved" : "Conflict marked as not resolved";

--- a/frontend/app/src/entities/proposed-changes/ui/proposed-change-details.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/proposed-change-details.tsx
@@ -26,7 +26,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import LoadingScreen from "../../../shared/components/loading-screen";
 import { getObjectPermissionsQuery } from "../../permission/queries/getObjectPermissions";
 import { getPermission } from "../../permission/utils";
-import { PROPOSED_CHANGE_MERGE_WORKFLOW } from "../../tasks/constants";
+import { PROPOSED_CHANGE_MERGE_WORKFLOW, TASK_ONGOING_STATES } from "../../tasks/constants";
 import { TaskDisplay } from "../../tasks/ui/task-display";
 
 export const ProposedChangeDetails = ({ className, ...props }: HTMLAttributes<HTMLDivElement>) => {
@@ -42,6 +42,7 @@ export const ProposedChangeDetails = ({ className, ...props }: HTMLAttributes<HT
   const { loading: loadingCheck, data: checkData } = useQuery(TASK_DETAILS_CHECK, {
     variables: {
       workflow: [PROPOSED_CHANGE_MERGE_WORKFLOW],
+      state: TASK_ONGOING_STATES,
       relatedNodes: proposedChangeId ? [proposedChangeId] : undefined,
     },
     pollInterval: 2000,

--- a/frontend/app/src/entities/tasks/api/checkTasksItemDetails.ts
+++ b/frontend/app/src/entities/tasks/api/checkTasksItemDetails.ts
@@ -1,8 +1,8 @@
 import { gql } from "@apollo/client";
 
 export const TASK_DETAILS_CHECK = gql`
-query TASK_DETAILS_CHECK($ids: [String], $branch: String, $workflow: [String], $relatedNodes: [String]) {
-  InfrahubTask(ids: $ids, branch: $branch, workflow: $workflow, related_node__ids: $relatedNodes) {
+query TASK_DETAILS_CHECK($ids: [String], $branch: String, $workflow: [String], $state: [StateType], $relatedNodes: [String]) {
+  InfrahubTask(ids: $ids, branch: $branch, workflow: $workflow, state: $state, related_node__ids: $relatedNodes) {
     count
   }
 }


### PR DESCRIPTION
Issue: https://github.com/opsmill/infrahub/issues/5565

Modify the query for the current tasks, ensuring the correct determination of the merge button state for ongoing tasks.