### PR TITLE
fix error in peer count query

### DIFF
--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -583,6 +583,7 @@ class RelationshipGetPeerQuery(Query):
         query = """
         MATCH (source_node:Node)%(arrow_left_start)s[:IS_RELATED]%(arrow_left_end)s(rl:Relationship { name: $rel_identifier })
         WHERE source_node.uuid IN $source_ids
+        WITH DISTINCT source_node, rl
         CALL {
             WITH rl, source_node
             MATCH path = (source_node)%(path)s(peer:Node)
@@ -659,10 +660,23 @@ class RelationshipGetPeerQuery(Query):
         # QUERY Properties
         # ----------------------------------------------------------------------------
         query = """
-        MATCH (rl)-[rel_is_visible:IS_VISIBLE]-(is_visible)
-        MATCH (rl)-[rel_is_protected:IS_PROTECTED]-(is_protected)
-        WHERE all(r IN [ rel_is_visible, rel_is_protected] WHERE (%s))
-        """ % (branch_filter,)
+        CALL {
+            WITH rl
+            MATCH (rl)-[r:IS_VISIBLE]-(is_visible)
+            WHERE %(branch_filter)s
+            RETURN r AS rel_is_visible, is_visible
+            ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+            LIMIT 1
+        }
+        CALL {
+            WITH rl
+            MATCH (rl)-[r:IS_PROTECTED]-(is_protected)
+            WHERE %(branch_filter)s
+            RETURN r AS rel_is_protected, is_protected
+            ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+            LIMIT 1
+        }
+        """ % {"branch_filter": branch_filter}
 
         self.add_to_query(query)
 
@@ -672,19 +686,23 @@ class RelationshipGetPeerQuery(Query):
         # We must query them one by one otherwise the second one won't return
         for node_prop in ["source", "owner"]:
             query = """
-            WITH %s
-            OPTIONAL MATCH (rl)-[rel_%s:HAS_%s]-(%s)
-            WHERE all(r IN [ rel_%s ] WHERE (%s))
-            """ % (
-                ",".join(self.return_labels),
-                node_prop,
-                node_prop.upper(),
-                node_prop,
-                node_prop,
-                branch_filter,
-            )
+        CALL {
+            WITH rl
+            OPTIONAL MATCH (rl)-[r:HAS_%(node_prop_type)s]-(%(node_prop)s)
+            WHERE %(branch_filter)s
+            RETURN r AS rel_%(node_prop)s, %(node_prop)s
+            ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+            LIMIT 1
+        }
+            """ % {
+                "node_prop": node_prop,
+                "node_prop_type": node_prop.upper(),
+                "branch_filter": branch_filter,
+            }
             self.add_to_query(query)
             self.update_return_labels([f"rel_{node_prop}", node_prop])
+
+        self.add_to_query("WITH " + ",".join(self.return_labels))
 
         # ----------------------------------------------------------------------------
         # ORDER Results

--- a/backend/tests/unit/core/diff/test_diff_and_merge.py
+++ b/backend/tests/unit/core/diff/test_diff_and_merge.py
@@ -301,6 +301,8 @@ class TestDiffAndMerge:
         car_camry_main: Node,
         conflict_selection: ConflictSelection,
     ):
+        person_schema = db.schema.get(name="TestPerson", duplicate=False)
+        cars_rel_schema = person_schema.get_relationship(name="cars")
         branch2 = await create_branch(db=db, branch_name="branch2")
         car_main = await NodeManager.get_one(db=db, id=car_accord_main.id)
         await car_main.owner.update(db=db, data={"id": person_john_main.id, "_relation__owner": person_alfred_main.id})
@@ -332,6 +334,16 @@ class TestDiffAndMerge:
             assert owner_prop.id == person_alfred_main.id
         if conflict_selection is ConflictSelection.DIFF_BRANCH:
             assert owner_prop.id == person_jane_main.id
+
+        john_car_count = await NodeManager.count_peers(
+            db=db,
+            ids=[person_john_main.id],
+            source_kind="TestPerson",
+            filters={},
+            schema=cars_rel_schema,
+            branch=branch2,
+        )
+        assert john_car_count == 1
 
         await diff_merger.rollback(at=at)
 
@@ -615,6 +627,8 @@ class TestDiffAndMerge:
         car_accord_main,
         car_camry_main,
     ):
+        person_schema = db.schema.get(name="TestPerson", duplicate=False)
+        cars_rel_schema = person_schema.get_relationship(name="cars")
         branch2 = await create_branch(db=db, branch_name="branch2")
         car_branch = await NodeManager.get_one(db=db, branch=branch2, id=car_accord_main.id)
         await car_branch.owner.update(db=db, data={"id": person_john_main.id, "_relation__is_protected": True})
@@ -639,6 +653,16 @@ class TestDiffAndMerge:
         assert owner_rel.peer_id == person_john_main.id
         assert owner_rel.is_protected is True
         assert owner_rel.is_visible is False
+
+        john_car_count = await NodeManager.count_peers(
+            db=db,
+            ids=[person_john_main.id],
+            source_kind="TestPerson",
+            filters={},
+            schema=cars_rel_schema,
+            branch=branch2,
+        )
+        assert john_car_count == 1
 
         await diff_merger.rollback(at=at)
 

--- a/changelog/+peer-count.fixed.md
+++ b/changelog/+peer-count.fixed.md
@@ -1,0 +1,1 @@
+Fix error in query to count the number of peers for a given cardinality-many relationship logic that could result in the count being multiplied by a power of 2 if changes were made to the relationship during a merge


### PR DESCRIPTION
IFC-1276

the query to count the number of peers of a given node on a given relationship can be incorrectly multiplied following a merge

the `RelationshipGetPeerQuery` can double- (or triple- or quadruple-) count relationships if the relationship or any of its properties were updated during a merge. these changes fix the error, but add more subqueries that could affect performance