### PR TITLE
Adds project argument to compose installation method in docs

### DIFF
--- a/docs/docs/guides/installation.mdx
+++ b/docs/docs/guides/installation.mdx
@@ -47,14 +47,14 @@ For a list of versions, check our [release notes on GitHub](https://github.com/o
 <TabItem value="MacOS" default>
 
 ```shell
-curl https://infrahub.opsmill.io | docker compose -f - up -d
+curl https://infrahub.opsmill.io | docker compose -p infrahub -f - up -d
 ```
 
 </TabItem>
 <TabItem value="Ubuntu">
 
 ```shell
-curl https://infrahub.opsmill.io | sudo docker compose -f - up -d
+curl https://infrahub.opsmill.io | sudo docker compose -p infrahub -f - up -d
 ```
 
 </TabItem>
@@ -66,14 +66,14 @@ curl https://infrahub.opsmill.io | sudo docker compose -f - up -d
 <TabItem value="MacOS" default>
 
 ```shell
-curl https://infrahub.opsmill.io | docker compose -f - down -v
+curl https://infrahub.opsmill.io | docker compose -p infrahub -f - down -v
 ```
 
 </TabItem>
 <TabItem value="Ubuntu">
 
 ```shell
-curl https://infrahub.opsmill.io | sudo docker compose -f - down -v
+curl https://infrahub.opsmill.io | sudo docker compose -p infrahub -f - down -v
 ```
 
 </TabItem>


### PR DESCRIPTION
By default `docker compose` derives the project from the basename of the directory that you execute the command in. 

Because we didn't specify the project explicitly for the `docker compose` installation method in our installation documentation, a user had to remember from which directory the `docker compose up` command was executed or has to be aware of how to use the `project` argument.

In this PR we explicitly add the `project` argument to the `docker compose` installation method commands to avoid this situation.