### PR TITLE
Use database sessions in compute attributes flows

### DIFF
--- a/backend/infrahub/computed_attribute/tasks.py
+++ b/backend/infrahub/computed_attribute/tasks.py
@@ -311,35 +311,36 @@ async def trigger_update_jinja2_computed_attributes(
 async def computed_attribute_setup_jinja2(
     service: InfrahubServices, context: InfrahubContext, branch_name: str | None = None, event_name: str | None = None
 ) -> None:
-    log = get_run_logger()
+    async with service.database.start_session() as db:
+        log = get_run_logger()
 
-    if branch_name:
-        await add_tags(branches=[branch_name])
-        await wait_for_schema_to_converge(branch_name=branch_name, service=service, log=log)
+        if branch_name:
+            await add_tags(branches=[branch_name])
+            await wait_for_schema_to_converge(branch_name=branch_name, component=service.component, db=db, log=log)
 
-    triggers = await gather_trigger_computed_attribute_jinja2()
+        triggers = await gather_trigger_computed_attribute_jinja2()
 
-    for trigger in triggers:
-        if event_name != BranchDeletedEvent.event_name and trigger.branch == branch_name:
-            await service.workflow.submit_workflow(
-                workflow=TRIGGER_UPDATE_JINJA_COMPUTED_ATTRIBUTES,
-                context=context,
-                parameters={
-                    "branch_name": trigger.branch,
-                    "computed_attribute_name": trigger.computed_attribute.attribute.name,
-                    "computed_attribute_kind": trigger.computed_attribute.kind,
-                },
-            )
+        for trigger in triggers:
+            if event_name != BranchDeletedEvent.event_name and trigger.branch == branch_name:
+                await service.workflow.submit_workflow(
+                    workflow=TRIGGER_UPDATE_JINJA_COMPUTED_ATTRIBUTES,
+                    context=context,
+                    parameters={
+                        "branch_name": trigger.branch,
+                        "computed_attribute_name": trigger.computed_attribute.attribute.name,
+                        "computed_attribute_kind": trigger.computed_attribute.kind,
+                    },
+                )
 
-    # Configure all ComputedAttrJinja2Trigger in Prefect
-    async with get_client(sync_client=False) as prefect_client:
-        await setup_triggers(
-            client=prefect_client,
-            triggers=triggers,
-            trigger_type=TriggerType.COMPUTED_ATTR_JINJA2,
-        )  # type: ignore[misc]
+        # Configure all ComputedAttrJinja2Trigger in Prefect
+        async with get_client(sync_client=False) as prefect_client:
+            await setup_triggers(
+                client=prefect_client,
+                triggers=triggers,
+                trigger_type=TriggerType.COMPUTED_ATTR_JINJA2,
+            )  # type: ignore[misc]
 
-    log.info(f"{len(triggers)} Computed Attribute for Jinja2 automation configuration completed")
+        log.info(f"{len(triggers)} Computed Attribute for Jinja2 automation configuration completed")
 
 
 @flow(
@@ -353,45 +354,48 @@ async def computed_attribute_setup_python(
     event_name: str | None = None,
     commit: str | None = None,  # noqa: ARG001
 ) -> None:
-    log = get_run_logger()
+    async with service.database.start_session() as db:
+        log = get_run_logger()
 
-    branch_name = branch_name or registry.default_branch
+        branch_name = branch_name or registry.default_branch
 
-    if branch_name:
-        await add_tags(branches=[branch_name])
-        await wait_for_schema_to_converge(branch_name=branch_name, service=service, log=log)
+        if branch_name:
+            await add_tags(branches=[branch_name])
+            await wait_for_schema_to_converge(branch_name=branch_name, component=service.component, db=db, log=log)
 
-    triggers_python, triggers_python_query = await gather_trigger_computed_attribute_python(db=service.database)
+        triggers_python, triggers_python_query = await gather_trigger_computed_attribute_python(db=db)
 
-    for trigger in triggers_python:
-        if event_name != BranchDeletedEvent.event_name and trigger.branch == branch_name:
+        for trigger in triggers_python:
+            if event_name != BranchDeletedEvent.event_name and trigger.branch == branch_name:
+                log.info(
+                    f"Triggering update for {trigger.computed_attribute.computed_attribute.attribute.name} on {branch_name}"
+                )
+                await service.workflow.submit_workflow(
+                    workflow=TRIGGER_UPDATE_PYTHON_COMPUTED_ATTRIBUTES,
+                    context=context,
+                    parameters={
+                        "branch_name": branch_name,
+                        "computed_attribute_name": trigger.computed_attribute.computed_attribute.attribute.name,
+                        "computed_attribute_kind": trigger.computed_attribute.computed_attribute.kind,
+                    },
+                )
+
+        async with get_client(sync_client=False) as prefect_client:
+            await setup_triggers(
+                client=prefect_client,
+                triggers=triggers_python,
+                trigger_type=TriggerType.COMPUTED_ATTR_PYTHON,
+            )  # type: ignore[misc]
+            log.info(f"{len(triggers_python)} Computed Attribute for Python automation configuration completed")
+
+            await setup_triggers(
+                client=prefect_client,
+                triggers=triggers_python_query,
+                trigger_type=TriggerType.COMPUTED_ATTR_PYTHON_QUERY,
+            )  # type: ignore[misc]
             log.info(
-                f"Triggering update for {trigger.computed_attribute.computed_attribute.attribute.name} on {branch_name}"
+                f"{len(triggers_python_query)} Computed Attribute for Python Query automation configuration completed"
             )
-            await service.workflow.submit_workflow(
-                workflow=TRIGGER_UPDATE_PYTHON_COMPUTED_ATTRIBUTES,
-                context=context,
-                parameters={
-                    "branch_name": branch_name,
-                    "computed_attribute_name": trigger.computed_attribute.computed_attribute.attribute.name,
-                    "computed_attribute_kind": trigger.computed_attribute.computed_attribute.kind,
-                },
-            )
-
-    async with get_client(sync_client=False) as prefect_client:
-        await setup_triggers(
-            client=prefect_client,
-            triggers=triggers_python,
-            trigger_type=TriggerType.COMPUTED_ATTR_PYTHON,
-        )  # type: ignore[misc]
-        log.info(f"{len(triggers_python)} Computed Attribute for Python automation configuration completed")
-
-        await setup_triggers(
-            client=prefect_client,
-            triggers=triggers_python_query,
-            trigger_type=TriggerType.COMPUTED_ATTR_PYTHON_QUERY,
-        )  # type: ignore[misc]
-        log.info(f"{len(triggers_python_query)} Computed Attribute for Python Query automation configuration completed")
 
 
 @flow(

--- a/backend/infrahub/trigger/tasks.py
+++ b/backend/infrahub/trigger/tasks.py
@@ -14,23 +14,24 @@ from .setup import setup_triggers
 
 @flow(name="trigger-configure-all", flow_run_name="Configure all triggers")
 async def trigger_configure_all(service: InfrahubServices) -> None:
-    webhook_trigger = await gather_trigger_webhook(db=service.database)
-    computed_attribute_j2_triggers = await gather_trigger_computed_attribute_jinja2()
-    (
-        computed_attribute_python_triggers,
-        computed_attribute_python_query_triggers,
-    ) = await gather_trigger_computed_attribute_python(db=service.database)
+    async with service.database.start_session() as db:
+        webhook_trigger = await gather_trigger_webhook(db=db)
+        computed_attribute_j2_triggers = await gather_trigger_computed_attribute_jinja2()
+        (
+            computed_attribute_python_triggers,
+            computed_attribute_python_query_triggers,
+        ) = await gather_trigger_computed_attribute_python(db=db)
 
-    triggers = (
-        computed_attribute_j2_triggers
-        + computed_attribute_python_triggers
-        + computed_attribute_python_query_triggers
-        + builtin_triggers
-        + webhook_trigger
-    )
-
-    async with get_client(sync_client=False) as prefect_client:
-        await setup_triggers(
-            client=prefect_client,
-            triggers=triggers,
+        triggers = (
+            computed_attribute_j2_triggers
+            + computed_attribute_python_triggers
+            + computed_attribute_python_query_triggers
+            + builtin_triggers
+            + webhook_trigger
         )
+
+        async with get_client(sync_client=False) as prefect_client:
+            await setup_triggers(
+                client=prefect_client,
+                triggers=triggers,
+            )

--- a/backend/infrahub/workflows/utils.py
+++ b/backend/infrahub/workflows/utils.py
@@ -15,7 +15,8 @@ from .constants import TAG_NAMESPACE, WorkflowTag
 if TYPE_CHECKING:
     import logging
 
-    from infrahub.services import InfrahubServices
+    from infrahub.database import InfrahubDatabase
+    from infrahub.services import InfrahubComponent
 
 
 async def add_tags(
@@ -56,7 +57,7 @@ async def add_related_node_tag(node_id: str) -> None:
 
 
 async def wait_for_schema_to_converge(
-    branch_name: str, service: InfrahubServices, log: logging.Logger | logging.LoggerAdapter
+    branch_name: str, component: InfrahubComponent, db: InfrahubDatabase, log: logging.Logger | logging.LoggerAdapter
 ) -> None:
     has_converged = False
     branch_id = branch_name
@@ -67,7 +68,7 @@ async def wait_for_schema_to_converge(
     max_iterations = delay * 5 * 30
     iteration = 0
     while not has_converged:
-        workers = await service.component.list_workers(branch=branch_id, schema_hash=True)
+        workers = await component.list_workers(branch=branch_id, schema_hash=True)
 
         hashes = {worker.schema_hash for worker in workers if worker.active}
         if len(hashes) == 1:
@@ -79,8 +80,7 @@ async def wait_for_schema_to_converge(
             log.warning(
                 f"Schema had not converged after {delay * iteration:.2f} seconds, refreshing schema on local worker manually"
             )
-            async with service.database.start_session() as db:
-                await refresh_branches(db=db)
+            await refresh_branches(db=db)
             return
 
         iteration += 1


### PR DESCRIPTION
To avoid some `RuntimeError: read() called while another coroutine is already waiting for incoming data` errors during concurrent workflows. Note that ideally we would automatically create db session at each flow start, potentially using dependency injection, but this is a different topic.

Using "Hide whitespaces" for this PR makes review easier.