### PR TITLE
Fix computed attribute relationship issue of passing object by reference

### DIFF
--- a/backend/infrahub/core/schema/schema_branch_computed.py
+++ b/backend/infrahub/core/schema/schema_branch_computed.py
@@ -140,17 +140,17 @@ class ComputedAttributes:
             if schema_path.active_attribute_schema.name not in trigger_node.local_fields:
                 trigger_node.local_fields[schema_path.active_attribute_schema.name] = []
 
-            trigger_node.local_fields[schema_path.active_attribute_schema.name].append(source_attribute)
+            trigger_node.local_fields[schema_path.active_attribute_schema.name].append(deepcopy(source_attribute))
         elif schema_path.is_type_relationship:
             if schema_path.active_attribute_schema.name not in trigger_node.local_fields:
                 trigger_node.local_fields[schema_path.active_attribute_schema.name] = []
 
-            trigger_node.local_fields[schema_path.active_attribute_schema.name].append(source_attribute)
+            trigger_node.local_fields[schema_path.active_attribute_schema.name].append(deepcopy(source_attribute))
 
             if schema_path.active_relationship_schema.name not in trigger_node.relationships:
                 trigger_node.relationships[schema_path.active_relationship_schema.name] = []
 
-            trigger_node.relationships[schema_path.active_relationship_schema.name].append(source_attribute)
+            trigger_node.relationships[schema_path.active_relationship_schema.name].append(deepcopy(source_attribute))
 
             if source_attribute.kind not in self._computed_jinja2_attribute_map:
                 self._computed_jinja2_attribute_map[source_attribute.kind] = RegisteredNodeComputedAttribute()
@@ -164,7 +164,7 @@ class ComputedAttributes:
                 ] = []
             self._computed_jinja2_attribute_map[source_attribute.kind].local_fields[
                 schema_path.active_relationship_schema.name
-            ].append(source_attribute)
+            ].append(deepcopy(source_attribute))
 
     def get_impacted_jinja2_targets(self, kind: str, updates: list[str] | None = None) -> list[ComputedAttributeTarget]:
         if mapping := self._computed_jinja2_attribute_map.get(kind):

--- a/backend/tests/integration_docker/test_computed_attributes.py
+++ b/backend/tests/integration_docker/test_computed_attributes.py
@@ -36,6 +36,12 @@ class TestComputedAttributes(TestInfrahubDockerClient):
         }
         color1 = await client.create(kind="TestingColor", data=data)
         await color1.save()
+        data = {
+            "name": "Ember Glow",
+            "description": "A deep, fiery red-orange reminiscent of smoldering embers at dusk.",
+        }
+        color2 = await client.create(kind="TestingColor", data=data)
+        await color2.save()
 
         data = {
             "name": "Explorer",
@@ -62,3 +68,20 @@ class TestComputedAttributes(TestInfrahubDockerClient):
             await sleep(1)
 
         assert tshirt1_updated.description.value == final_desc
+
+        tshirt1_second_update = await client.get(kind="TestingTShirt", id=tshirt1.id)
+        tshirt1_second_update.color = color2
+        await tshirt1_second_update.save()
+
+        expected_description = (
+            "A Ember Glow Explorer t-shirt. A deep, fiery red-orange reminiscent of smoldering embers at dusk."
+        )
+
+        for _ in range(10):
+            # Give the computed attribute triggers a little while to run
+            tshirt1_second_update_result = await client.get(kind="TestingTShirt", id=tshirt1.id)
+            if tshirt1_second_update_result.description.value == expected_description:
+                break
+            await sleep(1)
+
+        assert tshirt1_second_update_result.description.value == expected_description


### PR DESCRIPTION
This PR fixes a bug in the Jinja2 based computed attributes where it could be problematic if you update the relationship of a node when that node has computed attributes. The problem is that we used the relationship filter when searching for the device with the SDK. As an example if we had a TestDevice that had a relationship called "site" and it was connected to a TestSite. Then on TestDevice there's a computed attribute that uses information from the site. When we update the TestDevice and specifically the "site" relationship, such as moving the device to another site we use the SDK to find the correct node.

Instead of searching for the device ID using the `ids` filter we'd at times use `site__ids` which didn't return any results so the attribute didn't get properly updated.

I noticed this when looking at something else and I'm not sure if it's a new or an old problem, the workaround was to restart the prefect worker.

The root cause is that we're updating the `ComputedAttributeTarget` object depending on the circumstance and the problem here is that after the object is first created we're passing it as a reference so with the above example if we were to update the TestSite name it would be correct to use `site__ids` filter.

I view this as a quick fix to solve the current problem, but I think for 1.3 that there are some parts of the computed attributes that could use a refactoring.