### PR TITLE
Cleanup events payload

### DIFF
--- a/backend/infrahub/computed_attribute/tasks.py
+++ b/backend/infrahub/computed_attribute/tasks.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
-import ujson
 from infrahub_sdk.protocols import (
     CoreNode,  # noqa: TC002
     CoreTransformPython,
@@ -237,14 +236,12 @@ async def process_jinja2(
     computed_attribute_kind: str,
     context: InfrahubContext,  # noqa: ARG001
     service: InfrahubServices,
-    updated_fields: str | None = None,
+    updated_fields: list[str] | None = None,
 ) -> None:
     log = get_run_logger()
 
     await add_tags(branches=[branch_name])
-    updates: list[str] = []
-    if isinstance(updated_fields, str):
-        updates = ujson.loads(updated_fields)
+    updates: list[str] = updated_fields or []
 
     target_branch_schema = (
         branch_name if branch_name in registry.get_altered_schema_branches() else registry.default_branch
@@ -384,7 +381,13 @@ async def computed_attribute_setup(
                             "object_id": "{{ event.resource['infrahub.node.id'] }}",
                             "computed_attribute_name": computed_attribute.attribute.name,
                             "computed_attribute_kind": computed_attribute.kind,
-                            "updated_fields": "{{ event.payload['fields'] | tojson }}",
+                            "updated_fields": {
+                                "__prefect_kind": "json",
+                                "value": {
+                                    "__prefect_kind": "jinja",
+                                    "template": "{{ event.payload['data']['fields'] | tojson }}",
+                                },
+                            },
                             "context": {
                                 "__prefect_kind": "json",
                                 "value": {
@@ -457,7 +460,13 @@ async def computed_attribute_setup(
                                 "object_id": "{{ event.resource['infrahub.node.id'] }}",
                                 "computed_attribute_name": computed_attribute.attribute.name,
                                 "computed_attribute_kind": computed_attribute.kind,
-                                "updated_fields": "{{ event.payload['fields'] | tojson }}",
+                                "updated_fields": {
+                                    "__prefect_kind": "json",
+                                    "value": {
+                                        "__prefect_kind": "jinja",
+                                        "template": "{{ event.payload['data']['fields'] | tojson }}",
+                                    },
+                                },
                                 "context": {
                                     "__prefect_kind": "json",
                                     "value": {

--- a/backend/infrahub/computed_attribute/triggers.py
+++ b/backend/infrahub/computed_attribute/triggers.py
@@ -1,3 +1,6 @@
+from infrahub.events.branch_action import BranchCreatedEvent, BranchDeletedEvent
+from infrahub.events.repository_action import CommitUpdatedEvent
+from infrahub.events.schema_action import SchemaUpdatedEvent
 from infrahub.trigger.models import BuiltinTriggerDefinition, EventTrigger, ExecuteWorkflow
 from infrahub.workflows.catalogue import (
     COMPUTED_ATTRIBUTE_REMOVE_PYTHON,
@@ -9,7 +12,7 @@ TRIGGER_COMPUTED_ATTRIBUTE_PYTHON_SETUP_BRANCH = BuiltinTriggerDefinition(
     name="computed-attribute-python-setup-on-branch-creation",
     previous_names={"Trigger-schema-update-event"},
     description="Trigger actions on branch create event",
-    trigger=EventTrigger(events={"infrahub.branch.created"}),
+    trigger=EventTrigger(events={BranchCreatedEvent.event_name}),
     actions=[
         ExecuteWorkflow(
             workflow=COMPUTED_ATTRIBUTE_SETUP_PYTHON,
@@ -28,7 +31,7 @@ TRIGGER_COMPUTED_ATTRIBUTE_PYTHON_SETUP_BRANCH = BuiltinTriggerDefinition(
 TRIGGER_COMPUTED_ATTRIBUTE_PYTHON_SETUP_COMMIT = BuiltinTriggerDefinition(
     name="computed-attribute-python-setup-on-commit",
     description="Trigger actions on branch create event",
-    trigger=EventTrigger(events={"infrahub.repository.update_commit"}),
+    trigger=EventTrigger(events={CommitUpdatedEvent.event_name}),
     actions=[
         ExecuteWorkflow(
             workflow=COMPUTED_ATTRIBUTE_SETUP_PYTHON,
@@ -47,7 +50,7 @@ TRIGGER_COMPUTED_ATTRIBUTE_PYTHON_SETUP_COMMIT = BuiltinTriggerDefinition(
 TRIGGER_COMPUTED_ATTRIBUTE_PYTHON_CLEAN_BRANCH = BuiltinTriggerDefinition(
     name="computed-attribute-python-cleanup-on-branch-deletion",
     description="Trigger actions on branch delete event",
-    trigger=EventTrigger(events={"infrahub.branch.deleted"}),
+    trigger=EventTrigger(events={BranchDeletedEvent.event_name}),
     actions=[
         ExecuteWorkflow(
             workflow=COMPUTED_ATTRIBUTE_REMOVE_PYTHON,
@@ -64,7 +67,7 @@ TRIGGER_COMPUTED_ATTRIBUTE_PYTHON_CLEAN_BRANCH = BuiltinTriggerDefinition(
 
 TRIGGER_COMPUTED_ATTRIBUTE_ALL_SCHEMA = BuiltinTriggerDefinition(
     name="computed-attribute-all-setup-on-schema-update",
-    trigger=EventTrigger(events={"infrahub.schema.update"}),
+    trigger=EventTrigger(events={SchemaUpdatedEvent.event_name}),
     actions=[
         ExecuteWorkflow(
             workflow=COMPUTED_ATTRIBUTE_SETUP,

--- a/backend/infrahub/context.py
+++ b/backend/infrahub/context.py
@@ -1,8 +1,11 @@
+from typing import Any
+
 from pydantic import BaseModel, Field
 from typing_extensions import Self
 
 from infrahub.auth import AccountSession
 from infrahub.core.branch import Branch
+from infrahub.core.constants import GLOBAL_BRANCH_NAME
 
 
 class ParentEvent(BaseModel):
@@ -21,6 +24,10 @@ class BranchContext(BaseModel):
     name: str
     id: str | None = None
 
+    @property
+    def is_global(self) -> bool:
+        return self.name == GLOBAL_BRANCH_NAME
+
 
 class InfrahubContext(BaseModel):
     branch: BranchContext
@@ -37,3 +44,6 @@ class InfrahubContext(BaseModel):
             self.event.id = id
         else:
             self.event = EventContext(name=name, id=id)
+
+    def to_event(self) -> dict[str, Any]:
+        return self.model_dump(mode="json")

--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -29,7 +29,7 @@ from infrahub.core.validators.tasks import schema_validate_migrations
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.events.branch_action import BranchCreatedEvent, BranchDeletedEvent, BranchMergedEvent, BranchRebasedEvent
 from infrahub.events.models import EventMeta, InfrahubEvent
-from infrahub.events.node_action import NodeMutatedEvent
+from infrahub.events.node_action import get_node_event
 from infrahub.exceptions import BranchNotFoundError, MergeFailedError, ValidationError
 from infrahub.graphql.mutations.models import BranchCreateModel  # noqa: TC001
 from infrahub.log import get_log_data
@@ -46,7 +46,7 @@ from infrahub.workflows.utils import add_tags
 
 
 @flow(name="branch-rebase", flow_run_name="Rebase branch {branch}")
-async def rebase_branch(branch: str, context: InfrahubContext, service: InfrahubServices) -> None:
+async def rebase_branch(branch: str, context: InfrahubContext, service: InfrahubServices) -> None:  # noqa: PLR0915
     async with service.database.start_session() as db:
         log = get_run_logger()
         await add_tags(branches=[branch])
@@ -175,11 +175,11 @@ async def rebase_branch(branch: str, context: InfrahubContext, service: Infrahub
         diff=default_branch_diff, branch=obj, db=db, migration_tracker=MigrationTracker(migrations=migrations)
     )
     for action, node_changelog in changelog_collector.collect_changelogs():
-        mutate_event = NodeMutatedEvent(
+        node_event_class = get_node_event(MutationAction.from_diff_action(diff_action=action))
+        mutate_event = node_event_class(
             kind=node_changelog.node_kind,
             node_id=node_changelog.node_id,
-            data=node_changelog,
-            action=MutationAction.from_diff_action(diff_action=action),
+            changelog=node_changelog,
             fields=node_changelog.updated_fields,
             meta=EventMeta.from_parent(parent=rebase_event, branch=obj),
         )
@@ -282,11 +282,11 @@ async def merge_branch(branch: str, context: InfrahubContext, service: InfrahubS
 
         for action, node_changelog in node_events:
             meta = EventMeta.from_parent(parent=merge_event, branch=default_branch)
-            mutate_event = NodeMutatedEvent(
+            node_event_class = get_node_event(MutationAction.from_diff_action(diff_action=action))
+            mutate_event = node_event_class(
                 kind=node_changelog.node_kind,
                 node_id=node_changelog.node_id,
-                data=node_changelog,
-                action=MutationAction.from_diff_action(diff_action=action),
+                changelog=node_changelog,
                 fields=node_changelog.updated_fields,
                 meta=meta,
             )

--- a/backend/infrahub/core/constants/__init__.py
+++ b/backend/infrahub/core/constants/__init__.py
@@ -52,7 +52,7 @@ class EventType(InfrahubStringEnum):
     BRANCH_MERGED = f"{EVENT_NAMESPACE}.branch.merged"
     BRANCH_REBASED = f"{EVENT_NAMESPACE}.branch.rebased"
 
-    SCHEMA_UPDATED = f"{EVENT_NAMESPACE}.schema.update"
+    SCHEMA_UPDATED = f"{EVENT_NAMESPACE}.schema.updated"
 
     NODE_CREATED = f"{EVENT_NAMESPACE}.node.created"
     NODE_UPDATED = f"{EVENT_NAMESPACE}.node.updated"

--- a/backend/infrahub/events/__init__.py
+++ b/backend/infrahub/events/__init__.py
@@ -1,4 +1,27 @@
+from .artifact_action import ArtifactCreatedEvent, ArtifactUpdatedEvent
+from .branch_action import BranchCreatedEvent, BranchDeletedEvent, BranchMergedEvent, BranchRebasedEvent
+from .group_action import GroupMemberAddedEvent, GroupMemberRemovedEvent
 from .models import EventMeta, InfrahubEvent
-from .node_action import NodeMutatedEvent
+from .node_action import NodeCreatedEvent, NodeDeletedEvent, NodeUpdatedEvent
+from .repository_action import CommitUpdatedEvent
+from .validator_action import ValidatorFailedEvent, ValidatorPassedEvent, ValidatorStartedEvent
 
-__all__ = ["EventMeta", "InfrahubEvent", "NodeMutatedEvent"]
+__all__ = [
+    "ArtifactCreatedEvent",
+    "ArtifactUpdatedEvent",
+    "BranchCreatedEvent",
+    "BranchDeletedEvent",
+    "BranchMergedEvent",
+    "BranchRebasedEvent",
+    "CommitUpdatedEvent",
+    "EventMeta",
+    "GroupMemberAddedEvent",
+    "GroupMemberRemovedEvent",
+    "InfrahubEvent",
+    "NodeCreatedEvent",
+    "NodeDeletedEvent",
+    "NodeUpdatedEvent",
+    "ValidatorFailedEvent",
+    "ValidatorPassedEvent",
+    "ValidatorStartedEvent",
+]

--- a/backend/infrahub/events/artifact_action.py
+++ b/backend/infrahub/events/artifact_action.py
@@ -1,8 +1,6 @@
-from typing import Any
+from typing import ClassVar
 
-from pydantic import Field, computed_field
-
-from infrahub.message_bus import InfrahubMessage
+from pydantic import Field
 
 from .constants import EVENT_NAMESPACE
 from .models import InfrahubEvent
@@ -19,7 +17,6 @@ class ArtifactEvent(InfrahubEvent):
     checksum_previous: str | None = Field(default=None, description="The previous checksum of the artifact")
     storage_id: str = Field(..., description="The current storage id of the artifact")
     storage_id_previous: str | None = Field(default=None, description="The previous storage id of the artifact")
-    created: bool = Field(..., description="Indicates if the artifact was created with this event or already existed")
 
     def get_related(self) -> list[dict[str, str]]:
         related = super().get_related()
@@ -52,25 +49,10 @@ class ArtifactEvent(InfrahubEvent):
             "infrahub.branch.name": self.meta.context.branch.name,
         }
 
-    def get_payload(self) -> dict[str, Any]:
-        return {
-            "node_id": self.node_id,
-            "artifact_definition_id": self.artifact_definition_id,
-            "target_id": self.target_id,
-            "target_kind": self.target_kind,
-            "checksum": self.checksum,
-            "checksum_previous": self.checksum_previous,
-            "storage_id": self.storage_id,
-            "storage_id_previous": self.storage_id_previous,
-        }
 
-    def get_messages(self) -> list[InfrahubMessage]:
-        return []
+class ArtifactCreatedEvent(ArtifactEvent):
+    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.artifact.created"
 
-    @computed_field
-    def event_name(self) -> str:
-        match self.created:
-            case True:
-                return f"{EVENT_NAMESPACE}.artifact.created"
-            case False:
-                return f"{EVENT_NAMESPACE}.artifact.updated"
+
+class ArtifactUpdatedEvent(ArtifactEvent):
+    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.artifact.updated"

--- a/backend/infrahub/events/branch_action.py
+++ b/backend/infrahub/events/branch_action.py
@@ -1,4 +1,6 @@
-from pydantic import Field, computed_field
+from typing import ClassVar
+
+from pydantic import Field
 
 from infrahub.message_bus import InfrahubMessage
 from infrahub.message_bus.messages.refresh_registry_branches import RefreshRegistryBranches
@@ -10,6 +12,8 @@ from .models import InfrahubEvent
 
 class BranchDeletedEvent(InfrahubEvent):
     """Event generated when a branch has been deleted"""
+
+    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.branch.deleted"
 
     branch_name: str = Field(..., description="The name of the branch")
     branch_id: str = Field(..., description="The ID of the mutated node")
@@ -34,13 +38,11 @@ class BranchDeletedEvent(InfrahubEvent):
         ]
         return events
 
-    @computed_field
-    def event_name(self) -> str:
-        return f"{EVENT_NAMESPACE}.branch.deleted"
-
 
 class BranchCreatedEvent(InfrahubEvent):
     """Event generated when a branch has been created"""
+
+    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.branch.created"
 
     branch_name: str = Field(..., description="The name of the branch")
     branch_id: str = Field(..., description="The ID of the branch")
@@ -65,13 +67,11 @@ class BranchCreatedEvent(InfrahubEvent):
         ]
         return events
 
-    @computed_field
-    def event_name(self) -> str:
-        return f"{EVENT_NAMESPACE}.branch.created"
-
 
 class BranchMergedEvent(InfrahubEvent):
     """Event generated when a branch has been merged"""
+
+    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.branch.merged"
 
     branch_name: str = Field(..., description="The name of the branch")
     branch_id: str = Field(..., description="The ID of the branch")
@@ -83,16 +83,11 @@ class BranchMergedEvent(InfrahubEvent):
             "infrahub.branch.name": self.branch_name,
         }
 
-    def get_messages(self) -> list[InfrahubMessage]:
-        return []
-
-    @computed_field
-    def event_name(self) -> str:
-        return f"{EVENT_NAMESPACE}.branch.merged"
-
 
 class BranchRebasedEvent(InfrahubEvent):
     """Event generated when a branch has been rebased"""
+
+    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.branch.rebased"
 
     branch_id: str = Field(..., description="The ID of the mutated node")
     branch_name: str = Field(..., description="The name of the branch")
@@ -113,7 +108,3 @@ class BranchRebasedEvent(InfrahubEvent):
             RefreshRegistryRebasedBranch(branch=self.branch_name),
         ]
         return events
-
-    @computed_field
-    def event_name(self) -> str:
-        return f"{EVENT_NAMESPACE}.branch.rebased"

--- a/backend/infrahub/events/group_action.py
+++ b/backend/infrahub/events/group_action.py
@@ -1,9 +1,8 @@
-from typing import Any
+from typing import ClassVar
 
-from pydantic import Field, computed_field
+from pydantic import Field
 
 from infrahub.core.constants import MutationAction
-from infrahub.message_bus import InfrahubMessage
 
 from .constants import EVENT_NAMESPACE
 from .models import EventNode, InfrahubEvent
@@ -78,10 +77,6 @@ class GroupMutatedEvent(InfrahubEvent):
 
         return related
 
-    @computed_field
-    def event_name(self) -> str:
-        return f"{EVENT_NAMESPACE}.group.{self.action.value}"
-
     def get_resource(self) -> dict[str, str]:
         return {
             "prefect.resource.id": f"infrahub.node.{self.node_id}",
@@ -91,27 +86,12 @@ class GroupMutatedEvent(InfrahubEvent):
             "infrahub.node.root_id": self.node_id,
         }
 
-    def get_payload(self) -> dict[str, Any]:
-        return {
-            "ancestors": [ancestor.model_dump() for ancestor in self.ancestors],
-            "members": [member.model_dump() for member in self.members],
-        }
-
-    def get_messages(self) -> list[InfrahubMessage]:
-        return []
-
 
 class GroupMemberAddedEvent(GroupMutatedEvent):
     action: MutationAction = MutationAction.CREATED
-
-    @computed_field
-    def event_name(self) -> str:
-        return f"{EVENT_NAMESPACE}.group.member_added"
+    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.group.member_added"
 
 
 class GroupMemberRemovedEvent(GroupMutatedEvent):
     action: MutationAction = MutationAction.DELETED
-
-    @computed_field
-    def event_name(self) -> str:
-        return f"{EVENT_NAMESPACE}.group.member_removed"
+    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.group.member_removed"

--- a/backend/infrahub/events/models.py
+++ b/backend/infrahub/events/models.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import Any, Self, cast, final
+from typing import Any, ClassVar, Self, final
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, Field, PrivateAttr, computed_field, model_validator
+from pydantic import BaseModel, Field, PrivateAttr, model_validator
 
 from infrahub import __version__
 from infrahub.auth import AccountSession, AuthType
@@ -131,7 +131,7 @@ class EventMeta(BaseModel):
             account_id=parent.meta.account_id,
             level=parent.meta.level + 1,
             context=context,
-            ancestors=[ParentEvent(id=parent.get_id(), name=parent.get_name())] + parent.meta.ancestors,
+            ancestors=[ParentEvent(id=parent.get_id(), name=parent.event_name)] + parent.meta.ancestors,
         )
 
     @classmethod
@@ -148,21 +148,19 @@ class EventMeta(BaseModel):
 class InfrahubEvent(BaseModel):
     meta: EventMeta = Field(..., description="Metadata for the event")
 
+    event_name: ClassVar[str] = Field(..., description="The name of the event")
+
     def get_id(self) -> str:
         return self.meta.get_id()
 
     def get_event_namespace(self) -> str:
         return EVENT_NAMESPACE
 
-    def get_name(self) -> str:
-        # Convince linters that @computed_field is a property and not a method...
-        return cast(str, self.event_name)
-
     def get_resource(self) -> dict[str, str]:
         raise NotImplementedError
 
     def get_messages(self) -> list[InfrahubMessage]:
-        raise NotImplementedError
+        return []
 
     def get_related(self) -> list[dict[str, str]]:
         if not self.meta:
@@ -176,13 +174,12 @@ class InfrahubEvent(BaseModel):
         be used for that as it will always contain the 'context' key regardless of changes
         in child classes
         """
-        return {}
+        return self.model_dump(exclude={"meta"})
 
     @final
     def get_event_payload(self) -> dict[str, Any]:
         """This method should be used when emitting the event to the event broker"""
-        event_payload = self.get_payload()
-        event_payload["context"] = self.meta.context.model_dump(mode="json")
+        event_payload = {"data": self.get_payload(), "context": self.meta.context.to_event()}
         return event_payload
 
     def get_message_meta(self) -> Meta:
@@ -194,13 +191,9 @@ class InfrahubEvent(BaseModel):
 
         return meta
 
-    @computed_field
-    def event_name(self) -> str:
-        raise NotImplementedError("The event name has not been defined")
-
     @model_validator(mode="after")
     def update_context(self) -> Self:
         """Update the context object using this event provided that the meta data was created with a context."""
         if self.meta._created_with_context:
-            self.meta.context.set_event(self.get_name(), id=self.get_id())
+            self.meta.context.set_event(self.event_name, id=self.get_id())
         return self

--- a/backend/infrahub/events/node_action.py
+++ b/backend/infrahub/events/node_action.py
@@ -1,10 +1,9 @@
-from typing import Any
+from typing import ClassVar
 
-from pydantic import Field, computed_field
+from pydantic import Field
 
 from infrahub.core.changelog.models import NodeChangelog
 from infrahub.core.constants import MutationAction
-from infrahub.message_bus import InfrahubMessage
 
 from .constants import EVENT_NAMESPACE
 from .models import InfrahubEvent
@@ -16,12 +15,12 @@ class NodeMutatedEvent(InfrahubEvent):
     kind: str = Field(..., description="The type of object modified")
     node_id: str = Field(..., description="The ID of the mutated node")
     action: MutationAction = Field(..., description="The action taken on the node")
-    data: NodeChangelog = Field(..., description="Data on modified object")
+    changelog: NodeChangelog = Field(..., description="Data on modified object")
     fields: list[str] = Field(default_factory=list, description="Fields provided in the mutation")
 
     def get_related(self) -> list[dict[str, str]]:
         related = super().get_related()
-        for attribute in self.data.attributes.values():
+        for attribute in self.changelog.attributes.values():
             related.append(
                 {
                     "prefect.resource.id": f"infrahub.node.{self.node_id}",
@@ -36,13 +35,13 @@ class NodeMutatedEvent(InfrahubEvent):
                     "infrahub.attribute.action": attribute.value_update_status.value,  # type: ignore[attr-defined]
                 }
             )
-        if self.data.parent:
+        if self.changelog.parent:
             related.append(
                 {
-                    "prefect.resource.id": self.data.parent.node_id,
+                    "prefect.resource.id": self.changelog.parent.node_id,
                     "prefect.resource.role": "infrahub.node.parent",
-                    "infrahub.parent.kind": self.data.parent.node_kind,
-                    "infrahub.parent.id": self.data.parent.node_id,
+                    "infrahub.parent.kind": self.changelog.parent.node_kind,
+                    "infrahub.parent.id": self.changelog.parent.node_id,
                 }
             )
 
@@ -54,7 +53,7 @@ class NodeMutatedEvent(InfrahubEvent):
             }
         )
 
-        for related_node in self.data.get_related_nodes():
+        for related_node in self.changelog.get_related_nodes():
             related.append(
                 {
                     "prefect.resource.id": related_node.node_id,
@@ -65,43 +64,37 @@ class NodeMutatedEvent(InfrahubEvent):
 
         return related
 
-    @computed_field
-    def event_name(self) -> str:
-        return f"{EVENT_NAMESPACE}.node.{self.action.value}"
-
     def get_resource(self) -> dict[str, str]:
         return {
             "prefect.resource.id": f"infrahub.node.{self.node_id}",
             "infrahub.node.kind": self.kind,
             "infrahub.node.id": self.node_id,
             "infrahub.node.action": self.action.value,
-            "infrahub.node.root_id": self.data.root_node_id,
+            "infrahub.node.root_id": self.changelog.root_node_id,
             "infrahub.branch.name": self.meta.context.branch.name,
         }
 
-    def get_payload(self) -> dict[str, Any]:
-        return {"data": self.data.model_dump(), "fields": self.fields}
-
-    def get_messages(self) -> list[InfrahubMessage]:
-        return [
-            # EventNodeMutated(
-            #     branch=self.branch,
-            #     kind=self.kind,
-            #     node_id=self.node_id,
-            #     action=self.action.value,
-            #     data=self.data,
-            #     meta=self.get_message_meta(),
-            # )
-        ]
-
 
 class NodeCreatedEvent(NodeMutatedEvent):
+    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.node.created"
     action: MutationAction = MutationAction.CREATED
 
 
 class NodeUpdatedEvent(NodeMutatedEvent):
+    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.node.updated"
     action: MutationAction = MutationAction.UPDATED
 
 
 class NodeDeletedEvent(NodeMutatedEvent):
+    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.node.deleted"
     action: MutationAction = MutationAction.DELETED
+
+
+def get_node_event(action: MutationAction) -> type[NodeDeletedEvent] | type[NodeUpdatedEvent] | type[NodeCreatedEvent]:
+    if action == MutationAction.CREATED:
+        return NodeCreatedEvent
+    if action == MutationAction.UPDATED:
+        return NodeUpdatedEvent
+    if action == MutationAction.DELETED:
+        return NodeDeletedEvent
+    raise ValueError(f"Invalid action: {action}")

--- a/backend/infrahub/events/repository_action.py
+++ b/backend/infrahub/events/repository_action.py
@@ -1,8 +1,6 @@
-from typing import Any
+from typing import ClassVar
 
-from pydantic import Field, computed_field
-
-from infrahub.message_bus import InfrahubMessage
+from pydantic import Field
 
 from .constants import EVENT_NAMESPACE
 from .models import InfrahubEvent
@@ -10,6 +8,8 @@ from .models import InfrahubEvent
 
 class CommitUpdatedEvent(InfrahubEvent):
     """Event generated when the the commit within a repository has been updated."""
+
+    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.repository.update_commit"
 
     commit: str = Field(..., description="The commit the repository was updated to")
     repository_id: str = Field(..., description="The ID of the repository")
@@ -21,17 +21,3 @@ class CommitUpdatedEvent(InfrahubEvent):
             "infrahub.repository.name": self.repository_name,
             "infrahub.repository.id": self.repository_id,
         }
-
-    def get_payload(self) -> dict[str, Any]:
-        return {
-            "commit": self.commit,
-            "repository_id": self.repository_id,
-            "repository_name": self.repository_name,
-        }
-
-    def get_messages(self) -> list[InfrahubMessage]:
-        return []
-
-    @computed_field
-    def event_name(self) -> str:
-        return f"{EVENT_NAMESPACE}.repository.update_commit"

--- a/backend/infrahub/events/schema_action.py
+++ b/backend/infrahub/events/schema_action.py
@@ -1,6 +1,6 @@
-from typing import Any
+from typing import ClassVar
 
-from pydantic import Field, computed_field
+from pydantic import Field
 
 from infrahub.message_bus import InfrahubMessage
 from infrahub.message_bus.messages.refresh_registry_branches import RefreshRegistryBranches
@@ -11,6 +11,8 @@ from .models import InfrahubEvent
 
 class SchemaUpdatedEvent(InfrahubEvent):
     """Event generated when the schema within a branch has been updated."""
+
+    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.schema.updated"
 
     branch_name: str = Field(..., description="The name of the branch")
     schema_hash: str = Field(..., description="Schema hash after the update")
@@ -32,9 +34,6 @@ class SchemaUpdatedEvent(InfrahubEvent):
             "infrahub.branch.schema_hash": self.schema_hash,
         }
 
-    def get_payload(self) -> dict[str, Any]:
-        return {"branch": self.branch_name, "schema_hash": self.schema_hash}
-
     def get_messages(self) -> list[InfrahubMessage]:
         return [
             RefreshRegistryBranches(),
@@ -43,7 +42,3 @@ class SchemaUpdatedEvent(InfrahubEvent):
             #     meta=self.get_message_meta(),
             # )
         ]
-
-    @computed_field
-    def event_name(self) -> str:
-        return f"{EVENT_NAMESPACE}.schema.update"

--- a/backend/infrahub/events/utils.py
+++ b/backend/infrahub/events/utils.py
@@ -1,0 +1,8 @@
+from infrahub.events.models import InfrahubEvent
+from infrahub.utils import get_all_subclasses
+
+
+def get_all_events() -> list[type[InfrahubEvent]]:
+    """Recursively get all subclasses of the given class."""
+    subclasses = get_all_subclasses(InfrahubEvent)
+    return [cls for cls in subclasses if isinstance(cls.event_name, str)]

--- a/backend/infrahub/events/validator_action.py
+++ b/backend/infrahub/events/validator_action.py
@@ -1,6 +1,6 @@
-from pydantic import Field, computed_field
+from typing import ClassVar
 
-from infrahub.message_bus import InfrahubMessage
+from pydantic import Field
 
 from .constants import EVENT_NAMESPACE
 from .models import InfrahubEvent
@@ -33,29 +33,20 @@ class ValidatorEvent(InfrahubEvent):
 
         return related
 
-    def get_messages(self) -> list[InfrahubMessage]:
-        return []
-
 
 class ValidatorStartedEvent(ValidatorEvent):
     """Event generated when an validator within a pipeline has started."""
 
-    @computed_field
-    def event_name(self) -> str:
-        return f"{EVENT_NAMESPACE}.validator.started"
+    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.validator.started"
 
 
 class ValidatorPassedEvent(ValidatorEvent):
     """Event generated when an validator within a pipeline has completed successfully."""
 
-    @computed_field
-    def event_name(self) -> str:
-        return f"{EVENT_NAMESPACE}.validator.passed"
+    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.validator.passed"
 
 
 class ValidatorFailedEvent(ValidatorEvent):
     """Event generated when an validator within a pipeline has completed successfully."""
 
-    @computed_field
-    def event_name(self) -> str:
-        return f"{EVENT_NAMESPACE}.validator.failed"
+    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.validator.failed"

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -39,7 +39,7 @@ from typing_extensions import Self
 
 from infrahub.core.constants import ArtifactStatus, ContentType, InfrahubKind, RepositorySyncStatus
 from infrahub.core.registry import registry
-from infrahub.events.artifact_action import ArtifactEvent
+from infrahub.events.artifact_action import ArtifactCreatedEvent, ArtifactUpdatedEvent
 from infrahub.events.models import EventMeta
 from infrahub.events.repository_action import CommitUpdatedEvent
 from infrahub.exceptions import CheckError, RepositoryInvalidFileSystemError, TransformError
@@ -1324,7 +1324,9 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
             artifact.name.value = message.artifact_name
         await artifact.save()
 
-        event = ArtifactEvent(
+        event_class = ArtifactCreatedEvent if artifact_created else ArtifactUpdatedEvent
+
+        event = event_class(
             node_id=artifact.id,
             target_id=message.target_id,
             target_kind=message.target_kind,
@@ -1334,7 +1336,6 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
             checksum_previous=previous_checksum,
             storage_id=storage_id,
             storage_id_previous=previous_storage_id,
-            created=artifact_created,
         )
 
         await self.service.event.send(event=event)

--- a/backend/infrahub/graphql/mutations/computed_attribute.py
+++ b/backend/infrahub/graphql/mutations/computed_attribute.py
@@ -5,12 +5,12 @@ from typing import TYPE_CHECKING, Any
 from graphene import Boolean, InputObjectType, Mutation, String
 
 from infrahub.core.account import ObjectPermission
-from infrahub.core.constants import ComputedAttributeKind, MutationAction, PermissionAction, PermissionDecision
+from infrahub.core.constants import ComputedAttributeKind, PermissionAction, PermissionDecision
 from infrahub.core.manager import NodeManager
 from infrahub.core.registry import registry
 from infrahub.database import retry_db_transaction
 from infrahub.events import EventMeta
-from infrahub.events.node_action import NodeMutatedEvent
+from infrahub.events.node_action import NodeUpdatedEvent
 from infrahub.exceptions import NodeNotFoundError, ValidationError
 from infrahub.graphql.context import apply_external_context
 from infrahub.graphql.types.context import ContextInput
@@ -95,12 +95,11 @@ class UpdateComputedAttribute(Mutation):
             log_data = get_log_data()
             request_id = log_data.get("request_id", "")
 
-            event = NodeMutatedEvent(
+            event = NodeUpdatedEvent(
                 kind=node_schema.kind,
                 node_id=target_node.get_id(),
-                data=target_node.node_changelog.model_dump(),
+                changelog=target_node.node_changelog.model_dump(),
                 fields=[str(data.attribute)],
-                action=MutationAction.UPDATED,
                 meta=EventMeta(
                     context=graphql_context.get_context(),
                     initiator_id=WORKER_IDENTITY,

--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -22,7 +22,8 @@ from infrahub.core.schema.template_schema import TemplateSchema
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import retry_db_transaction
 from infrahub.dependencies.registry import get_component_registry
-from infrahub.events import EventMeta, NodeMutatedEvent
+from infrahub.events import EventMeta
+from infrahub.events.node_action import NodeDeletedEvent, NodeUpdatedEvent, get_node_event
 from infrahub.exceptions import ValidationError
 from infrahub.graphql.context import apply_external_context
 from infrahub.lock import InfrahubMultiLock, build_object_lock_name
@@ -68,7 +69,7 @@ class InfrahubMutationOptions(MutationOptions):
 
 class InfrahubMutationMixin:
     @classmethod
-    async def mutate(
+    async def mutate(  # noqa: PLR0915
         cls,
         root: dict,  # noqa: ARG003
         info: GraphQLResolveInfo,
@@ -135,11 +136,11 @@ class InfrahubMutationMixin:
                 branch=graphql_context.branch,
                 context=graphql_context.get_context(),
             )
-            main_event = NodeMutatedEvent(
+            node_event_class = get_node_event(action)
+            main_event = node_event_class(
                 kind=obj._schema.kind,
                 node_id=obj.id,
-                data=obj.node_changelog,
-                action=action,
+                changelog=obj.node_changelog,
                 fields=_get_data_fields(data),
                 meta=meta,
             )
@@ -153,11 +154,10 @@ class InfrahubMutationMixin:
 
             for node_changelog in deleted_changelogs:
                 meta = EventMeta.from_parent(parent=main_event)
-                event = NodeMutatedEvent(
+                event = NodeDeletedEvent(
                     kind=node_changelog.node_kind,
                     node_id=node_changelog.node_id,
-                    data=node_changelog,
-                    action=MutationAction.DELETED,
+                    changelog=node_changelog,
                     fields=node_changelog.updated_fields,
                     meta=meta,
                 )
@@ -166,11 +166,10 @@ class InfrahubMutationMixin:
             for node_changelog in node_changelogs:
                 if node_changelog.node_id not in deleted_ids:
                     meta = EventMeta.from_parent(parent=main_event)
-                    event = NodeMutatedEvent(
+                    event = NodeUpdatedEvent(
                         kind=node_changelog.node_kind,
                         node_id=node_changelog.node_id,
-                        data=node_changelog,
-                        action=MutationAction.UPDATED,
+                        changelog=node_changelog,
                         fields=node_changelog.updated_fields,
                         meta=meta,
                     )

--- a/backend/infrahub/graphql/mutations/relationship.py
+++ b/backend/infrahub/graphql/mutations/relationship.py
@@ -11,7 +11,6 @@ from infrahub.core.account import GlobalPermission, ObjectPermission
 from infrahub.core.changelog.models import NodeChangelog
 from infrahub.core.constants import (
     InfrahubKind,
-    MutationAction,
     PermissionAction,
     PermissionDecision,
     RelationshipCardinality,
@@ -26,9 +25,10 @@ from infrahub.core.query.relationship import (
 from infrahub.core.relationship import Relationship
 from infrahub.core.schema import NodeSchema
 from infrahub.database import retry_db_transaction
-from infrahub.events import EventMeta, NodeMutatedEvent
+from infrahub.events import EventMeta
 from infrahub.events.group_action import GroupMemberAddedEvent, GroupMemberRemovedEvent
 from infrahub.events.models import EventNode
+from infrahub.events.node_action import NodeUpdatedEvent
 from infrahub.exceptions import NodeNotFoundError, ValidationError
 from infrahub.graphql.context import apply_external_context
 from infrahub.graphql.types.context import ContextInput
@@ -148,11 +148,10 @@ class RelationshipAdd(Mutation):
                         graphql_context.background.add_task(graphql_context.active_service.event.send, group_add_event)
 
             else:
-                event = NodeMutatedEvent(
+                event = NodeUpdatedEvent(
                     kind=source.get_schema().kind,
                     node_id=source.id,
-                    data=node_changelog,
-                    action=MutationAction.UPDATED,
+                    changelog=node_changelog,
                     fields=[relationship_name],
                     meta=EventMeta(branch=graphql_context.branch, context=graphql_context.get_context()),
                 )
@@ -244,11 +243,10 @@ class RelationshipRemove(Mutation):
                             graphql_context.active_service.event.send, group_remove_event
                         )
             else:
-                event = NodeMutatedEvent(
+                event = NodeUpdatedEvent(
                     kind=source.get_schema().kind,
                     node_id=source.id,
-                    data=node_changelog,
-                    action=MutationAction.UPDATED,
+                    changelog=node_changelog,
                     fields=[relationship_name],
                     meta=EventMeta(branch=graphql_context.branch, context=graphql_context.get_context()),
                 )

--- a/backend/infrahub/graphql/types/event.py
+++ b/backend/infrahub/graphql/types/event.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING, Any
 from graphene import Boolean, DateTime, Field, InputObjectType, Int, Interface, List, NonNull, ObjectType, String
 from graphene.types.generic import GenericScalar
 
+from infrahub import events
+
 from .common import RelatedNode
 from .enums import DiffAction
 
@@ -143,16 +145,16 @@ class StandardEvent(ObjectType):
 
 
 EVENT_TYPES: dict[str, type[ObjectType]] = {
-    "infrahub.artifact.created": ArtifactEvent,
-    "infrahub.artifact.updated": ArtifactEvent,
-    "infrahub.node.created": NodeMutatedEvent,
-    "infrahub.node.updated": NodeMutatedEvent,
-    "infrahub.node.deleted": NodeMutatedEvent,
-    "infrahub.branch.created": BranchCreatedEvent,
-    "infrahub.branch.merged": BranchMergedEvent,
-    "infrahub.branch.rebased": BranchRebasedEvent,
-    "infrahub.branch.deleted": BranchDeletedEvent,
-    "infrahub.group.member_added": GroupEvent,
-    "infrahub.group.member_removed": GroupEvent,
+    events.ArtifactCreatedEvent.event_name: ArtifactEvent,
+    events.ArtifactUpdatedEvent.event_name: ArtifactEvent,
+    events.NodeCreatedEvent.event_name: NodeMutatedEvent,
+    events.NodeUpdatedEvent.event_name: NodeMutatedEvent,
+    events.NodeDeletedEvent.event_name: NodeMutatedEvent,
+    events.BranchCreatedEvent.event_name: BranchCreatedEvent,
+    events.BranchMergedEvent.event_name: BranchMergedEvent,
+    events.BranchRebasedEvent.event_name: BranchRebasedEvent,
+    events.BranchDeletedEvent.event_name: BranchDeletedEvent,
+    events.GroupMemberAddedEvent.event_name: GroupEvent,
+    events.GroupMemberRemovedEvent.event_name: GroupEvent,
     "undefined": StandardEvent,
 }

--- a/backend/infrahub/services/adapters/event/__init__.py
+++ b/backend/infrahub/services/adapters/event/__init__.py
@@ -31,7 +31,7 @@ class InfrahubEventService:
     async def _send_prefect(self, event: InfrahubEvent) -> None:
         emit_event(
             id=event.meta.id,
-            event=event.get_name(),
+            event=event.event_name,
             resource=event.get_resource(),
             related=event.get_related(),
             payload=event.get_event_payload(),

--- a/backend/infrahub/utils.py
+++ b/backend/infrahub/utils.py
@@ -2,9 +2,10 @@ import hashlib
 from enum import Enum, EnumMeta
 from pathlib import Path
 from re import finditer
-from typing import Any
+from typing import Any, TypeVar
 
 KWARGS_TO_DROP = ["session"]
+AnyClass = TypeVar("AnyClass", bound=type)
 
 
 def get_fixtures_dir() -> Path:
@@ -73,3 +74,12 @@ def get_nested_dict(nested_dict: dict[str, Any], keys: list[str]) -> dict[str, A
         else:
             return {}
     return current_level if isinstance(current_level, dict) else {}
+
+
+def get_all_subclasses(cls: AnyClass) -> list[AnyClass]:
+    """Recursively get all subclasses of the given class."""
+    subclasses: list[AnyClass] = []
+    for subclass in cls.__subclasses__():
+        subclasses.append(subclass)
+        subclasses.extend(get_all_subclasses(subclass))
+    return subclasses

--- a/backend/infrahub/webhook/models.py
+++ b/backend/infrahub/webhook/models.py
@@ -63,7 +63,9 @@ class WebhookTriggerDefinition(TriggerDefinition):
                     workflow=WEBHOOK_PROCESS,
                     parameters={
                         "webhook_id": obj.id,
+                        "webhook_name": obj.name.value,
                         "webhook_kind": obj.get_kind(),
+                        "branch_name": "{{ event.resource['infrahub.branch.name'] }}",
                         "event_id": "{{ event.id }}",
                         "event_type": "{{ event.event }}",
                         "event_occured_at": "{{ event.occurred }}",

--- a/backend/infrahub/webhook/tasks.py
+++ b/backend/infrahub/webhook/tasks.py
@@ -15,6 +15,7 @@ from infrahub.message_bus.types import KVTTL
 from infrahub.services import InfrahubServices  # noqa: TC001  needed for prefect flow
 from infrahub.trigger.models import TriggerType
 from infrahub.trigger.tasks import setup_triggers
+from infrahub.workflows.utils import add_tags
 
 from .constants import AUTOMATION_NAME_RUN
 from .models import CustomWebhook, EventContext, StandardWebhook, TransformWebhook, Webhook, WebhookTriggerDefinition
@@ -61,17 +62,22 @@ async def convert_node_to_webhook(webhook_node: CoreWebhook, client: InfrahubCli
     return CustomWebhook.from_object(obj=webhook_node)
 
 
-@flow(name="webhook-process", flow_run_name="Send webhook")
+@flow(name="webhook-process", flow_run_name="Send webhook for {webhook_name}")
 async def webhook_process(
     webhook_id: str,
+    webhook_name: str,  # noqa: ARG001
     webhook_kind: str,
     event_id: str,
     event_type: str,
     event_occured_at: str,
     event_payload: dict,
     service: InfrahubServices,
+    branch_name: str | None = None,
 ) -> None:
     log = get_run_logger()
+
+    if branch_name:
+        await add_tags(branches=[branch_name])
 
     webhook_data_str = await service.cache.get(key=f"webhook:{webhook_id}")
     if not webhook_data_str:
@@ -101,7 +107,7 @@ async def webhook_process(
     log.info(f"Successfully sent webhook to {response.url} with status {response.status_code}")
 
 
-@flow(name="webhook-setup-automation-all", flow_run_name="Configuration webhook automation for all webhooks")
+@flow(name="webhook-setup-automation-all", flow_run_name="Configure all webhooks")
 async def configure_webhook_all(service: InfrahubServices) -> None:
     log = get_run_logger()
 
@@ -119,7 +125,7 @@ async def configure_webhook_all(service: InfrahubServices) -> None:
     log.info(f"{len(triggers)} Webhooks automation configuration completed")
 
 
-@flow(name="webhook-setup-automation-one", flow_run_name="Configuration webhook automation for {webhook_name}")
+@flow(name="webhook-setup-automation-one", flow_run_name="Configurate webhook for {webhook_name}")
 async def configure_webhook_one(
     webhook_name: str,  # noqa: ARG001
     event_data: dict,
@@ -160,7 +166,6 @@ async def configure_webhook_one(
 async def delete_webhook_automation(
     webhook_id: str,
     webhook_name: str,  # noqa: ARG001
-    event_data: dict,  # noqa: ARG001
     service: InfrahubServices,
 ) -> None:
     log = get_run_logger()

--- a/backend/infrahub/webhook/triggers.py
+++ b/backend/infrahub/webhook/triggers.py
@@ -14,7 +14,7 @@ TRIGGER_WEBHOOK_SETUP_UPDATE = BuiltinTriggerDefinition(
         ExecuteWorkflow(
             workflow=WEBHOOK_CONFIGURE_ONE,
             parameters={
-                "webhook_name": "{{ event.payload['data']['display_label'] }}",
+                "webhook_name": "{{ event.payload['data']['changelog']['display_label'] }}",
                 "event_data": {
                     "__prefect_kind": "json",
                     "value": {"__prefect_kind": "jinja", "template": "{{ event.payload['data'] | tojson }}"},
@@ -37,11 +37,7 @@ TRIGGER_WEBHOOK_DELETE = BuiltinTriggerDefinition(
             workflow=WEBHOOK_DELETE_AUTOMATION,
             parameters={
                 "webhook_id": "{{ event.payload['data']['node_id'] }}",
-                "webhook_name": "{{ event.payload['data']['display_label'] }}",
-                "event_data": {
-                    "__prefect_kind": "json",
-                    "value": {"__prefect_kind": "jinja", "template": "{{ event.payload['data'] | tojson }}"},
-                },
+                "webhook_name": "{{ event.payload['data']['changelog']['display_label'] }}",
             },
         ),
     ],

--- a/backend/infrahub/workflows/utils.py
+++ b/backend/infrahub/workflows/utils.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from prefect import get_client
 from prefect.runtime import flow_run
 
+from infrahub.core.constants import GLOBAL_BRANCH_NAME
 from infrahub.core.registry import registry
 from infrahub.tasks.registry import refresh_branches
 
@@ -27,7 +28,15 @@ async def add_tags(
     client = get_client(sync_client=False)
     current_flow_run_id = flow_run.id
     current_tags: list[str] = flow_run.tags
-    branch_tags = [WorkflowTag.BRANCH.render(identifier=branch_name) for branch_name in branches] if branches else []
+    branch_tags = (
+        [
+            WorkflowTag.BRANCH.render(identifier=branch_name)
+            for branch_name in branches
+            if branch_name != GLOBAL_BRANCH_NAME
+        ]
+        if branches
+        else []
+    )
     node_tags = [WorkflowTag.RELATED_NODE.render(identifier=node_id) for node_id in nodes] if nodes else []
     others_tags = others or []
     new_tags = set(current_tags + branch_tags + node_tags + others_tags)

--- a/backend/tests/functional/computed_attributes/test_computed_attribute.py
+++ b/backend/tests/functional/computed_attributes/test_computed_attribute.py
@@ -106,7 +106,7 @@ class TestComputedAttribute(TestInfrahubApp):
             object_id=tshirt_1.id,
             computed_attribute_kind="TestingTShirt",
             computed_attribute_name="description",
-            updated_fields='"color"',
+            updated_fields=["color"],
             context=context,
             service=service,
         )

--- a/backend/tests/functional/webhook/test_task.py
+++ b/backend/tests/functional/webhook/test_task.py
@@ -176,9 +176,7 @@ class TestWebhookTasks(TestInfrahubApp):
         assert len(automations) == 1
 
         # Delete the webhook automation
-        await delete_webhook_automation(
-            webhook_id=webhook1.id, webhook_name="Webhook1", event_data={"node_id": webhook1.id}, service=service
-        )
+        await delete_webhook_automation(webhook_id=webhook1.id, webhook_name="Webhook1", service=service)
         automations = await prefect_client.read_automations_by_name(name=name)
         assert len(automations) == 0
 
@@ -268,6 +266,7 @@ class TestWebhookTasks(TestInfrahubApp):
 
         await webhook_process(
             webhook_id=webhook1.id,
+            webhook_name="Webhook1",
             webhook_kind="CoreStandardWebhook",
             event_id="ce3b7013-4abb-4945-89de-1f56da4ff636",
             event_type="infrahub.branch.created",
@@ -294,7 +293,9 @@ class TestWebhookTasks(TestInfrahubApp):
         with pytest.raises(httpx.HTTPStatusError):
             await webhook_process(
                 webhook_id=webhook1.id,
+                webhook_name="Webhook1",
                 webhook_kind="CoreStandardWebhook",
+                branch_name="main",
                 event_id="ce3b7013-4abb-4945-89de-1f56da4ff636",
                 event_type="infrahub.branch.created",
                 event_occured_at="2025-02-28T08:37:09.969Z",

--- a/backend/tests/helpers/events.py
+++ b/backend/tests/helpers/events.py
@@ -13,7 +13,7 @@ async def send_events(client: PrefectClient, events: list[InfrahubEvent]) -> lis
     events_data = [
         Event(
             id=event.meta.id,
-            event=event.get_name(),
+            event=event.event_name,
             payload=event.get_event_payload(),
             related=[RelatedResource(item) for item in event.get_related()],
             resource=Resource(event.get_resource()),

--- a/backend/tests/unit/event/test_event.py
+++ b/backend/tests/unit/event/test_event.py
@@ -1,0 +1,14 @@
+from infrahub_sdk.utils import compare_lists
+
+from infrahub.core.constants import EventType as MainEventType
+from infrahub.events.utils import get_all_events
+
+
+def test_event_type_mapping():
+    event_names = [event.event_name for event in get_all_events()]
+    main_event_types = MainEventType.available_types()
+
+    _, missing_events, wrong_events = compare_lists(list1=event_names, list2=main_event_types)
+
+    assert not missing_events, f"Missing event types: {missing_events}"
+    assert not wrong_events, f"Wrong event types: {wrong_events}"

--- a/backend/tests/unit/graphql/queries/test_event.py
+++ b/backend/tests/unit/graphql/queries/test_event.py
@@ -8,7 +8,6 @@ from prefect.client.orchestration import PrefectClient, get_client
 from infrahub.auth import AccountSession, AuthType
 from infrahub.context import InfrahubContext
 from infrahub.core.branch import Branch
-from infrahub.core.constants import MutationAction
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.schema.schema_branch import SchemaBranch
@@ -16,7 +15,7 @@ from infrahub.database import InfrahubDatabase
 from infrahub.events.branch_action import BranchCreatedEvent, BranchRebasedEvent
 from infrahub.events.group_action import GroupMemberAddedEvent
 from infrahub.events.models import EventMeta, EventNode, InfrahubEvent
-from infrahub.events.node_action import NodeMutatedEvent
+from infrahub.events.node_action import NodeCreatedEvent, NodeUpdatedEvent
 from infrahub.graphql.initialization import prepare_graphql_params
 from tests.helpers.events import send_events
 from tests.helpers.graphql import graphql
@@ -228,55 +227,50 @@ async def events_data(
             sync_with_git=True,
             meta=EventMeta.with_dummy_context(branch=branch3),
         ),
-        "branch1_mutated1": NodeMutatedEvent(
+        "branch1_mutated1": NodeCreatedEvent(
             kind="BuiltinTag",
             node_id=tag1.get_id(),
-            action=MutationAction.CREATED,
-            data=tag1.node_changelog,
+            changelog=tag1.node_changelog,
             meta=EventMeta(
                 branch=branch1,
                 account_id=ACCOUNT1_ID,
                 context=InfrahubContext.init(branch=branch1, account=ACCOUNT_SESSION_1),
             ),
         ),
-        "branch1_mutated2": NodeMutatedEvent(
+        "branch1_mutated2": NodeUpdatedEvent(
             kind="BuiltinTag",
             node_id=tag1_update.get_id(),
-            action=MutationAction.UPDATED,
-            data=tag1_update.node_changelog,
+            changelog=tag1_update.node_changelog,
             meta=EventMeta(
                 branch=branch1,
                 account_id=ACCOUNT1_ID,
                 context=InfrahubContext.init(branch=branch1, account=ACCOUNT_SESSION_1),
             ),
         ),
-        "branch1_mutated3": NodeMutatedEvent(
+        "branch1_mutated3": NodeCreatedEvent(
             kind="BuiltinTag",
             node_id=tag2.get_id(),
-            action=MutationAction.CREATED,
-            data=tag2.node_changelog,
+            changelog=tag2.node_changelog,
             meta=EventMeta(
                 branch=branch1,
                 account_id=ACCOUNT1_ID,
                 context=InfrahubContext.init(branch=branch1, account=ACCOUNT_SESSION_1),
             ),
         ),
-        "branch1_mutated4": NodeMutatedEvent(
+        "branch1_mutated4": NodeCreatedEvent(
             kind="BuiltinTag",
             node_id=tag3.get_id(),
-            action=MutationAction.CREATED,
-            data=tag3.node_changelog,
+            changelog=tag3.node_changelog,
             meta=EventMeta(
                 branch=branch1,
                 account_id=ACCOUNT2_ID,
                 context=InfrahubContext.init(branch=branch1, account=ACCOUNT_SESSION_2),
             ),
         ),
-        "branch1_mutated5": NodeMutatedEvent(
+        "branch1_mutated5": NodeCreatedEvent(
             kind=group_eu.get_kind(),
             node_id=group_eu.get_id(),
-            action=MutationAction.CREATED,
-            data=group_eu.node_changelog,
+            changelog=group_eu.node_changelog,
             meta=EventMeta(
                 branch=branch1,
                 account_id=ACCOUNT2_ID,
@@ -297,55 +291,50 @@ async def events_data(
                 context=InfrahubContext.init(branch=branch1, account=ACCOUNT_SESSION_2),
             ),
         ),
-        "branch2_mutated1": NodeMutatedEvent(
+        "branch2_mutated1": NodeCreatedEvent(
             kind="BuiltinTag",
             node_id=tag4.get_id(),
-            action=MutationAction.CREATED,
-            data=tag4.node_changelog,
+            changelog=tag4.node_changelog,
             meta=EventMeta(
                 branch=branch2,
                 account_id=ACCOUNT1_ID,
                 context=InfrahubContext.init(branch=branch2, account=ACCOUNT_SESSION_1),
             ),
         ),
-        "branch2_mutated2": NodeMutatedEvent(
+        "branch2_mutated2": NodeCreatedEvent(
             kind="BuiltinTag",
             node_id=tag5.get_id(),
-            action=MutationAction.CREATED,
-            data=tag5.node_changelog,
+            changelog=tag5.node_changelog,
             meta=EventMeta(
                 branch=branch2,
                 account_id=ACCOUNT2_ID,
                 context=InfrahubContext.init(branch=branch2, account=ACCOUNT_SESSION_2),
             ),
         ),
-        "branch2_mutated3": NodeMutatedEvent(
+        "branch2_mutated3": NodeCreatedEvent(
             kind="BuiltinTag",
             node_id=tag6.get_id(),
-            action=MutationAction.CREATED,
-            data=tag6.node_changelog,
+            changelog=tag6.node_changelog,
             meta=EventMeta(
                 branch=branch2,
                 account_id=ACCOUNT2_ID,
                 context=InfrahubContext.init(branch=branch2, account=ACCOUNT_SESSION_2),
             ),
         ),
-        "branch3_mutated1": NodeMutatedEvent(
+        "branch3_mutated1": NodeCreatedEvent(
             kind="TestPerson",
             node_id=person1.get_id(),
-            action=MutationAction.CREATED,
-            data=person1.node_changelog,
+            changelog=person1.node_changelog,
             meta=EventMeta(
                 branch=branch3,
                 account_id=ACCOUNT1_ID,
                 context=InfrahubContext.init(branch=branch3, account=ACCOUNT_SESSION_1),
             ),
         ),
-        "branch3_mutated2": NodeMutatedEvent(
+        "branch3_mutated2": NodeCreatedEvent(
             kind="TestPerson",
             node_id=person2.get_id(),
-            action=MutationAction.CREATED,
-            data=person2.node_changelog,
+            changelog=person2.node_changelog,
             meta=EventMeta(
                 branch=branch3,
                 account_id=ACCOUNT1_ID,
@@ -354,11 +343,10 @@ async def events_data(
         ),
     }
 
-    items["branch3_mutated3"] = NodeMutatedEvent(
+    items["branch3_mutated3"] = NodeCreatedEvent(
         kind="TestCar",
         node_id=car.get_id(),
-        action=MutationAction.CREATED,
-        data=car.node_changelog,
+        changelog=car.node_changelog,
         meta=EventMeta.from_parent(items["branch3_mutated1"]),
     )
 

--- a/backend/tests/unit/graphql/test_mutation_delete.py
+++ b/backend/tests/unit/graphql/test_mutation_delete.py
@@ -227,4 +227,4 @@ async def test_delete_events_with_cascade(
     assert secondary.action == MutationAction.DELETED
     assert not secondary.meta.has_children
     assert secondary.meta.parent == primary.meta.id
-    assert secondary.meta.ancestors == [ParentEvent(id=primary.get_id(), name=primary.get_name())]
+    assert secondary.meta.ancestors == [ParentEvent(id=primary.get_id(), name=primary.event_name)]

--- a/backend/tests/unit/graphql/test_mutation_relationship.py
+++ b/backend/tests/unit/graphql/test_mutation_relationship.py
@@ -96,8 +96,8 @@ async def test_relationship_add(
     assert len(memory_event.events) == 1
     node_event = memory_event.events[0]
     assert isinstance(node_event, NodeMutatedEvent)
-    assert node_event.data.node_id == person_jack_main.id
-    relationship = node_event.data.relationships["tags"]
+    assert node_event.changelog.node_id == person_jack_main.id
+    relationship = node_event.changelog.relationships["tags"]
     assert isinstance(relationship, RelationshipCardinalityManyChangelog)
     peers = [peer.peer_id for peer in relationship.peers]
     assert len(peers) == 2
@@ -165,8 +165,8 @@ async def test_relationship_add(
     assert len(memory_event.events) == 1
     node_event = memory_event.events[0]
     assert isinstance(node_event, NodeMutatedEvent)
-    assert node_event.data.node_id == person_jack_main.id
-    relationship = node_event.data.relationships["tags"]
+    assert node_event.changelog.node_id == person_jack_main.id
+    relationship = node_event.changelog.relationships["tags"]
     assert isinstance(relationship, RelationshipCardinalityManyChangelog)
     peers = [peer.peer_id for peer in relationship.peers]
     assert len(peers) == 1

--- a/backend/tests/unit/graphql/test_mutation_update.py
+++ b/backend/tests/unit/graphql/test_mutation_update.py
@@ -299,9 +299,9 @@ async def test_update_all_attributes(
     assert len(memory_event.events) == 1
     event = memory_event.events[0]
     assert isinstance(event, NodeMutatedEvent)
-    assert sorted(event.data.attributes.keys()) == ["ipaddress", "mybool", "myint", "mylist", "mystring", "prefix"]
-    assert event.data.attributes["ipaddress"].value == "10.3.4.254/24"
-    assert event.data.attributes["ipaddress"].value_previous == "10.5.0.1/27"
+    assert sorted(event.changelog.attributes.keys()) == ["ipaddress", "mybool", "myint", "mylist", "mystring", "prefix"]
+    assert event.changelog.attributes["ipaddress"].value == "10.3.4.254/24"
+    assert event.changelog.attributes["ipaddress"].value_previous == "10.5.0.1/27"
 
 
 @pytest.fixture
@@ -465,9 +465,9 @@ async def test_update_single_relationship(
     assert len(memory_event.events) == 1
     event = memory_event.events[0]
     assert isinstance(event, NodeMutatedEvent)
-    assert isinstance(event.data.relationships["owner"], RelationshipCardinalityOneChangelog)
-    assert event.data.relationships["owner"].peer_id == person_jim_main.id
-    assert event.data.relationships["owner"].peer_kind == "TestPerson"
+    assert isinstance(event.changelog.relationships["owner"], RelationshipCardinalityOneChangelog)
+    assert event.changelog.relationships["owner"].peer_id == person_jim_main.id
+    assert event.changelog.relationships["owner"].peer_kind == "TestPerson"
 
 
 async def test_update_default_value(

--- a/backend/tests/unit/graphql/test_mutation_upsert.py
+++ b/backend/tests/unit/graphql/test_mutation_upsert.py
@@ -117,7 +117,7 @@ async def test_upsert_event_on_no_change(
     assert len(memory_event.events) == 1
     event = memory_event.events[0]
     assert isinstance(event, NodeMutatedEvent)
-    assert sorted(event.data.attributes.keys()) == ["height", "name"]
+    assert sorted(event.changelog.attributes.keys()) == ["height", "name"]
 
     memory_event = MemoryInfrahubEvent()
     service = await InfrahubServices.new(event=memory_event)

--- a/docs/docs/reference/infrahub-events.mdx
+++ b/docs/docs/reference/infrahub-events.mdx
@@ -12,113 +12,13 @@ For more detailed explanations on how these events are used within Infrahub, see
 
 :::
 
-## Node events
-
-<!-- vale off -->
-### Node Mutated Event
-<!-- vale on -->
-
-**Type**: infrahub.node.mutated
-**Description**: Event generated when a node has been mutated
-<!-- vale off -->
-| Key | Description |
-|-----|-------------|
-| **meta.branch** | The branch on which originate this event |
-| **meta.request_id** | N/A |
-| **meta.account_id** | The ID of the account triggering this event |
-| **meta.initiator_id** | The worker identity of the initial sender of this message |
-| **meta.context** | The context used when originating this event |
-| **meta.level** | N/A |
-| **meta.has_children** | Indicates if this event might potentially have child events under it. |
-| **meta.id** | UUID of the event |
-| **meta.parent** | The UUID of the parent event if applicable |
-| **meta.ancestors** | Any event used to trigger this event |
-| **kind** | The type of object modified |
-| **node_id** | The ID of the mutated node |
-| **action** | The action taken on the node |
-| **data** | Data on modified object |
-| **fields** | Fields provided in the mutation |
-<!-- vale on -->
-<!-- vale off -->
-### Node Created Event
-<!-- vale on -->
-
-**Type**: infrahub.node.created
-<!-- vale off -->
-| Key | Description |
-|-----|-------------|
-| **meta.branch** | The branch on which originate this event |
-| **meta.request_id** | N/A |
-| **meta.account_id** | The ID of the account triggering this event |
-| **meta.initiator_id** | The worker identity of the initial sender of this message |
-| **meta.context** | The context used when originating this event |
-| **meta.level** | N/A |
-| **meta.has_children** | Indicates if this event might potentially have child events under it. |
-| **meta.id** | UUID of the event |
-| **meta.parent** | The UUID of the parent event if applicable |
-| **meta.ancestors** | Any event used to trigger this event |
-| **kind** | The type of object modified |
-| **node_id** | The ID of the mutated node |
-| **action** | N/A |
-| **data** | Data on modified object |
-| **fields** | Fields provided in the mutation |
-<!-- vale on -->
-<!-- vale off -->
-### Node Updated Event
-<!-- vale on -->
-
-**Type**: infrahub.node.updated
-<!-- vale off -->
-| Key | Description |
-|-----|-------------|
-| **meta.branch** | The branch on which originate this event |
-| **meta.request_id** | N/A |
-| **meta.account_id** | The ID of the account triggering this event |
-| **meta.initiator_id** | The worker identity of the initial sender of this message |
-| **meta.context** | The context used when originating this event |
-| **meta.level** | N/A |
-| **meta.has_children** | Indicates if this event might potentially have child events under it. |
-| **meta.id** | UUID of the event |
-| **meta.parent** | The UUID of the parent event if applicable |
-| **meta.ancestors** | Any event used to trigger this event |
-| **kind** | The type of object modified |
-| **node_id** | The ID of the mutated node |
-| **action** | N/A |
-| **data** | Data on modified object |
-| **fields** | Fields provided in the mutation |
-<!-- vale on -->
-<!-- vale off -->
-### Node Deleted Event
-<!-- vale on -->
-
-**Type**: infrahub.node.deleted
-<!-- vale off -->
-| Key | Description |
-|-----|-------------|
-| **meta.branch** | The branch on which originate this event |
-| **meta.request_id** | N/A |
-| **meta.account_id** | The ID of the account triggering this event |
-| **meta.initiator_id** | The worker identity of the initial sender of this message |
-| **meta.context** | The context used when originating this event |
-| **meta.level** | N/A |
-| **meta.has_children** | Indicates if this event might potentially have child events under it. |
-| **meta.id** | UUID of the event |
-| **meta.parent** | The UUID of the parent event if applicable |
-| **meta.ancestors** | Any event used to trigger this event |
-| **kind** | The type of object modified |
-| **node_id** | The ID of the mutated node |
-| **action** | N/A |
-| **data** | Data on modified object |
-| **fields** | Fields provided in the mutation |
-<!-- vale on -->
 ## Artifact events
 
 <!-- vale off -->
-### Artifact Event
+### Artifact Created Event
 <!-- vale on -->
 
-**Type**: infrahub.artifact
-**Description**: Event generated when an artifact has been created or updated.
+**Type**: infrahub.artifact.created
 <!-- vale off -->
 | Key | Description |
 |-----|-------------|
@@ -140,16 +40,12 @@ For more detailed explanations on how these events are used within Infrahub, see
 | **checksum_previous** | The previous checksum of the artifact |
 | **storage_id** | The current storage id of the artifact |
 | **storage_id_previous** | The previous storage id of the artifact |
-| **created** | Indicates if the artifact was created with this event or already existed |
 <!-- vale on -->
-## Branch events
-
 <!-- vale off -->
-### Branch Deleted Event
+### Artifact Updated Event
 <!-- vale on -->
 
-**Type**: infrahub.branch.deleted
-**Description**: Event generated when a branch has been deleted
+**Type**: infrahub.artifact.updated
 <!-- vale off -->
 | Key | Description |
 |-----|-------------|
@@ -163,10 +59,17 @@ For more detailed explanations on how these events are used within Infrahub, see
 | **meta.id** | UUID of the event |
 | **meta.parent** | The UUID of the parent event if applicable |
 | **meta.ancestors** | Any event used to trigger this event |
-| **branch_name** | The name of the branch |
-| **branch_id** | The ID of the mutated node |
-| **sync_with_git** | Indicates if the branch was extended to Git |
+| **node_id** | The ID of the artifact |
+| **artifact_definition_id** | The ID of the artifact definition |
+| **target_id** | The ID of the target of the artifact |
+| **target_kind** | The kind of the target of the artifact |
+| **checksum** | The current checksum of the artifact |
+| **checksum_previous** | The previous checksum of the artifact |
+| **storage_id** | The current storage id of the artifact |
+| **storage_id_previous** | The previous storage id of the artifact |
 <!-- vale on -->
+## Branch events
+
 <!-- vale off -->
 ### Branch Created Event
 <!-- vale on -->
@@ -188,6 +91,29 @@ For more detailed explanations on how these events are used within Infrahub, see
 | **meta.ancestors** | Any event used to trigger this event |
 | **branch_name** | The name of the branch |
 | **branch_id** | The ID of the branch |
+| **sync_with_git** | Indicates if the branch was extended to Git |
+<!-- vale on -->
+<!-- vale off -->
+### Branch Deleted Event
+<!-- vale on -->
+
+**Type**: infrahub.branch.deleted
+**Description**: Event generated when a branch has been deleted
+<!-- vale off -->
+| Key | Description |
+|-----|-------------|
+| **meta.branch** | The branch on which originate this event |
+| **meta.request_id** | N/A |
+| **meta.account_id** | The ID of the account triggering this event |
+| **meta.initiator_id** | The worker identity of the initial sender of this message |
+| **meta.context** | The context used when originating this event |
+| **meta.level** | N/A |
+| **meta.has_children** | Indicates if this event might potentially have child events under it. |
+| **meta.id** | UUID of the event |
+| **meta.parent** | The UUID of the parent event if applicable |
+| **meta.ancestors** | Any event used to trigger this event |
+| **branch_name** | The name of the branch |
+| **branch_id** | The ID of the mutated node |
 | **sync_with_git** | Indicates if the branch was extended to Git |
 <!-- vale on -->
 <!-- vale off -->
@@ -237,35 +163,10 @@ For more detailed explanations on how these events are used within Infrahub, see
 ## Group events
 
 <!-- vale off -->
-### Group Mutated Event
-<!-- vale on -->
-
-**Type**: infrahub.group.mutated
-**Description**: Event generated when a node has been mutated
-<!-- vale off -->
-| Key | Description |
-|-----|-------------|
-| **meta.branch** | The branch on which originate this event |
-| **meta.request_id** | N/A |
-| **meta.account_id** | The ID of the account triggering this event |
-| **meta.initiator_id** | The worker identity of the initial sender of this message |
-| **meta.context** | The context used when originating this event |
-| **meta.level** | N/A |
-| **meta.has_children** | Indicates if this event might potentially have child events under it. |
-| **meta.id** | UUID of the event |
-| **meta.parent** | The UUID of the parent event if applicable |
-| **meta.ancestors** | Any event used to trigger this event |
-| **kind** | The type of updated group |
-| **node_id** | The ID of the updated group |
-| **action** | The action taken on the node |
-| **members** | Updated members during this event. |
-| **ancestors** | A list of groups that are ancestors of this group. |
-<!-- vale on -->
-<!-- vale off -->
 ### Group Member Added Event
 <!-- vale on -->
 
-**Type**: infrahub.group.member.added
+**Type**: infrahub.group.member_added
 <!-- vale off -->
 | Key | Description |
 |-----|-------------|
@@ -289,7 +190,7 @@ For more detailed explanations on how these events are used within Infrahub, see
 ### Group Member Removed Event
 <!-- vale on -->
 
-**Type**: infrahub.group.member.removed
+**Type**: infrahub.group.member_removed
 <!-- vale off -->
 | Key | Description |
 |-----|-------------|
@@ -309,13 +210,87 @@ For more detailed explanations on how these events are used within Infrahub, see
 | **members** | Updated members during this event. |
 | **ancestors** | A list of groups that are ancestors of this group. |
 <!-- vale on -->
+## Node events
+
+<!-- vale off -->
+### Node Created Event
+<!-- vale on -->
+
+**Type**: infrahub.node.created
+<!-- vale off -->
+| Key | Description |
+|-----|-------------|
+| **meta.branch** | The branch on which originate this event |
+| **meta.request_id** | N/A |
+| **meta.account_id** | The ID of the account triggering this event |
+| **meta.initiator_id** | The worker identity of the initial sender of this message |
+| **meta.context** | The context used when originating this event |
+| **meta.level** | N/A |
+| **meta.has_children** | Indicates if this event might potentially have child events under it. |
+| **meta.id** | UUID of the event |
+| **meta.parent** | The UUID of the parent event if applicable |
+| **meta.ancestors** | Any event used to trigger this event |
+| **kind** | The type of object modified |
+| **node_id** | The ID of the mutated node |
+| **action** | N/A |
+| **changelog** | Data on modified object |
+| **fields** | Fields provided in the mutation |
+<!-- vale on -->
+<!-- vale off -->
+### Node Deleted Event
+<!-- vale on -->
+
+**Type**: infrahub.node.deleted
+<!-- vale off -->
+| Key | Description |
+|-----|-------------|
+| **meta.branch** | The branch on which originate this event |
+| **meta.request_id** | N/A |
+| **meta.account_id** | The ID of the account triggering this event |
+| **meta.initiator_id** | The worker identity of the initial sender of this message |
+| **meta.context** | The context used when originating this event |
+| **meta.level** | N/A |
+| **meta.has_children** | Indicates if this event might potentially have child events under it. |
+| **meta.id** | UUID of the event |
+| **meta.parent** | The UUID of the parent event if applicable |
+| **meta.ancestors** | Any event used to trigger this event |
+| **kind** | The type of object modified |
+| **node_id** | The ID of the mutated node |
+| **action** | N/A |
+| **changelog** | Data on modified object |
+| **fields** | Fields provided in the mutation |
+<!-- vale on -->
+<!-- vale off -->
+### Node Updated Event
+<!-- vale on -->
+
+**Type**: infrahub.node.updated
+<!-- vale off -->
+| Key | Description |
+|-----|-------------|
+| **meta.branch** | The branch on which originate this event |
+| **meta.request_id** | N/A |
+| **meta.account_id** | The ID of the account triggering this event |
+| **meta.initiator_id** | The worker identity of the initial sender of this message |
+| **meta.context** | The context used when originating this event |
+| **meta.level** | N/A |
+| **meta.has_children** | Indicates if this event might potentially have child events under it. |
+| **meta.id** | UUID of the event |
+| **meta.parent** | The UUID of the parent event if applicable |
+| **meta.ancestors** | Any event used to trigger this event |
+| **kind** | The type of object modified |
+| **node_id** | The ID of the mutated node |
+| **action** | N/A |
+| **changelog** | Data on modified object |
+| **fields** | Fields provided in the mutation |
+<!-- vale on -->
 ## Commit events
 
 <!-- vale off -->
 ### Commit Updated Event
 <!-- vale on -->
 
-**Type**: infrahub.commit.updated
+**Type**: infrahub.repository.update_commit
 **Description**: Event generated when the the commit within a repository has been updated.
 <!-- vale off -->
 | Key | Description |
@@ -334,61 +309,14 @@ For more detailed explanations on how these events are used within Infrahub, see
 | **repository_id** | The ID of the repository |
 | **repository_name** | The name of the repository |
 <!-- vale on -->
-## Schema events
-
-<!-- vale off -->
-### Schema Updated Event
-<!-- vale on -->
-
-**Type**: infrahub.schema.updated
-**Description**: Event generated when the schema within a branch has been updated.
-<!-- vale off -->
-| Key | Description |
-|-----|-------------|
-| **meta.branch** | The branch on which originate this event |
-| **meta.request_id** | N/A |
-| **meta.account_id** | The ID of the account triggering this event |
-| **meta.initiator_id** | The worker identity of the initial sender of this message |
-| **meta.context** | The context used when originating this event |
-| **meta.level** | N/A |
-| **meta.has_children** | Indicates if this event might potentially have child events under it. |
-| **meta.id** | UUID of the event |
-| **meta.parent** | The UUID of the parent event if applicable |
-| **meta.ancestors** | Any event used to trigger this event |
-| **branch_name** | The name of the branch |
-| **schema_hash** | Schema hash after the update |
-<!-- vale on -->
 ## Validator events
 
 <!-- vale off -->
-### Validator Event
+### Validator Failed Event
 <!-- vale on -->
 
-**Type**: infrahub.validator
-**Description**: Event generated when an validator within a pipeline has started.
-<!-- vale off -->
-| Key | Description |
-|-----|-------------|
-| **meta.branch** | The branch on which originate this event |
-| **meta.request_id** | N/A |
-| **meta.account_id** | The ID of the account triggering this event |
-| **meta.initiator_id** | The worker identity of the initial sender of this message |
-| **meta.context** | The context used when originating this event |
-| **meta.level** | N/A |
-| **meta.has_children** | Indicates if this event might potentially have child events under it. |
-| **meta.id** | UUID of the event |
-| **meta.parent** | The UUID of the parent event if applicable |
-| **meta.ancestors** | Any event used to trigger this event |
-| **node_id** | The ID of the validator |
-| **kind** | The kind of the validator |
-| **proposed_change_id** | The ID of the proposed change |
-<!-- vale on -->
-<!-- vale off -->
-### Validator Started Event
-<!-- vale on -->
-
-**Type**: infrahub.validator.started
-**Description**: Event generated when an validator within a pipeline has started.
+**Type**: infrahub.validator.failed
+**Description**: Event generated when an validator within a pipeline has completed successfully.
 <!-- vale off -->
 | Key | Description |
 |-----|-------------|
@@ -430,11 +358,11 @@ For more detailed explanations on how these events are used within Infrahub, see
 | **proposed_change_id** | The ID of the proposed change |
 <!-- vale on -->
 <!-- vale off -->
-### Validator Failed Event
+### Validator Started Event
 <!-- vale on -->
 
-**Type**: infrahub.validator.failed
-**Description**: Event generated when an validator within a pipeline has completed successfully.
+**Type**: infrahub.validator.started
+**Description**: Event generated when an validator within a pipeline has started.
 <!-- vale off -->
 | Key | Description |
 |-----|-------------|
@@ -451,4 +379,28 @@ For more detailed explanations on how these events are used within Infrahub, see
 | **node_id** | The ID of the validator |
 | **kind** | The kind of the validator |
 | **proposed_change_id** | The ID of the proposed change |
+<!-- vale on -->
+## Schema events
+
+<!-- vale off -->
+### Schema Updated Event
+<!-- vale on -->
+
+**Type**: infrahub.schema.updated
+**Description**: Event generated when the schema within a branch has been updated.
+<!-- vale off -->
+| Key | Description |
+|-----|-------------|
+| **meta.branch** | The branch on which originate this event |
+| **meta.request_id** | N/A |
+| **meta.account_id** | The ID of the account triggering this event |
+| **meta.initiator_id** | The worker identity of the initial sender of this message |
+| **meta.context** | The context used when originating this event |
+| **meta.level** | N/A |
+| **meta.has_children** | Indicates if this event might potentially have child events under it. |
+| **meta.id** | UUID of the event |
+| **meta.parent** | The UUID of the parent event if applicable |
+| **meta.ancestors** | Any event used to trigger this event |
+| **branch_name** | The name of the branch |
+| **schema_hash** | Schema hash after the update |
 <!-- vale on -->

--- a/tasks/docs.py
+++ b/tasks/docs.py
@@ -458,20 +458,13 @@ def _generate_infrahub_events_documentation() -> None:  # noqa: PLR0915
     import jinja2
 
     import infrahub.events
-    from infrahub.events.models import EventMeta, InfrahubEvent
+    from infrahub.events.models import EventMeta
+    from infrahub.events.utils import get_all_events
 
     def load_all_event_modules(package: Any) -> None:  # noqa: ANN401
         """Recursively load all modules in the given package."""
         for _, modname, _ in walk_packages(package.__path__, package.__name__ + "."):
             import_module(modname)
-
-    def get_all_event_subclasses(cls: type) -> list[type]:
-        """Recursively get all subclasses of the given class."""
-        subclasses: list[type] = []
-        for subclass in cls.__subclasses__():
-            subclasses.append(subclass)
-            subclasses.extend(get_all_event_subclasses(subclass))
-        return subclasses
 
     def format_event_name(raw_name: str) -> str:
         """
@@ -481,22 +474,9 @@ def _generate_infrahub_events_documentation() -> None:  # noqa: PLR0915
         formatted = re.sub(r"(?<!^)(?=[A-Z])", " ", raw_name)
         return formatted.strip()
 
-    def get_event_type(raw_name: str) -> str:
-        """
-        Convert a CamelCase event name into a dotted, lowercase event type string.
-        Removes a trailing "Event", then splits the name into parts.
-        For example: "NodeCreatedEvent" becomes "infrahub.node.created".
-        """
-        raw_name = raw_name.removesuffix("Event")
-        parts = re.findall(r"[A-Z][a-z]*", raw_name)
-        return "infrahub." + ".".join(part.lower() for part in parts)
-
     def group_events_by_category(event_classes: list[type]) -> dict[str, list[dict[str, Any]]]:
         grouped = defaultdict(list)
         for cls in event_classes:
-            if cls is InfrahubEvent:
-                continue
-
             # Extract the primary category from the class name (like "Node", "Group", "Commit")
             category = re.match(r"([A-Z][a-z]+)", cls.__name__)
             if not category:
@@ -505,7 +485,7 @@ def _generate_infrahub_events_documentation() -> None:  # noqa: PLR0915
             description = cls.__doc__.strip() if cls.__doc__ else ""
             # Use helper functions to produce a friendly event name and an event type
             event_name_formatted = format_event_name(cls.__name__)
-            event_type = get_event_type(cls.__name__)
+            event_type = cls.event_name
 
             schema = cls.model_json_schema().get("properties", {})
             fields = []
@@ -535,6 +515,10 @@ def _generate_infrahub_events_documentation() -> None:  # noqa: PLR0915
                 "fields": fields,
             }
             grouped[primary].append(event_info)
+
+        for primary, events in grouped.items():
+            grouped[primary] = sorted(events, key=lambda x: x["event_name"])
+
         return grouped
 
     template_file = DOCUMENTATION_DIRECTORY / "_templates" / "infrahub-events.j2"
@@ -552,7 +536,7 @@ def _generate_infrahub_events_documentation() -> None:  # noqa: PLR0915
 
     # IMPORTANT: Ensure all event classes are imported so that they are found by introspection.
     load_all_event_modules(package=infrahub.events)
-    all_event_classes = get_all_event_subclasses(cls=InfrahubEvent)
+    all_event_classes = get_all_events()
     event_groups = group_events_by_category(event_classes=all_event_classes)
 
     rendered_doc = template.render(event_groups=event_groups)


### PR DESCRIPTION
This PR standardize how the payload of all events are generated based on their respective `InfrahubEvent` model. Also, all events now have their own definition instead of having a single class used for multiple events. As a result the documentation now list all individual events and the content of the payload is based on the format of `InfrahubEvent`

> The field `event_name` has been converted to a `ClassVar` attribute instead of of `computed_attribute` which allow to access it directly on the class. 

The format for all events will looks like this
- **event** : name of the event
- **occured**: time of the event
- **payload**
  - **data**: content of of the InfrahubEvent model
  - **context**: context of the event with the name of the branch, account_id and more

Most events where already following the same structure as the model, except for the `infrahub.node.*` event that had a slightly different format.

the new format of the payload is as follow
- **payload**
  - **data**
    - **changelog** information about the node
      - **attributes**
      - **relationships**
      - **display_label**
      - **node_id**
      - **node_kind**   
    - **fields** list of fields that have been modified
    - **kind**
    - **node_id**
    - **action**

The main different is that there is an additional level of "data" 




