### PR TITLE
Fix file selection for documentation style CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -643,7 +643,7 @@ jobs:
       always() && !cancelled() &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
-      needs.files-changed.outputs.release == 'true'
+      (needs.files-changed.outputs.release == 'true') || (needs.files-changed.outputs.documentation == 'true')
     needs: ["files-changed", "yaml-lint", "python-lint", "infrahub-testcontainers-check"]
     runs-on: "ubuntu-22.04"
     timeout-minutes: 5

--- a/docs/_templates/infrahub-events.j2
+++ b/docs/_templates/infrahub-events.j2
@@ -8,7 +8,7 @@ This document provides detailed documentation for all events used in the Infrahu
 
 :::info
 
-For more detailed explanations on how these events are used within Infrahub, see the [infrahub event](../topics/infrahub-event) topic.
+For more detailed explanations on how these events are used within Infrahub, see the [Infrahub event](../topics/infrahub-event) topic.
 
 :::
 

--- a/docs/docs/reference/infrahub-events.mdx
+++ b/docs/docs/reference/infrahub-events.mdx
@@ -8,7 +8,7 @@ This document provides detailed documentation for all events used in the Infrahu
 
 :::info
 
-For more detailed explanations on how these events are used within Infrahub, see the [infrahub event](../topics/infrahub-event) topic.
+For more detailed explanations on how these events are used within Infrahub, see the [Infrahub event](../topics/infrahub-event) topic.
 
 :::
 


### PR DESCRIPTION
Fix broken CI where the job to validate documentation style could fail after a PR with violations was merged due to incorrect file filtering.