### PR TITLE
IFC-1243 Set operational status of repo after fetch

### DIFF
--- a/backend/infrahub/exceptions.py
+++ b/backend/infrahub/exceptions.py
@@ -78,23 +78,27 @@ class RepositoryError(Error):
 
 class RepositoryConnectionError(RepositoryError):
     def __init__(self, identifier: str, message: str | None = None) -> None:
-        super().__init__(identifier=identifier)
-        self.message = (
-            message or f"Unable to clone the repository {identifier}, please check the address and the credential"
+        super().__init__(
+            identifier=identifier,
+            message=message
+            or f"Unable to clone the repository {identifier}, please check the address and the credential",
         )
 
 
 class RepositoryCredentialsError(RepositoryError):
     def __init__(self, identifier: str, message: str | None = None) -> None:
-        super().__init__(identifier=identifier)
-        self.message = message or f"Authentication failed for {identifier}, please validate the credentials."
+        super().__init__(
+            identifier=identifier,
+            message=message or f"Authentication failed for {identifier}, please validate the credentials.",
+        )
 
 
 class RepositoryInvalidBranchError(RepositoryError):
     def __init__(self, identifier: str, branch_name: str, location: str, message: str | None = None) -> None:
-        super().__init__(identifier=identifier)
-        self.message = (
-            message or f"The branch {branch_name} isn't a valid branch for the repository {identifier} at {location}."
+        super().__init__(
+            identifier=identifier,
+            message=message
+            or f"The branch {branch_name} isn't a valid branch for the repository {identifier} at {location}.",
         )
 
 
@@ -105,9 +109,11 @@ class RepositoryInvalidFileSystemError(RepositoryError):
         directory: Path,
         message: str | None = None,
     ) -> None:
-        super().__init__(identifier=identifier)
+        super().__init__(
+            identifier=identifier,
+            message=message or f"Invalid file system for {identifier}, Local directory {directory} missing.",
+        )
         self.directory = directory
-        self.message = message or f"Invalid file system for {identifier}, Local directory {directory} missing."
 
 
 class CommitNotFoundError(Error):

--- a/backend/infrahub/exceptions.py
+++ b/backend/infrahub/exceptions.py
@@ -76,6 +76,28 @@ class RepositoryError(Error):
         super().__init__(self.message)
 
 
+class RepositoryConnectionError(RepositoryError):
+    def __init__(self, identifier: str, message: str | None = None) -> None:
+        super().__init__(identifier=identifier)
+        self.message = (
+            message or f"Unable to clone the repository {identifier}, please check the address and the credential"
+        )
+
+
+class RepositoryCredentialsError(RepositoryError):
+    def __init__(self, identifier: str, message: str | None = None) -> None:
+        super().__init__(identifier=identifier)
+        self.message = message or f"Authentication failed for {identifier}, please validate the credentials."
+
+
+class RepositoryInvalidBranchError(RepositoryError):
+    def __init__(self, identifier: str, branch_name: str, location: str, message: str | None = None) -> None:
+        super().__init__(identifier=identifier)
+        self.message = (
+            message or f"The branch {branch_name} isn't a valid branch for the repository {identifier} at {location}."
+        )
+
+
 class RepositoryInvalidFileSystemError(RepositoryError):
     def __init__(
         self,

--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -17,13 +17,16 @@ from pydantic import BaseModel, ConfigDict, Field
 from pydantic import ValidationError as PydanticValidationError
 
 from infrahub.core.branch import Branch
-from infrahub.core.constants import InfrahubKind
+from infrahub.core.constants import InfrahubKind, RepositoryOperationalStatus, RepositorySyncStatus
 from infrahub.core.registry import registry
 from infrahub.exceptions import (
     CommitNotFoundError,
     FileOutOfRepositoryError,
+    RepositoryConnectionError,
+    RepositoryCredentialsError,
     RepositoryError,
     RepositoryFileNotFoundError,
+    RepositoryInvalidBranchError,
     RepositoryInvalidFileSystemError,
 )
 from infrahub.git.constants import BRANCHES_DIRECTORY_NAME, COMMITS_DIRECTORY_NAME, TEMPORARY_DIRECTORY_NAME
@@ -200,6 +203,54 @@ class InfrahubRepositoryBase(BaseModel, ABC):
         """Return the path to the directory where the temp worktrees of all the commits pending validation are stored."""
         return self.directory_root / TEMPORARY_DIRECTORY_NAME
 
+    async def _update_operational_status(self, status: RepositoryOperationalStatus) -> None:
+        update_status = """
+        mutation UpdateRepositoryStatus(
+            $repo_id: String!,
+            $status: String!,
+        ) {
+            CoreGenericRepositoryUpdate(
+                data: {
+                    id: $repo_id,
+                    operational_status: { value: $status },
+                }
+            ) {
+                ok
+            }
+        }
+        """
+
+        await self.sdk.execute_graphql(
+            branch_name=self.infrahub_branch_name or registry.default_branch,
+            query=update_status,
+            variables={"repo_id": str(self.id), "status": status.value},
+            tracker="mutation-repository-update-operational-status",
+        )
+
+    async def _update_sync_status(self, branch_name: str, status: RepositorySyncStatus) -> None:
+        update_status = """
+        mutation UpdateRepositoryStatus(
+            $repo_id: String!,
+            $status: String!,
+        ) {
+            CoreGenericRepositoryUpdate(
+                data: {
+                    id: $repo_id,
+                    sync_status: { value: $status },
+                }
+            ) {
+                ok
+            }
+        }
+        """
+
+        await self.sdk.execute_graphql(
+            branch_name=branch_name,
+            query=update_status,
+            variables={"repo_id": str(self.id), "status": status.value},
+            tracker="mutation-repository-update-admin-status",
+        )
+
     def get_git_repo_main(self) -> Repo:
         """Return Git Repo object of the main repository.
 
@@ -340,7 +391,7 @@ class InfrahubRepositoryBase(BaseModel, ABC):
             repo = Repo.clone_from(self.location, self.directory_default)
             repo.git.checkout(checkout_ref or self.default_branch)
         except GitCommandError as exc:
-            self._raise_enriched_error(error=exc)
+            await self._raise_enriched_error(error=exc)
 
         self.has_origin = True
 
@@ -572,7 +623,7 @@ class InfrahubRepositoryBase(BaseModel, ABC):
             try:
                 br_repo.remotes.origin.pull(branch_name)
             except GitCommandError as exc:
-                self._raise_enriched_error(error=exc, branch_name=branch_name)
+                await self._raise_enriched_error(error=exc, branch_name=branch_name)
             self.create_commit_worktree(str(br_repo.head.reference.commit))
             log.debug(
                 f"Branch {branch_name} created in Git, tracking remote branch {remote_branch[0]}.",
@@ -668,7 +719,9 @@ class InfrahubRepositoryBase(BaseModel, ABC):
         try:
             repo.remotes.origin.fetch()
         except GitCommandError as exc:
-            self._raise_enriched_error(error=exc)
+            await self._raise_enriched_error(error=exc)
+
+        await self._update_operational_status(status=RepositoryOperationalStatus.ONLINE)
 
         return True
 
@@ -765,7 +818,7 @@ class InfrahubRepositoryBase(BaseModel, ABC):
                 commit_before = str(repo.head.commit)
                 repo.remotes.origin.pull(branch_name)
             except GitCommandError as exc:
-                self._raise_enriched_error(error=exc, branch_name=branch_name)
+                await self._raise_enriched_error(error=exc, branch_name=branch_name)
 
             commit_after = str(repo.head.commit)
 
@@ -862,49 +915,47 @@ class InfrahubRepositoryBase(BaseModel, ABC):
         except GitCommandError as exc:
             cls._raise_enriched_error_static(name=name, location=url, error=exc)
 
-    def _raise_enriched_error(self, error: GitCommandError, branch_name: str | None = None) -> NoReturn:
-        self._raise_enriched_error_static(
-            error=error, name=self.name, location=self.location, branch_name=branch_name or self.default_branch
-        )
+    async def _raise_enriched_error(self, error: GitCommandError, branch_name: str | None = None) -> NoReturn:
+        try:
+            self._raise_enriched_error_static(
+                error=error, name=self.name, location=self.location, branch_name=branch_name or self.default_branch
+            )
+        except RepositoryError as exc:
+            await self._update_operational_status(
+                status={
+                    RepositoryConnectionError: RepositoryOperationalStatus.ERROR_CONNECTION,
+                    RepositoryCredentialsError: RepositoryOperationalStatus.ERROR_CRED,
+                }.get(type(exc), RepositoryOperationalStatus.ERROR)
+            )
+            raise
 
     @staticmethod
     def _raise_enriched_error_static(
         error: GitCommandError, name: str, location: str, branch_name: str | None = None
     ) -> NoReturn:
         if "Repository not found" in error.stderr or "does not appear to be a git" in error.stderr:
-            raise RepositoryError(
-                identifier=name,
-                message=f"Unable to clone the repository {name}, please check the address and the credential",
-            ) from error
+            raise RepositoryConnectionError(identifier=name) from error
 
         if "error: pathspec" in error.stderr:
-            raise RepositoryError(
-                identifier=name,
-                message=f"The branch {branch_name} isn't a valid branch for the repository {name} at {location}.",
-            ) from error
+            raise RepositoryInvalidBranchError(identifier=name, branch_name=branch_name, location=location) from error
 
         if "SSL certificate problem" in error.stderr or "server certificate verification failed" in error.stderr:
-            raise RepositoryError(
-                identifier=name,
-                message=f"SSL verification failed for {name}, please validate the certificate chain.",
+            raise RepositoryConnectionError(
+                identifier=name, message=f"SSL verification failed for {name}, please validate the certificate chain."
             ) from error
 
         if "authentication failed for" in error.stderr.lower():
-            raise RepositoryError(
-                identifier=name,
-                message=f"Authentication failed for {name}, please validate the credentials.",
+            raise RepositoryCredentialsError(identifier=name) from error
+
+        if "fatal: could not read Username for" in error.stderr and "terminal prompts disable" in error.stderr:
+            raise RepositoryCredentialsError(
+                identifier=name, message=f"Unable to correctly lookup credentials for repository {name} ({location})."
             ) from error
 
         if any(err in error.stderr for err in ("Need to specify how to reconcile", "because you have unmerged files")):
             raise RepositoryError(
                 identifier=name,
                 message=f"Unable to pull the branch {branch_name} for repository {name}, there are conflicts that must be resolved.",
-            ) from error
-
-        if "fatal: could not read Username for" in error.stderr and "terminal prompts disable" in error.stderr:
-            raise RepositoryError(
-                identifier=name,
-                message=f"Unable to correctly lookup credentials for repository {name} ({location}).",
             ) from error
 
         raise RepositoryError(identifier=name, message=error.stderr) from error

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -212,30 +212,6 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
             )
         )
 
-    async def _update_sync_status(self, branch_name: str, status: RepositorySyncStatus) -> None:
-        update_status = """
-        mutation UpdateRepositoryStatus(
-            $repo_id: String!,
-            $status: String!,
-            ) {
-            CoreGenericRepositoryUpdate(
-                data: {
-                    id: $repo_id,
-                    sync_status: { value: $status },
-                }
-            ) {
-                ok
-            }
-        }
-        """
-
-        await self.sdk.execute_graphql(
-            branch_name=branch_name,
-            query=update_status,
-            variables={"repo_id": str(self.id), "status": status.value},
-            tracker="mutation-repository-update-admin-status",
-        )
-
     @task(name="import-jinja2-tansforms", task_run_name="Import Jinja2 transform", cache_policy=NONE)  # type: ignore[arg-type]
     async def import_jinja2_transforms(
         self,

--- a/backend/tests/integration/git/test_repository.py
+++ b/backend/tests/integration/git/test_repository.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
+from git import GitCommandError
 
-from infrahub.core.constants import InfrahubKind
+from infrahub.core.constants import InfrahubKind, RepositoryOperationalStatus
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
+from infrahub.exceptions import RepositoryError
+from infrahub.git.repository import get_initialized_repo
+from infrahub.services import InfrahubServices
+from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
+from tests.adapters.log import FakeLogger
+from tests.adapters.message_bus import BusRecorder
 from tests.constants import TestKind
 from tests.helpers.file_repo import FileRepo
 from tests.helpers.schema import CAR_SCHEMA, load_schema
@@ -63,4 +71,55 @@ class TestCreateRepository(TestInfrahubApp):
 
         assert repository.commit.value
         assert repository.internal_status.value == "active"
+        assert repository.operational_status.value == "online"
         assert check_definition.file_path.value == "checks/car_overview.py"
+
+    @pytest.mark.parametrize(
+        "stderr,expected_operational_status",
+        [
+            ("Repository not found", RepositoryOperationalStatus.ERROR_CONNECTION),
+            ("error: pathspec", RepositoryOperationalStatus.ERROR),
+            ("SSL certificate problem", RepositoryOperationalStatus.ERROR_CONNECTION),
+            ("authentication failed for", RepositoryOperationalStatus.ERROR_CRED),
+            ("Need to specify how to reconcile", RepositoryOperationalStatus.ERROR),
+            ("fatal: could not read Username for | terminal prompts disable", RepositoryOperationalStatus.ERROR_CRED),
+        ],
+    )
+    async def test_repository_operational_status(
+        self,
+        db: InfrahubDatabase,
+        initial_dataset: None,
+        git_repos_source_dir_module_scope: Path,
+        client: InfrahubClient,
+        stderr: str,
+        expected_operational_status: RepositoryOperationalStatus,
+    ) -> None:
+        """Validate that we can create a repository, that it gets updated with the commit id and that objects are created."""
+        client_repository = await client.get(kind=InfrahubKind.REPOSITORY, name__value="car-dealership")
+        repository: CoreRepository = await NodeManager.get_one(
+            db=db, id=client_repository.id, kind=InfrahubKind.REPOSITORY, raise_on_error=True
+        )
+
+        assert repository.commit.value
+
+        bus = BusRecorder()
+        infrahub_repo = await get_initialized_repo(
+            repository_id=repository.id,
+            name=repository.name.value,
+            service=InfrahubServices(
+                client=client,
+                message_bus=bus,
+                log=FakeLogger(),
+                workflow=WorkflowLocalExecution(),
+            ),
+            repository_kind=InfrahubKind.REPOSITORY,
+        )
+
+        with patch("git.remote.Remote.fetch", side_effect=GitCommandError("fetch", stderr=stderr)):
+            try:
+                await infrahub_repo.fetch()
+            except RepositoryError:
+                r: CoreRepository = await NodeManager.get_one(
+                    db=db, id=client_repository.id, kind=InfrahubKind.REPOSITORY, raise_on_error=True
+                )
+                assert r.operational_status.value == expected_operational_status.value

--- a/backend/tests/integration/git/test_repository.py
+++ b/backend/tests/integration/git/test_repository.py
@@ -11,10 +11,6 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.exceptions import RepositoryError
 from infrahub.git.repository import get_initialized_repo
-from infrahub.services import InfrahubServices
-from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
-from tests.adapters.log import FakeLogger
-from tests.adapters.message_bus import BusRecorder
 from tests.constants import TestKind
 from tests.helpers.file_repo import FileRepo
 from tests.helpers.schema import CAR_SCHEMA, load_schema
@@ -27,6 +23,7 @@ if TYPE_CHECKING:
 
     from infrahub.core.protocols import CoreCheckDefinition, CoreRepository
     from infrahub.database import InfrahubDatabase
+    from infrahub.services import InfrahubServices
 
 
 class TestCreateRepository(TestInfrahubApp):
@@ -93,6 +90,7 @@ class TestCreateRepository(TestInfrahubApp):
         client: InfrahubClient,
         stderr: str,
         expected_operational_status: RepositoryOperationalStatus,
+        service: InfrahubServices,
     ) -> None:
         """Validate that we can create a repository, that it gets updated with the commit id and that objects are created."""
         client_repository = await client.get(kind=InfrahubKind.REPOSITORY, name__value="car-dealership")
@@ -102,16 +100,10 @@ class TestCreateRepository(TestInfrahubApp):
 
         assert repository.commit.value
 
-        bus = BusRecorder()
         infrahub_repo = await get_initialized_repo(
             repository_id=repository.id,
             name=repository.name.value,
-            service=InfrahubServices(
-                client=client,
-                message_bus=bus,
-                log=FakeLogger(),
-                workflow=WorkflowLocalExecution(),
-            ),
+            service=service,
             repository_kind=InfrahubKind.REPOSITORY,
         )
 

--- a/backend/tests/unit/git/test_git_repository.py
+++ b/backend/tests/unit/git/test_git_repository.py
@@ -18,6 +18,7 @@ from infrahub.exceptions import (
     CommitNotFoundError,
     RepositoryError,
     RepositoryFileNotFoundError,
+    RepositoryInvalidBranchError,
     TransformError,
 )
 from infrahub.git import InfrahubRepository
@@ -127,7 +128,7 @@ async def test_new_wrong_location(git_upstream_repo_01: dict[str, str | Path], g
 
 
 async def test_new_wrong_branch(git_upstream_repo_01: dict[str, str | Path], git_repos_dir: Path, tmp_path: Path):
-    with pytest.raises(RepositoryError) as exc:
+    with pytest.raises(RepositoryInvalidBranchError) as exc:
         await InfrahubRepository.new(
             id=UUIDT.new(),
             name=git_upstream_repo_01["name"],

--- a/backend/tests/unit/git/test_git_repository.py
+++ b/backend/tests/unit/git/test_git_repository.py
@@ -474,6 +474,11 @@ async def test_sync_new_branch(
         json=admin_response,
         match_headers={"X-Infrahub-Tracker": "mutation-repository-update-admin-status"},
     )
+    httpx_mock.add_response(
+        method="POST",
+        json=admin_response,
+        match_headers={"X-Infrahub-Tracker": "mutation-repository-update-operational-status"},
+    )
 
     repo.client = client
     await repo.sync()

--- a/backend/tests/unit/git/test_git_repository.py
+++ b/backend/tests/unit/git/test_git_repository.py
@@ -120,7 +120,7 @@ async def test_new_wrong_location(git_upstream_repo_01: dict[str, str | Path], g
             id=UUIDT.new(),
             name=git_upstream_repo_01["name"],
             location=str(tmp_path),
-            service=await InfrahubServices.new(),
+            service=await InfrahubServices.new(client=InfrahubClient(config=Config(requester=dummy_async_request))),
         )
 
     assert f"fatal: repository '{tmp_path}' does not exist" in str(exc.value)
@@ -133,7 +133,7 @@ async def test_new_wrong_branch(git_upstream_repo_01: dict[str, str | Path], git
             name=git_upstream_repo_01["name"],
             location=str(git_upstream_repo_01["path"]),
             default_branch_name="notvalid",
-            service=await InfrahubServices.new(),
+            service=await InfrahubServices.new(client=InfrahubClient(config=Config(requester=dummy_async_request))),
         )
 
     assert "isn't a valid branch" in str(exc.value)

--- a/changelog/5755.fixed.md
+++ b/changelog/5755.fixed.md
@@ -1,0 +1,1 @@
+Fix operational status of repositories remaining to "Unknown" even after a synchronization


### PR DESCRIPTION
Fixes #5755

The operational status was always remaining to "unknown" as we never assigned it another value. This change will modify the status value according to the result of a git fetch call.