### PR TITLE
Add node changelog events for cascade delete mutations

### DIFF
--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -1315,7 +1315,7 @@ class NodeManager:
         nodes: list[Node],
         branch: Optional[Union[Branch, str]] = None,
         at: Optional[Union[Timestamp, str]] = None,
-    ) -> list[Any]:
+    ) -> list[Node]:
         """Returns list of deleted nodes because of cascading deletes"""
         branch = await registry.get_branch(branch=branch, db=db)
         node_delete_validator = NodeDeleteValidator(db=db, branch=branch)

--- a/backend/infrahub/graphql/mutations/ipam.py
+++ b/backend/infrahub/graphql/mutations/ipam.py
@@ -20,7 +20,7 @@ from infrahub.graphql.mutations.node_getter.interface import MutationNodeGetterI
 from infrahub.lock import InfrahubMultiLock, build_object_lock_name
 from infrahub.log import get_logger
 
-from .main import InfrahubMutationMixin, InfrahubMutationOptions
+from .main import DeleteResult, InfrahubMutationMixin, InfrahubMutationOptions
 
 if TYPE_CHECKING:
     from infrahub.graphql.initialization import GraphqlContext
@@ -235,7 +235,7 @@ class InfrahubIPAddressMutation(InfrahubMutationMixin, Mutation):
         info: GraphQLResolveInfo,
         data: InputObjectType,
         branch: Branch,
-    ):
+    ) -> DeleteResult:
         return await super().mutate_delete(info=info, data=data, branch=branch)
 
 
@@ -402,7 +402,7 @@ class InfrahubIPPrefixMutation(InfrahubMutationMixin, Mutation):
         info: GraphQLResolveInfo,
         data: InputObjectType,
         branch: Branch,
-    ) -> tuple[Node, Self, list[Node]]:
+    ) -> DeleteResult:
         graphql_context: GraphqlContext = info.context
         db = graphql_context.db
 
@@ -431,4 +431,4 @@ class InfrahubIPPrefixMutation(InfrahubMutationMixin, Mutation):
 
         ok = True
 
-        return reconciled_prefix, cls(ok=ok), []
+        return DeleteResult(node=reconciled_prefix, mutation=cls(ok=ok))

--- a/backend/infrahub/graphql/mutations/ipam.py
+++ b/backend/infrahub/graphql/mutations/ipam.py
@@ -402,7 +402,7 @@ class InfrahubIPPrefixMutation(InfrahubMutationMixin, Mutation):
         info: GraphQLResolveInfo,
         data: InputObjectType,
         branch: Branch,
-    ) -> tuple[Node, Self]:
+    ) -> tuple[Node, Self, list[Node]]:
         graphql_context: GraphqlContext = info.context
         db = graphql_context.db
 
@@ -431,4 +431,4 @@ class InfrahubIPPrefixMutation(InfrahubMutationMixin, Mutation):
 
         ok = True
 
-        return reconciled_prefix, cls(ok=ok)
+        return reconciled_prefix, cls(ok=ok), []

--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -64,6 +64,7 @@ class InfrahubMutationMixin:
         obj = None
         mutation = None
         action = MutationAction.UNDEFINED
+        deleted: list[Node] = []
 
         if "Create" in cls.__name__:
             obj, mutation = await cls.mutate_create(info=info, branch=graphql_context.branch, data=data, **kwargs)
@@ -86,7 +87,9 @@ class InfrahubMutationMixin:
             else:
                 action = MutationAction.UPDATED
         elif "Delete" in cls.__name__:
-            obj, mutation = await cls.mutate_delete(info=info, branch=graphql_context.branch, data=data, **kwargs)
+            obj, mutation, deleted = await cls.mutate_delete(
+                info=info, branch=graphql_context.branch, data=data, **kwargs
+            )
             action = MutationAction.DELETED
         else:
             raise ValueError(
@@ -124,17 +127,33 @@ class InfrahubMutationMixin:
 
             events = [main_event]
 
-            for node_changelog in node_changelogs:
+            deleted_changelogs = [node.node_changelog for node in deleted if node.id != obj.id]
+            deleted_ids = [node.node_id for node in deleted_changelogs]
+
+            for node_changelog in deleted_changelogs:
                 meta = EventMeta.from_parent(parent=main_event)
                 event = NodeMutatedEvent(
                     kind=node_changelog.node_kind,
                     node_id=node_changelog.node_id,
                     data=node_changelog,
-                    action=MutationAction.UPDATED,
+                    action=MutationAction.DELETED,
                     fields=node_changelog.updated_fields,
                     meta=meta,
                 )
                 events.append(event)
+
+            for node_changelog in node_changelogs:
+                if node_changelog.node_id not in deleted_ids:
+                    meta = EventMeta.from_parent(parent=main_event)
+                    event = NodeMutatedEvent(
+                        kind=node_changelog.node_kind,
+                        node_id=node_changelog.node_id,
+                        data=node_changelog,
+                        action=MutationAction.UPDATED,
+                        fields=node_changelog.updated_fields,
+                        meta=meta,
+                    )
+                    events.append(event)
 
             for event in events:
                 graphql_context.background.add_task(graphql_context.active_service.event.send, event)
@@ -494,7 +513,7 @@ class InfrahubMutationMixin:
         info: GraphQLResolveInfo,
         data: InputObjectType,
         branch: Branch,
-    ) -> tuple[Node, Self]:
+    ) -> tuple[Node, Self, list[Node]]:
         graphql_context: GraphqlContext = info.context
 
         obj = await NodeManager.find_object(
@@ -512,7 +531,7 @@ class InfrahubMutationMixin:
 
         ok = True
 
-        return obj, cls(ok=ok)
+        return obj, cls(ok=ok), deleted
 
 
 class InfrahubMutation(InfrahubMutationMixin, Mutation):

--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Union
 
 from graphene import InputObjectType, Mutation
@@ -49,6 +50,13 @@ log = get_logger()
 KINDS_CONCURRENT_MUTATIONS_NOT_ALLOWED = [InfrahubKind.GENERICGROUP]
 
 
+@dataclass
+class DeleteResult:
+    node: Node
+    mutation: InfrahubMutationMixin
+    deleted_nodes: list[Node] = field(default_factory=list)
+
+
 # ------------------------------------------
 # Infrahub GraphQLType
 # ------------------------------------------
@@ -64,7 +72,7 @@ class InfrahubMutationMixin:
         obj = None
         mutation = None
         action = MutationAction.UNDEFINED
-        deleted: list[Node] = []
+        deleted_nodes: list[Node] = []
 
         if "Create" in cls.__name__:
             obj, mutation = await cls.mutate_create(info=info, branch=graphql_context.branch, data=data, **kwargs)
@@ -87,9 +95,11 @@ class InfrahubMutationMixin:
             else:
                 action = MutationAction.UPDATED
         elif "Delete" in cls.__name__:
-            obj, mutation, deleted = await cls.mutate_delete(
-                info=info, branch=graphql_context.branch, data=data, **kwargs
-            )
+            delete_result = await cls.mutate_delete(info=info, branch=graphql_context.branch, data=data, **kwargs)
+            obj = delete_result.node
+            mutation = delete_result.mutation
+            deleted_nodes = delete_result.deleted_nodes
+
             action = MutationAction.DELETED
         else:
             raise ValueError(
@@ -127,8 +137,8 @@ class InfrahubMutationMixin:
 
             events = [main_event]
 
-            deleted_changelogs = [node.node_changelog for node in deleted if node.id != obj.id]
-            deleted_ids = [node.node_id for node in deleted_changelogs]
+            deleted_changelogs = [node.node_changelog for node in deleted_nodes if node.id != obj.id]
+            deleted_ids = {node.node_id for node in deleted_changelogs}
 
             for node_changelog in deleted_changelogs:
                 meta = EventMeta.from_parent(parent=main_event)
@@ -448,9 +458,9 @@ class InfrahubMutationMixin:
         await node_constraint_runner.check(node=obj, field_filters=fields_to_validate)
 
         fields = list(data.keys())
-        for field in ("id", "hfid"):
-            if field in fields:
-                fields.remove(field)
+        for field_to_remove in ("id", "hfid"):
+            if field_to_remove in fields:
+                fields.remove(field_to_remove)
 
         await obj.save(db=db, fields=fields)
 
@@ -513,7 +523,7 @@ class InfrahubMutationMixin:
         info: GraphQLResolveInfo,
         data: InputObjectType,
         branch: Branch,
-    ) -> tuple[Node, Self, list[Node]]:
+    ) -> DeleteResult:
         graphql_context: GraphqlContext = info.context
 
         obj = await NodeManager.find_object(
@@ -531,7 +541,7 @@ class InfrahubMutationMixin:
 
         ok = True
 
-        return obj, cls(ok=ok), deleted
+        return DeleteResult(node=obj, mutation=cls(ok=ok), deleted_nodes=deleted)
 
 
 class InfrahubMutation(InfrahubMutationMixin, Mutation):

--- a/backend/infrahub/graphql/mutations/menu.py
+++ b/backend/infrahub/graphql/mutations/menu.py
@@ -89,7 +89,7 @@ class InfrahubCoreMenuMutation(InfrahubMutationMixin, Mutation):
         info: GraphQLResolveInfo,
         data: InputObjectType,
         branch: Branch,
-    ) -> tuple[Node, Self]:
+    ) -> tuple[Node, Self, list[Node]]:
         graphql_context: GraphqlContext = info.context
         obj = await NodeManager.find_object(
             db=graphql_context.db, kind=CoreMenuItem, id=data.get("id"), hfid=data.get("hfid"), branch=branch

--- a/backend/infrahub/graphql/mutations/menu.py
+++ b/backend/infrahub/graphql/mutations/menu.py
@@ -14,7 +14,7 @@ from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import ValidationError
 from infrahub.graphql.mutations.main import InfrahubMutationMixin
 
-from .main import InfrahubMutationOptions
+from .main import DeleteResult, InfrahubMutationOptions
 
 if TYPE_CHECKING:
     from infrahub.graphql.initialization import GraphqlContext
@@ -89,7 +89,7 @@ class InfrahubCoreMenuMutation(InfrahubMutationMixin, Mutation):
         info: GraphQLResolveInfo,
         data: InputObjectType,
         branch: Branch,
-    ) -> tuple[Node, Self, list[Node]]:
+    ) -> DeleteResult:
         graphql_context: GraphqlContext = info.context
         obj = await NodeManager.find_object(
             db=graphql_context.db, kind=CoreMenuItem, id=data.get("id"), hfid=data.get("hfid"), branch=branch

--- a/backend/tests/unit/graphql/test_mutation_delete.py
+++ b/backend/tests/unit/graphql/test_mutation_delete.py
@@ -1,7 +1,16 @@
+from infrahub.auth import AccountSession
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.constants import MutationAction, RelationshipDeleteBehavior
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
+from infrahub.events.models import ParentEvent
+from infrahub.events.node_action import NodeMutatedEvent
 from infrahub.graphql.initialization import prepare_graphql_params
+from infrahub.services import InfrahubServices
+from tests.adapters.event import MemoryInfrahubEvent
 from tests.helpers.graphql import graphql
 
 
@@ -36,6 +45,7 @@ async def test_delete_object(db: InfrahubDatabase, default_branch, car_person_sc
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestPersonDelete"]["ok"] is True
 
     assert not await NodeManager.get_one(db=db, id=obj1.id)
@@ -70,6 +80,7 @@ async def test_delete_prevented(
         f"It is linked to mandatory relationship owner on node TestCar '{car_camry_main.id}'"
         in result.errors[0].message
     )
+    assert result.data
     assert result.data["TestPersonDelete"] is None
 
     assert await NodeManager.get_one(db=db, id=person_jane_main.id) is not None
@@ -109,6 +120,7 @@ async def test_delete_allowed_when_peer_rel_optional_on_generic(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestPersonDelete"]["ok"] is True
 
     updated_dog1 = await NodeManager.get_one(db=db, id=dog1.id)
@@ -151,3 +163,68 @@ async def test_delete_prevented_when_peer_rel_required_on_generic(
     assert result.errors
     assert len(result.errors) == 1
     assert expected_error_message in result.errors[0].message
+
+
+async def test_delete_events_with_cascade(
+    db,
+    default_branch: Branch,
+    dependent_generics_schema: SchemaBranch,
+    enable_broker_config: None,
+    session_first_account: AccountSession,
+) -> None:
+    # set TestPerson.animals to be cascade delete
+    schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+    for schema_kind in ("TestPerson", "TestHuman", "TestCylon"):
+        schema = schema_branch.get(name=schema_kind, duplicate=False)
+        schema.get_relationship("animals").on_delete = RelationshipDeleteBehavior.CASCADE
+
+    human = await Node.init(db=db, schema="TestHuman", branch=default_branch)
+    await human.new(db=db, name="Jane", height=180)
+    await human.save(db=db)
+    dog = await Node.init(db=db, schema="TestDog", branch=default_branch)
+    await dog.new(db=db, name="Roofus", breed="whocares", weight=50, owner=human)
+    await dog.save(db=db)
+
+    memory_event = MemoryInfrahubEvent()
+    service = await InfrahubServices.new(event=memory_event)
+    gql_params = await prepare_graphql_params(
+        db=db, include_subscription=False, branch=default_branch, service=service, account_session=session_first_account
+    )
+    query = """
+    mutation DeletePerson($human_id: String!){
+        TestHumanDelete(data: {id: $human_id}) {
+            ok
+        }
+    }
+    """
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"human_id": human.id},
+    )
+
+    assert not result.errors
+
+    node_map = await NodeManager.get_many(db=db, ids=[human.id, dog.id])
+    assert node_map == {}
+
+    assert gql_params.context.background
+    await gql_params.context.background()
+    assert len(memory_event.events) == 2
+    primary = memory_event.events[0]
+    secondary = memory_event.events[1]
+    assert isinstance(primary, NodeMutatedEvent)
+    assert isinstance(secondary, NodeMutatedEvent)
+    assert primary.kind == "TestHuman"
+    assert primary.node_id == human.id
+    assert primary.action == MutationAction.DELETED
+    assert primary.meta.has_children
+
+    assert secondary.kind == "TestDog"
+    assert secondary.node_id == dog.id
+    assert secondary.action == MutationAction.DELETED
+    assert not secondary.meta.has_children
+    assert secondary.meta.parent == primary.meta.id
+    assert secondary.meta.ancestors == [ParentEvent(id=primary.get_id(), name=primary.get_name())]


### PR DESCRIPTION
Changes:

* Send node mutations for nodes impacted by cascade delete operations.