### PR TITLE
Add node creations batch benchmark

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -175,6 +175,10 @@
   description: "Don't include this PR in the changelog"
   color: "c30664"
 
+- name: "ci/run-intensive-benchmarks"
+  description: "Run intensive CodSpeed benchmarks, usually excluded."
+  color: "73FA20"
+
 - name: "cd/preview"
   description: "Deploy preview branch"
   color: "d77e96"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1009,7 +1009,7 @@ jobs:
         uses: CodSpeedHQ/action@v3
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
-          run: "poetry run pytest -v backend/tests/benchmark/ --codspeed"
+          run: "poetry run pytest -v backend/tests/benchmark/test_batch_create.py --codspeed"
   # ------------------------------------------ Coverall Report  ------------------------------------------
   coverall-report:
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1005,11 +1005,28 @@ jobs:
         run: "poetry install --no-interaction --no-ansi"
       - name: Update PATH
         run: "echo ~/.cargo/bin >> $GITHUB_PATH"
+
+      - name: Run all benchmarks
+        if: contains(github.event.pull_request.labels.*.name, 'ci/run-intensive-benchmarks')
+        uses: CodSpeedHQ/action@v3
+        with:
+          token: ${{ secrets.CODSPEED_TOKEN }}
+          run: "poetry run pytest -v backend/tests/benchmark/ --codspeed"
+
+      - name: Run non-intensive benchmarks
+        if: |
+          !contains(github.event.pull_request.labels.*.name, 'ci/run-intensive-benchmarks')
+        uses: CodSpeedHQ/action@v3
+        with:
+          token: ${{ secrets.CODSPEED_TOKEN }}
+          run: "poetry run pytest -v backend/tests/benchmark/ --codspeed --ignore=backend/tests/benchmark/intensive"
+
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v3
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
-          run: "poetry run pytest -v backend/tests/benchmark/test_batch_create.py --codspeed"
+          run: "poetry run pytest -v backend/tests/benchmark/ --codspeed"
+
   # ------------------------------------------ Coverall Report  ------------------------------------------
   coverall-report:
     needs:

--- a/backend/tests/benchmark/intensive/test_batch_create.py
+++ b/backend/tests/benchmark/intensive/test_batch_create.py
@@ -1,10 +1,8 @@
-import time
 import uuid
 
 import pytest
 from infrahub_sdk import InfrahubClient
 from infrahub_sdk.batch import InfrahubBatch
-from mypy.checkexpr import defaultdict
 
 from infrahub.core.branch import Branch
 from infrahub.core.node import Node
@@ -12,39 +10,8 @@ from infrahub.database import InfrahubDatabase
 from tests.helpers.test_app import TestInfrahubApp
 
 
-class TestBenchmarkBatches(TestInfrahubApp):
-    @pytest.fixture
-    def timing_collector(self):
-        timing_info = defaultdict(dict)
-        yield timing_info
-        # Print the collected timing information in a grid format at the end of all test runs
-        print("\nTiming information for all test runs:")
-        # Dynamically generate column headers
-        all_keys = set()
-        for batch_size in timing_info:
-            all_keys.update(timing_info[batch_size].keys())
-        all_keys = sorted(all_keys)
-
-        # Calculate the maximum width for each column
-        col_widths = {
-            key: max(len(key), len(timing_info[batch_size].get(key, "N/A")))
-            for key in all_keys
-            for batch_size in timing_info
-        }
-
-        # Print header row
-        header = f"{'Batch Size':<10} | " + " | ".join(f"{key:<{col_widths[key]}}" for key in all_keys)
-        print(header)
-        print("=" * (10 + sum(col_widths.values()) + 3 * len(all_keys)))
-
-        # Print data rows
-        for batch_size in sorted(timing_info.keys()):
-            row = f"{batch_size:<10} | "
-            for key in all_keys:
-                elapsed_time = timing_info[batch_size].get(key, "N/A")
-                row += f"{elapsed_time:<{col_widths[key]}} | "
-            print(row)
-
+@pytest.mark.timeout(1000)  # Increase timeout as codspeed runs tests multiple times.
+class TestBenchmarkNodeCreationBatch(TestInfrahubApp):
     async def create_car_batch(
         self,
         batch_size: int,
@@ -90,7 +57,7 @@ class TestBenchmarkBatches(TestInfrahubApp):
         res = await client.schema.load([car_person_schema_unique_owner], branch=branch.name)
         assert len(res.errors) == 0, res.errors
 
-    @pytest.mark.parametrize("allow_upsert", [True])
+    @pytest.mark.parametrize("allow_upsert", [True, False])
     @pytest.mark.parametrize("batch_size", [100])
     def test_create_nodes_batch(
         self,
@@ -102,7 +69,6 @@ class TestBenchmarkBatches(TestInfrahubApp):
         batch_size: int,
         aio_benchmark,
         exec_async,
-        timing_collector,
     ) -> None:
         batch = exec_async(
             self.create_car_batch,
@@ -113,23 +79,12 @@ class TestBenchmarkBatches(TestInfrahubApp):
             branch=branch.name,
         )
 
-        # Raises a "loop already running" error
         aio_benchmark(
             execute_batch,
             infrahub_batch=batch,
-            branch=branch.name,
-            allow_upsert=allow_upsert,
-            batch_size=batch_size,
-            timing_collector=timing_collector,
         )
 
 
-async def execute_batch(infrahub_batch, branch, allow_upsert, batch_size, timing_collector):
-    start_time = time.time()
+async def execute_batch(infrahub_batch):
     async for _, _ in infrahub_batch.execute():
         pass
-
-    # Store data in order to have a manual report containing all test runs results
-    elapsed_time = time.time() - start_time
-    key = f"{branch}, allow_upsert={allow_upsert}"
-    timing_collector[batch_size][key] = f"{elapsed_time:.2f}s"

--- a/backend/tests/benchmark/test_batch_create.py
+++ b/backend/tests/benchmark/test_batch_create.py
@@ -1,0 +1,135 @@
+import time
+import uuid
+
+import pytest
+from infrahub_sdk import InfrahubClient
+from infrahub_sdk.batch import InfrahubBatch
+from mypy.checkexpr import defaultdict
+
+from infrahub.core.branch import Branch
+from infrahub.core.node import Node
+from infrahub.database import InfrahubDatabase
+from tests.helpers.test_app import TestInfrahubApp
+
+
+class TestBenchmarkBatches(TestInfrahubApp):
+    @pytest.fixture
+    def timing_collector(self):
+        timing_info = defaultdict(dict)
+        yield timing_info
+        # Print the collected timing information in a grid format at the end of all test runs
+        print("\nTiming information for all test runs:")
+        # Dynamically generate column headers
+        all_keys = set()
+        for batch_size in timing_info:
+            all_keys.update(timing_info[batch_size].keys())
+        all_keys = sorted(all_keys)
+
+        # Calculate the maximum width for each column
+        col_widths = {
+            key: max(len(key), len(timing_info[batch_size].get(key, "N/A")))
+            for key in all_keys
+            for batch_size in timing_info
+        }
+
+        # Print header row
+        header = f"{'Batch Size':<10} | " + " | ".join(f"{key:<{col_widths[key]}}" for key in all_keys)
+        print(header)
+        print("=" * (10 + sum(col_widths.values()) + 3 * len(all_keys)))
+
+        # Print data rows
+        for batch_size in sorted(timing_info.keys()):
+            row = f"{batch_size:<10} | "
+            for key in all_keys:
+                elapsed_time = timing_info[batch_size].get(key, "N/A")
+                row += f"{elapsed_time:<{col_widths[key]}} | "
+            print(row)
+
+    async def create_car_batch(
+        self,
+        batch_size: int,
+        client: InfrahubClient,
+        allow_upsert: bool,
+        branch: str,
+        db: InfrahubDatabase,
+    ) -> InfrahubBatch:
+        # Reset database state to not alter benchmark
+        await self.delete_nodes(db=db, kinds=["TestCar", "TestPerson"])
+
+        batch = await client.create_batch()
+        for _ in range(batch_size):
+            # First create the owner of the car, that is part of car's uniqueness constraint.
+            short_id = str(uuid.uuid4())[:8]
+            person_name = f"person-{short_id}"
+            person_node = await Node.init(db=db, schema="TestPerson", branch=branch)
+            await person_node.new(db=db, name=person_name)
+            await person_node.save(db=db)
+
+            # Add the car to the batch.
+            short_id = str(uuid.uuid4())[:8]
+            car_name = f"car-{short_id}"
+            car = await client.create(kind="TestCar", name=car_name, nbr_seats=4, owner=person_name, branch=branch)
+            batch.add(task=car.save, node=car, allow_upsert=allow_upsert)
+
+        return batch
+
+    @staticmethod
+    async def delete_nodes(db: InfrahubDatabase, kinds: list[str]) -> None:
+        query = """
+        MATCH (n)
+        WHERE n.kind in $kinds
+        DETACH DELETE n
+        """
+
+        params: dict = {"kinds": kinds}
+
+        await db.execute_query(query=query, params=params, name="delete_nodes")
+
+    @pytest.fixture
+    async def load_schema(self, client, branch, car_person_schema_unique_owner):
+        res = await client.schema.load([car_person_schema_unique_owner], branch=branch.name)
+        assert len(res.errors) == 0, res.errors
+
+    @pytest.mark.parametrize("allow_upsert", [True, False])
+    @pytest.mark.parametrize("batch_size", [100])
+    def test_create_nodes_batch(
+        self,
+        client: InfrahubClient,
+        db: InfrahubDatabase,
+        load_schema,
+        branch: Branch,
+        allow_upsert: bool,
+        batch_size: int,
+        aio_benchmark,
+        exec_async,
+        timing_collector,
+    ) -> None:
+        batch = exec_async(
+            self.create_car_batch,
+            batch_size=batch_size,
+            client=client,
+            allow_upsert=allow_upsert,
+            db=db,
+            branch=branch.name,
+        )
+
+        # Raises a "loop already running" error
+        aio_benchmark(
+            execute_batch,
+            infrahub_batch=batch,
+            branch=branch.name,
+            allow_upsert=allow_upsert,
+            batch_size=batch_size,
+            timing_collector=timing_collector,
+        )
+
+
+async def execute_batch(infrahub_batch, branch, allow_upsert, batch_size, timing_collector):
+    start_time = time.time()
+    async for _, _ in infrahub_batch.execute():
+        pass
+
+    # Store data in order to have a manual report containing all test runs results
+    elapsed_time = time.time() - start_time
+    key = f"{branch}, allow_upsert={allow_upsert}"
+    timing_collector[batch_size][key] = f"{elapsed_time:.2f}s"

--- a/backend/tests/benchmark/test_batch_create.py
+++ b/backend/tests/benchmark/test_batch_create.py
@@ -90,7 +90,7 @@ class TestBenchmarkBatches(TestInfrahubApp):
         res = await client.schema.load([car_person_schema_unique_owner], branch=branch.name)
         assert len(res.errors) == 0, res.errors
 
-    @pytest.mark.parametrize("allow_upsert", [True, False])
+    @pytest.mark.parametrize("allow_upsert", [True])
     @pytest.mark.parametrize("batch_size", [100])
     def test_create_nodes_batch(
         self,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1099,7 +1099,7 @@ async def car_person_schema_unique_owner(db: InfrahubDatabase, node_group_schema
     return schema
 
 
-@pytest.fixture(params=["main", "branch2"])
+@pytest.fixture(params=["main"])
 async def branch(request, db: InfrahubDatabase, default_branch: Branch):
     if request.param == "main":
         return default_branch

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -207,13 +207,7 @@ def neo4j(request: pytest.FixtureRequest, load_settings_before_session) -> dict[
         return None
 
     container = start_neo4j_container(NEO4J_IMAGE)
-
-    def finalize():
-        print("Neo4j container logs:")
-        print(container.get_logs())
-        container.stop()
-
-    request.addfinalizer(finalize)
+    request.addfinalizer(container.stop)
 
     return {
         PORT_BOLT_NEO4J: get_exposed_port(container, PORT_BOLT_NEO4J),
@@ -1099,7 +1093,7 @@ async def car_person_schema_unique_owner(db: InfrahubDatabase, node_group_schema
     return schema
 
 
-@pytest.fixture(params=["main"])
+@pytest.fixture(params=["main", "branch2"])
 async def branch(request, db: InfrahubDatabase, default_branch: Branch):
     if request.param == "main":
         return default_branch

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -207,7 +207,13 @@ def neo4j(request: pytest.FixtureRequest, load_settings_before_session) -> dict[
         return None
 
     container = start_neo4j_container(NEO4J_IMAGE)
-    request.addfinalizer(container.stop)
+
+    def finalize():
+        print("Neo4j container logs:")
+        print(container.get_logs())
+        container.stop()
+
+    request.addfinalizer(finalize)
 
     return {
         PORT_BOLT_NEO4J: get_exposed_port(container, PORT_BOLT_NEO4J),

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -23,6 +23,7 @@ from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import BranchSupportType, InfrahubKind, RelationshipCardinality, RelationshipDirection
 from infrahub.core.initialization import (
+    create_branch,
     create_default_branch,
     create_global_branch,
     create_ipam_namespace,
@@ -1043,3 +1044,58 @@ def car_person_branch_agnostic_schema() -> dict[str, Any]:
         ],
     }
     return schema
+
+
+@pytest.fixture
+async def car_person_schema_unique_owner(db: InfrahubDatabase, node_group_schema, data_schema) -> dict:
+    schema: dict[str, Any] = {
+        "version": "1.0",
+        "nodes": [
+            {
+                "name": "Car",
+                "namespace": "Test",
+                "default_filter": "name__value",
+                "display_labels": ["name__value"],
+                "uniqueness_constraints": [["name__value"], ["owner"]],
+                "branch": BranchSupportType.AWARE.value,
+                "attributes": [
+                    {"name": "name", "kind": "Text", "unique": True},
+                    {"name": "nbr_seats", "kind": "Number", "optional": True},
+                ],
+                "relationships": [
+                    {
+                        "name": "owner",
+                        "label": "Commander of Car",
+                        "peer": "TestPerson",
+                        "optional": False,
+                        "kind": "Parent",
+                        "cardinality": "one",
+                        "direction": "outbound",
+                    },
+                ],
+            },
+            {
+                "name": "Person",
+                "namespace": "Test",
+                "default_filter": "name__value",
+                "display_labels": ["name__value"],
+                "branch": BranchSupportType.AWARE.value,
+                "uniqueness_constraints": [["name__value"]],
+                "attributes": [
+                    {"name": "name", "kind": "Text", "unique": True},
+                    {"name": "height", "kind": "Number", "optional": True},
+                ],
+                "relationships": [{"name": "cars", "peer": "TestCar", "cardinality": "many", "direction": "inbound"}],
+            },
+        ],
+    }
+
+    return schema
+
+
+@pytest.fixture(params=["main", "branch2"])
+async def branch(request, db: InfrahubDatabase, default_branch: Branch):
+    if request.param == "main":
+        return default_branch
+
+    return await create_branch(branch_name=str(request.param), db=db)

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -73,14 +73,6 @@ def load_component_dependency_registry():
     build_component_registry()
 
 
-@pytest.fixture(params=["main", "branch2"])
-async def branch(request, db: InfrahubDatabase, default_branch: Branch):
-    if request.param == "main":
-        return default_branch
-
-    return await create_branch(branch_name=str(request.param), db=db)
-
-
 @pytest.fixture(scope="session")
 def neo4j_factory():
     """Return a Hydration Scope from Neo4j used to generate fake


### PR DESCRIPTION
Adding benchmarks creating car nodes in a batch, on both main and another branch, using both `allow_upsert=True/False` with `batch_size=100`.

Benchmarks are cpu intensive as they are ran multiple times by codspeed, thus they are disabled by default and we can manually trigger them on a PR using `ci/run-intensive-benchmarks` labels.


Side note, here are some results with `batch_size=1000` confirming the fact that:
- upsert are slower - due to extra queries to try to fetch the node
- running on main branch is slower - due too locks

![image](https://github.com/user-attachments/assets/9f94383e-c3a6-4fec-967f-de79177e2b87)

Note that introduced benchmarks use a `batch_size=100` that do not reveal performance differences between branches due to locks. These benchmarks are likely to evolve in the future, but this PR could at least serve as a setup basis.