### PR TITLE
fix(backend): include prefect-redis as dependency

### DIFF
--- a/backend/infrahub/computed_attribute/tasks.py
+++ b/backend/infrahub/computed_attribute/tasks.py
@@ -115,7 +115,7 @@ async def process_transform(
             service=service,
             repository_kind=str(transform.repository.peer.typename),
             commit=repo_node.commit.value,
-        )
+        )  # type: ignore[misc]
 
         data = await service.client.query_gql_query(
             name=transform.query.peer.name.value,
@@ -131,7 +131,7 @@ async def process_transform(
             location=f"{transform.file_path.value}::{transform.class_name.value}",
             data=data,
             client=service.client,
-        )
+        )  # type: ignore[misc]
 
         await service.client.execute_graphql(
             query=UPDATE_ATTRIBUTE,

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -171,27 +171,27 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         self.create_commit_worktree(commit)
         await self._update_sync_status(branch_name=infrahub_branch_name, status=RepositorySyncStatus.SYNCING)
 
-        config_file = await self.get_repository_config(branch_name=infrahub_branch_name, commit=commit)
+        config_file = await self.get_repository_config(branch_name=infrahub_branch_name, commit=commit)  # type: ignore[misc]
         sync_status = RepositorySyncStatus.IN_SYNC if config_file else RepositorySyncStatus.ERROR_IMPORT
         error: Exception | None = None
 
         try:
             if config_file:
-                await self.import_schema_files(branch_name=infrahub_branch_name, commit=commit, config_file=config_file)
+                await self.import_schema_files(branch_name=infrahub_branch_name, commit=commit, config_file=config_file)  # type: ignore[misc]
 
                 await self.import_all_graphql_query(
                     branch_name=infrahub_branch_name, commit=commit, config_file=config_file
-                )
+                )  # type: ignore[misc]
 
                 await self.import_all_python_files(  # type: ignore[call-overload]
                     branch_name=infrahub_branch_name, commit=commit, config_file=config_file
-                )
+                )  # type: ignore[misc]
                 await self.import_jinja2_transforms(
                     branch_name=infrahub_branch_name, commit=commit, config_file=config_file
-                )
+                )  # type: ignore[misc]
                 await self.import_artifact_definitions(
                     branch_name=infrahub_branch_name, commit=commit, config_file=config_file
-                )
+                )  # type: ignore[misc]
 
         except Exception as exc:
             sync_status = RepositorySyncStatus.ERROR_IMPORT
@@ -636,7 +636,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
                     module=module,
                     file_path=file_info.relative_path_file,
                     check_definition=check,
-                )
+                )  # type: ignore[misc]
             )
 
         local_check_definitions = {check.name: check for check in checks}
@@ -797,7 +797,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
                     module=module,
                     file_path=file_info.relative_path_file,
                     transform=transform,
-                )
+                )  # type: ignore[misc]
             )
 
         local_transform_definitions = {transform.name: transform for transform in transforms}
@@ -1070,9 +1070,9 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
     ) -> None:
         await add_tags(branches=[branch_name], nodes=[str(self.id)])
 
-        await self.import_python_check_definitions(branch_name=branch_name, commit=commit, config_file=config_file)
-        await self.import_python_transforms(branch_name=branch_name, commit=commit, config_file=config_file)
-        await self.import_generator_definitions(branch_name=branch_name, commit=commit, config_file=config_file)
+        await self.import_python_check_definitions(branch_name=branch_name, commit=commit, config_file=config_file)  # type: ignore[misc]
+        await self.import_python_transforms(branch_name=branch_name, commit=commit, config_file=config_file)  # type: ignore[misc]
+        await self.import_generator_definitions(branch_name=branch_name, commit=commit, config_file=config_file)  # type: ignore[misc]
 
     @task(name="jinja2-template-render", task_run_name="Render Jinja2 template", cache_policy=NONE)  # type: ignore[arg-type]
     async def render_jinja2_template(self, commit: str, location: str, data: dict) -> str:
@@ -1227,7 +1227,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         if transformation.typename == InfrahubKind.TRANSFORMJINJA2:
             artifact_content = await self.render_jinja2_template.with_options(
                 timeout_seconds=transformation.timeout.value
-            )(commit=commit, location=transformation.template_path.value, data=response)
+            )(commit=commit, location=transformation.template_path.value, data=response)  # type: ignore[misc]
         elif transformation.typename == InfrahubKind.TRANSFORMPYTHON:
             transformation_location = f"{transformation.file_path.value}::{transformation.class_name.value}"
             artifact_content = await self.execute_python_transform.with_options(
@@ -1238,7 +1238,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
                 location=transformation_location,
                 data=response,
                 client=self.sdk,
-            )
+            )  # type: ignore[misc]
 
         if definition.content_type.value == ContentType.APPLICATION_JSON.value and isinstance(artifact_content, dict):
             artifact_content_str = ujson.dumps(artifact_content, indent=2)
@@ -1289,7 +1289,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         if message.transform_type == InfrahubKind.TRANSFORMJINJA2:
             artifact_content = await self.render_jinja2_template.with_options(timeout_seconds=message.timeout)(
                 commit=message.commit, location=message.transform_location, data=response
-            )
+            )  # type: ignore[misc]
         elif message.transform_type == InfrahubKind.TRANSFORMPYTHON:
             artifact_content = await self.execute_python_transform.with_options(timeout_seconds=message.timeout)(
                 branch_name=message.branch_name,
@@ -1297,7 +1297,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
                 location=message.transform_location,
                 data=response,
                 client=self.sdk,
-            )
+            )  # type: ignore[misc]
 
         if message.content_type == ContentType.APPLICATION_JSON.value and isinstance(artifact_content, dict):
             artifact_content_str = ujson.dumps(artifact_content, indent=2)

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -822,7 +822,7 @@ async def run_user_check(model: UserCheckData, service: InfrahubServices) -> Val
             client=service.client,
             commit=model.commit,
             params=model.variables,
-        )
+        )  # type: ignore[misc]
         if check_run.passed:
             conclusion = ValidatorConclusion.SUCCESS
             severity = "info"

--- a/backend/infrahub/transformations/tasks.py
+++ b/backend/infrahub/transformations/tasks.py
@@ -30,7 +30,7 @@ async def transform_python(message: TransformPythonData, service: InfrahubServic
         location=message.transform_location,
         data=message.data,
         client=service.client,
-    )
+    )  # type: ignore[misc]
 
     return transformed_data
 
@@ -49,6 +49,6 @@ async def transform_render_jinja2_template(message: TransformJinjaTemplateData, 
 
     rendered_template = await repo.render_jinja2_template.with_options(timeout_seconds=message.timeout)(
         commit=message.commit, location=message.template_location, data={"data": message.data}
-    )
+    )  # type: ignore[misc]
 
     return rendered_template

--- a/backend/infrahub/webhook/models.py
+++ b/backend/infrahub/webhook/models.py
@@ -214,7 +214,7 @@ class TransformWebhook(Webhook):
             location=f"{self.transform_file}::{self.transform_class}",
             data={"data": data, **context.model_dump()},
             client=service.client,
-        )
+        )  # type: ignore[misc]
 
     @classmethod
     def from_object(cls, obj: CoreCustomWebhook, transform: CoreTransformPython) -> Self:

--- a/backend/infrahub/webhook/tasks.py
+++ b/backend/infrahub/webhook/tasks.py
@@ -114,7 +114,7 @@ async def configure_webhook_all(service: InfrahubServices) -> None:
             triggers=triggers,
             trigger_type=TriggerType.WEBHOOK,
             deprecated_triggers=[AUTOMATION_NAME_RUN],
-        )
+        )  # type: ignore[misc]
 
     log.info(f"{len(triggers)} Webhooks automation configuration completed")
 

--- a/backend/tests/helpers/utils.py
+++ b/backend/tests/helpers/utils.py
@@ -44,7 +44,7 @@ def start_prefect_server_container(
 
     prefect_base = Path(Path(__file__).parent.resolve() / "./../../infrahub/prefect_server")
     container = (
-        DockerContainer(image="prefecthq/prefect:3.1.14-python3.12")
+        DockerContainer(image="prefecthq/prefect:3.1.15-python3.12")
         .with_command("uvicorn --host 0.0.0.0 --port 4200 --factory prefect_server.app:create_infrahub_prefect")
         .with_exposed_ports(PORT_PREFECT)
         .with_volume_mapping(host=str(prefect_base), container="/opt/prefect/prefect_server", mode="ro")

--- a/backend/tests/integration/git/test_git_repository.py
+++ b/backend/tests/integration/git/test_git_repository.py
@@ -117,9 +117,9 @@ class TestInfrahubClient:
 
     async def test_import_schema_files(self, db: InfrahubDatabase, client: InfrahubClient, repo: InfrahubRepository):
         commit = repo.get_commit_value(branch_name="main")
-        config_file = await repo.get_repository_config(branch_name="main", commit=commit)
+        config_file = await repo.get_repository_config(branch_name="main", commit=commit)  # type: ignore[misc]
         assert config_file
-        await repo.import_schema_files(branch_name="main", commit=commit, config_file=config_file)
+        await repo.import_schema_files(branch_name="main", commit=commit, config_file=config_file)  # type: ignore[misc]
 
         assert await client.schema.get(kind="DemoEdgeFabric", refresh=True)
 
@@ -127,11 +127,11 @@ class TestInfrahubClient:
         self, db: InfrahubDatabase, client: InfrahubClient, repo: InfrahubRepository
     ):
         commit = repo.get_commit_value(branch_name="main")
-        config_file = await repo.get_repository_config(branch_name="main", commit=commit)
+        config_file = await repo.get_repository_config(branch_name="main", commit=commit)  # type: ignore[misc]
         assert config_file
 
         config_file.schemas = [Path("schemas")]
-        await repo.import_schema_files(branch_name="main", commit=commit, config_file=config_file)
+        await repo.import_schema_files(branch_name="main", commit=commit, config_file=config_file)  # type: ignore[misc]
 
         assert await client.schema.get(kind="DemoEdgeFabric", refresh=True)
 
@@ -139,17 +139,17 @@ class TestInfrahubClient:
         self, db: InfrahubDatabase, client: InfrahubClient, repo: InfrahubRepository
     ):
         commit = repo.get_commit_value(branch_name="main")
-        config_file = await repo.get_repository_config(branch_name="main", commit=commit)
+        config_file = await repo.get_repository_config(branch_name="main", commit=commit)  # type: ignore[misc]
         assert config_file
 
-        await repo.import_all_graphql_query(branch_name="main", commit=commit, config_file=config_file)
+        await repo.import_all_graphql_query(branch_name="main", commit=commit, config_file=config_file)  # type: ignore[misc]
 
         queries = await client.all(kind=CoreGraphQLQuery)
         assert len(queries) == 5
 
         # Validate if the function is idempotent, another import just after the first one shouldn't change anything
         nbr_relationships_before = await count_relationships(db=db)
-        await repo.import_all_graphql_query(branch_name="main", commit=commit, config_file=config_file)
+        await repo.import_all_graphql_query(branch_name="main", commit=commit, config_file=config_file)  # type: ignore[misc]
         assert await count_relationships(db=db) == nbr_relationships_before
 
         # 1. Modify an object to validate if its being properly updated
@@ -167,7 +167,7 @@ class TestInfrahubClient:
         )
         await obj.save(db=db)
 
-        await repo.import_all_graphql_query(branch_name="main", commit=commit, config_file=config_file)
+        await repo.import_all_graphql_query(branch_name="main", commit=commit, config_file=config_file)  # type: ignore[misc]
 
         modified_query = await client.get(kind=CoreGraphQLQuery, id=queries[0].id)
         assert modified_query.query.value == value_before_change
@@ -179,7 +179,7 @@ class TestInfrahubClient:
         self, db: InfrahubDatabase, client: InfrahubClient, repo: InfrahubRepository, query_99
     ):
         commit = repo.get_commit_value(branch_name="main")
-        config_file = await repo.get_repository_config(branch_name="main", commit=commit)
+        config_file = await repo.get_repository_config(branch_name="main", commit=commit)  # type: ignore[misc]
         assert config_file
 
         await repo.import_all_python_files(branch_name="main", commit=commit, config_file=config_file)  # type: ignore[call-overload]
@@ -256,16 +256,16 @@ class TestInfrahubClient:
         self, db: InfrahubDatabase, client: InfrahubClient, repo: InfrahubRepository, query_99
     ):
         commit = repo.get_commit_value(branch_name="main")
-        config_file = await repo.get_repository_config(branch_name="main", commit=commit)
+        config_file = await repo.get_repository_config(branch_name="main", commit=commit)  # type: ignore[misc]
         assert config_file
-        await repo.import_jinja2_transforms(branch_name="main", commit=commit, config_file=config_file)
+        await repo.import_jinja2_transforms(branch_name="main", commit=commit, config_file=config_file)  # type: ignore[misc]
 
         rfiles = await client.all(kind=CoreTransformJinja2)
         assert len(rfiles) == 2
 
         # Validate if the function is idempotent, another import just after the first one shouldn't change anything
         nbr_relationships_before = await count_relationships(db=db)
-        await repo.import_jinja2_transforms(branch_name="main", commit=commit, config_file=config_file)
+        await repo.import_jinja2_transforms(branch_name="main", commit=commit, config_file=config_file)  # type: ignore[misc]
         assert await count_relationships(db=db) == nbr_relationships_before
 
         # 1. Modify an object to validate if its being properly updated
@@ -286,7 +286,7 @@ class TestInfrahubClient:
         )
         await obj.save(db=db)
 
-        await repo.import_jinja2_transforms(branch_name="main", commit=commit, config_file=config_file)
+        await repo.import_jinja2_transforms(branch_name="main", commit=commit, config_file=config_file)  # type: ignore[misc]
 
         modified_rfile = await client.get(kind=CoreTransformJinja2, id=rfiles[0].id)
         assert modified_rfile.template_path.value == rfile_template_path_value_before_change

--- a/poetry.lock
+++ b/poetry.lock
@@ -3554,13 +3554,13 @@ virtualenv = ">=20.10.0"
 
 [[package]]
 name = "prefect"
-version = "3.1.14"
+version = "3.1.15"
 description = "Workflow orchestration and management."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "prefect-3.1.14-py3-none-any.whl", hash = "sha256:8de9b4d32ae045e46568822f6d8d234735f07f2ad8ffa899d502ee73be7396f6"},
-    {file = "prefect-3.1.14.tar.gz", hash = "sha256:2c9e2b29fc0bccb1a6addb883292d055fec9e14a51ed74b223bfb34958e96fe5"},
+    {file = "prefect-3.1.15-py3-none-any.whl", hash = "sha256:29d25d535d04e54db9a27db198ef5d31baf1cbcd73e3c7d1ae48135bb419dd39"},
+    {file = "prefect-3.1.15.tar.gz", hash = "sha256:6dd8d018acdd8e10294e4c2e26a2c6adf636984ff5e77f0681030e94d0a15922"},
 ]
 
 [package.dependencies]
@@ -3612,7 +3612,7 @@ rich = ">=11.0,<14.0"
 sniffio = ">=1.3.0,<2.0.0"
 sqlalchemy = {version = ">=2.0,<3.0.0", extras = ["asyncio"]}
 toml = ">=0.10.0"
-typer = ">=0.12.0,<0.12.2 || >0.12.2,<0.14.0"
+typer = ">=0.12.0,<0.12.2 || >0.12.2,<0.16.0"
 typing_extensions = ">=4.5.0,<5.0.0"
 ujson = ">=5.8.0,<6.0.0"
 uvicorn = ">=0.14.0,<0.29.0 || >0.29.0"
@@ -4747,24 +4747,24 @@ python-versions = ">=3.6"
 files = [
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b42169467c42b692c19cf539c38d4602069d8c1505e97b86387fcf7afb766e1d"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:07238db9cbdf8fc1e9de2489a4f68474e70dffcb32232db7c08fa61ca0c7c462"},
-    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:d92f81886165cb14d7b067ef37e142256f1c6a90a65cd156b063a43da1708cfd"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:fff3573c2db359f091e1589c3d7c5fc2f86f5bdb6f24252c2d8e539d4e45f412"},
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux_2_24_aarch64.whl", hash = "sha256:aa2267c6a303eb483de8d02db2871afb5c5fc15618d894300b88958f729ad74f"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:840f0c7f194986a63d2c2465ca63af8ccbbc90ab1c6001b1978f05119b5e7334"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:024cfe1fc7c7f4e1aff4a81e718109e13409767e4f871443cbff3dba3578203d"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-win32.whl", hash = "sha256:c69212f63169ec1cfc9bb44723bf2917cbbd8f6191a00ef3410f5a7fe300722d"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-win_amd64.whl", hash = "sha256:cabddb8d8ead485e255fe80429f833172b4cadf99274db39abc080e068cbcc31"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:bef08cd86169d9eafb3ccb0a39edb11d8e25f3dae2b28f5c52fd997521133069"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:b16420e621d26fdfa949a8b4b47ade8810c56002f5389970db4ddda51dbff248"},
-    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:b5edda50e5e9e15e54a6a8a0070302b00c518a9d32accc2346ad6c984aacd279"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:25c515e350e5b739842fc3228d662413ef28f295791af5e5110b543cf0b57d9b"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux_2_24_aarch64.whl", hash = "sha256:1707814f0d9791df063f8c19bb51b0d1278b8e9a2353abbb676c2f685dee6afe"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:46d378daaac94f454b3a0e3d8d78cafd78a026b1d71443f4966c696b48a6d899"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:09b055c05697b38ecacb7ac50bdab2240bfca1a0c4872b0fd309bb07dc9aa3a9"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-win32.whl", hash = "sha256:53a300ed9cea38cf5a2a9b069058137c2ca1ce658a874b79baceb8f892f915a7"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-win_amd64.whl", hash = "sha256:c2a72e9109ea74e511e29032f3b670835f8a59bbdc9ce692c5b4ed91ccf1eedb"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:ebc06178e8821efc9692ea7544aa5644217358490145629914d8020042c24aa1"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:edaef1c1200c4b4cb914583150dcaa3bc30e592e907c01117c08b13a07255ec2"},
-    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:7048c338b6c86627afb27faecf418768acb6331fc24cfa56c93e8c9780f815fa"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d176b57452ab5b7028ac47e7b3cf644bcfdc8cacfecf7e71759f7f51a59e5c92"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-manylinux_2_24_aarch64.whl", hash = "sha256:1dc67314e7e1086c9fdf2680b7b6c2be1c0d8e3a8279f2e993ca2a7545fecf62"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:3213ece08ea033eb159ac52ae052a4899b56ecc124bb80020d9bbceeb50258e9"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aab7fd643f71d7946f2ee58cc88c9b7bfc97debd71dcc93e03e2d174628e7e2d"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-win32.whl", hash = "sha256:5c365d91c88390c8d0a8545df0b5857172824b1c604e867161e6b3d59a827eaa"},
@@ -4772,7 +4772,7 @@ files = [
     {file = "ruamel.yaml.clib-0.2.8-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a5aa27bad2bb83670b71683aae140a1f52b0857a2deff56ad3f6c13a017a26ed"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c58ecd827313af6864893e7af0a3bb85fd529f862b6adbefe14643947cfe2942"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-macosx_12_0_arm64.whl", hash = "sha256:f481f16baec5290e45aebdc2a5168ebc6d35189ae6fea7a58787613a25f6e875"},
-    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:3fcc54cb0c8b811ff66082de1680b4b14cf8a81dce0d4fbf665c2265a81e07a1"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux_2_24_aarch64.whl", hash = "sha256:77159f5d5b5c14f7c34073862a6b7d34944075d9f93e681638f6d753606c6ce6"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:7f67a1ee819dc4562d444bbafb135832b0b909f81cc90f7aa00260968c9ca1b3"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:4ecbf9c3e19f9562c7fdd462e8d18dd902a47ca046a2e64dba80699f0b6c09b7"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:87ea5ff66d8064301a154b3933ae406b0863402a799b16e4a1d24d9fbbcbe0d3"},
@@ -4780,7 +4780,7 @@ files = [
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-win_amd64.whl", hash = "sha256:3f215c5daf6a9d7bbed4a0a4f760f3113b10e82ff4c5c44bec20a68c8014f675"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1b617618914cb00bf5c34d4357c37aa15183fa229b24767259657746c9077615"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:a6a9ffd280b71ad062eae53ac1659ad86a17f59a0fdc7699fd9be40525153337"},
-    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:665f58bfd29b167039f714c6998178d27ccd83984084c286110ef26b230f259f"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux_2_24_aarch64.whl", hash = "sha256:305889baa4043a09e5b76f8e2a51d4ffba44259f6b4c72dec8ca56207d9c6fe1"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:700e4ebb569e59e16a976857c8798aee258dceac7c7d6b50cab63e080058df91"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:e2b4c44b60eadec492926a7270abb100ef9f72798e18743939bdbf037aab8c28"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:e79e5db08739731b0ce4850bed599235d601701d5694c36570a99a0c5ca41a9d"},
@@ -4788,7 +4788,7 @@ files = [
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-win_amd64.whl", hash = "sha256:56f4252222c067b4ce51ae12cbac231bce32aee1d33fbfc9d17e5b8d6966c312"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:03d1162b6d1df1caa3a4bd27aa51ce17c9afc2046c31b0ad60a0a96ec22f8001"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:bba64af9fa9cebe325a62fa398760f5c7206b215201b0ec825005f1b18b9bccf"},
-    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:9eb5dee2772b0f704ca2e45b1713e4e5198c18f515b52743576d196348f374d3"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux_2_24_aarch64.whl", hash = "sha256:a1a45e0bb052edf6a1d3a93baef85319733a888363938e1fc9924cb00c8df24c"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:da09ad1c359a728e112d60116f626cc9f29730ff3e0e7db72b9a2dbc2e4beed5"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:184565012b60405d93838167f425713180b949e9d8dd0bbc7b49f074407c5a8b"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a75879bacf2c987c003368cf14bed0ffe99e8e85acfa6c0bfffc21a090f16880"},
@@ -5999,4 +5999,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10, < 3.13"
-content-hash = "7c26960c7f1fee3a9c08a4d7519915aff42d46594938e4a15e4a95c50e0ade1e"
+content-hash = "c0a51eb302eae68f4116146bade7b11c1b475008dd56a3d480a2bc9b31d9c1ab"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3641,6 +3641,24 @@ snowflake = ["prefect-snowflake (>=0.28.0)"]
 sqlalchemy = ["prefect-sqlalchemy (>=0.5.0)"]
 
 [[package]]
+name = "prefect-redis"
+version = "0.2.2"
+description = "Prefect integrations with Redis."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "prefect_redis-0.2.2-py3-none-any.whl", hash = "sha256:11c17c69231cecbed78a501694d318dafe92ad53fdfbd8fbab4451576186700d"},
+    {file = "prefect_redis-0.2.2.tar.gz", hash = "sha256:8185c2eb5d6ccb371f7d83461f5dac0bb490c7f0fbf7232092e15d14e0e85a28"},
+]
+
+[package.dependencies]
+prefect = ">=3.0.0"
+redis = ">=5.0.1"
+
+[package.extras]
+dev = ["coverage", "interrogate", "mkdocs", "mkdocs-gen-files", "mkdocs-material", "mkdocstrings[python]", "mypy", "pillow", "pre-commit", "pytest (>=8.3)", "pytest-asyncio", "pytest-env", "pytest-timeout", "pytest-xdist"]
+
+[[package]]
 name = "prometheus-client"
 version = "0.21.1"
 description = "Python client for the Prometheus monitoring system."
@@ -5999,4 +6017,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10, < 3.13"
-content-hash = "c0a51eb302eae68f4116146bade7b11c1b475008dd56a3d480a2bc9b31d9c1ab"
+content-hash = "6187e6e17aa41d028f48941a483b7063a91faefa56458e4931f778f4309bcfc9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ boto3 = "1.34.129"
 email-validator = "~2.1"
 redis = { version = "^5.0.0", extras = ["hiredis"] }
 typer = "0.12.5"
-prefect = "3.1.14"
+prefect = "3.1.15"
 ujson = "^5"
 Jinja2 = "^3"
 gitpython = "^3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ email-validator = "~2.1"
 redis = { version = "^5.0.0", extras = ["hiredis"] }
 typer = "0.12.5"
 prefect = "3.1.15"
+prefect-redis = "0.2.2"
 ujson = "^5"
 Jinja2 = "^3"
 gitpython = "^3"


### PR DESCRIPTION
This PR adds prefect-redis as dependency.

This is actually the default since 3.1.14.
We also need it for Redis messaging & cache support (required for HA).

Also upgrade to 3.1.15 to include some fixes regarding Redis messaging.

Edit: Prefect 3.1.15 introduced a change that breaks mypy, ignore these errors for now