### PR TITLE
Add support for NumberPool attribute kind

### DIFF
--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -30,6 +30,7 @@ from infrahub.core.schema import (
     RelationshipSchema,
     TemplateSchema,
 )
+from infrahub.core.schema.attribute_parameters import NumberPoolParameters
 from infrahub.core.timestamp import Timestamp
 from infrahub.exceptions import InitializationError, NodeNotFoundError, PoolExhaustedError, ValidationError
 from infrahub.types import ATTRIBUTE_TYPES
@@ -254,6 +255,12 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
         within the create code.
         """
 
+        number_pool_parameters: NumberPoolParameters | None = None
+        if attribute.schema.kind == "NumberPool" and isinstance(attribute.schema.parameters, NumberPoolParameters):
+            attribute.from_pool = {"id": attribute.schema.parameters.number_pool_id}
+            attribute.is_default = False
+            number_pool_parameters = attribute.schema.parameters
+
         if not attribute.from_pool:
             return
 
@@ -262,6 +269,11 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
                 db=db, id=attribute.from_pool["id"], kind=CoreNumberPool
             )
         except NodeNotFoundError:
+            if number_pool_parameters:
+                await self._create_number_pool(
+                    db=db, attribute=attribute, errors=errors, number_pool_parameters=number_pool_parameters
+                )
+                return
             errors.append(
                 ValidationError(
                     {f"{attribute.name}.from_pool": f"The pool requested {attribute.from_pool} was not found."}
@@ -291,6 +303,33 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
                     }
                 )
             )
+
+    async def _create_number_pool(
+        self, db: InfrahubDatabase, attribute: BaseAttribute, errors: list, number_pool_parameters: NumberPoolParameters
+    ) -> None:
+        schema = db.schema.get_node_schema(name="CoreNumberPool", duplicate=False)
+
+        pool_node = self._schema.kind
+        schema_attribute = self._schema.get_attribute(attribute.schema.name)
+        if schema_attribute.inherited:
+            for generic_name in self._schema.inherit_from:
+                generic_node = db.schema.get_generic_schema(name=generic_name, duplicate=False)
+                if attribute.schema.name in generic_node.attribute_names:
+                    pool_node = generic_node.kind
+                    break
+
+        number_pool = await Node.init(db=db, schema=schema, branch=self._branch)
+        await number_pool.new(
+            db=db,
+            id=number_pool_parameters.number_pool_id,
+            name=f"{pool_node}.{attribute.schema.name} [{number_pool_parameters.number_pool_id}]",
+            node=pool_node,
+            node_attribute=attribute.schema.name,
+            start_range=number_pool_parameters.start_range,
+            end_range=number_pool_parameters.end_range,
+        )
+        await number_pool.save(db=db)
+        await self.handle_pool(db=db, attribute=attribute, errors=errors)
 
     async def handle_object_template(self, fields: dict, db: InfrahubDatabase, errors: list) -> None:
         """Fill the `fields` parameters with values from an object template if one is in use."""
@@ -342,7 +381,7 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
             elif relationship_peers := await relationship.get_peers(db=db):
                 fields[relationship_name] = [{"id": peer_id} for peer_id in relationship_peers]
 
-    async def _process_fields(self, fields: dict, db: InfrahubDatabase) -> None:
+    async def _process_fields(self, fields: dict, db: InfrahubDatabase) -> None:  # noqa: PLR0915
         errors = []
 
         if "_source" in fields.keys():
@@ -374,6 +413,9 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
                             and mandatory_attribute.computed_attribute.kind == ComputedAttributeKind.JINJA2
                         ):
                             self._computed_jinja2_attributes.append(mandatory_attr)
+                            continue
+
+                        if mandatory_attribute.kind == "NumberPool":
                             continue
 
                     errors.append(

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -270,16 +270,17 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
             )
         except NodeNotFoundError:
             if number_pool_parameters:
-                await self._create_number_pool(
-                    db=db, attribute=attribute, errors=errors, number_pool_parameters=number_pool_parameters
+                number_pool = await self._create_number_pool(
+                    db=db, attribute=attribute, number_pool_parameters=number_pool_parameters
+                )
+
+            else:
+                errors.append(
+                    ValidationError(
+                        {f"{attribute.name}.from_pool": f"The pool requested {attribute.from_pool} was not found."}
+                    )
                 )
                 return
-            errors.append(
-                ValidationError(
-                    {f"{attribute.name}.from_pool": f"The pool requested {attribute.from_pool} was not found."}
-                )
-            )
-            return
 
         if (
             number_pool.node.value in [self._schema.kind] + self._schema.inherit_from
@@ -305,8 +306,8 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
             )
 
     async def _create_number_pool(
-        self, db: InfrahubDatabase, attribute: BaseAttribute, errors: list, number_pool_parameters: NumberPoolParameters
-    ) -> None:
+        self, db: InfrahubDatabase, attribute: BaseAttribute, number_pool_parameters: NumberPoolParameters
+    ) -> CoreNumberPool:
         schema = db.schema.get_node_schema(name="CoreNumberPool", duplicate=False)
 
         pool_node = self._schema.kind
@@ -329,7 +330,9 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
             end_range=number_pool_parameters.end_range,
         )
         await number_pool.save(db=db)
-        await self.handle_pool(db=db, attribute=attribute, errors=errors)
+        # Do a lookup of the number pool to get the correct mapped type from the registry
+        # without this we don't get access to the .get_resource() method.
+        return await registry.manager.get_one_by_id_or_default_filter(db=db, id=number_pool.id, kind=CoreNumberPool)
 
     async def handle_object_template(self, fields: dict, db: InfrahubDatabase, errors: list) -> None:
         """Fill the `fields` parameters with values from an object template if one is in use."""

--- a/backend/infrahub/core/node/resource_manager/number_pool.py
+++ b/backend/infrahub/core/node/resource_manager/number_pool.py
@@ -37,7 +37,6 @@ class CoreNumberPool(Node):
             db=db, pool_id=self.get_id(), identifier=identifier, reserved=number
         )
         await query_set.execute(db=db)
-
         return number
 
     async def get_next(self, db: InfrahubDatabase, branch: Branch) -> int:

--- a/backend/infrahub/core/schema/attribute_parameters.py
+++ b/backend/infrahub/core/schema/attribute_parameters.py
@@ -1,21 +1,50 @@
 from __future__ import annotations
 
-from pydantic import Field
+import sys
+from typing import Self
+
+from pydantic import Field, model_validator
 
 from infrahub.core.constants.schema import UpdateSupport
 from infrahub.core.models import HashableModel
 
 
 def get_attribute_parameters_class_for_kind(kind: str) -> type[AttributeParameters]:
-    return {
+    param_classes: dict[str, type[AttributeParameters]] = {
+        "NumberPool": NumberPoolParameters,
         "Text": TextAttributeParameters,
         "TextArea": TextAttributeParameters,
-    }.get(kind, AttributeParameters)
+    }
+    return param_classes.get(kind, AttributeParameters)
 
 
 class AttributeParameters(HashableModel):
     class Config:
         extra = "forbid"
+
+
+class NumberPoolParameters(AttributeParameters):
+    end_range: int = Field(
+        default=sys.maxsize,
+        description="End range for numbers for the associated NumberPool",
+        json_schema_extra={"update": UpdateSupport.VALIDATE_CONSTRAINT.value},
+    )
+    start_range: int = Field(
+        default=1,
+        description="Start range for numbers for the associated NumberPool",
+        json_schema_extra={"update": UpdateSupport.VALIDATE_CONSTRAINT.value},
+    )
+    number_pool_id: str | None = Field(
+        default=None,
+        description="The ID of the numberpool associated with this attribute",
+        json_schema_extra={"update": UpdateSupport.NOT_SUPPORTED.value},
+    )
+
+    @model_validator(mode="after")
+    def validate_ranges(self) -> Self:
+        if self.start_range > self.end_range:
+            raise ValueError("start_range can't be less than end_range")
+        return self
 
 
 class TextAttributeParameters(AttributeParameters):

--- a/backend/infrahub/core/schema/attribute_schema.py
+++ b/backend/infrahub/core/schema/attribute_schema.py
@@ -12,7 +12,12 @@ from infrahub.core.enums import generate_python_enum
 from infrahub.core.query.attribute import default_attribute_query_filter
 from infrahub.types import ATTRIBUTE_KIND_LABELS, ATTRIBUTE_TYPES
 
-from .attribute_parameters import AttributeParameters, TextAttributeParameters, get_attribute_parameters_class_for_kind
+from .attribute_parameters import (
+    AttributeParameters,
+    NumberPoolParameters,
+    TextAttributeParameters,
+    get_attribute_parameters_class_for_kind,
+)
 from .generated.attribute_schema import GeneratedAttributeSchema
 
 if TYPE_CHECKING:
@@ -25,6 +30,7 @@ if TYPE_CHECKING:
 
 def get_attribute_schema_class_for_kind(kind: str) -> type[AttributeSchema]:
     attribute_schema_class_by_kind: dict[str, type[AttributeSchema]] = {
+        "NumberPool": NumberPoolSchema,
         "Text": TextAttributeSchema,
         "TextArea": TextAttributeSchema,
     }
@@ -92,6 +98,16 @@ class AttributeSchema(GeneratedAttributeSchema):
         if not isinstance(value, expected_parameters_class) and isinstance(value, AttributeParameters):
             return expected_parameters_class(**value.model_dump())
         return value
+
+    @model_validator(mode="after")
+    def validate_parameters(self) -> Self:
+        if isinstance(self.parameters, NumberPoolParameters) and not self.kind == "NumberPool":
+            raise ValueError(f"NumberPoolParameters can't be used as parameters for {self.kind}")
+
+        if isinstance(self.parameters, TextAttributeParameters) and self.kind not in ["Text", "TextArea"]:
+            raise ValueError(f"TextAttributeParameters can't be used as parameters for {self.kind}")
+
+        return self
 
     def get_class(self) -> type[BaseAttribute]:
         return ATTRIBUTE_TYPES[self.kind].get_infrahub_class()
@@ -183,6 +199,14 @@ class AttributeSchema(GeneratedAttributeSchema):
             partial_match=partial_match,
             support_profiles=support_profiles,
         )
+
+
+class NumberPoolSchema(AttributeSchema):
+    parameters: NumberPoolParameters = Field(
+        default_factory=NumberPoolParameters,
+        description="Extra parameters specific to text attributes",
+        json_schema_extra={"update": UpdateSupport.VALIDATE_CONSTRAINT.value},
+    )
 
 
 class TextAttributeSchema(AttributeSchema):

--- a/backend/infrahub/core/schema/attribute_schema.py
+++ b/backend/infrahub/core/schema/attribute_schema.py
@@ -204,7 +204,7 @@ class AttributeSchema(GeneratedAttributeSchema):
 class NumberPoolSchema(AttributeSchema):
     parameters: NumberPoolParameters = Field(
         default_factory=NumberPoolParameters,
-        description="Extra parameters specific to text attributes",
+        description="Extra parameters specific to NumberPool attributes",
         json_schema_extra={"update": UpdateSupport.VALIDATE_CONSTRAINT.value},
     )
 

--- a/backend/infrahub/core/schema/definitions/internal.py
+++ b/backend/infrahub/core/schema/definitions/internal.py
@@ -31,7 +31,7 @@ from infrahub.core.constants import (
     RelationshipKind,
     UpdateSupport,
 )
-from infrahub.core.schema.attribute_parameters import AttributeParameters
+from infrahub.core.schema.attribute_parameters import AttributeParameters, NumberPoolParameters, TextAttributeParameters
 from infrahub.core.schema.attribute_schema import AttributeSchema
 from infrahub.core.schema.computed_attribute import ComputedAttribute
 from infrahub.core.schema.dropdown import DropdownChoice
@@ -48,7 +48,7 @@ class SchemaAttribute(BaseModel):
     kind: str
     description: str
     extra: ExtraField
-    internal_kind: type[Any] | GenericAlias | None = None
+    internal_kind: type[Any] | GenericAlias | list[type[Any]] | None = None
     regex: str | None = None
     unique: bool | None = None
     optional: bool | None = None
@@ -93,6 +93,9 @@ class SchemaAttribute(BaseModel):
     def object_kind(self) -> str:
         if isinstance(self.internal_kind, GenericAlias):
             return str(self.internal_kind)
+
+        if isinstance(self.internal_kind, list):
+            return " | ".join([internal_kind.__name__ for internal_kind in self.internal_kind])
 
         if self.internal_kind and self.kind == "List":
             return f"list[{self.internal_kind.__name__}]"
@@ -621,7 +624,7 @@ attribute_schema = SchemaNode(
         SchemaAttribute(
             name="parameters",
             kind="JSON",
-            internal_kind=AttributeParameters,
+            internal_kind=[AttributeParameters, TextAttributeParameters, NumberPoolParameters],
             optional=True,
             description="Extra parameters specific to this kind of attribute",
             extra={"update": UpdateSupport.VALIDATE_CONSTRAINT},

--- a/backend/infrahub/core/schema/generated/attribute_schema.py
+++ b/backend/infrahub/core/schema/generated/attribute_schema.py
@@ -8,7 +8,11 @@ from pydantic import Field
 
 from infrahub.core.constants import AllowOverrideType, BranchSupportType, HashableModelState
 from infrahub.core.models import HashableModel
-from infrahub.core.schema.attribute_parameters import AttributeParameters  # noqa: TC001
+from infrahub.core.schema.attribute_parameters import (
+    AttributeParameters,  # noqa: TC001
+    NumberPoolParameters,  # noqa: TC001
+    TextAttributeParameters,  # noqa: TC001
+)
 from infrahub.core.schema.computed_attribute import ComputedAttribute  # noqa: TC001
 from infrahub.core.schema.dropdown import DropdownChoice  # noqa: TC001
 
@@ -113,7 +117,7 @@ class GeneratedAttributeSchema(HashableModel):
         description="Type of allowed override for the attribute.",
         json_schema_extra={"update": "allowed"},
     )
-    parameters: AttributeParameters = Field(
+    parameters: AttributeParameters | TextAttributeParameters | NumberPoolParameters = Field(
         default_factory=AttributeParameters,
         description="Extra parameters specific to this kind of attribute",
         json_schema_extra={"update": "validate_constraint"},

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -5,6 +5,7 @@ import hashlib
 from collections import defaultdict
 from itertools import chain, combinations
 from typing import Any
+from uuid import uuid4
 
 from infrahub_sdk.template import Jinja2Template
 from infrahub_sdk.template.exceptions import JinjaTemplateError, JinjaTemplateOperationViolationError
@@ -49,6 +50,7 @@ from infrahub.core.schema import (
     SchemaRoot,
     TemplateSchema,
 )
+from infrahub.core.schema.attribute_parameters import NumberPoolParameters
 from infrahub.core.schema.attribute_schema import get_attribute_schema_class_for_kind
 from infrahub.core.schema.definitions.core import core_profile_schema_definition
 from infrahub.core.validators import CONSTRAINT_VALIDATOR_MAP
@@ -518,6 +520,7 @@ class SchemaBranch:
         self.validate_names()
         self.validate_kinds()
         self.validate_computed_attributes()
+        self.validate_attribute_parameters()
         self.validate_default_values()
         self.validate_count_against_cardinality()
         self.validate_identifiers()
@@ -994,6 +997,50 @@ class SchemaBranch:
                     raise ValueError(
                         f"{node.kind}: Relationship {rel.name!r} is referring an invalid peer {rel.peer!r}"
                     ) from None
+
+    def validate_attribute_parameters(self) -> None:
+        for name in self.generics.keys():
+            generic_schema = self.get_generic(name=name, duplicate=False)
+            for attribute in generic_schema.attributes:
+                if (
+                    attribute.kind == "NumberPool"
+                    and isinstance(attribute.parameters, NumberPoolParameters)
+                    and not attribute.parameters.number_pool_id
+                ):
+                    attribute.parameters.number_pool_id = str(uuid4())
+
+        for name in self.nodes.keys():
+            node_schema = self.get_node(name=name, duplicate=False)
+            for attribute in node_schema.attributes:
+                if (
+                    attribute.kind == "NumberPool"
+                    and isinstance(attribute.parameters, NumberPoolParameters)
+                    and not attribute.parameters.number_pool_id
+                ):
+                    self._validate_number_pool_parameters(
+                        node_schema=node_schema, attribute=attribute, number_pool_parameters=attribute.parameters
+                    )
+
+    def _validate_number_pool_parameters(
+        self, node_schema: NodeSchema, attribute: AttributeSchema, number_pool_parameters: NumberPoolParameters
+    ) -> None:
+        if attribute.inherited:
+            generics_with_attribute = []
+            for generic_name in node_schema.inherit_from:
+                generic_schema = self.get_generic(name=generic_name, duplicate=False)
+                if attribute.name in generic_schema.attribute_names:
+                    generic_attribute = generic_schema.get_attribute(name=attribute.name)
+                    generics_with_attribute.append(generic_schema)
+                    if isinstance(generic_attribute.parameters, NumberPoolParameters):
+                        number_pool_parameters.number_pool_id = generic_attribute.parameters.number_pool_id
+
+            if len(generics_with_attribute) > 1:
+                raise ValidationError(
+                    f"{node_schema.kind}.{attribute.name} is a NumberPool inherited from more than one generic"
+                )
+
+        else:
+            number_pool_parameters.number_pool_id = str(uuid4())
 
     def validate_computed_attributes(self) -> None:
         self.computed_attributes = ComputedAttributes()

--- a/backend/infrahub/database/__init__.py
+++ b/backend/infrahub/database/__init__.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
     from types import TracebackType
 
     from infrahub.core.branch import Branch
-    from infrahub.core.schema import MainSchemaTypes, NodeSchema
+    from infrahub.core.schema import GenericSchema, MainSchemaTypes, NodeSchema
     from infrahub.core.schema.schema_branch import SchemaBranch
 
 validated_database = {}
@@ -90,6 +90,15 @@ class DatabaseSchemaManager:
             return schema
 
         raise ValueError("The selected node is not of type NodeSchema")
+
+    def get_generic_schema(
+        self, name: str, branch: Branch | str | None = None, duplicate: bool = True
+    ) -> GenericSchema:
+        schema = self.get(name=name, branch=branch, duplicate=duplicate)
+        if schema.is_generic_schema:
+            return schema
+
+        raise ValueError("The selected node is not of type GenericSchema")
 
     def set(self, name: str, schema: MainSchemaTypes, branch: str | None = None) -> int:
         branch_name = get_branch_name(branch=branch)

--- a/backend/infrahub/types.py
+++ b/backend/infrahub/types.py
@@ -235,6 +235,10 @@ class Number(InfrahubDataType):
     infrahub = "Integer"
 
 
+class NumberPool(Number):
+    label: str = "Number Pool"
+
+
 class Bandwidth(InfrahubDataType):
     label: str = "Bandwidth"
     graphql = graphene.Int
@@ -329,6 +333,7 @@ ATTRIBUTE_TYPES: dict[str, type[InfrahubDataType]] = {
     "MacAddress": MacAddress,
     "Color": Color,
     "Number": Number,
+    "NumberPool": NumberPool,
     "Bandwidth": Bandwidth,
     "IPHost": IPHost,
     "IPNetwork": IPNetwork,
@@ -353,6 +358,7 @@ ATTRIBUTE_PYTHON_TYPES: dict[str, type] = {
     "MacAddress": str,  # MAC addresses can be straightforward strings
     "Color": str,  # Colors often represented as hex strings
     "Number": float,  # Numbers can be floats for general use
+    "NumberPool": float,  # Numbers can be floats for general use
     "Bandwidth": float,  # Bandwidth in some units, represented as a float
     "IPHost": IPvAnyAddress,  # type: ignore[dict-item]
     "IPNetwork": str,

--- a/backend/templates/attributeschema_imports.j2
+++ b/backend/templates/attributeschema_imports.j2
@@ -5,6 +5,8 @@ from typing import Any
 from infrahub.core.models import HashableModel
 from infrahub.core.constants import AllowOverrideType, BranchSupportType, ComputedAttributeKind, HashableModelState
 from infrahub.core.schema.attribute_parameters import AttributeParameters  # noqa: TC001
+from infrahub.core.schema.attribute_parameters import NumberPoolParameters  # noqa: TC001
+from infrahub.core.schema.attribute_parameters import TextAttributeParameters  # noqa: TC001
 from infrahub.core.schema.computed_attribute import ComputedAttribute  # noqa: TC001
 from infrahub.core.schema.dropdown import DropdownChoice  # noqa: TC001
 

--- a/backend/tests/helpers/schema/snow.py
+++ b/backend/tests/helpers/schema/snow.py
@@ -1,0 +1,66 @@
+from infrahub.core.constants import ComputedAttributeKind
+from infrahub.core.schema import AttributeSchema, GenericSchema, NodeSchema
+from infrahub.core.schema.computed_attribute import ComputedAttribute
+
+SNOW_TASK = GenericSchema(
+    name="Task",
+    namespace="Snow",
+    include_in_menu=False,
+    label="Task",
+    attributes=[
+        AttributeSchema(name="title", kind="Text", unique=False, optional=False),
+        AttributeSchema(name="number", kind="NumberPool", optional=False, read_only=True, unique=True),
+        AttributeSchema(
+            name="identifier",
+            kind="Text",
+            optional=False,
+            read_only=True,
+            computed_attribute=ComputedAttribute(
+                kind=ComputedAttributeKind.JINJA2,
+                jinja2_template="T{{ number__value}}",
+            ),
+        ),
+    ],
+)
+
+
+SNOW_INCIDENT = NodeSchema(
+    name="Incident",
+    namespace="Snow",
+    inherit_from=["SnowTask"],
+    include_in_menu=True,
+    label="Incident",
+    attributes=[
+        AttributeSchema(
+            name="identifier",
+            kind="Text",
+            optional=False,
+            read_only=True,
+            computed_attribute=ComputedAttribute(
+                kind=ComputedAttributeKind.JINJA2,
+                jinja2_template="INC{{ number__value}}",
+            ),
+        ),
+    ],
+)
+
+
+SNOW_REQUEST = NodeSchema(
+    name="Request",
+    namespace="Snow",
+    inherit_from=["SnowTask"],
+    include_in_menu=True,
+    label="Request",
+    attributes=[
+        AttributeSchema(
+            name="identifier",
+            kind="Text",
+            optional=False,
+            read_only=True,
+            computed_attribute=ComputedAttribute(
+                kind=ComputedAttributeKind.JINJA2,
+                jinja2_template="REQ{{ number__value}}",
+            ),
+        ),
+    ],
+)

--- a/backend/tests/unit/core/schema/test_attribute_parameters.py
+++ b/backend/tests/unit/core/schema/test_attribute_parameters.py
@@ -1,0 +1,131 @@
+from copy import deepcopy
+from typing import Any
+
+import pydantic
+import pytest
+
+from infrahub.core.constants import InfrahubKind
+from infrahub.core.node import Node
+from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
+from infrahub.core.registry import registry
+from infrahub.core.schema import NodeSchema, SchemaRoot
+from infrahub.core.schema.attribute_parameters import NumberPoolParameters
+from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.database import InfrahubDatabase
+from infrahub.exceptions import ValidationError
+from tests.helpers.schema.snow import SNOW_INCIDENT, SNOW_REQUEST, SNOW_TASK
+
+
+def test_number_pool_with_range() -> None:
+    node_schema: dict[str, Any] = {
+        "name": "NumberAttribute",
+        "namespace": "Test",
+        "attributes": [
+            {"name": "name", "kind": "Text", "unique": True},
+            {
+                "name": "assigned_number",
+                "kind": "NumberPool",
+                "optional": False,
+                "unique": True,
+                "read_only": True,
+                "parameters": {"start_range": 1, "end_range": 10},
+            },
+        ],
+    }
+
+    node = NodeSchema(**node_schema)
+    assigned_number_attribute = node.get_attribute("assigned_number")
+    assert isinstance(assigned_number_attribute.parameters, NumberPoolParameters)
+
+
+def test_number_pool_invalid_range() -> None:
+    node_schema: dict[str, Any] = {
+        "name": "NumberAttribute",
+        "namespace": "Test",
+        "attributes": [
+            {"name": "name", "kind": "Text", "unique": True},
+            {
+                "name": "assigned_number",
+                "kind": "NumberPool",
+                "optional": False,
+                "unique": True,
+                "read_only": True,
+                "parameters": {"start_range": 30, "end_range": 25},
+            },
+        ],
+    }
+    with pytest.raises(pydantic.ValidationError, match="start_range can't be less than end_range"):
+        NodeSchema(**node_schema)
+
+
+def test_number_pool_assign_from_generics() -> None:
+    schema = SchemaRoot(generics=[SNOW_TASK], nodes=[SNOW_INCIDENT, SNOW_REQUEST])
+    schema_branch = SchemaBranch(cache={})
+    schema_branch.load_schema(schema=schema)
+    schema_branch.process()
+
+    snow_incident = schema_branch.get_node(name="SnowIncident", duplicate=False)
+    snow_request = schema_branch.get_node(name="SnowRequest", duplicate=False)
+
+    incident_attribute = snow_incident.get_attribute(name="number")
+    request_attribute = snow_request.get_attribute(name="number")
+
+    assert isinstance(incident_attribute.parameters, NumberPoolParameters)
+    assert isinstance(request_attribute.parameters, NumberPoolParameters)
+    assert incident_attribute.parameters.number_pool_id
+    assert incident_attribute.parameters.number_pool_id == request_attribute.parameters.number_pool_id
+
+
+def test_number_pool_fail_on_multiple_generics() -> None:
+    alternate_base = deepcopy(SNOW_TASK)
+    alternate_base.name = "OtherTask"
+    for index, attribute in enumerate(list(alternate_base.attributes)):
+        if attribute.name == "identifier":
+            alternate_base.attributes.pop(index)
+
+    modified_incident = deepcopy(SNOW_INCIDENT)
+
+    modified_incident.inherit_from.append("SnowOtherTask")
+    schema = SchemaRoot(generics=[SNOW_TASK, alternate_base], nodes=[modified_incident])
+    schema_branch = SchemaBranch(cache={})
+    schema_branch.load_schema(schema=schema)
+    with pytest.raises(
+        ValidationError, match="SnowIncident.number is a NumberPool inherited from more than one generic"
+    ):
+        schema_branch.process()
+
+
+async def test_create_nodes_from_generic_numberpools(
+    db: InfrahubDatabase, register_core_models_schema: SchemaBranch
+) -> None:
+    schema = SchemaRoot(generics=[SNOW_TASK], nodes=[SNOW_INCIDENT, SNOW_REQUEST])
+    schema_branch = registry.schema.register_schema(schema=schema)
+    snow_incident = schema_branch.get_node(name="SnowIncident", duplicate=False)
+    incident_attribute = snow_incident.get_attribute(name="number")
+    assert isinstance(incident_attribute.parameters, NumberPoolParameters)
+    registry.node[InfrahubKind.NUMBERPOOL] = CoreNumberPool
+
+    incident_1 = await Node.init(db=db, schema="SnowIncident")
+    await incident_1.new(db=db, title="The first incident")
+    await incident_1.save(db=db)
+
+    request_1 = await Node.init(db=db, schema="SnowRequest")
+    await request_1.new(db=db, title="The first request")
+    await request_1.save(db=db)
+
+    request_2 = await Node.init(db=db, schema="SnowRequest")
+    await request_2.new(db=db, title="The second request")
+    await request_2.save(db=db)
+
+    incident_2 = await Node.init(db=db, schema="SnowIncident")
+    await incident_2.new(db=db, title="The second incident")
+    await incident_2.save(db=db)
+
+    assert incident_1.number.value == 1
+    assert incident_1.identifier.value == "INC1"
+    assert incident_2.number.value == 4
+    assert incident_2.identifier.value == "INC4"
+    assert request_1.number.value == 2
+    assert request_1.identifier.value == "REQ2"
+    assert request_2.number.value == 3
+    assert request_2.identifier.value == "REQ3"

--- a/docs/docs/reference/schema/attribute.mdx
+++ b/docs/docs/reference/schema/attribute.mdx
@@ -170,7 +170,7 @@ extensions:
 | **Optional** | False |
 | **Default Value** |  |
 | **Constraints** |  |
-| **Accepted Values** | `ID` `Dropdown` `Text` `TextArea` `DateTime` `Email` `Password` `HashedPassword` `URL` `File` `MacAddress` `Color` `Number` `Bandwidth` `IPHost` `IPNetwork` `Boolean` `Checkbox` `List` `JSON` `Any` |
+| **Accepted Values** | `ID` `Dropdown` `Text` `TextArea` `DateTime` `Email` `Password` `HashedPassword` `URL` `File` `MacAddress` `Color` `Number` `NumberPool` `Bandwidth` `IPHost` `IPNetwork` `Boolean` `Checkbox` `List` `JSON` `Any` |
 
 ### label
 


### PR DESCRIPTION
Changes in this PR:

* Adds support for an attribute kind called NumberPool
* The numberpool will be created by the first node that needs it
* As I added two lines to Node._process_fields the method grew to complex, for now I've just added an ignore rule to the linter as I didn't want to rewrite the method within the same PR. I can get back to that one later
* Changed the generated code for AttributeSchema since we need the public API to allow for all Parameter classes, this also forced me to add a validator to check that the mapping is correct.

Things missing for the NumberPool attribute
* We're missing schema migrations
* Also the required restrictions, i.e. a user shouldn't be allowed to delete a number pool if it's in use by the schema
* Some consideration for how this should behave when there are updates to the attribute within a branch

I will get back to these missing parts once this is in `develop`, as it will unblock the frontend.