### PR TITLE
Restrict computed attribute query to the required attribute

### DIFF
--- a/backend/infrahub/graphql/mutations/computed_attribute.py
+++ b/backend/infrahub/graphql/mutations/computed_attribute.py
@@ -71,7 +71,11 @@ class UpdateComputedAttribute(Mutation):
 
         if not (
             target_node := await NodeManager.get_one(
-                db=graphql_context.db, kind=node_schema.kind, id=str(data.id), branch=graphql_context.branch
+                db=graphql_context.db,
+                kind=node_schema.kind,
+                id=str(data.id),
+                branch=graphql_context.branch,
+                fields={target_attribute.name: None},
             )
         ):
             raise NodeNotFoundError(

--- a/changelog/6403.changed.md
+++ b/changelog/6403.changed.md
@@ -1,0 +1,1 @@
+Speedup for computed attribute mutation by changing the node query to only request the required attributes from the database. This change will provide performance improvements for the background processing of computed attributes.


### PR DESCRIPTION
Ensure that the node query within the computed attribute mutation only requests the attribute we are about to update instead of querying for all node attributes.

Fixes #6403.