### PR TITLE
Add API wrapper to Prefect for custom endpoints

### DIFF
--- a/.github/workflows/version-upgrade.yml
+++ b/.github/workflows/version-upgrade.yml
@@ -71,10 +71,14 @@ jobs:
       - name: Initialize Demo
         id: init-demo
         run: invoke demo.start demo.load-infra-schema
+        env:
+          PREFECT_SERVER_COMMAND: "prefect server start --host 0.0.0.0 --ui"
       - name: Check Demo Status
         run: invoke demo.status
       - name: Load Data
         run: invoke demo.load-infra-data
+        env:
+          PREFECT_SERVER_COMMAND: "prefect server start --host 0.0.0.0 --ui"
       - name: Stop Demo
         run: invoke demo.stop
 
@@ -111,6 +115,10 @@ jobs:
       - name: Display database logs
         if: always()
         run: docker logs "${INFRAHUB_BUILD_NAME}-database-1"
+
+      - name: Display task-manager logs
+        if: always()
+        run: docker logs "${INFRAHUB_BUILD_NAME}-task-manager-1"
 
       - name: Display server status
         if: always()

--- a/backend/infrahub/events/models.py
+++ b/backend/infrahub/events/models.py
@@ -31,9 +31,7 @@ class EventMeta(BaseModel):
 
     def get_related(self) -> list[dict[str, str]]:
         related: list[dict[str, str]] = []
-        event_resource = {"infrahub.event.level": self.level.value}
         if self.account_id:
-            event_resource["infrahub.account.id"] = self.account_id
             related.append(
                 {
                     "prefect.resource.id": f"infrahub.account.{self.account_id}",
@@ -43,7 +41,6 @@ class EventMeta(BaseModel):
             )
 
         if self.branch:
-            event_resource["infrahub.branch.label"] = self.branch.name
             related.append(
                 {
                     "prefect.resource.id": f"infrahub.branch.{self.branch.get_uuid()}",
@@ -52,12 +49,6 @@ class EventMeta(BaseModel):
                     "infrahub.resource.label": self.branch.name,
                 }
             )
-
-        # This is currently required to let us filter events with the InfrahubEvent query when matching
-        # against multiple components such as both branch and account
-        event_resource["prefect.resource.id"] = str(uuid4())
-        event_resource["prefect.resource.role"] = "infrahub.eventlog"
-        related.append(event_resource)
 
         related.append({"prefect.resource.id": __version__, "prefect.resource.role": "infrahub.version"})
 

--- a/backend/infrahub/graphql/queries/event.py
+++ b/backend/infrahub/graphql/queries/event.py
@@ -16,13 +16,13 @@ if TYPE_CHECKING:
 class Events(ObjectType):
     edges = List(NonNull(EventNodes), required=True)
     count = Int(required=True)
-    next_token = String(required=False)
 
     @staticmethod
     async def resolve(
         root: dict,  # noqa: ARG004
         info: GraphQLResolveInfo,
         limit: int = 10,
+        offset: int | None = None,
         account: str | None = None,
         ids: list[str] | None = None,
         branch: str | None = None,
@@ -38,36 +38,23 @@ class Events(ObjectType):
             branch=branch,
             account=account,
             limit=limit,
+            offset=offset,
             related_node__ids=related_node__ids,
             q=q,
             ids=ids,
         )
 
-    @staticmethod
-    async def resolve_next(
-        root: dict,  # noqa: ARG004
-        info: GraphQLResolveInfo,
-        next_token: str,
-    ) -> dict[str, Any]:
-        fields = await extract_fields_first_node(info)
-
-        prefect_tasks = await PrefectEvent.query_next(fields=fields, next_token=next_token)
-        return {
-            "count": prefect_tasks.get("count", 0),
-            "next_token": prefect_tasks.get("next_token"),
-            "edges": prefect_tasks.get("edges", []),
-        }
-
     @classmethod
     async def query(
         cls,
         info: GraphQLResolveInfo,
+        limit: int,
+        offset: int | None = None,
         q: str | None = None,
         ids: list[str] | None = None,
         related_node__ids: list[str] | None = None,
         branch: str | None = None,
         account: str | None = None,
-        limit: int | None = None,
     ) -> dict[str, Any]:
         fields = await extract_fields_first_node(info)
 
@@ -79,10 +66,10 @@ class Events(ObjectType):
             branch=branch,
             account=account,
             limit=limit,
+            offset=offset,
         )
         return {
             "count": prefect_tasks.get("count", 0),
-            "next_token": prefect_tasks.get("next_token"),
             "edges": prefect_tasks.get("edges", []),
         }
 
@@ -90,18 +77,12 @@ class Events(ObjectType):
 Event = Field(
     Events,
     limit=Int(required=False),
+    offset=Int(required=False),
     related_node__ids=List(String),
     branch=String(required=False),
     account=String(required=False),
     ids=List(String),
     q=String(required=False),
     resolver=Events.resolve,
-    required=True,
-)
-
-EventNext = Field(
-    Events,
-    next_token=String(required=True),
-    resolver=Events.resolve_next,
     required=True,
 )

--- a/backend/infrahub/graphql/schema.py
+++ b/backend/infrahub/graphql/schema.py
@@ -48,7 +48,7 @@ from .queries import (
     Relationship,
 )
 from .queries.diff.tree import DiffTreeQuery, DiffTreeSummaryQuery
-from .queries.event import Event, EventNext
+from .queries.event import Event
 from .queries.task import Task, TaskBranchStatus
 
 
@@ -69,7 +69,6 @@ class InfrahubBaseQuery(ObjectType):
 
     InfrahubTask = Task
     InfrahubEvent = Event
-    InfrahubEventNext = EventNext
     InfrahubTaskBranchStatus = TaskBranchStatus
 
     IPAddressGetNextAvailable = InfrahubIPAddressGetNextAvailable

--- a/backend/infrahub/prefect_server/app.py
+++ b/backend/infrahub/prefect_server/app.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, FastAPI
+from prefect.server.api.server import create_app
+
+from . import events
+
+router = APIRouter(prefix="/infrahub")
+
+router.include_router(events.router)
+
+
+def create_infrahub_prefect() -> FastAPI:
+    app = create_app()
+    api_app: FastAPI = app.__dict__["api_app"]
+    api_app.include_router(router=router)
+
+    return app

--- a/backend/infrahub/prefect_server/database.py
+++ b/backend/infrahub/prefect_server/database.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from prefect.server.events.schemas.events import ReceivedEvent
+from prefect.server.events.storage import INTERACTIVE_PAGE_SIZE
+from prefect.server.events.storage.database import raw_count_events, read_events
+
+if TYPE_CHECKING:
+    from prefect.server.events.filters import EventFilter
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def query_events(
+    session: AsyncSession, filter: EventFilter, page_size: int = INTERACTIVE_PAGE_SIZE, offset: int | None = None
+) -> tuple[list[ReceivedEvent], int]:
+    count = await raw_count_events(session, filter)  # type: ignore[attr-defined]
+    page = await read_events(session, filter, limit=page_size, offset=offset)  # type: ignore[attr-defined]
+    events = [ReceivedEvent.model_validate(e, from_attributes=True) for e in page]
+    return events, count

--- a/backend/infrahub/prefect_server/events.py
+++ b/backend/infrahub/prefect_server/events.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter
+from fastapi.param_functions import Depends
+from prefect.server.database import PrefectDBInterface, provide_database_interface
+
+from .database import query_events
+from .models import InfrahubEventfilterInput, InfrahubEventPage
+
+router = APIRouter(prefix="/events", tags=["Infrahub"])
+
+
+@router.post(
+    "/filter",
+)
+async def read_events(
+    event_filter: InfrahubEventfilterInput,
+    db: PrefectDBInterface = Depends(provide_database_interface),  # noqa: B008
+) -> InfrahubEventPage:
+    event_filter.filter.set_prefix()
+
+    async with db.session_context() as session:
+        events, total = await query_events(
+            session=session, filter=event_filter.filter, page_size=event_filter.limit, offset=event_filter.offset
+        )
+
+        return InfrahubEventPage(
+            events=events,
+            total=total,
+        )

--- a/backend/infrahub/prefect_server/models.py
+++ b/backend/infrahub/prefect_server/models.py
@@ -1,0 +1,46 @@
+from typing import TYPE_CHECKING, Sequence, cast
+
+from prefect.server.database import PrefectDBInterface, db_injector
+from prefect.server.events.filters import EventFilter, EventNameFilter, EventOrder, EventRelatedFilter
+from prefect.server.events.schemas.events import ReceivedEvent
+from prefect.server.utilities.schemas import PrefectBaseModel
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from sqlalchemy.sql.expression import ColumnExpressionArgument
+
+
+class InfrahubEventFilter(EventFilter):
+    matching_related: list[EventRelatedFilter] = Field(default_factory=list)
+
+    def set_prefix(self) -> None:
+        if self.event:
+            if self.event.prefix is not None and "infrahub." not in self.event.prefix:
+                self.event.prefix.append("infrahub.")
+        else:
+            self.event = EventNameFilter(prefix=["infrahub."], name=[], exclude_prefix=None, exclude_name=None)
+
+    @db_injector
+    def build_where_clauses(self, db: PrefectDBInterface) -> Sequence["ColumnExpressionArgument[bool]"]:
+        result = cast(list["ColumnExpressionArgument[bool]"], super().build_where_clauses())
+        top_level_filter = self._scoped_event_resources(db)
+        for matching_related in self.matching_related:
+            matching_related._top_level_filter = top_level_filter
+            result.extend(matching_related.build_where_clauses())
+
+        return result
+
+    @classmethod
+    def default(cls) -> "InfrahubEventFilter":
+        return cls(event=None, any_resource=None, resource=None, related=None, order=EventOrder.DESC)
+
+
+class InfrahubEventPage(PrefectBaseModel):
+    events: list[ReceivedEvent] = Field(..., description="The Events matching the query")
+    total: int = Field(..., description="The total number of matching Events")
+
+
+class InfrahubEventfilterInput(BaseModel):
+    limit: int = Field(default=50)
+    filter: InfrahubEventFilter = Field(default_factory=InfrahubEventFilter.default)
+    offset: int | None = Field(default=None)

--- a/backend/infrahub/task_manager/event.py
+++ b/backend/infrahub/task_manager/event.py
@@ -1,17 +1,21 @@
 import uuid
-from typing import Any, Self
+from typing import Any
 
 from prefect.client.orchestration import PrefectClient, get_client
-from prefect.events.filters import EventFilter, EventIDFilter, EventNameFilter, EventRelatedFilter, EventResourceFilter
+from prefect.events.filters import EventFilter, EventIDFilter, EventRelatedFilter, EventResourceFilter
 from prefect.events.schemas.events import Event as PrefectEventModel
 from prefect.events.schemas.events import ResourceSpecification
-from pydantic import BaseModel, Field, TypeAdapter, model_validator
+from pydantic import BaseModel, Field, TypeAdapter
 
 from infrahub.core.constants import EventLevel
 from infrahub.log import get_logger
 from infrahub.utils import get_nested_dict
 
 log = get_logger()
+
+
+class InfrahubEventFilter(EventFilter):
+    matching_related: list[EventRelatedFilter] = Field(default_factory=list)
 
 
 class PrefectEventData(PrefectEventModel):
@@ -95,58 +99,27 @@ class PrefectEventData(PrefectEventModel):
 
 class PrefectEventResponse(BaseModel):
     count: int = Field(..., description="Number of matching events")
-    next_token: str | None = Field(default=None, description="The token to use for the next query to InfrahubEventNext")
     events: list[PrefectEventData] = Field(..., description="Returned events")
-
-    @model_validator(mode="after")
-    def convert_next_page_token(self) -> Self:
-        """Converts the next_page token to strip out the url
-
-        The original format if present will look something like this:
-        http://localhost:4200/api/events/filter/next?page-token=ZXlKb...
-        """
-        if self.next_token:
-            token_parts = self.next_token.split("token=")
-            if len(token_parts) == 2:
-                self.next_token = token_parts[1]
-            else:
-                self.next_token = None
-
-        return self
 
 
 class PrefectEvent:
     @classmethod
     async def query_events(
-        cls, client: PrefectClient, filters: EventFilter | None = None, limit: int | None = None
+        cls,
+        client: PrefectClient,
+        limit: int,
+        filters: EventFilter,
+        offset: int | None = None,
     ) -> PrefectEventResponse:
-        body: dict[str, Any] = {}
-        if filters:
-            body["filter"] = filters.model_dump(mode="json", exclude_unset=True)
+        body = {"limit": limit, "filter": filters.model_dump(mode="json", exclude_none=True), "offset": offset}
 
-        if limit is not None:
-            body["limit"] = limit
-
-        response = await client._client.post("/events/filter", json=body)
+        response = await client._client.post("/infrahub/events/filter", json=body)
         response.raise_for_status()
         data: dict[str, Any] = response.json()
 
         return PrefectEventResponse(
             count=data.get("total", 0),
             events=TypeAdapter(list[PrefectEventData]).validate_python(data.get("events")),
-            next_token=data.get("next_page"),
-        )
-
-    @classmethod
-    async def query_next_events(cls, client: PrefectClient, next_token: str) -> PrefectEventResponse:
-        response = await client._client.get(f"/events/filter/next?page-token={next_token}")
-        response.raise_for_status()
-        data: dict[str, Any] = response.json()
-
-        return PrefectEventResponse(
-            count=data.get("total", 0),
-            events=TypeAdapter(list[PrefectEventData]).validate_python(data.get("events")),
-            next_token=data.get("next_page"),
         )
 
     @classmethod
@@ -156,8 +129,8 @@ class PrefectEvent:
         account: str | None = None,
         related_node__ids: list[str] | None = None,
         branch: str | None = None,
-    ) -> EventFilter:
-        filters = EventFilter(event=EventNameFilter(prefix=["infrahub."], name=[]))
+    ) -> InfrahubEventFilter:
+        filters = InfrahubEventFilter()
 
         if ids:
             filters.id = EventIDFilter(id=[uuid.UUID(id) for id in ids])
@@ -167,15 +140,23 @@ class PrefectEvent:
                 labels=ResourceSpecification({"infrahub.node.id": related_node__ids})
             )
 
-        related_filter: dict[str, str | list[str]] = {}
         if branch:
-            related_filter["infrahub.branch.label"] = branch
+            filters.matching_related.append(
+                EventRelatedFilter(
+                    labels=ResourceSpecification(
+                        {"prefect.resource.role": "infrahub.branch", "infrahub.resource.label": branch}
+                    )
+                )
+            )
 
         if account:
-            related_filter["infrahub.account.id"] = account
-
-        if related_filter:
-            filters.related = EventRelatedFilter(labels=ResourceSpecification(related_filter))
+            filters.matching_related.append(
+                EventRelatedFilter(
+                    labels=ResourceSpecification(
+                        {"prefect.resource.role": "infrahub.account", "infrahub.resource.id": account}
+                    )
+                )
+            )
 
         return filters
 
@@ -183,14 +164,16 @@ class PrefectEvent:
     async def query(
         cls,
         fields: dict[str, Any],
+        limit: int | None = None,
+        offset: int | None = None,
         q: str | None = None,  # noqa: ARG003
         ids: list[str] | None = None,
         branch: str | None = None,
         account: str | None = None,
-        limit: int | None = None,
         related_node__ids: list[str] | None = None,
     ) -> dict[str, Any]:
         nodes: list[dict] = []
+        limit = limit or 50
 
         node_fields = get_nested_dict(nested_dict=fields, keys=["edges", "node"])
         filters = cls._generate_filters(ids=ids, branch=branch, account=account, related_node__ids=related_node__ids)
@@ -201,21 +184,7 @@ class PrefectEvent:
             limit = 1
 
         async with get_client(sync_client=False) as client:
-            response = await cls.query_events(client=client, filters=filters, limit=limit)
+            response = await cls.query_events(client=client, filters=filters, limit=limit, offset=offset)
             nodes = [{"node": event.to_graphql()} for event in response.events]
 
-        return {"count": response.count, "edges": nodes, "next_token": response.next_token}
-
-    @classmethod
-    async def query_next(
-        cls,
-        fields: dict[str, Any],  # noqa: ARG003
-        next_token: str,
-    ) -> dict[str, Any]:
-        nodes: list[dict] = []
-
-        async with get_client(sync_client=False) as client:
-            response = await cls.query_next_events(client=client, next_token=next_token)
-            nodes = [{"node": event.to_graphql()} for event in response.events]
-
-        return {"count": response.count, "edges": nodes, "next_token": response.next_token}
+        return {"count": response.count, "edges": nodes}

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -1,7 +1,11 @@
+import os
 import shutil
+import subprocess  # noqa: S404
+import sys
 from itertools import islice
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import pendulum
 import pytest
@@ -9,6 +13,7 @@ from infrahub_sdk import Config, InfrahubClient
 from infrahub_sdk.uuidt import UUIDT
 from neo4j._codec.hydration.v1 import HydrationHandler
 from prefect.logging.loggers import disable_run_logger
+from prefect.settings import get_current_settings
 from prefect.testing.utilities import prefect_test_harness
 from pytest_httpx import HTTPXMock
 
@@ -91,8 +96,43 @@ def neo4j_factory():
 
 @pytest.fixture(scope="session", autouse=True)
 def prefect_test_fixture():
-    with prefect_test_harness(server_startup_timeout=60):
-        yield
+    def _run_uvicorn_command(self) -> subprocess.Popen[Any]:
+        """Patched version of prefect method to call the test server, pointing at the Infrahub entrypoint instead"""
+        # used to turn off serving the UI
+        server_env = {
+            "PREFECT_UI_ENABLED": "0",
+            "PREFECT__SERVER_EPHEMERAL": "1",
+            "PREFECT__SERVER_FINAL": "1",
+        }
+
+        return subprocess.Popen(
+            args=[
+                sys.executable,
+                "-m",
+                "uvicorn",
+                # "--app-dir",
+                # str(infrahub.__module_path__.parent),
+                "--factory",
+                "infrahub.prefect_server.app:create_infrahub_prefect",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(self.port),
+                "--log-level",
+                "error",
+                "--lifespan",
+                "on",
+            ],
+            env={
+                **os.environ,
+                **server_env,
+                **get_current_settings().to_environment_variables(exclude_unset=True),
+            },
+        )
+
+    with patch("prefect.server.api.server.SubprocessASGIServer._run_uvicorn_command", _run_uvicorn_command):
+        with prefect_test_harness(server_startup_timeout=60):
+            yield
 
 
 @pytest.fixture(scope="session")

--- a/backend/tests/unit/graphql/queries/test_event.py
+++ b/backend/tests/unit/graphql/queries/test_event.py
@@ -18,26 +18,9 @@ from tests.helpers.events import send_events
 from tests.helpers.graphql import graphql
 
 QUERY_EVENT = """
-query($branch: String, $account: String, $limit: Int) {
-  InfrahubEvent(branch: $branch, account: $account, limit: $limit) {
+query($branch: String, $account: String, $limit: Int, $offset: Int) {
+  InfrahubEvent(branch: $branch, account: $account, limit: $limit, offset: $offset) {
     count
-    next_token
-    edges {
-      node {
-        id
-        event
-        branch
-      }
-    }
-  }
-}
-"""
-
-QUERY_EVENT_NEXT = """
-query($next_token: String!) {
-  InfrahubEventNext(next_token: $next_token) {
-    count
-    next_token
     edges {
       node {
         id
@@ -379,21 +362,20 @@ async def test_event_query_prefect(
         db=db,
         branch=default_branch,
         query=QUERY_EVENT,
-        variables={"account": ACCOUNT1_ID, "limit": 3},
+        variables={"account": ACCOUNT1_ID, "limit": 3, "offset": 0},
     )
     assert paginated_account1_page1.errors is None
     assert paginated_account1_page1.data
     assert paginated_account1_page1.data["InfrahubEvent"]["count"] == 4
-    assert paginated_account1_page1.data["InfrahubEvent"]["next_token"]
-    next_token = paginated_account1_page1.data["InfrahubEvent"]["next_token"]
+    assert len(paginated_account1_page1.data["InfrahubEvent"]["edges"]) == 3
 
     paginated_account1_page2 = await run_query(
         db=db,
         branch=default_branch,
-        query=QUERY_EVENT_NEXT,
-        variables={"next_token": next_token},
+        query=QUERY_EVENT,
+        variables={"account": ACCOUNT1_ID, "limit": 3, "offset": 3},
     )
     assert paginated_account1_page2.errors is None
     assert paginated_account1_page2.data
-    assert paginated_account1_page2.data["InfrahubEventNext"]["count"] == 4
-    assert not paginated_account1_page2.data["InfrahubEventNext"]["next_token"]
+    assert paginated_account1_page2.data["InfrahubEvent"]["count"] == 4
+    assert len(paginated_account1_page2.data["InfrahubEvent"]["edges"]) == 1

--- a/development/docker-compose-deps-nats.yml
+++ b/development/docker-compose-deps-nats.yml
@@ -25,7 +25,7 @@ services:
   task-manager:
     profiles: [demo, dev]
     image: "${IMAGE_NAME}:${IMAGE_VER}"
-    command: prefect server start --host 0.0.0.0 --ui
+    command: uvicorn --host 0.0.0.0 --port 4200 --factory infrahub.prefect_server.app:create_infrahub_prefect
     environment:
       PREFECT_API_DATABASE_CONNECTION_URL: postgresql+asyncpg://postgres:postgres@task-manager-db:5432/prefect
       PREFECT_LOCAL_STORAGE_PATH: ${PREFECT_LOCAL_STORAGE_PATH:-/opt/prefect/}

--- a/development/docker-compose-deps.yml
+++ b/development/docker-compose-deps.yml
@@ -1,3 +1,4 @@
+# yamllint disable rule:line-length
 ---
 services:
   message-queue:
@@ -24,7 +25,7 @@ services:
   task-manager:
     profiles: [demo, dev]
     image: "${IMAGE_NAME}:${IMAGE_VER}"
-    command: prefect server start --host 0.0.0.0 --ui
+    command: "${PREFECT_SERVER_COMMAND:-uvicorn --host 0.0.0.0 --port 4200 --factory infrahub.prefect_server.app:create_infrahub_prefect}"
     environment:
       PREFECT_API_DATABASE_CONNECTION_URL: postgresql+asyncpg://postgres:postgres@task-manager-db:5432/prefect
       PREFECT_LOCAL_STORAGE_PATH: ${PREFECT_LOCAL_STORAGE_PATH:-/opt/prefect/}

--- a/development/docker-compose.local-build-deps.yml
+++ b/development/docker-compose.local-build-deps.yml
@@ -1,0 +1,5 @@
+---
+services:
+  task-manager:
+    volumes:
+      - ../:/source

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,7 +175,7 @@ services:
 
   task-manager:
     image: "${INFRAHUB_DOCKER_IMAGE:-registry.opsmill.io/opsmill/infrahub}:${VERSION:-1.1.4}"
-    command: prefect server start --host 0.0.0.0 --ui
+    command: uvicorn --host 0.0.0.0 --port 4200 --factory infrahub.prefect_server.app:create_infrahub_prefect
     restart: unless-stopped
     depends_on:
       task-manager-db:

--- a/python_testcontainers/infrahub_testcontainers/docker-compose.test.yml
+++ b/python_testcontainers/infrahub_testcontainers/docker-compose.test.yml
@@ -50,7 +50,7 @@ services:
 
   task-manager:
     image: "${INFRAHUB_TESTING_DOCKER_IMAGE}:${INFRAHUB_TESTING_IMAGE_VERSION}"
-    command: prefect server start --host 0.0.0.0 --ui
+    command: uvicorn --host 0.0.0.0 --port 4200 --factory infrahub.prefect_server.app:create_infrahub_prefect
     depends_on:
       task-manager-db:
         condition: service_healthy

--- a/tasks/shared.py
+++ b/tasks/shared.py
@@ -87,6 +87,7 @@ IMAGE_VER = REQUESTED_IMAGE_VER or "latest"
 OVERRIDE_FILE = Path("development/docker-compose.override.yml")
 DEFAULT_FILE = Path("development/docker-compose.default.yml")
 LOCAL_FILE = Path("development/docker-compose.local-build.yml")
+LOCAL_FILE_DEPS = Path("development/docker-compose.local-build-deps.yml")
 COMPOSE_FILES_MEMGRAPH = [
     COMPOSE_FILES_DEPS[INFRAHUB_USE_NATS],
     Path("development/docker-compose-database-memgraph.yml"),
@@ -267,6 +268,7 @@ def build_compose_files_cmd(database: str, namespace: Namespace = Namespace.DEFA
 
     if "local" in IMAGE_VER or (namespace == Namespace.DEV and not REQUESTED_IMAGE_VER):
         COMPOSE_FILES.append(LOCAL_FILE)
+        COMPOSE_FILES.append(LOCAL_FILE_DEPS)
 
     if os.getenv("CI") is not None:
         COMPOSE_FILES.append(TEST_METRICS_OVERRIDE_FILE)
@@ -286,6 +288,8 @@ def build_dev_compose_files_cmd(database: str) -> str:
     if DEV_OVERRIDE_FILE.exists():
         print("!! Found a dev override file for docker-compose !!")
         DEV_COMPOSE_FILES.append(DEV_OVERRIDE_FILE)
+
+    DEV_COMPOSE_FILES.append(LOCAL_FILE_DEPS)
 
     return f"-f {' -f '.join(map(str, DEV_COMPOSE_FILES))}"
 


### PR DESCRIPTION
The Prefect API is quite opinionated with regards to how you can query for events and the way we are looking to query for events and set them up with related resources would require a fairly convoluted setup of the resources within Prefect.

As a workaround for now this PR introduces a wrapper around prefect where we define an additional API entrypoint to Prefect. The goal is to take the `EventFilter` object from Prefect and use `InfrahubEventFilter` that has an extra `matching_related` attribute that is a list of related resources. A slight change to the database query within Prefect then lets us query for all of these related resources with an `AND` operator.

As we with this change also have control of the queries we can keep the standard offset pagination that Infrahub uses so I've removed the `InfrahubEventNext` GraphQL query for now, if these changes can get incorporated in Prefect we might need to revert that change again.

I've changed a few entrypoints that control how we start prefect in the future. For now i've just started it with uvicorn in the same way as Prefect managed this with their CLI. That part could change if we want to solve it in some other way.

During the upgrade migration test we need to set the old command and start with that one instead.