### PR TITLE
Add support for computed attributes on generics

### DIFF
--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1005,9 +1005,11 @@ class SchemaBranch:
             generic_schema = self.get_generic(name=name, duplicate=False)
             for attribute in generic_schema.attributes:
                 if attribute.computed_attribute and attribute.computed_attribute.kind != ComputedAttributeKind.USER:
-                    raise ValueError(
-                        f"{generic_schema.kind}: Attribute {attribute.name!r} computed attributes are only allowed on nodes not generics"
-                    )
+                    for inheriting_node in generic_schema.used_by:
+                        node_schema = self.get_node(name=inheriting_node, duplicate=False)
+                        self.computed_attributes.validate_generic_inheritance(
+                            node=node_schema, attribute=attribute, generic=generic_schema
+                        )
 
     def _validate_computed_attribute(self, node: NodeSchema, attribute: AttributeSchema) -> None:
         if not attribute.computed_attribute or attribute.computed_attribute.kind == ComputedAttributeKind.USER:

--- a/backend/infrahub/core/schema/schema_branch_computed.py
+++ b/backend/infrahub/core/schema/schema_branch_computed.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field
 from infrahub.core.schema import AttributeSchema  # noqa: TC001
 
 if TYPE_CHECKING:
-    from infrahub.core.schema import NodeSchema, SchemaAttributePath
+    from infrahub.core.schema import GenericSchema, NodeSchema, SchemaAttributePath
 
 
 @dataclass
@@ -90,6 +90,7 @@ class ComputedAttributes:
     ) -> None:
         self._computed_python_transform_attribute_map: dict[str, list[AttributeSchema]] = transform_attribute_map or {}
         self._computed_jinja2_attribute_map: dict[str, RegisteredNodeComputedAttribute] = jinja2_attribute_map or {}
+        self._defined_from_generic: dict[str, str] = {}
 
     def duplicate(self) -> ComputedAttributes:
         return self.__class__(
@@ -165,6 +166,16 @@ class ComputedAttributes:
             self._computed_jinja2_attribute_map[source_attribute.kind].local_fields[
                 schema_path.active_relationship_schema.name
             ].append(deepcopy(source_attribute))
+
+    def validate_generic_inheritance(
+        self, node: NodeSchema, attribute: AttributeSchema, generic: GenericSchema
+    ) -> None:
+        attribute_key = f"{node.kind}__{attribute.name}"
+        if duplicate := self._defined_from_generic.get(attribute_key):
+            raise ValueError(
+                f"{node.kind}: {attribute.name!r} is declared as a computed attribute from multiple generics {sorted([duplicate, generic.kind])}"
+            )
+        self._defined_from_generic[attribute_key] = generic.kind
 
     def get_impacted_jinja2_targets(self, kind: str, updates: list[str] | None = None) -> list[ComputedAttributeTarget]:
         if mapping := self._computed_jinja2_attribute_map.get(kind):

--- a/backend/tests/helpers/schema/location.py
+++ b/backend/tests/helpers/schema/location.py
@@ -13,6 +13,16 @@ LOCATION = GenericSchema(
         AttributeSchema(name="name", kind="Text", unique=True, optional=False),
         AttributeSchema(name="shortname", kind="Text", unique=True, optional=False),
         AttributeSchema(name="description", kind="Text", optional=True),
+        AttributeSchema(
+            name="code",
+            kind="Text",
+            optional=False,
+            read_only=True,
+            computed_attribute=ComputedAttribute(
+                kind=ComputedAttributeKind.JINJA2,
+                jinja2_template="{{ name__value[:2] | lower }}",
+            ),
+        ),
     ],
 )
 
@@ -48,7 +58,17 @@ COUNTRY = NodeSchema(
                 kind=ComputedAttributeKind.JINJA2,
                 jinja2_template="{{ parent__shortname__value }}-{{ shortname__value }}",
             ),
-        )
+        ),
+        AttributeSchema(
+            name="code",
+            kind="Text",
+            optional=False,
+            read_only=True,
+            computed_attribute=ComputedAttribute(
+                kind=ComputedAttributeKind.JINJA2,
+                jinja2_template="{{ name__value[:3] | lower }}",
+            ),
+        ),
     ],
 )
 

--- a/backend/tests/integration_docker/test_computed_attributes.py
+++ b/backend/tests/integration_docker/test_computed_attributes.py
@@ -56,6 +56,9 @@ class TestComputedAttributes(TestInfrahubDockerClient):
 
         assert tshirt1_initial.description.value == first_desc
 
+        # Validate computed attribute defined on generic
+        assert tshirt1_initial.name_code.value == "WEARABLE-EXPLORER"
+
         color1_initial.description.value = (
             "A striking, lively shade of orange that radiates the golden warmth of a sunset."
         )
@@ -86,6 +89,18 @@ class TestComputedAttributes(TestInfrahubDockerClient):
             await sleep(1)
 
         assert tshirt1_second_update_result.description.value == expected_description
+        tshirt1_second_update_result.name.value = "Gardener"
+        await tshirt1_second_update_result.save()
+
+        expected_name_code = "WEARABLE-GARDENER"
+        for _ in range(10):
+            # Give the computed attribute triggers a little while to run
+            tshirt1_last_update_result = await client.get(kind="TestingTShirt", id=tshirt1.id)
+            if tshirt1_last_update_result.name_code.value == expected_name_code:
+                break
+            await sleep(1)
+
+        assert tshirt1_last_update_result.name_code.value == expected_name_code
 
     async def test_transform_based_computed_attribute(self, client: InfrahubClient, remote_repos_dir: Path) -> None:
         src_directory = CURRENT_DIRECTORY / "test_files/repos/computed_attribute"

--- a/backend/tests/integration_docker/test_files/computed_tshirt.yml
+++ b/backend/tests/integration_docker/test_files/computed_tshirt.yml
@@ -18,6 +18,22 @@ generics:
         kind: Text
         optional: true
 
+  - name: Wearable
+    namespace: Testing
+    human_friendly_id: ["name__value"]
+    include_in_menu: true
+    attributes:
+      - name: name
+        kind: Text
+        optional: false
+      - name: name_code
+        kind: Text
+        optional: false
+        read_only: true
+        computed_attribute:
+          kind: Jinja2
+          jinja2_template: "WEARABLE-{{ name__value | upper }}"
+
 nodes:
   - name: Color
     namespace: Testing
@@ -45,6 +61,8 @@ nodes:
       - "name__value"
     display_labels:
       - "name__value"
+    inherit_from:
+      - TestingWearable
     attributes:
       - name: name
         kind: Text

--- a/backend/tests/unit/core/schema/schema_branch/test_validate_computed_attributes.py
+++ b/backend/tests/unit/core/schema/schema_branch/test_validate_computed_attributes.py
@@ -24,6 +24,25 @@ from infrahub.core.schema.schema_branch import SchemaBranch
                             AttributeSchema(
                                 name="computed",
                                 kind="Text",
+                                read_only=True,
+                                computed_attribute=ComputedAttribute(
+                                    kind=ComputedAttributeKind.JINJA2, jinja2_template="n/a"
+                                ),
+                            ),
+                        ],
+                    ),
+                    GenericSchema(
+                        name="Robot",
+                        namespace="Testing",
+                        attributes=[
+                            AttributeSchema(
+                                name="name",
+                                kind="Text",
+                            ),
+                            AttributeSchema(
+                                name="computed",
+                                kind="Text",
+                                read_only=True,
                                 computed_attribute=ComputedAttribute(
                                     kind=ComputedAttributeKind.JINJA2, jinja2_template="n/a"
                                 ),
@@ -31,9 +50,69 @@ from infrahub.core.schema.schema_branch import SchemaBranch
                         ],
                     ),
                 ],
+                nodes=[
+                    NodeSchema(
+                        name="Cyborg",
+                        namespace="Testing",
+                        inherit_from=["TestingPerson", "TestingRobot"],
+                    ),
+                ],
             ),
-            "TestingPerson: Attribute 'computed' computed attributes are only allowed on nodes not generics",
-            id="jinja2_on_generic",
+            "TestingCyborg: 'computed' is declared as a computed attribute from multiple generics ['TestingPerson', 'TestingRobot']",
+            id="jinja2_on_multiple_generics",
+        ),
+        pytest.param(
+            SchemaRoot(
+                generics=[
+                    GenericSchema(
+                        name="Person",
+                        namespace="Testing",
+                        attributes=[
+                            AttributeSchema(
+                                name="name",
+                                kind="Text",
+                            ),
+                            AttributeSchema(
+                                name="computed",
+                                kind="Text",
+                                read_only=True,
+                                optional=True,
+                                computed_attribute=ComputedAttribute(
+                                    kind=ComputedAttributeKind.TRANSFORM_PYTHON, transform="ComputedPerson"
+                                ),
+                            ),
+                        ],
+                    ),
+                    GenericSchema(
+                        name="Robot",
+                        namespace="Testing",
+                        attributes=[
+                            AttributeSchema(
+                                name="name",
+                                kind="Text",
+                            ),
+                            AttributeSchema(
+                                name="computed",
+                                kind="Text",
+                                read_only=True,
+                                optional=True,
+                                computed_attribute=ComputedAttribute(
+                                    kind=ComputedAttributeKind.TRANSFORM_PYTHON, transform="ComputedRobot"
+                                ),
+                            ),
+                        ],
+                    ),
+                ],
+                nodes=[
+                    NodeSchema(
+                        name="Cyborg",
+                        namespace="Testing",
+                        inherit_from=["TestingPerson", "TestingRobot"],
+                    ),
+                ],
+            ),
+            "TestingCyborg: 'computed' is declared as a computed attribute from multiple generics ['TestingPerson', 'TestingRobot']",
+            id="transform_on_multiple_generics",
         ),
         pytest.param(
             SchemaRoot(
@@ -291,6 +370,6 @@ async def test_schema_computed_attribute_violations(schema_root: SchemaRoot, exp
     schema.load_schema(schema=schema_root)
 
     with pytest.raises(ValueError) as exc:
-        schema.validate_computed_attributes()
+        schema.process()
 
     assert str(exc.value) == expected_error

--- a/backend/tests/unit/graphql/test_mutation_create_jinja2_attributes.py
+++ b/backend/tests/unit/graphql/test_mutation_create_jinja2_attributes.py
@@ -107,3 +107,110 @@ async def test_create_with_jinja2_computed_attributes_on_hierarchial_node(
     assert result.data
     assert result.data["TestingSiteCreate"]["ok"] is True
     assert result.data["TestingSiteCreate"]["object"]["slug"]["value"] == "eu-se-sth"
+
+
+async def test_create_with_jinja2_with_generics(
+    db: InfrahubDatabase, default_branch: Branch, node_group_schema: None, data_schema: None, branch: Branch
+) -> None:
+    schema = SchemaRoot(**internal_schema)
+    registry.schema.register_schema(schema=schema, branch=branch.name)
+    branch.update_schema_hash()
+    await branch.save(db=db)
+    await load_schema(db, branch_name=branch.name, schema=LOCATION_SCHEMA)
+
+    continent_query = """
+    mutation TestingContinentCreate {
+        TestingContinentCreate(data: {
+            name: { value: "Europe" },
+            shortname: { value: "eu" },
+        }
+        ) {
+            ok
+            object {
+                id
+                name { value }
+                code { value }
+            }
+        }
+    }
+    """
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    continent_result = await graphql(
+        schema=gql_params.schema,
+        source=continent_query,
+        context_value=gql_params.context,
+        root_value=None,
+    )
+
+    assert continent_result.errors is None
+    assert continent_result.data
+    assert continent_result.data["TestingContinentCreate"]["ok"] is True
+    assert continent_result.data["TestingContinentCreate"]["object"]["code"]["value"] == "eu"
+    assert continent_result.data["TestingContinentCreate"]["object"]["id"]
+    continent_id = continent_result.data["TestingContinentCreate"]["object"]["id"]
+
+    country_query = """
+    mutation TestingCountryCreate($parent: String!) {
+        TestingCountryCreate(data: {
+            name: { value: "Sweden" },
+            shortname: { value: "se" },
+            parent: { id: $parent },
+        }
+        ) {
+            ok
+            object {
+                id
+                name { value }
+                code { value }
+            }
+        }
+    }
+    """
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    country_result = await graphql(
+        schema=gql_params.schema,
+        source=country_query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"parent": continent_id},
+    )
+
+    assert country_result.errors is None
+    assert country_result.data
+    assert country_result.data["TestingCountryCreate"]["ok"] is True
+    # The country code is different and with three letters because the generic computed attribute
+    # is overriden on the country
+    assert country_result.data["TestingCountryCreate"]["object"]["code"]["value"] == "swe"
+    assert country_result.data["TestingCountryCreate"]["object"]["id"]
+    country_id = country_result.data["TestingCountryCreate"]["object"]["id"]
+
+    site_query = """
+    mutation TestingSiteCreate($parent: String!) {
+        TestingSiteCreate(data: {
+            name: { value: "Stockholm" },
+            shortname: { value: "sth" },
+            parent: { id: $parent },
+        }
+        ) {
+            ok
+            object {
+                id
+                name { value }
+                code { value }
+            }
+        }
+    }
+    """
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    site_result = await graphql(
+        schema=gql_params.schema,
+        source=site_query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"parent": country_id},
+    )
+
+    assert site_result.errors is None
+    assert site_result.data
+    assert site_result.data["TestingSiteCreate"]["ok"] is True
+    assert site_result.data["TestingSiteCreate"]["object"]["code"]["value"] == "st"

--- a/changelog/5736.added.md
+++ b/changelog/5736.added.md
@@ -1,0 +1,1 @@
+Added support for computed attributes on generics.

--- a/docs/docs/topics/computed-attributes.mdx
+++ b/docs/docs/topics/computed-attributes.mdx
@@ -13,7 +13,6 @@ Currently, Infrahub supports two main types of computed attributes:
 
 Computed attributes have some inherent restrictions due to system constraints and performance considerations. Keep these in mind when designing your schema:
 
-* Computed attributes **can only** be used on nodes, not generics. [FEATURE-5736](https://github.com/opsmill/infrahub/issues/5736)
 * Only `URL` and `Text` attribute kinds are supported for computed attributes.
 
 ::::
@@ -30,6 +29,7 @@ See the [guide](../guides/computed-attributes) for instructions on creating Jinj
 
 * Jinja2 computed attributes **cannot** reference relationships with cardinality `many`.
 * Only **direct** relationships can be used (i.e., a relationship of a relationship is not accessible).
+* A computed attribute can only be inherited from one generic, as the order of operations would be unclear if the same computed attribute was defined on multiple generics.
 
 ::::
 


### PR DESCRIPTION
This PR adds support for computed attributes on generics.

Changes:
* While processing the schema instead of rejecting computed attributes on generics we iterate over the "used_by" section and run a validation to ensure that we don't have any nodes that are inheriting from multiple generics as the order of operations would be unpredictable
* Because of this change the documentation has been updated to remove the node that computed attributes are not supported on generics and instead list the restriction that users can't have node attributes that inherits from more than one generic where that attribute is defined as a computed attribute.
* Some additional tests and changes to the one which previously restricted computed attributes on generics

Fixes #5736

