### PR TITLE
logic for deleting nodes removed from a diff

### DIFF
--- a/backend/infrahub/core/diff/coordinator.py
+++ b/backend/infrahub/core/diff/coordinator.py
@@ -16,6 +16,7 @@ from .model.path import (
     EnrichedDiffs,
     EnrichedDiffsMetadata,
     NameTrackingId,
+    NodeIdentifier,
     TrackingId,
 )
 
@@ -141,7 +142,7 @@ class DiffCoordinator:
             self.lock_registry.get(name=incremental_lock_name, namespace=self.lock_namespace),
         ):
             log.info(f"Acquired lock to run branch diff update for {base_branch.name} - {diff_branch.name}")
-            enriched_diffs = await self._update_diffs(
+            enriched_diffs, node_identifiers_to_drop = await self._update_diffs(
                 base_branch=base_branch,
                 diff_branch=diff_branch,
                 from_time=from_time,
@@ -149,7 +150,9 @@ class DiffCoordinator:
                 tracking_id=tracking_id,
                 force_branch_refresh=False,
             )
-            await self.diff_repo.save(enriched_diffs=enriched_diffs)
+            await self.diff_repo.save(
+                enriched_diffs=enriched_diffs, node_identifiers_to_drop=list(node_identifiers_to_drop)
+            )
             await self._update_core_data_checks(enriched_diff=enriched_diffs.diff_branch_diff)
             log.info(f"Branch diff update complete for {base_branch.name} - {diff_branch.name}")
         return enriched_diffs.diff_branch_diff
@@ -168,7 +171,7 @@ class DiffCoordinator:
         )
         async with self.lock_registry.get(name=general_lock_name, namespace=self.lock_namespace):
             log.info(f"Acquired lock to run arbitrary diff update for {base_branch.name} - {diff_branch.name}")
-            enriched_diffs = await self._update_diffs(
+            enriched_diffs, node_identifiers_to_drop = await self._update_diffs(
                 base_branch=base_branch,
                 diff_branch=diff_branch,
                 from_time=from_time,
@@ -177,7 +180,9 @@ class DiffCoordinator:
                 force_branch_refresh=False,
             )
 
-            await self.diff_repo.save(enriched_diffs=enriched_diffs)
+            await self.diff_repo.save(
+                enriched_diffs=enriched_diffs, node_identifiers_to_drop=list(node_identifiers_to_drop)
+            )
             await self._update_core_data_checks(enriched_diff=enriched_diffs.diff_branch_diff)
             log.info(f"Arbitrary diff update complete for {base_branch.name} - {diff_branch.name}")
         return enriched_diffs.diff_branch_diff
@@ -205,7 +210,7 @@ class DiffCoordinator:
             from_time = current_branch_diff.from_time
             branched_from_time = Timestamp(diff_branch.get_branched_from())
             from_time = max(from_time, branched_from_time)
-            enriched_diffs = await self._update_diffs(
+            enriched_diffs, _ = await self._update_diffs(
                 base_branch=base_branch,
                 diff_branch=diff_branch,
                 from_time=branched_from_time,
@@ -282,7 +287,7 @@ class DiffCoordinator:
         to_time: Timestamp,
         tracking_id: TrackingId,
         force_branch_refresh: Literal[True] = ...,
-    ) -> EnrichedDiffs: ...
+    ) -> tuple[EnrichedDiffs, set[NodeIdentifier]]: ...
 
     @overload
     async def _update_diffs(
@@ -293,7 +298,7 @@ class DiffCoordinator:
         to_time: Timestamp,
         tracking_id: TrackingId,
         force_branch_refresh: Literal[False] = ...,
-    ) -> EnrichedDiffs | EnrichedDiffsMetadata: ...
+    ) -> tuple[EnrichedDiffs | EnrichedDiffsMetadata, set[NodeIdentifier]]: ...
 
     async def _update_diffs(
         self,
@@ -303,7 +308,7 @@ class DiffCoordinator:
         to_time: Timestamp,
         tracking_id: TrackingId,
         force_branch_refresh: bool = False,
-    ) -> EnrichedDiffs | EnrichedDiffsMetadata:
+    ) -> tuple[EnrichedDiffs | EnrichedDiffsMetadata, set[NodeIdentifier]]:
         # start with empty diffs b/c we only care about their metadata for now, hydrate them with data as needed
         diff_pairs_metadata = await self.diff_repo.get_diff_pairs_metadata(
             base_branch_names=[base_branch.name],
@@ -312,7 +317,7 @@ class DiffCoordinator:
             to_time=to_time,
             tracking_id=tracking_id,
         )
-        aggregated_enriched_diffs = await self._aggregate_enriched_diffs(
+        aggregated_enriched_diffs, node_identifiers_to_drop = await self._aggregate_enriched_diffs(
             diff_request=EnrichedDiffRequest(
                 base_branch=base_branch,
                 diff_branch=diff_branch,
@@ -343,7 +348,7 @@ class DiffCoordinator:
         # this is an EnrichedDiffsMetadata, so there are no nodes to enrich
         if not isinstance(aggregated_enriched_diffs, EnrichedDiffs):
             aggregated_enriched_diffs.update_metadata(from_time=from_time, to_time=to_time, tracking_id=tracking_id)
-            return aggregated_enriched_diffs
+            return aggregated_enriched_diffs, set()
 
         await self.conflicts_enricher.add_conflicts_to_branch_diff(
             base_diff_root=aggregated_enriched_diffs.base_branch_diff,
@@ -353,27 +358,27 @@ class DiffCoordinator:
             enriched_diff_root=aggregated_enriched_diffs.diff_branch_diff, conflicts_only=True
         )
 
-        return aggregated_enriched_diffs
+        return aggregated_enriched_diffs, node_identifiers_to_drop
 
     @overload
     async def _aggregate_enriched_diffs(
         self,
         diff_request: EnrichedDiffRequest,
         partial_enriched_diffs: list[EnrichedDiffsMetadata],
-    ) -> EnrichedDiffs | EnrichedDiffsMetadata: ...
+    ) -> tuple[EnrichedDiffs | EnrichedDiffsMetadata, set[NodeIdentifier]]: ...
 
     @overload
     async def _aggregate_enriched_diffs(
         self,
         diff_request: EnrichedDiffRequest,
         partial_enriched_diffs: None,
-    ) -> EnrichedDiffs: ...
+    ) -> tuple[EnrichedDiffs, set[NodeIdentifier]]: ...
 
     async def _aggregate_enriched_diffs(
         self,
         diff_request: EnrichedDiffRequest,
         partial_enriched_diffs: list[EnrichedDiffsMetadata] | None,
-    ) -> EnrichedDiffs | EnrichedDiffsMetadata:
+    ) -> tuple[EnrichedDiffs | EnrichedDiffsMetadata, set[NodeIdentifier]]:
         """
         If return is an EnrichedDiffsMetadata, it acts as a pointer to a diff in the database that has all the
             necessary data for this diff_request. Might have a different time range and/or tracking_id
@@ -385,6 +390,7 @@ class DiffCoordinator:
                 diff_request=diff_request, is_incremental_diff=False
             )
 
+        node_identifiers_to_drop: set[NodeIdentifier] = set()
         if partial_enriched_diffs is not None and not aggregated_enriched_diffs:
             ordered_diffs = self._get_ordered_diff_pairs(diff_pairs=partial_enriched_diffs, allow_overlap=False)
             ordered_diff_reprs = [repr(d) for d in ordered_diffs]
@@ -430,31 +436,31 @@ class DiffCoordinator:
                 )
                 current_time = end_time
 
-            aggregated_enriched_diffs = await self._concatenate_diffs_and_requests(
+            aggregated_enriched_diffs, node_identifiers_to_drop = await self._concatenate_diffs_and_requests(
                 diff_or_request_list=incremental_diffs_and_requests, full_diff_request=diff_request
             )
 
         # no changes during this time period, so generate an EnrichedDiffs with no nodes
         if not aggregated_enriched_diffs:
-            return self._build_enriched_diffs_with_no_nodes(diff_request=diff_request)
+            return self._build_enriched_diffs_with_no_nodes(diff_request=diff_request), node_identifiers_to_drop
 
         # metadata-only diff, means that a diff exists in the database that covers at least
         # part of this time period, but it might need to have its start or end time extended
         # to cover time ranges with no changes
         if not isinstance(aggregated_enriched_diffs, EnrichedDiffs):
-            return aggregated_enriched_diffs
+            return aggregated_enriched_diffs, node_identifiers_to_drop
 
         # a new diff (with nodes) covering the time period
         aggregated_enriched_diffs.update_metadata(
             from_time=diff_request.from_time, to_time=diff_request.to_time, tracking_id=diff_request.tracking_id
         )
-        return aggregated_enriched_diffs
+        return aggregated_enriched_diffs, node_identifiers_to_drop
 
     async def _concatenate_diffs_and_requests(
         self,
         diff_or_request_list: Sequence[EnrichedDiffsMetadata | EnrichedDiffRequest | None],
         full_diff_request: EnrichedDiffRequest,
-    ) -> EnrichedDiffs | EnrichedDiffsMetadata | None:
+    ) -> tuple[EnrichedDiffs | EnrichedDiffsMetadata | None, set[NodeIdentifier]]:
         """
         Returns None if diff_or_request_list is empty or all Nones
             meaning there are no changes for the diff during this time period
@@ -464,7 +470,7 @@ class DiffCoordinator:
             meaning multiple diffs (some that may have been freshly calculated) were combined
         """
         previous_diff_pair: EnrichedDiffs | EnrichedDiffsMetadata | None = None
-        updated_node_uuids: set[str] = set()
+        updated_node_identifiers: set[NodeIdentifier] = set()
         for diff_or_request in diff_or_request_list:
             if isinstance(diff_or_request, EnrichedDiffRequest):
                 if previous_diff_pair:
@@ -478,8 +484,8 @@ class DiffCoordinator:
                 calculated_diff = await self._calculate_enriched_diff(
                     diff_request=diff_or_request, is_incremental_diff=is_incremental_diff
                 )
-                updated_node_uuids |= calculated_diff.base_node_uuids
-                updated_node_uuids |= calculated_diff.branch_node_uuids
+                updated_node_identifiers |= calculated_diff.base_node_identifiers
+                updated_node_identifiers |= calculated_diff.branch_node_identifiers
                 single_enriched_diffs: EnrichedDiffs | EnrichedDiffsMetadata = calculated_diff
 
             elif isinstance(diff_or_request, EnrichedDiffsMetadata):
@@ -495,17 +501,21 @@ class DiffCoordinator:
             previous_diff_pair = await self._combine_diffs(
                 earlier=previous_diff_pair,
                 later=single_enriched_diffs,
-                node_uuids=updated_node_uuids,
+                node_identifiers=updated_node_identifiers,
             )
             log.info("Diffs combined.")
 
-        return previous_diff_pair
+        node_identifiers_to_drop: set[NodeIdentifier] = set()
+        if isinstance(previous_diff_pair, EnrichedDiffs):
+            node_identifiers_to_drop = updated_node_identifiers - previous_diff_pair.branch_node_identifiers
+
+        return previous_diff_pair, node_identifiers_to_drop
 
     async def _combine_diffs(
         self,
         earlier: EnrichedDiffs | EnrichedDiffsMetadata,
         later: EnrichedDiffs | EnrichedDiffsMetadata,
-        node_uuids: set[str],
+        node_identifiers: set[NodeIdentifier],
     ) -> EnrichedDiffs | EnrichedDiffsMetadata:
         log.info(f"Earlier diff to combine: {earlier!r}")
         log.info(f"Later diff to combine: {later!r}")
@@ -519,6 +529,8 @@ class DiffCoordinator:
             earlier.diff_branch_diff.to_time = later.diff_branch_diff.to_time
             return earlier
 
+        # TODO: use NodeIdentifiers here
+        node_uuids = [ni.uuid for ni in node_identifiers]
         # hydrate the diffs to combine, if necessary
         if not isinstance(earlier, EnrichedDiffs):
             log.info("Hydrating earlier diff...")

--- a/backend/infrahub/core/diff/coordinator.py
+++ b/backend/infrahub/core/diff/coordinator.py
@@ -507,6 +507,7 @@ class DiffCoordinator:
 
         node_identifiers_to_drop: set[NodeIdentifier] = set()
         if isinstance(previous_diff_pair, EnrichedDiffs):
+            # nodes that were updated and that no longer exist on this diff have been removed
             node_identifiers_to_drop = updated_node_identifiers - previous_diff_pair.branch_node_identifiers
 
         return previous_diff_pair, node_identifiers_to_drop
@@ -529,16 +530,18 @@ class DiffCoordinator:
             earlier.diff_branch_diff.to_time = later.diff_branch_diff.to_time
             return earlier
 
-        # TODO: use NodeIdentifiers here
-        node_uuids = [ni.uuid for ni in node_identifiers]
         # hydrate the diffs to combine, if necessary
         if not isinstance(earlier, EnrichedDiffs):
             log.info("Hydrating earlier diff...")
-            earlier = await self.diff_repo.hydrate_diff_pair(enriched_diffs_metadata=earlier, node_uuids=node_uuids)
+            earlier = await self.diff_repo.hydrate_diff_pair(
+                enriched_diffs_metadata=earlier, node_identifiers=node_identifiers
+            )
             log.info("Earlier diff hydrated.")
         if not isinstance(later, EnrichedDiffs):
             log.info("Hydrating later diff...")
-            later = await self.diff_repo.hydrate_diff_pair(enriched_diffs_metadata=later, node_uuids=node_uuids)
+            later = await self.diff_repo.hydrate_diff_pair(
+                enriched_diffs_metadata=later, node_identifiers=node_identifiers
+            )
             log.info("Later diff hydrated.")
 
         return await self.diff_combiner.combine(earlier_diffs=earlier, later_diffs=later)

--- a/backend/infrahub/core/diff/data_check_synchronizer.py
+++ b/backend/infrahub/core/diff/data_check_synchronizer.py
@@ -1,6 +1,7 @@
 from enum import Enum
 
 from infrahub.core.constants import BranchConflictKeep, InfrahubKind
+from infrahub.core.diff.query.filters import EnrichedDiffQueryFilters
 from infrahub.core.integrity.object_conflict.conflict_recorder import ObjectConflictValidatorRecorder
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
@@ -74,7 +75,7 @@ class DiffDataCheckSynchronizer:
                 retrieved_diff_conflicts_only = await self.diff_repository.get_one(
                     diff_branch_name=enriched_diff.diff_branch_name,
                     diff_id=enriched_diff.uuid,
-                    filters={"only_conflicted": True},
+                    filters=EnrichedDiffQueryFilters(only_conflicted=True),
                 )
                 enriched_diff_all_conflicts = retrieved_diff_conflicts_only
                 # if `enriched_diff` is an EnrichedDiffRootsMetadata, then there have been no changes to the diff and

--- a/backend/infrahub/core/diff/ipam_diff_parser.py
+++ b/backend/infrahub/core/diff/ipam_diff_parser.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from infrahub.core.constants import DiffAction
 from infrahub.core.constants.database import DatabaseEdgeType
 from infrahub.core.diff.model.path import BranchTrackingId
+from infrahub.core.diff.query.filters import EnrichedDiffQueryFilters, IncExclActionFilterOptions, IncExclFilterOptions
 from infrahub.core.ipam.kinds_getter import IpamKindsGetter
 from infrahub.core.ipam.model import IpamNodeDetails
 from infrahub.core.manager import NodeManager
@@ -48,10 +49,10 @@ class IpamDiffParser:
             base_branch_name=target_branch_name,
             diff_branch_names=[source_branch_name],
             tracking_id=BranchTrackingId(name=source_branch_name),
-            filters={
-                "kind": {"includes": list(ip_address_kinds | ip_prefix_kinds)},
-                "status": {"excludes": {DiffAction.UNCHANGED}},
-            },
+            filters=EnrichedDiffQueryFilters(
+                kind=IncExclFilterOptions(includes=list(ip_address_kinds | ip_prefix_kinds)),
+                status=IncExclActionFilterOptions(excludes={DiffAction.UNCHANGED}),
+            ),
         )
         changed_node_details: list[ChangedIpamNodeDetails] = []
         for diff in enriched_diffs:

--- a/backend/infrahub/core/diff/model/path.py
+++ b/backend/infrahub/core/diff/model/path.py
@@ -82,6 +82,15 @@ def deserialize_tracking_id(tracking_id_str: str) -> TrackingId:
 
 
 @dataclass
+class NodeIdentifier:
+    uuid: str
+    kind: str
+
+    def __hash__(self) -> int:
+        return hash(f"{self.uuid}:{self.kind}")
+
+
+@dataclass
 class NodeDiffFieldSummary:
     kind: str
     attribute_names: set[str] = field(default_factory=set)
@@ -649,6 +658,14 @@ class EnrichedDiffs(EnrichedDiffsMetadata):
     @property
     def branch_node_uuids(self) -> set[str]:
         return {n.uuid for n in self.diff_branch_diff.nodes}
+
+    @property
+    def base_node_identifiers(self) -> set[NodeIdentifier]:
+        return {NodeIdentifier(uuid=n.uuid, kind=n.kind) for n in self.base_branch_diff.nodes}
+
+    @property
+    def branch_node_identifiers(self) -> set[NodeIdentifier]:
+        return {NodeIdentifier(uuid=n.uuid, kind=n.kind) for n in self.diff_branch_diff.nodes}
 
 
 @dataclass

--- a/backend/infrahub/core/diff/query/drop_nodes.py
+++ b/backend/infrahub/core/diff/query/drop_nodes.py
@@ -26,7 +26,17 @@ class EnrichedDiffDropNodesQuery(Query):
         MATCH (d_root)-[:DIFF_HAS_NODE]->(dn:DiffNode)
         WHERE dn.uuid IN $node_uuids
         AND dn.kind IN $node_identifiers_map[dn.uuid]
+        OPTIONAL MATCH (dn)-[:DIFF_HAS_ATTRIBUTE]-(da:DiffAttribute)
+        OPTIONAL MATCH (da)-[*]->(diff_thing)
+        DETACH DELETE diff_thing
+        DETACH DELETE da
+        WITH dn
+        OPTIONAL MATCH (dn)-[:DIFF_HAS_RELATIONSHIP]->(dr:DiffRelationship)
+        OPTIONAL MATCH (dr)-[:DIFF_HAS_ELEMENT]->(dre:DiffRelationshipElement)
+        OPTIONAL MATCH (dre)-[*]->(diff_thing)
+        DETACH DELETE diff_thing
+        DETACH DELETE dre
+        DETACH DELETE dr
         DETACH DELETE dn
         """
-        # TODO: this query needs to also delete attrs/rels/properties downstream from the DiffNode being deleted
         self.add_to_query(query=query)

--- a/backend/infrahub/core/diff/query/drop_nodes.py
+++ b/backend/infrahub/core/diff/query/drop_nodes.py
@@ -1,0 +1,32 @@
+from typing import Any
+
+from infrahub.core.diff.model.path import NodeIdentifier
+from infrahub.core.query import Query, QueryType
+from infrahub.database import InfrahubDatabase
+
+
+class EnrichedDiffDropNodesQuery(Query):
+    name = "enriched_diff_drop_nodes"
+    type = QueryType.WRITE
+    insert_return = False
+
+    def __init__(self, enriched_diff_uuid: str, node_identifiers: list[NodeIdentifier], **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.enriched_diff_uuid = enriched_diff_uuid
+        self.node_identifiers = node_identifiers
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
+        self.params = {
+            "diff_root_uuid": self.enriched_diff_uuid,
+            "node_uuids": [ni.uuid for ni in self.node_identifiers],
+            "node_identifiers_map": {ni.uuid: ni.kind for ni in self.node_identifiers},
+        }
+        query = """
+        MATCH (d_root:DiffRoot {uuid: $diff_root_uuid})
+        MATCH (d_root)-[:DIFF_HAS_NODE]->(dn:DiffNode)
+        WHERE dn.uuid IN $node_uuids
+        AND dn.kind IN $node_identifiers_map[dn.uuid]
+        DETACH DELETE dn
+        """
+        # TODO: this query needs to also delete attrs/rels/properties downstream from the DiffNode being deleted
+        self.add_to_query(query=query)

--- a/backend/infrahub/core/diff/query/filters.py
+++ b/backend/infrahub/core/diff/query/filters.py
@@ -1,6 +1,10 @@
+from collections import defaultdict
+from typing import Any
+
 from pydantic import BaseModel, Field
 
 from infrahub.core.constants import DiffAction
+from infrahub.core.diff.model.path import NodeIdentifier
 from infrahub.core.query.utils import filter_and, filter_or
 
 
@@ -29,6 +33,7 @@ class IncExclActionFilterOptions(BaseModel):
 class EnrichedDiffQueryFilters(BaseModel):
     ids: list[str] = Field(default_factory=list)
     kind: IncExclFilterOptions = IncExclFilterOptions()
+    identifiers: list[NodeIdentifier] = Field(default_factory=list)
     namespace: IncExclFilterOptions = IncExclFilterOptions()
     status: IncExclActionFilterOptions = IncExclActionFilterOptions()
     only_conflicted: bool = Field(default=False)
@@ -37,6 +42,7 @@ class EnrichedDiffQueryFilters(BaseModel):
     def is_empty(self) -> bool:
         if (
             not self.ids
+            and not self.identifiers
             and self.only_conflicted is False
             and self.kind.is_empty
             and self.namespace.is_empty
@@ -48,11 +54,19 @@ class EnrichedDiffQueryFilters(BaseModel):
     def generate(self) -> tuple[str, dict]:
         default_filter = ""
 
-        params = {}
+        params: dict[str, Any] = {}
 
         if self.ids:
             params["ids"] = self.ids
             return "diff_node.uuid in $ids", params
+
+        if self.identifiers:
+            params["ids"] = [n.uuid for n in self.identifiers]
+            id_kind_map: dict[str, list[str]] = defaultdict(list)
+            for node_identifier in self.identifiers:
+                id_kind_map[node_identifier.uuid].append(node_identifier.kind)
+            params["id_kind_map"] = id_kind_map
+            return "diff_node.uuid in $ids AND diff_node.kind IN $id_kind_map[diff_node.uuid]", params
 
         filters_list = []
 

--- a/backend/infrahub/core/diff/repository/repository.py
+++ b/backend/infrahub/core/diff/repository/repository.py
@@ -5,6 +5,7 @@ from neo4j.exceptions import TransientError
 
 from infrahub import config
 from infrahub.core import registry
+from infrahub.core.diff.query.drop_nodes import EnrichedDiffDropNodesQuery
 from infrahub.core.diff.query.field_summary import EnrichedDiffNodeFieldSummaryQuery
 from infrahub.core.diff.query.summary_counts_enricher import (
     DiffFieldsSummaryCountsEnricherQuery,
@@ -26,6 +27,7 @@ from ..model.path import (
     EnrichedDiffsMetadata,
     EnrichedNodeCreateRequest,
     NodeDiffFieldSummary,
+    NodeIdentifier,
     TimeRange,
     TrackingId,
 )
@@ -274,6 +276,12 @@ class DiffRepository:
                 )
                 await single_node_query.execute(db=self.db)
 
+    async def _drop_nodes(self, diff_root: EnrichedDiffRoot, node_identifiers: list[NodeIdentifier]) -> None:
+        drop_node_query = await EnrichedDiffDropNodesQuery.init(
+            db=self.db, enriched_diff_uuid=diff_root.uuid, node_identifiers=node_identifiers
+        )
+        await drop_node_query.execute(db=self.db)
+
     @retry_db_transaction(name="enriched_diff_hierarchy_update")
     async def _run_hierarchy_links_update_query(self, diff_root_uuid: str, diff_nodes: list[EnrichedDiffNode]) -> None:
         log.info(f"Updating diff hierarchy links, num_nodes={len(diff_nodes)}")
@@ -321,7 +329,12 @@ class DiffRepository:
                 node_uuids=node_uuids,
             )
 
-    async def save(self, enriched_diffs: EnrichedDiffs | EnrichedDiffsMetadata, do_summary_counts: bool = True) -> None:
+    async def save(
+        self,
+        enriched_diffs: EnrichedDiffs | EnrichedDiffsMetadata,
+        do_summary_counts: bool = True,
+        node_identifiers_to_drop: list[NodeIdentifier] | None = None,
+    ) -> None:
         # metadata-only update
         if not isinstance(enriched_diffs, EnrichedDiffs):
             await self._save_root_metadata(enriched_diffs=enriched_diffs)
@@ -336,6 +349,8 @@ class DiffRepository:
             await self._save_node_batch(node_create_batch=node_create_batch)
             count_nodes_remaining -= len(node_create_batch)
             log.info(f"Batch saved. {count_nodes_remaining=}")
+        if node_identifiers_to_drop:
+            await self._drop_nodes(diff_root=enriched_diffs.diff_branch_diff, node_identifiers=node_identifiers_to_drop)
         await self._update_hierarchy_links(enriched_diffs=enriched_diffs)
         if do_summary_counts:
             await self._update_summary_counts(diff_root=enriched_diffs.diff_branch_diff)

--- a/backend/infrahub/core/diff/repository/repository.py
+++ b/backend/infrahub/core/diff/repository/repository.py
@@ -110,7 +110,7 @@ class DiffRepository:
         diff_branch_names: list[str],
         from_time: Timestamp | None = None,
         to_time: Timestamp | None = None,
-        filters: dict | None = None,
+        filters: EnrichedDiffQueryFilters | None = None,
         include_parents: bool = True,
         limit: int | None = None,
         offset: int | None = None,
@@ -182,11 +182,11 @@ class DiffRepository:
     async def hydrate_diff_pair(
         self,
         enriched_diffs_metadata: EnrichedDiffsMetadata,
-        node_uuids: Iterable[str] | None = None,
+        node_identifiers: Iterable[NodeIdentifier] | None = None,
     ) -> EnrichedDiffs:
-        filters = None
-        if node_uuids:
-            filters = {"ids": list(node_uuids) if node_uuids is not None else None}
+        filters = EnrichedDiffQueryFilters()
+        if node_identifiers:
+            filters.identifiers = list(node_identifiers)
         hydrated_base_diff = await self.get_one(
             diff_branch_name=enriched_diffs_metadata.base_branch_name,
             diff_id=enriched_diffs_metadata.base_branch_diff.uuid,
@@ -209,7 +209,7 @@ class DiffRepository:
         diff_branch_name: str,
         tracking_id: TrackingId | None = None,
         diff_id: str | None = None,
-        filters: dict | None = None,
+        filters: EnrichedDiffQueryFilters | None = None,
         include_parents: bool = True,
     ) -> EnrichedDiffRoot:
         enriched_diffs = await self.get(

--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -10,6 +10,7 @@ from infrahub.core import registry
 from infrahub.core.constants import DiffAction, RelationshipCardinality
 from infrahub.core.constants.database import DatabaseEdgeType
 from infrahub.core.diff.model.path import NameTrackingId
+from infrahub.core.diff.query.filters import EnrichedDiffQueryFilters
 from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.query.diff import DiffCountChanges
 from infrahub.core.timestamp import Timestamp
@@ -415,7 +416,7 @@ class DiffTreeResolver:
             diff_branch_names=[diff_branch.name],
             from_time=from_timestamp,
             to_time=to_timestamp,
-            filters=filters_dict,
+            filters=EnrichedDiffQueryFilters(**filters_dict),
             include_parents=include_parents,
             limit=limit,
             offset=offset,

--- a/backend/tests/unit/core/diff/test_coordinator.py
+++ b/backend/tests/unit/core/diff/test_coordinator.py
@@ -79,6 +79,46 @@ class TestDiffCoordinator:
                 assert prop_diff.conflict is None
                 assert prop_diff.new_value is None
 
+    async def test_node_added_diff_updated_node_removed(
+        self, db: InfrahubDatabase, default_branch: Branch, person_john_main: Node
+    ):
+        branch = await create_branch(db=db, branch_name="branch")
+        branch_person = await Node.init(db=db, schema="TestPerson", branch=branch)
+        await branch_person.new(db=db, name="Ray", height=180)
+        await branch_person.save(db=db)
+        branch_john = await NodeManager.get_one(db=db, branch=branch, id=person_john_main.id)
+        branch_john.height.value += 1
+        await branch_john.save(db=db)
+
+        component_registry = get_component_registry()
+        diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch)
+        diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=branch)
+        diff_metadata = await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch)
+        diff = await diff_repository.get_one(
+            diff_branch_name=diff_metadata.diff_branch_name, diff_id=diff_metadata.uuid
+        )
+
+        assert diff.base_branch_name == default_branch.name
+        assert diff.diff_branch_name == branch.name
+        nodes_by_id = {n.uuid: n for n in diff.nodes}
+        assert set(nodes_by_id.keys()) == {branch_person.id, person_john_main.id}
+        branch_node_diff = nodes_by_id[branch_person.id]
+        assert branch_node_diff.action is DiffAction.ADDED
+        branch_john_diff = nodes_by_id[person_john_main.id]
+        assert branch_john_diff.action is DiffAction.UPDATED
+
+        fresh_branch_person = await NodeManager.get_one(db=db, branch=branch, id=branch_person.id)
+        await fresh_branch_person.delete(db=db)
+
+        diff_metadata = await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch)
+        diff = await diff_repository.get_one(
+            diff_branch_name=diff_metadata.diff_branch_name, diff_id=diff_metadata.uuid
+        )
+        assert diff.base_branch_name == default_branch.name
+        assert diff.diff_branch_name == branch.name
+        nodes_by_id = {n.uuid: n for n in diff.nodes}
+        assert set(nodes_by_id.keys()) == {person_john_main.id}
+
     async def test_overlapping_diffs(self, db: InfrahubDatabase, default_branch: Branch, person_john_main: Node):
         branch = await create_branch(db=db, branch_name="branch")
         component_registry = get_component_registry()

--- a/backend/tests/unit/core/diff/test_coordinator.py
+++ b/backend/tests/unit/core/diff/test_coordinator.py
@@ -82,10 +82,19 @@ class TestDiffCoordinator:
     async def test_node_added_diff_updated_node_removed(
         self, db: InfrahubDatabase, default_branch: Branch, person_john_main: Node
     ):
+        main_person_2 = await Node.init(db=db, schema="TestPerson", branch=default_branch)
+        await main_person_2.new(db=db, name="Rex", height=190)
+        await main_person_2.save(db=db)
         branch = await create_branch(db=db, branch_name="branch")
-        branch_person = await Node.init(db=db, schema="TestPerson", branch=branch)
-        await branch_person.new(db=db, name="Ray", height=180)
-        await branch_person.save(db=db)
+        # new person
+        branch_person_1 = await Node.init(db=db, schema="TestPerson", branch=branch)
+        await branch_person_1.new(db=db, name="Ray", height=180)
+        await branch_person_1.save(db=db)
+        # updated person
+        branch_person_2 = await NodeManager.get_one(db=db, branch=branch, id=main_person_2.id)
+        branch_person_2.height.value += 1
+        await branch_person_2.save(db=db)
+        # updated person
         branch_john = await NodeManager.get_one(db=db, branch=branch, id=person_john_main.id)
         branch_john.height.value += 1
         await branch_john.save(db=db)
@@ -101,14 +110,21 @@ class TestDiffCoordinator:
         assert diff.base_branch_name == default_branch.name
         assert diff.diff_branch_name == branch.name
         nodes_by_id = {n.uuid: n for n in diff.nodes}
-        assert set(nodes_by_id.keys()) == {branch_person.id, person_john_main.id}
-        branch_node_diff = nodes_by_id[branch_person.id]
-        assert branch_node_diff.action is DiffAction.ADDED
+        assert set(nodes_by_id.keys()) == {branch_person_1.id, main_person_2.id, person_john_main.id}
+        branch_node_diff_1 = nodes_by_id[branch_person_1.id]
+        assert branch_node_diff_1.action is DiffAction.ADDED
+        branch_node_diff_2 = nodes_by_id[main_person_2.id]
+        assert branch_node_diff_2.action is DiffAction.UPDATED
         branch_john_diff = nodes_by_id[person_john_main.id]
         assert branch_john_diff.action is DiffAction.UPDATED
 
-        fresh_branch_person = await NodeManager.get_one(db=db, branch=branch, id=branch_person.id)
-        await fresh_branch_person.delete(db=db)
+        # delete on branch to remove from diff
+        fresh_branch_person_1 = await NodeManager.get_one(db=db, branch=branch, id=branch_person_1.id)
+        await fresh_branch_person_1.delete(db=db)
+        # update on main, validate not removed from diff
+        fresh_main_person_2 = await NodeManager.get_one(db=db, branch=default_branch, id=main_person_2.id)
+        fresh_main_person_2.height.value += 1
+        await fresh_main_person_2.save(db=db)
 
         diff_metadata = await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch)
         diff = await diff_repository.get_one(
@@ -117,7 +133,11 @@ class TestDiffCoordinator:
         assert diff.base_branch_name == default_branch.name
         assert diff.diff_branch_name == branch.name
         nodes_by_id = {n.uuid: n for n in diff.nodes}
-        assert set(nodes_by_id.keys()) == {person_john_main.id}
+        assert set(nodes_by_id.keys()) == {person_john_main.id, fresh_main_person_2.id}
+        branch_node_diff_2 = nodes_by_id[main_person_2.id]
+        assert branch_node_diff_2.action is DiffAction.UPDATED
+        branch_john_diff = nodes_by_id[person_john_main.id]
+        assert branch_john_diff.action is DiffAction.UPDATED
 
     async def test_overlapping_diffs(self, db: InfrahubDatabase, default_branch: Branch, person_john_main: Node):
         branch = await create_branch(db=db, branch_name="branch")


### PR DESCRIPTION
fixes #6379 
IFC-1486

update diff logic to allow completely removing a node that was added on the diff branch and then deleted on the diff branch

basically, requires tracking what nodes were updated during a diff update (something we already do), then comparing those nodes to the nodes that still exist on the diff so that we can determine which nodes, if any, need to be deleted from the diff
- also includes some changes to use the `EnrichedDiffQueryFilters` object everywhere instead of passing a `dict` around and then loading the instantiating an `EnrichedDiffQueryFilters` object with the dict right before using it
- adds a new `NodeIdentifier (uuid:str, kind:str)` class to more uniquely identify a node in the diff b/c a node kind schema migration will result in two nodes with the same UUID and different kinds
  - this will be further expanded in the next PR I am working on for a different issue to support node inheritance migration in which a node is duplicated with the same kind and UUID but different labels at the database level