### PR TITLE
IFC-1328 Make template name not unique for components

### DIFF
--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1875,6 +1875,12 @@ class SchemaBranch:
                 )
             )
 
+            if relationship.kind == RelationshipKind.PARENT:
+                template_schema.human_friendly_id = [
+                    f"{relationship.name}__template_name__value"
+                ] + template_schema.human_friendly_id
+                template_schema.uniqueness_constraints[0].append(relationship.name)
+
     def generate_object_template_from_node(
         self, node: NodeSchema | GenericSchema, need_templates: set[NodeSchema | GenericSchema]
     ) -> TemplateSchema | GenericSchema:
@@ -1895,7 +1901,7 @@ class SchemaBranch:
         template: TemplateSchema | GenericSchema
         need_template_kinds = [n.kind for n in need_templates]
 
-        if isinstance(node, GenericSchema):
+        if node.is_generic_schema:
             # When needing a template for a generic, we generate an empty shell mostly to make sure that schemas (including the GraphQL one) will
             # look right. We don't really care about applying inheritance of fields as it was already processed and actual templates will have the
             # correct attributes and relationships

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -2936,6 +2936,8 @@ async def test_manage_object_templates(relationship_kind: RelationshipKind):
 
     # Verify the generated template
     test_object_template_thing = schema_branch.get_template(f"Template{TestKind.THING}", duplicate=False)
+    assert test_object_template_thing.human_friendly_id == ["template_name__value"]
+    assert test_object_template_thing.uniqueness_constraints == [["template_name__value"]]
     assert sorted(
         [a.name for a in test_object_template_thing.attributes if a.name != OBJECT_TEMPLATE_NAME_ATTR]
     ) == sorted([a.name for a in THING_WITH_TEMPLATE.attributes if not a.unique and not a.read_only])
@@ -2993,6 +2995,8 @@ async def test_manage_object_templates_with_component_relationships():
 
     # Verify attributes mapping of components
     test_interface_template = schema_branch.get(name=f"Template{TestKind.PHYSICAL_INTERFACE}", duplicate=False)
+    assert test_interface_template.human_friendly_id == ["device__template_name__value", "template_name__value"]
+    assert test_interface_template.uniqueness_constraints == [["template_name__value", "device"]]
     test_interface = schema_branch.get(name=TestKind.PHYSICAL_INTERFACE, duplicate=False)
     for attr in test_interface.attributes:
         template_attr = test_interface_template.get_attribute(name=attr.name)


### PR DESCRIPTION
This change also adjust the HFID and uniqueness constraint of component templates so they use both the template name itself but also the template name of the relationship of kind parent.