### PR TITLE
Fixed ability to override timeouts on Python transforms and checks

### DIFF
--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -954,7 +954,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
             source=self.id,
             is_protected=True,
         )
-        obj = await self.sdk.create(kind=CoreCheckDefinition, branch=branch_name, **create_payload)
+        obj = await self.sdk.create(kind=CoreCheckDefinition, branch=branch_name, data=create_payload)
         await obj.save()
 
         return obj
@@ -1012,7 +1012,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
             source=str(self.id),
             is_protected=True,
         )
-        obj = await self.sdk.create(kind=CoreTransformPython, branch=branch_name, **create_payload)
+        obj = await self.sdk.create(kind=CoreTransformPython, branch=branch_name, data=create_payload)
         await obj.save()
         return obj
 

--- a/backend/tests/functional/webhook/test_task.py
+++ b/backend/tests/functional/webhook/test_task.py
@@ -260,7 +260,7 @@ class TestWebhookTasks(TestInfrahubApp):
             "transform_class": "WebhookTransformer",
             "transform_file": "transforms/webhook_transformer.py",
             "transform_name": "WebhookTransformer",
-            "transform_timeout": 10,
+            "transform_timeout": 5,
             "url": "https://url.mock",
             "validate_certificates": False,
             "webhook_type": "TransformWebhook",

--- a/changelog/6267.fixed.md
+++ b/changelog/6267.fixed.md
@@ -1,0 +1,1 @@
+Fixed ability to override default timeout for Python transform and checks.


### PR DESCRIPTION
Fixes #6267

The problem here was that we were sending in data using `**kwargs` so when using a "timeout" key this value was swallowed by the .create() method which has its own "timeout" parameter. Switching to using the "data" param fixes this issue. 