### PR TITLE
Revert changes to base_dataset_02 fixture

### DIFF
--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -306,35 +306,35 @@ async def base_dataset_02(db: InfrahubDatabase, default_branch: Branch, car_pers
     CREATE (c1at4)-[:IS_VISIBLE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m60 }]->(bool_true)
 
     CREATE (c2:Node:TestCar { uuid: "c2", namespace: "Test", kind: "TestCar", branch_support: "aware" })
-    CREATE (c2)-[:IS_PART_OF {branch: $branch1, branch_level: 2, from: $time_m20, status: "active"}]->(root)
+    CREATE (c2)-[:IS_PART_OF {branch: $main_branch, branch_level: 1, from: $time_m20, status: "active"}]->(root)
 
     CREATE (c2at1:Attribute { uuid: "c2at1", name: "name", branch_support: "aware"})
     CREATE (c2at2:Attribute { uuid: "c2at2", name: "nbr_seats", branch_support: "aware"})
     CREATE (c2at3:Attribute { uuid: "c2at3", name: "is_electric", branch_support: "aware"})
     CREATE (c2at4:Attribute { uuid: "c2at4", name: "color", branch_support: "aware"})
-    CREATE (c2)-[:HAS_ATTRIBUTE {branch: $branch1, branch_level: 2, status: "active", from: $time_m20}]->(c2at1)
-    CREATE (c2)-[:HAS_ATTRIBUTE {branch: $branch1, branch_level: 2, status: "active", from: $time_m20}]->(c2at2)
-    CREATE (c2)-[:HAS_ATTRIBUTE {branch: $branch1, branch_level: 2, status: "active", from: $time_m20}]->(c2at3)
-    CREATE (c2)-[:HAS_ATTRIBUTE {branch: $branch1, branch_level: 2, status: "active", from: $time_m20}]->(c2at4)
+    CREATE (c2)-[:HAS_ATTRIBUTE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m20}]->(c2at1)
+    CREATE (c2)-[:HAS_ATTRIBUTE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m20}]->(c2at2)
+    CREATE (c2)-[:HAS_ATTRIBUTE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m20}]->(c2at3)
+    CREATE (c2)-[:HAS_ATTRIBUTE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m20}]->(c2at4)
 
     CREATE (c2av11:AttributeValue { value: "odyssey", is_default: false })
     CREATE (c2av21:AttributeValue { value: 8, is_default: false })
 
-    CREATE (c2at1)-[:HAS_VALUE {branch: $branch1, branch_level: 2, status: "active", from: $time_m20 }]->(c2av11)
-    CREATE (c2at1)-[:IS_PROTECTED {branch: $branch1, branch_level: 2, status: "active", from: $time_m20 }]->(bool_false)
-    CREATE (c2at1)-[:IS_VISIBLE {branch: $branch1, branch_level: 2, status: "active", from: $time_m20 }]->(bool_true)
+    CREATE (c2at1)-[:HAS_VALUE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m20 }]->(c2av11)
+    CREATE (c2at1)-[:IS_PROTECTED {branch: $main_branch, branch_level: 1, status: "active", from: $time_m20 }]->(bool_false)
+    CREATE (c2at1)-[:IS_VISIBLE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m20 }]->(bool_true)
 
-    CREATE (c2at2)-[:HAS_VALUE {branch: $branch1, branch_level: 2, status: "active", from: $time_m20 }]->(c2av21)
-    CREATE (c2at2)-[:IS_PROTECTED {branch: $branch1, branch_level: 2, status: "active", from: $time_m20 }]->(bool_false)
-    CREATE (c2at2)-[:IS_VISIBLE {branch: $branch1, branch_level: 2, status: "active", from: $time_m20 }]->(bool_true)
+    CREATE (c2at2)-[:HAS_VALUE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m20 }]->(c2av21)
+    CREATE (c2at2)-[:IS_PROTECTED {branch: $main_branch, branch_level: 1, status: "active", from: $time_m20 }]->(bool_false)
+    CREATE (c2at2)-[:IS_VISIBLE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m20 }]->(bool_true)
 
-    CREATE (c2at3)-[:HAS_VALUE {branch: $branch1, branch_level: 2, status: "active", from: $time_m20 }]->(atvf)
-    CREATE (c2at3)-[:IS_PROTECTED {branch: $branch1, branch_level: 2, status: "active", from: $time_m20 }]->(bool_false)
-    CREATE (c2at3)-[:IS_VISIBLE {branch: $branch1, branch_level: 2, status: "active", from: $time_m20 }]->(bool_true)
+    CREATE (c2at3)-[:HAS_VALUE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m20 }]->(atvf)
+    CREATE (c2at3)-[:IS_PROTECTED {branch: $main_branch, branch_level: 1, status: "active", from: $time_m20 }]->(bool_false)
+    CREATE (c2at3)-[:IS_VISIBLE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m20 }]->(bool_true)
 
-    CREATE (c2at4)-[:HAS_VALUE {branch: $branch1, branch_level: 2, status: "active", from: $time_m20 }]->(atv44)
-    CREATE (c2at4)-[:IS_PROTECTED {branch: $branch1, branch_level: 2, status: "active", from: $time_m20 }]->(bool_false)
-    CREATE (c2at4)-[:IS_VISIBLE {branch: $branch1, branch_level: 2, status: "active", from: $time_m20 }]->(bool_true)
+    CREATE (c2at4)-[:HAS_VALUE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m20 }]->(atv44)
+    CREATE (c2at4)-[:IS_PROTECTED {branch: $main_branch, branch_level: 1, status: "active", from: $time_m20 }]->(bool_false)
+    CREATE (c2at4)-[:IS_VISIBLE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m20 }]->(bool_true)
 
     CREATE (c3:Node:TestCar { uuid: "c3", namespace: "Test", kind: "TestCar", branch_support: "aware" })
     CREATE (c3)-[:IS_PART_OF {branch: $branch1, branch_level: 2, from: $time_m40, status: "active"}]->(root)
@@ -403,10 +403,10 @@ async def base_dataset_02(db: InfrahubDatabase, default_branch: Branch, car_pers
     CREATE (r1)-[:IS_VISIBLE {branch: $branch1, branch_level: 2, status: "active", from: $time_m20 }]->(bool_false)
 
     CREATE (r2:Relationship { uuid: "r2", name: "testcar__testperson", branch_support: "aware"})
-    CREATE (p1)-[:IS_RELATED { branch: $branch1, branch_level: 2, status: "active", from: $time_m20 }]->(r2)
-    CREATE (c2)-[:IS_RELATED { branch: $branch1, branch_level: 2, status: "active", from: $time_m20 }]->(r2)
-    CREATE (r2)-[:IS_PROTECTED {branch: $branch1, branch_level: 2, status: "active", from: $time_m20 }]->(bool_false)
-    CREATE (r2)-[:IS_VISIBLE {branch: $branch1, branch_level: 2, status: "active", from: $time_m20 }]->(bool_true)
+    CREATE (p1)-[:IS_RELATED { branch: $main_branch, branch_level: 1, status: "active", from: $time_m20 }]->(r2)
+    CREATE (c2)-[:IS_RELATED { branch: $main_branch, branch_level: 1, status: "active", from: $time_m20 }]->(r2)
+    CREATE (r2)-[:IS_PROTECTED {branch: $main_branch, branch_level: 1, status: "active", from: $time_m20 }]->(bool_false)
+    CREATE (r2)-[:IS_VISIBLE {branch: $main_branch, branch_level: 1, status: "active", from: $time_m20 }]->(bool_true)
 
     RETURN c1, c2, c3
     """

--- a/backend/tests/unit/core/test_branch.py
+++ b/backend/tests/unit/core/test_branch.py
@@ -275,7 +275,7 @@ async def test_is_isolated(db: InfrahubDatabase, base_dataset_02):
 
     branch1.is_isolated = True
     cars = sorted(await NodeManager.query(schema="TestCar", branch=branch1, db=db), key=lambda c: c.id)
-    assert len(cars) == 3
+    assert len(cars) == 2
     assert cars[0].id == "c1"
     assert cars[0].name.value == "accord"
 

--- a/backend/tests/unit/core/test_branch_merge.py
+++ b/backend/tests/unit/core/test_branch_merge.py
@@ -53,7 +53,7 @@ async def test_merge_graph(db: InfrahubDatabase, default_branch, base_dataset_02
 
     # Query All cars in MAIN, BEFORE the merge
     cars = sorted(await NodeManager.query(schema="TestCar", at=base_dataset_02["time0"], db=db), key=lambda c: c.id)
-    assert len(cars) == 1
+    assert len(cars) == 2
     assert cars[0].id == "c1"
     assert cars[0].nbr_seats.value == 5
     assert cars[0].nbr_seats.is_protected is False

--- a/backend/tests/unit/core/test_branch_rebase.py
+++ b/backend/tests/unit/core/test_branch_rebase.py
@@ -21,7 +21,7 @@ async def test_rebase_graph(db: InfrahubDatabase, base_dataset_02, register_core
 
     # Query all cars in MAIN, AFTER the rebase
     cars = sorted(await NodeManager.query(schema="TestCar", db=db), key=lambda c: c.id)
-    assert len(cars) == 1
+    assert len(cars) == 2
     assert cars[0].id == "c1"
     assert cars[0].nbr_seats.value == 5
     assert cars[0].nbr_seats.is_protected is False

--- a/backend/tests/unit/core/test_node_query.py
+++ b/backend/tests/unit/core/test_node_query.py
@@ -198,22 +198,22 @@ async def test_query_NodeListGetAttributeQuery_all_fields(db: InfrahubDatabase, 
     default_branch = await registry.get_branch(db=db, branch="main")
     branch1 = await registry.get_branch(db=db, branch="branch1")
 
-    # Query all the nodes in main but only c1 is present
-    # Expect 4 attributes per node(x1) = 4 attributes
+    # Query all the nodes in main but only c1 and c2 present
+    # Expect 4 attributes per node(x2) = 8 attributes
     query = await NodeListGetAttributeQuery.init(db=db, ids=["c1", "c2", "c3"], branch=default_branch)
     await query.execute(db=db)
-    assert sorted(query.get_attributes_group_by_node().keys()) == ["c1"]
-    assert len(list(query.get_results())) == 4
+    assert sorted(query.get_attributes_group_by_node().keys()) == ["c1", "c2"]
+    assert len(list(query.get_results())) == 8
     assert len(query.get_attributes_group_by_node()["c1"].attrs) == 4
+    assert len(query.get_attributes_group_by_node()["c2"].attrs) == 4
 
     # Query all the nodes in branch1, only c1 and c3 present
     # Expect 9 attributes because each node has 4 but c1at2 has a value both in Main and Branch1
-    query = await NodeListGetAttributeQuery.init(db=db, ids=["c1", "c2", "c3", "c4"], branch=branch1)
+    query = await NodeListGetAttributeQuery.init(db=db, ids=["c1", "c2", "c3"], branch=branch1)
     await query.execute(db=db)
-    assert sorted(query.get_attributes_group_by_node().keys()) == ["c1", "c2", "c3"]
-    assert len(list(query.get_results())) == 15
+    assert sorted(query.get_attributes_group_by_node().keys()) == ["c1", "c3"]
+    assert len(list(query.get_results())) == 11
     assert len(query.get_attributes_group_by_node()["c1"].attrs) == 4
-    assert len(query.get_attributes_group_by_node()["c2"].attrs) == 4
     assert len(query.get_attributes_group_by_node()["c3"].attrs) == 4
 
 
@@ -263,20 +263,21 @@ async def test_query_NodeListGetAttributeQuery(db: InfrahubDatabase, base_datase
         db=db, ids=["c1", "c2", "c3"], branch=default_branch, fields={"name": True, "is_electric": True}
     )
     await query.execute(db=db)
-    assert sorted(query.get_attributes_group_by_node().keys()) == ["c1"]
+    assert sorted(query.get_attributes_group_by_node().keys()) == ["c1", "c2"]
     assert len(query.get_attributes_group_by_node()["c1"].attrs) == 2
-    assert len(list(query.get_results())) == 2
+    assert len(query.get_attributes_group_by_node()["c2"].attrs) == 2
+    assert len(list(query.get_results())) == 4
 
     # Query all the nodes in branch1: c1 and c3 present
-    # Expect 6 attributes because each node has 1 but c1at2 has its value and its protected flag defined both in Main and Branch1
+    # Expect 5 attributes because each node has 1 but c1at2 has its value and its protected flag defined both in Main and Branch1
     query = await NodeListGetAttributeQuery.init(
         db=db, ids=["c1", "c2", "c3"], branch=branch1, fields={"nbr_seats": True}
     )
     await query.execute(db=db)
-    assert sorted(query.get_attributes_group_by_node().keys()) == ["c1", "c2", "c3"]
+    assert sorted(query.get_attributes_group_by_node().keys()) == ["c1", "c3"]
     assert len(query.get_attributes_group_by_node()["c1"].attrs) == 1
     assert len(query.get_attributes_group_by_node()["c3"].attrs) == 1
-    assert len(list(query.get_results())) == 6
+    assert len(list(query.get_results())) == 5
 
     # Query c1 in branch1
     # Expect 4 attributes because c1at2 has its value and its protected flag defined both in Main and Branch1
@@ -318,17 +319,16 @@ async def test_query_NodeListGetAttributeQuery_deleted(db: InfrahubDatabase, bas
         branch=default_branch,
     )
     await query.execute(db=db)
-    assert sorted(query.get_attributes_group_by_node().keys()) == ["c1"]
+    assert sorted(query.get_attributes_group_by_node().keys()) == ["c1", "c2"]
 
     assert len(query.get_attributes_group_by_node()["c1"].attrs) == 4
 
-    # Query all the nodes in branch1: c1, c2 and c3 present
-    # Expect 9 attributes because each node has 1 but c1at2 has its value and its protected flag defined both in Main and Branch1
+    # Query all the nodes in branch1: c1 and c3 present
+    # Expect 6 attributes because each node has 1 but c1at2 has its value and its protected flag defined both in Main and Branch1
     query = await NodeListGetAttributeQuery.init(db=db, ids=["c1", "c2", "c3"], branch=branch1)
     await query.execute(db=db)
-    assert sorted(query.get_attributes_group_by_node().keys()) == ["c1", "c2", "c3"]
+    assert sorted(query.get_attributes_group_by_node().keys()) == ["c1", "c3"]
     assert len(query.get_attributes_group_by_node()["c1"].attrs) == 3
-    assert len(query.get_attributes_group_by_node()["c2"].attrs) == 3
     assert len(query.get_attributes_group_by_node()["c3"].attrs) == 3
 
     # Query c1 in branch1


### PR DESCRIPTION
Reverts the changes from #5715, so that "c2" is created on the main branch as it was from the start, the change is instead that the final relationship is also changed to be on the main branch instead of "branch1".