### PR TITLE
Forbid the deletion of NumberPools in use by NumberPool attributes

### DIFF
--- a/backend/infrahub/core/schema/manager.py
+++ b/backend/infrahub/core/schema/manager.py
@@ -764,3 +764,6 @@ class SchemaManager(NodeManager):
                 del self._cache[hash_key]
 
         return removed_branches
+
+    def get_branches(self) -> list[str]:
+        return list(self._branches.keys())

--- a/backend/infrahub/graphql/mutations/resource_manager.py
+++ b/backend/infrahub/graphql/mutations/resource_manager.py
@@ -6,15 +6,16 @@ from graphene import Boolean, Field, InputField, InputObjectType, Int, List, Mut
 from graphene.types.generic import GenericScalar
 from typing_extensions import Self
 
-from infrahub.core import registry
+from infrahub.core import protocols, registry
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.ipam.constants import PrefixMemberType
+from infrahub.core.manager import NodeManager
 from infrahub.core.schema import NodeSchema
 from infrahub.database import retry_db_transaction
 from infrahub.exceptions import QueryValidationError, SchemaNotFoundError, ValidationError
 
 from ..queries.resource_manager import PoolAllocatedNode
-from .main import InfrahubMutationMixin, InfrahubMutationOptions
+from .main import DeleteResult, InfrahubMutationMixin, InfrahubMutationOptions
 
 if TYPE_CHECKING:
     from graphql import GraphQLResolveInfo
@@ -221,3 +222,43 @@ class InfrahubNumberPoolMutation(InfrahubMutationMixin, Mutation):
                 raise ValidationError(input_value="start_range can't be larger than end_range")
 
         return number_pool, result
+
+    @classmethod
+    @retry_db_transaction(name="resource_manager_update")
+    async def mutate_delete(
+        cls,
+        info: GraphQLResolveInfo,
+        data: InputObjectType,
+        branch: Branch,
+    ) -> DeleteResult:
+        graphql_context: GraphqlContext = info.context
+
+        number_pool = await NodeManager.find_object(
+            db=graphql_context.db,
+            kind=protocols.CoreNumberPool,
+            id=data.get("id"),
+            hfid=data.get("hfid"),
+            branch=branch,
+        )
+
+        active_branches = registry.schema.get_branches()
+        violating_branches = []
+        for active_branch in active_branches:
+            try:
+                schema = registry.schema.get(name=number_pool.node.value, branch=active_branch)
+            except SchemaNotFoundError:
+                continue
+
+            if number_pool.node_attribute.value in schema.attribute_names:
+                attribute = schema.get_attribute(name=number_pool.node_attribute.value)
+                if attribute.kind == "NumberPool":
+                    violating_branches.append(active_branch)
+
+        if violating_branches:
+            raise ValidationError(
+                input_value=f"Unable to delete number pool {number_pool.node.value}.{
+                    number_pool.node_attribute.value
+                } is in use (branches: {','.join(violating_branches)})"
+            )
+
+        return await super().mutate_delete(info=info, data=data, branch=branch)

--- a/backend/tests/helpers/schema/__init__.py
+++ b/backend/tests/helpers/schema/__init__.py
@@ -13,6 +13,7 @@ from .device import DEVICE, INTERFACE, INTERFACE_HOLDER, PHYSICAL_INTERFACE, SFP
 from .location import CONTINENT, COUNTRY, LOCATION, SITE
 from .manufacturer import MANUFACTURER
 from .person import PERSON
+from .snow import SNOW_INCIDENT, SNOW_REQUEST, SNOW_TASK
 from .thing import THING
 from .ticket import TICKET
 from .tshirt import TSHIRT
@@ -27,6 +28,7 @@ DEVICE_SCHEMA = SchemaRoot(
     generics=[INTERFACE, INTERFACE_HOLDER], nodes=[DEVICE, PHYSICAL_INTERFACE, VIRTUAL_INTERFACE, SFP]
 )
 LOCATION_SCHEMA = SchemaRoot(generics=[LOCATION], nodes=[CONTINENT, COUNTRY, SITE])
+SNOW_TICKET_SCHEMA = SchemaRoot(generics=[SNOW_TASK], nodes=[SNOW_INCIDENT, SNOW_REQUEST])
 
 
 async def load_schema(

--- a/backend/tests/unit/graphql/mutations/test_resource_manager.py
+++ b/backend/tests/unit/graphql/mutations/test_resource_manager.py
@@ -6,12 +6,14 @@ from infrahub.core.constants import InfrahubKind
 from infrahub.core.node import Node
 from infrahub.core.node.resource_manager.ip_address_pool import CoreIPAddressPool
 from infrahub.core.node.resource_manager.ip_prefix_pool import CoreIPPrefixPool
+from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
 from infrahub.core.schema import SchemaRoot
+from infrahub.core.schema.attribute_parameters import NumberPoolParameters
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
 from tests.helpers.graphql import graphql
-from tests.helpers.schema import TICKET, load_schema
+from tests.helpers.schema import SNOW_TICKET_SCHEMA, TICKET, load_schema
 
 
 @pytest.fixture
@@ -662,6 +664,34 @@ mutation UpdateNumberPool(
 """
 
 
+DELETE_NUMBER_POOL = """
+mutation DeleteNumberPool(
+    $id: String!,
+  ) {
+  CoreNumberPoolDelete(
+    data: {
+      id: $id,
+    }
+  ) {
+    ok
+  }
+}
+"""
+
+
+QUERY_NUMBER_POOL = """
+query NumberPool(
+    $id: ID!,
+  ) {
+  CoreNumberPool(
+    ids: [$id]
+  ) {
+    count
+  }
+}
+"""
+
+
 async def test_test_number_pool_creation_errors(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema
 ):
@@ -812,3 +842,117 @@ async def test_test_number_pool_update(db: InfrahubDatabase, default_branch: Bra
     assert "start_range can't be larger than end_range" in str(update_invalid_range.errors[0])
     assert update_ok.data
     assert not update_ok.errors
+
+    # Validate that we can delete a number pool that isn't tied to an attribute of kind NumberPool
+    delete_ok = await graphql(
+        schema=gql_params.schema,
+        source=DELETE_NUMBER_POOL,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={
+            "id": pool_id,
+        },
+    )
+    assert not delete_ok.errors
+    assert delete_ok.data
+    assert delete_ok.data["CoreNumberPoolDelete"]["ok"]
+
+    query_after_delete = await graphql(
+        schema=gql_params.schema,
+        source=QUERY_NUMBER_POOL,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={
+            "id": pool_id,
+        },
+    )
+    assert not query_after_delete.errors
+    assert query_after_delete.data
+    assert query_after_delete.data["CoreNumberPool"]["count"] == 0
+
+
+async def test_delete_number_pool_in_use_by_numberpool_attribute(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None
+) -> None:
+    await load_schema(db=db, schema=SNOW_TICKET_SCHEMA)
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    node_schema = registry.schema.get(name="SnowTask", branch=default_branch)
+    number_pool_attribute = node_schema.get_attribute(name="number")
+    assert isinstance(number_pool_attribute.parameters, NumberPoolParameters)
+    registry.node[InfrahubKind.NUMBERPOOL] = CoreNumberPool
+    query_before_creation = await graphql(
+        schema=gql_params.schema,
+        source=QUERY_NUMBER_POOL,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={
+            "id": number_pool_attribute.parameters.number_pool_id,
+        },
+    )
+
+    assert not query_before_creation.errors
+    assert query_before_creation.data
+    assert query_before_creation.data["CoreNumberPool"]["count"] == 0
+
+    create_snow_incident_mutation = """
+    mutation CreateSnowIncident(
+        $title: String!,
+    ) {
+    SnowIncidentCreate(
+        data: {
+        title: {value: $title},
+        }
+    ) {
+        object {
+            title {
+                value
+            }
+            number {
+                value
+                source {
+                    id
+                }
+            }
+            identifier {
+                value
+            }
+        }
+      }
+    }
+    """
+
+    create_snow_incident = await graphql(
+        schema=gql_params.schema,
+        source=create_snow_incident_mutation,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={
+            "title": "Printer is saying PC load Letter",
+        },
+    )
+
+    assert not create_snow_incident.errors
+    assert create_snow_incident.data
+    assert (
+        create_snow_incident.data["SnowIncidentCreate"]["object"]["title"]["value"]
+        == "Printer is saying PC load Letter"
+    )
+    assert create_snow_incident.data["SnowIncidentCreate"]["object"]["number"]["value"] == 1
+    assert (
+        create_snow_incident.data["SnowIncidentCreate"]["object"]["number"]["source"]["id"]
+        == number_pool_attribute.parameters.number_pool_id
+    )
+    assert create_snow_incident.data["SnowIncidentCreate"]["object"]["identifier"]["value"] == "INC1"
+
+    delete_fail = await graphql(
+        schema=gql_params.schema,
+        source=DELETE_NUMBER_POOL,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={
+            "id": number_pool_attribute.parameters.number_pool_id,
+        },
+    )
+
+    assert delete_fail.errors
+    assert "Unable to delete number pool SnowTask.number is in use (branches: main)" in str(delete_fail.errors)


### PR DESCRIPTION
This PR adds some constraints and checks when deleting NumberPools that are defined within the schema, the idea is to forbid the deletion of numberpools that are defined through NumberPool attributes when those attributes still exist within the schema on any branch (since the numberpools themselves are branch agnostic).

I've also added another test to verify that we can still delete other NumberPools.