### PR TITLE
Add missing context parameter

### DIFF
--- a/backend/infrahub/computed_attribute/tasks.py
+++ b/backend/infrahub/computed_attribute/tasks.py
@@ -692,6 +692,7 @@ async def computed_attribute_setup_python(
 )
 async def computed_attribute_remove_python(
     branch_name: str,
+    context: InfrahubContext,  # noqa: ARG001
 ) -> None:
     async with get_client(sync_client=False) as client:
         automations = await client.read_automations()


### PR DESCRIPTION
The `context` parameter is missing for the flow to remove transform based computed attributes automations. So when deleting a branch we'd see this in the logs:

```python
2025-02-24T15:08:51.357010Z [error    ] Failed to submit flow run '57b26917-41a9-49f9-a447-d65ff14b16b6' to infrastructure. [prefect.flow_runs.worker]
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/prefect/workers/base.py", line 1011, in _submit_run_and_capture_errors
    result = await self.run(
             ^^^^^^^^^^^^^^^
  File "/source/backend/infrahub/workers/infrahub_async.py", line 153, in run
    params = flow_func.validate_parameters(parameters=flow_run.parameters)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/prefect/flows.py", line 575, in validate_parameters
    args, kwargs = parameters_to_args_kwargs(self.fn, parameters)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/prefect/utilities/callables.py", line 190, in parameters_to_args_kwargs
    raise SignatureMismatchError.from_bad_params(
prefect.exceptions.SignatureMismatchError: Function expects parameters ['branch_name'] but was provided with parameters ['context', 'branch_name']
2025-02-24T15:08:51.539508Z [info     ] Reported flow run '57b26917-41a9-49f9-a447-d65ff14b16b6' as crashed: Flow run could not be submitted to infrastructure:
SignatureMismatchError("Function expects parameters ['branch_name'] but was provided with parameters ['context', 'branch_name']") [prefect.flow_runs.worker]

```