### PR TITLE
update NodeGetKindQuery for nodes with a migrated kind

### DIFF
--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -714,18 +714,22 @@ class NodeGetKindQuery(Query):
         super().__init__(**kwargs)
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
-        branch = await registry.get_branch(db=db, branch=getattr(self, "branch", None))
-        branch_filter, branch_params = branch.get_query_filter_path(at=self.at)
-        self.params.update(branch_params)
         self.params["ids"] = self.ids
         query = """
 MATCH (n:Node)-[r:IS_PART_OF {status: "active"}]->(:Root)
 WHERE toString(n.uuid) IN $ids
-AND %(branch_filter)s
+        """
+        # only add the branch filter logic if a branch is included in the query parameters
+        if branch := getattr(self, "branch", None):
+            branch = await registry.get_branch(db=db, branch=branch)
+            branch_filter, branch_params = branch.get_query_filter_path(at=self.at)
+            self.params.update(branch_params)
+            query += f"AND {branch_filter}"
+        query += """
 WITH n.uuid AS node_id, n.kind AS node_kind
 ORDER BY r.from DESC
 WITH node_id, head(collect(node_kind)) AS node_kind
-        """ % {"branch_filter": branch_filter}
+        """
         self.add_to_query(query)
         self.return_labels = ["node_id", "node_kind"]
 

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -8,6 +8,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, AsyncIterator, Generator
 
 from infrahub import config
+from infrahub.core import registry
 from infrahub.core.constants import (
     AttributeDBNodeType,
     RelationshipDirection,
@@ -713,14 +714,20 @@ class NodeGetKindQuery(Query):
         super().__init__(**kwargs)
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
-        query = """
-        MATCH p = (root:Root)<-[r_root:IS_PART_OF]-(n:Node)
-        WHERE n.uuid IN $ids
-        """
-        self.add_to_query(query)
+        branch = await registry.get_branch(db=db, branch=getattr(self, "branch", None))
+        branch_filter, branch_params = branch.get_query_filter_path(at=self.at)
+        self.params.update(branch_params)
         self.params["ids"] = self.ids
-
-        self.return_labels = ["n.uuid AS node_id", "n.kind AS node_kind"]
+        query = """
+MATCH (n:Node)-[r:IS_PART_OF {status: "active"}]->(:Root)
+WHERE toString(n.uuid) IN $ids
+AND %(branch_filter)s
+WITH n.uuid AS node_id, n.kind AS node_kind
+ORDER BY r.from DESC
+WITH node_id, head(collect(node_kind)) AS node_kind
+        """ % {"branch_filter": branch_filter}
+        self.add_to_query(query)
+        self.return_labels = ["node_id", "node_kind"]
 
     async def get_node_kind_map(self) -> dict[str, str]:
         node_kind_map: dict[str, str] = {}

--- a/backend/tests/unit/core/test_node_kind_query.py
+++ b/backend/tests/unit/core/test_node_kind_query.py
@@ -46,6 +46,18 @@ async def test_node_get_kind_query_with_migrated_nodes_on_branch(
         car_accord_main.id: "TestCar",
     }
 
+    # check results without branch parameter gets latest from any branch
+    query = await NodeGetKindQuery.init(
+        db=db, ids=[person_john_main.id, person_jane_main.id, car_accord_main.id, car_yaris_main.id]
+    )
+    await query.execute(db=db)
+    assert await query.get_node_kind_map() == {
+        person_jane_main.id: "TestBeing",
+        person_john_main.id: "TestBeing",
+        car_yaris_main.id: "TestCar",
+        car_accord_main.id: "TestCar",
+    }
+
     # check results on default branch
     query = await NodeGetKindQuery.init(
         db=db,

--- a/backend/tests/unit/core/test_node_kind_query.py
+++ b/backend/tests/unit/core/test_node_kind_query.py
@@ -1,0 +1,83 @@
+from infrahub.core.branch.models import Branch
+from infrahub.core.initialization import create_branch
+from infrahub.core.migrations.query.node_duplicate import NodeDuplicateQuery, SchemaNodeInfo
+from infrahub.core.node import Node
+from infrahub.core.query.node import NodeGetKindQuery
+from infrahub.database import InfrahubDatabase
+
+
+async def test_node_get_kind_query_no_migrated_nodes(
+    db: InfrahubDatabase, person_john_main: Node, person_jane_main: Node
+) -> None:
+    query = await NodeGetKindQuery.init(db=db, ids=[person_john_main.id, person_jane_main.id])
+    await query.execute(db=db)
+
+    assert await query.get_node_kind_map() == {person_jane_main.id: "TestPerson", person_john_main.id: "TestPerson"}
+
+
+async def test_node_get_kind_query_with_migrated_nodes_on_branch(
+    db: InfrahubDatabase,
+    person_john_main: Node,
+    person_jane_main: Node,
+    car_accord_main: Node,
+    car_yaris_main: Node,
+    default_branch: Branch,
+) -> None:
+    branch = await create_branch(db=db, branch_name="branch1")
+
+    # run migration on branch
+    migration_query = await NodeDuplicateQuery.init(
+        db=db,
+        branch=branch,
+        previous_node=SchemaNodeInfo(name="Person", namespace="Test", labels=["TestPerson"], kind="TestPerson"),
+        new_node=SchemaNodeInfo(name="Being", namespace="Test", labels=["TestBeing"], kind="TestBeing"),
+    )
+    await migration_query.execute(db=db)
+
+    # check results on branch
+    query = await NodeGetKindQuery.init(
+        db=db, branch=branch, ids=[person_john_main.id, person_jane_main.id, car_accord_main.id, car_yaris_main.id]
+    )
+    await query.execute(db=db)
+    assert await query.get_node_kind_map() == {
+        person_jane_main.id: "TestBeing",
+        person_john_main.id: "TestBeing",
+        car_yaris_main.id: "TestCar",
+        car_accord_main.id: "TestCar",
+    }
+
+    # check results on default branch
+    query = await NodeGetKindQuery.init(
+        db=db,
+        branch=default_branch,
+        ids=[person_john_main.id, person_jane_main.id, car_accord_main.id, car_yaris_main.id],
+    )
+    await query.execute(db=db)
+    assert await query.get_node_kind_map() == {
+        person_jane_main.id: "TestPerson",
+        person_john_main.id: "TestPerson",
+        car_yaris_main.id: "TestCar",
+        car_accord_main.id: "TestCar",
+    }
+
+    # run migration on default branch
+    migration_query = await NodeDuplicateQuery.init(
+        db=db,
+        branch=default_branch,
+        previous_node=SchemaNodeInfo(name="Person", namespace="Test", labels=["TestPerson"], kind="TestPerson"),
+        new_node=SchemaNodeInfo(name="Being", namespace="Test", labels=["TestBeing"], kind="TestBeing"),
+    )
+    await migration_query.execute(db=db)
+
+    # check updated results on default branch
+    query = await NodeGetKindQuery.init(
+        db=db,
+        ids=[person_john_main.id, person_jane_main.id, car_accord_main.id, car_yaris_main.id],
+    )
+    await query.execute(db=db)
+    assert await query.get_node_kind_map() == {
+        person_jane_main.id: "TestBeing",
+        person_john_main.id: "TestBeing",
+        car_yaris_main.id: "TestCar",
+        car_accord_main.id: "TestCar",
+    }

--- a/changelog/+node-kind-query.fixed.md
+++ b/changelog/+node-kind-query.fixed.md
@@ -1,0 +1,1 @@
+Fix an issue that could cause the display label to not appear for nodes that have had their kind updated


### PR DESCRIPTION
IFC-1241

update the NodeGetKindQuery we use in a few places to correctly support nodes that have had their kind migrated. in this case, there can be multiple nodes with the same UUID but different kinds