### PR TITLE
Add generation of test protocols

### DIFF
--- a/backend/templates/generate_protocols.j2
+++ b/backend/templates/generate_protocols.j2
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Protocol, runtime_checkable, Optional, Any
 
-from .protocols_base import CoreNode
+from infrahub.core.protocols_base import CoreNode
 
 if TYPE_CHECKING:
     from enum import Enum

--- a/backend/tests/helpers/schema/__init__.py
+++ b/backend/tests/helpers/schema/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from infrahub.core import registry
 from infrahub.core.schema import SchemaRoot
@@ -20,6 +20,7 @@ from .tshirt import TSHIRT
 from .widget import WIDGET
 
 if TYPE_CHECKING:
+    from infrahub.core.schema import GenericSchema, NodeSchema
     from infrahub.database import InfrahubDatabase
 
 
@@ -44,6 +45,25 @@ async def load_schema(
     branch.update_schema_hash()
     await branch.save(db=db)
     graphql_registry.clear_cache()
+
+
+test_generics: list[GenericSchema] = [SNOW_TASK, INTERFACE, INTERFACE_HOLDER]
+test_nodes: list[NodeSchema] = [
+    CAR,
+    MANUFACTURER,
+    PERSON,
+    SNOW_INCIDENT,
+    SNOW_REQUEST,
+    DEVICE,
+    PHYSICAL_INTERFACE,
+    VIRTUAL_INTERFACE,
+    SFP,
+]
+
+test_models: dict[str, Any] = {
+    "generics": [item.to_dict() for item in test_generics],
+    "nodes": [item.to_dict() for item in test_nodes],
+}
 
 
 __all__ = [

--- a/backend/tests/protocols.py
+++ b/backend/tests/protocols.py
@@ -240,6 +240,22 @@ class LineageSource(CoreNode):
     pass
 
 
+class SnowTask(CoreNode):
+    title: String
+    number: Integer
+    identifier: String
+
+
+class TestingInterface(CoreNode):
+    name: String
+    enabled: Boolean
+    device: RelationshipManager
+
+
+class TestingInterfaceHolder(CoreNode):
+    interfaces: RelationshipManager
+
+
 class BuiltinTag(CoreNode):
     name: String
     description: StringOptional
@@ -574,3 +590,60 @@ class InternalRefreshToken(CoreNode):
 
 class IpamNamespace(BuiltinIPNamespace):
     default: BooleanOptional
+
+
+class SnowIncident(SnowTask):
+    identifier: String
+
+
+class SnowRequest(SnowTask):
+    identifier: String
+
+
+class TestingCar(CoreNode):
+    name: String
+    description: StringOptional
+    color: String
+    owner: RelationshipManager
+    previous_owner: RelationshipManager
+    manufacturer: RelationshipManager
+
+
+class TestingDevice(TestingInterfaceHolder):
+    name: String
+    manufacturer: String
+    height: Integer
+    weight: Integer
+    airflow: Enum
+    part_number: StringOptional
+
+
+class TestingManufacturer(CoreNode):
+    name: String
+    description: StringOptional
+    cars: RelationshipManager
+    customers: RelationshipManager
+
+
+class TestingPerson(LineageOwner, LineageSource, CoreArtifactTarget):
+    name: String
+    description: StringOptional
+    height: IntegerOptional
+    age: IntegerOptional
+    cars: RelationshipManager
+
+
+class TestingPhysicalInterface(TestingInterface):
+    phys_type: Enum
+    sfp: RelationshipManager
+
+
+class TestingSfp(CoreNode):
+    phys_type: Enum
+    serial_number: String
+    part_number: StringOptional
+    interface: RelationshipManager
+
+
+class TestingVirtualInterface(TestingInterface):
+    pass

--- a/tasks/backend.py
+++ b/tasks/backend.py
@@ -182,7 +182,7 @@ def validate_generated(context: Context, docker: bool = False) -> None:  # noqa:
         context.run(exec_cmd)
 
     _generate_protocols(context=context)
-    exec_cmd = "git diff --exit-code backend/infrahub/core/protocols.py"
+    exec_cmd = "git diff --exit-code backend/infrahub/core/protocols.py backend/tests/protocols.py"
     with context.cd(ESCAPED_REPO_PATH):
         context.run(exec_cmd)
 
@@ -280,6 +280,7 @@ def _sort_and_filter_models(
 
 def _generate_protocols(context: Context) -> None:
     from jinja2 import Environment, FileSystemLoader, StrictUndefined
+    from tests.helpers.schema import test_models
 
     from infrahub.core.schema.definitions.core import core_models
 
@@ -293,6 +294,20 @@ def _generate_protocols(context: Context) -> None:
 
     protocols_rendered = template.render(
         generics=_sort_and_filter_models(core_models["generics"]), models=_sort_and_filter_models(core_models["nodes"])
+    )
+    protocols_output = f"{generated}/protocols.py"
+    Path(protocols_output).write_text(protocols_rendered, encoding="utf-8")
+
+    execute_command(context=context, command=f"ruff format {protocols_output}")
+    execute_command(context=context, command=f"ruff check --fix {protocols_output}")
+
+    # Export test protocols for backend code use
+    generated = f"{ESCAPED_REPO_PATH}/backend/tests/"
+
+    test_models["nodes"].extend(core_models["nodes"])
+    test_models["generics"].extend(core_models["generics"])
+    protocols_rendered = template.render(
+        generics=_sort_and_filter_models(test_models["generics"]), models=_sort_and_filter_models(test_models["nodes"])
     )
     protocols_output = f"{generated}/protocols.py"
     Path(protocols_output).write_text(protocols_rendered, encoding="utf-8")


### PR DESCRIPTION
The goal with this is to move away from any "test kind constants" and instead allow for the usage of protocols within the tests in the same way that we can do this within the main product.

* Due the the lineage and some other classes I'm adding a reference to the core models in the same file, it might get a bit verbose within that file. But as it's a test protocols file I'm not sure that it matters much.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Switched to absolute imports for improved module stability.
  - Enhanced protocol generation to also produce test protocols and run automated formatting/linting.
  - Updated validation to compare multiple generated protocol outputs for consistency.

- Tests
  - Added a comprehensive generated protocol schema for testing across IPAM, resources, governance, and sample domains.
  - Expanded test helpers with additional schemas and type hints to support richer scenarios.

- Refactor
  - Internal generation workflow streamlined without altering user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->