### PR TITLE
fix(backend): ignore neo4j deprecation logs

### DIFF
--- a/backend/infrahub/database/__init__.py
+++ b/backend/infrahub/database/__init__.py
@@ -487,7 +487,10 @@ async def get_db(retry: int = 0) -> AsyncDriver:
         auth=(config.SETTINGS.database.username, config.SETTINGS.database.password),
         encrypted=config.SETTINGS.database.tls_enabled,
         trusted_certificates=trusted_certificates,
-        notifications_disabled_categories=[NotificationDisabledCategory.UNRECOGNIZED],
+        notifications_disabled_categories=[
+            NotificationDisabledCategory.UNRECOGNIZED,
+            NotificationDisabledCategory.DEPRECATION,  # TODO: Remove me with 1.3
+        ],
         notifications_min_severity=NotificationMinimumSeverity.WARNING,
     )
 


### PR DESCRIPTION
Logs are emitted when running with neo4j >= 5.26.
Query compatibility will be available with Infrahub 1.3, we can revert this once 1.3 is released.