### PR TITLE
fix(backend): make uniqueness constraint query use indexes

### DIFF
--- a/backend/infrahub/core/validators/uniqueness/query.py
+++ b/backend/infrahub/core/validators/uniqueness/query.py
@@ -111,7 +111,7 @@ class NodeUniqueAttributeConstraintQuery(Query):
 
         attr_paths_with_value_subquery = """
         MATCH attr_path = (start_node:%(node_kind)s)-[:HAS_ATTRIBUTE]->(attr:Attribute)-[r:HAS_VALUE]->(attr_value:AttributeValue)
-        WHERE attr_value.value in $attr_values
+        WHERE attr.name in $attribute_names AND attr_value.value in $attr_values
             AND [attr.name, type(r), attr_value.value] in $attr_paths_with_value
         RETURN start_node, attr_path as potential_path, NULL as rel_identifier, attr.name as potential_attr, attr_value.value as potential_attr_value
         """ % {"node_kind": self.query_request.kind}
@@ -125,7 +125,7 @@ class NodeUniqueAttributeConstraintQuery(Query):
 
         relationship_attr_paths_with_value_subquery = """
         MATCH rel_path = (start_node:%(node_kind)s)-[:IS_RELATED]-(relationship_node:Relationship)-[:IS_RELATED]-(related_n:Node)-[:HAS_ATTRIBUTE]->(rel_attr:Attribute)-[:HAS_VALUE]->(rel_attr_value:AttributeValue)
-        WHERE rel_attr_value.value in $relationship_attr_values
+        WHERE relationship_node.name in $relationship_names AND rel_attr_value.value in $relationship_attr_values
             AND [relationship_node.name, rel_attr.name, rel_attr_value.value] in $relationship_attr_paths_with_value
         RETURN start_node, rel_path as potential_path, relationship_node.name as rel_identifier, rel_attr.name as potential_attr, rel_attr_value.value as potential_attr_value
         """ % {"node_kind": self.query_request.kind}

--- a/backend/infrahub/core/validators/uniqueness/query.py
+++ b/backend/infrahub/core/validators/uniqueness/query.py
@@ -30,7 +30,7 @@ class NodeUniqueAttributeConstraintQuery(Query):
     def get_context(self) -> dict[str, str]:
         return {"kind": self.query_request.kind}
 
-    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002,PLR0915
         branch_filter, branch_params = self.branch.get_query_filter_path(at=self.at.to_string(), is_isolated=False)
         self.params.update(branch_params)
         from_times = db.render_list_comprehension(items="relationships(potential_path)", item_name="from")
@@ -105,16 +105,28 @@ class NodeUniqueAttributeConstraintQuery(Query):
         attr_paths_subquery = """
         MATCH attr_path = (start_node:%(node_kind)s)-[:HAS_ATTRIBUTE]->(attr:Attribute)-[r:HAS_VALUE]->(attr_value:AttributeValue)
         WHERE attr.name in $attribute_names
-            AND ([attr.name, type(r)] in $attr_paths
-            OR (attr_value.value in $attr_values AND [attr.name, type(r), attr_value.value] in $attr_paths_with_value))
+            AND [attr.name, type(r)] in $attr_paths
         RETURN start_node, attr_path as potential_path, NULL as rel_identifier, attr.name as potential_attr, attr_value.value as potential_attr_value
+        """ % {"node_kind": self.query_request.kind}
+
+        attr_paths_with_value_subquery = """
+        MATCH attr_path = (start_node:%(node_kind)s)-[:HAS_ATTRIBUTE]->(attr:Attribute)-[r:HAS_VALUE]->(attr_value:AttributeValue)
+        WHERE attr_value.value in $attr_values
+            AND [attr.name, type(r), attr_value.value] in $attr_paths_with_value
+        RETURN start_node, attr_path as potential_path, NULL as rel_identifier, attr.name as potential_attr, attr_value.value as potential_attr_value
+        """ % {"node_kind": self.query_request.kind}
+
+        relationship_attr_paths_subquery = """
+        MATCH rel_path = (start_node:%(node_kind)s)-[:IS_RELATED]-(relationship_node:Relationship)-[:IS_RELATED]-(related_n:Node)-[:HAS_ATTRIBUTE]->(rel_attr:Attribute)-[:HAS_VALUE]->(rel_attr_value:AttributeValue)
+        WHERE relationship_node.name in $relationship_names
+            AND [relationship_node.name, rel_attr.name] in $relationship_attr_paths
+        RETURN start_node, rel_path as potential_path, relationship_node.name as rel_identifier, rel_attr.name as potential_attr, rel_attr_value.value as potential_attr_value
         """ % {"node_kind": self.query_request.kind}
 
         relationship_attr_paths_with_value_subquery = """
         MATCH rel_path = (start_node:%(node_kind)s)-[:IS_RELATED]-(relationship_node:Relationship)-[:IS_RELATED]-(related_n:Node)-[:HAS_ATTRIBUTE]->(rel_attr:Attribute)-[:HAS_VALUE]->(rel_attr_value:AttributeValue)
-        WHERE relationship_node.name in $relationship_names
-            AND ([relationship_node.name, rel_attr.name] in $relationship_attr_paths
-            OR (rel_attr_value.value in $relationship_attr_values AND [relationship_node.name, rel_attr.name, rel_attr_value.value] in $relationship_attr_paths_with_value))
+        WHERE rel_attr_value.value in $relationship_attr_values
+            AND [relationship_node.name, rel_attr.name, rel_attr_value.value] in $relationship_attr_paths_with_value
         RETURN start_node, rel_path as potential_path, relationship_node.name as rel_identifier, rel_attr.name as potential_attr, rel_attr_value.value as potential_attr_value
         """ % {"node_kind": self.query_request.kind}
 
@@ -130,9 +142,13 @@ class NodeUniqueAttributeConstraintQuery(Query):
         }
 
         select_subqueries = []
-        if attr_paths or attr_paths_with_value:
+        if attr_paths:
             select_subqueries.append(attr_paths_subquery)
-        if relationship_attr_paths_with_value or relationship_attr_paths:
+        if attr_paths_with_value:
+            select_subqueries.append(attr_paths_with_value_subquery)
+        if relationship_attr_paths:
+            select_subqueries.append(relationship_attr_paths_subquery)
+        if relationship_attr_paths_with_value:
             select_subqueries.append(relationship_attr_paths_with_value_subquery)
         if relationship_only_attr_paths:
             select_subqueries.append(relationship_only_attr_paths_subquery)


### PR DESCRIPTION
Use more granular subqueries depending on the parameters so that the planner can find the best index.
Otherwise the planner might use the attribute name index instead of the attribute value index when the latter is available.