### PR TITLE
fix off by one error in ip prefix reconcile query

### DIFF
--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -362,7 +362,7 @@ class IPPrefixReconcileQuery(Query):
         # possible prefix: highest possible prefix length for a match
         possible_prefix_map: dict[str, int] = {}
         start_prefixlen = prefixlen if is_address else prefixlen - 1
-        for max_prefix_len in range(start_prefixlen, 0, -1):
+        for max_prefix_len in range(start_prefixlen, -1, -1):
             tmp_prefix = prefix_bin_host[:max_prefix_len]
             possible_prefix = tmp_prefix.ljust(self.ip_value.max_prefixlen, "0")
             if possible_prefix not in possible_prefix_map:

--- a/backend/tests/unit/core/diff/test_diff_and_merge.py
+++ b/backend/tests/unit/core/diff/test_diff_and_merge.py
@@ -895,7 +895,7 @@ class TestDiffAndMerge:
             assert updated_person.height.value == main_value
         await verify_no_duplicate_paths(db=db)
 
-    async def test_hierarchy_preserver(
+    async def test_hierarchy_preserved(
         self,
         db: InfrahubDatabase,
         default_branch: Branch,

--- a/backend/tests/unit/core/ipam/test_ipam_reconcile_query.py
+++ b/backend/tests/unit/core/ipam/test_ipam_reconcile_query.py
@@ -561,3 +561,47 @@ async def test_adjacent_parents_and_addresses(
         await query.execute(db=db)
         assert prefix_id_map[query.get_calculated_parent_uuid()] == "192.0.2.0/29"
         assert query.get_calculated_children_uuids() == []
+
+
+async def test_root_ip_prefix_exists_reconcile(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: SchemaBranch,
+    register_ipam_schema: SchemaBranch,
+):
+    prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
+    ip_namespace = await Node.init(db=db, schema=InfrahubKind.NAMESPACE)
+    await ip_namespace.new(db=db, name="ns1")
+    await ip_namespace.save(db=db)
+    root_prefix_node = await Node.init(db=db, schema=prefix_schema)
+    await root_prefix_node.new(db=db, prefix="0.0.0.0/0", ip_namespace=ip_namespace)
+    await root_prefix_node.save(db=db)
+
+    query = await IPPrefixReconcileQuery.init(
+        db=db, branch=default_branch, namespace=ip_namespace.id, ip_value=ipaddress.ip_network("192.168.0.0/16")
+    )
+    await query.execute(db=db)
+    assert query.get_calculated_parent_uuid() == root_prefix_node.id
+    assert query.get_calculated_children_uuids() == []
+
+
+async def test_root_ip_prefix_added_reconcile(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: SchemaBranch,
+    register_ipam_schema: SchemaBranch,
+):
+    prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
+    ip_namespace = await Node.init(db=db, schema=InfrahubKind.NAMESPACE)
+    await ip_namespace.new(db=db, name="ns1")
+    await ip_namespace.save(db=db)
+    child_prefix_node = await Node.init(db=db, schema=prefix_schema)
+    await child_prefix_node.new(db=db, prefix="192.168.0.0/16", ip_namespace=ip_namespace)
+    await child_prefix_node.save(db=db)
+
+    query = await IPPrefixReconcileQuery.init(
+        db=db, branch=default_branch, namespace=ip_namespace.id, ip_value=ipaddress.ip_network("0.0.0.0/0")
+    )
+    await query.execute(db=db)
+    assert query.get_calculated_parent_uuid() is None
+    assert query.get_calculated_children_uuids() == [child_prefix_node.id]

--- a/changelog/6172.fixed.md
+++ b/changelog/6172.fixed.md
@@ -1,0 +1,1 @@
+Fix error in IPAM reconciliation logic to correctly assign 0.0.0.0/0 as a parent prefix


### PR DESCRIPTION
fixes #6172 

the logic for determining the parents/children of a new IP prefix had an off-by-one error that prevented it from ever linking `0.0.0.0/0` as a parent of a new prefix