### PR TITLE
Rename and rework `repository_dispatch`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,9 +124,9 @@ jobs:
     with:
       publish: true
 
-  update-submodule:
+  repository-dispatch:
     needs: check_release
-    uses: ./.github/workflows/update-submodule.yml
+    uses: ./.github/workflows/repository-dispatch.yml
     secrets: inherit
     with:
       version: ${{ github.ref_name }}

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -1,6 +1,6 @@
 ---
 # yamllint disable rule:truthy rule:line-length
-name: Trigger Submodule update
+name: Trigger Infrahub update in other repositories
 
 on:
   workflow_dispatch:
@@ -29,16 +29,23 @@ on:
         default: ''
 
 jobs:
-  trigger-submodule:
+  repository-dispatch:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        repo:
+          - ${{ secrets.INFRAHUB_ENTERPRISE_REPOSITORY }}
+          - opsmill/infrahub-demo-dc-fabric
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Trigger submodule update
-        run: |
-          curl -X POST \
-            -H 'Authorization: token ${{ secrets.GH_UPDATE_PACKAGE_OTTO }}' \
-            -H 'Accept: application/vnd.github.v3+json' \
-            'https://api.github.com/repos/${{ secrets.INFRAHUB_ENTERPRISE_REPOSITORY }}/dispatches' \
-            -d '{"event_type":"trigger-submodule-update","client_payload":{"version":"${{ inputs.version }}"}}'
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GH_UPDATE_PACKAGE_OTTO }}
+          repository: ${{ matrix.repo }}
+          event-type: trigger-infrahub-update
+          client-payload: |
+            {"version":"${{ inputs.version }}"}

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -35,30 +35,20 @@ jobs:
       matrix:
         # Etiher a literal path, or the name of a secret...
         repo:
-          - opsmill/infrahub-demo-dc-fabric
-          - INFRAHUB_ENTERPRISE_REPOSITORY
-          - INFRAHUB_CUSTOMER1_REPOSITORY
+          - "opsmill/infrahub-demo-dc-fabric"
+          - "INFRAHUB_ENTERPRISE_REPOSITORY"
+          - "INFRAHUB_CUSTOMER1_REPOSITORY"
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Resolve target repo
-        id: resolve
-        run: |
-          KEY=${{ matrix.repo }}
-          if [[ "$KEY" == *"/"* ]]; then
-            echo "TARGET_REPO=$KEY" >> $GITHUB_ENV
-          else
-            # Lookup the secret whose name is in KEY
-            echo "TARGET_REPO=${{ secrets[KEY] }}" >> $GITHUB_ENV
-          fi
-  
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.GH_UPDATE_PACKAGE_OTTO }}
-          repository: ${{ env.TARGET_REPO }}
+          # if matrix.repo contains a slash, use it literally; otherwise look up the secret named by matrix.repo
+          repository: ${{ contains(matrix.repo, '/') && matrix.repo || secrets[matrix.repo] }}
           event-type: trigger-infrahub-update
           client-payload: |
             {"version":"${{ inputs.version }}"}

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -33,20 +33,32 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
+        # Etiher a literal path, or the name of a secret...
         repo:
-          - ${{ secrets.INFRAHUB_ENTERPRISE_REPOSITORY }}
           - opsmill/infrahub-demo-dc-fabric
-          - ${{ secrets.INFRAHUB_CUSTOMER1_REPOSITORY }}
+          - INFRAHUB_ENTERPRISE_REPOSITORY
+          - INFRAHUB_CUSTOMER1_REPOSITORY
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Resolve target repo
+        id: resolve
+        run: |
+          KEY=${{ matrix.repo }}
+          if [[ "$KEY" == *"/"* ]]; then
+            echo "TARGET_REPO=$KEY" >> $GITHUB_ENV
+          else
+            # Lookup the secret whose name is in KEY
+            echo "TARGET_REPO=${{ secrets[KEY] }}" >> $GITHUB_ENV
+          fi
+  
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.GH_UPDATE_PACKAGE_OTTO }}
-          repository: ${{ matrix.repo }}
+          repository: ${{ env.TARGET_REPO }}
           event-type: trigger-infrahub-update
           client-payload: |
             {"version":"${{ inputs.version }}"}

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        # Etiher a literal path, or the name of a secret...
+        # Either a literal path, or the name of a secret...
         repo:
           - "opsmill/infrahub-demo-dc-fabric"
           - "INFRAHUB_ENTERPRISE_REPOSITORY"

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -36,6 +36,7 @@ jobs:
         repo:
           - ${{ secrets.INFRAHUB_ENTERPRISE_REPOSITORY }}
           - opsmill/infrahub-demo-dc-fabric
+          - ${{ secrets.INFRAHUB_CUSTOMER1_REPOSITORY }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/update-sdk-submodule.yml
+++ b/.github/workflows/update-sdk-submodule.yml
@@ -1,6 +1,6 @@
 ---
 # yamllint disable rule:truthy rule:line-length
-name: Handle Submodule Trigger
+name: Update Infrahub Python SDK Submodule
 
 on:
   repository_dispatch:
@@ -14,23 +14,24 @@ jobs:
         branch-name:
           - stable
           - develop
+
     runs-on: ubuntu-22.04
+    concurrency:
+      group: update-infrahub-${{ github.event.client_payload.version }}-${{ matrix.branch-name }}
+      cancel-in-progress: false
+
+    env:
+      SUBMODULE_PATH: python_sdk
+      SDK_VERSION: ${{ github.event.client_payload.version }}
+      BRANCH_NAME: ${{ matrix.branch-name}}-${SUBMODULE_PATH}-${SDK_VERSION}
+
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ref: "${{ matrix.branch-name }}"
           submodules: recursive
-
-      - name: Set branch name
-        id: set-branch-name
-        run: |
-          SUBMODULE_PATH="python_sdk"
-          SDK_VERSION="${{ github.event.client_payload.version }}"
-          BRANCH_NAME="${{ matrix.branch-name}}-${SUBMODULE_PATH}-${SDK_VERSION}"
-          echo "SUBMODULE_PATH=$SUBMODULE_PATH" >> $GITHUB_ENV
-          echo "SDK_VERSION=$SDK_VERSION" >> $GITHUB_ENV
-          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
 
       - name: Use the version from the client payload to update the submodule
         run: |


### PR DESCRIPTION
Rename and rework the dispatch to and from this repository to make it easier to follow/understand

I am replace the dirty curl by an existing github action for the same reason.

If we want to extend it by adding more repositories, we will just have to add more of them in the matrix, and create the "receiver" CI on the other side