### PR TITLE
Add parsing of variables and queries to GraphQL analyzer

### DIFF
--- a/backend/infrahub/graphql/analyzer.py
+++ b/backend/infrahub/graphql/analyzer.py
@@ -13,11 +13,27 @@ from graphql import (
     FragmentSpreadNode,
     GraphQLSchema,
     InlineFragmentNode,
+    ListTypeNode,
     NamedTypeNode,
     NonNullTypeNode,
     OperationDefinitionNode,
     OperationType,
     SelectionSetNode,
+    TypeNode,
+)
+from graphql.language.ast import (
+    BooleanValueNode,
+    ConstListValueNode,
+    ConstObjectValueNode,
+    EnumValueNode,
+    FloatValueNode,
+    IntValueNode,
+    ListValueNode,
+    NullValueNode,
+    ObjectValueNode,
+    StringValueNode,
+    ValueNode,
+    VariableNode,
 )
 from infrahub_sdk.analyzer import GraphQLQueryAnalyzer
 from infrahub_sdk.utils import extract_fields
@@ -91,8 +107,23 @@ class GraphQLSelectionSet:
 @dataclass
 class GraphQLArgument:
     name: str
-    value: str
+    value: Any
     kind: str
+
+    @property
+    def is_variable(self) -> bool:
+        return self.kind == "variable"
+
+    @property
+    def as_variable_name(self) -> str:
+        """Return the name without a $ prefix"""
+        return str(self.value).removeprefix("$")
+
+    @property
+    def fields(self) -> list[str]:
+        if self.kind != "object_value" or not isinstance(self.value, dict):
+            return []
+        return sorted(self.value.keys())
 
 
 @dataclass
@@ -106,6 +137,9 @@ class GraphQLVariable:
     name: str
     type: str
     required: bool
+    is_list: bool = False
+    inner_required: bool = False
+    default: Any | None = None
 
 
 @dataclass
@@ -267,6 +301,28 @@ class GraphQLQueryReport:
         return fields
 
     @cached_property
+    def variables(self) -> list[GraphQLVariable]:
+        """Return input variables defined on the query document
+
+        All subqueries will use the same document level queries,
+        so only the first entry is required
+        """
+        if self.queries:
+            return self.queries[0].variables
+        return []
+
+    def required_argument(self, argument: GraphQLArgument) -> bool:
+        if not argument.is_variable:
+            # If the argument isn't a variable it would have been
+            # statically defined in the input and as such required
+            return True
+        for variable in self.variables:
+            if variable.name == argument.as_variable_name and variable.required:
+                return True
+
+        return False
+
+    @cached_property
     def top_level_kinds(self) -> list[str]:
         return [query.infrahub_model.kind for query in self.queries if query.infrahub_model]
 
@@ -297,6 +353,22 @@ class GraphQLQueryReport:
                 node_actions.add(MutateAction.UPDATE)
 
         return access
+
+    @property
+    def only_has_unique_targets(self) -> bool:
+        """Indicate if the query document is defined so that it will return a single root level object"""
+        for query in self.queries:
+            targets_single_query = False
+            if query.infrahub_model and query.infrahub_model.uniqueness_constraints:
+                for argument in query.arguments:
+                    if [[argument.name]] == query.infrahub_model.uniqueness_constraints:
+                        if self.required_argument(argument=argument):
+                            targets_single_query = True
+
+            if not targets_single_query:
+                return False
+
+        return True
 
 
 class InfrahubGraphQLQueryAnalyzer(GraphQLQueryAnalyzer):
@@ -603,31 +675,80 @@ class InfrahubGraphQLQueryAnalyzer(GraphQLQueryAnalyzer):
             ],
         )
 
-    @staticmethod
-    def _get_variables(operation: OperationDefinitionNode) -> list[GraphQLVariable]:
-        variables = []
-        for variable in operation.variable_definitions:
-            if isinstance(variable.type, NamedTypeNode):
-                variables.append(
-                    GraphQLVariable(name=variable.variable.name.value, type=variable.type.name.value, required=False)
+    def _get_variables(self, operation: OperationDefinitionNode) -> list[GraphQLVariable]:
+        variables: list[GraphQLVariable] = []
+
+        for variable in operation.variable_definitions or []:
+            type_node: TypeNode = variable.type
+            required = False
+            is_list = False
+            inner_required = False
+
+            if isinstance(type_node, NonNullTypeNode):
+                required = True
+                type_node = type_node.type
+
+            if isinstance(type_node, ListTypeNode):
+                is_list = True
+                inner_type = type_node.type
+
+                if isinstance(inner_type, NonNullTypeNode):
+                    inner_required = True
+                    inner_type = inner_type.type
+
+                if isinstance(inner_type, NamedTypeNode):
+                    type_name = inner_type.name.value
+                else:
+                    raise TypeError(f"Unsupported inner type node: {inner_type}")
+            elif isinstance(type_node, NamedTypeNode):
+                type_name = type_node.name.value
+            else:
+                raise TypeError(f"Unsupported type node: {type_node}")
+
+            variables.append(
+                GraphQLVariable(
+                    name=variable.variable.name.value,
+                    type=type_name,
+                    required=required,
+                    is_list=is_list,
+                    inner_required=inner_required,
+                    default=self._parse_value(variable.default_value) if variable.default_value else None,
                 )
-            elif isinstance(variable.type, NonNullTypeNode):
-                if isinstance(variable.type.type, NamedTypeNode):
-                    variables.append(
-                        GraphQLVariable(
-                            name=variable.variable.name.value, type=variable.type.type.name.value, required=True
-                        )
-                    )
+            )
 
         return variables
 
-    @staticmethod
-    def _parse_arguments(field_node: FieldNode) -> list[GraphQLArgument]:
+    def _parse_arguments(self, field_node: FieldNode) -> list[GraphQLArgument]:
         return [
             GraphQLArgument(
                 name=argument.name.value,
-                value=getattr(argument.value, "value", ""),
+                value=self._parse_value(argument.value),
                 kind=argument.value.kind,
             )
             for argument in field_node.arguments
         ]
+
+    def _parse_value(self, node: ValueNode) -> Any:
+        match node:
+            case VariableNode():
+                value: Any = f"${node.name.value}"
+            case IntValueNode():
+                value = int(node.value)
+            case FloatValueNode():
+                value = float(node.value)
+            case StringValueNode():
+                value = node.value
+            case BooleanValueNode():
+                value = node.value
+            case NullValueNode():
+                value = None
+            case EnumValueNode():
+                value = node.value
+            case ListValueNode() | ConstListValueNode():
+                value = [self._parse_value(item) for item in node.values]
+            case ObjectValueNode() | ConstObjectValueNode():
+                value = {field.name.value: self._parse_value(field.value) for field in node.fields}
+            case _:
+                raise TypeError(f"Unsupported value node: {node}")
+
+        return value

--- a/backend/tests/helpers/schema/tshirt.py
+++ b/backend/tests/helpers/schema/tshirt.py
@@ -10,6 +10,7 @@ TSHIRT = NodeSchema(
     label="T-shirt",
     default_filter="name__value",
     display_labels=["name__value"],
+    uniqueness_constraints=[["name__value"]],
     attributes=[
         AttributeSchema(name="name", kind="Text"),
         AttributeSchema(

--- a/backend/tests/unit/graphql/test_query_analyzer.py
+++ b/backend/tests/unit/graphql/test_query_analyzer.py
@@ -3,9 +3,12 @@ from graphql import DocumentNode, GraphQLSchema
 from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.registry import registry
+from infrahub.core.schema import SchemaRoot
 from infrahub.database import InfrahubDatabase
-from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer, MutateAction
+from infrahub.graphql.analyzer import GraphQLArgument, GraphQLVariable, InfrahubGraphQLQueryAnalyzer, MutateAction
 from infrahub.graphql.initialization import prepare_graphql_params
+from tests.helpers.schema.color import COLOR
+from tests.helpers.schema.tshirt import TSHIRT
 
 
 async def test_analyzer_init_with_schema(
@@ -202,12 +205,25 @@ async def test_query_report(db: InfrahubDatabase, default_branch: Branch, car_pe
     assert len(gqa.query_report.requested_read.keys()) == 1
     assert gqa.query_report.requested_read["TestElectricCar"].attributes == set()
     assert gqa.query_report.requested_read["TestElectricCar"].relationships == set()
+    assert len(gqa.query_report.queries) == 1
+    assert len(gqa.query_report.queries[0].arguments) == 1
+    assert gqa.query_report.queries[0].arguments[0] == GraphQLArgument(
+        name="data",
+        value={
+            "name": {"value": "Accord"},
+            "nbr_seats": {"value": 5},
+            "is_electric": {"value": True},
+            "owner": {"id": "John"},
+        },
+        kind="object_value",
+    )
+    assert gqa.query_report.queries[0].arguments[0].fields == ["is_electric", "name", "nbr_seats", "owner"]
 
     mutation_query_with_return_data = """
-    mutation {
+    mutation CarCreator($car_name: String!) {
         TestElectricCarCreate(
             data: {
-                name: { value: "Accord" }
+                name: { value: $car_name }
                 nbr_seats: { value: 5 }
                 is_electric: { value: true }
                 owner: { id: "John" }
@@ -250,6 +266,24 @@ async def test_query_report(db: InfrahubDatabase, default_branch: Branch, car_pe
     assert len(gqa.query_report.kind_action_map.keys()) == 2
     assert gqa.query_report.kind_action_map["TestElectricCar"] == {MutateAction.CREATE}
     assert gqa.query_report.kind_action_map["TestPerson"] == {MutateAction.UPDATE}
+    assert gqa.query_report.variables == [
+        GraphQLVariable(
+            name="car_name", type="String", required=True, is_list=False, inner_required=False, default=None
+        )
+    ]
+    assert len(gqa.query_report.queries) == 1
+    assert len(gqa.query_report.queries[0].arguments) == 1
+    assert gqa.query_report.queries[0].arguments[0] == GraphQLArgument(
+        name="data",
+        value={
+            "name": {"value": "$car_name"},
+            "nbr_seats": {"value": 5},
+            "is_electric": {"value": True},
+            "owner": {"id": "John"},
+        },
+        kind="object_value",
+    )
+    assert gqa.query_report.queries[0].arguments[0].fields == ["is_electric", "name", "nbr_seats", "owner"]
 
     mutation_query_with_simple_return_data = """
     mutation {
@@ -358,3 +392,212 @@ async def test_query_report(db: InfrahubDatabase, default_branch: Branch, car_pe
     assert gqa.query_report.requested_read["TestElectricCar"].relationships == set()
     assert gqa.query_report.requested_read["TestPerson"].attributes == {"name", "height"}
     assert gqa.query_report.requested_read["TestPerson"].relationships == set()
+
+
+async def test_query_report_single_target(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None
+) -> None:
+    schema_root = SchemaRoot(nodes=[COLOR, TSHIRT])
+    registry.schema.register_schema(schema=schema_root, branch=default_branch.name)
+    default_branch.update_schema_hash()
+
+    schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch, include_subscription=False)
+
+    query_name_variable_required = """
+    query TshirtQuery($name: String!) {
+        TestingTShirt(name__value: $name) {
+            edges {
+                node {
+                    name {
+                        value
+                    }
+                    color {
+                        node {
+                            name {
+                                value
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+
+    query_name_variable_optional = """
+    query TshirtQuery($name: String) {
+        TestingTShirt(name__value: $name) {
+            edges {
+                node {
+                    name {
+                        value
+                    }
+                    color {
+                        node {
+                            name {
+                                value
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+
+    query_name_hardcoded = """
+    query TshirtQuery {
+        TestingTShirt(name__value: "explorer") {
+            edges {
+                node {
+                    name {
+                        value
+                    }
+                    color {
+                        node {
+                            name {
+                                value
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+
+    query_names_hardcoded = """
+    query TshirtQuery {
+        TestingTShirt(name__values: ["explorer"]) {
+            edges {
+                node {
+                    name {
+                        value
+                    }
+                    color {
+                        node {
+                            name {
+                                value
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+
+    query_name_variable_required_extra_nodes = """
+    query TshirtQuery($name: String!) {
+        TestingTShirt(name__value: $name) {
+            edges {
+                node {
+                    name {
+                        value
+                    }
+                    color {
+                        node {
+                            name {
+                                value
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        TestingColor {
+            edges {
+                node {
+                    name {
+                        value
+                    }
+                }
+            }
+        }
+    }
+    """
+
+    query_name_variable_required_extra_nodes_required_filter = """
+    query TshirtQuery($name: String!) {
+        TestingTShirt(name__value: $name) {
+            edges {
+                node {
+                    name {
+                        value
+                    }
+                    color {
+                        node {
+                            name {
+                                value
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        TestingColor(name__value: "orange") {
+            edges {
+                node {
+                    name {
+                        value
+                    }
+                }
+            }
+        }
+    }
+    """
+
+    gqa_required_name_variable = InfrahubGraphQLQueryAnalyzer(
+        query=query_name_variable_required,
+        schema=gql_params.schema,
+        branch=default_branch,
+        schema_branch=schema_branch,
+    )
+    gqa_optional_name_variable = InfrahubGraphQLQueryAnalyzer(
+        query=query_name_variable_optional,
+        schema=gql_params.schema,
+        branch=default_branch,
+        schema_branch=schema_branch,
+    )
+
+    gqa_required_name_hardcoded = InfrahubGraphQLQueryAnalyzer(
+        query=query_name_hardcoded,
+        schema=gql_params.schema,
+        branch=default_branch,
+        schema_branch=schema_branch,
+    )
+
+    gqa_names_hardcoded = InfrahubGraphQLQueryAnalyzer(
+        query=query_names_hardcoded,
+        schema=gql_params.schema,
+        branch=default_branch,
+        schema_branch=schema_branch,
+    )
+
+    gqa_required_name_variable_extra_query = InfrahubGraphQLQueryAnalyzer(
+        query=query_name_variable_required_extra_nodes,
+        schema=gql_params.schema,
+        branch=default_branch,
+        schema_branch=schema_branch,
+    )
+    gqa_required_name_variable_extra_query_required = InfrahubGraphQLQueryAnalyzer(
+        query=query_name_variable_required_extra_nodes_required_filter,
+        schema=gql_params.schema,
+        branch=default_branch,
+        schema_branch=schema_branch,
+    )
+
+    # A required variable matching a uniqueness constraint should indicate a single result query
+    assert gqa_required_name_variable.query_report.only_has_unique_targets is True
+    # If the variable is optional it's not a single result query
+    assert gqa_optional_name_variable.query_report.only_has_unique_targets is False
+    # A hardcoded name matching the uniqueness constraint would match a single result query
+    assert gqa_required_name_hardcoded.query_report.only_has_unique_targets is True
+    # While name_value is a uniqueness constraint when querying with "names_values" it will not be a single result query
+    assert gqa_names_hardcoded.query_report.only_has_unique_targets is False
+    # Adding a new model indicates that there this will not be a single result query
+    assert gqa_required_name_variable_extra_query.query_report.only_has_unique_targets is False
+    # Adding a uniqueness constraint to the second query let's us use it as a single result query again
+    assert gqa_required_name_variable_extra_query_required.query_report.only_has_unique_targets is True


### PR DESCRIPTION
This PR updates the InfrahubGraphQLQueryAnalyzer with better support for parsing variables to the overall query/mutation as well as arguments for each nested query within the GraphQL document.

The final goal is to be able to figure out if the query can uniquely identify a single result and then use this information to determine what artifacts etc need to be within the pipeline. It's related to #5540. With what we have in place in this PR the overall situation should be a lot better specifically for instances where we don't add an extra query like in the linked issue.

I'd like to get this merged with the current feature set. But there are a few follow ups that need to be in place before we can close the target issue:

* HFID support (if the query is setup to require an hfid we should be able to say that it would yield a single response
* Better overall support for the uniqueness constraints, which will be relevant if there are multiple constraints on the target node (this might be an extra future feature)
* With the example in #5540 we can clearly see that `InfraServer` is problematic with regards to a single identifying object based on the input. We could still extract the modules that are being queried for both of these subqueries to indicate which ones are within the single response part along with the ones where we'd have to look at any updated object of the same kind
* We need to consider what information should be stored to convey this information within the `CoreGraphqlQuery` node in the database

Another update in this PR was that I wanted to try a new approach to how we setup the test requirements. I introduced a new fixture `test_kit` that returns a TestKit object. The idea here is that we'd be able to simplify the test setup in a way that I think is cleared than what we typically have with loading multiple fixtures that can be verbose in some places and you need to track down what they are doing. This is similar to another fixture `helper`, which we haven't used much of late. The idea here was have a class with a better structure with shortcuts for various things we want to do such as `test_kit.schema` for schema related operations and `test_kit.graphql` for GraphQL related tasks. Then we can add others as needed. At the moment I send the registry to both schema and graphql, it's not used right now in the graphql part, but we should probably refactor that moving. forward so that the prepare_graphql function doesn't use the registry directly.