### PR TITLE
Generate group events from generic node mutation

### DIFF
--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -23,9 +23,10 @@ from infrahub.core.timestamp import Timestamp
 from infrahub.database import retry_db_transaction
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.events import EventMeta
-from infrahub.events.node_action import NodeDeletedEvent, NodeUpdatedEvent, get_node_event
+from infrahub.events.node_action import NodeDeletedEvent, NodeMutatedEvent, NodeUpdatedEvent, get_node_event
 from infrahub.exceptions import InitializationError, ValidationError
 from infrahub.graphql.context import apply_external_context
+from infrahub.groups.parsers import GroupNodeMutationParser
 from infrahub.lock import InfrahubMultiLock, build_object_lock_name
 from infrahub.log import get_log_data, get_logger
 from infrahub.worker import WORKER_IDENTITY
@@ -154,7 +155,7 @@ class InfrahubMutationMixin:
             relationship_changelogs = RelationshipChangelogGetter(db=graphql_context.db, branch=graphql_context.branch)
             node_changelogs = await relationship_changelogs.get_changelogs(primary_changelog=obj.node_changelog)
 
-            events = [main_event]
+            events: list[NodeMutatedEvent] = [main_event]
 
             deleted_changelogs = [node.node_changelog for node in deleted_nodes if node.id != obj.id]
             deleted_ids = {node.node_id for node in deleted_changelogs}
@@ -182,7 +183,10 @@ class InfrahubMutationMixin:
                     )
                     events.append(update_event)
 
-            for event in events:
+            group_parser = GroupNodeMutationParser(db=graphql_context.db, branch=graphql_context.branch)
+            group_events = await group_parser.group_events_from_node_actions(events=events)
+
+            for event in events + group_events:
                 graphql_context.background.add_task(graphql_context.active_service.event.send, event)
 
         return mutation

--- a/backend/infrahub/graphql/mutations/relationship.py
+++ b/backend/infrahub/graphql/mutations/relationship.py
@@ -14,7 +14,6 @@ from infrahub.core.constants import (
     PermissionAction,
     PermissionDecision,
     RelationshipCardinality,
-    RelationshipHierarchyDirection,
 )
 from infrahub.core.manager import NodeManager
 from infrahub.core.query.node import NodeGetKindQuery
@@ -23,7 +22,6 @@ from infrahub.core.query.relationship import (
     RelationshipPeerData,
 )
 from infrahub.core.relationship import Relationship
-from infrahub.core.schema import NodeSchema
 from infrahub.database import retry_db_transaction
 from infrahub.events import EventMeta
 from infrahub.events.group_action import GroupMemberAddedEvent, GroupMemberRemovedEvent
@@ -32,6 +30,7 @@ from infrahub.events.node_action import NodeUpdatedEvent
 from infrahub.exceptions import NodeNotFoundError, ValidationError
 from infrahub.graphql.context import apply_external_context
 from infrahub.graphql.types.context import ContextInput
+from infrahub.groups.ancestors import collect_ancestors
 from infrahub.permissions import get_global_permission_for_kind
 
 from ..types import RelatedNodeInput
@@ -119,7 +118,12 @@ class RelationshipAdd(Mutation):
 
         if config.SETTINGS.broker.enable and graphql_context.background and node_changelog.has_changes:
             if group_event_type == GroupUpdateType.MEMBERS:
-                ancestors = await _collect_ancestors(info=info, node_kind=source.get_schema().kind, node_id=source.id)
+                ancestors = await collect_ancestors(
+                    db=graphql_context.db,
+                    branch=graphql_context.branch,
+                    node_kind=source.get_schema().kind,
+                    node_id=source.id,
+                )
                 group_add_event = GroupMemberAddedEvent(
                     node_id=source.id,
                     kind=source.get_schema().kind,
@@ -137,7 +141,9 @@ class RelationshipAdd(Mutation):
                     node_kind_map = await node_kind_query.get_node_kind_map()
 
                     for node_id, node_kind in node_kind_map.items():
-                        ancestors = await _collect_ancestors(info=info, node_kind=node_kind, node_id=node_id)
+                        ancestors = await collect_ancestors(
+                            db=graphql_context.db, branch=graphql_context.branch, node_kind=node_kind, node_id=node_id
+                        )
                         group_add_event = GroupMemberAddedEvent(
                             node_id=node_id,
                             kind=node_kind,
@@ -234,7 +240,12 @@ class RelationshipRemove(Mutation):
 
         if config.SETTINGS.broker.enable and graphql_context.background and node_changelog.has_changes:
             if group_event_type == GroupUpdateType.MEMBERS:
-                ancestors = await _collect_ancestors(info=info, node_kind=source.get_schema().kind, node_id=source.id)
+                ancestors = await collect_ancestors(
+                    db=graphql_context.db,
+                    branch=graphql_context.branch,
+                    node_kind=source.get_schema().kind,
+                    node_id=source.id,
+                )
                 group_remove_event = GroupMemberRemovedEvent(
                     node_id=source.id,
                     kind=source.get_schema().kind,
@@ -251,7 +262,9 @@ class RelationshipRemove(Mutation):
                     node_kind_map = await node_kind_query.get_node_kind_map()
 
                     for node_id, node_kind in node_kind_map.items():
-                        ancestors = await _collect_ancestors(info=info, node_kind=node_kind, node_id=node_id)
+                        ancestors = await collect_ancestors(
+                            db=graphql_context.db, branch=graphql_context.branch, node_kind=node_kind, node_id=node_id
+                        )
                         group_remove_event = GroupMemberRemovedEvent(
                             node_id=node_id,
                             kind=node_kind,
@@ -391,24 +404,6 @@ async def _validate_peer_types(
                     raise ValidationError(
                         f"{node_id!r} {node.get_kind()!r} is already related to another peer on '{peer_relationships[0].name}'"
                     )
-
-
-async def _collect_ancestors(info: GraphQLResolveInfo, node_kind: str, node_id: str) -> list[EventNode]:
-    graphql_context: GraphqlContext = info.context
-    schema = graphql_context.db.schema.get(name=node_kind, branch=graphql_context.branch)
-
-    if not isinstance(schema, NodeSchema):
-        return []
-
-    ancestors = await NodeManager.query_hierarchy(
-        db=graphql_context.db,
-        branch=graphql_context.branch,
-        direction=RelationshipHierarchyDirection.ANCESTORS,
-        id=node_id,
-        node_schema=schema,
-        filters={"id": None},
-    )
-    return [EventNode(id=ancestor.get_id(), kind=ancestor.get_kind()) for ancestor in ancestors.values()]
 
 
 async def _collect_current_peers(

--- a/backend/infrahub/groups/ancestors.py
+++ b/backend/infrahub/groups/ancestors.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from infrahub.core.constants import RelationshipHierarchyDirection
+from infrahub.core.manager import NodeManager
+from infrahub.core.schema import NodeSchema
+from infrahub.events.models import EventNode
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.database import InfrahubDatabase
+
+
+async def collect_ancestors(db: InfrahubDatabase, branch: Branch, node_kind: str, node_id: str) -> list[EventNode]:
+    schema = db.schema.get(name=node_kind, branch=branch, duplicate=False)
+
+    if not isinstance(schema, NodeSchema):
+        return []
+
+    ancestors = await NodeManager.query_hierarchy(
+        db=db,
+        branch=branch,
+        direction=RelationshipHierarchyDirection.ANCESTORS,
+        id=node_id,
+        node_schema=schema,
+        filters={"id": None},
+    )
+    return [EventNode(id=ancestor.get_id(), kind=ancestor.get_kind()) for ancestor in ancestors.values()]

--- a/backend/infrahub/groups/parsers.py
+++ b/backend/infrahub/groups/parsers.py
@@ -1,0 +1,107 @@
+from dataclasses import dataclass
+
+from infrahub.core.branch import Branch
+from infrahub.core.changelog.models import RelationshipCardinalityManyChangelog
+from infrahub.core.constants import DiffAction, InfrahubKind
+from infrahub.core.schema import NodeSchema
+from infrahub.database import InfrahubDatabase
+from infrahub.events.group_action import GroupMemberAddedEvent, GroupMemberRemovedEvent, GroupMutatedEvent
+from infrahub.events.models import EventMeta, EventNode, InfrahubEvent
+from infrahub.events.node_action import NodeCreatedEvent, NodeMutatedEvent, NodeUpdatedEvent
+from infrahub.exceptions import SchemaNotFoundError
+
+from .ancestors import collect_ancestors
+
+
+@dataclass
+class ApplicableEvent:
+    event: NodeMutatedEvent
+    node_schema: NodeSchema
+    relationship: RelationshipCardinalityManyChangelog
+
+
+class GroupNodeMutationParser:
+    def __init__(self, db: InfrahubDatabase, branch: Branch) -> None:
+        self._db = db
+        self._branch = branch
+
+    def _get_schema(self, kind: str) -> NodeSchema | None:
+        try:
+            node_schema = self._db.schema.get_node_schema(name=kind, branch=self._branch, duplicate=False)
+        except (ValueError, SchemaNotFoundError):
+            return None
+        return node_schema
+
+    def _get_applicable_events(self, events: list[NodeMutatedEvent]) -> list[ApplicableEvent]:
+        applicable: list[ApplicableEvent] = []
+        for event in events:
+            if event_kind := self._get_schema(kind=event.kind):
+                if (
+                    InfrahubKind.GENERICGROUP in event_kind.inherit_from
+                    and "members" in event.changelog.relationships
+                    and isinstance(
+                        event.changelog.relationships["members"],
+                        RelationshipCardinalityManyChangelog,
+                    )
+                ):
+                    applicable.append(
+                        ApplicableEvent(
+                            event=event,
+                            node_schema=event_kind,
+                            relationship=event.changelog.relationships["members"],
+                        )
+                    )
+        return applicable
+
+    async def group_events_from_node_actions(self, events: list[NodeMutatedEvent]) -> list[InfrahubEvent]:
+        group_events: list[InfrahubEvent] = []
+
+        for applicable_event in self._get_applicable_events(events=events):
+            added_peers = [
+                EventNode(id=peer.peer_id, kind=peer.peer_kind)
+                for peer in applicable_event.relationship.peers
+                if peer.peer_status == DiffAction.ADDED
+            ]
+            removed_peers = [
+                EventNode(id=peer.peer_id, kind=peer.peer_kind)
+                for peer in applicable_event.relationship.peers
+                if peer.peer_status == DiffAction.REMOVED
+            ]
+            if added_peers:
+                group_events.append(
+                    await self._define_group_event(
+                        event_type=GroupMemberAddedEvent, parent=applicable_event.event, peers=added_peers
+                    )
+                )
+
+            if removed_peers:
+                group_events.append(
+                    await self._define_group_event(
+                        event_type=GroupMemberRemovedEvent, parent=applicable_event.event, peers=removed_peers
+                    )
+                )
+
+        return group_events
+
+    async def _define_group_event(
+        self,
+        event_type: type[GroupMemberAddedEvent | GroupMemberRemovedEvent],
+        parent: NodeMutatedEvent,
+        peers: list[EventNode],
+    ) -> GroupMutatedEvent:
+        event_meta = EventMeta.from_parent(parent=parent)
+        group_event = event_type(
+            meta=event_meta,
+            kind=parent.kind,
+            node_id=parent.node_id,
+            members=peers,
+        )
+        if isinstance(parent, NodeCreatedEvent | NodeUpdatedEvent):
+            # Avoid trying to find ancestors for deleted nodes
+            group_event.ancestors = await collect_ancestors(
+                db=self._db,
+                branch=self._branch,
+                node_kind=parent.kind,
+                node_id=parent.node_id,
+            )
+        return group_event

--- a/backend/tests/unit/graphql/mutations/test_group_event_collection.py
+++ b/backend/tests/unit/graphql/mutations/test_group_event_collection.py
@@ -1,0 +1,184 @@
+from infrahub.auth import AccountSession
+from infrahub.core.branch import Branch
+from infrahub.core.node import Node
+from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.database import InfrahubDatabase
+from infrahub.events.group_action import GroupMemberAddedEvent, GroupMemberRemovedEvent
+from infrahub.events.models import EventNode
+from infrahub.events.node_action import NodeCreatedEvent, NodeDeletedEvent, NodeUpdatedEvent
+from infrahub.graphql.initialization import prepare_graphql_params
+from infrahub.services import InfrahubServices
+from tests.adapters.event import MemoryInfrahubEvent
+from tests.helpers.graphql import graphql
+
+
+async def test_node_mutation_to_group_event(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_person_schema: SchemaBranch,
+    standard_group_schema: None,
+    enable_broker_config: None,
+    session_first_account: AccountSession,
+) -> None:
+    root_group = await Node.init(db=db, schema="CoreStandardGroup", branch=default_branch)
+    await root_group.new(db=db, name="root_group")
+    await root_group.save(db=db)
+    parent_group = await Node.init(db=db, schema="CoreStandardGroup", branch=default_branch)
+    await parent_group.new(db=db, name="parent_group", parent=root_group)
+    await parent_group.save(db=db)
+    child_group_1 = await Node.init(db=db, schema="CoreStandardGroup", branch=default_branch)
+    await child_group_1.new(db=db, name="child_group_1", parent=parent_group)
+    await child_group_1.save(db=db)
+    orphan_group_1 = await Node.init(db=db, schema="CoreStandardGroup", branch=default_branch)
+    await orphan_group_1.new(db=db, name="orphan_group_1")
+    await orphan_group_1.save(db=db)
+
+    memory_event = MemoryInfrahubEvent()
+    service = await InfrahubServices.new(event=memory_event)
+    gql_params = await prepare_graphql_params(
+        db=db, include_subscription=False, branch=default_branch, service=service, account_session=session_first_account
+    )
+
+    create_query = """
+    mutation($group: String) {
+        TestPersonCreate(data:
+            {
+                name: { value: "John"},
+                member_of_groups: [{id: $group}]
+            }
+        ) {
+            ok
+            object {
+                id
+            }
+        }
+    }
+    """
+    result = await graphql(
+        schema=gql_params.schema,
+        source=create_query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"group": child_group_1.id},
+    )
+
+    assert not result.errors
+    assert result.data
+    person_id = result.data["TestPersonCreate"]["object"]["id"]
+
+    assert gql_params.context.background
+    await gql_params.context.background()
+
+    assert len(memory_event.events) == 3
+    person_created = memory_event.events[0]
+    group_updated = memory_event.events[1]
+    member_added = memory_event.events[2]
+    assert isinstance(person_created, NodeCreatedEvent)
+    assert isinstance(group_updated, NodeUpdatedEvent)
+    assert isinstance(member_added, GroupMemberAddedEvent)
+    assert person_created.node_id == person_id
+    assert group_updated.node_id == child_group_1.get_id()
+    assert member_added.node_id == child_group_1.get_id()
+    assert len(member_added.members) == 1
+    assert EventNode(id=person_id, kind="TestPerson") in member_added.members
+    assert len(member_added.ancestors) == 2
+    assert EventNode(id=parent_group.id, kind="CoreStandardGroup") in member_added.ancestors
+    assert EventNode(id=root_group.id, kind="CoreStandardGroup") in member_added.ancestors
+
+    update_query = """
+    mutation($group1: String, $group2: String, $id: String!) {
+        TestPersonUpdate(data:
+            {
+                id: $id,
+                member_of_groups: [{id: $group1}, {id: $group2}]
+            }
+        ) {
+            ok
+            object {
+                id
+            }
+        }
+    }
+    """
+    memory_event = MemoryInfrahubEvent()
+    service = await InfrahubServices.new(event=memory_event)
+    gql_params = await prepare_graphql_params(
+        db=db, include_subscription=False, branch=default_branch, service=service, account_session=session_first_account
+    )
+    result = await graphql(
+        schema=gql_params.schema,
+        source=update_query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"group1": child_group_1.id, "group2": orphan_group_1.id, "id": person_id},
+    )
+    assert not result.errors
+    assert gql_params.context.background
+    await gql_params.context.background()
+
+    # As the TestPerson already was a member of child_group_1 we don't expect to see any group
+    # events for that group
+    assert len(memory_event.events) == 3
+    person_updated = memory_event.events[0]
+    group_updated = memory_event.events[1]
+    member_added = memory_event.events[2]
+    assert isinstance(person_updated, NodeUpdatedEvent)
+    assert isinstance(group_updated, NodeUpdatedEvent)
+    assert isinstance(member_added, GroupMemberAddedEvent)
+    assert person_updated.node_id == person_id
+    assert group_updated.node_id == orphan_group_1.get_id()
+    assert member_added.node_id == orphan_group_1.get_id()
+    assert len(member_added.members) == 1
+    assert EventNode(id=person_id, kind="TestPerson") in member_added.members
+    assert len(member_added.ancestors) == 0
+
+    delete_query = """
+    mutation( $id: String!) {
+        TestPersonDelete(data:
+            {
+                id: $id,
+            }
+        ) {
+            ok
+        }
+    }
+    """
+    memory_event = MemoryInfrahubEvent()
+    service = await InfrahubServices.new(event=memory_event)
+    gql_params = await prepare_graphql_params(
+        db=db, include_subscription=False, branch=default_branch, service=service, account_session=session_first_account
+    )
+    result = await graphql(
+        schema=gql_params.schema,
+        source=delete_query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"id": person_id},
+    )
+    assert not result.errors
+    assert gql_params.context.background
+    await gql_params.context.background()
+
+    assert len(memory_event.events) == 5
+    person_deleted = memory_event.events[0]
+    groups_updated = memory_event.events[1:3]
+    members_removed = memory_event.events[3:5]
+    assert isinstance(person_deleted, NodeDeletedEvent)
+    assert len(groups_updated) == 2
+    assert isinstance(groups_updated[0], NodeUpdatedEvent)
+    assert isinstance(groups_updated[1], NodeUpdatedEvent)
+    assert len(members_removed) == 2
+    assert isinstance(members_removed[0], GroupMemberRemovedEvent)
+    assert isinstance(members_removed[1], GroupMemberRemovedEvent)
+    assert person_deleted.node_id == person_id
+    removal_events: list[GroupMemberRemovedEvent] = [members_removed[0], members_removed[1]]
+    child_group_event = [event for event in removal_events if event.node_id == child_group_1.id][0]
+    orphan_group_event = [event for event in removal_events if event.node_id == orphan_group_1.id][0]
+    assert len(child_group_event.members) == 1
+    assert EventNode(id=person_id, kind="TestPerson") in child_group_event.members
+    assert len(child_group_event.ancestors) == 2
+    assert EventNode(id=parent_group.id, kind="CoreStandardGroup") in child_group_event.ancestors
+    assert EventNode(id=root_group.id, kind="CoreStandardGroup") in child_group_event.ancestors
+    assert len(orphan_group_event.members) == 1
+    assert EventNode(id=person_id, kind="TestPerson") in orphan_group_event.members
+    assert len(orphan_group_event.ancestors) == 0


### PR DESCRIPTION
This PR corrects an issue related to group events. The problem was that they were only being sent when using the RelationshipAdd or RelationshipRemove mutations. This PR makes use of the node mutation events to figure out changes to group memberships and creates group member added or removed events from that data.

Because we query for group ancestors this PR will introduce a slight delay to any mutation that updates members of groups.

