### PR TITLE
Add context to triggers/automations

### DIFF
--- a/backend/infrahub/api/schema.py
+++ b/backend/infrahub/api/schema.py
@@ -384,6 +384,7 @@ async def load_schema(
             request_id=request_id,
             account_id=account_session.account_id,
             branch=branch,
+            context=context,
         ),
     )
     await service.event.send(event=event)

--- a/backend/infrahub/computed_attribute/tasks.py
+++ b/backend/infrahub/computed_attribute/tasks.py
@@ -170,6 +170,7 @@ async def trigger_update_python_computed_attributes(
                 "object_id": node.id,
                 "computed_attribute_name": computed_attribute_name,
                 "computed_attribute_kind": computed_attribute_kind,
+                "context": context,
             },
         )
 
@@ -315,6 +316,7 @@ async def trigger_update_jinja2_computed_attributes(
                 "computed_attribute_kind": computed_attribute_kind,
                 "node_kind": computed_attribute_kind,
                 "object_id": node.id,
+                "context": context,
             },
         )
 
@@ -383,6 +385,13 @@ async def computed_attribute_setup(
                             "computed_attribute_name": computed_attribute.attribute.name,
                             "computed_attribute_kind": computed_attribute.kind,
                             "updated_fields": "{{ event.payload['fields'] | tojson }}",
+                            "context": {
+                                "__prefect_kind": "json",
+                                "value": {
+                                    "__prefect_kind": "jinja",
+                                    "template": "{{ event.payload['context'] | tojson }}",
+                                },
+                            },
                         },
                         job_variables={},
                     )
@@ -407,6 +416,7 @@ async def computed_attribute_setup(
                         "branch_name": registry.default_branch,
                         "computed_attribute_name": computed_attribute.attribute.name,
                         "computed_attribute_kind": computed_attribute.kind,
+                        "context": context,
                     },
                 )
 
@@ -448,6 +458,13 @@ async def computed_attribute_setup(
                                 "computed_attribute_name": computed_attribute.attribute.name,
                                 "computed_attribute_kind": computed_attribute.kind,
                                 "updated_fields": "{{ event.payload['fields'] | tojson }}",
+                                "context": {
+                                    "__prefect_kind": "json",
+                                    "value": {
+                                        "__prefect_kind": "jinja",
+                                        "template": "{{ event.payload['context'] | tojson }}",
+                                    },
+                                },
                             },
                             job_variables={},
                         )
@@ -474,6 +491,7 @@ async def computed_attribute_setup(
                             "branch_name": branch_name,
                             "computed_attribute_name": computed_attribute.attribute.name,
                             "computed_attribute_kind": computed_attribute.kind,
+                            "context": context,
                         },
                     )
 
@@ -565,6 +583,13 @@ async def computed_attribute_setup_python(
                             "object_id": "{{ event.resource['infrahub.node.id'] }}",
                             "computed_attribute_name": computed_attribute.computed_attribute.attribute.name,
                             "computed_attribute_kind": computed_attribute.computed_attribute.kind,
+                            "context": {
+                                "__prefect_kind": "json",
+                                "value": {
+                                    "__prefect_kind": "jinja",
+                                    "template": "{{ event.payload['context'] | tojson }}",
+                                },
+                            },
                         },
                         job_variables={},
                     )
@@ -613,6 +638,13 @@ async def computed_attribute_setup_python(
                             "branch_name": "{{ event.resource['infrahub.branch.name'] }}",
                             "node_kind": "{{ event.resource['infrahub.node.kind'] }}",
                             "object_id": "{{ event.resource['infrahub.node.id'] }}",
+                            "context": {
+                                "__prefect_kind": "json",
+                                "value": {
+                                    "__prefect_kind": "jinja",
+                                    "template": "{{ event.payload['context'] | tojson }}",
+                                },
+                            },
                         },
                         job_variables={},
                     )
@@ -641,6 +673,7 @@ async def computed_attribute_setup_python(
                         "branch_name": branch_name,
                         "computed_attribute_name": computed_attribute.computed_attribute.attribute.name,
                         "computed_attribute_kind": computed_attribute.computed_attribute.kind,
+                        "context": context,
                     },
                 )
 

--- a/backend/infrahub/computed_attribute/triggers.py
+++ b/backend/infrahub/computed_attribute/triggers.py
@@ -16,6 +16,10 @@ TRIGGER_COMPUTED_ATTRIBUTE_PYTHON_SETUP_BRANCH = BuiltinTriggerDefinition(
             parameters={
                 "branch_name": "{{ event.resource['infrahub.branch.name'] }}",
                 "trigger_updates": False,
+                "context": {
+                    "__prefect_kind": "json",
+                    "value": {"__prefect_kind": "jinja", "template": "{{ event.payload['context'] | tojson }}"},
+                },
             },
         )
     ],
@@ -31,6 +35,10 @@ TRIGGER_COMPUTED_ATTRIBUTE_PYTHON_SETUP_COMMIT = BuiltinTriggerDefinition(
             parameters={
                 "branch_name": "{{ event.resource['infrahub.branch.name'] }}",
                 "commit": "{{ event.payload['commit'] }}",
+                "context": {
+                    "__prefect_kind": "json",
+                    "value": {"__prefect_kind": "jinja", "template": "{{ event.payload['context'] | tojson }}"},
+                },
             },
         )
     ],
@@ -45,6 +53,10 @@ TRIGGER_COMPUTED_ATTRIBUTE_PYTHON_CLEAN_BRANCH = BuiltinTriggerDefinition(
             name=COMPUTED_ATTRIBUTE_REMOVE_PYTHON.name,
             parameters={
                 "branch_name": "{{ event.resource['infrahub.branch.name'] }}",
+                "context": {
+                    "__prefect_kind": "json",
+                    "value": {"__prefect_kind": "jinja", "template": "{{ event.payload['context'] | tojson }}"},
+                },
             },
         )
     ],
@@ -58,12 +70,20 @@ TRIGGER_COMPUTED_ATTRIBUTE_ALL_SCHEMA = BuiltinTriggerDefinition(
             name=COMPUTED_ATTRIBUTE_SETUP.name,
             parameters={
                 "branch_name": "{{ event.resource['infrahub.branch.name'] }}",
+                "context": {
+                    "__prefect_kind": "json",
+                    "value": {"__prefect_kind": "jinja", "template": "{{ event.payload['context'] | tojson }}"},
+                },
             },
         ),
         ExecuteWorkflow(
             name=COMPUTED_ATTRIBUTE_SETUP_PYTHON.name,
             parameters={
                 "branch_name": "{{ event.resource['infrahub.branch.name'] }}",
+                "context": {
+                    "__prefect_kind": "json",
+                    "value": {"__prefect_kind": "jinja", "template": "{{ event.payload['context'] | tojson }}"},
+                },
             },
         ),
     ],

--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -155,7 +155,9 @@ async def rebase_branch(branch: str, context: InfrahubContext, service: Infrahub
     # -------------------------------------------------------------
     # TODO Add account information
     await service.event.send(
-        event=BranchRebasedEvent(branch_name=obj.name, branch_id=str(obj.uuid), meta=EventMeta(branch=obj))
+        event=BranchRebasedEvent(
+            branch_name=obj.name, branch_id=str(obj.uuid), meta=EventMeta(branch=obj, context=context)
+        )
     )
 
 
@@ -250,7 +252,10 @@ async def delete_branch(branch: str, context: InfrahubContext, service: Infrahub
         await obj.delete(db=db)
 
         event = BranchDeletedEvent(
-            branch_name=branch, branch_id=str(obj.uuid), sync_with_git=obj.sync_with_git, meta=EventMeta(branch=obj)
+            branch_name=branch,
+            branch_id=str(obj.uuid),
+            sync_with_git=obj.sync_with_git,
+            meta=EventMeta(branch=obj, context=context),
         )
 
         await service.workflow.submit_workflow(
@@ -318,7 +323,9 @@ async def create_branch(model: BranchCreateModel, context: InfrahubContext, serv
             branch_name=obj.name,
             branch_id=str(obj.uuid),
             sync_with_git=obj.sync_with_git,
-            meta=EventMeta(branch=obj, account_id=context.account.account_id, initiator_id=WORKER_IDENTITY),
+            meta=EventMeta(
+                branch=obj, account_id=context.account.account_id, initiator_id=WORKER_IDENTITY, context=context
+            ),
         )
         await service.event.send(event=event)
 

--- a/backend/infrahub/events/models.py
+++ b/backend/infrahub/events/models.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any, cast, final
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field, computed_field
 
 from infrahub import __version__
+from infrahub.auth import AccountSession, AuthType
+from infrahub.context import InfrahubContext  # noqa: TC001
 from infrahub.core.branch import Branch  # noqa: TC001
 from infrahub.message_bus import InfrahubMessage, Meta
 from infrahub.worker import WORKER_IDENTITY
@@ -25,7 +27,7 @@ class EventMeta(BaseModel):
     initiator_id: str = Field(
         default=WORKER_IDENTITY, description="The worker identity of the initial sender of this message"
     )
-    context: list[dict] = Field(default_factory=list)
+    context: InfrahubContext = Field(..., description="The context used when originating this event")
     level: int = Field(default=0)
     has_children: bool = Field(
         default=False, description="Indicates if this event might potentially have child events under it."
@@ -81,8 +83,13 @@ class EventMeta(BaseModel):
         return related
 
     @classmethod
-    def default(cls) -> EventMeta:
-        return cls()
+    def with_dummy_context(cls, branch: Branch) -> EventMeta:
+        return cls(
+            branch=branch,
+            context=InfrahubContext.init(
+                branch=branch, account=AccountSession(auth_type=AuthType.NONE, authenticated=False, account_id="")
+            ),
+        )
 
     @classmethod
     def from_parent(cls, parent: InfrahubEvent) -> EventMeta:
@@ -98,11 +105,12 @@ class EventMeta(BaseModel):
             initiator_id=parent.meta.initiator_id,
             account_id=parent.meta.account_id,
             level=parent.meta.level + 1,
+            context=parent.meta.context,
         )
 
 
 class InfrahubEvent(BaseModel):
-    meta: EventMeta = Field(default_factory=EventMeta.default)
+    meta: EventMeta = Field(..., description="Metadata for the event")
 
     def get_id(self) -> str:
         return self.meta.get_id()
@@ -126,7 +134,20 @@ class InfrahubEvent(BaseModel):
         return self.meta.get_related()
 
     def get_payload(self) -> dict[str, Any]:
+        """The purpose if this method is to allow subclasses to define their own payload.
+
+        It should not be used to get the complete payload instead .get_event_payload() should
+        be used for that as it will always contain the 'context' key regardless of changes
+        in child classes
+        """
         return {}
+
+    @final
+    def get_event_payload(self) -> dict[str, Any]:
+        """This method should be used when emitting the event to the event broker"""
+        event_payload = self.get_payload()
+        event_payload["context"] = self.meta.context.model_dump(mode="json")
+        return event_payload
 
     def get_message_meta(self) -> Meta:
         meta = Meta()

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -207,7 +207,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
                 commit=commit,
                 repository_name=self.name,
                 repository_id=str(self.id),
-                meta=EventMeta(branch=infrahub_branch),
+                meta=EventMeta.with_dummy_context(branch=infrahub_branch),
             )
         )
 

--- a/backend/infrahub/graphql/mutations/computed_attribute.py
+++ b/backend/infrahub/graphql/mutations/computed_attribute.py
@@ -97,6 +97,7 @@ class UpdateComputedAttribute(Mutation):
                 fields=[str(data.attribute)],
                 action=MutationAction.UPDATED,
                 meta=EventMeta(
+                    context=graphql_context.get_context(),
                     initiator_id=WORKER_IDENTITY,
                     request_id=request_id,
                     account_id=graphql_context.active_account_session.account_id,

--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -106,6 +106,7 @@ class InfrahubMutationMixin:
                 initiator_id=WORKER_IDENTITY,
                 request_id=request_id,
                 branch=graphql_context.branch,
+                context=graphql_context.get_context(),
             )
             main_event = NodeMutatedEvent(
                 kind=obj._schema.kind,

--- a/backend/infrahub/graphql/mutations/relationship.py
+++ b/backend/infrahub/graphql/mutations/relationship.py
@@ -171,20 +171,24 @@ class RelationshipMixin:
                 data=node_changelog,
                 action=MutationAction.UPDATED,
                 fields=[relationship_name],
-                meta=EventMeta(
-                    branch=graphql_context.branch,
-                ),
+                meta=EventMeta(branch=graphql_context.branch, context=graphql_context.get_context()),
             )
             graphql_context.background.add_task(graphql_context.active_service.event.send, event)
             if group_event_type == GroupUpdateType.MEMBERS:
                 if cls.__name__ == "RelationshipAdd":
                     group_add_event = GroupMemberAddedEvent(
-                        node_id=source.id, kind=source.get_schema().kind, members=peers
+                        node_id=source.id,
+                        kind=source.get_schema().kind,
+                        members=peers,
+                        meta=EventMeta(branch=graphql_context.branch, context=graphql_context.get_context()),
                     )
                     graphql_context.background.add_task(graphql_context.active_service.event.send, group_add_event)
                 elif cls.__name__ == "RelationshipRemove":
                     group_remove_event = GroupMemberRemovedEvent(
-                        node_id=source.id, kind=source.get_schema().kind, members=peers
+                        node_id=source.id,
+                        kind=source.get_schema().kind,
+                        members=peers,
+                        meta=EventMeta(branch=graphql_context.branch, context=graphql_context.get_context()),
                     )
                     graphql_context.background.add_task(graphql_context.active_service.event.send, group_remove_event)
             elif group_event_type == GroupUpdateType.MEMBER_OF_GROUPS:
@@ -200,6 +204,7 @@ class RelationshipMixin:
                                 node_id=node_id,
                                 kind=node_kind,
                                 members=[EventNode(id=source.get_id(), kind=source.get_kind())],
+                                meta=EventMeta(branch=graphql_context.branch, context=graphql_context.get_context()),
                             )
                             graphql_context.background.add_task(
                                 graphql_context.active_service.event.send, group_add_event
@@ -209,6 +214,7 @@ class RelationshipMixin:
                                 node_id=node_id,
                                 kind=node_kind,
                                 members=[EventNode(id=source.get_id(), kind=source.get_kind())],
+                                meta=EventMeta(branch=graphql_context.branch, context=graphql_context.get_context()),
                             )
                             graphql_context.background.add_task(
                                 graphql_context.active_service.event.send, group_remove_event

--- a/backend/infrahub/graphql/mutations/schema.py
+++ b/backend/infrahub/graphql/mutations/schema.py
@@ -21,6 +21,7 @@ from ..types import DropdownFields
 if TYPE_CHECKING:
     from graphql import GraphQLResolveInfo
 
+    from infrahub.context import InfrahubContext
     from infrahub.core.branch import Branch
     from infrahub.services import InfrahubServices
 
@@ -84,6 +85,7 @@ class SchemaDropdownAdd(Mutation):
             db=graphql_context.db,
             account_id=graphql_context.active_account_session.account_id,
             service=graphql_context.active_service,
+            context=graphql_context.get_context(),
         )
 
         kind = graphql_context.db.schema.get(name=str(data.kind), branch=graphql_context.branch.name)
@@ -150,6 +152,7 @@ class SchemaDropdownRemove(Mutation):
             db=graphql_context.db,
             account_id=graphql_context.active_account_session.account_id,
             service=graphql_context.active_service,
+            context=graphql_context.get_context(),
         )
 
         return {"ok": True}
@@ -191,6 +194,7 @@ class SchemaEnumAdd(Mutation):
             db=graphql_context.db,
             account_id=graphql_context.active_account_session.account_id,
             service=graphql_context.active_service,
+            context=graphql_context.get_context(),
         )
 
         return {"ok": True}
@@ -242,6 +246,7 @@ class SchemaEnumRemove(Mutation):
             db=graphql_context.db,
             account_id=graphql_context.active_account_session.account_id,
             service=graphql_context.active_service,
+            context=graphql_context.get_context(),
         )
 
         return {"ok": True}
@@ -274,7 +279,12 @@ def validate_kind(kind: Union[GenericSchema, NodeSchema], attribute: str) -> Non
 
 
 async def update_registry(
-    kind: NodeSchema, db: InfrahubDatabase, branch: Branch, account_id: str, service: InfrahubServices
+    kind: NodeSchema,
+    db: InfrahubDatabase,
+    branch: Branch,
+    account_id: str,
+    service: InfrahubServices,
+    context: InfrahubContext,
 ) -> None:
     async with lock.registry.global_schema_lock():
         branch_schema = registry.schema.get_schema_branch(name=branch.name)
@@ -305,7 +315,11 @@ async def update_registry(
                 branch_name=branch.name,
                 schema_hash=branch.active_schema_hash.main,
                 meta=EventMeta(
-                    initiator_id=WORKER_IDENTITY, request_id=request_id, account_id=account_id, branch=branch
+                    initiator_id=WORKER_IDENTITY,
+                    request_id=request_id,
+                    account_id=account_id,
+                    branch=branch,
+                    context=context,
                 ),
             )
             await service.event.send(event=event)

--- a/backend/infrahub/services/adapters/event/__init__.py
+++ b/backend/infrahub/services/adapters/event/__init__.py
@@ -33,5 +33,5 @@ class InfrahubEventService:
             event=event.get_name(),
             resource=event.get_resource(),
             related=event.get_related(),
-            payload=event.get_payload(),
+            payload=event.get_event_payload(),
         )

--- a/backend/tests/helpers/events.py
+++ b/backend/tests/helpers/events.py
@@ -14,7 +14,7 @@ async def send_events(client: PrefectClient, events: list[InfrahubEvent]) -> lis
         Event(
             id=event.meta.id,
             event=event.get_name(),
-            payload=event.get_payload(),
+            payload=event.get_event_payload(),
             related=[RelatedResource(item) for item in event.get_related()],
             resource=Resource(event.get_resource()),
         )

--- a/backend/tests/integration_docker/test_computed_attributes.py
+++ b/backend/tests/integration_docker/test_computed_attributes.py
@@ -1,0 +1,64 @@
+from asyncio import sleep
+from pathlib import Path
+
+import pytest
+import yaml
+from infrahub_sdk import InfrahubClient
+from infrahub_sdk.testing.docker import TestInfrahubDockerClient
+
+CURRENT_DIRECTORY = Path(__file__).parent.resolve()
+
+
+class TestComputedAttributes(TestInfrahubDockerClient):
+    @pytest.fixture(scope="class")
+    def infrahub_version(self) -> str:
+        return "local"
+
+    async def test_load_schema(self, client: InfrahubClient) -> None:
+        """Prepare the schema"""
+        with Path(CURRENT_DIRECTORY / "test_files/computed_tshirt.yml").open(encoding="utf-8") as file:  # noqa: ASYNC230
+            computed_tshirt = yaml.safe_load(file.read())
+
+        tshirt_schema = await client.schema.load(schemas=[computed_tshirt], wait_until_converged=True)
+        assert tshirt_schema.schema_updated
+        # Validate that the schema is in sync after loading the device and interface schema
+        assert await client.schema.in_sync()
+
+    async def test_computed_attribute_update(self, client: InfrahubClient) -> None:
+        """Validate that the computed attribute is registered and created and also updated correctly."""
+        first_desc = "A Sunset Explorer t-shirt. A bold, vibrant orange that captures the warmth of the setting sun."
+        final_desc = (
+            "A Sunset Explorer t-shirt. A striking, lively shade of orange that radiates the golden warmth of a sunset."
+        )
+        data = {
+            "name": "Sunset",
+            "description": "A bold, vibrant orange that captures the warmth of the setting sun.",
+        }
+        color1 = await client.create(kind="TestingColor", data=data)
+        await color1.save()
+
+        data = {
+            "name": "Explorer",
+            "color": color1,
+        }
+        tshirt1 = await client.create(kind="TestingTShirt", data=data)
+        await tshirt1.save()
+
+        tshirt1_initial = await client.get(kind="TestingTShirt", id=tshirt1.id)
+        color1_initial = await client.get(kind="TestingColor", id=color1.id)
+
+        assert tshirt1_initial.description.value == first_desc
+
+        color1_initial.description.value = (
+            "A striking, lively shade of orange that radiates the golden warmth of a sunset."
+        )
+        await color1_initial.save()
+
+        for _ in range(10):
+            # Give the computed attribute triggers a little while to run
+            tshirt1_updated = await client.get(kind="TestingTShirt", id=tshirt1.id)
+            if tshirt1_updated.description.value != first_desc:
+                break
+            await sleep(1)
+
+        assert tshirt1_updated.description.value == final_desc

--- a/backend/tests/integration_docker/test_files/computed_tshirt.yml
+++ b/backend/tests/integration_docker/test_files/computed_tshirt.yml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://schema.infrahub.app/infrahub/schema/latest.json
+---
+version: '1.0'
+
+nodes:
+  - name: Color
+    namespace: Testing
+    description: "A color"
+    icon: "jam:world"
+    default_filter: "name__value"
+    order_by:
+      - "name__value"
+    display_labels:
+      - "name__value"
+    attributes:
+      - name: name
+        kind: Text
+        optional: false
+        unique: true
+      - name: description
+        kind: Text
+        optional: false
+  - name: TShirt
+    namespace: Testing
+    description: "A color"
+    icon: "jam:world"
+    default_filter: "name__value"
+    order_by:
+      - "name__value"
+    display_labels:
+      - "name__value"
+    attributes:
+      - name: name
+        kind: Text
+        optional: false
+      - name: description
+        kind: Text
+        optional: false
+        read_only: true
+        computed_attribute:
+          kind: Jinja2
+          jinja2_template: "A {{color__name__value }} {{ name__value}} t-shirt. {{ color__description__value }}"
+      - name: pitch
+        kind: Text
+        optional: true
+        read_only: true
+        computed_attribute:
+          kind: TransformPython
+          transform: TShirtPitch
+    relationships:
+      - name: color
+        optional: false
+        peer: TestingColor
+        cardinality: one

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -2669,7 +2669,7 @@ async def first_account(db: InfrahubDatabase, data_schema, node_group_schema, re
 
 
 @pytest.fixture
-async def session_first_account(db: InfrahubDatabase, first_account) -> AccountSession:
+async def session_first_account(db: InfrahubDatabase, first_account: Node) -> AccountSession:
     session = AccountSession(authenticated=True, auth_type=AuthType.API, account_id=first_account.id)
     return session
 

--- a/backend/tests/unit/graphql/queries/test_event.py
+++ b/backend/tests/unit/graphql/queries/test_event.py
@@ -5,6 +5,8 @@ import pytest
 from graphql import ExecutionResult
 from prefect.client.orchestration import PrefectClient, get_client
 
+from infrahub.auth import AccountSession, AuthType
+from infrahub.context import InfrahubContext
 from infrahub.core.branch import Branch
 from infrahub.core.constants import MutationAction
 from infrahub.core.manager import NodeManager
@@ -75,6 +77,9 @@ query MutatedNodes($id: [String]) {
 ACCOUNT1_ID = "33b15615-649e-4e9e-89b0-85e187251f1f"
 ACCOUNT2_ID = "518b434f-40bf-4b65-b700-04696535ca8e"
 
+ACCOUNT_SESSION_1 = AccountSession(authenticated=True, account_id=ACCOUNT1_ID, auth_type=AuthType.API)
+ACCOUNT_SESSION_2 = AccountSession(authenticated=True, account_id=ACCOUNT2_ID, auth_type=AuthType.API)
+
 
 @pytest.fixture
 async def branch1_id() -> uuid.UUID:
@@ -131,72 +136,100 @@ async def events_data(
             branch_name="branch1",
             branch_id=str(branch1_id),
             sync_with_git=True,
-            meta=EventMeta(branch=branch1),
+            meta=EventMeta.with_dummy_context(branch=branch1),
         ),
         "branch1_rebased": BranchRebasedEvent(
             branch_name="branch1",
             branch_id=str(branch1_id),
-            meta=EventMeta(branch=branch1),
+            meta=EventMeta.with_dummy_context(branch=branch1),
         ),
         "branch2_created": BranchCreatedEvent(
             branch_name="branch2",
             branch_id=str(branch2_id),
             sync_with_git=False,
-            meta=EventMeta(branch=branch2),
+            meta=EventMeta.with_dummy_context(branch=branch2),
         ),
         "branch2_rebased": BranchRebasedEvent(
             branch_name="branch2",
             branch_id=str(branch2_id),
-            meta=EventMeta(branch=branch2),
+            meta=EventMeta.with_dummy_context(branch=branch2),
         ),
         "branch1_mutated1": NodeMutatedEvent(
             kind="BuiltinTag",
             node_id=tag1.get_id(),
             action=MutationAction.CREATED,
             data=tag1.node_changelog,
-            meta=EventMeta(branch=branch1, account_id=ACCOUNT1_ID),
+            meta=EventMeta(
+                branch=branch1,
+                account_id=ACCOUNT1_ID,
+                context=InfrahubContext.init(branch=branch1, account=ACCOUNT_SESSION_1),
+            ),
         ),
         "branch1_mutated2": NodeMutatedEvent(
             kind="BuiltinTag",
             node_id=tag1_update.get_id(),
             action=MutationAction.UPDATED,
             data=tag1_update.node_changelog,
-            meta=EventMeta(branch=branch1, account_id=ACCOUNT1_ID),
+            meta=EventMeta(
+                branch=branch1,
+                account_id=ACCOUNT1_ID,
+                context=InfrahubContext.init(branch=branch1, account=ACCOUNT_SESSION_1),
+            ),
         ),
         "branch1_mutated3": NodeMutatedEvent(
             kind="BuiltinTag",
             node_id=tag2.get_id(),
             action=MutationAction.CREATED,
             data=tag2.node_changelog,
-            meta=EventMeta(branch=branch1, account_id=ACCOUNT1_ID),
+            meta=EventMeta(
+                branch=branch1,
+                account_id=ACCOUNT1_ID,
+                context=InfrahubContext.init(branch=branch1, account=ACCOUNT_SESSION_1),
+            ),
         ),
         "branch1_mutated4": NodeMutatedEvent(
             kind="BuiltinTag",
             node_id=tag3.get_id(),
             action=MutationAction.CREATED,
             data=tag3.node_changelog,
-            meta=EventMeta(branch=branch1, account_id=ACCOUNT2_ID),
+            meta=EventMeta(
+                branch=branch1,
+                account_id=ACCOUNT2_ID,
+                context=InfrahubContext.init(branch=branch1, account=ACCOUNT_SESSION_2),
+            ),
         ),
         "branch2_mutated1": NodeMutatedEvent(
             kind="BuiltinTag",
             node_id=tag4.get_id(),
             action=MutationAction.CREATED,
             data=tag4.node_changelog,
-            meta=EventMeta(branch=branch2, account_id=ACCOUNT1_ID),
+            meta=EventMeta(
+                branch=branch2,
+                account_id=ACCOUNT1_ID,
+                context=InfrahubContext.init(branch=branch2, account=ACCOUNT_SESSION_1),
+            ),
         ),
         "branch2_mutated2": NodeMutatedEvent(
             kind="BuiltinTag",
             node_id=tag5.get_id(),
             action=MutationAction.CREATED,
             data=tag5.node_changelog,
-            meta=EventMeta(branch=branch2, account_id=ACCOUNT2_ID),
+            meta=EventMeta(
+                branch=branch2,
+                account_id=ACCOUNT2_ID,
+                context=InfrahubContext.init(branch=branch2, account=ACCOUNT_SESSION_2),
+            ),
         ),
         "branch2_mutated3": NodeMutatedEvent(
             kind="BuiltinTag",
             node_id=tag6.get_id(),
             action=MutationAction.CREATED,
             data=tag6.node_changelog,
-            meta=EventMeta(branch=branch2, account_id=ACCOUNT2_ID),
+            meta=EventMeta(
+                branch=branch2,
+                account_id=ACCOUNT2_ID,
+                context=InfrahubContext.init(branch=branch2, account=ACCOUNT_SESSION_2),
+            ),
         ),
     }
 

--- a/backend/tests/unit/graphql/test_mutation_relationship.py
+++ b/backend/tests/unit/graphql/test_mutation_relationship.py
@@ -1,5 +1,6 @@
 from infrahub_sdk.uuidt import UUIDT
 
+from infrahub.auth import AccountSession
 from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.manager import NodeManager
@@ -317,6 +318,7 @@ async def test_relationship_groups_add(
     default_branch: Branch,
     car_person_generics_data,
     enable_broker_config: None,
+    session_first_account: AccountSession,
 ):
     c1 = car_person_generics_data["c1"]
     c2 = car_person_generics_data["c2"]
@@ -345,7 +347,9 @@ async def test_relationship_groups_add(
     )
     memory_event = MemoryInfrahubEvent()
     service = await InfrahubServices.new(event=memory_event)
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch, service=service)
+    gql_params = await prepare_graphql_params(
+        db=db, include_subscription=False, branch=default_branch, service=service, account_session=session_first_account
+    )
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -387,7 +391,9 @@ async def test_relationship_groups_add(
     )
     memory_event = MemoryInfrahubEvent()
     service = await InfrahubServices.new(event=memory_event)
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch, service=service)
+    gql_params = await prepare_graphql_params(
+        db=db, include_subscription=False, branch=default_branch, service=service, account_session=session_first_account
+    )
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -424,6 +430,7 @@ async def test_relationship_groups_remove(
     default_branch: Branch,
     car_person_generics_data,
     enable_broker_config: None,
+    session_first_account: AccountSession,
 ):
     c1 = car_person_generics_data["c1"]
     c2 = car_person_generics_data["c2"]
@@ -454,7 +461,9 @@ async def test_relationship_groups_remove(
     memory_event = MemoryInfrahubEvent()
     service = await InfrahubServices.new(event=memory_event)
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch, service=service)
+    gql_params = await prepare_graphql_params(
+        db=db, include_subscription=False, branch=default_branch, service=service, account_session=session_first_account
+    )
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -496,7 +505,9 @@ async def test_relationship_groups_remove(
     memory_event = MemoryInfrahubEvent()
     service = await InfrahubServices.new(event=memory_event)
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch, service=service)
+    gql_params = await prepare_graphql_params(
+        db=db, include_subscription=False, branch=default_branch, service=service, account_session=session_first_account
+    )
 
     result = await graphql(
         schema=gql_params.schema,

--- a/backend/tests/unit/graphql/test_mutation_update.py
+++ b/backend/tests/unit/graphql/test_mutation_update.py
@@ -1,6 +1,7 @@
 import pytest
 
 from infrahub import config
+from infrahub.auth import AccountSession
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.changelog.models import RelationshipCardinalityOneChangelog
@@ -224,6 +225,7 @@ async def test_update_all_attributes(
     default_branch,
     all_attribute_types_schema,
     enable_broker_config: None,
+    session_first_account: AccountSession,
 ):
     obj1 = await Node.init(db=db, schema="TestAllAttributeTypes")
     await obj1.new(
@@ -263,7 +265,9 @@ async def test_update_all_attributes(
 
     memory_event = MemoryInfrahubEvent()
     service = await InfrahubServices.new(event=memory_event)
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch, service=service)
+    gql_params = await prepare_graphql_params(
+        db=db, include_subscription=False, branch=default_branch, service=service, account_session=session_first_account
+    )
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -273,6 +277,7 @@ async def test_update_all_attributes(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestAllAttributeTypesUpdate"]["ok"] is True
 
     objs = await NodeManager.query(db=db, schema="TestAllAttributeTypes")
@@ -412,6 +417,7 @@ async def test_update_single_relationship(
     car_accord_main: Node,
     branch: Branch,
     enable_broker_config: None,
+    session_first_account: AccountSession,
 ):
     query = """
     mutation {
@@ -435,7 +441,9 @@ async def test_update_single_relationship(
     )
     memory_event = MemoryInfrahubEvent()
     service = await InfrahubServices.new(event=memory_event)
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch, service=service)
+    gql_params = await prepare_graphql_params(
+        db=db, include_subscription=False, branch=branch, service=service, account_session=session_first_account
+    )
     result = await graphql(
         schema=gql_params.schema,
         source=query,

--- a/backend/tests/unit/task_manager/test_event.py
+++ b/backend/tests/unit/task_manager/test_event.py
@@ -4,8 +4,9 @@ import pytest
 from prefect.client.orchestration import PrefectClient, get_client
 from tests.helpers.events import extract_expected_ids, send_events
 
+from infrahub.core.branch import Branch
 from infrahub.events.branch_action import BranchCreatedEvent, BranchRebasedEvent
-from infrahub.events.models import InfrahubEvent
+from infrahub.events.models import EventMeta, InfrahubEvent
 from infrahub.task_manager.event import PrefectEvent
 
 QUERY_EVENT = """
@@ -51,11 +52,28 @@ async def branch2_id() -> str:
 
 @pytest.fixture(scope="module")
 async def events_data(prefect_client: PrefectClient, branch1_id, branch2_id) -> dict[str, InfrahubEvent]:
+    branch1 = Branch(name="branch1", uuid=uuid.UUID(branch1_id))
+    branch2 = Branch(name="branch2", uuid=uuid.UUID(branch2_id))
+
     items: dict[str, InfrahubEvent] = {
-        "branch1_created": BranchCreatedEvent(branch_name="branch1", branch_id=branch1_id, sync_with_git=True),
-        "branch1_rebased": BranchRebasedEvent(branch_name="branch1", branch_id=branch1_id),
-        "branch2_created": BranchCreatedEvent(branch_name="branch2", branch_id=branch2_id, sync_with_git=False),
-        "branch2_rebased": BranchRebasedEvent(branch_name="branch2", branch_id=branch2_id),
+        "branch1_created": BranchCreatedEvent(
+            branch_name="branch1",
+            branch_id=branch1_id,
+            sync_with_git=True,
+            meta=EventMeta.with_dummy_context(branch=branch1),
+        ),
+        "branch1_rebased": BranchRebasedEvent(
+            branch_name="branch1", branch_id=branch1_id, meta=EventMeta.with_dummy_context(branch=branch1)
+        ),
+        "branch2_created": BranchCreatedEvent(
+            branch_name="branch2",
+            branch_id=branch2_id,
+            sync_with_git=False,
+            meta=EventMeta.with_dummy_context(branch=branch2),
+        ),
+        "branch2_rebased": BranchRebasedEvent(
+            branch_name="branch2", branch_id=branch2_id, meta=EventMeta.with_dummy_context(branch=branch2)
+        ),
     }
 
     await send_events(client=prefect_client, events=list(items.values()))
@@ -74,7 +92,6 @@ async def test_query_no_filters(event_ids_inscope):
     assert clean_events["count"] == 4
 
 
-@pytest.mark.xfail(reason="Was working with Prefect 3.1 but is failing with Prefect 3.0, need to investigate")
 async def test_query_branch_filter(events_data, event_ids_inscope):
     expected_ids = extract_expected_ids(expected_events=["branch1_created", "branch1_rebased"], data=events_data)
     fields = {"count": None, "edges": {"node": {"event": None, "branch": None}}}


### PR DESCRIPTION
The focus of this PR is to get the automation triggers from Prefect working again in the `develop` branch. This is done by ensuring that we send the now required `InfrahubContext` object in different formats depending on if it's a trigger setup within Prefect (then we send it as JSON payload from the event.payload['context'] data and convert it into a dictionary instead of sending it as a string. The alternative is when se just submit or execute a workflow and send the context object as is.

The InfrahubContext object has been added as a required object to the event Metadata field. There are a few things to note about this:

* With this in place some of the existing data in the metadata object such as account and branch are redundant. I didn't want to change to much within a single PR but before 1.2 is released we should phase out the old fields
* As the AccountSession is required for the InfrahubContext I've added that information where applicable (with some dummy data within the tests). However we also have it in git/integrator.py where we don't yet have access to the context object. As things weren't working right now with the triggers I added some dummy data in that specific location as well. There I think we need to start from the beginning and see where we can create a proper AccountSession object and send it from the originating task (the other option would be to make the AccountSession optional but I think we can use it pretty much everywhere)

Because we always want to send the InfrahubContext as part of the event payload I added a new .get_event_payload() method that should only be defined on the root InfrahubEvent object and then child classes can override the get_payload() method without having to worry about the requirement to include the "context" key.

I added a new test to infrahub_docker where we validate that the trigger for the computed attribute (for Jinja) is working. So now we at least won't run into the same situation again. Those tests should be expanded on upcoming PRs though to also run the same type of tests for the Python Transform based computed attributes as well as testing the computed attributes on different branches.

I also enabled a test that was previously disabled. I'm not sure why it was failing before or if it started to work after the recent changes to the InfrahubEvent GraphQL query.