### PR TITLE
Clear GraphQLSchemaManager cache when deleting branches

### DIFF
--- a/backend/infrahub/core/registry.py
+++ b/backend/infrahub/core/registry.py
@@ -222,7 +222,7 @@ class Registry:
 
     async def purge_inactive_branches(
         self, db: InfrahubDatabase, active_branches: list[Branch] | None = None
-    ) -> list[str]:
+    ) -> set[str]:
         """Return a list of branches that were purged from the registry."""
         active_branches = active_branches or await self.branch_object.get_list(db=db)
         active_branch_names = [branch.name for branch in active_branches]
@@ -235,8 +235,7 @@ class Registry:
 
         purged_branches.update(self.schema.purge_inactive_branches(active_branches=active_branch_names))
         purged_branches.update(db.purge_inactive_schemas(active_branches=active_branch_names))
-
-        return sorted(purged_branches)
+        return purged_branches
 
 
 registry = Registry()

--- a/backend/infrahub/graphql/manager.py
+++ b/backend/infrahub/graphql/manager.py
@@ -114,6 +114,16 @@ class GraphQLSchemaManager:
         cls._branch_details_by_name = {}
 
     @classmethod
+    def purge_inactive(cls, active_branches: list[str]) -> set[str]:
+        """Return inactive branches that were purged"""
+        inactive_branches: set[str] = set()
+        for branch_name in list(cls._branch_details_by_name):
+            if branch_name not in active_branches:
+                inactive_branches.add(branch_name)
+                del cls._branch_details_by_name[branch_name]
+        return inactive_branches
+
+    @classmethod
     def _cache_branch(
         cls, branch: Branch, schema_branch: SchemaBranch, schema_hash: str | None = None
     ) -> BranchDetails:

--- a/backend/infrahub/tasks/registry.py
+++ b/backend/infrahub/tasks/registry.py
@@ -61,5 +61,8 @@ async def refresh_branches(db: InfrahubDatabase) -> None:
                 )
 
         purged_branches = await registry.purge_inactive_branches(db=db, active_branches=branches)
-        for branch_name in purged_branches:
+        purged_branches.update(
+            GraphQLSchemaManager.purge_inactive(active_branches=[branch.name for branch in branches])
+        )
+        for branch_name in sorted(purged_branches):
             log.info(f"Removed branch {branch_name!r} from the registry", branch=branch_name, worker=WORKER_IDENTITY)

--- a/backend/tests/unit/graphql/test_manager.py
+++ b/backend/tests/unit/graphql/test_manager.py
@@ -1,4 +1,5 @@
 import inspect
+from copy import deepcopy
 
 import graphene
 import pytest
@@ -312,3 +313,33 @@ async def test_branch_caching_miss(
     manager2 = GraphQLSchemaManager.get_manager_for_branch(branch=same_branch, schema_branch=schema_branch)
 
     assert manager1 is not manager2
+
+
+async def test_branch_purge(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    data_schema: None,
+    car_person_schema_generics: None,
+) -> None:
+    default_branch.update_schema_hash()
+    purged_branch = "i-will-be-purged"
+    active_branch = "i-will-not-be-purged"
+    schema_branch = registry.schema.get_schema_branch(default_branch.name)
+
+    GraphQLSchemaManager.get_manager_for_branch(branch=default_branch, schema_branch=schema_branch)
+    GraphQLSchemaManager.purge_inactive(active_branches=[default_branch.name])
+    GraphQLSchemaManager._branch_details_by_name[active_branch] = deepcopy(
+        GraphQLSchemaManager._branch_details_by_name[default_branch.name]
+    )
+    GraphQLSchemaManager._branch_details_by_name[purged_branch] = deepcopy(
+        GraphQLSchemaManager._branch_details_by_name[default_branch.name]
+    )
+
+    assert default_branch.name in GraphQLSchemaManager._branch_details_by_name.keys()
+    assert active_branch in GraphQLSchemaManager._branch_details_by_name.keys()
+    assert purged_branch in GraphQLSchemaManager._branch_details_by_name.keys()
+    purged_branches = GraphQLSchemaManager.purge_inactive(active_branches=[active_branch, default_branch.name])
+    assert default_branch.name in GraphQLSchemaManager._branch_details_by_name.keys()
+    assert active_branch in GraphQLSchemaManager._branch_details_by_name.keys()
+    assert purged_branch not in GraphQLSchemaManager._branch_details_by_name.keys()
+    assert purged_branches == {purged_branch}

--- a/changelog/6021.fixed.md
+++ b/changelog/6021.fixed.md
@@ -1,0 +1,1 @@
+Clear GraphQL schema manager cache when deleting branches to release memory.


### PR DESCRIPTION
This PR is related to #6021 and specifically focuses on releasing memory as branches are deleted. It builds on some previous work where we removed cached references from the registry and schema manager. In this case it's the GraphQL schema within the GraphQLSchemaManager that gets removed it should produce a more visual result than the previous savings.

I've also made a slight update in `core/registry.py` so that the purge_inactive_branches returns a set instead of a list, the only reason for that change is to make the code within the registry task cleaner.

The GraphQLSchemaManager stores the cache within the class type itself, so the purge method might look a bit strange.