### PR TITLE
IFC-1378 Fix generation of too many templates

### DIFF
--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1956,10 +1956,11 @@ class SchemaBranch:
         identified.add(node_schema)
 
         for relationship in node_schema.relationships:
-            if relationship.peer in [InfrahubKind.GENERICGROUP, InfrahubKind.PROFILE] or relationship.kind not in [
-                RelationshipKind.COMPONENT,
-                RelationshipKind.PARENT,
-            ]:
+            if (
+                relationship.peer in [InfrahubKind.GENERICGROUP, InfrahubKind.PROFILE]
+                or (relationship.kind == RelationshipKind.PARENT and node_schema.generate_template)
+                or relationship.kind not in [RelationshipKind.PARENT, RelationshipKind.COMPONENT]
+            ):
                 continue
 
             peer_schema = self.get(name=relationship.peer, duplicate=False)
@@ -1968,10 +1969,13 @@ class SchemaBranch:
             # In a context of a generic, we won't be able to create objects out of it, so any kind of nodes implementing the generic is a valid
             # option, we therefore need to have a template for each of those nodes
             if isinstance(peer_schema, GenericSchema) and peer_schema.used_by:
-                for used_by in peer_schema.used_by:
-                    identified |= self.identify_required_object_templates(
-                        node_schema=self.get(name=used_by, duplicate=False), identified=identified
-                    )
+                if relationship.kind != RelationshipKind.PARENT or not any(
+                    u in [i.kind for i in identified] for u in peer_schema.used_by
+                ):
+                    for used_by in peer_schema.used_by:
+                        identified |= self.identify_required_object_templates(
+                            node_schema=self.get(name=used_by, duplicate=False), identified=identified
+                        )
 
             identified |= self.identify_required_object_templates(node_schema=peer_schema, identified=identified)
 

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -3019,3 +3019,37 @@ async def test_manage_object_templates_with_component_relationships():
         TestKind.PHYSICAL_INTERFACE,
         TestKind.SFP,
     }
+
+
+async def test_identify_object_templates_with_generics():
+    USELESS_DEVICE_SCHEMA = copy.deepcopy(DEVICE_SCHEMA)
+    USELESS_DEVICE_SCHEMA.nodes.append(
+        NodeSchema(
+            name="UselessDevice",
+            namespace="Testing",
+            inherit_from=[TestKind.INTERFACE_HOLDER],
+            include_in_menu=True,
+            label="Useless Device",
+            default_filter="name__value",
+            generate_template=True,
+            attributes=[AttributeSchema(name="name", kind="Text", unique=True)],
+        )
+    )
+
+    schema_branch = SchemaBranch(cache={}, name="test")
+    schema_branch.load_schema(schema=SchemaRoot(**core_models).merge(schema=USELESS_DEVICE_SCHEMA))
+    schema_branch.process_inheritance()
+
+    # As we requested template for TestingDevice, which is an implementation of generic TestingInterfaceHolder we must make sure not to propagate
+    # templating to TestingUselessDevice
+    identified = schema_branch.identify_required_object_templates(
+        node_schema=schema_branch.get(name=TestKind.DEVICE, duplicate=False), identified=set()
+    )
+    assert {n.kind for n in identified} == {
+        TestKind.DEVICE,
+        TestKind.INTERFACE,
+        TestKind.INTERFACE_HOLDER,
+        TestKind.PHYSICAL_INTERFACE,
+        TestKind.SFP,
+        TestKind.VIRTUAL_INTERFACE,
+    }


### PR DESCRIPTION
The template generation logic was inspecting parent relationships which if they used generics as peers could trigger the generation of templates for every implementations of the generics

This change allows to stop the generation of templates for a generic's implementations if we already have the implementation we needed.