### PR TITLE
Cleanup registry branch delete and remove schema_branch

### DIFF
--- a/backend/infrahub/core/registry.py
+++ b/backend/infrahub/core/registry.py
@@ -220,5 +220,23 @@ class Registry:
             and branch.active_schema_hash.main != default_branch.active_schema_hash.main
         ]
 
+    async def purge_inactive_branches(
+        self, db: InfrahubDatabase, active_branches: list[Branch] | None = None
+    ) -> list[str]:
+        """Return a list of branches that were purged from the registry."""
+        active_branches = active_branches or await self.branch_object.get_list(db=db)
+        active_branch_names = [branch.name for branch in active_branches]
+        purged_branches: set[str] = set()
+
+        for branch_name in list(registry.branch.keys()):
+            if branch_name not in active_branch_names:
+                del registry.branch[branch_name]
+                purged_branches.add(branch_name)
+
+        purged_branches.update(self.schema.purge_inactive_branches(active_branches=active_branch_names))
+        purged_branches.update(db.purge_inactive_schemas(active_branches=active_branch_names))
+
+        return sorted(purged_branches)
+
 
 registry = Registry()

--- a/backend/infrahub/core/schema/manager.py
+++ b/backend/infrahub/core/schema/manager.py
@@ -744,3 +744,24 @@ class SchemaManager(NodeManager):
         """Convert a schema_node object loaded from the database into GenericSchema object."""
         node_data = await cls._prepare_node_data(schema_node=schema_node, db=db)
         return GenericSchema(**node_data)
+
+    def purge_inactive_branches(self, active_branches: list[str]) -> list[str]:
+        """Return non active branches that were purged."""
+
+        hashes_to_keep: set[str] = set()
+        for active_branch in active_branches:
+            if branch := self._branches.get(active_branch):
+                nodes = branch.get_all(include_internal=True, duplicate=False)
+                hashes_to_keep.update([node.get_hash() for node in nodes.values()])
+
+        removed_branches: list[str] = []
+        for branch_name in list(self._branches.keys()):
+            if branch_name not in active_branches:
+                del self._branches[branch_name]
+                removed_branches.append(branch_name)
+
+        for hash_key in list(self._cache.keys()):
+            if hash_key not in hashes_to_keep:
+                del self._cache[hash_key]
+
+        return removed_branches

--- a/backend/infrahub/database/__init__.py
+++ b/backend/infrahub/database/__init__.py
@@ -205,6 +205,16 @@ class InfrahubDatabase:
     def add_schema(self, schema: SchemaBranch, name: str | None = None) -> None:
         self._schemas[name or schema.name] = schema
 
+    def purge_inactive_schemas(self, active_branches: list[str]) -> list[str]:
+        """Return non active schema branches that were purged."""
+        removed_branches: list[str] = []
+        for branch_name in list(self._schemas.keys()):
+            if branch_name not in active_branches:
+                del self._schemas[branch_name]
+                removed_branches.append(branch_name)
+
+        return removed_branches
+
     def start_session(self, read_only: bool = False, schemas: list[SchemaBranch] | None = None) -> InfrahubDatabase:
         """Create a new InfrahubDatabase object in Session mode."""
         session_mode = InfrahubDatabaseSessionMode.WRITE

--- a/backend/infrahub/tasks/registry.py
+++ b/backend/infrahub/tasks/registry.py
@@ -22,7 +22,6 @@ async def refresh_branches(db: InfrahubDatabase) -> None:
 
     async with lock.registry.local_schema_lock():
         branches = await registry.branch_object.get_list(db=db)
-        active_branches = [branch.name for branch in branches]
         for new_branch in branches:
             if new_branch.name in registry.branch:
                 branch_registry: Branch = registry.branch[new_branch.name]
@@ -61,9 +60,6 @@ async def refresh_branches(db: InfrahubDatabase) -> None:
                     include_types=True,
                 )
 
-        for branch_name in list(registry.branch.keys()):
-            if branch_name not in active_branches:
-                del registry.branch[branch_name]
-                log.info(
-                    f"Removed branch {branch_name!r} from the registry", branch=branch_name, worker=WORKER_IDENTITY
-                )
+        purged_branches = await registry.purge_inactive_branches(db=db, active_branches=branches)
+        for branch_name in purged_branches:
+            log.info(f"Removed branch {branch_name!r} from the registry", branch=branch_name, worker=WORKER_IDENTITY)

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -2204,6 +2204,62 @@ async def test_schema_manager_get(default_branch: Branch):
     assert schema11.namespace == schema.namespace
 
 
+async def test_schema_manager_purge(default_branch: Branch, reset_registry: None) -> None:
+    criticality_schema = NodeSchema(
+        name="Criticality",
+        namespace="Test",
+        default_filter="name__value",
+        attributes=[
+            AttributeSchema(name="name", kind="Text", unique=True),
+            AttributeSchema(name="description", kind="Text"),
+        ],
+    )
+
+    person_schema = NodeSchema(
+        name="Person",
+        namespace="Test",
+        default_filter="name__value",
+        attributes=[
+            AttributeSchema(name="name", kind="Text", unique=True),
+            AttributeSchema(name="description", kind="Text"),
+        ],
+    )
+
+    dog_schema = NodeSchema(
+        name="Dog",
+        namespace="Test",
+        default_filter="name__value",
+        attributes=[
+            AttributeSchema(name="name", kind="Text", unique=True),
+            AttributeSchema(name="description", kind="Text"),
+        ],
+    )
+
+    manager = SchemaManager()
+
+    manager.set(name="criticality_schema", schema=criticality_schema)
+    manager.set(name="criticality_schema", schema=criticality_schema, branch="main")
+    manager.set(name="criticality_schema", schema=criticality_schema, branch="branch1")
+    manager.set(name="criticality_schema", schema=criticality_schema, branch="branch2")
+    manager.set(name="criticality_schema", schema=criticality_schema, branch="branch3")
+    manager.set(name="person_schema", schema=person_schema, branch="main")
+    manager.set(name="person_schema", schema=person_schema, branch="branch1")
+    manager.set(name="person_schema", schema=person_schema, branch="branch2")
+    manager.set(name="person_schema", schema=person_schema, branch="branch3")
+    manager.set(name="criticality_schema", schema=criticality_schema, branch="branch4")
+    manager.set(name="dog_schema", schema=dog_schema, branch="branch4")
+    assert len(manager._cache) == 3
+    assert criticality_schema.get_hash() in manager._cache
+    assert person_schema.get_hash() in manager._cache
+    assert dog_schema.get_hash() in manager._cache
+    purged = manager.purge_inactive_branches(active_branches=["main", "branch1", "branch2"])
+    assert purged == ["branch3", "branch4"]
+    assert len(manager._cache) == 2
+    assert criticality_schema.get_hash() in manager._cache
+    assert person_schema.get_hash() in manager._cache
+    assert dog_schema.get_hash() not in manager._cache
+
+
 # -----------------------------------------------------------------
 
 

--- a/changelog/+e038e218.fixed.md
+++ b/changelog/+e038e218.fixed.md
@@ -1,0 +1,1 @@
+Properly clear references to old branches and schema objects from the registry when deleting branches.


### PR DESCRIPTION
This PR changes how we free up resources within the registry when we refresh or delete branches. Previously we only removed the branch from the registry.branch dictionary, however we still kept a reference to the deleted branch within the registry.schema (SchemaManager), as well as within the database object. Also since the cache is shared by all branches we didn't have a way to clear out stale cache entries which are now included within this PR.