### PR TITLE
IFC-1373 Remove `object_template` relationship if template is turned off

### DIFF
--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -13,6 +13,7 @@ from typing_extensions import Self
 from infrahub.computed_attribute.constants import VALID_KINDS as VALID_COMPUTED_ATTRIBUTE_KINDS
 from infrahub.core.constants import (
     OBJECT_TEMPLATE_NAME_ATTR,
+    OBJECT_TEMPLATE_RELATIONSHIP_NAME,
     RESERVED_ATTR_GEN_NAMES,
     RESERVED_ATTR_REL_NAMES,
     RESTRICTED_NAMESPACES,
@@ -1794,7 +1795,7 @@ class SchemaBranch:
                 continue
 
             template_rel_settings: dict[str, Any] = {
-                "name": "object_template",
+                "name": OBJECT_TEMPLATE_RELATIONSHIP_NAME,
                 "identifier": "node__objecttemplate",
                 "peer": self._get_object_template_kind(node.kind),
                 "kind": RelationshipKind.TEMPLATE,
@@ -1804,14 +1805,14 @@ class SchemaBranch:
             }
 
             # Add relationship between node and template
-            if "object_template" not in node.relationship_names:
+            if OBJECT_TEMPLATE_RELATIONSHIP_NAME not in node.relationship_names:
                 node_schema = self.get(name=node_name, duplicate=True)
 
                 node_schema.relationships.append(RelationshipSchema(**template_rel_settings))
                 self.set(name=node_name, schema=node_schema)
             else:
                 has_changes: bool = False
-                rel_template = node.get_relationship(name="object_template")
+                rel_template = node.get_relationship(name=OBJECT_TEMPLATE_RELATIONSHIP_NAME)
                 for name, value in template_rel_settings.items():
                     if getattr(rel_template, name) != value:
                         has_changes = True
@@ -1820,7 +1821,7 @@ class SchemaBranch:
                     continue
 
                 node_schema = self.get(name=node_name, duplicate=True)
-                rel_template = node_schema.get_relationship(name="object_template")
+                rel_template = node_schema.get_relationship(name=OBJECT_TEMPLATE_RELATIONSHIP_NAME)
                 for name, value in template_rel_settings.items():
                     if getattr(rel_template, name) != value:
                         setattr(rel_template, name, value)
@@ -1990,6 +1991,7 @@ class SchemaBranch:
                 or node.state == HashableModelState.ABSENT
             ):
                 try:
+                    node.relationships = [r for r in node.relationships if r.name != OBJECT_TEMPLATE_RELATIONSHIP_NAME]
                     self.delete(name=self._get_object_template_kind(node_kind=node.kind))
                 except SchemaNotFoundError:
                     ...

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -966,9 +966,9 @@ class SchemaBranch:
             for rel in node.relationships:
                 if rel.peer in [InfrahubKind.GENERICGROUP]:
                     continue
-                if not self.has(rel.peer):
+                if not self.has(rel.peer) or self.get(rel.peer, duplicate=False).state == HashableModelState.ABSENT:
                     raise ValueError(
-                        f"{node.kind}: Relationship {rel.name!r} is referencing an invalid peer {rel.peer!r}"
+                        f"{node.kind}: Relationship {rel.name!r} is referring an invalid peer {rel.peer!r}"
                     ) from None
 
     def validate_computed_attributes(self) -> None:

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -928,7 +928,7 @@ async def test_schema_branch_validate_kinds_peer():
     with pytest.raises(ValueError) as exc:
         schema.validate_kinds()
 
-    assert str(exc.value) == "TestCriticality: Relationship 'first' is referencing an invalid peer 'TestNotPresent'"
+    assert str(exc.value) == "TestCriticality: Relationship 'first' is referring an invalid peer 'TestNotPresent'"
 
 
 async def test_schema_branch_validate_kinds_inherit():

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -2851,6 +2851,36 @@ async def test_schema_branch_add_object_template_schema():
     assert set(core_template_schema.used_by) == {f"Template{TestKind.DEVICE}"}
 
 
+async def test_schema_branch_remove_object_template_schema():
+    core_template_schema = GenericSchema(**_get_schema_by_kind(core_models, kind=InfrahubKind.OBJECTTEMPLATE))
+    SIMPLE_DEVICE = copy.deepcopy(DEVICE)
+    SIMPLE_DEVICE.inherit_from = []
+    device_schema = SchemaRoot(generics=[core_template_schema], nodes=[SIMPLE_DEVICE])
+
+    schema = SchemaBranch(cache={}, name="test")
+    schema.load_schema(schema=device_schema)
+    schema.process_inheritance()
+    schema.manage_object_template_schemas()
+
+    node_template = schema.get(name=f"Template{TestKind.DEVICE}", duplicate=False)
+    assert node_template
+    core_template_schema = schema.get(name=InfrahubKind.OBJECTTEMPLATE, duplicate=False)
+    assert set(core_template_schema.used_by) == {f"Template{TestKind.DEVICE}"}
+
+    # Disable template
+    SIMPLE_DEVICE.generate_template = False
+
+    schema = SchemaBranch(cache={}, name="test")
+    schema.load_schema(schema=device_schema)
+    schema.process_inheritance()
+    schema.manage_object_template_schemas()
+
+    with pytest.raises(SchemaNotFoundError, match=r"Unable to find the schema"):
+        schema.get(name=f"Template{TestKind.DEVICE}", duplicate=False)
+    core_template_schema = schema.get(name=InfrahubKind.OBJECTTEMPLATE, duplicate=False)
+    assert not core_template_schema.used_by
+
+
 async def test_schema_branch_diff_core_object_template():
     core_template_schema = GenericSchema(**_get_schema_by_kind(core_models, kind=InfrahubKind.OBJECTTEMPLATE))
     SIMPLE_DEVICE = copy.deepcopy(DEVICE)


### PR DESCRIPTION
We have to note that turning off templating for a node will make the template schema disappear, like removing any other schema node. This will have side-effects such as GraphQL query failure when querying for attribute sources if they point to templates or when looking at changelog. My understanding is that it is an issue on its own (even without the template feature).