### PR TITLE
order results of the uniqueness constraint query

### DIFF
--- a/backend/infrahub/core/validators/uniqueness/query.py
+++ b/backend/infrahub/core/validators/uniqueness/query.py
@@ -225,6 +225,13 @@ class NodeUniqueAttributeConstraintQuery(Query):
             attr_name,
             attr_value,
             relationship_identifier
+        ORDER BY
+            node_id,
+            deepest_branch_name,
+            node_count,
+            attr_name,
+            attr_value,
+            relationship_identifier
         """ % {
             "select_subqueries_str": select_subqueries_str,
             "branch_filter": branch_filter,


### PR DESCRIPTION
if this query returns too many results, then they will be paginated, but if there is no ordering of these results before the pagination, then we cannot guarantee that the full results set will be correctly returned

this query is overdue for a rewrite to improve performance b/c it will return a lot of results if it includes a relationship to a node with many relationships. for example, in the case of an IP prefix or address including the IP namespace as part of its uniqueness constraint