### PR TITLE
Fix textarea UI display in object details view

### DIFF
--- a/changelog/6400.fixed.md
+++ b/changelog/6400.fixed.md
@@ -1,0 +1,1 @@
+Improve textarea values display in the object details view

--- a/changelog/6400.fixed.md
+++ b/changelog/6400.fixed.md
@@ -1,1 +1,3 @@
+<!-- vale Infrahub.spelling = NO -->
 Improve textarea values display in the object details view
+<!-- vale Infrahub.spelling = YES -->

--- a/changelog/6400.fixed.md
+++ b/changelog/6400.fixed.md
@@ -1,3 +1,3 @@
 <!-- vale Infrahub.spelling = NO -->
-Improve textarea values display in the object details view
+Fix textarea values display in the object details view
 <!-- vale Infrahub.spelling = YES -->

--- a/frontend/app/src/entities/nodes/getObjectItemDisplayValue.tsx
+++ b/frontend/app/src/entities/nodes/getObjectItemDisplayValue.tsx
@@ -22,7 +22,6 @@ import { PasswordDisplay } from "@/shared/components/display/password-display";
 import { TextDisplay } from "@/shared/components/display/text-display";
 import { CodeViewer } from "@/shared/components/editor/code/code-viewer";
 import { MarkdownRender } from "@/shared/components/editor/markdown/markdown-render";
-import { MarkdownViewer } from "@/shared/components/editor/markdown/markdown-viewer";
 import { Link } from "@/shared/components/ui/link";
 import { CheckIcon, XMarkIcon } from "@heroicons/react/24/outline";
 
@@ -61,7 +60,7 @@ export const getDisplayValue = (
   }
 
   if (attribute?.kind === "TextArea") {
-    return <MarkdownViewer markdownText={row[attribute?.name]?.value} />;
+    return <MarkdownRender markdownText={row[attribute?.name]?.value} />;
   }
 
   if (attribute?.kind === "JSON") {

--- a/frontend/app/src/entities/nodes/getObjectItemDisplayValue.tsx
+++ b/frontend/app/src/entities/nodes/getObjectItemDisplayValue.tsx
@@ -21,6 +21,7 @@ import { DateDisplay } from "@/shared/components/display/date-display";
 import { PasswordDisplay } from "@/shared/components/display/password-display";
 import { TextDisplay } from "@/shared/components/display/text-display";
 import { CodeViewer } from "@/shared/components/editor/code/code-viewer";
+import { MarkdownRender } from "@/shared/components/editor/markdown/markdown-render";
 import { MarkdownViewer } from "@/shared/components/editor/markdown/markdown-viewer";
 import { Link } from "@/shared/components/ui/link";
 import { CheckIcon, XMarkIcon } from "@heroicons/react/24/outline";
@@ -201,7 +202,7 @@ export const ObjectAttributeValue = ({
     case ATTRIBUTE_KIND.DATETIME:
       return <DateDisplay date={getTextValue(attributeValue)} />;
     case ATTRIBUTE_KIND.TEXTAREA:
-      return <MarkdownViewer markdownText={getTextValue(attributeValue)} />;
+      return <MarkdownRender markdownText={getTextValue(attributeValue)} />;
     case ATTRIBUTE_KIND.PASSWORD:
     case ATTRIBUTE_KIND.HASHED_PASSWORD:
       return <PasswordDisplay value={getTextValue(attributeValue)} />;


### PR DESCRIPTION
Issue: https://github.com/opsmill/infrahub/issues/6400

Use the right component to display textarea value with MarkdownRender instead of MarkdownViewer

<img width="1465" alt="Capture d’écran 2025-05-06 à 13 40 57" src="https://github.com/user-attachments/assets/ecd09334-6e93-4d8b-9f74-c0ee8314aa32" />
