### PR TITLE
Temporarily restrict GeneratorGroups from related resources in events

### DIFF
--- a/backend/infrahub/events/group_action.py
+++ b/backend/infrahub/events/group_action.py
@@ -22,7 +22,7 @@ class GroupMutatedEvent(InfrahubEvent):
     def get_related(self) -> list[dict[str, str]]:
         related = super().get_related()
 
-        if self.kind == InfrahubKind.GRAPHQLQUERYGROUP:
+        if self.kind in [InfrahubKind.GENERATORGROUP, InfrahubKind.GRAPHQLQUERYGROUP]:
             # Temporary workaround to avoid too large payloads for the related field
             return related
 

--- a/backend/infrahub/events/node_action.py
+++ b/backend/infrahub/events/node_action.py
@@ -24,7 +24,7 @@ class NodeMutatedEvent(InfrahubEvent):
 
     def get_related(self) -> list[dict[str, str]]:
         related = super().get_related()
-        if self.kind == InfrahubKind.GRAPHQLQUERYGROUP:
+        if self.kind in [InfrahubKind.GENERATORGROUP, InfrahubKind.GRAPHQLQUERYGROUP]:
             # Temporary workaround to avoid too large payloads for the related field
             return related
 


### PR DESCRIPTION
For now also add GeneratorGroups to the list of kinds what can have too many related resources within the events.