### PR TITLE
Add 'List' kinds to LARGE_ATTRIBUTE_TYPES

### DIFF
--- a/backend/infrahub/types.py
+++ b/backend/infrahub/types.py
@@ -366,7 +366,7 @@ ATTRIBUTE_PYTHON_TYPES: dict[str, type] = {
 ATTRIBUTE_KIND_LABELS = list(ATTRIBUTE_TYPES.keys())
 
 # Data types supporting large values, which can therefore not be indexed in neo4j.
-LARGE_ATTRIBUTE_TYPES = [TextArea, JSON]
+LARGE_ATTRIBUTE_TYPES = [TextArea, JSON, List]
 
 
 def get_attribute_type(kind: str = "Default") -> type[InfrahubDataType]:

--- a/changelog/+f9d7f87b.fixed.md
+++ b/changelog/+f9d7f87b.fixed.md
@@ -1,0 +1,1 @@
+Fixed an issue where it wasn't possible to have a high number of choices in the Dropdown schema kinds. Previously the payload was limited to 4096 characters.


### PR DESCRIPTION
This is a workaround to allow large Dropdown choices within the Schema. At some point we should convert these attributes to another type than "AttributeValue" in order to add an index to all "AttributeValue" nodes.