### PR TITLE
Fix node deletion with unidirectional optional relationship

### DIFF
--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -19,6 +19,7 @@ from infrahub.types import ATTRIBUTE_TYPES
 
 from ...graphql.constants import KIND_GRAPHQL_FIELD_NAME
 from ...graphql.models import OrderModel
+from ..query.relationship import RelationshipDeleteAllQuery
 from ..relationship import RelationshipManager
 from ..utils import update_relationships_to
 from .base import BaseNode, BaseNodeMeta, BaseNodeOptions
@@ -599,14 +600,10 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
             attr: BaseAttribute = getattr(self, name)
             await attr.delete(at=delete_at, db=db)
 
-        # Go over the list of relationships and update them one by one
-        for name in self._relationships:
-            rel: RelationshipManager = getattr(self, name)
-            await rel.delete(at=delete_at, db=db)
-
-        # Need to check if there are some unidirectional relationship as well
-        # For example, if we delete a tag, we must check the permissions and update all the relationships pointing at it
         branch = self.get_branch_based_on_support_type()
+
+        delete_query = await RelationshipDeleteAllQuery.init(db=db, node_id=self.get_id(), branch=branch, at=delete_at)
+        await delete_query.execute(db=db)
 
         # Update the relationship to the branch itself
         query = await NodeGetListQuery.init(

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -7,7 +7,13 @@ from infrahub_sdk.utils import is_valid_uuid
 from infrahub_sdk.uuidt import UUIDT
 
 from infrahub.core import registry
-from infrahub.core.constants import BranchSupportType, ComputedAttributeKind, InfrahubKind, RelationshipCardinality
+from infrahub.core.constants import (
+    GLOBAL_BRANCH_NAME,
+    BranchSupportType,
+    ComputedAttributeKind,
+    InfrahubKind,
+    RelationshipCardinality,
+)
 from infrahub.core.constants.schema import SchemaElementPathType
 from infrahub.core.protocols import CoreNumberPool
 from infrahub.core.query.node import NodeCheckIDQuery, NodeCreateAllQuery, NodeDeleteQuery, NodeGetListQuery
@@ -602,7 +608,9 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
 
         branch = self.get_branch_based_on_support_type()
 
-        delete_query = await RelationshipDeleteAllQuery.init(db=db, node_id=self.get_id(), branch=branch, at=delete_at)
+        delete_query = await RelationshipDeleteAllQuery.init(
+            db=db, node_id=self.get_id(), branch=branch, at=delete_at, branch_agnostic=branch.name == GLOBAL_BRANCH_NAME
+        )
         await delete_query.execute(db=db)
 
         # Update the relationship to the branch itself

--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -932,3 +932,122 @@ class RelationshipCountPerNodeQuery(Query):
                 data[node_id] = 0
 
         return data
+
+
+class RelationshipDeleteAllQuery(Query):
+    """
+    Delete all relationships linked to a given node on a given branch. So, it will both:
+    - Set `to` time on corresponding active edge.
+    - Create `deleted` edge.
+    """
+
+    name = "node_delete_all_relationships"
+    type = QueryType.WRITE
+    insert_return = False
+
+    def __init__(self, node_id: str, **kwargs):
+        self.node_id = node_id
+        super().__init__(**kwargs)
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs) -> None:
+        self.params["source_id"] = kwargs["node_id"]
+        self.params["branch"] = self.branch.name
+
+        self.params["rel_prop"] = {
+            "branch": self.branch.name,
+            "branch_level": self.branch.hierarchy_level,
+            "status": RelationshipStatus.DELETED.value,
+            "from": self.at.to_string(),
+        }
+
+        self.params["at"] = self.at.to_string()
+
+        edge_filter, rel_params = self.branch.get_query_filter_path(at=self.at, variable_name="edge")
+        self.params.update(rel_params)
+
+        r1_active_filter, _ = self.branch.get_query_filter_path(at=self.at.to_string(), variable_name="r1_active")
+        r2_active_filter, _ = self.branch.get_query_filter_path(at=self.at.to_string(), variable_name="r2_active")
+
+        arrows = [("<-", "-", "<-", "-"), ("-", "->", "-", "->"), ("<-", "-", "-", "->"), ("-", "->", "<-", "-")]
+
+        query = ""
+        for arrow_left_start, arrow_left_end, arrow_right_start, arrow_right_end in arrows:
+            query += """
+            CALL {
+                MATCH (s:Node { uuid: $source_id })%(arrow_left_start)s[r1_active:IS_RELATED]%(arrow_left_end)s \
+                (rl:Relationship)%(arrow_right_start)s[r2_active:IS_RELATED]%(arrow_right_end)s(d:Node)
+                WHERE %(r1_active_filter)s AND %(r2_active_filter)s AND r1_active.status = "active" AND r2_active.status = "active"
+
+                WITH s, rl, d, r1_active, r2_active
+                LIMIT 1
+                SET r1_active.to = $at
+                SET r2_active.to = $at
+                CREATE (s)%(arrow_left_start)s[r1:IS_RELATED $rel_prop]%(arrow_left_end)s(rl)
+                SET r1.hierarchical = r1_active.hierarchical
+                CREATE (rl)%(arrow_right_start)s[r2:IS_RELATED $rel_prop]%(arrow_right_end)s(d)
+                SET r2.hierarchical = r2_active.hierarchical
+                WITH rl
+                CALL {
+                    WITH rl
+                    MATCH (rl)-[edge:IS_VISIBLE]->(visible)
+                    WHERE %(rel_filter)s AND edge.status = "active"
+                    WITH rl, edge, visible
+                    ORDER BY edge.branch_level DESC
+                    LIMIT 1
+                    CREATE (rl)-[deleted_edge:IS_VISIBLE $rel_prop]->(visible)
+                    SET deleted_edge.hierarchical = edge.hierarchical
+                    WITH edge
+                    WHERE edge.branch = $branch
+                    SET edge.to = $at
+                }
+                CALL {
+                    WITH rl
+                    MATCH (rl)-[edge:IS_PROTECTED]->(protected)
+                    WHERE %(rel_filter)s AND edge.status = "active"
+                    WITH rl, edge, protected
+                    ORDER BY edge.branch_level DESC
+                    LIMIT 1
+                    CREATE (rl)-[deleted_edge:IS_PROTECTED $rel_prop]->(protected)
+                    SET deleted_edge.hierarchical = edge.hierarchical
+                    WITH edge
+                    WHERE edge.branch = $branch
+                    SET edge.to = $at
+                }
+                CALL {
+                    WITH rl
+                    MATCH (rl)-[edge:HAS_OWNER]->(owner_node)
+                    WHERE %(rel_filter)s AND edge.status = "active"
+                    WITH rl, edge, owner_node
+                    ORDER BY edge.branch_level DESC
+                    LIMIT 1
+                    CREATE (rl)-[deleted_edge:HAS_OWNER $rel_prop]->(owner_node)
+                    SET deleted_edge.hierarchical = edge.hierarchical
+                    WITH edge
+                    WHERE edge.branch = $branch
+                    SET edge.to = $at
+                }
+                CALL {
+                    WITH rl
+                    MATCH (rl)-[edge:HAS_SOURCE]->(source_node)
+                    WHERE %(rel_filter)s AND edge.status = "active"
+                    WITH rl, edge, source_node
+                    ORDER BY edge.branch_level DESC
+                    LIMIT 1
+                    CREATE (rl)-[deleted_edge:HAS_SOURCE $rel_prop]->(source_node)
+                    SET deleted_edge.hierarchical = edge.hierarchical
+                    WITH edge
+                    WHERE edge.branch = $branch
+                    SET edge.to = $at
+                }
+            }
+
+            """ % {
+                "arrow_left_start": arrow_left_start,
+                "arrow_left_end": arrow_left_end,
+                "arrow_right_start": arrow_right_start,
+                "arrow_right_end": arrow_right_end,
+                "rel_filter": edge_filter,
+                "r1_active_filter": r1_active_filter,
+                "r2_active_filter": r2_active_filter,
+            }
+        self.add_to_query(query)

--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -936,9 +936,10 @@ class RelationshipCountPerNodeQuery(Query):
 
 class RelationshipDeleteAllQuery(Query):
     """
-    Delete all relationships linked to a given node on a given branch. So, it will both:
-    - Set `to` time on corresponding active edge.
+    Delete all relationships linked to a given node on a given branch at a given time. For every IS_RELATED edge:
+    - Set `to` time if an active edge exist on the same branch.
     - Create `deleted` edge.
+    - Apply above to every edges linked to any connected Relationship node.
     """
 
     name = "node_delete_all_relationships"
@@ -962,11 +963,17 @@ class RelationshipDeleteAllQuery(Query):
 
         self.params["at"] = self.at.to_string()
 
-        edge_filter, rel_params = self.branch.get_query_filter_path(at=self.at, variable_name="edge")
+        edge_filter, rel_params = self.branch.get_query_filter_path(
+            at=self.at, variable_name="edge", branch_agnostic=self.branch_agnostic
+        )
         self.params.update(rel_params)
 
-        r1_active_filter, _ = self.branch.get_query_filter_path(at=self.at.to_string(), variable_name="r1_active")
-        r2_active_filter, _ = self.branch.get_query_filter_path(at=self.at.to_string(), variable_name="r2_active")
+        r1_active_filter, _ = self.branch.get_query_filter_path(
+            at=self.at.to_string(), variable_name="r1_active", branch_agnostic=self.branch_agnostic
+        )
+        r2_active_filter, _ = self.branch.get_query_filter_path(
+            at=self.at.to_string(), variable_name="r2_active", branch_agnostic=self.branch_agnostic
+        )
 
         arrows = [("<-", "-", "<-", "-"), ("-", "->", "-", "->"), ("<-", "-", "-", "->"), ("-", "->", "<-", "-")]
 
@@ -978,14 +985,27 @@ class RelationshipDeleteAllQuery(Query):
                 (rl:Relationship)%(arrow_right_start)s[r2_active:IS_RELATED]%(arrow_right_end)s(d:Node)
                 WHERE %(r1_active_filter)s AND %(r2_active_filter)s AND r1_active.status = "active" AND r2_active.status = "active"
 
-                WITH s, rl, d, r1_active, r2_active
-                LIMIT 1
-                SET r1_active.to = $at
-                SET r2_active.to = $at
-                CREATE (s)%(arrow_left_start)s[r1:IS_RELATED $rel_prop]%(arrow_left_end)s(rl)
-                SET r1.hierarchical = r1_active.hierarchical
-                CREATE (rl)%(arrow_right_start)s[r2:IS_RELATED $rel_prop]%(arrow_right_end)s(d)
-                SET r2.hierarchical = r2_active.hierarchical
+                CALL {
+                    WITH s, r1_active, rl
+                    WITH DISTINCT s, r1_active, rl
+                    CREATE (s)%(arrow_left_start)s[r1:IS_RELATED $rel_prop]%(arrow_left_end)s(rl)
+                    SET r1.hierarchy = r1_active.hierarchy
+                    WITH r1_active
+                    WHERE r1_active.branch = $branch
+                    SET r1_active.to = $at
+                }
+
+                CALL {
+                    WITH rl, r2_active, d
+                    WITH DISTINCT rl, r2_active, d
+                    CREATE (rl)%(arrow_right_start)s[r2:IS_RELATED $rel_prop]%(arrow_right_end)s(d)
+                    SET r2.hierarchy = r2_active.hierarchy
+                    WITH r2_active
+                    WHERE r2_active.branch = $branch
+                    SET r2_active.to = $at
+                }
+
+                // Delete other edges related to Relationship node
                 WITH rl
                 CALL {
                     WITH rl

--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Generator, Optional, Union
 from infrahub_sdk.uuidt import UUIDT
 
 from infrahub.core.constants import RelationshipDirection, RelationshipStatus
+from infrahub.core.constants.database import DatabaseEdgeType
 from infrahub.core.query import Query, QueryType
 from infrahub.core.query.subquery import build_subquery_filter, build_subquery_order
 from infrahub.core.timestamp import Timestamp
@@ -24,7 +25,7 @@ if TYPE_CHECKING:
     from infrahub.core.schema import RelationshipSchema
     from infrahub.database import InfrahubDatabase
 
-# pylint: disable=redefined-builtin
+# pylint: disable=redefined-builtin,too-many-lines
 
 
 @dataclass
@@ -963,111 +964,42 @@ class RelationshipDeleteAllQuery(Query):
 
         self.params["at"] = self.at.to_string()
 
-        edge_filter, rel_params = self.branch.get_query_filter_path(
-            at=self.at, variable_name="edge", branch_agnostic=self.branch_agnostic
+        active_rel_filter, rel_params = self.branch.get_query_filter_path(
+            at=self.at, variable_name="active_edge", branch_agnostic=self.branch_agnostic
         )
         self.params.update(rel_params)
 
-        r1_active_filter, _ = self.branch.get_query_filter_path(
-            at=self.at.to_string(), variable_name="r1_active", branch_agnostic=self.branch_agnostic
-        )
-        r2_active_filter, _ = self.branch.get_query_filter_path(
-            at=self.at.to_string(), variable_name="r2_active", branch_agnostic=self.branch_agnostic
-        )
+        query_match_relationships = """
+        MATCH (s:Node { uuid: $source_id })-[active_edge:IS_RELATED]-(rl:Relationship)
+        WHERE %(active_rel_filter)s AND active_edge.status = "active"
+        WITH DISTINCT rl
+        """ % {"active_rel_filter": active_rel_filter}
 
-        arrows = [("<-", "-", "<-", "-"), ("-", "->", "-", "->"), ("<-", "-", "-", "->"), ("-", "->", "<-", "-")]
+        self.add_to_query(query_match_relationships)
 
-        query = ""
-        for arrow_left_start, arrow_left_end, arrow_right_start, arrow_right_end in arrows:
-            query += """
-            CALL {
-                MATCH (s:Node { uuid: $source_id })%(arrow_left_start)s[r1_active:IS_RELATED]%(arrow_left_end)s \
-                (rl:Relationship)%(arrow_right_start)s[r2_active:IS_RELATED]%(arrow_right_end)s(d:Node)
-                WHERE %(r1_active_filter)s AND %(r2_active_filter)s AND r1_active.status = "active" AND r2_active.status = "active"
-
-                CALL {
-                    WITH s, r1_active, rl
-                    WITH DISTINCT s, r1_active, rl
-                    CREATE (s)%(arrow_left_start)s[r1:IS_RELATED $rel_prop]%(arrow_left_end)s(rl)
-                    SET r1.hierarchy = r1_active.hierarchy
-                    WITH r1_active
-                    WHERE r1_active.branch = $branch
-                    SET r1_active.to = $at
+        for arrow_left, arrow_right in (("<-", "-"), ("-", "->")):
+            for edge_type in [
+                DatabaseEdgeType.IS_RELATED.value,
+                DatabaseEdgeType.IS_VISIBLE.value,
+                DatabaseEdgeType.IS_PROTECTED.value,
+                DatabaseEdgeType.HAS_OWNER.value,
+                DatabaseEdgeType.HAS_SOURCE.value,
+            ]:
+                query = """
+                    CALL {
+                        WITH rl
+                        MATCH (rl)%(arrow_left)s[active_edge:%(edge_type)s]%(arrow_right)s(n)
+                        WHERE %(active_rel_filter)s AND active_edge.status ="active"
+                        CREATE (rl)%(arrow_left)s[deleted_edge:%(edge_type)s $rel_prop]%(arrow_right)s(n)
+                        SET deleted_edge.hierarchy = active_edge.hierarchy
+                        WITH active_edge
+                        WHERE active_edge.branch = $branch
+                        SET active_edge.to = $at
+                    }
+                """ % {
+                    "arrow_left": arrow_left,
+                    "arrow_right": arrow_right,
+                    "active_rel_filter": active_rel_filter,
+                    "edge_type": edge_type,
                 }
-
-                CALL {
-                    WITH rl, r2_active, d
-                    WITH DISTINCT rl, r2_active, d
-                    CREATE (rl)%(arrow_right_start)s[r2:IS_RELATED $rel_prop]%(arrow_right_end)s(d)
-                    SET r2.hierarchy = r2_active.hierarchy
-                    WITH r2_active
-                    WHERE r2_active.branch = $branch
-                    SET r2_active.to = $at
-                }
-
-                // Delete other edges related to Relationship node
-                WITH rl
-                CALL {
-                    WITH rl
-                    MATCH (rl)-[edge:IS_VISIBLE]->(visible)
-                    WHERE %(rel_filter)s AND edge.status = "active"
-                    WITH rl, edge, visible
-                    ORDER BY edge.branch_level DESC
-                    LIMIT 1
-                    CREATE (rl)-[deleted_edge:IS_VISIBLE $rel_prop]->(visible)
-                    SET deleted_edge.hierarchical = edge.hierarchical
-                    WITH edge
-                    WHERE edge.branch = $branch
-                    SET edge.to = $at
-                }
-                CALL {
-                    WITH rl
-                    MATCH (rl)-[edge:IS_PROTECTED]->(protected)
-                    WHERE %(rel_filter)s AND edge.status = "active"
-                    WITH rl, edge, protected
-                    ORDER BY edge.branch_level DESC
-                    LIMIT 1
-                    CREATE (rl)-[deleted_edge:IS_PROTECTED $rel_prop]->(protected)
-                    SET deleted_edge.hierarchical = edge.hierarchical
-                    WITH edge
-                    WHERE edge.branch = $branch
-                    SET edge.to = $at
-                }
-                CALL {
-                    WITH rl
-                    MATCH (rl)-[edge:HAS_OWNER]->(owner_node)
-                    WHERE %(rel_filter)s AND edge.status = "active"
-                    WITH rl, edge, owner_node
-                    ORDER BY edge.branch_level DESC
-                    LIMIT 1
-                    CREATE (rl)-[deleted_edge:HAS_OWNER $rel_prop]->(owner_node)
-                    SET deleted_edge.hierarchical = edge.hierarchical
-                    WITH edge
-                    WHERE edge.branch = $branch
-                    SET edge.to = $at
-                }
-                CALL {
-                    WITH rl
-                    MATCH (rl)-[edge:HAS_SOURCE]->(source_node)
-                    WHERE %(rel_filter)s AND edge.status = "active"
-                    WITH rl, edge, source_node
-                    ORDER BY edge.branch_level DESC
-                    LIMIT 1
-                    CREATE (rl)-[deleted_edge:HAS_SOURCE $rel_prop]->(source_node)
-                    SET deleted_edge.hierarchical = edge.hierarchical
-                    WITH edge
-                    WHERE edge.branch = $branch
-                    SET edge.to = $at
-                }
-            }
-
-            """ % {
-                "arrow_left_start": arrow_left_start,
-                "arrow_left_end": arrow_left_end,
-                "arrow_right_start": arrow_right_start,
-                "arrow_right_end": arrow_right_end,
-                "rel_filter": edge_filter,
-                "r1_active_filter": r1_active_filter,
-                "r2_active_filter": r2_active_filter,
-            }
-        self.add_to_query(query)
+                self.add_to_query(query)

--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -993,7 +993,7 @@ class RelationshipDeleteAllQuery(Query):
                         CREATE (rl)%(arrow_left)s[deleted_edge:%(edge_type)s $rel_prop]%(arrow_right)s(n)
                         SET deleted_edge.hierarchy = active_edge.hierarchy
                         WITH active_edge
-                        WHERE active_edge.branch = $branch
+                        WHERE active_edge.branch = $branch AND active_edge.to IS NULL
                         SET active_edge.to = $at
                     }
                 """ % {

--- a/backend/tests/unit/core/test_node_manager_delete.py
+++ b/backend/tests/unit/core/test_node_manager_delete.py
@@ -11,6 +11,9 @@ from infrahub.core.schema.relationship_schema import RelationshipSchema
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import ValidationError
+from tests.constants import TestKind
+from tests.helpers.schema import CAR_SCHEMA, load_schema
+from tests.helpers.test_app import TestInfrahubApp
 
 
 async def test_delete_succeeds(
@@ -202,3 +205,31 @@ async def test_delete_with_cascade_on_generic_allowed(db, default_branch, depend
     assert {d.id for d in deleted} == {human.id, dog.id}
     node_map = await NodeManager.get_many(db=db, ids=[human.id, dog.id])
     assert node_map == {}
+
+
+class TestDeleteUnidirectionalRelationship(TestInfrahubApp):
+    async def test_delete_unidirectional_optional_relationship(self, db, client, default_branch):
+        await load_schema(db, schema=CAR_SCHEMA)
+
+        owner = await Node.init(schema=TestKind.PERSON, db=db)
+        await owner.new(db=db, name="John Doe", height=175)
+        await owner.save(db=db)
+
+        previous_owner = await Node.init(schema=TestKind.PERSON, db=db)
+        await previous_owner.new(db=db, name="Eric", height=175)
+        await previous_owner.save(db=db)
+
+        koenigsegg = await Node.init(schema=TestKind.MANUFACTURER, db=db)
+        await koenigsegg.new(db=db, name="Koenigsegg")
+        await koenigsegg.save(db=db)
+
+        car = await Node.init(schema=TestKind.CAR, db=db)
+        await car.new(
+            db=db, name="Jesko", color="Red", owner=owner, manufacturer=koenigsegg, previous_owner=previous_owner
+        )
+        await car.save(db=db)
+
+        await previous_owner.delete(db=db)
+        res = await NodeManager.get_many(db=db, ids=[car.id])
+        rels = await res[car.id].previous_owner.get_relationships(db=db)
+        assert len(rels) == 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,7 +174,6 @@ disable = """,
     multiple-statements,
     self-assigning-variable,
     no-else-return,
-    too-many-lines,
     """
 
 [tool.pylint.miscellaneous]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,7 @@ disable = """,
     multiple-statements,
     self-assigning-variable,
     no-else-return,
+    too-many-lines,
     """
 
 [tool.pylint.miscellaneous]


### PR DESCRIPTION
Fixes #5619

While deleting a node, delete its relationships through a single database query instead of relying on RelationshipManager of each relationship.