### PR TITLE
Add back branch name to node mutation event resource

### DIFF
--- a/backend/infrahub/events/node_action.py
+++ b/backend/infrahub/events/node_action.py
@@ -77,6 +77,7 @@ class NodeMutatedEvent(InfrahubEvent):
             "infrahub.node.id": self.node_id,
             "infrahub.node.action": self.action.value,
             "infrahub.node.root_id": self.data.root_node_id,
+            "infrahub.branch.name": self.meta.context.branch.name,
         }
 
     def get_payload(self) -> dict[str, Any]:


### PR DESCRIPTION
This is a quickfix for an issue I noticed while looking for something else. I've opened IFC-1277 to indicate that we should add an additional test around this to ensure that we don't run into the same problem again.

The issue was that when we try to refer to a resource within prefect that doesn't exist the data gets sent as an empty string which was now the case for the branch name. So any branch within infrahub was returned as an empty string (which worked fine for the default branch but not others). As the type validator for the parameters is perfectly fine using an empty string this wasn't spotted earlier.