### PR TITLE
Fix duplication of relationships for templates

### DIFF
--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1824,6 +1824,10 @@ class SchemaBranch:
 
     def add_relationships_to_template(self, node: NodeSchema) -> None:
         template_schema = self.get(name=self._get_object_template_kind(node_kind=node.kind), duplicate=False)
+        # Remove previous relationships to account for new ones
+        template_schema.relationships = [
+            r for r in template_schema.relationships if r.kind == RelationshipKind.TEMPLATE
+        ]
 
         for relationship in node.relationships:
             if relationship.peer in [
@@ -1835,11 +1839,6 @@ class SchemaBranch:
                 RelationshipKind.ATTRIBUTE,
             ]:
                 continue
-
-            # Remove previous relationships to account for updates
-            template_schema.relationships = [
-                rel for rel in template_schema.relationships if rel.name != relationship.name
-            ]
 
             rel_template_peer = (
                 self._get_object_template_kind(node_kind=relationship.peer)

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1836,6 +1836,11 @@ class SchemaBranch:
             ]:
                 continue
 
+            # Remove previous relationships to account for updates
+            template_schema.relationships = [
+                rel for rel in template_schema.relationships if rel.name != relationship.name
+            ]
+
             rel_template_peer = (
                 self._get_object_template_kind(node_kind=relationship.peer)
                 if relationship.kind != RelationshipKind.ATTRIBUTE


### PR DESCRIPTION
When loading a new schema, generating relationships for templates could end up in trying to duplicate them which was leading to a schema load error (to avoid duplication). This change ensures that relationships that need update are removed fromt the template schema before re-adding them.