### PR TITLE
Use schema_hash in client.schema.all() to speed up Jinja2 attributes

### DIFF
--- a/backend/infrahub/computed_attribute/tasks.py
+++ b/backend/infrahub/computed_attribute/tasks.py
@@ -235,7 +235,7 @@ async def process_jinja2(
         branch_name if branch_name in registry.get_altered_schema_branches() else registry.default_branch
     )
     schema_branch = registry.schema.get_schema_branch(name=target_branch_schema)
-    await service.client.schema.all(branch=branch_name, refresh=True)
+    await service.client.schema.all(branch=branch_name, refresh=True, schema_hash=schema_branch.get_hash())
 
     computed_macros = [
         attrib

--- a/changelog/6133.changed.md
+++ b/changelog/6133.changed.md
@@ -1,0 +1,4 @@
+<!-- vale off -->
+Use the new `schema_hash` parameter from client.schema.all() in the SDK to only selectively refresh the branch schema cache if the current hash differs from the one in the cache. This will provide a speedup for Jinja2 based computed attributes.
+
+<!-- vale on -->


### PR DESCRIPTION
Use the new schema_hash parameter for client.schema.all() to only refresh the schema if the cached version differs from the expected hash of the branch. Previously we were required to always refresh the schema in the cache as we didn't have a way of knowing if the schema had been changed and if the old version was in the hash. This update will allow us to continue using the same cached schema if it doesn't need to be updated and because of that we don't have to download the rather large schema definition from the `/api/schema` endpoint each time we are updating a Jinja2 based computed attribute.

Fixes #6133