### PR TITLE
add missing database sessions

### DIFF
--- a/backend/infrahub/message_bus/operations/refresh/registry.py
+++ b/backend/infrahub/message_bus/operations/refresh/registry.py
@@ -26,6 +26,6 @@ async def rebased_branch(message: messages.RefreshRegistryRebasedBranch, service
 
     async with lock.registry.local_schema_lock():
         service.log.info("Refreshing rebased branch")
-        registry.branch[message.branch] = await registry.branch_object.get_by_name(
-            name=message.branch, db=service.database
-        )
+
+        async with service.database.start_session() as db:
+            registry.branch[message.branch] = await registry.branch_object.get_by_name(name=message.branch, db=db)

--- a/backend/infrahub/message_bus/operations/refresh/registry.py
+++ b/backend/infrahub/message_bus/operations/refresh/registry.py
@@ -27,5 +27,5 @@ async def rebased_branch(message: messages.RefreshRegistryRebasedBranch, service
     async with lock.registry.local_schema_lock():
         service.log.info("Refreshing rebased branch")
 
-        async with service.database.start_session() as db:
+        async with service.database.start_session(read_only=True) as db:
             registry.branch[message.branch] = await registry.branch_object.get_by_name(name=message.branch, db=db)

--- a/backend/infrahub/webhook/tasks.py
+++ b/backend/infrahub/webhook/tasks.py
@@ -111,7 +111,8 @@ async def webhook_process(
 async def configure_webhook_all(service: InfrahubServices) -> None:
     log = get_run_logger()
 
-    triggers = await gather_trigger_webhook(db=service.database)
+    async with service.database.start_session() as db:
+        triggers = await gather_trigger_webhook(db=db)
 
     async with get_client(sync_client=False) as prefect_client:
         await setup_triggers(

--- a/backend/infrahub/webhook/tasks.py
+++ b/backend/infrahub/webhook/tasks.py
@@ -111,7 +111,7 @@ async def webhook_process(
 async def configure_webhook_all(service: InfrahubServices) -> None:
     log = get_run_logger()
 
-    async with service.database.start_session() as db:
+    async with service.database.start_session(read_only=True) as db:
         triggers = await gather_trigger_webhook(db=db)
 
     async with get_client(sync_client=False) as prefect_client:

--- a/changelog/+add-missing-sessions.fixed.md
+++ b/changelog/+add-missing-sessions.fixed.md
@@ -1,0 +1,1 @@
+Add missing database session instantiations


### PR DESCRIPTION
database sessions were missing from a few workflows and these can result in a `RuntimeError('read() called while another coroutine is already waiting for incoming data')` if the database connection is closed elsewhere while one of these flows is waiting on data

I did not update the call to `gather_database_information` [here](https://github.com/opsmill/infrahub/blob/stable/backend/infrahub/telemetry/tasks.py#L83) because this function starts its own session

there is also one more call to be updated [here](https://github.com/opsmill/infrahub/blob/develop/backend/infrahub/webhook/tasks.py#L114) when this is merged forward to `develop`