### PR TITLE
Add reload option to dev.start

### DIFF
--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -116,17 +116,6 @@ services:
       target: backend
     image: "${IMAGE_NAME}:${IMAGE_VER}"
     pull_policy: always
-    command: >
-      gunicorn --config backend/infrahub/serve/gunicorn_config.py -w ${WEB_CONCURRENCY:-4} --logger-class infrahub.serve.log.GunicornLogger infrahub.server:app
-    depends_on:
-      database:
-        condition: service_healthy
-      message-queue:
-        condition: service_healthy
-      cache:
-        condition: service_healthy
-      task-manager:
-        condition: service_healthy
     environment:
       <<: *infrahub_config
       INFRAHUB_INTERNAL_ADDRESS: "http://server:8000"
@@ -145,6 +134,19 @@ services:
       INFRAHUB_DB_PORT: 7687
       INFRAHUB_DB_PROTOCOL: bolt
       INFRAHUB_STORAGE_DRIVER: local
+      # INFRAHUB_SERVER_COMMAND is defined while running with reload option as it requires to run server using `uvicorn`.
+      COMMAND: ${INFRAHUB_SERVER_COMMAND:- gunicorn --config backend/infrahub/serve/gunicorn_config.py -w ${WEB_CONCURRENCY:-4} --logger-class infrahub.serve.log.GunicornLogger infrahub.server:app}
+    command: >
+      sh -c "$$COMMAND"
+    depends_on:
+      database:
+        condition: service_healthy
+      message-queue:
+        condition: service_healthy
+      cache:
+        condition: service_healthy
+      task-manager:
+        condition: service_healthy
     volumes:
       - "storage_data:/opt/infrahub/storage"
     tty: true

--- a/tasks/dev.py
+++ b/tasks/dev.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 from invoke.tasks import task
@@ -172,8 +173,16 @@ def status(
 
 
 @task(optional=["database"])
-def start(context: Context, database: str = INFRAHUB_DATABASE, wait: bool = False) -> None:
+def start(context: Context, database: str = INFRAHUB_DATABASE, wait: bool = False, reload: bool = False) -> None:
     """Start a local instance of Infrahub within docker compose."""
+
+    if reload:
+        # Need to use `uvicorn` instead of `gunicorn` for reload option because of this issue:
+        # https://github.com/benoitc/gunicorn/issues/2339
+        os.environ["INFRAHUB_SERVER_COMMAND"] = (
+            "uvicorn infrahub.server:app --host 0.0.0.0 --port 8000 --workers 4 --timeout-keep-alive 90 --reload"
+        )
+
     start_services(context=context, database=database, namespace=NAMESPACE, wait=wait)
 
 


### PR DESCRIPTION
Allows to run `invoke dev.start --reload` for debugging purposes.