### PR TITLE
Set branch with label as primary node for branch events

### DIFF
--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -174,7 +174,11 @@ async def merge_branch(branch: str, context: InfrahubContext, service: InfrahubS
         obj = await Branch.get_by_name(db=db, name=branch)
         default_branch = await registry.get_branch(db=db, branch=registry.default_branch)
         component_registry = get_component_registry()
-        merge_event = BranchMergedEvent(meta=EventMeta.from_context(context=context, branch=obj))
+        merge_event = BranchMergedEvent(
+            branch_name=obj.name,
+            branch_id=str(obj.get_uuid()),
+            meta=EventMeta.from_context(context=context, branch=obj),
+        )
 
         merger: BranchMerger | None = None
         async with lock.registry.global_graph_lock():

--- a/backend/infrahub/events/branch_action.py
+++ b/backend/infrahub/events/branch_action.py
@@ -17,9 +17,10 @@ class BranchDeletedEvent(InfrahubEvent):
 
     def get_resource(self) -> dict[str, str]:
         return {
-            "prefect.resource.id": f"infrahub.branch.{self.branch_name}",
-            "infrahub.branch.id": self.branch_id,
-            "infrahub.branch.name": self.branch_name,
+            "prefect.resource.id": f"infrahub.branch.{self.branch_id}",
+            "infrahub.node.kind": "Branch",
+            "infrahub.node.id": self.branch_id,
+            "infrahub.node.label": self.branch_name,
         }
 
     def get_messages(self) -> list[InfrahubMessage]:
@@ -48,9 +49,10 @@ class BranchCreatedEvent(InfrahubEvent):
 
     def get_resource(self) -> dict[str, str]:
         return {
-            "prefect.resource.id": f"infrahub.branch.{self.branch_name}",
-            "infrahub.branch.id": self.branch_id,
-            "infrahub.branch.name": self.branch_name,
+            "prefect.resource.id": f"infrahub.branch.{self.branch_id}",
+            "infrahub.node.kind": "Branch",
+            "infrahub.node.id": self.branch_id,
+            "infrahub.node.label": self.branch_name,
         }
 
     def get_messages(self) -> list[InfrahubMessage]:
@@ -73,12 +75,15 @@ class BranchCreatedEvent(InfrahubEvent):
 class BranchMergedEvent(InfrahubEvent):
     """Event generated when a branch has been merged"""
 
+    branch_name: str = Field(..., description="The name of the branch")
+    branch_id: str = Field(..., description="The ID of the branch")
+
     def get_resource(self) -> dict[str, str]:
         return {
-            "prefect.resource.id": f"infrahub.branch.{self.meta.get_branch_id()}",
+            "prefect.resource.id": f"infrahub.branch.{self.branch_id}",
             "infrahub.node.kind": "Branch",
-            "infrahub.node.id": self.meta.get_branch_id(),
-            "infrahub.node.label": self.meta.context.branch.name,
+            "infrahub.node.id": self.branch_id,
+            "infrahub.node.label": self.branch_name,
         }
 
     def get_messages(self) -> list[InfrahubMessage]:
@@ -97,8 +102,10 @@ class BranchRebasedEvent(InfrahubEvent):
 
     def get_resource(self) -> dict[str, str]:
         return {
-            "prefect.resource.id": f"infrahub.branch.{self.branch_name}",
-            "infrahub.branch.id": self.branch_id,
+            "prefect.resource.id": f"infrahub.branch.{self.branch_id}",
+            "infrahub.node.kind": "Branch",
+            "infrahub.node.id": self.branch_id,
+            "infrahub.node.label": self.branch_name,
         }
 
     def get_messages(self) -> list[InfrahubMessage]:

--- a/backend/infrahub/graphql/types/common.py
+++ b/backend/infrahub/graphql/types/common.py
@@ -10,3 +10,4 @@ class IdentifierInput(InputObjectType):
 class RelatedNode(ObjectType):
     id = String(required=True, description="The ID of the requested object")
     kind = String(required=True, description="The ID of the requested object")
+    display_label = String(required=False, description="The display label of the node if present")

--- a/backend/infrahub/task_manager/event.py
+++ b/backend/infrahub/task_manager/event.py
@@ -44,11 +44,11 @@ class PrefectEventData(PrefectEventModel):
             return resource.get("infrahub.event_parent.id")
         return None
 
-    def get_primary_node(self) -> dict[str, str] | None:
+    def get_primary_node(self) -> dict[str, str | None] | None:
         node_id = self.resource.get("infrahub.node.id")
         node_kind = self.resource.get("infrahub.node.kind")
         if node_id and node_kind:
-            return {"id": node_id, "kind": node_kind}
+            return {"id": node_id, "kind": node_kind, "display_label": self.resource.get("infrahub.node.label")}
 
         return None
 


### PR DESCRIPTION
Populate primary_node information for branch related events to ensure that we get the correct name of the impacted branch even if we want to display some of the events within the main branch.