### PR TITLE
Clean up error logging on validation errors

### DIFF
--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -336,7 +336,7 @@ class InfrahubMutationMixin:
                             data=data,
                         )
         except ValidationError as exc:
-            raise ValueError(str(exc)) from exc
+            raise ValidationError(input_value=str(exc)) from exc
 
         if await cls._get_profile_ids(db=db, obj=obj):
             obj = await cls._refresh_for_profile_update(db=db, branch=branch, obj=obj)


### PR DESCRIPTION
This PR cleans up some log entries that we can see for various validation errors. Such as when you try to create a node and the creation violates a uniqueness constraint. Currently the user will be reported of the error but we also get an unhandled error in the server logs that looks something like this:

```python
2025-02-24T15:48:56.065244Z [critical ] Unhandled exception occurred in resolvers [infrahub.graphql] app=infrahub.api request_id=739dabe630af40d0bed8bff171468d71 worker=93e9add6-88ca-48fb-ae28-16869c11b0a1
Traceback (most recent call last):
  File "/Users/patrick/Code/opsmill/infrahub/backend/infrahub/graphql/mutations/main.py", line 326, in mutate_create_object
    await node_constraint_runner.check(node=obj, field_filters=fields_to_validate)
  File "/Users/patrick/Code/opsmill/infrahub/backend/infrahub/core/constraint/node/runner.py", line 31, in check
    await node_constraint.check(node, filters=field_filters)
  File "/Users/patrick/Code/opsmill/infrahub/backend/infrahub/core/node/constraints/grouped_uniqueness.py", line 188, in check
    await self._check_one_schema(node=node, node_schema=schema, at=at, filters=filters)
  File "/Users/patrick/Code/opsmill/infrahub/backend/infrahub/core/node/constraints/grouped_uniqueness.py", line 177, in _check_one_schema
    await self._check_results(updated_node=node, path_groups=path_groups, query_results=query.get_results())
  File "/Users/patrick/Code/opsmill/infrahub/backend/infrahub/core/node/constraints/grouped_uniqueness.py", line 155, in _check_results
    self._check_one_constraint_group(
  File "/Users/patrick/Code/opsmill/infrahub/backend/infrahub/core/node/constraints/grouped_uniqueness.py", line 140, in _check_one_constraint_group
    raise ValidationError(errors)
infrahub.exceptions.ValidationError: Violates uniqueness constraint 'name' at name

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/patrick/.virtualenvs/infrahub/lib/python3.12/site-packages/graphql/execution/execute.py", line 530, in await_result
    return_type, field_nodes, info, path, await result
                                          ^^^^^^^^^^^^
  File "/Users/patrick/Code/opsmill/infrahub/backend/infrahub/graphql/mutations/main.py", line 69, in mutate
    obj, mutation = await cls.mutate_create(info=info, branch=graphql_context.branch, data=data, **kwargs)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/Code/opsmill/infrahub/backend/infrahub/graphql/mutations/main.py", line 285, in mutate_create
    obj = await cls._call_mutate_create_object(data=data, db=db, branch=branch)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/Code/opsmill/infrahub/backend/infrahub/graphql/mutations/main.py", line 182, in _call_mutate_create_object
    return await cls.mutate_create_object(data=data, db=db, branch=branch)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/Code/opsmill/infrahub/backend/infrahub/database/__init__.py", line 511, in wrapper
    return await func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/Code/opsmill/infrahub/backend/infrahub/graphql/mutations/main.py", line 340, in mutate_create_object
    raise ValueError(str(exc)) from exc
ValueError: Violates uniqueness constraint 'name' at name
^C16:49:19.496 | INFO    | uvicorn.error - Shutting down
16:49:19.600 | INFO    | uvicorn.error - Waiting for application shutdown.
16:49:19.608 | INFO    | uvicorn.error - Application shutdown complete.
16:49:19.608 | INFO    | uvicorn.error - Finished server process [37877]
```

It's because we're taking a our own custom error and reraising it as a generic Python error that isn't handled in the same way. This currently adds extra noise in the e2e tests. A violation like this should be treated as a user error.