### PR TITLE
Check for permissions in rel add/delete mutations

### DIFF
--- a/backend/infrahub/graphql/mutations/relationship.py
+++ b/backend/infrahub/graphql/mutations/relationship.py
@@ -5,7 +5,8 @@ from typing import TYPE_CHECKING
 from graphene import Boolean, InputField, InputObjectType, List, Mutation, String
 from infrahub_sdk.utils import compare_lists
 
-from infrahub.core.constants import InfrahubKind, RelationshipCardinality
+from infrahub.core.account import GlobalPermission, ObjectPermission
+from infrahub.core.constants import InfrahubKind, PermissionAction, PermissionDecision, RelationshipCardinality
 from infrahub.core.manager import NodeManager
 from infrahub.core.query.relationship import (
     RelationshipGetPeerQuery,
@@ -14,6 +15,7 @@ from infrahub.core.query.relationship import (
 from infrahub.core.relationship import Relationship
 from infrahub.database import retry_db_transaction
 from infrahub.exceptions import NodeNotFoundError, ValidationError
+from infrahub.permissions import get_global_permission_for_kind
 
 from ..types import RelatedNodeInput
 
@@ -75,6 +77,32 @@ class RelationshipMixin:
         nodes = await NodeManager.get_many(
             db=context.db, ids=node_ids, fields={"display_label": None}, branch=context.branch
         )
+
+        if context.account_session:
+            impacted_schemas = {node.get_schema() for node in [source] + list(nodes.values())}
+            required_permissions: list[GlobalPermission | ObjectPermission] = []
+            decision = (
+                PermissionDecision.ALLOW_DEFAULT.value
+                if context.branch.is_default
+                else PermissionDecision.ALLOW_OTHER.value
+            )
+
+            for impacted_schema in impacted_schemas:
+                global_action = get_global_permission_for_kind(schema=impacted_schema)
+
+                if global_action:
+                    required_permissions.append(GlobalPermission(action=global_action, decision=decision))
+                else:
+                    required_permissions.append(
+                        ObjectPermission(
+                            namespace=impacted_schema.namespace,
+                            name=impacted_schema.name,
+                            action=PermissionAction.UPDATE.value,
+                            decision=decision,
+                        )
+                    )
+
+            context.active_permissions.raise_for_permissions(permissions=required_permissions)
 
         _, _, in_list2 = compare_lists(list1=list(nodes.keys()), list2=node_ids)
         if in_list2:

--- a/backend/infrahub/permissions/__init__.py
+++ b/backend/infrahub/permissions/__init__.py
@@ -2,12 +2,13 @@ from infrahub.permissions.backend import PermissionBackend
 from infrahub.permissions.local_backend import LocalPermissionBackend
 from infrahub.permissions.manager import PermissionManager
 from infrahub.permissions.report import report_schema_permissions
-from infrahub.permissions.types import AssignedPermissions
+from infrahub.permissions.types import AssignedPermissions, get_global_permission_for_kind
 
 __all__ = [
     "AssignedPermissions",
     "LocalPermissionBackend",
     "PermissionBackend",
     "PermissionManager",
+    "get_global_permission_for_kind",
     "report_schema_permissions",
 ]

--- a/backend/infrahub/permissions/types.py
+++ b/backend/infrahub/permissions/types.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, TypedDict
 
+from infrahub.core.constants import GlobalPermissions, InfrahubKind
+from infrahub.core.schema import NodeSchema
+
 if TYPE_CHECKING:
     from infrahub.core.account import GlobalPermission, ObjectPermission
+    from infrahub.core.schema import MainSchemaTypes
     from infrahub.permissions.constants import BranchRelativePermissionDecision
 
 
@@ -18,3 +22,25 @@ class KindPermissions(TypedDict):
     delete: BranchRelativePermissionDecision
     update: BranchRelativePermissionDecision
     view: BranchRelativePermissionDecision
+
+
+def get_global_permission_for_kind(schema: MainSchemaTypes) -> GlobalPermissions | None:
+    kind_permission_map = {
+        InfrahubKind.GENERICACCOUNT: GlobalPermissions.MANAGE_ACCOUNTS,
+        InfrahubKind.ACCOUNTGROUP: GlobalPermissions.MANAGE_ACCOUNTS,
+        InfrahubKind.ACCOUNTROLE: GlobalPermissions.MANAGE_ACCOUNTS,
+        InfrahubKind.BASEPERMISSION: GlobalPermissions.MANAGE_PERMISSIONS,
+        InfrahubKind.GENERICREPOSITORY: GlobalPermissions.MANAGE_REPOSITORIES,
+    }
+
+    if schema.kind in kind_permission_map:
+        return kind_permission_map[schema.kind]
+
+    if isinstance(schema, NodeSchema):
+        for base in schema.inherit_from:
+            try:
+                return kind_permission_map[base]
+            except KeyError:
+                continue
+
+    return None

--- a/backend/tests/unit/graphql/test_mutation_relationship.py
+++ b/backend/tests/unit/graphql/test_mutation_relationship.py
@@ -1,13 +1,25 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
 from infrahub_sdk.uuidt import UUIDT
 
-from infrahub.core.branch import Branch
-from infrahub.core.constants import InfrahubKind
+from infrahub.auth import AccountSession, AuthType
+from infrahub.core import registry
+from infrahub.core.account import ObjectPermission
+from infrahub.core.constants import InfrahubKind, PermissionAction, PermissionDecision
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.utils import count_relationships
-from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
+from infrahub.permissions import LocalPermissionBackend
 from tests.helpers.graphql import graphql
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.core.protocols import CoreAccount
+    from infrahub.database import InfrahubDatabase
 
 
 async def test_relationship_add(
@@ -746,3 +758,121 @@ async def test_add_generic_related_node_with_hfid(
     )
     assert result.errors is None
     assert result.data["TestPersonUpdate"]["object"]["car"]["node"]["name"]["value"] == "testing-car"
+
+
+async def test_with_permissions(
+    db: InfrahubDatabase,
+    register_core_models_schema: None,
+    default_branch: Branch,
+    first_account: CoreAccount,
+    person_jack_main: Node,
+    tag_blue_main: Node,
+):
+    registry.permission_backends = [LocalPermissionBackend()]
+
+    permissions = []
+    for object_permission in [
+        ObjectPermission(
+            namespace="Builtin",
+            name="Tag",
+            action=PermissionAction.UPDATE.value,
+            decision=PermissionDecision.ALLOW_ALL.value,
+        ),
+        ObjectPermission(
+            namespace="Test",
+            name="Person",
+            action=PermissionAction.UPDATE.value,
+            decision=PermissionDecision.ALLOW_ALL.value,
+        ),
+    ]:
+        obj = await Node.init(db=db, schema=InfrahubKind.OBJECTPERMISSION)
+        await obj.new(
+            db=db,
+            namespace=object_permission.namespace,
+            name=object_permission.name,
+            action=object_permission.action,
+            decision=object_permission.decision,
+        )
+        await obj.save(db=db)
+        permissions.append(obj)
+
+    role = await Node.init(db=db, schema=InfrahubKind.ACCOUNTROLE)
+    await role.new(db=db, name="chief-people-officer", permissions=permissions)
+    await role.save(db=db)
+
+    group = await Node.init(db=db, schema=InfrahubKind.ACCOUNTGROUP)
+    await group.new(db=db, name="hr", roles=[role])
+    await group.save(db=db)
+
+    await group.members.add(db=db, data={"id": first_account.id})
+    await group.members.save(db=db)
+
+    first_session = AccountSession(
+        authenticated=True, account_id=first_account.id, session_id=str(uuid4()), auth_type=AuthType.JWT
+    )
+
+    query = """
+    mutation {
+        RelationshipAdd(data: {
+            id: "%s",
+            name: "tags",
+            nodes: [{id: "%s"}],
+        }) {
+            ok
+        }
+    }
+    """
+
+    gql_params = await prepare_graphql_params(
+        db=db, include_subscription=False, branch=default_branch, account_session=first_session
+    )
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query % (person_jack_main.id, tag_blue_main.id),
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
+
+    assert result.errors is None
+
+
+async def test_without_permissions(
+    db: InfrahubDatabase,
+    register_core_models_schema: None,
+    default_branch: Branch,
+    first_account: CoreAccount,
+    person_jack_main: Node,
+    tag_red_main: Node,
+):
+    registry.permission_backends = [LocalPermissionBackend()]
+
+    first_session = AccountSession(
+        authenticated=True, account_id=first_account.id, session_id=str(uuid4()), auth_type=AuthType.JWT
+    )
+
+    query = """
+    mutation {
+        RelationshipAdd(data: {
+            id: "%s",
+            name: "tags",
+            nodes: [{id: "%s"}],
+        }) {
+            ok
+        }
+    }
+    """
+
+    gql_params = await prepare_graphql_params(
+        db=db, include_subscription=False, branch=default_branch, account_session=first_session
+    )
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query % (person_jack_main.id, tag_red_main.id),
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
+
+    assert result.errors
+    assert "You do not have one of the following permissions" in result.errors[0].message

--- a/backend/tests/unit/permissions/test_types.py
+++ b/backend/tests/unit/permissions/test_types.py
@@ -1,0 +1,25 @@
+import pytest
+
+from infrahub.core import registry
+from infrahub.core.constants import GlobalPermissions, InfrahubKind
+from infrahub.permissions import get_global_permission_for_kind
+
+
+@pytest.mark.parametrize(
+    "kinds,permission",
+    [
+        (
+            [InfrahubKind.ACCOUNT, InfrahubKind.ACCOUNTGROUP, InfrahubKind.ACCOUNTROLE],
+            GlobalPermissions.MANAGE_ACCOUNTS,
+        ),
+        ([InfrahubKind.GLOBALPERMISSION, InfrahubKind.OBJECTPERMISSION], GlobalPermissions.MANAGE_PERMISSIONS),
+        ([InfrahubKind.REPOSITORY, InfrahubKind.READONLYREPOSITORY], GlobalPermissions.MANAGE_REPOSITORIES),
+        ([InfrahubKind.TAG], None),
+    ],
+)
+def test_get_global_permission_for_kind(
+    register_core_models_schema: None, kinds: list[str], permission: GlobalPermissions
+):
+    for kind in kinds:
+        schema = registry.schema.get(name=kind)
+        assert get_global_permission_for_kind(schema=schema) == permission

--- a/changelog/+relationship-mutation-permission.fixed.md
+++ b/changelog/+relationship-mutation-permission.fixed.md
@@ -1,0 +1,1 @@
+Enforce permission checks when using relationship add or delete mutation


### PR DESCRIPTION
This should patch a security issue where user could add relationships between nodes without going through the permission check process.

In the add/delete relationship mutations, with this change, we identify the kinds of nodes that are involved in the mutations and infer what global and object permissions are required to mutate the nodes.