### PR TITLE
Fix issues with markdown lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,8 @@ jobs:
   markdown-lint:
     if: |
       needs.files-changed.outputs.documentation == 'true' ||
-      needs.files-changed.outputs.release == 'true'
+      needs.files-changed.outputs.release == 'true' ||
+      needs.files-changed.outputs.github_workflows
     needs: ["files-changed"]
     runs-on: "ubuntu-latest"
     timeout-minutes: 5

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -11,3 +11,5 @@ MD034: false # no-bare-urls
 MD041: false # allow 1st line to not be a top-level heading (required for Towncrier)
 MD045: false # no alt text around images
 MD047: false # single trailing newline
+MD059:       # Link descriptions that are provibited
+  prohibited_texts: []


### PR DESCRIPTION
* Ensure that the markdown lint job runs if we update the markdownlint action
* Disable (possibly for now) the new violating rule
* Also updates the SDK to the latest `develop` commit to include this PR: https://github.com/opsmill/infrahub-sdk-python/pull/419