### PR TITLE
improve diff save performance

### DIFF
--- a/backend/infrahub/core/diff/model/path.py
+++ b/backend/infrahub/core/diff/model/path.py
@@ -163,6 +163,10 @@ class EnrichedDiffAttribute(BaseSummary):
     def __hash__(self) -> int:
         return hash(self.name)
 
+    @property
+    def num_properties(self) -> int:
+        return len(self.properties)
+
     def get_all_conflicts(self) -> dict[str, EnrichedDiffConflict]:
         return {prop.path_identifier: prop.conflict for prop in self.properties if prop.conflict}
 
@@ -201,6 +205,10 @@ class EnrichedDiffSingleRelationship(BaseSummary):
 
     def __hash__(self) -> int:
         return hash(self.peer_id)
+
+    @property
+    def num_properties(self) -> int:
+        return len(self.properties)
 
     def get_all_conflicts(self) -> dict[str, EnrichedDiffConflict]:
         all_conflicts: dict[str, EnrichedDiffConflict] = {}
@@ -247,6 +255,10 @@ class EnrichedDiffRelationship(BaseSummary):
 
     def __hash__(self) -> int:
         return hash(self.name)
+
+    @property
+    def num_properties(self) -> int:
+        return sum(r.num_properties for r in self.relationships)
 
     def get_all_conflicts(self) -> dict[str, EnrichedDiffConflict]:
         all_conflicts: dict[str, EnrichedDiffConflict] = {}
@@ -307,6 +319,10 @@ class EnrichedDiffNode(BaseSummary):
 
     def __hash__(self) -> int:
         return hash(self.uuid)
+
+    @property
+    def num_properties(self) -> int:
+        return sum(a.num_properties for a in self.attributes) + sum(r.num_properties for r in self.relationships)
 
     def get_all_conflicts(self) -> dict[str, EnrichedDiffConflict]:
         all_conflicts: dict[str, EnrichedDiffConflict] = {}

--- a/backend/infrahub/core/diff/query/save.py
+++ b/backend/infrahub/core/diff/query/save.py
@@ -98,7 +98,7 @@ CALL {
     // delete parent-child relationships for included nodes, they will be added in EnrichedNodesLinkQuery
     // -------------------------
     WITH diff_node
-    MATCH (:DiffRelationship)-[parent_rel:DIFF_HAS_NODE]->(diff_node)
+    MATCH (diff_node)-[:DIFF_HAS_RELATIONSHIP]->(:DiffRelationship)-[parent_rel:DIFF_HAS_NODE]->(:DiffNode)
     DELETE parent_rel
 }
 OPTIONAL MATCH (diff_node)-[:DIFF_HAS_CONFLICT]->(current_node_conflict:DiffConflict)
@@ -440,14 +440,14 @@ WITH
     node_link_details.root_uuid AS root_uuid,
     node_link_details.parent_uuid AS parent_uuid,
     node_link_details.child_uuid AS child_uuid,
-    node_link_details.relationship_name AS relationship_name
+    node_link_details.child_relationship_name AS relationship_name
 CALL {
     WITH root_uuid, parent_uuid, child_uuid, relationship_name
     MATCH (diff_root {uuid: root_uuid})
-    MATCH (diff_root)-[:DIFF_HAS_NODE]->(parent_node:DiffNode {uuid: parent_uuid})
-        -[:DIFF_HAS_RELATIONSHIP]->(diff_rel_group:DiffRelationship {name: relationship_name})
     MATCH (diff_root)-[:DIFF_HAS_NODE]->(child_node:DiffNode {uuid: child_uuid})
-    MERGE (diff_rel_group)-[:DIFF_HAS_NODE]->(child_node)
+        -[:DIFF_HAS_RELATIONSHIP]->(diff_rel_group:DiffRelationship {name: relationship_name})
+    MATCH (diff_root)-[:DIFF_HAS_NODE]->(parent_node:DiffNode {uuid: parent_uuid})
+    MERGE (diff_rel_group)-[:DIFF_HAS_NODE]->(parent_node)
 }
         """
         self.add_to_query(query)
@@ -457,14 +457,14 @@ CALL {
             return []
         parent_links = []
         for relationship in enriched_node.relationships:
-            for child_node in relationship.nodes:
+            for parent_node in relationship.nodes:
                 parent_links.append(
                     {
-                        "parent_uuid": enriched_node.uuid,
-                        "relationship_name": relationship.name,
-                        "child_uuid": child_node.uuid,
+                        "child_uuid": enriched_node.uuid,
+                        "child_relationship_name": relationship.name,
+                        "parent_uuid": parent_node.uuid,
                         "root_uuid": root_uuid,
                     }
                 )
-                parent_links.extend(self._build_node_parent_links(enriched_node=child_node, root_uuid=root_uuid))
+                parent_links.extend(self._build_node_parent_links(enriched_node=parent_node, root_uuid=root_uuid))
         return parent_links

--- a/backend/infrahub/core/diff/query/save.py
+++ b/backend/infrahub/core/diff/query/save.py
@@ -83,33 +83,47 @@ class EnrichedNodeBatchCreateQuery(Query):
         query = """
 UNWIND $node_details_list AS node_details
 WITH node_details.root_uuid AS root_uuid, node_details.node_map AS node_map
+MATCH (diff_root:DiffRoot {uuid: root_uuid})
+MERGE (diff_root)-[:DIFF_HAS_NODE]->(diff_node:DiffNode {uuid: node_map.node_properties.uuid})
+WITH root_uuid, node_map, diff_node, (node_map.conflict_params IS NOT NULL) AS has_node_conflict
+SET
+    diff_node.kind = node_map.node_properties.kind,
+    diff_node.label = node_map.node_properties.label,
+    diff_node.changed_at = node_map.node_properties.changed_at,
+    diff_node.action = node_map.node_properties.action,
+    diff_node.path_identifier = node_map.node_properties.path_identifier
+WITH root_uuid, node_map, diff_node, has_node_conflict
 CALL {
-    WITH root_uuid, node_map
-    MATCH (diff_root {uuid: root_uuid})
-    MERGE (diff_root)-[:DIFF_HAS_NODE]->(diff_node:DiffNode {uuid: node_map.node_properties.uuid})
-    SET
-        diff_node.kind = node_map.node_properties.kind,
-        diff_node.label = node_map.node_properties.label,
-        diff_node.changed_at = node_map.node_properties.changed_at,
-        diff_node.action = node_map.node_properties.action,
-        diff_node.path_identifier = node_map.node_properties.path_identifier
     // -------------------------
-    // add/remove node-level conflict
+    // delete parent-child relationships for included nodes, they will be added in EnrichedNodesLinkQuery
     // -------------------------
-    WITH diff_node, node_map
-    OPTIONAL MATCH (diff_node)-[:DIFF_HAS_CONFLICT]->(current_diff_node_conflict:DiffConflict)
-    WITH diff_node, node_map, current_diff_node_conflict, (node_map.conflict_params IS NOT NULL) AS has_node_conflict
-    FOREACH (i in CASE WHEN has_node_conflict = FALSE THEN [1] ELSE [] END |
-        DETACH DELETE current_diff_node_conflict
-    )
-    FOREACH (i in CASE WHEN has_node_conflict = TRUE THEN [1] ELSE [] END |
-        MERGE (diff_node)-[:DIFF_HAS_CONFLICT]->(diff_node_conflict:DiffConflict)
-        SET diff_node_conflict = node_map.conflict_params
-    )
+    WITH diff_node
+    MATCH (:DiffRelationship)-[parent_rel:DIFF_HAS_NODE]->(diff_node)
+    DELETE parent_rel
+}
+OPTIONAL MATCH (diff_node)-[:DIFF_HAS_CONFLICT]->(current_node_conflict:DiffConflict)
+CALL {
+    WITH diff_node, current_node_conflict, has_node_conflict
+    WITH diff_node, current_node_conflict, has_node_conflict
+    WHERE current_node_conflict IS NULL AND has_node_conflict = TRUE
+    CREATE (diff_node)-[:DIFF_HAS_CONFLICT]->(:DiffConflict)
 }
 CALL {
-    WITH root_uuid, node_map
-    MATCH (diff_root {uuid: root_uuid})-[:DIFF_HAS_NODE]->(diff_node:DiffNode {uuid: node_map.node_properties.uuid})
+    WITH current_node_conflict, has_node_conflict
+    WITH current_node_conflict, has_node_conflict
+    WHERE current_node_conflict IS NOT NULL AND has_node_conflict = FALSE
+    DETACH DELETE current_node_conflict
+}
+WITH root_uuid, node_map, diff_node, has_node_conflict,
+    node_map.conflict_params AS node_conflict_params
+CALL {
+    WITH diff_node, has_node_conflict, node_conflict_params
+    WITH diff_node, has_node_conflict, node_conflict_params
+    WHERE has_node_conflict = TRUE
+    OPTIONAL MATCH (diff_node)-[:DIFF_HAS_CONFLICT]->(node_conflict:DiffConflict)
+    SET node_conflict = node_conflict_params
+}
+CALL {
     // -------------------------
     // remove stale attributes for this node
     // -------------------------

--- a/backend/infrahub/core/diff/query/save.py
+++ b/backend/infrahub/core/diff/query/save.py
@@ -103,20 +103,28 @@ CALL {
 }
 OPTIONAL MATCH (diff_node)-[:DIFF_HAS_CONFLICT]->(current_node_conflict:DiffConflict)
 CALL {
+    // -------------------------
+    // create a node-level conflict, if necessary
+    // -------------------------
     WITH diff_node, current_node_conflict, has_node_conflict
     WITH diff_node, current_node_conflict, has_node_conflict
     WHERE current_node_conflict IS NULL AND has_node_conflict = TRUE
     CREATE (diff_node)-[:DIFF_HAS_CONFLICT]->(:DiffConflict)
 }
 CALL {
+    // -------------------------
+    // delete a node-level conflict, if necessary
+    // -------------------------
     WITH current_node_conflict, has_node_conflict
     WITH current_node_conflict, has_node_conflict
     WHERE current_node_conflict IS NOT NULL AND has_node_conflict = FALSE
     DETACH DELETE current_node_conflict
 }
-WITH root_uuid, node_map, diff_node, has_node_conflict,
-    node_map.conflict_params AS node_conflict_params
+WITH root_uuid, node_map, diff_node, has_node_conflict, node_map.conflict_params AS node_conflict_params
 CALL {
+    // -------------------------
+    // set the properties of the node-level conflict, if necessary
+    // -------------------------
     WITH diff_node, has_node_conflict, node_conflict_params
     WITH diff_node, has_node_conflict, node_conflict_params
     WHERE has_node_conflict = TRUE

--- a/backend/infrahub/core/diff/repository/repository.py
+++ b/backend/infrahub/core/diff/repository/repository.py
@@ -1,6 +1,8 @@
 from collections import defaultdict
 from typing import AsyncGenerator, Generator, Iterable
 
+from neo4j.exceptions import TransientError
+
 from infrahub import config
 from infrahub.core import registry
 from infrahub.core.diff.query.field_summary import EnrichedDiffNodeFieldSummaryQuery
@@ -42,11 +44,10 @@ log = get_logger()
 
 
 class DiffRepository:
-    MAX_SAVE_BATCH_SIZE: int = 100
-
-    def __init__(self, db: InfrahubDatabase, deserializer: EnrichedDiffDeserializer):
+    def __init__(self, db: InfrahubDatabase, deserializer: EnrichedDiffDeserializer, max_save_batch_size: int = 1000):
         self.db = db
         self.deserializer = deserializer
+        self.max_save_batch_size = max_save_batch_size
 
     async def _run_get_diff_query(
         self,
@@ -230,20 +231,44 @@ class DiffRepository:
     ) -> Generator[list[EnrichedNodeCreateRequest], None, None]:
         node_requests = []
         for diff_root in (enriched_diffs.base_branch_diff, enriched_diffs.diff_branch_diff):
+            size_count = 0
             for node in diff_root.nodes:
-                node_requests.append(EnrichedNodeCreateRequest(node=node, root_uuid=diff_root.uuid))
-                if len(node_requests) == self.MAX_SAVE_BATCH_SIZE:
+                node_size_count = node.num_properties
+                if size_count + node_size_count < self.max_save_batch_size:
+                    node_requests.append(EnrichedNodeCreateRequest(node=node, root_uuid=diff_root.uuid))
+                    size_count += node_size_count
+                else:
+                    log.info(f"Num nodes in batch: {len(node_requests)}, num properties in batch: {size_count}")
                     yield node_requests
-                    node_requests = []
+                    size_count = node_size_count
+                    node_requests = [EnrichedNodeCreateRequest(node=node, root_uuid=diff_root.uuid)]
         if node_requests:
+            log.info(f"Num nodes in batch: {len(node_requests)}, num properties in batch: {size_count}")
             yield node_requests
 
-    @retry_db_transaction(name="enriched_diff_save")
-    async def save(self, enriched_diffs: EnrichedDiffs | EnrichedDiffsMetadata, do_summary_counts: bool = True) -> None:
+    @retry_db_transaction(name="enriched_diff_metadata_save")
+    async def _save_root_metadata(self, enriched_diffs: EnrichedDiffsMetadata) -> None:
         log.info("Updating diff metadata...")
         root_query = await EnrichedDiffRootsUpsertQuery.init(db=self.db, enriched_diffs=enriched_diffs)
         await root_query.execute(db=self.db)
         log.info("Diff metadata updated.")
+
+    async def _save_node_batch(self, node_create_batch: list[EnrichedNodeCreateRequest]) -> None:
+        node_query = await EnrichedNodeBatchCreateQuery.init(db=self.db, node_create_batch=node_create_batch)
+        try:
+            await node_query.execute(db=self.db)
+        except TransientError as exc:
+            if not exc.code or "OutOfMemoryError".lower() not in str(exc.code).lower():
+                raise
+            log.exception("Database memory error during save. Trying smaller transactions")
+            for node_request in node_create_batch:
+                single_node_query = await EnrichedNodeBatchCreateQuery.init(
+                    db=self.db, node_create_batch=[node_request]
+                )
+                await single_node_query.execute(db=self.db)
+
+    async def save(self, enriched_diffs: EnrichedDiffs | EnrichedDiffsMetadata, do_summary_counts: bool = True) -> None:
+        await self._save_root_metadata(enriched_diffs=enriched_diffs)
         if not isinstance(enriched_diffs, EnrichedDiffs):
             return
         num_nodes = len(enriched_diffs.base_branch_diff.nodes) + len(enriched_diffs.diff_branch_diff.nodes)
@@ -252,9 +277,8 @@ class DiffRepository:
             self._get_node_create_request_batch(enriched_diffs=enriched_diffs)
         ):
             log.info(f"Saving node batch #{batch_num}...")
-            node_query = await EnrichedNodeBatchCreateQuery.init(db=self.db, node_create_batch=node_create_batch)
-            await node_query.execute(db=self.db)
-            log.info(f"Batch #{batch_num} saved")
+            await self._save_node_batch(node_create_batch=node_create_batch)
+            log.info(f"Batch saved. num_nodes={len(node_create_batch)}")
         link_query = await EnrichedNodesLinkQuery.init(db=self.db, enriched_diffs=enriched_diffs)
         await link_query.execute(db=self.db)
         log.info("Diff saved.")
@@ -444,6 +468,7 @@ class DiffRepository:
             offset += limit
         return specifiers
 
+    @retry_db_transaction(name="enriched_diff_summary_counts")
     async def add_summary_counts(
         self,
         diff_branch_name: str,
@@ -460,4 +485,4 @@ class DiffRepository:
             node_uuids=node_uuids,
         )
         await query.execute(db=self.db)
-        log.info("Summary counts updated...")
+        log.info("Summary counts updated.")

--- a/backend/infrahub/database/__init__.py
+++ b/backend/infrahub/database/__init__.py
@@ -514,6 +514,7 @@ def retry_db_transaction(
                         if exc.code != "Neo.ClientError.Statement.EntityNotFound":
                             raise exc
                     retry_time: float = random.randrange(100, 500) / 1000
+                    log.exception("Retry handler caught database error")
                     log.info(
                         f"Retrying database transaction, attempt {attempt}/{config.SETTINGS.database.retry_limit}",
                         retry_time=retry_time,

--- a/backend/infrahub/graphql/mutations/diff.py
+++ b/backend/infrahub/graphql/mutations/diff.py
@@ -9,7 +9,6 @@ from infrahub.core.diff.model.path import NameTrackingId
 from infrahub.core.diff.models import RequestDiffUpdate
 from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.timestamp import Timestamp
-from infrahub.database import retry_db_transaction
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.exceptions import ValidationError
 from infrahub.workflows.catalogue import DIFF_UPDATE
@@ -37,7 +36,6 @@ class DiffUpdateMutation(Mutation):
     task = Field(TaskInfo, required=False)
 
     @classmethod
-    @retry_db_transaction(name="diff_update")
     async def mutate(
         cls,
         root: dict,  # pylint: disable=unused-argument

--- a/backend/tests/unit/core/diff/repository/base.py
+++ b/backend/tests/unit/core/diff/repository/base.py
@@ -81,8 +81,8 @@ class DiffRepositoryTestBase:
             this_node = nodes_to_check.pop(0)
             all_nodes.add(this_node)
             for rel in this_node.relationships:
-                for child_node in rel.nodes:
-                    nodes_to_check.append(child_node)
+                for parent_node in rel.nodes:
+                    nodes_to_check.append(parent_node)
         return all_nodes
 
     async def _save_single_diff(

--- a/backend/tests/unit/core/diff/repository/base.py
+++ b/backend/tests/unit/core/diff/repository/base.py
@@ -66,9 +66,7 @@ class DiffRepositoryTestBase:
             return enriched_node
         if num_sub_fields > 1 and len(enriched_node.relationships) > 0:
             for relationship_group in enriched_node.relationships:
-                relationship_group.nodes = {
-                    self.build_diff_node(num_sub_fields=num_sub_fields - 1) for _ in range(num_sub_fields - 1)
-                }
+                relationship_group.nodes = {self.build_diff_node(num_sub_fields=num_sub_fields - 1)}
                 break
         return enriched_node
 

--- a/backend/tests/unit/core/diff/repository/test_diff_repository.py
+++ b/backend/tests/unit/core/diff/repository/test_diff_repository.py
@@ -48,7 +48,7 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
         original_size = config.SETTINGS.database.query_size_limit
         config.SETTINGS.database.max_depth_search_hierarchy = 10
         config.SETTINGS.database.query_size_limit = 50
-        diff_repository = DiffRepository(db=db, deserializer=EnrichedDiffDeserializer())
+        diff_repository = DiffRepository(db=db, deserializer=EnrichedDiffDeserializer(), max_save_batch_size=30)
         yield diff_repository
         config.SETTINGS.database.max_depth_search_hierarchy = original_depth
         config.SETTINGS.database.query_size_limit = original_size
@@ -90,7 +90,6 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
         assert diff_root == enriched_diff
 
     async def test_save_and_retrieve_large_diff(self, diff_repository: DiffRepository, reset_database):
-        diff_repository.max_save_batch_size = 50
         enriched_branch_diff = EnrichedRootFactory.build(
             base_branch_name=self.base_branch_name,
             diff_branch_name=self.diff_branch_name,

--- a/backend/tests/unit/core/diff/repository/test_diff_repository.py
+++ b/backend/tests/unit/core/diff/repository/test_diff_repository.py
@@ -49,7 +49,6 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
         config.SETTINGS.database.max_depth_search_hierarchy = 10
         config.SETTINGS.database.query_size_limit = 50
         diff_repository = DiffRepository(db=db, deserializer=EnrichedDiffDeserializer())
-        diff_repository.MAX_SAVE_BATCH_SIZE = 3
         yield diff_repository
         config.SETTINGS.database.max_depth_search_hierarchy = original_depth
         config.SETTINGS.database.query_size_limit = original_size
@@ -91,7 +90,7 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
         assert diff_root == enriched_diff
 
     async def test_save_and_retrieve_large_diff(self, diff_repository: DiffRepository, reset_database):
-        diff_repository.MAX_SAVE_BATCH_SIZE = 3
+        diff_repository.max_save_batch_size = 50
         enriched_branch_diff = EnrichedRootFactory.build(
             base_branch_name=self.base_branch_name,
             diff_branch_name=self.diff_branch_name,
@@ -955,6 +954,47 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
         assert retrieved_diff_root.exists_on_database is True
         retrieved_diff_root.exists_on_database = False
         assert retrieved_diff_root == enriched_diff
+        await verify_no_orphaned_nodes(db=db)
+
+    async def test_update_existing_hierarchy(
+        self, db: InfrahubDatabase, diff_repository: DiffRepository, reset_database
+    ):
+        nodes = self._build_nodes(num_nodes=2, num_sub_fields=3)
+        for n in nodes:
+            for r in n.relationships:
+                if r.nodes:
+                    child_node, parent_rel = n, r
+                    break
+        enriched_diff = EnrichedRootFactory.build(
+            base_branch_name=self.base_branch_name,
+            diff_branch_name=self.diff_branch_name,
+            from_time=Timestamp(self.diff_from_time),
+            to_time=Timestamp(self.diff_to_time),
+            nodes=set(nodes),
+            tracking_id=NameTrackingId(name="the-best-diff"),
+        )
+        saved_diffs = await self._save_single_diff(
+            diff_repository=diff_repository, enriched_diff=enriched_diff, do_summary_counts=False
+        )
+
+        # replace a parent
+        new_parent = self.build_diff_node(num_sub_fields=2, no_recurse=True)
+        removed_parent = parent_rel.nodes.pop()
+        parent_rel.nodes.add(new_parent)
+        saved_diffs.base_branch_diff.nodes = set()
+        saved_diffs.diff_branch_diff.nodes = {child_node, new_parent, removed_parent}
+        await diff_repository.save(enriched_diffs=saved_diffs, do_summary_counts=False)
+
+        retrieved_diff = await diff_repository.get_one(
+            diff_branch_name=enriched_diff.diff_branch_name, diff_id=enriched_diff.uuid
+        )
+
+        retrieved_child = retrieved_diff.get_node(child_node.uuid)
+        retrieved_parent_rel = retrieved_child.get_relationship(name=parent_rel.name)
+        assert {n.uuid for n in retrieved_parent_rel.nodes} == {n.uuid for n in parent_rel.nodes}
+        retrieved_removed_parent = retrieved_diff.get_node(removed_parent.uuid)
+        assert retrieved_removed_parent == removed_parent
+        assert retrieved_diff == enriched_diff
         await verify_no_orphaned_nodes(db=db)
 
 

--- a/backend/tests/unit/core/diff/repository/test_diff_repository.py
+++ b/backend/tests/unit/core/diff/repository/test_diff_repository.py
@@ -970,7 +970,7 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
             diff_branch_name=self.diff_branch_name,
             from_time=Timestamp(self.diff_from_time),
             to_time=Timestamp(self.diff_to_time),
-            nodes=set(nodes),
+            nodes=nodes,
             tracking_id=NameTrackingId(name="the-best-diff"),
         )
         saved_diffs = await self._save_single_diff(
@@ -981,10 +981,17 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
         new_parent = self.build_diff_node(num_sub_fields=2, no_recurse=True)
         removed_parent = parent_rel.nodes.pop()
         parent_rel.nodes.add(new_parent)
-        saved_diffs.base_branch_diff.nodes = set()
-        saved_diffs.diff_branch_diff.nodes = {child_node, new_parent, removed_parent}
-        await diff_repository.save(enriched_diffs=saved_diffs, do_summary_counts=False)
+        saved_diffs.diff_branch_diff.nodes.add(new_parent)
 
+        # the update includes some nodes in the existing diff, but not all
+        updated_base_branch_diff = replace(saved_diffs.base_branch_diff, nodes=set())
+        updated_diff_branch_diff = replace(saved_diffs.diff_branch_diff, nodes={child_node, new_parent, removed_parent})
+        updated_diffs = replace(
+            saved_diffs, base_branch_diff=updated_base_branch_diff, diff_branch_diff=updated_diff_branch_diff
+        )
+        await diff_repository.save(enriched_diffs=updated_diffs, do_summary_counts=False)
+
+        # retrieving the diff still gets all the nodes for the whole diff
         retrieved_diff = await diff_repository.get_one(
             diff_branch_name=enriched_diff.diff_branch_name, diff_id=enriched_diff.uuid
         )
@@ -992,9 +999,13 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
         retrieved_child = retrieved_diff.get_node(child_node.uuid)
         retrieved_parent_rel = retrieved_child.get_relationship(name=parent_rel.name)
         assert {n.uuid for n in retrieved_parent_rel.nodes} == {n.uuid for n in parent_rel.nodes}
+        assert retrieved_child == child_node
         retrieved_removed_parent = retrieved_diff.get_node(removed_parent.uuid)
         assert retrieved_removed_parent == removed_parent
-        assert retrieved_diff == enriched_diff
+
+        assert retrieved_diff.exists_on_database is True
+        retrieved_diff.exists_on_database = False
+        assert retrieved_diff == saved_diffs.diff_branch_diff
         await verify_no_orphaned_nodes(db=db)
 
 

--- a/changelog/+diff-save.changed.md
+++ b/changelog/+diff-save.changed.md
@@ -1,0 +1,1 @@
+Improve performance of cypher query that saves a diff


### PR DESCRIPTION
IFC-1249

improves the performance of the cypher query to save/update a diff on the database.
- a few small adjustments to use subqueries in place of some `FOREACH` clauses that functioned as a hack for conditional statement execution seems to have improved performance on this query by a factor of 2 - 3
- removed some `retry_database_transaction` decorators from diff-related calls b/c if the diff is big enough, then the transaction will crash with an out-of-memory error. there is still more to do on this and it will be handled in IFC-1274
- updated the batching logic that determines how many nodes to save a time to more accurately calculate the size of the batch and allow expanding the batch into single elements if the save query runs out of memory
- some naming updates to parent/child nodes in a diff in a few spots b/c I believe that they were reversed