### PR TITLE
Add validator events

### DIFF
--- a/backend/infrahub/core/constants/__init__.py
+++ b/backend/infrahub/core/constants/__init__.py
@@ -66,6 +66,10 @@ class EventType(InfrahubStringEnum):
     ARTIFACT_CREATED = f"{EVENT_NAMESPACE}.artifact.created"
     ARTIFACT_UPDATED = f"{EVENT_NAMESPACE}.artifact.updated"
 
+    VALIDATOR_STARTED = f"{EVENT_NAMESPACE}.validator.started"
+    VALIDATOR_PASSED = f"{EVENT_NAMESPACE}.validator.passed"
+    VALIDATOR_FAILED = f"{EVENT_NAMESPACE}.validator.failed"
+
 
 class PermissionLevel(enum.Flag):
     READ = 1

--- a/backend/infrahub/core/validators/checks_runner.py
+++ b/backend/infrahub/core/validators/checks_runner.py
@@ -1,14 +1,21 @@
 import asyncio
 from typing import Any, Coroutine
 
-from infrahub_sdk.node import InfrahubNode
+from infrahub_sdk.protocols import CoreValidator
 
+from infrahub.context import InfrahubContext
 from infrahub.core.constants import ValidatorConclusion, ValidatorState
 from infrahub.core.timestamp import Timestamp
+from infrahub.services import InfrahubServices
+from infrahub.validators.events import send_failed_validator, send_passed_validator
 
 
 async def run_checks_and_update_validator(
-    checks: list[Coroutine[Any, None, ValidatorConclusion]], validator: InfrahubNode
+    checks: list[Coroutine[Any, None, ValidatorConclusion]],
+    validator: CoreValidator,
+    context: InfrahubContext,
+    service: InfrahubServices,
+    proposed_change_id: str,
 ) -> None:
     """
     Execute a list of checks coroutines, and set validator fields accordingly.
@@ -22,11 +29,17 @@ async def run_checks_and_update_validator(
     validator.completed_at.value = ""
     await validator.save()
 
+    failed_early = False
+
     for earliest_task in asyncio.as_completed(checks):
         result = await earliest_task
         if validator.conclusion.value != ValidatorConclusion.FAILURE.value and result == ValidatorConclusion.FAILURE:
             validator.conclusion.value = ValidatorConclusion.FAILURE.value
+            failed_early = True
             await validator.save()
+            await send_failed_validator(
+                service=service, validator=validator, proposed_change_id=proposed_change_id, context=context
+            )
             # Continue to iterate to wait for the end of all checks
 
     validator.state.value = ValidatorState.COMPLETED.value
@@ -35,3 +48,13 @@ async def run_checks_and_update_validator(
         validator.conclusion.value = ValidatorConclusion.SUCCESS.value
 
     await validator.save()
+
+    if not failed_early:
+        if validator.conclusion.value == ValidatorConclusion.SUCCESS.value:
+            await send_passed_validator(
+                service=service, validator=validator, proposed_change_id=proposed_change_id, context=context
+            )
+        else:
+            await send_failed_validator(
+                service=service, validator=validator, proposed_change_id=proposed_change_id, context=context
+            )

--- a/backend/infrahub/events/validator_action.py
+++ b/backend/infrahub/events/validator_action.py
@@ -1,0 +1,61 @@
+from pydantic import Field, computed_field
+
+from infrahub.message_bus import InfrahubMessage
+
+from .constants import EVENT_NAMESPACE
+from .models import InfrahubEvent
+
+
+class ValidatorEvent(InfrahubEvent):
+    """Event generated when an validator within a pipeline has started."""
+
+    node_id: str = Field(..., description="The ID of the validator")
+    kind: str = Field(..., description="The kind of the validator")
+    proposed_change_id: str = Field(..., description="The ID of the proposed change")
+
+    def get_resource(self) -> dict[str, str]:
+        return {
+            "prefect.resource.id": self.node_id,
+            "infrahub.node.kind": self.kind,
+            "infrahub.node.id": self.node_id,
+            "infrahub.branch.name": self.meta.context.branch.name,
+        }
+
+    def get_related(self) -> list[dict[str, str]]:
+        related = super().get_related()
+        related.append(
+            {
+                "prefect.resource.id": self.proposed_change_id,
+                "prefect.resource.role": "infrahub.related.node",
+                "infrahub.node.kind": "CoreProposedChange",
+            }
+        )
+
+        return related
+
+    def get_messages(self) -> list[InfrahubMessage]:
+        return []
+
+
+class ValidatorStartedEvent(ValidatorEvent):
+    """Event generated when an validator within a pipeline has started."""
+
+    @computed_field
+    def event_name(self) -> str:
+        return f"{EVENT_NAMESPACE}.validator.started"
+
+
+class ValidatorPassedEvent(ValidatorEvent):
+    """Event generated when an validator within a pipeline has completed successfully."""
+
+    @computed_field
+    def event_name(self) -> str:
+        return f"{EVENT_NAMESPACE}.validator.passed"
+
+
+class ValidatorFailedEvent(ValidatorEvent):
+    """Event generated when an validator within a pipeline has completed successfully."""
+
+    @computed_field
+    def event_name(self) -> str:
+        return f"{EVENT_NAMESPACE}.validator.failed"

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -1,5 +1,12 @@
 from infrahub_sdk import InfrahubClient
-from infrahub_sdk.protocols import CoreArtifact, CoreArtifactDefinition, CoreCheckDefinition, CoreRepository
+from infrahub_sdk.protocols import (
+    CoreArtifact,
+    CoreArtifactDefinition,
+    CoreCheckDefinition,
+    CoreRepository,
+    CoreRepositoryValidator,
+    CoreUserValidator,
+)
 from infrahub_sdk.uuidt import UUIDT
 from prefect import flow, task
 from prefect.cache_policies import NONE
@@ -12,6 +19,7 @@ from infrahub.core.registry import registry
 from infrahub.exceptions import CheckError, RepositoryError
 from infrahub.message_bus import Meta, messages
 from infrahub.services import InfrahubServices
+from infrahub.validators.events import send_start_validator
 from infrahub.worker import WORKER_IDENTITY
 
 from ..core.manager import NodeManager
@@ -509,7 +517,9 @@ async def git_repository_diff_names_only(
     name="git-repository-user-checks-definition-trigger",
     flow_run_name="Trigger user defined checks for repository {model.repository_name}",
 )
-async def trigger_repository_user_checks_definitions(model: UserCheckDefinitionData, service: InfrahubServices) -> None:
+async def trigger_repository_user_checks_definitions(
+    model: UserCheckDefinitionData, context: InfrahubContext, service: InfrahubServices
+) -> None:
     await add_tags(branches=[model.branch_name], nodes=[model.proposed_change])
     log = get_run_logger()
 
@@ -520,7 +530,7 @@ async def trigger_repository_user_checks_definitions(model: UserCheckDefinitionD
     validator_execution_id = str(UUIDT())
     check_execution_ids: list[str] = []
     await proposed_change.validations.fetch()
-    validator = None
+    validator: CoreUserValidator | None = None
 
     for relationship in proposed_change.validations.peers:
         existing_validator = relationship.peer
@@ -541,7 +551,7 @@ async def trigger_repository_user_checks_definitions(model: UserCheckDefinitionD
         await validator.save()
     else:
         validator = await service.client.create(
-            kind=InfrahubKind.USERVALIDATOR,
+            kind=CoreUserValidator,
             data={
                 "label": f"Check: {definition.name.value}",
                 "proposed_change": model.proposed_change,
@@ -550,6 +560,10 @@ async def trigger_repository_user_checks_definitions(model: UserCheckDefinitionD
             },
         )
         await validator.save()
+
+    await send_start_validator(
+        service=service, validator=validator, proposed_change_id=model.proposed_change, context=context
+    )
 
     if definition.targets.id:
         # Check against a group of targets
@@ -612,14 +626,22 @@ async def trigger_repository_user_checks_definitions(model: UserCheckDefinitionD
         for model in check_models
     ]
 
-    await run_checks_and_update_validator(checks_coroutines, validator)
+    await run_checks_and_update_validator(
+        checks=checks_coroutines,
+        validator=validator,
+        context=context,
+        service=service,
+        proposed_change_id=model.proposed_change,
+    )
 
 
 @flow(
     name="git-repository-trigger-user-checks",
     flow_run_name="Evaluating user-defined checks on repository {model.repository_name}",
 )
-async def trigger_user_checks(model: TriggerRepositoryUserChecks, service: InfrahubServices) -> None:
+async def trigger_user_checks(
+    model: TriggerRepositoryUserChecks, service: InfrahubServices, context: InfrahubContext
+) -> None:
     """Request to start validation checks on a specific repository for User-defined checks."""
 
     await add_tags(branches=[model.source_branch], nodes=[model.proposed_change])
@@ -645,7 +667,9 @@ async def trigger_user_checks(model: TriggerRepositoryUserChecks, service: Infra
             branch_diff=model.branch_diff,
         )
         await service.workflow.submit_workflow(
-            workflow=GIT_REPOSITORY_USER_CHECKS_DEFINITIONS_TRIGGER, parameters={"model": user_check_definition_model}
+            workflow=GIT_REPOSITORY_USER_CHECKS_DEFINITIONS_TRIGGER,
+            context=context,
+            parameters={"model": user_check_definition_model},
         )
 
 
@@ -653,7 +677,9 @@ async def trigger_user_checks(model: TriggerRepositoryUserChecks, service: Infra
     name="git-repository-trigger-internal-checks",
     flow_run_name="Running repository checks for repository {model.repository}",
 )
-async def trigger_internal_checks(model: TriggerRepositoryInternalChecks, service: InfrahubServices) -> None:
+async def trigger_internal_checks(
+    model: TriggerRepositoryInternalChecks, service: InfrahubServices, context: InfrahubContext
+) -> None:
     """Request to start validation checks on a specific repository."""
     await add_tags(branches=[model.source_branch], nodes=[model.proposed_change])
     log = get_run_logger()
@@ -669,7 +695,7 @@ async def trigger_internal_checks(model: TriggerRepositoryInternalChecks, servic
     await repository.checks.fetch()
 
     validator_name = f"Repository Validator: {repository.name.value}"
-    validator = None
+    validator: CoreRepositoryValidator | None = None
     for relationship in proposed_change.validations.peers:
         existing_validator = relationship.peer
 
@@ -687,7 +713,7 @@ async def trigger_internal_checks(model: TriggerRepositoryInternalChecks, servic
         await validator.save()
     else:
         validator = await service.client.create(
-            kind=InfrahubKind.REPOSITORYVALIDATOR,
+            kind=CoreRepositoryValidator,
             data={
                 "label": validator_name,
                 "proposed_change": model.proposed_change,
@@ -695,6 +721,10 @@ async def trigger_internal_checks(model: TriggerRepositoryInternalChecks, servic
             },
         )
         await validator.save()
+
+    await send_start_validator(
+        service=service, validator=validator, proposed_change_id=model.proposed_change, context=context
+    )
 
     check_execution_id = str(UUIDT())
     check_execution_ids.append(check_execution_id)
@@ -718,7 +748,13 @@ async def trigger_internal_checks(model: TriggerRepositoryInternalChecks, servic
         expected_return=ValidatorConclusion,
     )
 
-    await run_checks_and_update_validator(checks=[check_coroutine], validator=validator)
+    await run_checks_and_update_validator(
+        checks=[check_coroutine],
+        validator=validator,
+        context=context,
+        service=service,
+        proposed_change_id=model.proposed_change,
+    )
 
 
 @flow(

--- a/backend/infrahub/message_bus/messages/finalize_validator_execution.py
+++ b/backend/infrahub/message_bus/messages/finalize_validator_execution.py
@@ -1,5 +1,6 @@
 from pydantic import Field
 
+from infrahub.context import InfrahubContext
 from infrahub.message_bus import InfrahubMessage
 
 
@@ -10,3 +11,5 @@ class FinalizeValidatorExecution(InfrahubMessage):
     validator_execution_id: str = Field(..., description="The id of current execution of the associated validator")
     start_time: str = Field(..., description="Start time when the message was first created")
     validator_type: str = Field(..., description="The type of validator to complete")
+    context: InfrahubContext = Field(..., description="The Infrahub context")
+    proposed_change: str = Field(..., description="The ID of the proposed change")

--- a/backend/infrahub/message_bus/messages/request_generatordefinition_check.py
+++ b/backend/infrahub/message_bus/messages/request_generatordefinition_check.py
@@ -1,5 +1,6 @@
 from pydantic import ConfigDict, Field
 
+from infrahub.context import InfrahubContext
 from infrahub.generators.models import ProposedChangeGeneratorDefinition
 from infrahub.message_bus import InfrahubMessage
 from infrahub.message_bus.types import ProposedChangeBranchDiff
@@ -16,3 +17,4 @@ class RequestGeneratorDefinitionCheck(InfrahubMessage):
     source_branch: str = Field(..., description="The source branch")
     source_branch_sync_with_git: bool = Field(..., description="Indicates if the source branch should sync with git")
     destination_branch: str = Field(..., description="The target branch")
+    context: InfrahubContext = Field(..., description="The Infrahub context")

--- a/backend/infrahub/message_bus/operations/finalize/validator.py
+++ b/backend/infrahub/message_bus/operations/finalize/validator.py
@@ -1,11 +1,22 @@
+from infrahub_sdk.protocols import (
+    CoreArtifactValidator,
+    CoreDataValidator,
+    CoreGeneratorValidator,
+    CoreRepositoryValidator,
+    CoreSchemaValidator,
+    CoreUserValidator,
+    CoreValidator,
+)
 from prefect import flow
 
 from infrahub import config
+from infrahub.core.constants import InfrahubKind, ValidatorConclusion
 from infrahub.core.timestamp import Timestamp
 from infrahub.log import get_logger
 from infrahub.message_bus import messages
 from infrahub.message_bus.types import KVTTL, MessageTTL
 from infrahub.services import InfrahubServices
+from infrahub.validators.events import send_failed_validator, send_passed_validator
 
 log = get_logger()
 
@@ -20,7 +31,8 @@ async def execution(message: messages.FinalizeValidatorExecution, service: Infra
 
     The message will get rescheduled until the timeout has exceeded or until all checks are accounted for.
     """
-    validator = await service.client.get(kind=message.validator_type, id=message.validator_id)
+    validator_type = get_validator_type(validator_type=message.validator_type)
+    validator = await service.client.get(kind=validator_type, id=message.validator_id)
     checks_key = f"validator_execution_id:{message.validator_execution_id}:checks"
     current_conclusion = validator.conclusion.value
     if validator.state.value != "in_progress":
@@ -81,3 +93,41 @@ async def execution(message: messages.FinalizeValidatorExecution, service: Infra
     validator.completed_at.value = Timestamp().to_string()
     validator.conclusion.value = conclusion
     await validator.save()
+    if validator.conclusion.value == ValidatorConclusion.SUCCESS.value:
+        await send_passed_validator(
+            service=service, validator=validator, proposed_change_id=message.proposed_change, context=message.context
+        )
+    else:
+        await send_failed_validator(
+            service=service, validator=validator, proposed_change_id=message.proposed_change, context=message.context
+        )
+
+
+def get_validator_type(
+    validator_type: str,
+) -> (
+    type[CoreArtifactValidator]
+    | type[CoreDataValidator]
+    | type[CoreGeneratorValidator]
+    | type[CoreRepositoryValidator]
+    | type[CoreSchemaValidator]
+    | type[CoreUserValidator]
+    | type[CoreValidator]
+):
+    match validator_type:
+        case InfrahubKind.USERVALIDATOR:
+            validator_kind = CoreUserValidator
+        case InfrahubKind.SCHEMAVALIDATOR:
+            validator_kind = CoreSchemaValidator
+        case InfrahubKind.GENERATORVALIDATOR:
+            validator_kind = CoreGeneratorValidator
+        case InfrahubKind.REPOSITORYVALIDATOR:
+            validator_kind = CoreRepositoryValidator
+        case InfrahubKind.DATAVALIDATOR:
+            validator_kind = CoreDataValidator
+        case InfrahubKind.ARTIFACTVALIDATOR:
+            validator_kind = CoreArtifactValidator
+        case _:
+            validator_kind = CoreValidator
+
+    return validator_kind

--- a/backend/infrahub/message_bus/operations/requests/generator_definition.py
+++ b/backend/infrahub/message_bus/operations/requests/generator_definition.py
@@ -1,3 +1,4 @@
+from infrahub_sdk.protocols import CoreGeneratorValidator
 from infrahub_sdk.uuidt import UUIDT
 from prefect import flow
 from prefect.logging import get_run_logger
@@ -7,6 +8,7 @@ from infrahub.core.timestamp import Timestamp
 from infrahub.message_bus import InfrahubMessage, Meta, messages
 from infrahub.message_bus.types import KVTTL
 from infrahub.services import InfrahubServices
+from infrahub.validators.events import send_start_validator
 from infrahub.workflows.utils import add_tags
 
 
@@ -27,7 +29,7 @@ async def check(message: messages.RequestGeneratorDefinitionCheck, service: Infr
 
     await proposed_change.validations.fetch()
 
-    validator = None
+    validator: CoreGeneratorValidator | None = None
     for relationship in proposed_change.validations.peers:
         existing_validator = relationship.peer
         if (
@@ -44,7 +46,7 @@ async def check(message: messages.RequestGeneratorDefinitionCheck, service: Infr
         await validator.save()
     else:
         validator = await service.client.create(
-            kind=InfrahubKind.GENERATORVALIDATOR,
+            kind=CoreGeneratorValidator,
             data={
                 "label": validator_name,
                 "proposed_change": message.proposed_change,
@@ -52,6 +54,9 @@ async def check(message: messages.RequestGeneratorDefinitionCheck, service: Infr
             },
         )
         await validator.save()
+    await send_start_validator(
+        service=service, validator=validator, proposed_change_id=message.proposed_change, context=message.context
+    )
 
     group = await service.client.get(
         kind=InfrahubKind.GENERICGROUP,
@@ -119,6 +124,8 @@ async def check(message: messages.RequestGeneratorDefinitionCheck, service: Infr
             validator_id=validator.id,
             validator_execution_id=validator_execution_id,
             validator_type=InfrahubKind.GENERATORVALIDATOR,
+            context=message.context,
+            proposed_change=message.proposed_change,
         )
     )
     for event in events:

--- a/backend/infrahub/message_bus/operations/requests/proposed_change.py
+++ b/backend/infrahub/message_bus/operations/requests/proposed_change.py
@@ -85,7 +85,9 @@ async def pipeline(message: messages.RequestProposedChangePipeline, service: Inf
                     target_branch=repo.destination_branch,
                 )
                 await service.workflow.submit_workflow(
-                    workflow=GIT_REPOSITORY_INTERNAL_CHECKS_TRIGGER, parameters={"model": model}
+                    workflow=GIT_REPOSITORY_INTERNAL_CHECKS_TRIGGER,
+                    context=message.context,
+                    parameters={"model": model},
                 )
         return
 

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
-from infrahub_sdk.protocols import CoreGeneratorDefinition, CoreProposedChange
+from infrahub_sdk.protocols import CoreArtifactValidator, CoreGeneratorDefinition, CoreProposedChange
 from prefect import flow, task
 from prefect.cache_policies import NONE
 from prefect.client.schemas.objects import (
@@ -52,6 +52,7 @@ from infrahub.proposed_change.models import (
 )
 from infrahub.pytest_plugin import InfrahubBackendPlugin
 from infrahub.services import InfrahubServices  # noqa: TC001  needed for prefect flow
+from infrahub.validators.events import send_start_validator
 from infrahub.workflows.catalogue import (
     COMPUTED_ATTRIBUTE_SETUP_PYTHON,
     GIT_REPOSITORIES_CHECK_ARTIFACT_CREATE,
@@ -275,6 +276,7 @@ async def run_generators(
 
         if select:
             msg = messages.RequestGeneratorDefinitionCheck(
+                context=context,
                 generator_definition=generator_definition,
                 branch_diff=model.branch_diff,
                 proposed_change=model.proposed_change,
@@ -415,7 +417,9 @@ async def _get_proposed_change_schema_integrity_constraints(
     name="proposed-changed-repository-checks",
     flow_run_name="Process user defined checks",
 )
-async def repository_checks(model: RequestProposedChangeRepositoryChecks, service: InfrahubServices) -> None:
+async def repository_checks(
+    model: RequestProposedChangeRepositoryChecks, service: InfrahubServices, context: InfrahubContext
+) -> None:
     await add_tags(branches=[model.source_branch], nodes=[model.proposed_change])
 
     for repository in model.branch_diff.repositories:
@@ -431,7 +435,9 @@ async def repository_checks(model: RequestProposedChangeRepositoryChecks, servic
                 target_branch=model.destination_branch,
             )
             await service.workflow.submit_workflow(
-                workflow=GIT_REPOSITORY_INTERNAL_CHECKS_TRIGGER, parameters={"model": trigger_internal_checks_model}
+                workflow=GIT_REPOSITORY_INTERNAL_CHECKS_TRIGGER,
+                context=context,
+                parameters={"model": trigger_internal_checks_model},
             )
 
         trigger_user_checks_model = TriggerRepositoryUserChecks(
@@ -444,7 +450,9 @@ async def repository_checks(model: RequestProposedChangeRepositoryChecks, servic
             branch_diff=model.branch_diff,
         )
         await service.workflow.submit_workflow(
-            workflow=GIT_REPOSITORY_USER_CHECKS_TRIGGER, parameters={"model": trigger_user_checks_model}
+            workflow=GIT_REPOSITORY_USER_CHECKS_TRIGGER,
+            context=context,
+            parameters={"model": trigger_user_checks_model},
         )
 
 
@@ -532,7 +540,7 @@ async def validate_artifacts_generation(model: RequestArtifactDefinitionCheck, s
 
     await proposed_change.validations.fetch()
 
-    validator = None
+    validator: CoreArtifactValidator | None = None
     for relationship in proposed_change.validations.peers:
         existing_validator = relationship.peer
         if (
@@ -549,7 +557,7 @@ async def validate_artifacts_generation(model: RequestArtifactDefinitionCheck, s
         await validator.save()
     else:
         validator = await service.client.create(
-            kind=InfrahubKind.ARTIFACTVALIDATOR,
+            kind=CoreArtifactValidator,
             data={
                 "label": validator_name,
                 "proposed_change": model.proposed_change,
@@ -557,6 +565,10 @@ async def validate_artifacts_generation(model: RequestArtifactDefinitionCheck, s
             },
         )
         await validator.save()
+
+    await send_start_validator(
+        service=service, validator=validator, proposed_change_id=model.proposed_change, context=model.context
+    )
 
     await artifact_definition.targets.fetch()
     group = artifact_definition.targets.peer
@@ -617,7 +629,13 @@ async def validate_artifacts_generation(model: RequestArtifactDefinitionCheck, s
                 )
             )
 
-    await run_checks_and_update_validator(checks, validator)
+    await run_checks_and_update_validator(
+        checks=checks,
+        validator=validator,
+        proposed_change_id=model.proposed_change,
+        context=model.context,
+        service=service,
+    )
 
 
 def _should_render_artifact(artifact_id: str | None, managed_branch: bool, impacted_artifacts: list[str]) -> bool:  # noqa: ARG001

--- a/backend/infrahub/validators/events.py
+++ b/backend/infrahub/validators/events.py
@@ -1,0 +1,42 @@
+from infrahub_sdk.protocols import CoreValidator
+
+from infrahub.context import InfrahubContext
+from infrahub.events.models import EventMeta
+from infrahub.events.validator_action import ValidatorFailedEvent, ValidatorPassedEvent, ValidatorStartedEvent
+from infrahub.services import InfrahubServices
+
+
+async def send_failed_validator(
+    service: InfrahubServices, validator: CoreValidator, proposed_change_id: str, context: InfrahubContext
+) -> None:
+    event = ValidatorFailedEvent(
+        node_id=validator.id,
+        kind=validator.get_kind(),
+        proposed_change_id=proposed_change_id,
+        meta=EventMeta.from_context(context=context),
+    )
+    await service.event.send(event=event)
+
+
+async def send_passed_validator(
+    service: InfrahubServices, validator: CoreValidator, proposed_change_id: str, context: InfrahubContext
+) -> None:
+    event = ValidatorPassedEvent(
+        node_id=validator.id,
+        kind=validator.get_kind(),
+        proposed_change_id=proposed_change_id,
+        meta=EventMeta.from_context(context=context),
+    )
+    await service.event.send(event=event)
+
+
+async def send_start_validator(
+    service: InfrahubServices, validator: CoreValidator, proposed_change_id: str, context: InfrahubContext
+) -> None:
+    event = ValidatorStartedEvent(
+        node_id=validator.id,
+        kind=validator.get_kind(),
+        proposed_change_id=proposed_change_id,
+        meta=EventMeta.from_context(context=context),
+    )
+    await service.event.send(event=event)

--- a/backend/infrahub/workers/utils.py
+++ b/backend/infrahub/workers/utils.py
@@ -24,7 +24,7 @@ def inject_service_parameter(func: Flow, parameters: dict[str, Any], service: In
 
     if service_parameter_name := get_parameter_name(func=func, types=[InfrahubServices.__name__, InfrahubServices]):
         if any(isinstance(param_value, InfrahubServices) for param_value in parameters):
-            raise ValueError(f"{func} parameters contains an InfrahubServices object while it should be injected")
+            raise ValueError(f"{func.name} parameters contains an InfrahubServices object while it should be injected")
         parameters[service_parameter_name] = service
         return
 
@@ -37,7 +37,7 @@ def inject_context_parameter(func: Flow, parameters: dict[str, Any], context: In
 
     if service_parameter_name and not context:
         raise ValueError(
-            f"{func} has a {service_parameter_name} parameter of type InfrahubContext, while context is not provided"
+            f"{func.name} has a {service_parameter_name} parameter of type InfrahubContext, while context is not provided"
         )
 
 

--- a/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
@@ -309,6 +309,44 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
         ]
         assert len(latest_artifact_event["related_nodes"]) == 1
         assert latest_artifact_event["related_nodes"][0]["kind"] == "TestingPerson"
+        validator_started_events = await client.execute_graphql(
+            query=QUERY_EVENT,
+            variables={"related_node__ids": [proposed_change_after.id], "event_type": ["infrahub.validator.started"]},
+        )
+        validator_passed_events = await client.execute_graphql(
+            query=QUERY_EVENT,
+            variables={"related_node__ids": [proposed_change_after.id], "event_type": ["infrahub.validator.passed"]},
+        )
+        assert validator_started_events["InfrahubEvent"]["count"] == 9
+        assert validator_passed_events["InfrahubEvent"]["count"] == 9
+        started_validators = [
+            event["node"]["primary_node"]["kind"] for event in validator_started_events["InfrahubEvent"]["edges"]
+        ]
+        passed_validators = [
+            event["node"]["primary_node"]["kind"] for event in validator_passed_events["InfrahubEvent"]["edges"]
+        ]
+        assert sorted(started_validators) == [
+            "CoreArtifactValidator",
+            "CoreArtifactValidator",
+            "CoreArtifactValidator",
+            "CoreArtifactValidator",
+            "CoreGeneratorValidator",
+            "CoreGeneratorValidator",
+            "CoreRepositoryValidator",
+            "CoreUserValidator",
+            "CoreUserValidator",
+        ]
+        assert sorted(passed_validators) == [
+            "CoreArtifactValidator",
+            "CoreArtifactValidator",
+            "CoreArtifactValidator",
+            "CoreArtifactValidator",
+            "CoreGeneratorValidator",
+            "CoreGeneratorValidator",
+            "CoreRepositoryValidator",
+            "CoreUserValidator",
+            "CoreUserValidator",
+        ]
 
     async def test_merge_failure(
         self,
@@ -351,6 +389,7 @@ query(
     $branch: [String!],
     $parent__ids: [String!],
     $event_type: [String!]
+    $related_node__ids: [String!],
     $event_type_filter: EventTypeFilter
 ) {
   InfrahubEvent(
@@ -358,6 +397,7 @@ query(
     parent__ids: $parent__ids
     event_type: $event_type
     event_type_filter: $event_type_filter
+    related_node__ids: $related_node__ids
   ) {
     count
     edges {

--- a/docs/docs/reference/infrahub-events.mdx
+++ b/docs/docs/reference/infrahub-events.mdx
@@ -358,3 +358,97 @@ For more detailed explanations on how these events are used within Infrahub, see
 | **branch_name** | The name of the branch |
 | **schema_hash** | Schema hash after the update |
 <!-- vale on -->
+## Validator events
+
+<!-- vale off -->
+### Validator Event
+<!-- vale on -->
+
+**Type**: infrahub.validator
+**Description**: Event generated when an validator within a pipeline has started.
+<!-- vale off -->
+| Key | Description |
+|-----|-------------|
+| **meta.branch** | The branch on which originate this event |
+| **meta.request_id** | N/A |
+| **meta.account_id** | The ID of the account triggering this event |
+| **meta.initiator_id** | The worker identity of the initial sender of this message |
+| **meta.context** | The context used when originating this event |
+| **meta.level** | N/A |
+| **meta.has_children** | Indicates if this event might potentially have child events under it. |
+| **meta.id** | UUID of the event |
+| **meta.parent** | The UUID of the parent event if applicable |
+| **meta.ancestors** | Any event used to trigger this event |
+| **node_id** | The ID of the validator |
+| **kind** | The kind of the validator |
+| **proposed_change_id** | The ID of the proposed change |
+<!-- vale on -->
+<!-- vale off -->
+### Validator Started Event
+<!-- vale on -->
+
+**Type**: infrahub.validator.started
+**Description**: Event generated when an validator within a pipeline has started.
+<!-- vale off -->
+| Key | Description |
+|-----|-------------|
+| **meta.branch** | The branch on which originate this event |
+| **meta.request_id** | N/A |
+| **meta.account_id** | The ID of the account triggering this event |
+| **meta.initiator_id** | The worker identity of the initial sender of this message |
+| **meta.context** | The context used when originating this event |
+| **meta.level** | N/A |
+| **meta.has_children** | Indicates if this event might potentially have child events under it. |
+| **meta.id** | UUID of the event |
+| **meta.parent** | The UUID of the parent event if applicable |
+| **meta.ancestors** | Any event used to trigger this event |
+| **node_id** | The ID of the validator |
+| **kind** | The kind of the validator |
+| **proposed_change_id** | The ID of the proposed change |
+<!-- vale on -->
+<!-- vale off -->
+### Validator Passed Event
+<!-- vale on -->
+
+**Type**: infrahub.validator.passed
+**Description**: Event generated when an validator within a pipeline has completed successfully.
+<!-- vale off -->
+| Key | Description |
+|-----|-------------|
+| **meta.branch** | The branch on which originate this event |
+| **meta.request_id** | N/A |
+| **meta.account_id** | The ID of the account triggering this event |
+| **meta.initiator_id** | The worker identity of the initial sender of this message |
+| **meta.context** | The context used when originating this event |
+| **meta.level** | N/A |
+| **meta.has_children** | Indicates if this event might potentially have child events under it. |
+| **meta.id** | UUID of the event |
+| **meta.parent** | The UUID of the parent event if applicable |
+| **meta.ancestors** | Any event used to trigger this event |
+| **node_id** | The ID of the validator |
+| **kind** | The kind of the validator |
+| **proposed_change_id** | The ID of the proposed change |
+<!-- vale on -->
+<!-- vale off -->
+### Validator Failed Event
+<!-- vale on -->
+
+**Type**: infrahub.validator.failed
+**Description**: Event generated when an validator within a pipeline has completed successfully.
+<!-- vale off -->
+| Key | Description |
+|-----|-------------|
+| **meta.branch** | The branch on which originate this event |
+| **meta.request_id** | N/A |
+| **meta.account_id** | The ID of the account triggering this event |
+| **meta.initiator_id** | The worker identity of the initial sender of this message |
+| **meta.context** | The context used when originating this event |
+| **meta.level** | N/A |
+| **meta.has_children** | Indicates if this event might potentially have child events under it. |
+| **meta.id** | UUID of the event |
+| **meta.parent** | The UUID of the parent event if applicable |
+| **meta.ancestors** | Any event used to trigger this event |
+| **node_id** | The ID of the validator |
+| **kind** | The kind of the validator |
+| **proposed_change_id** | The ID of the proposed change |
+<!-- vale on -->

--- a/docs/docs/reference/message-bus-events.mdx
+++ b/docs/docs/reference/message-bus-events.mdx
@@ -193,6 +193,8 @@ For more detailed explanations on how these events are used within Infrahub, see
 | **validator_execution_id** | The id of current execution of the associated validator | string | None |
 | **start_time** | Start time when the message was first created | string | None |
 | **validator_type** | The type of validator to complete | string | None |
+| **context** | The Infrahub context | N/A | None |
+| **proposed_change** | The ID of the proposed change | string | None |
 <!-- vale on -->
 
 <!-- vale off -->
@@ -316,6 +318,7 @@ For more detailed explanations on how these events are used within Infrahub, see
 | **source_branch** | The source branch | string | None |
 | **source_branch_sync_with_git** | Indicates if the source branch should sync with git | boolean | None |
 | **destination_branch** | The target branch | string | None |
+| **context** | The Infrahub context | N/A | None |
 <!-- vale on -->
 
 <!-- vale off -->

--- a/frontend/app/src/entities/events/constants.ts
+++ b/frontend/app/src/entities/events/constants.ts
@@ -64,4 +64,16 @@ export const EVENT_TYPE_CHOICES = [
     label: "Commit updated",
     name: "infrahub.repository.update_commit",
   },
+  {
+    label: "Validator failed",
+    name: "infrahub.validator.failed",
+  },
+  {
+    label: "Validator passed",
+    name: "infrahub.validator.passed",
+  },
+  {
+    label: "Validator started",
+    name: "infrahub.validator.started",
+  },
 ];


### PR DESCRIPTION
* Add validator events
* Add context to several places within the pipeline

Note that there are still two places where we need to add the validator events, those are within the pytest plugin (which is running as synchronous code now) and the other is within the data validation code that currently doesn't have access to the `service` object (only the database). I'll revisit those two specifically once this PR has been merged. There's also some other slight cleanup I'd like to do with regards to how the validators are created and updated within the pipeline.

For now the data within the validators are quite limited, could be that we'd have to refactor the pipeline a bit more to fix that with regards to data related to failures etc within the failing events. Some of this can be cleaned up a bit after #5956. 