### PR TITLE
Additional tests and guard rails for triggers and actions

### DIFF
--- a/backend/infrahub/actions/models.py
+++ b/backend/infrahub/actions/models.py
@@ -71,7 +71,7 @@ class CoreNodeTriggerAttributeMatch(CoreNodeTriggerMatch):
 class CoreNodeTriggerRelationshipMatch(CoreNodeTriggerMatch):
     relationship_name: str
     added: bool
-    peer: str
+    peer: str | None
 
 
 class CoreNodeTriggerRule(CoreTriggerRule):
@@ -138,9 +138,10 @@ class ActionTriggerRuleTriggerDefinition(TriggerDefinition):
                 event_trigger.match_related = {
                     "prefect.resource.role": "infrahub.node.relationship_update",
                     "infrahub.field.name": match.relationship_name,
-                    "infrahub.relationship.peer_id": match.peer,
                     "infrahub.relationship.peer_status": peer_status,
                 }
+                if isinstance(match.peer, str):
+                    event_trigger.match_related["infrahub.relationship.peer_id"] = match.peer
 
         if isinstance(trigger_rule.action, CoreGeneratorAction):
             workflow = ExecuteWorkflow(

--- a/backend/infrahub/graphql/manager.py
+++ b/backend/infrahub/graphql/manager.py
@@ -25,7 +25,7 @@ from infrahub.types import ATTRIBUTE_TYPES, InfrahubDataType, get_attribute_type
 from .directives import DIRECTIVES
 from .enums import generate_graphql_enum, get_enum_attribute_type_name
 from .metrics import SCHEMA_GENERATE_GRAPHQL_METRICS
-from .mutations.action import InfrahubTriggerRuleMutation
+from .mutations.action import InfrahubTriggerRuleMatchMutation, InfrahubTriggerRuleMutation
 from .mutations.artifact_definition import InfrahubArtifactDefinitionMutation
 from .mutations.ipam import (
     InfrahubIPAddressMutation,
@@ -526,6 +526,8 @@ class GraphQLSchemaManager:
                 InfrahubKind.STANDARDWEBHOOK: InfrahubWebhookMutation,
                 InfrahubKind.CUSTOMWEBHOOK: InfrahubWebhookMutation,
                 InfrahubKind.NODETRIGGERRULE: InfrahubTriggerRuleMutation,
+                InfrahubKind.NODETRIGGERATTRIBUTEMATCH: InfrahubTriggerRuleMatchMutation,
+                InfrahubKind.NODETRIGGERRELATIONSHIPMATCH: InfrahubTriggerRuleMatchMutation,
             }
 
             if isinstance(node_schema, NodeSchema) and node_schema.is_ip_prefix():

--- a/backend/infrahub/graphql/mutations/action.py
+++ b/backend/infrahub/graphql/mutations/action.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from graphene import InputObjectType, Mutation
 from typing_extensions import Self
 
-from infrahub.core.schema import NodeSchema
+from infrahub.core.protocols import CoreNodeTriggerAttributeMatch, CoreNodeTriggerRelationshipMatch, CoreNodeTriggerRule
+from infrahub.exceptions import SchemaNotFoundError, ValidationError
 from infrahub.log import get_logger
 
 from .main import InfrahubMutationMixin, InfrahubMutationOptions
@@ -15,7 +16,10 @@ if TYPE_CHECKING:
 
     from infrahub.core.branch import Branch
     from infrahub.core.node import Node
+    from infrahub.core.schema import NodeSchema
     from infrahub.database import InfrahubDatabase
+
+    from ..initialization import GraphqlContext
 
 log = get_logger()
 
@@ -28,10 +32,53 @@ class InfrahubTriggerRuleMutation(InfrahubMutationMixin, Mutation):
         _meta: Any | None = None,
         **options: dict[str, Any],
     ) -> None:
-        # Make sure schema is a valid NodeSchema Node Class
-        if not isinstance(schema, NodeSchema):
-            raise ValueError(f"You need to pass a valid NodeSchema in '{cls.__name__}.Meta', received '{schema}'")
+        if not _meta:
+            _meta = InfrahubMutationOptions(cls)
 
+        _meta.schema = schema
+
+        super().__init_subclass_with_meta__(_meta=_meta, **options)
+
+    @classmethod
+    async def mutate_create(
+        cls,
+        info: GraphQLResolveInfo,
+        data: InputObjectType,
+        branch: Branch,
+        database: InfrahubDatabase | None = None,
+    ) -> tuple[Node, Self]:
+        graphql_context: GraphqlContext = info.context
+        db = database or graphql_context.db
+        _validate_node_kind(data=data, db=db)
+        trigger_rule_definition, result = await super().mutate_create(info=info, data=data, branch=branch, database=db)
+
+        return trigger_rule_definition, result
+
+    @classmethod
+    async def mutate_update(
+        cls,
+        info: GraphQLResolveInfo,
+        data: InputObjectType,
+        branch: Branch,
+        database: InfrahubDatabase | None = None,
+        node: Node | None = None,  # noqa: ARG003
+    ) -> tuple[Node, Self]:
+        graphql_context: GraphqlContext = info.context
+        db = database or graphql_context.db
+        _validate_node_kind(data=data, db=db)
+        trigger_rule_definition, result = await super().mutate_update(info=info, data=data, branch=branch, database=db)
+
+        return trigger_rule_definition, result
+
+
+class InfrahubTriggerRuleMatchMutation(InfrahubMutationMixin, Mutation):
+    @classmethod
+    def __init_subclass_with_meta__(
+        cls,
+        schema: NodeSchema,
+        _meta: Any | None = None,
+        **options: dict[str, Any],
+    ) -> None:
         if not _meta:
             _meta = InfrahubMutationOptions(cls)
 
@@ -47,9 +94,17 @@ class InfrahubTriggerRuleMutation(InfrahubMutationMixin, Mutation):
         branch: Branch,
         database: InfrahubDatabase | None = None,  # noqa: ARG003
     ) -> tuple[Node, Self]:
-        trigger_rule_definition, result = await super().mutate_create(info=info, data=data, branch=branch)
+        graphql_context: GraphqlContext = info.context
 
-        return trigger_rule_definition, result
+        async with graphql_context.db.start_transaction() as dbt:
+            trigger_match, result = await super().mutate_create(info=info, data=data, branch=branch, database=dbt)
+            trigger_match_model = cast(CoreNodeTriggerAttributeMatch | CoreNodeTriggerRelationshipMatch, trigger_match)
+            node_trigger_rule = await trigger_match_model.trigger.get_peer(db=dbt, raise_on_error=True)
+            node_trigger_rule_model = cast(CoreNodeTriggerRule, node_trigger_rule)
+            node_schema = dbt.schema.get_node_schema(name=node_trigger_rule_model.node_kind.value, duplicate=False)
+            _validate_node_kind_field(data=data, node_schema=node_schema)
+
+        return trigger_match, result
 
     @classmethod
     async def mutate_update(
@@ -60,6 +115,50 @@ class InfrahubTriggerRuleMutation(InfrahubMutationMixin, Mutation):
         database: InfrahubDatabase | None = None,  # noqa: ARG003
         node: Node | None = None,  # noqa: ARG003
     ) -> tuple[Node, Self]:
-        trigger_rule_definition, result = await super().mutate_update(info=info, data=data, branch=branch)
+        graphql_context: GraphqlContext = info.context
+        async with graphql_context.db.start_transaction() as dbt:
+            trigger_match, result = await super().mutate_update(info=info, data=data, branch=branch, database=dbt)
+            trigger_match_model = cast(CoreNodeTriggerAttributeMatch | CoreNodeTriggerRelationshipMatch, trigger_match)
+            node_trigger_rule = await trigger_match_model.trigger.get_peer(db=dbt, raise_on_error=True)
+            node_trigger_rule_model = cast(CoreNodeTriggerRule, node_trigger_rule)
+            node_schema = dbt.schema.get_node_schema(name=node_trigger_rule_model.node_kind.value, duplicate=False)
+            _validate_node_kind_field(data=data, node_schema=node_schema)
 
-        return trigger_rule_definition, result
+        return trigger_match, result
+
+
+def _validate_node_kind(data: InputObjectType, db: InfrahubDatabase) -> None:
+    input_data = cast(dict[str, dict[str, Any]], data)
+    if node_kind := input_data.get("node_kind"):
+        value = node_kind.get("value")
+        if isinstance(value, str):
+            try:
+                db.schema.get_node_schema(name=value, duplicate=False)
+            except SchemaNotFoundError as exc:
+                raise ValidationError(
+                    input_value={"node_kind": "The requested node_kind schema was not found"}
+                ) from exc
+            except ValueError as exc:
+                raise ValidationError(input_value={"node_kind": "The requested node_kind is not a valid node"}) from exc
+
+
+def _validate_node_kind_field(data: InputObjectType, node_schema: NodeSchema) -> None:
+    input_data = cast(dict[str, dict[str, Any]], data)
+    if attribute_name := input_data.get("attribute_name"):
+        value = attribute_name.get("value")
+        if isinstance(value, str):
+            if value not in node_schema.attribute_names:
+                raise ValidationError(
+                    input_value={
+                        "attribute_name": f"The attribute {value} doesn't exist on related node trigger using {node_schema.kind}"
+                    }
+                )
+    if relationship_name := input_data.get("relationship_name"):
+        value = relationship_name.get("value")
+        if isinstance(value, str):
+            if value not in node_schema.relationship_names:
+                raise ValidationError(
+                    input_value={
+                        "relationship_name": f"The relationship {value} doesn't exist on related node trigger using {node_schema.kind}"
+                    }
+                )

--- a/backend/tests/unit/actions/test_gather.py
+++ b/backend/tests/unit/actions/test_gather.py
@@ -9,6 +9,7 @@ from infrahub.core.protocols import (
     CoreGroupAction,
     CoreGroupTriggerRule,
     CoreNodeTriggerAttributeMatch,
+    CoreNodeTriggerRelationshipMatch,
     CoreNodeTriggerRule,
     CoreRepository,
     CoreStandardGroup,
@@ -134,6 +135,108 @@ async def test_gather_trigger_gather_trigger_action_rules_node_attribute(
             "infrahub.attribute.action": ["added", "updated", "removed"],
             "infrahub.attribute.value": "something_new",
             "infrahub.attribute.value_previous": "something_old",
+        },
+    )
+
+    main_node_trigger_rule.active.value = False
+    await main_node_trigger_rule.save(db=db)
+
+    triggers = await gather_trigger_action_rules(db=db)
+    assert len(triggers) == 0
+
+
+async def test_gather_trigger_gather_trigger_action_rules_node_relationship(
+    register_core_models_schema: SchemaBranch, car_person_schema: SchemaBranch, db: InfrahubDatabase
+) -> None:
+    group_action_target = await Node.init(db=db, schema=CoreStandardGroup)
+    await group_action_target.new(db=db, name="GroupActionTarget")
+    await group_action_target.save(db=db)
+
+    group_action = await Node.init(db=db, schema=CoreGroupAction)
+    await group_action.new(db=db, name="MainGroupAction", group=group_action_target)
+    await group_action.save(db=db)
+
+    car_owner = await Node.init(db=db, schema="TestPerson")
+    await car_owner.new(db=db, name="Bobby")
+    await car_owner.save(db=db)
+
+    main_node_trigger_rule = await Node.init(db=db, schema=CoreNodeTriggerRule)
+    await main_node_trigger_rule.new(
+        db=db,
+        name="main_node_trigger",
+        node_kind="TestCar",
+        mutation_action="created",
+        action=group_action,
+        branch_scope="all_branches",
+    )
+    await main_node_trigger_rule.save(db=db)
+
+    triggers = await gather_trigger_action_rules(db=db)
+    assert len(triggers) == 1
+    automation = triggers[0]
+
+    assert automation.trigger == EventTrigger(
+        events={"infrahub.node.created"},
+        match={"infrahub.node.kind": "TestCar"},
+        match_related={},
+    )
+
+    relationship_match = await Node.init(db=db, schema=CoreNodeTriggerRelationshipMatch)
+    await relationship_match.new(
+        db=db,
+        relationship_name="owner",
+        peer=car_owner.id,
+        trigger=main_node_trigger_rule,
+    )
+    await relationship_match.save(db=db)
+
+    triggers = await gather_trigger_action_rules(db=db)
+    assert len(triggers) == 1
+    automation = triggers[0]
+    assert automation.trigger == EventTrigger(
+        events={"infrahub.node.created"},
+        match={"infrahub.node.kind": "TestCar"},
+        match_related={
+            "prefect.resource.role": "infrahub.node.relationship_update",
+            "infrahub.field.name": "owner",
+            "infrahub.relationship.peer_id": car_owner.id,
+            "infrahub.relationship.peer_status": "added",
+        },
+    )
+
+    relationship_match.added.value = False
+    await relationship_match.save(db=db)
+
+    triggers = await gather_trigger_action_rules(db=db)
+    assert len(triggers) == 1
+    automation = triggers[0]
+    assert automation.trigger == EventTrigger(
+        events={"infrahub.node.created"},
+        match={"infrahub.node.kind": "TestCar"},
+        match_related={
+            "prefect.resource.role": "infrahub.node.relationship_update",
+            "infrahub.field.name": "owner",
+            "infrahub.relationship.peer_id": car_owner.id,
+            "infrahub.relationship.peer_status": "removed",
+        },
+    )
+
+    main_node_trigger_rule.branch_scope.value = "other_branches"
+    main_node_trigger_rule.mutation_action.value = "deleted"
+    await main_node_trigger_rule.save(db=db)
+
+    triggers = await gather_trigger_action_rules(db=db)
+    assert len(triggers) == 1
+    automation = triggers[0]
+
+    assert automation.trigger == EventTrigger(
+        events={"infrahub.node.deleted"},
+        match={"infrahub.node.kind": "TestCar", "infrahub.branch.name": "!main"},
+        match_related={
+            "prefect.resource.role": "infrahub.node.relationship_update",
+            "infrahub.field.name": "owner",
+            "infrahub.relationship.peer_id": car_owner.id,
+            "infrahub.relationship.peer_status": "removed",
         },
     )
 

--- a/backend/tests/unit/graphql/mutations/test_action.py
+++ b/backend/tests/unit/graphql/mutations/test_action.py
@@ -1,0 +1,317 @@
+from uuid import uuid4
+
+from infrahub.core.branch import Branch
+from infrahub.database import InfrahubDatabase
+from infrahub.graphql.initialization import prepare_graphql_params
+from tests.helpers.graphql import graphql
+
+
+async def _prepare_group_action(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+) -> str:
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    query = """
+    mutation {
+        CoreStandardGroupCreate(data: {
+            name: { value: "group1"},
+        })
+        {
+            ok
+            object {
+                id
+            }
+        }
+    }
+    """
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
+
+    assert result.errors is None
+    query = """
+    mutation {
+        CoreGroupActionCreate(data: {
+            name: { value: "group1-action1"},
+            group: { id: "group1"}
+        })
+        {
+            ok
+            object {
+                id
+            }
+        }
+    }
+    """
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
+
+    assert result.errors is None
+    assert result.data
+    return result.data["CoreGroupActionCreate"]["object"]["id"]
+
+
+async def test_create_node_trigger_failure_states(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None, car_person_schema: None
+) -> None:
+    group_id = await _prepare_group_action(db=db, default_branch=default_branch)
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=CREATE_NODE_TRIGGER,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"name": "trigger1", "node_kind": "InvalidNodeKind", "action": group_id},
+    )
+
+    assert result.errors
+    assert "The requested node_kind schema was not found at node_kind" in str(result.errors)
+
+    result = await graphql(
+        schema=gql_params.schema,
+        source=CREATE_NODE_TRIGGER,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"name": "trigger1", "node_kind": "CoreGenericRepository", "action": "group1-action1"},
+    )
+
+    assert result.errors
+    assert "The requested node_kind is not a valid node" in str(result.errors)
+
+
+async def test_modify_action_node_attribute_matches(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None, car_person_schema: None
+) -> None:
+    group_id = await _prepare_group_action(db=db, default_branch=default_branch)
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+
+    result = await graphql(
+        schema=gql_params.schema,
+        source=CREATE_NODE_TRIGGER,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"name": "trigger1", "node_kind": "TestCar", "action": group_id},
+    )
+    assert not result.errors
+    assert result.data
+    trigger_id = result.data["CoreNodeTriggerRuleCreate"]["object"]["id"]
+
+    result = await graphql(
+        schema=gql_params.schema,
+        source=CREATE_NODE_TRIGGER_ATTRIBUTE_MATCH,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"attribute_name": "missing_attribute", "trigger": trigger_id, "value": "trigger-on-this"},
+    )
+
+    assert "The attribute missing_attribute doesn't exist on related node trigger using TestCar" in str(result.errors)
+
+    result = await graphql(
+        schema=gql_params.schema,
+        source=CREATE_NODE_TRIGGER_ATTRIBUTE_MATCH,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"attribute_name": "color", "trigger": trigger_id, "value": "trigger-on-this"},
+    )
+    assert not result.errors
+    assert result.data
+    attribute_match_id = result.data["CoreNodeTriggerAttributeMatchCreate"]["object"]["id"]
+
+    result = await graphql(
+        schema=gql_params.schema,
+        source=UPDATE_NODE_TRIGGER_ATTRIBUTE_MATCH,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"attribute_name": "invalid_attribute_name", "id": attribute_match_id},
+    )
+
+    assert "The attribute invalid_attribute_name doesn't exist on related node trigger using TestCar" in str(
+        result.errors
+    )
+
+    result = await graphql(
+        schema=gql_params.schema,
+        source=UPDATE_NODE_TRIGGER_ATTRIBUTE_MATCH,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"attribute_name": "name", "id": attribute_match_id},
+    )
+    assert not result.errors
+    assert result.data
+
+
+async def test_modify_action_node_relationship_matches(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None, car_person_schema: None
+) -> None:
+    group_id = await _prepare_group_action(db=db, default_branch=default_branch)
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+
+    result = await graphql(
+        schema=gql_params.schema,
+        source=CREATE_NODE_TRIGGER,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"name": "trigger1", "node_kind": "TestCar", "action": group_id},
+    )
+    assert not result.errors
+    assert result.data
+    trigger_id = result.data["CoreNodeTriggerRuleCreate"]["object"]["id"]
+
+    result = await graphql(
+        schema=gql_params.schema,
+        source=CREATE_NODE_TRIGGER_RELATIONSHIP_MATCH,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"relationship_name": "missing_relationship", "trigger": trigger_id, "peer": str(uuid4())},
+    )
+
+    assert "The relationship missing_relationship doesn't exist on related node trigger using TestCar" in str(
+        result.errors
+    )
+
+    result = await graphql(
+        schema=gql_params.schema,
+        source=CREATE_NODE_TRIGGER_RELATIONSHIP_MATCH,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"relationship_name": "owner", "trigger": trigger_id, "peer": str(uuid4())},
+    )
+    assert not result.errors
+    assert result.data
+    relationship_match_id = result.data["CoreNodeTriggerRelationshipMatchCreate"]["object"]["id"]
+
+    result = await graphql(
+        schema=gql_params.schema,
+        source=UPDATE_NODE_TRIGGER_RELATIONSHIP_MATCH,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"relationship_name": "leasing_company", "id": relationship_match_id},
+    )
+
+    assert "The relationship leasing_company doesn't exist on related node trigger using TestCar" in str(result.errors)
+
+    result = await graphql(
+        schema=gql_params.schema,
+        source=UPDATE_NODE_TRIGGER_RELATIONSHIP_MATCH,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"relationship_name": "owner", "id": relationship_match_id, "peer": str(uuid4())},
+    )
+    assert not result.errors
+    assert result.data
+
+
+CREATE_NODE_TRIGGER = """
+mutation(
+    $name: String!,
+    $node_kind: String!,
+    $action: String!,
+    )
+{
+    CoreNodeTriggerRuleCreate(data: {
+        name: { value: $name},
+        node_kind: {value: $node_kind}
+        action: {id: $action}
+        mutation_action: { value: "updated" }
+    })
+    {
+        ok
+        object {
+            id
+        }
+    }
+}
+"""
+
+
+CREATE_NODE_TRIGGER_ATTRIBUTE_MATCH = """
+mutation(
+    $attribute_name: String!,
+    $value: String,
+    $trigger: String!,
+    )
+{
+    CoreNodeTriggerAttributeMatchCreate(data: {
+        attribute_name: { value: $attribute_name},
+        value: { value: $value}
+        trigger: {id: $trigger}
+    })
+    {
+        ok
+        object {
+            id
+        }
+    }
+}
+"""
+
+CREATE_NODE_TRIGGER_RELATIONSHIP_MATCH = """
+mutation(
+    $relationship_name: String!,
+    $peer: String,
+    $trigger: String!,
+    )
+{
+    CoreNodeTriggerRelationshipMatchCreate(data: {
+        relationship_name: { value: $relationship_name},
+        peer: { value: $peer}
+        trigger: {id: $trigger}
+    })
+    {
+        ok
+        object {
+            id
+        }
+    }
+}
+"""
+
+
+UPDATE_NODE_TRIGGER_ATTRIBUTE_MATCH = """
+mutation(
+    $id: String!,
+    $attribute_name: String!
+)
+{
+    CoreNodeTriggerAttributeMatchUpdate(data: {
+        id: $id,
+        attribute_name: { value: $attribute_name}
+    })
+    {
+        ok
+        object {
+            id
+        }
+    }
+}
+"""
+
+UPDATE_NODE_TRIGGER_RELATIONSHIP_MATCH = """
+mutation(
+    $id: String!,
+    $relationship_name: String!,
+    $peer: String
+)
+{
+    CoreNodeTriggerRelationshipMatchUpdate(data: {
+        id: $id,
+        relationship_name: { value: $relationship_name}
+        peer: { value: $peer }
+    })
+    {
+        ok
+        object {
+            id
+        }
+    }
+}
+"""


### PR DESCRIPTION
This PR adds some additional test for the trigger/action system and also adds validations to new mutations to restrict users from trying to use nodes and attributes that doesn't exist.