### PR TITLE
[FLAKY] Immediately show new account token modal after creation

### DIFF
--- a/frontend/app/src/entities/user-profile/ui/account-token-create-action.tsx
+++ b/frontend/app/src/entities/user-profile/ui/account-token-create-action.tsx
@@ -26,8 +26,8 @@ export function AccountTokenCreateAction() {
   if (!schema) return <LoadingIndicator className="p-4" />;
 
   const handleSuccess = async (result: AccountTokenCreateResponse) => {
-    await queryClient.invalidateQueries(getInfrahubAccountTokenQueryOptions());
     setResult(result);
+    await queryClient.invalidateQueries(getInfrahubAccountTokenQueryOptions());
   };
 
   return (


### PR DESCRIPTION
this pr fixes a flaky test. Previously, a data refetching was done before displaying the modal, which could cause big delay on slow networks.