### PR TITLE
fix(testcontainers): measurement durations are wrong

### DIFF
--- a/python_testcontainers/infrahub_testcontainers/models.py
+++ b/python_testcontainers/infrahub_testcontainers/models.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
 
@@ -27,7 +27,7 @@ class InfrahubResultContext(BaseModel):
 
 class InfrahubActiveMeasurementItem(BaseModel):
     definition: MeasurementDefinition
-    start_time: datetime = datetime.now(UTC)
+    start_time: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     context: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/python_testcontainers/infrahub_testcontainers/performance_test.py
+++ b/python_testcontainers/infrahub_testcontainers/performance_test.py
@@ -1,6 +1,6 @@
 import hashlib
 import json
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from types import TracebackType
 from typing import Any
 
@@ -35,7 +35,7 @@ class InfrahubPerformanceTest:
         self.env_vars = {}
         self.project_name = ""
         self.test_info = {}
-        self.start_time = datetime.now(UTC)
+        self.start_time = datetime.now(timezone.utc)
         self.end_time: datetime | None = None
         self.results_url = results_url
         self.scraper_endpoint = ""
@@ -57,7 +57,7 @@ class InfrahubPerformanceTest:
 
     def finalize(self, session: pytest.Session) -> None:
         if self.initialized:
-            self.end_time = datetime.now(UTC)
+            self.end_time = datetime.now(timezone.utc)
             self.extract_test_session_information(session)
             self.send_results()
 
@@ -129,7 +129,7 @@ class InfrahubPerformanceTest:
         if not exc_type and self.active_measurements:
             self.add_measurement(
                 definition=self.active_measurements.definition,
-                value=(datetime.now(UTC) - self.active_measurements.start_time).total_seconds() * 1000,
+                value=(datetime.now(timezone.utc) - self.active_measurements.start_time).total_seconds() * 1000,
                 context=self.active_measurements.context,
             )
 


### PR DESCRIPTION
Active measurement start_time was initialized at module load rather than at each object initialization.

Also make the code < 3.11 compatible by not using the UTC alias.