### PR TITLE
upsert with changed relationships bug

### DIFF
--- a/backend/infrahub/core/constraint/node/runner.py
+++ b/backend/infrahub/core/constraint/node/runner.py
@@ -27,6 +27,8 @@ class NodeConstraintRunner:
         async with self.db.start_session() as db:
             await node.resolve_relationships(db=db)
 
+            await self.uniqueness_constraint.check(node, filters=field_filters)
+
             for relationship_name in node.get_schema().relationship_names:
                 if field_filters and relationship_name not in field_filters:
                     continue
@@ -34,7 +36,3 @@ class NodeConstraintRunner:
                 await relationship_manager.fetch_relationship_ids(db=db, force_refresh=True)
                 for relationship_constraint in self.relationship_manager_constraints:
                     await relationship_constraint.check(relm=relationship_manager, node_schema=node.get_schema())
-
-            # If HFID constraint is the only constraint violated, all other constraints need to have ran before,
-            # as it means there is an existing node that we might want to update in the case of an upsert
-            await self.uniqueness_constraint.check(node, filters=field_filters)

--- a/backend/infrahub/core/constraint/node/runner.py
+++ b/backend/infrahub/core/constraint/node/runner.py
@@ -23,11 +23,14 @@ class NodeConstraintRunner:
         self.uniqueness_constraint = uniqueness_constraint
         self.relationship_manager_constraints = relationship_manager_constraints
 
-    async def check(self, node: Node, field_filters: list[str] | None = None) -> None:
+    async def check(
+        self, node: Node, field_filters: list[str] | None = None, skip_uniqueness_check: bool = False
+    ) -> None:
         async with self.db.start_session() as db:
             await node.resolve_relationships(db=db)
 
-            await self.uniqueness_constraint.check(node, filters=field_filters)
+            if not skip_uniqueness_check:
+                await self.uniqueness_constraint.check(node, filters=field_filters)
 
             for relationship_name in node.get_schema().relationship_names:
                 if field_filters and relationship_name not in field_filters:

--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -363,7 +363,7 @@ class InfrahubMutationMixin:
         branch: Branch,
         db: InfrahubDatabase,
         obj: Node,
-        run_constraint_checks: bool = True,
+        skip_uniqueness_check: bool = False,
     ) -> tuple[Node, Self]:
         """
         Wrapper around mutate_update to potentially activate locking and call it within a database transaction.
@@ -378,11 +378,11 @@ class InfrahubMutationMixin:
             if lock_names:
                 async with InfrahubMultiLock(lock_registry=lock.registry, locks=lock_names):
                     obj = await cls.mutate_update_object(
-                        db=db, info=info, data=data, branch=branch, obj=obj, run_constraint_checks=run_constraint_checks
+                        db=db, info=info, data=data, branch=branch, obj=obj, skip_uniqueness_check=skip_uniqueness_check
                     )
             else:
                 obj = await cls.mutate_update_object(
-                    db=db, info=info, data=data, branch=branch, obj=obj, run_constraint_checks=run_constraint_checks
+                    db=db, info=info, data=data, branch=branch, obj=obj, skip_uniqueness_check=skip_uniqueness_check
                 )
             result = await cls.mutate_update_to_graphql(db=db, info=info, obj=obj)
             return obj, result
@@ -396,11 +396,11 @@ class InfrahubMutationMixin:
                         data=data,
                         branch=branch,
                         obj=obj,
-                        run_constraint_checks=run_constraint_checks,
+                        skip_uniqueness_check=skip_uniqueness_check,
                     )
             else:
                 obj = await cls.mutate_update_object(
-                    db=dbt, info=info, data=data, branch=branch, obj=obj, run_constraint_checks=run_constraint_checks
+                    db=dbt, info=info, data=data, branch=branch, obj=obj, skip_uniqueness_check=skip_uniqueness_check
                 )
             result = await cls.mutate_update_to_graphql(db=dbt, info=info, obj=obj)
             return obj, result
@@ -434,7 +434,7 @@ class InfrahubMutationMixin:
         data: InputObjectType,
         branch: Branch,
         obj: Node,
-        run_constraint_checks: bool = True,
+        skip_uniqueness_check: bool = False,
     ) -> Node:
         component_registry = get_component_registry()
         node_constraint_runner = await component_registry.get_component(NodeConstraintRunner, db=db, branch=branch)
@@ -442,8 +442,9 @@ class InfrahubMutationMixin:
         before_mutate_profile_ids = await cls._get_profile_ids(db=db, obj=obj)
         await obj.from_graphql(db=db, data=data)
         fields_to_validate = list(data)
-        if run_constraint_checks:
-            await node_constraint_runner.check(node=obj, field_filters=fields_to_validate)
+        await node_constraint_runner.check(
+            node=obj, field_filters=fields_to_validate, skip_uniqueness_check=skip_uniqueness_check
+        )
 
         fields = list(data.keys())
         for field_to_remove in ("id", "hfid"):
@@ -494,7 +495,6 @@ class InfrahubMutationMixin:
         db = database or graphql_context.db
         dict_data = dict(data)
         node = None
-        run_constraint_checks = True
 
         if "id" in dict_data:
             node = await NodeManager.get_one(
@@ -506,7 +506,6 @@ class InfrahubMutationMixin:
                 db=db,
                 branch=branch,
                 obj=node,
-                run_constraint_checks=run_constraint_checks,
             )
             return updated_obj, mutation, False
 
@@ -525,7 +524,6 @@ class InfrahubMutationMixin:
                 db=db,
                 branch=branch,
                 obj=node,
-                run_constraint_checks=run_constraint_checks,
             )
             return updated_obj, mutation, False
 
@@ -545,7 +543,7 @@ class InfrahubMutationMixin:
                 db=db,
                 branch=branch,
                 obj=node,
-                run_constraint_checks=run_constraint_checks,
+                skip_uniqueness_check=True,
             )
             return updated_obj, mutation, False
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -779,7 +779,7 @@ async def person_schema_unique_attr_non_hfid_unregistered(
                     {
                         "name": "car",
                         "peer": "TestCar",
-                        "cardinality": "many",
+                        "cardinality": "one",
                         "optional": True,
                         "identifier": "carthings",
                     }

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -747,7 +747,44 @@ async def person_schema_unique_attr_non_hfid_unregistered(
                     {"name": "height", "kind": "Number", "optional": True},
                     {"name": "bag", "kind": "Text", "unique": True},
                 ],
-            }
+            },
+            {
+                "name": "Car",
+                "namespace": "Test",
+                "display_labels": ["name__value"],
+                "human_friendly_id": ["owner__name__value", "name__value"],
+                "attributes": [
+                    {"name": "name", "kind": "Text"},
+                    {"name": "color", "kind": "Text", "optional": True},
+                ],
+                "relationships": [
+                    {"name": "owner", "peer": "TestPerson", "cardinality": "one", "optional": False},
+                    {
+                        "name": "things",
+                        "peer": "TestThing",
+                        "cardinality": "many",
+                        "optional": True,
+                        "identifier": "carthings",
+                    },
+                ],
+            },
+            {
+                "name": "Thing",
+                "namespace": "Test",
+                "display_labels": ["value__value"],
+                "attributes": [
+                    {"name": "value", "kind": "Text"},
+                ],
+                "relationships": [
+                    {
+                        "name": "car",
+                        "peer": "TestCar",
+                        "cardinality": "many",
+                        "optional": True,
+                        "identifier": "carthings",
+                    }
+                ],
+            },
         ],
     }
 

--- a/backend/tests/unit/graphql/test_mutation_upsert.py
+++ b/backend/tests/unit/graphql/test_mutation_upsert.py
@@ -263,16 +263,55 @@ async def test_non_unique_value_raises_error(db: InfrahubDatabase, person_schema
 
 
 async def test_upsert_existing_with_enough_information_for_hfid(
-    db: InfrahubDatabase, person_schema_unique_attr_non_hfid, branch: Branch
+    db: InfrahubDatabase, person_schema_unique_attr_non_hfid, default_branch: Branch
 ):
     car_name = "Ferramboghinierati"
     car_color_1 = "blue"
     car_color_2 = "red"
-    fred = await create_and_save(db=db, schema="TestPerson", name="Fred", bag="bag-fred", branch=branch)
-    car = await create_and_save(db=db, schema="TestCar", name=car_name, owner=fred, color=car_color_1, branch=branch)
-    thing1 = await create_and_save(db=db, schema="TestThing", value="thing1", branch=branch)
-    thing2 = await create_and_save(db=db, schema="TestThing", value="thing2", branch=branch)
+    fred = await create_and_save(db=db, schema="TestPerson", name="Fred", bag="bag-fred", branch=default_branch)
+    car = await create_and_save(
+        db=db, schema="TestCar", name=car_name, owner=fred, color=car_color_1, branch=default_branch
+    )
+    other_car = await create_and_save(
+        db=db, schema="TestCar", name="pinto", owner=fred, color="brown", branch=default_branch
+    )
+    thing1 = await create_and_save(db=db, schema="TestThing", value="thing1", branch=default_branch)
+    thing2 = await create_and_save(db=db, schema="TestThing", value="thing2", car=other_car, branch=default_branch)
 
+    # upsert the existing car with new attr and relationship data
+    query = """
+    mutation($car_name: String!, $owner_id: String!, $color: String!) {
+        TestCarUpsert(
+            data: {
+                name: {value: $car_name},
+                owner: {id: $owner_id},
+                color: {value: $color},
+                things: [
+                    {id: "%(id1)s"}
+                ]
+            }
+        ) {
+            ok
+            object {
+                id
+                name {value}
+                color {value}
+                owner {node {id}}
+            }
+        }
+    }
+    """ % {"id1": thing1.id}
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"car_name": car_name, "owner_id": fred.id, "color": car_color_2},
+    )
+    assert result.errors is None
+
+    # illegal upsert that would add two peers on a TestThing.car relationship
     query = """
     mutation($car_name: String!, $owner_id: String!, $color: String!) {
         TestCarUpsert(
@@ -295,8 +334,7 @@ async def test_upsert_existing_with_enough_information_for_hfid(
         }
     }
     """ % {"id1": thing1.id, "id2": thing2.id}
-
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -304,8 +342,13 @@ async def test_upsert_existing_with_enough_information_for_hfid(
         root_value=None,
         variable_values={"car_name": car_name, "owner_id": fred.id, "color": car_color_2},
     )
-    assert result.errors is None
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    assert result.errors
+    assert result.errors[0].message == f"Node {thing2.id} has 2 peers for carthings, maximum of 1 allowed"
+
+    # delete the TestThing.car relationship and try again
+    await thing2.car.update(db=db, data=[None])
+    await thing2.save(db=db)
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -313,15 +356,16 @@ async def test_upsert_existing_with_enough_information_for_hfid(
         root_value=None,
         variable_values={"car_name": car_name, "owner_id": fred.id, "color": car_color_2},
     )
-    assert result.errors is None
-
+    assert not result.errors
     assert result.data["TestCarUpsert"]["object"]["id"] == car.id
     assert result.data["TestCarUpsert"]["object"]["color"]["value"] == car_color_2
     assert result.data["TestCarUpsert"]["object"]["owner"]["node"]["id"] == fred.id
 
-    all_cars = await NodeManager.query(db=db, branch=branch, schema="TestCar")
-    assert len(all_cars) == 1
-    retrieved_car = await NodeManager.get_one(db=db, branch=branch, id=car.id, prefetch_relationships=True)
+    # validate upsert succeeded and all data is as expected
+    all_cars = await NodeManager.query(db=db, branch=default_branch, schema="TestCar")
+    assert len(all_cars) == 2
+    assert {one_car.id for one_car in all_cars} == {car.id, other_car.id}
+    retrieved_car = await NodeManager.get_one(db=db, branch=default_branch, id=car.id, prefetch_relationships=True)
     assert retrieved_car.name.value == car_name
     assert retrieved_car.color.value == car_color_2
     assert (await retrieved_car.owner.get_peer(db=db)).id == fred.id

--- a/backend/tests/unit/graphql/test_mutation_upsert.py
+++ b/backend/tests/unit/graphql/test_mutation_upsert.py
@@ -262,6 +262,73 @@ async def test_non_unique_value_raises_error(db: InfrahubDatabase, person_schema
     assert "Violates uniqueness constraint 'bag'" in result.errors[0].message
 
 
+async def test_upsert_existing_with_enough_information_for_hfid(
+    db: InfrahubDatabase, person_schema_unique_attr_non_hfid, branch: Branch
+):
+    car_name = "Ferramboghinierati"
+    car_color_1 = "blue"
+    car_color_2 = "red"
+    fred = await create_and_save(db=db, schema="TestPerson", name="Fred", bag="bag-fred", branch=branch)
+    car = await create_and_save(db=db, schema="TestCar", name=car_name, owner=fred, color=car_color_1, branch=branch)
+    thing1 = await create_and_save(db=db, schema="TestThing", value="thing1", branch=branch)
+    thing2 = await create_and_save(db=db, schema="TestThing", value="thing2", branch=branch)
+
+    query = """
+    mutation($car_name: String!, $owner_id: String!, $color: String!) {
+        TestCarUpsert(
+            data: {
+                name: {value: $car_name},
+                owner: {id: $owner_id},
+                color: {value: $color},
+                things: [
+                    {id: "%(id1)s"}, {id: "%(id2)s"}
+                ]
+            }
+        ) {
+            ok
+            object {
+                id
+                name {value}
+                color {value}
+                owner {node {id}}
+            }
+        }
+    }
+    """ % {"id1": thing1.id, "id2": thing2.id}
+
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"car_name": car_name, "owner_id": fred.id, "color": car_color_2},
+    )
+    assert result.errors is None
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"car_name": car_name, "owner_id": fred.id, "color": car_color_2},
+    )
+    assert result.errors is None
+
+    assert result.data["TestCarUpsert"]["object"]["id"] == car.id
+    assert result.data["TestCarUpsert"]["object"]["color"]["value"] == car_color_2
+    assert result.data["TestCarUpsert"]["object"]["owner"]["node"]["id"] == fred.id
+
+    all_cars = await NodeManager.query(db=db, branch=branch, schema="TestCar")
+    assert len(all_cars) == 1
+    retrieved_car = await NodeManager.get_one(db=db, branch=branch, id=car.id, prefetch_relationships=True)
+    assert retrieved_car.name.value == car_name
+    assert retrieved_car.color.value == car_color_2
+    assert (await retrieved_car.owner.get_peer(db=db)).id == fred.id
+    thing_peers = await retrieved_car.things.get_peers(db=db)
+    assert set(thing_peers.keys()) == {thing1.id, thing2.id}
+
+
 async def test_upsert_existing_hfid_with_non_hfid_unique_attr(
     db: InfrahubDatabase, person_schema_unique_attr_non_hfid, branch: Branch
 ):

--- a/changelog/+fixupsertwithrelationships
+++ b/changelog/+fixupsertwithrelationships
@@ -1,0 +1,1 @@
+Fix upsert operation when updating relationships with cardinality `one` or `many` having min/max count constraints


### PR DESCRIPTION
a problem in our updated upsert logic could prevent upserting a node with updated relationship(s) that have min or max counts. this would affect cardinality one relationships as well b/c those have an implicit min of 0 or 1 and an implicit max of 1
trying to upsert the exact same node with a cardinality one relationship would fail with an error like `Node <UUID> has 2 peers for <RELATIONSHIP_NAME>, maximum of 1 allowed`

the root cause was that we were running relationship constraints (including the relationship count constraint) on a "new" node even if that "new" node was an upsert for a node that already exists. this would cause the relationship count constraint to basically double-count any relationships included in the upsert.

the solution is to separate running the uniqueness constraint (required for identifying if an upsert is actually a create or an update) from the relationship constraints. the new approach is to run the uniqueness constraint first (instead of last) and if this is an upsert that is actually an update, then we will skip running the uniqueness constraint again during the update operation