### PR TITLE
Add additional parameters to InfrahubEvent

### DIFF
--- a/backend/infrahub/core/changelog/models.py
+++ b/backend/infrahub/core/changelog/models.py
@@ -102,10 +102,10 @@ class RelationshipCardinalityOneChangelog(BaseModel):
     properties: dict[str, PropertyChangelog] = Field(
         default_factory=dict, description="Changes to properties of this relationship if any were made"
     )
-    _parent: ChangelogNodeParent | None = PrivateAttr(default=None)
+    _parent: ChangelogRelatedNode | None = PrivateAttr(default=None)
 
     @property
-    def parent(self) -> ChangelogNodeParent | None:
+    def parent(self) -> ChangelogRelatedNode | None:
         return self._parent
 
     @computed_field
@@ -127,7 +127,7 @@ class RelationshipCardinalityOneChangelog(BaseModel):
         self.properties[name] = PropertyChangelog(name=name, value=value_current, value_previous=value_previous)
 
     def set_parent(self, parent_id: str, parent_kind: str) -> None:
-        self._parent = ChangelogNodeParent(node_id=parent_id, node_kind=parent_kind)
+        self._parent = ChangelogRelatedNode(node_id=parent_id, node_kind=parent_kind)
 
     def set_parent_from_relationship(self, relationship: Relationship) -> None:
         if relationship.schema.kind == RelationshipKind.PARENT:
@@ -136,9 +136,9 @@ class RelationshipCardinalityOneChangelog(BaseModel):
                 and self.peer_id
                 and self.peer_kind
             ):
-                self._parent = ChangelogNodeParent(node_id=self.peer_id, node_kind=self.peer_kind)
+                self._parent = ChangelogRelatedNode(node_id=self.peer_id, node_kind=self.peer_kind)
             elif self.peer_id_previous and self.peer_kind_previous:
-                self._parent = ChangelogNodeParent(node_id=self.peer_id_previous, node_kind=self.peer_kind_previous)
+                self._parent = ChangelogRelatedNode(node_id=self.peer_id_previous, node_kind=self.peer_kind_previous)
 
     @property
     def is_empty(self) -> bool:
@@ -200,7 +200,7 @@ class RelationshipCardinalityManyChangelog(BaseModel):
         return not self.peers
 
 
-class ChangelogNodeParent(BaseModel):
+class ChangelogRelatedNode(BaseModel):
     node_id: str
     node_kind: str
 
@@ -217,10 +217,10 @@ class NodeChangelog(BaseModel):
         default_factory=dict
     )
 
-    _parent: ChangelogNodeParent | None = PrivateAttr(default=None)
+    _parent: ChangelogRelatedNode | None = PrivateAttr(default=None)
 
     @property
-    def parent(self) -> ChangelogNodeParent | None:
+    def parent(self) -> ChangelogRelatedNode | None:
         return self._parent
 
     @property
@@ -239,18 +239,18 @@ class NodeChangelog(BaseModel):
             return self.parent.node_id
         return self.node_id
 
-    def add_parent(self, parent: ChangelogNodeParent) -> None:
+    def add_parent(self, parent: ChangelogRelatedNode) -> None:
         self._parent = parent
 
     def add_parent_from_relationship(self, parent: Relationship) -> None:
-        self._parent = ChangelogNodeParent(node_id=parent.get_peer_id(), node_kind=parent.get_peer_kind())
+        self._parent = ChangelogRelatedNode(node_id=parent.get_peer_id(), node_kind=parent.get_peer_kind())
 
     def create_relationship(self, relationship: Relationship) -> None:
         if relationship.schema.cardinality == RelationshipCardinality.ONE:
             peer_id = relationship.get_peer_id()
             peer_kind = relationship.get_peer_kind()
             if relationship.schema.kind == RelationshipKind.PARENT:
-                self._parent = ChangelogNodeParent(node_id=peer_id, node_kind=peer_kind)
+                self._parent = ChangelogRelatedNode(node_id=peer_id, node_kind=peer_kind)
             changelog_relationship = RelationshipCardinalityOneChangelog(
                 name=relationship.schema.name,
                 peer_id=peer_id,
@@ -324,6 +324,27 @@ class NodeChangelog(BaseModel):
         changelog_attribute.add_property(name="is_protected", value_current=attribute.is_protected, value_previous=None)
         changelog_attribute.add_property(name="is_visible", value_current=attribute.is_visible, value_previous=None)
         self.attributes[changelog_attribute.name] = changelog_attribute
+
+    def get_related_nodes(self) -> list[ChangelogRelatedNode]:
+        related_nodes: dict[str, ChangelogRelatedNode] = {}
+        for relationship in self.relationships.values():
+            if isinstance(relationship, RelationshipCardinalityOneChangelog):
+                if relationship.peer_id and relationship.peer_kind:
+                    related_nodes[relationship.peer_id] = ChangelogRelatedNode(
+                        node_id=relationship.peer_id, node_kind=relationship.peer_kind
+                    )
+                if relationship.peer_id_previous and relationship.peer_kind_previous:
+                    related_nodes[relationship.peer_id_previous] = ChangelogRelatedNode(
+                        node_id=relationship.peer_id_previous, node_kind=relationship.peer_kind_previous
+                    )
+            elif isinstance(relationship, RelationshipCardinalityManyChangelog):
+                for peer in relationship.peers:
+                    related_nodes[peer.peer_id] = ChangelogRelatedNode(node_id=peer.peer_id, node_kind=peer.peer_kind)
+
+        if self.parent:
+            related_nodes[self.parent.node_id] = self.parent
+
+        return list(related_nodes.values())
 
 
 class ChangelogRelationshipMapper:

--- a/backend/infrahub/events/group_action.py
+++ b/backend/infrahub/events/group_action.py
@@ -19,12 +19,19 @@ class GroupMutatedEvent(InfrahubEvent):
 
     def get_related(self) -> list[dict[str, str]]:
         related = super().get_related()
+        related.append(
+            {
+                "prefect.resource.id": self.node_id,
+                "prefect.resource.role": "infrahub.related.node",
+                "infrahub.node.kind": self.kind,
+            }
+        )
         for member in self.members:
             related.append(
                 {
                     "prefect.resource.id": member.id,
-                    "prefect.resource.role": "infrahub.group.member",
-                    "infrahub.group.kind": member.kind,
+                    "prefect.resource.role": "infrahub.related.node",
+                    "infrahub.node.kind": member.kind,
                 }
             )
 

--- a/backend/infrahub/events/models.py
+++ b/backend/infrahub/events/models.py
@@ -40,6 +40,15 @@ class EventMeta(BaseModel):
 
     parent: UUID | None = Field(default=None, description="The UUID of the parent event if applicable")
 
+    def get_branch_id(self) -> str:
+        if self.context.branch.id:
+            return self.context.branch.id
+
+        if self.branch:
+            return str(self.branch.get_uuid())
+
+        return ""
+
     def get_id(self) -> str:
         return str(self.id)
 
@@ -50,26 +59,20 @@ class EventMeta(BaseModel):
                 "prefect.resource.id": self.get_id(),
                 "prefect.resource.role": "infrahub.event",
                 "infrahub.event.has_children": str(self.has_children).lower(),
+                "infrahub.event.level": str(self.level),
+            },
+            {
+                "prefect.resource.id": f"infrahub.account.{self.context.account.account_id}",
+                "prefect.resource.role": "infrahub.account",
+                "infrahub.resource.id": self.context.account.account_id,
+            },
+            {
+                "prefect.resource.id": f"infrahub.branch.{self.get_branch_id()}",
+                "prefect.resource.role": "infrahub.branch",
+                "infrahub.resource.id": self.get_branch_id(),
+                "infrahub.resource.label": self.context.branch.name,
             },
         ]
-        if self.account_id:
-            related.append(
-                {
-                    "prefect.resource.id": f"infrahub.account.{self.account_id}",
-                    "prefect.resource.role": "infrahub.account",
-                    "infrahub.resource.id": self.account_id,
-                }
-            )
-
-        if self.branch:
-            related.append(
-                {
-                    "prefect.resource.id": f"infrahub.branch.{self.branch.get_uuid()}",
-                    "prefect.resource.role": "infrahub.branch",
-                    "infrahub.resource.id": str(self.branch.get_uuid()),
-                    "infrahub.resource.label": self.branch.name,
-                }
-            )
 
         if self.parent:
             related.append(

--- a/backend/infrahub/events/node_action.py
+++ b/backend/infrahub/events/node_action.py
@@ -46,6 +46,23 @@ class NodeMutatedEvent(InfrahubEvent):
                 }
             )
 
+        related.append(
+            {
+                "prefect.resource.id": self.node_id,
+                "prefect.resource.role": "infrahub.related.node",
+                "infrahub.node.kind": self.kind,
+            }
+        )
+
+        for related_node in self.data.get_related_nodes():
+            related.append(
+                {
+                    "prefect.resource.id": related_node.node_id,
+                    "prefect.resource.role": "infrahub.related.node",
+                    "infrahub.node.kind": related_node.node_kind,
+                }
+            )
+
         return related
 
     @computed_field

--- a/backend/infrahub/graphql/queries/event.py
+++ b/backend/infrahub/graphql/queries/event.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from graphene import Field, Int, List, NonNull, ObjectType, String
+from graphene import Boolean, DateTime, Field, Int, List, NonNull, ObjectType, String
 from infrahub_sdk.utils import extract_fields_first_node
 
 from infrahub.exceptions import ValidationError
@@ -10,6 +10,8 @@ from infrahub.graphql.types.event import EventNodes
 from infrahub.task_manager.event import PrefectEvent
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     from graphql import GraphQLResolveInfo
 
 
@@ -22,12 +24,18 @@ class Events(ObjectType):
         root: dict,  # noqa: ARG004
         info: GraphQLResolveInfo,
         limit: int = 10,
+        has_children: bool | None = None,
+        level: int | None = None,
         offset: int | None = None,
-        account: str | None = None,
+        account__ids: list[str] | None = None,
         ids: list[str] | None = None,
-        branch: str | None = None,
-        q: str | None = None,
+        branches: list[str] | None = None,
+        event_type: list[str] | None = None,
         related_node__ids: list[str] | None = None,
+        primary_node__ids: list[str] | None = None,
+        parent__ids: list[str] | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
     ) -> dict[str, Any]:
         ids = ids or []
         if limit > 50:
@@ -35,13 +43,19 @@ class Events(ObjectType):
             raise ValidationError(input_value="The parameter 'limit' can't be above 50")
         return await Events.query(
             info=info,
-            branch=branch,
-            account=account,
+            branch=branches,
+            account=account__ids,
             limit=limit,
+            level=level,
+            event_type=event_type,
+            has_children=has_children,
             offset=offset,
             related_node__ids=related_node__ids,
-            q=q,
+            primary_node__ids=primary_node__ids,
+            parent__ids=parent__ids,
             ids=ids,
+            since=since,
+            until=until,
         )
 
     @classmethod
@@ -50,23 +64,35 @@ class Events(ObjectType):
         info: GraphQLResolveInfo,
         limit: int,
         offset: int | None = None,
-        q: str | None = None,
+        level: int | None = None,
+        has_children: bool | None = None,
         ids: list[str] | None = None,
+        event_type: list[str] | None = None,
         related_node__ids: list[str] | None = None,
-        branch: str | None = None,
-        account: str | None = None,
+        primary_node__ids: list[str] | None = None,
+        parent__ids: list[str] | None = None,
+        branch: list[str] | None = None,
+        account: list[str] | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
     ) -> dict[str, Any]:
         fields = await extract_fields_first_node(info)
 
         prefect_tasks = await PrefectEvent.query(
             fields=fields,
-            q=q,
             ids=ids,
             related_node__ids=related_node__ids,
+            primary_node__ids=primary_node__ids,
+            parent__ids=parent__ids,
             branch=branch,
+            event_type=event_type,
+            has_children=has_children,
             account=account,
+            level=level,
             limit=limit,
             offset=offset,
+            since=since,
+            until=until,
         )
         return {
             "count": prefect_tasks.get("count", 0),
@@ -78,11 +104,23 @@ Event = Field(
     Events,
     limit=Int(required=False),
     offset=Int(required=False),
-    related_node__ids=List(String),
-    branch=String(required=False),
-    account=String(required=False),
-    ids=List(String),
-    q=String(required=False),
+    level=Int(required=False),
+    has_children=Boolean(required=False, description="Filter events based on if they can have children or not"),
+    event_type=List(NonNull(String), description="Filter events that match a specific type"),
+    primary_node__ids=List(
+        NonNull(String), description="Filter events where the primary node id is within indicated node ids"
+    ),
+    related_node__ids=List(
+        NonNull(String), description="Filter events where the related node ids are within indicated node ids"
+    ),
+    parent__ids=List(
+        NonNull(String), description="Search events that has any of the indicated event ids listed as parents"
+    ),
+    since=DateTime(required=False, description="Search events since this timestamp, defaults to 180 days back"),
+    until=DateTime(required=False, description="Search events until this timestamp, defaults the current time"),
+    branches=List(NonNull(String), required=False, description="Filter the query to specific branches"),
+    account__ids=List(NonNull(String), required=False, description="Filter the query to specific accounts"),
+    ids=List(NonNull(String)),
     resolver=Events.resolve,
     required=True,
 )

--- a/backend/infrahub/graphql/types/event.py
+++ b/backend/infrahub/graphql/types/event.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from graphene import Boolean, Field, Int, Interface, List, NonNull, ObjectType, String
+from graphene import Boolean, DateTime, Field, Int, Interface, List, NonNull, ObjectType, String
 from graphene.types.generic import GenericScalar
 
 from .common import RelatedNode
@@ -25,9 +25,10 @@ class EventNodeInterface(Interface):
     event = String(required=True)
     branch = String(required=False)
     account_id = String(required=False)
-    occurred_at = String(required=True)
+    occurred_at = DateTime(required=True)
     level = Int(required=True)
     primary_node = Field(RelatedNode, required=False)
+    related_nodes = List(NonNull(RelatedNode), required=True)
     has_children = Boolean(required=True)
     parent_id = String(required=False)
 

--- a/backend/infrahub/task_manager/event.py
+++ b/backend/infrahub/task_manager/event.py
@@ -1,20 +1,135 @@
+from __future__ import annotations
+
 import uuid
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from prefect.client.orchestration import PrefectClient, get_client
-from prefect.events.filters import EventFilter, EventIDFilter, EventRelatedFilter, EventResourceFilter
+from prefect.events.filters import (
+    EventFilter,
+    EventIDFilter,
+    EventNameFilter,
+    EventOccurredFilter,
+    EventRelatedFilter,
+    EventResourceFilter,
+)
 from prefect.events.schemas.events import Event as PrefectEventModel
 from prefect.events.schemas.events import ResourceSpecification
 from pydantic import BaseModel, Field, TypeAdapter
 
+from infrahub.core.timestamp import Timestamp
 from infrahub.log import get_logger
 from infrahub.utils import get_nested_dict
 
 log = get_logger()
 
+if TYPE_CHECKING:
+    from datetime import datetime
+
 
 class InfrahubEventFilter(EventFilter):
     matching_related: list[EventRelatedFilter] = Field(default_factory=list)
+
+    def add_account_filter(self, account: list[str] | None) -> None:
+        if account:
+            self.matching_related.append(
+                EventRelatedFilter(
+                    labels=ResourceSpecification(
+                        {"prefect.resource.role": "infrahub.account", "infrahub.resource.id": account}
+                    )
+                )
+            )
+
+    def add_branch_filter(self, branch: list[str] | None = None) -> None:
+        if branch:
+            self.matching_related.append(
+                EventRelatedFilter(
+                    labels=ResourceSpecification(
+                        {"prefect.resource.role": "infrahub.branch", "infrahub.resource.label": branch}
+                    )
+                )
+            )
+
+    def add_event_filter(self, level: int | None = None, has_children: bool | None = None) -> None:
+        event_filter: dict[str, list[str] | str] = {}
+        if level is not None:
+            event_filter["infrahub.event.level"] = str(level)
+
+        if has_children is not None:
+            event_filter["infrahub.event.has_children"] = str(has_children).lower()
+
+        if event_filter:
+            event_filter["prefect.resource.role"] = "infrahub.event"
+            self.matching_related.append(EventRelatedFilter(labels=ResourceSpecification(event_filter)))
+
+    def add_event_id_filter(self, ids: list[str] | None = None) -> None:
+        if ids:
+            self.id = EventIDFilter(id=[uuid.UUID(id) for id in ids])
+
+    def add_event_type_filter(self, event_type: list[str] | None = None) -> None:
+        if event_type:
+            self.event = EventNameFilter(name=event_type)
+
+    def add_primary_node_filter(self, primary_node__ids: list[str] | None) -> None:
+        if primary_node__ids:
+            self.resource = EventResourceFilter(labels=ResourceSpecification({"infrahub.node.id": primary_node__ids}))
+
+    def add_parent_filter(self, parent__ids: list[str] | None) -> None:
+        if parent__ids:
+            self.matching_related.append(
+                EventRelatedFilter(
+                    labels=ResourceSpecification(
+                        {"prefect.resource.role": "infrahub.child_event", "infrahub.event_parent.id": parent__ids}
+                    )
+                )
+            )
+
+    def add_related_node_filter(self, related_node__ids: list[str] | None) -> None:
+        if related_node__ids:
+            self.matching_related.append(
+                EventRelatedFilter(
+                    labels=ResourceSpecification(
+                        {"prefect.resource.role": "infrahub.related.node", "prefect.resource.id": related_node__ids}
+                    )
+                )
+            )
+
+    @classmethod
+    def from_filters(
+        cls,
+        ids: list[str] | None = None,
+        account: list[str] | None = None,
+        related_node__ids: list[str] | None = None,
+        parent__ids: list[str] | None = None,
+        primary_node__ids: list[str] | None = None,
+        event_type: list[str] | None = None,
+        branch: list[str] | None = None,
+        level: int | None = None,
+        has_children: bool | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+    ) -> InfrahubEventFilter:
+        occurred_filter = {}
+        if since:
+            occurred_filter["since"] = Timestamp(since.isoformat()).obj
+
+        if until:
+            occurred_filter["until"] = Timestamp(until.isoformat()).obj
+
+        if occurred_filter:
+            filters = cls(occurred=EventOccurredFilter(**occurred_filter))
+        else:
+            filters = cls()
+
+        filters.add_event_filter(level=level, has_children=has_children)
+        filters.add_event_id_filter(ids=ids)
+        filters.add_event_type_filter(event_type=event_type)
+        filters.add_branch_filter(branch=branch)
+        filters.add_account_filter(account=account)
+        filters.add_parent_filter(parent__ids=parent__ids)
+        filters.add_primary_node_filter(primary_node__ids=primary_node__ids)
+        filters.add_related_node_filter(related_node__ids=related_node__ids)
+
+        return filters
 
 
 class PrefectEventData(PrefectEventModel):
@@ -53,6 +168,22 @@ class PrefectEventData(PrefectEventModel):
             return {"id": node_id, "kind": node_kind}
 
         return None
+
+    def get_related_nodes(self) -> list[dict[str, str]]:
+        related_nodes = []
+        for resource in self.related:
+            if resource.get("prefect.resource.role") != "infrahub.related.node":
+                continue
+
+            node_id = resource.get("prefect.resource.id")
+            node_kind = resource.get("infrahub.node.kind")
+            if node_id == self.resource.get("infrahub.node.id"):
+                # Don't include the primary node as a related node.
+                continue
+            if node_id and node_kind:
+                related_nodes.append({"id": node_id, "kind": node_kind})
+
+        return related_nodes
 
     def get_account_id(self) -> str | None:
         for resource in self.related:
@@ -106,12 +237,13 @@ class PrefectEventData(PrefectEventModel):
             "event": self.event,
             "branch": self.get_branch(),
             "account_id": self.get_account_id(),
-            "occurred_at": self.occurred.to_iso8601_string(),
+            "occurred_at": self.occurred,
             "has_children": self.has_children(),
             "payload": self.payload,
             "level": self.get_level(),
             "primary_node": self.get_primary_node(),
             "parent_id": self.get_parent(),
+            "related_nodes": self.get_related_nodes(),
         }
         response.update(self._return_event_specifics())
         return response
@@ -143,60 +275,40 @@ class PrefectEvent:
         )
 
     @classmethod
-    def _generate_filters(
-        cls,
-        ids: list[str] | None = None,
-        account: str | None = None,
-        related_node__ids: list[str] | None = None,
-        branch: str | None = None,
-    ) -> InfrahubEventFilter:
-        filters = InfrahubEventFilter()
-
-        if ids:
-            filters.id = EventIDFilter(id=[uuid.UUID(id) for id in ids])
-
-        if related_node__ids:
-            filters.resource = EventResourceFilter(
-                labels=ResourceSpecification({"infrahub.node.id": related_node__ids})
-            )
-
-        if branch:
-            filters.matching_related.append(
-                EventRelatedFilter(
-                    labels=ResourceSpecification(
-                        {"prefect.resource.role": "infrahub.branch", "infrahub.resource.label": branch}
-                    )
-                )
-            )
-
-        if account:
-            filters.matching_related.append(
-                EventRelatedFilter(
-                    labels=ResourceSpecification(
-                        {"prefect.resource.role": "infrahub.account", "infrahub.resource.id": account}
-                    )
-                )
-            )
-
-        return filters
-
-    @classmethod
     async def query(
         cls,
         fields: dict[str, Any],
         limit: int | None = None,
         offset: int | None = None,
-        q: str | None = None,  # noqa: ARG003
+        level: int | None = None,
         ids: list[str] | None = None,
-        branch: str | None = None,
-        account: str | None = None,
+        branch: list[str] | None = None,
+        has_children: bool | None = None,
+        account: list[str] | None = None,
+        event_type: list[str] | None = None,
         related_node__ids: list[str] | None = None,
+        primary_node__ids: list[str] | None = None,
+        parent__ids: list[str] | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
     ) -> dict[str, Any]:
         nodes: list[dict] = []
         limit = limit or 50
 
         node_fields = get_nested_dict(nested_dict=fields, keys=["edges", "node"])
-        filters = cls._generate_filters(ids=ids, branch=branch, account=account, related_node__ids=related_node__ids)
+        filters = InfrahubEventFilter.from_filters(
+            ids=ids,
+            branch=branch,
+            account=account,
+            has_children=has_children,
+            event_type=event_type,
+            related_node__ids=related_node__ids,
+            primary_node__ids=primary_node__ids,
+            parent__ids=parent__ids,
+            since=since,
+            until=until,
+            level=level,
+        )
 
         if not node_fields:
             # This means that it's purely a count query and as such we can override the limit to avoid

--- a/backend/tests/unit/graphql/queries/test_event.py
+++ b/backend/tests/unit/graphql/queries/test_event.py
@@ -11,6 +11,7 @@ from infrahub.core.branch import Branch
 from infrahub.core.constants import MutationAction
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
 from infrahub.events.branch_action import BranchCreatedEvent, BranchRebasedEvent
 from infrahub.events.models import EventMeta, InfrahubEvent
@@ -20,14 +21,42 @@ from tests.helpers.events import send_events
 from tests.helpers.graphql import graphql
 
 QUERY_EVENT = """
-query($branch: String, $account: String, $limit: Int, $offset: Int) {
-  InfrahubEvent(branch: $branch, account: $account, limit: $limit, offset: $offset) {
+query(
+    $branch: [String!],
+    $account: [String!],
+    $parent__ids: [String!],
+    $limit: Int,
+    $offset: Int
+    $level: Int
+    $has_children: Boolean
+    $event_type: [String!]
+    $since: DateTime
+) {
+  InfrahubEvent(
+    branches: $branch,
+    account__ids: $account,
+    limit: $limit,
+    offset: $offset,
+    level: $level
+    has_children: $has_children
+    parent__ids: $parent__ids
+    event_type: $event_type
+    since: $since
+  ) {
     count
     edges {
       node {
         id
         event
         branch
+        has_children
+        parent_id
+        level
+        occurred_at
+        related_nodes {
+            id
+            kind
+        }
       }
     }
   }
@@ -36,16 +65,16 @@ query($branch: String, $account: String, $limit: Int, $offset: Int) {
 
 
 QUERY_SIMPLE_COUNT_EVENT = """
-query($branch: String) {
-  InfrahubEvent(branch: $branch) {
+query($branch: [String!]) {
+  InfrahubEvent(branches: $branch) {
     count
   }
 }
 """
 
 QUERY_MUTATED_NODES = """
-query MutatedNodes($id: [String]) {
-  InfrahubEvent(related_node__ids: $id) {
+query MutatedNodes($id: [String!]) {
+  InfrahubEvent(primary_node__ids: $id) {
     count
     edges {
       node {
@@ -92,13 +121,20 @@ async def branch2_id() -> uuid.UUID:
 
 
 @pytest.fixture
+async def branch3_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+@pytest.fixture
 async def events_data(
     db: InfrahubDatabase,
     default_branch: Branch,
     register_core_models_schema: None,
+    car_person_schema: SchemaBranch,
     prefect_client: PrefectClient,
-    branch1_id,
-    branch2_id,
+    branch1_id: uuid.UUID,
+    branch2_id: uuid.UUID,
+    branch3_id: uuid.UUID,
 ) -> dict[str, InfrahubEvent]:
     tag1 = await Node.init(db=db, schema="BuiltinTag", branch=default_branch)
     await tag1.new(db=db, name="red", description="The red tag")
@@ -128,8 +164,21 @@ async def events_data(
     await tag6.new(db=db, name="brown", description="The brown tag")
     await tag6.save(db=db)
 
+    person1 = await Node.init(db=db, schema="TestPerson", branch=default_branch)
+    await person1.new(db=db, name="Alfred", height=160)
+    await person1.save(db=db)
+
+    person2 = await Node.init(db=db, schema="TestPerson", branch=default_branch)
+    await person2.new(db=db, name="Sarah", height=174)
+    await person2.save(db=db)
+
+    car = await Node.init(db=db, schema="TestCar", branch=default_branch)
+    await car.new(db=db, name="Volvo", nbr_seats=5, is_electric=False, owner=person1.id)
+    await car.save(db=db)
+
     branch1 = Branch(uuid=branch1_id, name="branch1")
     branch2 = Branch(uuid=branch2_id, name="branch2")
+    branch3 = Branch(uuid=branch3_id, name="branch3")
 
     items: dict[str, InfrahubEvent] = {
         "branch1_created": BranchCreatedEvent(
@@ -153,6 +202,12 @@ async def events_data(
             branch_name="branch2",
             branch_id=str(branch2_id),
             meta=EventMeta.with_dummy_context(branch=branch2),
+        ),
+        "branch3_created": BranchCreatedEvent(
+            branch_name="branch3",
+            branch_id=str(branch3_id),
+            sync_with_git=True,
+            meta=EventMeta.with_dummy_context(branch=branch3),
         ),
         "branch1_mutated1": NodeMutatedEvent(
             kind="BuiltinTag",
@@ -231,9 +286,39 @@ async def events_data(
                 context=InfrahubContext.init(branch=branch2, account=ACCOUNT_SESSION_2),
             ),
         ),
+        "branch3_mutated1": NodeMutatedEvent(
+            kind="TestPerson",
+            node_id=person1.get_id(),
+            action=MutationAction.CREATED,
+            data=person1.node_changelog,
+            meta=EventMeta(
+                branch=branch3,
+                account_id=ACCOUNT1_ID,
+                context=InfrahubContext.init(branch=branch3, account=ACCOUNT_SESSION_1),
+            ),
+        ),
+        "branch3_mutated2": NodeMutatedEvent(
+            kind="TestPerson",
+            node_id=person2.get_id(),
+            action=MutationAction.CREATED,
+            data=person2.node_changelog,
+            meta=EventMeta(
+                branch=branch3,
+                account_id=ACCOUNT1_ID,
+                context=InfrahubContext.init(branch=branch3, account=ACCOUNT_SESSION_1),
+            ),
+        ),
     }
 
-    await send_events(client=prefect_client, events=items.values())
+    items["branch3_mutated3"] = NodeMutatedEvent(
+        kind="TestCar",
+        node_id=car.get_id(),
+        action=MutationAction.CREATED,
+        data=car.node_changelog,
+        meta=EventMeta.from_parent(items["branch3_mutated1"]),
+    )
+
+    await send_events(client=prefect_client, events=list(items.values()))
     return items
 
 
@@ -395,20 +480,101 @@ async def test_event_query_prefect(
         db=db,
         branch=default_branch,
         query=QUERY_EVENT,
-        variables={"account": ACCOUNT1_ID, "limit": 3, "offset": 0},
+        variables={"account": ACCOUNT1_ID, "limit": 4, "offset": 0},
     )
     assert paginated_account1_page1.errors is None
     assert paginated_account1_page1.data
-    assert paginated_account1_page1.data["InfrahubEvent"]["count"] == 4
-    assert len(paginated_account1_page1.data["InfrahubEvent"]["edges"]) == 3
+    assert paginated_account1_page1.data["InfrahubEvent"]["count"] == 7
+    assert len(paginated_account1_page1.data["InfrahubEvent"]["edges"]) == 4
 
     paginated_account1_page2 = await run_query(
         db=db,
         branch=default_branch,
         query=QUERY_EVENT,
-        variables={"account": ACCOUNT1_ID, "limit": 3, "offset": 3},
+        variables={"account": ACCOUNT1_ID, "limit": 4, "offset": 4},
     )
     assert paginated_account1_page2.errors is None
     assert paginated_account1_page2.data
-    assert paginated_account1_page2.data["InfrahubEvent"]["count"] == 4
-    assert len(paginated_account1_page2.data["InfrahubEvent"]["edges"]) == 1
+    assert paginated_account1_page2.data["InfrahubEvent"]["count"] == 7
+    assert len(paginated_account1_page2.data["InfrahubEvent"]["edges"]) == 3
+
+    account1_branch1_branch3 = await run_query(
+        db=db,
+        branch=default_branch,
+        query=QUERY_EVENT,
+        variables={"account": ACCOUNT1_ID, "branch": ["branch1", "branch3"]},
+    )
+    assert account1_branch1_branch3.errors is None
+    assert account1_branch1_branch3.data
+    assert account1_branch1_branch3.data["InfrahubEvent"]["count"] == 6
+    assert len(account1_branch1_branch3.data["InfrahubEvent"]["edges"]) == 6
+
+    branch3_level_1 = await run_query(
+        db=db,
+        branch=default_branch,
+        query=QUERY_EVENT,
+        variables={"level": 1, "branch": ["branch3"]},
+    )
+    assert branch3_level_1.errors is None
+    assert branch3_level_1.data
+    assert branch3_level_1.data["InfrahubEvent"]["count"] == 1
+    assert len(branch3_level_1.data["InfrahubEvent"]["edges"]) == 1
+    assert len(branch3_level_1.data["InfrahubEvent"]["edges"][0]["node"]["related_nodes"]) == 1
+
+    branch3_has_children_true = await run_query(
+        db=db,
+        branch=default_branch,
+        query=QUERY_EVENT,
+        variables={"has_children": True, "branch": ["branch3"]},
+    )
+    assert branch3_has_children_true.errors is None
+    assert branch3_has_children_true.data
+    assert branch3_has_children_true.data["InfrahubEvent"]["count"] == 1
+    assert len(branch3_has_children_true.data["InfrahubEvent"]["edges"]) == 1
+    parent_node_id = branch3_has_children_true.data["InfrahubEvent"]["edges"][0]["node"]["id"]
+
+    find_parent = await run_query(
+        db=db,
+        branch=default_branch,
+        query=QUERY_EVENT,
+        variables={"parent__ids": [parent_node_id]},
+    )
+    assert find_parent.errors is None
+    assert find_parent.data
+    assert find_parent.data["InfrahubEvent"]["count"] == 1
+    assert len(find_parent.data["InfrahubEvent"]["edges"]) == 1
+    assert find_parent.data["InfrahubEvent"]["edges"][0]["node"]["parent_id"] == parent_node_id
+
+    created_branch1 = await run_query(
+        db=db,
+        branch=default_branch,
+        query=QUERY_EVENT,
+        variables={"event_type": ["infrahub.node.created"]},
+    )
+    assert created_branch1.errors is None
+    assert created_branch1.data
+    assert created_branch1.data["InfrahubEvent"]["count"] == 9
+    assert [node["node"]["event"] for node in created_branch1.data["InfrahubEvent"]["edges"]] == [
+        "infrahub.node.created"
+    ] * 9
+
+    all_branch1 = await run_query(
+        db=db,
+        branch=default_branch,
+        query=QUERY_EVENT,
+        variables={"branch": ["branch1"]},
+    )
+    assert all_branch1.errors is None
+    assert all_branch1.data
+    assert all_branch1.data["InfrahubEvent"]["count"] > 2
+    occurred_at = all_branch1.data["InfrahubEvent"]["edges"][1]["node"]["occurred_at"]
+
+    since_timestamp = await run_query(
+        db=db,
+        branch=default_branch,
+        query=QUERY_EVENT,
+        variables={"branch": ["branch1"], "since": occurred_at},
+    )
+    assert since_timestamp.errors is None
+    assert since_timestamp.data
+    assert since_timestamp.data["InfrahubEvent"]["count"] == 2


### PR DESCRIPTION
This PR does some cleanup of parameters for InfrahubEvent and some refactoring.

* The ChangeLogParent class has been renamed to ChangeLogRelatedNode as it is used for additional things
* Modify group_action metadata so that the related events look the same as those of the node_mutation events (making them easier to find with a similar query)
* Add a get_branch_id method to the EventMeta (as the ID isn't yet required anywhere. I'm thinking that this method should probably be removed soon with the change that we'd have the Branch ID as required within the context
* Refactoring of related_resources within the EventMeta to use information from the InfrahubContext object instead
* Add related_nodes information to the node_mutation events
* Add query parameters to InfrahubEvent:
   * has_children
   * level
   * account: str -> list[str]
   * branch: str -> list[str]
   * event_type
   * primary_node__ids
   * parent__ids
   * since & until for time
* Removed parameters
  * "q" which was never used. I'm not sure we will be able to have any free text search but we can consider other filtering options moving forward
* Refactoring of `_generate_filters` move it into a class method of the InfrahubEventFilter class instead