### PR TITLE
Add migration for Prefect objects

### DIFF
--- a/backend/infrahub/cli/upgrade.py
+++ b/backend/infrahub/cli/upgrade.py
@@ -27,10 +27,10 @@ from infrahub.menu.utils import create_default_menu
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.message_bus.local import BusSimulator
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
+from infrahub.trigger.tasks import trigger_configure_all
 from infrahub.workflows.initialization import (
     setup_blocks,
     setup_deployments,
-    setup_task_manager,
     setup_worker_pools,
 )
 
@@ -89,17 +89,11 @@ async def upgrade_cmd(
     # -------------------------------------------
     # Upgrade External system : Task Manager
     # -------------------------------------------
-    await setup_task_manager()
-
     async with get_client(sync_client=False) as client:
         await setup_blocks()
         await setup_worker_pools(client=client)
         await setup_deployments(client=client)
-        # await setup_triggers(
-        #     client=client,
-        #     triggers=builtin_triggers,
-        #     trigger_type=TriggerType.BUILTIN,
-        # )
+        await trigger_configure_all(service=service)
 
     await dbdriver.close()
 

--- a/backend/infrahub/computed_attribute/gather.py
+++ b/backend/infrahub/computed_attribute/gather.py
@@ -3,15 +3,16 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
-from infrahub_sdk import InfrahubClient  # noqa: TC002  needed for prefect flow
-from infrahub_sdk.protocols import (
-    CoreTransformPython,
-)
 from prefect import task
 from prefect.cache_policies import NONE
 from prefect.logging import get_run_logger
 
+from infrahub.core.constants import InfrahubKind
+from infrahub.core.manager import NodeManager
+from infrahub.core.protocols import CoreGenericRepository, CoreGraphQLQuery
 from infrahub.core.registry import registry
+from infrahub.database import InfrahubDatabase  # noqa: TC001  needed for prefect flow
+from infrahub.git.utils import get_repositories_commit_per_branch
 
 from .models import (
     ComputedAttrJinja2TriggerDefinition,
@@ -21,7 +22,8 @@ from .models import (
 )
 
 if TYPE_CHECKING:
-    from infrahub_sdk.data import RepositoryData
+    from infrahub.core.protocols import CoreTransformPython as CoreTransformPythonNode
+    from infrahub.git.models import RepositoryData
 
 
 @task(
@@ -30,7 +32,7 @@ if TYPE_CHECKING:
     cache_policy=NONE,
 )
 async def gather_python_transform_attributes(
-    branch_name: str, client: InfrahubClient, repositories: dict[str, RepositoryData] | None = None
+    db: InfrahubDatabase, branch_name: str, repositories: dict[str, RepositoryData] | None = None
 ) -> list[PythonTransformComputedAttribute]:
     log = get_run_logger()
     schema_branch = registry.schema.get_schema_branch(name=branch_name)
@@ -39,15 +41,17 @@ async def gather_python_transform_attributes(
     transform_attributes = schema_branch.computed_attributes.python_attributes_by_transform
 
     transform_names = list(transform_attributes.keys())
+
     if not transform_names:
         return []
 
-    transforms = await client.filters(
-        kind=CoreTransformPython,
+    transforms: list[CoreTransformPythonNode] = await NodeManager.query(
+        db=db,
+        schema=InfrahubKind.TRANSFORMPYTHON,
         branch=branch_name,
+        fields={"id": None, "name": None, "repository": None, "query": None},
+        filters={"name__values": transform_names},
         prefetch_relationships=True,
-        populate_store=True,
-        name__values=transform_names,
     )
 
     found_transforms_names = [transform.name.value for transform in transforms]
@@ -56,24 +60,27 @@ async def gather_python_transform_attributes(
             log.warning(
                 msg=f"The transform {transform_name} is assigned to a computed attribute but the transform could not be found in the database."
             )
-    repositories = repositories or await client.get_list_repositories()
+    repositories = repositories or await get_repositories_commit_per_branch(db=db)
 
     computed_attributes: list[PythonTransformComputedAttribute] = []
     for transform in transforms:
+        repository = await transform.repository.get_peer(db=db, peer_type=CoreGenericRepository, raise_on_error=True)
+        query = await transform.query.get_peer(db=db, peer_type=CoreGraphQLQuery, raise_on_error=True)
+
         for attribute in transform_attributes[transform.name.value]:
             python_transform_computed_attribute = PythonTransformComputedAttribute(
                 name=transform.name.value,
                 branch_name=branch_name,
-                repository_id=transform.repository.peer.id,
-                repository_name=transform.repository.peer.name.value,
-                repository_kind=transform.repository.peer.typename,
-                query_name=transform.query.peer.name.value,
-                query_models=transform.query.peer.models.value,
+                repository_id=repository.get_id(),
+                repository_name=repository.name.value,
+                repository_kind=repository.get_kind(),
+                query_name=query.name.value,
+                query_models=query.models.value or [],
                 computed_attribute=attribute,
                 default_schema=branch_name not in branches_with_diff_from_main,
             )
             python_transform_computed_attribute.populate_branch_commit(
-                repository_data=repositories.get(transform.repository.peer.name.value)
+                repository_data=repositories.get(repository.name.value)
             )
             computed_attributes.append(python_transform_computed_attribute)
 
@@ -118,17 +125,20 @@ async def gather_trigger_computed_attribute_jinja2() -> list[ComputedAttrJinja2T
     cache_policy=NONE,
 )
 async def gather_trigger_computed_attribute_python(
-    client: InfrahubClient,
+    db: InfrahubDatabase,
 ) -> tuple[list[ComputedAttrPythonTriggerDefinition], list[ComputedAttrPythonQueryTriggerDefinition]]:
     triggers_python = []
     triggers_python_query = []
 
-    repositories = await client.get_list_repositories()
+    repositories = await get_repositories_commit_per_branch(db=db)
 
     all_computed_attributes: dict[str, dict[str, PythonTransformComputedAttribute]] = defaultdict(dict)
     for branch in list(registry.branch.values()):
+        if branch.is_global:
+            continue
+
         computed_attributes = await gather_python_transform_attributes(
-            branch_name=branch.name, client=client, repositories=repositories
+            db=db, branch_name=branch.name, repositories=repositories
         )
         for computed_attribute in computed_attributes:
             all_computed_attributes[computed_attribute.name][branch.name] = computed_attribute

--- a/backend/infrahub/computed_attribute/models.py
+++ b/backend/infrahub/computed_attribute/models.py
@@ -31,7 +31,7 @@ from infrahub.workflows.catalogue import (
 if TYPE_CHECKING:
     from uuid import UUID
 
-    from infrahub_sdk.data import RepositoryData
+    from infrahub.git.models import RepositoryData
 
 
 class ComputedAttributeAutomations(BaseModel):

--- a/backend/infrahub/computed_attribute/tasks.py
+++ b/backend/infrahub/computed_attribute/tasks.py
@@ -361,7 +361,7 @@ async def computed_attribute_setup_python(
         await add_tags(branches=[branch_name])
         await wait_for_schema_to_converge(branch_name=branch_name, service=service, log=log)
 
-    triggers_python, triggers_python_query = await gather_trigger_computed_attribute_python(client=service.client)
+    triggers_python, triggers_python_query = await gather_trigger_computed_attribute_python(db=service.database)
 
     for trigger in triggers_python:
         if event_name != BranchDeletedEvent.event_name and trigger.branch == branch_name:

--- a/backend/infrahub/git/models.py
+++ b/backend/infrahub/git/models.py
@@ -187,3 +187,18 @@ class CheckRepositoryMergeConflicts(BaseModel):
     repository_name: str = Field(..., description="The name of the Repository")
     source_branch: str = Field(..., description="The source branch")
     target_branch: str = Field(..., description="The target branch")
+
+
+class RepositoryBranchInfo(BaseModel):
+    internal_status: str
+
+
+class RepositoryData(BaseModel):
+    repository_id: str = Field(..., description="Id of the repository")
+    repository_name: str = Field(..., description="Name of the repository")
+    branches: dict[str, str] = Field(
+        ...,
+        description="Dictionary with the name of the branch as the key and the active commit id as the value",
+    )
+
+    branch_info: dict[str, RepositoryBranchInfo] = Field(default_factory=dict)

--- a/backend/infrahub/git/utils.py
+++ b/backend/infrahub/git/utils.py
@@ -1,0 +1,48 @@
+from typing import TYPE_CHECKING
+
+from infrahub.core import registry
+from infrahub.core.constants import InfrahubKind
+from infrahub.core.manager import NodeManager
+from infrahub.database import InfrahubDatabase
+
+from .models import RepositoryBranchInfo, RepositoryData
+
+if TYPE_CHECKING:
+    from infrahub.core.protocols import CoreGenericRepository
+
+
+async def get_repositories_commit_per_branch(
+    db: InfrahubDatabase,
+) -> dict[str, RepositoryData]:
+    """Get a list of all repositories and their commit on each branches.
+
+    This method is similar to 'get_list_repositories' method in the Python SDK.
+
+    NOTE: At some point, we should refactor this function to use a single Database query instead of one per branch
+    """
+
+    repositories: dict[str, RepositoryData] = {}
+
+    for branch in list(registry.branch.values()):
+        repos: list[CoreGenericRepository] = await NodeManager.query(
+            db=db,
+            branch=branch,
+            fields={"id": None, "name": None, "commit": None, "internal_status": None},
+            schema=InfrahubKind.GENERICREPOSITORY,
+        )
+
+        for repository in repos:
+            repo_name = repository.name.value
+            if repo_name not in repositories:
+                repositories[repo_name] = RepositoryData(
+                    repository_id=repository.get_id(),
+                    repository_name=repo_name,
+                    branches={},
+                )
+
+            repositories[repo_name].branches[branch.name] = repository.commit.value  # type: ignore[attr-defined]
+            repositories[repo_name].branch_info[branch.name] = RepositoryBranchInfo(
+                internal_status=repository.internal_status.value
+            )
+
+    return repositories

--- a/backend/infrahub/trigger/tasks.py
+++ b/backend/infrahub/trigger/tasks.py
@@ -14,12 +14,12 @@ from .setup import setup_triggers
 
 @flow(name="trigger-configure-all", flow_run_name="Configure all triggers")
 async def trigger_configure_all(service: InfrahubServices) -> None:
-    webhook_trigger = await gather_trigger_webhook(client=service.client)
+    webhook_trigger = await gather_trigger_webhook(db=service.database)
     computed_attribute_j2_triggers = await gather_trigger_computed_attribute_jinja2()
     (
         computed_attribute_python_triggers,
         computed_attribute_python_query_triggers,
-    ) = await gather_trigger_computed_attribute_python(client=service.client)
+    ) = await gather_trigger_computed_attribute_python(db=service.database)
 
     triggers = (
         computed_attribute_j2_triggers

--- a/backend/infrahub/webhook/gather.py
+++ b/backend/infrahub/webhook/gather.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
-from infrahub_sdk import InfrahubClient  # noqa: TC002  needed for prefect flow
-from infrahub_sdk.protocols import CoreWebhook
 from prefect import task
 from prefect.cache_policies import NONE
+
+from infrahub.core.manager import NodeManager
+from infrahub.core.protocols import CoreWebhook
+from infrahub.database import InfrahubDatabase  # noqa: TC001  needed for prefect flow
 
 from .models import WebhookTriggerDefinition
 
 
 @task(name="gather-trigger-webhook", task_run_name="Gather webhook triggers", cache_policy=NONE)
-async def gather_trigger_webhook(client: InfrahubClient) -> list[WebhookTriggerDefinition]:
-    webhooks = await client.all(kind=CoreWebhook)
+async def gather_trigger_webhook(db: InfrahubDatabase) -> list[WebhookTriggerDefinition]:
+    webhooks = await NodeManager.query(db=db, schema=CoreWebhook)
     triggers = [WebhookTriggerDefinition.from_object(webhook) for webhook in webhooks]
     return triggers

--- a/backend/infrahub/webhook/models.py
+++ b/backend/infrahub/webhook/models.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from httpx import Response
     from infrahub_sdk.protocols import CoreCustomWebhook, CoreStandardWebhook, CoreTransformPython, CoreWebhook
 
+    from infrahub.core.protocols import CoreWebhook as CoreWebhookNode
     from infrahub.services import InfrahubServices
 
 
@@ -37,7 +38,7 @@ class WebhookTriggerDefinition(TriggerDefinition):
         return f"{TriggerType.WEBHOOK.value}{NAME_SEPARATOR}{id}"
 
     @classmethod
-    def from_object(cls, obj: CoreWebhook) -> Self:
+    def from_object(cls, obj: CoreWebhook | CoreWebhookNode) -> Self:
         event_trigger = EventTrigger()
         if obj.event_type.value == "all":
             event_trigger.events.add("infrahub.*")

--- a/backend/infrahub/webhook/tasks.py
+++ b/backend/infrahub/webhook/tasks.py
@@ -111,7 +111,7 @@ async def webhook_process(
 async def configure_webhook_all(service: InfrahubServices) -> None:
     log = get_run_logger()
 
-    triggers = await gather_trigger_webhook(client=service.client)
+    triggers = await gather_trigger_webhook(db=service.database)
 
     async with get_client(sync_client=False) as prefect_client:
         await setup_triggers(

--- a/backend/tests/functional/computed_attributes/test_computed_attribute.py
+++ b/backend/tests/functional/computed_attributes/test_computed_attribute.py
@@ -88,11 +88,12 @@ class TestComputedAttribute(TestInfrahubApp):
 
     async def test_gather_trigger_computed_attribute_python_main(
         self,
+        db: InfrahubDatabase,
         data: dict[str, Node],
         client: InfrahubClient,
         default_branch: Branch,
     ) -> None:
-        triggers_python, triggers_python_query = await gather_trigger_computed_attribute_python(client=client)
+        triggers_python, triggers_python_query = await gather_trigger_computed_attribute_python(db=db)
         assert len(triggers_python) == 1
         assert triggers_python[0].generate_name() == "computed_attr_python::main::TestingTShirt_pitch"
         assert len(triggers_python_query) == 1
@@ -100,6 +101,7 @@ class TestComputedAttribute(TestInfrahubApp):
 
     async def test_gather_trigger_computed_attribute_python_branch(
         self,
+        db: InfrahubDatabase,
         data: dict[str, Node],
         client: InfrahubClient,
         default_branch: Branch,
@@ -110,7 +112,7 @@ class TestComputedAttribute(TestInfrahubApp):
         repo.commit.value = "decc6d49679404b201c54bbe7b0c788e268e25b7"
         await repo.save()
 
-        triggers_python, triggers_python_query = await gather_trigger_computed_attribute_python(client=client)
+        triggers_python, triggers_python_query = await gather_trigger_computed_attribute_python(db=db)
         assert len(triggers_python) == 2
         assert len(triggers_python_query) == 2
 

--- a/backend/tests/unit/computed_attribute/conftest.py
+++ b/backend/tests/unit/computed_attribute/conftest.py
@@ -3,8 +3,10 @@ import pytest
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import (
+    InfrahubKind,
     RelationshipCardinality,
 )
+from infrahub.core.node import Node
 from infrahub.core.schema import (
     AttributeSchema,
     NodeSchema,
@@ -13,6 +15,38 @@ from infrahub.core.schema import (
 )
 from infrahub.core.schema.computed_attribute import ComputedAttribute, ComputedAttributeKind
 from infrahub.database import InfrahubDatabase
+
+
+@pytest.fixture
+async def gqlquery01(db: InfrahubDatabase, register_core_models_schema, default_branch: Branch) -> Node:
+    query = await Node.init(db=db, schema=InfrahubKind.GRAPHQLQUERY, branch=default_branch)
+    await query.new(
+        db=db, name="query01", query="query { TestCar { name { value } } }", models=["TestCar", "TestPerson"]
+    )
+    await query.save(db=db)
+    return query
+
+
+@pytest.fixture
+async def repo01(db: InfrahubDatabase, register_core_models_schema, default_branch: Branch, gqlquery01: Node) -> Node:
+    repo = await Node.init(db=db, schema=InfrahubKind.READONLYREPOSITORY, branch=default_branch)
+    repo = await repo.new(
+        db=db, name="repo02", ref=default_branch.name, commit="commit02", location="location02", queries=[gqlquery01]
+    )
+    await repo.save(db=db)
+    return repo
+
+
+@pytest.fixture
+async def transform01(
+    db: InfrahubDatabase, register_core_models_schema, default_branch: Branch, gqlquery01: Node, repo01: Node
+) -> Node:
+    transform = await Node.init(db=db, schema=InfrahubKind.TRANSFORMPYTHON, branch=default_branch)
+    await transform.new(
+        db=db, name="transform01", file_path="transform.py", class_name="Transform", query=gqlquery01, repository=repo01
+    )
+    await transform.save(db=db)
+    return transform
 
 
 @pytest.fixture
@@ -41,6 +75,16 @@ async def car_person_schema_computed_attr(
                         computed_attribute=ComputedAttribute(
                             kind=ComputedAttributeKind.JINJA2,
                             jinja2_template="{{ name__value }} has {{ nbr_seats__value }} seats",
+                        ),
+                    ),
+                    AttributeSchema(
+                        name="computed_desc_python",
+                        kind="Text",
+                        read_only=True,
+                        optional=True,
+                        computed_attribute=ComputedAttribute(
+                            kind=ComputedAttributeKind.TRANSFORM_PYTHON,
+                            transform="transform01",
                         ),
                     ),
                 ],

--- a/backend/tests/unit/computed_attribute/test_gather.py
+++ b/backend/tests/unit/computed_attribute/test_gather.py
@@ -1,7 +1,11 @@
-from infrahub.computed_attribute.gather import gather_trigger_computed_attribute_jinja2
+from infrahub.computed_attribute.gather import (
+    gather_trigger_computed_attribute_jinja2,
+    gather_trigger_computed_attribute_python,
+)
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.initialization import create_branch
+from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
 
 
@@ -56,3 +60,14 @@ async def test_gather_trigger_computed_attribute_jinja2_different_branch(
     trigger_branch = triggers_by_name[name_branch_second]
     assert "infrahub.branch.name" in trigger_branch.trigger.match
     assert trigger_branch.trigger.match["infrahub.branch.name"] == "branch2"
+
+
+async def test_gather_trigger_computed_attribute_python(
+    db: InfrahubDatabase, default_branch: Branch, car_person_schema_computed_attr, transform01: Node
+):
+    triggers, trigger_queries = await gather_trigger_computed_attribute_python(db=db)
+    assert triggers
+    assert trigger_queries
+
+    trigger = triggers[0]
+    assert trigger.name == "TestCar_computed_desc_python"

--- a/backend/tests/unit/git/test_utils.py
+++ b/backend/tests/unit/git/test_utils.py
@@ -1,0 +1,95 @@
+import pytest
+
+from infrahub.core.branch import Branch
+from infrahub.core.constants import InfrahubKind
+from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
+from infrahub.database import InfrahubDatabase
+from infrahub.git.utils import get_repositories_commit_per_branch
+
+
+@pytest.fixture
+async def repository_01(db: InfrahubDatabase, register_core_models_schema, default_branch: Branch):
+    repo = await Node.init(db=db, schema=InfrahubKind.REPOSITORY, branch=default_branch)
+    await repo.new(db=db, name="repo01", default_branch=default_branch.name, commit="commit01", location="location01")
+    await repo.save(db=db)
+    return repo
+
+
+@pytest.fixture
+async def repository_02(db: InfrahubDatabase, register_core_models_schema, default_branch: Branch):
+    repo = await Node.init(db=db, schema=InfrahubKind.READONLYREPOSITORY, branch=default_branch)
+    await repo.new(db=db, name="repo02", ref=default_branch.name, commit="commit02", location="location02")
+    await repo.save(db=db)
+    return repo
+
+
+async def test_get_repositories_commit_per_branch_main(
+    db: InfrahubDatabase, register_core_models_schema, repository_01: Node, repository_02: Node
+):
+    repositories = await get_repositories_commit_per_branch(db=db)
+    assert list(repositories.keys()) == ["repo01", "repo02"]
+
+    assert repositories["repo01"].model_dump() == {
+        "repository_id": repository_01.id,
+        "repository_name": "repo01",
+        "branches": {"main": "commit01", "-global-": "commit01"},
+        "branch_info": {"main": {"internal_status": "inactive"}, "-global-": {"internal_status": "inactive"}},
+    }
+    assert repositories["repo02"].model_dump() == {
+        "repository_id": repository_02.id,
+        "repository_name": "repo02",
+        "branches": {"main": "commit02", "-global-": None},
+        "branch_info": {"main": {"internal_status": "inactive"}, "-global-": {"internal_status": "inactive"}},
+    }
+
+
+async def test_get_repositories_commit_per_branch_branches(
+    db: InfrahubDatabase, register_core_models_schema, repository_01: Node, repository_02: Node
+):
+    branch2 = await create_branch(db=db, branch_name="branch2")
+    repo01_branch = await NodeManager.get_one(db=db, id=repository_01.id, branch=branch2)
+    repo01_branch.commit.value = "commit21"
+    await repo01_branch.save(db=db)
+
+    branch3 = await create_branch(db=db, branch_name="branch3")
+    repo02_branch = await NodeManager.get_one(db=db, id=repository_02.id, branch=branch3)
+    repo02_branch.commit.value = "commit32"
+    await repo02_branch.save(db=db)
+
+    repositories = await get_repositories_commit_per_branch(db=db)
+    assert list(repositories.keys()) == ["repo01", "repo02"]
+
+    assert repositories["repo01"].model_dump() == {
+        "repository_id": repository_01.id,
+        "repository_name": "repo01",
+        "branches": {
+            "-global-": "commit01",
+            "branch2": "commit21",
+            "branch3": "commit01",
+            "main": "commit01",
+        },
+        "branch_info": {
+            "-global-": {"internal_status": "inactive"},
+            "branch2": {"internal_status": "inactive"},
+            "branch3": {"internal_status": "inactive"},
+            "main": {"internal_status": "inactive"},
+        },
+    }
+    assert repositories["repo02"].model_dump() == {
+        "repository_id": repository_02.id,
+        "repository_name": "repo02",
+        "branches": {
+            "-global-": None,
+            "branch2": "commit02",
+            "branch3": "commit32",
+            "main": "commit02",
+        },
+        "branch_info": {
+            "-global-": {"internal_status": "inactive"},
+            "branch2": {"internal_status": "inactive"},
+            "branch3": {"internal_status": "inactive"},
+            "main": {"internal_status": "inactive"},
+        },
+    }


### PR DESCRIPTION
This finalize the support for Prefect Objects (Deployment, Automation) during the upgrade process. (`infrahub upgrade`)

In order to configure the trigger from the CLI, we had to refactor Webhook and Computed attribute triggers to use the Database instead of the SDK, ultimately I think it's making this feature easier to test so it's a net positive.