### PR TITLE
Add optional proposed change ID to branch merged event

### DIFF
--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -190,7 +190,9 @@ async def rebase_branch(branch: str, context: InfrahubContext, service: Infrahub
 
 
 @flow(name="branch-merge", flow_run_name="Merge branch {branch} into main")
-async def merge_branch(branch: str, context: InfrahubContext, service: InfrahubServices) -> None:
+async def merge_branch(
+    branch: str, context: InfrahubContext, service: InfrahubServices, proposed_change_id: str | None = None
+) -> None:
     async with service.database.start_session() as db:
         log = get_run_logger()
 
@@ -202,6 +204,7 @@ async def merge_branch(branch: str, context: InfrahubContext, service: InfrahubS
         merge_event = BranchMergedEvent(
             branch_name=obj.name,
             branch_id=str(obj.get_uuid()),
+            proposed_change_id=proposed_change_id,
             meta=EventMeta.from_context(context=context, branch=registry.get_global_branch()),
         )
 

--- a/backend/infrahub/events/branch_action.py
+++ b/backend/infrahub/events/branch_action.py
@@ -2,6 +2,7 @@ from typing import ClassVar
 
 from pydantic import Field
 
+from infrahub.core.constants import InfrahubKind
 from infrahub.message_bus import InfrahubMessage
 from infrahub.message_bus.messages.refresh_registry_branches import RefreshRegistryBranches
 from infrahub.message_bus.messages.refresh_registry_rebasedbranch import RefreshRegistryRebasedBranch
@@ -75,6 +76,9 @@ class BranchMergedEvent(InfrahubEvent):
 
     branch_name: str = Field(..., description="The name of the branch")
     branch_id: str = Field(..., description="The ID of the branch")
+    proposed_change_id: str | None = Field(
+        default=None, description="The ID of the proposed change that merged this branch if applicable"
+    )
 
     def get_resource(self) -> dict[str, str]:
         return {
@@ -82,6 +86,19 @@ class BranchMergedEvent(InfrahubEvent):
             "infrahub.branch.id": self.branch_id,
             "infrahub.branch.name": self.branch_name,
         }
+
+    def get_related(self) -> list[dict[str, str]]:
+        related = super().get_related()
+        if self.proposed_change_id:
+            related.append(
+                {
+                    "prefect.resource.id": self.proposed_change_id,
+                    "prefect.resource.role": "infrahub.related.node",
+                    "infrahub.node.kind": InfrahubKind.PROPOSEDCHANGE,
+                }
+            )
+
+        return related
 
 
 class BranchRebasedEvent(InfrahubEvent):

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -151,7 +151,9 @@ async def merge_proposed_change(
 
         log.info("Proposed change is eligible to be merged")
         try:
-            await merge_branch(branch=source_branch.name, context=context, service=service)
+            await merge_branch(
+                branch=source_branch.name, context=context, service=service, proposed_change_id=proposed_change_id
+            )
         except MergeFailedError as exc:
             await _proposed_change_transition_state(
                 proposed_change=proposed_change, state=ProposedChangeState.OPEN, service=service

--- a/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
@@ -267,6 +267,8 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
 
         assert merge_event["InfrahubEvent"]["count"] == 1
         merge_event_id = merge_event["InfrahubEvent"]["edges"][0]["node"]["id"]
+        assert len(merge_event["InfrahubEvent"]["edges"][0]["node"]["related_nodes"]) == 1
+        assert merge_event["InfrahubEvent"]["edges"][0]["node"]["related_nodes"][0]["id"] == proposed_change.id
 
         secondary_events = await client.execute_graphql(query=QUERY_EVENT, variables={"parent__ids": merge_event_id})
 

--- a/docs/docs/reference/infrahub-events.mdx
+++ b/docs/docs/reference/infrahub-events.mdx
@@ -137,6 +137,7 @@ For more detailed explanations on how these events are used within Infrahub, see
 | **meta.ancestors** | Any event used to trigger this event |
 | **branch_name** | The name of the branch |
 | **branch_id** | The ID of the branch |
+| **proposed_change_id** | The ID of the proposed change that merged this branch if applicable |
 <!-- vale on -->
 <!-- vale off -->
 ### Branch Rebased Event


### PR DESCRIPTION
Add optional proposed change ID to branch merged event, it's optional as the proposed change field will only be populated if the merge came from a proposed change and not a direct branch merge mutation.