### PR TITLE
fix relationship query loopback bug

### DIFF
--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -666,18 +666,21 @@ class NodeListGetRelationshipsQuery(Query):
         MATCH paths_in = ((n)<-[r1:IS_RELATED]-(rel:Relationship)<-[r2:IS_RELATED]-(peer))
         WHERE ($relationship_identifiers IS NULL OR rel.name in $relationship_identifiers)
         AND all(r IN relationships(paths_in) WHERE (%(filters)s))
+        AND n.uuid <> peer.uuid
         RETURN n, rel, peer, r1, r2, "inbound" as direction
         UNION
         MATCH (n:Node) WHERE n.uuid IN $ids
         MATCH paths_out = ((n)-[r1:IS_RELATED]->(rel:Relationship)-[r2:IS_RELATED]->(peer))
         WHERE ($relationship_identifiers IS NULL OR rel.name in $relationship_identifiers)
         AND all(r IN relationships(paths_out) WHERE (%(filters)s))
+        AND n.uuid <> peer.uuid
         RETURN n, rel, peer, r1, r2, "outbound" as direction
         UNION
         MATCH (n:Node) WHERE n.uuid IN $ids
         MATCH paths_bidir = ((n)-[r1:IS_RELATED]->(rel:Relationship)<-[r2:IS_RELATED]-(peer))
         WHERE ($relationship_identifiers IS NULL OR rel.name in $relationship_identifiers)
         AND all(r IN relationships(paths_bidir) WHERE (%(filters)s))
+        AND n.uuid <> peer.uuid
         RETURN n, rel, peer, r1, r2, "bidirectional" as direction
         """ % {"filters": rels_filter}
 

--- a/backend/tests/integration/schema_lifecycle/shared.py
+++ b/backend/tests/integration/schema_lifecycle/shared.py
@@ -90,6 +90,19 @@ class TestSchemaLifecycleBase(TestInfrahubApp):
         return schema_car_base
 
     @pytest.fixture(scope="class")
+    def schema_car_06_interiors(self, schema_car_05_no_profile) -> dict[str, Any]:
+        schema_car_05_no_profile["relationships"].append(
+            {
+                "name": "interiors",
+                "kind": "Attribute",
+                "optional": True,
+                "peer": "TestingInterior",
+                "cardinality": "many",
+            },
+        )
+        return schema_car_05_no_profile
+
+    @pytest.fixture(scope="class")
     def schema_manufacturer_base(self) -> dict[str, Any]:
         return {
             "name": "Manufacturer",
@@ -149,6 +162,19 @@ class TestSchemaLifecycleBase(TestInfrahubApp):
         return schema_tag_base
 
     @pytest.fixture(scope="class")
+    def schema_interior_base(self) -> dict[str, Any]:
+        return {
+            "name": "Interior",
+            "namespace": "Testing",
+            "include_in_menu": True,
+            "label": "Testing Interior",
+            "attributes": [{"name": "material", "kind": "Text", "optional": False}],
+            "relationships": [
+                {"name": "cars", "kind": "Generic", "optional": True, "peer": "TestingCar", "cardinality": "many"},
+            ],
+        }
+
+    @pytest.fixture(scope="class")
     def schema_step01(
         self, schema_car_base, schema_person_base, schema_manufacturer_base, schema_tag_base
     ) -> dict[str, Any]:
@@ -205,5 +231,23 @@ class TestSchemaLifecycleBase(TestInfrahubApp):
                 schema_car_05_no_profile,
                 schema_manufacturer_02_car_maker,
                 # TestingTag is removed in previous step
+            ],
+        }
+
+    @pytest.fixture(scope="class")
+    def schema_step06(
+        self,
+        schema_car_06_interiors,
+        schema_person_03_no_height,
+        schema_manufacturer_02_car_maker,
+        schema_interior_base,
+    ) -> dict[str, Any]:
+        return {
+            "version": "1.0",
+            "nodes": [
+                schema_person_03_no_height,
+                schema_car_06_interiors,
+                schema_manufacturer_02_car_maker,
+                schema_interior_base,
             ],
         }

--- a/backend/tests/integration/schema_lifecycle/test_schema_migration_branch.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_migration_branch.py
@@ -419,3 +419,21 @@ class TestSchemaLifecycleBranch(TestSchemaLifecycleBase):
             registry.schema.get(name=f"Profile{CAR_KIND}", branch=self.branch1, check_branch_only=True)
         car_schema = registry.schema.get(name=CAR_KIND, branch=self.branch1, duplicate=False)
         assert "profiles" in car_schema.relationship_names
+
+    async def test_step05_merge(
+        self, db: InfrahubDatabase, client: InfrahubClient, initial_dataset, schema_step06, schema_interior_base
+    ):
+        response = await client.schema.load(schemas=[schema_step06], branch=self.branch1.name)
+        assert not response.errors
+
+        await client.branch.merge(branch_name=self.branch1.name)
+
+        updated_branch = await Branch.get_by_name(name=self.branch1.name, db=db)
+        updated_schema_default = await registry.schema.load_schema_from_db(db=db)
+        default_interiors_schema = updated_schema_default.get(name="TestingInterior", duplicate=False)
+        assert default_interiors_schema.attribute_names == ["material"]
+        assert "cars" in default_interiors_schema.relationship_names
+        updated_schema_branch = await registry.schema.load_schema_from_db(db=db, branch=updated_branch)
+        updated_interiors_schema = updated_schema_branch.get(name="TestingInterior", duplicate=False)
+        assert updated_interiors_schema.attribute_names == ["material"]
+        assert "cars" in updated_interiors_schema.relationship_names

--- a/changelog/+relationship_query.fixed.md
+++ b/changelog/+relationship_query.fixed.md
@@ -1,0 +1,1 @@
+Fix a bug in one of the cypher queries to get related nodes that could cause a crash when trying to retrieve a schema from the database if that schema was merged in from a branch


### PR DESCRIPTION
IFC-1367

fixes a bug that could appear if a branch with schema changes was merged into the default branch and then the server was restarted 

the problem was in the `NodeListGetRelationshipsQuery`. when trying to retrieve a relationship from a merged branch, the query would allow incorrectly identify a path that led from the `SchemaNode` in question back to itself as valid
for example 
```
(s:SchemaNode)-[:IS_RELATED]->(:Relationship)<-[:IS_RELATED]-(s)
```
this would cause `convert_node_schema_to_schema` to try to turn a `SchemaNode` node from the database into a `RelationshipSchema` object in memory, which would fail pydantic violation big time