### PR TITLE
feat(testcontainers): add api and task worker scale out

### DIFF
--- a/python_testcontainers/infrahub_testcontainers/container.py
+++ b/python_testcontainers/infrahub_testcontainers/container.py
@@ -17,7 +17,7 @@ class ContainerService:
 
 
 INFRAHUB_SERVICES: dict[str, ContainerService] = {
-    "server": ContainerService(container="infrahub-server", port=8000),
+    "server": ContainerService(container="infrahub-server-lb", port=8000),
     "task-manager": ContainerService(container="task-manager", port=4200),
 }
 
@@ -32,8 +32,8 @@ PROJECT_ENV_VARIABLES: dict[str, str] = {
     "INFRAHUB_TESTING_INITIAL_ADMIN_TOKEN": "06438eb2-8019-4776-878c-0941b1f1d1ec",
     "INFRAHUB_TESTING_INITIAL_AGENT_TOKEN": "44af444d-3b26-410d-9546-b758657e026c",
     "INFRAHUB_TESTING_SECURITY_SECRET_KEY": "327f747f-efac-42be-9e73-999f08f86b92",
-    "INFRAHUB_TESTING_ADDRESS": "http://infrahub-server:8000",
-    "INFRAHUB_TESTING_INTERNAL_ADDRESS": "http://infrahub-server:8000",
+    "INFRAHUB_TESTING_ADDRESS": "http://infrahub-server-lb:8000",
+    "INFRAHUB_TESTING_INTERNAL_ADDRESS": "http://infrahub-server-lb:8000",
     "INFRAHUB_TESTING_BROKER_ADDRESS": "message-queue",
     "INFRAHUB_TESTING_CACHE_ADDRESS": "cache",
     "INFRAHUB_TESTING_WORKFLOW_ADDRESS": "task-manager",
@@ -44,6 +44,8 @@ PROJECT_ENV_VARIABLES: dict[str, str] = {
     "INFRAHUB_TESTING_WEB_CONCURRENCY": "4",
     "INFRAHUB_TESTING_LOCAL_DB_BACKUP_DIRECTORY": "backups",
     "INFRAHUB_TESTING_INTERNAL_DB_BACKUP_DIRECTORY": "/backups",
+    "INFRAHUB_TESTING_API_SERVER_COUNT": "2",
+    "INFRAHUB_TESTING_TASK_WORKER_COUNT": "2",
 }
 
 
@@ -80,6 +82,11 @@ class InfrahubDockerCompose(DockerCompose):
 
         test_compose_file = directory / "docker-compose.yml"
         test_compose_file.write_bytes(compose_file.read_bytes())
+
+        haproxy_config_file = current_directory / "haproxy.cfg"
+
+        test_haproxy_config_file = directory / "haproxy.cfg"
+        test_haproxy_config_file.write_bytes(haproxy_config_file.read_bytes())
 
         return test_compose_file
 

--- a/python_testcontainers/infrahub_testcontainers/docker-compose.test.yml
+++ b/python_testcontainers/infrahub_testcontainers/docker-compose.test.yml
@@ -28,6 +28,22 @@ services:
       timeout: 5s
       retries: 3
 
+  infrahub-server-lb:
+    image: haproxy:3.1-alpine
+    volumes:
+      - ./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg
+    depends_on:
+      infrahub-server:
+        condition: service_started
+    healthcheck:
+      test: wget -O /dev/null http://127.0.0.1:8000/api/config || exit 1
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
+    ports:
+      - ${INFRAHUB_TESTING_SERVER_PORT:-0}:8000
+
   database:
     image: ${NEO4J_DOCKER_IMAGE:-neo4j:5.20.0-community}
     restart: unless-stopped
@@ -82,6 +98,9 @@ services:
       retries: 5
 
   infrahub-server:
+    deploy:
+      mode: replicated
+      replicas: ${INFRAHUB_TESTING_API_SERVER_COUNT}
     image: "${INFRAHUB_TESTING_DOCKER_IMAGE}:${INFRAHUB_TESTING_IMAGE_VERSION}"
     command: >
       gunicorn --config backend/infrahub/serve/gunicorn_config.py
@@ -108,8 +127,6 @@ services:
         condition: service_healthy
       task-manager:
         condition: service_healthy
-    ports:
-      - ${INFRAHUB_TESTING_SERVER_PORT:-0}:8000
     volumes:
       - "storage_data:/opt/infrahub/storage"
     tty: true
@@ -123,7 +140,7 @@ services:
   task-worker:
     deploy:
       mode: replicated
-      replicas: 2
+      replicas: ${INFRAHUB_TESTING_TASK_WORKER_COUNT}
     image: "${INFRAHUB_TESTING_DOCKER_IMAGE}:${INFRAHUB_TESTING_IMAGE_VERSION}"
     command: prefect worker start --type infrahubasync --pool infrahub-worker --with-healthcheck
     environment:

--- a/python_testcontainers/infrahub_testcontainers/haproxy.cfg
+++ b/python_testcontainers/infrahub_testcontainers/haproxy.cfg
@@ -1,0 +1,43 @@
+global
+    log stdout local0
+    log stdout local1 notice
+    #chroot /var/lib/haproxy
+    #stats socket /run/haproxy/admin.sock mode 660 level admin
+    stats timeout 30s
+    user haproxy
+    group haproxy
+    daemon
+
+    # Default SSL material locations
+    ca-base /etc/ssl/certs
+    crt-base /etc/ssl/private
+
+    # See: https://ssl-config.mozilla.org/#server=haproxy&server-version=2.0.3&config=intermediate
+    ssl-default-bind-ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+    ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
+    ssl-default-bind-options ssl-min-ver TLSv1.2 no-tls-tickets
+
+defaults
+    log        global
+    mode       http
+    option     httplog
+    option     dontlognull
+    timeout connect 5000
+    timeout client  50000
+    timeout server  50000
+
+resolvers docker
+    parse-resolv-conf
+    accepted_payload_size 8192
+
+frontend fe
+    mode http
+    bind *:8000
+    option forwardfor
+
+    default_backend be
+
+backend be
+    mode http
+    balance roundrobin
+    server-template api 100 infrahub-server:8000 check resolvers docker init-addr none


### PR DESCRIPTION
With this change, we can scale out Infrahub components using environment variables:

- `INFRAHUB_TESTING_API_SERVER_COUNT` to scale the API server out
- `INFRAHUB_TESTING_WEB_CONCURRENCY` to configure the number of gunicorn workers
- `INFRAHUB_TESTING_TASK_WORKER_COUNT` to scale the task workers out

It also adds a real load balancer on top of the API servers to have a more predictible/reproducible setup. Balancing method is hardcoded to round-robin for now.