### PR TITLE
Increase tasks logs limit

### DIFF
--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import Any
 from uuid import uuid4
 
@@ -342,6 +343,12 @@ async def validate_branch(branch: str, service: InfrahubServices) -> State:
 @flow(name="create-branch", flow_run_name="Create branch {model.name}")
 async def create_branch(model: BranchCreateModel, context: InfrahubContext, service: InfrahubServices) -> None:
     await add_tags(branches=[model.name])
+
+    value = str(uuid4())
+
+    tasks_log = logging.getLogger("infrahub.tasks")
+    for i in range(85_000):
+        tasks_log.info(f"Demo log entry {i + 1} {value=}")
 
     async with service.database.start_session() as db:
         try:

--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from typing import Any
 from uuid import uuid4
 
@@ -343,12 +342,6 @@ async def validate_branch(branch: str, service: InfrahubServices) -> State:
 @flow(name="create-branch", flow_run_name="Create branch {model.name}")
 async def create_branch(model: BranchCreateModel, context: InfrahubContext, service: InfrahubServices) -> None:
     await add_tags(branches=[model.name])
-
-    value = str(uuid4())
-
-    tasks_log = logging.getLogger("infrahub.tasks")
-    for i in range(85_000):
-        tasks_log.info(f"Demo log entry {i + 1} {value=}")
 
     async with service.database.start_session() as db:
         try:

--- a/backend/infrahub/graphql/queries/task.py
+++ b/backend/infrahub/graphql/queries/task.py
@@ -32,6 +32,8 @@ class Tasks(ObjectType):
         workflow: list[str] | None = None,
         related_node__ids: list | None = None,
         q: str | None = None,
+        log_limit: int | None = None,
+        log_offset: int | None = None,
     ) -> dict[str, Any]:
         related_nodes = related_node__ids or []
         ids = ids or []
@@ -45,6 +47,8 @@ class Tasks(ObjectType):
             statuses=state,
             workflows=workflow,
             related_nodes=related_nodes,
+            log_limit=log_limit,
+            log_offset=log_offset,
         )
 
     @staticmethod
@@ -71,6 +75,8 @@ class Tasks(ObjectType):
         branch: str | None = None,
         limit: int | None = None,
         offset: int | None = None,
+        log_limit: int | None = None,
+        log_offset: int | None = None,
     ) -> dict[str, Any]:
         graphql_context: GraphqlContext = info.context
         fields = await extract_fields_first_node(info)
@@ -87,6 +93,8 @@ class Tasks(ObjectType):
             related_nodes=related_nodes,
             limit=limit,
             offset=offset,
+            log_limit=log_limit,
+            log_offset=log_offset,
         )
         prefect_count = prefect_tasks.get("count", None)
         return {
@@ -105,6 +113,8 @@ Task = Field(
     workflow=List(String),
     ids=List(String),
     q=String(required=False),
+    log_limit=Int(required=False),
+    log_offset=Int(required=False),
     resolver=Tasks.resolve,
     required=True,
 )

--- a/backend/infrahub/graphql/types/task_log.py
+++ b/backend/infrahub/graphql/types/task_log.py
@@ -1,4 +1,4 @@
-from graphene import Field, InputObjectType, List, ObjectType, String
+from graphene import Field, InputObjectType, Int, List, NonNull, ObjectType, String
 from graphene.types.uuid import UUID
 
 from .enums import Severity
@@ -26,4 +26,5 @@ class TaskLogNodes(ObjectType):
 
 
 class TaskLogEdge(ObjectType):
-    edges = List(TaskLogNodes)
+    edges = List(NonNull(TaskLogNodes), required=True)
+    count = Int(required=True)

--- a/backend/infrahub/task_manager/task.py
+++ b/backend/infrahub/task_manager/task.py
@@ -36,6 +36,7 @@ from .models import FlowLogs, FlowProgress, RelatedNodesInfo
 log = get_logger()
 
 NB_LOGS_LIMIT = 10_000
+PREFECT_MAX_LOGS_PER_CALL = 200
 
 
 class PrefectTask:
@@ -85,25 +86,42 @@ class PrefectTask:
         return related_nodes
 
     @classmethod
-    async def _get_logs(cls, client: PrefectClient, flow_ids: list[UUID]) -> FlowLogs:
-        offset = 0
-        all_logs = []
-
-        while True and offset < NB_LOGS_LIMIT:
-            # Retrieve logs with the current offset, without specifying a limit
-            logs_batch = await client.read_logs(
-                log_filter=LogFilter(flow_run_id=LogFilterFlowRunId(any_=flow_ids)), offset=offset
-            )
-            if not logs_batch:
-                break
-
-            all_logs.extend(logs_batch)
-            offset += len(logs_batch)
-
-        if offset >= NB_LOGS_LIMIT:
-            log.warning(f"Could not retrieve all logs for flows {flow_ids}, number of logs exceeded {NB_LOGS_LIMIT}")
+    async def _get_logs(
+        cls, client: PrefectClient, flow_ids: list[UUID], log_limit: int | None, log_offset: int | None
+    ) -> FlowLogs:
+        """
+        Return the logs for a flow run, based on log_limit and log_offset.
+        At most, NB_LOGS_LIMIT logs will be returned per flow.
+        """
 
         logs_flow = FlowLogs()
+
+        log_limit = log_limit if log_limit is not None else NB_LOGS_LIMIT
+        log_offset = log_offset or 0
+        current_offset = log_offset
+
+        if log_limit > NB_LOGS_LIMIT:
+            raise ValueError("log_limit cannot be greater than NB_LOGS_LIMIT")
+
+        all_logs = []
+
+        # Fetch the logs in batches of PREFECT_MAX_LOGS_PER_CALL, as prefect does not allow to fetch more logs at once.
+        remaining = min(log_limit, NB_LOGS_LIMIT)
+        while remaining > 0:
+            batch_limit = min(PREFECT_MAX_LOGS_PER_CALL, remaining)
+            logs_batch = await client.read_logs(
+                log_filter=LogFilter(flow_run_id=LogFilterFlowRunId(any_=flow_ids)),
+                offset=current_offset,
+                limit=batch_limit,
+            )
+            all_logs.extend(logs_batch)
+            nb_fetched = len(logs_batch)
+            if nb_fetched < batch_limit:
+                break  # No more logs to fetch
+
+            current_offset += nb_fetched
+            remaining -= nb_fetched
+
         for flow_log in all_logs:
             if flow_log.flow_run_id and flow_log.message not in ["Finished in state Completed()"]:
                 logs_flow.logs[flow_log.flow_run_id].append(flow_log)
@@ -206,6 +224,8 @@ class PrefectTask:
         branch: str | None = None,
         limit: int | None = None,
         offset: int | None = None,
+        log_limit: int | None = None,
+        log_offset: int | None = None,
     ) -> dict[str, Any]:
         nodes: list[dict] = []
         count = None
@@ -237,7 +257,9 @@ class PrefectTask:
                     sort=FlowRunSort.START_TIME_DESC,
                 )
                 if log_fields:
-                    logs_flow = await cls._get_logs(client=client, flow_ids=[flow.id for flow in flows])
+                    logs_flow = await cls._get_logs(
+                        client=client, flow_ids=[flow.id for flow in flows], log_limit=log_limit, log_offset=log_offset
+                    )
 
                 if "progress" in node_fields:
                     progress_flow = await cls._get_progress(client=client, flow_ids=[flow.id for flow in flows])
@@ -283,7 +305,7 @@ class PrefectTask:
                                 "updated_at": flow.updated.to_iso8601_string(),  # type: ignore
                                 "start_time": flow.start_time.to_iso8601_string() if flow.start_time else None,
                                 "id": flow.id,
-                                "logs": {"edges": logs},
+                                "logs": {"edges": logs, "count": len(logs)},
                             }
                         }
                     )

--- a/backend/infrahub/task_manager/task.py
+++ b/backend/infrahub/task_manager/task.py
@@ -35,6 +35,8 @@ from .models import FlowLogs, FlowProgress, RelatedNodesInfo
 
 log = get_logger()
 
+NB_LOGS_LIMIT = 10_000
+
 
 class PrefectTask:
     @classmethod
@@ -84,8 +86,24 @@ class PrefectTask:
 
     @classmethod
     async def _get_logs(cls, client: PrefectClient, flow_ids: list[UUID]) -> FlowLogs:
+        offset = 0
+        all_logs = []
+
+        while True and offset < NB_LOGS_LIMIT:
+            # Retrieve logs with the current offset, without specifying a limit
+            logs_batch = await client.read_logs(
+                log_filter=LogFilter(flow_run_id=LogFilterFlowRunId(any_=flow_ids)), offset=offset
+            )
+            if not logs_batch:
+                break
+
+            all_logs.extend(logs_batch)
+            offset += len(logs_batch)
+
+        if offset >= NB_LOGS_LIMIT:
+            log.warning(f"Could not retrieve all logs for flows {flow_ids}, number of logs exceeded {NB_LOGS_LIMIT}")
+
         logs_flow = FlowLogs()
-        all_logs = await client.read_logs(log_filter=LogFilter(flow_run_id=LogFilterFlowRunId(any_=flow_ids)))
         for flow_log in all_logs:
             if flow_log.flow_run_id and flow_log.message not in ["Finished in state Completed()"]:
                 logs_flow.logs[flow_log.flow_run_id].append(flow_log)

--- a/backend/infrahub/task_manager/task.py
+++ b/backend/infrahub/task_manager/task.py
@@ -101,7 +101,7 @@ class PrefectTask:
         current_offset = log_offset
 
         if log_limit > NB_LOGS_LIMIT:
-            raise ValueError("log_limit cannot be greater than NB_LOGS_LIMIT")
+            raise ValueError(f"log_limit cannot be greater than {NB_LOGS_LIMIT}")
 
         all_logs = []
 

--- a/backend/tests/unit/graphql/queries/test_task.py
+++ b/backend/tests/unit/graphql/queries/test_task.py
@@ -85,6 +85,42 @@ query TaskQuery(
 """
 
 
+QUERY_TASK_WITH_LOG_OFFSET = """
+query TaskQuery(
+    $related_nodes: [String]
+) {
+  InfrahubTask(related_node__ids: $related_nodes, log_offset: 1, log_limit: 10) {
+    count
+    edges {
+      node {
+        conclusion
+        created_at
+        id
+        related_node
+        related_node_kind
+        related_nodes {
+            id
+            kind
+        }
+        title
+        updated_at
+        logs {
+            edges {
+                node {
+                    id
+                    message
+                    severity
+                    timestamp
+                }
+            }
+        }
+      }
+    }
+  }
+}
+"""
+
+
 @pytest.fixture
 async def tag_blue(db: InfrahubDatabase, default_branch: Branch) -> Node:
     blue = await Node.init(db=db, schema=InfrahubKind.TAG, branch=default_branch)
@@ -570,6 +606,43 @@ async def test_task_query_both(
         db=db,
         branch=default_branch,
         query=QUERY_TASK_WITH_LOGS,
+        variables={},
+    )
+    assert result.errors is None
+    assert result.data
+
+    task_names = sorted([task["node"]["title"] for task in result.data["InfrahubTask"]["edges"]])
+    assert task_names == [
+        "dummy-completed-account-br1-db",
+        "dummy-completed-br1-db",
+        "dummy-completed-no-branch",
+        "dummy-running-br1",
+        "dummy-running-br1-db",
+        "dummy-scheduled-blue-db",
+        "dummy-scheduled-br1-db",
+    ]
+    assert result.data["InfrahubTask"]["count"] == len(task_names)
+
+
+async def test_task_query_with_log_offset(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_core_models_schema: None,
+    tag_blue,
+    account_bob,
+    delete_flow_runs,
+    flow_runs_data: dict[str, FlowRun],
+):
+    """
+    In unit tests logs are not forwarded to the Prefect server for unknown reasons.
+    Therefore this test mainly tests log_offset and log_limit do not break the query when they are specified,
+    but their logic itself is not tested on a large amount of logs.
+    """
+
+    result = await run_query(
+        db=db,
+        branch=default_branch,
+        query=QUERY_TASK_WITH_LOG_OFFSET,
         variables={},
     )
     assert result.errors is None


### PR DESCRIPTION
Fixes #5912

Prefect default log retrieval limit is 200, cf

```
    default_limit: int = Field(
        default=200,
        description="The default limit applied to queries that can return multiple objects, such as `POST /flow_runs/filter`.",
        validation_alias=AliasChoices(
            AliasPath("default_limit"),
            "prefect_server_api_default_limit",
            "prefect_api_default_limit",
        ),
    )
```

This PR:
- Allows to retrieve up to 10 000 logs per task by performing multiple call to prefect API. The limit of 10 000 is arbitrary and may be modified.
- Allows logs pagination by introducing `log_offset` and `log_limit`


I tested the fix manually on large amount of logs. I initially wanted to add a regression test for it but it appears that:
- logs are somehow not captured within tests using local prefect server, cf `test_task_query_prefect`
- triggering `DUMMY_FLOW` run on a backend docker integration test resulted in a timeout that would require deeper investigation

In the end I added a test specifying log_offset and log_limit in the graphql query, even though it does not fully test the logic on large amount of logs.