### PR TITLE
Add RelationshipManager.get_parent()

### DIFF
--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -600,8 +600,8 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
             if parent_relationship := self._get_parent_relationship_name():
                 if parent_relationship not in processed_relationships:
                     rel: RelationshipManager = getattr(self, parent_relationship)
-                    for peer in await rel.get_relationships(db=db):
-                        node_changelog.add_parent_from_relationship(parent=peer)
+                    if parent := await rel.get_parent(db=db):
+                        node_changelog.add_parent_from_relationship(parent=parent)
 
         node_changelog.display_label = await self.render_display_label(db=db)
         return node_changelog

--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -979,6 +979,19 @@ class RelationshipManager:
 
         return rels
 
+    async def get_parent(
+        self, db: InfrahubDatabase, branch_agnostic: bool = False, force_refresh: bool = False
+    ) -> Relationship | None:
+        if self.schema.kind == RelationshipKind.PARENT:
+            for relationship in await self.get_relationships(
+                db=db, branch_agnostic=branch_agnostic, force_refresh=force_refresh
+            ):
+                # As parent relationships requires cardinality=one there will always only be one relationship
+                # here even though it's within a loop
+                return relationship
+
+        return None
+
     async def get_relationships(
         self, db: InfrahubDatabase, branch_agnostic: bool = False, force_refresh: bool = False
     ) -> list[Relationship]:

--- a/backend/tests/unit/core/test_relationship_manager.py
+++ b/backend/tests/unit/core/test_relationship_manager.py
@@ -294,3 +294,14 @@ async def test_many_add(
         db=db, source_id=tag_red_main.db_id, destination_id=person_jack_main.db_id, max_length=2
     )
     assert len(paths) == 2
+
+
+async def test_get_parent(db: InfrahubDatabase, car_accord_main: Node, person_john_main: Node, branch: Branch):
+    car_schema = registry.schema.get(name="TestCar")
+    rel_schema = car_schema.get_relationship("owner")
+
+    relm = await RelationshipManager.init(db=db, schema=rel_schema, branch=branch, at=Timestamp(), node=car_accord_main)
+    parent = await relm.get_parent(db=db)
+    assert parent
+    assert parent.get_peer_id() == person_john_main.id
+    assert parent.get_peer_kind() == person_john_main.get_kind()


### PR DESCRIPTION
Adds .get_parent() to relationship manager in order to clean up the code in other places. It can also be helpful just to know... https://www.youtube.com/watch?v=pKypFhCse9E