### PR TITLE
IFC-1501 Generate templates for inherited kinds

### DIFF
--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -2050,6 +2050,9 @@ class SchemaBranch:
 
         identified.add(node_schema)
 
+        if node_schema.is_node_schema:
+            identified.update([self.get(name=kind, duplicate=False) for kind in node_schema.inherit_from])
+
         for relationship in node_schema.relationships:
             if (
                 relationship.peer in [InfrahubKind.GENERICGROUP, InfrahubKind.PROFILE]

--- a/changelog/6415.fixed.md
+++ b/changelog/6415.fixed.md
@@ -1,0 +1,1 @@
+Add inherited kinds of a node as templates to fix GraphQL schema when inheritance is involved


### PR DESCRIPTION
Fixes #6415 

This might trigger the creation of a lot of templates from a schema perspective but this is required to fix the inheritance for the GraphQL schema.