### PR TITLE
IFC-1246 Add support for attribute rel in object templates

### DIFF
--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -320,9 +320,10 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
 
             relationship: RelationshipManager = getattr(template, relationship_name)
             if relationship_schema.cardinality == RelationshipCardinality.ONE:
-                fields[relationship_name] = {"id": (await relationship.get_peer(db=db)).id}
-            else:
-                fields[relationship_name] = [{"id": peer_id} for peer_id in await relationship.get_peers(db=db)]
+                if relationship_peer := await relationship.get_peer(db=db):
+                    fields[relationship_name] = {"id": relationship_peer.id}
+            elif relationship_peers := await relationship.get_peers(db=db):
+                fields[relationship_name] = [{"id": peer_id} for peer_id in relationship_peers]
 
     async def _process_fields(self, fields: dict, db: InfrahubDatabase) -> None:
         errors = []

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -310,6 +310,20 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
                 continue
             fields[attribute] = {"value": getattr(template, attribute).value}
 
+        for relationship_name in template._relationships:
+            relationship_schema = template._schema.get_relationship(name=relationship_name)
+            if (
+                relationship_schema.kind != RelationshipKind.ATTRIBUTE
+                or relationship_name == OBJECT_TEMPLATE_RELATIONSHIP_NAME
+            ):
+                continue
+
+            relationship: RelationshipManager = getattr(template, relationship_name)
+            if relationship_schema.cardinality == RelationshipCardinality.ONE:
+                fields[relationship_name] = {"id": (await relationship.get_peer(db=db)).id}
+            else:
+                fields[relationship_name] = [{"id": peer_id} for peer_id in await relationship.get_peers(db=db)]
+
     async def _process_fields(self, fields: dict, db: InfrahubDatabase) -> None:
         errors = []
 

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -305,15 +305,16 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
 
         # Handle attributes, copy values from template
         # Relationships handling in performed in GraphQL mutation to create nodes for relationships
-        for attribute in template._attributes:
-            if attribute in list(fields) + [OBJECT_TEMPLATE_NAME_ATTR]:
+        for attribute_name in template._attributes:
+            if attribute_name in list(fields) + [OBJECT_TEMPLATE_NAME_ATTR]:
                 continue
-            fields[attribute] = {"value": getattr(template, attribute).value}
+            fields[attribute_name] = {"value": getattr(template, attribute_name).value}
 
         for relationship_name in template._relationships:
             relationship_schema = template._schema.get_relationship(name=relationship_name)
             if (
-                relationship_schema.kind != RelationshipKind.ATTRIBUTE
+                relationship_name in list(fields)
+                or relationship_schema.kind != RelationshipKind.ATTRIBUTE
                 or relationship_name == OBJECT_TEMPLATE_RELATIONSHIP_NAME
             ):
                 continue

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1792,7 +1792,7 @@ class SchemaBranch:
                 "name": "object_template",
                 "identifier": "node__objecttemplate",
                 "peer": self._get_object_template_kind(node.kind),
-                "kind": RelationshipKind.ATTRIBUTE,
+                "kind": RelationshipKind.TEMPLATE,
                 "cardinality": RelationshipCardinality.ONE,
                 "branch": BranchSupportType.AWARE,
                 "order_weight": 1,
@@ -1829,16 +1829,24 @@ class SchemaBranch:
             if relationship.peer in [
                 InfrahubKind.GENERICGROUP,
                 InfrahubKind.PROFILE,
-            ] or relationship.kind not in [RelationshipKind.COMPONENT, RelationshipKind.PARENT]:
+            ] or relationship.kind not in [
+                RelationshipKind.COMPONENT,
+                RelationshipKind.PARENT,
+                RelationshipKind.ATTRIBUTE,
+            ]:
                 continue
 
-            rel_template_peer = self._get_object_template_kind(node_kind=relationship.peer)
+            rel_template_peer = (
+                self._get_object_template_kind(node_kind=relationship.peer)
+                if relationship.kind != RelationshipKind.ATTRIBUTE
+                else relationship.peer
+            )
             template_schema.relationships.append(
                 RelationshipSchema(
                     name=relationship.name,
                     peer=rel_template_peer,
                     kind=relationship.kind,
-                    optional=relationship.kind == RelationshipKind.COMPONENT,
+                    optional=relationship.kind in [RelationshipKind.COMPONENT, RelationshipKind.ATTRIBUTE],
                     cardinality=relationship.cardinality,
                     branch=relationship.branch,
                     identifier=self._generate_identifier_string(template_schema.kind, rel_template_peer),


### PR DESCRIPTION
This change adds the support of relationships of kind `Attribute` in object templates. If a node has such relationship, its template will have the same ones but marked as optional. If the relationships are set in the templates, they will be replicated in objects created from it.