### PR TITLE
remove needlessly scary error message

### DIFF
--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -533,7 +533,7 @@ class InfrahubMutationMixin:
         except HFIDViolatedError as exc:
             # Only the HFID constraint has been violated, it means the node exists and we can update without rerunning constraints
             if len(exc.matching_nodes_ids) > 1:
-                raise RuntimeError(f"Multiple {schema_name} nodes have the same hfid (database corrupted)") from exc
+                raise RuntimeError(f"Multiple {schema_name} nodes have the same hfid") from exc
             node_id = list(exc.matching_nodes_ids)[0]
             node = await NodeManager.get_one(db=db, id=node_id, kind=schema_name, branch=branch, raise_on_error=True)
             updated_obj, mutation = await cls._call_mutate_update(


### PR DESCRIPTION
saying a database is corrupted makes people think that nothing the database can be trusted. or that the disks are melting or something. the user still gets the same information from this error message without the jump scare