### PR TITLE
set maximum number of related resources for a Prefect event to 500

### DIFF
--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -83,7 +83,8 @@ RUN mkdir -p /opt/infrahub/git /opt/infrahub/storage /opt/infrahub/source /opt/i
 
 WORKDIR /source
 
-ENV PREFECT_WORKER_QUERY_SECONDS="2"
+ENV PREFECT_WORKER_QUERY_SECONDS="2" \
+    PREFECT_SERVER_EVENTS_MAXIMUM_RELATED_RESOURCES=500
 
 # --------------------------------------------
 # Import Frontend Build


### PR DESCRIPTION
We should probably expose this a Infrahub configuration variable in the future.