### PR TITLE
Add `infrahub upgrade` command

### DIFF
--- a/.github/workflows/version-upgrade.yml
+++ b/.github/workflows/version-upgrade.yml
@@ -32,8 +32,8 @@ jobs:
       max-parallel: 4
       matrix:
         include:
-          - name: From 1.0.0
-            source_version: 1.0.0
+          - name: From 1.1.0
+            source_version: 1.1.0
     name: ${{ matrix.name }}
     runs-on:
       group: huge-runners

--- a/.github/workflows/version-upgrade.yml
+++ b/.github/workflows/version-upgrade.yml
@@ -90,8 +90,8 @@ jobs:
       - name: Build Demo
         run: invoke dev.build
 
-      - name: Run database migration
-        run: invoke dev.migrate
+      - name: Upgrade Infrahub and apply the latest database migrations
+        run: invoke dev.upgrade
 
       - name: Start Demo
         run: invoke dev.start

--- a/backend/infrahub/cli/__init__.py
+++ b/backend/infrahub/cli/__init__.py
@@ -1,18 +1,21 @@
 from asyncio import run as aiorun
 
 import typer
+from infrahub_sdk.async_typer import AsyncTyper
 
 from infrahub import config
-from infrahub.cli.context import CliContext
-from infrahub.cli.db import app as db_app
-from infrahub.cli.events import app as events_app
-from infrahub.cli.git_agent import app as git_app
-from infrahub.cli.server import app as server_app
-from infrahub.cli.tasks import app as tasks_app
 from infrahub.core.initialization import initialization
 from infrahub.database import InfrahubDatabase, get_db
 
-app = typer.Typer(name="Infrahub CLI", pretty_exceptions_enable=False)
+from .context import CliContext
+from .db import app as db_app
+from .events import app as events_app
+from .git_agent import app as git_app
+from .server import app as server_app
+from .tasks import app as tasks_app
+from .upgrade import upgrade_cmd
+
+app = AsyncTyper(name="Infrahub CLI", pretty_exceptions_enable=False)
 
 
 @app.callback()
@@ -26,6 +29,7 @@ app.add_typer(git_app, name="git-agent", hidden=True)
 app.add_typer(db_app, name="db")
 app.add_typer(events_app, name="events", help="Interact with the events system.", hidden=True)
 app.add_typer(tasks_app, name="tasks", hidden=True)
+app.command(name="upgrade")(upgrade_cmd)
 
 
 async def _init_shell(config_file: str) -> None:

--- a/backend/infrahub/cli/constants.py
+++ b/backend/infrahub/cli/constants.py
@@ -1,0 +1,3 @@
+ERROR_BADGE = "[bold red]ERROR[/bold red]"
+SUCCESS_BADGE = "[green]SUCCESS[/green]"
+FAILED_BADGE = "[bold red]FAILED[/bold red]"

--- a/backend/infrahub/cli/db.py
+++ b/backend/infrahub/cli/db.py
@@ -16,22 +16,16 @@ from rich.table import Table
 
 from infrahub import config
 from infrahub.core import registry
-from infrahub.core.constants import InfrahubKind
 from infrahub.core.graph import GRAPH_VERSION
 from infrahub.core.graph.constraints import ConstraintManagerBase, ConstraintManagerMemgraph, ConstraintManagerNeo4j
 from infrahub.core.graph.index import node_indexes, rel_indexes
 from infrahub.core.graph.schema import GRAPH_SCHEMA
 from infrahub.core.initialization import (
-    create_anonymous_role,
-    create_default_roles,
-    create_super_administrator_role,
-    create_super_administrators_group,
     first_time_initialization,
     get_root_node,
     initialization,
     initialize_registry,
 )
-from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.graph import get_graph_migrations
 from infrahub.core.migrations.schema.models import SchemaApplyMigrationData
 from infrahub.core.migrations.schema.tasks import schema_apply_migrations
@@ -43,12 +37,11 @@ from infrahub.core.validators.models.validate_migration import SchemaValidateMig
 from infrahub.core.validators.tasks import schema_validate_migrations
 from infrahub.database import DatabaseType
 from infrahub.log import get_logger
-from infrahub.menu.menu import default_menu
-from infrahub.menu.models import MenuDict
-from infrahub.menu.utils import create_default_menu, get_existing_menu, update_menu
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.message_bus.local import BusSimulator
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
+
+from .constants import ERROR_BADGE, FAILED_BADGE, SUCCESS_BADGE
 
 if TYPE_CHECKING:
     from infrahub.cli.context import CliContext
@@ -123,6 +116,7 @@ async def load_test_data(
 
     context: CliContext = ctx.obj
     dbdriver = await context.init_db(retry=1)
+
     async with dbdriver.start_session() as db:
         await initialization(db=db)
 
@@ -138,8 +132,8 @@ async def load_test_data(
     await dbdriver.close()
 
 
-@app.command()
-async def migrate(
+@app.command(name="migrate")
+async def migrate_cmd(
     ctx: typer.Context,
     check: bool = typer.Option(False, help="Check the state of the database without applying the migrations."),
     config_file: str = typer.Argument("infrahub.toml", envvar="INFRAHUB_CONFIG"),
@@ -149,53 +143,18 @@ async def migrate(
     logging.getLogger("neo4j").setLevel(logging.ERROR)
     logging.getLogger("prefect").setLevel(logging.ERROR)
 
-    log = get_logger()
-
     config.load_and_exit(config_file_name=config_file)
 
     context: CliContext = ctx.obj
     dbdriver = await context.init_db(retry=1)
-    async with dbdriver.start_session() as db:
-        rprint("Checking current state of the Database")
 
-        await initialize_registry(db=db)
-        root_node = await get_root_node(db=db)
-        migrations = await get_graph_migrations(root=root_node)
-
-        if not migrations:
-            rprint(f"Database up-to-date (v{root_node.graph_version}), no migration to execute.")
-        else:
-            rprint(
-                f"Database needs to be updated (v{root_node.graph_version} -> v{GRAPH_VERSION}), {len(migrations)} migrations pending"
-            )
-
-        if migrations and not check:
-            for migration in migrations:
-                log.debug(f"Execute Migration: {migration.name}")
-                execution_result = await migration.execute(db=db)
-                validation_result = None
-
-                if execution_result.success:
-                    validation_result = await migration.validate_migration(db=db)
-                    if validation_result.success:
-                        rprint(f"Migration: {migration.name} [green]SUCCESS[/green]")
-                        root_node.graph_version = migration.minimum_version + 1
-                        await root_node.save(db=db)
-
-                if not execution_result.success or validation_result and not validation_result.success:
-                    rprint(f"Migration: {migration.name} [bold red]FAILED[/bold red]")
-                    for error in execution_result.errors:
-                        rprint(f"  {error}")
-                    if validation_result and not validation_result.success:
-                        for error in validation_result.errors:
-                            rprint(f"  {error}")
-                    break
+    await migrate_database(db=dbdriver, initialize=True, check=check)
 
     await dbdriver.close()
 
 
-@app.command()
-async def update_core_schema(
+@app.command(name="update-core-schema")
+async def update_core_schema_cmd(
     ctx: typer.Context,
     debug: bool = typer.Option(False, help="Enable advanced logging and troubleshooting"),
     config_file: str = typer.Argument("infrahub.toml", envvar="INFRAHUB_CONFIG"),
@@ -211,116 +170,14 @@ async def update_core_schema(
     context: CliContext = ctx.obj
     dbdriver = await context.init_db(retry=1)
 
-    error_badge = "[bold red]ERROR[/bold red]"
+    service = await InfrahubServices.new(
+        database=dbdriver, message_bus=BusSimulator(), workflow=WorkflowLocalExecution()
+    )
 
-    async with dbdriver.start_session() as db:
-        with prefect_test_harness():
-            # ----------------------------------------------------------
-            # Initialize Schema and Registry
-            # ----------------------------------------------------------
-            service = await InfrahubServices.new(
-                database=db, message_bus=BusSimulator(), workflow=WorkflowLocalExecution()
-            )
-            await initialize_registry(db=db)
+    with prefect_test_harness():
+        await update_core_schema(db=dbdriver, service=service, initialize=True, debug=debug)
 
-            default_branch = registry.get_branch_from_registry(branch=registry.default_branch)
-
-            registry.schema = SchemaManager()
-            schema = SchemaRoot(**internal_schema)
-            registry.schema.register_schema(schema=schema)
-
-            # ----------------------------------------------------------
-            # Load Current Schema from the database
-            # ----------------------------------------------------------
-            schema_default_branch = await registry.schema.load_schema_from_db(db=db, branch=default_branch)
-            registry.schema.set_schema_branch(name=default_branch.name, schema=schema_default_branch)
-            branch_schema = registry.schema.get_schema_branch(name=registry.default_branch)
-
-            candidate_schema = branch_schema.duplicate()
-            candidate_schema.load_schema(schema=SchemaRoot(**internal_schema))
-            candidate_schema.load_schema(schema=SchemaRoot(**core_models))
-            candidate_schema.load_schema(schema=SchemaRoot(**deprecated_models))
-            candidate_schema.process()
-
-            schema_diff = branch_schema.diff(other=candidate_schema)
-            branch_schema.validate_node_deletions(diff=schema_diff)
-            result = branch_schema.validate_update(
-                other=candidate_schema, diff=schema_diff, enforce_update_support=False
-            )
-            if result.errors:
-                rprint(f"{error_badge} | Unable to update the schema, due to failed validations")
-                for error in result.errors:
-                    rprint(error.to_string())
-                raise typer.Exit(1)
-
-            if not result.diff.all:
-                await create_defaults(db=db)
-                rprint("Core Schema Up to date, nothing to update")
-                raise typer.Exit(0)
-
-            rprint("Core Schema has diff, will need to be updated")
-            if debug:
-                result.diff.print()
-
-            # ----------------------------------------------------------
-            # Validate if the new schema is valid with the content of the database
-            # ----------------------------------------------------------
-            validate_migration_data = SchemaValidateMigrationData(
-                branch=default_branch,
-                schema_branch=candidate_schema,
-                constraints=result.constraints,
-            )
-            responses = await schema_validate_migrations(message=validate_migration_data, service=service)
-            error_messages = [violation.message for response in responses for violation in response.violations]
-            if error_messages:
-                rprint(f"{error_badge} | Unable to update the schema, due to failed validations")
-                for message in error_messages:
-                    rprint(message)
-                raise typer.Exit(1)
-
-            # ----------------------------------------------------------
-            # Update the schema
-            # ----------------------------------------------------------
-            origin_schema = branch_schema.duplicate()
-
-            # Update the internal schema
-            schema_default_branch.load_schema(schema=SchemaRoot(**internal_schema))
-            schema_default_branch.process()
-            registry.schema.set_schema_branch(name=default_branch.name, schema=schema_default_branch)
-
-            async with db.start_transaction() as dbt:
-                await registry.schema.update_schema_branch(
-                    schema=candidate_schema,
-                    db=dbt,
-                    branch=default_branch.name,
-                    diff=result.diff,
-                    limit=result.diff.all,
-                    update_db=True,
-                )
-                default_branch.update_schema_hash()
-                rprint("The Core Schema has been updated")
-                if debug:
-                    rprint(f"New schema hash: {default_branch.active_schema_hash.main}")
-                await default_branch.save(db=dbt)
-
-            # ----------------------------------------------------------
-            # Run the migrations
-            # ----------------------------------------------------------
-            apply_migration_data = SchemaApplyMigrationData(
-                branch=default_branch,
-                new_schema=candidate_schema,
-                previous_schema=origin_schema,
-                migrations=result.migrations,
-            )
-            migration_error_msgs = await schema_apply_migrations(message=apply_migration_data, service=service)
-
-            if migration_error_msgs:
-                rprint(f"{error_badge} | Some error(s) happened while running the schema migrations")
-                for message in migration_error_msgs:
-                    rprint(message)
-                raise typer.Exit(1)
-
-            await create_defaults(db=db)
+    await dbdriver.close()
 
 
 @app.command()
@@ -407,36 +264,158 @@ async def index(
     await dbdriver.close()
 
 
-async def create_defaults(db: InfrahubDatabase) -> None:
-    """Create and assign default objects."""
-    existing_permissions = await NodeManager.query(
-        schema=InfrahubKind.OBJECTPERMISSION,
-        db=db,
-        limit=1,
+async def migrate_database(db: InfrahubDatabase, initialize: bool = False, check: bool = False) -> None:
+    """Apply the latest migrations to the database, this function will print the status directly in the console.
+
+    This function is expected to run on an empty
+
+    Args:
+        db: The database object.
+        check: If True, the function will only check the status of the database and not apply the migrations. Defaults to False.
+    """
+    rprint("Checking current state of the Database")
+
+    if initialize:
+        await initialize_registry(db=db)
+
+    root_node = await get_root_node(db=db)
+    migrations = await get_graph_migrations(root=root_node)
+
+    if not migrations:
+        rprint(f"Database up-to-date (v{root_node.graph_version}), no migration to execute.")
+        return
+
+    rprint(
+        f"Database needs to be updated (v{root_node.graph_version} -> v{GRAPH_VERSION}), {len(migrations)} migrations pending"
     )
-    if not existing_permissions:
-        await setup_permissions(db=db)
 
-    menu_nodes = await get_existing_menu(db=db)
-    menu_items = await MenuDict.from_db(db=db, nodes=list(menu_nodes.values()))
-    default_menu_dict = MenuDict.from_definition_list(default_menu)
+    if check:
+        return
 
-    if not menu_nodes:
-        await create_default_menu(db=db)
-    else:
-        await update_menu(db=db, existing_menu=menu_items, new_menu=default_menu_dict, menu_nodes=menu_nodes)
+    for migration in migrations:
+        execution_result = await migration.execute(db=db)
+        validation_result = None
+
+        if execution_result.success:
+            validation_result = await migration.validate_migration(db=db)
+            if validation_result.success:
+                rprint(f"Migration: {migration.name} {SUCCESS_BADGE}")
+                root_node.graph_version = migration.minimum_version + 1
+                await root_node.save(db=db)
+
+        if not execution_result.success or validation_result and not validation_result.success:
+            rprint(f"Migration: {migration.name} {FAILED_BADGE}")
+            for error in execution_result.errors:
+                rprint(f"  {error}")
+            if validation_result and not validation_result.success:
+                for error in validation_result.errors:
+                    rprint(f"  {error}")
+            break
 
 
-async def setup_permissions(db: InfrahubDatabase) -> None:
-    existing_accounts = await NodeManager.query(
-        schema=InfrahubKind.ACCOUNT,
-        db=db,
-        limit=1,
+async def initialize_internal_schema() -> None:
+    registry.schema = SchemaManager()
+    schema = SchemaRoot(**internal_schema)
+    registry.schema.register_schema(schema=schema)
+
+
+async def update_core_schema(
+    db: InfrahubDatabase, service: InfrahubServices, initialize: bool = True, debug: bool = False
+) -> None:
+    """Update the core schema of Infrahub to the latest version"""
+    # ----------------------------------------------------------
+    # Initialize Schema and Registry
+    # ----------------------------------------------------------
+    if initialize:
+        await initialize_registry(db=db)
+        await initialize_internal_schema()
+
+    default_branch = registry.get_branch_from_registry(branch=registry.default_branch)
+
+    # ----------------------------------------------------------
+    # Load Current Schema from the database
+    # ----------------------------------------------------------
+    schema_default_branch = await registry.schema.load_schema_from_db(db=db, branch=default_branch)
+    registry.schema.set_schema_branch(name=default_branch.name, schema=schema_default_branch)
+    branch_schema = registry.schema.get_schema_branch(name=registry.default_branch)
+
+    candidate_schema = branch_schema.duplicate()
+    candidate_schema.load_schema(schema=SchemaRoot(**internal_schema))
+    candidate_schema.load_schema(schema=SchemaRoot(**core_models))
+    candidate_schema.load_schema(schema=SchemaRoot(**deprecated_models))
+    candidate_schema.process()
+
+    schema_diff = branch_schema.diff(other=candidate_schema)
+    branch_schema.validate_node_deletions(diff=schema_diff)
+    result = branch_schema.validate_update(other=candidate_schema, diff=schema_diff, enforce_update_support=False)
+    if result.errors:
+        rprint(f"{ERROR_BADGE} | Unable to update the schema, due to failed validations")
+        for error in result.errors:
+            rprint(error.to_string())
+        raise typer.Exit(1)
+
+    if not result.diff.all:
+        rprint("Core Schema Up to date, nothing to update")
+        return
+
+    rprint("Core Schema has diff, will need to be updated")
+    if debug:
+        result.diff.print()
+
+    # ----------------------------------------------------------
+    # Validate if the new schema is valid with the content of the database
+    # ----------------------------------------------------------
+    validate_migration_data = SchemaValidateMigrationData(
+        branch=default_branch,
+        schema_branch=candidate_schema,
+        constraints=result.constraints,
     )
-    administrator_role = await create_super_administrator_role(db=db)
-    await create_super_administrators_group(db=db, role=administrator_role, admin_accounts=existing_accounts)
+    responses = await schema_validate_migrations(message=validate_migration_data, service=service)
+    error_messages = [violation.message for response in responses for violation in response.violations]
+    if error_messages:
+        rprint(f"{ERROR_BADGE} | Unable to update the schema, due to failed validations")
+        for message in error_messages:
+            rprint(message)
+        raise typer.Exit(1)
 
-    await create_default_roles(db=db)
+    # ----------------------------------------------------------
+    # Update the schema
+    # ----------------------------------------------------------
+    origin_schema = branch_schema.duplicate()
 
-    if config.SETTINGS.main.allow_anonymous_access:
-        await create_anonymous_role(db=db)
+    # Update the internal schema
+    schema_default_branch.load_schema(schema=SchemaRoot(**internal_schema))
+    schema_default_branch.process()
+    registry.schema.set_schema_branch(name=default_branch.name, schema=schema_default_branch)
+
+    async with db.start_transaction() as dbt:
+        await registry.schema.update_schema_branch(
+            schema=candidate_schema,
+            db=dbt,
+            branch=default_branch.name,
+            diff=result.diff,
+            limit=result.diff.all,
+            update_db=True,
+        )
+        default_branch.update_schema_hash()
+        rprint("The Core Schema has been updated")
+        if debug:
+            rprint(f"New schema hash: {default_branch.active_schema_hash.main}")
+        await default_branch.save(db=dbt)
+
+    # ----------------------------------------------------------
+    # Run the migrations
+    # ----------------------------------------------------------
+    apply_migration_data = SchemaApplyMigrationData(
+        branch=default_branch,
+        new_schema=candidate_schema,
+        previous_schema=origin_schema,
+        migrations=result.migrations,
+    )
+    migration_error_msgs = await schema_apply_migrations(message=apply_migration_data, service=service)
+
+    if migration_error_msgs:
+        rprint(f"{ERROR_BADGE} | Some error(s) happened while running the schema migrations")
+        for message in migration_error_msgs:
+            rprint(message)
+        raise typer.Exit(1)

--- a/backend/infrahub/cli/upgrade.py
+++ b/backend/infrahub/cli/upgrade.py
@@ -22,7 +22,8 @@ from infrahub.core.initialization import (
 from infrahub.core.manager import NodeManager
 from infrahub.menu.menu import default_menu
 from infrahub.menu.models import MenuDict
-from infrahub.menu.utils import create_default_menu, get_existing_menu, update_menu
+from infrahub.menu.repository import MenuRepository
+from infrahub.menu.utils import create_default_menu
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.message_bus.local import BusSimulator
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
@@ -104,8 +105,9 @@ async def upgrade_cmd(
 
 
 async def upgrade_menu(db: InfrahubDatabase) -> None:
-    menu_nodes = await get_existing_menu(db=db)
-    menu_items = await MenuDict.from_db(db=db, nodes=list(menu_nodes.values()))
+    menu_repository = MenuRepository(db=db)
+    menu_nodes = await menu_repository.get_menu_db()
+    menu_items = await menu_repository.get_menu(nodes=menu_nodes)
     default_menu_dict = MenuDict.from_definition_list(default_menu)
 
     if not menu_nodes:
@@ -118,7 +120,7 @@ async def upgrade_menu(db: InfrahubDatabase) -> None:
         rprint("Menu Up to date, nothing to update")
         return
 
-    await update_menu(db=db, existing_menu=menu_items, new_menu=default_menu_dict, menu_nodes=menu_nodes)
+    await menu_repository.update_menu(existing_menu=menu_items, new_menu=default_menu_dict, menu_nodes=menu_nodes)
     rprint("Menu has been updated")
 
 

--- a/backend/infrahub/cli/upgrade.py
+++ b/backend/infrahub/cli/upgrade.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import typer
 from deepdiff import DeepDiff
 from infrahub_sdk.async_typer import AsyncTyper
-from prefect.testing.utilities import prefect_test_harness
+from prefect.client.orchestration import get_client
 from rich import print as rprint
 
 from infrahub import config
@@ -26,6 +26,12 @@ from infrahub.menu.utils import create_default_menu, get_existing_menu, update_m
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.message_bus.local import BusSimulator
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
+from infrahub.workflows.initialization import (
+    setup_blocks,
+    setup_deployments,
+    setup_task_manager,
+    setup_worker_pools,
+)
 
 from .db import initialize_internal_schema, migrate_database, update_core_schema
 
@@ -59,24 +65,40 @@ async def upgrade_cmd(
     )
     await initialize_registry(db=dbdriver)
 
-    with prefect_test_harness():
-        # -------------------------------------------
-        # Add pre-upgrade  validation
-        # -------------------------------------------
+    # NOTE add step to validate if the database and the task manager are reachable
 
-        # -------------------------------------------
-        # Upgrade Infrahub Database and Schema
-        # -------------------------------------------
-        await migrate_database(db=dbdriver, initialize=False, check=check)
+    # -------------------------------------------
+    # Add pre-upgrade  validation
+    # -------------------------------------------
 
-        await initialize_internal_schema()
-        await update_core_schema(db=dbdriver, service=service, initialize=False)
+    # -------------------------------------------
+    # Upgrade Infrahub Database and Schema
+    # -------------------------------------------
+    await migrate_database(db=dbdriver, initialize=False, check=check)
 
-        # -------------------------------------------
-        # Upgrade Internal Objects, generated and managed by Infrahub
-        # -------------------------------------------
-        await upgrade_menu(db=dbdriver)
-        await upgrade_permissions(db=dbdriver)
+    await initialize_internal_schema()
+    await update_core_schema(db=dbdriver, service=service, initialize=False)
+
+    # -------------------------------------------
+    # Upgrade Internal Objects, generated and managed by Infrahub
+    # -------------------------------------------
+    await upgrade_menu(db=dbdriver)
+    await upgrade_permissions(db=dbdriver)
+
+    # -------------------------------------------
+    # Upgrade External system : Task Manager
+    # -------------------------------------------
+    await setup_task_manager()
+
+    async with get_client(sync_client=False) as client:
+        await setup_blocks()
+        await setup_worker_pools(client=client)
+        await setup_deployments(client=client)
+        # await setup_triggers(
+        #     client=client,
+        #     triggers=builtin_triggers,
+        #     trigger_type=TriggerType.BUILTIN,
+        # )
 
     await dbdriver.close()
 

--- a/backend/infrahub/cli/upgrade.py
+++ b/backend/infrahub/cli/upgrade.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING
+
+import typer
+from deepdiff import DeepDiff
+from infrahub_sdk.async_typer import AsyncTyper
+from prefect.testing.utilities import prefect_test_harness
+from rich import print as rprint
+
+from infrahub import config
+from infrahub.core.constants import InfrahubKind
+from infrahub.core.initialization import (
+    create_anonymous_role,
+    create_default_roles,
+    create_super_administrator_role,
+    create_super_administrators_group,
+    initialize_registry,
+)
+from infrahub.core.manager import NodeManager
+from infrahub.menu.menu import default_menu
+from infrahub.menu.models import MenuDict
+from infrahub.menu.utils import create_default_menu, get_existing_menu, update_menu
+from infrahub.services import InfrahubServices
+from infrahub.services.adapters.message_bus.local import BusSimulator
+from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
+
+from .db import initialize_internal_schema, migrate_database, update_core_schema
+
+if TYPE_CHECKING:
+    from infrahub.cli.context import CliContext
+    from infrahub.database import InfrahubDatabase
+
+app = AsyncTyper()
+
+
+@app.command(name="upgrade")
+async def upgrade_cmd(
+    ctx: typer.Context,
+    config_file: str = typer.Argument("infrahub.toml", envvar="INFRAHUB_CONFIG"),
+    check: bool = typer.Option(False, help="Check the state of the system without upgrading."),
+) -> None:
+    """Upgrade Infrahub to the latest version."""
+
+    logging.getLogger("infrahub").setLevel(logging.WARNING)
+    logging.getLogger("neo4j").setLevel(logging.ERROR)
+    logging.getLogger("prefect").setLevel(logging.ERROR)
+    os.environ["PREFECT_SERVER_ANALYTICS_ENABLED"] = "false"
+
+    config.load_and_exit(config_file_name=config_file)
+
+    context: CliContext = ctx.obj
+    dbdriver = await context.init_db(retry=1)
+
+    service = await InfrahubServices.new(
+        database=dbdriver, message_bus=BusSimulator(), workflow=WorkflowLocalExecution()
+    )
+    await initialize_registry(db=dbdriver)
+
+    with prefect_test_harness():
+        # -------------------------------------------
+        # Add pre-upgrade  validation
+        # -------------------------------------------
+
+        # -------------------------------------------
+        # Upgrade Infrahub Database and Schema
+        # -------------------------------------------
+        await migrate_database(db=dbdriver, initialize=False, check=check)
+
+        await initialize_internal_schema()
+        await update_core_schema(db=dbdriver, service=service, initialize=False)
+
+        # -------------------------------------------
+        # Upgrade Internal Objects, generated and managed by Infrahub
+        # -------------------------------------------
+        await upgrade_menu(db=dbdriver)
+        await upgrade_permissions(db=dbdriver)
+
+    await dbdriver.close()
+
+
+async def upgrade_menu(db: InfrahubDatabase) -> None:
+    menu_nodes = await get_existing_menu(db=db)
+    menu_items = await MenuDict.from_db(db=db, nodes=list(menu_nodes.values()))
+    default_menu_dict = MenuDict.from_definition_list(default_menu)
+
+    if not menu_nodes:
+        await create_default_menu(db=db)
+        return
+
+    diff_menu = DeepDiff(menu_items.to_rest(), default_menu_dict.to_rest(), ignore_order=True)
+
+    if not diff_menu:
+        rprint("Menu Up to date, nothing to update")
+        return
+
+    await update_menu(db=db, existing_menu=menu_items, new_menu=default_menu_dict, menu_nodes=menu_nodes)
+    rprint("Menu has been updated")
+
+
+async def upgrade_permissions(db: InfrahubDatabase) -> None:
+    existing_permissions = await NodeManager.query(
+        schema=InfrahubKind.OBJECTPERMISSION,
+        db=db,
+        limit=1,
+    )
+    if existing_permissions:
+        rprint("Permissions Up to date, nothing to update")
+        return
+
+    await setup_permissions(db=db)
+    rprint("Permissions have been updated")
+
+
+async def setup_permissions(db: InfrahubDatabase) -> None:
+    existing_accounts = await NodeManager.query(
+        schema=InfrahubKind.ACCOUNT,
+        db=db,
+        limit=1,
+    )
+    administrator_role = await create_super_administrator_role(db=db)
+    await create_super_administrators_group(db=db, role=administrator_role, admin_accounts=existing_accounts)
+    await create_default_roles(db=db)
+
+    if config.SETTINGS.main.allow_anonymous_access:
+        await create_anonymous_role(db=db)

--- a/backend/infrahub/menu/models.py
+++ b/backend/infrahub/menu/models.py
@@ -77,35 +77,6 @@ class MenuDict:
     def get_all_identifiers(self) -> set[str]:
         return {identifier for item in self.data.values() for identifier in item.get_all_identifiers()}
 
-    @classmethod
-    async def from_db(cls, db: InfrahubDatabase, nodes: list[CoreMenuItem]) -> Self:
-        menu = cls()
-        menu_by_ids = {menu_node.get_id(): MenuItemDict.from_node(menu_node) for menu_node in nodes}
-
-        async def add_children(menu_item: MenuItemDict, menu_node: CoreMenuItem) -> MenuItemDict:
-            children = await menu_node.children.get_peers(db=db, peer_type=CoreMenuItem)
-            for child_id, child_node in children.items():
-                child_menu_item = menu_by_ids[child_id]
-                child = await add_children(child_menu_item, child_node)
-                menu_item.children[str(child.identifier)] = child
-            return menu_item
-
-        for menu_node in nodes:
-            menu_item = menu_by_ids[menu_node.get_id()]
-            parent = await menu_node.parent.get_peer(db=db, peer_type=CoreMenuItem)
-            if parent:
-                continue
-
-            children = await menu_node.children.get_peers(db=db, peer_type=CoreMenuItem)
-            for child_id, child_node in children.items():
-                child_menu_item = menu_by_ids[child_id]
-                child = await add_children(child_menu_item, child_node)
-                menu_item.children[str(child.identifier)] = child
-
-            menu.data[str(menu_item.identifier)] = menu_item
-
-        return menu
-
 
 @dataclass
 class Menu:
@@ -113,7 +84,7 @@ class Menu:
 
 
 class MenuItem(BaseModel):
-    _id: str | None = None
+    id: str | None = None
     namespace: str = Field(..., description="Namespace of the menu item")
     name: str = Field(..., description="Name of the menu item")
     description: str = Field(default="", description="Description of the menu item")
@@ -142,7 +113,7 @@ class MenuItem(BaseModel):
     @classmethod
     def from_node(cls, obj: CoreMenuItem) -> Self:
         return cls(
-            _id=obj.get_id(),
+            id=obj.get_id(),
             name=obj.name.value,
             namespace=obj.namespace.value,
             protected=obj.protected.value,
@@ -246,7 +217,6 @@ class MenuItemList(MenuItem):
 
 
 class MenuItemDefinition(BaseModel):
-    _id: str | None = None
     namespace: str
     name: str
     label: str
@@ -281,7 +251,6 @@ class MenuItemDefinition(BaseModel):
     @classmethod
     async def from_node(cls, node: CoreMenuItem) -> Self:
         return cls(
-            _id=node.get_id(),
             namespace=node.namespace.value,
             name=node.name.value,
             label=node.label.value or "",

--- a/backend/infrahub/menu/repository.py
+++ b/backend/infrahub/menu/repository.py
@@ -1,0 +1,111 @@
+from infrahub.core.manager import NodeManager
+from infrahub.core.protocols import CoreMenuItem
+from infrahub.database import InfrahubDatabase
+
+from .models import MenuDict, MenuItemDefinition, MenuItemDict
+
+
+class MenuRepository:
+    def __init__(self, db: InfrahubDatabase):
+        self.db = db
+
+    async def get_menu(self, nodes: dict[str, CoreMenuItem] | None = None) -> MenuDict:
+        menu_nodes = nodes or await self.get_menu_db()
+        return await self._convert_menu_from_db(nodes=menu_nodes)
+
+    async def _convert_menu_from_db(self, nodes: dict[str, CoreMenuItem]) -> MenuDict:
+        menu = MenuDict()
+        menu_by_ids = {menu_node.get_id(): MenuItemDict.from_node(menu_node) for menu_node in nodes.values()}
+
+        async def add_children(menu_item: MenuItemDict, menu_node: CoreMenuItem) -> MenuItemDict:
+            children = await menu_node.children.get_peers(db=self.db, peer_type=CoreMenuItem)
+            for child_id, child_node in children.items():
+                child_menu_item = menu_by_ids[child_id]
+                child = await add_children(child_menu_item, child_node)
+                menu_item.children[str(child.identifier)] = child
+            return menu_item
+
+        for menu_node in nodes.values():
+            menu_item = menu_by_ids[menu_node.get_id()]
+            parent = await menu_node.parent.get_peer(db=self.db, peer_type=CoreMenuItem)
+            if parent:
+                continue
+
+            children = await menu_node.children.get_peers(db=self.db, peer_type=CoreMenuItem)
+            for child_id, child_node in children.items():
+                child_menu_item = menu_by_ids[child_id]
+                child = await add_children(child_menu_item, child_node)
+                menu_item.children[str(child.identifier)] = child
+
+            menu.data[str(menu_item.identifier)] = menu_item
+
+        return menu
+
+    async def get_menu_db(self) -> dict[str, CoreMenuItem]:
+        menu_nodes = await NodeManager.query(
+            schema=CoreMenuItem,
+            filters={"namespace__value": "Builtin"},
+            prefetch_relationships=True,
+            db=self.db,
+        )
+        return {node.get_id(): node for node in menu_nodes}
+
+    async def create_menu(self, menu: list[MenuItemDefinition]) -> None:
+        for item in menu:
+            obj = await item.to_node(db=self.db)
+            await obj.save(db=self.db)
+            if item.children:
+                await self.create_menu_children(parent=obj, children=item.children)
+
+    async def create_menu_children(self, parent: CoreMenuItem, children: list[MenuItemDefinition]) -> None:
+        for child in children:
+            obj = await child.to_node(db=self.db, parent=parent)
+            await obj.save(db=self.db)
+            if child.children:
+                await self.create_menu_children(parent=obj, children=child.children)
+
+    async def update_menu(
+        self, existing_menu: MenuDict, new_menu: MenuDict, menu_nodes: dict[str, CoreMenuItem]
+    ) -> None:
+        async def process_menu_item(menu_item: MenuItemDict, parent: CoreMenuItem | None) -> None:
+            existing_item = existing_menu.find_item(name=str(menu_item.identifier))
+            if existing_item and existing_item.id:
+                node = menu_nodes[existing_item.id]
+                await self.update_menu_item(
+                    node=node, existing_menu_item=existing_item, new_menu_item=menu_item, parent=parent
+                )
+            else:
+                node = await self.create_menu_item(new_menu_item=menu_item, parent=parent)
+
+            for child_item in menu_item.children.values():
+                await process_menu_item(menu_item=child_item, parent=node)
+
+        for top_level_item in new_menu.data.values():
+            await process_menu_item(menu_item=top_level_item, parent=None)
+
+        # Delete items that are not in the new menu
+        menu_to_delete = existing_menu.get_all_identifiers() - new_menu.get_all_identifiers()
+        for item_to_delete in menu_to_delete:
+            existing_item = existing_menu.find_item(name=item_to_delete)
+            if existing_item and existing_item.id:
+                node = menu_nodes[existing_item.id]
+                await node.delete(db=self.db)
+
+    async def update_menu_item(
+        self,
+        node: CoreMenuItem,
+        existing_menu_item: MenuItemDict,
+        new_menu_item: MenuItemDict,
+        parent: CoreMenuItem | None,
+    ) -> None:
+        attrs_to_update = existing_menu_item.diff_attributes(new_menu_item)
+        for attr_name, value in attrs_to_update.items():
+            attr = getattr(node, attr_name)
+            attr.value = value
+        await node.parent.update(data=parent, db=self.db)  # type: ignore[arg-type]
+        await node.save(db=self.db)
+
+    async def create_menu_item(self, new_menu_item: MenuItemDict, parent: CoreMenuItem | None) -> CoreMenuItem:
+        obj = await new_menu_item.to_node(db=self.db, parent=parent)
+        await obj.save(db=self.db)
+        return obj

--- a/backend/infrahub/menu/utils.py
+++ b/backend/infrahub/menu/utils.py
@@ -1,87 +1,9 @@
-from infrahub.core.manager import NodeManager
-from infrahub.core.protocols import CoreMenuItem
 from infrahub.database import InfrahubDatabase
 
 from .menu import default_menu
-from .models import MenuDict, MenuItemDefinition, MenuItemDict
+from .repository import MenuRepository
 
 
 async def create_default_menu(db: InfrahubDatabase) -> None:
-    await create_menu(db=db, menu=default_menu)
-
-
-async def create_menu(db: InfrahubDatabase, menu: list[MenuItemDefinition]) -> None:
-    for item in menu:
-        obj = await item.to_node(db=db)
-        await obj.save(db=db)
-        if item.children:
-            await create_menu_children(db=db, parent=obj, children=item.children)
-
-
-async def create_menu_children(db: InfrahubDatabase, parent: CoreMenuItem, children: list[MenuItemDefinition]) -> None:
-    for child in children:
-        obj = await child.to_node(db=db, parent=parent)
-        await obj.save(db=db)
-        if child.children:
-            await create_menu_children(db=db, parent=obj, children=child.children)
-
-
-async def get_existing_menu(db: InfrahubDatabase) -> dict[str, CoreMenuItem]:
-    menu_nodes = await NodeManager.query(
-        schema=CoreMenuItem,
-        filters={"namespace__value": "Builtin"},
-        prefetch_relationships=True,
-        db=db,
-    )
-    return {node.get_id(): node for node in menu_nodes}
-
-
-async def update_menu_item(
-    db: InfrahubDatabase,
-    node: CoreMenuItem,
-    existing_menu_item: MenuItemDict,
-    new_menu_item: MenuItemDict,
-    parent: CoreMenuItem | None,
-) -> None:
-    attrs_to_update = existing_menu_item.diff_attributes(new_menu_item)
-    for attr_name, value in attrs_to_update.items():
-        attr = getattr(node, attr_name)
-        attr.value = value
-    await node.parent.update(data=parent, db=db)  # type: ignore[arg-type]
-    await node.save(db=db)
-
-
-async def create_menu_item(
-    db: InfrahubDatabase, new_menu_item: MenuItemDict, parent: CoreMenuItem | None
-) -> CoreMenuItem:
-    obj = await new_menu_item.to_node(db=db, parent=parent)
-    await obj.save(db=db)
-    return obj
-
-
-async def update_menu(
-    db: InfrahubDatabase, existing_menu: MenuDict, new_menu: MenuDict, menu_nodes: dict[str, CoreMenuItem]
-) -> None:
-    async def process_menu_item(menu_item: MenuItemDict, parent: CoreMenuItem | None) -> None:
-        existing_item = existing_menu.find_item(name=str(menu_item.identifier))
-        if existing_item and existing_item._id:
-            node = menu_nodes[existing_item._id]
-            await update_menu_item(
-                db=db, node=node, existing_menu_item=existing_item, new_menu_item=menu_item, parent=parent
-            )
-        else:
-            node = await create_menu_item(db=db, new_menu_item=menu_item, parent=parent)
-
-        for child_item in menu_item.children.values():
-            await process_menu_item(menu_item=child_item, parent=node)
-
-    for top_level_item in new_menu.data.values():
-        await process_menu_item(menu_item=top_level_item, parent=None)
-
-    # Delete items that are not in the new menu
-    menu_to_delete = existing_menu.get_all_identifiers() - new_menu.get_all_identifiers()
-    for item_to_delete in menu_to_delete:
-        existing_item = existing_menu.find_item(name=item_to_delete)
-        if existing_item and existing_item._id:
-            node = menu_nodes[existing_item._id]
-            await node.delete(db=db)
+    repository = MenuRepository(db=db)
+    await repository.create_menu(menu=default_menu)

--- a/backend/tests/unit/menu/conftest.py
+++ b/backend/tests/unit/menu/conftest.py
@@ -5,7 +5,7 @@ from infrahub.core.constants import InfrahubKind
 from infrahub.database import InfrahubDatabase
 from infrahub.menu.constants import DEFAULT_MENU
 from infrahub.menu.models import MenuItemDefinition, MenuSection
-from infrahub.menu.utils import create_menu
+from infrahub.menu.repository import MenuRepository
 
 
 @pytest.fixture
@@ -114,8 +114,15 @@ async def menu_fixture_01_data() -> list[MenuItemDefinition]:
 
 
 @pytest.fixture
-async def menu_fixture_01(db: InfrahubDatabase, default_branch: Branch, menu_fixture_01_data: list[MenuItemDefinition]):
-    await create_menu(db=db, menu=menu_fixture_01_data)
+async def menu_repository(db: InfrahubDatabase) -> MenuRepository:
+    return MenuRepository(db=db)
+
+
+@pytest.fixture
+async def menu_fixture_01(
+    menu_repository: MenuRepository, default_branch: Branch, menu_fixture_01_data: list[MenuItemDefinition]
+):
+    await menu_repository.create_menu(menu=menu_fixture_01_data)
 
 
 @pytest.fixture

--- a/backend/tests/unit/menu/test_generator.py
+++ b/backend/tests/unit/menu/test_generator.py
@@ -7,7 +7,7 @@ from infrahub.database import InfrahubDatabase
 from infrahub.menu.constants import FULL_DEFAULT_MENU, MenuSection
 from infrahub.menu.generator import generate_menu
 from infrahub.menu.models import MenuItemDefinition
-from infrahub.menu.utils import create_menu_children
+from infrahub.menu.repository import MenuRepository
 
 
 def generate_menu_fixtures(prefix: str = "Menu", depth: int = 1, nbr_item: int = 10) -> list[MenuItemDefinition]:
@@ -37,6 +37,7 @@ async def test_generate_menu_placement(
     db: InfrahubDatabase,
     default_branch: Branch,
     car_person_schema_generics: SchemaRoot,
+    menu_repository: MenuRepository,
     helper,
 ):
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
@@ -48,12 +49,7 @@ async def test_generate_menu_placement(
     await create_default_menu(db=db)
 
     new_menu_items = generate_menu_fixtures(nbr_item=2)
-
-    for item in new_menu_items:
-        obj = await item.to_node(db=db)
-        await obj.save(db=db)
-        if item.children:
-            await create_menu_children(db=db, parent=obj, children=item.children)
+    await menu_repository.create_menu(menu=new_menu_items)
 
     menu_items = await registry.manager.query(db=db, schema=CoreMenuItem, branch=default_branch)
     menu = await generate_menu(db=db, branch=default_branch, menu_items=menu_items)
@@ -66,6 +62,7 @@ async def test_generate_menu_placement(
 
 async def test_generate_menu_top_level(
     db: InfrahubDatabase,
+    menu_repository: MenuRepository,
     default_branch: Branch,
     car_person_schema_generics: SchemaRoot,
     helper,
@@ -73,12 +70,7 @@ async def test_generate_menu_top_level(
     await create_default_menu(db=db)
 
     new_menu_items = generate_menu_fixtures(nbr_item=2)
-
-    for item in new_menu_items:
-        obj = await item.to_node(db=db)
-        await obj.save(db=db)
-        if item.children:
-            await create_menu_children(db=db, parent=obj, children=item.children)
+    await menu_repository.create_menu(menu=new_menu_items)
 
     menu_items = await registry.manager.query(db=db, schema=CoreMenuItem, branch=default_branch)
     menu = await generate_menu(db=db, branch=default_branch, menu_items=menu_items)
@@ -91,6 +83,7 @@ async def test_generate_menu_top_level(
 
 async def test_generate_menu_default(
     db: InfrahubDatabase,
+    menu_repository: MenuRepository,
     default_branch: Branch,
     car_person_schema_generics: SchemaRoot,
     helper,
@@ -103,12 +96,7 @@ async def test_generate_menu_default(
     await create_default_menu(db=db)
 
     new_menu_items = generate_menu_fixtures(nbr_item=2)
-
-    for item in new_menu_items:
-        obj = await item.to_node(db=db)
-        await obj.save(db=db)
-        if item.children:
-            await create_menu_children(db=db, parent=obj, children=item.children)
+    await menu_repository.create_menu(menu=new_menu_items)
 
     menu_items = await registry.manager.query(db=db, schema=CoreMenuItem, branch=default_branch)
     menu = await generate_menu(db=db, branch=default_branch, menu_items=menu_items)

--- a/backend/tests/unit/menu/test_repository.py
+++ b/backend/tests/unit/menu/test_repository.py
@@ -2,80 +2,78 @@ from deepdiff import DeepDiff
 
 from infrahub.core.branch import Branch
 from infrahub.core.schema import SchemaRoot
-from infrahub.database import InfrahubDatabase
 from infrahub.menu.menu import default_menu
 from infrahub.menu.models import MenuDict, MenuItemDefinition
-from infrahub.menu.utils import create_menu, get_existing_menu, update_menu
+from infrahub.menu.repository import MenuRepository
 
 
-async def test_get_existing_menu(
-    db: InfrahubDatabase,
+async def test_get_menu(
+    menu_repository: MenuRepository,
     default_branch: Branch,
     register_core_models_schema: SchemaRoot,
     menu_fixture_01: list[MenuItemDefinition],
 ):
-    menu_nodes = await get_existing_menu(db=db)
-    existing_menu = await MenuDict.from_db(db=db, nodes=list(menu_nodes.values()))
+    existing_menu = await menu_repository.get_menu()
+
     assert sorted(existing_menu.data.keys()) == [
         "BuiltinDeployment",
         "BuiltinIPAM",
         "BuiltinOther",
         "BuiltinProposedChanges",
     ]
+    assert existing_menu.data["BuiltinDeployment"].id
     assert existing_menu.data["BuiltinDeployment"].children["BuiltinArtifactMenu"]
+    assert existing_menu.data["BuiltinDeployment"].children["BuiltinArtifactMenu"].id
     assert existing_menu.data["BuiltinDeployment"].children["BuiltinArtifactMenu"].children["BuiltinArtifact"]
+    assert existing_menu.data["BuiltinDeployment"].children["BuiltinArtifactMenu"].children["BuiltinArtifact"].id
 
 
 async def test_update_menu_small_dataset(
-    db: InfrahubDatabase,
+    menu_repository: MenuRepository,
     default_branch: Branch,
     register_core_models_schema: SchemaRoot,
     menu_fixture_11_data: list[MenuItemDefinition],
     menu_fixture_12_data: list[MenuItemDefinition],
 ):
-    await create_menu(db=db, menu=menu_fixture_11_data)
+    await menu_repository.create_menu(menu=menu_fixture_11_data)
 
-    menu_nodes = await get_existing_menu(db=db)
-    existing_menu = await MenuDict.from_db(db=db, nodes=list(menu_nodes.values()))
+    menu_nodes = await menu_repository.get_menu_db()
+    existing_menu = await menu_repository.get_menu(nodes=menu_nodes)
 
     initial_menu_dict = MenuDict.from_definition_list(menu_fixture_12_data)
 
-    await update_menu(
-        db=db,
+    await menu_repository.update_menu(
         existing_menu=existing_menu,
         new_menu=initial_menu_dict,
         menu_nodes=menu_nodes,
     )
 
-    menu_nodes_after = await get_existing_menu(db=db)
-    menu_after = await MenuDict.from_db(db=db, nodes=list(menu_nodes_after.values()))
+    menu_after = await menu_repository.get_menu()
 
     diff = DeepDiff(initial_menu_dict.to_rest().sections["object"], menu_after.to_rest().sections["object"])
     assert diff == {}
 
 
 async def test_update_menu_default_menu(
-    db: InfrahubDatabase,
+    menu_repository: MenuRepository,
     default_branch: Branch,
     register_core_models_schema: SchemaRoot,
     menu_fixture_02_data: list[MenuItemDefinition],
 ):
-    await create_menu(db=db, menu=menu_fixture_02_data)
+    await menu_repository.create_menu(menu=menu_fixture_02_data)
 
-    menu_nodes = await get_existing_menu(db=db)
-    existing_menu = await MenuDict.from_db(db=db, nodes=list(menu_nodes.values()))
+    menu_nodes = await menu_repository.get_menu_db()
+    existing_menu = await menu_repository.get_menu(nodes=menu_nodes)
 
     default_menu_dict = MenuDict.from_definition_list(default_menu)
 
-    await update_menu(
-        db=db,
+    await menu_repository.update_menu(
         existing_menu=existing_menu,
         new_menu=default_menu_dict,
         menu_nodes=menu_nodes,
     )
 
-    menu_nodes_after = await get_existing_menu(db=db)
-    menu_after = await MenuDict.from_db(db=db, nodes=list(menu_nodes_after.values()))
+    menu_after = await menu_repository.get_menu()
 
     diff = DeepDiff(default_menu_dict.to_rest().sections["object"], menu_after.to_rest().sections["object"])
     assert diff == {}

--- a/tasks/container_ops.py
+++ b/tasks/container_ops.py
@@ -137,6 +137,16 @@ def update_core_schema(context: Context, database: str, namespace: Namespace, de
         execute_command(context=context, command=command)
 
 
+def upgrade_infrahub(context: Context, database: str, namespace: Namespace) -> None:
+    """Update Infrahub to the latest version."""
+    with context.cd(ESCAPED_REPO_PATH):
+        compose_files_cmd = build_compose_files_cmd(database=database, namespace=namespace)
+        compose_cmd = get_compose_cmd(namespace=namespace)
+        base_cmd = f"{get_env_vars(context, namespace=namespace)} {compose_cmd} {compose_files_cmd} -p {BUILD_NAME}"
+        command = f"{base_cmd} run {SERVICE_SERVER_NAME} infrahub upgrade"
+        execute_command(context=context, command=command)
+
+
 def format_bytes(bytes_value: int) -> str:
     """Convert bytes to human readable format."""
     for unit in ["B", "KB", "MB", "GB", "TB"]:

--- a/tasks/dev.py
+++ b/tasks/dev.py
@@ -9,13 +9,12 @@ from .container_ops import (
     build_images,
     destroy_environment,
     display_container_status,
-    migrate_database,
     pull_images,
     restart_services,
     show_service_status,
     start_services,
     stop_services,
-    update_core_schema,
+    upgrade_infrahub,
 )
 from .infra_ops import load_infrastructure_data, load_infrastructure_menu, load_infrastructure_schema
 from .shared import (
@@ -192,7 +191,6 @@ def stop(context: Context, database: str = INFRAHUB_DATABASE) -> None:
 
 
 @task(optional=["database"])
-def migrate(context: Context, database: str = INFRAHUB_DATABASE) -> None:
-    """Apply the latest database migrations."""
-    migrate_database(context=context, database=database, namespace=NAMESPACE)
-    update_core_schema(context=context, database=database, namespace=NAMESPACE, debug=True)
+def upgrade(context: Context, database: str = INFRAHUB_DATABASE) -> None:
+    """Upgrade Infrahub to the latest version and apply the required migrations."""
+    upgrade_infrahub(context=context, database=database, namespace=NAMESPACE)


### PR DESCRIPTION
Add a new command to execute all the steps required to upgrade infrahub instead of having to run multiple commands

Currently the command update the following components
- internal graph
- core schema
- menu
- permission

We also discussed about adding more validation before doing the upgrade to ensure that everything is good but this is not included in this PR