### PR TITLE
Switch Trigger/Action menu items to Builtin namespace

### DIFF
--- a/backend/infrahub/menu/menu.py
+++ b/backend/infrahub/menu/menu.py
@@ -256,7 +256,7 @@ default_menu = [
                 order_weight=6000,
                 children=[
                     MenuItemDefinition(
-                        namespace="Core",
+                        namespace="Builtin",
                         name="TriggerRule",
                         label="Rules",
                         kind=InfrahubKind.TRIGGERRULE,
@@ -266,7 +266,7 @@ default_menu = [
                         order_weight=1000,
                     ),
                     MenuItemDefinition(
-                        namespace="Core",
+                        namespace="Builtin",
                         name="Action",
                         label="Actions",
                         kind=InfrahubKind.ACTION,


### PR DESCRIPTION
Switch to the Builtin namespace as that's what the upgrade script is looking for, previously `infrahub upgrade` caused schema conflicts within the pipeline if you ran the command multiple times after the menu had been loaded.