### PR TITLE
Various fixes for Webhook

### DIFF
--- a/backend/infrahub/trigger/catalogue.py
+++ b/backend/infrahub/trigger/catalogue.py
@@ -5,12 +5,13 @@ from infrahub.computed_attribute.triggers import (
     TRIGGER_COMPUTED_ATTRIBUTE_PYTHON_SETUP_COMMIT,
 )
 from infrahub.trigger.models import TriggerDefinition
-from infrahub.webhook.triggers import TRIGGER_WEBHOOK_SETUP_UPDATE
+from infrahub.webhook.triggers import TRIGGER_WEBHOOK_DELETE, TRIGGER_WEBHOOK_SETUP_UPDATE
 
 builtin_triggers: list[TriggerDefinition] = [
     TRIGGER_COMPUTED_ATTRIBUTE_ALL_SCHEMA,
     TRIGGER_COMPUTED_ATTRIBUTE_PYTHON_CLEAN_BRANCH,
     TRIGGER_COMPUTED_ATTRIBUTE_PYTHON_SETUP_BRANCH,
     TRIGGER_COMPUTED_ATTRIBUTE_PYTHON_SETUP_COMMIT,
+    TRIGGER_WEBHOOK_DELETE,
     TRIGGER_WEBHOOK_SETUP_UPDATE,
 ]

--- a/backend/infrahub/trigger/models.py
+++ b/backend/infrahub/trigger/models.py
@@ -93,6 +93,9 @@ class TriggerDefinition(BaseModel):
         """Return the name of all deployments used by this trigger"""
         return [action.name for action in self.actions]
 
+    def get_description(self) -> str:
+        return f"Automation for Trigger {self.name} of type {self.type.value}"
+
     def generate_name(self) -> str:
         return f"{self.type.value}{NAME_SEPARATOR}{self.name}"
 

--- a/backend/infrahub/webhook/models.py
+++ b/backend/infrahub/webhook/models.py
@@ -13,6 +13,7 @@ from infrahub.core import registry
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.timestamp import Timestamp
 from infrahub.git.repository import InfrahubReadOnlyRepository, InfrahubRepository
+from infrahub.trigger.constants import NAME_SEPARATOR
 from infrahub.trigger.models import EventTrigger, ExecuteWorkflow, TriggerDefinition, TriggerType
 from infrahub.workflows.catalogue import WEBHOOK_PROCESS
 
@@ -24,7 +25,15 @@ if TYPE_CHECKING:
 
 
 class WebhookTriggerDefinition(TriggerDefinition):
+    id: str
     type: TriggerType = TriggerType.WEBHOOK
+
+    def generate_name(self) -> str:
+        return f"{self.type.value}{NAME_SEPARATOR}{self.id}"
+
+    @classmethod
+    def generate_name_from_id(cls, id: str) -> str:
+        return f"{TriggerType.WEBHOOK.value}{NAME_SEPARATOR}{id}"
 
     @classmethod
     def from_object(cls, obj: CoreWebhook) -> Self:
@@ -46,6 +55,7 @@ class WebhookTriggerDefinition(TriggerDefinition):
             }
 
         definition = cls(
+            id=obj.id,
             name=obj.name.value,
             trigger=event_trigger,
             actions=[

--- a/backend/infrahub/webhook/tasks.py
+++ b/backend/infrahub/webhook/tasks.py
@@ -119,14 +119,16 @@ async def configure_webhook_all(service: InfrahubServices) -> None:
     log.info(f"{len(triggers)} Webhooks automation configuration completed")
 
 
-@flow(name="webhook-setup-automation-one", flow_run_name="Configuration webhook automation for one webhook")
-async def configure_webhook_one(event_type: str, event_data: dict, service: InfrahubServices) -> None:
+@flow(name="webhook-setup-automation-one", flow_run_name="Configuration webhook automation for {webhook_name}")
+async def configure_webhook_one(
+    webhook_name: str,  # noqa: ARG001
+    event_data: dict,
+    service: InfrahubServices,
+) -> None:
     log = get_run_logger()
 
     webhook = await service.client.get(kind=CoreWebhook, id=event_data["node_id"])
     trigger = WebhookTriggerDefinition.from_object(webhook)
-
-    delete_automation: bool = "infrahub.node.deleted" in event_type
 
     async with get_client(sync_client=False) as prefect_client:
         # Query the deployment associated with the trigger to have its ID
@@ -135,22 +137,42 @@ async def configure_webhook_one(event_type: str, event_data: dict, service: Infr
 
         automation = AutomationCore(
             name=trigger.generate_name(),
-            description=trigger.description,
+            description=trigger.get_description(),
             enabled=True,
             trigger=trigger.trigger.get_prefect(),
             actions=[action.get(deployment.id) for action in trigger.actions],
         )
 
         existing_automations = await prefect_client.read_automations_by_name(trigger.generate_name())
+        existing_automation = existing_automations[0] if existing_automations else None
 
-        if existing_automations and not delete_automation:
-            existing_automation = existing_automations[0]
+        if existing_automation:
             await prefect_client.update_automation(automation_id=existing_automation.id, automation=automation)
             log.info(f"Automation {trigger.generate_name()} updated")
-        elif existing_automations and delete_automation:
-            existing_automation = existing_automations[0]
-            await prefect_client.delete_automation(automation_id=existing_automation.id)
-            log.info(f"Automation {trigger.generate_name()} deleted")
         else:
             await prefect_client.create_automation(automation=automation)
             log.info(f"Automation {trigger.generate_name()} created")
+
+        await service.cache.delete(key=f"webhook:{webhook.id}")
+
+
+@flow(name="webhook-delete-automation", flow_run_name="Delete webhook automation for {webhook_name}")
+async def delete_webhook_automation(
+    webhook_id: str,
+    webhook_name: str,  # noqa: ARG001
+    event_data: dict,  # noqa: ARG001
+    service: InfrahubServices,
+) -> None:
+    log = get_run_logger()
+
+    async with get_client(sync_client=False) as prefect_client:
+        automation_name = WebhookTriggerDefinition.generate_name_from_id(id=webhook_id)
+
+        existing_automations = await prefect_client.read_automations_by_name(automation_name)
+        existing_automation = existing_automations[0] if existing_automations else None
+
+        if existing_automation:
+            await prefect_client.delete_automation(automation_id=existing_automation.id)
+            log.info(f"Automation {automation_name} deleted")
+
+        await service.cache.delete(key=f"webhook:{webhook_id}")

--- a/backend/infrahub/webhook/triggers.py
+++ b/backend/infrahub/webhook/triggers.py
@@ -1,13 +1,11 @@
 from infrahub.core.constants import InfrahubKind
 from infrahub.trigger.models import BuiltinTriggerDefinition, EventTrigger, ExecuteWorkflow
-from infrahub.workflows.catalogue import (
-    WEBHOOK_CONFIGURE_ONE,
-)
+from infrahub.workflows.catalogue import WEBHOOK_CONFIGURE_ONE, WEBHOOK_DELETE_AUTOMATION
 
 TRIGGER_WEBHOOK_SETUP_UPDATE = BuiltinTriggerDefinition(
     name="webhook-configure-one",
     trigger=EventTrigger(
-        events={"infrahub.node.*"},
+        events={"infrahub.node.created", "infrahub.node.updated"},
         match={
             "infrahub.node.kind": [InfrahubKind.CUSTOMWEBHOOK, InfrahubKind.STANDARDWEBHOOK],
         },
@@ -16,7 +14,30 @@ TRIGGER_WEBHOOK_SETUP_UPDATE = BuiltinTriggerDefinition(
         ExecuteWorkflow(
             workflow=WEBHOOK_CONFIGURE_ONE,
             parameters={
-                "event_type": "{{ event.event }}",
+                "webhook_name": "{{ event.payload['data']['display_label'] }}",
+                "event_data": {
+                    "__prefect_kind": "json",
+                    "value": {"__prefect_kind": "jinja", "template": "{{ event.payload['data'] | tojson }}"},
+                },
+            },
+        ),
+    ],
+)
+
+TRIGGER_WEBHOOK_DELETE = BuiltinTriggerDefinition(
+    name="webhook-delete",
+    trigger=EventTrigger(
+        events={"infrahub.node.deleted"},
+        match={
+            "infrahub.node.kind": [InfrahubKind.CUSTOMWEBHOOK, InfrahubKind.STANDARDWEBHOOK],
+        },
+    ),
+    actions=[
+        ExecuteWorkflow(
+            workflow=WEBHOOK_DELETE_AUTOMATION,
+            parameters={
+                "webhook_id": "{{ event.payload['data']['node_id'] }}",
+                "webhook_name": "{{ event.payload['data']['display_label'] }}",
                 "event_data": {
                     "__prefect_kind": "json",
                     "value": {"__prefect_kind": "jinja", "template": "{{ event.payload['data'] | tojson }}"},

--- a/backend/infrahub/workflows/catalogue.py
+++ b/backend/infrahub/workflows/catalogue.py
@@ -366,10 +366,17 @@ WEBHOOK_CONFIGURE_ONE = WorkflowDefinition(
 
 WEBHOOK_CONFIGURE_ALL = WorkflowDefinition(
     name="webhook-setup-automation-all",
-    type=WorkflowType.CORE,
+    type=WorkflowType.INTERNAL,
     cron=f"{random.randint(0, 59)} 3 * * *",
     module="infrahub.webhook.tasks",
     function="configure_webhook_all",
+)
+
+WEBHOOK_DELETE_AUTOMATION = WorkflowDefinition(
+    name="webhook-delete-automation",
+    type=WorkflowType.CORE,
+    module="infrahub.webhook.tasks",
+    function="delete_webhook_automation",
 )
 
 GIT_REPOSITORIES_CHECK_ARTIFACT_CREATE = WorkflowDefinition(
@@ -472,5 +479,6 @@ workflows = [
     UPDATE_COMPUTED_ATTRIBUTE_TRANSFORM,
     WEBHOOK_CONFIGURE_ALL,
     WEBHOOK_CONFIGURE_ONE,
+    WEBHOOK_DELETE_AUTOMATION,
     WEBHOOK_PROCESS,
 ]

--- a/backend/tests/functional/webhook/test_task.py
+++ b/backend/tests/functional/webhook/test_task.py
@@ -14,6 +14,7 @@ from infrahub.webhook.tasks import (
     configure_webhook_all,
     configure_webhook_one,
     convert_node_to_webhook,
+    delete_webhook_automation,
     webhook_process,
 )
 from infrahub.workflows.catalogue import WEBHOOK_PROCESS, worker_pools
@@ -155,11 +156,9 @@ class TestWebhookTasks(TestInfrahubApp):
     async def test_configure_one(
         self, db: InfrahubDatabase, service, prefect_client: PrefectClient, webhook1: Node, webhook_deployment
     ) -> None:
-        await configure_webhook_one(
-            event_type="infrahub.node.created", event_data={"node_id": webhook1.id}, service=service
-        )
+        await configure_webhook_one(webhook_name="Webhook1", event_data={"node_id": webhook1.id}, service=service)
 
-        name = "webhook::Webhook1"
+        name = f"webhook::{webhook1.id}"
         automations = await prefect_client.read_automations_by_name(name=name)
         assert len(automations) == 1
         automation = automations[0]
@@ -172,15 +171,13 @@ class TestWebhookTasks(TestInfrahubApp):
         assert action.parameters["webhook_kind"] == "CoreStandardWebhook"
 
         # Configure it a second time to ensure the function is idempotent
-        await configure_webhook_one(
-            event_type="infrahub.node.created", event_data={"node_id": webhook1.id}, service=service
-        )
+        await configure_webhook_one(webhook_name="Webhook1", event_data={"node_id": webhook1.id}, service=service)
         automations = await prefect_client.read_automations_by_name(name=name)
         assert len(automations) == 1
 
         # Delete the webhook automation
-        await configure_webhook_one(
-            event_type="infrahub.node.deleted", event_data={"node_id": webhook1.id}, service=service
+        await delete_webhook_automation(
+            webhook_id=webhook1.id, webhook_name="Webhook1", event_data={"node_id": webhook1.id}, service=service
         )
         automations = await prefect_client.read_automations_by_name(name=name)
         assert len(automations) == 0
@@ -199,10 +196,10 @@ class TestWebhookTasks(TestInfrahubApp):
         automations = await prefect_client.read_automations()
         automations_by_name = {automation.name: automation for automation in automations}
 
-        assert "webhook::Webhook1" in automations_by_name.keys()
-        assert "webhook::Webhook2" in automations_by_name.keys()
+        assert f"webhook::{webhook1.id}" in automations_by_name.keys()
+        assert f"webhook::{webhook2.id}" in automations_by_name.keys()
 
-        automation = automations_by_name["webhook::Webhook2"]
+        automation = automations_by_name[f"webhook::{webhook2.id}"]
         assert len(automation.actions) == 1
         action: RunDeployment = automation.actions[0]  # type: ignore[assignment]
         assert action.parameters

--- a/backend/tests/unit/trigger/test_catalogue.py
+++ b/backend/tests/unit/trigger/test_catalogue.py
@@ -20,4 +20,4 @@ def test_builtin_trigger_definition(trigger: TriggerDefinition) -> None:
 def test_builtin_triggers_sorted() -> None:
     names = sorted(name for name in dir(catalogue) if name.isupper())
     ordered_triggers = [getattr(catalogue, name) for name in names]
-    assert ordered_triggers == builtin_triggers, "The list of workflows isn't sorted alphabetically"
+    assert ordered_triggers == builtin_triggers, "The list of triggers isn't sorted alphabetically"

--- a/docs/docs/reference/infrahub-events.mdx
+++ b/docs/docs/reference/infrahub-events.mdx
@@ -8,7 +8,7 @@ This document provides detailed documentation for all events used in the Infrahu
 
 :::info
 
-For more detailed explanations on how these events are used within Infrahub, see the [Infrahub event](../topics/infrahub-event) topic.
+For more detailed explanations on how these events are used within Infrahub, see the [infrahub event](../topics/infrahub-event) topic.
 
 :::
 


### PR DESCRIPTION
fixes ifc-1355

- Ensure that the cache will be cleanup when we update a webhook node
- Create dedicated Trigger to delete webhook automation
- Use the id instead of the name to create the automation to allow webhook name to change overtime