### PR TITLE
Add artifact events

### DIFF
--- a/backend/infrahub/artifacts/models.py
+++ b/backend/infrahub/artifacts/models.py
@@ -2,6 +2,8 @@ from typing import Optional
 
 from pydantic import BaseModel, Field
 
+from infrahub.context import InfrahubContext
+
 
 class CheckArtifactCreate(BaseModel):
     """Runs a check to verify the creation of an artifact."""
@@ -17,9 +19,11 @@ class CheckArtifactCreate(BaseModel):
     repository_kind: str = Field(..., description="The kind of the Repository")
     branch_name: str = Field(..., description="The branch where the check is run")
     target_id: str = Field(..., description="The ID of the target object for this artifact")
+    target_kind: str = Field(..., description="The kind of the target object for this artifact")
     target_name: str = Field(..., description="Name of the artifact target")
     artifact_id: Optional[str] = Field(default=None, description="The id of the artifact if it previously existed")
     query: str = Field(..., description="The name of the query to use when collecting data")
     timeout: int = Field(..., description="Timeout for requests used to generate this artifact")
     variables: dict = Field(..., description="Input variables when generating the artifact")
     validator_id: str = Field(..., description="The ID of the validator")
+    context: InfrahubContext = Field(..., description="The context of the task")

--- a/backend/infrahub/artifacts/tasks.py
+++ b/backend/infrahub/artifacts/tasks.py
@@ -32,7 +32,7 @@ async def create(model: CheckArtifactCreate, service: InfrahubServices) -> Valid
             service=service,
         )
 
-    artifact = await define_artifact(model=model, service=service)
+    artifact, artifact_created = await define_artifact(model=model, service=service)
 
     severity = "info"
     artifact_result: dict[str, Union[str, bool, None]] = {
@@ -44,7 +44,7 @@ async def create(model: CheckArtifactCreate, service: InfrahubServices) -> Valid
     check_message = "Failed to render artifact"
 
     try:
-        result = await repo.render_artifact(artifact=artifact, message=model)
+        result = await repo.render_artifact(artifact=artifact, artifact_created=artifact_created, message=model)
         artifact_result["changed"] = result.changed
         artifact_result["checksum"] = result.checksum
         artifact_result["artifact_id"] = result.artifact_id

--- a/backend/infrahub/events/artifact_action.py
+++ b/backend/infrahub/events/artifact_action.py
@@ -1,0 +1,76 @@
+from typing import Any
+
+from pydantic import Field, computed_field
+
+from infrahub.message_bus import InfrahubMessage
+
+from .constants import EVENT_NAMESPACE
+from .models import InfrahubEvent
+
+
+class ArtifactEvent(InfrahubEvent):
+    """Event generated when an artifact has been created or updated."""
+
+    node_id: str = Field(..., description="The ID of the artifact")
+    artifact_definition_id: str = Field(..., description="The ID of the artifact definition")
+    target_id: str = Field(..., description="The ID of the target of the artifact")
+    target_kind: str = Field(..., description="The kind of the target of the artifact")
+    checksum: str = Field(..., description="The current checksum of the artifact")
+    checksum_previous: str | None = Field(default=None, description="The previous checksum of the artifact")
+    storage_id: str = Field(..., description="The current storage id of the artifact")
+    storage_id_previous: str | None = Field(default=None, description="The previous storage id of the artifact")
+    created: bool = Field(..., description="Indicates if the artifact was created with this event or already existed")
+
+    def get_related(self) -> list[dict[str, str]]:
+        related = super().get_related()
+        related.append(
+            {
+                "prefect.resource.id": self.target_id,
+                "prefect.resource.role": "infrahub.related.node",
+                "infrahub.node.kind": self.target_kind,
+            }
+        )
+        related.append(
+            {
+                "prefect.resource.id": self.target_id,
+                "prefect.resource.role": "infrahub.artifact",
+                "infrahub.artifact.checksum": self.checksum,
+                "infrahub.artifact.checksum_previous": self.checksum_previous or "",
+                "infrahub.artifact.storage_id": self.storage_id,
+                "infrahub.artifact.storage_id_previous": self.storage_id_previous or "",
+                "infrahub.artifact.artifact_definition_id": self.artifact_definition_id,
+            }
+        )
+
+        return related
+
+    def get_resource(self) -> dict[str, str]:
+        return {
+            "prefect.resource.id": self.node_id,
+            "infrahub.node.kind": "CoreArtifact",
+            "infrahub.node.id": self.node_id,
+            "infrahub.branch.name": self.meta.context.branch.name,
+        }
+
+    def get_payload(self) -> dict[str, Any]:
+        return {
+            "node_id": self.node_id,
+            "artifact_definition_id": self.artifact_definition_id,
+            "target_id": self.target_id,
+            "target_kind": self.target_kind,
+            "checksum": self.checksum,
+            "checksum_previous": self.checksum_previous,
+            "storage_id": self.storage_id,
+            "storage_id_previous": self.storage_id_previous,
+        }
+
+    def get_messages(self) -> list[InfrahubMessage]:
+        return []
+
+    @computed_field
+    def event_name(self) -> str:
+        match self.created:
+            case True:
+                return f"{EVENT_NAMESPACE}.artifact.created"
+            case False:
+                return f"{EVENT_NAMESPACE}.artifact.updated"

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -39,6 +39,7 @@ from typing_extensions import Self
 
 from infrahub.core.constants import ArtifactStatus, ContentType, InfrahubKind, RepositorySyncStatus
 from infrahub.core.registry import registry
+from infrahub.events.artifact_action import ArtifactEvent
 from infrahub.events.models import EventMeta
 from infrahub.events.repository_action import CommitUpdatedEvent
 from infrahub.exceptions import CheckError, RepositoryInvalidFileSystemError, TransformError
@@ -54,7 +55,7 @@ if TYPE_CHECKING:
     from infrahub_sdk.schema.repository import InfrahubRepositoryArtifactDefinitionConfig
     from infrahub_sdk.transforms import InfrahubTransform
 
-    from infrahub.core.checks.models import CheckArtifactCreate
+    from infrahub.artifacts.models import CheckArtifactCreate
     from infrahub.git.models import RequestArtifactGenerate
     from infrahub.services import InfrahubServices
 
@@ -1266,7 +1267,10 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         return ArtifactGenerateResult(changed=True, checksum=checksum, storage_id=storage_id, artifact_id=artifact.id)
 
     async def render_artifact(
-        self, artifact: CoreArtifact, message: Union[CheckArtifactCreate, RequestArtifactGenerate]
+        self,
+        artifact: CoreArtifact,
+        artifact_created: bool,
+        message: Union[CheckArtifactCreate, RequestArtifactGenerate],
     ) -> ArtifactGenerateResult:
         response = await self.sdk.query_gql_query(
             name=message.query,
@@ -1277,6 +1281,10 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
             branch_name=message.branch_name,
             timeout=message.timeout,
         )
+        branch = registry.get_branch_from_registry(branch=message.branch_name)
+
+        previous_checksum = artifact.checksum.value
+        previous_storage_id = artifact.storage_id.value
 
         if message.transform_type == InfrahubKind.TRANSFORMJINJA2:
             artifact_content = await self.render_jinja2_template.with_options(timeout_seconds=message.timeout)(
@@ -1315,4 +1323,19 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         if artifact.name.value != message.artifact_name:
             artifact.name.value = message.artifact_name
         await artifact.save()
+
+        event = ArtifactEvent(
+            node_id=artifact.id,
+            target_id=message.target_id,
+            target_kind=message.target_kind,
+            artifact_definition_id=message.artifact_definition,
+            meta=EventMeta.from_context(context=message.context, branch=branch),
+            checksum=checksum,
+            checksum_previous=previous_checksum,
+            storage_id=storage_id,
+            storage_id_previous=previous_storage_id,
+            created=artifact_created,
+        )
+
+        await self.service.event.send(event=event)
         return ArtifactGenerateResult(changed=True, checksum=checksum, storage_id=storage_id, artifact_id=artifact.id)

--- a/backend/infrahub/git/models.py
+++ b/backend/infrahub/git/models.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from infrahub.context import InfrahubContext
 from infrahub.message_bus.types import ProposedChangeBranchDiff
 
 
@@ -31,11 +32,13 @@ class RequestArtifactGenerate(BaseModel):
     repository_kind: str = Field(..., description="The kind of the Repository")
     branch_name: str = Field(..., description="The branch where the check is run")
     target_id: str = Field(..., description="The ID of the target object for this artifact")
+    target_kind: str = Field(..., description="The kind of the target object for this artifact")
     target_name: str = Field(..., description="Name of the artifact target")
     artifact_id: Optional[str] = Field(default=None, description="The id of the artifact if it previously existed")
     query: str = Field(..., description="The name of the query to use when collecting data")
     timeout: int = Field(..., description="Timeout for requests used to generate this artifact")
     variables: dict = Field(..., description="Input variables when generating the artifact")
+    context: InfrahubContext = Field(..., description="The context of the task")
 
 
 class GitRepositoryAdd(BaseModel):

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -272,10 +272,10 @@ async def generate_artifact(model: RequestArtifactGenerate, service: InfrahubSer
         commit=model.commit,
     )
 
-    artifact = await define_artifact(model=model, service=service)
+    artifact, artifact_created = await define_artifact(model=model, service=service)
 
     try:
-        result = await repo.render_artifact(artifact=artifact, message=model)
+        result = await repo.render_artifact(artifact=artifact, artifact_created=artifact_created, message=model)
         log.debug(
             f"Generated artifact | changed: {result.changed} | {result.checksum} | {result.storage_id}",
         )
@@ -358,7 +358,9 @@ async def generate_request_artifact_definition(
             variables=member.extract(params=artifact_definition.parameters.value),
             target_id=member.id,
             target_name=member.display_label,
+            target_kind=member.get_kind(),
             timeout=transform.timeout.value,
+            context=context,
         )
 
         await service.workflow.submit_workflow(

--- a/backend/infrahub/graphql/types/event.py
+++ b/backend/infrahub/graphql/types/event.py
@@ -113,6 +113,17 @@ class NodeMutatedEvent(ObjectType):
     attributes = Field(List(of_type=NonNull(InfrahubMutatedAttribute), required=True), required=True)
 
 
+class ArtifactEvent(ObjectType):
+    class Meta:
+        interfaces = (EventNodeInterface,)
+
+    checksum = String(required=True, description="The current checksum of the artifact")
+    checksum_previous = String(required=False, description="The previous checksum of the artifact")
+    storage_id = String(required=True, description="The current storage_id of the artifact")
+    storage_id_previous = String(required=False, description="The previous storage_id of the artifact")
+    artifact_definition_id = String(required=True, description="Artifact definition ID")
+
+
 class GroupEvent(ObjectType):
     class Meta:
         interfaces = (EventNodeInterface,)
@@ -129,6 +140,8 @@ class StandardEvent(ObjectType):
 
 
 EVENT_TYPES: dict[str, type[ObjectType]] = {
+    "infrahub.artifact.created": ArtifactEvent,
+    "infrahub.artifact.updated": ArtifactEvent,
     "infrahub.node.created": NodeMutatedEvent,
     "infrahub.node.updated": NodeMutatedEvent,
     "infrahub.node.deleted": NodeMutatedEvent,

--- a/backend/infrahub/message_bus/messages/proposed_change/request_proposedchange_refreshartifacts.py
+++ b/backend/infrahub/message_bus/messages/proposed_change/request_proposedchange_refreshartifacts.py
@@ -1,5 +1,11 @@
+from pydantic import Field
+
+from infrahub.context import InfrahubContext
+
 from .base_with_diff import BaseProposedChangeWithDiffMessage
 
 
 class RequestProposedChangeRefreshArtifacts(BaseProposedChangeWithDiffMessage):
     """Sent trigger the refresh of artifacts that are impacted by the proposed change."""
+
+    context: InfrahubContext = Field(..., description="The context of the task")

--- a/backend/infrahub/message_bus/operations/requests/proposed_change.py
+++ b/backend/infrahub/message_bus/operations/requests/proposed_change.py
@@ -105,6 +105,7 @@ async def pipeline(message: messages.RequestProposedChangePipeline, service: Inf
     if message.check_type is CheckType.ARTIFACT:
         events.append(
             messages.RequestProposedChangeRefreshArtifacts(
+                context=message.context,
                 proposed_change=message.proposed_change,
                 source_branch=message.source_branch,
                 source_branch_sync_with_git=message.source_branch_sync_with_git,
@@ -243,6 +244,7 @@ async def refresh_artifacts(message: messages.RequestProposedChangeRefreshArtifa
         if select:
             log.info(f"Trigger processing of {artifact_definition.definition_name}")
             model = RequestArtifactDefinitionCheck(
+                context=message.context,
                 artifact_definition=artifact_definition,
                 branch_diff=message.branch_diff,
                 proposed_change=message.proposed_change,

--- a/backend/infrahub/proposed_change/models.py
+++ b/backend/infrahub/proposed_change/models.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, ConfigDict, Field
 
+from infrahub.context import InfrahubContext
 from infrahub.message_bus.messages.proposed_change.base_with_diff import BaseProposedChangeWithDiffMessage
 from infrahub.message_bus.types import ProposedChangeArtifactDefinition, ProposedChangeBranchDiff
 
@@ -40,3 +41,5 @@ class RequestArtifactDefinitionCheck(BaseModel):
     source_branch: str = Field(..., description="The source branch")
     source_branch_sync_with_git: bool = Field(..., description="Indicates if the source branch should sync with git")
     destination_branch: str = Field(..., description="The target branch")
+
+    context: InfrahubContext = Field(..., description="The context of the task")

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -289,6 +289,7 @@ async def run_generators(
     if model.refresh_artifacts:
         next_messages.append(
             messages.RequestProposedChangeRefreshArtifacts(
+                context=context,
                 proposed_change=model.proposed_change,
                 source_branch=model.source_branch,
                 source_branch_sync_with_git=model.source_branch_sync_with_git,
@@ -587,6 +588,7 @@ async def validate_artifacts_generation(model: RequestArtifactDefinitionCheck, s
             log.info(f"Trigger Artifact processing for {member.display_label}")
 
             check_model = CheckArtifactCreate(
+                context=model.context,
                 artifact_name=model.artifact_definition.artifact_name,
                 artifact_id=artifact_id,
                 artifact_definition=model.artifact_definition.definition_id,
@@ -601,6 +603,7 @@ async def validate_artifacts_generation(model: RequestArtifactDefinitionCheck, s
                 query=model.artifact_definition.query_name,
                 variables=member.extract(params=artifact_definition.parameters.value),
                 target_id=member.id,
+                target_kind=member.get_kind(),
                 target_name=member.display_label,
                 timeout=model.artifact_definition.timeout,
                 validator_id=validator.id,

--- a/backend/infrahub/task_manager/event.py
+++ b/backend/infrahub/task_manager/event.py
@@ -113,6 +113,28 @@ class PrefectEventData(PrefectEventModel):
     def _get_branch_name_from_resource(self) -> str:
         return self.resource.get("infrahub.branch.name") or ""
 
+    def _return_artifact_event(self) -> dict[str, Any]:
+        checksum = ""
+        checksum_previous: str | None = None
+        storage_id = ""
+        storage_id_previous: str | None = None
+        artifact_definition_id = ""
+        for resource in self.related:
+            if resource.role == "infrahub.artifact":
+                checksum = resource.get("infrahub.artifact.checksum") or ""
+                checksum_previous = resource.get("infrahub.artifact.checksum_previous")
+                storage_id = resource.get("infrahub.artifact.storage_id") or ""
+                storage_id_previous = resource.get("infrahub.artifact.storage_id_previous")
+                artifact_definition_id = resource.get("infrahub.artifact.artifact_definition_id") or ""
+
+        return {
+            "checksum": checksum,
+            "checksum_previous": checksum_previous,
+            "storage_id": storage_id,
+            "storage_id_previous": storage_id_previous,
+            "artifact_definition_id": artifact_definition_id,
+        }
+
     def _return_branch_created(self) -> dict[str, Any]:
         return {"created_branch": self._get_branch_name_from_resource()}
 
@@ -143,6 +165,8 @@ class PrefectEventData(PrefectEventModel):
         event_specifics = {}
 
         match self.event:
+            case "infrahub.artifact.created" | "infrahub.artifact.updated":
+                event_specifics = self._return_artifact_event()
             case "infrahub.node.created" | "infrahub.node.updated" | "infrahub.node.deleted":
                 event_specifics = self._return_node_mutation()
             case "infrahub.branch.created":

--- a/backend/infrahub/tasks/artifact.py
+++ b/backend/infrahub/tasks/artifact.py
@@ -14,7 +14,9 @@ from infrahub.services import InfrahubServices
 @task(name="define-artifact", task_run_name="Define Artifact", cache_policy=NONE)  # type: ignore[arg-type]
 async def define_artifact(
     model: Union[CheckArtifactCreate, RequestArtifactGenerate], service: InfrahubServices
-) -> InfrahubNode:
+) -> tuple[InfrahubNode, bool]:
+    """Return an artifact together with a flag to indicate if the artifact is created now or already existed."""
+    created = False
     if model.artifact_id:
         artifact = await service.client.get(kind=InfrahubKind.ARTIFACT, id=model.artifact_id, branch=model.branch_name)
     else:
@@ -40,4 +42,5 @@ async def define_artifact(
                     },
                 )
                 await artifact.save()
-    return artifact
+                created = True
+    return artifact, created

--- a/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
@@ -115,6 +115,7 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
         john = await NodeManager.get_one_by_id_or_default_filter(
             db=db, id="John", kind=TestKind.PERSON, branch=branch1.name
         )
+        john.name.value = "Johnny"  # type: ignore[attr-defined]
         john.age.value = 26  # type: ignore[attr-defined]
         await john.save(db=db)
         return branch_name
@@ -237,8 +238,8 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
 
         tags = await client.all(kind="BuiltinTag", branch=happy_data_branch)
         # The Generator defined in the repository is expected to have created this tag during the pipeline
-        assert "john-jesko" in [tag.name.value for tag in tags]  # type: ignore[attr-defined]
-        assert "InfrahubNode-john-jesko" in [tag.name.value for tag in tags]  # type: ignore[attr-defined]
+        assert "johnny-jesko" in [tag.name.value for tag in tags]  # type: ignore[attr-defined]
+        assert "InfrahubNode-johnny-jesko" in [tag.name.value for tag in tags]  # type: ignore[attr-defined]
 
         # -------------------------------------------------
         # Merge the proposed change and ensure everything looks good
@@ -265,7 +266,7 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
 
         secondary_events = await client.execute_graphql(query=QUERY_EVENT, variables={"parent__ids": merge_event_id})
 
-        john = await NodeManager.get_one_by_id_or_default_filter(db=db, id="John", kind=TestKind.PERSON)
+        john = await NodeManager.get_one_by_id_or_default_filter(db=db, id="Johnny", kind=TestKind.PERSON)
         richard = await NodeManager.get_one_by_id_or_default_filter(db=db, id="Richard", kind=TestKind.PERSON)
         assert secondary_events["InfrahubEvent"]["count"] >= 2
         johns_events = [
@@ -283,6 +284,31 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
 
         assert johns_events[0]["node"]["event"] == "infrahub.node.updated"
         assert richards_events[0]["node"]["event"] == "infrahub.node.created"
+
+        artifact_events = await client.execute_graphql(
+            query=QUERY_EVENT,
+            variables={"branch": [happy_data_branch], "event_type": ["infrahub.artifact.updated"]},
+        )
+        assert artifact_events["InfrahubEvent"]["count"] > 0
+        latest_artifact_event = artifact_events["InfrahubEvent"]["edges"][0]["node"]
+        assert sorted(latest_artifact_event.keys()) == [
+            "artifact_definition_id",
+            "branch",
+            "checksum",
+            "checksum_previous",
+            "event",
+            "has_children",
+            "id",
+            "level",
+            "occurred_at",
+            "parent_id",
+            "primary_node",
+            "related_nodes",
+            "storage_id",
+            "storage_id_previous",
+        ]
+        assert len(latest_artifact_event["related_nodes"]) == 1
+        assert latest_artifact_event["related_nodes"][0]["kind"] == "TestingPerson"
 
     async def test_merge_failure(
         self,
@@ -350,6 +376,14 @@ query(
         related_nodes {
             id
             kind
+        }
+        ... on ArtifactEvent {
+          id
+          artifact_definition_id
+          storage_id
+          storage_id_previous
+          checksum_previous
+          checksum
         }
       }
     }

--- a/docs/docs/reference/message-bus-events.mdx
+++ b/docs/docs/reference/message-bus-events.mdx
@@ -363,6 +363,7 @@ For more detailed explanations on how to use these events within Infrahub, see t
 | **source_branch_sync_with_git** | Indicates if the source branch should sync with git | boolean | None |
 | **destination_branch** | The destination branch of the proposed change | string | None |
 | **branch_diff** | The calculated diff between the two branches | N/A | None |
+| **context** | The context of the task | N/A | None |
 <!-- vale on -->
 
 
@@ -756,6 +757,7 @@ For more detailed explanations on how to use these events within Infrahub, see t
 | **source_branch_sync_with_git** | Indicates if the source branch should sync with git | boolean | None |
 | **destination_branch** | The destination branch of the proposed change | string | None |
 | **branch_diff** | The calculated diff between the two branches | N/A | None |
+| **context** | The context of the task | N/A | None |
 <!-- vale on -->
 
 


### PR DESCRIPTION
This PR adds artifact events to Infrahub. The new events are `infrahub.artifact.created` and `infrahub.artifact.updated`. The issue stated that we should also have `infrahub.artifact.deleted`, I'm not completely sure about that usecase as we never really provide a way to delete artifacts. But if desired we can loop any node mutation events through a loop and specifically look for scenarios where CoreArtifact objects have been deleted and then create a new event for those.

For the most part the PR should be pretty straightforward, I had to add the context to some models and messages, aside from that it's some additional fields that have been added to the models.

I also needed to do a slight change in the pipeline test to have something that would generate updated artifacts.