### PR TITLE
Reenable convert query test for transforms and fix code

### DIFF
--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -1222,6 +1222,9 @@ query GatherArtifactDefinitions {
               file_path {
                 value
               }
+              convert_query_response {
+                value
+              }
             }
             repository {
               node {
@@ -1429,6 +1432,9 @@ def _parse_artifact_definitions(definitions: list[dict]) -> list[ProposedChangeA
         elif artifact_definition.transform_kind == InfrahubKind.TRANSFORMPYTHON:
             artifact_definition.class_name = definition["node"]["transformation"]["node"]["class_name"]["value"]
             artifact_definition.file_path = definition["node"]["transformation"]["node"]["file_path"]["value"]
+            artifact_definition.convert_query_response = definition["node"]["transformation"]["node"][
+                "convert_query_response"
+            ]["value"]
 
         parsed.append(artifact_definition)
 

--- a/backend/tests/fixtures/repos/car-dealership/initial__main/transforms/converted_person_with_cars.py
+++ b/backend/tests/fixtures/repos/car-dealership/initial__main/transforms/converted_person_with_cars.py
@@ -9,8 +9,6 @@ class ConvertedPersonWith(InfrahubTransform):
     async def transform(self, data: dict[str, Any]) -> dict[str, Any]:
         node_id = data["TestingPerson"]["edges"][0]["node"]["id"]
 
-        person = self.store.get(key=node_id, kind="TestingPerson", raise_when_missing=False)
-        if not person:
-            person = await self.client.get(kind="TestingPerson", id=node_id)
+        person = self.store.get(key=node_id, kind="TestingPerson")
 
         return {"name": person.name.value, "age": person.age.value}


### PR DESCRIPTION
This PR corrects an issue where a test was pretty much disabled as we weren't able to merge `stable` back into `develop` without it.

The problem came when we were migrating Prefect tasks in #6231 (targeting develop) and at the same time updating this code in #6363 targeting stable. When we merged stable back into develop an old but moved code path was used causing the test not to work (the idea of the test was that the node object store would be populated if the transform was configured to do so.