### PR TITLE
Add ancestors to group events

### DIFF
--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -451,7 +451,7 @@ class NodeManager:
         limit: Optional[int] = None,
         at: Optional[Union[Timestamp, str]] = None,
         branch: Optional[Union[Branch, str]] = None,
-    ) -> dict[str, Any]:
+    ) -> dict[str, Node]:
         branch = await registry.get_branch(branch=branch, db=db)
         at = Timestamp(at)
 

--- a/backend/infrahub/events/group_action.py
+++ b/backend/infrahub/events/group_action.py
@@ -16,6 +16,9 @@ class GroupMutatedEvent(InfrahubEvent):
     node_id: str = Field(..., description="The ID of the updated group")
     action: MutationAction = Field(..., description="The action taken on the node")
     members: list[EventNode] = Field(default_factory=list, description="Updated members during this event.")
+    ancestors: list[EventNode] = Field(
+        default_factory=list, description="A list of groups that are ancestors of this group."
+    )
 
     def get_related(self) -> list[dict[str, str]]:
         related = super().get_related()
@@ -26,12 +29,50 @@ class GroupMutatedEvent(InfrahubEvent):
                 "infrahub.node.kind": self.kind,
             }
         )
+        related.append(
+            {
+                "prefect.resource.id": self.node_id,
+                "prefect.resource.role": "infrahub.group.update",
+                "infrahub.node.kind": self.kind,
+            }
+        )
+
         for member in self.members:
+            related.append(
+                {
+                    "prefect.resource.id": member.id,
+                    "prefect.resource.role": "infrahub.group.member",
+                    "infrahub.node.kind": member.kind,
+                }
+            )
             related.append(
                 {
                     "prefect.resource.id": member.id,
                     "prefect.resource.role": "infrahub.related.node",
                     "infrahub.node.kind": member.kind,
+                }
+            )
+
+        for ancestor in self.ancestors:
+            related.append(
+                {
+                    "prefect.resource.id": ancestor.id,
+                    "prefect.resource.role": "infrahub.group.ancestor",
+                    "infrahub.node.kind": ancestor.kind,
+                }
+            )
+            related.append(
+                {
+                    "prefect.resource.id": ancestor.id,
+                    "prefect.resource.role": "infrahub.related.node",
+                    "infrahub.node.kind": ancestor.kind,
+                }
+            )
+            related.append(
+                {
+                    "prefect.resource.id": ancestor.id,
+                    "prefect.resource.role": "infrahub.group.update",
+                    "infrahub.node.kind": ancestor.kind,
                 }
             )
 
@@ -51,7 +92,10 @@ class GroupMutatedEvent(InfrahubEvent):
         }
 
     def get_payload(self) -> dict[str, Any]:
-        return {"members": [member.model_dump() for member in self.members]}
+        return {
+            "ancestors": [ancestor.model_dump() for ancestor in self.ancestors],
+            "members": [member.model_dump() for member in self.members],
+        }
 
     def get_messages(self) -> list[InfrahubMessage]:
         return []

--- a/backend/infrahub/graphql/mutations/relationship.py
+++ b/backend/infrahub/graphql/mutations/relationship.py
@@ -15,6 +15,7 @@ from infrahub.core.constants import (
     PermissionAction,
     PermissionDecision,
     RelationshipCardinality,
+    RelationshipHierarchyDirection,
 )
 from infrahub.core.manager import NodeManager
 from infrahub.core.query.node import NodeGetKindQuery
@@ -23,6 +24,7 @@ from infrahub.core.query.relationship import (
     RelationshipPeerData,
 )
 from infrahub.core.relationship import Relationship
+from infrahub.core.schema import NodeSchema
 from infrahub.database import retry_db_transaction
 from infrahub.events import EventMeta, NodeMutatedEvent
 from infrahub.events.group_action import GroupMemberAddedEvent, GroupMemberRemovedEvent
@@ -89,6 +91,10 @@ class RelationshipAdd(Mutation):
 
         existing_peers = await _collect_current_peers(info=info, data=data, source_node=source)
 
+        group_event_type = _get_group_event_type(
+            node=source, relationship_schema=rel_schema, relationship_name=relationship_name
+        )
+
         async with graphql_context.db.start_transaction() as db:
             peers: list[EventNode] = []
             for node_data in data.get("nodes"):
@@ -99,19 +105,19 @@ class RelationshipAdd(Mutation):
                 await rel.resolve(db=db)
                 # Save it only if it does not exist
                 if rel.get_peer_id() not in existing_peers.keys():
-                    peers.append(EventNode(id=rel.get_peer_id(), kind=rel.get_peer_kind()))
+                    if group_event_type != GroupUpdateType.NONE:
+                        peers.append(EventNode(id=rel.get_peer_id(), kind=nodes[rel.get_peer_id()].get_kind()))
                     node_changelog.create_relationship(relationship=rel)
                     await rel.save(db=db)
 
         if config.SETTINGS.broker.enable and graphql_context.background and node_changelog.has_changes:
-            group_event_type = _get_group_event_type(
-                node=source, relationship_schema=rel_schema, relationship_name=relationship_name
-            )
             if group_event_type == GroupUpdateType.MEMBERS:
+                ancestors = await _collect_ancestors(info=info, node_kind=source.get_schema().kind, node_id=source.id)
                 group_add_event = GroupMemberAddedEvent(
                     node_id=source.id,
                     kind=source.get_schema().kind,
                     members=peers,
+                    ancestors=ancestors,
                     meta=EventMeta(branch=graphql_context.branch, context=graphql_context.get_context()),
                 )
                 graphql_context.background.add_task(graphql_context.active_service.event.send, group_add_event)
@@ -124,9 +130,11 @@ class RelationshipAdd(Mutation):
                     node_kind_map = await node_kind_query.get_node_kind_map()
 
                     for node_id, node_kind in node_kind_map.items():
+                        ancestors = await _collect_ancestors(info=info, node_kind=node_kind, node_id=node_id)
                         group_add_event = GroupMemberAddedEvent(
                             node_id=node_id,
                             kind=node_kind,
+                            ancestors=ancestors,
                             members=[EventNode(id=source.get_id(), kind=source.get_kind())],
                             meta=EventMeta(branch=graphql_context.branch, context=graphql_context.get_context()),
                         )
@@ -175,6 +183,9 @@ class RelationshipRemove(Mutation):
         )
 
         existing_peers = await _collect_current_peers(info=info, data=data, source_node=source)
+        group_event_type = _get_group_event_type(
+            node=source, relationship_schema=rel_schema, relationship_name=relationship_name
+        )
 
         async with graphql_context.db.start_transaction() as db:
             peers: list[EventNode] = []
@@ -186,19 +197,19 @@ class RelationshipRemove(Mutation):
                     # it would be more query efficient
                     rel = Relationship(schema=rel_schema, branch=graphql_context.branch, node=source)
                     await rel.load(db=db, data=existing_peers[node_data.get("id")])
-                    peers.append(EventNode(id=rel.get_peer_id(), kind=rel.get_peer_kind()))
+                    if group_event_type != GroupUpdateType.NONE:
+                        peers.append(EventNode(id=rel.get_peer_id(), kind=nodes[rel.get_peer_id()].get_kind()))
                     node_changelog.delete_relationship(relationship=rel)
                     await rel.delete(db=db)
 
         if config.SETTINGS.broker.enable and graphql_context.background and node_changelog.has_changes:
-            group_event_type = _get_group_event_type(
-                node=source, relationship_schema=rel_schema, relationship_name=relationship_name
-            )
             if group_event_type == GroupUpdateType.MEMBERS:
+                ancestors = await _collect_ancestors(info=info, node_kind=source.get_schema().kind, node_id=source.id)
                 group_remove_event = GroupMemberRemovedEvent(
                     node_id=source.id,
                     kind=source.get_schema().kind,
                     members=peers,
+                    ancestors=ancestors,
                     meta=EventMeta(branch=graphql_context.branch, context=graphql_context.get_context()),
                 )
                 graphql_context.background.add_task(graphql_context.active_service.event.send, group_remove_event)
@@ -210,6 +221,7 @@ class RelationshipRemove(Mutation):
                     node_kind_map = await node_kind_query.get_node_kind_map()
 
                     for node_id, node_kind in node_kind_map.items():
+                        ancestors = await _collect_ancestors(info=info, node_kind=node_kind, node_id=node_id)
                         group_remove_event = GroupMemberRemovedEvent(
                             node_id=node_id,
                             kind=node_kind,
@@ -330,6 +342,24 @@ async def _validate_peer_types(
                     raise ValidationError(
                         f"{node_id!r} {node.get_kind()!r} is already related to another peer on '{peer_relationships[0].name}'"
                     )
+
+
+async def _collect_ancestors(info: GraphQLResolveInfo, node_kind: str, node_id: str) -> list[EventNode]:
+    graphql_context: GraphqlContext = info.context
+    schema = graphql_context.db.schema.get(name=node_kind, branch=graphql_context.branch)
+
+    if not isinstance(schema, NodeSchema):
+        return []
+
+    ancestors = await NodeManager.query_hierarchy(
+        db=graphql_context.db,
+        branch=graphql_context.branch,
+        direction=RelationshipHierarchyDirection.ANCESTORS,
+        id=node_id,
+        node_schema=schema,
+        filters={"id": None},
+    )
+    return [EventNode(id=ancestor.get_id(), kind=ancestor.get_kind()) for ancestor in ancestors.values()]
 
 
 async def _collect_current_peers(

--- a/backend/infrahub/graphql/types/event.py
+++ b/backend/infrahub/graphql/types/event.py
@@ -113,6 +113,14 @@ class NodeMutatedEvent(ObjectType):
     attributes = Field(List(of_type=NonNull(InfrahubMutatedAttribute), required=True), required=True)
 
 
+class GroupEvent(ObjectType):
+    class Meta:
+        interfaces = (EventNodeInterface,)
+
+    members = List(NonNull(RelatedNode), required=True, description="Group members modified in this event")
+    ancestors = List(NonNull(RelatedNode), required=True, description="Ancestor groups of this impacted group")
+
+
 class StandardEvent(ObjectType):
     class Meta:
         interfaces = (EventNodeInterface,)
@@ -128,5 +136,7 @@ EVENT_TYPES: dict[str, type[ObjectType]] = {
     "infrahub.branch.merged": BranchMergedEvent,
     "infrahub.branch.rebased": BranchRebasedEvent,
     "infrahub.branch.deleted": BranchDeletedEvent,
+    "infrahub.group.member_added": GroupEvent,
+    "infrahub.group.member_removed": GroupEvent,
     "undefined": StandardEvent,
 }

--- a/backend/infrahub/task_manager/event.py
+++ b/backend/infrahub/task_manager/event.py
@@ -125,21 +125,38 @@ class PrefectEventData(PrefectEventModel):
     def _return_branch_rebased(self) -> dict[str, Any]:
         return {"rebased_branch": self._get_branch_name_from_resource()}
 
+    def _return_group_event(self) -> dict[str, Any]:
+        members = []
+        ancestors = []
+
+        for resource in self.related:
+            if resource.role == "infrahub.group.member" and resource.get("infrahub.node.kind"):
+                members.append({"id": resource.id, "kind": resource.get("infrahub.node.kind")})
+            elif resource.role == "infrahub.group.ancestor" and resource.get("infrahub.node.kind"):
+                ancestors.append({"id": resource.id, "kind": resource.get("infrahub.node.kind")})
+
+        return {"members": members, "ancestors": ancestors}
+
     def _return_event_specifics(self) -> dict[str, Any]:
         """Return event specific data based on the type of event being processed"""
+
+        event_specifics = {}
+
         match self.event:
             case "infrahub.node.created" | "infrahub.node.updated" | "infrahub.node.deleted":
-                return self._return_node_mutation()
+                event_specifics = self._return_node_mutation()
             case "infrahub.branch.created":
-                return self._return_branch_created()
+                event_specifics = self._return_branch_created()
             case "infrahub.branch.deleted":
-                return self._return_branch_deleted()
+                event_specifics = self._return_branch_deleted()
             case "infrahub.branch.merged":
-                return self._return_branch_merged()
+                event_specifics = self._return_branch_merged()
             case "infrahub.branch.rebased":
-                return self._return_branch_rebased()
+                event_specifics = self._return_branch_rebased()
+            case "infrahub.group.member_added" | "infrahub.group.member_removed":
+                event_specifics = self._return_group_event()
 
-        return {}
+        return event_specifics
 
     def to_graphql(self) -> dict[str, Any]:
         response = {

--- a/backend/tests/unit/graphql/queries/test_event.py
+++ b/backend/tests/unit/graphql/queries/test_event.py
@@ -14,7 +14,8 @@ from infrahub.core.node import Node
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
 from infrahub.events.branch_action import BranchCreatedEvent, BranchRebasedEvent
-from infrahub.events.models import EventMeta, InfrahubEvent
+from infrahub.events.group_action import GroupMemberAddedEvent
+from infrahub.events.models import EventMeta, EventNode, InfrahubEvent
 from infrahub.events.node_action import NodeMutatedEvent
 from infrahub.graphql.initialization import prepare_graphql_params
 from tests.helpers.events import send_events
@@ -56,6 +57,16 @@ query(
         related_nodes {
             id
             kind
+        }
+        ... on GroupEvent {
+          ancestors {
+            id
+            kind
+          }
+          members {
+            id
+            kind
+          }
         }
       }
     }
@@ -176,6 +187,14 @@ async def events_data(
     await car.new(db=db, name="Volvo", nbr_seats=5, is_electric=False, owner=person1.id)
     await car.save(db=db)
 
+    group_fr = await Node.init(db=db, schema="CoreStandardGroup", branch=default_branch)
+    await group_fr.new(db=db, name="France", members=[person1, person2])
+    await group_fr.save(db=db)
+
+    group_eu = await Node.init(db=db, schema="CoreStandardGroup", branch=default_branch)
+    await group_eu.new(db=db, name="Europe", children=[group_fr])
+    await group_eu.save(db=db)
+
     branch1 = Branch(uuid=branch1_id, name="branch1")
     branch2 = Branch(uuid=branch2_id, name="branch2")
     branch3 = Branch(uuid=branch3_id, name="branch3")
@@ -247,6 +266,31 @@ async def events_data(
             node_id=tag3.get_id(),
             action=MutationAction.CREATED,
             data=tag3.node_changelog,
+            meta=EventMeta(
+                branch=branch1,
+                account_id=ACCOUNT2_ID,
+                context=InfrahubContext.init(branch=branch1, account=ACCOUNT_SESSION_2),
+            ),
+        ),
+        "branch1_mutated5": NodeMutatedEvent(
+            kind=group_eu.get_kind(),
+            node_id=group_eu.get_id(),
+            action=MutationAction.CREATED,
+            data=group_eu.node_changelog,
+            meta=EventMeta(
+                branch=branch1,
+                account_id=ACCOUNT2_ID,
+                context=InfrahubContext.init(branch=branch1, account=ACCOUNT_SESSION_2),
+            ),
+        ),
+        "branch1_mutated6": GroupMemberAddedEvent(
+            kind=group_fr.get_kind(),
+            node_id=group_fr.get_id(),
+            members=[
+                EventNode(id=person1.get_id(), kind=person1.get_kind()),
+                EventNode(id=person2.get_id(), kind=person2.get_kind()),
+            ],
+            ancestors=[EventNode(id=group_eu.get_id(), kind=group_eu.get_kind())],
             meta=EventMeta(
                 branch=branch1,
                 account_id=ACCOUNT2_ID,
@@ -382,7 +426,7 @@ async def test_event_query_prefect(
     assert result_branch1.data
 
     clean_result = filter_outofscope_events(result_branch1.data, event_ids_inscope)
-    assert clean_result["InfrahubEvent"]["count"] == 6
+    assert clean_result["InfrahubEvent"]["count"] == 8
 
     result_count_branch1 = await run_query(
         db=db,
@@ -454,7 +498,7 @@ async def test_event_query_prefect(
     )
     assert branch1_account2.errors is None
     assert branch1_account2.data
-    assert branch1_account2.data["InfrahubEvent"]["count"] == 1
+    assert branch1_account2.data["InfrahubEvent"]["count"] == 3
 
     branch2_account1 = await run_query(
         db=db,
@@ -553,10 +597,10 @@ async def test_event_query_prefect(
     )
     assert created_branch1.errors is None
     assert created_branch1.data
-    assert created_branch1.data["InfrahubEvent"]["count"] == 9
+    assert created_branch1.data["InfrahubEvent"]["count"] == 10
     assert [node["node"]["event"] for node in created_branch1.data["InfrahubEvent"]["edges"]] == [
         "infrahub.node.created"
-    ] * 9
+    ] * 10
 
     all_branch1 = await run_query(
         db=db,
@@ -578,3 +622,20 @@ async def test_event_query_prefect(
     assert since_timestamp.errors is None
     assert since_timestamp.data
     assert since_timestamp.data["InfrahubEvent"]["count"] == 2
+
+    group_add_event = await run_query(
+        db=db,
+        branch=default_branch,
+        query=QUERY_EVENT,
+        variables={"event_type": ["infrahub.group.member_added"], "account": ACCOUNT2_ID},
+    )
+    assert group_add_event.errors is None
+    assert group_add_event.data
+    assert group_add_event.data["InfrahubEvent"]["count"] == 1
+    members = [member["id"] for member in group_add_event.data["InfrahubEvent"]["edges"][0]["node"]["members"]]
+    ancestors = [member["id"] for member in group_add_event.data["InfrahubEvent"]["edges"][0]["node"]["ancestors"]]
+    assert len(members) == 2
+    assert len(ancestors) == 1
+    assert events_data["branch3_mutated1"].node_id in members
+    assert events_data["branch3_mutated2"].node_id in members
+    assert events_data["branch1_mutated5"].node_id in ancestors

--- a/backend/tests/unit/graphql/test_mutation_relationship.py
+++ b/backend/tests/unit/graphql/test_mutation_relationship.py
@@ -16,6 +16,7 @@ from infrahub.core.node import Node
 from infrahub.core.utils import count_relationships
 from infrahub.database import InfrahubDatabase
 from infrahub.events.group_action import GroupMemberAddedEvent, GroupMemberRemovedEvent
+from infrahub.events.models import EventNode
 from infrahub.events.node_action import NodeMutatedEvent
 from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.permissions import LocalPermissionBackend
@@ -385,7 +386,7 @@ async def test_relationship_wrong_node(
 async def test_relationship_groups_add(
     db: InfrahubDatabase,
     default_branch: Branch,
-    car_person_generics_data,
+    car_person_generics_data: dict[str, Node],
     enable_broker_config: None,
     session_first_account: AccountSession,
     first_account: Node,
@@ -424,6 +425,10 @@ async def test_relationship_groups_add(
     g2 = await Node.init(db=db, schema=InfrahubKind.STANDARDGROUP)
     await g2.new(db=db, name="group2", members=[c2, c3])
     await g2.save(db=db)
+
+    g1_root = await Node.init(db=db, schema=InfrahubKind.STANDARDGROUP)
+    await g1_root.new(db=db, name="group1_root", children=[g1])
+    await g1_root.save(db=db)
 
     query = """
     mutation {
@@ -464,8 +469,13 @@ async def test_relationship_groups_add(
     assert len(memory_event.events) == 1
     group_event = memory_event.events[0]
     assert isinstance(group_event, GroupMemberAddedEvent)
-
     assert [member.id for member in group_event.members] == [c2.id]
+    assert group_event.members == [EventNode(id=c2.id, kind=c2.get_kind())]
+    assert group_event.ancestors == [EventNode(id=g1_root.id, kind=g1_root.get_kind())]
+
+    g_root = await Node.init(db=db, schema=InfrahubKind.STANDARDGROUP)
+    await g_root.new(db=db, name="root-group", children=[g2, g1_root])
+    await g_root.save(db=db)
 
     query = """
     mutation {
@@ -515,6 +525,9 @@ async def test_relationship_groups_add(
     # group as c3 was already a member of g2 we don't see an event for that entry
     assert group_event.node_id == g1.id
     assert [member.id for member in group_event.members] == [c3.id]
+    assert len(group_event.ancestors) == 2
+    assert EventNode(id=g1_root.id, kind=g1_root.get_kind()) in group_event.ancestors
+    assert EventNode(id=g_root.id, kind=g_root.get_kind()) in group_event.ancestors
 
 
 async def test_relationship_groups_remove(
@@ -560,6 +573,10 @@ async def test_relationship_groups_remove(
     await g2.new(db=db, name="group2", members=[c2, c3])
     await g2.save(db=db)
 
+    g_root = await Node.init(db=db, schema=InfrahubKind.STANDARDGROUP)
+    await g_root.new(db=db, name="group1_root", children=[g1])
+    await g_root.save(db=db)
+
     query = """
     mutation {
         RelationshipRemove(data: {
@@ -602,6 +619,7 @@ async def test_relationship_groups_remove(
     group_event = memory_event.events[0]
     assert isinstance(group_event, GroupMemberRemovedEvent)
     assert [member.id for member in group_event.members] == [c1.id]
+    assert group_event.ancestors == [EventNode(id=g_root.id, kind=g_root.get_kind())]
 
     query = """
     mutation {
@@ -652,6 +670,7 @@ async def test_relationship_groups_remove(
     # The c3 node is not member of g1 so we only expect to see a group event for the g2 group
     assert group_event.node_id == g2.id
     assert [member.id for member in group_event.members] == [c3.id]
+    assert group_event.ancestors == []
 
 
 async def test_relationship_groups_add_remove(db: InfrahubDatabase, default_branch: Branch, car_person_generics_data):


### PR DESCRIPTION
Changes in this PR:

* Add ancestor information to group events
* Related nodes of the event will be both members and ancestors
* Using the Group specific interfaces it's possible to query specifically for members and ancestors:

```graphql
query {
  InfrahubEvent{
    count
    edges {
      node {
        id
        event
        branch
        has_children
        parent_id
        level
        occurred_at
        related_nodes {
            id
            kind
        }
        ... on GroupEvent {
          ancestors {
            id
            kind
          }
          members {
            id
            kind
          }
        }
      }
    }
  }
```

