### PR TITLE
Add support for alternate fields in schema path

### DIFF
--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -782,6 +782,10 @@ class Dropdown(BaseAttribute):
 
         return ""
 
+    @staticmethod
+    def get_allowed_property_in_path() -> list[str]:
+        return ["color", "description", "label", "value"]
+
     @classmethod
     def validate_content(cls, value: Any, name: str, schema: AttributeSchema) -> None:
         """Validate the content of the dropdown."""
@@ -817,7 +821,18 @@ class IPNetwork(BaseAttribute):
 
     @staticmethod
     def get_allowed_property_in_path() -> list[str]:
-        return ["value", "version", "binary_address", "prefixlen"]
+        return [
+            "binary_address",
+            "broadcast_address",
+            "hostmask",
+            "netmask",
+            "num_addresses",
+            "prefixlen",
+            "value",
+            "version",
+            "with_hostmask",
+            "with_netmask",
+        ]
 
     @property
     def obj(self) -> ipaddress.IPv4Network | ipaddress.IPv6Network:
@@ -950,7 +965,17 @@ class IPHost(BaseAttribute):
 
     @staticmethod
     def get_allowed_property_in_path() -> list[str]:
-        return ["value", "version", "binary_address"]
+        return [
+            "binary_address",
+            "hostmask",
+            "ip",
+            "netmask",
+            "prefixlen",
+            "value",
+            "version",
+            "with_hostmask",
+            "with_netmask",
+        ]
 
     @property
     def obj(self) -> ipaddress.IPv4Interface | ipaddress.IPv6Interface:
@@ -1169,6 +1194,22 @@ class MacAddress(BaseAttribute):
     def serialize_value(self) -> str:
         """Serialize the value as standard EUI-48 or EUI-64 before storing it in the database."""
         return str(netaddr.EUI(addr=self.value))
+
+    @staticmethod
+    def get_allowed_property_in_path() -> list[str]:
+        return [
+            "bare",
+            "binary",
+            "dot_notation",
+            "ei",
+            "eui48",
+            "eui64",
+            "oui",
+            "semicolon_notation",
+            "split_notation",
+            "value",
+            "version",
+        ]
 
 
 class MacAddressOptional(MacAddress):

--- a/backend/tests/unit/core/test_types.py
+++ b/backend/tests/unit/core/test_types.py
@@ -1,0 +1,49 @@
+import pytest
+from graphene.types.field import Field
+
+from infrahub.core import attribute
+from infrahub.graphql import types
+from infrahub.types import ATTRIBUTE_TYPES
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [pytest.param(attribute_name, id=attribute_name) for attribute_name in ATTRIBUTE_TYPES.keys()],
+)
+def test_attribute_types_allowed_property_path(test_case: str) -> None:
+    """Validates that the get_allowed_property_in_path() method returns the correct fields for all types
+
+    This ensures that we can use the entries properly when evaluating the schema path for instance with the
+    computed attributes
+    """
+    attribute_type = ATTRIBUTE_TYPES[test_case]
+
+    graphql_query_type = getattr(types, attribute_type.graphql_query)
+    include_binary_address = test_case in ["IPHost", "IPNetwork"]
+    path_list = _get_path_field_list(
+        include_binary_address=include_binary_address, fields=graphql_query_type._meta.fields
+    )
+    infrahub_type: attribute.BaseAttribute = getattr(attribute, attribute_type.infrahub)
+    assert path_list == infrahub_type.get_allowed_property_in_path()
+
+
+def _get_path_field_list(include_binary_address: bool, fields: dict[str, Field]) -> list[str]:
+    """Return list of valid property paths for the specified type"""
+    excluded_fields = [
+        "id",
+        "is_default",
+        "is_from_profile",
+        "is_inherited",
+        "is_protected",
+        "is_visible",
+        "owner",
+        "source",
+        "permissions",
+        "updated_at",
+    ]
+    included = ["binary_address"] if include_binary_address else []
+    for name in fields.keys():
+        if name not in excluded_fields:
+            included.append(name)
+
+    return sorted(included)

--- a/changelog/5769.added.md
+++ b/changelog/5769.added.md
@@ -1,0 +1,3 @@
+<!-- vale off -->
+Added the ability to use alternative value types for all attribute types with computed attributes. For attributes of type IPHost or Dropdown you can now access the `ip` or `label` fields and not only the `value` field.
+<!-- vale on -->


### PR DESCRIPTION
Fixes issue with using additional value types when the schema path is used for instance with the computed attributes

Fixes #5769