### PR TITLE
Multiple related resources for triggers

### DIFF
--- a/backend/infrahub/actions/models.py
+++ b/backend/infrahub/actions/models.py
@@ -116,9 +116,10 @@ class ActionTriggerRuleTriggerDefinition(TriggerDefinition):
             case BranchScope.OTHER_BRANCHES:
                 event_trigger.match["infrahub.branch.name"] = f"!{registry.default_branch}"
 
+        related_matches: list[dict[str, str | list[str]]] = []
         for match in trigger_rule.matches:
             if isinstance(match, CoreNodeTriggerAttributeMatch):
-                event_trigger.match_related = {
+                match_related: dict[str, str | list[str]] = {
                     "prefect.resource.role": "infrahub.node.attribute_update",
                     "infrahub.field.name": match.attribute_name,
                     "infrahub.attribute.action": ["added", "updated", "removed"],
@@ -126,22 +127,25 @@ class ActionTriggerRuleTriggerDefinition(TriggerDefinition):
 
                 match match.value_match:
                     case ValueMatch.VALUE:
-                        event_trigger.match_related["infrahub.attribute.value"] = match.value or ""
+                        match_related["infrahub.attribute.value"] = match.value or ""
                     case ValueMatch.VALUE_PREVIOUS:
-                        event_trigger.match_related["infrahub.attribute.value_previous"] = match.value_previous or ""
+                        match_related["infrahub.attribute.value_previous"] = match.value_previous or ""
                     case ValueMatch.VALUE_FULL:
-                        event_trigger.match_related["infrahub.attribute.value"] = match.value or ""
-                        event_trigger.match_related["infrahub.attribute.value_previous"] = match.value_previous or ""
+                        match_related["infrahub.attribute.value"] = match.value or ""
+                        match_related["infrahub.attribute.value_previous"] = match.value_previous or ""
 
             elif isinstance(match, CoreNodeTriggerRelationshipMatch):
                 peer_status = "added" if match.added else "removed"
-                event_trigger.match_related = {
+                match_related = {
                     "prefect.resource.role": "infrahub.node.relationship_update",
                     "infrahub.field.name": match.relationship_name,
                     "infrahub.relationship.peer_status": peer_status,
                 }
                 if isinstance(match.peer, str):
-                    event_trigger.match_related["infrahub.relationship.peer_id"] = match.peer
+                    match_related["infrahub.relationship.peer_id"] = match.peer
+            related_matches.append(match_related)
+
+        event_trigger.match_related = related_matches or {}
 
         if isinstance(trigger_rule.action, CoreGeneratorAction):
             workflow = ExecuteWorkflow(

--- a/backend/infrahub/trigger/models.py
+++ b/backend/infrahub/trigger/models.py
@@ -39,10 +39,15 @@ class TriggerType(str, Enum):
     # OBJECT = "object"
 
 
+def _match_related_dict() -> dict:
+    # Make Mypy happy as match related is a dict[str, Any] | list[dict[str, Any]]
+    return {}
+
+
 class EventTrigger(BaseModel):
     events: set = Field(default_factory=set)
     match: dict[str, Any] = Field(default_factory=dict)
-    match_related: dict[str, Any] = Field(default_factory=dict)
+    match_related: dict[str, Any] | list[dict[str, Any]] = Field(default_factory=_match_related_dict)
 
     def get_prefect(self) -> PrefectEventTrigger:
         return PrefectEventTrigger(
@@ -50,9 +55,19 @@ class EventTrigger(BaseModel):
             expect=self.events,
             within=timedelta(0),
             match=ResourceSpecification(self.match),
-            match_related=ResourceSpecification(self.match_related),
+            match_related=self.related_resource_specification,
             threshold=1,
         )
+
+    @property
+    def related_resource_specification(self) -> ResourceSpecification | list[ResourceSpecification]:
+        if isinstance(self.match_related, dict):
+            return ResourceSpecification(self.match_related)
+
+        if len(self.match_related) == 1:
+            return ResourceSpecification(self.match_related[0])
+
+        return [ResourceSpecification(related_match) for related_match in self.match_related]
 
 
 class ExecuteWorkflow(BaseModel):

--- a/backend/tests/unit/actions/test_gather.py
+++ b/backend/tests/unit/actions/test_gather.py
@@ -75,12 +75,14 @@ async def test_gather_trigger_gather_trigger_action_rules_node_attribute(
     assert automation.trigger == EventTrigger(
         events={"infrahub.node.updated"},
         match={"infrahub.node.kind": "BuiltinTag", "infrahub.branch.name": "main"},
-        match_related={
-            "prefect.resource.role": "infrahub.node.attribute_update",
-            "infrahub.field.name": "description",
-            "infrahub.attribute.action": ["added", "updated", "removed"],
-            "infrahub.attribute.value": "something_new",
-        },
+        match_related=[
+            {
+                "prefect.resource.role": "infrahub.node.attribute_update",
+                "infrahub.field.name": "description",
+                "infrahub.attribute.action": ["added", "updated", "removed"],
+                "infrahub.attribute.value": "something_new",
+            }
+        ],
     )
 
     attribute_match.value_match.value = "value_previous"
@@ -92,12 +94,14 @@ async def test_gather_trigger_gather_trigger_action_rules_node_attribute(
     assert automation.trigger == EventTrigger(
         events={"infrahub.node.updated"},
         match={"infrahub.node.kind": "BuiltinTag", "infrahub.branch.name": "main"},
-        match_related={
-            "prefect.resource.role": "infrahub.node.attribute_update",
-            "infrahub.field.name": "description",
-            "infrahub.attribute.action": ["added", "updated", "removed"],
-            "infrahub.attribute.value_previous": "something_old",
-        },
+        match_related=[
+            {
+                "prefect.resource.role": "infrahub.node.attribute_update",
+                "infrahub.field.name": "description",
+                "infrahub.attribute.action": ["added", "updated", "removed"],
+                "infrahub.attribute.value_previous": "something_old",
+            }
+        ],
     )
 
     attribute_match.value_match.value = "value_full"
@@ -110,13 +114,15 @@ async def test_gather_trigger_gather_trigger_action_rules_node_attribute(
     assert automation.trigger == EventTrigger(
         events={"infrahub.node.updated"},
         match={"infrahub.node.kind": "BuiltinTag", "infrahub.branch.name": "main"},
-        match_related={
-            "prefect.resource.role": "infrahub.node.attribute_update",
-            "infrahub.field.name": "description",
-            "infrahub.attribute.action": ["added", "updated", "removed"],
-            "infrahub.attribute.value": "something_new",
-            "infrahub.attribute.value_previous": "something_old",
-        },
+        match_related=[
+            {
+                "prefect.resource.role": "infrahub.node.attribute_update",
+                "infrahub.field.name": "description",
+                "infrahub.attribute.action": ["added", "updated", "removed"],
+                "infrahub.attribute.value": "something_new",
+                "infrahub.attribute.value_previous": "something_old",
+            }
+        ],
     )
 
     main_node_trigger_rule.branch_scope.value = "other_branches"
@@ -129,13 +135,51 @@ async def test_gather_trigger_gather_trigger_action_rules_node_attribute(
     assert automation.trigger == EventTrigger(
         events={"infrahub.node.updated"},
         match={"infrahub.node.kind": "BuiltinTag", "infrahub.branch.name": "!main"},
-        match_related={
-            "prefect.resource.role": "infrahub.node.attribute_update",
-            "infrahub.field.name": "description",
-            "infrahub.attribute.action": ["added", "updated", "removed"],
-            "infrahub.attribute.value": "something_new",
-            "infrahub.attribute.value_previous": "something_old",
-        },
+        match_related=[
+            {
+                "prefect.resource.role": "infrahub.node.attribute_update",
+                "infrahub.field.name": "description",
+                "infrahub.attribute.action": ["added", "updated", "removed"],
+                "infrahub.attribute.value": "something_new",
+                "infrahub.attribute.value_previous": "something_old",
+            }
+        ],
+    )
+
+    second_attribute_match = await Node.init(db=db, schema=CoreNodeTriggerAttributeMatch)
+    await second_attribute_match.new(
+        db=db,
+        attribute_name="another_attribute",
+        value="the-new-value",
+        value_previous="the-old-value",
+        value_match="value_full",
+        trigger=main_node_trigger_rule,
+    )
+    await second_attribute_match.save(db=db)
+
+    triggers = await gather_trigger_action_rules(db=db)
+    assert len(triggers) == 1
+    automation = triggers[0]
+
+    assert automation.trigger == EventTrigger(
+        events={"infrahub.node.updated"},
+        match={"infrahub.node.kind": "BuiltinTag", "infrahub.branch.name": "!main"},
+        match_related=[
+            {
+                "prefect.resource.role": "infrahub.node.attribute_update",
+                "infrahub.field.name": "description",
+                "infrahub.attribute.action": ["added", "updated", "removed"],
+                "infrahub.attribute.value": "something_new",
+                "infrahub.attribute.value_previous": "something_old",
+            },
+            {
+                "prefect.resource.role": "infrahub.node.attribute_update",
+                "infrahub.field.name": "another_attribute",
+                "infrahub.attribute.action": ["added", "updated", "removed"],
+                "infrahub.attribute.value": "the-new-value",
+                "infrahub.attribute.value_previous": "the-old-value",
+            },
+        ],
     )
 
     main_node_trigger_rule.active.value = False
@@ -196,12 +240,14 @@ async def test_gather_trigger_gather_trigger_action_rules_node_relationship(
     assert automation.trigger == EventTrigger(
         events={"infrahub.node.created"},
         match={"infrahub.node.kind": "TestCar"},
-        match_related={
-            "prefect.resource.role": "infrahub.node.relationship_update",
-            "infrahub.field.name": "owner",
-            "infrahub.relationship.peer_id": car_owner.id,
-            "infrahub.relationship.peer_status": "added",
-        },
+        match_related=[
+            {
+                "prefect.resource.role": "infrahub.node.relationship_update",
+                "infrahub.field.name": "owner",
+                "infrahub.relationship.peer_id": car_owner.id,
+                "infrahub.relationship.peer_status": "added",
+            }
+        ],
     )
 
     relationship_match.added.value = False
@@ -213,12 +259,14 @@ async def test_gather_trigger_gather_trigger_action_rules_node_relationship(
     assert automation.trigger == EventTrigger(
         events={"infrahub.node.created"},
         match={"infrahub.node.kind": "TestCar"},
-        match_related={
-            "prefect.resource.role": "infrahub.node.relationship_update",
-            "infrahub.field.name": "owner",
-            "infrahub.relationship.peer_id": car_owner.id,
-            "infrahub.relationship.peer_status": "removed",
-        },
+        match_related=[
+            {
+                "prefect.resource.role": "infrahub.node.relationship_update",
+                "infrahub.field.name": "owner",
+                "infrahub.relationship.peer_id": car_owner.id,
+                "infrahub.relationship.peer_status": "removed",
+            }
+        ],
     )
 
     main_node_trigger_rule.branch_scope.value = "other_branches"
@@ -232,12 +280,14 @@ async def test_gather_trigger_gather_trigger_action_rules_node_relationship(
     assert automation.trigger == EventTrigger(
         events={"infrahub.node.deleted"},
         match={"infrahub.node.kind": "TestCar", "infrahub.branch.name": "!main"},
-        match_related={
-            "prefect.resource.role": "infrahub.node.relationship_update",
-            "infrahub.field.name": "owner",
-            "infrahub.relationship.peer_id": car_owner.id,
-            "infrahub.relationship.peer_status": "removed",
-        },
+        match_related=[
+            {
+                "prefect.resource.role": "infrahub.node.relationship_update",
+                "infrahub.field.name": "owner",
+                "infrahub.relationship.peer_id": car_owner.id,
+                "infrahub.relationship.peer_status": "removed",
+            }
+        ],
     )
 
     main_node_trigger_rule.active.value = False


### PR DESCRIPTION
Adds support within the new trigger/action system to match against multiple related_resources as per the new features in Prefect 3.4.1.

The changes is basically that previous you could only match against a related_resource in the form of a dictionary where as now it's a `dict | list[dict]`.