### PR TITLE
Add pagination support for InfrahubEvent through InfrahubEventNext

### DIFF
--- a/backend/infrahub/graphql/queries/event.py
+++ b/backend/infrahub/graphql/queries/event.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any
 from graphene import Field, Int, List, NonNull, ObjectType, String
 from infrahub_sdk.utils import extract_fields_first_node
 
+from infrahub.exceptions import ValidationError
 from infrahub.graphql.types.event import EventNodes
 from infrahub.task_manager.event import PrefectEvent
 
@@ -15,13 +16,13 @@ if TYPE_CHECKING:
 class Events(ObjectType):
     edges = List(NonNull(EventNodes), required=True)
     count = Int(required=True)
+    next_token = String(required=False)
 
     @staticmethod
     async def resolve(
         root: dict,  # noqa: ARG004
         info: GraphQLResolveInfo,
         limit: int = 10,
-        offset: int = 0,
         account: str | None = None,
         ids: list[str] | None = None,
         branch: str | None = None,
@@ -29,16 +30,33 @@ class Events(ObjectType):
         related_node__ids: list[str] | None = None,
     ) -> dict[str, Any]:
         ids = ids or []
+        if limit > 50:
+            # Prefect restricts this to 50
+            raise ValidationError(input_value="The parameter 'limit' can't be above 50")
         return await Events.query(
             info=info,
             branch=branch,
             account=account,
             limit=limit,
-            offset=offset,
             related_node__ids=related_node__ids,
             q=q,
             ids=ids,
         )
+
+    @staticmethod
+    async def resolve_next(
+        root: dict,  # noqa: ARG004
+        info: GraphQLResolveInfo,
+        next_token: str,
+    ) -> dict[str, Any]:
+        fields = await extract_fields_first_node(info)
+
+        prefect_tasks = await PrefectEvent.query_next(fields=fields, next_token=next_token)
+        return {
+            "count": prefect_tasks.get("count", 0),
+            "next_token": prefect_tasks.get("next_token"),
+            "edges": prefect_tasks.get("edges", []),
+        }
 
     @classmethod
     async def query(
@@ -50,7 +68,6 @@ class Events(ObjectType):
         branch: str | None = None,
         account: str | None = None,
         limit: int | None = None,
-        offset: int | None = None,
     ) -> dict[str, Any]:
         fields = await extract_fields_first_node(info)
 
@@ -62,10 +79,10 @@ class Events(ObjectType):
             branch=branch,
             account=account,
             limit=limit,
-            offset=offset,
         )
         return {
             "count": prefect_tasks.get("count", 0),
+            "next_token": prefect_tasks.get("next_token"),
             "edges": prefect_tasks.get("edges", []),
         }
 
@@ -73,12 +90,18 @@ class Events(ObjectType):
 Event = Field(
     Events,
     limit=Int(required=False),
-    offset=Int(required=False),
     related_node__ids=List(String),
     branch=String(required=False),
     account=String(required=False),
     ids=List(String),
     q=String(required=False),
     resolver=Events.resolve,
+    required=True,
+)
+
+EventNext = Field(
+    Events,
+    next_token=String(required=True),
+    resolver=Events.resolve_next,
     required=True,
 )

--- a/backend/infrahub/graphql/schema.py
+++ b/backend/infrahub/graphql/schema.py
@@ -48,7 +48,7 @@ from .queries import (
     Relationship,
 )
 from .queries.diff.tree import DiffTreeQuery, DiffTreeSummaryQuery
-from .queries.event import Event
+from .queries.event import Event, EventNext
 from .queries.task import Task, TaskBranchStatus
 
 
@@ -69,6 +69,7 @@ class InfrahubBaseQuery(ObjectType):
 
     InfrahubTask = Task
     InfrahubEvent = Event
+    InfrahubEventNext = EventNext
     InfrahubTaskBranchStatus = TaskBranchStatus
 
     IPAddressGetNextAvailable = InfrahubIPAddressGetNextAvailable

--- a/backend/infrahub/task_manager/event.py
+++ b/backend/infrahub/task_manager/event.py
@@ -1,11 +1,11 @@
 import uuid
-from typing import Any
+from typing import Any, Self
 
 from prefect.client.orchestration import PrefectClient, get_client
 from prefect.events.filters import EventFilter, EventIDFilter, EventNameFilter, EventRelatedFilter, EventResourceFilter
 from prefect.events.schemas.events import Event as PrefectEventModel
 from prefect.events.schemas.events import ResourceSpecification
-from pydantic import BaseModel, Field, TypeAdapter
+from pydantic import BaseModel, Field, TypeAdapter, model_validator
 
 from infrahub.log import get_logger
 from infrahub.utils import get_nested_dict
@@ -75,7 +75,24 @@ class PrefectEventData(PrefectEventModel):
 
 class PrefectEventResponse(BaseModel):
     count: int = Field(..., description="Number of matching events")
+    next_token: str | None = Field(default=None, description="The token to use for the next query to InfrahubEventNext")
     events: list[PrefectEventData] = Field(..., description="Returned events")
+
+    @model_validator(mode="after")
+    def convert_next_page_token(self) -> Self:
+        """Converts the next_page token to strip out the url
+
+        The original format if present will look something like this:
+        http://localhost:4200/api/events/filter/next?page-token=ZXlKb...
+        """
+        if self.next_token:
+            token_parts = self.next_token.split("token=")
+            if len(token_parts) == 2:
+                self.next_token = token_parts[1]
+            else:
+                self.next_token = None
+
+        return self
 
 
 class PrefectEvent:
@@ -92,10 +109,24 @@ class PrefectEvent:
 
         response = await client._client.post("/events/filter", json=body)
         response.raise_for_status()
-        # TODO need to implement pagination :(
+        data: dict[str, Any] = response.json()
+
         return PrefectEventResponse(
-            count=response.json().get("total", 0),
-            events=TypeAdapter(list[PrefectEventData]).validate_python(response.json().get("events")),
+            count=data.get("total", 0),
+            events=TypeAdapter(list[PrefectEventData]).validate_python(data.get("events")),
+            next_token=data.get("next_page"),
+        )
+
+    @classmethod
+    async def query_next_events(cls, client: PrefectClient, next_token: str) -> PrefectEventResponse:
+        response = await client._client.get(f"/events/filter/next?page-token={next_token}")
+        response.raise_for_status()
+        data: dict[str, Any] = response.json()
+
+        return PrefectEventResponse(
+            count=data.get("total", 0),
+            events=TypeAdapter(list[PrefectEventData]).validate_python(data.get("events")),
+            next_token=data.get("next_page"),
         )
 
     @classmethod
@@ -138,7 +169,6 @@ class PrefectEvent:
         account: str | None = None,
         limit: int | None = None,
         related_node__ids: list[str] | None = None,
-        offset: int | None = None,  # noqa: ARG003
     ) -> dict[str, Any]:
         nodes: list[dict] = []
 
@@ -154,4 +184,18 @@ class PrefectEvent:
             response = await cls.query_events(client=client, filters=filters, limit=limit)
             nodes = [{"node": event.to_graphql()} for event in response.events]
 
-        return {"count": response.count, "edges": nodes}
+        return {"count": response.count, "edges": nodes, "next_token": response.next_token}
+
+    @classmethod
+    async def query_next(
+        cls,
+        fields: dict[str, Any],  # noqa: ARG003
+        next_token: str,
+    ) -> dict[str, Any]:
+        nodes: list[dict] = []
+
+        async with get_client(sync_client=False) as client:
+            response = await cls.query_next_events(client=client, next_token=next_token)
+            nodes = [{"node": event.to_graphql()} for event in response.events]
+
+        return {"count": response.count, "edges": nodes, "next_token": response.next_token}

--- a/backend/tests/unit/graphql/queries/test_event.py
+++ b/backend/tests/unit/graphql/queries/test_event.py
@@ -18,9 +18,10 @@ from tests.helpers.events import send_events
 from tests.helpers.graphql import graphql
 
 QUERY_EVENT = """
-query($branch: String, $account: String) {
-  InfrahubEvent(branch: $branch, account: $account) {
+query($branch: String, $account: String, $limit: Int) {
+  InfrahubEvent(branch: $branch, account: $account, limit: $limit) {
     count
+    next_token
     edges {
       node {
         id
@@ -31,6 +32,23 @@ query($branch: String, $account: String) {
   }
 }
 """
+
+QUERY_EVENT_NEXT = """
+query($next_token: String!) {
+  InfrahubEventNext(next_token: $next_token) {
+    count
+    next_token
+    edges {
+      node {
+        id
+        event
+        branch
+      }
+    }
+  }
+}
+"""
+
 
 QUERY_SIMPLE_COUNT_EVENT = """
 query($branch: String) {
@@ -346,3 +364,26 @@ async def test_event_query_prefect(
     assert branch2_account2.errors is None
     assert branch2_account2.data
     assert branch2_account2.data["InfrahubEvent"]["count"] == 2
+
+    paginated_account1_page1 = await run_query(
+        db=db,
+        branch=default_branch,
+        query=QUERY_EVENT,
+        variables={"account": ACCOUNT1_ID, "limit": 3},
+    )
+    assert paginated_account1_page1.errors is None
+    assert paginated_account1_page1.data
+    assert paginated_account1_page1.data["InfrahubEvent"]["count"] == 4
+    assert paginated_account1_page1.data["InfrahubEvent"]["next_token"]
+    next_token = paginated_account1_page1.data["InfrahubEvent"]["next_token"]
+
+    paginated_account1_page2 = await run_query(
+        db=db,
+        branch=default_branch,
+        query=QUERY_EVENT_NEXT,
+        variables={"next_token": next_token},
+    )
+    assert paginated_account1_page2.errors is None
+    assert paginated_account1_page2.data
+    assert paginated_account1_page2.data["InfrahubEventNext"]["count"] == 4
+    assert not paginated_account1_page2.data["InfrahubEventNext"]["next_token"]


### PR DESCRIPTION
This PR adds pagination support to the InfrahubEvent query, as we are currently just proxying the request to Prefect we have to rely on Prefects pagination which is a variation of offset and cursor based pagination, but the cursor/token is only used to avoid issuing an extra count query.

Changes:

* Remove offset from InfrahubEvent
* Add next_token to InfrahubEvent
* The next_token should be used in the InfrahubEventNext query
* Set an upper limit of the "limit" parameter to 50