### PR TITLE
Allow renaming of inherited kinds

### DIFF
--- a/backend/infrahub/core/migrations/__init__.py
+++ b/backend/infrahub/core/migrations/__init__.py
@@ -13,6 +13,7 @@ MIGRATION_MAP: dict[str, Optional[type[SchemaMigration]]] = {
     "node.branch.update": None,
     "node.attribute.add": NodeAttributeAddMigration,
     "node.attribute.remove": NodeAttributeRemoveMigration,
+    "node.inherit_from.update": NodeKindUpdateMigration,
     "node.name.update": NodeKindUpdateMigration,
     "node.namespace.update": NodeKindUpdateMigration,
     "node.relationship.remove": PlaceholderDummyMigration,

--- a/backend/infrahub/core/migrations/query/node_duplicate.py
+++ b/backend/infrahub/core/migrations/query/node_duplicate.py
@@ -9,8 +9,6 @@ from infrahub.core.graph.schema import GraphNodeRelationships, GraphRelDirection
 from infrahub.core.query import Query, QueryType
 
 if TYPE_CHECKING:
-    from pydantic.fields import FieldInfo
-
     from infrahub.database import InfrahubDatabase
 
 
@@ -47,17 +45,13 @@ class NodeDuplicateQuery(Query):
         return query
 
     @staticmethod
-    def _render_sub_query_per_rel_type(
-        rel_name: str,
-        rel_type: str,
-        rel_def: FieldInfo,
-    ) -> str:
+    def _render_sub_query_per_rel_type(rel_name: str, rel_type: str, rel_dir: GraphRelDirection) -> str:
         subquery = [
             f"WITH peer_node, {rel_name}, active_node, new_node",
             f"WITH peer_node, {rel_name}, active_node, new_node",
             f'WHERE type({rel_name}) = "{rel_type}"',
         ]
-        if rel_def.default.direction in [GraphRelDirection.OUTBOUND, GraphRelDirection.EITHER]:
+        if rel_dir in [GraphRelDirection.OUTBOUND, GraphRelDirection.EITHER]:
             subquery.append(f"""
                 CREATE (new_node)-[new_active_edge:{rel_type} $rel_props_new ]->(peer_node)
                 SET new_active_edge.branch = CASE WHEN {rel_name}.branch = "-global-" THEN "-global-" ELSE $branch END
@@ -70,7 +64,7 @@ class NodeDuplicateQuery(Query):
                 SET deleted_edge.branch_level = CASE WHEN {rel_name}.branch = "-global-" THEN {rel_name}.branch_level ELSE $branch_level END
                 SET deleted_edge.hierarchy = COALESCE({rel_name}.hierarchy, NULL)
                 """)
-        elif rel_def.default.direction in [GraphRelDirection.INBOUND, GraphRelDirection.EITHER]:
+        elif rel_dir in [GraphRelDirection.INBOUND, GraphRelDirection.EITHER]:
             subquery.append(f"""
                 CREATE (new_node)<-[new_active_edge:{rel_type} $rel_props_new ]-(peer_node)
                 SET new_active_edge.branch = CASE WHEN {rel_name}.branch = "-global-" THEN "-global-" ELSE $branch END
@@ -90,11 +84,10 @@ class NodeDuplicateQuery(Query):
     def _render_sub_query_out(cls) -> str:
         sub_queries_out = [
             cls._render_sub_query_per_rel_type(
-                rel_name="rel_outband",
-                rel_type=rel_type,
-                rel_def=rel_def,
+                rel_name="rel_outband", rel_type=rel_type, rel_dir=GraphRelDirection.OUTBOUND
             )
-            for rel_type, rel_def in GraphNodeRelationships.model_fields.items()
+            for rel_type, field_info in GraphNodeRelationships.model_fields.items()
+            if field_info.default.direction in (GraphRelDirection.OUTBOUND, GraphRelDirection.EITHER)
         ]
         sub_query_out = "\nUNION\n".join(sub_queries_out)
         return sub_query_out
@@ -103,11 +96,10 @@ class NodeDuplicateQuery(Query):
     def _render_sub_query_in(cls) -> str:
         sub_queries_in = [
             cls._render_sub_query_per_rel_type(
-                rel_name="rel_inband",
-                rel_type=rel_type,
-                rel_def=rel_def,
+                rel_name="rel_inband", rel_type=rel_type, rel_dir=GraphRelDirection.INBOUND
             )
-            for rel_type, rel_def in GraphNodeRelationships.model_fields.items()
+            for rel_type, field_info in GraphNodeRelationships.model_fields.items()
+            if field_info.default.direction in (GraphRelDirection.INBOUND, GraphRelDirection.EITHER)
         ]
         sub_query_in = "\nUNION\n".join(sub_queries_in)
         return sub_query_in
@@ -172,7 +164,7 @@ class NodeDuplicateQuery(Query):
         FOREACH (i in CASE WHEN rel_outband.branch IN ["-global-", $branch] THEN [1] ELSE [] END |
             SET rel_outband.to = $current_time
         )
-        WITH active_node, new_node
+        WITH DISTINCT active_node, new_node
         // Process Inbound Relationship
         MATCH (active_node)<-[]-(peer)
         CALL {

--- a/backend/infrahub/core/migrations/query/node_duplicate.py
+++ b/backend/infrahub/core/migrations/query/node_duplicate.py
@@ -169,10 +169,11 @@ class NodeDuplicateQuery(Query):
             SET rel_outband.to = $current_time
         )
         WITH active_node, new_node
+        // Process Inbound Relationship
         MATCH (active_node)<-[]-(peer)
         CALL {
             WITH active_node, peer
-            MATCH (active_node)-[r]->(peer)
+            MATCH (active_node)<-[r]-(peer)
             WHERE %(branch_filter)s
             RETURN active_node as n1, r as rel_inband1, peer as p1
             ORDER BY r.branch_level DESC, r.from DESC

--- a/backend/infrahub/core/migrations/query/node_duplicate.py
+++ b/backend/infrahub/core/migrations/query/node_duplicate.py
@@ -62,22 +62,26 @@ class NodeDuplicateQuery(Query):
                 CREATE (new_node)-[new_active_edge:{rel_type} $rel_props_new ]->(peer_node)
                 SET new_active_edge.branch = CASE WHEN {rel_name}.branch = "-global-" THEN "-global-" ELSE $branch END
                 SET new_active_edge.branch_level = CASE WHEN {rel_name}.branch = "-global-" THEN {rel_name}.branch_level ELSE $branch_level END
+                SET new_active_edge.hierarchy = COALESCE({rel_name}.hierarchy, NULL)
                 """)
             subquery.append(f"""
                 CREATE (active_node)-[deleted_edge:{rel_type} $rel_props_prev ]->(peer_node)
                 SET deleted_edge.branch = CASE WHEN {rel_name}.branch = "-global-" THEN "-global-" ELSE $branch END
                 SET deleted_edge.branch_level = CASE WHEN {rel_name}.branch = "-global-" THEN {rel_name}.branch_level ELSE $branch_level END
+                SET deleted_edge.hierarchy = COALESCE({rel_name}.hierarchy, NULL)
                 """)
         elif rel_def.default.direction in [GraphRelDirection.INBOUND, GraphRelDirection.EITHER]:
             subquery.append(f"""
                 CREATE (new_node)<-[new_active_edge:{rel_type} $rel_props_new ]-(peer_node)
                 SET new_active_edge.branch = CASE WHEN {rel_name}.branch = "-global-" THEN "-global-" ELSE $branch END
                 SET new_active_edge.branch_level = CASE WHEN {rel_name}.branch = "-global-" THEN {rel_name}.branch_level ELSE $branch_level END
+                SET new_active_edge.hierarchy = COALESCE({rel_name}.hierarchy, NULL)
                 """)
             subquery.append(f"""
                 CREATE (active_node)<-[deleted_edge:{rel_type} $rel_props_prev ]-(peer_node)
                 SET new_active_edge.branch = CASE WHEN {rel_name}.branch = "-global-" THEN "-global-" ELSE $branch END
                 SET new_active_edge.branch_level = CASE WHEN {rel_name}.branch = "-global-" THEN {rel_name}.branch_level ELSE $branch_level END
+                SET new_active_edge.hierarchy = COALESCE({rel_name}.hierarchy, NULL)
                 """)
         subquery.append("RETURN peer_node as p2")
         return "\n".join(subquery)

--- a/backend/infrahub/core/migrations/query/node_duplicate.py
+++ b/backend/infrahub/core/migrations/query/node_duplicate.py
@@ -79,9 +79,9 @@ class NodeDuplicateQuery(Query):
                 """)
             subquery.append(f"""
                 CREATE (active_node)<-[deleted_edge:{rel_type} $rel_props_prev ]-(peer_node)
-                SET new_active_edge.branch = CASE WHEN {rel_name}.branch = "-global-" THEN "-global-" ELSE $branch END
-                SET new_active_edge.branch_level = CASE WHEN {rel_name}.branch = "-global-" THEN {rel_name}.branch_level ELSE $branch_level END
-                SET new_active_edge.hierarchy = COALESCE({rel_name}.hierarchy, NULL)
+                SET deleted_edge.branch = CASE WHEN {rel_name}.branch = "-global-" THEN "-global-" ELSE $branch END
+                SET deleted_edge.branch_level = CASE WHEN {rel_name}.branch = "-global-" THEN {rel_name}.branch_level ELSE $branch_level END
+                SET deleted_edge.hierarchy = COALESCE({rel_name}.hierarchy, NULL)
                 """)
         subquery.append("RETURN peer_node as p2")
         return "\n".join(subquery)

--- a/backend/infrahub/core/models.py
+++ b/backend/infrahub/core/models.py
@@ -182,6 +182,15 @@ class SchemaUpdateValidationResult(BaseModel):
 
         for schema_name, schema_diff in self.diff.changed.items():
             schema_node = schema.get(name=schema_name, duplicate=False)
+            if "inherit_from" in schema_diff.changed:
+                self.migrations.append(
+                    SchemaUpdateMigrationInfo(
+                        path=SchemaPath(  # type: ignore[call-arg]
+                            schema_kind=schema_name, path_type=SchemaPathType.NODE
+                        ),
+                        migration_name="node.inherit_from.update",
+                    )
+                )
 
             # Nothing to do today if we add a new attribute to a node in the schema
             # for node_field_name, _ in schema_diff.added.items():

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -45,7 +45,6 @@ from infrahub.core.schema import (
     SchemaRoot,
 )
 from infrahub.core.schema.definitions.core import core_profile_schema_definition
-from infrahub.core.validators import CONSTRAINT_VALIDATOR_MAP
 from infrahub.exceptions import SchemaNotFoundError, ValidationError
 from infrahub.log import get_logger
 from infrahub.support.macro import MacroDefinition
@@ -250,6 +249,9 @@ class SchemaBranch:
     def validate_update(
         self, other: SchemaBranch, diff: SchemaDiff, enforce_update_support: bool = True
     ) -> SchemaUpdateValidationResult:
+        # FIXME: I' mot a big fan of this approach to solve import loop
+        from infrahub.core.validators import CONSTRAINT_VALIDATOR_MAP
+
         result = SchemaUpdateValidationResult.init(
             diff=diff, schema=other, enforce_update_support=enforce_update_support
         )

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -45,6 +45,7 @@ from infrahub.core.schema import (
     SchemaRoot,
 )
 from infrahub.core.schema.definitions.core import core_profile_schema_definition
+from infrahub.core.validators import CONSTRAINT_VALIDATOR_MAP
 from infrahub.exceptions import SchemaNotFoundError, ValidationError
 from infrahub.log import get_logger
 from infrahub.support.macro import MacroDefinition
@@ -249,9 +250,6 @@ class SchemaBranch:
     def validate_update(
         self, other: SchemaBranch, diff: SchemaDiff, enforce_update_support: bool = True
     ) -> SchemaUpdateValidationResult:
-        # FIXME: I' mot a big fan of this approach to solve import loop
-        from infrahub.core.validators import CONSTRAINT_VALIDATOR_MAP
-
         result = SchemaUpdateValidationResult.init(
             diff=diff, schema=other, enforce_update_support=enforce_update_support
         )

--- a/backend/infrahub/core/validators/interface.py
+++ b/backend/infrahub/core/validators/interface.py
@@ -1,8 +1,12 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
-from infrahub.core.path import GroupedDataPaths
+if TYPE_CHECKING:
+    from infrahub.core.path import GroupedDataPaths
 
-from .model import SchemaConstraintValidatorRequest
+    from .model import SchemaConstraintValidatorRequest
 
 
 class ConstraintCheckerInterface(ABC):

--- a/backend/infrahub/core/validators/model.py
+++ b/backend/infrahub/core/validators/model.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, Field
 from infrahub.core.branch import Branch
 from infrahub.core.path import SchemaPath
 from infrahub.core.schema import GenericSchema, NodeSchema
+from infrahub.core.schema.schema_branch import SchemaBranch
 
 
 class SchemaConstraintValidatorRequest(BaseModel):
@@ -12,6 +13,7 @@ class SchemaConstraintValidatorRequest(BaseModel):
     constraint_name: str = Field(..., description="The name of the constraint to validate")
     node_schema: Union[NodeSchema, GenericSchema] = Field(..., description="Schema of Node or Generic to validate")
     schema_path: SchemaPath = Field(..., description="SchemaPath to the element of the schema to validate")
+    schema_branch: SchemaBranch = Field(..., description="SchemaBranch of the element to validate")
 
 
 class SchemaViolation(BaseModel):

--- a/backend/infrahub/core/validators/node/hierarchy.py
+++ b/backend/infrahub/core/validators/node/hierarchy.py
@@ -7,9 +7,7 @@ from infrahub.core.path import DataPath, GroupedDataPaths
 from infrahub.core.schema import NodeSchema
 
 from ..interface import ConstraintCheckerInterface
-from ..shared import (
-    SchemaValidatorQuery,
-)
+from ..shared import SchemaValidatorQuery
 
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch

--- a/backend/infrahub/core/validators/node/inherit_from.py
+++ b/backend/infrahub/core/validators/node/inherit_from.py
@@ -38,7 +38,7 @@ class NodeInheritFromChecker(ConstraintCheckerInterface):
             name=request.node_schema.kind, branch=request.branch, duplicate=False
         )
 
-        if not isinstance(request.node_schema, NodeSchema) or request.schema_branch is None:
+        if not isinstance(request.node_schema, NodeSchema):
             return grouped_data_paths_list
 
         _, removed, _ = compare_lists(list1=current_schema.inherit_from, list2=request.node_schema.inherit_from)
@@ -53,17 +53,18 @@ class NodeInheritFromChecker(ConstraintCheckerInterface):
         request_inherited: list[MainSchemaTypes] = []
         for n in request.node_schema.inherit_from:
             try:
-                request_inherited.append(request.schema_branch.get(name=n, duplicate=False))
+                schema = request.schema_branch.get(name=n, duplicate=False)
             except SchemaNotFoundError:
-                request_inherited.append(self.db.schema.get(name=n, branch=request.branch, duplicate=False))
+                schema = self.db.schema.get(name=n, branch=request.branch, duplicate=False)
+            request_inherited.append(schema)
         request_inherit_from_ids = {g.id: g.kind for g in request_inherited}
 
         # Compare IDs to find out if some inherited nodes were removed
         # Comparing IDs helps us in understanding if a node was renamed or really removed
-        _, removedIds, _ = compare_lists(
+        _, removed_ids, _ = compare_lists(
             list1=list(current_inherit_from_ids.keys()), list2=list(request_inherit_from_ids.keys())
         )
-        if removed := [current_inherit_from_ids[k] for k in removedIds]:
+        if removed := [current_inherit_from_ids[k] for k in removed_ids]:
             group_data_path.add_data_path(
                 DataPath(
                     branch=str(request.branch.name),

--- a/backend/infrahub/core/validators/node/inherit_from.py
+++ b/backend/infrahub/core/validators/node/inherit_from.py
@@ -6,7 +6,8 @@ from infrahub_sdk.utils import compare_lists
 
 from infrahub.core.constants import PathType
 from infrahub.core.path import DataPath, GroupedDataPaths
-from infrahub.core.schema import NodeSchema
+from infrahub.core.schema import MainSchemaTypes, NodeSchema
+from infrahub.exceptions import SchemaNotFoundError
 
 from ..interface import ConstraintCheckerInterface
 
@@ -37,12 +38,32 @@ class NodeInheritFromChecker(ConstraintCheckerInterface):
             name=request.node_schema.kind, branch=request.branch, duplicate=False
         )
 
-        if not isinstance(request.node_schema, NodeSchema):
+        if not isinstance(request.node_schema, NodeSchema) or request.schema_branch is None:
             return grouped_data_paths_list
 
         _, removed, _ = compare_lists(list1=current_schema.inherit_from, list2=request.node_schema.inherit_from)
+        current_inherit_from_ids = {
+            g.id: g.kind
+            for g in [
+                self.db.schema.get(name=n, branch=request.branch, duplicate=False) for n in current_schema.inherit_from
+            ]
+        }
 
-        if removed:
+        # Gather IDs for each inherited node in use for candidate schema
+        request_inherited: list[MainSchemaTypes] = []
+        for n in request.node_schema.inherit_from:
+            try:
+                request_inherited.append(request.schema_branch.get(name=n, duplicate=False))
+            except SchemaNotFoundError:
+                request_inherited.append(self.db.schema.get(name=n, branch=request.branch, duplicate=False))
+        request_inherit_from_ids = {g.id: g.kind for g in request_inherited}
+
+        # Compare IDs to find out if some inherited nodes were removed
+        # Comparing IDs helps us in understanding if a node was renamed or really removed
+        _, removedIds, _ = compare_lists(
+            list1=list(current_inherit_from_ids.keys()), list2=list(request_inherit_from_ids.keys())
+        )
+        if removed := [current_inherit_from_ids[k] for k in removedIds]:
             group_data_path.add_data_path(
                 DataPath(
                     branch=str(request.branch.name),

--- a/backend/infrahub/core/validators/tasks.py
+++ b/backend/infrahub/core/validators/tasks.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from infrahub_sdk.batch import InfrahubBatch
 from prefect import flow, task
 from prefect.cache_policies import NONE
@@ -17,6 +19,9 @@ from infrahub.services import services
 from infrahub.workflows.utils import add_tags
 
 from .models.validate_migration import SchemaValidateMigrationData, SchemaValidatorPathResponseData
+
+if TYPE_CHECKING:
+    from infrahub.core.schema.schema_branch import SchemaBranch
 
 
 @flow(name="schema_validate_migrations", flow_run_name="Validate schema migrations", persist_result=True)
@@ -41,6 +46,7 @@ async def schema_validate_migrations(message: SchemaValidateMigrationData) -> li
             constraint_name=constraint.constraint_name,
             node_schema=schema,
             schema_path=constraint.path,
+            schema_branch=message.schema_branch,
         )
 
     results = [result async for _, result in batch.execute()]
@@ -59,6 +65,7 @@ async def schema_path_validate(
     constraint_name: str,
     node_schema: NodeSchema | GenericSchema,
     schema_path: SchemaPath,
+    schema_branch: SchemaBranch,
 ) -> SchemaValidatorPathResponseData:
     service = services.service
 
@@ -68,6 +75,7 @@ async def schema_path_validate(
             constraint_name=constraint_name,
             node_schema=node_schema,
             schema_path=schema_path,
+            schema_branch=schema_branch,
         )
 
         component_registry = get_component_registry()

--- a/backend/infrahub/core/validators/uniqueness/checker.py
+++ b/backend/infrahub/core/validators/uniqueness/checker.py
@@ -1,21 +1,16 @@
+from __future__ import annotations
+
 import asyncio
 from itertools import chain
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.path import DataPath, GroupedDataPaths
-from infrahub.core.query import QueryResult
-from infrahub.core.schema import (
-    AttributeSchema,
-    MainSchemaTypes,
-    RelationshipSchema,
-)
+from infrahub.core.schema import AttributeSchema, MainSchemaTypes, RelationshipSchema
 from infrahub.core.validators.uniqueness.index import UniquenessQueryResultsIndex
-from infrahub.database import InfrahubDatabase
 
 from ..interface import ConstraintCheckerInterface
-from ..model import SchemaConstraintValidatorRequest
 from .model import (
     NodeUniquenessQueryRequest,
     NonUniqueAttribute,
@@ -25,6 +20,12 @@ from .model import (
     QueryRelationshipAttributePath,
 )
 from .query import NodeUniqueAttributeConstraintQuery
+
+if TYPE_CHECKING:
+    from infrahub.core.query import QueryResult
+    from infrahub.database import InfrahubDatabase
+
+    from ..model import SchemaConstraintValidatorRequest
 
 
 def get_attribute_path_from_string(

--- a/backend/tests/unit/core/constraint_validators/test_attribute_choices_update.py
+++ b/backend/tests/unit/core/constraint_validators/test_attribute_choices_update.py
@@ -5,6 +5,7 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.path import DataPath, SchemaPath
 from infrahub.core.schema import DropdownChoice
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.validators.attribute.choices import AttributeChoicesChecker, AttributeChoicesUpdateValidatorQuery
 from infrahub.core.validators.model import SchemaConstraintValidatorRequest
 from infrahub.database import InfrahubDatabase
@@ -250,6 +251,7 @@ async def test_validator(db: InfrahubDatabase, branch: Branch, criticality_schem
         constraint_name="attribute.choices.update",
         node_schema=crit_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCriticality", field_name="status"),
+        schema_branch=SchemaBranch(cache={}),
     )
 
     constraint_checker = AttributeChoicesChecker(db=db, branch=branch)

--- a/backend/tests/unit/core/constraint_validators/test_attribute_enum_update.py
+++ b/backend/tests/unit/core/constraint_validators/test_attribute_enum_update.py
@@ -3,6 +3,7 @@ from infrahub.core.branch import Branch
 from infrahub.core.constants import PathType, SchemaPathType
 from infrahub.core.manager import NodeManager
 from infrahub.core.path import DataPath, SchemaPath
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.validators.attribute.enum import AttributeEnumChecker, AttributeEnumUpdateValidatorQuery
 from infrahub.core.validators.model import SchemaConstraintValidatorRequest
 from infrahub.database import InfrahubDatabase
@@ -147,6 +148,7 @@ async def test_validator(
         constraint_name="attribute.enum.update",
         node_schema=car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="color"),
+        schema_branch=SchemaBranch(cache={}),
     )
 
     constraint_checker = AttributeEnumChecker(db=db, branch=branch)

--- a/backend/tests/unit/core/constraint_validators/test_attribute_kind_update.py
+++ b/backend/tests/unit/core/constraint_validators/test_attribute_kind_update.py
@@ -4,6 +4,7 @@ from infrahub.core.constants import PathType, SchemaPathType
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.path import DataPath, SchemaPath
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.validators.attribute.kind import AttributeKindChecker, AttributeKindUpdateValidatorQuery
 from infrahub.core.validators.model import SchemaConstraintValidatorRequest
 from infrahub.database import InfrahubDatabase
@@ -192,6 +193,7 @@ async def test_validator(
         constraint_name="attribute.kind.update",
         node_schema=car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="name"),
+        schema_branch=SchemaBranch(cache={}),
     )
 
     constraint_checker = AttributeKindChecker(db=db, branch=branch)

--- a/backend/tests/unit/core/constraint_validators/test_attribute_length.py
+++ b/backend/tests/unit/core/constraint_validators/test_attribute_length.py
@@ -5,6 +5,7 @@ from infrahub.core.branch import Branch
 from infrahub.core.constants import PathType, SchemaPathType
 from infrahub.core.manager import NodeManager
 from infrahub.core.path import DataPath, SchemaPath
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.validators.attribute.length import AttributeLengthChecker, AttributeLengthUpdateValidatorQuery
 from infrahub.core.validators.model import SchemaConstraintValidatorRequest
 from infrahub.database import InfrahubDatabase
@@ -201,6 +202,7 @@ async def test_validator(
         constraint_name="attribute.min_length.update",
         node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="name"),
+        schema_branch=SchemaBranch(cache={}),
     )
 
     constraint_checker = AttributeLengthChecker(db=db, branch=branch)

--- a/backend/tests/unit/core/constraint_validators/test_attribute_optional.py
+++ b/backend/tests/unit/core/constraint_validators/test_attribute_optional.py
@@ -4,6 +4,7 @@ from infrahub.core.constants import PathType, SchemaPathType
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.path import DataPath, SchemaPath
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.validators.attribute.optional import AttributeOptionalChecker, AttributeOptionalUpdateValidatorQuery
 from infrahub.core.validators.model import SchemaConstraintValidatorRequest
 from infrahub.database import InfrahubDatabase
@@ -161,6 +162,7 @@ async def test_validator(db: InfrahubDatabase, branch: Branch, person_john_main,
         constraint_name="attribute.optional.update",
         node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="height"),
+        schema_branch=SchemaBranch(cache={}),
     )
 
     constraint_checker = AttributeOptionalChecker(db=db, branch=branch)

--- a/backend/tests/unit/core/constraint_validators/test_attribute_regex_update.py
+++ b/backend/tests/unit/core/constraint_validators/test_attribute_regex_update.py
@@ -4,6 +4,7 @@ from infrahub.core.constants import NULL_VALUE, PathType, SchemaPathType
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.path import DataPath, SchemaPath
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.validators.attribute.regex import AttributeRegexChecker, AttributeRegexUpdateValidatorQuery
 from infrahub.core.validators.model import SchemaConstraintValidatorRequest
 from infrahub.database import InfrahubDatabase
@@ -169,6 +170,7 @@ async def test_validator(
         constraint_name="attribute.regex.update",
         node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="name"),
+        schema_branch=SchemaBranch(cache={}),
     )
 
     constraint_checker = AttributeRegexChecker(db=db, branch=default_branch)

--- a/backend/tests/unit/core/constraint_validators/test_attribute_unique_update.py
+++ b/backend/tests/unit/core/constraint_validators/test_attribute_unique_update.py
@@ -3,6 +3,7 @@ from infrahub.core.branch import Branch
 from infrahub.core.constants import PathType, SchemaPathType
 from infrahub.core.node import Node
 from infrahub.core.path import DataPath, SchemaPath
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.validators.attribute.unique import (
     AttributeUniquenessChecker,
     AttributeUniqueUpdateValidatorQuery,
@@ -183,6 +184,7 @@ async def test_validator(
         constraint_name="attribute.regex.update",
         node_schema=car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="nbr_seats"),
+        schema_branch=SchemaBranch(cache={}),
     )
 
     constraint_checker = AttributeUniquenessChecker(db=db, branch=branch)

--- a/backend/tests/unit/core/constraint_validators/test_node_generate_profiles_update.py
+++ b/backend/tests/unit/core/constraint_validators/test_node_generate_profiles_update.py
@@ -9,6 +9,7 @@ from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.path import DataPath, SchemaPath
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.validators.model import SchemaConstraintValidatorRequest
 from infrahub.core.validators.node.generate_profile import NodeGenerateProfileChecker
 from infrahub.database import InfrahubDatabase
@@ -26,6 +27,7 @@ async def test_set_generate_profile_success(
         constraint_name="node.generate_profile.update",
         node_schema=updated_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestCar"),
+        schema_branch=SchemaBranch(cache={}),
     )
 
     checker = NodeGenerateProfileChecker(db=db, branch=branch)
@@ -46,6 +48,7 @@ async def test_set_generate_profile_success_generics(
         constraint_name="node.generate_profile.update",
         node_schema=updated_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestAnimal"),
+        schema_branch=SchemaBranch(cache={}),
     )
 
     checker = NodeGenerateProfileChecker(db=db, branch=branch)
@@ -67,6 +70,7 @@ async def test_set_generate_profile_false_fail(db: InfrahubDatabase, default_bra
         constraint_name="node.generate_profile.update",
         node_schema=updated_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestCar"),
+        schema_branch=SchemaBranch(cache={}),
     )
 
     checker = NodeGenerateProfileChecker(db=db, branch=branch)
@@ -94,6 +98,7 @@ async def test_set_generate_profile_false_fail_generic(
         constraint_name="node.generate_profile.update",
         node_schema=updated_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestAnimal"),
+        schema_branch=SchemaBranch(cache={}),
     )
 
     checker = NodeGenerateProfileChecker(db=db, branch=branch)
@@ -123,6 +128,7 @@ async def test_set_generate_profile_false_branch_delete_profile_success(
         constraint_name="node.generate_profile.update",
         node_schema=updated_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestCar"),
+        schema_branch=SchemaBranch(cache={}),
     )
 
     checker = NodeGenerateProfileChecker(db=db, branch=branch)

--- a/backend/tests/unit/core/constraint_validators/test_node_hierarchy_update.py
+++ b/backend/tests/unit/core/constraint_validators/test_node_hierarchy_update.py
@@ -6,6 +6,7 @@ from infrahub.core.constants import PathType, SchemaPathType
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.path import DataPath, SchemaPath
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.validators.model import SchemaConstraintValidatorRequest
 from infrahub.core.validators.node.hierarchy import NodeHierarchyChecker, NodeHierarchyUpdateValidatorQuery
 from infrahub.database import InfrahubDatabase
@@ -369,6 +370,7 @@ async def test_validator_parents_failure(
         constraint_name="node.parent.update",
         node_schema=site_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="LocationSite", field_name="parent"),
+        schema_branch=SchemaBranch(cache={}),
     )
 
     constraint_checker = NodeHierarchyChecker(db=db, branch=default_branch)
@@ -395,6 +397,7 @@ async def test_validator_parents_success(
         constraint_name="node.parent.update",
         node_schema=site_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="LocationSite", field_name="parent"),
+        schema_branch=SchemaBranch(cache={}),
     )
 
     constraint_checker = NodeHierarchyChecker(db=db, branch=default_branch)
@@ -419,6 +422,7 @@ async def test_validator_children_failure(
         constraint_name="node.children.update",
         node_schema=site_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="LocationSite", field_name="children"),
+        schema_branch=SchemaBranch(cache={}),
     )
 
     constraint_checker = NodeHierarchyChecker(db=db, branch=default_branch)
@@ -445,6 +449,7 @@ async def test_validator_children_success(
         constraint_name="node.children.update",
         node_schema=site_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="LocationSite", field_name="children"),
+        schema_branch=SchemaBranch(cache={}),
     )
 
     constraint_checker = NodeHierarchyChecker(db=db, branch=default_branch)

--- a/backend/tests/unit/core/constraint_validators/test_node_inherit_from_update.py
+++ b/backend/tests/unit/core/constraint_validators/test_node_inherit_from_update.py
@@ -1,3 +1,4 @@
+import copy
 import uuid
 from itertools import chain
 
@@ -6,6 +7,7 @@ from infrahub.core.branch import Branch
 from infrahub.core.constants import PathType, SchemaPathType
 from infrahub.core.initialization import create_branch
 from infrahub.core.path import DataPath, SchemaPath
+from infrahub.core.schema import GenericSchema
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.validators.model import SchemaConstraintValidatorRequest
 from infrahub.core.validators.node.inherit_from import NodeInheritFromChecker
@@ -15,14 +17,22 @@ from infrahub.database import InfrahubDatabase
 async def test_add_generic_success(db: InfrahubDatabase, default_branch: Branch, animal_person_schema):
     branch = await create_branch(branch_name="branch", db=db)
 
+    good_animal_schema = GenericSchema(
+        name="GoodAnimal", namespace="Test", attributes=[{"name": "is_good", "kind": "Boolean", "default_value": True}]
+    )
     dog_schema = registry.schema.get_node_schema(name="TestDog")
-    dog_schema.inherit_from.append("TestXXX")
+    dog_schema.inherit_from.append(good_animal_schema.kind)
+
+    schema_branch = SchemaBranch(cache={}, name="test")
+    schema_branch.set(name=good_animal_schema.kind, schema=good_animal_schema)
+    schema_branch.set(name=dog_schema.kind, schema=dog_schema)
+
     request = SchemaConstraintValidatorRequest(
         branch=branch,
         constraint_name="node.inherit_from.update",
         node_schema=dog_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestDog"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=schema_branch,
     )
 
     checker = NodeInheritFromChecker(db=db, branch=branch)
@@ -38,12 +48,16 @@ async def test_remove_generic_fail(db: InfrahubDatabase, default_branch: Branch,
     dog_schema = registry.schema.get_node_schema(name="TestDog")
     dog_schema.id = str(uuid.uuid4())
     dog_schema.inherit_from = []
+
+    schema_branch = SchemaBranch(cache={}, name="test")
+    schema_branch.set(name=dog_schema.kind, schema=dog_schema)
+
     request = SchemaConstraintValidatorRequest(
         branch=branch,
         constraint_name="node.inherit_from.update",
         node_schema=dog_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestDog"),
-        schema_branch=SchemaBranch(cache={}),
+        schema_branch=schema_branch,
     )
 
     checker = NodeInheritFromChecker(db=db, branch=branch)
@@ -61,3 +75,34 @@ async def test_remove_generic_fail(db: InfrahubDatabase, default_branch: Branch,
         )
         in all_data_paths
     )
+
+
+async def test_rename_generic_success(db: InfrahubDatabase, default_branch: Branch, animal_person_schema):
+    branch = await create_branch(branch_name="branch", db=db)
+
+    animal_schema = registry.schema.get(name="TestAnimal")
+    dog_schema = registry.schema.get(name="TestDog")
+
+    good_animal_schema = copy.deepcopy(animal_schema)
+    good_animal_schema.name = "GoodAnimal"
+    good_dog_schema = copy.deepcopy(dog_schema)
+    good_dog_schema.inherit_from = [good_animal_schema.kind]
+
+    schema_branch = SchemaBranch(cache={}, name="test")
+    schema_branch.set(name=good_animal_schema.kind, schema=good_animal_schema)
+    schema_branch.set(name=good_dog_schema.kind, schema=good_dog_schema)
+
+    request = SchemaConstraintValidatorRequest(
+        branch=branch,
+        constraint_name="node.inherit_from.update",
+        node_schema=good_dog_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind=good_dog_schema.kind),
+        schema_branch=schema_branch,
+    )
+
+    checker = NodeInheritFromChecker(db=db, branch=branch)
+
+    grouped_data_paths = await checker.check(request=request)
+    all_data_paths = list(chain(*[gdp.get_all_data_paths() for gdp in grouped_data_paths]))
+
+    assert len(all_data_paths) == 0

--- a/backend/tests/unit/core/constraint_validators/test_node_inherit_from_update.py
+++ b/backend/tests/unit/core/constraint_validators/test_node_inherit_from_update.py
@@ -6,6 +6,7 @@ from infrahub.core.branch import Branch
 from infrahub.core.constants import PathType, SchemaPathType
 from infrahub.core.initialization import create_branch
 from infrahub.core.path import DataPath, SchemaPath
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.validators.model import SchemaConstraintValidatorRequest
 from infrahub.core.validators.node.inherit_from import NodeInheritFromChecker
 from infrahub.database import InfrahubDatabase
@@ -21,6 +22,7 @@ async def test_add_generic_success(db: InfrahubDatabase, default_branch: Branch,
         constraint_name="node.inherit_from.update",
         node_schema=dog_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestDog"),
+        schema_branch=SchemaBranch(cache={}),
     )
 
     checker = NodeInheritFromChecker(db=db, branch=branch)
@@ -41,6 +43,7 @@ async def test_remove_generic_fail(db: InfrahubDatabase, default_branch: Branch,
         constraint_name="node.inherit_from.update",
         node_schema=dog_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.NODE, schema_kind="TestDog"),
+        schema_branch=SchemaBranch(cache={}),
     )
 
     checker = NodeInheritFromChecker(db=db, branch=branch)

--- a/backend/tests/unit/core/constraint_validators/test_relationship_count.py
+++ b/backend/tests/unit/core/constraint_validators/test_relationship_count.py
@@ -7,6 +7,7 @@ from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.path import DataPath, SchemaPath
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.validators.model import SchemaConstraintValidatorRequest
 from infrahub.core.validators.relationship.count import RelationshipCountChecker, RelationshipCountUpdateValidatorQuery
 from infrahub.database import InfrahubDatabase
@@ -455,6 +456,7 @@ async def test_validator(
         constraint_name="relationship.max_count.update",
         node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="cars"),
+        schema_branch=SchemaBranch(cache={}),
     )
 
     constraint_checker = RelationshipCountChecker(db=db, branch=branch)
@@ -496,6 +498,7 @@ async def test_validator_cardinality_failure(
         constraint_name="relationship.cardinality.update",
         node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="cars"),
+        schema_branch=SchemaBranch(cache={}),
     )
 
     constraint_checker = RelationshipCountChecker(db=db, branch=branch)

--- a/backend/tests/unit/core/constraint_validators/test_relationship_optional_update.py
+++ b/backend/tests/unit/core/constraint_validators/test_relationship_optional_update.py
@@ -3,6 +3,7 @@ from infrahub.core.branch import Branch
 from infrahub.core.constants import PathType, SchemaPathType
 from infrahub.core.node import Node
 from infrahub.core.path import DataPath, SchemaPath
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.validators.model import SchemaConstraintValidatorRequest
 from infrahub.core.validators.relationship.optional import (
     RelationshipOptionalChecker,
@@ -61,6 +62,7 @@ async def test_validator(
         constraint_name="attribute.regex.update",
         node_schema=person_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.RELATIONSHIP, schema_kind="TestPerson", field_name="cars"),
+        schema_branch=SchemaBranch(cache={}),
     )
 
     constraint_checker = RelationshipOptionalChecker(db=db, branch=default_branch)

--- a/backend/tests/unit/core/constraint_validators/test_relationship_peer_update.py
+++ b/backend/tests/unit/core/constraint_validators/test_relationship_peer_update.py
@@ -9,6 +9,7 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.path import DataPath, SchemaPath
 from infrahub.core.schema import SchemaRoot
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.validators.model import SchemaConstraintValidatorRequest
 from infrahub.core.validators.relationship.peer import RelationshipPeerChecker, RelationshipPeerUpdateValidatorQuery
 from infrahub.database import InfrahubDatabase
@@ -439,6 +440,7 @@ async def test_validator(
         constraint_name="relationship.peer.update",
         node_schema=car_schema,
         schema_path=SchemaPath(path_type=SchemaPathType.RELATIONSHIP, schema_kind="TestCar", field_name="owner"),
+        schema_branch=SchemaBranch(cache={}),
     )
 
     constraint_checker = RelationshipPeerChecker(db=db, branch=default_branch)

--- a/backend/tests/unit/core/constraint_validators/test_uniqueness_checker.py
+++ b/backend/tests/unit/core/constraint_validators/test_uniqueness_checker.py
@@ -8,6 +8,7 @@ from infrahub.core.node import Node
 from infrahub.core.path import DataPath, SchemaPath
 from infrahub.core.schema import SchemaRoot
 from infrahub.core.schema.relationship_schema import RelationshipSchema
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.validators.model import SchemaConstraintValidatorRequest
 from infrahub.core.validators.uniqueness.checker import UniquenessChecker
 from infrahub.database import InfrahubDatabase
@@ -22,6 +23,7 @@ class TestUniquenessChecker:
             constraint_name="node.uniqueness_constraints.update",
             node_schema=schema,
             schema_path=schema_path,
+            schema_branch=SchemaBranch(cache={}),
         )
         return await checker.check(request)
 

--- a/backend/tests/unit/core/migrations/schema/test_node_kind_update.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_kind_update.py
@@ -1,17 +1,16 @@
 from infrahub.core import registry
 from infrahub.core.branch import Branch
-from infrahub.core.constants import SchemaPathType
-from infrahub.core.migrations.schema.node_kind_update import (
-    NodeKindUpdateMigration,
-    NodeKindUpdateMigrationQuery01,
-)
+from infrahub.core.constants import RelationshipHierarchyDirection, SchemaPathType
+from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration, NodeKindUpdateMigrationQuery01
 from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
+from infrahub.core.query.node import NodeGetHierarchyQuery
 from infrahub.core.schema import SchemaRoot
 from infrahub.core.utils import count_nodes, count_relationships
 from infrahub.database import InfrahubDatabase
+from tests.constants import TestKind
 from tests.helpers.db_validation import validate_node_relationships
-from tests.helpers.schema import load_schema
+from tests.helpers.schema import LOCATION_SCHEMA, load_schema
 
 
 async def test_query_default_branch(db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main):
@@ -128,3 +127,55 @@ async def test_migration_agnostic_relationship(
 
     await validate_node_relationships(node=person_john, db=db, branch=registry.get_global_branch())
     await validate_node_relationships(node=car, db=db, branch=registry.get_global_branch())
+
+
+async def test_migration_hierarchy(db: InfrahubDatabase, default_branch: Branch):
+    await load_schema(db=db, schema=LOCATION_SCHEMA)
+
+    continent_europe = await Node.init(db=db, schema=TestKind.CONTINENT)
+    await continent_europe.new(db=db, name={"value": "Europe"}, shortname={"value": "EU"})
+    await continent_europe.save(db=db)
+
+    country_france = await Node.init(db=db, schema=TestKind.COUNTRY)
+    await country_france.new(db=db, name="France", shortname={"value": "FR"}, parent=continent_europe.id)
+    await country_france.save(db=db)
+
+    schema = registry.schema.get_schema_branch(name=default_branch.name)
+    candidate_schema = schema.duplicate()
+    continent_schema = candidate_schema.get(name=TestKind.CONTINENT)
+    candidate_schema.delete(name=TestKind.CONTINENT)
+    continent_schema.name = "NewContinent"
+    continent_schema.namespace = "Test2"
+    candidate_schema.set(name="Test2NewContinent", schema=continent_schema)
+    assert continent_schema.kind == "Test2NewContinent"
+    candidate_schema.get(name=TestKind.COUNTRY, duplicate=False).parent = "Test2NewContinent"
+
+    assert await count_nodes(db=db, label=TestKind.CONTINENT) == 1
+    assert await count_nodes(db=db, label="Test2NewContinent") == 0
+
+    migration = NodeKindUpdateMigration(
+        previous_node_schema=schema.get(name=TestKind.CONTINENT),
+        new_node_schema=continent_schema,
+        schema_path=SchemaPath(
+            path_type=SchemaPathType.ATTRIBUTE, schema_kind=TestKind.CONTINENT, field_name="namespace"
+        ),
+    )
+
+    execution_result = await migration.execute(db=db, branch=default_branch)
+    assert not execution_result.errors
+    assert execution_result.nbr_migrations_executed == 1
+    assert await count_nodes(db=db, label=TestKind.CONTINENT) == 1
+    assert await count_nodes(db=db, label="Test2NewContinent") == 1
+
+    country_schema = schema.get(name=TestKind.COUNTRY, duplicate=False)
+    assert country_schema.parent == "Test2NewContinent"
+
+    hierarchy_query = await NodeGetHierarchyQuery.init(
+        db=db,
+        direction=RelationshipHierarchyDirection.ANCESTORS,
+        node_id=country_france.id,
+        node_schema=country_schema,
+        branch=default_branch,
+    )
+    await hierarchy_query.execute(db=db)
+    assert list(hierarchy_query.get_peer_ids())

--- a/backend/tests/unit/core/migrations/schema/test_node_kind_update.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_kind_update.py
@@ -178,4 +178,4 @@ async def test_migration_hierarchy(db: InfrahubDatabase, default_branch: Branch)
         branch=default_branch,
     )
     await hierarchy_query.execute(db=db)
-    assert list(hierarchy_query.get_peer_ids())
+    assert list(hierarchy_query.get_peer_ids()) == [continent_europe.get_id()]

--- a/changelog/6051.fixed.md
+++ b/changelog/6051.fixed.md
@@ -1,0 +1,1 @@
+Fixed broken hierarchy when renaming a kind participating to a hierarchy

--- a/changelog/6060.fixed.md
+++ b/changelog/6060.fixed.md
@@ -1,0 +1,1 @@
+Fixed schema migration validator to allow renaming the kind of a generic


### PR DESCRIPTION
Tweak the `inherited_from` to use schema IDs instead of kinds to spot renaming and stop identifying it as unsupported removal.

Fixes #6051
Fixes #6060