### PR TITLE
fix(ci): use separate workflows for preview builds

### DIFF
--- a/.github/workflows/publish-preview-dev-docker-image.yml
+++ b/.github/workflows/publish-preview-dev-docker-image.yml
@@ -1,32 +1,16 @@
 ---
 # yamllint disable rule:truthy rule:line-length
-name: Publish development docker image
+name: Publish preview development docker image
 
 on:
-  workflow_dispatch:
-    inputs:
-      publish:
-        type: boolean
-        description: Publish the image
-        default: false
-        required: true
-      commit:
-        type: string
-        description: commit sha or branch name
-        default: ''
-        required: false
-      platforms:
-        type: string
-        description: Comma separated platform list to build the image for
-        default: "linux/amd64,linux/arm64"
-      tag:
-        type: string
-        description: additional image tag
-        default: ''
-        required: false
+  pull_request:
+    types:
+      - labeled
+      - synchronize
 
 jobs:
   meta_data:
+    if: contains(github.event.pull_request.labels.*.name, 'cd/preview')
     runs-on:
       group: huge-runners
     outputs:
@@ -36,7 +20,7 @@ jobs:
       short_ref: ${{ steps.short_ref.outputs.short_ref }}
     steps:
       - name: Set GIT ref
-        run: echo "ref=${{ inputs.commit == '' && github.sha || inputs.commit }} " >> $GITHUB_OUTPUT
+        run: echo "ref=${{ github.event.pull_request.head.sha == '' && github.sha || github.event.pull_request.head.sha }} " >> $GITHUB_OUTPUT
         id: ref
       - name: Set GIT short ref
         run: echo "short_ref=$(echo ${{ steps.ref.outputs.ref }} | cut -c1-7)" >> $GITHUB_OUTPUT
@@ -49,22 +33,21 @@ jobs:
             ${{ vars.HARBOR_HOST }}/${{ github.repository }}
           tags: |
             type=raw,value=dev-${{ steps.short_ref.outputs.short_ref }}
-            type=raw,value=${{ inputs.tag }}
           labels: |
             org.opencontainers.image.source=${{ github.repository }}
             org.opencontainers.image.version=dev-${{ steps.short_ref.outputs.short_ref }}
           flavor: |
             latest=false
 
-
   publish-docker-image:
+    if: contains(github.event.pull_request.labels.*.name, 'cd/preview')
     uses: ./.github/workflows/ci-docker-image.yml
     needs: meta_data
     secrets: inherit
     with:
-      publish: ${{ inputs.publish }}
+      publish: true
       version: dev-${{ needs.meta_data.outputs.short_ref }}
       ref: ${{ needs.meta_data.outputs.ref }}
-      tags: ${{needs.meta_data.outputs.tags}}
-      labels: ${{needs.meta_data.outputs.labels}}
-      platforms: ${{ inputs.platforms }}
+      tags: ${{ needs.meta_data.outputs.tags }}
+      labels: ${{ needs.meta_data.outputs.labels }}
+      platforms: "linux/amd64"


### PR DESCRIPTION
Fixes a syntax error within GHA:
Publish development docker image
.github/workflows/publish-dev-docker-image.yml (Line: 71, Col: 16): Unexpected value ''