### PR TITLE
data loader for many relationship resolver

### DIFF
--- a/backend/infrahub/graphql/initialization.py
+++ b/backend/infrahub/graphql/initialization.py
@@ -8,6 +8,7 @@ from starlette.background import BackgroundTasks
 from infrahub.core import registry
 from infrahub.core.timestamp import Timestamp
 from infrahub.exceptions import InitializationError
+from infrahub.graphql.resolvers.many_relationship import ManyRelationshipResolver
 from infrahub.graphql.resolvers.single_relationship import SingleRelationshipResolver
 from infrahub.permissions import PermissionManager
 
@@ -35,6 +36,7 @@ class GraphqlContext:
     branch: Branch
     types: dict
     single_relationship_resolver: SingleRelationshipResolver
+    many_relationship_resolver: ManyRelationshipResolver
     at: Timestamp | None = None
     related_node_ids: set | None = None
     service: InfrahubServices | None = None
@@ -107,6 +109,7 @@ async def prepare_graphql_params(
             db=db,
             branch=branch,
             single_relationship_resolver=SingleRelationshipResolver(),
+            many_relationship_resolver=ManyRelationshipResolver(),
             at=Timestamp(at),
             types=gqlm.get_graphql_types(),
             related_node_ids=set(),

--- a/backend/infrahub/graphql/loaders/node.py
+++ b/backend/infrahub/graphql/loaders/node.py
@@ -10,6 +10,8 @@ from infrahub.core.node import Node
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 
+from .shared import to_frozen_set
+
 
 @dataclass
 class GetManyParams:
@@ -68,15 +70,3 @@ class NodeDataLoader(DataLoader[str, Node | None]):
         for node_id in keys:
             results.append(nodes_by_id.get(node_id, None))
         return results
-
-
-def to_frozen_set(to_freeze: dict[str, Any]) -> frozenset:
-    freezing_dict = {}
-    for k, v in to_freeze.items():
-        if isinstance(v, dict):
-            freezing_dict[k] = to_frozen_set(v)
-        elif isinstance(v, (list, set)):
-            freezing_dict[k] = frozenset(v)
-        else:
-            freezing_dict[k] = v
-    return frozenset(freezing_dict)

--- a/backend/infrahub/graphql/loaders/peers.py
+++ b/backend/infrahub/graphql/loaders/peers.py
@@ -1,0 +1,83 @@
+from dataclasses import dataclass
+from typing import Any
+
+from aiodataloader import DataLoader
+
+from infrahub.core.branch.models import Branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.relationship.model import Relationship
+from infrahub.core.schema.relationship_schema import RelationshipSchema
+from infrahub.core.timestamp import Timestamp
+from infrahub.database import InfrahubDatabase
+
+from .shared import to_frozen_set
+
+
+@dataclass
+class QueryPeerParams:
+    branch: Branch | str
+    source_kind: str
+    schema: RelationshipSchema
+    filters: dict[str, Any]
+    fields: dict | None = None
+    at: Timestamp | str | None = None
+    branch_agnostic: bool = False
+    limit: int | None = None
+    offset: int | None = None
+
+    def __hash__(self) -> int:
+        frozen_fields: frozenset | None = None
+        if self.fields:
+            frozen_fields = to_frozen_set(self.fields)
+        frozen_filters = to_frozen_set(self.filters)
+        timestamp = Timestamp(self.at)
+        branch = self.branch.name if isinstance(self.branch, Branch) else self.branch
+        hash_str = "|".join(
+            [
+                str(hash(frozen_fields)),
+                str(hash(frozen_filters)),
+                timestamp.to_string(),
+                branch,
+                self.schema.name,
+                str(self.source_kind),
+                str(self.branch_agnostic),
+                str(self.limit),
+                str(self.offset),
+            ]
+        )
+        return hash(hash_str)
+
+
+class PeerRelationshipsDataLoader(DataLoader[str, list[Relationship]]):
+    def __init__(self, db: InfrahubDatabase, query_params: QueryPeerParams, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.query_params = query_params
+        self.db = db
+
+    async def batch_load_fn(self, keys: list[Any]) -> list[list[Relationship]]:  # pylint: disable=method-hidden
+        async with self.db.start_session() as db:
+            peer_rels = await NodeManager.query_peers(
+                db=db,
+                ids=keys,
+                source_kind=self.query_params.source_kind,
+                schema=self.query_params.schema,
+                filters=self.query_params.filters,
+                fields=self.query_params.fields,
+                offset=self.query_params.offset,
+                limit=self.query_params.limit,
+                at=self.query_params.at,
+                branch=self.query_params.branch,
+                branch_agnostic=self.query_params.branch_agnostic,
+                fetch_peers=True,
+            )
+        peer_rels_by_node_id: dict[str, list[Relationship]] = {}
+        for rel in peer_rels:
+            node_id = rel.node_id
+            if node_id not in peer_rels_by_node_id:
+                peer_rels_by_node_id[node_id] = []
+            peer_rels_by_node_id[node_id].append(rel)
+
+        results = []
+        for node_id in keys:
+            results.append(peer_rels_by_node_id.get(node_id, []))
+        return results

--- a/backend/infrahub/graphql/loaders/peers.py
+++ b/backend/infrahub/graphql/loaders/peers.py
@@ -22,8 +22,6 @@ class QueryPeerParams:
     fields: dict | None = None
     at: Timestamp | str | None = None
     branch_agnostic: bool = False
-    limit: int | None = None
-    offset: int | None = None
 
     def __hash__(self) -> int:
         frozen_fields: frozenset | None = None
@@ -41,8 +39,6 @@ class QueryPeerParams:
                 self.schema.name,
                 str(self.source_kind),
                 str(self.branch_agnostic),
-                str(self.limit),
-                str(self.offset),
             ]
         )
         return hash(hash_str)
@@ -63,8 +59,6 @@ class PeerRelationshipsDataLoader(DataLoader[str, list[Relationship]]):
                 schema=self.query_params.schema,
                 filters=self.query_params.filters,
                 fields=self.query_params.fields,
-                offset=self.query_params.offset,
-                limit=self.query_params.limit,
                 at=self.query_params.at,
                 branch=self.query_params.branch,
                 branch_agnostic=self.query_params.branch_agnostic,

--- a/backend/infrahub/graphql/loaders/shared.py
+++ b/backend/infrahub/graphql/loaders/shared.py
@@ -1,0 +1,13 @@
+from typing import Any
+
+
+def to_frozen_set(to_freeze: dict[str, Any]) -> frozenset:
+    freezing_dict = {}
+    for k, v in to_freeze.items():
+        if isinstance(v, dict):
+            freezing_dict[k] = to_frozen_set(v)
+        elif isinstance(v, (list, set)):
+            freezing_dict[k] = frozenset(v)
+        else:
+            freezing_dict[k] = v
+    return frozenset(freezing_dict)

--- a/backend/infrahub/graphql/resolvers/many_relationship.py
+++ b/backend/infrahub/graphql/resolvers/many_relationship.py
@@ -1,0 +1,268 @@
+from typing import TYPE_CHECKING, Any
+
+from graphql import GraphQLResolveInfo
+from infrahub_sdk.utils import deep_merge_dict, extract_fields
+
+from infrahub.core.branch.models import Branch
+from infrahub.core.constants import BranchSupportType, RelationshipHierarchyDirection
+from infrahub.core.manager import NodeManager
+from infrahub.core.query.node import NodeGetHierarchyQuery
+from infrahub.core.schema.node_schema import NodeSchema
+from infrahub.core.schema.relationship_schema import RelationshipSchema
+from infrahub.core.timestamp import Timestamp
+from infrahub.database import InfrahubDatabase
+
+from ..loaders.peers import PeerRelationshipsDataLoader, QueryPeerParams
+from ..types import RELATIONS_PROPERTY_MAP, RELATIONS_PROPERTY_MAP_REVERSED
+
+if TYPE_CHECKING:
+    from ..initialization import GraphqlContext
+
+
+class ManyRelationshipResolver:
+    def __init__(self) -> None:
+        self._data_loader_instances: dict[QueryPeerParams, PeerRelationshipsDataLoader] = {}
+
+    async def get_descendant_ids(
+        self,
+        db: InfrahubDatabase,
+        branch: Branch,
+        at: Timestamp | None,
+        parent_id: str,
+        node_schema: NodeSchema,
+    ) -> list[str]:
+        async with db.start_session() as dbs:
+            query = await NodeGetHierarchyQuery.init(
+                db=dbs,
+                direction=RelationshipHierarchyDirection.DESCENDANTS,
+                node_id=parent_id,
+                node_schema=node_schema,
+                at=at,
+                branch=branch,
+            )
+            await query.execute(db=dbs)
+        return list(query.get_peer_ids())
+
+    async def get_peer_count(
+        self,
+        db: InfrahubDatabase,
+        branch: Branch,
+        at: Timestamp | None,
+        ids: list[str],
+        source_kind: str,
+        rel_schema: RelationshipSchema,
+        filters: dict[str, Any],
+    ) -> int:
+        async with db.start_session() as dbs:
+            return await NodeManager.count_peers(
+                db=dbs,
+                ids=ids,
+                source_kind=source_kind,
+                schema=rel_schema,
+                filters=filters,
+                at=at,
+                branch=branch,
+                branch_agnostic=rel_schema.branch is BranchSupportType.AGNOSTIC,
+            )
+
+    async def resolve(
+        self,
+        parent: dict,
+        info: GraphQLResolveInfo,
+        include_descendants: bool = False,
+        offset: int | None = None,
+        limit: int | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Resolver for relationships of cardinality=one for Edged responses
+
+        This resolver is used for paginated responses and as such we redefined the requested
+        fields by only reusing information below the 'node' key.
+        """
+        # Extract the InfraHub schema by inspecting the GQL Schema
+
+        node_schema: NodeSchema = info.parent_type.graphene_type._meta.schema  # type: ignore[attr-defined]
+
+        context: GraphqlContext = info.context
+
+        # Extract the name of the fields in the GQL query
+        fields = await extract_fields(info.field_nodes[0].selection_set)
+        edges = fields.get("edges", {})
+        node_fields = edges.get("node", {})
+        property_fields = edges.get("properties", {})
+        for key, value in property_fields.items():
+            mapped_name = RELATIONS_PROPERTY_MAP[key]
+            node_fields[mapped_name] = value
+
+        metadata_field_names = {prop_name for prop_name in RELATIONS_PROPERTY_MAP if prop_name != "__typename"}
+        requires_relationship_metadata = bool(set(property_fields.keys()) & metadata_field_names)
+
+        filters = {
+            f"{info.field_name}__{key}": value
+            for key, value in kwargs.items()
+            if "__" in key and value or key in ["id", "ids"]
+        }
+
+        # Extract the schema of the node on the other end of the relationship from the GQL Schema
+        node_rel = node_schema.get_relationship(info.field_name)
+        source_kind = node_schema.kind
+        if node_schema.hierarchy:
+            source_kind = node_schema.hierarchy
+
+        response: dict[str, Any] = {"edges": [], "count": None}
+
+        ids = [parent["id"]]
+        if include_descendants:
+            descendant_ids = await self.get_descendant_ids(
+                db=context.db,
+                branch=context.branch,
+                at=context.at,
+                parent_id=ids[0],
+                node_schema=node_schema,
+            )
+            ids.extend(descendant_ids)
+
+        if "count" in fields:
+            peer_count = await self.get_peer_count(
+                db=context.db,
+                branch=context.branch,
+                at=context.at,
+                ids=ids,
+                source_kind=source_kind,
+                rel_schema=node_rel,
+                filters=filters,
+            )
+            response["count"] = peer_count
+
+        if not node_fields:
+            return response
+
+        if requires_relationship_metadata:
+            node_graph = await self._get_entities_simple(
+                db=context.db,
+                branch=context.branch,
+                ids=ids,
+                at=context.at,
+                related_node_ids=context.related_node_ids,
+                source_kind=source_kind,
+                rel_schema=node_rel,
+                filters=filters,
+                node_fields=node_fields,
+                offset=offset,
+                limit=limit,
+            )
+        else:
+            node_graph = await self._get_entities_with_data_loader(
+                db=context.db,
+                branch=context.branch,
+                ids=ids,
+                at=context.at,
+                related_node_ids=context.related_node_ids,
+                source_kind=source_kind,
+                rel_schema=node_rel,
+                filters=filters,
+                node_fields=node_fields,
+                offset=offset,
+                limit=limit,
+            )
+
+        if not node_graph:
+            return response
+
+        entries = []
+        for node in node_graph:
+            entry: dict[str, dict[str, Any]] = {"node": {}, "properties": {}}
+            for key, mapped in RELATIONS_PROPERTY_MAP_REVERSED.items():
+                value = node.pop(key, None)
+                if value:
+                    entry["properties"][mapped] = value
+            entry["node"] = node
+            entries.append(entry)
+
+        response["edges"] = entries
+        return response
+
+    async def _get_entities_simple(
+        self,
+        db: InfrahubDatabase,
+        branch: Branch,
+        ids: list[str],
+        at: Timestamp | None,
+        related_node_ids: set[str] | None,
+        source_kind: str,
+        rel_schema: RelationshipSchema,
+        filters: dict[str, Any],
+        node_fields: dict[str, Any],
+        offset: int | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]] | None:
+        async with db.start_session() as dbs:
+            objs = await NodeManager.query_peers(
+                db=dbs,
+                ids=ids,
+                source_kind=source_kind,
+                schema=rel_schema,
+                filters=filters,
+                fields=node_fields,
+                offset=offset,
+                limit=limit,
+                at=at,
+                branch=branch,
+                branch_agnostic=rel_schema.branch is BranchSupportType.AGNOSTIC,
+                fetch_peers=True,
+            )
+            if not objs:
+                return None
+            return [await obj.to_graphql(db=dbs, fields=node_fields, related_node_ids=related_node_ids) for obj in objs]
+
+    async def _get_entities_with_data_loader(
+        self,
+        db: InfrahubDatabase,
+        branch: Branch,
+        ids: list[str],
+        at: Timestamp | None,
+        related_node_ids: set[str] | None,
+        source_kind: str,
+        rel_schema: RelationshipSchema,
+        filters: dict[str, Any],
+        node_fields: dict[str, Any],
+        offset: int | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]] | None:
+        if node_fields and "display_label" in node_fields:
+            schema_branch = db.schema.get_schema_branch(name=branch.name)
+            display_label_fields = schema_branch.generate_fields_for_display_label(name=rel_schema.peer)
+            if display_label_fields:
+                node_fields = deep_merge_dict(dicta=node_fields, dictb=display_label_fields)
+
+        if node_fields and "hfid" in node_fields:
+            peer_schema = db.schema.get(name=rel_schema.peer, branch=branch, duplicate=False)
+            hfid_fields = peer_schema.generate_fields_for_hfid()
+            if hfid_fields:
+                node_fields = deep_merge_dict(dicta=node_fields, dictb=hfid_fields)
+
+        query_params = QueryPeerParams(
+            branch=branch,
+            source_kind=source_kind,
+            schema=rel_schema,
+            filters=filters,
+            fields=node_fields,
+            at=at,
+            branch_agnostic=rel_schema.branch is BranchSupportType.AGNOSTIC,
+            limit=limit,
+            offset=offset,
+        )
+        if query_params in self._data_loader_instances:
+            loader = self._data_loader_instances[query_params]
+        else:
+            loader = PeerRelationshipsDataLoader(db=db, query_params=query_params)
+            self._data_loader_instances[query_params] = loader
+        all_peer_rels = []
+        for node_id in ids:
+            node_peer_rels = await loader.load(key=node_id)
+            all_peer_rels.extend(node_peer_rels)
+        if not all_peer_rels:
+            return None
+        return [
+            await obj.to_graphql(db=db, fields=node_fields, related_node_ids=related_node_ids) for obj in all_peer_rels
+        ]

--- a/backend/infrahub/graphql/resolvers/many_relationship.py
+++ b/backend/infrahub/graphql/resolvers/many_relationship.py
@@ -137,19 +137,32 @@ class ManyRelationshipResolver:
         if not node_fields:
             return response
 
-        node_graph = await self._get_entities_with_data_loader(
-            db=context.db,
-            branch=context.branch,
-            ids=ids,
-            at=context.at,
-            related_node_ids=context.related_node_ids,
-            source_kind=source_kind,
-            rel_schema=node_rel,
-            filters=filters,
-            node_fields=node_fields,
-            offset=offset,
-            limit=limit,
-        )
+        if offset or limit:
+            node_graph = await self._get_entities_simple(
+                db=context.db,
+                branch=context.branch,
+                ids=ids,
+                at=context.at,
+                related_node_ids=context.related_node_ids,
+                source_kind=source_kind,
+                rel_schema=node_rel,
+                filters=filters,
+                node_fields=node_fields,
+                offset=offset,
+                limit=limit,
+            )
+        else:
+            node_graph = await self._get_entities_with_data_loader(
+                db=context.db,
+                branch=context.branch,
+                ids=ids,
+                at=context.at,
+                related_node_ids=context.related_node_ids,
+                source_kind=source_kind,
+                rel_schema=node_rel,
+                filters=filters,
+                node_fields=node_fields,
+            )
 
         if not node_graph:
             return response
@@ -167,7 +180,7 @@ class ManyRelationshipResolver:
         response["edges"] = entries
         return response
 
-    async def _get_entities_with_data_loader(
+    async def _get_entities_simple(
         self,
         db: InfrahubDatabase,
         branch: Branch,
@@ -180,6 +193,37 @@ class ManyRelationshipResolver:
         node_fields: dict[str, Any],
         offset: int | None = None,
         limit: int | None = None,
+    ) -> list[dict[str, Any]] | None:
+        async with db.start_session() as dbs:
+            objs = await NodeManager.query_peers(
+                db=dbs,
+                ids=ids,
+                source_kind=source_kind,
+                schema=rel_schema,
+                filters=filters,
+                fields=node_fields,
+                offset=offset,
+                limit=limit,
+                at=at,
+                branch=branch,
+                branch_agnostic=rel_schema.branch is BranchSupportType.AGNOSTIC,
+                fetch_peers=True,
+            )
+            if not objs:
+                return None
+            return [await obj.to_graphql(db=dbs, fields=node_fields, related_node_ids=related_node_ids) for obj in objs]
+
+    async def _get_entities_with_data_loader(
+        self,
+        db: InfrahubDatabase,
+        branch: Branch,
+        ids: list[str],
+        at: Timestamp | None,
+        related_node_ids: set[str] | None,
+        source_kind: str,
+        rel_schema: RelationshipSchema,
+        filters: dict[str, Any],
+        node_fields: dict[str, Any],
     ) -> list[dict[str, Any]] | None:
         if node_fields and "display_label" in node_fields:
             schema_branch = db.schema.get_schema_branch(name=branch.name)
@@ -201,8 +245,6 @@ class ManyRelationshipResolver:
             fields=node_fields,
             at=at,
             branch_agnostic=rel_schema.branch is BranchSupportType.AGNOSTIC,
-            limit=limit,
-            offset=offset,
         )
         if query_params in self._data_loader_instances:
             loader = self._data_loader_instances[query_params]

--- a/backend/infrahub/graphql/resolvers/many_relationship.py
+++ b/backend/infrahub/graphql/resolvers/many_relationship.py
@@ -137,6 +137,7 @@ class ManyRelationshipResolver:
         if not node_fields:
             return response
 
+        requires_relationship_metadata = False
         if requires_relationship_metadata:
             node_graph = await self._get_entities_simple(
                 db=context.db,

--- a/backend/infrahub/graphql/resolvers/many_relationship.py
+++ b/backend/infrahub/graphql/resolvers/many_relationship.py
@@ -16,6 +16,8 @@ from ..loaders.peers import PeerRelationshipsDataLoader, QueryPeerParams
 from ..types import RELATIONS_PROPERTY_MAP, RELATIONS_PROPERTY_MAP_REVERSED
 
 if TYPE_CHECKING:
+    from infrahub.core.schema import MainSchemaTypes
+
     from ..initialization import GraphqlContext
 
 
@@ -81,7 +83,7 @@ class ManyRelationshipResolver:
         """
         # Extract the InfraHub schema by inspecting the GQL Schema
 
-        node_schema: NodeSchema = info.parent_type.graphene_type._meta.schema  # type: ignore[attr-defined]
+        node_schema: MainSchemaTypes = info.parent_type.graphene_type._meta.schema  # type: ignore[attr-defined]
 
         context: GraphqlContext = info.context
 
@@ -94,33 +96,31 @@ class ManyRelationshipResolver:
             mapped_name = RELATIONS_PROPERTY_MAP[key]
             node_fields[mapped_name] = value
 
-        metadata_field_names = {prop_name for prop_name in RELATIONS_PROPERTY_MAP if prop_name != "__typename"}
-        requires_relationship_metadata = bool(set(property_fields.keys()) & metadata_field_names)
-
         filters = {
             f"{info.field_name}__{key}": value
             for key, value in kwargs.items()
             if "__" in key and value or key in ["id", "ids"]
         }
 
+        response: dict[str, Any] = {"edges": [], "count": None}
+
         # Extract the schema of the node on the other end of the relationship from the GQL Schema
         node_rel = node_schema.get_relationship(info.field_name)
         source_kind = node_schema.kind
-        if node_schema.hierarchy:
-            source_kind = node_schema.hierarchy
-
-        response: dict[str, Any] = {"edges": [], "count": None}
-
         ids = [parent["id"]]
-        if include_descendants:
-            descendant_ids = await self.get_descendant_ids(
-                db=context.db,
-                branch=context.branch,
-                at=context.at,
-                parent_id=ids[0],
-                node_schema=node_schema,
-            )
-            ids.extend(descendant_ids)
+        if isinstance(node_schema, NodeSchema):
+            if node_schema.hierarchy:
+                source_kind = node_schema.hierarchy
+
+            if include_descendants:
+                descendant_ids = await self.get_descendant_ids(
+                    db=context.db,
+                    branch=context.branch,
+                    at=context.at,
+                    parent_id=ids[0],
+                    node_schema=node_schema,
+                )
+                ids.extend(descendant_ids)
 
         if "count" in fields:
             peer_count = await self.get_peer_count(
@@ -137,35 +137,19 @@ class ManyRelationshipResolver:
         if not node_fields:
             return response
 
-        requires_relationship_metadata = False
-        if requires_relationship_metadata:
-            node_graph = await self._get_entities_simple(
-                db=context.db,
-                branch=context.branch,
-                ids=ids,
-                at=context.at,
-                related_node_ids=context.related_node_ids,
-                source_kind=source_kind,
-                rel_schema=node_rel,
-                filters=filters,
-                node_fields=node_fields,
-                offset=offset,
-                limit=limit,
-            )
-        else:
-            node_graph = await self._get_entities_with_data_loader(
-                db=context.db,
-                branch=context.branch,
-                ids=ids,
-                at=context.at,
-                related_node_ids=context.related_node_ids,
-                source_kind=source_kind,
-                rel_schema=node_rel,
-                filters=filters,
-                node_fields=node_fields,
-                offset=offset,
-                limit=limit,
-            )
+        node_graph = await self._get_entities_with_data_loader(
+            db=context.db,
+            branch=context.branch,
+            ids=ids,
+            at=context.at,
+            related_node_ids=context.related_node_ids,
+            source_kind=source_kind,
+            rel_schema=node_rel,
+            filters=filters,
+            node_fields=node_fields,
+            offset=offset,
+            limit=limit,
+        )
 
         if not node_graph:
             return response
@@ -182,39 +166,6 @@ class ManyRelationshipResolver:
 
         response["edges"] = entries
         return response
-
-    async def _get_entities_simple(
-        self,
-        db: InfrahubDatabase,
-        branch: Branch,
-        ids: list[str],
-        at: Timestamp | None,
-        related_node_ids: set[str] | None,
-        source_kind: str,
-        rel_schema: RelationshipSchema,
-        filters: dict[str, Any],
-        node_fields: dict[str, Any],
-        offset: int | None = None,
-        limit: int | None = None,
-    ) -> list[dict[str, Any]] | None:
-        async with db.start_session() as dbs:
-            objs = await NodeManager.query_peers(
-                db=dbs,
-                ids=ids,
-                source_kind=source_kind,
-                schema=rel_schema,
-                filters=filters,
-                fields=node_fields,
-                offset=offset,
-                limit=limit,
-                at=at,
-                branch=branch,
-                branch_agnostic=rel_schema.branch is BranchSupportType.AGNOSTIC,
-                fetch_peers=True,
-            )
-            if not objs:
-                return None
-            return [await obj.to_graphql(db=dbs, fields=node_fields, related_node_ids=related_node_ids) for obj in objs]
 
     async def _get_entities_with_data_loader(
         self,
@@ -264,6 +215,8 @@ class ManyRelationshipResolver:
             all_peer_rels.extend(node_peer_rels)
         if not all_peer_rels:
             return None
-        return [
-            await obj.to_graphql(db=db, fields=node_fields, related_node_ids=related_node_ids) for obj in all_peer_rels
-        ]
+        async with db.start_session() as dbs:
+            return [
+                await obj.to_graphql(db=dbs, fields=node_fields, related_node_ids=related_node_ids)
+                for obj in all_peer_rels
+            ]

--- a/backend/infrahub/graphql/resolvers/resolver.py
+++ b/backend/infrahub/graphql/resolvers/resolver.py
@@ -6,13 +6,11 @@ from infrahub_sdk.utils import extract_fields
 
 from infrahub.core.constants import BranchSupportType, InfrahubKind, RelationshipHierarchyDirection
 from infrahub.core.manager import NodeManager
-from infrahub.core.query.node import NodeGetHierarchyQuery
 from infrahub.exceptions import NodeNotFoundError
 
 from ..models import OrderModel
 from ..parser import extract_selection
 from ..permissions import get_permissions
-from ..types import RELATIONS_PROPERTY_MAP, RELATIONS_PROPERTY_MAP_REVERSED
 
 if TYPE_CHECKING:
     from graphql import GraphQLResolveInfo
@@ -217,109 +215,11 @@ async def single_relationship_resolver(parent: dict, info: GraphQLResolveInfo, *
 
 
 async def many_relationship_resolver(
-    parent: dict, info: GraphQLResolveInfo, include_descendants: Optional[bool] = False, **kwargs: Any
+    parent: dict, info: GraphQLResolveInfo, include_descendants: bool | None = False, **kwargs: Any
 ) -> dict[str, Any]:
-    """Resolver for relationships of cardinality=many for Edged responses
-
-    This resolver is used for paginated responses and as such we redefined the requested
-    fields by only reusing information below the 'node' key.
-    """
-    # Extract the InfraHub schema by inspecting the GQL Schema
-    node_schema: NodeSchema = info.parent_type.graphene_type._meta.schema
-
     context: GraphqlContext = info.context
-
-    # Extract the name of the fields in the GQL query
-    fields = await extract_fields(info.field_nodes[0].selection_set)
-    edges = fields.get("edges", {})
-    node_fields = edges.get("node", {})
-    property_fields = edges.get("properties", {})
-    for key, value in property_fields.items():
-        mapped_name = RELATIONS_PROPERTY_MAP[key]
-        node_fields[mapped_name] = value
-
-    # Extract the schema of the node on the other end of the relationship from the GQL Schema
-    node_rel = node_schema.get_relationship(info.field_name)
-
-    # Extract only the filters from the kwargs and prepend the name of the field to the filters
-    offset = kwargs.pop("offset", None)
-    limit = kwargs.pop("limit", None)
-
-    filters = {
-        f"{info.field_name}__{key}": value
-        for key, value in kwargs.items()
-        if "__" in key and value or key in ["id", "ids"]
-    }
-
-    response: dict[str, Any] = {"edges": [], "count": None}
-
-    source_kind = node_schema.kind
-
-    async with context.db.start_session() as db:
-        ids = [parent["id"]]
-        if include_descendants:
-            query = await NodeGetHierarchyQuery.init(
-                db=db,
-                direction=RelationshipHierarchyDirection.DESCENDANTS,
-                node_id=parent["id"],
-                node_schema=node_schema,
-                at=context.at,
-                branch=context.branch,
-            )
-            if node_schema.hierarchy:
-                source_kind = node_schema.hierarchy
-            await query.execute(db=db)
-            descendants_ids = list(query.get_peer_ids())
-            ids.extend(descendants_ids)
-
-        if "count" in fields:
-            response["count"] = await NodeManager.count_peers(
-                db=db,
-                ids=ids,
-                source_kind=source_kind,
-                schema=node_rel,
-                filters=filters,
-                at=context.at,
-                branch=context.branch,
-                branch_agnostic=node_rel.branch is BranchSupportType.AGNOSTIC,
-            )
-
-        if not node_fields:
-            return response
-
-        objs = await NodeManager.query_peers(
-            db=db,
-            ids=ids,
-            source_kind=source_kind,
-            schema=node_rel,
-            filters=filters,
-            fields=node_fields,
-            offset=offset,
-            limit=limit,
-            at=context.at,
-            branch=context.branch,
-            branch_agnostic=node_rel.branch is BranchSupportType.AGNOSTIC,
-            fetch_peers=True,
-        )
-
-        if not objs:
-            return response
-        node_graph = [
-            await obj.to_graphql(db=db, fields=node_fields, related_node_ids=context.related_node_ids) for obj in objs
-        ]
-
-        entries = []
-        for node in node_graph:
-            entry = {"node": {}, "properties": {}}
-            for key, mapped in RELATIONS_PROPERTY_MAP_REVERSED.items():
-                value = node.pop(key, None)
-                if value:
-                    entry["properties"][mapped] = value
-            entry["node"] = node
-            entries.append(entry)
-        response["edges"] = entries
-
-        return response
+    resolver = context.many_relationship_resolver
+    return await resolver.resolve(parent=parent, info=info, include_descendants=include_descendants, **kwargs)
 
 
 async def ancestors_resolver(parent: dict, info: GraphQLResolveInfo, **kwargs) -> dict[str, Any]:

--- a/backend/infrahub/graphql/subscription/graphql_query.py
+++ b/backend/infrahub/graphql/subscription/graphql_query.py
@@ -8,6 +8,7 @@ from infrahub.core.constants import InfrahubKind
 from infrahub.core.manager import NodeManager
 from infrahub.core.protocols import CoreGraphQLQuery
 from infrahub.core.timestamp import Timestamp
+from infrahub.graphql.resolvers.many_relationship import ManyRelationshipResolver
 from infrahub.graphql.resolvers.single_relationship import SingleRelationshipResolver
 from infrahub.log import get_logger
 
@@ -48,6 +49,7 @@ async def resolver_graphql_query(
                     related_node_ids=set(),
                     types=context.types,
                     single_relationship_resolver=SingleRelationshipResolver(),
+                    many_relationship_resolver=ManyRelationshipResolver(),
                 ),
                 root_value=None,
                 variable_values=params or {},

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -2119,8 +2119,18 @@ async def location_rack_protocol(location_generic_protocol):
 
 @pytest.fixture
 async def hierarchical_location_schema(
-    db: InfrahubDatabase, default_branch: Branch, hierarchical_location_schema_simple, register_core_models_schema
-) -> None: ...
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    hierarchical_location_schema_simple_unregistered: SchemaRoot,
+    register_core_models_schema,
+) -> None:
+    for node in hierarchical_location_schema_simple_unregistered.nodes:
+        if "LineageSource" not in node.inherit_from:
+            node.inherit_from.append("LineageSource")
+        if "LineageOwner" not in node.inherit_from:
+            node.inherit_from.append("LineageOwner")
+    registry.schema.register_schema(schema=hierarchical_location_schema_simple_unregistered, branch=default_branch.name)
+    return hierarchical_location_schema_simple_unregistered
 
 
 @pytest.fixture

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -2119,18 +2119,8 @@ async def location_rack_protocol(location_generic_protocol):
 
 @pytest.fixture
 async def hierarchical_location_schema(
-    db: InfrahubDatabase,
-    default_branch: Branch,
-    hierarchical_location_schema_simple_unregistered: SchemaRoot,
-    register_core_models_schema,
-) -> None:
-    for node in hierarchical_location_schema_simple_unregistered.nodes:
-        if "LineageSource" not in node.inherit_from:
-            node.inherit_from.append("LineageSource")
-        if "LineageOwner" not in node.inherit_from:
-            node.inherit_from.append("LineageOwner")
-    registry.schema.register_schema(schema=hierarchical_location_schema_simple_unregistered, branch=default_branch.name)
-    return hierarchical_location_schema_simple_unregistered
+    db: InfrahubDatabase, default_branch: Branch, hierarchical_location_schema_simple, register_core_models_schema
+) -> None: ...
 
 
 @pytest.fixture

--- a/backend/tests/unit/graphql/auth/query_permission_checker/test_default_branch_checker.py
+++ b/backend/tests/unit/graphql/auth/query_permission_checker/test_default_branch_checker.py
@@ -97,6 +97,7 @@ class TestDefaultBranchPermission:
             branch=MagicMock(),
             types=MagicMock(),
             single_relationship_resolver=MagicMock(),
+            many_relationship_resolver=MagicMock(),
             account_session=session,
             permissions=permission_manager,
         )
@@ -136,6 +137,7 @@ class TestDefaultBranchPermission:
             branch=MagicMock(),
             types=MagicMock(),
             single_relationship_resolver=MagicMock(),
+            many_relationship_resolver=MagicMock(),
             account_session=session,
             permissions=permission_manager,
         )

--- a/backend/tests/unit/graphql/auth/query_permission_checker/test_merge_operation_checker.py
+++ b/backend/tests/unit/graphql/auth/query_permission_checker/test_merge_operation_checker.py
@@ -137,6 +137,7 @@ class TestMergeBranchPermission:
             branch=MagicMock(),
             types=MagicMock(),
             single_relationship_resolver=MagicMock(),
+            many_relationship_resolver=MagicMock(),
             account_session=session,
             permissions=permission_manager,
         )

--- a/backend/tests/unit/graphql/auth/query_permission_checker/test_super_admin_checker.py
+++ b/backend/tests/unit/graphql/auth/query_permission_checker/test_super_admin_checker.py
@@ -106,6 +106,7 @@ class TestSuperAdminPermission:
             branch=MagicMock(),
             types=MagicMock(),
             single_relationship_resolver=MagicMock(),
+            many_relationship_resolver=MagicMock(),
             account_session=session,
             permissions=permission_manager,
         )

--- a/backend/tests/unit/graphql/conftest.py
+++ b/backend/tests/unit/graphql/conftest.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
 import pytest
 
+from infrahub.core.constants import InfrahubKind
+from infrahub.core.node import Node
 from infrahub.dependencies.registry import build_component_registry
 
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
     from infrahub.core.protocols import CoreAccount
+    from infrahub.database import InfrahubDatabase
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -372,3 +376,19 @@ def query_introspection() -> str:
         }
     """
     return query
+
+
+@pytest.fixture
+async def account_bob(db: InfrahubDatabase, default_branch: Branch) -> Node:
+    bob = await Node.init(db=db, schema=InfrahubKind.ACCOUNT, branch=default_branch)
+    await bob.new(db=db, name="bob", password=str(uuid4()))
+    await bob.save(db=db)
+    return bob
+
+
+@pytest.fixture
+async def account_bill(db: InfrahubDatabase, default_branch: Branch) -> Node:
+    bill = await Node.init(db=db, schema=InfrahubKind.ACCOUNT, branch=default_branch)
+    await bill.new(db=db, name="bill", password=str(uuid4()))
+    await bill.save(db=db)
+    return bill

--- a/backend/tests/unit/graphql/queries/test_task.py
+++ b/backend/tests/unit/graphql/queries/test_task.py
@@ -1,5 +1,4 @@
 from typing import Any
-from uuid import uuid4
 
 import pytest
 from graphql import ExecutionResult
@@ -106,22 +105,6 @@ async def tag_red(db: InfrahubDatabase, default_branch: Branch) -> Node:
     await blue.new(db=db, name="Red", description="The REd tag")
     await blue.save(db=db)
     return blue
-
-
-@pytest.fixture
-async def account_bob(db: InfrahubDatabase, default_branch: Branch) -> Node:
-    bob = await Node.init(db=db, schema=InfrahubKind.ACCOUNT, branch=default_branch)
-    await bob.new(db=db, name="bob", password=str(uuid4()))
-    await bob.save(db=db)
-    return bob
-
-
-@pytest.fixture
-async def account_bill(db: InfrahubDatabase, default_branch: Branch) -> Node:
-    bill = await Node.init(db=db, schema=InfrahubKind.ACCOUNT, branch=default_branch)
-    await bill.new(db=db, name="bill", password=str(uuid4()))
-    await bill.save(db=db)
-    return bill
 
 
 @pytest.fixture

--- a/backend/tests/unit/graphql/test_graphql_query.py
+++ b/backend/tests/unit/graphql/test_graphql_query.py
@@ -2538,6 +2538,85 @@ async def test_query_relationship_node_property(
     assert gql_params.context.related_node_ids == {p1.id, p2.id, c1.id, c2.id, first_account.id}
 
 
+async def test_same_many_relationship_with_different_limits_offsets(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    person_john_main: Node,
+    person_jane_main: Node,
+    car_accord_main: Node,
+    car_prius_main: Node,
+    car_camry_main: Node,
+    car_yaris_main: Node,
+) -> None:
+    query = """
+    query {
+        people_with_cars_1: TestPerson {
+            edges {
+                node {
+                    id
+                    name {
+                        value
+                    }
+                    cars(limit: 1, offset: 0) {
+                        edges {
+                            node {
+                                id
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        people_with_cars_2: TestPerson {
+            edges {
+                node {
+                    id
+                    name {
+                        value
+                    }
+                    cars(limit: 1, offset: 1) {
+                        edges {
+                            node {
+                                id
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+    john_cars_by_uuid = sorted([car_accord_main, car_prius_main], key=lambda c: c.id)
+    jane_cars_by_uuid = sorted([car_camry_main, car_yaris_main], key=lambda c: c.id)
+
+    gql_params = await prepare_graphql_params(
+        db=db, include_mutation=False, include_subscription=False, branch=default_branch
+    )
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
+    assert result.errors is None
+
+    for person_node in result.data["people_with_cars_1"]["edges"]:
+        person_name = person_node["node"]["name"]["value"]
+        assert len(person_node["node"]["cars"]["edges"]) == 1
+        if person_name == "John":
+            assert person_node["node"]["cars"]["edges"][0]["node"]["id"] == john_cars_by_uuid[0].id
+        elif person_name == "Jane":
+            assert person_node["node"]["cars"]["edges"][0]["node"]["id"] == jane_cars_by_uuid[0].id
+    for person_node in result.data["people_with_cars_2"]["edges"]:
+        person_name = person_node["node"]["name"]["value"]
+        assert len(person_node["node"]["cars"]["edges"]) == 1
+        if person_name == "John":
+            assert person_node["node"]["cars"]["edges"][0]["node"]["id"] == john_cars_by_uuid[1].id
+        elif person_name == "Jane":
+            assert person_node["node"]["cars"]["edges"][0]["node"]["id"] == jane_cars_by_uuid[1].id
+
+
 async def test_query_attribute_flag_property(
     db: InfrahubDatabase,
     default_branch: Branch,
@@ -3350,6 +3429,129 @@ async def test_hierarchical_location_include_descendants(
         "thing-singapore-r2",
     ]
     assert asia["things"]["count"] == 7
+
+
+async def test_properties_on_different_query_paths(
+    db: InfrahubDatabase, default_branch: Branch, hierarchical_location_data_thing: dict[str, Node]
+):
+    paris_owner = hierarchical_location_data_thing["singapore"]
+    paris_rack_ids = [node.id for name, node in hierarchical_location_data_thing.items() if name.startswith("paris-r")]
+    paris_racks = await NodeManager.get_many(db=db, ids=paris_rack_ids)
+    for rack in paris_racks.values():
+        thing_rels = await rack.things.get_relationships(db=db)
+        await rack.things.update(
+            db=db, data=[{"id": rel.peer_id, "_relation__owner": paris_owner.id} for rel in thing_rels]
+        )
+        await rack.save(db=db)
+
+    london_source = hierarchical_location_data_thing["seattle"]
+    london_rack_ids = [
+        node.id for name, node in hierarchical_location_data_thing.items() if name.startswith("london-r")
+    ]
+    london_racks = await NodeManager.get_many(db=db, ids=london_rack_ids)
+    for rack in london_racks.values():
+        thing_rels = await rack.things.get_relationships(db=db)
+        await rack.things.update(
+            db=db, data=[{"id": rel.peer_id, "_relation__source": london_source.id} for rel in thing_rels]
+        )
+        await rack.save(db=db)
+
+    query = """
+    query GetRack {
+        LocationRack(parent__name__values: "europe") {
+            edges {
+                node {
+                    id
+                    name {
+                        value
+                    }
+                    things {
+                        edges {
+                            properties {
+                                owner {
+                                    id
+                                }
+                            }
+                            node {
+                                id
+                                name {
+                                    value
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        LocationSite(parent__name__values: "europe") {
+            edges {
+                node {
+                    id
+                    name {
+                        value
+                    }
+                    children {
+                        edges {
+                            node {
+                                name {
+                                    value
+                                }
+                                things {
+                                    edges {
+                                        properties {
+                                        source {
+                                                id
+                                            }
+                                        }
+                                        node {
+                                            id
+                                            name {
+                                                value
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+    gql_params = await prepare_graphql_params(
+        db=db, include_mutation=False, include_subscription=False, branch=default_branch
+    )
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
+
+    assert result.errors is None
+
+    # check owners are correct
+    for rack in result.data["LocationRack"]["edges"]:
+        rack_name = rack["node"]["name"]["value"]
+        for thing_rel in rack["node"]["things"]["edges"]:
+            assert "source" not in thing_rel["properties"]
+            if rack_name.startswith("paris"):
+                assert thing_rel["properties"]["owner"]["id"] == paris_owner.id
+            else:
+                assert thing_rel["properties"]["owner"] is None
+
+    # check sources are correct
+    for site in result.data["LocationSite"]["edges"]:
+        for rack in site["node"]["children"]["edges"]:
+            rack_name = rack["node"]["name"]["value"]
+            for thing_rel in rack["node"]["things"]["edges"]:
+                assert "owner" not in thing_rel["properties"]
+                if rack_name.startswith("london"):
+                    assert thing_rel["properties"]["source"]["id"] == london_source.id
+                else:
+                    assert thing_rel["properties"]["source"] is None
 
 
 async def test_hierarchical_groups_descendants(

--- a/backend/tests/unit/graphql/test_graphql_query.py
+++ b/backend/tests/unit/graphql/test_graphql_query.py
@@ -2437,6 +2437,106 @@ async def test_query_relationship_node_property(
     assert results["bolt"]["owner"]["properties"]["source"]["id"] == first_account.id
     assert gql_params.context.related_node_ids == {p1.id, p2.id, c1.id, c2.id, first_account.id}
 
+    # test many relationship query with mixed properties on peer
+    query = """
+    query {
+        people_with_cars_and_owners: TestPerson {
+            edges {
+                node {
+                    id
+                    name {
+                        value
+                    }
+                    cars {
+                        edges {
+                            node {
+                                name {
+                                    value
+                                }
+                            }
+                            properties {
+                                owner {
+                                    id
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        people_with_cars_and_sources: TestPerson {
+            edges {
+                node {
+                    id
+                    name {
+                        value
+                    }
+                    cars {
+                        edges {
+                            node {
+                                name {
+                                    value
+                                }
+                            }
+                            properties {
+                                source {
+                                    id
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+
+    gql_params = await prepare_graphql_params(
+        db=db, include_mutation=False, include_subscription=False, branch=default_branch
+    )
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
+    assert result.errors is None
+
+    owner_results = {
+        item["node"]["name"]["value"]: item["node"] for item in result.data["people_with_cars_and_owners"]["edges"]
+    }
+    assert sorted(list(owner_results.keys())) == ["Jane", "John"]
+    assert len(owner_results["John"]["cars"]["edges"]) == 1
+    assert len(owner_results["Jane"]["cars"]["edges"]) == 1
+
+    assert owner_results["John"]["cars"]["edges"][0]["node"]["name"]["value"] == "volt"
+    assert owner_results["John"]["cars"]["edges"][0]["properties"]["owner"]
+    assert owner_results["John"]["cars"]["edges"][0]["properties"]["owner"]["id"] == first_account.id
+    assert "source" not in owner_results["John"]["cars"]["edges"][0]["properties"]
+
+    assert owner_results["Jane"]["cars"]["edges"][0]["node"]["name"]["value"] == "bolt"
+    assert owner_results["Jane"]["cars"]["edges"][0]["properties"]["owner"] is None
+    assert "source" not in owner_results["Jane"]["cars"]["edges"][0]["properties"]
+
+    source_results = {
+        item["node"]["name"]["value"]: item["node"] for item in result.data["people_with_cars_and_sources"]["edges"]
+    }
+    assert sorted(list(source_results.keys())) == ["Jane", "John"]
+    assert len(source_results["John"]["cars"]["edges"]) == 1
+    assert len(source_results["Jane"]["cars"]["edges"]) == 1
+
+    assert source_results["John"]["cars"]["edges"][0]["node"]["name"]["value"] == "volt"
+    assert "owner" not in source_results["John"]["cars"]["edges"][0]["properties"]
+    assert source_results["John"]["cars"]["edges"][0]["properties"]["source"] is None
+
+    assert source_results["Jane"]["cars"]["edges"][0]["node"]["name"]["value"] == "bolt"
+    assert "owner" not in source_results["Jane"]["cars"]["edges"][0]["properties"]
+    assert source_results["Jane"]["cars"]["edges"][0]["properties"]["source"]
+    assert source_results["Jane"]["cars"]["edges"][0]["properties"]["source"]["id"] == first_account.id
+
+    assert gql_params.context.related_node_ids == {p1.id, p2.id, c1.id, c2.id, first_account.id}
+
 
 async def test_query_attribute_flag_property(
     db: InfrahubDatabase,

--- a/backend/tests/unit/graphql/test_graphql_query.py
+++ b/backend/tests/unit/graphql/test_graphql_query.py
@@ -3432,9 +3432,13 @@ async def test_hierarchical_location_include_descendants(
 
 
 async def test_properties_on_different_query_paths(
-    db: InfrahubDatabase, default_branch: Branch, hierarchical_location_data_thing: dict[str, Node]
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    hierarchical_location_data_thing: dict[str, Node],
+    account_bob: Node,
+    account_bill: Node,
 ):
-    paris_owner = hierarchical_location_data_thing["singapore"]
+    paris_owner = account_bob
     paris_rack_ids = [node.id for name, node in hierarchical_location_data_thing.items() if name.startswith("paris-r")]
     paris_racks = await NodeManager.get_many(db=db, ids=paris_rack_ids)
     for rack in paris_racks.values():
@@ -3444,7 +3448,7 @@ async def test_properties_on_different_query_paths(
         )
         await rack.save(db=db)
 
-    london_source = hierarchical_location_data_thing["seattle"]
+    london_source = account_bill
     london_rack_ids = [
         node.id for name, node in hierarchical_location_data_thing.items() if name.startswith("london-r")
     ]

--- a/backend/tests/unit/graphql/test_graphql_query.py
+++ b/backend/tests/unit/graphql/test_graphql_query.py
@@ -3295,19 +3295,27 @@ async def test_hierarchical_groups_descendants(
 
     member_names = [hierarchical_groups_data[member_id].name.value for member_id in members_ids]
 
+    # members returned in order of group names
     assert member_names == [
+        # grp1
         "tag-0",
         "tag-1",
+        # grp11
         "tag-2",
         "tag-3",
-        "tag-4",
-        "tag-5",
+        # grp111
         "tag-6",
         "tag-7",
+        # grp112
         "tag-8",
         "tag-9",
+        # grp12
+        "tag-4",
+        "tag-5",
+        # grp 121
         "tag-10",
         "tag-11",
+        # grp 122
         "tag-12",
         "tag-13",
     ]

--- a/changelog/+many_data_loader.added.md
+++ b/changelog/+many_data_loader.added.md
@@ -1,0 +1,1 @@
+Improve performance of GraphQL cardinality-many relationship resolver by batching database calls together


### PR DESCRIPTION
IFC-1375

adds the DataLoader pattern to the many_relationships_resolver to reduce the number of database calls. if a many relationship includes a `limit` or `offset`, we need to fall back to the old way of retrieving cardinality-many relationships (at least one query for each node) b/c the offsets and limits will not work correctly when multiple nodes are batched together

I've captured more performance improvement ideas in IFC-1382

