### PR TITLE
Add event levels, related nodes and enforce use of EventMeta

### DIFF
--- a/backend/infrahub/core/constants/__init__.py
+++ b/backend/infrahub/core/constants/__init__.py
@@ -289,6 +289,18 @@ class AttributeDBNodeType(InfrahubStringEnum):
     IPNETWORK = "ipnetwork"
 
 
+class EventLevel(InfrahubStringEnum):
+    ZERO = "zero"
+    ONE = "one"
+
+    def to_int(self) -> int:
+        match self:
+            case EventLevel.ZERO:
+                return 0
+            case EventLevel.ONE:
+                return 1
+
+
 RESTRICTED_NAMESPACES: list[str] = [
     "Account",
     "Branch",

--- a/backend/infrahub/events/models.py
+++ b/backend/infrahub/events/models.py
@@ -5,8 +5,11 @@ from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field, computed_field
 
+from infrahub import __version__
 from infrahub.core.branch import Branch  # noqa: TC001
+from infrahub.core.constants import EventLevel
 from infrahub.message_bus import InfrahubMessage, Meta
+from infrahub.worker import WORKER_IDENTITY
 
 from .constants import EVENT_NAMESPACE
 
@@ -15,14 +18,15 @@ class EventMeta(BaseModel):
     branch: Branch | None = Field(default=None)
     request_id: str = ""
     account_id: str | None = Field(default=None, description="The ID of the account triggering this event")
-    initiator_id: str | None = Field(
-        default=None, description="The worker identity of the initial sender of this message"
+    initiator_id: str = Field(
+        default=WORKER_IDENTITY, description="The worker identity of the initial sender of this message"
     )
     context: list[dict] = Field(default_factory=list)
+    level: EventLevel = Field(default=EventLevel.ZERO)
 
     def get_related(self) -> list[dict[str, str]]:
         related: list[dict[str, str]] = []
-        event_resource = {}
+        event_resource = {"infrahub.event.level": self.level.value}
         if self.account_id:
             event_resource["infrahub.account.id"] = self.account_id
             related.append(
@@ -44,18 +48,23 @@ class EventMeta(BaseModel):
                 }
             )
 
-        if event_resource:
-            # This is currently required to let us filter events with the InfrahubEvent query when matching
-            # against multiple components such as both branch and account
-            event_resource["prefect.resource.id"] = str(uuid4())
-            event_resource["prefect.resource.role"] = "infrahub.eventlog"
-            related.append(event_resource)
+        # This is currently required to let us filter events with the InfrahubEvent query when matching
+        # against multiple components such as both branch and account
+        event_resource["prefect.resource.id"] = str(uuid4())
+        event_resource["prefect.resource.role"] = "infrahub.eventlog"
+        related.append(event_resource)
+
+        related.append({"prefect.resource.id": __version__, "prefect.resource.role": "infrahub.version"})
 
         return related
 
+    @classmethod
+    def default(cls) -> EventMeta:
+        return cls()
+
 
 class InfrahubEvent(BaseModel):
-    meta: EventMeta | None = None
+    meta: EventMeta = Field(default_factory=EventMeta.default)
 
     id: UUID = Field(
         default_factory=uuid4,
@@ -88,11 +97,8 @@ class InfrahubEvent(BaseModel):
 
     def get_message_meta(self) -> Meta:
         meta = Meta()
-        if not self.meta:
-            return meta
 
-        if self.meta.initiator_id:
-            meta.initiator_id = self.meta.initiator_id
+        meta.initiator_id = self.meta.initiator_id
         if self.meta.request_id:
             meta.initiator_id = self.meta.request_id
 

--- a/backend/infrahub/graphql/types/common.py
+++ b/backend/infrahub/graphql/types/common.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
-from graphene import InputObjectType, String
+from graphene import InputObjectType, ObjectType, String
 
 
 class IdentifierInput(InputObjectType):
     id = String(required=True, description="The ID of the requested object")
+
+
+class RelatedNode(ObjectType):
+    id = String(required=True, description="The ID of the requested object")
+    kind = String(required=True, description="The ID of the requested object")

--- a/backend/infrahub/graphql/types/event.py
+++ b/backend/infrahub/graphql/types/event.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from graphene import Field, Interface, List, NonNull, ObjectType, String
+from graphene import Field, Int, Interface, List, NonNull, ObjectType, String
 from graphene.types.generic import GenericScalar
 
+from .common import RelatedNode
 from .enums import DiffAction
 
 if TYPE_CHECKING:
@@ -25,6 +26,8 @@ class EventNodeInterface(Interface):
     branch = String(required=False)
     account_id = String(required=False)
     occurred_at = String(required=True)
+    level = Int(required=True)
+    primary_node = Field(RelatedNode, required=False)
 
     @classmethod
     def resolve_type(

--- a/backend/infrahub/task_manager/event.py
+++ b/backend/infrahub/task_manager/event.py
@@ -7,6 +7,7 @@ from prefect.events.schemas.events import Event as PrefectEventModel
 from prefect.events.schemas.events import ResourceSpecification
 from pydantic import BaseModel, Field, TypeAdapter, model_validator
 
+from infrahub.core.constants import EventLevel
 from infrahub.log import get_logger
 from infrahub.utils import get_nested_dict
 
@@ -21,6 +22,23 @@ class PrefectEventData(PrefectEventModel):
             if "infrahub.resource.label" not in resource:
                 continue
             return resource.get("infrahub.resource.label")
+        return None
+
+    def get_level(self) -> int:
+        for resource in self.related:
+            level = resource.get("infrahub.event.level")
+            if level is None:
+                continue
+            return EventLevel(level).to_int()
+
+        return 0
+
+    def get_primary_node(self) -> dict[str, str] | None:
+        node_id = self.resource.get("infrahub.node.id")
+        node_kind = self.resource.get("infrahub.node.kind")
+        if node_id and node_kind:
+            return {"id": node_id, "kind": node_kind}
+
         return None
 
     def get_account_id(self) -> str | None:
@@ -68,6 +86,8 @@ class PrefectEventData(PrefectEventModel):
             "account_id": self.get_account_id(),
             "occurred_at": self.occurred.to_iso8601_string(),
             "payload": self.payload,
+            "level": self.get_level(),
+            "primary_node": self.get_primary_node(),
         }
         response.update(self._return_event_specifics())
         return response

--- a/backend/tests/unit/graphql/queries/test_event.py
+++ b/backend/tests/unit/graphql/queries/test_event.py
@@ -65,11 +65,16 @@ query MutatedNodes($id: [String]) {
     edges {
       node {
         id
+        level
         ... on NodeMutatedEvent {
           __typename
           branch
           event
           payload
+          primary_node {
+            id
+            kind
+          }
           attributes {
             action
             kind
@@ -314,6 +319,9 @@ async def test_event_query_prefect(
         {"action": "ADDED", "kind": "Text", "name": "name", "value": "red", "value_previous": None},
         {"action": "ADDED", "kind": "Text", "name": "description", "value": "The red tag", "value_previous": None},
     ]
+    assert created["node"]["level"] == 0
+    assert created["node"]["primary_node"]["id"] == events_data["branch1_mutated1"].node_id
+    assert created["node"]["primary_node"]["kind"] == "BuiltinTag"
 
     assert updated["node"]["attributes"] == [
         {
@@ -324,6 +332,8 @@ async def test_event_query_prefect(
             "value_previous": "The red tag",
         }
     ]
+    assert created["node"]["primary_node"]["id"] == events_data["branch1_mutated2"].node_id
+    assert created["node"]["primary_node"]["kind"] == "BuiltinTag"
 
     branch1_account1 = await run_query(
         db=db,


### PR DESCRIPTION
Changes:

* Add related_node information to node_mutation events
* Add an event level to later indicate hierarchy of child events
* Refactor EventMeta so that it's required and created automatically
* 