### PR TITLE
IFC-1409 Fix HFID duplicates for component templates

### DIFF
--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1955,10 +1955,9 @@ class SchemaBranch:
                 )
             )
 
-            if relationship.kind == RelationshipKind.PARENT:
-                template_schema.human_friendly_id = [
-                    f"{relationship.name}__template_name__value"
-                ] + template_schema.human_friendly_id
+            parent_hfid = f"{relationship.name}__template_name__value"
+            if relationship.kind == RelationshipKind.PARENT and parent_hfid not in template_schema.human_friendly_id:
+                template_schema.human_friendly_id = [parent_hfid] + template_schema.human_friendly_id
                 template_schema.uniqueness_constraints[0].append(relationship.name)
 
     def generate_object_template_from_node(

--- a/backend/tests/integration/schema_lifecycle/test_schema_template_update.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_template_update.py
@@ -1,14 +1,15 @@
 from typing import Any
 
-from infrahub.core.schema import SchemaRoot
-from infrahub.core.schema.attribute_schema import AttributeSchema
-from infrahub.core.schema.node_schema import NodeSchema
 import pytest
 from infrahub_sdk import InfrahubClient
 
-from .shared import TestSchemaLifecycleBase
-from tests.helpers.schema import DEVICE_SCHEMA
+from infrahub.core.schema import SchemaRoot
+from infrahub.core.schema.attribute_schema import AttributeSchema
+from infrahub.core.schema.node_schema import NodeSchema
 from tests.constants import TestKind
+from tests.helpers.schema import DEVICE_SCHEMA
+
+from .shared import TestSchemaLifecycleBase
 
 
 class TestSchemaLifecycleTemplateUpdate(TestSchemaLifecycleBase):

--- a/backend/tests/integration/schema_lifecycle/test_schema_template_update.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_template_update.py
@@ -1,0 +1,63 @@
+from typing import Any
+
+from infrahub.core.schema import SchemaRoot
+from infrahub.core.schema.attribute_schema import AttributeSchema
+from infrahub.core.schema.node_schema import NodeSchema
+import pytest
+from infrahub_sdk import InfrahubClient
+
+from .shared import TestSchemaLifecycleBase
+from tests.helpers.schema import DEVICE_SCHEMA
+from tests.constants import TestKind
+
+
+class TestSchemaLifecycleTemplateUpdate(TestSchemaLifecycleBase):
+    @pytest.fixture(scope="class")
+    def schema_network(self) -> dict[str, Any]:
+        DEVICE_SCHEMA.version = "1.0"
+        return DEVICE_SCHEMA.model_dump()
+
+    @pytest.fixture(scope="class")
+    def schema_node_server(self) -> dict[str, Any]:
+        return SchemaRoot(
+            version="1.0",
+            generics=[],
+            nodes=[
+                NodeSchema(
+                    name="Server",
+                    namespace="Testing",
+                    inherit_from=[TestKind.INTERFACE_HOLDER],
+                    include_in_menu=True,
+                    label="Server",
+                    default_filter="name__value",
+                    generate_template=True,
+                    attributes=[AttributeSchema(name="name", kind="Text", unique=True)],
+                )
+            ],
+        ).model_dump()
+
+    async def test_step_01_create_branch(self, client: InfrahubClient) -> None:
+        branch = await client.branch.create(branch_name="test", sync_with_git=False)
+        assert branch
+
+    async def test_step_02_load_schema(self, client: InfrahubClient, schema_network: dict[str, Any]) -> None:
+        response = await client.schema.load(schemas=[schema_network], branch="test")
+        assert not response.errors
+
+    async def test_step_03_add_node_to_schema(self, client: InfrahubClient, schema_node_server: dict[str, Any]) -> None:
+        response = await client.schema.load(schemas=[schema_node_server], branch="test")
+        assert not response.errors
+
+    async def test_step_03_check_main_template(self, client: InfrahubClient) -> None:
+        device_template = await client.schema.get(kind=f"Template{TestKind.DEVICE}", branch="test")
+        assert device_template.human_friendly_id == ["template_name__value"]
+        assert len(device_template.uniqueness_constraints) == 1
+        assert device_template.uniqueness_constraints[0] == ["template_name__value"]
+
+    async def test_step04_check_component_template(self, client: InfrahubClient) -> None:
+        physical_interface_template = await client.schema.get(
+            kind=f"Template{TestKind.PHYSICAL_INTERFACE}", branch="test"
+        )
+        assert physical_interface_template.human_friendly_id == ["device__template_name__value", "template_name__value"]
+        assert len(physical_interface_template.uniqueness_constraints) == 1
+        assert physical_interface_template.uniqueness_constraints[0] == ["template_name__value", "device"]

--- a/changelog/+hfid-template.fixed.md
+++ b/changelog/+hfid-template.fixed.md
@@ -1,0 +1,1 @@
+Fix an issue where HFID and uniqueness constraints for component templates would end up having duplicate elements after loading several schemas


### PR DESCRIPTION
When loading several schemas without a restart the logic was adding the same HFID and uniqueness constraint element more than once for component templates. This lead to a final schema with unpractical HFID and uniqueness constraints (mostly from a user perspective). While a restart would fix the issue, this change makes sure it does not happen between restarts.

An integration test has also been added to highlight the issue in case of a regression.