### PR TITLE
remove txn for diff calculation in pc pipeline

### DIFF
--- a/backend/infrahub/message_bus/operations/requests/proposed_change.py
+++ b/backend/infrahub/message_bus/operations/requests/proposed_change.py
@@ -105,11 +105,11 @@ async def pipeline(message: messages.RequestProposedChangePipeline, service: Inf
 
     await _gather_repository_repository_diffs(repositories=repositories, service=service)
 
-    async with service.database.start_transaction() as dbt:
-        destination_branch = await registry.get_branch(db=dbt, branch=message.destination_branch)
-        source_branch = await registry.get_branch(db=dbt, branch=message.source_branch)
+    async with service.database.start_session() as dbs:
+        destination_branch = await registry.get_branch(db=dbs, branch=message.destination_branch)
+        source_branch = await registry.get_branch(db=dbs, branch=message.source_branch)
         component_registry = get_component_registry()
-        diff_coordinator = await component_registry.get_component(DiffCoordinator, db=dbt, branch=source_branch)
+        diff_coordinator = await component_registry.get_component(DiffCoordinator, db=dbs, branch=source_branch)
         await diff_coordinator.update_branch_diff(base_branch=destination_branch, diff_branch=source_branch)
 
     diff_summary = await service.client.get_diff_summary(branch=message.source_branch)


### PR DESCRIPTION
this transaction is not necessary. the final step of diff update is to save the metadata for the diff (branch, from time, to time, etc.) and this acts as a final stamp indicating that the diff is complete. if the diff update fails for some reason, there will be some unused nodes left behind in the database, but they will be ignored b/c the `DiffRoot` nodes will not have any of the metadata that we use to query for them.