### PR TITLE
fix(testcontainers): change json format to JS compatible

### DIFF
--- a/python_testcontainers/infrahub_testcontainers/docker-compose.test.yml
+++ b/python_testcontainers/infrahub_testcontainers/docker-compose.test.yml
@@ -57,8 +57,8 @@ services:
       NEO4J_dbms_security_procedures_unrestricted: "apoc.*"
       NEO4J_dbms_security_auth__minimum__password__length: 4
       NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"
-      NEO4J_dbms_memory_heap_initial__size: ${INFRAHUB_TESTING_DB_HEAP_INITIAL_SIZE}
-      NEO4J_dbms_memory_heap_max__size: ${INFRAHUB_TESTING_DB_HEAP_MAX_SIZE}
+      NEO4J_server_memory_heap_initial__size: ${INFRAHUB_TESTING_DB_HEAP_INITIAL_SIZE}
+      NEO4J_server_memory_heap_max__size: ${INFRAHUB_TESTING_DB_HEAP_MAX_SIZE}
     volumes:
       - "database_data:/data"
       - "database_logs:/logs"

--- a/python_testcontainers/infrahub_testcontainers/performance_test.py
+++ b/python_testcontainers/infrahub_testcontainers/performance_test.py
@@ -158,9 +158,12 @@ class InfrahubPerformanceTest:
             "kind": PERFORMANCE_TEST_KIND,
             "payload_format": PERFORMANCE_TEST_VERSION,
             "data": data,
-            "checksum": hashlib.sha256(json.dumps(data).encode()).hexdigest(),
+            "checksum": hashlib.sha256(json.dumps(data, separators=(",", ":")).encode()).hexdigest(),
         }
 
         with httpx.Client() as client:
-            response = client.post(self.results_url, json=payload)
-            response.raise_for_status()
+            try:
+                response = client.post(self.results_url, json=payload)
+                response.raise_for_status()
+            except Exception as exc:
+                print(exc)


### PR DESCRIPTION
json.dumps serializes to a format that is not equivalent to the JSON.Stringify (javascript) format.

Also do not raise Exception if the payload was not successfully sent.