### PR TITLE
Simplify main mutation code and move out event collection

### DIFF
--- a/backend/infrahub/events/generator.py
+++ b/backend/infrahub/events/generator.py
@@ -1,0 +1,71 @@
+from infrahub.context import InfrahubContext
+from infrahub.core.branch import Branch
+from infrahub.core.changelog.models import RelationshipChangelogGetter
+from infrahub.core.constants import MutationAction
+from infrahub.core.node import Node
+from infrahub.database import InfrahubDatabase
+from infrahub.events.node_action import NodeDeletedEvent, NodeMutatedEvent, NodeUpdatedEvent, get_node_event
+from infrahub.groups.parsers import GroupNodeMutationParser
+from infrahub.worker import WORKER_IDENTITY
+
+from .models import EventMeta, InfrahubEvent
+
+
+async def generate_node_mutation_events(
+    node: Node,
+    deleted_nodes: list[Node],
+    db: InfrahubDatabase,
+    branch: Branch,
+    context: InfrahubContext,
+    request_id: str,
+    action: MutationAction,
+) -> list[InfrahubEvent]:
+    meta = EventMeta(
+        account_id=context.account.account_id,
+        initiator_id=WORKER_IDENTITY,
+        request_id=request_id,
+        branch=branch,
+        context=context,
+    )
+    node_event_class = get_node_event(action)
+    main_event = node_event_class(
+        kind=node.get_kind(),
+        node_id=node.id,
+        changelog=node.node_changelog,
+        fields=node.node_changelog.updated_fields,
+        meta=meta,
+    )
+    relationship_changelogs = RelationshipChangelogGetter(db=db, branch=branch)
+    node_changelogs = await relationship_changelogs.get_changelogs(primary_changelog=node.node_changelog)
+
+    events: list[NodeMutatedEvent] = [main_event]
+
+    deleted_changelogs = [deleted_node.node_changelog for deleted_node in deleted_nodes if deleted_node.id != node.id]
+    deleted_ids = {deleted_node.node_id for deleted_node in deleted_changelogs}
+
+    for node_changelog in deleted_changelogs:
+        meta = EventMeta.from_parent(parent=main_event)
+        delete_event = NodeDeletedEvent(
+            kind=node_changelog.node_kind,
+            node_id=node_changelog.node_id,
+            changelog=node_changelog,
+            fields=node_changelog.updated_fields,
+            meta=meta,
+        )
+        events.append(delete_event)
+
+    for node_changelog in node_changelogs:
+        if node_changelog.node_id not in deleted_ids:
+            meta = EventMeta.from_parent(parent=main_event)
+            update_event = NodeUpdatedEvent(
+                kind=node_changelog.node_kind,
+                node_id=node_changelog.node_id,
+                changelog=node_changelog,
+                fields=node_changelog.updated_fields,
+                meta=meta,
+            )
+            events.append(update_event)
+
+    group_parser = GroupNodeMutationParser(db=db, branch=branch)
+    group_events = await group_parser.group_events_from_node_actions(events=events)
+    return events + group_events

--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -10,7 +10,6 @@ from typing_extensions import Self
 
 from infrahub import config, lock
 from infrahub.core import registry
-from infrahub.core.changelog.models import RelationshipChangelogGetter
 from infrahub.core.constants import InfrahubKind, MutationAction, RelationshipCardinality, RelationshipKind
 from infrahub.core.constraint.node.runner import NodeConstraintRunner
 from infrahub.core.manager import NodeManager
@@ -22,14 +21,11 @@ from infrahub.core.schema.template_schema import TemplateSchema
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import retry_db_transaction
 from infrahub.dependencies.registry import get_component_registry
-from infrahub.events import EventMeta
-from infrahub.events.node_action import NodeDeletedEvent, NodeMutatedEvent, NodeUpdatedEvent, get_node_event
+from infrahub.events.generator import generate_node_mutation_events
 from infrahub.exceptions import InitializationError, ValidationError
 from infrahub.graphql.context import apply_external_context
-from infrahub.groups.parsers import GroupNodeMutationParser
 from infrahub.lock import InfrahubMultiLock, build_object_lock_name
 from infrahub.log import get_log_data, get_logger
-from infrahub.worker import WORKER_IDENTITY
 
 from .node_getter.by_default_filter import MutationNodeGetterByDefaultFilter
 from .node_getter.by_hfid import MutationNodeGetterByHfid
@@ -78,7 +74,7 @@ class InfrahubMutationMixin:
     _meta: InfrahubMutationOptions
 
     @classmethod
-    async def mutate(  # noqa: PLR0915
+    async def mutate(
         cls,
         root: dict,  # noqa: ARG003
         info: GraphQLResolveInfo,
@@ -133,60 +129,17 @@ class InfrahubMutationMixin:
             log_data = get_log_data()
             request_id = log_data.get("request_id", "")
 
-            account_id: str | None = None
-            if graphql_context.account_session:
-                account_id = graphql_context.account_session.account_id
-
-            meta = EventMeta(
-                account_id=account_id,
-                initiator_id=WORKER_IDENTITY,
-                request_id=request_id,
+            events = await generate_node_mutation_events(
+                node=obj,
+                deleted_nodes=deleted_nodes,
+                db=graphql_context.db,
                 branch=graphql_context.branch,
                 context=graphql_context.get_context(),
+                request_id=request_id,
+                action=action,
             )
-            node_event_class = get_node_event(action)
-            main_event = node_event_class(
-                kind=obj._schema.kind,
-                node_id=obj.id,
-                changelog=obj.node_changelog,
-                fields=_get_data_fields(data),
-                meta=meta,
-            )
-            relationship_changelogs = RelationshipChangelogGetter(db=graphql_context.db, branch=graphql_context.branch)
-            node_changelogs = await relationship_changelogs.get_changelogs(primary_changelog=obj.node_changelog)
 
-            events: list[NodeMutatedEvent] = [main_event]
-
-            deleted_changelogs = [node.node_changelog for node in deleted_nodes if node.id != obj.id]
-            deleted_ids = {node.node_id for node in deleted_changelogs}
-
-            for node_changelog in deleted_changelogs:
-                meta = EventMeta.from_parent(parent=main_event)
-                delete_event = NodeDeletedEvent(
-                    kind=node_changelog.node_kind,
-                    node_id=node_changelog.node_id,
-                    changelog=node_changelog,
-                    fields=node_changelog.updated_fields,
-                    meta=meta,
-                )
-                events.append(delete_event)
-
-            for node_changelog in node_changelogs:
-                if node_changelog.node_id not in deleted_ids:
-                    meta = EventMeta.from_parent(parent=main_event)
-                    update_event = NodeUpdatedEvent(
-                        kind=node_changelog.node_kind,
-                        node_id=node_changelog.node_id,
-                        changelog=node_changelog,
-                        fields=node_changelog.updated_fields,
-                        meta=meta,
-                    )
-                    events.append(update_event)
-
-            group_parser = GroupNodeMutationParser(db=graphql_context.db, branch=graphql_context.branch)
-            group_events = await group_parser.group_events_from_node_actions(events=events)
-
-            for event in events + group_events:
+            for event in events:
                 graphql_context.background.add_task(graphql_context.active_service.event.send, event)
 
         return mutation


### PR DESCRIPTION
This PR moves out some of the logic related to events from the main mutation code.

Note there's a job in the pipeline failing related to Cloudflare, that would be completely unrelated to this change.