### PR TITLE
Don't collect 'source' and 'owner' for relationship

### DIFF
--- a/backend/infrahub/graphql/mutations/relationship.py
+++ b/backend/infrahub/graphql/mutations/relationship.py
@@ -52,8 +52,8 @@ class RelationshipMixin:
                 db=graphql_context.db,
                 id=input_id,
                 branch=graphql_context.branch,
-                include_owner=True,
-                include_source=True,
+                include_owner=False,
+                include_source=False,
             )
         ):
             raise NodeNotFoundError(graphql_context.branch, None, input_id)


### PR DESCRIPTION
It seems like we're collecting the "source" and "owner" metadata fields here without actually using the data for anything which would just add overhead.