### PR TITLE
Fix testcontainers check

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -17,8 +17,8 @@ sdk_files: &sdk_files
   - "python_sdk" # Catch updates to the submodule commit
 
 infrahub_poetry_files: &infrahub_poetry_files
-  - "pyproject.toml"
-  - "poetry.lock"
+  - "**/pyproject.toml"
+  - "**/poetry.lock"
 
 frontend_files: &frontend_files
   - "frontend/app/**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
       directory: "./"
 
   infrahub-testcontainers-check:
-    if: needs.files-changed.outputs.python == 'true'
+    if: needs.files-changed.outputs.infrahub_poetry_files == 'true'
     needs: ["files-changed"]
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "infrahub-testcontainers"
-version = "1.2.0rc0"
+version = "1.2.0b1"
 requires-python = ">=3.9"
 
 [tool.poetry]
 name = "infrahub-testcontainers"
-version = "1.2.0rc0"
+version = "1.2.0b1"
 description = "Testcontainers instance for Infrahub to easily build integration tests"
 authors = ["OpsMill <info@opsmill.com>"]
 readme = "README.md"


### PR DESCRIPTION
There's currently a problem with the `infrahub-testcontainers-check` job as it only triggers when Python files have been changed when the relevant part here is when pyproject.toml files change. This being incorrect leads to a situation when we only bump the version, then this check doesn't run instead it will fail later if we've forgotten to update both values. A failure then happens later instead when we try to merge one branch into another such as here in #5870. https://github.com/opsmill/infrahub/actions/runs/13675008868/job/38233479980?pr=5870