### PR TITLE
fix batching bug in diff query

### DIFF
--- a/backend/infrahub/core/diff/query_parser.py
+++ b/backend/infrahub/core/diff/query_parser.py
@@ -526,7 +526,11 @@ class DiffQueryParser:
         return self._current_node_field_specifiers
 
     def read_result(self, query_result: QueryResult) -> None:
-        path = query_result.get_path(label="diff_path")
+        try:
+            path = query_result.get_path(label="diff_path")
+        except ValueError:
+            # the path was null, so nothing to read
+            return
         database_path = DatabasePath.from_cypher_path(cypher_path=path)
         self._parse_path(database_path=database_path)
         self._current_node_field_specifiers = None

--- a/backend/infrahub/core/query/diff.py
+++ b/backend/infrahub/core/query/diff.py
@@ -201,6 +201,13 @@ WITH reduce(
     diff_rel_paths = [], item IN [penultimate_path, peer_path] |
     CASE WHEN item IS NULL THEN diff_rel_paths ELSE diff_rel_paths + [item] END
 ) AS diff_rel_paths, has_more_data
+// ------------------------
+// make sure we still include has_more_data if diff_rel_paths is empty
+// ------------------------
+WITH CASE
+    WHEN diff_rel_paths = [] THEN [NULL]
+    ELSE diff_rel_paths
+END AS diff_rel_paths, has_more_data
     """
 
     def get_previous_base_path_query(self, db: InfrahubDatabase) -> str:

--- a/changelog/+diff_batch_bug.fixed.md
+++ b/changelog/+diff_batch_bug.fixed.md
@@ -1,0 +1,1 @@
+Fix a problem in the logic to calculate a diff that could cause it to quit too early under certain unlikely circumstances


### PR DESCRIPTION
fix a small bug in the diff calculation queries that no one is likely to have encountered
the diff calculation queries can be batched in such a manner that they don't actually return any diff paths even though there are more diff paths to return for a later batch

the diff logic was not up to handling this task and would stop returning results midway through if it encountered this situation.

these small changes make sure that we always return `has_more_data` even if there are no results in this batch