### PR TITLE
Add relationship info to node mutation activity log entries

### DIFF
--- a/backend/infrahub/computed_attribute/models.py
+++ b/backend/infrahub/computed_attribute/models.py
@@ -134,7 +134,7 @@ class ComputedAttrJinja2TriggerDefinition(TriggerBranchDefinition):
             event_trigger.match["infrahub.branch.name"] = branch
 
         event_trigger.match_related = {
-            "prefect.resource.role": "infrahub.node.field_update",
+            "prefect.resource.role": ["infrahub.node.attribute_update", "infrahub.node.relationship_update"],
             "infrahub.field.name": trigger_node.fields,
         }
 

--- a/backend/infrahub/events/node_action.py
+++ b/backend/infrahub/events/node_action.py
@@ -2,8 +2,12 @@ from typing import ClassVar
 
 from pydantic import Field
 
-from infrahub.core.changelog.models import NodeChangelog
-from infrahub.core.constants import MutationAction
+from infrahub.core.changelog.models import (
+    NodeChangelog,
+    RelationshipCardinalityManyChangelog,
+    RelationshipCardinalityOneChangelog,
+)
+from infrahub.core.constants import DiffAction, MutationAction
 
 from .constants import EVENT_NAMESPACE
 from .models import InfrahubEvent
@@ -24,7 +28,7 @@ class NodeMutatedEvent(InfrahubEvent):
             related.append(
                 {
                     "prefect.resource.id": f"infrahub.node.{self.node_id}",
-                    "prefect.resource.role": "infrahub.node.field_update",
+                    "prefect.resource.role": "infrahub.node.attribute_update",
                     "infrahub.field.name": attribute.name,
                     "infrahub.attribute.name": attribute.name,
                     "infrahub.attribute.value": "NULL" if attribute.value is None else str(attribute.value),
@@ -37,14 +41,39 @@ class NodeMutatedEvent(InfrahubEvent):
                 }
             )
 
-        for relationship_name in self.changelog.relationships.keys():
-            related.append(
-                {
-                    "prefect.resource.id": f"infrahub.node.{self.node_id}",
-                    "prefect.resource.role": "infrahub.node.field_update",
-                    "infrahub.field.name": relationship_name,
-                }
-            )
+        for relationship in self.changelog.relationships.values():
+            if isinstance(relationship, RelationshipCardinalityOneChangelog) and not relationship.is_empty:
+                if relationship.peer_id and relationship.peer_kind:
+                    related.append(
+                        self._format_relationship_resource(
+                            relationship_name=relationship.name,
+                            peer_id=relationship.peer_id,
+                            peer_kind=relationship.peer_kind,
+                            action=DiffAction.ADDED,
+                        )
+                    )
+
+                if relationship.peer_id_previous and relationship.peer_kind_previous:
+                    related.append(
+                        self._format_relationship_resource(
+                            relationship_name=relationship.name,
+                            peer_id=relationship.peer_id_previous,
+                            peer_kind=relationship.peer_kind_previous,
+                            action=DiffAction.REMOVED,
+                        )
+                    )
+
+            elif isinstance(relationship, RelationshipCardinalityManyChangelog):
+                for peer in relationship.peers:
+                    if peer.peer_status in [DiffAction.ADDED, DiffAction.REMOVED]:
+                        related.append(
+                            self._format_relationship_resource(
+                                relationship_name=relationship.name,
+                                peer_id=peer.peer_id,
+                                peer_kind=peer.peer_kind,
+                                action=peer.peer_status,
+                            )
+                        )
 
         if self.changelog.parent:
             related.append(
@@ -74,6 +103,19 @@ class NodeMutatedEvent(InfrahubEvent):
             )
 
         return related
+
+    def _format_relationship_resource(
+        self, relationship_name: str, peer_id: str, peer_kind: str, action: DiffAction
+    ) -> dict[str, str]:
+        return {
+            "prefect.resource.id": f"infrahub.node.{self.node_id}",
+            "prefect.resource.role": "infrahub.node.relationship_update",
+            "infrahub.field.name": relationship_name,
+            "infrahub.relationship.name": relationship_name,
+            "infrahub.relationship.peer_status": action.value,
+            "infrahub.relationship.peer_id": peer_id,
+            "infrahub.relationship.peer_kind": peer_kind,
+        }
 
     def get_resource(self) -> dict[str, str]:
         return {

--- a/backend/infrahub/graphql/types/event.py
+++ b/backend/infrahub/graphql/types/event.py
@@ -22,6 +22,12 @@ class InfrahubMutatedAttribute(ObjectType):
     value_previous = String(required=False)
 
 
+class InfrahubMutatedRelationship(ObjectType):
+    name = String(required=True)
+    action = DiffAction(required=True)
+    peer = Field(RelatedNode, required=True)
+
+
 class EventNodeInterface(Interface):
     id = String(required=True, description="The ID of the event.")
     event = String(required=True, description="The name of the event.")
@@ -116,6 +122,7 @@ class NodeMutatedEvent(ObjectType):
 
     payload = Field(GenericScalar, required=True)
     attributes = Field(List(of_type=NonNull(InfrahubMutatedAttribute), required=True), required=True)
+    relationships = Field(List(of_type=NonNull(InfrahubMutatedRelationship), required=True), required=True)
 
 
 class ArtifactEvent(ObjectType):

--- a/backend/infrahub/task_manager/event.py
+++ b/backend/infrahub/task_manager/event.py
@@ -92,11 +92,10 @@ class PrefectEventData(PrefectEventModel):
 
     def _return_node_mutation(self) -> dict[str, Any]:
         attributes = []
+        relationships = []
 
         for resource in self.related:
-            if resource.get("prefect.resource.role") == "infrahub.node.field_update" and resource.get(
-                "infrahub.attribute.name"
-            ):
+            if resource.role == "infrahub.node.attribute_update" and resource.get("infrahub.attribute.name"):
                 attributes.append(
                     {
                         "name": resource.get("infrahub.attribute.name", ""),
@@ -110,8 +109,19 @@ class PrefectEventData(PrefectEventModel):
                         "action": resource.get("infrahub.attribute.action", "unchanged"),
                     }
                 )
+            elif resource.role == "infrahub.node.relationship_update":
+                relationships.append(
+                    {
+                        "name": resource.get("infrahub.relationship.name"),
+                        "action": resource.get("infrahub.relationship.peer_status"),
+                        "peer": {
+                            "id": resource.get("infrahub.relationship.peer_id"),
+                            "kind": resource.get("infrahub.relationship.peer_kind"),
+                        },
+                    }
+                )
 
-        return {"attributes": attributes}
+        return {"attributes": attributes, "relationships": relationships}
 
     def _get_branch_name_from_resource(self) -> str:
         return self.resource.get("infrahub.branch.name") or ""

--- a/backend/tests/unit/graphql/queries/test_event.py
+++ b/backend/tests/unit/graphql/queries/test_event.py
@@ -31,6 +31,7 @@ query(
     $has_children: Boolean
     $event_type: [String!]
     $since: DateTime
+    $primary_node__ids: [String!]
 ) {
   InfrahubEvent(
     branches: $branch,
@@ -40,6 +41,7 @@ query(
     level: $level
     has_children: $has_children
     parent__ids: $parent__ids
+    primary_node__ids: $primary_node__ids
     event_type: $event_type
     since: $since
   ) {
@@ -65,6 +67,30 @@ query(
           members {
             id
             kind
+          }
+        }
+        ... on NodeMutatedEvent {
+          branch
+          event
+          payload
+          primary_node {
+            id
+            kind
+          }
+          attributes {
+            action
+            kind
+            name
+            value
+            value_previous
+          }
+          relationships {
+            name
+            action
+            peer {
+              id
+              kind
+            }
           }
         }
       }
@@ -291,6 +317,16 @@ async def events_data(
                 context=InfrahubContext.init(branch=branch1, account=ACCOUNT_SESSION_2),
             ),
         ),
+        "branch1_mutated7": NodeCreatedEvent(
+            kind=group_fr.get_kind(),
+            node_id=group_fr.get_id(),
+            changelog=group_fr.node_changelog,
+            meta=EventMeta(
+                branch=branch1,
+                account_id=ACCOUNT2_ID,
+                context=InfrahubContext.init(branch=branch1, account=ACCOUNT_SESSION_2),
+            ),
+        ),
         "branch2_mutated1": NodeCreatedEvent(
             kind="BuiltinTag",
             node_id=tag4.get_id(),
@@ -414,7 +450,7 @@ async def test_event_query_prefect(
     assert result_branch1.data
 
     clean_result = filter_outofscope_events(result_branch1.data, event_ids_inscope)
-    assert clean_result["InfrahubEvent"]["count"] == 8
+    assert clean_result["InfrahubEvent"]["count"] == 9
 
     result_count_branch1 = await run_query(
         db=db,
@@ -486,7 +522,7 @@ async def test_event_query_prefect(
     )
     assert branch1_account2.errors is None
     assert branch1_account2.data
-    assert branch1_account2.data["InfrahubEvent"]["count"] == 3
+    assert branch1_account2.data["InfrahubEvent"]["count"] == 4
 
     branch2_account1 = await run_query(
         db=db,
@@ -585,7 +621,7 @@ async def test_event_query_prefect(
     )
     assert created_branch1.errors is None
     assert created_branch1.data
-    assert created_branch1.data["InfrahubEvent"]["count"] == 10
+    assert created_branch1.data["InfrahubEvent"]["count"] == 11
     assert [node["node"]["event"] for node in created_branch1.data["InfrahubEvent"]["edges"]] == [
         "infrahub.node.created"
     ] * 10
@@ -627,3 +663,29 @@ async def test_event_query_prefect(
     assert events_data["branch3_mutated1"].node_id in members
     assert events_data["branch3_mutated2"].node_id in members
     assert events_data["branch1_mutated5"].node_id in ancestors
+
+    relationship_cardinality_many = await run_query(
+        db=db,
+        branch=default_branch,
+        query=QUERY_EVENT,
+        variables={
+            "event_type": ["infrahub.node.created"],
+            "primary_node__ids": events_data["branch1_mutated7"].node_id,
+        },
+    )
+    assert not relationship_cardinality_many.errors
+    assert relationship_cardinality_many.data
+    assert relationship_cardinality_many.data["InfrahubEvent"]["count"] == 1
+    event = relationship_cardinality_many.data["InfrahubEvent"]["edges"][0]["node"]
+    assert len(event["relationships"]) == 2
+
+    assert {
+        "name": "members",
+        "action": "ADDED",
+        "peer": {"id": events_data["branch3_mutated1"].node_id, "kind": "TestPerson"},
+    } in event["relationships"]
+    assert {
+        "name": "members",
+        "action": "ADDED",
+        "peer": {"id": events_data["branch3_mutated2"].node_id, "kind": "TestPerson"},
+    } in event["relationships"]


### PR DESCRIPTION
Add relationship information to the node mutated events.

In order to fix this I had to make a small update to the triggers for computed attributes as well as it seemed convoluted to fit the same type of data in into `"prefect.resource.role" = "infrahub.node.field_update"`

The relationships part of the response will treat cardinality=one and cardinality=many relationships in the same way meaning that the everything will be presented in the same format under "relationships". Which means a relationship name can show up multiple times. It feels cleaner to me than to specifically have a "relationship_cardinality_one" section and a "relationship_cardinality_many" section (which would have multiple peers). Though it could also be that both of the relationship types should instead have a "peers" section that can contain multiple peers and instead place the "action" field there.

Does anyone have any thoughts around the structure of the returned data?

A query would look like this:

```graphql
query MyQuery {
  InfrahubEvent(event_type: "infrahub.node.created") {
    edges {
      node {
        ... on NodeMutatedEvent {
          id
          event
          relationships {
            action
            name
            peer {
              id
              kind
            }
          }
        }
      }
    }
  }
}
```

Example response:

```json
{
  "data": {
    "InfrahubEvent": {
      "edges": [
        {
          "node": {
            "id": "c5f7e3e1-7273-4cad-9635-bf9f32c308bd",
            "event": "infrahub.node.created",
            "relationships": [
              {
                "action": "ADDED",
                "name": "race",
                "peer": {
                  "id": "182e312d-9b08-a508-58d3-174692cc48cf",
                  "kind": "RpgRace"
                }
              },
              {
                "action": "ADDED",
                "name": "profession",
                "peer": {
                  "id": "182e312c-a520-c940-58d3-1746ba023b18",
                  "kind": "RpgClass"
                }
              }
            ]
          }
        },
        {
          "node": {
            "id": "c4796285-4d3e-4d97-8102-f5c585f3dc8b",
            "event": "infrahub.node.created",
            "relationships": [
              {
                "action": "ADDED",
                "name": "race",
                "peer": {
                  "id": "182e312d-a0c8-d008-58d2-17468e8bb9bd",
                  "kind": "RpgRace"
                }
              },
              {
                "action": "ADDED",
                "name": "profession",
                "peer": {
                  "id": "182e312d-0971-b990-58d2-17465c882c4d",
                  "kind": "RpgClass"
                }
              }
            ]
          }
        },
        {
          "node": {
            "id": "79a5e78d-b32b-49a3-af98-bbac6e3b2bbd",
            "event": "infrahub.node.created",
            "relationships": [
              {
                "action": "ADDED",
                "name": "race",
                "peer": {
                  "id": "182e312d-a0c8-d008-58d2-17468e8bb9bd",
                  "kind": "RpgRace"
                }
              },
              {
                "action": "ADDED",
                "name": "profession",
                "peer": {
                  "id": "182e312c-a520-c940-58d3-1746ba023b18",
                  "kind": "RpgClass"
                }
              }
            ]
          }
        },
        {
          "node": {
            "id": "4b4abcde-399f-434b-8902-04b5442a9f66",
            "event": "infrahub.node.created",
            "relationships": [
              {
                "action": "ADDED",
                "name": "race",
                "peer": {
                  "id": "182e312d-a0c8-d008-58d2-17468e8bb9bd",
                  "kind": "RpgRace"
                }
              },
              {
                "action": "ADDED",
                "name": "profession",
                "peer": {
                  "id": "182e312d-10b4-c3a0-58df-17467908f7b4",
                  "kind": "RpgClass"
                }
              }
            ]
          }
        },
        {
          "node": {
            "id": "8e0138cc-3221-4c12-8d24-676dc38b2d77",
            "event": "infrahub.node.created",
            "relationships": [
              {
                "action": "ADDED",
                "name": "race",
                "peer": {
                  "id": "182e312d-9841-dc18-58d9-17469685f1e4",
                  "kind": "RpgRace"
                }
              },
              {
                "action": "ADDED",
                "name": "profession",
                "peer": {
                  "id": "182e312c-a520-c940-58d3-1746ba023b18",
                  "kind": "RpgClass"
                }
              }
            ]
          }
        },
        {
          "node": {
            "id": "8800f6bd-d5e1-4755-81fc-fd0ffe1575ae",
            "event": "infrahub.node.created",
            "relationships": [
              {
                "action": "ADDED",
                "name": "race",
                "peer": {
                  "id": "182e312d-3e86-0af0-58d6-17465b8c54ea",
                  "kind": "RpgRace"
                }
              },
              {
                "action": "ADDED",
                "name": "profession",
                "peer": {
                  "id": "182e312c-a520-c940-58d3-1746ba023b18",
                  "kind": "RpgClass"
                }
              }
            ]
          }
        },
        {
          "node": {
            "id": "8986b286-a0c1-4f3d-abd6-77d0d07ada2b",
            "event": "infrahub.node.created",
            "relationships": [
              {
                "action": "ADDED",
                "name": "race",
                "peer": {
                  "id": "182e312d-3e86-0af0-58d6-17465b8c54ea",
                  "kind": "RpgRace"
                }
              },
              {
                "action": "ADDED",
                "name": "profession",
                "peer": {
                  "id": "182e312c-a520-c940-58d3-1746ba023b18",
                  "kind": "RpgClass"
                }
              }
            ]
          }
        },
        {
          "node": {
            "id": "3a564440-e7d2-482e-a604-5954b67693f1",
            "event": "infrahub.node.created",
            "relationships": []
          }
        },
        {
          "node": {
            "id": "2ebb9f79-d446-47ee-93bf-39217073fd62",
            "event": "infrahub.node.created",
            "relationships": []
          }
        },
        {
          "node": {
            "id": "2e415aab-8300-484d-8a20-500455b62a46",
            "event": "infrahub.node.created",
            "relationships": []
          }
        }
      ]
    }
  }
}
````