### PR TITLE
Enable display label lookup in the backend for event logs

### DIFF
--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -678,6 +678,16 @@ class NodeGetKindQuery(Query):
             node_kind_map[str(result.get("node_id"))] = str(result.get("node_kind"))
         return node_kind_map
 
+    def get_id_by_kind(self) -> dict[str, set[str]]:
+        node_kind_map: dict[str, set[str]] = {}
+        for result in self.get_results():
+            kind = str(result.get("node_kind"))
+            node_id = str(result.get("node_id"))
+            if kind not in node_kind_map:
+                node_kind_map[kind] = set()
+            node_kind_map[kind].add(node_id)
+        return node_kind_map
+
 
 class NodeListGetInfoQuery(Query):
     name = "node_list_get_info"

--- a/backend/infrahub/graphql/queries/event.py
+++ b/backend/infrahub/graphql/queries/event.py
@@ -15,6 +15,8 @@ if TYPE_CHECKING:
 
     from graphql import GraphQLResolveInfo
 
+    from infrahub.graphql.initialization import GraphqlContext
+
 
 class Events(ObjectType):
     edges = List(NonNull(EventNodes), required=True)
@@ -74,9 +76,11 @@ class Events(ObjectType):
         limit: int,
         offset: int | None = None,
     ) -> dict[str, Any]:
+        graphql_context: GraphqlContext = info.context
         fields = await extract_fields_first_node(info)
 
         prefect_tasks = await PrefectEvent.query(
+            db=graphql_context.db,
             fields=fields,
             event_filter=event_filter,
             limit=limit,

--- a/backend/infrahub/graphql/types/common.py
+++ b/backend/infrahub/graphql/types/common.py
@@ -10,3 +10,4 @@ class IdentifierInput(InputObjectType):
 class RelatedNode(ObjectType):
     id = String(required=True, description="The ID of the requested object")
     kind = String(required=True, description="The ID of the requested object")
+    display_label = String(required=False, description="The ID of the requested object")

--- a/backend/infrahub/graphql/types/event.py
+++ b/backend/infrahub/graphql/types/event.py
@@ -24,6 +24,7 @@ class EventNodeInterface(Interface):
     id = String(required=True, description="The ID of the event.")
     event = String(required=True, description="The name of the event.")
     branch = String(required=False, description="The branch where the event occurred.")
+    account = Field(RelatedNode, required=False, description="The account that triggered the event.")
     account_id = String(required=False, description="The account ID that triggered the event.")
     occurred_at = DateTime(required=True, description="The timestamp when the event occurred.")
     level = Int(

--- a/backend/infrahub/task_manager/event.py
+++ b/backend/infrahub/task_manager/event.py
@@ -1,27 +1,38 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 
 from prefect.client.orchestration import PrefectClient, get_client
 from prefect.events.schemas.events import Event as PrefectEventModel
 from pydantic import BaseModel, Field, TypeAdapter
 
 from infrahub.core.constants import GLOBAL_BRANCH_NAME
-from infrahub.exceptions import ServiceUnavailableError
+from infrahub.core.diff.payload_builder import get_display_labels_per_kind
+from infrahub.core.query.node import NodeGetKindQuery
+from infrahub.core.registry import registry
+from infrahub.exceptions import BranchNotFoundError, ServiceUnavailableError
 from infrahub.log import get_logger
 from infrahub.utils import get_nested_dict
 
 log = get_logger()
 
 if TYPE_CHECKING:
+    from infrahub.database import InfrahubDatabase
+
     from .models import InfrahubEventFilter
+
+
+class EventNode(TypedDict):
+    id: str
+    kind: str
+    display_label: str | None
 
 
 class PrefectEventData(PrefectEventModel):
     def get_branch(self) -> str | None:
         for resource in self.related:
-            if resource.get("prefect.resource.role") != "infrahub.branch":
+            if resource.role != "infrahub.branch":
                 continue
             if "infrahub.resource.label" not in resource:
                 continue
@@ -49,18 +60,28 @@ class PrefectEventData(PrefectEventModel):
             return resource.get("infrahub.event_parent.id")
         return None
 
-    def get_primary_node(self) -> dict[str, str] | None:
+    def get_primary_node(
+        self, branch_name: str | None = None, label_mapper: DisplayLabelMapper | None = None
+    ) -> EventNode | None:
         node_id = self.resource.get("infrahub.node.id")
         node_kind = self.resource.get("infrahub.node.kind")
         if node_id and node_kind:
-            return {"id": node_id, "kind": node_kind}
+            return {
+                "id": node_id,
+                "kind": node_kind,
+                "display_label": label_mapper.get_node_label(branch_name=branch_name, node_id=node_id)
+                if label_mapper
+                else None,
+            }
 
         return None
 
-    def get_related_nodes(self) -> list[dict[str, str]]:
-        related_nodes = []
+    def get_related_nodes(
+        self, branch_name: str | None = None, label_mapper: DisplayLabelMapper | None = None
+    ) -> list[EventNode]:
+        related_nodes: list[EventNode] = []
         for resource in self.related:
-            if resource.get("prefect.resource.role") != "infrahub.related.node":
+            if resource.role != "infrahub.related.node":
                 continue
 
             node_id = resource.get("prefect.resource.id")
@@ -69,20 +90,28 @@ class PrefectEventData(PrefectEventModel):
                 # Don't include the primary node as a related node.
                 continue
             if node_id and node_kind:
-                related_nodes.append({"id": node_id, "kind": node_kind})
+                related_nodes.append(
+                    {
+                        "id": node_id,
+                        "kind": node_kind,
+                        "display_label": label_mapper.get_node_label(branch_name=branch_name, node_id=node_id)
+                        if label_mapper
+                        else None,
+                    }
+                )
 
         return related_nodes
 
     def get_account_id(self) -> str | None:
         for resource in self.related:
-            if resource.get("prefect.resource.role") != "infrahub.account":
+            if resource.role != "infrahub.account":
                 continue
             return resource.get("infrahub.resource.id")
         return None
 
     def has_children(self) -> bool:
         for resource in self.related:
-            if resource.get("prefect.resource.role") != "infrahub.event":
+            if resource.role != "infrahub.event":
                 continue
             if resource.get("infrahub.event.has_children") == "true":
                 return True
@@ -93,9 +122,7 @@ class PrefectEventData(PrefectEventModel):
         attributes = []
 
         for resource in self.related:
-            if resource.get("prefect.resource.role") == "infrahub.node.field_update" and resource.get(
-                "infrahub.attribute.name"
-            ):
+            if resource.role == "infrahub.node.field_update" and resource.get("infrahub.attribute.name"):
                 attributes.append(
                     {
                         "name": resource.get("infrahub.attribute.name", ""),
@@ -149,19 +176,31 @@ class PrefectEventData(PrefectEventModel):
     def _return_branch_rebased(self) -> dict[str, Any]:
         return {"rebased_branch": self._get_branch_name_from_resource()}
 
-    def _return_group_event(self) -> dict[str, Any]:
+    def _return_group_event(self, branch_name: str | None, label_mapper: DisplayLabelMapper) -> dict[str, Any]:
         members = []
         ancestors = []
 
         for resource in self.related:
             if resource.role == "infrahub.group.member" and resource.get("infrahub.node.kind"):
-                members.append({"id": resource.id, "kind": resource.get("infrahub.node.kind")})
+                members.append(
+                    {
+                        "id": resource.id,
+                        "kind": resource.get("infrahub.node.kind"),
+                        "display_label": label_mapper.get_node_label(branch_name=branch_name, node_id=resource.id),
+                    }
+                )
             elif resource.role == "infrahub.group.ancestor" and resource.get("infrahub.node.kind"):
-                ancestors.append({"id": resource.id, "kind": resource.get("infrahub.node.kind")})
+                ancestors.append(
+                    {
+                        "id": resource.id,
+                        "kind": resource.get("infrahub.node.kind"),
+                        "display_label": label_mapper.get_node_label(branch_name=branch_name, node_id=resource.id),
+                    }
+                )
 
         return {"members": members, "ancestors": ancestors}
 
-    def _return_event_specifics(self) -> dict[str, Any]:
+    def _return_event_specifics(self, branch_name: str | None, label_mapper: DisplayLabelMapper) -> dict[str, Any]:
         """Return event specific data based on the type of event being processed"""
 
         event_specifics = {}
@@ -180,26 +219,106 @@ class PrefectEventData(PrefectEventModel):
             case "infrahub.branch.rebased":
                 event_specifics = self._return_branch_rebased()
             case "infrahub.group.member_added" | "infrahub.group.member_removed":
-                event_specifics = self._return_group_event()
+                event_specifics = self._return_group_event(branch_name=branch_name, label_mapper=label_mapper)
 
         return event_specifics
 
-    def to_graphql(self) -> dict[str, Any]:
+    def to_graphql(self, label_mapper: DisplayLabelMapper) -> dict[str, Any]:
+        branch_name = self.get_branch()
         response = {
             "id": str(self.id),
             "event": self.event,
-            "branch": self.get_branch(),
+            "branch": branch_name,
             "account_id": self.get_account_id(),
+            "account": label_mapper.get_account(account_id=self.get_account_id()),
             "occurred_at": self.occurred,
             "has_children": self.has_children(),
             "payload": self.payload,
             "level": self.get_level(),
-            "primary_node": self.get_primary_node(),
+            "primary_node": self.get_primary_node(branch_name=branch_name, label_mapper=label_mapper),
             "parent_id": self.get_parent(),
-            "related_nodes": self.get_related_nodes(),
+            "related_nodes": self.get_related_nodes(branch_name=branch_name, label_mapper=label_mapper),
         }
-        response.update(self._return_event_specifics())
+        response.update(self._return_event_specifics(branch_name=branch_name, label_mapper=label_mapper))
         return response
+
+
+class DisplayLabelMapper:
+    def __init__(self, db: InfrahubDatabase, events: list[PrefectEventData]) -> None:
+        self._db = db
+        self._events = events
+        self._display_labels: dict[str, dict[str, str]] = {}
+        self._account_labels: dict[str, EventNode] = {}
+
+    @property
+    def account_labels(self) -> dict[str, EventNode]:
+        return self._account_labels
+
+    @property
+    def display_labels(self) -> dict[str, dict[str, str]]:
+        return self._display_labels
+
+    def get_account(self, account_id: str | None) -> EventNode | None:
+        if not account_id:
+            return None
+        if account_id in self.account_labels:
+            return self.account_labels[account_id]
+
+        return {"id": account_id, "kind": "CoreGenericAccount", "display_label": None}
+
+    def get_node_label(self, branch_name: str | None, node_id: str | None) -> str | None:
+        branch_name = branch_name or registry.default_branch
+        if branch_name not in self._display_labels or not node_id:
+            return None
+
+        return self._display_labels[branch_name].get(node_id)
+
+    async def populate_display_labels(self) -> None:
+        await self._populate_account_labels()
+        await self._populate_node_labels()
+
+    async def _populate_account_labels(self) -> None:
+        account_ids = set()
+        for event in self._events:
+            if account_id := event.get_account_id():
+                account_ids.add(account_id)
+
+        query = await NodeGetKindQuery.init(db=self._db, ids=list(account_ids))
+        await query.execute(db=self._db)
+        node_kind_map = query.get_id_by_kind()
+        for kind, accounts in node_kind_map.items():
+            account_labels = await get_display_labels_per_kind(
+                kind=kind, branch_name=registry.default_branch, ids=list(accounts), db=self._db
+            )
+            for account_id, display_label in account_labels.items():
+                self._account_labels[account_id] = {"display_label": display_label, "id": account_id, "kind": kind}
+
+    async def _populate_node_labels(self) -> None:
+        node_ids_by_branch_and_kind: dict[str, dict[str, set[str]]] = {}
+        for event in self._events:
+            branch = event.get_branch() or registry.default_branch
+            if branch not in node_ids_by_branch_and_kind:
+                node_ids_by_branch_and_kind[branch] = {}
+            observed_nodes = event.get_related_nodes()
+            if primary := event.get_primary_node():
+                observed_nodes.append(primary)
+            for observed_node in observed_nodes:
+                if observed_node["kind"] not in node_ids_by_branch_and_kind[branch]:
+                    node_ids_by_branch_and_kind[branch][observed_node["kind"]] = set()
+                node_ids_by_branch_and_kind[branch][observed_node["kind"]].add(observed_node["id"])
+
+        for branch, ids_by_kind in node_ids_by_branch_and_kind.items():
+            for kind, ids in ids_by_kind.items():
+                try:
+                    labels = await get_display_labels_per_kind(
+                        kind=kind, ids=list(ids), branch_name=branch, db=self._db, skip_missing_schema=True
+                    )
+                except BranchNotFoundError:
+                    # Ignore display labels for branches that have been deleted
+                    continue
+                if branch not in self._display_labels:
+                    self._display_labels[branch] = {}
+                self._display_labels[branch].update(labels)
 
 
 class PrefectEventResponse(BaseModel):
@@ -239,6 +358,7 @@ class PrefectEvent:
     @classmethod
     async def query(
         cls,
+        db: InfrahubDatabase,
         fields: dict[str, Any],
         event_filter: InfrahubEventFilter,
         limit: int | None = None,
@@ -256,6 +376,10 @@ class PrefectEvent:
 
         async with get_client(sync_client=False) as client:
             response = await cls.query_events(client=client, filters=event_filter, limit=limit, offset=offset)
-            nodes = [{"node": event.to_graphql()} for event in response.events]
+
+        label_mapper = DisplayLabelMapper(db=db, events=response.events)
+        await label_mapper.populate_display_labels()
+
+        nodes = [{"node": event.to_graphql(label_mapper=label_mapper)} for event in response.events]
 
         return {"count": response.count, "edges": nodes}

--- a/backend/tests/unit/graphql/queries/test_event.py
+++ b/backend/tests/unit/graphql/queries/test_event.py
@@ -1,4 +1,3 @@
-import uuid
 from typing import Any
 
 import pytest
@@ -9,6 +8,7 @@ from infrahub.auth import AccountSession, AuthType
 from infrahub.context import InfrahubContext
 from infrahub.core.branch import Branch
 from infrahub.core.constants import MutationAction
+from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.schema.schema_branch import SchemaBranch
@@ -51,21 +51,34 @@ query(
         event
         branch
         has_children
+        account {
+            id
+            kind
+            display_label
+        }
         parent_id
         level
         occurred_at
+        primary_node {
+            id
+            kind
+            display_label
+        }
         related_nodes {
             id
             kind
+            display_label
         }
         ... on GroupEvent {
           ancestors {
             id
             kind
+            display_label
           }
           members {
             id
             kind
+            display_label
           }
         }
       }
@@ -99,6 +112,7 @@ query MutatedNodes($id: [String!]) {
           primary_node {
             id
             kind
+            display_label
           }
           attributes {
             action
@@ -122,31 +136,21 @@ ACCOUNT_SESSION_2 = AccountSession(authenticated=True, account_id=ACCOUNT2_ID, a
 
 
 @pytest.fixture
-async def branch1_id() -> uuid.UUID:
-    return uuid.uuid4()
-
-
-@pytest.fixture
-async def branch2_id() -> uuid.UUID:
-    return uuid.uuid4()
-
-
-@pytest.fixture
-async def branch3_id() -> uuid.UUID:
-    return uuid.uuid4()
-
-
-@pytest.fixture
 async def events_data(
     db: InfrahubDatabase,
     default_branch: Branch,
     register_core_models_schema: None,
     car_person_schema: SchemaBranch,
     prefect_client: PrefectClient,
-    branch1_id: uuid.UUID,
-    branch2_id: uuid.UUID,
-    branch3_id: uuid.UUID,
 ) -> dict[str, InfrahubEvent]:
+    account1 = await Node.init(db=db, schema="CoreAccount")
+    await account1.new(db=db, name="first-account", account_type="User", password="something-secret", id=ACCOUNT1_ID)
+    await account1.save(db=db)
+
+    account2 = await Node.init(db=db, schema="CoreAccount")
+    await account2.new(db=db, name="second-account", account_type="User", password="something-secret", id=ACCOUNT2_ID)
+    await account2.save(db=db)
+
     tag1 = await Node.init(db=db, schema="BuiltinTag", branch=default_branch)
     await tag1.new(db=db, name="red", description="The red tag")
     await tag1.save(db=db)
@@ -195,36 +199,36 @@ async def events_data(
     await group_eu.new(db=db, name="Europe", children=[group_fr])
     await group_eu.save(db=db)
 
-    branch1 = Branch(uuid=branch1_id, name="branch1")
-    branch2 = Branch(uuid=branch2_id, name="branch2")
-    branch3 = Branch(uuid=branch3_id, name="branch3")
+    branch1 = await create_branch(branch_name="branch1", db=db)
+    branch2 = await create_branch(branch_name="branch2", db=db)
+    branch3 = await create_branch(branch_name="branch3", db=db)
 
     items: dict[str, InfrahubEvent] = {
         "branch1_created": BranchCreatedEvent(
             branch_name="branch1",
-            branch_id=str(branch1_id),
+            branch_id=str(branch1.get_uuid()),
             sync_with_git=True,
             meta=EventMeta.with_dummy_context(branch=branch1),
         ),
         "branch1_rebased": BranchRebasedEvent(
             branch_name="branch1",
-            branch_id=str(branch1_id),
+            branch_id=str(branch1.get_uuid()),
             meta=EventMeta.with_dummy_context(branch=branch1),
         ),
         "branch2_created": BranchCreatedEvent(
             branch_name="branch2",
-            branch_id=str(branch2_id),
+            branch_id=str(branch2.get_uuid()),
             sync_with_git=False,
             meta=EventMeta.with_dummy_context(branch=branch2),
         ),
         "branch2_rebased": BranchRebasedEvent(
             branch_name="branch2",
-            branch_id=str(branch2_id),
+            branch_id=str(branch2.get_uuid()),
             meta=EventMeta.with_dummy_context(branch=branch2),
         ),
         "branch3_created": BranchCreatedEvent(
             branch_name="branch3",
-            branch_id=str(branch3_id),
+            branch_id=str(branch3.get_uuid()),
             sync_with_git=True,
             meta=EventMeta.with_dummy_context(branch=branch3),
         ),
@@ -632,10 +636,22 @@ async def test_event_query_prefect(
     assert group_add_event.errors is None
     assert group_add_event.data
     assert group_add_event.data["InfrahubEvent"]["count"] == 1
-    members = [member["id"] for member in group_add_event.data["InfrahubEvent"]["edges"][0]["node"]["members"]]
+    member_ids = [member["id"] for member in group_add_event.data["InfrahubEvent"]["edges"][0]["node"]["members"]]
+    member_labels = [
+        member["display_label"] for member in group_add_event.data["InfrahubEvent"]["edges"][0]["node"]["members"]
+    ]
     ancestors = [member["id"] for member in group_add_event.data["InfrahubEvent"]["edges"][0]["node"]["ancestors"]]
-    assert len(members) == 2
+    assert len(member_ids) == 2
     assert len(ancestors) == 1
-    assert events_data["branch3_mutated1"].node_id in members
-    assert events_data["branch3_mutated2"].node_id in members
+    assert events_data["branch3_mutated1"].node_id in member_ids
+    assert events_data["branch3_mutated2"].node_id in member_ids
     assert events_data["branch1_mutated5"].node_id in ancestors
+    assert sorted(member_labels) == ["Alfred", "Sarah"]
+    assert group_add_event.data["InfrahubEvent"]["edges"][0]["node"]["ancestors"][0]["display_label"] == "Europe"
+    assert group_add_event.data["InfrahubEvent"]["edges"][0]["node"]["primary_node"]["display_label"] == "France"
+    assert len(group_add_event.data["InfrahubEvent"]["edges"][0]["node"]["related_nodes"]) == 3
+    related_node_labels = [
+        related["display_label"]
+        for related in group_add_event.data["InfrahubEvent"]["edges"][0]["node"]["related_nodes"]
+    ]
+    assert sorted(related_node_labels) == ["Alfred", "Europe", "Sarah"]

--- a/backend/tests/unit/task_manager/test_event.py
+++ b/backend/tests/unit/task_manager/test_event.py
@@ -5,6 +5,7 @@ from prefect.client.orchestration import PrefectClient, get_client
 from tests.helpers.events import extract_expected_ids, send_events
 
 from infrahub.core.branch import Branch
+from infrahub.database import InfrahubDatabase
 from infrahub.events.branch_action import BranchCreatedEvent, BranchRebasedEvent
 from infrahub.events.models import EventMeta, InfrahubEvent
 from infrahub.task_manager.event import PrefectEvent
@@ -86,32 +87,44 @@ async def event_ids_inscope(events_data: dict[str, InfrahubEvent]) -> list[str]:
     return [str(event.meta.id) for event in events_data.values()]
 
 
-async def test_query_no_filters(event_ids_inscope):
+async def test_query_no_filters(
+    event_ids_inscope: list[str], db: InfrahubDatabase, register_core_models_schema: None
+) -> None:
     fields = {"count": None, "edges": {"node": {"event": None, "branch": None}}}
-    events = await PrefectEvent.query(fields=fields, event_filter=InfrahubEventFilter())
+    events = await PrefectEvent.query(db=db, fields=fields, event_filter=InfrahubEventFilter())
     clean_events = filter_outofscope_events(events, event_ids_inscope)
     assert clean_events["count"] == 4
 
 
-async def test_query_branch_filter(events_data, event_ids_inscope):
+async def test_query_branch_filter(
+    events_data: dict[str, InfrahubEvent],
+    event_ids_inscope: list[str],
+    db: InfrahubDatabase,
+    register_core_models_schema: None,
+) -> None:
     expected_ids = extract_expected_ids(expected_events=["branch1_created", "branch1_rebased"], data=events_data)
     fields = {"count": None, "edges": {"node": {"event": None, "branch": None}}}
     event_filter = InfrahubEventFilter()
     event_filter.add_branch_filter(branches=["branch1"])
-    events = await PrefectEvent.query(fields=fields, event_filter=event_filter)
+    events = await PrefectEvent.query(db=db, fields=fields, event_filter=event_filter)
     clean_events = filter_outofscope_events(events, event_ids_inscope)
 
     received_ids = sorted([event["node"]["id"] for event in clean_events["edges"]])
     assert received_ids == expected_ids
 
 
-async def test_query_ids_filter(events_data, event_ids_inscope):
+async def test_query_ids_filter(
+    events_data: dict[str, InfrahubEvent],
+    event_ids_inscope: list[str],
+    db: InfrahubDatabase,
+    register_core_models_schema: None,
+) -> None:
     expected_ids = extract_expected_ids(expected_events=["branch1_created", "branch2_created"], data=events_data)
     fields = {"count": None, "edges": {"node": {"event": None, "branch": None}}}
     event_filter = InfrahubEventFilter()
     event_filter.add_event_id_filter(ids=expected_ids)
 
-    events = await PrefectEvent.query(fields=fields, event_filter=event_filter)
+    events = await PrefectEvent.query(db=db, fields=fields, event_filter=event_filter)
     clean_events = filter_outofscope_events(events, event_ids_inscope)
 
     received_ids = sorted([event["node"]["id"] for event in clean_events["edges"]])


### PR DESCRIPTION
This PR adds an optional display label to several fields within the `InfrahubEvent` query. The display labels are optional as there are situations where they are not easily accessible such as when a node or even a branch has been deleted. 

The purpose of this is to perform these lookups directly within the backend instead of having the frontend send a high number of queries in order to fetch the information after the initial response.

The second change of this PR is that the `account_id` field has been replaced with `account` (which can return the id, kind and display label). The `account_id` will be removed as soon as the frontend has been updated to read the new object instead.

(Potentially we could consider populating that information directly within the events but that "static" information could also be outdated if the display labels change within the database)