### PR TITLE
Hide infrahub events and infrahub git-agent

### DIFF
--- a/backend/infrahub/cli/__init__.py
+++ b/backend/infrahub/cli/__init__.py
@@ -22,9 +22,9 @@ def common(ctx: typer.Context) -> None:
 
 
 app.add_typer(server_app, name="server")
-app.add_typer(git_app, name="git-agent")
+app.add_typer(git_app, name="git-agent", hidden=True)
 app.add_typer(db_app, name="db")
-app.add_typer(events_app, name="events", help="Interact with the events system.")
+app.add_typer(events_app, name="events", help="Interact with the events system.", hidden=True)
 app.add_typer(tasks_app, name="tasks", hidden=True)
 
 


### PR DESCRIPTION
Removes these command from `infrahub --help`

* infrahub git-agent
* infrahub events