### PR TITLE
fix bug in rel create for migrated kind nodes

### DIFF
--- a/backend/infrahub/core/branch/models.py
+++ b/backend/infrahub/core/branch/models.py
@@ -295,6 +295,7 @@ class Branch(StandardNode):
         is_isolated: bool = True,
         branch_agnostic: bool = False,
         variable_name: str = "r",
+        params_prefix: str = "",
     ) -> tuple[str, dict]:
         """
         Generate a CYPHER Query filter based on a path to query a part of the graph at a specific time and on a specific branch.
@@ -306,30 +307,28 @@ class Branch(StandardNode):
 
             There is a currently an assumption that the relationship in the path will be named 'r'
         """
-
+        pp = params_prefix
         params: dict[str, Any] = {}
         at = Timestamp(at)
         at_str = at.to_string()
         if branch_agnostic:
-            filter_str = (
-                f"{variable_name}.from <= $time1 AND ({variable_name}.to IS NULL or {variable_name}.to >= $time1)"
-            )
-            params["time1"] = at_str
+            filter_str = f"{variable_name}.from <= ${pp}time1 AND ({variable_name}.to IS NULL or {variable_name}.to >= ${pp}time1)"
+            params[f"{pp}time1"] = at_str
             return filter_str, params
 
         branches_times = self.get_branches_and_times_to_query_global(at=at_str, is_isolated=is_isolated)
 
         for idx, (branch_name, time_to_query) in enumerate(branches_times.items()):
-            params[f"branch{idx}"] = list(branch_name)
-            params[f"time{idx}"] = time_to_query
+            params[f"{pp}branch{idx}"] = list(branch_name)
+            params[f"{pp}time{idx}"] = time_to_query
 
         filters = []
         for idx in range(len(branches_times)):
             filters.append(
-                f"({variable_name}.branch IN $branch{idx} AND {variable_name}.from <= $time{idx} AND {variable_name}.to IS NULL)"
+                f"({variable_name}.branch IN ${pp}branch{idx} AND {variable_name}.from <= ${pp}time{idx} AND {variable_name}.to IS NULL)"
             )
             filters.append(
-                f"({variable_name}.branch IN $branch{idx} AND {variable_name}.from <= $time{idx} AND {variable_name}.to >= $time{idx})"
+                f"({variable_name}.branch IN ${pp}branch{idx} AND {variable_name}.from <= ${pp}time{idx} AND {variable_name}.to >= ${pp}time{idx})"
             )
 
         filter_str = "(" + "\n OR ".join(filters) + ")"

--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -237,10 +237,40 @@ class RelationshipCreateQuery(RelationshipQuery):
         self.params["is_protected"] = self.rel.is_protected
         self.params["is_visible"] = self.rel.is_visible
 
-        query_match = """
-        MATCH (s:Node { uuid: $source_id })
-        MATCH (d:Node { uuid: $destination_id })
-        """
+        if self.branch.is_default:
+            query_match = """
+            MATCH (s:Node { uuid: $source_id })
+            WHERE NOT exists((s)-[:IS_PART_OF {status: "deleted", branch: $branch}]->(:Root))
+            MATCH (d:Node { uuid: $destination_id })
+            WHERE NOT exists((d)-[:IS_PART_OF {status: "deleted", branch: $branch}]->(:Root))
+            """
+        else:
+            node_filter, filter_params = self.branch.get_query_filter_path(at=self.at, variable_name="r")
+            query_match = """
+            MATCH (s:Node { uuid: $source_id })
+            CALL {
+                WITH s
+                MATCH (s)-[r:IS_PART_OF]->(:Root)
+                WHERE %(node_filter)s
+                RETURN r.status = "active" AS is_active
+                ORDER BY r.from DESC
+                LIMIT 1
+            }
+            WITH s, is_active WHERE is_active = TRUE
+            WITH s
+            MATCH (d:Node { uuid: $destination_id })
+            CALL {
+                WITH d
+                MATCH (d)-[r:IS_PART_OF]->(:Root)
+                WHERE %(node_filter)s
+                RETURN r.status = "active" AS is_active
+                ORDER BY r.from DESC
+                LIMIT 1
+            }
+            WITH s, d, is_active WHERE is_active = TRUE
+            """ % {"node_filter": node_filter}
+            self.params.update(filter_params)
+
         self.add_to_query(query_match)
 
         self.query_add_all_node_property_match()

--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -237,41 +237,57 @@ class RelationshipCreateQuery(RelationshipQuery):
         self.params["is_protected"] = self.rel.is_protected
         self.params["is_visible"] = self.rel.is_visible
 
-        if self.branch.is_default:
-            query_match = """
+        source_branch = self.source.get_branch_based_on_support_type()
+        if source_branch.is_global or source_branch.is_default:
+            source_query_match = """
             MATCH (s:Node { uuid: $source_id })
-            WHERE NOT exists((s)-[:IS_PART_OF {status: "deleted", branch: $branch}]->(:Root))
-            MATCH (d:Node { uuid: $destination_id })
-            WHERE NOT exists((d)-[:IS_PART_OF {status: "deleted", branch: $branch}]->(:Root))
+            WHERE NOT exists((s)-[:IS_PART_OF {status: "deleted", branch: $source_branch}]->(:Root))
             """
+            self.params["source_branch"] = source_branch.name
         else:
-            node_filter, filter_params = self.branch.get_query_filter_path(at=self.at, variable_name="r")
-            query_match = """
+            source_filter, source_filter_params = source_branch.get_query_filter_path(
+                at=self.at, variable_name="r", params_prefix="src_"
+            )
+            source_query_match = """
             MATCH (s:Node { uuid: $source_id })
             CALL {
                 WITH s
                 MATCH (s)-[r:IS_PART_OF]->(:Root)
-                WHERE %(node_filter)s
-                RETURN r.status = "active" AS is_active
+                WHERE %(source_filter)s
+                RETURN r.status = "active" AS s_is_active
                 ORDER BY r.from DESC
                 LIMIT 1
             }
-            WITH s, is_active WHERE is_active = TRUE
-            WITH s
+            WITH s WHERE s_is_active = TRUE
+            """ % {"source_filter": source_filter}
+            self.params.update(source_filter_params)
+        self.add_to_query(source_query_match)
+
+        destination_branch = self.destination.get_branch_based_on_support_type()
+        if destination_branch.is_global or destination_branch.is_default:
+            destination_query_match = """
+            MATCH (d:Node { uuid: $destination_id })
+            WHERE NOT exists((d)-[:IS_PART_OF {status: "deleted", branch: $destination_branch}]->(:Root))
+            """
+            self.params["destination_branch"] = destination_branch.name
+        else:
+            destination_filter, destination_filter_params = destination_branch.get_query_filter_path(
+                at=self.at, variable_name="r", params_prefix="dst_"
+            )
+            destination_query_match = """
             MATCH (d:Node { uuid: $destination_id })
             CALL {
                 WITH d
                 MATCH (d)-[r:IS_PART_OF]->(:Root)
-                WHERE %(node_filter)s
-                RETURN r.status = "active" AS is_active
+                WHERE %(destination_filter)s
+                RETURN r.status = "active" AS d_is_active
                 ORDER BY r.from DESC
                 LIMIT 1
             }
-            WITH s, d, is_active WHERE is_active = TRUE
-            """ % {"node_filter": node_filter}
-            self.params.update(filter_params)
-
-        self.add_to_query(query_match)
+            WITH s, d WHERE d_is_active = TRUE
+            """ % {"destination_filter": destination_filter}
+            self.params.update(destination_filter_params)
+        self.add_to_query(destination_query_match)
 
         self.query_add_all_node_property_match()
 

--- a/backend/tests/unit/core/test_relationship_query.py
+++ b/backend/tests/unit/core/test_relationship_query.py
@@ -5,10 +5,12 @@ import pytest
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
-from infrahub.core.constants import RelationshipDirection
+from infrahub.core.constants import RelationshipDirection, SchemaPathType
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
+from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration
 from infrahub.core.node import Node
+from infrahub.core.path import SchemaPath
 from infrahub.core.query.relationship import (
     RelationshipCountPerNodeQuery,
     RelationshipCreateQuery,
@@ -149,12 +151,15 @@ async def test_query_RelationshipCreateQuery(
     )
     await query.execute(db=db)
 
-    # We should have 2 paths between t1 and p1
-    # First for the relationship, Second via the branch
+    # We should have 1 path between t1 and p1
     paths = await get_paths_between_nodes(
-        db=db, source_id=tag_blue_main.db_id, destination_id=person_jack_main.db_id, max_length=2
+        db=db,
+        source_id=tag_blue_main.db_id,
+        destination_id=person_jack_main.db_id,
+        max_length=2,
+        relationships=["IS_RELATED"],
     )
-    assert len(paths) == 2
+    assert len(paths) == 1
 
 
 async def test_query_RelationshipCreateQuery_w_node_property(
@@ -188,6 +193,57 @@ async def test_query_RelationshipCreateQuery_w_node_property(
         max_length=2,
     )
     assert len(paths) == 1
+
+
+async def test_query_RelationshipCreateQuery_for_node_with_migrated_kind(
+    db: InfrahubDatabase, tag_blue_main: Node, person_jack_main: Node, branch: Branch
+):
+    schema = registry.schema.get_schema_branch(name=branch.name)
+    person_schema = schema.get(name="TestPerson")
+    person_schema.name = "GreatPerson"
+    new_person_kind = "TestGreatPerson"
+    assert person_schema.kind == new_person_kind
+    registry.schema.set(name=new_person_kind, schema=person_schema, branch=branch.name)
+    migration = NodeKindUpdateMigration(
+        previous_node_schema=schema.get(name="TestPerson"),
+        new_node_schema=person_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind=new_person_kind, field_name="name"),
+    )
+    execution_result = await migration.execute(db=db, branch=branch)
+    assert not execution_result.errors
+
+    rel_schema = person_schema.get_relationship("tags")
+    migrated_person_jack = await NodeManager.get_one(db=db, branch=branch, id=person_jack_main.id)
+    query = await RelationshipCreateQuery.init(
+        db=db,
+        source=migrated_person_jack,
+        destination=tag_blue_main,
+        schema=rel_schema,
+        rel=Relationship,
+        branch=branch,
+        at=Timestamp(),
+    )
+    await query.execute(db=db)
+
+    # We should have 1 path between tag_blue and migrated_person_jack
+    paths = await get_paths_between_nodes(
+        db=db,
+        source_id=tag_blue_main.db_id,
+        destination_id=migrated_person_jack.db_id,
+        max_length=2,
+        relationships=["IS_RELATED"],
+    )
+    assert len(paths) == 1
+
+    # We should have 0 path between tag_blue and person_jack_main
+    paths = await get_paths_between_nodes(
+        db=db,
+        source_id=tag_blue_main.db_id,
+        destination_id=person_jack_main.db_id,
+        max_length=2,
+        relationships=["IS_RELATED"],
+    )
+    assert len(paths) == 0
 
 
 async def test_query_RelationshipDeleteQuery(

--- a/changelog/+rel_create_on_migrated_kind_node.fixed.md
+++ b/changelog/+rel_create_on_migrated_kind_node.fixed.md
@@ -1,0 +1,1 @@
+Prevent creating duplicate edges on the database when adding a relationship to a node that had its kind or inheritance updated


### PR DESCRIPTION
we have a small bug in the cypher query to create a new Relationship.

if a node schema has its kind or inheritance updated, then we run a migration that results in two nodes with the same UUID but different `kind`s (or labels in the case of an inheritance update). the old version of these 2 nodes is set to deleted. the `RelationshipCreateQuery` was not capable of handling this situation and would create two duplicate relationships: one to the active node with the updated kind/labels and one to the deleted node with old kind/labels. a user would probably not encounter this issue b/c we would never get relationships for a deleted node, but the diff will pick up this extraneous relationship and could show it to the end user.

I've tried to keep performance in mind for this query and use a simpler query when running on the default branch, but when creating a relationship on a branch, we will need to use the full subquery to make sure we are only linking the correct active nodes