### PR TITLE
Remove deprecated "fetch" parameter in prefect result.state

### DIFF
--- a/backend/infrahub/services/adapters/workflow/worker.py
+++ b/backend/infrahub/services/adapters/workflow/worker.py
@@ -66,7 +66,7 @@ class WorkflowWorkerExecution(InfrahubWorkflow):
         if response.state.type == StateType.CRASHED:
             raise RuntimeError(response.state.message)
 
-        return await response.state.result(raise_on_failure=True, fetch=True)  # type: ignore[call-overload]
+        return await response.state.result(raise_on_failure=True)
 
     async def submit_workflow(
         self,


### PR DESCRIPTION
This PR removes a deprecated "fetch" parameter that is removed from Prefect in the upcoming version as highlighted by this PR: https://github.com/opsmill/infrahub/actions/runs/14360560490/job/40260767476?pr=6261.

We want this in place for the 3.3.4 upgrade of Prefect which is needed to resolve the issue of inserting events with a high number of related resources into the database.