### PR TITLE
Fix incorrect event value for proposed change state after merging

### DIFF
--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -135,6 +135,10 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
                     "proposed_change_name": proposed_change.name.value,
                 },
             )
+            # When the PROPOSED_CHANGE_MERGE succeeds it will have correctly changed the state
+            # from the overridden "merging" value, so here we change it back to reflect the
+            # correct value for the event that will be generated.
+            proposed_change.node_changelog.attributes["state"].value = ProposedChangeState.MERGED.value
 
         return proposed_change, result
 

--- a/changelog/5600.fixed.md
+++ b/changelog/5600.fixed.md
@@ -1,0 +1,1 @@
+Set correct state in events after merging a proposed change, they were incorrectly set as "merging" instead of "merged"


### PR DESCRIPTION
While merging a proposed change we set the state to "merged", however the mutation currently overrides this and updates the value to "merging" instead. This change resets back the value within the node_changelog.

This was reported due to a webhook issue when the state always was listed as "merging". While this change fixes that specific issue I don't think these events like this in the future instead we'll add specific events for the merging of proposed changes.

Fixes #5600