### PR TITLE
Remove `InfrahubServices` ref on flows/messages

### DIFF
--- a/backend/infrahub/artifacts/tasks.py
+++ b/backend/infrahub/artifacts/tasks.py
@@ -4,25 +4,28 @@ from infrahub.artifacts.models import CheckArtifactCreate
 from infrahub.core.constants import InfrahubKind, ValidatorConclusion
 from infrahub.core.timestamp import Timestamp
 from infrahub.git.repository import get_initialized_repo
-from infrahub.services import InfrahubServices
 from infrahub.tasks.artifact import define_artifact
+from infrahub.workers.dependencies import get_client
 from infrahub.workflows.utils import add_tags
 
 
 @flow(name="git-repository-check-artifact-create", flow_run_name="Check artifact creation")
-async def create(model: CheckArtifactCreate, service: InfrahubServices) -> ValidatorConclusion:
+async def create(model: CheckArtifactCreate) -> ValidatorConclusion:
     await add_tags(branches=[model.branch_name], nodes=[model.target_id])
-    validator = await service.client.get(kind=InfrahubKind.ARTIFACTVALIDATOR, id=model.validator_id, include=["checks"])
+
+    client = get_client()
+
+    validator = await client.get(kind=InfrahubKind.ARTIFACTVALIDATOR, id=model.validator_id, include=["checks"])
 
     repo = await get_initialized_repo(
-        client=service.client,
+        client=client,
         repository_id=model.repository_id,
         name=model.repository_name,
         repository_kind=model.repository_kind,
         commit=model.commit,
     )
 
-    artifact, artifact_created = await define_artifact(model=model, service=service)
+    artifact, artifact_created = await define_artifact(model=model)
 
     severity = "info"
     artifact_result: dict[str, str | bool | None] = {
@@ -51,7 +54,7 @@ async def create(model: CheckArtifactCreate, service: InfrahubServices) -> Valid
 
     check = None
     check_name = f"{model.artifact_name}: {model.target_name}"
-    existing_check = await service.client.filters(
+    existing_check = await client.filters(
         kind=InfrahubKind.ARTIFACTCHECK, validator__ids=validator.id, name__value=check_name
     )
     if existing_check:
@@ -67,7 +70,7 @@ async def create(model: CheckArtifactCreate, service: InfrahubServices) -> Valid
         check.storage_id.value = artifact_result["storage_id"]
         await check.save()
     else:
-        check = await service.client.create(
+        check = await client.create(
             kind=InfrahubKind.ARTIFACTCHECK,
             data={
                 "name": check_name,

--- a/backend/infrahub/cli/db.py
+++ b/backend/infrahub/cli/db.py
@@ -51,9 +51,6 @@ from infrahub.database import DatabaseType
 from infrahub.database.memgraph import IndexManagerMemgraph
 from infrahub.database.neo4j import IndexManagerNeo4j
 from infrahub.log import get_logger
-from infrahub.services import InfrahubServices
-from infrahub.services.adapters.message_bus.local import BusSimulator
-from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 
 from .constants import ERROR_BADGE, FAILED_BADGE, SUCCESS_BADGE
 from .patch import patch_app
@@ -186,10 +183,6 @@ async def update_core_schema_cmd(
 
     context: CliContext = ctx.obj
     dbdriver = await context.init_db(retry=1)
-
-    service = await InfrahubServices.new(
-        database=dbdriver, message_bus=BusSimulator(), workflow=WorkflowLocalExecution()
-    )
 
     with prefect_test_harness():
         await update_core_schema(db=dbdriver, initialize=True, debug=debug)

--- a/backend/infrahub/cli/db.py
+++ b/backend/infrahub/cli/db.py
@@ -192,7 +192,7 @@ async def update_core_schema_cmd(
     )
 
     with prefect_test_harness():
-        await update_core_schema(db=dbdriver, service=service, initialize=True, debug=debug)
+        await update_core_schema(db=dbdriver, initialize=True, debug=debug)
 
     await dbdriver.close()
 
@@ -342,9 +342,7 @@ async def initialize_internal_schema() -> None:
     registry.schema.register_schema(schema=schema)
 
 
-async def update_core_schema(
-    db: InfrahubDatabase, service: InfrahubServices, initialize: bool = True, debug: bool = False
-) -> None:
+async def update_core_schema(db: InfrahubDatabase, initialize: bool = True, debug: bool = False) -> None:
     """Update the core schema of Infrahub to the latest version"""
     # ----------------------------------------------------------
     # Initialize Schema and Registry
@@ -393,7 +391,7 @@ async def update_core_schema(
         schema_branch=candidate_schema,
         constraints=result.constraints,
     )
-    responses = await schema_validate_migrations(message=validate_migration_data, service=service)
+    responses = await schema_validate_migrations(message=validate_migration_data)
     error_messages = [violation.message for response in responses for violation in response.violations]
     if error_messages:
         rprint(f"{ERROR_BADGE} | Unable to update the schema, due to failed validations")
@@ -435,7 +433,7 @@ async def update_core_schema(
         previous_schema=origin_schema,
         migrations=result.migrations,
     )
-    migration_error_msgs = await schema_apply_migrations(message=apply_migration_data, service=service)
+    migration_error_msgs = await schema_apply_migrations(message=apply_migration_data)
 
     if migration_error_msgs:
         rprint(f"{ERROR_BADGE} | Some error(s) happened while running the schema migrations")

--- a/backend/infrahub/cli/upgrade.py
+++ b/backend/infrahub/cli/upgrade.py
@@ -24,9 +24,6 @@ from infrahub.menu.menu import default_menu
 from infrahub.menu.models import MenuDict
 from infrahub.menu.repository import MenuRepository
 from infrahub.menu.utils import create_default_menu
-from infrahub.services import InfrahubServices
-from infrahub.services.adapters.message_bus.local import BusSimulator
-from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from infrahub.trigger.tasks import trigger_configure_all
 from infrahub.workflows.initialization import (
     setup_blocks,
@@ -61,9 +58,6 @@ async def upgrade_cmd(
     context: CliContext = ctx.obj
     dbdriver = await context.init_db(retry=1)
 
-    service = await InfrahubServices.new(
-        database=dbdriver, message_bus=BusSimulator(), workflow=WorkflowLocalExecution()
-    )
     await initialize_registry(db=dbdriver)
 
     # NOTE add step to validate if the database and the task manager are reachable

--- a/backend/infrahub/cli/upgrade.py
+++ b/backend/infrahub/cli/upgrade.py
@@ -78,7 +78,7 @@ async def upgrade_cmd(
     await migrate_database(db=dbdriver, initialize=False, check=check)
 
     await initialize_internal_schema()
-    await update_core_schema(db=dbdriver, service=service, initialize=False)
+    await update_core_schema(db=dbdriver, initialize=False)
 
     # -------------------------------------------
     # Upgrade Internal Objects, generated and managed by Infrahub
@@ -93,7 +93,7 @@ async def upgrade_cmd(
         await setup_blocks()
         await setup_worker_pools(client=client)
         await setup_deployments(client=client)
-        await trigger_configure_all(service=service)
+        await trigger_configure_all()
 
     await dbdriver.close()
 

--- a/backend/infrahub/computed_attribute/tasks.py
+++ b/backend/infrahub/computed_attribute/tasks.py
@@ -15,7 +15,7 @@ from infrahub.events import BranchDeletedEvent
 from infrahub.git.repository import get_initialized_repo
 from infrahub.trigger.models import TriggerSetupReport, TriggerType
 from infrahub.trigger.setup import setup_triggers, setup_triggers_specific
-from infrahub.workers.dependencies import get_client, get_database, get_infrahub_services, get_workflow
+from infrahub.workers.dependencies import get_client, get_component, get_database, get_workflow
 from infrahub.workflows.catalogue import (
     COMPUTED_ATTRIBUTE_PROCESS_JINJA2,
     COMPUTED_ATTRIBUTE_PROCESS_TRANSFORM,
@@ -294,8 +294,8 @@ async def computed_attribute_setup_jinja2(
 
         if branch_name:
             await add_tags(branches=[branch_name])
-            service = await get_infrahub_services()
-            await wait_for_schema_to_converge(branch_name=branch_name, component=service.component, db=db, log=log)
+            component = await get_component()
+            await wait_for_schema_to_converge(branch_name=branch_name, component=component, db=db, log=log)
 
         report: TriggerSetupReport = await setup_triggers_specific(
             gatherer=gather_trigger_computed_attribute_jinja2, trigger_type=TriggerType.COMPUTED_ATTR_JINJA2
@@ -310,7 +310,7 @@ async def computed_attribute_setup_jinja2(
         }
         for branch, kind, attribute_name in unique_nodes:
             if event_name != BranchDeletedEvent.event_name and branch == branch_name:
-                await service.workflow.submit_workflow(
+                await get_workflow().submit_workflow(
                     workflow=TRIGGER_UPDATE_JINJA_COMPUTED_ATTRIBUTES,
                     context=context,
                     parameters={
@@ -338,11 +338,10 @@ async def computed_attribute_setup_python(
         log = get_run_logger()
 
         branch_name = branch_name or registry.default_branch
-
         if branch_name:
             await add_tags(branches=[branch_name])
-            service = await get_infrahub_services()
-            await wait_for_schema_to_converge(branch_name=branch_name, component=service.component, db=db, log=log)
+            component = await get_component()
+            await wait_for_schema_to_converge(branch_name=branch_name, component=component, db=db, log=log)
 
         triggers_python, triggers_python_query = await gather_trigger_computed_attribute_python(db=db)
 
@@ -362,7 +361,7 @@ async def computed_attribute_setup_python(
         for branch, kind, attribute_name in unique_nodes:
             if event_name != BranchDeletedEvent.event_name and branch == branch_name:
                 log.info(f"Triggering update for {kind}.{attribute_name} on {branch}")
-                await service.workflow.submit_workflow(
+                await get_workflow().submit_workflow(
                     workflow=TRIGGER_UPDATE_PYTHON_COMPUTED_ATTRIBUTES,
                     context=context,
                     parameters={

--- a/backend/infrahub/computed_attribute/tasks.py
+++ b/backend/infrahub/computed_attribute/tasks.py
@@ -66,10 +66,8 @@ async def process_transform(
     await add_tags(branches=[branch_name], nodes=[object_id])
     client = get_client()
 
-    node_schema = await client.schema.get(kind=node_kind, branch=branch_name)
-
-    # schema_branch = registry.schema.get_schema_branch(name=branch_name)
-    # node_schema = schema_branch.get_node(name=node_kind, duplicate=False)
+    schema_branch = registry.schema.get_schema_branch(name=branch_name)
+    node_schema = schema_branch.get_node(name=node_kind, duplicate=False)
     transform_attributes: dict[str, ComputedAttribute] = {}
     for attribute in node_schema.attributes:
         if attribute.computed_attribute and attribute.computed_attribute.kind == ComputedAttributeKind.TRANSFORM_PYTHON:

--- a/backend/infrahub/computed_attribute/tasks.py
+++ b/backend/infrahub/computed_attribute/tasks.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from infrahub_sdk.protocols import CoreTransformPython
 from infrahub_sdk.template import Jinja2Template
 from prefect import flow
-from prefect.client.orchestration import get_client
+from prefect.client.orchestration import get_client as get_prefect_client
 from prefect.logging import get_run_logger
 
 from infrahub.context import InfrahubContext  # noqa: TC001  needed for prefect flow
@@ -13,9 +13,9 @@ from infrahub.core.constants import ComputedAttributeKind, InfrahubKind
 from infrahub.core.registry import registry
 from infrahub.events import BranchDeletedEvent
 from infrahub.git.repository import get_initialized_repo
-from infrahub.services import InfrahubServices  # noqa: TC001  needed for prefect flow
 from infrahub.trigger.models import TriggerSetupReport, TriggerType
 from infrahub.trigger.setup import setup_triggers, setup_triggers_specific
+from infrahub.workers.dependencies import get_client, get_database, get_infrahub_services, get_workflow
 from infrahub.workflows.catalogue import (
     COMPUTED_ATTRIBUTE_PROCESS_JINJA2,
     COMPUTED_ATTRIBUTE_PROCESS_TRANSFORM,
@@ -61,13 +61,15 @@ async def process_transform(
     computed_attribute_name: str,  # noqa: ARG001
     computed_attribute_kind: str,  # noqa: ARG001
     context: InfrahubContext,  # noqa: ARG001
-    service: InfrahubServices,
     updated_fields: list[str] | None = None,  # noqa: ARG001
 ) -> None:
     await add_tags(branches=[branch_name], nodes=[object_id])
+    client = get_client()
 
-    schema_branch = registry.schema.get_schema_branch(name=branch_name)
-    node_schema = schema_branch.get_node(name=node_kind, duplicate=False)
+    node_schema = await client.schema.get(kind=node_kind, branch=branch_name)
+
+    # schema_branch = registry.schema.get_schema_branch(name=branch_name)
+    # node_schema = schema_branch.get_node(name=node_kind, duplicate=False)
     transform_attributes: dict[str, ComputedAttribute] = {}
     for attribute in node_schema.attributes:
         if attribute.computed_attribute and attribute.computed_attribute.kind == ComputedAttributeKind.TRANSFORM_PYTHON:
@@ -77,7 +79,7 @@ async def process_transform(
         return
 
     for attribute_name, transform_attribute in transform_attributes.items():
-        transform = await service.client.get(
+        transform = await client.get(
             kind=CoreTransformPython,
             branch=branch_name,
             id=transform_attribute.transform,
@@ -88,7 +90,7 @@ async def process_transform(
         if not transform:
             continue
 
-        repo_node = await service.client.get(
+        repo_node = await client.get(
             kind=str(transform.repository.peer.typename),
             branch=branch_name,
             id=transform.repository.peer.id,
@@ -96,14 +98,14 @@ async def process_transform(
         )
 
         repo = await get_initialized_repo(
-            client=service.client,
+            client=client,
             repository_id=transform.repository.peer.id,
             name=transform.repository.peer.name.value,
             repository_kind=str(transform.repository.peer.typename),
             commit=repo_node.commit.value,
         )  # type: ignore[misc]
 
-        data = await service.client.query_gql_query(
+        data = await client.query_gql_query(
             name=transform.query.peer.name.value,
             branch_name=branch_name,
             variables={"id": object_id},
@@ -112,22 +114,17 @@ async def process_transform(
         )
 
         transformed_data = await repo.execute_python_transform.with_options(timeout_seconds=transform.timeout.value)(
+            client=client,
             branch_name=branch_name,
             commit=repo_node.commit.value,
             location=f"{transform.file_path.value}::{transform.class_name.value}",
             data=data,
-            client=service.client,
             convert_query_response=transform.convert_query_response.value,
         )  # type: ignore[misc]
 
-        await service.client.execute_graphql(
+        await client.execute_graphql(
             query=UPDATE_ATTRIBUTE,
-            variables={
-                "id": object_id,
-                "kind": node_kind,
-                "attribute": attribute_name,
-                "value": transformed_data,
-            },
+            variables={"id": object_id, "kind": node_kind, "attribute": attribute_name, "value": transformed_data},
             branch_name=branch_name,
         )
 
@@ -141,14 +138,13 @@ async def trigger_update_python_computed_attributes(
     computed_attribute_name: str,
     computed_attribute_kind: str,
     context: InfrahubContext,
-    service: InfrahubServices,
 ) -> None:
     await add_tags(branches=[branch_name])
 
-    nodes = await service.client.all(kind=computed_attribute_kind, branch=branch_name)
+    nodes = await get_client().all(kind=computed_attribute_kind, branch=branch_name)
 
     for node in nodes:
-        await service.workflow.submit_workflow(
+        await get_workflow().submit_workflow(
             workflow=COMPUTED_ATTRIBUTE_PROCESS_TRANSFORM,
             context=context,
             parameters={
@@ -172,9 +168,9 @@ async def computed_attribute_jinja2_update_value(
     node_kind: str,
     attribute_name: str,
     template: Jinja2Template,
-    service: InfrahubServices,
 ) -> None:
     log = get_run_logger()
+    client = get_client()
 
     await add_tags(branches=[branch_name], nodes=[obj.node_id], db_change=True)
 
@@ -183,14 +179,9 @@ async def computed_attribute_jinja2_update_value(
         log.debug(f"Ignoring to update {obj} with existing value on {attribute_name}={value}")
         return
 
-    await service.client.execute_graphql(
+    await client.execute_graphql(
         query=UPDATE_ATTRIBUTE,
-        variables={
-            "id": obj.node_id,
-            "kind": node_kind,
-            "attribute": attribute_name,
-            "value": value,
-        },
+        variables={"id": obj.node_id, "kind": node_kind, "attribute": attribute_name, "value": value},
         branch_name=branch_name,
     )
     log.info(f"Updating computed attribute {node_kind}.{attribute_name}='{value}' ({obj.node_id})")
@@ -207,10 +198,10 @@ async def process_jinja2(
     computed_attribute_name: str,
     computed_attribute_kind: str,
     context: InfrahubContext,  # noqa: ARG001
-    service: InfrahubServices,
     updated_fields: list[str] | None = None,
 ) -> None:
     log = get_run_logger()
+    client = get_client()
 
     await add_tags(branches=[branch_name])
     updates: list[str] = updated_fields or []
@@ -240,14 +231,14 @@ async def process_jinja2(
 
         for id_filter in computed_macro.node_filters:
             query = attribute_graphql.render_graphql_query(query_filter=id_filter, filter_id=object_id)
-            response = await service.client.execute_graphql(query=query, branch_name=branch_name)
+            response = await client.execute_graphql(query=query, branch_name=branch_name)
             output = attribute_graphql.parse_response(response=response)
             found.extend(output)
 
         if not found:
             log.debug("No nodes found that requires updates")
 
-        batch = await service.client.create_batch()
+        batch = await client.create_batch()
         for node in found:
             batch.add(
                 task=computed_attribute_jinja2_update_value,
@@ -256,7 +247,6 @@ async def process_jinja2(
                 node_kind=node_schema.kind,
                 attribute_name=computed_macro.attribute.name,
                 template=jinja_template,
-                service=service,
             )
 
         _ = [response async for _, response in batch.execute()]
@@ -271,15 +261,16 @@ async def trigger_update_jinja2_computed_attributes(
     computed_attribute_name: str,
     computed_attribute_kind: str,
     context: InfrahubContext,
-    service: InfrahubServices,
 ) -> None:
     await add_tags(branches=[branch_name])
 
+    client = get_client()
+
     # NOTE we only need the id of the nodes, we need to ooptimize the query here
-    nodes = await service.client.all(kind=computed_attribute_kind, branch=branch_name)
+    nodes = await client.all(kind=computed_attribute_kind, branch=branch_name)
 
     for node in nodes:
-        await service.workflow.submit_workflow(
+        await get_workflow().submit_workflow(
             workflow=COMPUTED_ATTRIBUTE_PROCESS_JINJA2,
             context=context,
             parameters={
@@ -295,13 +286,15 @@ async def trigger_update_jinja2_computed_attributes(
 
 @flow(name="computed-attribute-setup-jinja2", flow_run_name="Setup computed attributes in task-manager")
 async def computed_attribute_setup_jinja2(
-    service: InfrahubServices, context: InfrahubContext, branch_name: str | None = None, event_name: str | None = None
+    context: InfrahubContext, branch_name: str | None = None, event_name: str | None = None
 ) -> None:
-    async with service.database.start_session() as db:
+    database = await get_database()
+    async with database.start_session() as db:
         log = get_run_logger()
 
         if branch_name:
             await add_tags(branches=[branch_name])
+            service = await get_infrahub_services()
             await wait_for_schema_to_converge(branch_name=branch_name, component=service.component, db=db, log=log)
 
         report: TriggerSetupReport = await setup_triggers_specific(
@@ -335,19 +328,20 @@ async def computed_attribute_setup_jinja2(
     flow_run_name="Setup computed attributes for Python transforms in task-manager",
 )
 async def computed_attribute_setup_python(
-    service: InfrahubServices,
     context: InfrahubContext,
     branch_name: str | None = None,
     event_name: str | None = None,
     commit: str | None = None,  # noqa: ARG001
 ) -> None:
-    async with service.database.start_session() as db:
+    database = await get_database()
+    async with database.start_session() as db:
         log = get_run_logger()
 
         branch_name = branch_name or registry.default_branch
 
         if branch_name:
             await add_tags(branches=[branch_name])
+            service = await get_infrahub_services()
             await wait_for_schema_to_converge(branch_name=branch_name, component=service.component, db=db, log=log)
 
         triggers_python, triggers_python_query = await gather_trigger_computed_attribute_python(db=db)
@@ -378,7 +372,7 @@ async def computed_attribute_setup_python(
                     },
                 )
 
-        async with get_client(sync_client=False) as prefect_client:
+        async with get_prefect_client(sync_client=False) as prefect_client:
             await setup_triggers(
                 client=prefect_client,
                 triggers=triggers_python,
@@ -405,11 +399,10 @@ async def query_transform_targets(
     node_kind: str,  # noqa: ARG001
     object_id: str,
     context: InfrahubContext,
-    service: InfrahubServices,
 ) -> None:
     await add_tags(branches=[branch_name])
     schema_branch = registry.schema.get_schema_branch(name=branch_name)
-    targets = await service.client.execute_graphql(
+    targets = await get_client().execute_graphql(
         query=GATHER_GRAPHQL_QUERY_SUBSCRIBERS, variables={"members": [object_id]}, branch_name=branch_name
     )
 
@@ -425,7 +418,7 @@ async def query_transform_targets(
     for subscriber in subscribers:
         if subscriber.kind in nodes_with_computed_attributes:
             for computed_attribute in nodes_with_computed_attributes[subscriber.kind]:
-                await service.workflow.submit_workflow(
+                await get_workflow().submit_workflow(
                     workflow=COMPUTED_ATTRIBUTE_PROCESS_TRANSFORM,
                     context=context,
                     parameters={

--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -33,7 +33,7 @@ from infrahub.events.models import EventMeta, InfrahubEvent
 from infrahub.events.node_action import get_node_event
 from infrahub.exceptions import BranchNotFoundError, MergeFailedError, ValidationError
 from infrahub.graphql.mutations.models import BranchCreateModel  # noqa: TC001
-from infrahub.services import InfrahubServices  # noqa: TC001  needed for prefect flow
+from infrahub.workers.dependencies import get_infrahub_services
 from infrahub.workflows.catalogue import (
     BRANCH_CANCEL_PROPOSED_CHANGES,
     BRANCH_MERGE_POST_PROCESS,
@@ -48,7 +48,9 @@ from infrahub.workflows.utils import add_tags
 
 
 @flow(name="branch-rebase", flow_run_name="Rebase branch {branch}")
-async def rebase_branch(branch: str, context: InfrahubContext, service: InfrahubServices) -> None:  # noqa: PLR0915
+async def rebase_branch(branch: str, context: InfrahubContext) -> None:  # noqa: PLR0915
+    service = await get_infrahub_services()
+
     async with service.database.start_session() as db:
         log = get_run_logger()
         await add_tags(branches=[branch])
@@ -92,10 +94,7 @@ async def rebase_branch(branch: str, context: InfrahubContext, service: Infrahub
             constraints += await merger.calculate_validations(target_schema=candidate_schema)
         if constraints:
             responses = await schema_validate_migrations(
-                message=SchemaValidateMigrationData(
-                    branch=obj, schema_branch=candidate_schema, constraints=constraints
-                ),
-                service=service,
+                message=SchemaValidateMigrationData(branch=obj, schema_branch=candidate_schema, constraints=constraints)
             )
             error_messages = [violation.message for response in responses for violation in response.violations]
             if error_messages:
@@ -133,8 +132,7 @@ async def rebase_branch(branch: str, context: InfrahubContext, service: Infrahub
                         new_schema=candidate_schema,
                         previous_schema=schema_in_main_before,
                         migrations=migrations,
-                    ),
-                    service=service,
+                    )
                 )
                 for error in errors:
                     log.error(error)
@@ -192,9 +190,9 @@ async def rebase_branch(branch: str, context: InfrahubContext, service: Infrahub
 
 
 @flow(name="branch-merge", flow_run_name="Merge branch {branch} into main")
-async def merge_branch(
-    branch: str, context: InfrahubContext, service: InfrahubServices, proposed_change_id: str | None = None
-) -> None:
+async def merge_branch(branch: str, context: InfrahubContext, proposed_change_id: str | None = None) -> None:
+    service = await get_infrahub_services()
+
     async with service.database.start_session() as db:
         log = get_run_logger()
 
@@ -240,8 +238,7 @@ async def merge_branch(
                     new_schema=merger.destination_schema,
                     previous_schema=merger.initial_source_schema,
                     migrations=merger.migrations,
-                ),
-                service=service,
+                )
             )
             for error in errors:
                 log.error(error)
@@ -296,8 +293,10 @@ async def merge_branch(
 
 
 @flow(name="branch-delete", flow_run_name="Delete branch {branch}")
-async def delete_branch(branch: str, context: InfrahubContext, service: InfrahubServices) -> None:
+async def delete_branch(branch: str, context: InfrahubContext) -> None:
     await add_tags(branches=[branch])
+
+    service = await get_infrahub_services()
 
     async with service.database.start_session() as db:
         obj = await Branch.get_by_name(db=db, name=str(branch))
@@ -323,8 +322,10 @@ async def delete_branch(branch: str, context: InfrahubContext, service: Infrahub
     description="Validate if the branch has some conflicts",
     persist_result=True,
 )
-async def validate_branch(branch: str, service: InfrahubServices) -> State:
+async def validate_branch(branch: str) -> State:
     await add_tags(branches=[branch])
+
+    service = await get_infrahub_services()
 
     async with service.database.start_session() as db:
         obj = await Branch.get_by_name(db=db, name=branch)
@@ -340,8 +341,10 @@ async def validate_branch(branch: str, service: InfrahubServices) -> State:
 
 
 @flow(name="create-branch", flow_run_name="Create branch {model.name}")
-async def create_branch(model: BranchCreateModel, context: InfrahubContext, service: InfrahubServices) -> None:
+async def create_branch(model: BranchCreateModel, context: InfrahubContext) -> None:
     await add_tags(branches=[model.name])
+
+    service = await get_infrahub_services()
 
     async with service.database.start_session() as db:
         try:
@@ -414,9 +417,9 @@ async def _get_diff_root(
     name="branch-merge-post-process",
     flow_run_name="Run additional tasks after merging {source_branch} in {target_branch}",
 )
-async def post_process_branch_merge(
-    source_branch: str, target_branch: str, context: InfrahubContext, service: InfrahubServices
-) -> None:
+async def post_process_branch_merge(source_branch: str, target_branch: str, context: InfrahubContext) -> None:
+    service = await get_infrahub_services()
+
     async with service.database.start_session() as db:
         await add_tags(branches=[source_branch])
         log = get_run_logger()

--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -33,7 +33,7 @@ from infrahub.events.models import EventMeta, InfrahubEvent
 from infrahub.events.node_action import get_node_event
 from infrahub.exceptions import BranchNotFoundError, MergeFailedError, ValidationError
 from infrahub.graphql.mutations.models import BranchCreateModel  # noqa: TC001
-from infrahub.workers.dependencies import get_infrahub_services
+from infrahub.workers.dependencies import get_component, get_database, get_event_service, get_workflow
 from infrahub.workflows.catalogue import (
     BRANCH_CANCEL_PROPOSED_CHANGES,
     BRANCH_MERGE_POST_PROCESS,
@@ -49,9 +49,8 @@ from infrahub.workflows.utils import add_tags
 
 @flow(name="branch-rebase", flow_run_name="Rebase branch {branch}")
 async def rebase_branch(branch: str, context: InfrahubContext) -> None:  # noqa: PLR0915
-    service = await get_infrahub_services()
-
-    async with service.database.start_session() as db:
+    database = await get_database()
+    async with database.start_session() as db:
         log = get_run_logger()
         await add_tags(branches=[branch])
         obj = await Branch.get_by_name(db=db, name=branch)
@@ -67,7 +66,7 @@ async def rebase_branch(branch: str, context: InfrahubContext) -> None:  # noqa:
             diff_merger=diff_merger,
             diff_repository=diff_repository,
             source_branch=obj,
-            service=service,
+            workflow=get_workflow(),
         )
 
         enriched_diff_metadata = await diff_coordinator.update_branch_diff(base_branch=base_branch, diff_branch=obj)
@@ -154,13 +153,13 @@ async def rebase_branch(branch: str, context: InfrahubContext) -> None:  # noqa:
             target_branch_name=registry.default_branch,
         )
         if ipam_node_details:
-            await service.workflow.submit_workflow(
+            await get_workflow().submit_workflow(
                 workflow=IPAM_RECONCILIATION,
                 context=context,
                 parameters={"branch": obj.name, "ipam_node_details": ipam_node_details},
             )
 
-    await service.workflow.submit_workflow(
+    await get_workflow().submit_workflow(
         workflow=DIFF_REFRESH_ALL, context=context, parameters={"branch_name": obj.name}
     )
 
@@ -185,15 +184,15 @@ async def rebase_branch(branch: str, context: InfrahubContext) -> None:  # noqa:
         )
         events.append(mutate_event)
 
+    event_service = await get_event_service()
     for event in events:
-        await service.event.send(event)
+        await event_service.send(event)
 
 
 @flow(name="branch-merge", flow_run_name="Merge branch {branch} into main")
 async def merge_branch(branch: str, context: InfrahubContext, proposed_change_id: str | None = None) -> None:
-    service = await get_infrahub_services()
-
-    async with service.database.start_session() as db:
+    database = await get_database()
+    async with database.start_session() as db:
         log = get_run_logger()
 
         await add_tags(branches=[branch, registry.default_branch])
@@ -219,7 +218,7 @@ async def merge_branch(branch: str, context: InfrahubContext, proposed_change_id
                 diff_merger=diff_merger,
                 diff_repository=diff_repository,
                 source_branch=obj,
-                service=service,
+                workflow=get_workflow(),
             )
             try:
                 branch_diff = await merger.merge()
@@ -252,7 +251,7 @@ async def merge_branch(branch: str, context: InfrahubContext, proposed_change_id
             target_branch_name=registry.default_branch,
         )
         if ipam_node_details:
-            await service.workflow.submit_workflow(
+            await get_workflow().submit_workflow(
                 workflow=IPAM_RECONCILIATION,
                 context=context,
                 parameters={"branch": registry.default_branch, "ipam_node_details": ipam_node_details},
@@ -268,7 +267,7 @@ async def merge_branch(branch: str, context: InfrahubContext, proposed_change_id
         # NOTE: we still need to convert this event and potentially pull
         #   some tasks currently executed based on the event into this workflow
         # -------------------------------------------------------------
-        await service.workflow.submit_workflow(
+        await get_workflow().submit_workflow(
             workflow=BRANCH_MERGE_POST_PROCESS,
             context=context,
             parameters={"source_branch": obj.name, "target_branch": registry.default_branch},
@@ -288,17 +287,17 @@ async def merge_branch(branch: str, context: InfrahubContext, proposed_change_id
             )
             events.append(mutate_event)
 
+        event_service = await get_event_service()
         for event in events:
-            await service.event.send(event=event)
+            await event_service.send(event=event)
 
 
 @flow(name="branch-delete", flow_run_name="Delete branch {branch}")
 async def delete_branch(branch: str, context: InfrahubContext) -> None:
     await add_tags(branches=[branch])
 
-    service = await get_infrahub_services()
-
-    async with service.database.start_session() as db:
+    database = await get_database()
+    async with database.start_session() as db:
         obj = await Branch.get_by_name(db=db, name=str(branch))
         await obj.delete(db=db)
 
@@ -309,11 +308,12 @@ async def delete_branch(branch: str, context: InfrahubContext) -> None:
             meta=EventMeta.from_context(context=context, branch=registry.get_global_branch()),
         )
 
-        await service.workflow.submit_workflow(
+        await get_workflow().submit_workflow(
             workflow=BRANCH_CANCEL_PROPOSED_CHANGES, context=context, parameters={"branch_name": branch}
         )
 
-        await service.event.send(event=event)
+        event_service = await get_event_service()
+        await event_service.send(event=event)
 
 
 @flow(
@@ -325,9 +325,8 @@ async def delete_branch(branch: str, context: InfrahubContext) -> None:
 async def validate_branch(branch: str) -> State:
     await add_tags(branches=[branch])
 
-    service = await get_infrahub_services()
-
-    async with service.database.start_session() as db:
+    database = await get_database()
+    async with database.start_session() as db:
         obj = await Branch.get_by_name(db=db, name=branch)
 
         component_registry = get_component_registry()
@@ -344,9 +343,8 @@ async def validate_branch(branch: str) -> State:
 async def create_branch(model: BranchCreateModel, context: InfrahubContext) -> None:
     await add_tags(branches=[model.name])
 
-    service = await get_infrahub_services()
-
-    async with service.database.start_session() as db:
+    database = await get_database()
+    async with database.start_session() as db:
         try:
             await Branch.get_by_name(db=db, name=model.name)
             raise ValueError(f"The branch {model.name}, already exist")
@@ -372,7 +370,8 @@ async def create_branch(model: BranchCreateModel, context: InfrahubContext) -> N
 
             # Add Branch to registry
             registry.branch[obj.name] = obj
-            await service.component.refresh_schema_hash(branches=[obj.name])
+            component = await get_component()
+            await component.refresh_schema_hash(branches=[obj.name])
 
         event = BranchCreatedEvent(
             branch_name=obj.name,
@@ -380,10 +379,11 @@ async def create_branch(model: BranchCreateModel, context: InfrahubContext) -> N
             sync_with_git=obj.sync_with_git,
             meta=EventMeta.from_context(context=context, branch=registry.get_global_branch()),
         )
-        await service.event.send(event=event)
+        event_service = await get_event_service()
+        await event_service.send(event=event)
 
         if obj.sync_with_git:
-            await service.workflow.submit_workflow(
+            await get_workflow().submit_workflow(
                 workflow=GIT_REPOSITORIES_CREATE_BRANCH,
                 context=context,
                 parameters={"branch": obj.name, "branch_id": str(obj.uuid)},
@@ -418,9 +418,8 @@ async def _get_diff_root(
     flow_run_name="Run additional tasks after merging {source_branch} in {target_branch}",
 )
 async def post_process_branch_merge(source_branch: str, target_branch: str, context: InfrahubContext) -> None:
-    service = await get_infrahub_services()
-
-    async with service.database.start_session() as db:
+    database = await get_database()
+    async with database.start_session() as db:
         await add_tags(branches=[source_branch])
         log = get_run_logger()
         log.info(f"Running additional tasks after merging {source_branch} within {target_branch}")
@@ -431,13 +430,13 @@ async def post_process_branch_merge(source_branch: str, target_branch: str, cont
         # send diff update requests for every branch-tracking diff
         branch_diff_roots = await diff_repository.get_roots_metadata(base_branch_names=[target_branch])
 
-        await service.workflow.submit_workflow(
+        await get_workflow().submit_workflow(
             workflow=TRIGGER_ARTIFACT_DEFINITION_GENERATE,
             context=context,
             parameters={"branch": target_branch},
         )
 
-        await service.workflow.submit_workflow(
+        await get_workflow().submit_workflow(
             workflow=TRIGGER_GENERATOR_DEFINITION_RUN,
             context=context,
             parameters={"branch": target_branch},
@@ -450,6 +449,6 @@ async def post_process_branch_merge(source_branch: str, target_branch: str, cont
                 and isinstance(diff_root.tracking_id, BranchTrackingId)
             ):
                 request_diff_update_model = RequestDiffUpdate(branch_name=diff_root.diff_branch_name)
-                await service.workflow.submit_workflow(
+                await get_workflow().submit_workflow(
                     workflow=DIFF_UPDATE, context=context, parameters={"model": request_diff_update_model}
                 )

--- a/backend/infrahub/core/diff/tasks.py
+++ b/backend/infrahub/core/diff/tasks.py
@@ -9,7 +9,7 @@ from infrahub.core.diff.models import RequestDiffUpdate  # noqa: TC001  needed f
 from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.log import get_logger
-from infrahub.services import InfrahubServices  # noqa: TC001  needed for prefect flow
+from infrahub.workers.dependencies import get_database, get_workflow
 from infrahub.workflows.catalogue import DIFF_REFRESH
 from infrahub.workflows.utils import add_tags
 
@@ -17,10 +17,11 @@ log = get_logger()
 
 
 @flow(name="diff-update", flow_run_name="Update diff for branch {model.branch_name}")
-async def update_diff(model: RequestDiffUpdate, service: InfrahubServices) -> None:
+async def update_diff(model: RequestDiffUpdate) -> None:
     await add_tags(branches=[model.branch_name])
 
-    async with service.database.start_session(read_only=False) as db:
+    database = await get_database()
+    async with database.start_session(read_only=False) as db:
         component_registry = get_component_registry()
         base_branch = await registry.get_branch(db=db, branch=registry.default_branch)
         diff_branch = await registry.get_branch(db=db, branch=model.branch_name)
@@ -37,10 +38,11 @@ async def update_diff(model: RequestDiffUpdate, service: InfrahubServices) -> No
 
 
 @flow(name="diff-refresh", flow_run_name="Recreate diff for branch {branch_name}")
-async def refresh_diff(branch_name: str, diff_id: str, service: InfrahubServices) -> None:
+async def refresh_diff(branch_name: str, diff_id: str) -> None:
     await add_tags(branches=[branch_name])
 
-    async with service.database.start_session(read_only=False) as db:
+    database = await get_database()
+    async with database.start_session(read_only=False) as db:
         component_registry = get_component_registry()
         base_branch = await registry.get_branch(db=db, branch=registry.default_branch)
         diff_branch = await registry.get_branch(db=db, branch=branch_name)
@@ -50,10 +52,11 @@ async def refresh_diff(branch_name: str, diff_id: str, service: InfrahubServices
 
 
 @flow(name="diff-refresh-all", flow_run_name="Recreate all diffs for branch {branch_name}")
-async def refresh_diff_all(branch_name: str, context: InfrahubContext, service: InfrahubServices) -> None:
+async def refresh_diff_all(branch_name: str, context: InfrahubContext) -> None:
     await add_tags(branches=[branch_name])
 
-    async with service.database.start_session(read_only=True) as db:
+    database = await get_database()
+    async with database.start_session(read_only=False) as db:
         component_registry = get_component_registry()
         default_branch = registry.get_branch_from_registry()
         diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=default_branch)
@@ -61,7 +64,7 @@ async def refresh_diff_all(branch_name: str, context: InfrahubContext, service: 
 
         for diff_root in diff_roots_to_refresh:
             if diff_root.base_branch_name != diff_root.diff_branch_name:
-                await service.workflow.submit_workflow(
+                await get_workflow().submit_workflow(
                     workflow=DIFF_REFRESH,
                     context=context,
                     parameters={"branch_name": diff_root.diff_branch_name, "diff_id": diff_root.uuid},

--- a/backend/infrahub/core/ipam/tasks.py
+++ b/backend/infrahub/core/ipam/tasks.py
@@ -5,7 +5,7 @@ from prefect import flow
 
 from infrahub.core import registry
 from infrahub.core.ipam.reconciler import IpamReconciler
-from infrahub.services import InfrahubServices
+from infrahub.workers.dependencies import get_database
 from infrahub.workflows.utils import add_branch_tag
 
 from .model import IpamNodeDetails
@@ -20,8 +20,9 @@ if TYPE_CHECKING:
     description="Ensure the IPAM Tree is up to date",
     persist_result=False,
 )
-async def ipam_reconciliation(branch: str, ipam_node_details: list[IpamNodeDetails], service: InfrahubServices) -> None:
-    async with service.database.start_session() as db:
+async def ipam_reconciliation(branch: str, ipam_node_details: list[IpamNodeDetails]) -> None:
+    database = await get_database()
+    async with database.start_session() as db:
         branch_obj = await registry.get_branch(db=db, branch=branch)
 
         await add_branch_tag(branch_name=branch_obj.name)

--- a/backend/infrahub/core/merge.py
+++ b/backend/infrahub/core/merge.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from infrahub.core.schema.manager import SchemaDiff
     from infrahub.core.schema.schema_branch import SchemaBranch
     from infrahub.database import InfrahubDatabase
-    from infrahub.services import InfrahubServices
+    from infrahub.services.adapters.workflow import InfrahubWorkflow
 
 
 log = get_logger()
@@ -40,7 +40,7 @@ class BranchMerger:
         diff_merger: DiffMerger,
         diff_repository: DiffRepository,
         destination_branch: Branch | None = None,
-        service: InfrahubServices | None = None,
+        workflow: InfrahubWorkflow | None = None,
     ):
         self.source_branch = source_branch
         self.destination_branch: Branch = destination_branch or registry.get_branch_from_registry()
@@ -55,7 +55,7 @@ class BranchMerger:
         self._destination_schema: SchemaBranch | None = None
         self._initial_source_schema: SchemaBranch | None = None
 
-        self._service = service
+        self._workflow = workflow
 
     @property
     def source_schema(self) -> SchemaBranch:
@@ -78,10 +78,10 @@ class BranchMerger:
         raise ValueError("_initial_source_schema hasn't been initialized")
 
     @property
-    def service(self) -> InfrahubServices:
-        if not self._service:
-            raise ValueError("BranchMerger hasn't been initialized with a service object")
-        return self._service
+    def workflow(self) -> InfrahubWorkflow:
+        if not self._workflow:
+            raise ValueError("BranchMerger hasn't been initialized with a workflow object")
+        return self._workflow
 
     async def get_initial_source_branch(self) -> SchemaBranch:
         """Retrieve the schema of the source branch when the branch was created.
@@ -231,6 +231,4 @@ class BranchMerger:
                     destination_branch_id=str(self.destination_branch.get_uuid()),
                     default_branch=repo.default_branch.value,
                 )
-                await self.service.workflow.submit_workflow(
-                    workflow=GIT_REPOSITORIES_MERGE, parameters={"model": model}
-                )
+                await self.workflow.submit_workflow(workflow=GIT_REPOSITORIES_MERGE, parameters={"model": model})

--- a/backend/infrahub/core/migrations/schema/tasks.py
+++ b/backend/infrahub/core/migrations/schema/tasks.py
@@ -56,7 +56,7 @@ async def schema_apply_migrations(message: SchemaApplyMigrationData) -> list[str
             new_node_schema=new_node_schema,
             previous_node_schema=previous_node_schema,
             schema_path=migration.path,
-            database=get_database(),
+            database=await get_database(),
         )
 
     async for _, result in batch.execute():

--- a/backend/infrahub/core/migrations/schema/tasks.py
+++ b/backend/infrahub/core/migrations/schema/tasks.py
@@ -10,17 +10,18 @@ from prefect.logging import get_run_logger
 from infrahub.core.branch import Branch  # noqa: TC001
 from infrahub.core.migrations import MIGRATION_MAP
 from infrahub.core.path import SchemaPath  # noqa: TC001
-from infrahub.services import InfrahubServices  # noqa: TC001  needed for prefect flow
+from infrahub.workers.dependencies import get_database
 from infrahub.workflows.utils import add_branch_tag
 
 from .models import SchemaApplyMigrationData, SchemaMigrationPathResponseData
 
 if TYPE_CHECKING:
     from infrahub.core.schema import MainSchemaTypes
+    from infrahub.database import InfrahubDatabase
 
 
 @flow(name="schema_apply_migrations", flow_run_name="Apply schema migrations", persist_result=True)
-async def schema_apply_migrations(message: SchemaApplyMigrationData, service: InfrahubServices) -> list[str]:
+async def schema_apply_migrations(message: SchemaApplyMigrationData) -> list[str]:
     await add_branch_tag(branch_name=message.branch.name)
     log = get_run_logger()
 
@@ -55,7 +56,7 @@ async def schema_apply_migrations(message: SchemaApplyMigrationData, service: In
             new_node_schema=new_node_schema,
             previous_node_schema=previous_node_schema,
             schema_path=migration.path,
-            service=service,
+            database=get_database(),
         )
 
     async for _, result in batch.execute():
@@ -75,13 +76,13 @@ async def schema_path_migrate(
     branch: Branch,
     migration_name: str,
     schema_path: SchemaPath,
-    service: InfrahubServices,
+    database: InfrahubDatabase,
     new_node_schema: MainSchemaTypes | None = None,
     previous_node_schema: MainSchemaTypes | None = None,
 ) -> SchemaMigrationPathResponseData:
     log = get_run_logger()
 
-    async with service.database.start_session() as db:
+    async with database.start_session() as db:
         node_kind = None
         if new_node_schema:
             node_kind = new_node_schema.kind

--- a/backend/infrahub/core/validators/checks_runner.py
+++ b/backend/infrahub/core/validators/checks_runner.py
@@ -6,7 +6,7 @@ from infrahub_sdk.protocols import CoreValidator
 from infrahub.context import InfrahubContext
 from infrahub.core.constants import ValidatorConclusion, ValidatorState
 from infrahub.core.timestamp import Timestamp
-from infrahub.services import InfrahubServices
+from infrahub.services.adapters.event import InfrahubEventService
 from infrahub.validators.events import send_failed_validator, send_passed_validator
 
 
@@ -14,7 +14,7 @@ async def run_checks_and_update_validator(
     checks: list[Coroutine[Any, None, ValidatorConclusion]],
     validator: CoreValidator,
     context: InfrahubContext,
-    service: InfrahubServices,
+    event_service: InfrahubEventService,
     proposed_change_id: str,
 ) -> None:
     """
@@ -38,7 +38,7 @@ async def run_checks_and_update_validator(
             failed_early = True
             await validator.save()
             await send_failed_validator(
-                service=service, validator=validator, proposed_change_id=proposed_change_id, context=context
+                event_service=event_service, validator=validator, proposed_change_id=proposed_change_id, context=context
             )
             # Continue to iterate to wait for the end of all checks
 
@@ -52,9 +52,9 @@ async def run_checks_and_update_validator(
     if not failed_early:
         if validator.conclusion.value == ValidatorConclusion.SUCCESS.value:
             await send_passed_validator(
-                service=service, validator=validator, proposed_change_id=proposed_change_id, context=context
+                event_service=event_service, validator=validator, proposed_change_id=proposed_change_id, context=context
             )
         else:
             await send_failed_validator(
-                service=service, validator=validator, proposed_change_id=proposed_change_id, context=context
+                event_service=event_service, validator=validator, proposed_change_id=proposed_change_id, context=context
             )

--- a/backend/infrahub/core/validators/tasks.py
+++ b/backend/infrahub/core/validators/tasks.py
@@ -15,19 +15,18 @@ from infrahub.core.validators.model import (
     SchemaConstraintValidatorRequest,
 )
 from infrahub.dependencies.registry import get_component_registry
-from infrahub.services import InfrahubServices  # noqa: TC001  needed for prefect flow
+from infrahub.workers.dependencies import get_database
 from infrahub.workflows.utils import add_tags
 
 from .models.validate_migration import SchemaValidateMigrationData, SchemaValidatorPathResponseData
 
 if TYPE_CHECKING:
     from infrahub.core.schema.schema_branch import SchemaBranch
+    from infrahub.database import InfrahubDatabase
 
 
 @flow(name="schema_validate_migrations", flow_run_name="Validate schema migrations", persist_result=True)
-async def schema_validate_migrations(
-    message: SchemaValidateMigrationData, service: InfrahubServices
-) -> list[SchemaValidatorPathResponseData]:
+async def schema_validate_migrations(message: SchemaValidateMigrationData) -> list[SchemaValidatorPathResponseData]:
     batch = InfrahubBatch(return_exceptions=True)
     log = get_run_logger()
     await add_tags(branches=[message.branch.name])
@@ -49,7 +48,7 @@ async def schema_validate_migrations(
             node_schema=schema,
             schema_path=constraint.path,
             schema_branch=message.schema_branch,
-            service=service,
+            database=await get_database(),
         )
 
     results = [result async for _, result in batch.execute()]
@@ -69,9 +68,9 @@ async def schema_path_validate(
     node_schema: NodeSchema | GenericSchema,
     schema_path: SchemaPath,
     schema_branch: SchemaBranch,
-    service: InfrahubServices,
+    database: InfrahubDatabase,
 ) -> SchemaValidatorPathResponseData:
-    async with service.database.start_session(read_only=True) as db:
+    async with database.start_session(read_only=False) as db:
         constraint_request = SchemaConstraintValidatorRequest(
             branch=branch,
             constraint_name=constraint_name,

--- a/backend/infrahub/generators/tasks.py
+++ b/backend/infrahub/generators/tasks.py
@@ -21,23 +21,27 @@ from infrahub.generators.models import (
 )
 from infrahub.git.base import extract_repo_file_information
 from infrahub.git.repository import get_initialized_repo
-from infrahub.services import InfrahubServices  # noqa: TC001 needed for prefect flow
+from infrahub.workers.dependencies import get_client, get_workflow
 from infrahub.workflows.catalogue import REQUEST_GENERATOR_DEFINITION_RUN, REQUEST_GENERATOR_RUN
 from infrahub.workflows.utils import add_tags
 
 if TYPE_CHECKING:
     from collections.abc import Coroutine
 
+    from infrahub_sdk.client import InfrahubClient
+
 
 @flow(
     name="generator-run",
     flow_run_name="Run generator {model.generator_definition.definition_name}",
 )
-async def run_generator(model: RequestGeneratorRun, service: InfrahubServices) -> None:
+async def run_generator(model: RequestGeneratorRun) -> None:
     await add_tags(branches=[model.branch_name], nodes=[model.target_id])
 
+    client = get_client()
+
     repository = await get_initialized_repo(
-        client=service.client,
+        client=client,
         repository_id=model.repository_id,
         name=model.repository_name,
         repository_kind=model.repository_kind,
@@ -60,7 +64,7 @@ async def run_generator(model: RequestGeneratorRun, service: InfrahubServices) -
         repo_directory=repository.directory_root,
         worktree_directory=commit_worktree.directory,
     )
-    generator_instance = await _define_instance(model=model, service=service)
+    generator_instance = await _define_instance(model=model, client=client)
 
     try:
         generator_class = generator_definition.load_class(
@@ -69,7 +73,7 @@ async def run_generator(model: RequestGeneratorRun, service: InfrahubServices) -
 
         generator = generator_class(
             query=generator_definition.query,
-            client=service.client,
+            client=client,
             branch=model.branch_name,
             params=model.variables,
             generator_instance=generator_instance.id,
@@ -87,11 +91,9 @@ async def run_generator(model: RequestGeneratorRun, service: InfrahubServices) -
 
 
 @task(name="generator-define-instance", task_run_name="Define Instance", cache_policy=NONE)  # type: ignore[arg-type]
-async def _define_instance(model: RequestGeneratorRun, service: InfrahubServices) -> CoreGeneratorInstance:
+async def _define_instance(model: RequestGeneratorRun, client: InfrahubClient) -> CoreGeneratorInstance:
     if model.generator_instance:
-        instance = await service.client.get(
-            kind=CoreGeneratorInstance, id=model.generator_instance, branch=model.branch_name
-        )
+        instance = await client.get(kind=CoreGeneratorInstance, id=model.generator_instance, branch=model.branch_name)
         instance.status.value = GeneratorInstanceStatus.PENDING.value
         await instance.update(do_full_update=True)
 
@@ -99,7 +101,7 @@ async def _define_instance(model: RequestGeneratorRun, service: InfrahubServices
         async with lock.registry.get(
             f"{model.target_id}-{model.generator_definition.definition_id}", namespace="generator"
         ):
-            instances = await service.client.filters(
+            instances = await client.filters(
                 kind=CoreGeneratorInstance,
                 definition__ids=[model.generator_definition.definition_id],
                 object__ids=[model.target_id],
@@ -110,7 +112,7 @@ async def _define_instance(model: RequestGeneratorRun, service: InfrahubServices
                 instance.status.value = GeneratorInstanceStatus.PENDING.value
                 await instance.update(do_full_update=True)
             else:
-                instance = await service.client.create(
+                instance = await client.create(
                     kind=CoreGeneratorInstance,
                     branch=model.branch_name,
                     data={
@@ -125,10 +127,10 @@ async def _define_instance(model: RequestGeneratorRun, service: InfrahubServices
 
 
 @flow(name="generator-definition-run", flow_run_name="Run all generators")
-async def run_generator_definition(branch: str, context: InfrahubContext, service: InfrahubServices) -> None:
+async def run_generator_definition(branch: str, context: InfrahubContext) -> None:
     await add_tags(branches=[branch])
 
-    generators = await service.client.filters(
+    generators = await get_client().filters(
         kind=InfrahubKind.GENERATORDEFINITION, prefetch_relationships=True, populate_store=True, branch=branch
     )
 
@@ -150,7 +152,7 @@ async def run_generator_definition(branch: str, context: InfrahubContext, servic
 
     for generator_definition in generator_definitions:
         model = RequestGeneratorDefinitionRun(branch=branch, generator_definition=generator_definition)
-        await service.workflow.submit_workflow(
+        await get_workflow().submit_workflow(
             workflow=REQUEST_GENERATOR_DEFINITION_RUN, context=context, parameters={"model": model}
         )
 
@@ -160,11 +162,13 @@ async def run_generator_definition(branch: str, context: InfrahubContext, servic
     flow_run_name="Execute generator {model.generator_definition.definition_name}",
 )
 async def request_generator_definition_run(
-    model: RequestGeneratorDefinitionRun, context: InfrahubContext, service: InfrahubServices
+    model: RequestGeneratorDefinitionRun, context: InfrahubContext
 ) -> State[Any]:
     await add_tags(branches=[model.branch], nodes=[model.generator_definition.definition_id])
 
-    group = await service.client.get(
+    client = get_client()
+
+    group = await client.get(
         kind=InfrahubKind.GENERICGROUP,
         prefetch_relationships=True,
         populate_store=True,
@@ -173,7 +177,7 @@ async def request_generator_definition_run(
     )
     await group.members.fetch()
 
-    existing_instances = await service.client.filters(
+    existing_instances = await client.filters(
         kind=InfrahubKind.GENERATORINSTANCE,
         definition__ids=[model.generator_definition.definition_id],
         include=["object"],
@@ -183,14 +187,14 @@ async def request_generator_definition_run(
     for instance in existing_instances:
         instance_by_member[instance.object.peer.id] = instance.id
 
-    repository = await service.client.get(
+    repository = await client.get(
         kind=InfrahubKind.REPOSITORY,
         branch=model.branch,
         id=model.generator_definition.repository_id,
         raise_when_missing=False,
     )
     if not repository:
-        repository = await service.client.get(
+        repository = await client.get(
             kind=InfrahubKind.READONLYREPOSITORY,
             branch=model.branch,
             id=model.generator_definition.repository_id,
@@ -219,7 +223,7 @@ async def request_generator_definition_run(
             target_name=member.display_label,
         )
         tasks.append(
-            service.workflow.execute_workflow(
+            get_workflow().execute_workflow(
                 workflow=REQUEST_GENERATOR_RUN, context=context, parameters={"model": request_generator_run_model}
             )
         )

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -234,6 +234,22 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
             )
         )
 
+    @task(name="import-data-from-files", task_run_name="Import data from files", cache_policy=NONE)  # type: ignore[arg-type]
+    async def import_data_from_files(
+        self, branch_name: str, commit: str, config_file: InfrahubRepositoryConfig
+    ) -> None:
+        log = get_run_logger()
+        log.info(f"Found {len(config_file.object_data)} object data files in the repository")
+
+        processed = 0
+        for object_file in config_file.object_data:
+            # 1. Load data from file
+            # 2. Create object from data inside the given branch
+            # 3. Store the commit in a metadata attribute
+            processed += 1
+
+        log.info(f"Processed {processed} object data files out of {len(config_file.object_data)}")
+
     @task(name="import-jinja2-tansforms", task_run_name="Import Jinja2 transform", cache_policy=NONE)  # type: ignore[arg-type]
     async def import_jinja2_transforms(
         self,

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -234,22 +234,6 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
             )
         )
 
-    @task(name="import-data-from-files", task_run_name="Import data from files", cache_policy=NONE)  # type: ignore[arg-type]
-    async def import_data_from_files(
-        self, branch_name: str, commit: str, config_file: InfrahubRepositoryConfig
-    ) -> None:
-        log = get_run_logger()
-        log.info(f"Found {len(config_file.object_data)} object data files in the repository")
-
-        processed = 0
-        for object_file in config_file.object_data:
-            # 1. Load data from file
-            # 2. Create object from data inside the given branch
-            # 3. Store the commit in a metadata attribute
-            processed += 1
-
-        log.info(f"Processed {processed} object data files out of {len(config_file.object_data)}")
-
     @task(name="import-jinja2-tansforms", task_run_name="Import Jinja2 transform", cache_policy=NONE)  # type: ignore[arg-type]
     async def import_jinja2_transforms(
         self,

--- a/backend/infrahub/git/repository.py
+++ b/backend/infrahub/git/repository.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any
 from git.exc import BadName, GitCommandError
 from infrahub_sdk.exceptions import GraphQLError
 from prefect import task
+from prefect.cache_policies import NONE
 from pydantic import Field
 
 from infrahub.core.constants import InfrahubKind, RepositoryInternalStatus
@@ -250,6 +251,7 @@ class InfrahubReadOnlyRepository(InfrahubRepositoryIntegrator):
 @task(
     name="Fetch repository commit",
     description="Retrieve a git repository at a given commit, if it does not already exist locally",
+    cache_policy=NONE,
 )
 async def get_initialized_repo(
     client: InfrahubClient, repository_id: str, name: str, repository_kind: str, commit: str | None = None

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -26,7 +26,7 @@ from infrahub.workers.dependencies import get_client, get_database, get_event_se
 
 from ..core.timestamp import Timestamp
 from ..core.validators.checks_runner import run_checks_and_update_validator
-from ..log import get_log_data
+from ..log import get_log_data, get_logger
 from ..tasks.artifact import define_artifact
 from ..workflows.catalogue import (
     GIT_REPOSITORY_MERGE_CONFLICTS_CHECKS_RUN,
@@ -182,7 +182,7 @@ async def sync_remote_repositories() -> None:
                     default_branch_name=repository_data.repository.default_branch.value,
                 )
             except RepositoryError as exc:
-                log.error(str(exc))
+                get_logger().error(str(exc))
                 init_failed = True
 
             if init_failed:
@@ -548,7 +548,7 @@ async def trigger_repository_user_checks_definitions(model: UserCheckDefinitionD
             and existing_validator.check_definition.id == model.check_definition_id
         ):
             previous_validator = existing_validator
-            log.info("Found the same validator {previous_validator}")
+            get_logger().info("Found the same validator", validator=previous_validator)
 
     validator = await start_validator(
         client=client,

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -15,14 +15,15 @@ from prefect.logging import get_run_logger
 from infrahub import lock
 from infrahub.context import InfrahubContext
 from infrahub.core.constants import InfrahubKind, RepositoryInternalStatus, ValidatorConclusion
+from infrahub.core.manager import NodeManager
 from infrahub.core.registry import registry
 from infrahub.exceptions import CheckError, RepositoryError
 from infrahub.message_bus import Meta, messages
-from infrahub.services import InfrahubServices
+from infrahub.services.adapters.message_bus import InfrahubMessageBus
 from infrahub.validators.tasks import start_validator
 from infrahub.worker import WORKER_IDENTITY
+from infrahub.workers.dependencies import get_client, get_database, get_event_service, get_message_bus, get_workflow
 
-from ..core.manager import NodeManager
 from ..core.timestamp import Timestamp
 from ..core.validators.checks_runner import run_checks_and_update_validator
 from ..log import get_log_data
@@ -58,7 +59,7 @@ from .repository import InfrahubReadOnlyRepository, InfrahubRepository, get_init
     name="git-repository-add-read-write",
     flow_run_name="Adding repository {model.repository_name} in branch {model.infrahub_branch_name}",
 )
-async def add_git_repository(model: GitRepositoryAdd, service: InfrahubServices) -> None:
+async def add_git_repository(model: GitRepositoryAdd) -> None:
     await add_tags(branches=[model.infrahub_branch_name], nodes=[model.repository_id])
 
     async with lock.registry.get(name=model.repository_name, namespace="repository"):
@@ -66,7 +67,7 @@ async def add_git_repository(model: GitRepositoryAdd, service: InfrahubServices)
             id=model.repository_id,
             name=model.repository_name,
             location=model.location,
-            client=service.client,
+            client=get_client(),
             infrahub_branch_name=model.infrahub_branch_name,
             internal_status=model.internal_status,
             default_branch_name=model.default_branch_name,
@@ -87,14 +88,15 @@ async def add_git_repository(model: GitRepositoryAdd, service: InfrahubServices)
                 infrahub_branch_name=model.infrahub_branch_name,
                 infrahub_branch_id=model.infrahub_branch_id,
             )
-            await service.message_bus.send(message=notification)
+            message_bus = await get_message_bus()
+            await message_bus.send(message=notification)
 
 
 @flow(
     name="git-repository-add-read-only",
     flow_run_name="Adding read only repository {model.repository_name} in branch {model.infrahub_branch_name}",
 )
-async def add_git_repository_read_only(model: GitRepositoryAddReadOnly, service: InfrahubServices) -> None:
+async def add_git_repository_read_only(model: GitRepositoryAddReadOnly) -> None:
     await add_tags(branches=[model.infrahub_branch_name], nodes=[model.repository_id])
 
     async with lock.registry.get(name=model.repository_name, namespace="repository"):
@@ -102,7 +104,7 @@ async def add_git_repository_read_only(model: GitRepositoryAddReadOnly, service:
             id=model.repository_id,
             name=model.repository_name,
             location=model.location,
-            client=service.client,
+            client=get_client(),
             ref=model.ref,
             infrahub_branch_name=model.infrahub_branch_name,
         )
@@ -120,25 +122,29 @@ async def add_git_repository_read_only(model: GitRepositoryAddReadOnly, service:
                 infrahub_branch_name=model.infrahub_branch_name,
                 infrahub_branch_id=model.infrahub_branch_id,
             )
-            await service.message_bus.send(message=notification)
+            message_bus = await get_message_bus()
+            await message_bus.send(message=notification)
 
 
 @flow(name="git-repositories-create-branch", flow_run_name="Create branch '{branch}' in Git Repositories")
-async def create_branch(branch: str, branch_id: str, service: InfrahubServices) -> None:
+async def create_branch(branch: str, branch_id: str) -> None:
     """Request to the creation of git branches in available repositories."""
     await add_tags(branches=[branch])
-    repositories: list[CoreRepository] = await service.client.filters(kind=CoreRepository)
-    batch = await service.client.create_batch()
+
+    client = get_client()
+
+    repositories: list[CoreRepository] = await client.filters(kind=CoreRepository)
+    batch = await client.create_batch()
     for repository in repositories:
         batch.add(
             task=git_branch_create,
-            client=service.client.client,
+            client=client,
             branch=branch,
             branch_id=branch_id,
             repository_name=repository.name.value,
             repository_id=repository.id,
             repository_location=repository.location.value,
-            service=service,
+            message_bus=await get_message_bus(),
         )
 
     async for _, _ in batch.execute():
@@ -146,11 +152,13 @@ async def create_branch(branch: str, branch_id: str, service: InfrahubServices) 
 
 
 @flow(name="git_repositories_sync", flow_run_name="Sync Git Repositories")
-async def sync_remote_repositories(service: InfrahubServices) -> None:
+async def sync_remote_repositories() -> None:
     log = get_run_logger()
 
-    branches = await service.client.branch.all()
-    repositories = await service.client.get_list_repositories(branches=branches, kind=InfrahubKind.REPOSITORY)
+    client = get_client()
+
+    branches = await client.branch.all()
+    repositories = await client.get_list_repositories(branches=branches, kind=InfrahubKind.REPOSITORY)
 
     for repo_name, repository_data in repositories.items():
         active_internal_status = RepositoryInternalStatus.ACTIVE.value
@@ -169,12 +177,12 @@ async def sync_remote_repositories(service: InfrahubServices) -> None:
                     id=repository_data.repository.id,
                     name=repository_data.repository.name.value,
                     location=repository_data.repository.location.value,
-                    client=service.client,
+                    client=client,
                     internal_status=active_internal_status,
                     default_branch_name=repository_data.repository.default_branch.value,
                 )
             except RepositoryError as exc:
-                service.log.error(str(exc))
+                log.error(str(exc))
                 init_failed = True
 
             if init_failed:
@@ -183,7 +191,7 @@ async def sync_remote_repositories(service: InfrahubServices) -> None:
                         id=repository_data.repository.id,
                         name=repository_data.repository.name.value,
                         location=repository_data.repository.location.value,
-                        client=service.client,
+                        client=client,
                         internal_status=active_internal_status,
                         default_branch_name=repository_data.repository.default_branch.value,
                     )
@@ -206,7 +214,8 @@ async def sync_remote_repositories(service: InfrahubServices) -> None:
                     infrahub_branch_name=infrahub_branch,
                     infrahub_branch_id=branches[infrahub_branch].id,
                 )
-                await service.message_bus.send(message=message)
+                message_bus = await get_message_bus()
+                await message_bus.send(message=message)
             except RepositoryError as exc:
                 log.info(exc.message)
 
@@ -223,7 +232,7 @@ async def git_branch_create(
     repository_id: str,
     repository_name: str,
     repository_location: str,
-    service: InfrahubServices,
+    message_bus: InfrahubMessageBus,
 ) -> None:
     log = get_run_logger()
     repo = await InfrahubRepository.init(
@@ -243,15 +252,15 @@ async def git_branch_create(
             infrahub_branch_name=branch,
             infrahub_branch_id=branch_id,
         )
-        await service.message_bus.send(message=message)
+        await message_bus.send(message=message)
         log.debug("Sent message to all workers to fetch the latest version of the repository (RefreshGitFetch)")
 
 
 @flow(name="artifact-definition-generate", flow_run_name="Generate all artifacts")
-async def generate_artifact_definition(branch: str, context: InfrahubContext, service: InfrahubServices) -> None:
+async def generate_artifact_definition(branch: str, context: InfrahubContext) -> None:
     await add_branch_tag(branch_name=branch)
 
-    artifact_definitions = await service.client.all(kind=CoreArtifactDefinition, branch=branch, include=["id"])
+    artifact_definitions = await get_client().all(kind=CoreArtifactDefinition, branch=branch, include=["id"])
 
     for artifact_definition in artifact_definitions:
         model = RequestArtifactDefinitionGenerate(
@@ -259,24 +268,24 @@ async def generate_artifact_definition(branch: str, context: InfrahubContext, se
             artifact_definition_id=artifact_definition.id,
             artifact_definition_name=artifact_definition.name.value,
         )
-        await service.workflow.submit_workflow(
+        await get_workflow().submit_workflow(
             workflow=REQUEST_ARTIFACT_DEFINITION_GENERATE, context=context, parameters={"model": model}
         )
 
 
 @flow(name="artifact-generate", flow_run_name="Generate artifact {model.artifact_name}")
-async def generate_artifact(model: RequestArtifactGenerate, service: InfrahubServices) -> None:
+async def generate_artifact(model: RequestArtifactGenerate) -> None:
     await add_tags(branches=[model.branch_name], nodes=[model.target_id])
     log = get_run_logger()
     repo = await get_initialized_repo(
-        client=service.client,
+        client=get_client(),
         repository_id=model.repository_id,
         name=model.repository_name,
         repository_kind=model.repository_kind,
         commit=model.commit,
     )
 
-    artifact, artifact_created = await define_artifact(model=model, service=service)
+    artifact, artifact_created = await define_artifact(model=model)
 
     try:
         result = await repo.render_artifact(artifact=artifact, artifact_created=artifact_created, message=model)
@@ -295,11 +304,13 @@ async def generate_artifact(model: RequestArtifactGenerate, service: InfrahubSer
     flow_run_name="Trigger Generation of Artifacts for {model.artifact_definition_name}",
 )
 async def generate_request_artifact_definition(
-    model: RequestArtifactDefinitionGenerate, context: InfrahubContext, service: InfrahubServices
+    model: RequestArtifactDefinitionGenerate, context: InfrahubContext
 ) -> None:
     await add_tags(branches=[model.branch])
 
-    artifact_definition = await service.client.get(
+    client = get_client()
+
+    artifact_definition = await client.get(
         kind=CoreArtifactDefinition, id=model.artifact_definition_id, branch=model.branch
     )
 
@@ -308,7 +319,7 @@ async def generate_request_artifact_definition(
     await group.members.fetch()
     current_members = [member.id for member in group.members.peers]
 
-    existing_artifacts = await service.client.filters(
+    existing_artifacts = await client.filters(
         kind=CoreArtifact,
         definition__ids=[model.artifact_definition_id],
         include=["object"],
@@ -328,9 +339,9 @@ async def generate_request_artifact_definition(
     await transform.query.fetch()
     query = transform.query.peer
     repository = transformation_repository.peer
-    branch = await service.client.branch.get(branch_name=model.branch)
+    branch = await client.branch.get(branch_name=model.branch)
     if branch.sync_with_git:
-        repository = await service.client.get(
+        repository = await client.get(
             kind=InfrahubKind.GENERICREPOSITORY, id=repository.id, branch=model.branch, fragment=True
         )
     transform_location = ""
@@ -370,13 +381,13 @@ async def generate_request_artifact_definition(
             context=context,
         )
 
-        await service.workflow.submit_workflow(
+        await get_workflow().submit_workflow(
             workflow=REQUEST_ARTIFACT_GENERATE, context=context, parameters={"model": request_artifact_generate_model}
         )
 
 
 @flow(name="git-repository-pull-read-only", flow_run_name="Pull latest commit on {model.repository_name}")
-async def pull_read_only(model: GitRepositoryPullReadOnly, service: InfrahubServices) -> None:
+async def pull_read_only(model: GitRepositoryPullReadOnly) -> None:
     await add_tags(branches=[model.infrahub_branch_name], nodes=[model.repository_id])
     log = get_run_logger()
 
@@ -390,7 +401,7 @@ async def pull_read_only(model: GitRepositoryPullReadOnly, service: InfrahubServ
                 id=model.repository_id,
                 name=model.repository_name,
                 location=model.location,
-                client=service.client,
+                client=get_client(),
                 ref=model.ref,
                 infrahub_branch_name=model.infrahub_branch_name,
             )
@@ -402,7 +413,7 @@ async def pull_read_only(model: GitRepositoryPullReadOnly, service: InfrahubServ
                 id=model.repository_id,
                 name=model.repository_name,
                 location=model.location,
-                client=service.client,
+                client=get_client(),
                 ref=model.ref,
                 infrahub_branch_name=model.infrahub_branch_name,
             )
@@ -420,28 +431,28 @@ async def pull_read_only(model: GitRepositoryPullReadOnly, service: InfrahubServ
             infrahub_branch_name=model.infrahub_branch_name,
             infrahub_branch_id=model.infrahub_branch_id,
         )
-        await service.message_bus.send(message=message)
+        message_bus = await get_message_bus()
+        await message_bus.send(message=message)
 
 
 @flow(
     name="git-repository-merge",
     flow_run_name="Merge {model.source_branch} > {model.destination_branch} in git repository",
 )
-async def merge_git_repository(model: GitRepositoryMerge, service: InfrahubServices) -> None:
+async def merge_git_repository(model: GitRepositoryMerge) -> None:
     await add_tags(branches=[model.source_branch, model.destination_branch], nodes=[model.repository_id])
 
+    client = get_client()
+
     repo = await InfrahubRepository.init(
-        id=model.repository_id,
-        name=model.repository_name,
-        client=service.client,
-        default_branch_name=model.default_branch,
+        id=model.repository_id, name=model.repository_name, client=client, default_branch_name=model.default_branch
     )
 
     if model.internal_status == RepositoryInternalStatus.STAGING.value:
-        repo_source = await service.client.get(
+        repo_source = await client.get(
             kind=InfrahubKind.GENERICREPOSITORY, id=model.repository_id, branch=model.source_branch
         )
-        repo_main = await service.client.get(kind=InfrahubKind.GENERICREPOSITORY, id=model.repository_id)
+        repo_main = await client.get(kind=InfrahubKind.GENERICREPOSITORY, id=model.repository_id)
         repo_main.internal_status.value = RepositoryInternalStatus.ACTIVE.value
         repo_main.sync_status.value = repo_source.sync_status.value
 
@@ -463,14 +474,18 @@ async def merge_git_repository(model: GitRepositoryMerge, service: InfrahubServi
                     infrahub_branch_name=model.destination_branch,
                     infrahub_branch_id=model.destination_branch_id,
                 )
-                await service.message_bus.send(message=message)
+                message_bus = await get_message_bus()
+                await message_bus.send(message=message)
 
 
 @flow(name="git-repository-import-object", flow_run_name="Import objects from git repository")
-async def import_objects_from_git_repository(model: GitRepositoryImportObjects, service: InfrahubServices) -> None:
+async def import_objects_from_git_repository(model: GitRepositoryImportObjects) -> None:
     await add_branch_tag(model.infrahub_branch_name)
+
+    client = get_client()
+
     repo = await get_initialized_repo(
-        client=service.client,
+        client=client,
         repository_id=model.repository_id,
         name=model.repository_name,
         repository_kind=model.repository_kind,
@@ -484,11 +499,9 @@ async def import_objects_from_git_repository(model: GitRepositoryImportObjects, 
     flow_run_name="Collecting modifications between commits {model.first_commit} and {model.second_commit}",
     persist_result=True,
 )
-async def git_repository_diff_names_only(
-    model: GitDiffNamesOnly, service: InfrahubServices
-) -> GitDiffNamesOnlyResponse:
+async def git_repository_diff_names_only(model: GitDiffNamesOnly) -> GitDiffNamesOnlyResponse:
     repo = await get_initialized_repo(
-        client=service.client,
+        client=get_client(),
         repository_id=model.repository_id,
         name=model.repository_name,
         repository_kind=model.repository_kind,
@@ -513,16 +526,14 @@ async def git_repository_diff_names_only(
     name="git-repository-user-checks-definition-trigger",
     flow_run_name="Trigger user defined checks for repository {model.repository_name}",
 )
-async def trigger_repository_user_checks_definitions(
-    model: UserCheckDefinitionData, context: InfrahubContext, service: InfrahubServices
-) -> None:
+async def trigger_repository_user_checks_definitions(model: UserCheckDefinitionData, context: InfrahubContext) -> None:
     await add_tags(branches=[model.branch_name], nodes=[model.proposed_change])
-    log = get_run_logger()
 
-    definition = await service.client.get(
-        kind=CoreCheckDefinition, id=model.check_definition_id, branch=model.branch_name
-    )
-    proposed_change = await service.client.get(kind=InfrahubKind.PROPOSEDCHANGE, id=model.proposed_change)
+    log = get_run_logger()
+    client = get_client()
+
+    definition = await client.get(kind=CoreCheckDefinition, id=model.check_definition_id, branch=model.branch_name)
+    proposed_change = await client.get(kind=InfrahubKind.PROPOSEDCHANGE, id=model.proposed_change)
     validator_execution_id = str(UUIDT())
     check_execution_ids: list[str] = []
     await proposed_change.validations.fetch()
@@ -537,10 +548,10 @@ async def trigger_repository_user_checks_definitions(
             and existing_validator.check_definition.id == model.check_definition_id
         ):
             previous_validator = existing_validator
-            service.log.info("Found the same validator", validator=previous_validator)
+            log.info("Found the same validator {previous_validator}")
 
     validator = await start_validator(
-        service=service,
+        client=client,
         validator=previous_validator,
         validator_type=CoreUserValidator,
         proposed_change=model.proposed_change,
@@ -606,18 +617,20 @@ async def trigger_repository_user_checks_definitions(
     checks_in_execution = ",".join(check_execution_ids)
     log.info(f"Checks in execution {checks_in_execution}")
 
+    workflow = get_workflow()
     checks_coroutines = [
-        service.workflow.execute_workflow(
+        workflow.execute_workflow(
             workflow=GIT_REPOSITORY_USER_CHECK_RUN, parameters={"model": model}, expected_return=ValidatorConclusion
         )
         for model in check_models
     ]
 
+    event_service = await get_event_service()
     await run_checks_and_update_validator(
+        event_service=event_service,
         checks=checks_coroutines,
         validator=validator,
         context=context,
-        service=service,
         proposed_change_id=model.proposed_change,
     )
 
@@ -626,19 +639,19 @@ async def trigger_repository_user_checks_definitions(
     name="git-repository-trigger-user-checks",
     flow_run_name="Evaluating user-defined checks on repository {model.repository_name}",
 )
-async def trigger_user_checks(
-    model: TriggerRepositoryUserChecks, service: InfrahubServices, context: InfrahubContext
-) -> None:
+async def trigger_user_checks(model: TriggerRepositoryUserChecks, context: InfrahubContext) -> None:
     """Request to start validation checks on a specific repository for User-defined checks."""
-
     await add_tags(branches=[model.source_branch], nodes=[model.proposed_change])
-    log = get_run_logger()
 
-    repository = await service.client.get(
+    log = get_run_logger()
+    client = get_client()
+
+    repository = await client.get(
         kind=InfrahubKind.GENERICREPOSITORY, id=model.repository_id, branch=model.source_branch, fragment=True
     )
     await repository.checks.fetch()
 
+    workflow = get_workflow()
     for relationship in repository.checks.peers:
         log.info("Adding check for user defined check")
         check_definition = relationship.peer
@@ -653,7 +666,7 @@ async def trigger_user_checks(
             proposed_change=model.proposed_change,
             branch_diff=model.branch_diff,
         )
-        await service.workflow.submit_workflow(
+        await workflow.submit_workflow(
             workflow=GIT_REPOSITORY_USER_CHECKS_DEFINITIONS_TRIGGER,
             context=context,
             parameters={"model": user_check_definition_model},
@@ -664,17 +677,15 @@ async def trigger_user_checks(
     name="git-repository-trigger-internal-checks",
     flow_run_name="Running repository checks for repository {model.repository}",
 )
-async def trigger_internal_checks(
-    model: TriggerRepositoryInternalChecks, service: InfrahubServices, context: InfrahubContext
-) -> None:
+async def trigger_internal_checks(model: TriggerRepositoryInternalChecks, context: InfrahubContext) -> None:
     """Request to start validation checks on a specific repository."""
     await add_tags(branches=[model.source_branch], nodes=[model.proposed_change])
-    log = get_run_logger()
 
-    repository = await service.client.get(
-        kind=InfrahubKind.GENERICREPOSITORY, id=model.repository, branch=model.source_branch
-    )
-    proposed_change = await service.client.get(kind=InfrahubKind.PROPOSEDCHANGE, id=model.proposed_change)
+    log = get_run_logger()
+    client = get_client()
+
+    repository = await client.get(kind=InfrahubKind.GENERICREPOSITORY, id=model.repository, branch=model.source_branch)
+    proposed_change = await client.get(kind=InfrahubKind.PROPOSEDCHANGE, id=model.proposed_change)
 
     validator_execution_id = str(UUIDT())
     check_execution_ids: list[str] = []
@@ -693,14 +704,11 @@ async def trigger_internal_checks(
             previous_validator = existing_validator
 
     validator = await start_validator(
-        service=service,
+        client=client,
         validator=previous_validator,
         validator_type=CoreRepositoryValidator,
         proposed_change=model.proposed_change,
-        data={
-            "label": validator_name,
-            "repository": model.repository,
-        },
+        data={"label": validator_name, "repository": model.repository},
         context=context,
     )
 
@@ -720,17 +728,19 @@ async def trigger_internal_checks(
         source_branch=model.source_branch,
         target_branch=model.target_branch,
     )
-    check_coroutine = service.workflow.execute_workflow(
+
+    check_coroutine = get_workflow().execute_workflow(
         workflow=GIT_REPOSITORY_MERGE_CONFLICTS_CHECKS_RUN,
         parameters={"model": check_merge_conflict_model},
         expected_return=ValidatorConclusion,
     )
 
+    event_service = await get_event_service()
     await run_checks_and_update_validator(
+        event_service=event_service,
         checks=[check_coroutine],
         validator=validator,
         context=context,
-        service=service,
         proposed_change_id=model.proposed_change,
     )
 
@@ -739,18 +749,18 @@ async def trigger_internal_checks(
     name="git-repository-check-merge-conflict",
     flow_run_name="Check for merge conflicts between {model.source_branch} and {model.target_branch}",
 )
-async def run_check_merge_conflicts(
-    model: CheckRepositoryMergeConflicts, service: InfrahubServices
-) -> ValidatorConclusion:
+async def run_check_merge_conflicts(model: CheckRepositoryMergeConflicts) -> ValidatorConclusion:
     """Runs a check to see if there are merge conflicts between two branches."""
     await add_tags(branches=[model.source_branch], nodes=[model.proposed_change])
 
+    client = get_client()
+
     success_condition = "-"
-    validator = await service.client.get(kind=InfrahubKind.REPOSITORYVALIDATOR, id=model.validator_id)
+    validator = await client.get(kind=InfrahubKind.REPOSITORYVALIDATOR, id=model.validator_id)
     await validator.checks.fetch()
 
     repo = await get_initialized_repo(
-        client=service.client,
+        client=client,
         repository_id=model.repository_id,
         name=model.repository_name,
         repository_kind=InfrahubKind.REPOSITORY,
@@ -777,7 +787,7 @@ async def run_check_merge_conflicts(
                 await existing_checks[conflict_key].save()
                 existing_checks.pop(conflict_key)
             else:
-                check = await service.client.create(
+                check = await client.create(
                     kind=InfrahubKind.FILECHECK,
                     data={
                         "name": conflict,
@@ -800,7 +810,7 @@ async def run_check_merge_conflicts(
 
     else:
         validator_conclusion = ValidatorConclusion.SUCCESS
-        check = await service.client.create(
+        check = await client.create(
             kind=InfrahubKind.FILECHECK,
             data={
                 "name": "Merge Conflict Check",
@@ -814,22 +824,25 @@ async def run_check_merge_conflicts(
         )
         await check.save()
 
-    async with service.database.start_session() as db:
+    database = await get_database()
+    async with database.start_session() as db:
         await NodeManager.delete(db=db, nodes=list(existing_checks.values()))
 
     return validator_conclusion
 
 
 @flow(name="git-repository-run-user-check", flow_run_name="Execute user defined Check '{model.name}'")
-async def run_user_check(model: UserCheckData, service: InfrahubServices) -> ValidatorConclusion:
+async def run_user_check(model: UserCheckData) -> ValidatorConclusion:
     await add_tags(branches=[model.branch_name], nodes=[model.proposed_change])
-    log = get_run_logger()
 
-    validator = await service.client.get(kind=InfrahubKind.USERVALIDATOR, id=model.validator_id)
+    log = get_run_logger()
+    client = get_client()
+
+    validator = await client.get(kind=InfrahubKind.USERVALIDATOR, id=model.validator_id)
     await validator.checks.fetch()
 
     repo = await get_initialized_repo(
-        client=service.client,
+        client=client,
         repository_id=model.repository_id,
         name=model.repository_name,
         repository_kind=InfrahubKind.REPOSITORY,
@@ -842,7 +855,7 @@ async def run_user_check(model: UserCheckData, service: InfrahubServices) -> Val
             branch_name=model.branch_name,
             location=model.file_path,
             class_name=model.class_name,
-            client=service.client,
+            client=client,
             commit=model.commit,
             params=model.variables,
         )  # type: ignore[misc]
@@ -877,7 +890,7 @@ async def run_user_check(model: UserCheckData, service: InfrahubServices) -> Val
         check.severity.value = severity
         await check.save()
     else:
-        check = await service.client.create(
+        check = await client.create(
             kind=InfrahubKind.STANDARDCHECK,
             data={
                 "name": model.name,

--- a/backend/infrahub/graphql/mutations/tasks.py
+++ b/backend/infrahub/graphql/mutations/tasks.py
@@ -14,14 +14,16 @@ from infrahub.core.validators.models.validate_migration import SchemaValidateMig
 from infrahub.core.validators.tasks import schema_validate_migrations
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.exceptions import ValidationError
-from infrahub.services import InfrahubServices  # noqa: TC001  needed for prefect flow
+from infrahub.workers.dependencies import get_infrahub_services
 from infrahub.workflows.catalogue import BRANCH_MERGE
 from infrahub.workflows.utils import add_tags
 
 
 @flow(name="merge-branch-mutation", flow_run_name="Merge branch graphQL mutation")
-async def merge_branch_mutation(branch: str, context: InfrahubContext, service: InfrahubServices) -> None:
+async def merge_branch_mutation(branch: str, context: InfrahubContext) -> None:
     await add_tags(branches=[branch])
+
+    service = await get_infrahub_services()
 
     async with service.database.start_session() as db:
         obj = await Branch.get_by_name(db=db, name=branch)
@@ -60,10 +62,7 @@ async def merge_branch_mutation(branch: str, context: InfrahubContext, service: 
 
         if constraints:
             responses = await schema_validate_migrations(
-                message=SchemaValidateMigrationData(
-                    branch=obj, schema_branch=candidate_schema, constraints=constraints
-                ),
-                service=service,
+                message=SchemaValidateMigrationData(branch=obj, schema_branch=candidate_schema, constraints=constraints)
             )
             error_messages = [violation.message for response in responses for violation in response.violations]
             if error_messages:

--- a/backend/infrahub/graphql/mutations/tasks.py
+++ b/backend/infrahub/graphql/mutations/tasks.py
@@ -14,7 +14,7 @@ from infrahub.core.validators.models.validate_migration import SchemaValidateMig
 from infrahub.core.validators.tasks import schema_validate_migrations
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.exceptions import ValidationError
-from infrahub.workers.dependencies import get_infrahub_services
+from infrahub.workers.dependencies import get_database, get_workflow
 from infrahub.workflows.catalogue import BRANCH_MERGE
 from infrahub.workflows.utils import add_tags
 
@@ -23,9 +23,8 @@ from infrahub.workflows.utils import add_tags
 async def merge_branch_mutation(branch: str, context: InfrahubContext) -> None:
     await add_tags(branches=[branch])
 
-    service = await get_infrahub_services()
-
-    async with service.database.start_session() as db:
+    database = await get_database()
+    async with database.start_session() as db:
         obj = await Branch.get_by_name(db=db, name=branch)
         base_branch = await Branch.get_by_name(db=db, name=registry.default_branch)
 
@@ -52,7 +51,7 @@ async def merge_branch_mutation(branch: str, context: InfrahubContext) -> None:
             diff_merger=diff_merger,
             diff_repository=diff_repository,
             source_branch=obj,
-            service=service,
+            workflow=get_workflow(),
         )
         candidate_schema = merger.get_candidate_schema()
         determiner = ConstraintValidatorDeterminer(schema_branch=candidate_schema)
@@ -68,4 +67,4 @@ async def merge_branch_mutation(branch: str, context: InfrahubContext) -> None:
             if error_messages:
                 raise ValidationError(",\n".join(error_messages))
 
-        await service.workflow.execute_workflow(workflow=BRANCH_MERGE, context=context, parameters={"branch": obj.name})
+        await get_workflow().execute_workflow(workflow=BRANCH_MERGE, context=context, parameters={"branch": obj.name})

--- a/backend/infrahub/groups/tasks.py
+++ b/backend/infrahub/groups/tasks.py
@@ -4,13 +4,15 @@ from prefect import flow
 
 from infrahub.core.constants import InfrahubKind
 from infrahub.groups.models import RequestGraphQLQueryGroupUpdate
-from infrahub.services import InfrahubServices
+from infrahub.workers.dependencies import get_client
 from infrahub.workflows.utils import add_tags
 
 
 @flow(name="graphql-query-group-update", flow_run_name="Update GraphQLQuery Group '{model.query_name}'")
-async def update_graphql_query_group(model: RequestGraphQLQueryGroupUpdate, service: InfrahubServices) -> None:
+async def update_graphql_query_group(model: RequestGraphQLQueryGroupUpdate) -> None:
     """Create or Update a GraphQLQueryGroup."""
+
+    client = get_client()
 
     # If there is only one subscriber, associate the task to it
     # If there are more than one, for now we can't associate all of them
@@ -23,7 +25,7 @@ async def update_graphql_query_group(model: RequestGraphQLQueryGroupUpdate, serv
     params_hash = dict_hash(model.params)
     group_name = f"{model.query_name}__{params_hash}"
     group_label = f"Query {model.query_name} Hash({params_hash[:8]})"
-    group = await service.client.create(
+    group = await client.create(
         kind=InfrahubKind.GRAPHQLQUERYGROUP,
         branch=model.branch,
         name=group_name,
@@ -36,6 +38,4 @@ async def update_graphql_query_group(model: RequestGraphQLQueryGroupUpdate, serv
     await group.save(allow_upsert=True)
 
     if model.subscribers:
-        await group_add_subscriber(
-            client=service.client, group=group, subscribers=model.subscribers, branch=model.branch
-        )
+        await group_add_subscriber(client=client, group=group, subscribers=model.subscribers, branch=model.branch)

--- a/backend/infrahub/message_bus/operations/__init__.py
+++ b/backend/infrahub/message_bus/operations/__init__.py
@@ -6,7 +6,7 @@ from infrahub.message_bus.operations import git, refresh, send
 from infrahub.message_bus.types import MessageTTL
 from infrahub.services.adapters.message_bus import InfrahubMessageBus
 from infrahub.tasks.check import set_check_status
-from infrahub.workers.dependencies import get_infrahub_services
+from infrahub.workers.dependencies import get_log
 
 COMMAND_MAP = {
     "git.file.get": git.file.get,
@@ -35,8 +35,7 @@ async def execute_message(
             await message_bus.reply_if_initiator_meta(message=response, initiator=message)
             return None
         if message.reached_max_retries:
-            service = await get_infrahub_services()
-            service.log.exception("Message failed after maximum number of retries", error=exc)
+            get_log().exception("Message failed after maximum number of retries", error=exc)
             await set_check_status(message, conclusion="failure")
             return None
         message.increase_retry_count()

--- a/backend/infrahub/message_bus/operations/__init__.py
+++ b/backend/infrahub/message_bus/operations/__init__.py
@@ -1,12 +1,12 @@
 import ujson
 from prefect import Flow
 
+from infrahub.log import get_logger
 from infrahub.message_bus import RPCErrorResponse, messages
 from infrahub.message_bus.operations import git, refresh, send
 from infrahub.message_bus.types import MessageTTL
 from infrahub.services.adapters.message_bus import InfrahubMessageBus
 from infrahub.tasks.check import set_check_status
-from infrahub.workers.dependencies import get_log
 
 COMMAND_MAP = {
     "git.file.get": git.file.get,
@@ -35,7 +35,7 @@ async def execute_message(
             await message_bus.reply_if_initiator_meta(message=response, initiator=message)
             return None
         if message.reached_max_retries:
-            get_log().exception("Message failed after maximum number of retries", error=exc)
+            get_logger().exception("Message failed after maximum number of retries", error=exc)
             await set_check_status(message, conclusion="failure")
             return None
         message.increase_retry_count()

--- a/backend/infrahub/message_bus/operations/__init__.py
+++ b/backend/infrahub/message_bus/operations/__init__.py
@@ -2,14 +2,11 @@ import ujson
 from prefect import Flow
 
 from infrahub.message_bus import RPCErrorResponse, messages
-from infrahub.message_bus.operations import (
-    git,
-    refresh,
-    send,
-)
+from infrahub.message_bus.operations import git, refresh, send
 from infrahub.message_bus.types import MessageTTL
-from infrahub.services import InfrahubServices
+from infrahub.services.adapters.message_bus import InfrahubMessageBus
 from infrahub.tasks.check import set_check_status
+from infrahub.workers.dependencies import get_infrahub_services
 
 COMMAND_MAP = {
     "git.file.get": git.file.get,
@@ -22,7 +19,7 @@ COMMAND_MAP = {
 
 
 async def execute_message(
-    routing_key: str, message_body: bytes, service: InfrahubServices, skip_flow: bool = False
+    routing_key: str, message_body: bytes, message_bus: InfrahubMessageBus, skip_flow: bool = False
 ) -> MessageTTL | None:
     message_data = ujson.loads(message_body)
     message = messages.MESSAGE_MAP[routing_key](**message_data)
@@ -31,16 +28,17 @@ async def execute_message(
         func = COMMAND_MAP[routing_key]
         if skip_flow and isinstance(func, Flow):
             func = func.fn
-        await func(message=message, service=service)
+        await func(message=message)
     except Exception as exc:
         if message.reply_requested:
             response = RPCErrorResponse(errors=[str(exc)], initial_message=message.model_dump())
-            await service.message_bus.reply_if_initiator_meta(message=response, initiator=message)
+            await message_bus.reply_if_initiator_meta(message=response, initiator=message)
             return None
         if message.reached_max_retries:
+            service = await get_infrahub_services()
             service.log.exception("Message failed after maximum number of retries", error=exc)
-            await set_check_status(message, conclusion="failure", service=service)
+            await set_check_status(message, conclusion="failure")
             return None
         message.increase_retry_count()
-        await service.message_bus.send(message, delay=MessageTTL.FIVE, is_retry=True)
+        await message_bus.send(message, delay=MessageTTL.FIVE, is_retry=True)
         return MessageTTL.FIVE

--- a/backend/infrahub/message_bus/operations/git/file.py
+++ b/backend/infrahub/message_bus/operations/git/file.py
@@ -6,29 +6,30 @@ from infrahub.message_bus.messages.git_file_get import (
     GitFileGetResponse,
     GitFileGetResponseData,
 )
-from infrahub.services import InfrahubServices
+from infrahub.workers.dependencies import get_client, get_message_bus
 
 log = get_logger()
 
 
-async def get(message: messages.GitFileGet, service: InfrahubServices) -> None:
+async def get(message: messages.GitFileGet) -> None:
     log.info("Collecting file from repository", repository=message.repository_name, file=message.file)
 
     repo = await get_initialized_repo(
-        client=service.client,
+        client=get_client(),
         repository_id=message.repository_id,
         name=message.repository_name,
         repository_kind=message.repository_kind,
         commit=message.commit,
     )
 
+    message_bus = await get_message_bus()
     try:
         content = await repo.get_file(commit=message.commit, location=message.file)
     except (FileOutOfRepositoryError, RepositoryFileNotFoundError) as e:
         if message.reply_requested:
             response = GitFileGetResponse(data=GitFileGetResponseData(error_message=e.message, http_code=e.HTTP_CODE))
-            await service.message_bus.reply_if_initiator_meta(message=response, initiator=message)
+            await message_bus.reply_if_initiator_meta(message=response, initiator=message)
     else:
         if message.reply_requested:
             response = GitFileGetResponse(data=GitFileGetResponseData(content=content))
-            await service.message_bus.reply_if_initiator_meta(message=response, initiator=message)
+            await message_bus.reply_if_initiator_meta(message=response, initiator=message)

--- a/backend/infrahub/message_bus/operations/git/repository.py
+++ b/backend/infrahub/message_bus/operations/git/repository.py
@@ -8,14 +8,14 @@ from infrahub.message_bus.messages.git_repository_connectivity import (
     GitRepositoryConnectivityResponse,
     GitRepositoryConnectivityResponseData,
 )
-from infrahub.services import InfrahubServices
 from infrahub.worker import WORKER_IDENTITY
+from infrahub.workers.dependencies import get_client, get_message_bus
 
 log = get_logger()
 
 
 @flow(name="git-repository-check-connectivity", flow_run_name="Check connectivity for {message.repository_name}")
-async def connectivity(message: messages.GitRepositoryConnectivity, service: InfrahubServices) -> None:
+async def connectivity(message: messages.GitRepositoryConnectivity) -> None:
     response_data = GitRepositoryConnectivityResponseData(message="Successfully accessed repository", success=True)
 
     try:
@@ -28,17 +28,18 @@ async def connectivity(message: messages.GitRepositoryConnectivity, service: Inf
         response = GitRepositoryConnectivityResponse(
             data=response_data,
         )
-        await service.message_bus.reply_if_initiator_meta(message=response, initiator=message)
+        message_bus = await get_message_bus()
+        await message_bus.reply_if_initiator_meta(message=response, initiator=message)
 
 
 @flow(name="refresh-git-fetch", flow_run_name="Fetch git repository {message.repository_name} on " + WORKER_IDENTITY)
-async def fetch(message: messages.RefreshGitFetch, service: InfrahubServices) -> None:
+async def fetch(message: messages.RefreshGitFetch) -> None:
     if message.meta and message.meta.initiator_id == WORKER_IDENTITY:
         log.info("Ignoring git fetch request originating from self", worker=WORKER_IDENTITY)
         return
 
     repo = await get_initialized_repo(
-        client=service.client,
+        client=get_client(),
         repository_id=message.repository_id,
         name=message.repository_name,
         repository_kind=message.repository_kind,

--- a/backend/infrahub/message_bus/operations/refresh/registry.py
+++ b/backend/infrahub/message_bus/operations/refresh/registry.py
@@ -8,7 +8,7 @@ from infrahub.workers.dependencies import get_component, get_database, get_log
 
 async def branches(message: messages.RefreshRegistryBranches) -> None:
     if message.meta and message.meta.initiator_id == WORKER_IDENTITY:
-        get_log().log.info("Ignoring refresh registry refresh request originating from self", worker=WORKER_IDENTITY)
+        get_log().info("Ignoring refresh registry refresh request originating from self", worker=WORKER_IDENTITY)
         return
 
     database = await get_database()

--- a/backend/infrahub/message_bus/operations/refresh/registry.py
+++ b/backend/infrahub/message_bus/operations/refresh/registry.py
@@ -3,34 +3,31 @@ from infrahub.core.registry import registry
 from infrahub.message_bus import messages
 from infrahub.tasks.registry import refresh_branches
 from infrahub.worker import WORKER_IDENTITY
-from infrahub.workers.dependencies import get_database, get_infrahub_services
+from infrahub.workers.dependencies import get_component, get_database, get_log
 
 
 async def branches(message: messages.RefreshRegistryBranches) -> None:
-    service = await get_infrahub_services()
-
     if message.meta and message.meta.initiator_id == WORKER_IDENTITY:
-        service.log.info("Ignoring refresh registry refresh request originating from self", worker=WORKER_IDENTITY)
+        get_log().log.info("Ignoring refresh registry refresh request originating from self", worker=WORKER_IDENTITY)
         return
 
     database = await get_database()
     async with database.start_session(read_only=False) as db:
         await refresh_branches(db=db)
 
-    await service.component.refresh_schema_hash()
+    component = await get_component()
+    await component.refresh_schema_hash()
 
 
 async def rebased_branch(message: messages.RefreshRegistryRebasedBranch) -> None:
-    service = await get_infrahub_services()
-
     if message.meta and message.meta.initiator_id == WORKER_IDENTITY:
-        service.log.info(
+        get_log().info(
             "Ignoring refresh registry refreshed branch for request originating from self", worker=WORKER_IDENTITY
         )
         return
 
     async with lock.registry.local_schema_lock():
-        service.log.info("Refreshing rebased branch")
+        get_log().info("Refreshing rebased branch")
 
         database = await get_database()
         async with database.start_session(read_only=True) as db:

--- a/backend/infrahub/message_bus/operations/refresh/registry.py
+++ b/backend/infrahub/message_bus/operations/refresh/registry.py
@@ -1,14 +1,15 @@
 from infrahub import lock
 from infrahub.core.registry import registry
+from infrahub.log import get_logger
 from infrahub.message_bus import messages
 from infrahub.tasks.registry import refresh_branches
 from infrahub.worker import WORKER_IDENTITY
-from infrahub.workers.dependencies import get_component, get_database, get_log
+from infrahub.workers.dependencies import get_component, get_database
 
 
 async def branches(message: messages.RefreshRegistryBranches) -> None:
     if message.meta and message.meta.initiator_id == WORKER_IDENTITY:
-        get_log().info("Ignoring refresh registry refresh request originating from self", worker=WORKER_IDENTITY)
+        get_logger().info("Ignoring refresh registry refresh request originating from self", worker=WORKER_IDENTITY)
         return
 
     database = await get_database()
@@ -21,13 +22,13 @@ async def branches(message: messages.RefreshRegistryBranches) -> None:
 
 async def rebased_branch(message: messages.RefreshRegistryRebasedBranch) -> None:
     if message.meta and message.meta.initiator_id == WORKER_IDENTITY:
-        get_log().info(
+        get_logger().info(
             "Ignoring refresh registry refreshed branch for request originating from self", worker=WORKER_IDENTITY
         )
         return
 
     async with lock.registry.local_schema_lock():
-        get_log().info("Refreshing rebased branch")
+        get_logger().info("Refreshing rebased branch")
 
         database = await get_database()
         async with database.start_session(read_only=True) as db:

--- a/backend/infrahub/message_bus/operations/refresh/registry.py
+++ b/backend/infrahub/message_bus/operations/refresh/registry.py
@@ -1,23 +1,28 @@
 from infrahub import lock
 from infrahub.core.registry import registry
 from infrahub.message_bus import messages
-from infrahub.services import InfrahubServices
 from infrahub.tasks.registry import refresh_branches
 from infrahub.worker import WORKER_IDENTITY
+from infrahub.workers.dependencies import get_database, get_infrahub_services
 
 
-async def branches(message: messages.RefreshRegistryBranches, service: InfrahubServices) -> None:
+async def branches(message: messages.RefreshRegistryBranches) -> None:
+    service = await get_infrahub_services()
+
     if message.meta and message.meta.initiator_id == WORKER_IDENTITY:
         service.log.info("Ignoring refresh registry refresh request originating from self", worker=WORKER_IDENTITY)
         return
 
-    async with service.database.start_session(read_only=True) as db:
+    database = await get_database()
+    async with database.start_session(read_only=False) as db:
         await refresh_branches(db=db)
 
     await service.component.refresh_schema_hash()
 
 
-async def rebased_branch(message: messages.RefreshRegistryRebasedBranch, service: InfrahubServices) -> None:
+async def rebased_branch(message: messages.RefreshRegistryRebasedBranch) -> None:
+    service = await get_infrahub_services()
+
     if message.meta and message.meta.initiator_id == WORKER_IDENTITY:
         service.log.info(
             "Ignoring refresh registry refreshed branch for request originating from self", worker=WORKER_IDENTITY
@@ -27,5 +32,6 @@ async def rebased_branch(message: messages.RefreshRegistryRebasedBranch, service
     async with lock.registry.local_schema_lock():
         service.log.info("Refreshing rebased branch")
 
-        async with service.database.start_session(read_only=True) as db:
+        database = await get_database()
+        async with database.start_session(read_only=True) as db:
             registry.branch[message.branch] = await registry.branch_object.get_by_name(name=message.branch, db=db)

--- a/backend/infrahub/message_bus/operations/send/echo.py
+++ b/backend/infrahub/message_bus/operations/send/echo.py
@@ -1,13 +1,14 @@
 from prefect import flow
 
+from infrahub.log import get_logger
 from infrahub.message_bus import messages
 from infrahub.message_bus.messages.send_echo_request import SendEchoRequestResponse, SendEchoRequestResponseData
-from infrahub.workers.dependencies import get_log, get_message_bus
+from infrahub.workers.dependencies import get_message_bus
 
 
 @flow(name="echo-request")
 async def request(message: messages.SendEchoRequest) -> None:
-    get_log().info(f"Received message: {message.message}")
+    get_logger().info(f"Received message: {message.message}")
 
     if message.reply_requested:
         response = SendEchoRequestResponse(data=SendEchoRequestResponseData(response=f"Reply to: {message.message}"))

--- a/backend/infrahub/message_bus/operations/send/echo.py
+++ b/backend/infrahub/message_bus/operations/send/echo.py
@@ -2,12 +2,15 @@ from prefect import flow
 
 from infrahub.message_bus import messages
 from infrahub.message_bus.messages.send_echo_request import SendEchoRequestResponse, SendEchoRequestResponseData
-from infrahub.services import InfrahubServices
+from infrahub.workers.dependencies import get_infrahub_services, get_message_bus
 
 
 @flow(name="echo-request")
-async def request(message: messages.SendEchoRequest, service: InfrahubServices) -> None:
+async def request(message: messages.SendEchoRequest) -> None:
+    service = await get_infrahub_services()
     service.log.info(f"Received message: {message.message}")
+
     if message.reply_requested:
         response = SendEchoRequestResponse(data=SendEchoRequestResponseData(response=f"Reply to: {message.message}"))
-        await service.message_bus.reply_if_initiator_meta(message=response, initiator=message)
+        message_bus = await get_message_bus()
+        await message_bus.reply_if_initiator_meta(message=response, initiator=message)

--- a/backend/infrahub/message_bus/operations/send/echo.py
+++ b/backend/infrahub/message_bus/operations/send/echo.py
@@ -2,13 +2,12 @@ from prefect import flow
 
 from infrahub.message_bus import messages
 from infrahub.message_bus.messages.send_echo_request import SendEchoRequestResponse, SendEchoRequestResponseData
-from infrahub.workers.dependencies import get_infrahub_services, get_message_bus
+from infrahub.workers.dependencies import get_log, get_message_bus
 
 
 @flow(name="echo-request")
 async def request(message: messages.SendEchoRequest) -> None:
-    service = await get_infrahub_services()
-    service.log.info(f"Received message: {message.message}")
+    get_log().info(f"Received message: {message.message}")
 
     if message.reply_requested:
         response = SendEchoRequestResponse(data=SendEchoRequestResponseData(response=f"Reply to: {message.message}"))

--- a/backend/infrahub/proposed_change/branch_diff.py
+++ b/backend/infrahub/proposed_change/branch_diff.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, cast
 
 from infrahub.exceptions import ResourceNotFoundError
 from infrahub.message_bus.types import KVTTL
+from infrahub.workers.dependencies import get_cache
 
 if TYPE_CHECKING:
     from uuid import UUID
@@ -54,7 +55,8 @@ async def set_diff_summary_cache(pipeline_id: UUID, diff_summary: list[NodeDiff]
     )
 
 
-async def get_diff_summary_cache(pipeline_id: UUID, cache: InfrahubCache) -> list[NodeDiff]:
+async def get_diff_summary_cache(pipeline_id: UUID) -> list[NodeDiff]:
+    cache = await get_cache()
     summary_payload = await cache.get(
         key=f"proposed_change:pipeline:pipeline_id:{pipeline_id}:diff_summary",
     )

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -1013,7 +1013,9 @@ async def run_proposed_change_pipeline(model: RequestProposedChangePipeline, con
     diff_summary = await client.get_diff_summary(branch=model.source_branch)
     await set_diff_summary_cache(pipeline_id=model.pipeline_id, diff_summary=diff_summary, cache=await get_cache())
     branch_diff = ProposedChangeBranchDiff(pipeline_id=model.pipeline_id, repositories=repositories)
-    await _populate_subscribers(branch_diff=branch_diff, diff_summary=diff_summary, branch=model.source_branch)
+    await _populate_subscribers(
+        branch_diff=branch_diff, diff_summary=diff_summary, branch=model.source_branch, client=client
+    )
 
     if model.check_type is CheckType.ARTIFACT:
         request_refresh_artifact_model = RequestProposedChangeRefreshArtifacts(

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -1005,7 +1005,7 @@ async def run_proposed_change_pipeline(model: RequestProposedChangePipeline, con
         diff_coordinator = await component_registry.get_component(DiffCoordinator, db=dbt, branch=source_branch)
         await diff_coordinator.update_branch_diff(base_branch=destination_branch, diff_branch=source_branch)
 
-    client = await get_client()
+    client = get_client()
 
     diff_summary = await client.get_diff_summary(branch=model.source_branch)
     await set_diff_summary_cache(pipeline_id=model.pipeline_id, diff_summary=diff_summary, cache=await get_cache())

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -83,8 +83,8 @@ from infrahub.proposed_change.models import (
     RunGeneratorAsCheckModel,
 )
 from infrahub.pytest_plugin import InfrahubBackendPlugin
-from infrahub.services import InfrahubServices  # noqa: TC001  needed for prefect flow
 from infrahub.validators.tasks import start_validator
+from infrahub.workers.dependencies import get_client, get_database, get_infrahub_services
 from infrahub.workflows.catalogue import (
     GIT_REPOSITORIES_CHECK_ARTIFACT_CREATE,
     GIT_REPOSITORY_INTERNAL_CHECKS_TRIGGER,
@@ -104,19 +104,21 @@ from infrahub.workflows.utils import add_tags
 from .branch_diff import get_diff_summary_cache, get_modified_kinds
 
 if TYPE_CHECKING:
+    from infrahub_sdk.client import InfrahubClient
     from infrahub_sdk.diff import NodeDiff
 
     from infrahub.core.models import SchemaUpdateConstraintInfo
     from infrahub.core.schema.schema_branch import SchemaBranch
+    from infrahub.database import InfrahubDatabase
 
 
 async def _proposed_change_transition_state(
     state: ProposedChangeState,
-    service: InfrahubServices,
+    database: InfrahubDatabase,
     proposed_change: InternalCoreProposedChange | None = None,
     proposed_change_id: str | None = None,
 ) -> None:
-    async with service.database.start_session() as db:
+    async with database.start_session() as db:
         if proposed_change is None and proposed_change_id:
             proposed_change = await registry.manager.get_one(
                 db=db, id=proposed_change_id, kind=InternalCoreProposedChange, raise_on_error=True
@@ -152,9 +154,9 @@ async def merge_proposed_change(
     proposed_change_id: str,
     proposed_change_name: str,  # noqa: ARG001
     context: InfrahubContext,
-    service: InfrahubServices,
 ) -> State:
     log = get_run_logger()
+    service = await get_infrahub_services()
 
     await add_tags(nodes=[proposed_change_id])
 
@@ -175,7 +177,7 @@ async def merge_proposed_change(
             ):
                 # Ignoring Data integrity checks as they are handled again later
                 await _proposed_change_transition_state(
-                    proposed_change=proposed_change, state=ProposedChangeState.OPEN, service=service
+                    proposed_change=proposed_change, state=ProposedChangeState.OPEN, database=db
                 )
                 return Failed(message="Unable to merge proposed change containing failing checks")
             if validator_kind == InfrahubKind.DATAVALIDATOR:
@@ -183,7 +185,7 @@ async def merge_proposed_change(
                 for check in data_checks.values():
                     if check.conflicts.value and not check.keep_branch.value:
                         await _proposed_change_transition_state(
-                            proposed_change=proposed_change, state=ProposedChangeState.OPEN, service=service
+                            proposed_change=proposed_change, state=ProposedChangeState.OPEN, database=db
                         )
                         return Failed(
                             message="Data conflicts found on branch and missing decisions about what branch to keep"
@@ -191,19 +193,17 @@ async def merge_proposed_change(
 
         log.info("Proposed change is eligible to be merged")
         try:
-            await merge_branch(
-                branch=source_branch.name, context=context, service=service, proposed_change_id=proposed_change_id
-            )
+            await merge_branch(branch=source_branch.name, context=context, proposed_change_id=proposed_change_id)
         except MergeFailedError as exc:
             await _proposed_change_transition_state(
-                proposed_change=proposed_change, state=ProposedChangeState.OPEN, service=service
+                proposed_change=proposed_change, state=ProposedChangeState.OPEN, database=db
             )
             return Failed(message=f"Merge failure when trying to merge {exc.message}")
 
         log.info(f"Branch {source_branch.name} has been merged successfully")
 
         await _proposed_change_transition_state(
-            proposed_change=proposed_change, state=ProposedChangeState.MERGED, service=service
+            proposed_change=proposed_change, state=ProposedChangeState.MERGED, database=db
         )
         return Completed(message="proposed change merged successfully")
 
@@ -213,8 +213,10 @@ async def merge_proposed_change(
     flow_run_name="Cancel all proposed change associated with branch {branch_name}",
     description="Cancel all Proposed change associated with a branch.",
 )
-async def cancel_proposed_changes_branch(branch_name: str, service: InfrahubServices) -> None:
+async def cancel_proposed_changes_branch(branch_name: str) -> None:
     await add_tags(branches=[branch_name])
+
+    service = await get_infrahub_services()
 
     proposed_changed_opened = await service.client.filters(
         kind=CoreProposedChange,
@@ -230,16 +232,16 @@ async def cancel_proposed_changes_branch(branch_name: str, service: InfrahubServ
     )
 
     for proposed_change in proposed_changed_opened + proposed_changed_closed:
-        await cancel_proposed_change(proposed_change=proposed_change, service=service)
+        await cancel_proposed_change(proposed_change=proposed_change, client=get_client())
 
 
 @task(name="Cancel a propose change", description="Cancel a propose change", cache_policy=NONE)  # type: ignore[arg-type]
-async def cancel_proposed_change(proposed_change: CoreProposedChange, service: InfrahubServices) -> None:
+async def cancel_proposed_change(proposed_change: CoreProposedChange, client: InfrahubClient) -> None:
     await add_tags(nodes=[proposed_change.id])
     log = get_run_logger()
 
     log.info("Canceling proposed change as the source branch was deleted")
-    proposed_change = await service.client.get(kind=CoreProposedChange, id=proposed_change.id)
+    proposed_change = await client.get(kind=CoreProposedChange, id=proposed_change.id)
     proposed_change.state.value = ProposedChangeState.CANCELED.value
     await proposed_change.save()
 
@@ -248,13 +250,12 @@ async def cancel_proposed_change(proposed_change: CoreProposedChange, service: I
     name="proposed-changed-data-integrity",
     flow_run_name="Triggers data integrity check",
 )
-async def run_proposed_change_data_integrity_check(
-    model: RequestProposedChangeDataIntegrity, service: InfrahubServices
-) -> None:
+async def run_proposed_change_data_integrity_check(model: RequestProposedChangeDataIntegrity) -> None:
     """Triggers a data integrity validation check on the provided proposed change to start."""
     await add_tags(branches=[model.source_branch], nodes=[model.proposed_change])
 
-    async with service.database.start_transaction() as dbt:
+    database = await get_database()
+    async with database.start_transaction() as dbt:
         destination_branch = await registry.get_branch(db=dbt, branch=model.destination_branch)
         source_branch = await registry.get_branch(db=dbt, branch=model.source_branch)
         component_registry = get_component_registry()
@@ -267,10 +268,10 @@ async def run_proposed_change_data_integrity_check(
     name="proposed-changed-run-generator",
     flow_run_name="Run generators",
 )
-async def run_generators(
-    model: RequestProposedChangeRunGenerators, context: InfrahubContext, service: InfrahubServices
-) -> None:
+async def run_generators(model: RequestProposedChangeRunGenerators, context: InfrahubContext) -> None:
     await add_tags(branches=[model.source_branch], nodes=[model.proposed_change], db_change=True)
+
+    service = await get_infrahub_services()
 
     generators = await service.client.filters(
         kind=CoreGeneratorDefinition,
@@ -366,12 +367,12 @@ async def run_generators(
     name="proposed-changed-schema-integrity",
     flow_run_name="Process schema integrity",
 )
-async def run_proposed_change_schema_integrity_check(
-    model: RequestProposedChangeSchemaIntegrity, service: InfrahubServices
-) -> None:
+async def run_proposed_change_schema_integrity_check(model: RequestProposedChangeSchemaIntegrity) -> None:
     # For now, we retrieve the latest schema for each branch from the registry
     # In the future it would be good to generate the object SchemaUpdateValidationResult from message.branch_diff
     await add_tags(branches=[model.source_branch], nodes=[model.proposed_change])
+
+    service = await get_infrahub_services()
 
     source_schema = registry.schema.get_schema_branch(name=model.source_branch).duplicate()
     dest_schema = registry.schema.get_schema_branch(name=model.destination_branch).duplicate()
@@ -398,8 +399,7 @@ async def run_proposed_change_schema_integrity_check(
     responses = await schema_validate_migrations(
         message=SchemaValidateMigrationData(
             branch=source_branch, schema_branch=candidate_schema, constraints=list(constraints)
-        ),
-        service=service,
+        )
     )
 
     # TODO we need to report a failure if an error happened during the execution of a validator
@@ -462,10 +462,10 @@ async def _get_proposed_change_schema_integrity_constraints(
     name="proposed-changed-repository-checks",
     flow_run_name="Process user defined checks",
 )
-async def repository_checks(
-    model: RequestProposedChangeRepositoryChecks, service: InfrahubServices, context: InfrahubContext
-) -> None:
+async def repository_checks(model: RequestProposedChangeRepositoryChecks, context: InfrahubContext) -> None:
     await add_tags(branches=[model.source_branch], nodes=[model.proposed_change])
+
+    service = await get_infrahub_services()
 
     for repository in model.branch_diff.repositories:
         if (
@@ -501,14 +501,14 @@ async def repository_checks(
         )
 
 
-@flow(
-    name="proposed-changed-user-tests",
-    flow_run_name="Run unit tests in repositories",
-)
-async def run_proposed_change_user_tests(model: RequestProposedChangeUserTests, service: InfrahubServices) -> None:
-    log = get_run_logger()
+@flow(name="proposed-changed-user-tests", flow_run_name="Run unit tests in repositories")
+async def run_proposed_change_user_tests(model: RequestProposedChangeUserTests) -> None:
     await add_tags(branches=[model.source_branch], nodes=[model.proposed_change])
-    proposed_change = await service.client.get(kind=InfrahubKind.PROPOSEDCHANGE, id=model.proposed_change)
+
+    log = get_run_logger()
+    client = get_client()
+
+    proposed_change = await client.get(kind=InfrahubKind.PROPOSEDCHANGE, id=model.proposed_change)
 
     def _execute(
         directory: Path, repository: ProposedChangeRepository, proposed_change: InfrahubNode
@@ -542,7 +542,7 @@ async def run_proposed_change_user_tests(model: RequestProposedChangeUserTests, 
                     "-qqqq",
                     "-s",
                 ],
-                plugins=[InfrahubBackendPlugin(service.client.config, repository.repository_id, proposed_change.id)],
+                plugins=[InfrahubBackendPlugin(client.config, repository.repository_id, proposed_change.id)],
             )
 
         # Restore stdout/stderr back to their orignal states
@@ -554,7 +554,7 @@ async def run_proposed_change_user_tests(model: RequestProposedChangeUserTests, 
     for repository in model.branch_diff.repositories:
         if model.source_branch_sync_with_git:
             repo = await get_initialized_repo(
-                client=service.client,
+                client=client,
                 repository_id=repository.repository_id,
                 name=repository.repository_name,
                 repository_kind=repository.kind,
@@ -570,12 +570,14 @@ async def run_proposed_change_user_tests(model: RequestProposedChangeUserTests, 
     name="artifacts-generation-validation",
     flow_run_name="Validating generation of artifacts for {model.artifact_definition.definition_name}",
 )
-async def validate_artifacts_generation(
-    model: RequestArtifactDefinitionCheck, service: InfrahubServices, context: InfrahubContext
-) -> None:
+async def validate_artifacts_generation(model: RequestArtifactDefinitionCheck, context: InfrahubContext) -> None:
     await add_tags(branches=[model.source_branch], nodes=[model.proposed_change], db_change=True)
 
+    service = await get_infrahub_services()
+
     log = get_run_logger()
+    client = get_client()
+
     artifact_definition = await service.client.get(
         kind=InfrahubKind.ARTIFACTDEFINITION,
         id=model.artifact_definition.definition_id,
@@ -597,7 +599,7 @@ async def validate_artifacts_generation(
             previous_validator = existing_validator
 
     validator = await start_validator(
-        service=service,
+        client=client,
         validator=previous_validator,
         validator_type=CoreArtifactValidator,
         proposed_change=model.proposed_change,
@@ -669,11 +671,11 @@ async def validate_artifacts_generation(
             )
 
     await run_checks_and_update_validator(
+        event_service=service.event,
         checks=checks,
         validator=validator,
         proposed_change_id=model.proposed_change,
         context=context,
-        service=service,
     )
 
 
@@ -698,15 +700,14 @@ def _should_render_artifact(artifact_id: str | None, managed_branch: bool, impac
     name="run-generator-as-check",
     flow_run_name="Execute Generator {model.generator_definition.definition_name} for {model.target_name}",
 )
-async def run_generator_as_check(
-    model: RunGeneratorAsCheckModel, service: InfrahubServices, context: InfrahubContext
-) -> ValidatorConclusion:
+async def run_generator_as_check(model: RunGeneratorAsCheckModel, context: InfrahubContext) -> ValidatorConclusion:
     await add_tags(branches=[model.branch_name], nodes=[model.proposed_change], db_change=True)
 
+    client = get_client()
     log = get_run_logger()
 
     repository = await get_initialized_repo(
-        client=service.client,
+        client=client,
         repository_id=model.repository_id,
         name=model.repository_name,
         repository_kind=model.repository_kind,
@@ -731,7 +732,7 @@ async def run_generator_as_check(
         repo_directory=repository.directory_root,
         worktree_directory=commit_worktree.directory,
     )
-    generator_instance = await _define_instance(model=model, service=service)
+    generator_instance = await _define_instance(model=model, client=client)
 
     check_message = "Instance successfully generated"
     try:
@@ -743,7 +744,7 @@ async def run_generator_as_check(
 
         generator = generator_class(
             query=generator_definition.query,
-            client=service.client,
+            client=client,
             branch=model.branch_name,
             params=model.variables,
             generator_instance=generator_instance.id,
@@ -768,7 +769,7 @@ async def run_generator_as_check(
     await generator_instance.update(do_full_update=True)
 
     check = None
-    existing_check = await service.client.filters(
+    existing_check = await client.filters(
         kind=InfrahubKind.GENERATORCHECK, validator__ids=model.validator_id, instance__value=generator_instance.id
     )
     if existing_check:
@@ -779,7 +780,7 @@ async def run_generator_as_check(
         check.conclusion.value = conclusion.value
         await check.save()
     else:
-        check = await service.client.create(
+        check = await client.create(
             kind=InfrahubKind.GENERATORCHECK,
             data={
                 "name": model.target_name,
@@ -797,9 +798,9 @@ async def run_generator_as_check(
     return conclusion
 
 
-async def _define_instance(model: RunGeneratorAsCheckModel, service: InfrahubServices) -> InfrahubNode:
+async def _define_instance(model: RunGeneratorAsCheckModel, client: InfrahubClient) -> InfrahubNode:
     if model.generator_instance:
-        instance = await service.client.get(
+        instance = await client.get(
             kind=InfrahubKind.GENERATORINSTANCE, id=model.generator_instance, branch=model.branch_name
         )
         instance.status.value = GeneratorInstanceStatus.PENDING.value
@@ -809,7 +810,7 @@ async def _define_instance(model: RunGeneratorAsCheckModel, service: InfrahubSer
         async with lock.registry.get(
             f"{model.target_id}-{model.generator_definition.definition_id}", namespace="generator"
         ):
-            instances = await service.client.filters(
+            instances = await client.filters(
                 kind=InfrahubKind.GENERATORINSTANCE,
                 definition__ids=[model.generator_definition.definition_id],
                 object__ids=[model.target_id],
@@ -820,7 +821,7 @@ async def _define_instance(model: RunGeneratorAsCheckModel, service: InfrahubSer
                 instance.status.value = GeneratorInstanceStatus.PENDING.value
                 await instance.update(do_full_update=True)
             else:
-                instance = await service.client.create(
+                instance = await client.create(
                     kind=InfrahubKind.GENERATORINSTANCE,
                     branch=model.branch_name,
                     data={
@@ -838,13 +839,14 @@ async def _define_instance(model: RunGeneratorAsCheckModel, service: InfrahubSer
     name="request-generator-definition-check",
     flow_run_name="Validate Generator selection for {model.generator_definition.definition_name}",
 )
-async def request_generator_definition_check(
-    model: RequestGeneratorDefinitionCheck, service: InfrahubServices, context: InfrahubContext
-) -> None:
-    log = get_run_logger()
+async def request_generator_definition_check(model: RequestGeneratorDefinitionCheck, context: InfrahubContext) -> None:
     await add_tags(branches=[model.source_branch], nodes=[model.proposed_change])
 
-    proposed_change = await service.client.get(kind=InfrahubKind.PROPOSEDCHANGE, id=model.proposed_change)
+    log = get_run_logger()
+    client = get_client()
+    service = await get_infrahub_services()
+
+    proposed_change = await client.get(kind=InfrahubKind.PROPOSEDCHANGE, id=model.proposed_change)
 
     validator_name = f"Generator Validator: {model.generator_definition.definition_name}"
     await proposed_change.validations.fetch()
@@ -859,7 +861,7 @@ async def request_generator_definition_check(
             previous_validator = existing_validator
 
     validator = await start_validator(
-        service=service,
+        client=client,
         validator=previous_validator,
         validator_type=CoreGeneratorValidator,
         proposed_change=model.proposed_change,
@@ -870,7 +872,7 @@ async def request_generator_definition_check(
         context=context,
     )
 
-    group = await service.client.get(
+    group = await client.get(
         kind=InfrahubKind.GENERICGROUP,
         prefetch_relationships=True,
         populate_store=True,
@@ -879,7 +881,7 @@ async def request_generator_definition_check(
     )
     await group.members.fetch()
 
-    existing_instances = await service.client.filters(
+    existing_instances = await client.filters(
         kind=InfrahubKind.GENERATORINSTANCE,
         definition__ids=[model.generator_definition.definition_id],
         include=["object"],
@@ -932,10 +934,10 @@ async def request_generator_definition_check(
     ]
 
     await run_checks_and_update_validator(
+        event_service=service.event,
         checks=checks_coroutines,
         validator=validator,
         context=context,
-        service=service,
         proposed_change_id=proposed_change.id,
     )
 
@@ -981,14 +983,12 @@ class DefinitionSelect(IntFlag):
 
 
 @flow(name="proposed-changed-pipeline", flow_run_name="Execute proposed changed pipeline")
-async def run_proposed_change_pipeline(
-    model: RequestProposedChangePipeline, service: InfrahubServices, context: InfrahubContext
-) -> None:
-    repositories = await _get_proposed_change_repositories(model=model, service=service)
+async def run_proposed_change_pipeline(model: RequestProposedChangePipeline, context: InfrahubContext) -> None:
+    service = await get_infrahub_services()
 
-    if model.source_branch_sync_with_git and await _validate_repository_merge_conflicts(
-        repositories=repositories, service=service
-    ):
+    repositories = await _get_proposed_change_repositories(model=model)
+
+    if model.source_branch_sync_with_git and await _validate_repository_merge_conflicts(repositories=repositories):
         for repo in repositories:
             if not repo.read_only and repo.internal_status == RepositoryInternalStatus.ACTIVE.value:
                 trigger_repo_checks_model = TriggerRepositoryInternalChecks(
@@ -1004,7 +1004,7 @@ async def run_proposed_change_pipeline(
                 )
         return
 
-    await _gather_repository_repository_diffs(repositories=repositories, service=service)
+    await _gather_repository_repository_diffs(repositories=repositories)
 
     async with service.database.start_transaction() as dbt:
         destination_branch = await registry.get_branch(db=dbt, branch=model.destination_branch)
@@ -1016,9 +1016,7 @@ async def run_proposed_change_pipeline(
     diff_summary = await service.client.get_diff_summary(branch=model.source_branch)
     await set_diff_summary_cache(pipeline_id=model.pipeline_id, diff_summary=diff_summary, cache=service.cache)
     branch_diff = ProposedChangeBranchDiff(pipeline_id=model.pipeline_id, repositories=repositories)
-    await _populate_subscribers(
-        branch_diff=branch_diff, diff_summary=diff_summary, service=service, branch=model.source_branch
-    )
+    await _populate_subscribers(branch_diff=branch_diff, diff_summary=diff_summary, branch=model.source_branch)
 
     if model.check_type is CheckType.ARTIFACT:
         request_refresh_artifact_model = RequestProposedChangeRefreshArtifacts(
@@ -1117,11 +1115,10 @@ async def run_proposed_change_pipeline(
     name="proposed-changed-refresh-artifacts",
     flow_run_name="Trigger artifacts refresh",
 )
-async def refresh_artifacts(
-    model: RequestProposedChangeRefreshArtifacts, service: InfrahubServices, context: InfrahubContext
-) -> None:
+async def refresh_artifacts(model: RequestProposedChangeRefreshArtifacts, context: InfrahubContext) -> None:
     await add_tags(branches=[model.source_branch], nodes=[model.proposed_change])
     log = get_run_logger()
+    service = await get_infrahub_services()
 
     definition_information = await service.client.execute_graphql(
         query=GATHER_ARTIFACT_DEFINITIONS,
@@ -1441,9 +1438,9 @@ def _parse_artifact_definitions(definitions: list[dict]) -> list[ProposedChangeA
     return parsed
 
 
-async def _get_proposed_change_repositories(
-    model: RequestProposedChangePipeline, service: InfrahubServices
-) -> list[ProposedChangeRepository]:
+async def _get_proposed_change_repositories(model: RequestProposedChangePipeline) -> list[ProposedChangeRepository]:
+    service = await get_infrahub_services()
+
     destination_all = await service.client.execute_graphql(
         query=DESTINATION_ALLREPOSITORIES, branch_name=model.destination_branch
     )
@@ -1461,10 +1458,9 @@ async def _get_proposed_change_repositories(
 
 
 @task(name="proposed-change-validate-repository-conflicts", task_run_name="Validate conflicts on repository")  # type: ignore[arg-type]
-async def _validate_repository_merge_conflicts(
-    repositories: list[ProposedChangeRepository], service: InfrahubServices
-) -> bool:
+async def _validate_repository_merge_conflicts(repositories: list[ProposedChangeRepository]) -> bool:
     log = get_run_logger()
+    service = await get_infrahub_services()
     conflicts = False
     for repo in repositories:
         if repo.has_diff and not repo.is_staging:
@@ -1484,9 +1480,8 @@ async def _validate_repository_merge_conflicts(
     return conflicts
 
 
-async def _gather_repository_repository_diffs(
-    repositories: list[ProposedChangeRepository], service: InfrahubServices
-) -> None:
+async def _gather_repository_repository_diffs(repositories: list[ProposedChangeRepository]) -> None:
+    service = await get_infrahub_services()
     for repo in repositories:
         if repo.has_diff and repo.source_commit and repo.destination_commit:
             # TODO we need to find a way to return all files in the repo if the repo is new
@@ -1511,8 +1506,10 @@ async def _gather_repository_repository_diffs(
 
 
 async def _populate_subscribers(
-    branch_diff: ProposedChangeBranchDiff, diff_summary: list[NodeDiff], service: InfrahubServices, branch: str
+    branch_diff: ProposedChangeBranchDiff, diff_summary: list[NodeDiff], branch: str
 ) -> None:
+    service = await get_infrahub_services()
+
     result = await service.client.execute_graphql(
         query=GATHER_GRAPHQL_QUERY_SUBSCRIBERS,
         branch_name=branch,

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -245,10 +245,7 @@ async def cancel_proposed_change(proposed_change: CoreProposedChange, client: In
     await proposed_change.save()
 
 
-@flow(
-    name="proposed-changed-data-integrity",
-    flow_run_name="Triggers data integrity check",
-)
+@flow(name="proposed-changed-data-integrity", flow_run_name="Triggers data integrity check")
 async def run_proposed_change_data_integrity_check(model: RequestProposedChangeDataIntegrity) -> None:
     """Triggers a data integrity validation check on the provided proposed change to start."""
     await add_tags(branches=[model.source_branch], nodes=[model.proposed_change])
@@ -1452,7 +1449,11 @@ async def _get_proposed_change_repositories(
     return _parse_proposed_change_repositories(model=model, source=source_all, destination=destination_all)
 
 
-@task(name="proposed-change-validate-repository-conflicts", task_run_name="Validate conflicts on repository")  # type: ignore[arg-type]
+@task(
+    name="proposed-change-validate-repository-conflicts",
+    task_run_name="Validate conflicts on repository",
+    cache_policy=NONE,
+)  # type: ignore[arg-type]
 async def _validate_repository_merge_conflicts(
     repositories: list[ProposedChangeRepository], client: InfrahubClient
 ) -> bool:

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -362,10 +362,7 @@ async def run_generators(model: RequestProposedChangeRunGenerators, context: Inf
         )
 
 
-@flow(
-    name="proposed-changed-schema-integrity",
-    flow_run_name="Process schema integrity",
-)
+@flow(name="proposed-changed-schema-integrity", flow_run_name="Process schema integrity")
 async def run_proposed_change_schema_integrity_check(model: RequestProposedChangeSchemaIntegrity) -> None:
     # For now, we retrieve the latest schema for each branch from the registry
     # In the future it would be good to generate the object SchemaUpdateValidationResult from message.branch_diff

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -84,7 +84,7 @@ from infrahub.proposed_change.models import (
 )
 from infrahub.pytest_plugin import InfrahubBackendPlugin
 from infrahub.validators.tasks import start_validator
-from infrahub.workers.dependencies import get_client, get_database, get_infrahub_services
+from infrahub.workers.dependencies import get_cache, get_client, get_database, get_event_service, get_workflow
 from infrahub.workflows.catalogue import (
     GIT_REPOSITORIES_CHECK_ARTIFACT_CREATE,
     GIT_REPOSITORY_INTERNAL_CHECKS_TRIGGER,
@@ -156,11 +156,10 @@ async def merge_proposed_change(
     context: InfrahubContext,
 ) -> State:
     log = get_run_logger()
-    service = await get_infrahub_services()
-
     await add_tags(nodes=[proposed_change_id])
 
-    async with service.database.start_session() as db:
+    database = await get_database()
+    async with database.start_session() as db:
         proposed_change = await registry.manager.get_one(
             db=db, id=proposed_change_id, kind=InternalCoreProposedChange, raise_on_error=True
         )
@@ -216,15 +215,15 @@ async def merge_proposed_change(
 async def cancel_proposed_changes_branch(branch_name: str) -> None:
     await add_tags(branches=[branch_name])
 
-    service = await get_infrahub_services()
+    client = get_client()
 
-    proposed_changed_opened = await service.client.filters(
+    proposed_changed_opened = await client.filters(
         kind=CoreProposedChange,
         include=["id", "source_branch"],
         state__value=ProposedChangeState.OPEN.value,
         source_branch__value=branch_name,
     )
-    proposed_changed_closed = await service.client.filters(
+    proposed_changed_closed = await client.filters(
         kind=CoreProposedChange,
         include=["id", "source_branch"],
         state__value=ProposedChangeState.CLOSED.value,
@@ -271,9 +270,9 @@ async def run_proposed_change_data_integrity_check(model: RequestProposedChangeD
 async def run_generators(model: RequestProposedChangeRunGenerators, context: InfrahubContext) -> None:
     await add_tags(branches=[model.source_branch], nodes=[model.proposed_change], db_change=True)
 
-    service = await get_infrahub_services()
+    client = get_client()
 
-    generators = await service.client.filters(
+    generators = await client.filters(
         kind=CoreGeneratorDefinition,
         prefetch_relationships=True,
         populate_store=True,
@@ -295,7 +294,7 @@ async def run_generators(model: RequestProposedChangeRunGenerators, context: Inf
         for generator in generators
     ]
 
-    diff_summary = await get_diff_summary_cache(pipeline_id=model.branch_diff.pipeline_id, cache=service.cache)
+    diff_summary = await get_diff_summary_cache(pipeline_id=model.branch_diff.pipeline_id, cache=await get_cache())
     modified_kinds = get_modified_kinds(diff_summary=diff_summary, branch=model.source_branch)
 
     for generator_definition in generator_definitions:
@@ -328,7 +327,7 @@ async def run_generators(model: RequestProposedChangeRunGenerators, context: Inf
                 source_branch_sync_with_git=model.source_branch_sync_with_git,
                 destination_branch=model.destination_branch,
             )
-            await service.workflow.submit_workflow(
+            await get_workflow().submit_workflow(
                 workflow=REQUEST_GENERATOR_DEFINITION_CHECK,
                 parameters={"model": request_generator_def_check_model},
                 context=context,
@@ -342,7 +341,7 @@ async def run_generators(model: RequestProposedChangeRunGenerators, context: Inf
             destination_branch=model.destination_branch,
             branch_diff=model.branch_diff,
         )
-        await service.workflow.submit_workflow(
+        await get_workflow().submit_workflow(
             workflow=REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS,
             parameters={"model": request_refresh_artifact_model},
             context=context,
@@ -356,7 +355,7 @@ async def run_generators(model: RequestProposedChangeRunGenerators, context: Inf
             destination_branch=model.destination_branch,
             branch_diff=model.branch_diff,
         )
-        await service.workflow.submit_workflow(
+        await get_workflow().submit_workflow(
             workflow=REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS,
             context=context,
             parameters={"model": model_proposed_change_repo_checks},
@@ -372,8 +371,6 @@ async def run_proposed_change_schema_integrity_check(model: RequestProposedChang
     # In the future it would be good to generate the object SchemaUpdateValidationResult from message.branch_diff
     await add_tags(branches=[model.source_branch], nodes=[model.proposed_change])
 
-    service = await get_infrahub_services()
-
     source_schema = registry.schema.get_schema_branch(name=model.source_branch).duplicate()
     dest_schema = registry.schema.get_schema_branch(name=model.destination_branch).duplicate()
 
@@ -382,7 +379,7 @@ async def run_proposed_change_schema_integrity_check(model: RequestProposedChang
     schema_diff = dest_schema.diff(other=candidate_schema)
     validation_result = dest_schema.validate_update(other=candidate_schema, diff=schema_diff)
 
-    diff_summary = await get_diff_summary_cache(pipeline_id=model.branch_diff.pipeline_id, cache=service.cache)
+    diff_summary = await get_diff_summary_cache(pipeline_id=model.branch_diff.pipeline_id, cache=await get_cache())
     constraints_from_data_diff = await _get_proposed_change_schema_integrity_constraints(
         schema=candidate_schema, diff_summary=diff_summary
     )
@@ -421,7 +418,8 @@ async def run_proposed_change_schema_integrity_check(model: RequestProposedChang
     if not conflicts:
         return
 
-    async with service.database.start_transaction() as db:
+    database = await get_database()
+    async with database.start_transaction() as db:
         object_conflict_validator_recorder = ObjectConflictValidatorRecorder(
             db=db,
             validator_kind=InfrahubKind.SCHEMAVALIDATOR,
@@ -465,8 +463,6 @@ async def _get_proposed_change_schema_integrity_constraints(
 async def repository_checks(model: RequestProposedChangeRepositoryChecks, context: InfrahubContext) -> None:
     await add_tags(branches=[model.source_branch], nodes=[model.proposed_change])
 
-    service = await get_infrahub_services()
-
     for repository in model.branch_diff.repositories:
         if (
             model.source_branch_sync_with_git
@@ -479,7 +475,7 @@ async def repository_checks(model: RequestProposedChangeRepositoryChecks, contex
                 source_branch=model.source_branch,
                 target_branch=model.destination_branch,
             )
-            await service.workflow.submit_workflow(
+            await get_workflow().submit_workflow(
                 workflow=GIT_REPOSITORY_INTERNAL_CHECKS_TRIGGER,
                 context=context,
                 parameters={"model": trigger_internal_checks_model},
@@ -494,7 +490,7 @@ async def repository_checks(model: RequestProposedChangeRepositoryChecks, contex
             target_branch=model.destination_branch,
             branch_diff=model.branch_diff,
         )
-        await service.workflow.submit_workflow(
+        await get_workflow().submit_workflow(
             workflow=GIT_REPOSITORY_USER_CHECKS_TRIGGER,
             context=context,
             parameters={"model": trigger_user_checks_model},
@@ -573,17 +569,15 @@ async def run_proposed_change_user_tests(model: RequestProposedChangeUserTests) 
 async def validate_artifacts_generation(model: RequestArtifactDefinitionCheck, context: InfrahubContext) -> None:
     await add_tags(branches=[model.source_branch], nodes=[model.proposed_change], db_change=True)
 
-    service = await get_infrahub_services()
-
     log = get_run_logger()
     client = get_client()
 
-    artifact_definition = await service.client.get(
+    artifact_definition = await client.get(
         kind=InfrahubKind.ARTIFACTDEFINITION,
         id=model.artifact_definition.definition_id,
         branch=model.source_branch,
     )
-    proposed_change = await service.client.get(kind=InfrahubKind.PROPOSEDCHANGE, id=model.proposed_change)
+    proposed_change = await client.get(kind=InfrahubKind.PROPOSEDCHANGE, id=model.proposed_change)
 
     validator_name = f"Artifact Validator: {model.artifact_definition.definition_name}"
 
@@ -614,7 +608,7 @@ async def validate_artifacts_generation(model: RequestArtifactDefinitionCheck, c
     group = artifact_definition.targets.peer
     await group.members.fetch()
 
-    existing_artifacts = await service.client.filters(
+    existing_artifacts = await client.filters(
         kind=InfrahubKind.ARTIFACT,
         definition__ids=[model.artifact_definition.definition_id],
         include=["object"],
@@ -663,7 +657,7 @@ async def validate_artifacts_generation(model: RequestArtifactDefinitionCheck, c
             )
 
             checks.append(
-                service.workflow.execute_workflow(
+                get_workflow().execute_workflow(
                     workflow=GIT_REPOSITORIES_CHECK_ARTIFACT_CREATE,
                     parameters={"model": check_model},
                     expected_return=ValidatorConclusion,
@@ -671,7 +665,7 @@ async def validate_artifacts_generation(model: RequestArtifactDefinitionCheck, c
             )
 
     await run_checks_and_update_validator(
-        event_service=service.event,
+        event_service=await get_event_service(),
         checks=checks,
         validator=validator,
         proposed_change_id=model.proposed_change,
@@ -844,7 +838,6 @@ async def request_generator_definition_check(model: RequestGeneratorDefinitionCh
 
     log = get_run_logger()
     client = get_client()
-    service = await get_infrahub_services()
 
     proposed_change = await client.get(kind=InfrahubKind.PROPOSEDCHANGE, id=model.proposed_change)
 
@@ -924,7 +917,7 @@ async def request_generator_definition_check(model: RequestGeneratorDefinitionCh
             check_generator_run_models.append(check_generator_run_model)
 
     checks_coroutines = [
-        service.workflow.execute_workflow(
+        get_workflow().execute_workflow(
             workflow=RUN_GENERATOR_AS_CHECK,
             parameters={"model": check_generator_run_model},
             expected_return=ValidatorConclusion,
@@ -934,7 +927,7 @@ async def request_generator_definition_check(model: RequestGeneratorDefinitionCh
     ]
 
     await run_checks_and_update_validator(
-        event_service=service.event,
+        event_service=await get_event_service(),
         checks=checks_coroutines,
         validator=validator,
         context=context,
@@ -984,11 +977,12 @@ class DefinitionSelect(IntFlag):
 
 @flow(name="proposed-changed-pipeline", flow_run_name="Execute proposed changed pipeline")
 async def run_proposed_change_pipeline(model: RequestProposedChangePipeline, context: InfrahubContext) -> None:
-    service = await get_infrahub_services()
+    client = get_client()
+    repositories = await _get_proposed_change_repositories(model=model, client=client)
 
-    repositories = await _get_proposed_change_repositories(model=model)
-
-    if model.source_branch_sync_with_git and await _validate_repository_merge_conflicts(repositories=repositories):
+    if model.source_branch_sync_with_git and await _validate_repository_merge_conflicts(
+        repositories=repositories, client=client
+    ):
         for repo in repositories:
             if not repo.read_only and repo.internal_status == RepositoryInternalStatus.ACTIVE.value:
                 trigger_repo_checks_model = TriggerRepositoryInternalChecks(
@@ -997,24 +991,27 @@ async def run_proposed_change_pipeline(model: RequestProposedChangePipeline, con
                     source_branch=repo.source_branch,
                     target_branch=repo.destination_branch,
                 )
-                await service.workflow.submit_workflow(
+                await get_workflow().submit_workflow(
                     workflow=GIT_REPOSITORY_INTERNAL_CHECKS_TRIGGER,
                     context=context,
                     parameters={"model": trigger_repo_checks_model},
                 )
         return
 
-    await _gather_repository_repository_diffs(repositories=repositories)
+    await _gather_repository_repository_diffs(repositories=repositories, client=client)
 
-    async with service.database.start_transaction() as dbt:
+    database = await get_database()
+    async with database.start_transaction() as dbt:
         destination_branch = await registry.get_branch(db=dbt, branch=model.destination_branch)
         source_branch = await registry.get_branch(db=dbt, branch=model.source_branch)
         component_registry = get_component_registry()
         diff_coordinator = await component_registry.get_component(DiffCoordinator, db=dbt, branch=source_branch)
         await diff_coordinator.update_branch_diff(base_branch=destination_branch, diff_branch=source_branch)
 
-    diff_summary = await service.client.get_diff_summary(branch=model.source_branch)
-    await set_diff_summary_cache(pipeline_id=model.pipeline_id, diff_summary=diff_summary, cache=service.cache)
+    client = await get_client()
+
+    diff_summary = await client.get_diff_summary(branch=model.source_branch)
+    await set_diff_summary_cache(pipeline_id=model.pipeline_id, diff_summary=diff_summary, cache=await get_cache())
     branch_diff = ProposedChangeBranchDiff(pipeline_id=model.pipeline_id, repositories=repositories)
     await _populate_subscribers(branch_diff=branch_diff, diff_summary=diff_summary, branch=model.source_branch)
 
@@ -1026,7 +1023,7 @@ async def run_proposed_change_pipeline(model: RequestProposedChangePipeline, con
             destination_branch=model.destination_branch,
             branch_diff=branch_diff,
         )
-        await service.workflow.submit_workflow(
+        await get_workflow().submit_workflow(
             workflow=REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS,
             parameters={"model": request_refresh_artifact_model},
             context=context,
@@ -1042,7 +1039,7 @@ async def run_proposed_change_pipeline(model: RequestProposedChangePipeline, con
             refresh_artifacts=model.check_type is CheckType.ALL,
             do_repository_checks=model.check_type is CheckType.ALL,
         )
-        await service.workflow.submit_workflow(
+        await get_workflow().submit_workflow(
             workflow=REQUEST_PROPOSED_CHANGE_RUN_GENERATORS,
             context=context,
             parameters={"model": model_proposed_change_run_generator},
@@ -1058,7 +1055,7 @@ async def run_proposed_change_pipeline(model: RequestProposedChangePipeline, con
             destination_branch=model.destination_branch,
             branch_diff=branch_diff,
         )
-        await service.workflow.submit_workflow(
+        await get_workflow().submit_workflow(
             workflow=REQUEST_PROPOSED_CHANGE_DATA_INTEGRITY,
             context=context,
             parameters={"model": model_proposed_change_data_integrity},
@@ -1072,7 +1069,7 @@ async def run_proposed_change_pipeline(model: RequestProposedChangePipeline, con
             destination_branch=model.destination_branch,
             branch_diff=branch_diff,
         )
-        await service.workflow.submit_workflow(
+        await get_workflow().submit_workflow(
             workflow=REQUEST_PROPOSED_CHANGE_REPOSITORY_CHECKS,
             context=context,
             parameters={"model": model_proposed_change_repo_checks},
@@ -1081,7 +1078,7 @@ async def run_proposed_change_pipeline(model: RequestProposedChangePipeline, con
     if model.check_type in [CheckType.ALL, CheckType.SCHEMA] and has_data_changes(
         diff_summary=diff_summary, branch=model.source_branch
     ):
-        await service.workflow.submit_workflow(
+        await get_workflow().submit_workflow(
             workflow=REQUEST_PROPOSED_CHANGE_SCHEMA_INTEGRITY,
             context=context,
             parameters={
@@ -1096,7 +1093,7 @@ async def run_proposed_change_pipeline(model: RequestProposedChangePipeline, con
         )
 
     if model.check_type in [CheckType.ALL, CheckType.TEST]:
-        await service.workflow.submit_workflow(
+        await get_workflow().submit_workflow(
             workflow=REQUEST_PROPOSED_CHANGE_USER_TESTS,
             context=context,
             parameters={
@@ -1118,16 +1115,17 @@ async def run_proposed_change_pipeline(model: RequestProposedChangePipeline, con
 async def refresh_artifacts(model: RequestProposedChangeRefreshArtifacts, context: InfrahubContext) -> None:
     await add_tags(branches=[model.source_branch], nodes=[model.proposed_change])
     log = get_run_logger()
-    service = await get_infrahub_services()
 
-    definition_information = await service.client.execute_graphql(
+    client = get_client()
+
+    definition_information = await client.execute_graphql(
         query=GATHER_ARTIFACT_DEFINITIONS,
         branch_name=model.source_branch,
     )
     artifact_definitions = _parse_artifact_definitions(
         definitions=definition_information[InfrahubKind.ARTIFACTDEFINITION]["edges"]
     )
-    diff_summary = await get_diff_summary_cache(pipeline_id=model.branch_diff.pipeline_id, cache=service.cache)
+    diff_summary = await get_diff_summary_cache(pipeline_id=model.branch_diff.pipeline_id, cache=await get_cache())
     modified_kinds = get_modified_kinds(diff_summary=diff_summary, branch=model.source_branch)
 
     for artifact_definition in artifact_definitions:
@@ -1169,7 +1167,7 @@ async def refresh_artifacts(model: RequestProposedChangeRefreshArtifacts, contex
                 destination_branch=model.destination_branch,
             )
 
-            await service.workflow.submit_workflow(
+            await get_workflow().submit_workflow(
                 REQUEST_ARTIFACT_DEFINITION_CHECK,
                 parameters={"model": request_artifacts_definitions_model},
                 context=context,
@@ -1438,16 +1436,14 @@ def _parse_artifact_definitions(definitions: list[dict]) -> list[ProposedChangeA
     return parsed
 
 
-async def _get_proposed_change_repositories(model: RequestProposedChangePipeline) -> list[ProposedChangeRepository]:
-    service = await get_infrahub_services()
-
-    destination_all = await service.client.execute_graphql(
+async def _get_proposed_change_repositories(
+    model: RequestProposedChangePipeline, client: InfrahubClient
+) -> list[ProposedChangeRepository]:
+    destination_all = await client.execute_graphql(
         query=DESTINATION_ALLREPOSITORIES, branch_name=model.destination_branch
     )
-    source_managed = await service.client.execute_graphql(query=SOURCE_REPOSITORIES, branch_name=model.source_branch)
-    source_readonly = await service.client.execute_graphql(
-        query=SOURCE_READONLY_REPOSITORIES, branch_name=model.source_branch
-    )
+    source_managed = await client.execute_graphql(query=SOURCE_REPOSITORIES, branch_name=model.source_branch)
+    source_readonly = await client.execute_graphql(query=SOURCE_READONLY_REPOSITORIES, branch_name=model.source_branch)
 
     destination_all = destination_all[InfrahubKind.GENERICREPOSITORY]["edges"]
     source_all = (
@@ -1458,15 +1454,15 @@ async def _get_proposed_change_repositories(model: RequestProposedChangePipeline
 
 
 @task(name="proposed-change-validate-repository-conflicts", task_run_name="Validate conflicts on repository")  # type: ignore[arg-type]
-async def _validate_repository_merge_conflicts(repositories: list[ProposedChangeRepository]) -> bool:
+async def _validate_repository_merge_conflicts(
+    repositories: list[ProposedChangeRepository], client: InfrahubClient
+) -> bool:
     log = get_run_logger()
-    service = await get_infrahub_services()
+
     conflicts = False
     for repo in repositories:
         if repo.has_diff and not repo.is_staging:
-            git_repo = await InfrahubRepository.init(
-                id=repo.repository_id, name=repo.repository_name, client=service.client
-            )
+            git_repo = await InfrahubRepository.init(id=repo.repository_id, name=repo.repository_name, client=client)
             async with lock.registry.get(name=repo.repository_name, namespace="repository"):
                 repo.conflicts = await git_repo.get_conflicts(
                     source_branch=repo.source_branch, dest_branch=repo.destination_branch
@@ -1480,14 +1476,13 @@ async def _validate_repository_merge_conflicts(repositories: list[ProposedChange
     return conflicts
 
 
-async def _gather_repository_repository_diffs(repositories: list[ProposedChangeRepository]) -> None:
-    service = await get_infrahub_services()
+async def _gather_repository_repository_diffs(
+    repositories: list[ProposedChangeRepository], client: InfrahubClient
+) -> None:
     for repo in repositories:
         if repo.has_diff and repo.source_commit and repo.destination_commit:
             # TODO we need to find a way to return all files in the repo if the repo is new
-            git_repo = await InfrahubRepository.init(
-                id=repo.repository_id, name=repo.repository_name, client=service.client
-            )
+            git_repo = await InfrahubRepository.init(id=repo.repository_id, name=repo.repository_name, client=client)
 
             files_changed: list[str] = []
             files_added: list[str] = []
@@ -1506,11 +1501,9 @@ async def _gather_repository_repository_diffs(repositories: list[ProposedChangeR
 
 
 async def _populate_subscribers(
-    branch_diff: ProposedChangeBranchDiff, diff_summary: list[NodeDiff], branch: str
+    branch_diff: ProposedChangeBranchDiff, diff_summary: list[NodeDiff], branch: str, client: InfrahubClient
 ) -> None:
-    service = await get_infrahub_services()
-
-    result = await service.client.execute_graphql(
+    result = await client.execute_graphql(
         query=GATHER_GRAPHQL_QUERY_SUBSCRIBERS,
         branch_name=branch,
         variables={"members": get_modified_node_ids(diff_summary=diff_summary, branch=branch)},

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -291,7 +291,7 @@ async def run_generators(model: RequestProposedChangeRunGenerators, context: Inf
         for generator in generators
     ]
 
-    diff_summary = await get_diff_summary_cache(pipeline_id=model.branch_diff.pipeline_id, cache=await get_cache())
+    diff_summary = await get_diff_summary_cache(pipeline_id=model.branch_diff.pipeline_id)
     modified_kinds = get_modified_kinds(diff_summary=diff_summary, branch=model.source_branch)
 
     for generator_definition in generator_definitions:
@@ -373,7 +373,7 @@ async def run_proposed_change_schema_integrity_check(model: RequestProposedChang
     schema_diff = dest_schema.diff(other=candidate_schema)
     validation_result = dest_schema.validate_update(other=candidate_schema, diff=schema_diff)
 
-    diff_summary = await get_diff_summary_cache(pipeline_id=model.branch_diff.pipeline_id, cache=await get_cache())
+    diff_summary = await get_diff_summary_cache(pipeline_id=model.branch_diff.pipeline_id)
     constraints_from_data_diff = await _get_proposed_change_schema_integrity_constraints(
         schema=candidate_schema, diff_summary=diff_summary
     )
@@ -1121,7 +1121,7 @@ async def refresh_artifacts(model: RequestProposedChangeRefreshArtifacts, contex
     artifact_definitions = _parse_artifact_definitions(
         definitions=definition_information[InfrahubKind.ARTIFACTDEFINITION]["edges"]
     )
-    diff_summary = await get_diff_summary_cache(pipeline_id=model.branch_diff.pipeline_id, cache=await get_cache())
+    diff_summary = await get_diff_summary_cache(pipeline_id=model.branch_diff.pipeline_id)
     modified_kinds = get_modified_kinds(diff_summary=diff_summary, branch=model.source_branch)
 
     for artifact_definition in artifact_definitions:

--- a/backend/infrahub/server.py
+++ b/backend/infrahub/server.py
@@ -34,7 +34,7 @@ from infrahub.middleware import InfrahubCORSMiddleware
 from infrahub.services import InfrahubServices
 from infrahub.trace import add_span_exception, configure_trace, get_traceid
 from infrahub.worker import WORKER_IDENTITY
-from infrahub.workers.dependencies import get_cache, get_message_bus, get_workflow, set_component_type
+from infrahub.workers.dependencies import get_cache, get_component, get_message_bus, get_workflow, set_component_type
 
 CURRENT_DIRECTORY = Path(__file__).parent.resolve()
 
@@ -66,8 +66,14 @@ async def app_initialization(application: FastAPI, enable_scheduler: bool = True
     message_bus = await get_message_bus()
 
     cache = await get_cache()
+    component = await get_component()
     service = await InfrahubServices.new(
-        cache=cache, database=database, message_bus=message_bus, workflow=workflow, component_type=component_type
+        cache=cache,
+        database=database,
+        message_bus=message_bus,
+        workflow=workflow,
+        component=component,
+        component_type=component_type,
     )
     initialize_lock(service=service)
     # We must initialize DB after initialize lock and initialize lock depends on cache initialization

--- a/backend/infrahub/server.py
+++ b/backend/infrahub/server.py
@@ -24,6 +24,7 @@ from infrahub.api import router as api
 from infrahub.api.exception_handlers import generic_api_exception_handler
 from infrahub.components import ComponentType
 from infrahub.core.initialization import initialization
+from infrahub.database import InfrahubDatabase, InfrahubDatabaseMode
 from infrahub.dependencies.registry import build_component_registry
 from infrahub.exceptions import Error, ValidationError
 from infrahub.graphql.api.endpoints import router as graphql_router
@@ -31,7 +32,6 @@ from infrahub.lock import initialize_lock
 from infrahub.log import clear_log_context, get_logger, set_log_data
 from infrahub.middleware import InfrahubCORSMiddleware
 from infrahub.services import InfrahubServices
-from infrahub.services.adapters.message_bus import InfrahubMessageBus
 from infrahub.trace import add_span_exception, configure_trace, get_traceid
 from infrahub.worker import WORKER_IDENTITY
 from infrahub.workers.dependencies import get_cache, get_database, get_message_bus, get_workflow, set_component_type
@@ -52,8 +52,11 @@ async def app_initialization(application: FastAPI, enable_scheduler: bool = True
             exporter_protocol=config.SETTINGS.trace.exporter_protocol,
         )
 
+    component_type = ComponentType.API_SERVER
+    set_component_type(component_type=component_type)
+
     # Initialize database Driver and load local registry
-    database = application.state.db = await get_database()
+    database = application.state.db = InfrahubDatabase(mode=InfrahubDatabaseMode.DRIVER, driver=await get_database())
 
     build_component_registry()
 

--- a/backend/infrahub/server.py
+++ b/backend/infrahub/server.py
@@ -24,7 +24,7 @@ from infrahub.api import router as api
 from infrahub.api.exception_handlers import generic_api_exception_handler
 from infrahub.components import ComponentType
 from infrahub.core.initialization import initialization
-from infrahub.database import InfrahubDatabase, InfrahubDatabaseMode
+from infrahub.database import InfrahubDatabase, InfrahubDatabaseMode, get_db
 from infrahub.dependencies.registry import build_component_registry
 from infrahub.exceptions import Error, ValidationError
 from infrahub.graphql.api.endpoints import router as graphql_router
@@ -34,7 +34,7 @@ from infrahub.middleware import InfrahubCORSMiddleware
 from infrahub.services import InfrahubServices
 from infrahub.trace import add_span_exception, configure_trace, get_traceid
 from infrahub.worker import WORKER_IDENTITY
-from infrahub.workers.dependencies import get_cache, get_database, get_message_bus, get_workflow, set_component_type
+from infrahub.workers.dependencies import get_cache, get_message_bus, get_workflow, set_component_type
 
 CURRENT_DIRECTORY = Path(__file__).parent.resolve()
 
@@ -56,7 +56,7 @@ async def app_initialization(application: FastAPI, enable_scheduler: bool = True
     set_component_type(component_type=component_type)
 
     # Initialize database Driver and load local registry
-    database = application.state.db = InfrahubDatabase(mode=InfrahubDatabaseMode.DRIVER, driver=await get_database())
+    database = application.state.db = InfrahubDatabase(mode=InfrahubDatabaseMode.DRIVER, driver=await get_db())
 
     build_component_registry()
 

--- a/backend/infrahub/server.py
+++ b/backend/infrahub/server.py
@@ -24,7 +24,6 @@ from infrahub.api import router as api
 from infrahub.api.exception_handlers import generic_api_exception_handler
 from infrahub.components import ComponentType
 from infrahub.core.initialization import initialization
-from infrahub.database import InfrahubDatabase, InfrahubDatabaseMode, get_db
 from infrahub.dependencies.registry import build_component_registry
 from infrahub.exceptions import Error, ValidationError
 from infrahub.graphql.api.endpoints import router as graphql_router
@@ -32,12 +31,10 @@ from infrahub.lock import initialize_lock
 from infrahub.log import clear_log_context, get_logger, set_log_data
 from infrahub.middleware import InfrahubCORSMiddleware
 from infrahub.services import InfrahubServices
-from infrahub.services.adapters.cache import InfrahubCache
-from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
-from infrahub.services.adapters.workflow.worker import WorkflowWorkerExecution
+from infrahub.services.adapters.message_bus import InfrahubMessageBus
 from infrahub.trace import add_span_exception, configure_trace, get_traceid
 from infrahub.worker import WORKER_IDENTITY
-from infrahub.workers.dependencies import get_message_bus, set_component_type
+from infrahub.workers.dependencies import get_cache, get_database, get_message_bus, get_workflow, set_component_type
 
 CURRENT_DIRECTORY = Path(__file__).parent.resolve()
 
@@ -56,26 +53,18 @@ async def app_initialization(application: FastAPI, enable_scheduler: bool = True
         )
 
     # Initialize database Driver and load local registry
-    database = application.state.db = InfrahubDatabase(mode=InfrahubDatabaseMode.DRIVER, driver=await get_db())
+    database = application.state.db = await get_database()
 
     build_component_registry()
 
-    workflow = config.OVERRIDE.workflow or (
-        WorkflowWorkerExecution()
-        if config.SETTINGS.workflow.driver == config.WorkflowDriver.WORKER
-        else WorkflowLocalExecution()
-    )
+    workflow = get_workflow()
     component_type = ComponentType.API_SERVER
     set_component_type(component_type=component_type)
     message_bus = await get_message_bus()
 
-    cache = config.OVERRIDE.cache or (await InfrahubCache.new_from_driver(driver=config.SETTINGS.cache.driver))
+    cache = await get_cache()
     service = await InfrahubServices.new(
-        cache=cache,
-        database=database,
-        message_bus=message_bus,
-        workflow=workflow,
-        component_type=component_type,
+        cache=cache, database=database, message_bus=message_bus, workflow=workflow, component_type=component_type
     )
     initialize_lock(service=service)
     # We must initialize DB after initialize lock and initialize lock depends on cache initialization

--- a/backend/infrahub/services/__init__.py
+++ b/backend/infrahub/services/__init__.py
@@ -164,6 +164,8 @@ class InfrahubServices:
     async def shutdown(self) -> None:
         await self.scheduler.shutdown()
         await self.message_bus.shutdown()
+        if self._cache is not None:
+            await self._cache.close_connection()
 
     async def send(self, message: InfrahubMessage, delay: MessageTTL | None = None, is_retry: bool = False) -> None:
         routing_key = ROUTING_KEY_MAP.get(type(message))

--- a/backend/infrahub/services/__init__.py
+++ b/backend/infrahub/services/__init__.py
@@ -9,7 +9,6 @@ from infrahub.message_bus.messages import ROUTING_KEY_MAP
 
 from .adapters.event import InfrahubEventService
 from .adapters.http.httpx import HttpxAdapter
-from .adapters.workflow.local import WorkflowLocalExecution
 from .adapters.workflow.worker import WorkflowWorkerExecution
 from .component import InfrahubComponent
 from .scheduler import InfrahubScheduler
@@ -109,10 +108,6 @@ class InfrahubServices:
         scheduler.service = service
 
         if message_bus is not None:
-            # Need circular dependency for injecting `service`  within `execute_message`. This might be removed
-            # using proper dependency injections.
-            message_bus.service = service
-
             if cache is not None and database is not None:
                 component = await InfrahubComponent.new(
                     cache=cache, component_type=component_type, db=database, message_bus=message_bus
@@ -121,18 +116,12 @@ class InfrahubServices:
                 # itself relying on service.
                 service._component = component
 
-        if workflow is not None:
-            if isinstance(workflow, WorkflowWorkerExecution):
-                assert service.component is not None
-                # Ideally `WorkflowWorkerExecution.initialize` would be directly part of WorkflowWorkerExecution
-                # constructor but this requires some redesign as it depends on InfrahubComponent which is instantiated
-                # after workflow instantiation.
-                await workflow.initialize(
-                    component_is_primary_server=await service.component.is_primary_gunicorn_worker()
-                )
-            elif isinstance(workflow, WorkflowLocalExecution):
-                # Circular dependency is only needed for injecting `service` within `execute_workflow` while testing.
-                workflow.service = service
+        if workflow is not None and isinstance(workflow, WorkflowWorkerExecution):
+            assert service.component is not None
+            # Ideally `WorkflowWorkerExecution.initialize` would be directly part of WorkflowWorkerExecution
+            # constructor but this requires some redesign as it depends on InfrahubComponent which is instantiated
+            # after workflow instantiation.
+            await workflow.initialize(component_is_primary_server=await service.component.is_primary_gunicorn_worker())
 
         return service
 

--- a/backend/infrahub/services/__init__.py
+++ b/backend/infrahub/services/__init__.py
@@ -10,7 +10,6 @@ from infrahub.message_bus.messages import ROUTING_KEY_MAP
 from .adapters.event import InfrahubEventService
 from .adapters.http.httpx import HttpxAdapter
 from .adapters.workflow.worker import WorkflowWorkerExecution
-from .component import InfrahubComponent
 from .scheduler import InfrahubScheduler
 
 if TYPE_CHECKING:
@@ -24,6 +23,7 @@ if TYPE_CHECKING:
     from .adapters.http import InfrahubHTTP
     from .adapters.message_bus import InfrahubMessageBus
     from .adapters.workflow import InfrahubWorkflow
+    from .component import InfrahubComponent
     from .protocols import InfrahubLogger
 
 
@@ -53,6 +53,7 @@ class InfrahubServices:
         database: InfrahubDatabase | None = None,
         message_bus: InfrahubMessageBus | None = None,
         workflow: InfrahubWorkflow | None = None,
+        component: InfrahubComponent | None = None,
     ):
         """
         This method should not be called directly, use `new` instead for a proper initialization.
@@ -63,12 +64,12 @@ class InfrahubServices:
         self._database = database
         self._message_bus = message_bus
         self._workflow = workflow
+        self._component = component
         self.log = log
         self.component_type = component_type
         self.http = http
         self.event = event
         self.scheduler = scheduler
-        self._component = None
 
     @classmethod
     async def new(
@@ -80,6 +81,7 @@ class InfrahubServices:
         message_bus: InfrahubMessageBus | None = None,
         workflow: InfrahubWorkflow | None = None,
         log: InfrahubLogger | None = None,
+        component: InfrahubComponent | None = None,
         component_type: ComponentType | None = None,
         http: InfrahubHTTP | None = None,
     ) -> InfrahubServices:
@@ -98,6 +100,7 @@ class InfrahubServices:
             message_bus=message_bus,
             workflow=workflow,
             log=log or get_logger(),
+            component=component,
             component_type=component_type,
             scheduler=scheduler,
             event=event or InfrahubEventService(message_bus),
@@ -106,15 +109,6 @@ class InfrahubServices:
 
         # This circular dependency could be removed if InfrahubScheduler only depends on what it needs.
         scheduler.service = service
-
-        if message_bus is not None:
-            if cache is not None and database is not None:
-                component = await InfrahubComponent.new(
-                    cache=cache, component_type=component_type, db=database, message_bus=message_bus
-                )
-                # We need to post init `service._component` because InfrahubComponent.new relies on message_bus
-                # itself relying on service.
-                service._component = component
 
         if workflow is not None and isinstance(workflow, WorkflowWorkerExecution):
             assert service.component is not None

--- a/backend/infrahub/services/adapters/cache/__init__.py
+++ b/backend/infrahub/services/adapters/cache/__init__.py
@@ -51,3 +51,7 @@ class InfrahubCache(ABC):
     @classmethod
     async def new(cls) -> InfrahubCache:
         raise NotImplementedError()
+
+    @abstractmethod
+    async def close_connection(self) -> None:
+        raise NotImplementedError()

--- a/backend/infrahub/services/adapters/cache/nats.py
+++ b/backend/infrahub/services/adapters/cache/nats.py
@@ -151,4 +151,4 @@ class NATSCache(InfrahubCache):
         return True
 
     async def close_connection(self) -> None:
-        pass
+        """"""

--- a/backend/infrahub/services/adapters/cache/nats.py
+++ b/backend/infrahub/services/adapters/cache/nats.py
@@ -149,3 +149,6 @@ class NATSCache(InfrahubCache):
                 return False
         await self._get_kv(key).put(key=key, value=value.encode())
         return True
+
+    async def close_connection(self) -> None:
+        pass

--- a/backend/infrahub/services/adapters/cache/redis.py
+++ b/backend/infrahub/services/adapters/cache/redis.py
@@ -54,3 +54,6 @@ class RedisCache(InfrahubCache):
     @classmethod
     async def new(cls) -> RedisCache:
         return cls()
+
+    async def close_connection(self) -> None:
+        await self.connection.aclose()

--- a/backend/infrahub/services/adapters/message_bus/__init__.py
+++ b/backend/infrahub/services/adapters/message_bus/__init__.py
@@ -13,7 +13,6 @@ if TYPE_CHECKING:
     from infrahub.config import BrokerDriver, BrokerSettings
     from infrahub.message_bus import InfrahubMessage, InfrahubResponse
     from infrahub.message_bus.types import MessageTTL
-    from infrahub.services import InfrahubServices
 
 
 class InfrahubMessageBus(ABC):
@@ -32,7 +31,6 @@ class InfrahubMessageBus(ABC):
     ]
     event_bindings: list[str] = ["refresh.registry.*"]
     broadcasted_event_bindings: list[str] = ["refresh.git.*"]
-    service: InfrahubServices
 
     async def shutdown(self) -> None:  # noqa: B027 We want a default empty behavior, so it's ok to have an empty non-abstract method.
         """Shutdown the Message bus"""

--- a/backend/infrahub/services/adapters/message_bus/local.py
+++ b/backend/infrahub/services/adapters/message_bus/local.py
@@ -36,8 +36,7 @@ class BusSimulator(InfrahubMessageBus):
         if routing_key not in self.messages_per_routing_key:
             self.messages_per_routing_key[routing_key] = []
         self.messages_per_routing_key[routing_key].append(message)
-        assert self.service is not None
-        await execute_message(routing_key=routing_key, message_body=message.body, service=self.service)
+        await execute_message(routing_key=routing_key, message_body=message.body, message_bus=self)
 
     async def reply(self, message: InfrahubMessage, routing_key: str) -> None:  # noqa: ARG002
         correlation_id = message.meta.correlation_id or "default"

--- a/backend/infrahub/services/adapters/message_bus/nats.py
+++ b/backend/infrahub/services/adapters/message_bus/nats.py
@@ -100,7 +100,9 @@ class NATSMessageBus(InfrahubMessageBus):
 
                 clear_log_context()
                 if message.subject in messages.MESSAGE_MAP:
-                    await execute_message(routing_key=message.subject, message_body=message.data, service=self.service)
+                    await execute_message(
+                        routing_key=message.subject, message_body=message.data, message_bus=self.service.message_bus
+                    )
                 else:
                     self.service.log.error("Invalid message received", message=f"{message!r}")
         finally:
@@ -119,7 +121,7 @@ class NATSMessageBus(InfrahubMessageBus):
                 clear_log_context()
                 if message.subject in messages.MESSAGE_MAP:
                     delay = await execute_message(
-                        routing_key=message.subject, message_body=message.data, service=self.service
+                        routing_key=message.subject, message_body=message.data, message_bus=self.service.message_bus
                     )
                     if delay:
                         return await message.nak(delay / 1000)

--- a/backend/infrahub/services/adapters/message_bus/rabbitmq.py
+++ b/backend/infrahub/services/adapters/message_bus/rabbitmq.py
@@ -30,7 +30,6 @@ if TYPE_CHECKING:
     from opentelemetry.instrumentation.aio_pika.span_builder import SpanBuilder
 
     from infrahub.config import BrokerSettings
-    from infrahub.services import InfrahubServices
 
 MessageFunction = Callable[[InfrahubMessage], Awaitable[None]]
 ResponseClass = TypeVar("ResponseClass")
@@ -72,7 +71,6 @@ class RabbitMQMessageBus(InfrahubMessageBus):
         self.channel: AbstractChannel
         self.exchange: AbstractExchange
         self.delayed_exchange: AbstractExchange
-        self.service: InfrahubServices  # Needed because we inject `service` while sending messages.
         self.connection: AbstractRobustConnection
         self.callback_queue: AbstractQueue
         self.events_queue: AbstractQueue
@@ -130,23 +128,25 @@ class RabbitMQMessageBus(InfrahubMessageBus):
 
         clear_log_context()
         if message.routing_key in messages.MESSAGE_MAP:
-            await execute_message(routing_key=message.routing_key, message_body=message.body, service=self.service)
+            await execute_message(routing_key=message.routing_key, message_body=message.body, message_bus=self)
         else:
-            self.service.log.error("Invalid message received", message=f"{message!r}")
+            # self.service.log.error("Invalid message received", message=f"{message!r}")
+            pass
 
     async def on_message(self, message: AbstractIncomingMessage) -> None:
         async with message.process():
             clear_log_context()
             if message.routing_key in messages.MESSAGE_MAP:
-                await execute_message(routing_key=message.routing_key, message_body=message.body, service=self.service)
+                await execute_message(routing_key=message.routing_key, message_body=message.body, message_bus=self)
             else:
-                self.service.log.error("Invalid message received", message=f"{message!r}")
+                # self.service.log.error("Invalid message received", message=f"{message!r}")
+                pass
 
     async def on_reconnect(
         self,
         weak: bool = False,  # noqa: ARG002
     ) -> None:
-        self.service.log.info("Reconnected to RabbitMQ, reinitializing connection")
+        # self.service.log.info("Reconnected to RabbitMQ, reinitializing connection")
         await self._initialize_connection()
 
     async def _initialize_api_server(self) -> None:
@@ -195,7 +195,7 @@ class RabbitMQMessageBus(InfrahubMessageBus):
 
     async def _initialize_git_worker(self) -> None:
         bindings = self.event_bindings + self.broadcasted_event_bindings
-        events_queue = await self.channel.declare_queue(name=f"worker-events-{WORKER_IDENTITY}", exclusive=True)
+        events_queue = await self.channel.declare_queue(name=f"worker-events-{WORKER_IDENTITY}")
 
         self.exchange = await self.channel.declare_exchange(
             f"{self.settings.namespace}.events", type="topic", durable=True
@@ -206,9 +206,7 @@ class RabbitMQMessageBus(InfrahubMessageBus):
         self.delayed_exchange = await self.channel.get_exchange(name=f"{self.settings.namespace}.delayed")
 
         await events_queue.consume(callback=self.on_callback, no_ack=True)
-        self.callback_queue = await self.channel.declare_queue(
-            name=f"worker-callback-{WORKER_IDENTITY}", exclusive=True
-        )
+        self.callback_queue = await self.channel.declare_queue(name=f"worker-callback-{WORKER_IDENTITY}")
         await self.callback_queue.consume(self.on_callback, no_ack=True)
 
         message_channel = await self.connection.channel()
@@ -246,7 +244,7 @@ class RabbitMQMessageBus(InfrahubMessageBus):
         request_id = log_data.get("request_id", "")
         message.meta = Meta(request_id=request_id, correlation_id=correlation_id, reply_to=self.callback_queue.name)
 
-        await self.service.message_bus.send(message=message)
+        await self.send(message=message)
 
         response: AbstractIncomingMessage = await future
         data = ujson.loads(response.body)

--- a/backend/infrahub/services/adapters/message_bus/rabbitmq.py
+++ b/backend/infrahub/services/adapters/message_bus/rabbitmq.py
@@ -18,6 +18,7 @@ from infrahub.message_bus.operations import execute_message
 from infrahub.message_bus.types import MessageTTL
 from infrahub.services.adapters.message_bus import InfrahubMessageBus
 from infrahub.worker import WORKER_IDENTITY
+from infrahub.workers.dependencies import get_log
 
 if TYPE_CHECKING:
     from aio_pika.abc import (
@@ -130,8 +131,7 @@ class RabbitMQMessageBus(InfrahubMessageBus):
         if message.routing_key in messages.MESSAGE_MAP:
             await execute_message(routing_key=message.routing_key, message_body=message.body, message_bus=self)
         else:
-            # self.service.log.error("Invalid message received", message=f"{message!r}")
-            pass
+            get_log().error("Invalid message received", message=f"{message!r}")
 
     async def on_message(self, message: AbstractIncomingMessage) -> None:
         async with message.process():
@@ -139,14 +139,13 @@ class RabbitMQMessageBus(InfrahubMessageBus):
             if message.routing_key in messages.MESSAGE_MAP:
                 await execute_message(routing_key=message.routing_key, message_body=message.body, message_bus=self)
             else:
-                # self.service.log.error("Invalid message received", message=f"{message!r}")
-                pass
+                get_log().error("Invalid message received", message=f"{message!r}")
 
     async def on_reconnect(
         self,
         weak: bool = False,  # noqa: ARG002
     ) -> None:
-        # self.service.log.info("Reconnected to RabbitMQ, reinitializing connection")
+        get_log().info("Reconnected to RabbitMQ, reinitializing connection")
         await self._initialize_connection()
 
     async def _initialize_api_server(self) -> None:

--- a/backend/infrahub/services/adapters/message_bus/rabbitmq.py
+++ b/backend/infrahub/services/adapters/message_bus/rabbitmq.py
@@ -194,7 +194,7 @@ class RabbitMQMessageBus(InfrahubMessageBus):
 
     async def _initialize_git_worker(self) -> None:
         bindings = self.event_bindings + self.broadcasted_event_bindings
-        events_queue = await self.channel.declare_queue(name=f"worker-events-{WORKER_IDENTITY}")
+        events_queue = await self.channel.declare_queue(name=f"worker-events-{WORKER_IDENTITY}", exclusive=True)
 
         self.exchange = await self.channel.declare_exchange(
             f"{self.settings.namespace}.events", type="topic", durable=True
@@ -205,7 +205,9 @@ class RabbitMQMessageBus(InfrahubMessageBus):
         self.delayed_exchange = await self.channel.get_exchange(name=f"{self.settings.namespace}.delayed")
 
         await events_queue.consume(callback=self.on_callback, no_ack=True)
-        self.callback_queue = await self.channel.declare_queue(name=f"worker-callback-{WORKER_IDENTITY}")
+        self.callback_queue = await self.channel.declare_queue(
+            name=f"worker-callback-{WORKER_IDENTITY}", exclusive=True
+        )
         await self.callback_queue.consume(self.on_callback, no_ack=True)
 
         message_channel = await self.connection.channel()

--- a/backend/infrahub/services/adapters/message_bus/rabbitmq.py
+++ b/backend/infrahub/services/adapters/message_bus/rabbitmq.py
@@ -12,13 +12,12 @@ from opentelemetry.semconv.trace import SpanAttributes
 
 from infrahub import config
 from infrahub.components import ComponentType
-from infrahub.log import clear_log_context, get_log_data
+from infrahub.log import clear_log_context, get_log_data, get_logger
 from infrahub.message_bus import InfrahubMessage, Meta, messages
 from infrahub.message_bus.operations import execute_message
 from infrahub.message_bus.types import MessageTTL
 from infrahub.services.adapters.message_bus import InfrahubMessageBus
 from infrahub.worker import WORKER_IDENTITY
-from infrahub.workers.dependencies import get_log
 
 if TYPE_CHECKING:
     from aio_pika.abc import (
@@ -131,7 +130,7 @@ class RabbitMQMessageBus(InfrahubMessageBus):
         if message.routing_key in messages.MESSAGE_MAP:
             await execute_message(routing_key=message.routing_key, message_body=message.body, message_bus=self)
         else:
-            get_log().error("Invalid message received", message=f"{message!r}")
+            get_logger().error("Invalid message received", message=f"{message!r}")
 
     async def on_message(self, message: AbstractIncomingMessage) -> None:
         async with message.process():
@@ -139,13 +138,13 @@ class RabbitMQMessageBus(InfrahubMessageBus):
             if message.routing_key in messages.MESSAGE_MAP:
                 await execute_message(routing_key=message.routing_key, message_body=message.body, message_bus=self)
             else:
-                get_log().error("Invalid message received", message=f"{message!r}")
+                get_logger().error("Invalid message received", message=f"{message!r}")
 
     async def on_reconnect(
         self,
         weak: bool = False,  # noqa: ARG002
     ) -> None:
-        get_log().info("Reconnected to RabbitMQ, reinitializing connection")
+        get_logger().info("Reconnected to RabbitMQ, reinitializing connection")
         await self._initialize_connection()
 
     async def _initialize_api_server(self) -> None:

--- a/backend/infrahub/services/adapters/workflow/local.py
+++ b/backend/infrahub/services/adapters/workflow/local.py
@@ -5,19 +5,16 @@ from typing import Any
 
 from typing_extensions import TYPE_CHECKING
 
-from infrahub.workers.utils import inject_context_parameter, inject_service_parameter
+from infrahub.workers.utils import inject_context_parameter
 from infrahub.workflows.models import WorkflowDefinition, WorkflowInfo
 
 from . import InfrahubWorkflow, Return
 
 if TYPE_CHECKING:
     from infrahub.context import InfrahubContext
-    from infrahub.services import InfrahubServices
 
 
 class WorkflowLocalExecution(InfrahubWorkflow):
-    service: InfrahubServices | None = None  # needed for local injections
-
     async def execute_workflow(
         self,
         workflow: WorkflowDefinition,
@@ -26,12 +23,8 @@ class WorkflowLocalExecution(InfrahubWorkflow):
         parameters: dict[str, Any] | None = None,
         tags: list[str] | None = None,  # noqa: ARG002
     ) -> Any:
-        if self.service is None:
-            raise ValueError("WorkflowLocalExecution.service is not initialized")
-
         flow_func = workflow.load_function()
         parameters = dict(parameters) if parameters is not None else {}  # avoid mutating input parameters
-        inject_service_parameter(func=flow_func, parameters=parameters, service=self.service)
         inject_context_parameter(func=flow_func, parameters=parameters, context=context)
 
         parameters = flow_func.validate_parameters(parameters=parameters)

--- a/backend/infrahub/tasks/artifact.py
+++ b/backend/infrahub/tasks/artifact.py
@@ -6,20 +6,19 @@ from infrahub import lock
 from infrahub.artifacts.models import CheckArtifactCreate
 from infrahub.core.constants import InfrahubKind
 from infrahub.git.models import RequestArtifactGenerate
-from infrahub.services import InfrahubServices
+from infrahub.workers.dependencies import get_client
 
 
 @task(name="define-artifact", task_run_name="Define Artifact", cache_policy=NONE)  # type: ignore[arg-type]
-async def define_artifact(
-    model: CheckArtifactCreate | RequestArtifactGenerate, service: InfrahubServices
-) -> tuple[InfrahubNode, bool]:
+async def define_artifact(model: CheckArtifactCreate | RequestArtifactGenerate) -> tuple[InfrahubNode, bool]:
     """Return an artifact together with a flag to indicate if the artifact is created now or already existed."""
+    client = get_client()
     created = False
     if model.artifact_id:
-        artifact = await service.client.get(kind=InfrahubKind.ARTIFACT, id=model.artifact_id, branch=model.branch_name)
+        artifact = await client.get(kind=InfrahubKind.ARTIFACT, id=model.artifact_id, branch=model.branch_name)
     else:
         async with lock.registry.get(f"{model.target_id}-{model.artifact_definition}", namespace="artifact"):
-            artifacts = await service.client.filters(
+            artifacts = await client.filters(
                 kind=InfrahubKind.ARTIFACT,
                 branch=model.branch_name,
                 definition__ids=[model.artifact_definition],
@@ -28,7 +27,7 @@ async def define_artifact(
             if artifacts:
                 artifact = artifacts[0]
             else:
-                artifact = await service.client.create(
+                artifact = await client.create(
                     kind=InfrahubKind.ARTIFACT,
                     branch=model.branch_name,
                     data={

--- a/backend/infrahub/tasks/check.py
+++ b/backend/infrahub/tasks/check.py
@@ -1,17 +1,14 @@
 from infrahub.log import get_logger
 from infrahub.message_bus import InfrahubMessage
 from infrahub.message_bus.types import KVTTL
-from infrahub.services import InfrahubServices
+from infrahub.workers.dependencies import get_cache
 
 log = get_logger()
 
 
-async def set_check_status(message: InfrahubMessage, conclusion: str, service: InfrahubServices) -> None:
+async def set_check_status(message: InfrahubMessage, conclusion: str) -> None:
     if message.meta.validator_execution_id and message.meta.check_execution_id:
         key = f"validator_execution_id:{message.meta.validator_execution_id}:check_execution_id:{message.meta.check_execution_id}"
-        await service.cache.set(
-            key=key,
-            value=conclusion,
-            expires=KVTTL.TWO_HOURS,
-        )
+        cache = await get_cache()
+        await cache.set(key=key, value=conclusion, expires=KVTTL.TWO_HOURS)
         log.debug("setting check status in cache", key=key, conclusion=conclusion)

--- a/backend/infrahub/telemetry/tasks.py
+++ b/backend/infrahub/telemetry/tasks.py
@@ -12,7 +12,7 @@ from infrahub import __version__, config
 from infrahub.core import registry, utils
 from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind
-from infrahub.workers.dependencies import get_database, get_http, get_infrahub_services
+from infrahub.workers.dependencies import get_component, get_database, get_http
 
 from .constants import TELEMETRY_KIND, TELEMETRY_VERSION
 from .database import gather_database_information
@@ -58,8 +58,8 @@ async def gather_anonymous_telemetry_data() -> TelemetryData:
     start_time = time.time()
 
     default_branch = registry.get_branch_from_registry()
-    service = await get_infrahub_services()
-    workers = await service.component.list_workers(branch=default_branch.name, schema_hash=False)
+    component = await get_component()
+    workers = await component.list_workers(branch=default_branch.name, schema_hash=False)
 
     data = TelemetryData(
         deployment_id=registry.id,

--- a/backend/infrahub/telemetry/tasks.py
+++ b/backend/infrahub/telemetry/tasks.py
@@ -12,16 +12,11 @@ from infrahub import __version__, config
 from infrahub.core import registry, utils
 from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind
-from infrahub.services import InfrahubServices
+from infrahub.workers.dependencies import get_database, get_http, get_infrahub_services
 
 from .constants import TELEMETRY_KIND, TELEMETRY_VERSION
 from .database import gather_database_information
-from .models import (
-    TelemetryBranchData,
-    TelemetryData,
-    TelemetrySchemaData,
-    TelemetryWorkerData,
-)
+from .models import TelemetryBranchData, TelemetryData, TelemetrySchemaData, TelemetryWorkerData
 from .task_manager import gather_prefect_information
 from .utils import determine_infrahub_type
 
@@ -37,8 +32,9 @@ async def gather_schema_information(branch: Branch) -> TelemetrySchemaData:
 
 
 @task(name="telemetry-feature-information", task_run_name="Gather Feature Information", cache_policy=NONE)
-async def gather_feature_information(service: InfrahubServices) -> dict[str, int]:
-    async with service.database.start_session(read_only=True) as db:
+async def gather_feature_information() -> dict[str, int]:
+    database = await get_database()
+    async with database.start_session(read_only=False) as db:
         data = {}
         features_to_count = [
             InfrahubKind.ARTIFACT,
@@ -58,10 +54,11 @@ async def gather_feature_information(service: InfrahubServices) -> dict[str, int
 
 
 @task(name="telemetry-gather-data", task_run_name="Gather Anonynous Data", cache_policy=NONE)
-async def gather_anonymous_telemetry_data(service: InfrahubServices) -> TelemetryData:
+async def gather_anonymous_telemetry_data() -> TelemetryData:
     start_time = time.time()
 
     default_branch = registry.get_branch_from_registry()
+    service = await get_infrahub_services()
     workers = await service.component.list_workers(branch=default_branch.name, schema_hash=False)
 
     data = TelemetryData(
@@ -78,9 +75,9 @@ async def gather_anonymous_telemetry_data(service: InfrahubServices) -> Telemetr
         branches=TelemetryBranchData(
             total=len(registry.branch),
         ),
-        features=await gather_feature_information(service=service),
+        features=await gather_feature_information(),
         schema_info=await gather_schema_information(branch=default_branch),
-        database=await gather_database_information(db=service.database),
+        database=await gather_database_information(db=await get_database()),
         prefect=await gather_prefect_information(),
     )
 
@@ -90,14 +87,14 @@ async def gather_anonymous_telemetry_data(service: InfrahubServices) -> Telemetr
 
 
 @task(name="telemetry-post-data", task_run_name="Upload data", retries=5, cache_policy=NONE)
-async def post_telemetry_data(service: InfrahubServices, url: str, payload: dict[str, Any]) -> None:
+async def post_telemetry_data(url: str, payload: dict[str, Any]) -> None:
     """Send the telemetry data to the specified URL, using HTTP POST."""
-    response = await service.http.post(url=url, json=payload)
+    response = await get_http().post(url=url, json=payload)
     response.raise_for_status()
 
 
 @flow(name="anonymous_telemetry_send", flow_run_name="Send anonymous telemetry")
-async def send_telemetry_push(service: InfrahubServices) -> None:
+async def send_telemetry_push() -> None:
     log = get_run_logger()
     if config.SETTINGS.main.telemetry_optout:
         log.info("Skipping, User opted out of this service.")
@@ -105,7 +102,7 @@ async def send_telemetry_push(service: InfrahubServices) -> None:
 
     log.info(f"Pushing anonymous telemetry data to {config.SETTINGS.main.telemetry_endpoint}...")
 
-    data = await gather_anonymous_telemetry_data(service=service)
+    data = await gather_anonymous_telemetry_data()
     data_dict = data.model_dump(mode="json")
     log.info(f"Anonymous usage telemetry gathered in {data.execution_time} seconds. | {data_dict}")
 
@@ -116,4 +113,4 @@ async def send_telemetry_push(service: InfrahubServices) -> None:
         "checksum": hashlib.sha256(json.dumps(data_dict).encode()).hexdigest(),
     }
 
-    await post_telemetry_data(service=service, url=config.SETTINGS.main.telemetry_endpoint, payload=payload)
+    await post_telemetry_data(url=config.SETTINGS.main.telemetry_endpoint, payload=payload)

--- a/backend/infrahub/transformations/tasks.py
+++ b/backend/infrahub/transformations/tasks.py
@@ -4,7 +4,7 @@ from prefect import flow
 
 from infrahub.git.repository import get_initialized_repo
 from infrahub.log import get_logger
-from infrahub.services import InfrahubServices
+from infrahub.workers.dependencies import get_client
 from infrahub.workflows.utils import add_branch_tag
 
 from .models import TransformJinjaTemplateData, TransformPythonData
@@ -13,11 +13,13 @@ log = get_logger()
 
 
 @flow(name="transform_render_python", flow_run_name="Render transform python", persist_result=True)
-async def transform_python(message: TransformPythonData, service: InfrahubServices) -> Any:
+async def transform_python(message: TransformPythonData) -> Any:
     await add_branch_tag(branch_name=message.branch)
 
+    client = get_client()
+
     repo = await get_initialized_repo(
-        client=service.client,
+        client=client,
         repository_id=message.repository_id,
         name=message.repository_name,
         repository_kind=message.repository_kind,
@@ -25,11 +27,11 @@ async def transform_python(message: TransformPythonData, service: InfrahubServic
     )
 
     transformed_data = await repo.execute_python_transform.with_options(timeout_seconds=message.timeout)(
+        client=client,
         branch_name=message.branch,
         commit=message.commit,
         location=message.transform_location,
         data=message.data,
-        client=service.client,
         convert_query_response=message.convert_query_response,
     )  # type: ignore[misc]
 
@@ -37,11 +39,13 @@ async def transform_python(message: TransformPythonData, service: InfrahubServic
 
 
 @flow(name="transform_render_jinja2_template", flow_run_name="Render transform Jinja2", persist_result=True)
-async def transform_render_jinja2_template(message: TransformJinjaTemplateData, service: InfrahubServices) -> str:
+async def transform_render_jinja2_template(message: TransformJinjaTemplateData) -> str:
     await add_branch_tag(branch_name=message.branch)
 
+    client = get_client()
+
     repo = await get_initialized_repo(
-        client=service.client,
+        client=client,
         repository_id=message.repository_id,
         name=message.repository_name,
         repository_kind=message.repository_kind,

--- a/backend/infrahub/trigger/tasks.py
+++ b/backend/infrahub/trigger/tasks.py
@@ -6,16 +6,17 @@ from infrahub.computed_attribute.gather import (
     gather_trigger_computed_attribute_jinja2,
     gather_trigger_computed_attribute_python,
 )
-from infrahub.services import InfrahubServices
 from infrahub.trigger.catalogue import builtin_triggers
 from infrahub.webhook.gather import gather_trigger_webhook
+from infrahub.workers.dependencies import get_database
 
 from .setup import setup_triggers
 
 
 @flow(name="trigger-configure-all", flow_run_name="Configure all triggers")
-async def trigger_configure_all(service: InfrahubServices) -> None:
-    async with service.database.start_session() as db:
+async def trigger_configure_all() -> None:
+    database = await get_database()
+    async with database.start_session() as db:
         webhook_trigger = await gather_trigger_webhook(db=db)
         computed_attribute_j2_triggers = await gather_trigger_computed_attribute_jinja2()
         (

--- a/backend/infrahub/validators/events.py
+++ b/backend/infrahub/validators/events.py
@@ -3,11 +3,11 @@ from infrahub_sdk.protocols import CoreValidator
 from infrahub.context import InfrahubContext
 from infrahub.events.models import EventMeta
 from infrahub.events.validator_action import ValidatorFailedEvent, ValidatorPassedEvent, ValidatorStartedEvent
-from infrahub.services import InfrahubServices
+from infrahub.services.adapters.event import InfrahubEventService
 
 
 async def send_failed_validator(
-    service: InfrahubServices, validator: CoreValidator, proposed_change_id: str, context: InfrahubContext
+    event_service: InfrahubEventService, validator: CoreValidator, proposed_change_id: str, context: InfrahubContext
 ) -> None:
     event = ValidatorFailedEvent(
         node_id=validator.id,
@@ -15,11 +15,11 @@ async def send_failed_validator(
         proposed_change_id=proposed_change_id,
         meta=EventMeta.from_context(context=context),
     )
-    await service.event.send(event=event)
+    await event_service.send(event=event)
 
 
 async def send_passed_validator(
-    service: InfrahubServices, validator: CoreValidator, proposed_change_id: str, context: InfrahubContext
+    event_service: InfrahubEventService, validator: CoreValidator, proposed_change_id: str, context: InfrahubContext
 ) -> None:
     event = ValidatorPassedEvent(
         node_id=validator.id,
@@ -27,11 +27,11 @@ async def send_passed_validator(
         proposed_change_id=proposed_change_id,
         meta=EventMeta.from_context(context=context),
     )
-    await service.event.send(event=event)
+    await event_service.send(event=event)
 
 
 async def send_start_validator(
-    service: InfrahubServices, validator: CoreValidator, proposed_change_id: str, context: InfrahubContext
+    event_service: InfrahubEventService, validator: CoreValidator, proposed_change_id: str, context: InfrahubContext
 ) -> None:
     event = ValidatorStartedEvent(
         node_id=validator.id,
@@ -39,4 +39,4 @@ async def send_start_validator(
         proposed_change_id=proposed_change_id,
         meta=EventMeta.from_context(context=context),
     )
-    await service.event.send(event=event)
+    await event_service.send(event=event)

--- a/backend/infrahub/validators/tasks.py
+++ b/backend/infrahub/validators/tasks.py
@@ -1,10 +1,11 @@
 from typing import Any, TypeVar, cast
 
+from infrahub_sdk.client import InfrahubClient
 from infrahub_sdk.protocols import CoreValidator
 
 from infrahub.context import InfrahubContext
 from infrahub.core.constants import ValidatorConclusion, ValidatorState
-from infrahub.services import InfrahubServices
+from infrahub.workers.dependencies import get_event_service
 
 from .events import send_start_validator
 
@@ -12,7 +13,7 @@ ValidatorType = TypeVar("ValidatorType", bound=CoreValidator)
 
 
 async def start_validator(
-    service: InfrahubServices,
+    client: InfrahubClient,
     validator: CoreValidator | None,
     validator_type: type[ValidatorType],
     proposed_change: str,
@@ -28,14 +29,12 @@ async def start_validator(
         validator = cast(ValidatorType, validator)
     else:
         data["proposed_change"] = proposed_change
-        validator = await service.client.create(
-            kind=validator_type,
-            data=data,
-        )
+        validator = await client.create(kind=validator_type, data=data)
         await validator.save()
 
+    event_service = await get_event_service()
     await send_start_validator(
-        service=service, validator=validator, proposed_change_id=proposed_change, context=context
+        event_service=event_service, validator=validator, proposed_change_id=proposed_change, context=context
     )
 
     return validator

--- a/backend/infrahub/webhook/models.py
+++ b/backend/infrahub/webhook/models.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field, computed_field
 from typing_extensions import Self
 
 from infrahub.core import registry
-from infrahub.core.constants import InfrahubKind
+from infrahub.core.constants import GLOBAL_BRANCH_NAME, InfrahubKind
 from infrahub.core.timestamp import Timestamp
 from infrahub.events.utils import get_all_infrahub_node_kind_events
 from infrahub.git.repository import InfrahubReadOnlyRepository, InfrahubRepository
@@ -21,10 +21,11 @@ from infrahub.workflows.catalogue import WEBHOOK_PROCESS
 
 if TYPE_CHECKING:
     from httpx import Response
+    from infrahub_sdk.client import InfrahubClient
     from infrahub_sdk.protocols import CoreCustomWebhook, CoreStandardWebhook, CoreTransformPython, CoreWebhook
 
     from infrahub.core.protocols import CoreWebhook as CoreWebhookNode
-    from infrahub.services import InfrahubServices
+    from infrahub.services.adapters.http import InfrahubHTTP
 
 
 class WebhookTriggerDefinition(TriggerDefinition):
@@ -104,9 +105,8 @@ class EventContext(BaseModel):
 
         return cls(
             id=event_id,
-            branch=branch_info.get("name")
-            if branch_info and branch_info.get("name") != registry.get_global_branch().name
-            else None,
+            # We use `GLOBAL_BRANCH_NAME` constant instead of `registry.get_global_branch().name` to the flow from depending on the registry
+            branch=branch_info.get("name") if branch_info and branch_info.get("name") != GLOBAL_BRANCH_NAME else None,
             account_id=account_info.get("account_id"),
             occured_at=event_occured_at,
             event=event_type,
@@ -122,7 +122,7 @@ class Webhook(BaseModel):
     _payload: Any = None
     _headers: dict[str, Any] | None = None
 
-    async def _prepare_payload(self, data: dict[str, Any], context: EventContext, service: InfrahubServices) -> None:  # noqa: ARG002
+    async def _prepare_payload(self, data: dict[str, Any], context: EventContext, client: InfrahubClient) -> None:  # noqa: ARG002
         self._payload = {"data": data, **context.model_dump()}
 
     def _assign_headers(self) -> None:
@@ -133,13 +133,15 @@ class Webhook(BaseModel):
     def webhook_type(self) -> str:
         return self.__class__.__name__
 
-    async def prepare(self, data: dict[str, Any], context: EventContext, service: InfrahubServices) -> None:
-        await self._prepare_payload(data=data, context=context, service=service)
+    async def prepare(self, data: dict[str, Any], context: EventContext, client: InfrahubClient) -> None:
+        await self._prepare_payload(data=data, context=context, client=client)
         self._assign_headers()
 
-    async def send(self, data: dict[str, Any], context: EventContext, service: InfrahubServices) -> Response:
-        await self.prepare(data=data, context=context, service=service)
-        return await service.http.post(url=self.url, json=self.get_payload(), headers=self._headers)
+    async def send(
+        self, data: dict[str, Any], context: EventContext, http_service: InfrahubHTTP, client: InfrahubClient
+    ) -> Response:
+        await self.prepare(data=data, context=context, client=client)
+        return await http_service.post(url=self.url, json=self.get_payload(), headers=self._headers)
 
     def get_payload(self) -> dict[str, Any]:
         return self._payload
@@ -207,16 +209,14 @@ class TransformWebhook(Webhook):
     transform_timeout: int = Field(...)
     convert_query_response: bool = Field(...)
 
-    async def _prepare_payload(self, data: dict[str, Any], context: EventContext, service: InfrahubServices) -> None:
+    async def _prepare_payload(self, data: dict[str, Any], context: EventContext, client: InfrahubClient) -> None:
         repo: InfrahubReadOnlyRepository | InfrahubRepository
         if self.repository_kind == InfrahubKind.READONLYREPOSITORY:
             repo = await InfrahubReadOnlyRepository.init(
-                id=self.repository_id, name=self.repository_name, client=service.client
+                id=self.repository_id, name=self.repository_name, client=client
             )
         else:
-            repo = await InfrahubRepository.init(
-                id=self.repository_id, name=self.repository_name, client=service.client
-            )
+            repo = await InfrahubRepository.init(id=self.repository_id, name=self.repository_name, client=client)
 
         branch = context.branch or repo.default_branch
         commit = repo.get_commit_value(branch_name=branch)
@@ -227,7 +227,7 @@ class TransformWebhook(Webhook):
             location=f"{self.transform_file}::{self.transform_class}",
             convert_query_response=self.convert_query_response,
             data={"data": data, **context.model_dump()},
-            client=service.client,
+            client=client,
         )  # type: ignore[misc]
 
     @classmethod

--- a/backend/infrahub/webhook/tasks.py
+++ b/backend/infrahub/webhook/tasks.py
@@ -8,13 +8,13 @@ from infrahub_sdk.protocols import CoreTransformPython, CoreWebhook
 from prefect import flow, task
 from prefect.automations import AutomationCore
 from prefect.cache_policies import NONE
-from prefect.client.orchestration import get_client
+from prefect.client.orchestration import get_client as get_prefect_client
 from prefect.logging import get_run_logger
 
 from infrahub.message_bus.types import KVTTL
-from infrahub.services import InfrahubServices  # noqa: TC001  needed for prefect flow
 from infrahub.trigger.models import TriggerType
 from infrahub.trigger.setup import setup_triggers_specific
+from infrahub.workers.dependencies import get_cache, get_client, get_database, get_http
 from infrahub.workflows.utils import add_tags
 
 from .gather import gather_trigger_webhook
@@ -22,6 +22,7 @@ from .models import CustomWebhook, EventContext, StandardWebhook, TransformWebho
 
 if TYPE_CHECKING:
     from httpx import Response
+
 
 WEBHOOK_MAP: dict[str, type[Webhook]] = {
     "StandardWebhook": StandardWebhook,
@@ -31,10 +32,10 @@ WEBHOOK_MAP: dict[str, type[Webhook]] = {
 
 
 @task(name="webhook-send", task_run_name="Send Standard Webhook {webhook.name}", cache_policy=NONE, retries=3)
-async def webhook_send(
-    webhook: Webhook, context: EventContext, event_data: dict, service: InfrahubServices
-) -> Response:
-    response = await webhook.send(data=event_data, context=context, service=service)
+async def webhook_send(webhook: Webhook, context: EventContext, event_data: dict) -> Response:
+    http_service = get_http()
+    client = get_client()
+    response = await webhook.send(data=event_data, context=context, http_service=http_service, client=client)
     response.raise_for_status()
     return response
 
@@ -71,21 +72,22 @@ async def webhook_process(
     event_type: str,
     event_occured_at: str,
     event_payload: dict,
-    service: InfrahubServices,
     branch_name: str | None = None,
 ) -> None:
     log = get_run_logger()
+    client = get_client()
+    cache = await get_cache()
 
     if branch_name:
         await add_tags(branches=[branch_name])
 
-    webhook_data_str = await service.cache.get(key=f"webhook:{webhook_id}")
+    webhook_data_str = await cache.get(key=f"webhook:{webhook_id}")
     if not webhook_data_str:
         log.info(f"Webhook {webhook_id} not found in cache")
-        webhook_node = await service.client.get(kind=webhook_kind, id=webhook_id)
-        webhook = await convert_node_to_webhook(webhook_node=webhook_node, client=service.client)
+        webhook_node = await client.get(kind=webhook_kind, id=webhook_id)
+        webhook = await convert_node_to_webhook(webhook_node=webhook_node, client=client)
         webhook_data = webhook.to_cache()
-        await service.cache.set(key=f"webhook:{webhook_id}", value=ujson.dumps(webhook_data), expires=KVTTL.TWO_HOURS)
+        await cache.set(key=f"webhook:{webhook_id}", value=ujson.dumps(webhook_data), expires=KVTTL.TWO_HOURS)
 
     else:
         webhook_data = ujson.loads(webhook_data_str)
@@ -103,35 +105,33 @@ async def webhook_process(
         event_payload=event_payload,
     )
     event_data = event_payload.get("data", {})
-    response = await webhook_send(webhook=webhook, context=webhook_context, event_data=event_data, service=service)
+    response = await webhook_send(webhook=webhook, context=webhook_context, event_data=event_data)
     log.info(f"Successfully sent webhook to {response.url} with status {response.status_code}")
 
 
 @flow(name="webhook-setup-automation-all", flow_run_name="Configure all webhooks")
-async def configure_webhook_all(service: InfrahubServices) -> None:
+async def configure_webhook_all() -> None:
     log = get_run_logger()
 
-    async with service.database.start_session(read_only=True) as db:
+    database = await get_database()
+    async with database.start_session(read_only=True) as db:
         triggers = await gather_trigger_webhook(db=db)
 
     log.info(f"{len(triggers)} Webhooks automation configuration completed")
-    await setup_triggers_specific(
-        gatherer=gather_trigger_webhook, db=service.database, trigger_type=TriggerType.WEBHOOK
-    )  # type: ignore[misc]
+    await setup_triggers_specific(gatherer=gather_trigger_webhook, db=database, trigger_type=TriggerType.WEBHOOK)  # type: ignore[misc]
 
 
 @flow(name="webhook-setup-automation-one", flow_run_name="Configurate webhook for {webhook_name}")
 async def configure_webhook_one(
     webhook_name: str,  # noqa: ARG001
     event_data: dict,
-    service: InfrahubServices,
 ) -> None:
     log = get_run_logger()
 
-    webhook = await service.client.get(kind=CoreWebhook, id=event_data["node_id"])
+    webhook = await get_client().get(kind=CoreWebhook, id=event_data["node_id"])
     trigger = WebhookTriggerDefinition.from_object(webhook)
 
-    async with get_client(sync_client=False) as prefect_client:
+    async with get_prefect_client(sync_client=False) as prefect_client:
         # Query the deployment associated with the trigger to have its ID
         deployment_name = trigger.get_deployment_names()[0]
         deployment = await prefect_client.read_deployment_by_name(name=f"{deployment_name}/{deployment_name}")
@@ -154,18 +154,18 @@ async def configure_webhook_one(
             await prefect_client.create_automation(automation=automation)
             log.info(f"Automation {trigger.generate_name()} created")
 
-        await service.cache.delete(key=f"webhook:{webhook.id}")
+        cache = await get_cache()
+        await cache.delete(key=f"webhook:{webhook.id}")
 
 
 @flow(name="webhook-delete-automation", flow_run_name="Delete webhook automation for {webhook_name}")
 async def delete_webhook_automation(
     webhook_id: str,
     webhook_name: str,  # noqa: ARG001
-    service: InfrahubServices,
 ) -> None:
     log = get_run_logger()
 
-    async with get_client(sync_client=False) as prefect_client:
+    async with get_prefect_client(sync_client=False) as prefect_client:
         automation_name = WebhookTriggerDefinition.generate_name_from_id(id=webhook_id)
 
         existing_automations = await prefect_client.read_automations_by_name(automation_name)
@@ -175,4 +175,5 @@ async def delete_webhook_automation(
             await prefect_client.delete_automation(automation_id=existing_automation.id)
             log.info(f"Automation {automation_name} deleted")
 
-        await service.cache.delete(key=f"webhook:{webhook_id}")
+        cache = await get_cache()
+        await cache.delete(key=f"webhook:{webhook_id}")

--- a/backend/infrahub/workers/infrahub_async.py
+++ b/backend/infrahub/workers/infrahub_async.py
@@ -112,7 +112,6 @@ class InfrahubWorkerAsync(BaseWorker):
         )
 
         set_component_type(component_type=self.component_type)
-        await self._init_services(client=client)
 
         if not registry.schema_has_been_initialized():
             initialize_lock(service=self.service)

--- a/backend/infrahub/workers/infrahub_async.py
+++ b/backend/infrahub/workers/infrahub_async.py
@@ -18,17 +18,12 @@ from infrahub import config
 from infrahub.components import ComponentType
 from infrahub.core import registry
 from infrahub.core.initialization import initialization
-from infrahub.database import InfrahubDatabase, get_db
 from infrahub.dependencies.registry import build_component_registry
 from infrahub.git import initialize_repositories_directory
 from infrahub.lock import initialize_lock
 from infrahub.services import InfrahubServices
-from infrahub.services.adapters.cache import InfrahubCache
-from infrahub.services.adapters.workflow import InfrahubWorkflow
-from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
-from infrahub.services.adapters.workflow.worker import WorkflowWorkerExecution
 from infrahub.trace import configure_trace
-from infrahub.workers.dependencies import get_message_bus, set_component_type
+from infrahub.workers.dependencies import get_cache, get_database, get_message_bus, get_workflow, set_component_type
 from infrahub.workers.utils import inject_service_parameter, load_flow_function
 from infrahub.workflows.models import TASK_RESULT_STORAGE_NAME
 
@@ -180,32 +175,15 @@ class InfrahubWorkerAsync(BaseWorker):
 
         return client
 
-    async def _init_database(self) -> InfrahubDatabase:
-        return InfrahubDatabase(driver=await get_db(retry=1))
-
-    async def _init_workflow(self) -> InfrahubWorkflow:
-        return config.OVERRIDE.workflow or (
-            WorkflowWorkerExecution()
-            if config.SETTINGS.workflow.driver == config.WorkflowDriver.WORKER
-            else WorkflowLocalExecution()
-        )
-
-    async def _init_cache(self) -> InfrahubCache:
-        return config.OVERRIDE.cache or (await InfrahubCache.new_from_driver(driver=config.SETTINGS.cache.driver))
-
     async def _init_services(self, client: InfrahubClient) -> None:
         client = await self._init_infrahub_client(client=client)
-        database = await self._init_database()
-        workflow = await self._init_workflow()
-        message_bus = await get_message_bus()
-        cache = await self._init_cache()
 
         service = await InfrahubServices.new(
-            cache=cache,
+            cache=await get_cache(),
             client=client,
-            database=database,
-            message_bus=message_bus,
-            workflow=workflow,
+            database=await get_database(),
+            message_bus=await get_message_bus(),
+            workflow=get_workflow(),
             component_type=self.component_type,
         )
 

--- a/backend/infrahub/workers/infrahub_async.py
+++ b/backend/infrahub/workers/infrahub_async.py
@@ -143,8 +143,7 @@ class InfrahubWorkerAsync(BaseWorker):
         entrypoint: str = configuration._related_objects["deployment"].entrypoint
 
         file_path, flow_name = entrypoint.split(":")
-        file_path.replace("/", ".")
-        module_path = file_path.replace("backend/", "").replace(".py", "").replace("/", ".")
+        module_path = file_path.removeprefix("backend/").removesuffix(".py").replace("/", ".")
         flow_func = load_flow_function(module_path=module_path, flow_name=flow_name)
         inject_service_parameter(func=flow_func, parameters=flow_run.parameters, service=self.service)
         flow_run_logger.debug("Validating parameters")
@@ -155,10 +154,7 @@ class InfrahubWorkerAsync(BaseWorker):
 
         await run_flow_async(flow=flow_func, flow_run=flow_run, parameters=params, return_type="state")
 
-        return InfrahubWorkerAsyncResult(
-            status_code=0,
-            identifier=str(flow_run.id),
-        )
+        return InfrahubWorkerAsyncResult(status_code=0, identifier=str(flow_run.id))
 
     def _init_logger(self) -> None:
         """Initialize loggers to use the API handle provided by Prefect."""

--- a/backend/infrahub/workers/infrahub_async.py
+++ b/backend/infrahub/workers/infrahub_async.py
@@ -112,6 +112,7 @@ class InfrahubWorkerAsync(BaseWorker):
         )
 
         set_component_type(component_type=self.component_type)
+        await self._init_services(client=client)
 
         if not registry.schema_has_been_initialized():
             initialize_lock(service=self.service)

--- a/backend/infrahub/workers/infrahub_async.py
+++ b/backend/infrahub/workers/infrahub_async.py
@@ -23,8 +23,14 @@ from infrahub.git import initialize_repositories_directory
 from infrahub.lock import initialize_lock
 from infrahub.services import InfrahubServices
 from infrahub.trace import configure_trace
-from infrahub.workers.dependencies import get_cache, get_database, get_message_bus, get_workflow, set_component_type
-from infrahub.workers.utils import inject_service_parameter, load_flow_function
+from infrahub.workers.dependencies import (
+    get_cache,
+    get_component,
+    get_database,
+    get_message_bus,
+    get_workflow,
+    set_component_type,
+)
 from infrahub.workflows.models import TASK_RESULT_STORAGE_NAME
 
 WORKER_QUERY_SECONDS = "2"
@@ -184,6 +190,7 @@ class InfrahubWorkerAsync(BaseWorker):
             database=await get_database(),
             message_bus=await get_message_bus(),
             workflow=get_workflow(),
+            component=await get_component(),
             component_type=self.component_type,
         )
 

--- a/backend/infrahub/workers/infrahub_async.py
+++ b/backend/infrahub/workers/infrahub_async.py
@@ -31,6 +31,7 @@ from infrahub.workers.dependencies import (
     get_workflow,
     set_component_type,
 )
+from infrahub.workers.utils import inject_service_parameter, load_flow_function
 from infrahub.workflows.models import TASK_RESULT_STORAGE_NAME
 
 WORKER_QUERY_SECONDS = "2"

--- a/backend/infrahub/workflows/catalogue.py
+++ b/backend/infrahub/workflows/catalogue.py
@@ -391,7 +391,7 @@ GIT_REPOSITORIES_DIFF_NAMES_ONLY = WorkflowDefinition(
 
 GIT_REPOSITORIES_IMPORT_OBJECTS = WorkflowDefinition(
     name="git-repository-import-object",
-    type=WorkflowType.INTERNAL,  # I think it's not supposed to be user
+    type=WorkflowType.USER,
     module="infrahub.git.tasks",
     function="import_objects_from_git_repository",
     tags=[WorkflowTag.DATABASE_CHANGE],

--- a/backend/infrahub/workflows/catalogue.py
+++ b/backend/infrahub/workflows/catalogue.py
@@ -391,7 +391,7 @@ GIT_REPOSITORIES_DIFF_NAMES_ONLY = WorkflowDefinition(
 
 GIT_REPOSITORIES_IMPORT_OBJECTS = WorkflowDefinition(
     name="git-repository-import-object",
-    type=WorkflowType.USER,
+    type=WorkflowType.INTERNAL,  # I think it's not supposed to be user
     module="infrahub.git.tasks",
     function="import_objects_from_git_repository",
     tags=[WorkflowTag.DATABASE_CHANGE],

--- a/backend/infrahub/workflows/initialization.py
+++ b/backend/infrahub/workflows/initialization.py
@@ -10,6 +10,7 @@ from infrahub import config
 from infrahub.trigger.catalogue import builtin_triggers
 from infrahub.trigger.models import TriggerType
 from infrahub.trigger.setup import setup_triggers
+# from infrahub.workflows.constants import WorkerType
 
 from .catalogue import worker_pools, workflows
 from .models import TASK_RESULT_STORAGE_NAME
@@ -24,6 +25,24 @@ async def setup_worker_pools(client: PrefectClient) -> None:
             type=worker.worker_type or config.SETTINGS.workflow.default_worker_type,
             description=worker.description,
         )
+
+        # if worker.worker_type == WorkerType.PROCESS:
+        #     wp.base_job_template = {
+        #         "job_configuration": {"env": "{{ env }}", "working_dir": "{{ working_dir }}"},
+        #         "variables": {
+        #             "type": "object",
+        #             "properties": {
+        #                 "env": {"type": "object", "default": {"INFRAHUB_ADDRESS": "", "INFRAHUB_API_TOKEN": ""}},
+        #                 "working_dir": {"type": "string", "default": "/tmp"},
+        #                 "command": {"type": ["string", "null"], "default": None},
+        #                 "labels": {"type": "object", "default": {}},
+        #                 "name": {"type": ["string", "null"], "default": None},
+        #                 "stream_output": {"type": "boolean", "default": True},
+        #             },
+        #             "required": [],
+        #         },
+        #     }
+
         try:
             await client.create_work_pool(work_pool=wp, overwrite=True)
             log.info(f"Work pool {worker.name} created successfully ... ")

--- a/backend/infrahub/workflows/initialization.py
+++ b/backend/infrahub/workflows/initialization.py
@@ -11,7 +11,6 @@ from infrahub.trigger.catalogue import builtin_triggers
 from infrahub.trigger.models import TriggerType
 from infrahub.trigger.setup import setup_triggers
 
-# from infrahub.workflows.constants import WorkerType
 from .catalogue import worker_pools, workflows
 from .models import TASK_RESULT_STORAGE_NAME
 

--- a/backend/infrahub/workflows/initialization.py
+++ b/backend/infrahub/workflows/initialization.py
@@ -10,8 +10,8 @@ from infrahub import config
 from infrahub.trigger.catalogue import builtin_triggers
 from infrahub.trigger.models import TriggerType
 from infrahub.trigger.setup import setup_triggers
-# from infrahub.workflows.constants import WorkerType
 
+# from infrahub.workflows.constants import WorkerType
 from .catalogue import worker_pools, workflows
 from .models import TASK_RESULT_STORAGE_NAME
 

--- a/backend/infrahub/workflows/models.py
+++ b/backend/infrahub/workflows/models.py
@@ -11,7 +11,7 @@ from prefect.client.schemas.schedules import CronSchedule
 from pydantic import BaseModel, Field
 from typing_extensions import Self
 
-from infrahub import __version__
+from infrahub import __version__, config
 
 from .constants import TAG_NAMESPACE, WorkflowTag, WorkflowType
 
@@ -51,6 +51,8 @@ class WorkflowDefinition(BaseModel):
 
     @property
     def entrypoint(self) -> str:
+        if self.type == WorkflowType.USER:
+            return f"{self.module}:{self.function}"
         return f"backend/{self.module.replace('.', '/')}:{self.function}"
 
     @property
@@ -61,6 +63,21 @@ class WorkflowDefinition(BaseModel):
         payload: dict[str, Any] = {"name": self.name, "entrypoint": self.entrypoint, "tags": self.get_tags()}
         if self.type == WorkflowType.CORE:
             payload["version"] = __version__
+        # if self.type == WorkflowType.USER:
+        #     # This is not supposed to be necessary, I think, but without this the worker just crashes when it processes flows
+        #     payload["pull_steps"] = [
+        #         {
+        #             "prefect.deployments.steps.set_working_directory": {
+        #                 "directory": config.SETTINGS.workflow.worker_working_directory
+        #             }
+        #         }
+        #     ]
+        #     payload["job_variables"] = {
+        #         "env": {
+        #             "INFRAHUB_ADDRESS": config.SETTINGS.main.internal_address,
+        #             "INFRAHUB_API_TOKEN": config.SETTINGS.initial.admin_token,
+        #         }
+        #     }
         if self.cron:
             payload["schedules"] = [DeploymentScheduleCreate(schedule=CronSchedule(cron=self.cron))]
 

--- a/backend/infrahub/workflows/models.py
+++ b/backend/infrahub/workflows/models.py
@@ -11,7 +11,7 @@ from prefect.client.schemas.schedules import CronSchedule
 from pydantic import BaseModel, Field
 from typing_extensions import Self
 
-from infrahub import __version__, config
+from infrahub import __version__
 
 from .constants import TAG_NAMESPACE, WorkflowTag, WorkflowType
 

--- a/backend/infrahub/workflows/models.py
+++ b/backend/infrahub/workflows/models.py
@@ -63,21 +63,6 @@ class WorkflowDefinition(BaseModel):
         payload: dict[str, Any] = {"name": self.name, "entrypoint": self.entrypoint, "tags": self.get_tags()}
         if self.type == WorkflowType.CORE:
             payload["version"] = __version__
-        # if self.type == WorkflowType.USER:
-        #     # This is not supposed to be necessary, I think, but without this the worker just crashes when it processes flows
-        #     payload["pull_steps"] = [
-        #         {
-        #             "prefect.deployments.steps.set_working_directory": {
-        #                 "directory": config.SETTINGS.workflow.worker_working_directory
-        #             }
-        #         }
-        #     ]
-        #     payload["job_variables"] = {
-        #         "env": {
-        #             "INFRAHUB_ADDRESS": config.SETTINGS.main.internal_address,
-        #             "INFRAHUB_API_TOKEN": config.SETTINGS.initial.admin_token,
-        #         }
-        #     }
         if self.cron:
             payload["schedules"] = [DeploymentScheduleCreate(schedule=CronSchedule(cron=self.cron))]
 

--- a/backend/tests/adapters/cache.py
+++ b/backend/tests/adapters/cache.py
@@ -26,4 +26,4 @@ class MemoryCache(InfrahubCache):
         return True
 
     async def close_connection(self) -> None:
-        pass
+        """"""

--- a/backend/tests/adapters/cache.py
+++ b/backend/tests/adapters/cache.py
@@ -24,3 +24,6 @@ class MemoryCache(InfrahubCache):
     async def set(self, key: str, value: str, expires: int | None = None, not_exists: bool = False) -> bool | None:
         self.storage[key] = value
         return True
+
+    async def close_connection(self) -> None:
+        pass

--- a/backend/tests/adapters/message_bus.py
+++ b/backend/tests/adapters/message_bus.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import TYPE_CHECKING, TypeVar
+from typing import TypeVar
 
 import ujson
 from infrahub_sdk.uuidt import UUIDT
@@ -12,9 +12,6 @@ from infrahub.message_bus.types import MessageTTL
 from infrahub.services.adapters.message_bus import InfrahubMessageBus
 
 ResponseClass = TypeVar("ResponseClass")
-
-if TYPE_CHECKING:
-    from infrahub.services import InfrahubServices
 
 
 class BusRecorder(InfrahubMessageBus):
@@ -49,8 +46,6 @@ class BusSimulator(InfrahubMessageBus):
         self.replies: dict[str, list[InfrahubMessage]] = defaultdict(list)
         build_component_registry()
 
-        self.service: InfrahubServices
-
     async def publish(
         self, message: InfrahubMessage, routing_key: str, delay: MessageTTL | None = None, is_retry: bool = False
     ) -> None:
@@ -58,7 +53,7 @@ class BusSimulator(InfrahubMessageBus):
         if routing_key not in self.messages_per_routing_key:
             self.messages_per_routing_key[routing_key] = []
         self.messages_per_routing_key[routing_key].append(message)
-        await execute_message(routing_key=routing_key, message_body=message.body, service=self.service, skip_flow=True)
+        await execute_message(routing_key=routing_key, message_body=message.body, message_bus=self, skip_flow=True)
 
     async def reply(self, message: InfrahubMessage, routing_key: str) -> None:
         correlation_id = message.meta.correlation_id or "default"

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -108,8 +108,9 @@ def event_loop():
 
 
 @pytest.fixture
-def dependency_provider() -> Provider:
-    return provider
+def dependency_provider():
+    yield provider
+    provider.clear()
 
 
 @pytest.fixture(scope="module")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -108,7 +108,7 @@ def event_loop():
 
 
 @pytest.fixture
-def dependency_provider():
+def dependency_provider() -> Generator[Provider, Any, None]:
     yield provider
     provider.clear()
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -108,9 +108,8 @@ def event_loop():
 
 
 @pytest.fixture
-def dependency_provider() -> Generator[Provider, Any, None]:
-    yield provider
-    provider.clear()
+def dependency_provider() -> Provider:
+    return provider
 
 
 @pytest.fixture(scope="module")

--- a/backend/tests/functional/branch/test_graphql_mutation.py
+++ b/backend/tests/functional/branch/test_graphql_mutation.py
@@ -80,7 +80,6 @@ class TestBranchMutations(TestInfrahubApp):
         )
         await jesko.save(db=db)
 
-        # bus_simulator.service._cache = RedisCache()
         FileRepo(name="car-dealership", sources_directory=git_repos_source_dir_module_scope)
         client_repository = await client.create(
             kind=InfrahubKind.REPOSITORY,

--- a/backend/tests/functional/branch/test_graphql_mutation.py
+++ b/backend/tests/functional/branch/test_graphql_mutation.py
@@ -12,7 +12,6 @@ from infrahub.core.diff.coordinator import DiffCoordinator
 from infrahub.core.node import Node
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.git.directory import get_repositories_directory
-from infrahub.services.adapters.cache.redis import RedisCache
 from tests.constants import TestKind
 from tests.helpers.file_repo import FileRepo
 from tests.helpers.schema import CAR_SCHEMA, load_schema

--- a/backend/tests/functional/branch/test_graphql_mutation.py
+++ b/backend/tests/functional/branch/test_graphql_mutation.py
@@ -81,7 +81,7 @@ class TestBranchMutations(TestInfrahubApp):
         )
         await jesko.save(db=db)
 
-        bus_simulator.service._cache = RedisCache()
+        # bus_simulator.service._cache = RedisCache()
         FileRepo(name="car-dealership", sources_directory=git_repos_source_dir_module_scope)
         client_repository = await client.create(
             kind=InfrahubKind.REPOSITORY,

--- a/backend/tests/functional/computed_attributes/test_computed_attribute.py
+++ b/backend/tests/functional/computed_attributes/test_computed_attribute.py
@@ -26,7 +26,6 @@ if TYPE_CHECKING:
 
     from infrahub.core.branch import Branch
     from infrahub.database import InfrahubDatabase
-    from infrahub.services import InfrahubServices
     from tests.adapters.message_bus import BusSimulator
 
 
@@ -129,7 +128,6 @@ class TestComputedAttribute(TestInfrahubApp):
         client: InfrahubClient,
         default_branch: Branch,
         context: InfrahubContext,
-        service: InfrahubServices,
     ) -> None:
         tshirt_1 = await client.get(kind="TestingTShirt", id=data["t1"].id)
         assert (
@@ -150,7 +148,6 @@ class TestComputedAttribute(TestInfrahubApp):
             computed_attribute_name="description",
             updated_fields=["color"],
             context=context,
-            service=service,
         )
 
         tshirt_updated = await client.get(kind="TestingTShirt", id=data["t1"].id)
@@ -165,7 +162,6 @@ class TestComputedAttribute(TestInfrahubApp):
         client: InfrahubClient,
         default_branch: Branch,
         context: InfrahubContext,
-        service: InfrahubServices,
     ) -> None:
         # As we currently don't have a way to trigger on events within these tests we fire the automated workflow
         # manually
@@ -181,7 +177,6 @@ class TestComputedAttribute(TestInfrahubApp):
             computed_attribute_name="pitch",
             computed_attribute_kind="TestingTShirt",
             context=context,
-            service=service,
         )
 
         tshirt_first_pitch_allocation = await client.get(kind="TestingTShirt", id=tshirt_obj.id)
@@ -195,7 +190,6 @@ class TestComputedAttribute(TestInfrahubApp):
             node_kind="TestingColor",
             object_id=color_obj.id,
             context=context,
-            service=service,
         )
 
         tshirt_altered_pitch_allocation = await client.get(kind="TestingTShirt", id=tshirt_obj.id)

--- a/backend/tests/functional/generator/test_mutation_generator.py
+++ b/backend/tests/functional/generator/test_mutation_generator.py
@@ -35,8 +35,6 @@ class TestMutationGenerator(TestInfrahubApp):
     ) -> None:
         await load_schema(db, schema=CAR_SCHEMA)
 
-        # bus_simulator.service._cache = RedisCache()
-
         john = await Node.init(schema=TestKind.PERSON, db=db)
         await john.new(db=db, name="John", height=175, age=25, description="The famous Joe Doe")
         await john.save(db=db)

--- a/backend/tests/functional/generator/test_mutation_generator.py
+++ b/backend/tests/functional/generator/test_mutation_generator.py
@@ -12,7 +12,6 @@ from tests.helpers.test_app import TestInfrahubApp
 
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.node import Node
-from infrahub.services.adapters.cache.redis import RedisCache
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/backend/tests/functional/generator/test_mutation_generator.py
+++ b/backend/tests/functional/generator/test_mutation_generator.py
@@ -36,7 +36,7 @@ class TestMutationGenerator(TestInfrahubApp):
     ) -> None:
         await load_schema(db, schema=CAR_SCHEMA)
 
-        bus_simulator.service._cache = RedisCache()
+        # bus_simulator.service._cache = RedisCache()
 
         john = await Node.init(schema=TestKind.PERSON, db=db)
         await john.new(db=db, name="John", height=175, age=25, description="The famous Joe Doe")

--- a/backend/tests/functional/ipam/test_proposed_change_reconcile.py
+++ b/backend/tests/functional/ipam/test_proposed_change_reconcile.py
@@ -13,7 +13,6 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.timestamp import Timestamp
 from infrahub.message_bus.types import KVTTL
-from infrahub.services.adapters.cache.redis import RedisCache
 from infrahub.worker import WORKER_IDENTITY
 
 from .base import TestIpamReconcileBase
@@ -30,10 +29,6 @@ class TestProposedChangeReconcile(TestIpamReconcileBase):
     @pytest.fixture(scope="class", autouse=True)
     def enable_broker_settings(self):
         config.SETTINGS.broker.enable = True
-
-    @pytest.fixture(scope="class", autouse=True)
-    def bus_simulator_cache(self, bus_simulator):
-        bus_simulator.service._cache = RedisCache()
 
     @pytest.fixture(scope="class", autouse=True)
     def git_repos_dir(self, git_repos_source_dir_module_scope: Path): ...

--- a/backend/tests/functional/pools/test_numberpool_lifecycle.py
+++ b/backend/tests/functional/pools/test_numberpool_lifecycle.py
@@ -16,6 +16,7 @@ from infrahub.pools.registration import get_branches_with_schema_number_pool
 from infrahub.pools.tasks import validate_schema_number_pools
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.cache.redis import RedisCache
+from infrahub.workers.dependencies import build_cache
 from tests.helpers.test_app import TestInfrahubApp
 
 if TYPE_CHECKING:
@@ -53,8 +54,9 @@ class TestMutationGenerator(TestInfrahubApp):
         client: InfrahubClient,
         bus_simulator: BusSimulator,
         prefect_test_fixture,
+        dependency_provider,
     ) -> None:
-        bus_simulator.service._cache = RedisCache()
+        dependency_provider.override(build_cache, RedisCache)
 
         schema = {"version": "1.0", "nodes": [node_schema_definition]}
         schema_load_response = await client.schema.load(schemas=[schema], wait_until_converged=True)

--- a/backend/tests/functional/pools/test_numberpool_lifecycle.py
+++ b/backend/tests/functional/pools/test_numberpool_lifecycle.py
@@ -56,11 +56,10 @@ class TestMutationGenerator(TestInfrahubApp):
         prefect_test_fixture,
         dependency_provider,
     ) -> None:
-        dependency_provider.override(build_cache, RedisCache)
-
-        schema = {"version": "1.0", "nodes": [node_schema_definition]}
-        schema_load_response = await client.schema.load(schemas=[schema], wait_until_converged=True)
-        assert not schema_load_response.errors
+        with dependency_provider.scope(build_cache, RedisCache):
+            schema = {"version": "1.0", "nodes": [node_schema_definition]}
+            schema_load_response = await client.schema.load(schemas=[schema], wait_until_converged=True)
+            assert not schema_load_response.errors
 
     async def test_numberpool_assignment(
         self, db: InfrahubDatabase, initial_dataset: None, client: InfrahubClient, default_branch

--- a/backend/tests/functional/webhook/test_task.py
+++ b/backend/tests/functional/webhook/test_task.py
@@ -280,17 +280,16 @@ class TestWebhookTasks(TestInfrahubApp):
             url="https://url.mock",
             response=httpx.Response(request=httpx.Request(method="GET", url="https://url.mock"), status_code=200),
         )
-        dependency_provider.override(build_http_service, lambda: http)
-
-        await webhook_process(
-            webhook_id=webhook1.id,
-            webhook_name="Webhook1",
-            webhook_kind="CoreStandardWebhook",
-            event_id="ce3b7013-4abb-4945-89de-1f56da4ff636",
-            event_type="infrahub.branch.created",
-            event_occured_at="2025-02-28T08:37:09.969Z",
-            event_payload=BRANCH_CREATED_PAYLOAD,
-        )
+        with dependency_provider.scope(build_http_service, lambda: http):
+            await webhook_process(
+                webhook_id=webhook1.id,
+                webhook_name="Webhook1",
+                webhook_kind="CoreStandardWebhook",
+                event_id="ce3b7013-4abb-4945-89de-1f56da4ff636",
+                event_type="infrahub.branch.created",
+                event_occured_at="2025-02-28T08:37:09.969Z",
+                event_payload=BRANCH_CREATED_PAYLOAD,
+            )
 
     async def test_process_standard_webhook_failure(
         self,
@@ -306,9 +305,8 @@ class TestWebhookTasks(TestInfrahubApp):
             url="https://url.mock",
             response=httpx.Response(request=httpx.Request(method="GET", url="https://url.mock"), status_code=404),
         )
-        dependency_provider.override(build_http_service, lambda: http)
 
-        with pytest.raises(httpx.HTTPStatusError):
+        with pytest.raises(httpx.HTTPStatusError), dependency_provider.scope(build_http_service, lambda: http):
             await webhook_process(
                 webhook_id=webhook1.id,
                 webhook_name="Webhook1",

--- a/backend/tests/functional/webhook/test_task.py
+++ b/backend/tests/functional/webhook/test_task.py
@@ -18,6 +18,7 @@ from infrahub.webhook.tasks import (
     delete_webhook_automation,
     webhook_process,
 )
+from infrahub.workers.dependencies import build_http_service
 from infrahub.workflows.catalogue import WEBHOOK_PROCESS, worker_pools
 from infrahub.workflows.initialization import setup_worker_pools
 from tests.adapters.http import MemoryHTTP
@@ -29,6 +30,7 @@ from tests.helpers.test_app import TestInfrahubApp
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from fast_depends import Provider
     from infrahub_sdk import InfrahubClient
     from prefect.events.actions import RunDeployment
 
@@ -267,17 +269,18 @@ class TestWebhookTasks(TestInfrahubApp):
     async def test_process_standard_webhook_success(
         self,
         db: InfrahubDatabase,
-        service,
         prefect_client: PrefectClient,
         webhook1: Node,
         webhook2: Node,
         webhook_deployment,
+        dependency_provider: Provider,
     ) -> None:
-        service.http = MemoryHTTP()
-        service.http.add_post_response(
+        http = MemoryHTTP()
+        http.add_post_response(
             url="https://url.mock",
             response=httpx.Response(request=httpx.Request(method="GET", url="https://url.mock"), status_code=200),
         )
+        dependency_provider.override(build_http_service, lambda: http)
 
         await webhook_process(
             webhook_id=webhook1.id,
@@ -292,17 +295,18 @@ class TestWebhookTasks(TestInfrahubApp):
     async def test_process_standard_webhook_failure(
         self,
         db: InfrahubDatabase,
-        service,
         prefect_client: PrefectClient,
         webhook1: Node,
         webhook2: Node,
         webhook_deployment,
+        dependency_provider: Provider,
     ) -> None:
-        service.http = MemoryHTTP()
-        service.http.add_post_response(
+        http = MemoryHTTP()
+        http.add_post_response(
             url="https://url.mock",
             response=httpx.Response(request=httpx.Request(method="GET", url="https://url.mock"), status_code=404),
         )
+        dependency_provider.override(build_http_service, lambda: http)
 
         with pytest.raises(httpx.HTTPStatusError):
             await webhook_process(

--- a/backend/tests/functional/webhook/test_task.py
+++ b/backend/tests/functional/webhook/test_task.py
@@ -171,9 +171,9 @@ class TestWebhookTasks(TestInfrahubApp):
         return webhook
 
     async def test_configure_one(
-        self, db: InfrahubDatabase, service, prefect_client: PrefectClient, webhook1: Node, webhook_deployment
+        self, db: InfrahubDatabase, prefect_client: PrefectClient, webhook1: Node, webhook_deployment
     ) -> None:
-        await configure_webhook_one(webhook_name="Webhook1", event_data={"node_id": webhook1.id}, service=service)
+        await configure_webhook_one(webhook_name="Webhook1", event_data={"node_id": webhook1.id})
 
         name = f"webhook::{webhook1.id}"
         automations = await prefect_client.read_automations_by_name(name=name)
@@ -188,25 +188,24 @@ class TestWebhookTasks(TestInfrahubApp):
         assert action.parameters["webhook_kind"] == "CoreStandardWebhook"
 
         # Configure it a second time to ensure the function is idempotent
-        await configure_webhook_one(webhook_name="Webhook1", event_data={"node_id": webhook1.id}, service=service)
+        await configure_webhook_one(webhook_name="Webhook1", event_data={"node_id": webhook1.id})
         automations = await prefect_client.read_automations_by_name(name=name)
         assert len(automations) == 1
 
         # Delete the webhook automation
-        await delete_webhook_automation(webhook_id=webhook1.id, webhook_name="Webhook1", service=service)
+        await delete_webhook_automation(webhook_id=webhook1.id, webhook_name="Webhook1")
         automations = await prefect_client.read_automations_by_name(name=name)
         assert len(automations) == 0
 
     async def test_configure_all(
         self,
         db: InfrahubDatabase,
-        service,
         prefect_client: PrefectClient,
         webhook1: Node,
         webhook2: Node,
         webhook_deployment,
     ) -> None:
-        await configure_webhook_all(service=service)
+        await configure_webhook_all()
 
         automations = await prefect_client.read_automations()
         automations_by_name = {automation.name: automation for automation in automations}
@@ -226,7 +225,6 @@ class TestWebhookTasks(TestInfrahubApp):
     async def test_convert_node_to_webhook_standard(
         self,
         db: InfrahubDatabase,
-        service,
         webhook1: Node,
         client: InfrahubClient,
     ) -> None:
@@ -245,7 +243,6 @@ class TestWebhookTasks(TestInfrahubApp):
     async def test_convert_node_to_webhook_transform(
         self,
         db: InfrahubDatabase,
-        service,
         webhook2: Node,
         client: InfrahubClient,
     ) -> None:
@@ -290,7 +287,6 @@ class TestWebhookTasks(TestInfrahubApp):
             event_type="infrahub.branch.created",
             event_occured_at="2025-02-28T08:37:09.969Z",
             event_payload=BRANCH_CREATED_PAYLOAD,
-            service=service,
         )
 
     async def test_process_standard_webhook_failure(
@@ -318,13 +314,11 @@ class TestWebhookTasks(TestInfrahubApp):
                 event_type="infrahub.branch.created",
                 event_occured_at="2025-02-28T08:37:09.969Z",
                 event_payload=BRANCH_CREATED_PAYLOAD,
-                service=service,
             )
 
     async def test_webhook_check_payload_transform(
         self,
         db: InfrahubDatabase,
-        service,
         webhook2: Node,
         client: InfrahubClient,
     ) -> None:
@@ -338,7 +332,7 @@ class TestWebhookTasks(TestInfrahubApp):
             event_payload=BRANCH_CREATED_PAYLOAD,
         )
 
-        await webhook.prepare(data={}, context=context, service=service)
+        await webhook.prepare(data={}, context=context, client=client)
 
         assert webhook.get_payload() == {
             "ACCOUNT_ID": "182853f2-3a43-c7f9-3e84-c5152eff4b17",
@@ -352,7 +346,6 @@ class TestWebhookTasks(TestInfrahubApp):
     async def test_trigger_definition_node_kind_match(
         self,
         db: InfrahubDatabase,
-        service,
         webhook4: Node,
         client: InfrahubClient,
     ) -> None:

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -69,22 +69,26 @@ class TestInfrahubApp(TestInfrahub):
         return provider
 
     @pytest.fixture(scope="class")
-    async def bus_simulator(self, db: InfrahubDatabase, dependency_provider: Provider) -> BusSimulator:
+    async def bus_simulator(
+        self, db: InfrahubDatabase, dependency_provider: Provider
+    ) -> AsyncGenerator[BusSimulator, None]:
         # Creating another service object to get service correctly initialized is a hack.
         # We should either reuse `service` fixture (leading to circular fixture dependencies issue atm),
         # or ideally properly patch production code responsible for Bus instantiation instead
         bus = BusSimulator()
         _ = await InfrahubServices.new(database=db, workflow=WorkflowLocalExecution(), message_bus=bus)
         config.OVERRIDE.message_bus = bus
-        dependency_provider.override(build_message_bus, lambda: bus)
-        return bus
+        with dependency_provider.scope(build_message_bus, lambda: bus):
+            yield bus
 
     @pytest.fixture(scope="class")
-    async def memory_cache(self, db: InfrahubDatabase, dependency_provider: Provider) -> MemoryCache:
+    async def memory_cache(
+        self, db: InfrahubDatabase, dependency_provider: Provider
+    ) -> AsyncGenerator[MemoryCache, None]:
         cache = MemoryCache()
         config.OVERRIDE.cache = cache
-        dependency_provider.override(build_cache, lambda: cache)
-        return cache
+        with dependency_provider.scope(build_cache, lambda: cache):
+            yield cache
 
     @pytest.fixture(scope="class", autouse=True)
     async def workflow_local(
@@ -94,8 +98,8 @@ class TestInfrahubApp(TestInfrahub):
         workflow = WorkflowLocalExecution()
         await setup_task_manager()
         config.OVERRIDE.workflow = workflow
-        dependency_provider.override(build_workflow, lambda: workflow)
-        yield workflow
+        with dependency_provider.scope(build_workflow, lambda: workflow):
+            yield workflow
         config.OVERRIDE.workflow = original
 
     @pytest.fixture(scope="class", autouse=True)
@@ -159,8 +163,8 @@ class TestInfrahubApp(TestInfrahub):
         )
 
         service._client = sdk_client
-        dependency_provider.override(build_client, lambda: sdk_client)
-        return sdk_client
+        with dependency_provider.scope(build_client, lambda: sdk_client):
+            yield sdk_client
 
     @pytest.fixture(scope="class")
     async def initialize_registry(

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -61,10 +61,7 @@ class TestInfrahubApp(TestInfrahub):
         return str(UUIDT())
 
     @pytest.fixture(scope="class")
-    async def bus_simulator(
-        self,
-        db: InfrahubDatabase,
-    ) -> BusSimulator:
+    async def bus_simulator(self, db: InfrahubDatabase) -> BusSimulator:
         # Creating another service object to get service correctly initialized is a hack.
         # We should either reuse `service` fixture (leading to circular fixture dependencies issue atm),
         # or ideally properly patch production code responsible for Bus instantiation instead

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -27,8 +27,9 @@ from infrahub.database import InfrahubDatabase
 from infrahub.server import app, lifespan
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
-from infrahub.workers.dependencies import build_client, build_message_bus, build_workflow
+from infrahub.workers.dependencies import build_cache, build_client, build_message_bus, build_workflow
 from infrahub.workflows.initialization import setup_task_manager
+from tests.adapters.cache import MemoryCache
 from tests.adapters.message_bus import BusSimulator
 
 from .test_client import InfrahubTestClient
@@ -77,6 +78,13 @@ class TestInfrahubApp(TestInfrahub):
         config.OVERRIDE.message_bus = bus
         dependency_provider.override(build_message_bus, lambda: bus)
         return bus
+
+    @pytest.fixture(scope="class")
+    async def memory_cache(self, db: InfrahubDatabase, dependency_provider: Provider) -> MemoryCache:
+        cache = MemoryCache()
+        config.OVERRIDE.cache = cache
+        dependency_provider.override(build_cache, lambda: cache)
+        return cache
 
     @pytest.fixture(scope="class", autouse=True)
     async def workflow_local(

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -2,6 +2,8 @@ from pathlib import Path
 from typing import AsyncGenerator, Generator
 
 import pytest
+from fast_depends import Provider
+from fast_depends import dependency_provider as provider
 from infrahub_sdk import Config, InfrahubClient
 from infrahub_sdk.uuidt import UUIDT
 
@@ -25,6 +27,7 @@ from infrahub.database import InfrahubDatabase
 from infrahub.server import app, lifespan
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
+from infrahub.workers.dependencies import build_client, build_message_bus, build_workflow
 from infrahub.workflows.initialization import setup_task_manager
 from tests.adapters.message_bus import BusSimulator
 
@@ -61,21 +64,29 @@ class TestInfrahubApp(TestInfrahub):
         return str(UUIDT())
 
     @pytest.fixture(scope="class")
-    async def bus_simulator(self, db: InfrahubDatabase) -> BusSimulator:
+    def dependency_provider(self) -> Provider:
+        return provider
+
+    @pytest.fixture(scope="class")
+    async def bus_simulator(self, db: InfrahubDatabase, dependency_provider: Provider) -> BusSimulator:
         # Creating another service object to get service correctly initialized is a hack.
         # We should either reuse `service` fixture (leading to circular fixture dependencies issue atm),
         # or ideally properly patch production code responsible for Bus instantiation instead
         bus = BusSimulator()
         _ = await InfrahubServices.new(database=db, workflow=WorkflowLocalExecution(), message_bus=bus)
         config.OVERRIDE.message_bus = bus
+        dependency_provider.override(build_message_bus, lambda: bus)
         return bus
 
     @pytest.fixture(scope="class", autouse=True)
-    async def workflow_local(self, prefect: Generator[str, None, None]) -> AsyncGenerator[WorkflowLocalExecution, None]:
+    async def workflow_local(
+        self, prefect: Generator[str, None, None], dependency_provider: Provider
+    ) -> AsyncGenerator[WorkflowLocalExecution, None]:
         original = config.OVERRIDE.workflow
         workflow = WorkflowLocalExecution()
         await setup_task_manager()
         config.OVERRIDE.workflow = workflow
+        dependency_provider.override(build_workflow, lambda: workflow)
         yield workflow
         config.OVERRIDE.workflow = original
 
@@ -115,7 +126,12 @@ class TestInfrahubApp(TestInfrahub):
 
     @pytest.fixture(scope="class")
     async def client(
-        self, test_client: InfrahubTestClient, api_token: str, bus_simulator: BusSimulator, service: InfrahubServices
+        self,
+        test_client: InfrahubTestClient,
+        api_token: str,
+        bus_simulator: BusSimulator,
+        service: InfrahubServices,
+        dependency_provider: Provider,
     ) -> InfrahubClient:
         config = Config(
             api_token=api_token,
@@ -135,6 +151,7 @@ class TestInfrahubApp(TestInfrahub):
         )
 
         service._client = sdk_client
+        dependency_provider.override(build_client, lambda: sdk_client)
         return sdk_client
 
     @pytest.fixture(scope="class")

--- a/backend/tests/integration/diff/test_diff_incremental_addition.py
+++ b/backend/tests/integration/diff/test_diff_incremental_addition.py
@@ -17,7 +17,6 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.timestamp import Timestamp
 from infrahub.dependencies.registry import get_component_registry
-from infrahub.services.adapters.cache.redis import RedisCache
 from tests.constants import TestKind
 from tests.helpers.schema import CAR_SCHEMA, load_schema
 from tests.helpers.test_app import TestInfrahubApp

--- a/backend/tests/integration/diff/test_diff_incremental_addition.py
+++ b/backend/tests/integration/diff/test_diff_incremental_addition.py
@@ -68,8 +68,6 @@ class TestDiffUpdateConflict(TestInfrahubApp):
         await delorean.previous_owner.update(db=db, data={"id": doc_brown.id, "_relation__is_protected": True})  # type: ignore[attr-defined]
         await delorean.save(db=db)
 
-        # bus_simulator.service._cache = RedisCache()
-
         return {
             "doc_brown": doc_brown,
             "marty": marty,

--- a/backend/tests/integration/diff/test_diff_incremental_addition.py
+++ b/backend/tests/integration/diff/test_diff_incremental_addition.py
@@ -69,7 +69,7 @@ class TestDiffUpdateConflict(TestInfrahubApp):
         await delorean.previous_owner.update(db=db, data={"id": doc_brown.id, "_relation__is_protected": True})  # type: ignore[attr-defined]
         await delorean.save(db=db)
 
-        bus_simulator.service._cache = RedisCache()
+        # bus_simulator.service._cache = RedisCache()
 
         return {
             "doc_brown": doc_brown,

--- a/backend/tests/integration/diff/test_diff_merge.py
+++ b/backend/tests/integration/diff/test_diff_merge.py
@@ -56,7 +56,7 @@ class TestDiffMerge(TestInfrahubApp):
         )
         await delorean.save(db=db)
 
-        bus_simulator.service._cache = RedisCache()
+        # bus_simulator.service._cache = RedisCache()
 
         return {
             "doc_brown": doc_brown,

--- a/backend/tests/integration/diff/test_diff_merge.py
+++ b/backend/tests/integration/diff/test_diff_merge.py
@@ -55,8 +55,6 @@ class TestDiffMerge(TestInfrahubApp):
         )
         await delorean.save(db=db)
 
-        # bus_simulator.service._cache = RedisCache()
-
         return {
             "doc_brown": doc_brown,
             "marty": marty,

--- a/backend/tests/integration/diff/test_diff_merge.py
+++ b/backend/tests/integration/diff/test_diff_merge.py
@@ -13,7 +13,6 @@ from infrahub.core.node import Node
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.dependencies.registry import get_component_registry
-from infrahub.services.adapters.cache.redis import RedisCache
 from tests.adapters.message_bus import BusSimulator
 from tests.constants import TestKind
 from tests.helpers.schema import CAR_SCHEMA, load_schema

--- a/backend/tests/integration/diff/test_diff_rebase.py
+++ b/backend/tests/integration/diff/test_diff_rebase.py
@@ -14,7 +14,6 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.timestamp import Timestamp
 from infrahub.dependencies.registry import get_component_registry
-from infrahub.services.adapters.cache.redis import RedisCache
 from tests.constants import TestKind
 from tests.helpers.schema import CAR_SCHEMA, load_schema
 from tests.helpers.test_app import TestInfrahubApp

--- a/backend/tests/integration/diff/test_diff_rebase.py
+++ b/backend/tests/integration/diff/test_diff_rebase.py
@@ -132,7 +132,7 @@ class TestDiffRebase(TestInfrahubApp):
         )
         await ed_209.save(db=db)
 
-        bus_simulator.service._cache = RedisCache()
+        # bus_simulator.service._cache = RedisCache()
 
         return {
             "john": john,

--- a/backend/tests/integration/diff/test_diff_rebase.py
+++ b/backend/tests/integration/diff/test_diff_rebase.py
@@ -131,8 +131,6 @@ class TestDiffRebase(TestInfrahubApp):
         )
         await ed_209.save(db=db)
 
-        # bus_simulator.service._cache = RedisCache()
-
         return {
             "john": john,
             "kara": kara,

--- a/backend/tests/integration/diff/test_diff_update.py
+++ b/backend/tests/integration/diff/test_diff_update.py
@@ -169,7 +169,7 @@ class TestDiffUpdateConflict(TestInfrahubApp):
         )
         await ed_209.save(db=db)
 
-        bus_simulator.service._cache = RedisCache()
+        # bus_simulator.service._cache = RedisCache()
 
         return {
             "john": john,

--- a/backend/tests/integration/diff/test_diff_update.py
+++ b/backend/tests/integration/diff/test_diff_update.py
@@ -17,7 +17,6 @@ from infrahub.core.node import Node
 from infrahub.core.timestamp import Timestamp
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.proposed_change.constants import ProposedChangeState
-from infrahub.services.adapters.cache.redis import RedisCache
 from tests.constants import TestKind
 from tests.helpers.schema import CAR_SCHEMA, load_schema
 from tests.helpers.test_app import TestInfrahubApp

--- a/backend/tests/integration/diff/test_diff_update.py
+++ b/backend/tests/integration/diff/test_diff_update.py
@@ -168,8 +168,6 @@ class TestDiffUpdateConflict(TestInfrahubApp):
         )
         await ed_209.save(db=db)
 
-        # bus_simulator.service._cache = RedisCache()
-
         return {
             "john": john,
             "kara": kara,

--- a/backend/tests/integration/diff/test_merge_rollback.py
+++ b/backend/tests/integration/diff/test_merge_rollback.py
@@ -55,7 +55,7 @@ class TestBranchMergeRollback(TestInfrahubApp):
     ) -> dict[str, Node]:
         await load_schema(db, schema=CAR_SCHEMA)
 
-        bus_simulator.service._cache = RedisCache()
+        # bus_simulator.service._cache = RedisCache()
 
         john = await Node.init(schema=TestKind.PERSON, db=db)
         await john.new(db=db, name="John", height=175, description="The famous Joe Doe")

--- a/backend/tests/integration/diff/test_merge_rollback.py
+++ b/backend/tests/integration/diff/test_merge_rollback.py
@@ -54,8 +54,6 @@ class TestBranchMergeRollback(TestInfrahubApp):
     ) -> dict[str, Node]:
         await load_schema(db, schema=CAR_SCHEMA)
 
-        # bus_simulator.service._cache = RedisCache()
-
         john = await Node.init(schema=TestKind.PERSON, db=db)
         await john.new(db=db, name="John", height=175, description="The famous Joe Doe")
         await john.save(db=db)

--- a/backend/tests/integration/diff/test_merge_rollback.py
+++ b/backend/tests/integration/diff/test_merge_rollback.py
@@ -10,7 +10,6 @@ from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.merge import BranchMerger
 from infrahub.core.node import Node
-from infrahub.services.adapters.cache.redis import RedisCache
 from tests.constants import TestKind
 from tests.helpers.schema import CAR_SCHEMA, load_schema
 from tests.helpers.test_app import TestInfrahubApp

--- a/backend/tests/integration/message_bus/operations/request/test_proposed_change.py
+++ b/backend/tests/integration/message_bus/operations/request/test_proposed_change.py
@@ -24,6 +24,7 @@ from infrahub.services import InfrahubServices
 from infrahub.services.adapters.cache import InfrahubCache
 from infrahub.services.adapters.cache.redis import RedisCache
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
+from infrahub.workers.dependencies import build_client, build_message_bus
 from infrahub.workflows.catalogue import (
     REQUEST_PROPOSED_CHANGE_DATA_INTEGRITY,
     REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS,
@@ -120,9 +121,7 @@ class TestProposedChange(TestInfrahubApp):
             message_bus=bus, client=client, workflow=WorkflowLocalExecution(), database=db, cache=RedisCache()
         )
 
-        repo = await InfrahubRepository.new(
-            id=obj.id, name=file_repo.name, location=file_repo.path, client=client, service=service
-        )
+        repo = await InfrahubRepository.new(id=obj.id, name=file_repo.name, location=file_repo.path, client=client)
         await repo.sync()
 
         result = await graphql_mutation(
@@ -143,6 +142,7 @@ class TestProposedChange(TestInfrahubApp):
         test_client: InfrahubTestClient,
         client: InfrahubClient,
         context: InfrahubContext,
+        dependency_provider,
     ):
         model = RequestProposedChangePipeline(
             source_branch="change1",
@@ -151,19 +151,13 @@ class TestProposedChange(TestInfrahubApp):
             proposed_change=prepare_proposed_change,
         )
         bus_pre_data_changes = BusRecorder()
-        fake_log = FakeLogger()
-        service = await InfrahubServices.new(
-            client=client,
-            cache=await InfrahubCache.new_from_driver(driver=config.SETTINGS.cache.driver),
-            log=fake_log,
-            message_bus=bus_pre_data_changes,
-            database=db,
-            workflow=WorkflowLocalExecution(),
-        )
+        dependency_provider.override(build_client, lambda: client)
+        dependency_provider.overrude(build_message_bus, lambda: bus_pre_data_changes)
+
         with patch(
             "infrahub.services.adapters.workflow.local.WorkflowLocalExecution.submit_workflow"
         ) as mock_submit_workflow:
-            await run_proposed_change_pipeline(model=model, service=service, context=context)
+            await run_proposed_change_pipeline(model=model, context=context)
 
             expected_calls_before_data_changes = [
                 call(
@@ -185,7 +179,7 @@ class TestProposedChange(TestInfrahubApp):
             await obj.new(db=db, name="ci-pipeline-01", description="for use within tests")
             await obj.save(db=db)
 
-            await run_proposed_change_pipeline(model=model, service=service, context=context)
+            await run_proposed_change_pipeline(model=model, context=context)
 
             expected_calls_after_data_changes = [
                 call(
@@ -241,7 +235,7 @@ class TestProposedChange(TestInfrahubApp):
         with patch(
             "infrahub.services.adapters.workflow.local.WorkflowLocalExecution.submit_workflow"
         ) as mock_submit_workflow:
-            await run_generators(model=model, context=context, service=service)
+            await run_generators(model=model, context=context)
 
             expected_calls = [
                 call(

--- a/backend/tests/integration/message_bus/operations/request/test_proposed_change.py
+++ b/backend/tests/integration/message_bus/operations/request/test_proposed_change.py
@@ -24,7 +24,6 @@ from infrahub.services import InfrahubServices
 from infrahub.services.adapters.cache import InfrahubCache
 from infrahub.services.adapters.cache.redis import RedisCache
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
-from infrahub.workers.dependencies import build_client, build_message_bus
 from infrahub.workflows.catalogue import (
     REQUEST_PROPOSED_CHANGE_DATA_INTEGRITY,
     REQUEST_PROPOSED_CHANGE_REFRESH_ARTIFACTS,
@@ -142,7 +141,6 @@ class TestProposedChange(TestInfrahubApp):
         test_client: InfrahubTestClient,
         client: InfrahubClient,
         context: InfrahubContext,
-        dependency_provider,
     ):
         model = RequestProposedChangePipeline(
             source_branch="change1",
@@ -150,10 +148,6 @@ class TestProposedChange(TestInfrahubApp):
             destination_branch="main",
             proposed_change=prepare_proposed_change,
         )
-        bus_pre_data_changes = BusRecorder()
-        dependency_provider.override(build_client, lambda: client)
-        dependency_provider.overrude(build_message_bus, lambda: bus_pre_data_changes)
-
         with patch(
             "infrahub.services.adapters.workflow.local.WorkflowLocalExecution.submit_workflow"
         ) as mock_submit_workflow:

--- a/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
@@ -95,7 +95,7 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
         )
         await jesko.save(db=db)
 
-        bus_simulator.service._cache = RedisCache()
+        # bus_simulator.service._cache = RedisCache()
         repo_path, repo_name = car_dealership_copy
         FileRepo(name=repo_name, local_repo_base_path=repo_path, sources_directory=git_repos_source_dir_module_scope)
         client_repository = await client.create(

--- a/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
@@ -21,7 +21,6 @@ from infrahub.core.node import Node
 from infrahub.core.protocols import CoreProposedChange as InternalCoreProposedChange
 from infrahub.core.protocols import CoreValidator
 from infrahub.proposed_change.constants import ProposedChangeState
-from infrahub.services.adapters.cache.redis import RedisCache
 from infrahub.utils import get_fixtures_dir
 from tests.constants import TestKind
 from tests.helpers.file_repo import FileRepo

--- a/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
@@ -94,7 +94,6 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
         )
         await jesko.save(db=db)
 
-        # bus_simulator.service._cache = RedisCache()
         repo_path, repo_name = car_dealership_copy
         FileRepo(name=repo_name, local_repo_base_path=repo_path, sources_directory=git_repos_source_dir_module_scope)
         client_repository = await client.create(

--- a/backend/tests/integration/proposed_change/test_proposed_change_profile.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_profile.py
@@ -52,7 +52,7 @@ class TestProposedChangePipelineProfile(TestInfrahubApp):
         await jesko.new(db=db, name="Jesko", color="Red", owner=john, manufacturer=koenigsegg, profiles=[car_profile])
         await jesko.save(db=db)
 
-        bus_simulator.service._cache = RedisCache()
+        # bus_simulator.service._cache = RedisCache()
 
     @pytest.fixture(scope="class")
     async def update_profile(self, db: InfrahubDatabase, initial_dataset: None, client: InfrahubClient) -> None:

--- a/backend/tests/integration/proposed_change/test_proposed_change_profile.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_profile.py
@@ -51,8 +51,6 @@ class TestProposedChangePipelineProfile(TestInfrahubApp):
         await jesko.new(db=db, name="Jesko", color="Red", owner=john, manufacturer=koenigsegg, profiles=[car_profile])
         await jesko.save(db=db)
 
-        # bus_simulator.service._cache = RedisCache()
-
     @pytest.fixture(scope="class")
     async def update_profile(self, db: InfrahubDatabase, initial_dataset: None, client: InfrahubClient) -> None:
         branch1 = await client.branch.create(branch_name="update_profile")

--- a/backend/tests/integration/proposed_change/test_proposed_change_profile.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_profile.py
@@ -8,7 +8,6 @@ from infrahub.core.constants import InfrahubKind, TaskConclusion, ValidatorConcl
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.task import Task
-from infrahub.services.adapters.cache.redis import RedisCache
 from tests.constants import TestKind
 from tests.helpers.schema import CAR_SCHEMA, load_schema
 from tests.helpers.test_app import TestInfrahubApp

--- a/backend/tests/integration/proposed_change/test_proposed_change_repository.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_repository.py
@@ -34,8 +34,6 @@ class TestProposedChangePipelineRepository(TestInfrahubApp):
     ) -> None:
         await load_schema(db, schema=CAR_SCHEMA)
 
-        # bus_simulator.service._cache = RedisCache()
-
         john = await Node.init(schema=TestKind.PERSON, db=db)
         await john.new(db=db, name="John", height=175, age=25, description="The famous Joe Doe")
         await john.save(db=db)

--- a/backend/tests/integration/proposed_change/test_proposed_change_repository.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_repository.py
@@ -35,7 +35,7 @@ class TestProposedChangePipelineRepository(TestInfrahubApp):
     ) -> None:
         await load_schema(db, schema=CAR_SCHEMA)
 
-        bus_simulator.service._cache = RedisCache()
+        # bus_simulator.service._cache = RedisCache()
 
         john = await Node.init(schema=TestKind.PERSON, db=db)
         await john.new(db=db, name="John", height=175, age=25, description="The famous Joe Doe")

--- a/backend/tests/integration/proposed_change/test_proposed_change_repository.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_repository.py
@@ -7,7 +7,6 @@ import pytest
 from infrahub.core.constants import InfrahubKind, ValidatorConclusion
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
-from infrahub.services.adapters.cache.redis import RedisCache
 from tests.constants import TestKind
 from tests.helpers.file_repo import FileRepo
 from tests.helpers.schema import CAR_SCHEMA, load_schema

--- a/backend/tests/integration/services/adapters/message_bus/test_rabbitmq.py
+++ b/backend/tests/integration/services/adapters/message_bus/test_rabbitmq.py
@@ -229,7 +229,7 @@ async def test_rabbitmq_initial_setup(rabbitmq_api: RabbitMQManager) -> None:
             name=f"worker-events-{WORKER_IDENTITY}",
             arguments={},
             durable=False,
-            exclusive=True,
+            exclusive=False,
             queue_type="classic",
         )
         in agent_queues
@@ -464,4 +464,6 @@ async def test_rabbitmq_on_message_invalid_routing_key(rabbitmq_api: RabbitMQMan
 
 
 async def on_callback(message: AbstractIncomingMessage, service: InfrahubServices) -> None:
-    await execute_message(routing_key=message.routing_key or "", message_body=message.body, service=service)
+    await execute_message(
+        routing_key=message.routing_key or "", message_body=message.body, message_bus=service.message_bus
+    )

--- a/backend/tests/integration/services/adapters/message_bus/test_rabbitmq.py
+++ b/backend/tests/integration/services/adapters/message_bus/test_rabbitmq.py
@@ -229,7 +229,7 @@ async def test_rabbitmq_initial_setup(rabbitmq_api: RabbitMQManager) -> None:
             name=f"worker-events-{WORKER_IDENTITY}",
             arguments={},
             durable=False,
-            exclusive=False,
+            exclusive=True,
             queue_type="classic",
         )
         in agent_queues

--- a/backend/tests/integration/services/adapters/message_bus/test_rabbitmq.py
+++ b/backend/tests/integration/services/adapters/message_bus/test_rabbitmq.py
@@ -414,19 +414,18 @@ async def test_rabbitmq_rpc(rabbitmq_api: RabbitMQManager, fake_log: FakeLogger,
 
     bus = await RabbitMQMessageBus.new(settings=rabbitmq_api.settings, component_type=ComponentType.API_SERVER)
     service = await InfrahubServices.new(message_bus=bus, component_type=ComponentType.API_SERVER)
-    dependency_provider.override(build_message_bus, lambda: bus)
+    with dependency_provider.scope(build_message_bus, lambda: bus):
+        queue = await bus.channel.get_queue(f"{bus.settings.namespace}.rpcs")
+        callback = partial(on_callback, message_bus=bus)
+        await queue.consume(callback, no_ack=True)
 
-    queue = await bus.channel.get_queue(f"{bus.settings.namespace}.rpcs")
-    callback = partial(on_callback, message_bus=bus)
-    await queue.consume(callback, no_ack=True)
+        response = await bus.rpc(
+            message=messages.SendEchoRequest(message="You can reply to this message"),
+            response_class=SendEchoRequestResponse,
+        )
+        await service.shutdown()
 
-    response = await bus.rpc(
-        message=messages.SendEchoRequest(message="You can reply to this message"),
-        response_class=SendEchoRequestResponse,
-    )
-    await service.shutdown()
-
-    assert response.data.response == "Reply to: You can reply to this message"
+        assert response.data.response == "Reply to: You can reply to this message"
 
 
 async def test_rabbitmq_on_message(rabbitmq_api: RabbitMQManager, fake_log: FakeLogger) -> None:

--- a/backend/tests/integration/services/adapters/message_bus/test_rabbitmq.py
+++ b/backend/tests/integration/services/adapters/message_bus/test_rabbitmq.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from dataclasses import dataclass
 from functools import partial
 from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
 
 import httpx
 import pytest
@@ -20,11 +21,14 @@ from infrahub.message_bus.types import MessageTTL
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.message_bus.rabbitmq import RabbitMQMessageBus
 from infrahub.worker import WORKER_IDENTITY
+from infrahub.workers.dependencies import build_message_bus
 
 if TYPE_CHECKING:
     from aio_pika.abc import AbstractIncomingMessage
+    from fast_depends import Provider
 
     from infrahub.config import BrokerSettings
+    from infrahub.services.adapters.message_bus import InfrahubMessageBus
     from tests.adapters.log import FakeLogger
 
 
@@ -375,47 +379,45 @@ async def test_rabbitmq_callback(rabbitmq_api: RabbitMQManager, fake_log: FakeLo
     """Validates that incoming messages gets parsed by the callback method."""
 
     bus = await RabbitMQMessageBus.new(settings=rabbitmq_api.settings, component_type=ComponentType.API_SERVER)
-    service = await InfrahubServices.new(message_bus=bus, component_type=ComponentType.API_SERVER, log=fake_log)
+    service = await InfrahubServices.new(message_bus=bus, component_type=ComponentType.API_SERVER)
 
-    queue = await bus.channel.get_queue(
-        f"{bus.settings.namespace}.rpcs",
-    )
+    queue = await bus.channel.get_queue(f"{bus.settings.namespace}.rpcs")
     await queue.consume(bus.on_callback, no_ack=True)
 
-    await service.message_bus.send(message=messages.SendEchoRequest(message="Hello there"))
-    await asyncio.sleep(delay=1)
+    with patch("infrahub.message_bus.operations.send.echo.get_logger", return_value=fake_log):
+        await service.message_bus.send(message=messages.SendEchoRequest(message="Hello there"))
+        await asyncio.sleep(delay=1)
+        await service.shutdown()
 
     assert "Received message: Hello there" in fake_log.info_logs
-    await service.shutdown()
 
 
 async def test_rabbitmq_callback_with_invalid_routing_key(rabbitmq_api: RabbitMQManager, fake_log: FakeLogger) -> None:
     """Validate that messages with an invalid routing key is logged."""
 
     bus = await RabbitMQMessageBus.new(settings=rabbitmq_api.settings, component_type=ComponentType.API_SERVER)
-    service = await InfrahubServices.new(message_bus=bus, component_type=ComponentType.API_SERVER, log=fake_log)
+    service = await InfrahubServices.new(message_bus=bus, component_type=ComponentType.API_SERVER)
 
-    queue = await bus.channel.get_queue(
-        f"{bus.settings.namespace}.rpcs",
-    )
+    queue = await bus.channel.get_queue(f"{bus.settings.namespace}.rpcs")
     await queue.consume(bus.on_callback, no_ack=True)
 
-    await bus.exchange.publish(Message(body=b"Completely invalid"), routing_key="event.branch.invalid")
-    await asyncio.sleep(delay=1)
+    with patch("infrahub.services.adapters.message_bus.rabbitmq.get_logger", return_value=fake_log):
+        await bus.exchange.publish(Message(body=b"Completely invalid"), routing_key="event.branch.invalid")
+        await asyncio.sleep(delay=1)
+        await service.shutdown()
+
     assert "Invalid message received" in fake_log.error_logs
-    await service.shutdown()
 
 
-async def test_rabbitmq_rpc(rabbitmq_api: RabbitMQManager, fake_log: FakeLogger) -> None:
+async def test_rabbitmq_rpc(rabbitmq_api: RabbitMQManager, fake_log: FakeLogger, dependency_provider: Provider) -> None:
     """Validates that incoming messages gets parsed by the callback method."""
 
     bus = await RabbitMQMessageBus.new(settings=rabbitmq_api.settings, component_type=ComponentType.API_SERVER)
-    service = await InfrahubServices.new(message_bus=bus, component_type=ComponentType.API_SERVER, log=fake_log)
+    service = await InfrahubServices.new(message_bus=bus, component_type=ComponentType.API_SERVER)
+    dependency_provider.override(build_message_bus, lambda: bus)
 
-    queue = await bus.channel.get_queue(
-        f"{bus.settings.namespace}.rpcs",
-    )
-    callback = partial(on_callback, service=service)
+    queue = await bus.channel.get_queue(f"{bus.settings.namespace}.rpcs")
+    callback = partial(on_callback, message_bus=bus)
     await queue.consume(callback, no_ack=True)
 
     response = await bus.rpc(
@@ -431,15 +433,14 @@ async def test_rabbitmq_on_message(rabbitmq_api: RabbitMQManager, fake_log: Fake
     """Validates the on_message method."""
 
     bus = await RabbitMQMessageBus.new(settings=rabbitmq_api.settings, component_type=ComponentType.API_SERVER)
-    _ = await InfrahubServices.new(message_bus=bus, component_type=ComponentType.API_SERVER)
     await bus.shutdown()
 
     bus = await RabbitMQMessageBus.new(settings=rabbitmq_api.settings, component_type=ComponentType.GIT_AGENT)
-    _ = await InfrahubServices.new(message_bus=bus, component_type=ComponentType.GIT_AGENT, log=fake_log)
 
-    await bus.send(message=messages.SendEchoRequest(message="Hello there"))
-    await asyncio.sleep(delay=1)
-    await bus.shutdown()
+    with patch("infrahub.message_bus.operations.send.echo.get_logger", return_value=fake_log):
+        await bus.send(message=messages.SendEchoRequest(message="Hello there"))
+        await asyncio.sleep(delay=1)
+        await bus.shutdown()
 
     assert fake_log.info_logs == ["Received message: Hello there"]
     assert fake_log.error_logs == []
@@ -449,21 +450,20 @@ async def test_rabbitmq_on_message_invalid_routing_key(rabbitmq_api: RabbitMQMan
     """Validates logging of invalid routing key"""
 
     bus = await RabbitMQMessageBus.new(settings=rabbitmq_api.settings, component_type=ComponentType.API_SERVER)
-    _ = await InfrahubServices.new(message_bus=bus, component_type=ComponentType.API_SERVER)
     await bus.shutdown()
 
     bus = await RabbitMQMessageBus.new(settings=rabbitmq_api.settings, component_type=ComponentType.GIT_AGENT)
-    _ = await InfrahubServices.new(message_bus=bus, component_type=ComponentType.GIT_AGENT, log=fake_log)
 
-    await bus.publish(routing_key="request.something.invalid", message=messages.SendEchoRequest(message="Hello there"))
-    await asyncio.sleep(delay=1)
-    await bus.shutdown()
+    with patch("infrahub.services.adapters.message_bus.rabbitmq.get_logger", return_value=fake_log):
+        await bus.publish(
+            routing_key="request.something.invalid", message=messages.SendEchoRequest(message="Hello there")
+        )
+        await asyncio.sleep(delay=1)
+        await bus.shutdown()
 
     assert fake_log.info_logs == []
     assert fake_log.error_logs == ["Invalid message received"]
 
 
-async def on_callback(message: AbstractIncomingMessage, service: InfrahubServices) -> None:
-    await execute_message(
-        routing_key=message.routing_key or "", message_body=message.body, message_bus=service.message_bus
-    )
+async def on_callback(message: AbstractIncomingMessage, message_bus: InfrahubMessageBus) -> None:
+    await execute_message(routing_key=message.routing_key or "", message_body=message.body, message_bus=message_bus)

--- a/backend/tests/integration_docker/test_computed_attributes.py
+++ b/backend/tests/integration_docker/test_computed_attributes.py
@@ -11,11 +11,9 @@ from infrahub_sdk.task.models import TaskFilter, TaskState
 from infrahub_sdk.testing.docker import TestInfrahubDockerClient
 from infrahub_sdk.testing.repository import GitRepo
 
-from infrahub.workers.dependencies import build_client
 from infrahub.workflows.catalogue import COMPUTED_ATTRIBUTE_JINJA2_UPDATE_VALUE
 
 if TYPE_CHECKING:
-    from fast_depends import Provider
     from infrahub_sdk import InfrahubClient
 
 CURRENT_DIRECTORY = Path(__file__).parent.resolve()
@@ -123,11 +121,7 @@ class TestComputedAttributes(TestInfrahubDockerClient):
 
         assert tshirt1_last_update_result.name_code.value == expected_name_code
 
-    async def test_transform_based_computed_attribute(
-        self, client: InfrahubClient, remote_repos_dir: Path, dependency_provider: Provider
-    ) -> None:
-        dependency_provider.override(build_client, lambda: client)
-
+    async def test_transform_based_computed_attribute(self, client: InfrahubClient, remote_repos_dir: Path) -> None:
         src_directory = CURRENT_DIRECTORY / "test_files/repos/computed_attribute"
         repo = GitRepo(name="computed_attribute", src_directory=src_directory, dst_directory=remote_repos_dir)
         commit = repo._repo.git[repo._repo.git.head()]

--- a/backend/tests/integration_docker/test_computed_attributes.py
+++ b/backend/tests/integration_docker/test_computed_attributes.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 from asyncio import sleep
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 import yaml
@@ -8,7 +11,12 @@ from infrahub_sdk.task.models import TaskFilter, TaskState
 from infrahub_sdk.testing.docker import TestInfrahubDockerClient
 from infrahub_sdk.testing.repository import GitRepo
 
+from infrahub.workers.dependencies import build_client
 from infrahub.workflows.catalogue import COMPUTED_ATTRIBUTE_JINJA2_UPDATE_VALUE
+
+if TYPE_CHECKING:
+    from fast_depends import Provider
+    from infrahub_sdk import InfrahubClient
 
 CURRENT_DIRECTORY = Path(__file__).parent.resolve()
 
@@ -115,7 +123,11 @@ class TestComputedAttributes(TestInfrahubDockerClient):
 
         assert tshirt1_last_update_result.name_code.value == expected_name_code
 
-    async def test_transform_based_computed_attribute(self, client: InfrahubClient, remote_repos_dir: Path) -> None:
+    async def test_transform_based_computed_attribute(
+        self, client: InfrahubClient, remote_repos_dir: Path, dependency_provider: Provider
+    ) -> None:
+        dependency_provider.override(build_client, lambda: client)
+
         src_directory = CURRENT_DIRECTORY / "test_files/repos/computed_attribute"
         repo = GitRepo(name="computed_attribute", src_directory=src_directory, dst_directory=remote_repos_dir)
         commit = repo._repo.git[repo._repo.git.head()]

--- a/backend/tests/unit/api/conftest.py
+++ b/backend/tests/unit/api/conftest.py
@@ -36,8 +36,8 @@ def rpc_bus(helper, dependency_provider):
     original = config.OVERRIDE.message_bus
     bus = helper.get_message_bus_rpc()
     config.OVERRIDE.message_bus = bus
-    dependency_provider.override(build_message_bus, lambda: bus)
-    yield bus
+    with dependency_provider.scope(build_message_bus, lambda: bus):
+        yield bus
     config.OVERRIDE.message_bus = original
 
 
@@ -47,8 +47,8 @@ async def workflow_local(dependency_provider):
     workflow = WorkflowLocalExecution()
     await setup_task_manager()
     config.OVERRIDE.workflow = workflow
-    dependency_provider.override(build_workflow, lambda: workflow)
-    yield workflow
+    with dependency_provider.scope(build_workflow, lambda: workflow):
+        yield workflow
     config.OVERRIDE.workflow = original
 
 

--- a/backend/tests/unit/api/conftest.py
+++ b/backend/tests/unit/api/conftest.py
@@ -9,7 +9,7 @@ from infrahub.core.node import Node
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
-from infrahub.workers.dependencies import build_message_bus
+from infrahub.workers.dependencies import build_message_bus, build_workflow
 from infrahub.workflows.initialization import setup_task_manager
 
 
@@ -42,11 +42,12 @@ def rpc_bus(helper, dependency_provider):
 
 
 @pytest.fixture
-async def workflow_local():
+async def workflow_local(dependency_provider):
     original = config.OVERRIDE.workflow
     workflow = WorkflowLocalExecution()
     await setup_task_manager()
     config.OVERRIDE.workflow = workflow
+    dependency_provider.override(build_workflow, lambda: workflow)
     yield workflow
     config.OVERRIDE.workflow = original
 

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -8,6 +8,7 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
+from fast_depends import Provider
 from infrahub_sdk import Config, InfrahubClient
 from infrahub_sdk.uuidt import UUIDT
 from neo4j._codec.hydration.v1 import HydrationHandler
@@ -63,6 +64,7 @@ from infrahub.database import InfrahubDatabase
 from infrahub.dependencies.registry import build_component_registry
 from infrahub.git import InfrahubRepository
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
+from infrahub.workers.dependencies import build_workflow
 from tests.helpers.file_repo import FileRepo
 from tests.helpers.test_client import dummy_async_request
 from tests.test_data import dataset01 as ds01
@@ -3007,10 +3009,11 @@ async def prefix_pool_01(
 
 
 @pytest.fixture
-def workflow_local():
+def workflow_local(dependency_provider: Provider):
     original = config.OVERRIDE.workflow
     workflow = WorkflowLocalExecution()
     config.OVERRIDE.workflow = workflow
+    dependency_provider.override(build_workflow, lambda: workflow)
     yield workflow
     config.OVERRIDE.workflow = original
 

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -3013,8 +3013,8 @@ def workflow_local(dependency_provider: Provider):
     original = config.OVERRIDE.workflow
     workflow = WorkflowLocalExecution()
     config.OVERRIDE.workflow = workflow
-    dependency_provider.override(build_workflow, lambda: workflow)
-    yield workflow
+    with dependency_provider.scope(build_workflow, lambda: workflow):
+        yield workflow
     config.OVERRIDE.workflow = original
 
 

--- a/backend/tests/unit/core/constraint_validators/test_task_schema_validate_migrations.py
+++ b/backend/tests/unit/core/constraint_validators/test_task_schema_validate_migrations.py
@@ -1,5 +1,3 @@
-from infrahub_sdk import InfrahubClient
-
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import SchemaPathType
@@ -9,9 +7,6 @@ from infrahub.core.path import SchemaPath
 from infrahub.core.validators.models.validate_migration import SchemaValidateMigrationData
 from infrahub.core.validators.tasks import schema_validate_migrations
 from infrahub.database import InfrahubDatabase
-from infrahub.services import InfrahubServices
-from infrahub.services.adapters.message_bus.local import BusSimulator
-from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 
 
 async def test_schema_validate_migrations(
@@ -36,15 +31,8 @@ async def test_schema_validate_migrations(
         )
     ]
 
-    service = await InfrahubServices.new(
-        message_bus=BusSimulator(), client=InfrahubClient(), workflow=WorkflowLocalExecution(), database=db
-    )
-
     message = SchemaValidateMigrationData(branch=default_branch, schema_branch=schema, constraints=constraints)
-    responses = await schema_validate_migrations(
-        message=message,
-        service=service,
-    )
+    responses = await schema_validate_migrations(message=message)
 
     assert len(responses) == 1
     assert len(responses[0].violations) == 1

--- a/backend/tests/unit/core/test_branch_rebase.py
+++ b/backend/tests/unit/core/test_branch_rebase.py
@@ -12,7 +12,7 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import ValidationError
-from infrahub.workers.dependencies import build_workflow
+from infrahub.workers.dependencies import build_database
 
 
 async def test_rebase_graph(db: InfrahubDatabase, base_dataset_02, register_core_models_schema):
@@ -98,7 +98,8 @@ async def test_branch_rebase_diff_conflict(
     car_person_schema,
     car_camry_main,
 ):
-    dependency_provider.override(build_workflow, lambda: workflow_local)
+    # NOTE: Ideally, this should be somewhere else for all tests to benefit from it
+    dependency_provider.override(build_database, lambda: db)
 
     branch2 = await create_branch(db=db, branch_name="branch2")
     car_main = await NodeManager.get_one(db=db, id=car_camry_main.id)

--- a/backend/tests/unit/core/test_branch_rebase.py
+++ b/backend/tests/unit/core/test_branch_rebase.py
@@ -99,21 +99,20 @@ async def test_branch_rebase_diff_conflict(
     car_camry_main,
 ):
     # NOTE: Ideally, this should be somewhere else for all tests to benefit from it
-    dependency_provider.override(build_database, lambda: db)
+    with dependency_provider.scope(build_database, lambda: db):
+        branch2 = await create_branch(db=db, branch_name="branch2")
+        car_main = await NodeManager.get_one(db=db, id=car_camry_main.id)
+        car_main.name.value += "-main"
+        await car_main.save(db=db)
+        car_branch = await NodeManager.get_one(db=db, branch=branch2, id=car_camry_main.id)
+        car_branch.name.value += "-branch"
+        await car_branch.save(db=db)
 
-    branch2 = await create_branch(db=db, branch_name="branch2")
-    car_main = await NodeManager.get_one(db=db, id=car_camry_main.id)
-    car_main.name.value += "-main"
-    await car_main.save(db=db)
-    car_branch = await NodeManager.get_one(db=db, branch=branch2, id=car_camry_main.id)
-    car_branch.name.value += "-branch"
-    await car_branch.save(db=db)
-
-    with pytest.raises(ValidationError, match="contains conflicts with the default branch that must be addressed"):
-        await rebase_branch(
-            branch=branch2.name,
-            context=InfrahubContext.init(
-                branch=default_branch,
-                account=AccountSession(account_id=str(uuid4()), auth_type=AuthType.NONE),
-            ),
-        )
+        with pytest.raises(ValidationError, match="contains conflicts with the default branch that must be addressed"):
+            await rebase_branch(
+                branch=branch2.name,
+                context=InfrahubContext.init(
+                    branch=default_branch,
+                    account=AccountSession(account_id=str(uuid4()), auth_type=AuthType.NONE),
+                ),
+            )

--- a/backend/tests/unit/core/test_branch_rebase.py
+++ b/backend/tests/unit/core/test_branch_rebase.py
@@ -12,8 +12,7 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import ValidationError
-from infrahub.services import InfrahubServices
-from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
+from infrahub.workers.dependencies import build_workflow
 
 
 async def test_rebase_graph(db: InfrahubDatabase, base_dataset_02, register_core_models_schema):
@@ -95,9 +94,12 @@ async def test_branch_rebase_diff_conflict(
     db: InfrahubDatabase,
     default_branch: Branch,
     workflow_local,
+    dependency_provider,
     car_person_schema,
     car_camry_main,
 ):
+    dependency_provider.override(build_workflow, lambda: workflow_local)
+
     branch2 = await create_branch(db=db, branch_name="branch2")
     car_main = await NodeManager.get_one(db=db, id=car_camry_main.id)
     car_main.name.value += "-main"
@@ -106,12 +108,9 @@ async def test_branch_rebase_diff_conflict(
     car_branch.name.value += "-branch"
     await car_branch.save(db=db)
 
-    service = await InfrahubServices.new(database=db, workflow=WorkflowLocalExecution())
-
     with pytest.raises(ValidationError, match="contains conflicts with the default branch that must be addressed"):
         await rebase_branch(
             branch=branch2.name,
-            service=service,
             context=InfrahubContext.init(
                 branch=default_branch,
                 account=AccountSession(account_id=str(uuid4()), auth_type=AuthType.NONE),

--- a/backend/tests/unit/git/test_git_rpc.py
+++ b/backend/tests/unit/git/test_git_rpc.py
@@ -26,7 +26,7 @@ from infrahub.lock import InfrahubLockRegistry
 from infrahub.message_bus.messages import RefreshGitFetch
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
-from infrahub.workers.dependencies import build_client, build_message_bus
+from infrahub.workers.dependencies import build_client, build_message_bus, build_workflow
 from infrahub.workflows.catalogue import GIT_REPOSITORIES_DIFF_NAMES_ONLY, GIT_REPOSITORIES_MERGE
 from tests.adapters.message_bus import BusSimulator
 from tests.helpers.test_client import dummy_async_request
@@ -75,7 +75,11 @@ class TestAddRepository:
 
         patch.stopall()
 
-    async def test_git_rpc_create_successful(self, prefect_test_fixture, git_upstream_repo_01: dict[str, str], setup):
+    async def test_git_rpc_create_successful(
+        self, prefect_test_fixture, git_upstream_repo_01: dict[str, str], setup, dependency_provider
+    ):
+        dependency_provider.override(build_message_bus, lambda: self.recorder)
+
         repo_id = str(UUIDT())
         model = GitRepositoryAdd(
             repository_id=repo_id,
@@ -149,16 +153,16 @@ async def test_git_rpc_merge(
     bus_simulator = await helper.get_message_bus_simulator()
     dependency_provider.override(build_message_bus, lambda: bus_simulator)
 
-    service = await InfrahubServices.new(client=client, message_bus=bus_simulator, workflow=WorkflowLocalExecution())
+    workflow = WorkflowLocalExecution()
+    dependency_provider.override(build_workflow, lambda: workflow)
+
     context = InfrahubContext(
         branch=BranchContext(name=branch01.name, id=branch01.id),
         account=AccountSession(
             authenticated=True, account_id=create_test_admin.id, session_id=None, auth_type=AuthType.API
         ),
     )
-    await service.workflow.submit_workflow(
-        workflow=GIT_REPOSITORIES_MERGE, context=context, parameters={"model": model}
-    )
+    await workflow.submit_workflow(workflow=GIT_REPOSITORIES_MERGE, context=context, parameters={"model": model})
 
     commit_main_after = repo.get_commit_value(branch_name="main")
 
@@ -272,11 +276,12 @@ class TestPullReadOnly:
     async def setup(self, dependency_provider):
         self.client = AsyncMock(spec=InfrahubClient)
         self.recorder = BusSimulator()
-        self.service = await InfrahubServices.new(
-            client=self.client, workflow=WorkflowLocalExecution(), message_bus=self.recorder
-        )
+        self.workflow = WorkflowLocalExecution()
+        self.service = await InfrahubServices.new(client=self.client, workflow=self.workflow, message_bus=self.recorder)
 
         dependency_provider.override(build_message_bus, lambda: self.recorder)
+        dependency_provider.override(build_workflow, lambda: self.workflow)
+        dependency_provider.override(build_client, lambda: self.client)
 
         self.commit = str(UUIDT())
         self.infrahub_branch_name = "read-only-branch"

--- a/backend/tests/unit/git/test_git_rpc.py
+++ b/backend/tests/unit/git/test_git_rpc.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import ANY, AsyncMock, patch
 
 import pytest
 from infrahub_sdk import Config, InfrahubClient
@@ -26,6 +26,7 @@ from infrahub.lock import InfrahubLockRegistry
 from infrahub.message_bus.messages import RefreshGitFetch
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
+from infrahub.workers.dependencies import build_client, build_message_bus
 from infrahub.workflows.catalogue import GIT_REPOSITORIES_DIFF_NAMES_ONLY, GIT_REPOSITORIES_MERGE
 from tests.adapters.message_bus import BusSimulator
 from tests.helpers.test_client import dummy_async_request
@@ -57,11 +58,13 @@ class AsyncContextManagerMock:
 
 class TestAddRepository:
     @pytest.fixture
-    async def setup(self):
+    async def setup(self, dependency_provider):
         self.default_branch_name = "default-branch"
         self.client = AsyncMock(spec=InfrahubClient)
         self.recorder = BusSimulator()
         self.service = await InfrahubServices.new(client=self.client, message_bus=self.recorder)
+
+        dependency_provider.override(build_message_bus, lambda: self.recorder)
 
         self.mock_repo = AsyncMock(spec=InfrahubRepository)
         self.mock_repo.default_branch = self.default_branch_name
@@ -92,7 +95,7 @@ class TestAddRepository:
         ):
             mock_infra_lock.registry = AsyncMock(spec=InfrahubLockRegistry)
             mock_repo_class.new.return_value = self.mock_repo
-            await add_git_repository(model=model, service=self.service)
+            await add_git_repository(model=model)
 
             mock_infra_lock.registry.get.assert_called_once_with(
                 name=git_upstream_repo_01["name"], namespace="repository"
@@ -102,7 +105,7 @@ class TestAddRepository:
                 id=repo_id,
                 name=git_upstream_repo_01["name"],
                 location=str(git_upstream_repo_01["path"]),
-                client=self.client,
+                client=ANY,
                 infrahub_branch_name=self.default_branch_name,
                 internal_status="active",
                 default_branch_name=self.default_branch_name,
@@ -118,6 +121,7 @@ class TestAddRepository:
 
 async def test_git_rpc_merge(
     prefect_test_fixture,
+    dependency_provider,
     git_repo_01: InfrahubRepository,
     branch01: BranchData,
     helper: TestHelper,
@@ -139,11 +143,13 @@ async def test_git_rpc_merge(
         default_branch="main",
     )
 
-    client_config = Config(requester=dummy_async_request)
+    client = InfrahubClient(config=Config(requester=dummy_async_request))
+    dependency_provider.override(build_client, lambda: client)
+
     bus_simulator = await helper.get_message_bus_simulator()
-    service = await InfrahubServices.new(
-        client=InfrahubClient(config=client_config), message_bus=bus_simulator, workflow=WorkflowLocalExecution()
-    )
+    dependency_provider.override(build_message_bus, lambda: bus_simulator)
+
+    service = await InfrahubServices.new(client=client, message_bus=bus_simulator, workflow=WorkflowLocalExecution())
     context = InfrahubContext(
         branch=BranchContext(name=branch01.name, id=branch01.id),
         account=AccountSession(
@@ -208,10 +214,12 @@ async def test_git_rpc_diff(
 
 class TestAddReadOnly:
     @pytest.fixture
-    async def setup(self):
+    async def setup(self, dependency_provider):
         self.client = AsyncMock(spec=InfrahubClient)
         self.recorder = BusSimulator()
         self.service = await InfrahubServices.new(client=self.client, message_bus=self.recorder)
+
+        dependency_provider.override(build_message_bus, lambda: self.recorder)
 
         lock_patcher = patch("infrahub.git.tasks.lock")
         self.mock_infra_lock = lock_patcher.start()
@@ -236,18 +244,19 @@ class TestAddReadOnly:
             infrahub_branch_name="read-only-branch",
             infrahub_branch_id="469cd407-0a8f-4d4e-9629-84fa435cf5ad",
             internal_status="active",
+            client=ANY,
         )
 
         self.mock_repo.import_objects_from_files = AsyncMock()
 
-        await add_git_repository_read_only(model=model, service=self.service)
+        await add_git_repository_read_only(model=model)
 
         self.mock_infra_lock.registry.get(name=git_upstream_repo_01["name"], namespace="repository")
         self.mock_repo_class.new.assert_awaited_once_with(
             id=repo_id,
             name=git_upstream_repo_01["name"],
             location=str(git_upstream_repo_01["path"]),
-            client=self.client,
+            client=ANY,
             ref="branch01",
             infrahub_branch_name="read-only-branch",
         )
@@ -260,12 +269,14 @@ class TestAddReadOnly:
 
 class TestPullReadOnly:
     @pytest.fixture
-    async def setup(self):
+    async def setup(self, dependency_provider):
         self.client = AsyncMock(spec=InfrahubClient)
         self.recorder = BusSimulator()
         self.service = await InfrahubServices.new(
             client=self.client, workflow=WorkflowLocalExecution(), message_bus=self.recorder
         )
+
+        dependency_provider.override(build_message_bus, lambda: self.recorder)
 
         self.commit = str(UUIDT())
         self.infrahub_branch_name = "read-only-branch"
@@ -302,7 +313,7 @@ class TestPullReadOnly:
         self.model.ref = None
         self.model.commit = None
 
-        await pull_read_only(model=self.model, service=self.service)
+        await pull_read_only(model=self.model)
 
         self.mock_repo_class.new.assert_not_awaited()
         self.mock_repo_class.init.assert_not_awaited()
@@ -310,14 +321,14 @@ class TestPullReadOnly:
     async def test_existing_repository(self, setup):
         self.mock_repo.import_objects_from_files = AsyncMock()
 
-        await pull_read_only(model=self.model, service=self.service)
+        await pull_read_only(model=self.model)
 
         self.mock_infra_lock.registry.get(name=self.repo_name, namespace="repository")
         self.mock_repo_class.init.assert_awaited_once_with(
             id=self.repo_id,
             name=self.repo_name,
             location=self.location,
-            client=self.client,
+            client=ANY,
             ref=self.ref,
             infrahub_branch_name=self.infrahub_branch_name,
         )
@@ -333,14 +344,14 @@ class TestPullReadOnly:
         self.mock_repo_class.init.side_effect = RepositoryError(self.repo_name, "it is broken")
         self.mock_repo.import_objects_from_files = AsyncMock()
 
-        await pull_read_only(model=self.model, service=self.service)
+        await pull_read_only(model=self.model)
 
         self.mock_infra_lock.registry.get(name=self.repo_name, namespace="repository")
         self.mock_repo_class.init.assert_awaited_once_with(
             id=self.repo_id,
             name=self.repo_name,
             location=self.location,
-            client=self.client,
+            client=ANY,
             ref=self.ref,
             infrahub_branch_name=self.infrahub_branch_name,
         )
@@ -348,7 +359,7 @@ class TestPullReadOnly:
             id=self.repo_id,
             name=self.repo_name,
             location=self.location,
-            client=self.client,
+            client=ANY,
             ref=self.ref,
             infrahub_branch_name=self.infrahub_branch_name,
         )

--- a/backend/tests/unit/git/test_git_rpc.py
+++ b/backend/tests/unit/git/test_git_rpc.py
@@ -75,11 +75,7 @@ class TestAddRepository:
 
         patch.stopall()
 
-    async def test_git_rpc_create_successful(
-        self, prefect_test_fixture, git_upstream_repo_01: dict[str, str], setup, dependency_provider
-    ):
-        dependency_provider.override(build_message_bus, lambda: self.recorder)
-
+    async def test_git_rpc_create_successful(self, prefect_test_fixture, git_upstream_repo_01: dict[str, str], setup):
         repo_id = str(UUIDT())
         model = GitRepositoryAdd(
             repository_id=repo_id,

--- a/backend/tests/unit/git/test_git_rpc.py
+++ b/backend/tests/unit/git/test_git_rpc.py
@@ -64,16 +64,16 @@ class TestAddRepository:
         self.recorder = BusSimulator()
         self.service = await InfrahubServices.new(client=self.client, message_bus=self.recorder)
 
-        dependency_provider.override(build_message_bus, lambda: self.recorder)
+        with dependency_provider.scope(build_message_bus, lambda: self.recorder):
+            self.mock_repo = AsyncMock(spec=InfrahubRepository)
+            self.mock_repo = AsyncMock(spec=InfrahubRepository)
+            self.mock_repo.default_branch = self.default_branch_name
+            self.mock_repo.infrahub_branch_name = self.default_branch_name
+            self.mock_repo.internal_status = "active"
 
-        self.mock_repo = AsyncMock(spec=InfrahubRepository)
-        self.mock_repo.default_branch = self.default_branch_name
-        self.mock_repo.infrahub_branch_name = self.default_branch_name
-        self.mock_repo.internal_status = "active"
+            yield
 
-        yield
-
-        patch.stopall()
+            patch.stopall()
 
     async def test_git_rpc_create_successful(self, prefect_test_fixture, git_upstream_repo_01: dict[str, str], setup):
         repo_id = str(UUIDT())
@@ -144,25 +144,24 @@ async def test_git_rpc_merge(
     )
 
     client = InfrahubClient(config=Config(requester=dummy_async_request))
-    dependency_provider.override(build_client, lambda: client)
-
     bus_simulator = await helper.get_message_bus_simulator()
-    dependency_provider.override(build_message_bus, lambda: bus_simulator)
-
     workflow = WorkflowLocalExecution()
-    dependency_provider.override(build_workflow, lambda: workflow)
+    with (
+        dependency_provider.scope(build_client, lambda: client),
+        dependency_provider.scope(build_message_bus, lambda: bus_simulator),
+        dependency_provider.scope(build_workflow, lambda: workflow),
+    ):
+        context = InfrahubContext(
+            branch=BranchContext(name=branch01.name, id=branch01.id),
+            account=AccountSession(
+                authenticated=True, account_id=create_test_admin.id, session_id=None, auth_type=AuthType.API
+            ),
+        )
+        await workflow.submit_workflow(workflow=GIT_REPOSITORIES_MERGE, context=context, parameters={"model": model})
 
-    context = InfrahubContext(
-        branch=BranchContext(name=branch01.name, id=branch01.id),
-        account=AccountSession(
-            authenticated=True, account_id=create_test_admin.id, session_id=None, auth_type=AuthType.API
-        ),
-    )
-    await workflow.submit_workflow(workflow=GIT_REPOSITORIES_MERGE, context=context, parameters={"model": model})
+        commit_main_after = repo.get_commit_value(branch_name="main")
 
-    commit_main_after = repo.get_commit_value(branch_name="main")
-
-    assert commit_main_before != commit_main_after
+        assert commit_main_before != commit_main_after
 
 
 async def test_git_rpc_diff(
@@ -219,20 +218,19 @@ class TestAddReadOnly:
         self.recorder = BusSimulator()
         self.service = await InfrahubServices.new(client=self.client, message_bus=self.recorder)
 
-        dependency_provider.override(build_message_bus, lambda: self.recorder)
+        with dependency_provider.scope(build_message_bus, lambda: self.recorder):
+            lock_patcher = patch("infrahub.git.tasks.lock")
+            self.mock_infra_lock = lock_patcher.start()
+            self.mock_infra_lock.registry = AsyncMock(spec=InfrahubLockRegistry)
+            repo_class_patcher = patch("infrahub.git.tasks.InfrahubReadOnlyRepository", spec=InfrahubReadOnlyRepository)
+            self.mock_repo_class = repo_class_patcher.start()
+            self.mock_repo = AsyncMock(spec=InfrahubReadOnlyRepository)
+            self.mock_repo_class.new.return_value = self.mock_repo
 
-        lock_patcher = patch("infrahub.git.tasks.lock")
-        self.mock_infra_lock = lock_patcher.start()
-        self.mock_infra_lock.registry = AsyncMock(spec=InfrahubLockRegistry)
-        repo_class_patcher = patch("infrahub.git.tasks.InfrahubReadOnlyRepository", spec=InfrahubReadOnlyRepository)
-        self.mock_repo_class = repo_class_patcher.start()
-        self.mock_repo = AsyncMock(spec=InfrahubReadOnlyRepository)
-        self.mock_repo_class.new.return_value = self.mock_repo
+            yield
 
-        yield
-
-        # teardown
-        patch.stopall()
+            # teardown
+            patch.stopall()
 
     async def test_git_rpc_add_read_only_success(self, git_upstream_repo_01: dict[str, str], setup):
         repo_id = str(UUIDT())
@@ -275,40 +273,41 @@ class TestPullReadOnly:
         self.workflow = WorkflowLocalExecution()
         self.service = await InfrahubServices.new(client=self.client, workflow=self.workflow, message_bus=self.recorder)
 
-        dependency_provider.override(build_message_bus, lambda: self.recorder)
-        dependency_provider.override(build_workflow, lambda: self.workflow)
-        dependency_provider.override(build_client, lambda: self.client)
+        with (
+            dependency_provider.scope(build_message_bus, lambda: self.recorder),
+            dependency_provider.scope(build_workflow, lambda: self.workflow),
+            dependency_provider.scope(build_client, lambda: self.client),
+        ):
+            self.commit = str(UUIDT())
+            self.infrahub_branch_name = "read-only-branch"
+            self.repo_id = str(UUIDT())
+            self.location = "/some/directory/over/here"
+            self.repo_name = "dont-update-this-dude"
+            self.ref = "stable-branch"
 
-        self.commit = str(UUIDT())
-        self.infrahub_branch_name = "read-only-branch"
-        self.repo_id = str(UUIDT())
-        self.location = "/some/directory/over/here"
-        self.repo_name = "dont-update-this-dude"
-        self.ref = "stable-branch"
+            self.model = GitRepositoryPullReadOnly(
+                location=self.location,
+                repository_id=self.repo_id,
+                repository_name=self.repo_name,
+                ref=self.ref,
+                commit=self.commit,
+                infrahub_branch_name=self.infrahub_branch_name,
+                infrahub_branch_id="469cd407-0a8f-4d4e-9629-84fa435cf5ad",
+            )
 
-        self.model = GitRepositoryPullReadOnly(
-            location=self.location,
-            repository_id=self.repo_id,
-            repository_name=self.repo_name,
-            ref=self.ref,
-            commit=self.commit,
-            infrahub_branch_name=self.infrahub_branch_name,
-            infrahub_branch_id="469cd407-0a8f-4d4e-9629-84fa435cf5ad",
-        )
+            lock_patcher = patch("infrahub.git.tasks.lock")
+            self.mock_infra_lock = lock_patcher.start()
+            self.mock_infra_lock.registry = AsyncMock(spec=InfrahubLockRegistry)  # TODO fix mock?
+            repo_class_patcher = patch("infrahub.git.tasks.InfrahubReadOnlyRepository", spec=InfrahubReadOnlyRepository)
+            self.mock_repo_class = repo_class_patcher.start()
+            self.mock_repo = AsyncMock(spec=InfrahubReadOnlyRepository)
+            self.mock_repo_class.new.return_value = self.mock_repo
+            self.mock_repo_class.init.return_value = self.mock_repo
 
-        lock_patcher = patch("infrahub.git.tasks.lock")
-        self.mock_infra_lock = lock_patcher.start()
-        self.mock_infra_lock.registry = AsyncMock(spec=InfrahubLockRegistry)  # TODO fix mock?
-        repo_class_patcher = patch("infrahub.git.tasks.InfrahubReadOnlyRepository", spec=InfrahubReadOnlyRepository)
-        self.mock_repo_class = repo_class_patcher.start()
-        self.mock_repo = AsyncMock(spec=InfrahubReadOnlyRepository)
-        self.mock_repo_class.new.return_value = self.mock_repo
-        self.mock_repo_class.init.return_value = self.mock_repo
+            yield
 
-        yield
-
-        # teardown
-        patch.stopall()
+            # teardown
+            patch.stopall()
 
     async def test_improper_message(self, setup):
         self.model.ref = None

--- a/backend/tests/unit/git/test_git_transform.py
+++ b/backend/tests/unit/git/test_git_transform.py
@@ -35,7 +35,7 @@ potum
 album
 magnum
 """
-    response = await transform_render_jinja2_template(message=message, service=init_service)
+    response = await transform_render_jinja2_template(message=message)
     assert response == expected_response
 
 
@@ -56,7 +56,7 @@ async def test_git_transform_jinja2_missing(
     )
 
     with pytest.raises(RepositoryFileNotFoundError) as exc:
-        await transform_render_jinja2_template(message=message, service=init_service)
+        await transform_render_jinja2_template(message=message)
 
     assert "Unable to find the file" in exc.value.message
 
@@ -82,7 +82,7 @@ async def test_git_transform_jinja2_invalid(
     )
 
     with pytest.raises(TransformError) as exc:
-        await transform_render_jinja2_template(message=message, service=init_service)
+        await transform_render_jinja2_template(message=message)
 
     assert "Encountered unknown tag" in exc.value.message
 
@@ -104,5 +104,5 @@ async def test_transform_python_success(
         convert_query_response=False,
     )
 
-    response = await transform_python(message=message, service=init_service)
+    response = await transform_python(message=message)
     assert response == {"key": "abcabc", "answer": 42}

--- a/backend/tests/unit/graphql/mutations/test_branch.py
+++ b/backend/tests/unit/graphql/mutations/test_branch.py
@@ -1,3 +1,5 @@
+from infrahub_sdk.client import InfrahubClient
+
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.initialization import create_branch
@@ -6,7 +8,7 @@ from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
-from infrahub.workers.dependencies import build_client
+from tests.adapters.cache import MemoryCache
 from tests.adapters.message_bus import BusRecorder
 from tests.helpers.graphql import graphql, graphql_mutation
 from tests.helpers.test_app import TestInfrahubApp
@@ -20,12 +22,10 @@ class TestBranchCreate(TestInfrahubApp):
         car_person_schema,
         register_core_models_schema,
         session_admin,
-        client,
+        client: InfrahubClient,
         service: InfrahubServices,
-        dependency_provider,
+        memory_cache: MemoryCache,
     ):
-        dependency_provider.override(build_client, lambda: service.client)
-
         query = """
             mutation {
                 BranchCreate(data: { name: "branch2", sync_with_git: false }) {

--- a/backend/tests/unit/graphql/mutations/test_branch.py
+++ b/backend/tests/unit/graphql/mutations/test_branch.py
@@ -1,3 +1,4 @@
+import pytest
 from infrahub_sdk.client import InfrahubClient
 
 from infrahub.core import registry
@@ -8,6 +9,7 @@ from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
+from infrahub.workers.dependencies import build_database, build_message_bus, build_workflow
 from tests.adapters.message_bus import BusRecorder
 from tests.helpers.graphql import graphql, graphql_mutation
 from tests.helpers.test_app import TestInfrahubApp
@@ -239,8 +241,25 @@ class TestBranchCreate(TestInfrahubApp):
         assert branch2.active_schema_hash.main == default_branch.active_schema_hash.main
 
 
+@pytest.fixture
+async def local_services(db: InfrahubDatabase, dependency_provider) -> InfrahubServices:
+    message_bus = BusRecorder()
+    workflow = WorkflowLocalExecution()
+
+    dependency_provider.override(build_database, lambda: db)
+    dependency_provider.override(build_message_bus, lambda: message_bus)
+    dependency_provider.override(build_workflow, lambda: workflow)
+
+    return await InfrahubServices.new(message_bus=message_bus, database=db, workflow=workflow)
+
+
 async def test_branch_delete(
-    db: InfrahubDatabase, default_branch: Branch, car_person_schema, register_core_models_schema, session_admin
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_person_schema,
+    register_core_models_schema,
+    session_admin,
+    local_services: InfrahubServices,
 ):
     delete_query = """
     mutation {
@@ -249,11 +268,8 @@ async def test_branch_delete(
         }
     }
     """
-
-    service = await InfrahubServices.new(message_bus=BusRecorder(), database=db, workflow=WorkflowLocalExecution())
-
     delete_before_create = await graphql_mutation(
-        query=delete_query, db=db, branch=default_branch, account_session=session_admin, service=service
+        query=delete_query, db=db, branch=default_branch, account_session=session_admin, service=local_services
     )
 
     assert delete_before_create.errors
@@ -261,7 +277,7 @@ async def test_branch_delete(
 
 
 async def test_branch_rebase_wrong_branch(
-    db: InfrahubDatabase, default_branch: Branch, car_person_schema, session_admin
+    db: InfrahubDatabase, default_branch: Branch, car_person_schema, session_admin, local_services: InfrahubServices
 ):
     query = """
     mutation {
@@ -273,12 +289,11 @@ async def test_branch_rebase_wrong_branch(
         }
     }
     """
-    recorder = BusRecorder()
-    service = await InfrahubServices.new(message_bus=recorder)
+
     gql_params = await prepare_graphql_params(
         db=db,
         include_subscription=False,
-        service=service,
+        service=local_services,
         branch=default_branch,
         account_session=session_admin,
     )
@@ -295,7 +310,7 @@ async def test_branch_rebase_wrong_branch(
     assert result.errors[0].message == "Branch: branch2 not found."
 
 
-async def test_branch_update_description(db: InfrahubDatabase, base_dataset_02):
+async def test_branch_update_description(db: InfrahubDatabase, base_dataset_02, local_services: InfrahubServices):
     branch4 = await create_branch(branch_name="branch4", db=db)
 
     query = """
@@ -310,9 +325,8 @@ async def test_branch_update_description(db: InfrahubDatabase, base_dataset_02):
     }
     }
     """
-    service = await InfrahubServices.new(message_bus=BusRecorder(), database=db, workflow=WorkflowLocalExecution())
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch4, service=service)
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch4, service=local_services)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -331,7 +345,7 @@ async def test_branch_update_description(db: InfrahubDatabase, base_dataset_02):
 
 
 async def test_branch_merge_wrong_branch(
-    db: InfrahubDatabase, base_dataset_02, register_core_models_schema, session_admin
+    db: InfrahubDatabase, base_dataset_02, register_core_models_schema, session_admin, local_services: InfrahubServices
 ):
     branch1 = await Branch.get_by_name(db=db, name="branch1")
 
@@ -345,10 +359,9 @@ async def test_branch_merge_wrong_branch(
         }
     }
     """
-    service = await InfrahubServices.new(message_bus=BusRecorder(), database=db, workflow=WorkflowLocalExecution())
 
     gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=branch1, account_session=session_admin, service=service
+        db=db, include_subscription=False, branch=branch1, account_session=session_admin, service=local_services
     )
     result = await graphql(
         schema=gql_params.schema,
@@ -363,7 +376,9 @@ async def test_branch_merge_wrong_branch(
     assert result.errors[0].message == "Branch: branch99 not found."
 
 
-async def test_branch_merge_with_conflict_fails(db: InfrahubDatabase, car_person_schema, car_camry_main, session_admin):
+async def test_branch_merge_with_conflict_fails(
+    db: InfrahubDatabase, car_person_schema, car_camry_main, session_admin, local_services: InfrahubServices
+):
     query = """
     mutation {
         BranchMerge(data: { name: "branch2" }) {
@@ -383,11 +398,8 @@ async def test_branch_merge_with_conflict_fails(db: InfrahubDatabase, car_person
     car_branch.name.value += "-branch"
     await car_branch.save(db=db)
 
-    recorder = BusRecorder()
-    service = await InfrahubServices.new(message_bus=recorder, database=db, workflow=WorkflowLocalExecution())
-
     gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=branch2, account_session=session_admin, service=service
+        db=db, include_subscription=False, branch=branch2, account_session=session_admin, service=local_services
     )
     result = await graphql(
         schema=gql_params.schema,

--- a/backend/tests/unit/graphql/mutations/test_branch.py
+++ b/backend/tests/unit/graphql/mutations/test_branch.py
@@ -6,7 +6,7 @@ from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
-from infrahub.workers.dependencies import build_client, build_message_bus
+from infrahub.workers.dependencies import build_client
 from tests.adapters.message_bus import BusRecorder
 from tests.helpers.graphql import graphql, graphql_mutation
 from tests.helpers.test_app import TestInfrahubApp

--- a/backend/tests/unit/graphql/mutations/test_branch.py
+++ b/backend/tests/unit/graphql/mutations/test_branch.py
@@ -8,7 +8,6 @@ from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
-from tests.adapters.cache import MemoryCache
 from tests.adapters.message_bus import BusRecorder
 from tests.helpers.graphql import graphql, graphql_mutation
 from tests.helpers.test_app import TestInfrahubApp
@@ -24,7 +23,6 @@ class TestBranchCreate(TestInfrahubApp):
         session_admin,
         client: InfrahubClient,
         service: InfrahubServices,
-        memory_cache: MemoryCache,
     ):
         query = """
             mutation {

--- a/backend/tests/unit/graphql/mutations/test_branch.py
+++ b/backend/tests/unit/graphql/mutations/test_branch.py
@@ -246,11 +246,12 @@ async def local_services(db: InfrahubDatabase, dependency_provider) -> InfrahubS
     message_bus = BusRecorder()
     workflow = WorkflowLocalExecution()
 
-    dependency_provider.override(build_database, lambda: db)
-    dependency_provider.override(build_message_bus, lambda: message_bus)
-    dependency_provider.override(build_workflow, lambda: workflow)
-
-    return await InfrahubServices.new(message_bus=message_bus, database=db, workflow=workflow)
+    with (
+        dependency_provider.scope(build_database, lambda: db),
+        dependency_provider.scope(build_message_bus, lambda: message_bus),
+        dependency_provider.scope(build_workflow, lambda: workflow),
+    ):
+        yield await InfrahubServices.new(message_bus=message_bus, database=db, workflow=workflow)
 
 
 async def test_branch_delete(

--- a/backend/tests/unit/graphql/mutations/test_branch.py
+++ b/backend/tests/unit/graphql/mutations/test_branch.py
@@ -6,6 +6,7 @@ from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
+from infrahub.workers.dependencies import build_client, build_message_bus
 from tests.adapters.message_bus import BusRecorder
 from tests.helpers.graphql import graphql, graphql_mutation
 from tests.helpers.test_app import TestInfrahubApp
@@ -20,23 +21,26 @@ class TestBranchCreate(TestInfrahubApp):
         register_core_models_schema,
         session_admin,
         client,
-        service,
+        service: InfrahubServices,
+        dependency_provider,
     ):
+        dependency_provider.override(build_client, lambda: service.client)
+
         query = """
-        mutation {
-            BranchCreate(data: { name: "branch2", sync_with_git: false }) {
-                ok
-                object {
-                    id
-                    name
-                    description
-                    sync_with_git
-                    is_default
-                    branched_from
+            mutation {
+                BranchCreate(data: { name: "branch2", sync_with_git: false }) {
+                    ok
+                    object {
+                        id
+                        name
+                        description
+                        sync_with_git
+                        is_default
+                        branched_from
+                    }
                 }
             }
-        }
-        """
+            """
 
         result = await graphql_mutation(
             query=query, db=db, service=service, branch=default_branch, account_session=session_admin

--- a/backend/tests/unit/graphql/mutations/test_proposed_change.py
+++ b/backend/tests/unit/graphql/mutations/test_proposed_change.py
@@ -19,7 +19,7 @@ from infrahub.proposed_change.models import RequestProposedChangePipeline
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from infrahub.worker import WORKER_IDENTITY
-from infrahub.workers.dependencies import build_cache, build_client, build_message_bus
+from infrahub.workers.dependencies import build_client
 from infrahub.workflows.catalogue import REQUEST_PROPOSED_CHANGE_PIPELINE
 from infrahub.workflows.initialization import setup_deployments, setup_worker_pools
 from tests.adapters.cache import MemoryCache
@@ -273,14 +273,14 @@ class TestMergeProposedChangePermissionFailure(TestInfrahubApp):
         dependency_provider,
     ):
         dependency_provider.override(build_client, lambda: client)
-        bus_recorder = BusRecorder()
-        dependency_provider.override(build_message_bus, lambda: bus_recorder)
-        cache = MemoryCache()
-        dependency_provider.override(build_cache, lambda: cache)
-
         service = await InfrahubServices.new(
-            database=db, message_bus=bus_recorder, workflow=WorkflowLocalExecution(), cache=cache, client=client
+            database=db,
+            message_bus=BusRecorder(),
+            workflow=WorkflowLocalExecution(),
+            cache=MemoryCache(),
+            client=client,
         )
+
         async with get_client(sync_client=False) as prefect_client:
             await setup_worker_pools(client=prefect_client)
             await setup_deployments(prefect_client)

--- a/backend/tests/unit/graphql/mutations/test_proposed_change.py
+++ b/backend/tests/unit/graphql/mutations/test_proposed_change.py
@@ -5,6 +5,7 @@ from infrahub_sdk import InfrahubClient
 from prefect.client.orchestration import get_client
 
 from infrahub.auth import AccountSession, AuthType
+from infrahub.components import ComponentType
 from infrahub.core.branch import Branch
 from infrahub.core.constants import CheckType, InfrahubKind
 from infrahub.core.initialization import create_branch
@@ -18,6 +19,7 @@ from infrahub.permissions.local_backend import LocalPermissionBackend
 from infrahub.proposed_change.models import RequestProposedChangePipeline
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
+from infrahub.services.component import InfrahubComponent
 from infrahub.worker import WORKER_IDENTITY
 from infrahub.workers.dependencies import build_client
 from infrahub.workflows.catalogue import REQUEST_PROPOSED_CHANGE_PIPELINE
@@ -273,12 +275,15 @@ class TestMergeProposedChangePermissionFailure(TestInfrahubApp):
         dependency_provider,
     ):
         dependency_provider.override(build_client, lambda: client)
+        cache = MemoryCache()
+        message_bus = BusRecorder()
         service = await InfrahubServices.new(
             database=db,
-            message_bus=BusRecorder(),
+            message_bus=message_bus,
             workflow=WorkflowLocalExecution(),
-            cache=MemoryCache(),
+            cache=cache,
             client=client,
+            component=InfrahubComponent(cache=cache, db=db, message_bus=message_bus, component_type=ComponentType.NONE),
         )
 
         async with get_client(sync_client=False) as prefect_client:

--- a/backend/tests/unit/graphql/mutations/test_proposed_change.py
+++ b/backend/tests/unit/graphql/mutations/test_proposed_change.py
@@ -19,7 +19,7 @@ from infrahub.proposed_change.models import RequestProposedChangePipeline
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from infrahub.worker import WORKER_IDENTITY
-from infrahub.workers.dependencies import build_client
+from infrahub.workers.dependencies import build_cache, build_client, build_message_bus
 from infrahub.workflows.catalogue import REQUEST_PROPOSED_CHANGE_PIPELINE
 from infrahub.workflows.initialization import setup_deployments, setup_worker_pools
 from tests.adapters.cache import MemoryCache
@@ -273,13 +273,13 @@ class TestMergeProposedChangePermissionFailure(TestInfrahubApp):
         dependency_provider,
     ):
         dependency_provider.override(build_client, lambda: client)
+        bus_recorder = BusRecorder()
+        dependency_provider.override(build_message_bus, lambda: bus_recorder)
+        cache = MemoryCache()
+        dependency_provider.override(build_cache, lambda: cache)
 
         service = await InfrahubServices.new(
-            database=db,
-            message_bus=BusRecorder(),
-            workflow=WorkflowLocalExecution(),
-            cache=MemoryCache(),
-            client=client,
+            database=db, message_bus=bus_recorder, workflow=WorkflowLocalExecution(), cache=cache, client=client
         )
         async with get_client(sync_client=False) as prefect_client:
             await setup_worker_pools(client=prefect_client)

--- a/backend/tests/unit/graphql/mutations/test_proposed_change.py
+++ b/backend/tests/unit/graphql/mutations/test_proposed_change.py
@@ -274,64 +274,66 @@ class TestMergeProposedChangePermissionFailure(TestInfrahubApp):
         client: InfrahubClient,
         dependency_provider,
     ):
-        dependency_provider.override(build_client, lambda: client)
-        cache = MemoryCache()
-        message_bus = BusRecorder()
-        service = await InfrahubServices.new(
-            database=db,
-            message_bus=message_bus,
-            workflow=WorkflowLocalExecution(),
-            cache=cache,
-            client=client,
-            component=InfrahubComponent(cache=cache, db=db, message_bus=message_bus, component_type=ComponentType.NONE),
-        )
+        with dependency_provider.scope(build_client, lambda: client):
+            cache = MemoryCache()
+            message_bus = BusRecorder()
+            service = await InfrahubServices.new(
+                database=db,
+                message_bus=message_bus,
+                workflow=WorkflowLocalExecution(),
+                cache=cache,
+                client=client,
+                component=InfrahubComponent(
+                    cache=cache, db=db, message_bus=message_bus, component_type=ComponentType.NONE
+                ),
+            )
 
-        async with get_client(sync_client=False) as prefect_client:
-            await setup_worker_pools(client=prefect_client)
-            await setup_deployments(prefect_client)
+            async with get_client(sync_client=False) as prefect_client:
+                await setup_worker_pools(client=prefect_client)
+                await setup_deployments(prefect_client)
 
-        registry.permission_backends = [LocalPermissionBackend()]
+            registry.permission_backends = [LocalPermissionBackend()]
 
-        branch_name = "merge-proposed-change-perm"
-        branch = await create_branch(branch_name=branch_name, db=db)
-        await service.cache.set(
-            key=f"workers:schema_hash:branch:{str(branch.get_uuid)}:{service.component_type.value}:worker:{WORKER_IDENTITY}",
-            value=branch.active_schema_hash.main,
-            expires=KVTTL.TWO_HOURS,
-        )
-        await service.cache.set(
-            key=f"workers:active:{service.component_type.value}:worker:{WORKER_IDENTITY}",
-            value=Timestamp().to_string(),
-            expires=KVTTL.FIFTEEN,
-        )
-        await service.component.refresh_heartbeat()
+            branch_name = "merge-proposed-change-perm"
+            branch = await create_branch(branch_name=branch_name, db=db)
+            await service.cache.set(
+                key=f"workers:schema_hash:branch:{str(branch.get_uuid)}:{service.component_type.value}:worker:{WORKER_IDENTITY}",
+                value=branch.active_schema_hash.main,
+                expires=KVTTL.TWO_HOURS,
+            )
+            await service.cache.set(
+                key=f"workers:active:{service.component_type.value}:worker:{WORKER_IDENTITY}",
+                value=Timestamp().to_string(),
+                expires=KVTTL.FIFTEEN,
+            )
+            await service.component.refresh_heartbeat()
 
-        proposed_change = await Node.init(db=db, schema=InfrahubKind.PROPOSEDCHANGE)
-        await proposed_change.new(
-            db=db, name="pc-merge-perm-1234", destination_branch="main", source_branch=branch_name, state="open"
-        )
-        await proposed_change.save(db=db)
+            proposed_change = await Node.init(db=db, schema=InfrahubKind.PROPOSEDCHANGE)
+            await proposed_change.new(
+                db=db, name="pc-merge-perm-1234", destination_branch="main", source_branch=branch_name, state="open"
+            )
+            await proposed_change.save(db=db)
 
-        update_status = await graphql_mutation(
-            query=UPDATE_PROPOSED_CHANGE,
-            db=db,
-            variables={"proposed_change": proposed_change.id, "state": "merged"},
-            account_session=session_first_account,
-            service=service,
-        )
+            update_status = await graphql_mutation(
+                query=UPDATE_PROPOSED_CHANGE,
+                db=db,
+                variables={"proposed_change": proposed_change.id, "state": "merged"},
+                account_session=session_first_account,
+                service=service,
+            )
 
-        assert update_status.errors
-        assert update_status.errors[0].message == "You are not allowed to merge proposed changes"
+            assert update_status.errors
+            assert update_status.errors[0].message == "You are not allowed to merge proposed changes"
 
-        update_status = await graphql_mutation(
-            query=UPDATE_PROPOSED_CHANGE,
-            db=db,
-            variables={"proposed_change": proposed_change.id, "state": "merged"},
-            account_session=session_admin,
-            service=service,
-        )
+            update_status = await graphql_mutation(
+                query=UPDATE_PROPOSED_CHANGE,
+                db=db,
+                variables={"proposed_change": proposed_change.id, "state": "merged"},
+                account_session=session_admin,
+                service=service,
+            )
 
-        assert not update_status.errors
+            assert not update_status.errors
 
 
 async def test_create_thread(

--- a/backend/tests/unit/graphql/mutations/test_proposed_change.py
+++ b/backend/tests/unit/graphql/mutations/test_proposed_change.py
@@ -19,6 +19,7 @@ from infrahub.proposed_change.models import RequestProposedChangePipeline
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from infrahub.worker import WORKER_IDENTITY
+from infrahub.workers.dependencies import build_client
 from infrahub.workflows.catalogue import REQUEST_PROPOSED_CHANGE_PIPELINE
 from infrahub.workflows.initialization import setup_deployments, setup_worker_pools
 from tests.adapters.cache import MemoryCache
@@ -269,7 +270,10 @@ class TestMergeProposedChangePermissionFailure(TestInfrahubApp):
         session_first_account: AccountSession,
         session_admin: AccountSession,
         client: InfrahubClient,
+        dependency_provider,
     ):
+        dependency_provider.override(build_client, lambda: client)
+
         service = await InfrahubServices.new(
             database=db,
             message_bus=BusRecorder(),

--- a/backend/tests/unit/graphql/queries/test_branch.py
+++ b/backend/tests/unit/graphql/queries/test_branch.py
@@ -3,14 +3,24 @@ import operator
 from infrahub.core.branch import Branch
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
+from infrahub.workers.dependencies import build_client
 from tests.helpers.graphql import graphql
 from tests.helpers.test_app import TestInfrahubApp
 
 
-class TestBranchuQuery(TestInfrahubApp):
+class TestBranchQuery(TestInfrahubApp):
     async def test_branch_query(
-        self, db: InfrahubDatabase, default_branch: Branch, register_core_models_schema, session_admin, client, service
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        register_core_models_schema,
+        session_admin,
+        client,
+        service,
+        dependency_provider,
     ):
+        dependency_provider.override(build_client, lambda: client)
+
         create_branch_query = """
         mutation {
             BranchCreate(data: { name: "branch3", description: "my description" }) {

--- a/backend/tests/unit/graphql/queries/test_branch.py
+++ b/backend/tests/unit/graphql/queries/test_branch.py
@@ -3,7 +3,6 @@ import operator
 from infrahub.core.branch import Branch
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
-from infrahub.workers.dependencies import build_client
 from tests.helpers.graphql import graphql
 from tests.helpers.test_app import TestInfrahubApp
 
@@ -17,10 +16,7 @@ class TestBranchQuery(TestInfrahubApp):
         session_admin,
         client,
         service,
-        dependency_provider,
     ):
-        dependency_provider.override(build_client, lambda: client)
-
         create_branch_query = """
         mutation {
             BranchCreate(data: { name: "branch3", description: "my description" }) {

--- a/backend/tests/unit/graphql/queries/test_branch.py
+++ b/backend/tests/unit/graphql/queries/test_branch.py
@@ -16,7 +16,6 @@ class TestBranchQuery(TestInfrahubApp):
         session_admin,
         client,
         service,
-        memory_cache,
     ):
         create_branch_query = """
         mutation {

--- a/backend/tests/unit/graphql/queries/test_branch.py
+++ b/backend/tests/unit/graphql/queries/test_branch.py
@@ -3,6 +3,7 @@ import operator
 from infrahub.core.branch import Branch
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
+from infrahub.workers.dependencies import build_client
 from tests.helpers.graphql import graphql
 from tests.helpers.test_app import TestInfrahubApp
 
@@ -16,7 +17,10 @@ class TestBranchQuery(TestInfrahubApp):
         session_admin,
         client,
         service,
+        dependency_provider,
     ):
+        dependency_provider.override(build_client, lambda: client)
+
         create_branch_query = """
         mutation {
             BranchCreate(data: { name: "branch3", description: "my description" }) {

--- a/backend/tests/unit/graphql/queries/test_branch.py
+++ b/backend/tests/unit/graphql/queries/test_branch.py
@@ -3,7 +3,6 @@ import operator
 from infrahub.core.branch import Branch
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
-from infrahub.workers.dependencies import build_client
 from tests.helpers.graphql import graphql
 from tests.helpers.test_app import TestInfrahubApp
 
@@ -17,10 +16,8 @@ class TestBranchQuery(TestInfrahubApp):
         session_admin,
         client,
         service,
-        dependency_provider,
+        memory_cache,
     ):
-        dependency_provider.override(build_client, lambda: client)
-
         create_branch_query = """
         mutation {
             BranchCreate(data: { name: "branch3", description: "my description" }) {

--- a/backend/tests/unit/graphql/queries/test_status.py
+++ b/backend/tests/unit/graphql/queries/test_status.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from infrahub.components import ComponentType
 from infrahub.core.registry import registry
 from infrahub.services import InfrahubServices
+from infrahub.services.component import InfrahubComponent
 from infrahub.worker import WORKER_IDENTITY
 from tests.adapters.cache import MemoryCache
 from tests.adapters.message_bus import BusRecorder
@@ -19,7 +20,11 @@ async def test_status_query(db: InfrahubDatabase, default_branch: Branch, regist
     cache = MemoryCache()
     bus = BusRecorder()
     service = await InfrahubServices.new(
-        cache=cache, database=db, component_type=ComponentType.API_SERVER, message_bus=bus
+        cache=cache,
+        database=db,
+        component_type=ComponentType.API_SERVER,
+        message_bus=bus,
+        component=InfrahubComponent(cache=cache, db=db, message_bus=bus, component_type=ComponentType.API_SERVER),
     )
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
 

--- a/backend/tests/unit/message_bus/operations/event/test_branch.py
+++ b/backend/tests/unit/message_bus/operations/event/test_branch.py
@@ -87,7 +87,7 @@ async def test_merged(default_branch: Branch, prefect_test_fixture, context: Inf
         patch("infrahub.core.branch.tasks.get_run_logger"),
     ):
         await post_process_branch_merge.fn(
-            source_branch=source_branch_name, target_branch=target_branch_name, context=context, service=init_service
+            source_branch=source_branch_name, target_branch=target_branch_name, context=context
         )
 
         expected_calls = [

--- a/backend/tests/unit/message_bus/operations/git/test_file.py
+++ b/backend/tests/unit/message_bus/operations/git/test_file.py
@@ -1,12 +1,10 @@
-from infrahub_sdk import InfrahubClient
-
 from infrahub.core.constants import InfrahubKind
 from infrahub.git import InfrahubRepository
 from infrahub.message_bus import messages
-from infrahub.services import InfrahubServices
+from infrahub.workers.dependencies import build_message_bus
 
 
-async def test_file_get(git_fixture_repo: InfrahubRepository, helper):
+async def test_file_get(git_fixture_repo: InfrahubRepository, helper, dependency_provider):
     repo = git_fixture_repo.get_git_repo_main()
 
     message = messages.GitFileGet(
@@ -18,8 +16,9 @@ async def test_file_get(git_fixture_repo: InfrahubRepository, helper):
     )
 
     bus_simulator = await helper.get_message_bus_simulator()
-    service = await InfrahubServices.new(client=InfrahubClient(), message_bus=bus_simulator)
+    dependency_provider.override(build_message_bus, lambda: bus_simulator)
 
-    reply = await service.message_bus.rpc(message=message, response_class=messages.GitFileGetResponse)
+    reply = await bus_simulator.rpc(message=message, response_class=messages.GitFileGetResponse)
+
     assert reply.passed
     assert reply.data.content == "Someone will read this from Git."

--- a/backend/tests/unit/message_bus/operations/git/test_file.py
+++ b/backend/tests/unit/message_bus/operations/git/test_file.py
@@ -16,9 +16,8 @@ async def test_file_get(git_fixture_repo: InfrahubRepository, helper, dependency
     )
 
     bus_simulator = await helper.get_message_bus_simulator()
-    dependency_provider.override(build_message_bus, lambda: bus_simulator)
+    with dependency_provider.scope(build_message_bus, lambda: bus_simulator):
+        reply = await bus_simulator.rpc(message=message, response_class=messages.GitFileGetResponse)
 
-    reply = await bus_simulator.rpc(message=message, response_class=messages.GitFileGetResponse)
-
-    assert reply.passed
-    assert reply.data.content == "Someone will read this from Git."
+        assert reply.passed
+        assert reply.data.content == "Someone will read this from Git."

--- a/backend/tests/unit/message_bus/operations/requests/test_graphql_query_group.py
+++ b/backend/tests/unit/message_bus/operations/requests/test_graphql_query_group.py
@@ -23,46 +23,48 @@ async def mock_schema_query_02(helper, httpx_mock: HTTPXMock) -> HTTPXMock:
 async def test_graphql_group_update(
     db: InfrahubDatabase, httpx_mock: HTTPXMock, mock_schema_query_02, dependency_provider
 ):
-    dependency_provider.override(
+    with dependency_provider.scope(
         build_client, lambda: InfrahubClient(config=Config(address="http://mock", insert_tracker=True))
-    )
+    ):
+        q1 = str(uuid.uuid4())
+        p1 = str(uuid.uuid4())
+        p2 = str(uuid.uuid4())
+        c1 = str(uuid.uuid4())
+        c2 = str(uuid.uuid4())
+        c3 = str(uuid.uuid4())
+        r1 = str(uuid.uuid4())
 
-    q1 = str(uuid.uuid4())
-    p1 = str(uuid.uuid4())
-    p2 = str(uuid.uuid4())
-    c1 = str(uuid.uuid4())
-    c2 = str(uuid.uuid4())
-    c3 = str(uuid.uuid4())
-    r1 = str(uuid.uuid4())
+        model = RequestGraphQLQueryGroupUpdate(
+            query_id=q1,
+            query_name="query01",
+            branch="main",
+            related_node_ids={p1, p2, c1, c2, c3},
+            subscribers={r1},
+            params={"name": "John"},
+        )
 
-    model = RequestGraphQLQueryGroupUpdate(
-        query_id=q1,
-        query_name="query01",
-        branch="main",
-        related_node_ids={p1, p2, c1, c2, c3},
-        subscribers={r1},
-        params={"name": "John"},
-    )
-
-    with patch("infrahub.groups.tasks.add_tags"):
-        # add_branch_tag requires a prefect client, ie it does not work with WorkflowLocal
-        response1 = {
-            "data": {
-                "CoreGraphQLQueryGroupUpsert": {"ok": True, "object": {"id": "957aea37-4510-4386-916f-3febd6665ae6"}}
+        with patch("infrahub.groups.tasks.add_tags"):
+            # add_branch_tag requires a prefect client, ie it does not work with WorkflowLocal
+            response1 = {
+                "data": {
+                    "CoreGraphQLQueryGroupUpsert": {
+                        "ok": True,
+                        "object": {"id": "957aea37-4510-4386-916f-3febd6665ae6"},
+                    }
+                }
             }
-        }
 
-        httpx_mock.add_response(
-            method="POST",
-            json=response1,
-            match_headers={"X-Infrahub-Tracker": "mutation-coregraphqlquerygroup-upsert"},
-        )
+            httpx_mock.add_response(
+                method="POST",
+                json=response1,
+                match_headers={"X-Infrahub-Tracker": "mutation-coregraphqlquerygroup-upsert"},
+            )
 
-        response2 = {"data": {"RelationshipAdd": {"ok": True}}}
-        httpx_mock.add_response(
-            method="POST",
-            json=response2,
-            match_headers={"X-Infrahub-Tracker": "mutation-relationshipadd"},
-        )
+            response2 = {"data": {"RelationshipAdd": {"ok": True}}}
+            httpx_mock.add_response(
+                method="POST",
+                json=response2,
+                match_headers={"X-Infrahub-Tracker": "mutation-relationshipadd"},
+            )
 
-        await update_graphql_query_group.fn(model=model)
+            await update_graphql_query_group.fn(model=model)

--- a/backend/tests/unit/message_bus/operations/requests/test_graphql_query_group.py
+++ b/backend/tests/unit/message_bus/operations/requests/test_graphql_query_group.py
@@ -9,8 +9,6 @@ from pytest_httpx import HTTPXMock
 from infrahub.database import InfrahubDatabase
 from infrahub.groups.models import RequestGraphQLQueryGroupUpdate
 from infrahub.groups.tasks import update_graphql_query_group
-from infrahub.services import InfrahubServices
-from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 
 
 @pytest.fixture
@@ -38,13 +36,14 @@ async def test_graphql_group_update(db: InfrahubDatabase, httpx_mock: HTTPXMock,
         subscribers={r1},
         params={"name": "John"},
     )
-    config = Config(address="http://mock", insert_tracker=True)
-    client = InfrahubClient(
-        config=config,
-    )
-    service = await InfrahubServices.new(client=client, workflow=WorkflowLocalExecution())
 
-    with patch("infrahub.groups.tasks.add_tags"):
+    with (
+        patch("infrahub.groups.tasks.add_tags"),
+        patch(
+            "infrahub.workers.dependencies.build_client",
+            return_value=InfrahubClient(config=Config(address="http://mock", insert_tracker=True)),
+        ),
+    ):
         # add_branch_tag requires a prefect client, ie it does not work with WorkflowLocal
         response1 = {
             "data": {
@@ -65,4 +64,4 @@ async def test_graphql_group_update(db: InfrahubDatabase, httpx_mock: HTTPXMock,
             match_headers={"X-Infrahub-Tracker": "mutation-relationshipadd"},
         )
 
-        await update_graphql_query_group.fn(model=model, service=service)
+        await update_graphql_query_group.fn(model=model)

--- a/backend/tests/unit/message_bus/operations/requests/test_graphql_query_group.py
+++ b/backend/tests/unit/message_bus/operations/requests/test_graphql_query_group.py
@@ -9,6 +9,7 @@ from pytest_httpx import HTTPXMock
 from infrahub.database import InfrahubDatabase
 from infrahub.groups.models import RequestGraphQLQueryGroupUpdate
 from infrahub.groups.tasks import update_graphql_query_group
+from infrahub.workers.dependencies import build_client
 
 
 @pytest.fixture
@@ -19,7 +20,13 @@ async def mock_schema_query_02(helper, httpx_mock: HTTPXMock) -> HTTPXMock:
     return httpx_mock
 
 
-async def test_graphql_group_update(db: InfrahubDatabase, httpx_mock: HTTPXMock, mock_schema_query_02):
+async def test_graphql_group_update(
+    db: InfrahubDatabase, httpx_mock: HTTPXMock, mock_schema_query_02, dependency_provider
+):
+    dependency_provider.override(
+        build_client, lambda: InfrahubClient(config=Config(address="http://mock", insert_tracker=True))
+    )
+
     q1 = str(uuid.uuid4())
     p1 = str(uuid.uuid4())
     p2 = str(uuid.uuid4())
@@ -37,13 +44,7 @@ async def test_graphql_group_update(db: InfrahubDatabase, httpx_mock: HTTPXMock,
         params={"name": "John"},
     )
 
-    with (
-        patch("infrahub.groups.tasks.add_tags"),
-        patch(
-            "infrahub.workers.dependencies.build_client",
-            return_value=InfrahubClient(config=Config(address="http://mock", insert_tracker=True)),
-        ),
-    ):
+    with patch("infrahub.groups.tasks.add_tags"):
         # add_branch_tag requires a prefect client, ie it does not work with WorkflowLocal
         response1 = {
             "data": {

--- a/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
+++ b/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
@@ -20,7 +20,7 @@ from infrahub.proposed_change.tasks import (
     _get_proposed_change_schema_integrity_constraints,
     run_proposed_change_schema_integrity_check,
 )
-from infrahub.workers.dependencies import build_cache, build_database
+from infrahub.workers.dependencies import build_cache
 from tests.adapters.cache import MemoryCache
 from tests.conftest import TestHelper
 
@@ -276,7 +276,6 @@ async def test_schema_integrity(
     person_john_main: Node,
 ):
     cache = MemoryCache()
-    dependency_provider.override(build_database, lambda: db)
     dependency_provider.override(build_cache, lambda: cache)
 
     branch2 = await create_branch(branch_name=SOURCE_BRANCH_A, db=db)

--- a/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
+++ b/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
@@ -276,40 +276,39 @@ async def test_schema_integrity(
     person_john_main: Node,
 ):
     cache = MemoryCache()
-    dependency_provider.override(build_cache, lambda: cache)
+    with dependency_provider.scope(build_cache, lambda: cache):
+        branch2 = await create_branch(branch_name=SOURCE_BRANCH_A, db=db)
 
-    branch2 = await create_branch(branch_name=SOURCE_BRANCH_A, db=db)
+        person = await Node.init(db=db, schema="TestPerson", branch=branch2)
+        await person.new(db=db, name="ALFRED", height=160, cars=[car_accord_main.id])
+        await person.save(db=db)
 
-    person = await Node.init(db=db, schema="TestPerson", branch=branch2)
-    await person.new(db=db, name="ALFRED", height=160, cars=[car_accord_main.id])
-    await person.save(db=db)
+        branch2_schema = registry.schema.get_schema_branch(name=branch2.name)
+        person_schema = branch2_schema.get(name="TestPerson")
+        name_attr = person_schema.get_attribute(name="name")
+        name_attr.parameters.regex = r"^[A-Z]+$"
+        branch2_schema.set(name="TestPerson", schema=person_schema)
 
-    branch2_schema = registry.schema.get_schema_branch(name=branch2.name)
-    person_schema = branch2_schema.get(name="TestPerson")
-    name_attr = person_schema.get_attribute(name="name")
-    name_attr.parameters.regex = r"^[A-Z]+$"
-    branch2_schema.set(name="TestPerson", schema=person_schema)
+        await set_diff_summary_cache(
+            pipeline_id=schema_integrity_01.branch_diff.pipeline_id, diff_summary=branch_diff_01_summary, cache=cache
+        )
 
-    await set_diff_summary_cache(
-        pipeline_id=schema_integrity_01.branch_diff.pipeline_id, diff_summary=branch_diff_01_summary, cache=cache
-    )
+        await run_proposed_change_schema_integrity_check(model=schema_integrity_01)
 
-    await run_proposed_change_schema_integrity_check(model=schema_integrity_01)
+        checks = await registry.manager.query(db=db, schema=InfrahubKind.SCHEMACHECK)
+        assert len(checks) == 1
+        check = checks[0]
+        assert check.conclusion.value.value == "failure"
 
-    checks = await registry.manager.query(db=db, schema=InfrahubKind.SCHEMACHECK)
-    assert len(checks) == 1
-    check = checks[0]
-    assert check.conclusion.value.value == "failure"
-
-    assert check.conflicts.value == [
-        {
-            "branch": "placeholder",
-            "id": person_john_main.id,
-            "kind": "TestPerson",
-            "name": "schema/TestPerson/name/parameters.regex",
-            "path": "schema/TestPerson/name/parameters.regex",
-            "type": ConstraintIdentifier.ATTRIBUTE_PARAMETERS_REGEX_UPDATE.value,
-            # ruff: noqa: E501
-            "value": f"Attribute-level 'regex' constraint violation on schema 'TestPerson'. Node (TestPerson: {person_john_main.id}) is not compliant. The error relates to field name='{person_john_main.name.value}'.",
-        }
-    ]
+        assert check.conflicts.value == [
+            {
+                "branch": "placeholder",
+                "id": person_john_main.id,
+                "kind": "TestPerson",
+                "name": "schema/TestPerson/name/parameters.regex",
+                "path": "schema/TestPerson/name/parameters.regex",
+                "type": ConstraintIdentifier.ATTRIBUTE_PARAMETERS_REGEX_UPDATE.value,
+                # ruff: noqa: E501
+                "value": f"Attribute-level 'regex' constraint violation on schema 'TestPerson'. Node (TestPerson: {person_john_main.id}) is not compliant. The error relates to field name='{person_john_main.name.value}'.",
+            }
+        ]

--- a/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
+++ b/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
@@ -22,6 +22,7 @@ from infrahub.proposed_change.tasks import (
     run_proposed_change_schema_integrity_check,
 )
 from infrahub.services import InfrahubServices
+from infrahub.workers.dependencies import build_cache, build_database
 from tests.adapters.cache import MemoryCache
 from tests.conftest import TestHelper
 
@@ -284,10 +285,14 @@ async def test_schema_integrity(
     schema_integrity_01: RequestProposedChangeSchemaIntegrity,
     branch_diff_01_summary: list[NodeDiff],
     service_all: InfrahubServices,
+    dependency_provider,
     car_accord_main: Node,
     car_volt_main: Node,
-    person_john_main,
+    person_john_main: Node,
 ):
+    dependency_provider.override(build_database, lambda: db)
+    dependency_provider.override(build_cache, lambda: service_all.cache)
+
     branch2 = await create_branch(branch_name=SOURCE_BRANCH_A, db=db)
 
     person = await Node.init(db=db, schema="TestPerson", branch=branch2)
@@ -305,7 +310,8 @@ async def test_schema_integrity(
         diff_summary=branch_diff_01_summary,
         cache=service_all.cache,
     )
-    await run_proposed_change_schema_integrity_check(model=schema_integrity_01, service=service_all)
+
+    await run_proposed_change_schema_integrity_check(model=schema_integrity_01)
 
     checks = await registry.manager.query(db=db, schema=InfrahubKind.SCHEMACHECK)
     assert len(checks) == 1

--- a/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
+++ b/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
@@ -2,7 +2,6 @@ from uuid import uuid4
 
 import pytest
 import ujson
-from infrahub_sdk import Config, InfrahubClient
 from infrahub_sdk.diff import NodeDiff
 from pytest_httpx import HTTPXMock
 
@@ -21,22 +20,9 @@ from infrahub.proposed_change.tasks import (
     _get_proposed_change_schema_integrity_constraints,
     run_proposed_change_schema_integrity_check,
 )
-from infrahub.services import InfrahubServices
 from infrahub.workers.dependencies import build_cache, build_database
 from tests.adapters.cache import MemoryCache
 from tests.conftest import TestHelper
-
-
-@pytest.fixture
-async def service_all(db: InfrahubDatabase, helper: TestHelper) -> InfrahubServices:
-    config = Config(address="http://mock", insert_tracker=True)
-    client = InfrahubClient(config=config)
-    bus_simulator = await helper.get_message_bus_simulator()
-    service = await InfrahubServices.new(message_bus=bus_simulator, cache=MemoryCache(), client=client, database=db)
-    bus_simulator.service = service
-
-    return service
-
 
 SOURCE_BRANCH_A = "branch2"
 DST_BRANCH_A = "main"
@@ -284,14 +270,14 @@ async def test_schema_integrity(
     car_person_schema,
     schema_integrity_01: RequestProposedChangeSchemaIntegrity,
     branch_diff_01_summary: list[NodeDiff],
-    service_all: InfrahubServices,
     dependency_provider,
     car_accord_main: Node,
     car_volt_main: Node,
     person_john_main: Node,
 ):
+    cache = MemoryCache()
     dependency_provider.override(build_database, lambda: db)
-    dependency_provider.override(build_cache, lambda: service_all.cache)
+    dependency_provider.override(build_cache, lambda: cache)
 
     branch2 = await create_branch(branch_name=SOURCE_BRANCH_A, db=db)
 
@@ -306,9 +292,7 @@ async def test_schema_integrity(
     branch2_schema.set(name="TestPerson", schema=person_schema)
 
     await set_diff_summary_cache(
-        pipeline_id=schema_integrity_01.branch_diff.pipeline_id,
-        diff_summary=branch_diff_01_summary,
-        cache=service_all.cache,
+        pipeline_id=schema_integrity_01.branch_diff.pipeline_id, diff_summary=branch_diff_01_summary, cache=cache
     )
 
     await run_proposed_change_schema_integrity_check(model=schema_integrity_01)


### PR DESCRIPTION
This change aims to remove the `InfrahubServices` dependency on flows and messages going through the message bus. Code for which the service dependency is required should now call individual sub-service  get functions when needed.

This PR depends on https://github.com/opsmill/infrahub/pull/6406.