### PR TITLE
Send node mutation events after branch merge

### DIFF
--- a/backend/infrahub/context.py
+++ b/backend/infrahub/context.py
@@ -5,8 +5,16 @@ from infrahub.auth import AccountSession
 from infrahub.core.branch import Branch
 
 
-class EventContext(BaseModel):
+class ParentEvent(BaseModel):
+    id: str
     name: str
+
+
+class EventContext(BaseModel):
+    name: str = Field(..., description="The name of the event")
+    id: str = Field(..., description="The ID of the event")
+    parent_id: str | None = Field(default=None)
+    ancestors: list[ParentEvent] = Field(default_factory=list)
 
 
 class BranchContext(BaseModel):
@@ -17,8 +25,15 @@ class BranchContext(BaseModel):
 class InfrahubContext(BaseModel):
     branch: BranchContext
     account: AccountSession
-    events: list[EventContext] = Field(default_factory=list)
+    event: EventContext | None = Field(default=None)
 
     @classmethod
     def init(cls, branch: Branch, account: AccountSession) -> Self:
         return cls(branch=BranchContext(name=branch.name, id=str(branch.uuid)), account=account)
+
+    def set_event(self, name: str, id: str) -> None:
+        if self.event:
+            self.event.name = name
+            self.event.id = id
+        else:
+            self.event = EventContext(name=name, id=id)

--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -11,6 +11,8 @@ from infrahub import lock
 from infrahub.context import InfrahubContext  # noqa: TC001  needed for prefect flow
 from infrahub.core import registry
 from infrahub.core.branch import Branch
+from infrahub.core.changelog.diff import DiffChangelogCollector
+from infrahub.core.constants import MutationAction
 from infrahub.core.diff.coordinator import DiffCoordinator
 from infrahub.core.diff.ipam_diff_parser import IpamDiffParser
 from infrahub.core.diff.merger.merger import DiffMerger
@@ -23,8 +25,9 @@ from infrahub.core.validators.determiner import ConstraintValidatorDeterminer
 from infrahub.core.validators.models.validate_migration import SchemaValidateMigrationData
 from infrahub.core.validators.tasks import schema_validate_migrations
 from infrahub.dependencies.registry import get_component_registry
-from infrahub.events.branch_action import BranchCreatedEvent, BranchDeletedEvent, BranchRebasedEvent
-from infrahub.events.models import EventMeta
+from infrahub.events.branch_action import BranchCreatedEvent, BranchDeletedEvent, BranchMergedEvent, BranchRebasedEvent
+from infrahub.events.models import EventMeta, InfrahubEvent
+from infrahub.events.node_action import NodeMutatedEvent
 from infrahub.exceptions import BranchNotFoundError, MergeFailedError, ValidationError
 from infrahub.graphql.mutations.models import BranchCreateModel  # noqa: TC001
 from infrahub.log import get_log_data
@@ -169,7 +172,9 @@ async def merge_branch(branch: str, context: InfrahubContext, service: InfrahubS
         await add_tags(branches=[branch, registry.default_branch])
 
         obj = await Branch.get_by_name(db=db, name=branch)
+        default_branch = await registry.get_branch(db=db, branch=registry.default_branch)
         component_registry = get_component_registry()
+        merge_event = BranchMergedEvent(meta=EventMeta.from_context(context=context, branch=obj))
 
         merger: BranchMerger | None = None
         async with lock.registry.global_graph_lock():
@@ -187,13 +192,15 @@ async def merge_branch(branch: str, context: InfrahubContext, service: InfrahubS
                 service=service,
             )
             try:
-                await merger.merge()
+                branch_diff = await merger.merge()
             except Exception as exc:
                 log.exception("Merge failed, beginning rollback")
                 await merger.rollback()
                 raise MergeFailedError(branch_name=branch) from exc
             await merger.update_schema()
 
+        changelog_collector = DiffChangelogCollector(diff=branch_diff, branch=obj, db=db)
+        node_events = changelog_collector.collect_changelogs()
         if merger and merger.migrations:
             errors = await schema_apply_migrations(
                 message=SchemaApplyMigrationData(
@@ -241,6 +248,24 @@ async def merge_branch(branch: str, context: InfrahubContext, service: InfrahubS
             meta=Meta(initiator_id=WORKER_IDENTITY, request_id=request_id),
         )
         await service.message_bus.send(message=message)
+
+        events: list[InfrahubEvent] = [merge_event]
+
+        for action, node_changelog in node_events:
+            meta = EventMeta.from_parent(parent=merge_event)
+            mutate_event = NodeMutatedEvent(
+                kind=node_changelog.node_kind,
+                node_id=node_changelog.node_id,
+                data=node_changelog,
+                action=MutationAction.from_diff_action(diff_action=action),
+                fields=node_changelog.updated_fields,
+                meta=meta,
+            )
+            mutate_event.set_context_branch(branch=default_branch)
+            events.append(mutate_event)
+
+        for event in events:
+            await service.event.send(event=event)
 
 
 @flow(name="branch-delete", flow_run_name="Delete branch {branch}")

--- a/backend/infrahub/core/changelog/diff.py
+++ b/backend/infrahub/core/changelog/diff.py
@@ -50,6 +50,15 @@ class DiffChangelogCollector:
     def get_node(self, node_id: str) -> NodeInDiff:
         return self._diff_nodes[node_id]
 
+    def get_peer_kind(self, peer_id: str, node_kind: str, relationship_name: str) -> str:
+        """If the peer kind doesn't exist in the diff use the peer kind from the schema"""
+        try:
+            return self.get_node(node_id=peer_id).kind
+        except KeyError:
+            schema = self._db.schema.get(node_kind, branch=self._branch, duplicate=False)
+            rel_schema = schema.get_relationship(name=relationship_name)
+            return rel_schema.peer
+
     def _process_node(self, node: EnrichedDiffNode) -> NodeChangelog:
         node_changelog = NodeChangelog(node_id=node.uuid, node_kind=node.kind, display_label=node.label)
         schema = self._db.schema.get(node_changelog.node_kind, branch=self._branch, duplicate=False)
@@ -64,8 +73,15 @@ class DiffChangelogCollector:
     def _process_node_attribute(
         self, node: NodeChangelog, attribute: EnrichedDiffAttribute, schema: MainSchemaTypes
     ) -> None:
-        schema_attribute = schema.get_attribute(name=attribute.name)
-        changelog_attribute = AttributeChangelog(name=attribute.name, kind=schema_attribute.kind)
+        try:
+            schema_attribute = schema.get_attribute(name=attribute.name)
+            attribute_kind = schema_attribute.kind
+        except ValueError:
+            # This would currently happen if there has been a schema migration as part of the merge
+            # then we don't have access to the attribute kind
+            attribute_kind = "n/a"
+
+        changelog_attribute = AttributeChangelog(name=attribute.name, kind=attribute_kind)
         for attr_property in attribute.properties:
             match attr_property.property_type:
                 case DatabaseEdgeType.HAS_VALUE:
@@ -117,10 +133,18 @@ class DiffChangelogCollector:
                     case DatabaseEdgeType.IS_RELATED:
                         if rel_prop.new_value:
                             changelog_rel.peer_id = rel_prop.new_value
-                            changelog_rel.peer_kind = self.get_node(node_id=rel_prop.new_value).kind
+                            changelog_rel.peer_kind = self.get_peer_kind(
+                                peer_id=rel_prop.new_value,
+                                node_kind=node.node_kind,
+                                relationship_name=relationship.name,
+                            )
                         if rel_prop.previous_value:
                             changelog_rel.peer_id_previous = rel_prop.previous_value
-                            changelog_rel.peer_kind_previous = self.get_node(node_id=rel_prop.previous_value).kind
+                            changelog_rel.peer_kind_previous = self.get_peer_kind(
+                                peer_id=rel_prop.previous_value,
+                                node_kind=node.node_kind,
+                                relationship_name=relationship.name,
+                            )
                     case DatabaseEdgeType.IS_PROTECTED:
                         changelog_rel.add_property(
                             name="is_protected",
@@ -161,7 +185,11 @@ class DiffChangelogCollector:
         changelog_rel = RelationshipCardinalityManyChangelog(name=relationship.name)
         for peer in relationship.relationships:
             peer_log = RelationshipPeerChangelog(
-                peer_id=peer.peer_id, peer_kind=self.get_node(node_id=peer.peer_id).kind, peer_status=peer.action
+                peer_id=peer.peer_id,
+                peer_kind=self.get_peer_kind(
+                    peer_id=peer.peer_id, node_kind=node.node_kind, relationship_name=relationship.name
+                ),
+                peer_status=peer.action,
             )
             for peer_prop in peer.properties:
                 match peer_prop.property_type:

--- a/backend/infrahub/core/constants/__init__.py
+++ b/backend/infrahub/core/constants/__init__.py
@@ -180,6 +180,18 @@ class MutationAction(InfrahubStringEnum):
     UPDATED = "updated"
     UNDEFINED = "undefined"
 
+    @classmethod
+    def from_diff_action(cls, diff_action: DiffAction) -> MutationAction:
+        match diff_action:
+            case DiffAction.ADDED:
+                return MutationAction.CREATED
+            case DiffAction.REMOVED:
+                return MutationAction.DELETED
+            case DiffAction.UPDATED:
+                return MutationAction.UPDATED
+            case DiffAction.UNCHANGED:
+                return MutationAction.UNDEFINED
+
 
 class PathResourceType(InfrahubStringEnum):
     SCHEMA = "schema"

--- a/backend/infrahub/events/branch_action.py
+++ b/backend/infrahub/events/branch_action.py
@@ -70,6 +70,25 @@ class BranchCreatedEvent(InfrahubEvent):
         return f"{EVENT_NAMESPACE}.branch.created"
 
 
+class BranchMergedEvent(InfrahubEvent):
+    """Event generated when a branch has been merged"""
+
+    def get_resource(self) -> dict[str, str]:
+        return {
+            "prefect.resource.id": f"infrahub.branch.{self.meta.get_branch_id()}",
+            "infrahub.node.kind": "Branch",
+            "infrahub.node.id": self.meta.get_branch_id(),
+            "infrahub.node.label": self.meta.context.branch.name,
+        }
+
+    def get_messages(self) -> list[InfrahubMessage]:
+        return []
+
+    @computed_field
+    def event_name(self) -> str:
+        return f"{EVENT_NAMESPACE}.branch.merged"
+
+
 class BranchRebasedEvent(InfrahubEvent):
     """Event generated when a branch has been rebased"""
 

--- a/backend/infrahub/events/models.py
+++ b/backend/infrahub/events/models.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import Any, cast, final
+from copy import deepcopy
+from typing import Any, Self, cast, final
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, Field, computed_field
+from pydantic import BaseModel, Field, PrivateAttr, computed_field, model_validator
 
 from infrahub import __version__
 from infrahub.auth import AccountSession, AuthType
@@ -45,6 +46,7 @@ class EventMeta(BaseModel):
 
     parent: UUID | None = Field(default=None, description="The UUID of the parent event if applicable")
     ancestors: list[ParentEvent] = Field(default_factory=list, description="Any event used to trigger this event")
+    _created_with_context: bool = PrivateAttr(default=False)
 
     def get_branch_id(self) -> str:
         if self.context.branch.id:
@@ -123,9 +125,19 @@ class EventMeta(BaseModel):
             initiator_id=parent.meta.initiator_id,
             account_id=parent.meta.account_id,
             level=parent.meta.level + 1,
-            context=parent.meta.context,
+            context=deepcopy(parent.meta.context),
             ancestors=[ParentEvent(id=parent.get_id(), name=parent.get_name())] + parent.meta.ancestors,
         )
+
+    @classmethod
+    def from_context(cls, context: InfrahubContext, branch: Branch | None = None) -> EventMeta:
+        # Create a copy of the context so local changes aren't brought back to a parent object
+        meta = cls(context=deepcopy(context))
+        meta._created_with_context = True
+        if branch:
+            meta.context.branch.name = branch.name
+            meta.context.branch.id = str(branch.get_uuid())
+        return meta
 
 
 class InfrahubEvent(BaseModel):
@@ -180,3 +192,10 @@ class InfrahubEvent(BaseModel):
     @computed_field
     def event_name(self) -> str:
         raise NotImplementedError("The event name has not been defined")
+
+    @model_validator(mode="after")
+    def update_context(self) -> Self:
+        """Update the context object using this event provided that the meta data was created with a context."""
+        if self.meta._created_with_context:
+            self.meta.context.set_event(self.get_name(), id=self.get_id())
+        return self

--- a/backend/infrahub/events/node_action.py
+++ b/backend/infrahub/events/node_action.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from pydantic import Field, computed_field
 
+from infrahub.core.branch import Branch
 from infrahub.core.changelog.models import NodeChangelog
 from infrahub.core.constants import MutationAction
 from infrahub.message_bus import InfrahubMessage
@@ -92,6 +93,10 @@ class NodeMutatedEvent(InfrahubEvent):
             #     meta=self.get_message_meta(),
             # )
         ]
+
+    def set_context_branch(self, branch: Branch) -> None:
+        self.meta.context.branch.id = str(branch.get_uuid())
+        self.meta.context.branch.name = branch.name
 
 
 class NodeCreatedEvent(NodeMutatedEvent):

--- a/backend/infrahub/services/adapters/event/__init__.py
+++ b/backend/infrahub/services/adapters/event/__init__.py
@@ -30,6 +30,7 @@ class InfrahubEventService:
 
     async def _send_prefect(self, event: InfrahubEvent) -> None:
         emit_event(
+            id=event.meta.id,
             event=event.get_name(),
             resource=event.get_resource(),
             related=event.get_related(),

--- a/backend/tests/helpers/utils.py
+++ b/backend/tests/helpers/utils.py
@@ -1,3 +1,7 @@
+import time
+from pathlib import Path
+
+import httpx
 import pytest
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
@@ -38,17 +42,38 @@ def start_prefect_server_container(
     if not INFRAHUB_USE_TEST_CONTAINERS:
         return None
 
+    prefect_base = Path(Path(__file__).parent.resolve() / "./../../infrahub/prefect_server")
     container = (
         DockerContainer(image="prefecthq/prefect:3.1.14-python3.12")
-        .with_command("prefect server start --host 0.0.0.0 --ui")
+        .with_command("uvicorn --host 0.0.0.0 --port 4200 --factory prefect_server.app:create_infrahub_prefect")
         .with_exposed_ports(PORT_PREFECT)
+        .with_volume_mapping(host=str(prefect_base), container="/opt/prefect/prefect_server", mode="ro")
+        .with_env(key="PREFECT_SERVER_SERVICES_EVENT_PERSISTER_FLUSH_INTERVAL", value="1")
     )
 
     def cleanup() -> None:
         container.stop()
 
     container.start()
-    wait_for_logs(container, "Configure Prefect to communicate with the server")
+
+    mapped_port = get_exposed_port(container, PORT_PREFECT)
+    # As our entrypoint doesn't print out any logs on startup we can't "wait for logs"
+    wait_for_prefect(port=mapped_port)
     request.addfinalizer(cleanup)
 
-    return {PORT_PREFECT: get_exposed_port(container, PORT_PREFECT)}
+    return {PORT_PREFECT: mapped_port}
+
+
+url = "http://localhost:52879/api/admin/version"  # Replace with your target URL
+
+
+def wait_for_prefect(port: int) -> None:
+    for _ in range(120):
+        try:
+            response = httpx.get(f"http://localhost:{port}/api/admin/version", timeout=1)
+            if response.status_code == 200:
+                return
+        except httpx.HTTPError:
+            time.sleep(1)
+
+    pytest.fail(reason="Prefect didn't start in an orderly fashion")

--- a/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import asyncio
 import shutil
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import patch
+from uuid import uuid4
 
 import pytest
 from infrahub_sdk.exceptions import GraphQLError
@@ -103,8 +105,9 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
         return client_repository.id
 
     @pytest.fixture(scope="class")
-    async def happy_dataset(self, db: InfrahubDatabase, initial_dataset: None, client: InfrahubClient) -> None:
-        branch1 = await client.branch.create(branch_name="conflict_free")
+    async def happy_data_branch(self, db: InfrahubDatabase, initial_dataset: None, client: InfrahubClient) -> str:
+        branch_name = f"conflict_free-{uuid4()}"
+        branch1 = await client.branch.create(branch_name=branch_name)
         richard = await Node.init(schema=TestKind.PERSON, db=db, branch=branch1.name)
         await richard.new(db=db, name="Richard", height=180, description="The less famous Richard Doe")
         await richard.save(db=db)
@@ -114,6 +117,7 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
         )
         john.age.value = 26  # type: ignore[attr-defined]
         await john.save(db=db)
+        return branch_name
 
     @pytest.fixture(scope="class")
     async def failing_branch_dataset(self, db: InfrahubDatabase, initial_dataset: None, client: InfrahubClient) -> None:
@@ -197,10 +201,10 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
         # as the branch to keep in the data conflict
         assert john.description.value == "Oh boy"  # type: ignore[attr-defined]
 
-    async def test_happy_pipeline(self, db: InfrahubDatabase, happy_dataset: None, client: InfrahubClient) -> None:
+    async def test_happy_pipeline(self, db: InfrahubDatabase, happy_data_branch: str, client: InfrahubClient) -> None:
         proposed_change_create = await client.create(
             kind=CoreProposedChange,
-            data={"source_branch": "conflict_free", "destination_branch": "main", "name": "happy-test"},
+            data={"source_branch": happy_data_branch, "destination_branch": "main", "name": "happy-test"},
         )
         await proposed_change_create.save()
 
@@ -231,7 +235,7 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
         ][0]
         assert repository_merge_conflict.conclusion.value.value == ValidatorConclusion.SUCCESS.value
 
-        tags = await client.all(kind="BuiltinTag", branch="conflict_free")
+        tags = await client.all(kind="BuiltinTag", branch=happy_data_branch)
         # The Generator defined in the repository is expected to have created this tag during the pipeline
         assert "john-jesko" in [tag.name.value for tag in tags]  # type: ignore[attr-defined]
         assert "InfrahubNode-john-jesko" in [tag.name.value for tag in tags]  # type: ignore[attr-defined]
@@ -244,6 +248,38 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
 
         proposed_change_after = await client.get(kind=CoreProposedChange, id=proposed_change_create.id)
         assert proposed_change_after.state.value == ProposedChangeState.MERGED.value
+
+        for _ in range(10):
+            merge_event = await client.execute_graphql(
+                query=QUERY_EVENT, variables={"branch": happy_data_branch, "event_type": "infrahub.branch.merged"}
+            )
+            if merge_event["InfrahubEvent"]["count"] == 1:
+                break
+            await asyncio.sleep(1)
+
+        assert merge_event["InfrahubEvent"]["count"] == 1
+        merge_event_id = merge_event["InfrahubEvent"]["edges"][0]["node"]["id"]
+
+        secondary_events = await client.execute_graphql(query=QUERY_EVENT, variables={"parent__ids": merge_event_id})
+
+        john = await NodeManager.get_one_by_id_or_default_filter(db=db, id="John", kind=TestKind.PERSON)
+        richard = await NodeManager.get_one_by_id_or_default_filter(db=db, id="Richard", kind=TestKind.PERSON)
+        assert secondary_events["InfrahubEvent"]["count"] >= 2
+        johns_events = [
+            event
+            for event in secondary_events["InfrahubEvent"]["edges"]
+            if event["node"]["primary_node"]["id"] == john.id
+        ]
+        richards_events = [
+            event
+            for event in secondary_events["InfrahubEvent"]["edges"]
+            if event["node"]["primary_node"]["id"] == richard.id
+        ]
+        assert len(johns_events) == 1
+        assert len(richards_events) == 1
+
+        assert johns_events[0]["node"]["event"] == "infrahub.node.updated"
+        assert richards_events[0]["node"]["event"] == "infrahub.node.created"
 
     async def test_merge_failure(
         self,
@@ -279,3 +315,39 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
         result = await client.execute_graphql(query=query, variables={"id": initial_dataset})
         assert result["InfrahubRepositoryConnectivity"]["ok"]
         assert result["InfrahubRepositoryConnectivity"]["message"] == "Successfully accessed repository"
+
+
+QUERY_EVENT = """
+query(
+    $branch: [String!],
+    $parent__ids: [String!],
+    $event_type: [String!]
+) {
+  InfrahubEvent(
+    branches: $branch,
+    parent__ids: $parent__ids
+    event_type: $event_type
+  ) {
+    count
+    edges {
+      node {
+        id
+        event
+        branch
+        has_children
+        parent_id
+        level
+        occurred_at
+        primary_node {
+          id
+          kind
+        }
+        related_nodes {
+            id
+            kind
+        }
+      }
+    }
+  }
+}
+"""

--- a/backend/tests/integration/proposed_change/test_proposed_change_profile.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_profile.py
@@ -78,7 +78,7 @@ class TestProposedChangePipelineProfile(TestInfrahubApp):
         peers = await proposed_change.validations.get_peers(db=db)  # type: ignore[attr-defined]
         assert peers
 
-        # Ensure all validators and all tasks are successfull
+        # Ensure all validators and all tasks are successful
         assert all(
             validator.conclusion.value.value == ValidatorConclusion.SUCCESS.value for validator in peers.values()
         )

--- a/backend/tests/unit/graphql/queries/test_event.py
+++ b/backend/tests/unit/graphql/queries/test_event.py
@@ -80,8 +80,8 @@ query MutatedNodes($id: [String!]) {
       node {
         id
         level
+        __typename
         ... on NodeMutatedEvent {
-          __typename
           branch
           event
           payload


### PR DESCRIPTION
Changes in this PR:

* Add a new "prefect event" for branch merged (some of the logic still remains as a separate RabbitMQ message, I think some additional cleanup could be done with that later)
* Tie the previously created `DiffChangelogCollector` into the merge_branch operation to analyze the branch diff and create node mutation events
* Send those node mutation events to prefect
* Modify the `DiffChangelogCollector` to account for situations where we can't lookup the attribute (could happen when attributes are removed as part of the proposed change)
* Modify the DiffChangelogCollector` to account for situations when the peer kind doesn't exist within the branch diff, in those situations we use the peer from the schema for the given source node and relationship name
* Added a method to MutationAction to convert from DiffAction, at first I considered replacing MutationAction with DiffAction but I think the values on MutationAction are more in line with what users would expect to see externally as it also matches the public name of our mutations (i.e. create and delete, instead of add and removed).
* Made a modification to how the context within a message is managed, as objects are passed as a reference there was an issue if you merged a branch on "branch1" and then wanted to send node mutation events for the "main" branch changing the context outside of the parent event would switch the context to something else.
* Slight change to the "happy pipeline" test with regards to the branch being used. This is mainly for local development as old events might still exist in prefect when we search for events related to a branch called "conflict_free", I've added a uuid on creation to avoid issues when you run the same test multiple times.
* Update the `InfrahubEventService` to use our own ID as the Prefect ID.

Note I saw that the tests within `TestProposedChangePipelineConflict` are written in a way that the conflict test and happy path test impacts each other with regards to what is updated. This is mostly relevant if you run the test locally and target a single one as the results would differ. I didn't want to modify the data within those tests in this PR but I think it can be cleaned up a bit for clarity in an upcoming PR. 