### PR TITLE
Allow to specify a node kind on a webhook to match against a kind

### DIFF
--- a/backend/infrahub/core/protocols.py
+++ b/backend/infrahub/core/protocols.py
@@ -199,6 +199,7 @@ class CoreWebhook(CoreNode):
     name: String
     event_type: Enum
     branch_scope: Dropdown
+    node_kind: StringOptional
     description: StringOptional
     url: URL
     validate_certificates: BooleanOptional

--- a/backend/infrahub/core/schema/definitions/core/webhook.py
+++ b/backend/infrahub/core/schema/definitions/core/webhook.py
@@ -50,6 +50,13 @@ core_webhook = {
             "order_weight": 2000,
             "allow_override": AllowOverrideType.NONE,
         },
+        {
+            "name": "node_kind",
+            "kind": "Text",
+            "optional": True,
+            "description": "Only send node mutation events for nodes of this kind",
+            "order_weight": 2250,
+        },
         {"name": "description", "kind": "Text", "optional": True, "order_weight": 2500},
         {"name": "url", "kind": "URL", "order_weight": 3000},
         {

--- a/backend/infrahub/events/artifact_action.py
+++ b/backend/infrahub/events/artifact_action.py
@@ -52,7 +52,9 @@ class ArtifactEvent(InfrahubEvent):
 
 class ArtifactCreatedEvent(ArtifactEvent):
     event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.artifact.created"
+    infrahub_node_kind_event: ClassVar[bool] = True
 
 
 class ArtifactUpdatedEvent(ArtifactEvent):
     event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.artifact.updated"
+    infrahub_node_kind_event: ClassVar[bool] = True

--- a/backend/infrahub/events/group_action.py
+++ b/backend/infrahub/events/group_action.py
@@ -90,8 +90,10 @@ class GroupMutatedEvent(InfrahubEvent):
 class GroupMemberAddedEvent(GroupMutatedEvent):
     action: MutationAction = MutationAction.CREATED
     event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.group.member_added"
+    infrahub_node_kind_event: ClassVar[bool] = True
 
 
 class GroupMemberRemovedEvent(GroupMutatedEvent):
     action: MutationAction = MutationAction.DELETED
     event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.group.member_removed"
+    infrahub_node_kind_event: ClassVar[bool] = True

--- a/backend/infrahub/events/models.py
+++ b/backend/infrahub/events/models.py
@@ -149,6 +149,7 @@ class InfrahubEvent(BaseModel):
     meta: EventMeta = Field(..., description="Metadata for the event")
 
     event_name: ClassVar[str] = Field(..., description="The name of the event")
+    infrahub_node_kind_event: ClassVar[bool] = False
 
     def get_id(self) -> str:
         return self.meta.get_id()

--- a/backend/infrahub/events/node_action.py
+++ b/backend/infrahub/events/node_action.py
@@ -78,16 +78,19 @@ class NodeMutatedEvent(InfrahubEvent):
 class NodeCreatedEvent(NodeMutatedEvent):
     event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.node.created"
     action: MutationAction = MutationAction.CREATED
+    infrahub_node_kind_event: ClassVar[bool] = True
 
 
 class NodeUpdatedEvent(NodeMutatedEvent):
     event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.node.updated"
     action: MutationAction = MutationAction.UPDATED
+    infrahub_node_kind_event: ClassVar[bool] = True
 
 
 class NodeDeletedEvent(NodeMutatedEvent):
     event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.node.deleted"
     action: MutationAction = MutationAction.DELETED
+    infrahub_node_kind_event: ClassVar[bool] = True
 
 
 def get_node_event(action: MutationAction) -> type[NodeDeletedEvent] | type[NodeUpdatedEvent] | type[NodeCreatedEvent]:

--- a/backend/infrahub/events/utils.py
+++ b/backend/infrahub/events/utils.py
@@ -6,3 +6,11 @@ def get_all_events() -> list[type[InfrahubEvent]]:
     """Recursively get all subclasses of the given class."""
     subclasses = get_all_subclasses(InfrahubEvent)
     return [cls for cls in subclasses if isinstance(cls.event_name, str)]
+
+
+def get_all_infrahub_node_kind_events() -> list[str]:
+    """Recursively get all events marked as infrahub.node.kind events.
+
+    These events can be used to filter on a specific type for the webhooks
+    """
+    return [event.event_name for event in get_all_events() if event.infrahub_node_kind_event] + ["all"]

--- a/backend/infrahub/events/validator_action.py
+++ b/backend/infrahub/events/validator_action.py
@@ -38,15 +38,18 @@ class ValidatorStartedEvent(ValidatorEvent):
     """Event generated when an validator within a pipeline has started."""
 
     event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.validator.started"
+    infrahub_node_kind_event: ClassVar[bool] = True
 
 
 class ValidatorPassedEvent(ValidatorEvent):
     """Event generated when an validator within a pipeline has completed successfully."""
 
     event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.validator.passed"
+    infrahub_node_kind_event: ClassVar[bool] = True
 
 
 class ValidatorFailedEvent(ValidatorEvent):
     """Event generated when an validator within a pipeline has completed successfully."""
 
     event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.validator.failed"
+    infrahub_node_kind_event: ClassVar[bool] = True

--- a/backend/infrahub/graphql/manager.py
+++ b/backend/infrahub/graphql/manager.py
@@ -38,6 +38,7 @@ from .mutations.repository import InfrahubRepositoryMutation
 from .mutations.resource_manager import (
     InfrahubNumberPoolMutation,
 )
+from .mutations.webhook import InfrahubWebhookMutation
 from .resolvers.resolver import (
     account_resolver,
     ancestors_resolver,
@@ -511,6 +512,8 @@ class GraphQLSchemaManager:
                 InfrahubKind.NAMESPACE: InfrahubIPNamespaceMutation,
                 InfrahubKind.NUMBERPOOL: InfrahubNumberPoolMutation,
                 InfrahubKind.MENUITEM: InfrahubCoreMenuMutation,
+                InfrahubKind.STANDARDWEBHOOK: InfrahubWebhookMutation,
+                InfrahubKind.CUSTOMWEBHOOK: InfrahubWebhookMutation,
             }
 
             if isinstance(node_schema, NodeSchema) and node_schema.is_ip_prefix():
@@ -641,7 +644,9 @@ class GraphQLSchemaManager:
         self.set_type(name=type_name, graphql_type=relationship_property)
 
     def generate_graphql_mutations(
-        self, schema: NodeSchema | ProfileSchema | TemplateSchema, base_class: type[InfrahubMutation]
+        self,
+        schema: NodeSchema | ProfileSchema | TemplateSchema,
+        base_class: type[InfrahubMutation],
     ) -> GraphqlMutations:
         graphql_mutation_create_input = self.generate_graphql_mutation_create_input(schema)
         graphql_mutation_update_input = self.generate_graphql_mutation_update_input(schema)

--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -24,7 +24,7 @@ from infrahub.database import retry_db_transaction
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.events import EventMeta
 from infrahub.events.node_action import NodeDeletedEvent, NodeUpdatedEvent, get_node_event
-from infrahub.exceptions import ValidationError
+from infrahub.exceptions import InitializationError, ValidationError
 from infrahub.graphql.context import apply_external_context
 from infrahub.lock import InfrahubMultiLock, build_object_lock_name
 from infrahub.log import get_log_data, get_logger
@@ -65,6 +65,12 @@ class DeleteResult:
 # ------------------------------------------
 class InfrahubMutationOptions(MutationOptions):
     schema: NodeSchema | None = None
+
+    @property
+    def active_schema(self) -> NodeSchema:
+        if self.schema:
+            return self.schema
+        raise InitializationError("This class is not initialized with a schema")
 
 
 class InfrahubMutationMixin:

--- a/backend/infrahub/graphql/mutations/webhook.py
+++ b/backend/infrahub/graphql/mutations/webhook.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Self, cast
+
+from graphene import InputObjectType, Mutation
+
+from infrahub.core.manager import NodeManager
+from infrahub.core.protocols import CoreWebhook
+from infrahub.core.schema import NodeSchema
+from infrahub.database import retry_db_transaction
+from infrahub.events.utils import get_all_infrahub_node_kind_events
+from infrahub.exceptions import ValidationError
+from infrahub.log import get_logger
+
+from .main import InfrahubMutationMixin, InfrahubMutationOptions
+
+if TYPE_CHECKING:
+    from graphql import GraphQLResolveInfo
+
+    from infrahub.core.branch import Branch
+    from infrahub.core.node import Node
+    from infrahub.database import InfrahubDatabase
+    from infrahub.graphql.initialization import GraphqlContext
+
+log = get_logger()
+
+
+@dataclass
+class StringValue:
+    value: str
+
+
+@dataclass
+class WebhookCreate:
+    event_type: StringValue | None = field(default=None)
+    node_kind: StringValue | None = field(default=None)
+
+
+class WebhookUpdate(WebhookCreate):
+    id: str | None = field(default=None)
+    hfid: list[str] | None = field(default=None)
+
+
+class InfrahubWebhookMutation(InfrahubMutationMixin, Mutation):
+    _meta: InfrahubMutationOptions
+
+    @classmethod
+    def __init_subclass_with_meta__(
+        cls, schema: NodeSchema | None = None, _meta: InfrahubMutationOptions | None = None, **options: dict[str, Any]
+    ) -> None:
+        # Make sure schema is a valid NodeSchema Node Class
+        if not isinstance(schema, NodeSchema):
+            raise ValueError(f"You need to pass a valid NodeSchema in '{cls.__name__}.Meta', received '{schema}'")
+
+        if not _meta:
+            _meta = InfrahubMutationOptions(cls)
+
+        _meta.schema = schema
+
+        super().__init_subclass_with_meta__(_meta=_meta, **options)
+
+    @classmethod
+    async def mutate_create(
+        cls,
+        info: GraphQLResolveInfo,
+        data: InputObjectType,
+        branch: Branch,
+        database: InfrahubDatabase | None = None,
+    ) -> tuple[Node, Self]:
+        graphql_context: GraphqlContext = info.context
+
+        input_data = cast("WebhookCreate", data)
+
+        _validate_input(graphql_context=graphql_context, branch=branch, input_data=input_data)
+
+        obj, result = await super().mutate_create(info=info, data=data, branch=branch, database=database)
+
+        return obj, result
+
+    @classmethod
+    @retry_db_transaction(name="object_update")
+    async def mutate_update(
+        cls,
+        info: GraphQLResolveInfo,
+        data: InputObjectType,
+        branch: Branch,
+        database: InfrahubDatabase | None = None,
+        node: Node | None = None,
+    ) -> tuple[Node, Self]:
+        graphql_context: GraphqlContext = info.context
+
+        db = database or graphql_context.db
+
+        input_data = cast("WebhookUpdate", data)
+
+        _validate_input(graphql_context=graphql_context, branch=branch, input_data=input_data)
+
+        obj = node or await NodeManager.find_object(
+            db=db,
+            kind=cls._meta.active_schema.kind,
+            id=input_data.id,
+            hfid=input_data.hfid,
+            branch=branch,
+        )
+
+        webhook = cast(CoreWebhook, obj)
+
+        event_type = input_data.event_type.value if input_data.event_type else webhook.event_type.value.value
+        node_kind = input_data.node_kind.value if input_data.node_kind else webhook.node_kind.value
+
+        if event_type and node_kind:
+            updated_data = WebhookUpdate(
+                event_type=StringValue(value=event_type), node_kind=StringValue(value=node_kind)
+            )
+            _validate_input(graphql_context=graphql_context, branch=branch, input_data=updated_data)
+
+        try:
+            obj, result = await cls._call_mutate_update(info=info, data=data, db=db, branch=branch, obj=obj)
+        except ValidationError as exc:
+            raise ValueError(str(exc)) from exc
+
+        return obj, result
+
+
+def _validate_input(graphql_context: GraphqlContext, branch: Branch, input_data: WebhookCreate) -> None:
+    if input_data.node_kind:
+        # Validate that the requested node_kind exists, will raise an error if not
+        graphql_context.db.schema.get(name=input_data.node_kind.value, branch=branch, duplicate=False)
+
+        if input_data.event_type:
+            # If the event type is not set then all events are applicable, this will mean that some events
+            # would be filtered out, as they won't match the node.
+            if input_data.event_type.value not in get_all_infrahub_node_kind_events():
+                raise ValidationError(
+                    input_value=f"Defining a node_kind is not valid for {input_data.event_type.value} events"
+                )

--- a/backend/infrahub/webhook/models.py
+++ b/backend/infrahub/webhook/models.py
@@ -12,6 +12,7 @@ from typing_extensions import Self
 from infrahub.core import registry
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.timestamp import Timestamp
+from infrahub.events.utils import get_all_infrahub_node_kind_events
 from infrahub.git.repository import InfrahubReadOnlyRepository, InfrahubRepository
 from infrahub.trigger.constants import NAME_SEPARATOR
 from infrahub.trigger.models import EventTrigger, ExecuteWorkflow, TriggerDefinition, TriggerType
@@ -53,6 +54,9 @@ class WebhookTriggerDefinition(TriggerDefinition):
                 "prefect.resource.role": "infrahub.branch",
                 "infrahub.resource.label": f"!{registry.default_branch}",
             }
+
+        if obj.node_kind.value and obj.event_type.value in get_all_infrahub_node_kind_events():
+            event_trigger.match = {"infrahub.node.kind": obj.node_kind.value}
 
         definition = cls(
             id=obj.id,

--- a/backend/tests/functional/webhook/test_task.py
+++ b/backend/tests/functional/webhook/test_task.py
@@ -4,12 +4,13 @@ from typing import TYPE_CHECKING, Any, AsyncGenerator
 
 import httpx
 import pytest
+from infrahub_sdk.protocols import CoreStandardWebhook
 from prefect.client.orchestration import PrefectClient, get_client
 from prefect.events.actions import RunDeployment
 
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.node import Node
-from infrahub.webhook.models import EventContext
+from infrahub.webhook.models import EventContext, WebhookTriggerDefinition
 from infrahub.webhook.tasks import (
     configure_webhook_all,
     configure_webhook_one,
@@ -149,6 +150,22 @@ class TestWebhookTasks(TestInfrahubApp):
             validate_certificates=False,
             event_type="infrahub.node.created",
             branch_scope="other_branches",
+        )
+        await webhook.save(db=db)
+        return webhook
+
+    @pytest.fixture(scope="class")
+    async def webhook4(self, db: InfrahubDatabase, initial_dataset: None, client: InfrahubClient) -> Node:
+        webhook = await Node.init(schema=InfrahubKind.STANDARDWEBHOOK, db=db)
+        await webhook.new(
+            db=db,
+            name="Webhook4",
+            url="https://url.mock",
+            shared_key="1234567890",
+            validate_certificates=False,
+            node_kind="BuiltinTag",
+            event_type="infrahub.node.created",
+            branch_scope="all_branches",
         )
         await webhook.save(db=db)
         return webhook
@@ -330,3 +347,14 @@ class TestWebhookTasks(TestInfrahubApp):
             "ID": "ce3b7013-4abb-4945-89de-1f56da4ff636",
             "OCCURED_AT": "2025-02-28T08:37:09.969Z",
         }
+
+    async def test_trigger_definition_node_kind_match(
+        self,
+        db: InfrahubDatabase,
+        service,
+        webhook4: Node,
+        client: InfrahubClient,
+    ) -> None:
+        webhook = await client.get(kind=CoreStandardWebhook, id=webhook4.id)
+        trigger_definition = WebhookTriggerDefinition.from_object(obj=webhook)
+        assert trigger_definition.trigger.match == {"infrahub.node.kind": "BuiltinTag"}

--- a/backend/tests/unit/graphql/mutations/test_webhook.py
+++ b/backend/tests/unit/graphql/mutations/test_webhook.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from infrahub.core.branch.models import Branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.protocols import CoreStandardWebhook
+from infrahub.database import InfrahubDatabase
+from infrahub.graphql.initialization import prepare_graphql_params
+from tests.helpers.graphql import graphql
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.database import InfrahubDatabase
+
+
+async def test_create_webhook_invalid_node(
+    db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch
+) -> None:
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=CREATE_WEBHOOK,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"name": "invalid-hook", "node_kind": "InvalidNodeKind"},
+    )
+    assert result.errors
+    assert "Unable to find the schema 'InvalidNodeKind' in the registry" in str(result.errors)
+
+
+async def test_create_webhook_invalid_node_event(
+    db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch
+) -> None:
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=CREATE_WEBHOOK,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"name": "invalid-hook", "node_kind": "BuiltinTag", "event_type": "infrahub.branch.created"},
+    )
+    assert result.errors
+    assert "Defining a node_kind is not valid for infrahub.branch.created events" in str(result.errors)
+
+
+async def test_create_webhook_with_node_kind_and_valid_node_event(
+    db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch
+) -> None:
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=CREATE_WEBHOOK,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={
+            "name": "valid-node-created-event",
+            "node_kind": "BuiltinTag",
+            "event_type": "infrahub.node.created",
+        },
+    )
+    assert not result.errors
+    assert result.data
+    webhook_id = result.data["CoreStandardWebhookCreate"]["object"]["id"]
+    webhook = await NodeManager.get_one_by_id_or_default_filter(db=db, id=webhook_id, kind=CoreStandardWebhook)
+    assert webhook.name.value == "valid-node-created-event"
+    assert webhook.node_kind.value == "BuiltinTag"
+    assert webhook.event_type.value.value == "infrahub.node.created"
+
+
+async def test_create_webhook_with_node_kind_and_all_events(
+    db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch
+) -> None:
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=CREATE_WEBHOOK,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"name": "valid-node-all-events", "node_kind": "BuiltinTag", "event_type": "all"},
+    )
+    assert not result.errors
+    assert result.data
+    result = await graphql(
+        schema=gql_params.schema,
+        source=CREATE_WEBHOOK,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={
+            "name": "valid-node-all-events-by-default",
+            "node_kind": "BuiltinTag",
+        },
+    )
+    assert not result.errors
+    assert result.data
+    webhook_id = result.data["CoreStandardWebhookCreate"]["object"]["id"]
+    webhook = await NodeManager.get_one_by_id_or_default_filter(db=db, id=webhook_id, kind=CoreStandardWebhook)
+    assert webhook.name.value == "valid-node-all-events-by-default"
+    assert webhook.node_kind.value == "BuiltinTag"
+    assert webhook.event_type.value.value == "all"
+
+
+async def test_update_to_invalid_states(
+    db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch
+) -> None:
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=CREATE_WEBHOOK,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"name": "builtin-tag-update-1", "node_kind": "BuiltinTag", "event_type": "all"},
+    )
+    assert not result.errors
+    assert result.data
+    webhook_id = result.data["CoreStandardWebhookCreate"]["object"]["id"]
+
+    result = await graphql(
+        schema=gql_params.schema,
+        source=UPDATE_WEBHOOK,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={
+            "id": webhook_id,
+            "node_kind": "InvalidNodeKind",
+        },
+    )
+    assert result.errors
+    assert "Unable to find the schema 'InvalidNodeKind' in the registry" in str(result.errors)
+
+    result = await graphql(
+        schema=gql_params.schema,
+        source=UPDATE_WEBHOOK,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={
+            "id": webhook_id,
+            "event_type": "infrahub.branch.merged",
+        },
+    )
+    assert result.errors
+    assert "Defining a node_kind is not valid for infrahub.branch.merged events" in str(result.errors)
+
+
+async def test_update_to_valid_states(
+    db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch
+) -> None:
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=CREATE_WEBHOOK,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"name": "repository-update-1", "node_kind": "CoreRepository"},
+    )
+    assert not result.errors
+    assert result.data
+    webhook_id = result.data["CoreStandardWebhookCreate"]["object"]["id"]
+    webhook = await NodeManager.get_one_by_id_or_default_filter(db=db, id=webhook_id, kind=CoreStandardWebhook)
+    assert webhook.name.value == "repository-update-1"
+    assert webhook.node_kind.value == "CoreRepository"
+    assert webhook.event_type.value.value == "all"
+
+    result = await graphql(
+        schema=gql_params.schema,
+        source=UPDATE_WEBHOOK,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={
+            "id": webhook_id,
+            "node_kind": "BuiltinTag",
+        },
+    )
+    assert not result.errors
+    assert result.data
+    updated_webhook = await NodeManager.get_one_by_id_or_default_filter(db=db, id=webhook_id, kind=CoreStandardWebhook)
+    assert updated_webhook.name.value == "repository-update-1"
+    assert updated_webhook.node_kind.value == "BuiltinTag"
+    assert updated_webhook.event_type.value.value == "all"
+
+
+async def test_update_description_only(
+    db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch
+) -> None:
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=CREATE_WEBHOOK,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"name": "tag-update-2", "node_kind": "BuiltinTag", "event_type": "infrahub.node.created"},
+    )
+    assert not result.errors
+    assert result.data
+    webhook_id = result.data["CoreStandardWebhookCreate"]["object"]["id"]
+    webhook = await NodeManager.get_one_by_id_or_default_filter(db=db, id=webhook_id, kind=CoreStandardWebhook)
+    assert webhook.name.value == "tag-update-2"
+    assert webhook.node_kind.value == "BuiltinTag"
+    assert webhook.description.value is None
+    assert webhook.event_type.value.value == "infrahub.node.created"
+
+    result = await graphql(
+        schema=gql_params.schema,
+        source=UPDATE_WEBHOOK,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={
+            "id": webhook_id,
+            "description": "Sent when tags are created",
+        },
+    )
+    assert not result.errors
+    assert result.data
+
+    updated_webhook = await NodeManager.get_one_by_id_or_default_filter(db=db, id=webhook_id, kind=CoreStandardWebhook)
+    assert updated_webhook.name.value == "tag-update-2"
+    assert updated_webhook.node_kind.value == "BuiltinTag"
+    assert updated_webhook.description.value == "Sent when tags are created"
+    assert updated_webhook.event_type.value.value == "infrahub.node.created"
+
+
+CREATE_WEBHOOK = """
+mutation CreateWebhook(
+    $event_type: String
+    $node_kind: String
+    $name: String!
+) {
+    CoreStandardWebhookCreate(
+        data: {
+            event_type: {value: $event_type},
+            node_kind: {value: $node_kind},
+            url: {value: "https://webhook.example.com/infrahub"},
+            name: {value: $name},
+            shared_key: {value: "very-secret"}
+        }
+    ) {
+        object {
+            id
+        }
+    }
+}
+"""
+
+UPDATE_WEBHOOK = """
+mutation UpdateWebhook(
+    $event_type: String
+    $node_kind: String
+    $description: String
+    $id: String!
+) {
+  CoreStandardWebhookUpdate(
+    data: {
+        id: $id,
+        event_type: {value: $event_type},
+        node_kind: {value: $node_kind},
+        description: {value: $description}
+  }
+  ) {
+    object {
+      id
+    }
+  }
+}
+"""


### PR DESCRIPTION
This PR provides more of a workaround in order to configure webhooks that trigger on a specific node kind.

In upcoming releases we'll want to have unique match options per event type and any webhook that's created with this new `node_kind` attribute will have to be migrated to that new type.

A small caveat is that the node_kind is a free text field. Some form of selector would require a custom form on the frontend.

The current logic rejects webhooks that combines the use of node_kind with an event_type that doesn't support node_kind. One thing to note about this is that by default `all` is allowed, when either using `all` or not specifying an event_type the webhook would still be accepted even though not all event_types would trigger. Without this we'd have to setup multiple webhooks to have one per event type. I don't really like either of the solutions, but I think the current one makes the most sense in terms of expectations.

In order to validate the node_kind and event_type combination I've added custom mutations for the webhooks, in order to avoid some typing issues I also added an `active_schema` property to the `InfrahubMutationOptions` class we can also start to use that in the other mutations for the same reason.