### PR TITLE
Remove matching_related from events and use native Prefect 3.4.1

### DIFF
--- a/backend/infrahub/prefect_server/models.py
+++ b/backend/infrahub/prefect_server/models.py
@@ -1,34 +1,16 @@
-from typing import TYPE_CHECKING, Sequence, cast
-
-from prefect.server.database import PrefectDBInterface, db_injector
-from prefect.server.events.filters import EventFilter, EventNameFilter, EventOrder, EventRelatedFilter
+from prefect.server.events.filters import EventFilter, EventNameFilter, EventOrder
 from prefect.server.events.schemas.events import ReceivedEvent
 from prefect.server.utilities.schemas import PrefectBaseModel
 from pydantic import BaseModel, Field
 
-if TYPE_CHECKING:
-    from sqlalchemy.sql.expression import ColumnExpressionArgument
-
 
 class InfrahubEventFilter(EventFilter):
-    matching_related: list[EventRelatedFilter] = Field(default_factory=list)
-
     def set_prefix(self) -> None:
         if self.event:
             if self.event.prefix is not None and "infrahub." not in self.event.prefix:
                 self.event.prefix.append("infrahub.")
         else:
             self.event = EventNameFilter(prefix=["infrahub."], name=[], exclude_prefix=None, exclude_name=None)
-
-    @db_injector
-    def build_where_clauses(self, db: PrefectDBInterface) -> Sequence["ColumnExpressionArgument[bool]"]:
-        result = cast(list["ColumnExpressionArgument[bool]"], super().build_where_clauses())
-        top_level_filter = self._scoped_event_resources(db)
-        for matching_related in self.matching_related:
-            matching_related._top_level_filter = top_level_filter
-            result.extend(matching_related.build_where_clauses())
-
-        return result
 
     @classmethod
     def default(cls) -> "InfrahubEventFilter":

--- a/backend/infrahub/task_manager/models.py
+++ b/backend/infrahub/task_manager/models.py
@@ -84,11 +84,15 @@ class FlowProgress(BaseModel):
 
 
 class InfrahubEventFilter(EventFilter):
-    matching_related: list[EventRelatedFilter] = Field(default_factory=list)
+    def add_related_filter(self, related: EventRelatedFilter) -> None:
+        if not isinstance(self.related, list):
+            self.related = []
+
+        self.related.append(related)
 
     def add_account_filter(self, account__ids: list[str] | None) -> None:
         if account__ids:
-            self.matching_related.append(
+            self.add_related_filter(
                 EventRelatedFilter(
                     labels=ResourceSpecification(
                         {"prefect.resource.role": "infrahub.account", "infrahub.resource.id": account__ids}
@@ -98,7 +102,7 @@ class InfrahubEventFilter(EventFilter):
 
     def add_branch_filter(self, branches: list[str] | None = None) -> None:
         if branches:
-            self.matching_related.append(
+            self.add_related_filter(
                 EventRelatedFilter(
                     labels=ResourceSpecification(
                         {"prefect.resource.role": "infrahub.branch", "infrahub.resource.label": branches}
@@ -116,7 +120,7 @@ class InfrahubEventFilter(EventFilter):
 
         if event_filter:
             event_filter["prefect.resource.role"] = "infrahub.event"
-            self.matching_related.append(EventRelatedFilter(labels=ResourceSpecification(event_filter)))
+            self.add_related_filter(EventRelatedFilter(labels=ResourceSpecification(event_filter)))
 
     def add_event_id_filter(self, ids: list[str] | None = None) -> None:
         if ids:
@@ -151,7 +155,7 @@ class InfrahubEventFilter(EventFilter):
 
     def add_parent_filter(self, parent__ids: list[str] | None) -> None:
         if parent__ids:
-            self.matching_related.append(
+            self.add_related_filter(
                 EventRelatedFilter(
                     labels=ResourceSpecification(
                         {"prefect.resource.role": "infrahub.child_event", "infrahub.event_parent.id": parent__ids}
@@ -161,7 +165,7 @@ class InfrahubEventFilter(EventFilter):
 
     def add_related_node_filter(self, related_node__ids: list[str] | None) -> None:
         if related_node__ids:
-            self.matching_related.append(
+            self.add_related_filter(
                 EventRelatedFilter(
                     labels=ResourceSpecification(
                         {"prefect.resource.role": "infrahub.related.node", "prefect.resource.id": related_node__ids}


### PR DESCRIPTION
This PR removes some code I had in place as a workaround when Prefect didn't support combining multiple related resources in the event queries.

Due to the difference in how the pagination works I can't completely remove the route we're using, but perhaps that is something that we should revisit..