### PR TITLE
display node label based on row's object kind instead of query kind

### DIFF
--- a/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-relationship-cell.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/cells/table-relationship-cell.tsx
@@ -39,7 +39,7 @@ export function TableRelationshipCell({
 export function RelationshipNodeDisplay({ node }: NodeRelationshipOne) {
   const { schema } = useSchema(node.__typename);
 
-  if (!schema) return "Unknown schema";
+  if (!schema) return `Schema for ${node.__typename} not found`;
 
   return (
     <LinkButton
@@ -49,7 +49,7 @@ export function RelationshipNodeDisplay({ node }: NodeRelationshipOne) {
       className="rounded-full truncate hover:underline hover:border-custom-blue-700 pr-2.5"
     >
       <Icon icon={schema.icon ?? "mdi:cube-outline"} className="mr-1 text-custom-blue-800" />
-      {getNodeLabel({ node, schema })}
+      {getNodeLabel(node)}
     </LinkButton>
   );
 }

--- a/frontend/app/src/entities/nodes/object/ui/object-table/get-object-table-columns.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/get-object-table-columns.tsx
@@ -32,7 +32,7 @@ export const getObjectTableColumns = (
   return [
     {
       id: "id",
-      accessorFn: (node) => getNodeLabel({ node, schema }),
+      accessorFn: (node) => getNodeLabel(node),
       header: () => (
         <div className={classNames(cellsStyle, cellHeaderStyle, "left-0 z-10 hover:bg-white")}>
           {schema.icon && <Icon icon={schema.icon} className="text-stone-400" />}

--- a/frontend/app/src/entities/nodes/object/utils/get-node-label.test.ts
+++ b/frontend/app/src/entities/nodes/object/utils/get-node-label.test.ts
@@ -1,10 +1,19 @@
 import { NodeCore } from "@/entities/nodes/types";
-import { describe, expect, it } from "vitest";
+import { getSchema } from "@/entities/schema/domain/get-schema";
+import { describe, expect, it, vi } from "vitest";
 import { generateNodeSchema } from "../../../../../tests/fake/schema";
 import { getNodeLabel } from "./get-node-label";
 
+vi.mock("@/entities/schema/domain/get-schema", () => ({
+  getSchema: vi.fn(() => ({
+    schema: generateNodeSchema(),
+    isGeneric: false,
+    isNode: true,
+    isProfile: false,
+  })),
+}));
+
 describe("getNodeLabel", () => {
-  const baseSchema = generateNodeSchema();
   const baseNode: NodeCore = {
     id: "test-id",
     hfid: null,
@@ -14,11 +23,10 @@ describe("getNodeLabel", () => {
 
   it("should join multiple hfids with comma when node has hfid array", () => {
     // GIVEN
-    const node = { ...baseNode, hfid: ["hfid-1", "hfid-2"] };
-    const schema = baseSchema;
+    const node: NodeCore = { ...baseNode, hfid: ["hfid-1", "hfid-2"] };
 
     // WHEN
-    const result = getNodeLabel({ node, schema });
+    const result = getNodeLabel(node);
 
     // THEN
     expect(result).toBe("hfid-1, hfid-2");
@@ -26,11 +34,10 @@ describe("getNodeLabel", () => {
 
   it("should use display_label when hfid is not present", () => {
     // GIVEN
-    const node = { ...baseNode, display_label: "Display Label" };
-    const schema = baseSchema;
+    const node: NodeCore = { ...baseNode, display_label: "Display Label" };
 
     // WHEN
-    const result = getNodeLabel({ node, schema });
+    const result = getNodeLabel(node);
 
     // THEN
     expect(result).toBe("Display Label");
@@ -38,7 +45,7 @@ describe("getNodeLabel", () => {
 
   it("should fallback to node.id when neither hfid nor display_label are present", () => {
     // WHEN
-    const result = getNodeLabel({ node: baseNode, schema: baseSchema });
+    const result = getNodeLabel(baseNode);
 
     // THEN
     expect(result).toBe("test-id");
@@ -46,46 +53,44 @@ describe("getNodeLabel", () => {
 
   it("should prefer hfid over display_label when both are available", () => {
     // GIVEN
-    const node = {
+    const node: NodeCore = {
       ...baseNode,
       hfid: ["hfid-1"],
       display_label: "Display Label",
     };
-    const schema = baseSchema;
 
     // WHEN
-    const result = getNodeLabel({ node, schema });
+    const result = getNodeLabel(node);
 
     // THEN
     expect(result).toBe("hfid-1");
   });
 
-  it("should fallback to node.id when schema allows special labels but node values are null", () => {
-    // GIVEN
-    const schema = baseSchema;
-
+  it("should fallback to node.id when special labels are null", () => {
     // WHEN
-    const result = getNodeLabel({ node: baseNode, schema });
+    const result = getNodeLabel(baseNode);
 
     // THEN
     expect(result).toBe("test-id");
   });
 
-  it("should use node.id when schema disables special labels even if node has them", () => {
+  it("should use node.id when schema is not found even if node has special labels", () => {
     // GIVEN
-    const node = {
+    vi.mocked(getSchema).mockReturnValueOnce({
+      schema: null,
+      isGeneric: false,
+      isNode: false,
+      isProfile: false,
+    });
+    const node: NodeCore = {
       ...baseNode,
       hfid: ["hfid-1"],
       display_label: "Display Label",
-    };
-    const schema = {
-      ...baseSchema,
-      human_friendly_id: null,
-      display_labels: null,
+      __typename: "UnknownType",
     };
 
     // WHEN
-    const result = getNodeLabel({ node, schema: schema });
+    const result = getNodeLabel(node);
 
     // THEN
     expect(result).toBe("test-id");

--- a/frontend/app/src/entities/nodes/object/utils/get-node-label.ts
+++ b/frontend/app/src/entities/nodes/object/utils/get-node-label.ts
@@ -1,7 +1,11 @@
 import { NodeCore } from "@/entities/nodes/types";
-import { IModelSchema } from "@/entities/schema/stores/schema.atom";
+import { getSchema } from "@/entities/schema/domain/get-schema";
 
-export function getNodeLabel({ node, schema }: { node: NodeCore; schema: IModelSchema }): string {
+export function getNodeLabel(node: NodeCore): string {
+  const { schema } = getSchema(node.__typename);
+
+  if (!schema) return node.id;
+
   if (schema.human_friendly_id && node.hfid) {
     return node.hfid.join(", ");
   }


### PR DESCRIPTION
Before:
If you display the list of CoreNode, the identifier column will display only id, regardeless of the current row object schema

Now:
the identifier column follows row's schema definition