### PR TITLE
fix generic schema attr delete migration for overridden attrs

### DIFF
--- a/backend/infrahub/core/migrations/schema/node_attribute_remove.py
+++ b/backend/infrahub/core/migrations/schema/node_attribute_remove.py
@@ -25,12 +25,12 @@ class NodeAttributeRemoveMigrationQuery01(AttributeMigrationQuery):
 
         attr_name = self.migration.schema_path.field_name
         kinds_to_ignore = []
-        if isinstance(self.migration.new_node_schema, GenericSchema):
+        if isinstance(self.migration.new_node_schema, GenericSchema) and attr_name is not None:
             for inheriting_schema_kind in self.migration.new_node_schema.used_by:
                 node_schema = db.schema.get_node_schema(
                     name=inheriting_schema_kind, branch=self.branch, duplicate=False
                 )
-                attr_schema = node_schema.get_attribute_or_none(name=attr_name) if attr_name else None
+                attr_schema = node_schema.get_attribute_or_none(name=attr_name)
                 if attr_schema and not attr_schema.inherited:
                     kinds_to_ignore.append(inheriting_schema_kind)
 

--- a/backend/infrahub/core/migrations/schema/node_attribute_remove.py
+++ b/backend/infrahub/core/migrations/schema/node_attribute_remove.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Sequence
 
 from infrahub.core.constants import RelationshipStatus
 from infrahub.core.graph.schema import GraphAttributeRelationships
+from infrahub.core.schema.generic_schema import GenericSchema
 
 from ..query import AttributeMigrationQuery
 from ..shared import AttributeSchemaMigration
@@ -22,8 +23,20 @@ class NodeAttributeRemoveMigrationQuery01(AttributeMigrationQuery):
         branch_filter, branch_params = self.branch.get_query_filter_path(at=self.at.to_string())
         self.params.update(branch_params)
 
+        attr_name = self.migration.schema_path.field_name
+        kinds_to_ignore = []
+        if isinstance(self.migration.new_node_schema, GenericSchema):
+            for inheriting_schema_kind in self.migration.new_node_schema.used_by:
+                node_schema = db.schema.get_node_schema(
+                    name=inheriting_schema_kind, branch=self.branch, duplicate=False
+                )
+                attr_schema = node_schema.get_attribute_or_none(name=attr_name) if attr_name else None
+                if attr_schema and not attr_schema.inherited:
+                    kinds_to_ignore.append(inheriting_schema_kind)
+
         self.params["node_kind"] = self.migration.new_schema.kind
-        self.params["attr_name"] = self.migration.schema_path.field_name
+        self.params["kinds_to_ignore"] = kinds_to_ignore
+        self.params["attr_name"] = attr_name
         self.params["current_time"] = self.at.to_string()
         self.params["branch_name"] = self.branch.name
         self.params["branch_support"] = self.migration.previous_attribute_schema.get_branch().value
@@ -60,7 +73,8 @@ class NodeAttributeRemoveMigrationQuery01(AttributeMigrationQuery):
         query = """
         // Find all the active nodes
         MATCH (node:%(node_kind)s)
-        WHERE exists((node)-[:HAS_ATTRIBUTE]-(:Attribute { name: $attr_name }))
+        WHERE (size($kinds_to_ignore) = 0 OR NOT any(l IN labels(node) WHERE l IN $kinds_to_ignore))
+        AND exists((node)-[:HAS_ATTRIBUTE]-(:Attribute { name: $attr_name }))
         CALL {
             WITH node
             MATCH (root:Root)<-[r:IS_PART_OF]-(node)

--- a/backend/tests/integration/schema_lifecycle/test_generic_migrations.py
+++ b/backend/tests/integration/schema_lifecycle/test_generic_migrations.py
@@ -992,9 +992,7 @@ class SchemaLifecycleGenericBase(TestSchemaLifecycleBase):
 
         await self._refresh_registry(db=db, branch=branch)
         retrieved_specific_one = await NodeManager.get_one(db=db, branch=branch, id=initial_dataset["specific_one"].id)
-        # TODO: this fails b/c of a bug in the NodeAttributeRemove migration
-        # captured in https://github.com/opsmill/infrahub/issues/6073
-        # assert retrieved_specific_one.generic_attr_text.value == "Alpha"
+        assert retrieved_specific_one.generic_attr_text.value == "Alpha"
         assert retrieved_specific_one.generic_attr_num.value == 1
         rels_one = await retrieved_specific_one.favorite_thing.get_relationships(db=db)
         assert len(rels_one) == 1

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -1269,10 +1269,8 @@ async def car_person_manufacturer_schema(db: InfrahubDatabase, default_branch: B
 
 
 @pytest.fixture
-async def car_person_schema_generics(
-    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema, data_schema
-) -> SchemaRoot:
-    SCHEMA: dict[str, Any] = {
+async def car_person_schema_generics_unregistered(register_core_models_schema, data_schema) -> dict[str, Any]:
+    return {
         "generics": [
             {
                 "name": "Car",
@@ -1387,7 +1385,16 @@ async def car_person_schema_generics(
         ],
     }
 
-    schema = SchemaRoot(**SCHEMA)
+
+@pytest.fixture
+async def car_person_schema_generics(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema,
+    data_schema,
+    car_person_schema_generics_unregistered,
+) -> SchemaRoot:
+    schema = SchemaRoot(**car_person_schema_generics_unregistered)
     registry.schema.register_schema(schema=schema, branch=default_branch.name)
     return schema
 

--- a/backend/tests/unit/core/migrations/schema/test_node_attribute_remove.py
+++ b/backend/tests/unit/core/migrations/schema/test_node_attribute_remove.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import HashableModelState, SchemaPathType
@@ -5,7 +7,9 @@ from infrahub.core.migrations.schema.node_attribute_remove import (
     NodeAttributeRemoveMigration,
     NodeAttributeRemoveMigrationQuery01,
 )
+from infrahub.core.node import Node
 from infrahub.core.path import SchemaPath
+from infrahub.core.schema import SchemaRoot
 from infrahub.core.utils import count_nodes, count_relationships
 from infrahub.database import InfrahubDatabase
 
@@ -39,6 +43,59 @@ async def test_query_default_branch(db: InfrahubDatabase, default_branch: Branch
     assert query.get_nbr_migrations_executed() == 0
     assert await count_nodes(db=db, label="Attribute") == count_attr_node
     assert await count_relationships(db=db) == count_rels + 8
+
+
+async def test_query_default_branch_generic_with_override(
+    db: InfrahubDatabase, default_branch: Branch, car_person_schema_generics_unregistered: dict[str, Any]
+):
+    for node_schema_dict in car_person_schema_generics_unregistered["nodes"]:
+        if node_schema_dict["name"] == "ElectricCar":
+            node_schema_dict["attributes"].append(
+                {"name": "color", "kind": "Text", "default_value": "#555555", "max_length": 8}
+            )
+    schema_root = SchemaRoot(**car_person_schema_generics_unregistered)
+    schema = registry.schema.register_schema(schema=schema_root, branch=default_branch.name)
+
+    p1 = await Node.init(db=db, schema="TestPerson")
+    await p1.new(db=db, name="John", height=180)
+    await p1.save(db=db)
+    p2 = await Node.init(db=db, schema="TestPerson")
+    await p2.new(db=db, name="Jane", height=170)
+    await p2.save(db=db)
+    e_car = await Node.init(db=db, schema="TestElectricCar")
+    await e_car.new(db=db, name="volt", nbr_seats=3, nbr_engine=4, owner=p1, color="#aaabbbc")
+    await e_car.save(db=db)
+    g_car = await Node.init(db=db, schema="TestGazCar")
+    await g_car.new(db=db, name="nolt", nbr_seats=4, mpg=25, owner=p2)
+    await g_car.save(db=db)
+
+    candidate_schema = schema.duplicate()
+    car_schema = candidate_schema.get(name="TestCar")
+    attr = car_schema.get_attribute(name="color")
+    attr.state = HashableModelState.ABSENT
+
+    count_attr_node = await count_nodes(db=db, label="Attribute")
+    count_rels = await count_relationships(db=db)
+
+    migration = NodeAttributeRemoveMigration(
+        previous_node_schema=schema.get(name="TestCar"),
+        new_node_schema=car_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="color"),
+    )
+    query = await NodeAttributeRemoveMigrationQuery01.init(db=db, branch=default_branch, migration=migration)
+    await query.execute(db=db)
+    assert query.get_nbr_migrations_executed() == 1
+
+    # We expect 8 more relationships because there are 2 attributes with 4 relationships each
+    assert await count_relationships(db=db) == count_rels + 4
+    assert await count_nodes(db=db, label="Attribute") == count_attr_node
+
+    # Re-execute the query once to ensure that it won't change anything
+    query = await NodeAttributeRemoveMigrationQuery01.init(db=db, branch=default_branch, migration=migration)
+    await query.execute(db=db)
+    assert query.get_nbr_migrations_executed() == 0
+    assert await count_nodes(db=db, label="Attribute") == count_attr_node
+    assert await count_relationships(db=db) == count_rels + 4
 
 
 async def test_migration(db: InfrahubDatabase, default_branch: Branch, car_accord_main, car_camry_main):

--- a/changelog/6073.fixed.md
+++ b/changelog/6073.fixed.md
@@ -1,0 +1,1 @@
+Fix migration to remove an attribute from a schema to correctly ignore overridden attributes from a generic schema


### PR DESCRIPTION
fixes #6073 
IFC-1396

fixes issue where deleting an attribute from a generic schema would also delete the same attribute on inheriting node schema **even if the node-schema-level attribute was an override for the generic-schema-level-attribute**

there is no migration for this change b/c it is unlikely that anyone has encountered it and the migration would be somewhat complex to implement