### PR TITLE
update remaining cypher CALL subqueries to new format

### DIFF
--- a/backend/infrahub/core/migrations/query/attribute_rename.py
+++ b/backend/infrahub/core/migrations/query/attribute_rename.py
@@ -56,7 +56,6 @@ class AttributeRenameQuery(Query):
     def _render_sub_query_per_rel_type_update_active(rel_type: str, rel_def: FieldInfo) -> str:
         subquery = [
             "WITH peer_node, rb, active_attr",
-            "WITH peer_node, rb, active_attr",
             f'WHERE type(rb) = "{rel_type}"',
         ]
         if rel_def.default.direction.value == "outbound":
@@ -72,7 +71,6 @@ class AttributeRenameQuery(Query):
     @staticmethod
     def _render_sub_query_per_rel_type_create_new(rel_type: str, rel_def: FieldInfo) -> str:
         subquery = [
-            "WITH peer_node, rb, active_attr, new_attr",
             "WITH peer_node, rb, active_attr, new_attr",
             f'WHERE type(rb) = "{rel_type}"',
         ]
@@ -158,7 +156,7 @@ class AttributeRenameQuery(Query):
         }
         WITH a1 as active_attr, r1 as rb, p1 as peer_node, new_attr
         WHERE rb.status = "active"
-        CALL {
+        CALL (peer_node, rb, active_attr, new_attr){
             %(sub_query_create_all)s
         }
         WITH p2 as peer_node, rb, new_attr, active_attr
@@ -167,7 +165,7 @@ class AttributeRenameQuery(Query):
 
         if not (self.branch.is_default or self.branch.is_global):
             query = """
-            CALL {
+            CALL (peer_node, rb, active_attr) {
                 %(sub_query_update_all)s
             }
             WITH p2 as peer_node, rb, new_attr

--- a/backend/infrahub/core/migrations/query/delete_element_in_schema.py
+++ b/backend/infrahub/core/migrations/query/delete_element_in_schema.py
@@ -56,7 +56,6 @@ class DeleteElementInSchemaQuery(Query):
     def _render_sub_query_per_rel_type(rel_name: str, rel_type: str, direction: GraphRelDirection) -> str:
         subquery = [
             f"WITH peer_node, {rel_name}, element_to_delete",
-            f"WITH peer_node, {rel_name}, element_to_delete",
             f'WHERE type({rel_name}) = "{rel_type}"',
         ]
         if direction == GraphRelDirection.OUTBOUND:
@@ -67,28 +66,32 @@ class DeleteElementInSchemaQuery(Query):
         return "\n".join(subquery)
 
     @classmethod
-    def _render_sub_query_out(cls) -> str:
+    def _render_sub_query_out(cls) -> tuple[str, str]:
+        rel_name = "rel_outband"
+        sub_query_out_args = f"peer_node, {rel_name}, element_to_delete"
         sub_queries_out = [
             cls._render_sub_query_per_rel_type(
-                rel_name="rel_outband", rel_type=rel_type, direction=GraphRelDirection.OUTBOUND
+                rel_name=rel_name, rel_type=rel_type, direction=GraphRelDirection.OUTBOUND
             )
             for rel_type, rel_def in GraphNodeRelationships.model_fields.items()
             if rel_def.default.direction in [GraphRelDirection.OUTBOUND, GraphRelDirection.EITHER]
         ]
         sub_query_out = "\nUNION\n".join(sub_queries_out)
-        return sub_query_out
+        return sub_query_out, sub_query_out_args
 
     @classmethod
-    def _render_sub_query_in(cls) -> str:
+    def _render_sub_query_in(cls) -> tuple[str, str]:
+        rel_name = "rel_inband"
+        sub_query_in_args = f"peer_node, {rel_name}, element_to_delete"
         sub_queries_in = [
             cls._render_sub_query_per_rel_type(
-                rel_name="rel_inband", rel_type=rel_type, direction=GraphRelDirection.INBOUND
+                rel_name=rel_name, rel_type=rel_type, direction=GraphRelDirection.INBOUND
             )
             for rel_type, rel_def in GraphNodeRelationships.model_fields.items()
             if rel_def.default.direction in [GraphRelDirection.INBOUND, GraphRelDirection.EITHER]
         ]
         sub_query_in = "\nUNION\n".join(sub_queries_in)
-        return sub_query_in
+        return sub_query_in, sub_query_in_args
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
         branch_filter, branch_params = self.branch.get_query_filter_path(at=self.at.to_string())
@@ -108,8 +111,8 @@ class DeleteElementInSchemaQuery(Query):
             "from": self.at.to_string(),
         }
 
-        sub_query_out = self._render_sub_query_out()
-        sub_query_in = self._render_sub_query_in()
+        sub_query_out, sub_query_out_args = self._render_sub_query_out()
+        sub_query_in, sub_query_in_args = self._render_sub_query_in()
 
         self.add_to_query(self.render_match())
         self.add_to_query(self.render_where())
@@ -138,7 +141,7 @@ class DeleteElementInSchemaQuery(Query):
         }
         WITH n1 as element_to_delete, rel_outband1 as rel_outband, p1 as peer_node
         WHERE rel_outband.status = "active"
-        CALL {
+        CALL (%(sub_query_out_args)s) {
             %(sub_query_out)s
         }
         WITH p2 as peer_node, rel_outband, element_to_delete
@@ -157,7 +160,7 @@ class DeleteElementInSchemaQuery(Query):
         }
         WITH n1 as element_to_delete, rel_inband1 as rel_inband, p1 as peer_node
         WHERE rel_inband.status = "active"
-        CALL {
+        CALL (%(sub_query_in_args)s) {
             %(sub_query_in)s
         }
         WITH p2 as peer_node, rel_inband, element_to_delete
@@ -169,5 +172,7 @@ class DeleteElementInSchemaQuery(Query):
             "branch_filter": branch_filter,
             "sub_query_out": sub_query_out,
             "sub_query_in": sub_query_in,
+            "sub_query_out_args": sub_query_out_args,
+            "sub_query_in_args": sub_query_in_args,
         }
         self.add_to_query(query)

--- a/backend/infrahub/core/migrations/query/node_duplicate.py
+++ b/backend/infrahub/core/migrations/query/node_duplicate.py
@@ -48,7 +48,6 @@ class NodeDuplicateQuery(Query):
     def _render_sub_query_per_rel_type(rel_name: str, rel_type: str, rel_dir: GraphRelDirection) -> str:
         subquery = [
             f"WITH peer_node, {rel_name}, active_node, new_node",
-            f"WITH peer_node, {rel_name}, active_node, new_node",
             f'WHERE type({rel_name}) = "{rel_type}"',
         ]
         if rel_dir in [GraphRelDirection.OUTBOUND, GraphRelDirection.EITHER]:
@@ -81,28 +80,28 @@ class NodeDuplicateQuery(Query):
         return "\n".join(subquery)
 
     @classmethod
-    def _render_sub_query_out(cls) -> str:
+    def _render_sub_query_out(cls) -> tuple[str, str]:
+        rel_name = "rel_outband"
+        sub_query_out_args = f"peer_node, {rel_name}, active_node, new_node"
         sub_queries_out = [
-            cls._render_sub_query_per_rel_type(
-                rel_name="rel_outband", rel_type=rel_type, rel_dir=GraphRelDirection.OUTBOUND
-            )
+            cls._render_sub_query_per_rel_type(rel_name=rel_name, rel_type=rel_type, rel_dir=GraphRelDirection.OUTBOUND)
             for rel_type, field_info in GraphNodeRelationships.model_fields.items()
             if field_info.default.direction in (GraphRelDirection.OUTBOUND, GraphRelDirection.EITHER)
         ]
         sub_query_out = "\nUNION\n".join(sub_queries_out)
-        return sub_query_out
+        return sub_query_out, sub_query_out_args
 
     @classmethod
-    def _render_sub_query_in(cls) -> str:
+    def _render_sub_query_in(cls) -> tuple[str, str]:
+        rel_name = "rel_inband"
+        sub_query_in_args = f"peer_node, {rel_name}, active_node, new_node"
         sub_queries_in = [
-            cls._render_sub_query_per_rel_type(
-                rel_name="rel_inband", rel_type=rel_type, rel_dir=GraphRelDirection.INBOUND
-            )
+            cls._render_sub_query_per_rel_type(rel_name=rel_name, rel_type=rel_type, rel_dir=GraphRelDirection.INBOUND)
             for rel_type, field_info in GraphNodeRelationships.model_fields.items()
             if field_info.default.direction in (GraphRelDirection.INBOUND, GraphRelDirection.EITHER)
         ]
         sub_query_in = "\nUNION\n".join(sub_queries_in)
-        return sub_query_in
+        return sub_query_in, sub_query_in_args
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
         branch_filter, branch_params = self.branch.get_query_filter_path(at=self.at.to_string())
@@ -126,8 +125,8 @@ class NodeDuplicateQuery(Query):
             "from": self.at.to_string(),
         }
 
-        sub_query_out = self._render_sub_query_out()
-        sub_query_in = self._render_sub_query_in()
+        sub_query_out, sub_query_out_args = self._render_sub_query_out()
+        sub_query_in, sub_query_in_args = self._render_sub_query_in()
 
         self.add_to_query(self.render_match())
 
@@ -155,7 +154,7 @@ class NodeDuplicateQuery(Query):
         }
         WITH n1 as active_node, rel_outband1 as rel_outband, p1 as peer_node, new_node
         WHERE rel_outband.status = "active" AND rel_outband.to IS NULL
-        CALL {
+        CALL (%(sub_query_out_args)s) {
             %(sub_query_out)s
         }
         WITH p2 as peer_node, rel_outband, active_node, new_node
@@ -174,7 +173,7 @@ class NodeDuplicateQuery(Query):
         }
         WITH n1 as active_node, rel_inband1 as rel_inband, p1 as peer_node, new_node
         WHERE rel_inband.status = "active" AND rel_inband.to IS NULL
-        CALL {
+        CALL (%(sub_query_in_args)s) {
             %(sub_query_in)s
         }
         WITH p2 as peer_node, rel_inband, active_node, new_node
@@ -188,5 +187,7 @@ class NodeDuplicateQuery(Query):
             "labels": ":".join(self.new_node.labels),
             "sub_query_out": sub_query_out,
             "sub_query_in": sub_query_in,
+            "sub_query_out_args": sub_query_out_args,
+            "sub_query_in_args": sub_query_in_args,
         }
         self.add_to_query(query)

--- a/backend/infrahub/core/migrations/query/relationship_duplicate.py
+++ b/backend/infrahub/core/migrations/query/relationship_duplicate.py
@@ -48,7 +48,6 @@ class RelationshipDuplicateQuery(Query):
     def _render_sub_query_per_rel_type(rel_name: str, rel_type: str, direction: GraphRelDirection) -> str:
         subquery = [
             f"WITH peer_node, {rel_name}, active_rel, new_rel",
-            f"WITH peer_node, {rel_name}, active_rel, new_rel",
             f'WHERE type({rel_name}) = "{rel_type}"',
         ]
         if direction == GraphRelDirection.OUTBOUND:
@@ -61,28 +60,32 @@ class RelationshipDuplicateQuery(Query):
         return "\n".join(subquery)
 
     @classmethod
-    def _render_sub_query_out(cls) -> str:
+    def _render_sub_query_out(cls) -> tuple[str, str]:
+        rel_name = "rel_outband"
+        sub_query_out_args = f"peer_node, {rel_name}, active_rel, new_rel"
         sub_queries_out = [
             cls._render_sub_query_per_rel_type(
-                rel_name="rel_outband", rel_type=rel_type, direction=GraphRelDirection.OUTBOUND
+                rel_name=rel_name, rel_type=rel_type, direction=GraphRelDirection.OUTBOUND
             )
             for rel_type, rel_def in GraphRelationshipRelationships.model_fields.items()
             if rel_def.default.direction in [GraphRelDirection.OUTBOUND, GraphRelDirection.EITHER]
         ]
         sub_query_out = "\nUNION\n".join(sub_queries_out)
-        return sub_query_out
+        return sub_query_out, sub_query_out_args
 
     @classmethod
-    def _render_sub_query_in(cls) -> str:
+    def _render_sub_query_in(cls) -> tuple[str, str]:
+        rel_name = "rel_inband"
+        sub_query_in_args = f"peer_node, {rel_name}, active_rel, new_rel"
         sub_queries_in = [
             cls._render_sub_query_per_rel_type(
-                rel_name="rel_inband", rel_type=rel_type, direction=GraphRelDirection.INBOUND
+                rel_name=rel_name, rel_type=rel_type, direction=GraphRelDirection.INBOUND
             )
             for rel_type, rel_def in GraphRelationshipRelationships.model_fields.items()
             if rel_def.default.direction in [GraphRelDirection.INBOUND, GraphRelDirection.EITHER]
         ]
         sub_query_in = "\nUNION\n".join(sub_queries_in)
-        return sub_query_in
+        return sub_query_in, sub_query_in_args
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
         branch_filter, branch_params = self.branch.get_query_filter_path(at=self.at.to_string())
@@ -109,8 +112,8 @@ class RelationshipDuplicateQuery(Query):
             "from": self.at.to_string(),
         }
 
-        sub_query_out = self._render_sub_query_out()
-        sub_query_in = self._render_sub_query_in()
+        sub_query_out, sub_query_out_args = self._render_sub_query_out()
+        sub_query_in, sub_query_in_args = self._render_sub_query_in()
 
         self.add_to_query(self.render_match())
 
@@ -138,7 +141,7 @@ class RelationshipDuplicateQuery(Query):
         }
         WITH n1 as active_rel, rel_inband1 as rel_inband, p1 as peer_node, new_rel
         WHERE rel_inband.status = "active"
-        CALL {
+        CALL (%(sub_query_in_args)s) {
             %(sub_query_in)s
         }
         WITH p2 as peer_node, rel_inband, active_rel, new_rel
@@ -157,7 +160,7 @@ class RelationshipDuplicateQuery(Query):
         }
         WITH n1 as active_rel, rel_outband1 as rel_outband, p1 as peer_node, new_rel
         WHERE rel_outband.status = "active"
-        CALL {
+        CALL (%(sub_query_out_args)s) {
             %(sub_query_out)s
         }
         WITH p2 as peer_node, rel_outband, active_rel, new_rel
@@ -169,5 +172,7 @@ class RelationshipDuplicateQuery(Query):
             "branch_filter": branch_filter,
             "sub_query_out": sub_query_out,
             "sub_query_in": sub_query_in,
+            "sub_query_in_args": sub_query_in_args,
+            "sub_query_out_args": sub_query_out_args,
         }
         self.add_to_query(query)

--- a/backend/infrahub/core/migrations/schema/node_attribute_remove.py
+++ b/backend/infrahub/core/migrations/schema/node_attribute_remove.py
@@ -51,7 +51,6 @@ class NodeAttributeRemoveMigrationQuery01(AttributeMigrationQuery):
         def render_sub_query_per_rel_type(rel_type: str, rel_def: FieldInfo) -> str:
             subquery = [
                 "WITH peer_node, rb, active_attr",
-                "WITH peer_node, rb, active_attr",
                 f'WHERE type(rb) = "{rel_type}"',
             ]
             if rel_def.default.direction.value == "outbound":
@@ -105,7 +104,7 @@ class NodeAttributeRemoveMigrationQuery01(AttributeMigrationQuery):
         }
         WITH a1 as active_attr, r1 as rb, p1 as peer_node
         WHERE rb.status = "active"
-        CALL {
+        CALL (peer_node, rb, active_attr) {
             %(sub_query_all)s
         }
         WITH p2 as peer_node, rb, active_attr

--- a/backend/infrahub/core/migrations/schema/node_remove.py
+++ b/backend/infrahub/core/migrations/schema/node_remove.py
@@ -22,7 +22,6 @@ class NodeRemoveMigrationBaseQuery(MigrationQuery):
     ) -> str:
         subquery = [
             f"WITH peer_node, {rel_name}, active_node",
-            f"WITH peer_node, {rel_name}, active_node",
             f'WHERE type({rel_name}) = "{rel_type}"',
         ]
         if rel_def.default.direction in [GraphRelDirection.OUTBOUND, GraphRelDirection.EITHER]:
@@ -90,7 +89,7 @@ class NodeRemoveMigrationQueryIn(NodeRemoveMigrationBaseQuery):
     insert_return: bool = False
 
     def render_node_remove_query(self, branch_filter: str) -> str:
-        sub_query = self.render_sub_query_in()
+        sub_query, sub_query_args = self.render_sub_query_in()
         query = """
         // Process Inbound Relationship
         WITH active_node
@@ -104,27 +103,29 @@ class NodeRemoveMigrationQueryIn(NodeRemoveMigrationBaseQuery):
         }
         WITH n1 as active_node, rel_inband1 as rel_inband, p1 as peer_node
         WHERE rel_inband.status = "active"
-        CALL {
+        CALL (%(sub_query_args)s) {
             %(sub_query)s
         }
         WITH p2 as peer_node, rel_inband, active_node
         FOREACH (i in CASE WHEN rel_inband.branch IN ["-global-", $branch] THEN [1] ELSE [] END |
             SET rel_inband.to = $current_time
         )
-        """ % {"sub_query": sub_query, "branch_filter": branch_filter}
+        """ % {"sub_query": sub_query, "sub_query_args": sub_query_args, "branch_filter": branch_filter}
         return query
 
-    def render_sub_query_in(self) -> str:
+    def render_sub_query_in(self) -> tuple[str, str]:
+        rel_name = "rel_inband"
+        sub_query_in_args = f"peer_node, {rel_name}, active_node"
         sub_queries_in = [
             self.render_sub_query_per_rel_type(
-                rel_name="rel_inband",
+                rel_name=rel_name,
                 rel_type=rel_type,
                 rel_def=rel_def,
             )
             for rel_type, rel_def in GraphNodeRelationships.model_fields.items()
         ]
         sub_query_in = "\nUNION\n".join(sub_queries_in)
-        return sub_query_in
+        return sub_query_in, sub_query_in_args
 
     def get_nbr_migrations_executed(self) -> int:
         return 0
@@ -135,7 +136,7 @@ class NodeRemoveMigrationQueryOut(NodeRemoveMigrationBaseQuery):
     insert_return: bool = False
 
     def render_node_remove_query(self, branch_filter: str) -> str:
-        sub_query = self.render_sub_query_out()
+        sub_query, sub_query_args = self.render_sub_query_out()
         query = """
         // Process Outbound Relationship
         WITH active_node
@@ -149,27 +150,29 @@ class NodeRemoveMigrationQueryOut(NodeRemoveMigrationBaseQuery):
         }
         WITH n1 as active_node, rel_outband1 as rel_outband, p1 as peer_node
         WHERE rel_outband.status = "active"
-        CALL {
+        CALL (%(sub_query_args)s) {
             %(sub_query)s
         }
         FOREACH (i in CASE WHEN rel_outband.branch IN ["-global-", $branch] THEN [1] ELSE [] END |
             SET rel_outband.to = $current_time
         )
-        """ % {"sub_query": sub_query, "branch_filter": branch_filter}
+        """ % {"sub_query": sub_query, "sub_query_args": sub_query_args, "branch_filter": branch_filter}
 
         return query
 
-    def render_sub_query_out(self) -> str:
+    def render_sub_query_out(self) -> tuple[str, str]:
+        rel_name = "rel_outband"
+        sub_query_out_args = f"peer_node, {rel_name}, active_node"
         sub_queries_out = [
             self.render_sub_query_per_rel_type(
-                rel_name="rel_outband",
+                rel_name=rel_name,
                 rel_type=rel_type,
                 rel_def=rel_def,
             )
             for rel_type, rel_def in GraphNodeRelationships.model_fields.items()
         ]
         sub_query_out = "\nUNION\n".join(sub_queries_out)
-        return sub_query_out
+        return sub_query_out, sub_query_out_args
 
     def get_nbr_migrations_executed(self) -> int:
         return self.num_of_results

--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -217,8 +217,7 @@ class RelationshipQuery(Query):
         )
         source_query_match = """
             MATCH (s:Node { uuid: $source_id })
-            CALL {
-                WITH s
+            CALL (s) {
                 MATCH (s)-[r:IS_PART_OF]->(:Root)
                 WHERE %(source_filter)s
                 RETURN r.status = "active" AS s_is_active
@@ -246,8 +245,7 @@ class RelationshipQuery(Query):
             )
             destination_query_match = """
             MATCH (d:Node { uuid: $destination_id })
-            CALL {
-                WITH d
+            CALL (d) {
                 MATCH (d)-[r:IS_PART_OF]->(:Root)
                 WHERE %(destination_filter)s
                 RETURN r.status = "active" AS d_is_active


### PR DESCRIPTION
using the latest version of neo4j, cypher CALL subqueries are expected to receive their parameters in this manner
```
CALL (x, y) {
    RETURN x > y
}
```

instead of the old format
```
CALL {
    WITH x, y
    RETURN x > y
}
```

this update should cover all the remaining `CALL` subqueries currently in `develop`