### PR TITLE
IFC-1517 Don't set unique constraints on generic templates

### DIFF
--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1957,7 +1957,11 @@ class SchemaBranch:
             )
 
             parent_hfid = f"{relationship.name}__template_name__value"
-            if relationship.kind == RelationshipKind.PARENT and parent_hfid not in template_schema.human_friendly_id:
+            if (
+                not isinstance(template_schema, GenericSchema)
+                and relationship.kind == RelationshipKind.PARENT
+                and parent_hfid not in template_schema.human_friendly_id
+            ):
                 template_schema.human_friendly_id = [parent_hfid] + template_schema.human_friendly_id
                 template_schema.uniqueness_constraints[0].append(relationship.name)
 
@@ -1992,7 +1996,6 @@ class SchemaBranch:
                 include_in_menu=False,
                 display_labels=["template_name__value"],
                 human_friendly_id=["template_name__value"],
-                uniqueness_constraints=[["template_name__value"]],
                 attributes=[template_name_attr],
             )
 
@@ -2011,7 +2014,6 @@ class SchemaBranch:
                 human_friendly_id=["template_name__value"],
                 uniqueness_constraints=[["template_name__value"]],
                 inherit_from=[InfrahubKind.LINEAGESOURCE, InfrahubKind.NODE, core_template_schema.kind],
-                default_filter="template_name__value",
                 attributes=[template_name_attr],
                 relationships=[
                     RelationshipSchema(

--- a/changelog/6478.fixed.md
+++ b/changelog/6478.fixed.md
@@ -1,0 +1,1 @@
+Remove uniqueness constraint on generic templates to support upsert mutations


### PR DESCRIPTION
When we run the uniquess constraint checker for a given node, we check for its uniqueness constraints as well as the uniqueness constraints of its generics if their are any. In the case of component template, it was causing an issue where component templates were expected to have unique template names while in fact, their uniqueness is based on a name and a parent template.

The `default_filter` on templates as also been removed as it is somehow deprecated by HFID and can cause confusion.