### PR TITLE
Tighten event filtering constraints for Jinja2 based computed attributes

### DIFF
--- a/backend/infrahub/computed_attribute/gather.py
+++ b/backend/infrahub/computed_attribute/gather.py
@@ -96,18 +96,19 @@ async def gather_trigger_computed_attribute_jinja2() -> list[ComputedAttrJinja2T
 
     for branch_scope, branches_out_of_scope in branches_to_process:
         schema_branch = registry.schema.get_schema_branch(name=branch_scope)
-        mapping = schema_branch.computed_attributes.get_jinja2_target_map()
+        mapping = schema_branch.computed_attributes.get_jinja2_trigger_nodes()
 
         log.info(f"Generating {len(mapping)} Jinja2 trigger for {branch_scope} (except {branches_out_of_scope})")
 
-        for computed_attribute, source_node_types in mapping.items():
-            trigger = ComputedAttrJinja2TriggerDefinition.from_computed_attribute(
-                branch=branch_scope,
-                computed_attribute=computed_attribute,
-                source_node_types=source_node_types,
-                branches_out_of_scope=branches_out_of_scope,
-            )
-            triggers.append(trigger)
+        for computed_attribute, trigger_nodes in mapping.items():
+            for trigger_node in trigger_nodes:
+                trigger = ComputedAttrJinja2TriggerDefinition.from_computed_attribute(
+                    branch=branch_scope,
+                    computed_attribute=computed_attribute,
+                    trigger_node=trigger_node,
+                    branches_out_of_scope=branches_out_of_scope,
+                )
+                triggers.append(trigger)
 
     return triggers
 

--- a/backend/infrahub/computed_attribute/models.py
+++ b/backend/infrahub/computed_attribute/models.py
@@ -9,7 +9,11 @@ from pydantic import BaseModel, Field, computed_field
 from typing_extensions import Self
 
 from infrahub.core import registry
-from infrahub.core.schema.schema_branch_computed import ComputedAttributeTarget, PythonDefinition  # noqa: TC001
+from infrahub.core.schema.schema_branch_computed import (  # noqa: TC001
+    ComputedAttributeTarget,
+    ComputedAttributeTriggerNode,
+    PythonDefinition,
+)
 from infrahub.events import NodeCreatedEvent, NodeUpdatedEvent
 from infrahub.trigger.constants import NAME_SEPARATOR
 from infrahub.trigger.models import (
@@ -115,7 +119,7 @@ class ComputedAttrJinja2TriggerDefinition(TriggerBranchDefinition):
         cls,
         branch: str,
         computed_attribute: ComputedAttributeTarget,
-        source_node_types: list[str],
+        trigger_node: ComputedAttributeTriggerNode,
         branches_out_of_scope: list[str] | None = None,
     ) -> Self:
         """
@@ -126,11 +130,16 @@ class ComputedAttrJinja2TriggerDefinition(TriggerBranchDefinition):
         """
         event_trigger = EventTrigger()
         event_trigger.events.update({NodeCreatedEvent.event_name, NodeUpdatedEvent.event_name})
-        event_trigger.match = {"infrahub.node.kind": source_node_types}
+        event_trigger.match = {"infrahub.node.kind": trigger_node.kind}
         if branches_out_of_scope:
             event_trigger.match["infrahub.branch.name"] = [f"!{branch}" for branch in branches_out_of_scope]
         elif not branches_out_of_scope and branch != registry.default_branch:
             event_trigger.match["infrahub.branch.name"] = branch
+
+        event_trigger.match_related = {
+            "prefect.resource.role": "infrahub.node.field_update",
+            "infrahub.field.name": trigger_node.fields,
+        }
 
         workflow = ExecuteWorkflow(
             workflow=COMPUTED_ATTRIBUTE_PROCESS_JINJA2,
@@ -158,7 +167,7 @@ class ComputedAttrJinja2TriggerDefinition(TriggerBranchDefinition):
         )
 
         definition = cls(
-            name=computed_attribute.key_name,
+            name=f"{computed_attribute.key_name} [{trigger_node.kind}]",
             branch=branch,
             computed_attribute=computed_attribute,
             trigger=event_trigger,

--- a/backend/infrahub/core/schema/schema_branch_computed.py
+++ b/backend/infrahub/core/schema/schema_branch_computed.py
@@ -42,6 +42,17 @@ class ComputedAttributeTarget(BaseModel):
         return hash((self.kind, self.attribute, tuple(self.filter_keys)))
 
 
+class ComputedAttributeTriggerNode(BaseModel):
+    kind: str
+    attributes: list[str] = Field(default_factory=list)
+    relationships: list[str] = Field(default_factory=list)
+    targets_self: bool = Field(default=False)
+
+    @property
+    def fields(self) -> list[str]:
+        return self.attributes + self.relationships
+
+
 class RegisteredNodeComputedAttribute(BaseModel):
     local_fields: dict[str, list[ComputedAttributeTarget]] = Field(
         default_factory=dict,
@@ -172,3 +183,29 @@ class ComputedAttributes:
                     mapping[local_field].add(node)
 
         return {key: list(value) for key, value in mapping.items()}
+
+    def get_jinja2_trigger_nodes(self) -> dict[ComputedAttributeTarget, list[ComputedAttributeTriggerNode]]:
+        working_map: dict[ComputedAttributeTarget, dict[str, ComputedAttributeTriggerNode]] = {}
+        for node_kind, registered_computed_attribute in self._computed_jinja2_attribute_map.items():
+            for local_field, computed_attribute_targets in registered_computed_attribute.local_fields.items():
+                for computed_attribute_target in computed_attribute_targets:
+                    if computed_attribute_target not in working_map:
+                        working_map[computed_attribute_target] = {}
+                    if node_kind not in working_map[computed_attribute_target]:
+                        working_map[computed_attribute_target][node_kind] = ComputedAttributeTriggerNode(kind=node_kind)
+                    working_map[computed_attribute_target][node_kind].attributes.append(local_field)
+                    if computed_attribute_target.kind == node_kind:
+                        working_map[computed_attribute_target][node_kind].targets_self = True
+            for relationship, computed_attribute_targets in registered_computed_attribute.relationships.items():
+                for computed_attribute_target in computed_attribute_targets:
+                    if computed_attribute_target not in working_map:
+                        working_map[computed_attribute_target] = {}
+                    if node_kind not in working_map[computed_attribute_target]:
+                        working_map[computed_attribute_target][node_kind] = ComputedAttributeTriggerNode(kind=node_kind)
+                    working_map[computed_attribute_target][node_kind].relationships.append(relationship)
+                    if computed_attribute_target.kind == node_kind:
+                        working_map[computed_attribute_target][node_kind].targets_self = True
+
+        return {
+            computed_attribute_target: list(nodes.values()) for computed_attribute_target, nodes in working_map.items()
+        }

--- a/backend/infrahub/events/node_action.py
+++ b/backend/infrahub/events/node_action.py
@@ -25,6 +25,7 @@ class NodeMutatedEvent(InfrahubEvent):
                 {
                     "prefect.resource.id": f"infrahub.node.{self.node_id}",
                     "prefect.resource.role": "infrahub.node.field_update",
+                    "infrahub.field.name": attribute.name,
                     "infrahub.attribute.name": attribute.name,
                     "infrahub.attribute.value": "NULL" if attribute.value is None else str(attribute.value),
                     "infrahub.attribute.kind": attribute.kind,
@@ -35,6 +36,16 @@ class NodeMutatedEvent(InfrahubEvent):
                     "infrahub.attribute.action": attribute.value_update_status.value,  # type: ignore[attr-defined]
                 }
             )
+
+        for relationship_name in self.changelog.relationships.keys():
+            related.append(
+                {
+                    "prefect.resource.id": f"infrahub.node.{self.node_id}",
+                    "prefect.resource.role": "infrahub.node.field_update",
+                    "infrahub.field.name": relationship_name,
+                }
+            )
+
         if self.changelog.parent:
             related.append(
                 {

--- a/backend/tests/unit/computed_attribute/test_gather.py
+++ b/backend/tests/unit/computed_attribute/test_gather.py
@@ -14,8 +14,8 @@ async def test_gather_trigger_computed_attribute_jinja2_only_main(car_person_sch
     triggers = await gather_trigger_computed_attribute_jinja2()
     assert len(triggers) == 1
     trigger = triggers[0]
-    assert trigger.name == "TestCar_computed_desc"
-    assert trigger.generate_name() == "computed_attr_jinja2::main::TestCar_computed_desc"
+    assert trigger.name == "TestCar_computed_desc [TestCar]"
+    assert trigger.generate_name() == "computed_attr_jinja2::main::TestCar_computed_desc [TestCar]"
     assert "infrahub.branch.name" not in trigger.trigger.match
 
 
@@ -37,17 +37,22 @@ async def test_gather_trigger_computed_attribute_jinja2_different_branch(
     schema_branch.process()
     await branch.save(db=db)
 
-    name_main = "computed_attr_jinja2::main::TestCar_computed_desc"
-    name_branch = "computed_attr_jinja2::branch2::TestCar_computed_desc"
+    name_main = "computed_attr_jinja2::main::TestCar_computed_desc [TestCar]"
+    name_branch_first = "computed_attr_jinja2::branch2::TestCar_computed_desc [TestCar]"
+    name_branch_second = "computed_attr_jinja2::branch2::TestCar_computed_desc [TestPerson]"
 
     triggers = await gather_trigger_computed_attribute_jinja2()
     triggers_by_name = {trigger.generate_name(): trigger for trigger in triggers}
-    assert set(triggers_by_name.keys()) == {name_main, name_branch}
+    assert set(triggers_by_name.keys()) == {name_main, name_branch_first, name_branch_second}
 
     trigger_main = triggers_by_name[name_main]
     assert "infrahub.branch.name" in trigger_main.trigger.match
     assert trigger_main.trigger.match["infrahub.branch.name"] == ["!branch2"]
 
-    trigger_branch = triggers_by_name[name_branch]
+    trigger_branch = triggers_by_name[name_branch_first]
+    assert "infrahub.branch.name" in trigger_branch.trigger.match
+    assert trigger_branch.trigger.match["infrahub.branch.name"] == "branch2"
+
+    trigger_branch = triggers_by_name[name_branch_second]
     assert "infrahub.branch.name" in trigger_branch.trigger.match
     assert trigger_branch.trigger.match["infrahub.branch.name"] == "branch2"


### PR DESCRIPTION
This PR tightens the event filtering for Jinja2 based computed attributes so that we don't only look at the node kind of a mutation event instead we look at the "fields" being updated (i.e. attributes and or relationships). Because the fields can be different on the node kinds involved with the computed attribute we need to have separate automations/triggers for each node kind of each computed attribute.

The benefit should be that it potentially removes a lot of noise as we don't have to process mutations that we know for a fact wouldn't impact the computed attributes. I.e. such as. when we modify an attribute on a node and that attribute isn't used within any computed attribute.

One thing I'm sceptical regarding this PR is the way I changed the names of the triggers. Previously they were just named after the computed attributes themselves, however as we might need more than one node I've added the kind as a suffix with [NodeKind]. We might want some other format for that.. (see the tests for an example of how these are changed)

I've also added information about relationships as "field" updates for relationships of the node mutation events.

Another change that was needed was to add the match_related part for the event.

The new get_jinja2_trigger_nodes() method returns the computed attributes in a format better suited for this use case.