### PR TITLE
Fix deprecated warnings for Pydantic

### DIFF
--- a/backend/infrahub/core/migrations/schema/models.py
+++ b/backend/infrahub/core/migrations/schema/models.py
@@ -1,4 +1,6 @@
-from pydantic import BaseModel, ConfigDict, Field
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_serializer
 
 from infrahub.core.branch import Branch
 from infrahub.core.models import SchemaUpdateMigrationInfo
@@ -7,13 +9,26 @@ from infrahub.core.schema.schema_branch import SchemaBranch
 
 
 class SchemaApplyMigrationData(BaseModel):
-    model_config = ConfigDict(
-        arbitrary_types_allowed=True, json_encoders={SchemaBranch: SchemaBranch.to_dict_schema_object}
-    )
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     branch: Branch
     new_schema: SchemaBranch
     previous_schema: SchemaBranch
     migrations: list[SchemaUpdateMigrationInfo]
+
+    @model_serializer()
+    def serialize_model(self) -> dict[str, Any]:
+        return {
+            "branch": self.branch.model_dump(),
+            "previous_schema": self.previous_schema.to_dict_schema_object(),
+            "new_schema": self.new_schema.to_dict_schema_object(),
+            "migrations": [migration.model_dump() for migration in self.migrations],
+        }
+
+    @field_validator("new_schema", "previous_schema", mode="before")
+    @classmethod
+    def validate_schema_branch(cls, value: Any) -> SchemaBranch:
+        return SchemaBranch.validate(data=value)
 
 
 class SchemaMigrationPathResponseData(BaseModel):

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -4,7 +4,7 @@ import copy
 import hashlib
 from collections import defaultdict
 from itertools import chain, combinations
-from typing import TYPE_CHECKING, Any, Callable, Iterator
+from typing import Any
 
 from infrahub_sdk.topological_sort import DependencyCycleExistsError, topological_sort
 from infrahub_sdk.utils import compare_lists, deep_merge_dict, duplicates, intersection
@@ -62,9 +62,6 @@ from .schema_branch_computed import ComputedAttributes
 
 log = get_logger()
 
-if TYPE_CHECKING:
-    from pydantic import ValidationInfo
-
 
 class SchemaBranch:
     def __init__(
@@ -89,15 +86,11 @@ class SchemaBranch:
             self.templates = data.get("templates", {})
 
     @classmethod
-    def __get_validators__(cls) -> Iterator[Callable[..., Any]]:  # noqa: PLW3201
-        yield cls.validate
-
-    @classmethod
-    def validate(cls, v: Any, info: ValidationInfo) -> Self:  # noqa: ARG003
-        if isinstance(v, cls):
-            return v
-        if isinstance(v, dict):
-            return cls.from_dict_schema_object(data=v)
+    def validate(cls, data: Any) -> Self:  # noqa: ARG003
+        if isinstance(data, cls):
+            return data
+        if isinstance(data, dict):
+            return cls.from_dict_schema_object(data=data)
         raise ValueError("must be a class or a dict")
 
     @property

--- a/backend/infrahub/core/validators/models/validate_migration.py
+++ b/backend/infrahub/core/validators/models/validate_migration.py
@@ -1,4 +1,6 @@
-from pydantic import BaseModel, ConfigDict, Field
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_serializer
 
 from infrahub.core.branch import Branch
 from infrahub.core.models import SchemaUpdateConstraintInfo
@@ -9,12 +11,23 @@ from infrahub.message_bus import InfrahubResponseData
 
 
 class SchemaValidateMigrationData(BaseModel):
-    model_config = ConfigDict(
-        arbitrary_types_allowed=True, json_encoders={SchemaBranch: SchemaBranch.to_dict_schema_object}
-    )
+    model_config = ConfigDict(arbitrary_types_allowed=True)
     branch: Branch
     schema_branch: SchemaBranch
     constraints: list[SchemaUpdateConstraintInfo]
+
+    @model_serializer()
+    def serialize_model(self) -> dict[str, Any]:
+        return {
+            "branch": self.branch.model_dump(),
+            "schema_branch": self.schema_branch.to_dict_schema_object(),
+            "constraints": [constraint.model_dump() for constraint in self.constraints],
+        }
+
+    @field_validator("schema_branch", mode="before")
+    @classmethod
+    def validate_schema_branch(cls, value: Any) -> SchemaBranch:
+        return SchemaBranch.validate(data=value)
 
 
 class SchemaValidatorPathResponseData(InfrahubResponseData):

--- a/backend/tests/unit/core/constraint_validators/test_models.py
+++ b/backend/tests/unit/core/constraint_validators/test_models.py
@@ -1,0 +1,32 @@
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.constants import SchemaPathType
+from infrahub.core.models import SchemaUpdateConstraintInfo
+from infrahub.core.path import SchemaPath
+from infrahub.core.validators.models.validate_migration import SchemaValidateMigrationData
+from infrahub.database import InfrahubDatabase
+
+
+async def test_schema_validate_migrations(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_person_schema,
+):
+    schema = registry.schema.get_schema_branch(name=default_branch.name)
+
+    constraints = [
+        SchemaUpdateConstraintInfo(
+            constraint_name="attribute.regex.update",
+            path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="name"),
+        )
+    ]
+
+    migration_data = SchemaValidateMigrationData(branch=default_branch, schema_branch=schema, constraints=constraints)
+
+    # Validate that we can serialize and deserialize the SchemaValidateMigrationData properly
+    # This is important because the message is used in Prefect
+    data = migration_data.model_dump(mode="json")
+    assert data
+
+    new_migration_data = SchemaValidateMigrationData(**data)
+    assert new_migration_data.model_dump(mode="json") == data

--- a/backend/tests/unit/core/migrations/schema/test_models.py
+++ b/backend/tests/unit/core/migrations/schema/test_models.py
@@ -1,0 +1,36 @@
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.migrations.schema.models import SchemaApplyMigrationData
+from infrahub.core.models import SchemaUpdateMigrationInfo
+from infrahub.core.path import SchemaPath, SchemaPathType
+from infrahub.database import InfrahubDatabase
+
+
+def test_SchemaApplyMigrationData_serializer(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema, car_person_schema
+):
+    schema_main = registry.schema.get_schema_branch(name=default_branch.name)
+
+    data = SchemaApplyMigrationData(
+        branch=default_branch,
+        new_schema=schema_main,
+        previous_schema=schema_main,
+        migrations=[
+            SchemaUpdateMigrationInfo(
+                path=SchemaPath(
+                    path_type=SchemaPathType.ATTRIBUTE,
+                    schema_kind="TestCar",
+                    schema_id=None,
+                    field_name="4motion",
+                    property_name=None,
+                ),
+                migration_name="node.attribute.add",
+            ),
+        ],
+    )
+
+    data_dict = data.model_dump(mode="json")
+    assert data_dict
+
+    new_data = SchemaApplyMigrationData(**data_dict)
+    assert new_data.model_dump(mode="json") == data_dict


### PR DESCRIPTION
This PR fixes 2 warnings generated by pydantic related to deprecated features

```
`__get_validators__` is deprecated and will be removed, use `__get_pydantic_core_schema__` instead. 
Deprecated in Pydantic V2.0 to be removed in V3.0. 
See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.10/migration/
```

```
  `json_encoders` is deprecated. 
  See https://docs.pydantic.dev/2.10/concepts/serialization/#custom-serializers for alternatives. 
 Deprecated in Pydantic V2.0 to be removed in V3.0. 
 See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.10/migration/
```