### PR TITLE
fix(backend): improve uniqueness constraint query

### DIFF
--- a/backend/infrahub/core/validators/uniqueness/query.py
+++ b/backend/infrahub/core/validators/uniqueness/query.py
@@ -103,7 +103,7 @@ class NodeUniqueAttributeConstraintQuery(Query):
         )
 
         attr_paths_subquery = """
-        MATCH attr_path = (attr_start_node:%(node_kind)s)-[:HAS_ATTRIBUTE]->(attr:Attribute)-[r:HAS_VALUE]->(attr_value:AttributeValue)
+        OPTIONAL MATCH attr_path = (attr_start_node:%(node_kind)s)-[:HAS_ATTRIBUTE]->(attr:Attribute)-[r:HAS_VALUE]->(attr_value:AttributeValue)
         WHERE attr.name in $attribute_names
             AND [attr.name, type(r)] in $attr_paths
         """ % {"node_kind": self.query_request.kind}
@@ -115,19 +115,19 @@ class NodeUniqueAttributeConstraintQuery(Query):
         """ % {"node_kind": self.query_request.kind}
 
         relationship_attr_paths_subquery = """
-        OPTIONAL MATCH rel_path = (attr_start_node:%(node_kind)s)-[:IS_RELATED]-(relationship_node:Relationship)-[:IS_RELATED]-(related_n:Node)-[:HAS_ATTRIBUTE]->(rel_attr:Attribute)-[:HAS_VALUE]->(rel_attr_value:AttributeValue)
+        OPTIONAL MATCH rel_path = (rel_start_node:%(node_kind)s)-[:IS_RELATED]-(relationship_node:Relationship)-[:IS_RELATED]-(related_n:Node)-[:HAS_ATTRIBUTE]->(rel_attr:Attribute)-[:HAS_VALUE]->(rel_attr_value:AttributeValue)
         WHERE relationship_node.name in $relationship_names
             AND [relationship_node.name, rel_attr.name] in $relationship_attr_paths
         """ % {"node_kind": self.query_request.kind}
 
         relationship_attr_paths_with_value_subquery = """
-        OPTIONAL MATCH rel_path = (attr_start_node:%(node_kind)s)-[:IS_RELATED]-(relationship_node:Relationship)-[:IS_RELATED]-(related_n:Node)-[:HAS_ATTRIBUTE]->(rel_attr:Attribute)-[:HAS_VALUE]->(rel_attr_value:AttributeValue)
+        OPTIONAL MATCH rel_path = (rel_start_node:%(node_kind)s)-[:IS_RELATED]-(relationship_node:Relationship)-[:IS_RELATED]-(related_n:Node)-[:HAS_ATTRIBUTE]->(rel_attr:Attribute)-[:HAS_VALUE]->(rel_attr_value:AttributeValue)
         WHERE relationship_node.name in $relationship_names AND rel_attr_value.value in $relationship_attr_values
             AND [relationship_node.name, rel_attr.name, rel_attr_value.value] in $relationship_attr_paths_with_value
         """ % {"node_kind": self.query_request.kind}
 
         relationship_only_attr_paths_subquery = """
-        OPTIONAL MATCH rel_path = (attr_start_node:%(node_kind)s)-[:IS_RELATED]-(relationship_node:Relationship)-[:IS_RELATED]-(related_n:Node)
+        OPTIONAL MATCH rel_path = (rel_only_start_node:%(node_kind)s)-[:IS_RELATED]-(relationship_node:Relationship)-[:IS_RELATED]-(related_n:Node)
         WHERE %(rel_node_filter)s relationship_node.name in $relationship_only_attr_paths
         """ % {
             "node_kind": self.query_request.kind,
@@ -142,38 +142,40 @@ class NodeUniqueAttributeConstraintQuery(Query):
         """
 
         relationship_attr_paths_with_value_filter_subquery = """
-        WITH attr_start_node, rel_path, relationship_node, related_n, rel_attr, rel_attr_value
-        RETURN attr_start_node AS start_node, rel_path AS potential_path, relationship_node.name as rel_identifier, rel_attr.name as potential_attr, rel_attr_value.value as potential_attr_value
+        WITH rel_start_node, rel_path, relationship_node, related_n, rel_attr, rel_attr_value
+        RETURN rel_start_node AS start_node, rel_path AS potential_path, relationship_node.name as rel_identifier, rel_attr.name as potential_attr, rel_attr_value.value as potential_attr_value
         """
 
         relationship_only_attr_paths_filter_subquery = """
-        WITH attr_start_node, rel_path, relationship_node, related_n
-        RETURN attr_start_node AS start_node, rel_path as potential_path, relationship_node.name as rel_identifier, "id" as potential_attr, related_n.uuid as potential_attr_value
+        WITH rel_only_start_node, rel_path, relationship_node, related_n
+        RETURN rel_only_start_node AS start_node, rel_path as potential_path, relationship_node.name as rel_identifier, "id" as potential_attr, related_n.uuid as potential_attr_value
         """
 
         select_subqueries = []
         filter_subqueries = []
-        returned_attributes = ["attr_start_node"]
+        returned_attributes = []
         if attr_paths:
             select_subqueries.append(attr_paths_subquery)
             filter_subqueries.append(attr_paths_filter_subquery)
-            returned_attributes.extend(["attr_path", "attr", "attr_value"])
+            returned_attributes.extend(["attr_start_node", "attr_path", "attr", "attr_value"])
         if attr_paths_with_value:
             select_subqueries.append(attr_paths_with_value_subquery)
             filter_subqueries.append(attr_paths_filter_subquery)
-            returned_attributes.extend(["attr_path", "attr", "attr_value"])
+            returned_attributes.extend(["attr_start_node", "attr_path", "attr", "attr_value"])
         if relationship_attr_paths:
             select_subqueries.append(relationship_attr_paths_subquery)
             filter_subqueries.append(relationship_attr_paths_with_value_filter_subquery)
-            returned_attributes.extend(["rel_path", "relationship_node", "related_n", "rel_attr", "rel_attr_value"])
+            returned_attributes.extend(["rel_start_node", "rel_path", "relationship_node", "related_n", "rel_attr", "rel_attr_value"])
         if relationship_attr_paths_with_value:
             select_subqueries.append(relationship_attr_paths_with_value_subquery)
             filter_subqueries.append(relationship_attr_paths_with_value_filter_subquery)
-            returned_attributes.extend(["rel_path", "relationship_node", "related_n", "rel_attr", "rel_attr_value"])
+            returned_attributes.extend(
+                ["rel_start_node", "rel_path", "relationship_node", "related_n", "rel_attr", "rel_attr_value"]
+            )
         if relationship_only_attr_paths:
             select_subqueries.append(relationship_only_attr_paths_subquery)
             filter_subqueries.append(relationship_only_attr_paths_filter_subquery)
-            returned_attributes.extend(["rel_path", "relationship_node", "related_n"])
+            returned_attributes.extend(["rel_only_start_node", "rel_path", "relationship_node", "related_n"])
 
         select_subqueries_str = "".join(select_subqueries)
         return_subqueries_str = ", ".join(returned_attributes)
@@ -189,7 +191,7 @@ class NodeUniqueAttributeConstraintQuery(Query):
         CALL {
             %(filter_subqueries_str)s
         }
-        WITH start_node, potential_path, rel_identifier, potential_attr, potential_attr_value
+        WITH DISTINCT start_node, potential_path, rel_identifier, potential_attr, potential_attr_value
         CALL {
             WITH potential_path
             WITH potential_path  // workaround for neo4j not allowing WHERE in a WITH of a subquery

--- a/backend/infrahub/core/validators/uniqueness/query.py
+++ b/backend/infrahub/core/validators/uniqueness/query.py
@@ -103,37 +103,32 @@ class NodeUniqueAttributeConstraintQuery(Query):
         )
 
         attr_paths_subquery = """
-        MATCH attr_path = (start_node:%(node_kind)s)-[:HAS_ATTRIBUTE]->(attr:Attribute)-[r:HAS_VALUE]->(attr_value:AttributeValue)
+        MATCH attr_path = (attr_start_node:%(node_kind)s)-[:HAS_ATTRIBUTE]->(attr:Attribute)-[r:HAS_VALUE]->(attr_value:AttributeValue)
         WHERE attr.name in $attribute_names
             AND [attr.name, type(r)] in $attr_paths
-        RETURN start_node, attr_path as potential_path, NULL as rel_identifier, attr.name as potential_attr, attr_value.value as potential_attr_value
         """ % {"node_kind": self.query_request.kind}
 
         attr_paths_with_value_subquery = """
-        MATCH attr_path = (start_node:%(node_kind)s)-[:HAS_ATTRIBUTE]->(attr:Attribute)-[r:HAS_VALUE]->(attr_value:AttributeValue)
+        OPTIONAL MATCH attr_path = (attr_start_node:%(node_kind)s)-[:HAS_ATTRIBUTE]->(attr:Attribute)-[r:HAS_VALUE]->(attr_value:AttributeValue)
         WHERE attr.name in $attribute_names AND attr_value.value in $attr_values
             AND [attr.name, type(r), attr_value.value] in $attr_paths_with_value
-        RETURN start_node, attr_path as potential_path, NULL as rel_identifier, attr.name as potential_attr, attr_value.value as potential_attr_value
         """ % {"node_kind": self.query_request.kind}
 
         relationship_attr_paths_subquery = """
-        MATCH rel_path = (start_node:%(node_kind)s)-[:IS_RELATED]-(relationship_node:Relationship)-[:IS_RELATED]-(related_n:Node)-[:HAS_ATTRIBUTE]->(rel_attr:Attribute)-[:HAS_VALUE]->(rel_attr_value:AttributeValue)
+        OPTIONAL MATCH rel_path = (attr_start_node:%(node_kind)s)-[:IS_RELATED]-(relationship_node:Relationship)-[:IS_RELATED]-(related_n:Node)-[:HAS_ATTRIBUTE]->(rel_attr:Attribute)-[:HAS_VALUE]->(rel_attr_value:AttributeValue)
         WHERE relationship_node.name in $relationship_names
             AND [relationship_node.name, rel_attr.name] in $relationship_attr_paths
-        RETURN start_node, rel_path as potential_path, relationship_node.name as rel_identifier, rel_attr.name as potential_attr, rel_attr_value.value as potential_attr_value
         """ % {"node_kind": self.query_request.kind}
 
         relationship_attr_paths_with_value_subquery = """
-        MATCH rel_path = (start_node:%(node_kind)s)-[:IS_RELATED]-(relationship_node:Relationship)-[:IS_RELATED]-(related_n:Node)-[:HAS_ATTRIBUTE]->(rel_attr:Attribute)-[:HAS_VALUE]->(rel_attr_value:AttributeValue)
+        OPTIONAL MATCH rel_path = (attr_start_node:%(node_kind)s)-[:IS_RELATED]-(relationship_node:Relationship)-[:IS_RELATED]-(related_n:Node)-[:HAS_ATTRIBUTE]->(rel_attr:Attribute)-[:HAS_VALUE]->(rel_attr_value:AttributeValue)
         WHERE relationship_node.name in $relationship_names AND rel_attr_value.value in $relationship_attr_values
             AND [relationship_node.name, rel_attr.name, rel_attr_value.value] in $relationship_attr_paths_with_value
-        RETURN start_node, rel_path as potential_path, relationship_node.name as rel_identifier, rel_attr.name as potential_attr, rel_attr_value.value as potential_attr_value
         """ % {"node_kind": self.query_request.kind}
 
         relationship_only_attr_paths_subquery = """
-        MATCH rel_path = (start_node:%(node_kind)s)-[:IS_RELATED]-(relationship_node:Relationship)-[:IS_RELATED]-(related_n:Node)
+        OPTIONAL MATCH rel_path = (attr_start_node:%(node_kind)s)-[:IS_RELATED]-(relationship_node:Relationship)-[:IS_RELATED]-(related_n:Node)
         WHERE %(rel_node_filter)s relationship_node.name in $relationship_only_attr_paths
-        RETURN start_node, rel_path as potential_path, relationship_node.name as rel_identifier, "id" as potential_attr, related_n.uuid as potential_attr_value
         """ % {
             "node_kind": self.query_request.kind,
             "rel_node_filter": "related_n.uuid IN $relationship_only_attr_values AND "
@@ -141,26 +136,60 @@ class NodeUniqueAttributeConstraintQuery(Query):
             else "",
         }
 
+        attr_paths_filter_subquery = """
+        WITH attr_start_node, attr_path, attr, attr_value
+        RETURN attr_start_node AS start_node, attr_path AS potential_path, NULL as rel_identifier, attr.name as potential_attr, attr_value.value as potential_attr_value
+        """
+
+        relationship_attr_paths_with_value_filter_subquery = """
+        WITH attr_start_node, rel_path, relationship_node, related_n, rel_attr, rel_attr_value
+        RETURN attr_start_node AS start_node, rel_path AS potential_path, relationship_node.name as rel_identifier, rel_attr.name as potential_attr, rel_attr_value.value as potential_attr_value
+        """
+
+        relationship_only_attr_paths_filter_subquery = """
+        WITH attr_start_node, rel_path, relationship_node, related_n
+        RETURN attr_start_node AS start_node, rel_path as potential_path, relationship_node.name as rel_identifier, "id" as potential_attr, related_n.uuid as potential_attr_value
+        """
+
         select_subqueries = []
+        filter_subqueries = []
+        returned_attributes = ["attr_start_node"]
         if attr_paths:
             select_subqueries.append(attr_paths_subquery)
+            filter_subqueries.append(attr_paths_filter_subquery)
+            returned_attributes.extend(["attr_path", "attr", "attr_value"])
         if attr_paths_with_value:
             select_subqueries.append(attr_paths_with_value_subquery)
+            filter_subqueries.append(attr_paths_filter_subquery)
+            returned_attributes.extend(["attr_path", "attr", "attr_value"])
         if relationship_attr_paths:
             select_subqueries.append(relationship_attr_paths_subquery)
+            filter_subqueries.append(relationship_attr_paths_with_value_filter_subquery)
+            returned_attributes.extend(["rel_path", "relationship_node", "related_n", "rel_attr", "rel_attr_value"])
         if relationship_attr_paths_with_value:
             select_subqueries.append(relationship_attr_paths_with_value_subquery)
+            filter_subqueries.append(relationship_attr_paths_with_value_filter_subquery)
+            returned_attributes.extend(["rel_path", "relationship_node", "related_n", "rel_attr", "rel_attr_value"])
         if relationship_only_attr_paths:
             select_subqueries.append(relationship_only_attr_paths_subquery)
+            filter_subqueries.append(relationship_only_attr_paths_filter_subquery)
+            returned_attributes.extend(["rel_path", "relationship_node", "related_n"])
 
-        select_subqueries_str = "UNION".join(select_subqueries)
+        select_subqueries_str = "".join(select_subqueries)
+        return_subqueries_str = ", ".join(returned_attributes)
+        filter_subqueries_str = "UNION".join(filter_subqueries)
 
         # ruff: noqa: E501
         query = """
         // get attributes for node and its relationships
         CALL {
             %(select_subqueries_str)s
+            RETURN %(return_subqueries_str)s
         }
+        CALL {
+            %(filter_subqueries_str)s
+        }
+        WITH start_node, potential_path, rel_identifier, potential_attr, potential_attr_value
         CALL {
             WITH potential_path
             WITH potential_path  // workaround for neo4j not allowing WHERE in a WITH of a subquery
@@ -234,6 +263,8 @@ class NodeUniqueAttributeConstraintQuery(Query):
             relationship_identifier
         """ % {
             "select_subqueries_str": select_subqueries_str,
+            "return_subqueries_str": return_subqueries_str,
+            "filter_subqueries_str": filter_subqueries_str,
             "branch_filter": branch_filter,
             "from_times": from_times,
             "branch_name_and_level": branch_name_and_level,

--- a/backend/infrahub/core/validators/uniqueness/query.py
+++ b/backend/infrahub/core/validators/uniqueness/query.py
@@ -109,7 +109,7 @@ class NodeUniqueAttributeConstraintQuery(Query):
         """ % {"node_kind": self.query_request.kind}
 
         attr_paths_with_value_subquery = """
-        OPTIONAL MATCH attr_path = (attr_start_node:%(node_kind)s)-[:HAS_ATTRIBUTE]->(attr:Attribute)-[r:HAS_VALUE]->(attr_value:AttributeValue)
+        OPTIONAL MATCH attr_path_with_value = (attr_start_node:%(node_kind)s)-[:HAS_ATTRIBUTE]->(attr:Attribute)-[r:HAS_VALUE]->(attr_value:AttributeValue)
         WHERE attr.name in $attribute_names AND attr_value.value in $attr_values
             AND [attr.name, type(r), attr_value.value] in $attr_paths_with_value
         """ % {"node_kind": self.query_request.kind}
@@ -121,13 +121,13 @@ class NodeUniqueAttributeConstraintQuery(Query):
         """ % {"node_kind": self.query_request.kind}
 
         relationship_attr_paths_with_value_subquery = """
-        OPTIONAL MATCH rel_path = (rel_start_node:%(node_kind)s)-[:IS_RELATED]-(relationship_node:Relationship)-[:IS_RELATED]-(related_n:Node)-[:HAS_ATTRIBUTE]->(rel_attr:Attribute)-[:HAS_VALUE]->(rel_attr_value:AttributeValue)
+        OPTIONAL MATCH rel_path_with_value = (rel_start_node:%(node_kind)s)-[:IS_RELATED]-(relationship_node:Relationship)-[:IS_RELATED]-(related_n:Node)-[:HAS_ATTRIBUTE]->(rel_attr:Attribute)-[:HAS_VALUE]->(rel_attr_value:AttributeValue)
         WHERE relationship_node.name in $relationship_names AND rel_attr_value.value in $relationship_attr_values
             AND [relationship_node.name, rel_attr.name, rel_attr_value.value] in $relationship_attr_paths_with_value
         """ % {"node_kind": self.query_request.kind}
 
         relationship_only_attr_paths_subquery = """
-        OPTIONAL MATCH rel_path = (rel_only_start_node:%(node_kind)s)-[:IS_RELATED]-(relationship_node:Relationship)-[:IS_RELATED]-(related_n:Node)
+        OPTIONAL MATCH rel_only_attr_path = (rel_only_start_node:%(node_kind)s)-[:IS_RELATED]-(relationship_node:Relationship)-[:IS_RELATED]-(related_n:Node)
         WHERE %(rel_node_filter)s relationship_node.name in $relationship_only_attr_paths
         """ % {
             "node_kind": self.query_request.kind,
@@ -141,14 +141,24 @@ class NodeUniqueAttributeConstraintQuery(Query):
         RETURN attr_start_node AS start_node, attr_path AS potential_path, NULL as rel_identifier, attr.name as potential_attr, attr_value.value as potential_attr_value
         """
 
-        relationship_attr_paths_with_value_filter_subquery = """
+        attr_paths_with_value_filter_subquery = """
+        WITH attr_start_node, attr_path_with_value, attr, attr_value
+        RETURN attr_start_node AS start_node, attr_path_with_value AS potential_path, NULL as rel_identifier, attr.name as potential_attr, attr_value.value as potential_attr_value
+        """
+
+        relationship_attr_paths_filter_subquery = """
         WITH rel_start_node, rel_path, relationship_node, related_n, rel_attr, rel_attr_value
         RETURN rel_start_node AS start_node, rel_path AS potential_path, relationship_node.name as rel_identifier, rel_attr.name as potential_attr, rel_attr_value.value as potential_attr_value
         """
 
+        relationship_attr_paths_with_value_filter_subquery = """
+        WITH rel_start_node, rel_path_with_value, relationship_node, related_n, rel_attr, rel_attr_value
+        RETURN rel_start_node AS start_node, rel_path_with_value AS potential_path, relationship_node.name as rel_identifier, rel_attr.name as potential_attr, rel_attr_value.value as potential_attr_value
+        """
+
         relationship_only_attr_paths_filter_subquery = """
-        WITH rel_only_start_node, rel_path, relationship_node, related_n
-        RETURN rel_only_start_node AS start_node, rel_path as potential_path, relationship_node.name as rel_identifier, "id" as potential_attr, related_n.uuid as potential_attr_value
+        WITH rel_only_start_node, rel_only_attr_path, relationship_node, related_n
+        RETURN rel_only_start_node AS start_node, rel_only_attr_path as potential_path, relationship_node.name as rel_identifier, "id" as potential_attr, related_n.uuid as potential_attr_value
         """
 
         select_subqueries = []
@@ -160,25 +170,34 @@ class NodeUniqueAttributeConstraintQuery(Query):
             returned_attributes.extend(["attr_start_node", "attr_path", "attr", "attr_value"])
         if attr_paths_with_value:
             select_subqueries.append(attr_paths_with_value_subquery)
-            filter_subqueries.append(attr_paths_filter_subquery)
-            returned_attributes.extend(["attr_start_node", "attr_path", "attr", "attr_value"])
+            filter_subqueries.append(attr_paths_with_value_filter_subquery)
+            returned_attributes.extend(["attr_start_node", "attr_path_with_value", "attr", "attr_value"])
         if relationship_attr_paths:
             select_subqueries.append(relationship_attr_paths_subquery)
-            filter_subqueries.append(relationship_attr_paths_with_value_filter_subquery)
-            returned_attributes.extend(["rel_start_node", "rel_path", "relationship_node", "related_n", "rel_attr", "rel_attr_value"])
+            filter_subqueries.append(relationship_attr_paths_filter_subquery)
+            returned_attributes.extend(
+                ["rel_start_node", "rel_path", "relationship_node", "related_n", "rel_attr", "rel_attr_value"]
+            )
         if relationship_attr_paths_with_value:
             select_subqueries.append(relationship_attr_paths_with_value_subquery)
             filter_subqueries.append(relationship_attr_paths_with_value_filter_subquery)
             returned_attributes.extend(
-                ["rel_start_node", "rel_path", "relationship_node", "related_n", "rel_attr", "rel_attr_value"]
+                [
+                    "rel_start_node",
+                    "rel_path_with_value",
+                    "relationship_node",
+                    "related_n",
+                    "rel_attr",
+                    "rel_attr_value",
+                ]
             )
         if relationship_only_attr_paths:
             select_subqueries.append(relationship_only_attr_paths_subquery)
             filter_subqueries.append(relationship_only_attr_paths_filter_subquery)
-            returned_attributes.extend(["rel_only_start_node", "rel_path", "relationship_node", "related_n"])
+            returned_attributes.extend(["rel_only_start_node", "rel_only_attr_path", "relationship_node", "related_n"])
 
         select_subqueries_str = "".join(select_subqueries)
-        return_subqueries_str = ", ".join(returned_attributes)
+        return_subqueries_str = ", ".join(set(returned_attributes))
         filter_subqueries_str = "UNION".join(filter_subqueries)
 
         # ruff: noqa: E501

--- a/backend/tests/unit/core/constraint_validators/test_node_grouped_uniqueness.py
+++ b/backend/tests/unit/core/constraint_validators/test_node_grouped_uniqueness.py
@@ -201,6 +201,172 @@ class TestNodeGroupedUniquenessConstraint:
 
         await self.__call_system_under_test(db=db, branch=default_branch, node=car_node)
 
+    async def test_uniqueness_constraint_single_element_constraints(
+        self, db: InfrahubDatabase, default_branch: Branch, car_person_schema_generics_simple
+    ):
+        p1 = await Node.init(db=db, schema="TestPerson")
+        await p1.new(db=db, name="John", height=180)
+        await p1.save(db=db)
+        p2 = await Node.init(db=db, schema="TestPerson")
+        await p2.new(db=db, name="Jane", height=170)
+        await p2.save(db=db)
+        p3 = await Node.init(db=db, schema="TestPerson")
+        await p3.new(db=db, name="Jake", height=175)
+        await p3.save(db=db)
+        c1 = await Node.init(db=db, schema="TestElectricCar")
+        await c1.new(db=db, name="volt", nbr_seats=4, nbr_engine=4, owner=p1, previous_owner=p2, color="#111111")
+        await c1.save(db=db)
+        c2 = await Node.init(db=db, schema="TestElectricCar")
+        await c2.new(db=db, name="bolt", nbr_seats=5, nbr_engine=2, owner=p2, previous_owner=p1, color="#222222")
+        await c2.save(db=db)
+
+        # TestPerson attribute constraints
+        p_test = await Node.init(db=db, schema="TestPerson")
+        await p_test.new(db=db, name="Jerm", height=172)
+        p_test.get_schema().uniqueness_constraints = [["name"], ["height"]]
+        await self.__call_system_under_test(db=db, branch=default_branch, node=p_test)
+        p_test.height.value = 170
+        with pytest.raises(ValidationError, match="Violates uniqueness constraint 'height'"):
+            await self.__call_system_under_test(db=db, branch=default_branch, node=p_test)
+        p_test.height.value = 172
+
+        p_test.name.value = p1.name.value
+        with pytest.raises(ValidationError, match="Violates uniqueness constraint 'name'"):
+            await self.__call_system_under_test(db=db, branch=default_branch, node=p_test)
+
+        # TestElectricCar attribute constraints
+        c_test = await Node.init(db=db, schema="TestElectricCar")
+        await c_test.new(db=db, name="colt", nbr_seats=6, nbr_engine=3, owner=p3, color="#333333")
+        c_test.get_schema().uniqueness_constraints = [["nbr_seats"], ["color"], ["owner"], ["previous_owner"]]
+        await self.__call_system_under_test(db=db, branch=default_branch, node=c_test)
+
+        c_test.nbr_seats.value = 4
+        with pytest.raises(ValidationError, match="Violates uniqueness constraint 'nbr_seats'"):
+            await self.__call_system_under_test(db=db, branch=default_branch, node=c_test)
+        c_test.nbr_seats.value = 6
+
+        c_test.color.value = "#111111"
+        with pytest.raises(ValidationError, match="Violates uniqueness constraint 'color'"):
+            await self.__call_system_under_test(db=db, branch=default_branch, node=c_test)
+        c_test.color.value = "#333333"
+
+        # TestElectricCar relationship constraints
+        await c_test.owner.update(db=db, data=p1)
+        with pytest.raises(ValidationError, match="Violates uniqueness constraint 'owner'"):
+            await self.__call_system_under_test(db=db, branch=default_branch, node=c_test)
+        await c_test.owner.update(db=db, data=p3)
+
+        await c_test.previous_owner.update(db=db, data=p2)
+        with pytest.raises(ValidationError, match="Violates uniqueness constraint 'previous_owner'"):
+            await self.__call_system_under_test(db=db, branch=default_branch, node=c_test)
+        await c_test.previous_owner.update(db=db, data=p3)
+
+    async def test_uniqueness_constraint_multi_element_constraints(
+        self, db: InfrahubDatabase, default_branch: Branch, car_person_schema_generics_simple
+    ):
+        p1 = await Node.init(db=db, schema="TestPerson")
+        await p1.new(db=db, name="John", height=180)
+        await p1.save(db=db)
+        p2 = await Node.init(db=db, schema="TestPerson")
+        await p2.new(db=db, name="Jane", height=170)
+        await p2.save(db=db)
+        p3 = await Node.init(db=db, schema="TestPerson")
+        await p3.new(db=db, name="Jake", height=175)
+        await p3.save(db=db)
+        c1 = await Node.init(db=db, schema="TestElectricCar")
+        await c1.new(db=db, name="volt", nbr_seats=1, nbr_engine=2, owner=p1, previous_owner=p2, color="#111111")
+        await c1.save(db=db)
+        c2 = await Node.init(db=db, schema="TestElectricCar")
+        await c2.new(db=db, name="bolt", nbr_seats=2, nbr_engine=3, owner=p2, previous_owner=p3, color="#222222")
+        await c2.save(db=db)
+        c3 = await Node.init(db=db, schema="TestElectricCar")
+        await c3.new(db=db, name="colt", nbr_seats=3, nbr_engine=4, owner=p3, previous_owner=p1, color="#333333")
+        await c3.save(db=db)
+
+        # TestPerson attribute constraints
+        p_test = await Node.init(db=db, schema="TestPerson")
+        await p_test.new(db=db, name="Jerm", height=172)
+        p_test.get_schema().uniqueness_constraints = [["name", "height"]]
+        await self.__call_system_under_test(db=db, branch=default_branch, node=p_test)
+        p_test.height.value = p1.height.value
+        await self.__call_system_under_test(db=db, branch=default_branch, node=p_test)
+        p_test.name.value = p2.name.value
+        await self.__call_system_under_test(db=db, branch=default_branch, node=p_test)
+        p_test.name.value = p1.name.value
+        with pytest.raises(ValidationError, match="Violates uniqueness constraint 'name-height'"):
+            await self.__call_system_under_test(db=db, branch=default_branch, node=p_test)
+
+        # TestElectricCar relationship constraints
+        c_test = await Node.init(db=db, schema="TestElectricCar")
+        c_test_name = "jolt"
+        c_test_nbr_seats = 4
+        c_test_nbr_engine = 5
+        c_test_owner = p3
+        c_test_previous_owner = p3
+        c_test_color = "#aaaaaa"
+        await c_test.new(
+            db=db,
+            name=c_test_name,
+            nbr_seats=c_test_nbr_seats,
+            nbr_engine=c_test_nbr_engine,
+            owner=c_test_owner,
+            previous_owner=c_test_previous_owner,
+            color=c_test_color,
+        )
+        c_test.get_schema().uniqueness_constraints = [
+            ["nbr_seats", "color"],  # 1
+            ["nbr_seats", "owner"],  # 2
+            ["owner", "previous_owner"],  # 3
+            ["previous_owner", "color"],  # 4
+        ]
+        await self.__call_system_under_test(db=db, branch=default_branch, node=c_test)
+
+        # test constraint 1 nbr_seats-color
+        c_test.nbr_seats.value = c1.nbr_seats.value
+        await self.__call_system_under_test(db=db, branch=default_branch, node=c_test)
+        c_test.color.value = c3.color.value
+        await self.__call_system_under_test(db=db, branch=default_branch, node=c_test)
+        c_test.color.value = c1.color.value
+        with pytest.raises(ValidationError, match="Violates uniqueness constraint 'nbr_seats-color'"):
+            await self.__call_system_under_test(db=db, branch=default_branch, node=c_test)
+        c_test.nbr_seats.value = c_test_nbr_seats
+        c_test.color.value = c_test_color
+
+        # test constraint 2 nbr_seats-owner
+        c_test.nbr_seats.value = c1.nbr_seats.value
+        await self.__call_system_under_test(db=db, branch=default_branch, node=c_test)
+        c3_owner = await c3.owner.get_peer(db=db)
+        await c_test.owner.update(db=db, data=c3_owner)
+        await self.__call_system_under_test(db=db, branch=default_branch, node=c_test)
+        c_test.nbr_seats.value = c3.nbr_seats.value
+        with pytest.raises(ValidationError, match="Violates uniqueness constraint 'nbr_seats-owner'"):
+            await self.__call_system_under_test(db=db, branch=default_branch, node=c_test)
+        c_test.nbr_seats.value = c_test_nbr_seats
+        await c_test.owner.update(db=db, data=c_test_owner)
+
+        # test constraint 3 owner-previous_owner
+        c1_owner = await c1.owner.get_peer(db=db)
+        await c_test.owner.update(db=db, data=c1_owner)
+        await self.__call_system_under_test(db=db, branch=default_branch, node=c_test)
+        c2_previous_owner = await c2.previous_owner.get_peer(db=db)
+        await c_test.previous_owner.update(db=db, data=c2_previous_owner)
+        await self.__call_system_under_test(db=db, branch=default_branch, node=c_test)
+        c1_previous_owner = await c1.previous_owner.get_peer(db=db)
+        await c_test.previous_owner.update(db=db, data=c1_previous_owner)
+        with pytest.raises(ValidationError, match="Violates uniqueness constraint 'owner-previous_owner'"):
+            await self.__call_system_under_test(db=db, branch=default_branch, node=c_test)
+        await c_test.owner.update(db=db, data=c_test_owner)
+        await c_test.previous_owner.update(db=db, data=c_test_previous_owner)
+
+        # test constraint 4 previous_owner-color
+        await c_test.previous_owner.update(db=db, data=c1_previous_owner)
+        await self.__call_system_under_test(db=db, branch=default_branch, node=c_test)
+        c_test.color.value = c2.color.value
+        await self.__call_system_under_test(db=db, branch=default_branch, node=c_test)
+        await c_test.previous_owner.update(db=db, data=c2_previous_owner)
+        with pytest.raises(ValidationError, match="Violates uniqueness constraint 'previous_owner-color'"):
+            await self.__call_system_under_test(db=db, branch=default_branch, node=c_test)
+
     @pytest.mark.parametrize(
         ["node_constraints", "parent_constraints", "node_query_should_run"],
         [

--- a/backend/tests/unit/core/constraint_validators/test_uniqueness_constraint_query.py
+++ b/backend/tests/unit/core/constraint_validators/test_uniqueness_constraint_query.py
@@ -661,7 +661,7 @@ async def test_query_response_min_count_0_attribute_paths_with_value(
     )
     query_result = await query.execute(db=db)
 
-    assert len(query_result.results) == 3
+    assert len(query_result.results) == 2
     for result in query_result.results:
         serial_result = dict(result.data)
         assert serial_result in expected_result_dicts
@@ -711,7 +711,7 @@ async def test_query_response_min_count_0_relationship_paths_with_value(
     )
     query_result = await query.execute(db=db)
 
-    assert len(query_result.results) == 3
+    assert len(query_result.results) == 2
     for result in query_result.results:
         serial_result = dict(result.data)
         assert serial_result in expected_result_dicts


### PR DESCRIPTION
This should avoid processing useless rows when we have relationship only constraints.
This especially improves the IPAM use-case, where the uniqueness constraint is the (address/prefix, namespace) tuple. Without this change, the query would check for nodes having that same address and fetch ALL nodes present in the same namespace. With this change, the query is now FIRST checking nodes having that same address and THEN checking if these previous nodes are in the same namespace.

I'm not sure if our test coverage is enough to correctly test this change, a thorough review along with additional unit tests may be required...

EDIT: the "OPTIONAL MATCH" fix was caught only by this test: `backend/tests/unit/core/constraint_validators/test_node_grouped_uniqueness.py::TestNodeGroupedUniquenessConstraint::test_subset_hfid_violated` so I'm afraid of missing more unit tests to cover all cases...