### PR TITLE
Refactor import and init of adapter drivers

### DIFF
--- a/backend/infrahub/cli/git_agent.py
+++ b/backend/infrahub/cli/git_agent.py
@@ -19,10 +19,8 @@ from infrahub.git import initialize_repositories_directory
 from infrahub.lock import initialize_lock
 from infrahub.log import get_logger
 from infrahub.services import InfrahubServices
-from infrahub.services.adapters.cache.nats import NATSCache
-from infrahub.services.adapters.cache.redis import RedisCache
-from infrahub.services.adapters.message_bus.nats import NATSMessageBus
-from infrahub.services.adapters.message_bus.rabbitmq import RabbitMQMessageBus
+from infrahub.services.adapters.cache import InfrahubCache
+from infrahub.services.adapters.message_bus import InfrahubMessageBus
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from infrahub.services.adapters.workflow.worker import WorkflowWorkerExecution
 from infrahub.trace import configure_trace
@@ -121,13 +119,9 @@ async def start(
 
     component_type = ComponentType.GIT_AGENT
     message_bus = config.OVERRIDE.message_bus or (
-        await NATSMessageBus.new(component_type=component_type)
-        if config.SETTINGS.broker.driver == config.BrokerDriver.NATS
-        else await RabbitMQMessageBus.new(component_type=component_type)
+        await InfrahubMessageBus.new_from_driver(component_type=component_type, driver=config.SETTINGS.broker.driver)
     )
-    cache = config.OVERRIDE.cache or (
-        await NATSCache.new() if config.SETTINGS.cache.driver == config.CacheDriver.NATS else RedisCache()
-    )
+    cache = config.OVERRIDE.cache or (await InfrahubCache.new_from_driver(driver=config.SETTINGS.cache.driver))
 
     service = await InfrahubServices.new(
         cache=cache,

--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -115,10 +115,42 @@ class BrokerDriver(str, Enum):
     RabbitMQ = "rabbitmq"
     NATS = "nats"
 
+    @property
+    def driver_module_path(self) -> str:
+        match self:
+            case BrokerDriver.NATS:
+                return "infrahub.services.adapters.message_bus.nats"
+            case BrokerDriver.RabbitMQ:
+                return "infrahub.services.adapters.message_bus.rabbitmq"
+
+    @property
+    def driver_class_name(self) -> str:
+        match self:
+            case BrokerDriver.NATS:
+                return "NATSMessageBus"
+            case BrokerDriver.RabbitMQ:
+                return "RabbitMQMessageBus"
+
 
 class CacheDriver(str, Enum):
     Redis = "redis"
     NATS = "nats"
+
+    @property
+    def driver_module_path(self) -> str:
+        match self:
+            case CacheDriver.NATS:
+                return "infrahub.services.adapters.cache.nats"
+            case CacheDriver.Redis:
+                return "infrahub.services.adapters.cache.redis"
+
+    @property
+    def driver_class_name(self) -> str:
+        match self:
+            case CacheDriver.NATS:
+                return "NATSCache"
+            case CacheDriver.Redis:
+                return "RedisCache"
 
 
 class WorkflowDriver(str, Enum):

--- a/backend/infrahub/server.py
+++ b/backend/infrahub/server.py
@@ -33,10 +33,8 @@ from infrahub.lock import initialize_lock
 from infrahub.log import clear_log_context, get_logger, set_log_data
 from infrahub.middleware import InfrahubCORSMiddleware
 from infrahub.services import InfrahubServices
-from infrahub.services.adapters.cache.nats import NATSCache
-from infrahub.services.adapters.cache.redis import RedisCache
-from infrahub.services.adapters.message_bus.nats import NATSMessageBus
-from infrahub.services.adapters.message_bus.rabbitmq import RabbitMQMessageBus
+from infrahub.services.adapters.cache import InfrahubCache
+from infrahub.services.adapters.message_bus import InfrahubMessageBus
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from infrahub.services.adapters.workflow.worker import WorkflowWorkerExecution
 from infrahub.trace import add_span_exception, configure_trace, get_traceid
@@ -70,14 +68,11 @@ async def app_initialization(application: FastAPI, enable_scheduler: bool = True
         else WorkflowLocalExecution()
     )
     component_type = ComponentType.API_SERVER
-    message_bus = config.OVERRIDE.message_bus or (
-        await NATSMessageBus.new(component_type=component_type)
-        if config.SETTINGS.broker.driver == config.BrokerDriver.NATS
-        else await RabbitMQMessageBus.new(component_type=component_type)
+    message_bus = config.OVERRIDE.message_bus or await InfrahubMessageBus.new_from_driver(
+        component_type=component_type, driver=config.SETTINGS.broker.driver
     )
-    cache = config.OVERRIDE.cache or (
-        await NATSCache.new() if config.SETTINGS.cache.driver == config.CacheDriver.NATS else RedisCache()
-    )
+
+    cache = config.OVERRIDE.cache or (await InfrahubCache.new_from_driver(driver=config.SETTINGS.cache.driver))
     service = await InfrahubServices.new(
         cache=cache,
         database=database,

--- a/backend/infrahub/services/adapters/cache/__init__.py
+++ b/backend/infrahub/services/adapters/cache/__init__.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import importlib
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from infrahub.config import CacheDriver
     from infrahub.message_bus.types import KVTTL
 
 
@@ -33,4 +35,19 @@ class InfrahubCache(ABC):
     @abstractmethod
     async def set(self, key: str, value: str, expires: KVTTL | None = None, not_exists: bool = False) -> bool | None:
         """Set a value in the cache."""
+        raise NotImplementedError()
+
+    @classmethod
+    async def new_from_driver(cls, driver: CacheDriver) -> InfrahubCache:
+        """Imports and initializes the correct class based on the supplied driver.
+
+        This is to ensure that we only import the Python modules that we actually
+        need to operate and not import all possible options.
+        """
+        module = importlib.import_module(driver.driver_module_path)
+        broker_driver: InfrahubCache = getattr(module, driver.driver_class_name)
+        return await broker_driver.new()
+
+    @classmethod
+    async def new(cls) -> InfrahubCache:
         raise NotImplementedError()

--- a/backend/infrahub/services/adapters/cache/redis.py
+++ b/backend/infrahub/services/adapters/cache/redis.py
@@ -1,8 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import redis.asyncio as redis
 
 from infrahub import config
-from infrahub.message_bus.types import KVTTL
 from infrahub.services.adapters.cache import InfrahubCache
+
+if TYPE_CHECKING:
+    from infrahub.message_bus.types import KVTTL
 
 
 class RedisCache(InfrahubCache):
@@ -44,3 +50,7 @@ class RedisCache(InfrahubCache):
 
     async def set(self, key: str, value: str, expires: KVTTL | None = None, not_exists: bool = False) -> bool | None:
         return await self.connection.set(name=key, value=value, ex=expires.value if expires else None, nx=not_exists)
+
+    @classmethod
+    async def new(cls) -> RedisCache:
+        return cls()

--- a/backend/infrahub/services/adapters/message_bus/__init__.py
+++ b/backend/infrahub/services/adapters/message_bus/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, TypeVar
 
@@ -8,6 +9,8 @@ from infrahub.message_bus.messages import ROUTING_KEY_MAP
 ResponseClass = TypeVar("ResponseClass")
 
 if TYPE_CHECKING:
+    from infrahub.components import ComponentType
+    from infrahub.config import BrokerDriver, BrokerSettings
     from infrahub.message_bus import InfrahubMessage, InfrahubResponse
     from infrahub.message_bus.types import MessageTTL
     from infrahub.services import InfrahubServices
@@ -33,6 +36,23 @@ class InfrahubMessageBus(ABC):
 
     async def shutdown(self) -> None:  # noqa: B027 We want a default empty behavior, so it's ok to have an empty non-abstract method.
         """Shutdown the Message bus"""
+
+    @classmethod
+    async def new(cls, component_type: ComponentType, settings: BrokerSettings | None = None) -> InfrahubMessageBus:
+        raise NotImplementedError()
+
+    @classmethod
+    async def new_from_driver(
+        cls, component_type: ComponentType, driver: BrokerDriver, settings: BrokerSettings | None = None
+    ) -> InfrahubMessageBus:
+        """Imports and initializes the correct class based on the supplied driver.
+
+        This is to ensure that we only import the Python modules that we actually
+        need to operate and not import all possible options.
+        """
+        module = importlib.import_module(driver.driver_module_path)
+        broker_driver: InfrahubMessageBus = getattr(module, driver.driver_class_name)
+        return await broker_driver.new(component_type=component_type, settings=settings)
 
     @abstractmethod
     async def publish(

--- a/backend/infrahub/workers/infrahub_async.py
+++ b/backend/infrahub/workers/infrahub_async.py
@@ -24,11 +24,7 @@ from infrahub.git import initialize_repositories_directory
 from infrahub.lock import initialize_lock
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.cache import InfrahubCache
-from infrahub.services.adapters.cache.nats import NATSCache
-from infrahub.services.adapters.cache.redis import RedisCache
 from infrahub.services.adapters.message_bus import InfrahubMessageBus
-from infrahub.services.adapters.message_bus.nats import NATSMessageBus
-from infrahub.services.adapters.message_bus.rabbitmq import RabbitMQMessageBus
 from infrahub.services.adapters.workflow import InfrahubWorkflow
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from infrahub.services.adapters.workflow.worker import WorkflowWorkerExecution
@@ -198,15 +194,13 @@ class InfrahubWorkerAsync(BaseWorker):
 
     async def _init_message_bus(self, component_type: ComponentType) -> InfrahubMessageBus:
         return config.OVERRIDE.message_bus or (
-            await NATSMessageBus.new(component_type=component_type)
-            if config.SETTINGS.broker.driver == config.BrokerDriver.NATS
-            else await RabbitMQMessageBus.new(component_type=component_type)
+            await InfrahubMessageBus.new_from_driver(
+                component_type=component_type, driver=config.SETTINGS.broker.driver
+            )
         )
 
     async def _init_cache(self) -> InfrahubCache:
-        return config.OVERRIDE.cache or (
-            await NATSCache.new() if config.SETTINGS.cache.driver == config.CacheDriver.NATS else RedisCache()
-        )
+        return config.OVERRIDE.cache or (await InfrahubCache.new_from_driver(driver=config.SETTINGS.cache.driver))
 
     async def _init_services(self, client: InfrahubClient) -> None:
         component_type = ComponentType.GIT_AGENT


### PR DESCRIPTION
This PR has a small refactoring with regards to how we import drivers for the cache and message bus. Previously we'd import all drivers which meant that we'd import and waste some (not a lot) of memory for things that never ended up being used. It also cleans up the initialization code by shifting the logic to where it belongs.

There is still one instance where this currently doesn't work that great and it's the fact that multiple adapters could potentially share a connection such as NATS if used both for cache and message bus. Today we have the same issue for the "lock" which isn't an adapter but should be. That part should be cleaned up at a later stage.