### PR TITLE
Add events from relationship updates

### DIFF
--- a/backend/infrahub/core/changelog/models.py
+++ b/backend/infrahub/core/changelog/models.py
@@ -267,6 +267,28 @@ class NodeChangelog(BaseModel):
 
             relationship_container.add_new_peer(relationship=relationship)
 
+    def delete_relationship(self, relationship: Relationship) -> None:
+        if relationship.schema.cardinality == RelationshipCardinality.ONE:
+            peer_id = relationship.get_peer_id()
+            peer_kind = relationship.get_peer_kind()
+            changelog_relationship = RelationshipCardinalityOneChangelog(
+                name=relationship.schema.name,
+                peer_id_previous=peer_id,
+                peer_kind_previous=peer_kind,
+            )
+            self.relationships[changelog_relationship.name] = changelog_relationship
+        elif relationship.schema.cardinality == RelationshipCardinality.MANY:
+            if relationship.schema.name not in self.relationships:
+                self.relationships[relationship.schema.name] = RelationshipCardinalityManyChangelog(
+                    name=relationship.schema.name
+                )
+            relationship_container = cast(
+                RelationshipCardinalityManyChangelog, self.relationships[relationship.schema.name]
+            )
+            relationship_container.remove_peer(
+                peer_id=relationship.get_peer_id(), peer_kind=relationship.get_peer_kind()
+            )
+
     def add_attribute(self, attribute: AttributeChangelog) -> None:
         self.attributes[attribute.name] = attribute
 

--- a/backend/infrahub/events/group_action.py
+++ b/backend/infrahub/events/group_action.py
@@ -1,0 +1,66 @@
+from typing import Any
+
+from pydantic import Field, computed_field
+
+from infrahub.core.constants import MutationAction
+from infrahub.message_bus import InfrahubMessage
+
+from .constants import EVENT_NAMESPACE
+from .models import EventNode, InfrahubEvent
+
+
+class GroupMutatedEvent(InfrahubEvent):
+    """Event generated when a node has been mutated"""
+
+    kind: str = Field(..., description="The type of updated group")
+    node_id: str = Field(..., description="The ID of the updated group")
+    action: MutationAction = Field(..., description="The action taken on the node")
+    members: list[EventNode] = Field(default_factory=list, description="Updated members during this event.")
+
+    def get_related(self) -> list[dict[str, str]]:
+        related = super().get_related()
+        for member in self.members:
+            related.append(
+                {
+                    "prefect.resource.id": member.id,
+                    "prefect.resource.role": "infrahub.group.member",
+                    "infrahub.group.kind": member.kind,
+                }
+            )
+
+        return related
+
+    @computed_field
+    def event_name(self) -> str:
+        return f"{EVENT_NAMESPACE}.group.{self.action.value}"
+
+    def get_resource(self) -> dict[str, str]:
+        return {
+            "prefect.resource.id": f"infrahub.node.{self.node_id}",
+            "infrahub.node.kind": self.kind,
+            "infrahub.node.id": self.node_id,
+            "infrahub.node.action": self.action.value,
+            "infrahub.node.root_id": self.node_id,
+        }
+
+    def get_payload(self) -> dict[str, Any]:
+        return {"members": [member.model_dump() for member in self.members]}
+
+    def get_messages(self) -> list[InfrahubMessage]:
+        return []
+
+
+class GroupMemberAddedEvent(GroupMutatedEvent):
+    action: MutationAction = MutationAction.CREATED
+
+    @computed_field
+    def event_name(self) -> str:
+        return f"{EVENT_NAMESPACE}.group.member_added"
+
+
+class GroupMemberRemovedEvent(GroupMutatedEvent):
+    action: MutationAction = MutationAction.DELETED
+
+    @computed_field
+    def event_name(self) -> str:
+        return f"{EVENT_NAMESPACE}.group.member_removed"

--- a/backend/infrahub/events/models.py
+++ b/backend/infrahub/events/models.py
@@ -14,6 +14,11 @@ from infrahub.worker import WORKER_IDENTITY
 from .constants import EVENT_NAMESPACE
 
 
+class EventNode(BaseModel):
+    id: str
+    kind: str
+
+
 class EventMeta(BaseModel):
     branch: Branch | None = Field(default=None)
     request_id: str = ""

--- a/backend/infrahub/graphql/mutations/relationship.py
+++ b/backend/infrahub/graphql/mutations/relationship.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self
 
 from graphene import Boolean, InputField, InputObjectType, List, Mutation, String
 from infrahub_sdk.utils import compare_lists
 
-from infrahub.core.constants import InfrahubKind, RelationshipCardinality
+from infrahub import config
+from infrahub.core.changelog.models import NodeChangelog
+from infrahub.core.constants import InfrahubKind, MutationAction, RelationshipCardinality
 from infrahub.core.manager import NodeManager
 from infrahub.core.query.relationship import (
     RelationshipGetPeerQuery,
@@ -13,6 +15,9 @@ from infrahub.core.query.relationship import (
 )
 from infrahub.core.relationship import Relationship
 from infrahub.database import retry_db_transaction
+from infrahub.events import EventMeta, NodeMutatedEvent
+from infrahub.events.group_action import GroupMemberAddedEvent, GroupMemberRemovedEvent
+from infrahub.events.models import EventNode
 from infrahub.exceptions import NodeNotFoundError, ValidationError
 
 from ..types import RelatedNodeInput
@@ -38,14 +43,15 @@ class RelationshipNodesInput(InputObjectType):
 
 class RelationshipMixin:
     @classmethod
-    async def mutate(
+    async def mutate(  # noqa: PLR0915
         cls,
         root: dict,  # noqa: ARG003
         info: GraphQLResolveInfo,
         data: RelationshipNodesInput,
-    ):
+    ) -> Self:
         graphql_context: GraphqlContext = info.context
         input_id = str(data.id)
+        relationship_name = str(data.name)
 
         if not (
             source := await NodeManager.get_one(
@@ -56,17 +62,19 @@ class RelationshipMixin:
                 include_source=False,
             )
         ):
-            raise NodeNotFoundError(graphql_context.branch, None, input_id)
+            raise NodeNotFoundError(node_type="node", identifier=input_id, branch_name=graphql_context.branch.name)
 
         # Check if the name of the relationship provided exist for this node and is of cardinality Many
-        if data.get("name") not in source._schema.relationship_names:
+        if relationship_name not in source._schema.relationship_names:
             raise ValidationError(
-                {"name": f"'{data.get('name')}' is not a valid relationship for '{source.get_kind()}'"}
+                {"name": f"'{relationship_name}' is not a valid relationship for '{source.get_kind()}'"}
             )
 
-        rel_schema = source._schema.get_relationship(name=data.get("name"))
+        rel_schema = source._schema.get_relationship(name=relationship_name)
         if rel_schema.cardinality != RelationshipCardinality.MANY:
-            raise ValidationError({"name": f"'{data.get('name')}' must be a relationship of cardinality Many"})
+            raise ValidationError({"name": f"'{relationship_name}' must be a relationship of cardinality Many"})
+
+        is_group_event = rel_schema.identifier == "group_member" and "CoreGroup" in source._schema.inherit_from
 
         # Query the node in the database and validate that all of them exist and are if the correct kind
         node_ids: list[str] = [node_data["id"] for node_data in data.get("nodes") if "id" in node_data]
@@ -98,6 +106,11 @@ class RelationshipMixin:
                             f"{node_id!r} {node.get_kind()!r} is already related to another peer on '{peer_relationships[0].name}'"
                         )
 
+        display_label: str = await source.render_display_label(db=graphql_context.db)
+        node_changelog = NodeChangelog(
+            node_id=source.get_id(), node_kind=source.get_kind(), display_label=display_label
+        )
+
         # The nodes that are already present in the db
         query = await RelationshipGetPeerQuery.init(
             db=graphql_context.db,
@@ -105,9 +118,9 @@ class RelationshipMixin:
             rel=Relationship(schema=rel_schema, branch=graphql_context.branch, node=source),
         )
         await query.execute(db=graphql_context.db)
-        existing_peers: dict[str, RelationshipPeerData] = {peer.peer_id: peer for peer in query.get_peers()}
-
+        existing_peers: dict[str, RelationshipPeerData] = {str(peer.peer_id): peer for peer in query.get_peers()}
         async with graphql_context.db.start_transaction() as db:
+            members = []
             if cls.__name__ == "RelationshipAdd":
                 for node_data in data.get("nodes"):
                     # Instantiate and resolve a relationship
@@ -117,6 +130,8 @@ class RelationshipMixin:
                     await rel.resolve(db=db)
                     # Save it only if it does not exist
                     if rel.get_peer_id() not in existing_peers.keys():
+                        members.append(EventNode(id=rel.get_peer_id(), kind=rel.get_peer_kind()))
+                        node_changelog.create_relationship(relationship=rel)
                         await rel.save(db=db)
 
             elif cls.__name__ == "RelationshipRemove":
@@ -127,9 +142,35 @@ class RelationshipMixin:
                         # it would be more query efficient
                         rel = Relationship(schema=rel_schema, branch=graphql_context.branch, node=source)
                         await rel.load(db=db, data=existing_peers[node_data.get("id")])
+                        members.append(EventNode(id=rel.get_peer_id(), kind=rel.get_peer_kind()))
+                        node_changelog.delete_relationship(relationship=rel)
                         await rel.delete(db=db)
 
-        return cls(ok=True)
+        if config.SETTINGS.broker.enable and graphql_context.background:
+            event = NodeMutatedEvent(
+                kind=source._schema.kind,
+                node_id=source.id,
+                data=node_changelog,
+                action=MutationAction.UPDATED,
+                fields=[relationship_name],
+                meta=EventMeta(
+                    branch=graphql_context.branch,
+                ),
+            )
+            graphql_context.background.add_task(graphql_context.active_service.event.send, event)
+            if is_group_event:
+                if cls.__name__ == "RelationshipAdd":
+                    group_add_event = GroupMemberAddedEvent(
+                        node_id=source.id, kind=source._schema.kind, members=members
+                    )
+                    graphql_context.background.add_task(graphql_context.active_service.event.send, group_add_event)
+                elif cls.__name__ == "RelationshipRemove":
+                    group_remove_event = GroupMemberRemovedEvent(
+                        node_id=source.id, kind=source._schema.kind, members=members
+                    )
+                    graphql_context.background.add_task(graphql_context.active_service.event.send, group_remove_event)
+
+        return cls(ok=True)  # type: ignore[call-arg]
 
 
 class RelationshipAdd(RelationshipMixin, Mutation):
@@ -145,7 +186,7 @@ class RelationshipAdd(RelationshipMixin, Mutation):
         root: dict,
         info: GraphQLResolveInfo,
         data: RelationshipNodesInput,
-    ):
+    ) -> Self:
         return await super().mutate(root=root, info=info, data=data)
 
 
@@ -162,5 +203,5 @@ class RelationshipRemove(RelationshipMixin, Mutation):
         root: dict,
         info: GraphQLResolveInfo,
         data: RelationshipNodesInput,
-    ):
+    ) -> Self:
         return await super().mutate(root=root, info=info, data=data)

--- a/backend/tests/unit/graphql/test_mutation_relationship.py
+++ b/backend/tests/unit/graphql/test_mutation_relationship.py
@@ -6,7 +6,11 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.utils import count_relationships
 from infrahub.database import InfrahubDatabase
+from infrahub.events.group_action import GroupMemberAddedEvent, GroupMemberRemovedEvent
+from infrahub.events.node_action import NodeMutatedEvent
 from infrahub.graphql.initialization import prepare_graphql_params
+from infrahub.services import InfrahubServices
+from tests.adapters.event import MemoryInfrahubEvent
 from tests.helpers.graphql import graphql
 
 
@@ -308,7 +312,12 @@ async def test_relationship_wrong_node(
     )
 
 
-async def test_relationship_groups_add(db: InfrahubDatabase, default_branch: Branch, car_person_generics_data):
+async def test_relationship_groups_add(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_person_generics_data,
+    enable_broker_config: None,
+):
     c1 = car_person_generics_data["c1"]
     c2 = car_person_generics_data["c2"]
     c3 = car_person_generics_data["c3"]
@@ -334,8 +343,9 @@ async def test_relationship_groups_add(db: InfrahubDatabase, default_branch: Bra
         g1.id,
         c2.id,
     )
-
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    memory_event = MemoryInfrahubEvent()
+    service = await InfrahubServices.new(event=memory_event)
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch, service=service)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -349,6 +359,16 @@ async def test_relationship_groups_add(db: InfrahubDatabase, default_branch: Bra
     group1 = await NodeManager.get_one(db=db, id=g1.id, branch=default_branch)
     members = await group1.members.get(db=db)
     assert len(members) == 2
+
+    assert gql_params.context.background
+    await gql_params.context.background()
+
+    node_event = memory_event.events[0]
+    group_event = memory_event.events[1]
+    assert isinstance(node_event, NodeMutatedEvent)
+    assert isinstance(group_event, GroupMemberAddedEvent)
+
+    assert [member.id for member in group_event.members] == [c2.id]
 
     query = """
     mutation {
@@ -366,7 +386,6 @@ async def test_relationship_groups_add(db: InfrahubDatabase, default_branch: Bra
         g2.id,
     )
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -386,7 +405,12 @@ async def test_relationship_groups_add(db: InfrahubDatabase, default_branch: Bra
     assert len(members) == 2
 
 
-async def test_relationship_groups_remove(db: InfrahubDatabase, default_branch: Branch, car_person_generics_data):
+async def test_relationship_groups_remove(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_person_generics_data,
+    enable_broker_config: None,
+):
     c1 = car_person_generics_data["c1"]
     c2 = car_person_generics_data["c2"]
     c3 = car_person_generics_data["c3"]
@@ -413,7 +437,10 @@ async def test_relationship_groups_remove(db: InfrahubDatabase, default_branch: 
         c1.id,
     )
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    memory_event = MemoryInfrahubEvent()
+    service = await InfrahubServices.new(event=memory_event)
+
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch, service=service)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -427,6 +454,15 @@ async def test_relationship_groups_remove(db: InfrahubDatabase, default_branch: 
     group1 = await NodeManager.get_one(db=db, id=g1.id, branch=default_branch)
     members = await group1.members.get(db=db)
     assert len(members) == 0
+
+    assert gql_params.context.background
+    await gql_params.context.background()
+
+    node_event = memory_event.events[0]
+    group_event = memory_event.events[1]
+    assert isinstance(node_event, NodeMutatedEvent)
+    assert isinstance(group_event, GroupMemberRemovedEvent)
+    assert [member.id for member in group_event.members] == [c1.id]
 
     query = """
     mutation {
@@ -444,7 +480,6 @@ async def test_relationship_groups_remove(db: InfrahubDatabase, default_branch: 
         g2.id,
     )
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -278,10 +278,6 @@ module = "infrahub.graphql.mutations.proposed_change"
 ignore_errors = true
 
 [[tool.mypy.overrides]]
-module = "infrahub.graphql.mutations.relationship"
-ignore_errors = true
-
-[[tool.mypy.overrides]]
 module = "infrahub.graphql.mutations.repository"
 ignore_errors = true
 


### PR DESCRIPTION

Related to #5397 

Changes

* Add events for RelationshipAdd & RelationshipRemove mutations.
* Add new events for group actions, infrahub.group.member_added & infrahub.group.member_removed
* I've added a `# noqa: PLR0915` for the main relationship mutation (due to too many statements). I'd already planned to break apart this function and clean up the code, however due to upcoming changes that we'll want to merge back from the stable branch I'm leaving the function intact until that is done. Once this is done we'll also remove the type-ignore statement for the relationship mixin


A few limitations:

* The current logic assumes that members are added to group that's being targeted by the mutation. But the RelationshipAdd/Remove mutation could also be used on a group member where the goal is to add or remove it from a number of groups. This will come in an upcoming PR
* The regular node mutations can also be used to add or remove members from groups. An upcoming PR will ensure that we send group member add/remove events in those situations
* The feature lists adding all ancestors to the updated group, this is not addressed in this PR.