### PR TITLE
allow renaming unique attrs

### DIFF
--- a/backend/infrahub/core/schema/basenode_schema.py
+++ b/backend/infrahub/core/schema/basenode_schema.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import keyword
 import os
+from collections import defaultdict
 from dataclasses import asdict, dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Literal, overload
@@ -490,7 +491,61 @@ class BaseNodeSchema(GeneratedBaseNodeSchema):
             return UniquenessConstraintType.SUBSET_OF_HFID
         return UniquenessConstraintType.STANDARD
 
+    def _update_element_names(
+        self, element_list: list[str] | None, name_update_map: dict[str, str]
+    ) -> list[str] | None:
+        if not element_list:
+            return element_list
+        updated_element_list = []
+        for element in element_list:
+            current_schema_path = self.parse_schema_path(path=element)
+            current_field_name = current_schema_path.field_name
+            if not current_field_name or current_field_name not in name_update_map:
+                updated_element_list.append(element)
+                continue
+            new_field_name = name_update_map[current_field_name]
+            new_element_str = current_schema_path.to_string(field_name_override=new_field_name)
+            updated_element_list.append(new_element_str)
+        return updated_element_list
+
+    def handle_field_name_changes(self, other: BaseNodeSchema) -> None:
+        properties_to_update = [self.uniqueness_constraints, self.human_friendly_id, self.display_labels, self.order_by]
+        if not any(p for p in properties_to_update):
+            return
+
+        chronological_names = defaultdict(list)
+        for field in self.attributes + self.relationships:
+            if not field.id:
+                continue
+            chronological_names[field.id].append(field.name)
+        for field in other.attributes + other.relationships:
+            if not field.id:
+                continue
+            chronological_names[field.id].append(field.name)
+        field_name_map = {v[0]: v[-1] for v in chronological_names.values() if len(v) > 1}
+
+        if self.uniqueness_constraints:
+            updated_constraints = []
+            for constraint in self.uniqueness_constraints:
+                updated_constraint = self._update_element_names(element_list=constraint, name_update_map=field_name_map)
+                if updated_constraint:
+                    updated_constraints.append(updated_constraint)
+            self.uniqueness_constraints = updated_constraints
+        if self.human_friendly_id:
+            self.human_friendly_id = self._update_element_names(
+                element_list=self.human_friendly_id, name_update_map=field_name_map
+            )
+        if self.display_labels:
+            self.display_labels = self._update_element_names(
+                element_list=self.display_labels, name_update_map=field_name_map
+            )
+        if self.order_by:
+            self.order_by = self._update_element_names(element_list=self.order_by, name_update_map=field_name_map)
+
     def update(self, other: HashableModel) -> Self:
+        if isinstance(other, BaseNodeSchema):
+            self.handle_field_name_changes(other=other)
+
         super().update(other=other)
 
         # Allow to specify empty string to remove existing fields values
@@ -527,6 +582,24 @@ class SchemaAttributePath:
     attribute_schema: AttributeSchema | None = None
     attribute_property_name: str | None = None
 
+    def __str__(self) -> str:
+        return self.to_string()
+
+    def to_string(self, field_name_override: str | None = None) -> str:
+        str_path = ""
+        if self.relationship_schema:
+            str_path += field_name_override or self.relationship_schema.name
+        if self.attribute_schema:
+            if str_path:
+                str_path += "__"
+                attr_name = self.attribute_schema.name
+            else:
+                attr_name = field_name_override or self.attribute_schema.name
+            str_path += attr_name
+        if self.attribute_property_name:
+            str_path += f"__{self.attribute_property_name}"
+        return str_path
+
     @property
     def is_type_attribute(self) -> bool:
         return bool(self.attribute_schema and not self.related_schema and not self.relationship_schema)
@@ -538,6 +611,14 @@ class SchemaAttributePath:
     @property
     def has_property(self) -> bool:
         return bool(self.attribute_property_name)
+
+    @property
+    def field_name(self) -> str | None:
+        if self.relationship_schema:
+            return self.relationship_schema.name
+        if self.attribute_schema:
+            return self.attribute_schema.name
+        return None
 
     @property
     def active_relationship_schema(self) -> RelationshipSchema:

--- a/backend/infrahub/core/schema/basenode_schema.py
+++ b/backend/infrahub/core/schema/basenode_schema.py
@@ -491,72 +491,85 @@ class BaseNodeSchema(GeneratedBaseNodeSchema):
             return UniquenessConstraintType.SUBSET_OF_HFID
         return UniquenessConstraintType.STANDARD
 
-    def _update_element_list(
-        self, element_list: list[str] | None, name_update_map: dict[str, str], deleted_field_names: set[str]
-    ) -> list[str] | None:
-        if not element_list:
-            return element_list
+    def _update_schema_paths(
+        self, schema_paths_list: list[str], field_name_update_map: dict[str, str], deleted_field_names: set[str]
+    ) -> list[str]:
+        """
+        For each schema_path (eg name__value, device__name_value), update the field name if the current name is
+        in field_name_update_map, remove the path if the field name is in deleted_field_names
+        """
         updated_element_list = []
-        for element_path in element_list:
-            split_path = element_path.split("__", 1)
+        for schema_path in schema_paths_list:
+            split_path = schema_path.split("__", maxsplit=1)
             current_field_name = split_path[0]
             if current_field_name in deleted_field_names:
                 continue
-            the_rest = split_path[1] if len(split_path) > 1 else None
-            new_field_name = name_update_map.get(current_field_name)
+            new_field_name = field_name_update_map.get(current_field_name)
             if not new_field_name:
-                updated_element_list.append(element_path)
+                updated_element_list.append(schema_path)
                 continue
-            new_element_str = new_field_name
-            if the_rest:
-                new_element_str += f"__{the_rest}"
+            rest_of_path = f"__{split_path[1]}" if len(split_path) > 1 else ""
+            new_element_str = f"{new_field_name}{rest_of_path}"
             updated_element_list.append(new_element_str)
         return updated_element_list
 
-    def handle_field_name_changes(self, other: BaseNodeSchema) -> None:
+    def handle_field_renames_and_deletes(self, other: BaseNodeSchema) -> None:
         properties_to_update = [self.uniqueness_constraints, self.human_friendly_id, self.display_labels, self.order_by]
         if not any(p for p in properties_to_update):
             return
 
         deleted_names: set[str] = set()
-        chronological_names = defaultdict(list)
+        field_names_by_id = defaultdict(list)
         for field in self.attributes + self.relationships:
             if not field.id:
                 continue
-            chronological_names[field.id].append(field.name)
+            field_names_by_id[field.id].append(field.name)
         for field in other.attributes + other.relationships:
+            # identify fields deleted in the other schema
             if field.state is HashableModelState.ABSENT:
                 deleted_names.add(field.name)
             if not field.id:
                 continue
-            chronological_names[field.id].append(field.name)
-        field_name_map = {v[0]: v[-1] for v in chronological_names.values() if len(v) > 1}
+            if field.name not in field_names_by_id[field.id]:
+                field_names_by_id[field.id].append(field.name)
+        # identify fields renamed from this schema to the other schema
+        renamed_field_name_map = {v[0]: v[-1] for v in field_names_by_id.values() if len(v) > 1}
 
         if self.uniqueness_constraints:
             updated_constraints = []
             for constraint in self.uniqueness_constraints:
-                updated_constraint = self._update_element_list(
-                    element_list=constraint, name_update_map=field_name_map, deleted_field_names=deleted_names
+                updated_constraint = self._update_schema_paths(
+                    schema_paths_list=constraint,
+                    field_name_update_map=renamed_field_name_map,
+                    deleted_field_names=deleted_names,
                 )
                 if updated_constraint:
                     updated_constraints.append(updated_constraint)
             self.uniqueness_constraints = updated_constraints
         if self.human_friendly_id:
-            self.human_friendly_id = self._update_element_list(
-                element_list=self.human_friendly_id, name_update_map=field_name_map, deleted_field_names=deleted_names
+            self.human_friendly_id = self._update_schema_paths(
+                schema_paths_list=self.human_friendly_id,
+                field_name_update_map=renamed_field_name_map,
+                deleted_field_names=deleted_names,
             )
         if self.display_labels:
-            self.display_labels = self._update_element_list(
-                element_list=self.display_labels, name_update_map=field_name_map, deleted_field_names=deleted_names
+            self.display_labels = self._update_schema_paths(
+                schema_paths_list=self.display_labels,
+                field_name_update_map=renamed_field_name_map,
+                deleted_field_names=deleted_names,
             )
         if self.order_by:
-            self.order_by = self._update_element_list(
-                element_list=self.order_by, name_update_map=field_name_map, deleted_field_names=deleted_names
+            self.order_by = self._update_schema_paths(
+                schema_paths_list=self.order_by,
+                field_name_update_map=renamed_field_name_map,
+                deleted_field_names=deleted_names,
             )
 
     def update(self, other: HashableModel) -> Self:
+        # handle renamed/deleted field updates for schema properties here
+        # so that they can still be overridden during the call to `update()` below
         if isinstance(other, BaseNodeSchema):
-            self.handle_field_name_changes(other=other)
+            self.handle_field_renames_and_deletes(other=other)
 
         super().update(other=other)
 

--- a/backend/infrahub/core/schema/basenode_schema.py
+++ b/backend/infrahub/core/schema/basenode_schema.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, Callable, Iterable, Literal, overload
 from infrahub_sdk.utils import compare_lists, intersection
 from pydantic import field_validator
 
-from infrahub.core.constants import RelationshipCardinality, RelationshipKind
+from infrahub.core.constants import HashableModelState, RelationshipCardinality, RelationshipKind
 from infrahub.core.models import HashableModel, HashableModelDiff
 
 from .attribute_schema import AttributeSchema
@@ -491,20 +491,25 @@ class BaseNodeSchema(GeneratedBaseNodeSchema):
             return UniquenessConstraintType.SUBSET_OF_HFID
         return UniquenessConstraintType.STANDARD
 
-    def _update_element_names(
-        self, element_list: list[str] | None, name_update_map: dict[str, str]
+    def _update_element_list(
+        self, element_list: list[str] | None, name_update_map: dict[str, str], deleted_field_names: set[str]
     ) -> list[str] | None:
         if not element_list:
             return element_list
         updated_element_list = []
-        for element in element_list:
-            current_schema_path = self.parse_schema_path(path=element)
-            current_field_name = current_schema_path.field_name
-            if not current_field_name or current_field_name not in name_update_map:
-                updated_element_list.append(element)
+        for element_path in element_list:
+            split_path = element_path.split("__", 1)
+            current_field_name = split_path[0]
+            if current_field_name in deleted_field_names:
                 continue
-            new_field_name = name_update_map[current_field_name]
-            new_element_str = current_schema_path.to_string(field_name_override=new_field_name)
+            the_rest = split_path[1] if len(split_path) > 1 else None
+            new_field_name = name_update_map.get(current_field_name)
+            if not new_field_name:
+                updated_element_list.append(element_path)
+                continue
+            new_element_str = new_field_name
+            if the_rest:
+                new_element_str += f"__{the_rest}"
             updated_element_list.append(new_element_str)
         return updated_element_list
 
@@ -513,12 +518,15 @@ class BaseNodeSchema(GeneratedBaseNodeSchema):
         if not any(p for p in properties_to_update):
             return
 
+        deleted_names: set[str] = set()
         chronological_names = defaultdict(list)
         for field in self.attributes + self.relationships:
             if not field.id:
                 continue
             chronological_names[field.id].append(field.name)
         for field in other.attributes + other.relationships:
+            if field.state is HashableModelState.ABSENT:
+                deleted_names.add(field.name)
             if not field.id:
                 continue
             chronological_names[field.id].append(field.name)
@@ -527,20 +535,24 @@ class BaseNodeSchema(GeneratedBaseNodeSchema):
         if self.uniqueness_constraints:
             updated_constraints = []
             for constraint in self.uniqueness_constraints:
-                updated_constraint = self._update_element_names(element_list=constraint, name_update_map=field_name_map)
+                updated_constraint = self._update_element_list(
+                    element_list=constraint, name_update_map=field_name_map, deleted_field_names=deleted_names
+                )
                 if updated_constraint:
                     updated_constraints.append(updated_constraint)
             self.uniqueness_constraints = updated_constraints
         if self.human_friendly_id:
-            self.human_friendly_id = self._update_element_names(
-                element_list=self.human_friendly_id, name_update_map=field_name_map
+            self.human_friendly_id = self._update_element_list(
+                element_list=self.human_friendly_id, name_update_map=field_name_map, deleted_field_names=deleted_names
             )
         if self.display_labels:
-            self.display_labels = self._update_element_names(
-                element_list=self.display_labels, name_update_map=field_name_map
+            self.display_labels = self._update_element_list(
+                element_list=self.display_labels, name_update_map=field_name_map, deleted_field_names=deleted_names
             )
         if self.order_by:
-            self.order_by = self._update_element_names(element_list=self.order_by, name_update_map=field_name_map)
+            self.order_by = self._update_element_list(
+                element_list=self.order_by, name_update_map=field_name_map, deleted_field_names=deleted_names
+            )
 
     def update(self, other: HashableModel) -> Self:
         if isinstance(other, BaseNodeSchema):

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -706,7 +706,9 @@ class SchemaBranch:
                 ):
                     unique_attrs_in_constraints.add(schema_attribute_path.attribute_schema.name)
 
-            unique_attrs_in_attrs = {attr_schema.name for attr_schema in node_schema.unique_attributes}
+            unique_attrs_in_attrs = {
+                attr_schema.name for attr_schema in node_schema.unique_attributes if not attr_schema.inherited
+            }
             if unique_attrs_in_attrs == unique_attrs_in_constraints:
                 continue
 
@@ -818,11 +820,16 @@ class SchemaBranch:
                     ) from exc
 
     def _is_attr_combination_unique(
-        self, attrs_paths: list[str], uniqueness_constraints: list[list[str]] | None
+        self, attrs_paths: list[str], uniqueness_constraints: list[list[str]] | None, unique_attribute_names: list[str]
     ) -> bool:
         """
-        Return whether at least one combination of any length of `attrs_paths` is equal to a uniqueness constraint.
+        Return whether at least one combination of any length of `attrs_paths` is unique
         """
+        if unique_attribute_names:
+            for attr_path in attrs_paths:
+                for unique_attr_name in unique_attribute_names:
+                    if attr_path.startswith(unique_attr_name):
+                        return True
 
         if not uniqueness_constraints:
             return False
@@ -864,9 +871,14 @@ class SchemaBranch:
             if config.SETTINGS.main.schema_strict_mode:
                 # For every relationship referred within hfid, check whether the combination of attributes is unique is the peer schema node
                 for related_schema, attrs_paths in rel_schemas_to_paths.values():
-                    if not self._is_attr_combination_unique(attrs_paths, related_schema.uniqueness_constraints):
+                    if not self._is_attr_combination_unique(
+                        attrs_paths=attrs_paths,
+                        uniqueness_constraints=related_schema.uniqueness_constraints,
+                        unique_attribute_names=[a.name for a in related_schema.unique_attributes],
+                    ):
                         raise ValidationError(
-                            f"HFID of {node_schema.kind} refers peer {related_schema.kind} with a non-unique combination of attributes {attrs_paths}"
+                            f"HFID of {node_schema.kind} refers to peer {related_schema.kind}"
+                            f" with a non-unique combination of attributes {attrs_paths}"
                         )
 
     def validate_required_relationships(self) -> None:

--- a/backend/tests/integration/schema_lifecycle/shared.py
+++ b/backend/tests/integration/schema_lifecycle/shared.py
@@ -21,7 +21,7 @@ class TestSchemaLifecycleBase(TestInfrahubApp):
             "include_in_menu": True,
             "label": "Person",
             "attributes": [
-                {"name": "name", "kind": "Text"},
+                {"name": "name", "kind": "Text", "unique": True},
                 {"name": "description", "kind": "Text", "optional": True},
                 {"name": "height", "kind": "Number", "optional": True},
             ],

--- a/backend/tests/integration/schema_lifecycle/test_migration_attribute_branch.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_attribute_branch.py
@@ -214,6 +214,8 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
                                 },
                                 "removed": {},
                             },
+                            "human_friendly_id": None,
+                            "uniqueness_constraints": None,
                         },
                         "removed": {},
                     },
@@ -238,6 +240,14 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
         # Check if the branch has been properly updated
         branches = await client.branch.all()
         assert branches[self.branch1.name].has_schema_changes is True
+
+        # Check schema properties
+        schema_branch = await registry.schema.load_schema_from_db(db=db, branch=self.branch1)
+        updated_person_schema = schema_branch.get(name=PERSON_KIND)
+        assert updated_person_schema.uniqueness_constraints == [["firstname__value"]]
+        assert updated_person_schema.human_friendly_id == ["firstname__value"]
+        assert updated_person_schema.display_labels is None
+        assert updated_person_schema.order_by is None
 
         # Ensure that we can query the nodes with the new schema in BRANCH1
         persons = await registry.manager.query(

--- a/backend/tests/integration/schema_lifecycle/test_schema_migration_branch.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_migration_branch.py
@@ -187,6 +187,8 @@ class TestSchemaLifecycleBranch(TestSchemaLifecycleBase):
                                 },
                                 "removed": {},
                             },
+                            "uniqueness_constraints": None,
+                            "human_friendly_id": None,
                         },
                         "removed": {},
                     },

--- a/backend/tests/integration/schema_lifecycle/test_schema_migration_main.py
+++ b/backend/tests/integration/schema_lifecycle/test_schema_migration_main.py
@@ -116,6 +116,8 @@ class TestSchemaLifecycleMain(TestSchemaLifecycleBase):
                                 },
                                 "removed": {},
                             },
+                            "uniqueness_constraints": None,
+                            "human_friendly_id": None,
                         },
                         "removed": {},
                     },

--- a/backend/tests/integration/schema_lifecycle/test_unique_field_updates.py
+++ b/backend/tests/integration/schema_lifecycle/test_unique_field_updates.py
@@ -1,0 +1,333 @@
+from typing import Any
+
+import pytest
+from infrahub_sdk import InfrahubClient
+
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.initialization import (
+    create_branch,
+)
+from infrahub.database import InfrahubDatabase
+from tests.node_creation import create_and_save
+
+from ..shared import load_schema
+from .shared import (
+    CAR_KIND,
+    MANUFACTURER_KIND_01,
+    PERSON_KIND,
+    TestSchemaLifecycleBase,
+)
+
+
+class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
+    @pytest.fixture(scope="class")
+    async def branch_1(self, db: InfrahubDatabase):
+        return await create_branch(db=db, branch_name="branch1")
+
+    @pytest.fixture(scope="class")
+    async def initial_dataset(self, db: InfrahubDatabase, initialize_registry, schema_step01):
+        await load_schema(db=db, schema=schema_step01)
+
+        john = await create_and_save(db=db, schema=PERSON_KIND, name="John", height=175)
+        jane = await create_and_save(db=db, schema=PERSON_KIND, name="Jane", height=195)
+        deleted_bob = await create_and_save(
+            db=db, schema=PERSON_KIND, name="Deleted Bob", height=175, description="He's not here"
+        )
+        await deleted_bob.delete(db=db)
+        renault = await create_and_save(
+            db=db,
+            schema=MANUFACTURER_KIND_01,
+            name="renault",
+            description="Groupe Renault is a French multinational automobile manufacturer",
+        )
+        megane = await create_and_save(
+            db=db,
+            schema=CAR_KIND,
+            name="Megane",
+            description="Renault Megane",
+            color="#c93420",
+            manufacturer=renault,
+            owner=john,
+        )
+        clio = await create_and_save(
+            db=db,
+            schema=CAR_KIND,
+            name="Clio",
+            description="Renault Clio",
+            color="#ff3420",
+            manufacturer=renault,
+            owner=jane,
+        )
+        deleted_car = await create_and_save(
+            db=db, schema=CAR_KIND, name="Deleted", color="#aabbcc", manufacturer=renault, owner=john
+        )
+        await deleted_car.delete(db=db)
+
+        objs = {
+            "john": john.id,
+            "deleted_bob": deleted_bob.id,
+            "renault": renault.id,
+            "megane": megane.id,
+            "clio": clio.id,
+        }
+
+        return objs
+
+    @pytest.fixture(scope="class")
+    def schema_person_02_more_fields(self, schema_person_base) -> dict[str, Any]:
+        """Add a new attribute and a new relationship"""
+        updated_schema = {**schema_person_base}
+        updated_schema["attributes"].append(
+            {"name": "tax_id", "kind": "Number", "optional": True},
+        )
+        updated_schema["relationships"].append(
+            {"name": "best_friend", "kind": "Generic", "optional": True, "peer": PERSON_KIND, "cardinality": "one"}
+        )
+        updated_schema["uniqueness_constraints"] = [["name__value", "height__value"]]
+        updated_schema["order_by"] = ["name__value", "height__value"]
+        updated_schema["display_labels"] = ["name__value", "tax_id__value", "height__value"]
+        return updated_schema
+
+    @pytest.fixture(scope="class")
+    def schema_person_03_unique_fields(self, schema_person_02_more_fields) -> dict[str, Any]:
+        """Make the new attribute unique, use the new relationship in node-level properties"""
+        updated_schema = {**schema_person_02_more_fields}
+        for attr in updated_schema["attributes"]:
+            if attr["name"] == "tax_id":
+                attr["unique"] = True
+                attr["optional"] = False
+        for rel in updated_schema["relationships"]:
+            if rel["name"] == "best_friend":
+                rel["optional"] = False
+        updated_schema["human_friendly_id"] = ["name__value", "tax_id__value", "best_friend__name__value"]
+        return updated_schema
+
+    @pytest.fixture(scope="class")
+    def schema_person_04_rename_original_unique_fields(self, schema_person_03_unique_fields) -> dict[str, Any]:
+        """Rename the name attribute"""
+        updated_schema = {**schema_person_03_unique_fields}
+        for attr in updated_schema["attributes"]:
+            if attr["name"] == "name":
+                attr["name"] = "real_name"
+        updated_schema.pop("human_friendly_id", None)
+        updated_schema.pop("uniqueness_constraints", None)
+        updated_schema.pop("order_by", None)
+        updated_schema.pop("display_labels", None)
+        return updated_schema
+
+    @pytest.fixture(scope="class")
+    def schema_step_02(self, schema_person_02_more_fields) -> dict[str, Any]:
+        return {
+            "version": "1.0",
+            "nodes": [schema_person_02_more_fields],
+        }
+
+    @pytest.fixture(scope="class")
+    def schema_step_03(self, schema_person_03_unique_fields) -> dict[str, Any]:
+        return {
+            "version": "1.0",
+            "nodes": [schema_person_03_unique_fields],
+        }
+
+    @pytest.fixture(scope="class")
+    def schema_step_04(self, schema_person_04_rename_original_unique_fields) -> dict[str, Any]:
+        return {
+            "version": "1.0",
+            "nodes": [schema_person_04_rename_original_unique_fields],
+        }
+
+    async def test_step01_baseline_backend(self, db: InfrahubDatabase, initial_dataset, branch_1: Branch):
+        persons = await registry.manager.query(db=db, schema=PERSON_KIND, branch=branch_1.name)
+        assert len(persons) == 2
+
+    async def test_step02_check_more_fields(
+        self, db: InfrahubDatabase, branch_1: Branch, client: InfrahubClient, initial_dataset, schema_step_02
+    ):
+        success, response = await client.schema.check(schemas=[schema_step_02], branch=branch_1.name)
+        assert success, response.get("errors") if response else None
+        assert response == {
+            "diff": {
+                "added": {},
+                "changed": {
+                    "TestingPerson": {
+                        "added": {},
+                        "changed": {
+                            "attributes": {
+                                "added": {"tax_id": None},
+                                "changed": {},
+                                "removed": {},
+                            },
+                            "relationships": {
+                                "added": {"best_friend": None},
+                                "changed": {},
+                                "removed": {},
+                            },
+                            "uniqueness_constraints": None,
+                            "order_by": None,
+                            "display_labels": None,
+                        },
+                        "removed": {},
+                    },
+                },
+                "removed": {},
+            },
+        }
+
+    async def test_step02_load_more_fields(
+        self, db: InfrahubDatabase, branch_1: Branch, client: InfrahubClient, initial_dataset, schema_step_02
+    ):
+        # Load the new schema and apply the migrations
+        response = await client.schema.load(schemas=[schema_step_02], branch=branch_1.name)
+        assert not response.errors
+
+        # Check if the branch has been properly updated
+        branches = await client.branch.all()
+        assert branches[branch_1.name].has_schema_changes is True
+
+        # Ensure that we can query the nodes with the new schema in BRANCH1
+        persons = await registry.manager.query(
+            db=db, schema=PERSON_KIND, filters={"name__value": "John"}, branch=branch_1.name
+        )
+        assert len(persons) == 1
+        john = persons[0]
+        persons = await registry.manager.query(
+            db=db, schema=PERSON_KIND, filters={"name__value": "Jane"}, branch=branch_1.name
+        )
+        assert len(persons) == 1
+        jane = persons[0]
+
+        john.tax_id.value = 9999
+        jane.tax_id.value = 9998
+        await john.best_friend.update(db=db, data=jane)
+        await john.save(db=db)
+        await jane.save(db=db)
+
+    async def test_step03_check_unique_fields(
+        self, db: InfrahubDatabase, branch_1: Branch, client: InfrahubClient, initial_dataset, schema_step_03
+    ):
+        success, response = await client.schema.check(schemas=[schema_step_03], branch=branch_1.name)
+        assert success, response.get("errors") if response else None
+        assert response == {
+            "diff": {
+                "added": {},
+                "changed": {
+                    "TestingPerson": {
+                        "added": {},
+                        "changed": {
+                            "attributes": {
+                                "added": {},
+                                "changed": {
+                                    "tax_id": {
+                                        "added": {},
+                                        "removed": {},
+                                        "changed": {
+                                            "optional": None,
+                                            "unique": None,
+                                        },
+                                    }
+                                },
+                                "removed": {},
+                            },
+                            "relationships": {
+                                "added": {},
+                                "changed": {
+                                    "best_friend": {
+                                        "added": {},
+                                        "removed": {},
+                                        "changed": {
+                                            "optional": None,
+                                            "min_count": None,
+                                        },
+                                    }
+                                },
+                                "removed": {},
+                            },
+                            "human_friendly_id": None,
+                            "uniqueness_constraints": None,
+                        },
+                        "removed": {},
+                    },
+                },
+                "removed": {},
+            },
+        }
+
+    async def test_step03_load_unique_fields(
+        self, db: InfrahubDatabase, branch_1: Branch, client: InfrahubClient, initial_dataset, schema_step_03
+    ):
+        # Load the new schema and apply the migrations
+        response = await client.schema.load(schemas=[schema_step_03], branch=branch_1.name)
+        assert not response.errors
+
+        # Check if the branch has been properly updated
+        branches = await client.branch.all()
+        assert branches[branch_1.name].has_schema_changes is True
+
+        # Check schema properties
+        schema_branch = await registry.schema.load_schema_from_db(db=db, branch=branch_1)
+        updated_person_schema = schema_branch.get(name=PERSON_KIND)
+        assert updated_person_schema.uniqueness_constraints
+        unique_constraint_sets = frozenset(tuple(uc) for uc in updated_person_schema.uniqueness_constraints)
+        assert unique_constraint_sets == frozenset(
+            [
+                ("name__value", "height__value"),
+                ("name__value",),
+                ("tax_id__value",),
+                ("name__value", "tax_id__value", "best_friend"),
+            ]
+        )
+        assert updated_person_schema.human_friendly_id == ["name__value", "tax_id__value", "best_friend__name__value"]
+        assert updated_person_schema.display_labels == ["name__value", "tax_id__value", "height__value"]
+        assert updated_person_schema.order_by == ["name__value", "height__value"]
+
+    async def test_step04_check_rename_name(
+        self, db: InfrahubDatabase, branch_1: Branch, client: InfrahubClient, initial_dataset, schema_step_04
+    ):
+        person_schema = registry.schema.get_node_schema(name=PERSON_KIND, branch=branch_1)
+        attr = person_schema.get_attribute(name="name")
+
+        # Insert the ID of the attribute name into the schema in order to rename it
+        for attr_dict in schema_step_04["nodes"][0]["attributes"]:
+            if attr_dict["name"] == "real_name":
+                attr_dict["id"] = attr.id
+
+        success, response = await client.schema.check(schemas=[schema_step_04], branch=branch_1.name)
+        assert success, response.get("errors") if response else None
+        assert response == {
+            "diff": {
+                "added": {},
+                "changed": {
+                    "TestingPerson": {
+                        "added": {},
+                        "changed": {
+                            "attributes": {
+                                "added": {"real_name": None},
+                                "changed": {
+                                    "name": {
+                                        "added": {},
+                                        "removed": {},
+                                        "changed": {
+                                            "name": None,
+                                        },
+                                    }
+                                },
+                                "removed": {},
+                            },
+                            "human_friendly_id": None,
+                            "uniqueness_constraints": None,
+                            "display_labels": None,
+                            "order_by": None,
+                        },
+                        "removed": {},
+                    },
+                },
+                "removed": {},
+            },
+        }
+
+
+# rename original unique fields
+# delete original unique fields
+
+# TODO: generics?

--- a/backend/tests/integration/schema_lifecycle/test_unique_field_updates.py
+++ b/backend/tests/integration/schema_lifecycle/test_unique_field_updates.py
@@ -161,6 +161,16 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
         return updated_schema
 
     @pytest.fixture(scope="class")
+    def schema_person_06_delete_unique_generic_field(
+        self, schema_person_05_delete_original_unique_fields
+    ) -> dict[str, Any]:
+        """Update the human friendly ID to remove the deleted unique_attr field"""
+        updated_schema = {**schema_person_05_delete_original_unique_fields}
+        # has to be updated manually
+        updated_schema["human_friendly_id"] = ["tax_id__value"]
+        return updated_schema
+
+    @pytest.fixture(scope="class")
     def schema_step_01(
         self,
         schema_generic_01,
@@ -204,9 +214,12 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
         }
 
     @pytest.fixture(scope="class")
-    def schema_step_06(self, schema_generic_06_delete_unique_field) -> dict[str, Any]:
+    def schema_step_06(
+        self, schema_person_06_delete_unique_generic_field, schema_generic_06_delete_unique_field
+    ) -> dict[str, Any]:
         return {
             "version": "1.0",
+            "nodes": [schema_person_06_delete_unique_generic_field],
             "generics": [schema_generic_06_delete_unique_field],
         }
 
@@ -356,7 +369,6 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
                 ("name__value",),
                 ("tax_id__value",),
                 ("name__value", "tax_id__value", "best_friend"),
-                ("unique_attr__value",),
             ]
         )
         assert updated_person_schema.human_friendly_id == [
@@ -438,7 +450,6 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
                 ("real_name__value",),
                 ("tax_id__value",),
                 ("real_name__value", "tax_id__value", "best_friend"),
-                ("unique_attr__value",),
             ]
         )
         assert updated_person_schema.human_friendly_id == [
@@ -503,7 +514,6 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
                 ("height__value",),
                 ("tax_id__value",),
                 ("tax_id__value", "best_friend"),
-                ("unique_attr__value",),
             ]
         )
         assert updated_person_schema.human_friendly_id == [
@@ -544,7 +554,8 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
                                     "unique_attr": {"added": {}, "changed": {"state": None}, "removed": {}},
                                 },
                                 "removed": {},
-                            }
+                            },
+                            "human_friendly_id": None,
                         },
                         "removed": {},
                     },
@@ -577,7 +588,6 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
         )
         assert updated_person_schema.human_friendly_id == [
             "tax_id__value",
-            "best_friend__unique_attr__value",
         ]
         assert updated_person_schema.display_labels == ["tax_id__value", "height__value"]
         assert updated_person_schema.order_by == ["height__value"]

--- a/backend/tests/integration/schema_lifecycle/test_unique_field_updates.py
+++ b/backend/tests/integration/schema_lifecycle/test_unique_field_updates.py
@@ -26,13 +26,13 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
         return await create_branch(db=db, branch_name="branch1")
 
     @pytest.fixture(scope="class")
-    async def initial_dataset(self, db: InfrahubDatabase, initialize_registry, schema_step01):
-        await load_schema(db=db, schema=schema_step01)
+    async def initial_dataset(self, db: InfrahubDatabase, initialize_registry, schema_step_01):
+        await load_schema(db=db, schema=schema_step_01)
 
-        john = await create_and_save(db=db, schema=PERSON_KIND, name="John", height=175)
-        jane = await create_and_save(db=db, schema=PERSON_KIND, name="Jane", height=195)
+        john = await create_and_save(db=db, schema=PERSON_KIND, name="John", unique_attr="abc", height=175)
+        jane = await create_and_save(db=db, schema=PERSON_KIND, name="Jane", unique_attr="def", height=195)
         deleted_bob = await create_and_save(
-            db=db, schema=PERSON_KIND, name="Deleted Bob", height=175, description="He's not here"
+            db=db, schema=PERSON_KIND, name="Deleted Bob", unique_attr="ghi", height=175, description="He's not here"
         )
         await deleted_bob.delete(db=db)
         renault = await create_and_save(
@@ -75,6 +75,22 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
         return objs
 
     @pytest.fixture(scope="class")
+    def schema_generic_01(self) -> dict[str, Any]:
+        return {
+            "name": "Thing",
+            "namespace": "Testing",
+            "include_in_menu": True,
+            "attributes": [
+                {"name": "unique_attr", "kind": "Text", "unique": True},
+            ],
+        }
+
+    @pytest.fixture(scope="class")
+    def schema_person_base_with_generic(self, schema_person_base: dict[str, Any]) -> dict[str, Any]:
+        schema_person_base["inherit_from"] = ["TestingThing"]
+        return schema_person_base
+
+    @pytest.fixture(scope="class")
     def schema_person_02_more_fields(self, schema_person_base) -> dict[str, Any]:
         """Add a new attribute and a new relationship"""
         updated_schema = {**schema_person_base}
@@ -100,7 +116,7 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
         for rel in updated_schema["relationships"]:
             if rel["name"] == "best_friend":
                 rel["optional"] = False
-        updated_schema["human_friendly_id"] = ["name__value", "tax_id__value", "best_friend__name__value"]
+        updated_schema["human_friendly_id"] = ["name__value", "tax_id__value", "best_friend__unique_attr__value"]
         return updated_schema
 
     @pytest.fixture(scope="class")
@@ -115,6 +131,49 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
         updated_schema.pop("order_by", None)
         updated_schema.pop("display_labels", None)
         return updated_schema
+
+    @pytest.fixture(scope="class")
+    def schema_person_05_delete_original_unique_fields(
+        self, schema_person_04_rename_original_unique_fields
+    ) -> dict[str, Any]:
+        """Delete the name attribute"""
+        updated_schema = {**schema_person_04_rename_original_unique_fields}
+        for attr in updated_schema["attributes"]:
+            if attr["name"] == "real_name":
+                attr["state"] = "absent"
+        updated_schema.pop("human_friendly_id", None)
+        updated_schema.pop("uniqueness_constraints", None)
+        updated_schema.pop("order_by", None)
+        updated_schema.pop("display_labels", None)
+        return updated_schema
+
+    @pytest.fixture(scope="class")
+    def schema_generic_06_delete_unique_field(self, schema_generic_01) -> dict[str, Any]:
+        """Delete the unique attribute"""
+        updated_schema = {**schema_generic_01}
+        for attr in updated_schema["attributes"]:
+            if attr["name"] == "unique_attr":
+                attr["state"] = "absent"
+        updated_schema.pop("human_friendly_id", None)
+        updated_schema.pop("uniqueness_constraints", None)
+        updated_schema.pop("order_by", None)
+        updated_schema.pop("display_labels", None)
+        return updated_schema
+
+    @pytest.fixture(scope="class")
+    def schema_step_01(
+        self,
+        schema_generic_01,
+        schema_car_base,
+        schema_person_base_with_generic,
+        schema_manufacturer_base,
+        schema_tag_base,
+    ) -> dict[str, Any]:
+        return {
+            "version": "1.0",
+            "generics": [schema_generic_01],
+            "nodes": [schema_person_base_with_generic, schema_car_base, schema_manufacturer_base, schema_tag_base],
+        }
 
     @pytest.fixture(scope="class")
     def schema_step_02(self, schema_person_02_more_fields) -> dict[str, Any]:
@@ -137,7 +196,29 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
             "nodes": [schema_person_04_rename_original_unique_fields],
         }
 
+    @pytest.fixture(scope="class")
+    def schema_step_05(self, schema_person_05_delete_original_unique_fields) -> dict[str, Any]:
+        return {
+            "version": "1.0",
+            "nodes": [schema_person_05_delete_original_unique_fields],
+        }
+
+    @pytest.fixture(scope="class")
+    def schema_step_06(self, schema_generic_06_delete_unique_field) -> dict[str, Any]:
+        return {
+            "version": "1.0",
+            "generics": [schema_generic_06_delete_unique_field],
+        }
+
     async def test_step01_baseline_backend(self, db: InfrahubDatabase, initial_dataset, branch_1: Branch):
+        # Check schema properties
+        schema_branch = await registry.schema.load_schema_from_db(db=db, branch=branch_1)
+        # check that unique attribute is correctly synced to uniqueness constraints
+        person_schema = schema_branch.get(name=PERSON_KIND)
+        assert person_schema.uniqueness_constraints == [["name__value"]]
+        generic_schema = schema_branch.get(name="TestingThing")
+        assert generic_schema.uniqueness_constraints == [["unique_attr__value"]]
+
         persons = await registry.manager.query(db=db, schema=PERSON_KIND, branch=branch_1.name)
         assert len(persons) == 2
 
@@ -275,9 +356,14 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
                 ("name__value",),
                 ("tax_id__value",),
                 ("name__value", "tax_id__value", "best_friend"),
+                ("unique_attr__value",),
             ]
         )
-        assert updated_person_schema.human_friendly_id == ["name__value", "tax_id__value", "best_friend__name__value"]
+        assert updated_person_schema.human_friendly_id == [
+            "name__value",
+            "tax_id__value",
+            "best_friend__unique_attr__value",
+        ]
         assert updated_person_schema.display_labels == ["name__value", "tax_id__value", "height__value"]
         assert updated_person_schema.order_by == ["name__value", "height__value"]
 
@@ -302,9 +388,9 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
                         "added": {},
                         "changed": {
                             "attributes": {
-                                "added": {"real_name": None},
+                                "added": {},
                                 "changed": {
-                                    "name": {
+                                    "real_name": {
                                         "added": {},
                                         "removed": {},
                                         "changed": {
@@ -326,8 +412,172 @@ class TestSchemaLifecycleAttributeBranch(TestSchemaLifecycleBase):
             },
         }
 
+    async def test_step04_load_renamed_fields(
+        self, db: InfrahubDatabase, branch_1: Branch, client: InfrahubClient, initial_dataset, schema_step_04
+    ):
+        person_schema = registry.schema.get_node_schema(name=PERSON_KIND, branch=branch_1)
+        attr = person_schema.get_attribute(name="name")
 
-# rename original unique fields
-# delete original unique fields
+        # Insert the ID of the attribute name into the schema in order to rename it
+        for attr_dict in schema_step_04["nodes"][0]["attributes"]:
+            if attr_dict["name"] == "real_name":
+                attr_dict["id"] = attr.id
 
-# TODO: generics?
+        # Load the new schema and apply the migrations
+        response = await client.schema.load(schemas=[schema_step_04], branch=branch_1.name)
+        assert not response.errors
+
+        # Check schema properties
+        schema_branch = await registry.schema.load_schema_from_db(db=db, branch=branch_1)
+        updated_person_schema = schema_branch.get(name=PERSON_KIND)
+        assert updated_person_schema.uniqueness_constraints
+        unique_constraint_sets = frozenset(tuple(uc) for uc in updated_person_schema.uniqueness_constraints)
+        assert unique_constraint_sets == frozenset(
+            [
+                ("real_name__value", "height__value"),
+                ("real_name__value",),
+                ("tax_id__value",),
+                ("real_name__value", "tax_id__value", "best_friend"),
+                ("unique_attr__value",),
+            ]
+        )
+        assert updated_person_schema.human_friendly_id == [
+            "real_name__value",
+            "tax_id__value",
+            "best_friend__unique_attr__value",
+        ]
+        assert updated_person_schema.display_labels == ["real_name__value", "tax_id__value", "height__value"]
+        assert updated_person_schema.order_by == ["real_name__value", "height__value"]
+
+    async def test_step05_check_remove_original_unique(
+        self, db: InfrahubDatabase, branch_1: Branch, client: InfrahubClient, initial_dataset, schema_step_05
+    ):
+        success, response = await client.schema.check(schemas=[schema_step_05], branch=branch_1.name)
+        assert success, response.get("errors") if response else None
+        assert response == {
+            "diff": {
+                "added": {},
+                "changed": {
+                    "TestingPerson": {
+                        "added": {},
+                        "changed": {
+                            "attributes": {
+                                "added": {},
+                                "changed": {
+                                    # b/c there is now a uniqueness_constraint that is just height__value,
+                                    # so the height attribute is automatically set to unique as well
+                                    "height": {
+                                        "added": {},
+                                        "changed": {"unique": None},
+                                        "removed": {},
+                                    }
+                                },
+                                "removed": {"real_name": None},
+                            },
+                            "human_friendly_id": None,
+                            "uniqueness_constraints": None,
+                            "display_labels": None,
+                            "order_by": None,
+                        },
+                        "removed": {},
+                    },
+                },
+                "removed": {},
+            },
+        }
+
+    async def test_step05_load_remove_original_unique(
+        self, db: InfrahubDatabase, branch_1: Branch, client: InfrahubClient, initial_dataset, schema_step_05
+    ):
+        # Load the new schema and apply the migrations
+        response = await client.schema.load(schemas=[schema_step_05], branch=branch_1.name)
+        assert not response.errors
+
+        # Check schema properties
+        schema_branch = await registry.schema.load_schema_from_db(db=db, branch=branch_1)
+        updated_person_schema = schema_branch.get(name=PERSON_KIND)
+        assert updated_person_schema.uniqueness_constraints
+        unique_constraint_sets = frozenset(tuple(uc) for uc in updated_person_schema.uniqueness_constraints)
+        assert unique_constraint_sets == frozenset(
+            [
+                ("height__value",),
+                ("tax_id__value",),
+                ("tax_id__value", "best_friend"),
+                ("unique_attr__value",),
+            ]
+        )
+        assert updated_person_schema.human_friendly_id == [
+            "tax_id__value",
+            "best_friend__unique_attr__value",
+        ]
+        assert updated_person_schema.display_labels == ["tax_id__value", "height__value"]
+        assert updated_person_schema.order_by == ["height__value"]
+
+    async def test_step06_check_remove_unique_attr_from_generic(
+        self, db: InfrahubDatabase, branch_1: Branch, client: InfrahubClient, initial_dataset, schema_step_06
+    ):
+        success, response = await client.schema.check(schemas=[schema_step_06], branch=branch_1.name)
+        assert success, response.get("errors") if response else None
+        assert response == {
+            "diff": {
+                "added": {},
+                "changed": {
+                    "TestingThing": {
+                        "added": {},
+                        "changed": {
+                            "attributes": {
+                                "added": {},
+                                "changed": {},
+                                "removed": {"unique_attr": None},
+                            },
+                            "human_friendly_id": None,
+                            "uniqueness_constraints": None,
+                        },
+                        "removed": {},
+                    },
+                    "TestingPerson": {
+                        "added": {},
+                        "changed": {
+                            "attributes": {
+                                "added": {},
+                                "changed": {
+                                    "unique_attr": {"added": {}, "changed": {"state": None}, "removed": {}},
+                                },
+                                "removed": {},
+                            }
+                        },
+                        "removed": {},
+                    },
+                },
+                "removed": {},
+            },
+        }
+
+    async def test_step06_load_remove_unique_attr_from_generic(
+        self, db: InfrahubDatabase, branch_1: Branch, client: InfrahubClient, initial_dataset, schema_step_06
+    ):
+        # Load the new schema and apply the migrations
+        response = await client.schema.load(schemas=[schema_step_06], branch=branch_1.name)
+        assert not response.errors
+
+        # Check schema properties
+        schema_branch = await registry.schema.load_schema_from_db(db=db, branch=branch_1)
+        updated_generic_schema = schema_branch.get(name="TestingThing")
+        assert not updated_generic_schema.uniqueness_constraints
+
+        updated_person_schema = schema_branch.get(name=PERSON_KIND)
+        assert updated_person_schema.uniqueness_constraints
+        unique_constraint_sets = frozenset(tuple(uc) for uc in updated_person_schema.uniqueness_constraints)
+        assert unique_constraint_sets == frozenset(
+            [
+                ("height__value",),
+                ("tax_id__value",),
+                ("tax_id__value", "best_friend"),
+            ]
+        )
+        assert updated_person_schema.human_friendly_id == [
+            "tax_id__value",
+            "best_friend__unique_attr__value",
+        ]
+        assert updated_person_schema.display_labels == ["tax_id__value", "height__value"]
+        assert updated_person_schema.order_by == ["height__value"]

--- a/backend/tests/unit/core/node/test_node_field_name_update.py
+++ b/backend/tests/unit/core/node/test_node_field_name_update.py
@@ -1,0 +1,124 @@
+from uuid import uuid4
+
+import pytest
+
+from infrahub.core.schema.attribute_schema import AttributeSchema
+from infrahub.core.schema.basenode_schema import BaseNodeSchema
+
+
+class TestNodeUpdate:
+    @pytest.fixture
+    def original_node_schema(self) -> BaseNodeSchema:
+        return BaseNodeSchema(
+            namespace="Shnamespace",
+            name="Shname",
+        )
+
+    @pytest.fixture
+    def new_node_schema(self) -> BaseNodeSchema:
+        return BaseNodeSchema(
+            namespace="Shnamespace",
+            name="Shname",
+        )
+
+    def test_no_fields_update(self, original_node_schema: BaseNodeSchema, new_node_schema: BaseNodeSchema):
+        original_node_schema.update(other=new_node_schema)
+
+        assert original_node_schema.uniqueness_constraints is None
+        assert original_node_schema.human_friendly_id is None
+        assert original_node_schema.display_labels is None
+        assert original_node_schema.order_by is None
+
+    def test_new_fields_update(self, original_node_schema: BaseNodeSchema, new_node_schema: BaseNodeSchema):
+        new_node_schema.uniqueness_constraints = [["abc__value"]]
+        new_node_schema.human_friendly_id = ["abc__value"]
+        new_node_schema.display_labels = ["abc__value"]
+        new_node_schema.order_by = ["abc__value"]
+
+        original_node_schema.update(other=new_node_schema)
+
+        assert original_node_schema.uniqueness_constraints == new_node_schema.uniqueness_constraints
+        assert original_node_schema.human_friendly_id == new_node_schema.human_friendly_id
+        assert original_node_schema.display_labels == new_node_schema.display_labels
+        assert original_node_schema.order_by == new_node_schema.order_by
+
+    def test_old_fields_no_update(self, original_node_schema: BaseNodeSchema, new_node_schema: BaseNodeSchema):
+        original_node_schema.attributes = [AttributeSchema(name="abc", kind="Text")]
+        uniqueness_constraints = [["abc__value"]]
+        human_friendly_id = ["abc__value"]
+        display_labels = ["abc__value"]
+        order_by = ["abc__value"]
+        original_node_schema.uniqueness_constraints = uniqueness_constraints
+        original_node_schema.human_friendly_id = human_friendly_id
+        original_node_schema.display_labels = display_labels
+        original_node_schema.order_by = order_by
+
+        original_node_schema.update(other=new_node_schema)
+
+        assert original_node_schema.uniqueness_constraints == uniqueness_constraints
+        assert original_node_schema.human_friendly_id == human_friendly_id
+        assert original_node_schema.display_labels == display_labels
+        assert original_node_schema.order_by == order_by
+
+    @pytest.mark.parametrize(
+        ["uniqueness_constraints", "human_friendly_id", "display_labels", "order_by"],
+        [(None, None, None, None), ([["def__value"]], ["def__value"], ["def__value"], ["def__value"])],
+    )
+    def test_old_fields_with_update(
+        self,
+        original_node_schema: BaseNodeSchema,
+        new_node_schema: BaseNodeSchema,
+        uniqueness_constraints,
+        human_friendly_id,
+        display_labels,
+        order_by,
+    ):
+        original_node_schema.attributes = [AttributeSchema(name="abc", kind="Text")]
+        original_node_schema.uniqueness_constraints = [["abc__value"]]
+        original_node_schema.human_friendly_id = ["abc__value"]
+        original_node_schema.display_labels = ["abc__value"]
+        original_node_schema.order_by = ["abc__value"]
+        original_uniqueness_constraints = original_node_schema.uniqueness_constraints
+        original_human_friendly_id = original_node_schema.human_friendly_id
+        original_display_labels = original_node_schema.display_labels
+        original_order_by = original_node_schema.order_by
+        new_node_schema.uniqueness_constraints = uniqueness_constraints
+        new_node_schema.human_friendly_id = human_friendly_id
+        new_node_schema.display_labels = display_labels
+        new_node_schema.order_by = order_by
+
+        original_node_schema.update(other=new_node_schema)
+
+        assert original_node_schema.uniqueness_constraints == uniqueness_constraints or original_uniqueness_constraints
+        assert original_node_schema.human_friendly_id == human_friendly_id or original_human_friendly_id
+        assert original_node_schema.display_labels == display_labels or original_display_labels
+        assert original_node_schema.order_by == order_by or original_order_by
+
+    def test_old_fields_with_updated_name(
+        self,
+        original_node_schema: BaseNodeSchema,
+        new_node_schema: BaseNodeSchema,
+    ):
+        attribute_id = str(uuid4())
+        original_node_schema.attributes = [AttributeSchema(id=attribute_id, name="abc", kind="Text")]
+        original_node_schema.uniqueness_constraints = [["abc__value"]]
+        original_node_schema.human_friendly_id = ["abc__value"]
+        original_node_schema.display_labels = ["abc__value"]
+        original_node_schema.order_by = ["abc__value"]
+        new_node_schema.attributes = [AttributeSchema(id=attribute_id, name="def", kind="Text")]
+        new_node_schema.uniqueness_constraints = None
+        new_node_schema.human_friendly_id = None
+        new_node_schema.display_labels = None
+        new_node_schema.order_by = None
+
+        original_node_schema.update(other=new_node_schema)
+
+        assert original_node_schema.uniqueness_constraints == [["def__value"]]
+        assert original_node_schema.human_friendly_id == ["def__value"]
+        assert original_node_schema.display_labels == ["def__value"]
+        assert original_node_schema.order_by == ["def__value"]
+
+
+# TODO: test updating rel
+# TODO: test deleting attr
+# TODO: test deleting rel

--- a/backend/tests/unit/core/node/test_node_field_name_update.py
+++ b/backend/tests/unit/core/node/test_node_field_name_update.py
@@ -2,8 +2,10 @@ from uuid import uuid4
 
 import pytest
 
+from infrahub.core.constants import HashableModelState
 from infrahub.core.schema.attribute_schema import AttributeSchema
 from infrahub.core.schema.basenode_schema import BaseNodeSchema
+from infrahub.core.schema.relationship_schema import RelationshipSchema
 
 
 class TestNodeUpdate:
@@ -74,10 +76,11 @@ class TestNodeUpdate:
         order_by,
     ):
         original_node_schema.attributes = [AttributeSchema(name="abc", kind="Text")]
+        original_node_schema.relationships = [RelationshipSchema(name="xyz", peer="TestingXyz")]
         original_node_schema.uniqueness_constraints = [["abc__value"]]
-        original_node_schema.human_friendly_id = ["abc__value"]
+        original_node_schema.human_friendly_id = ["xyz__color__value"]
         original_node_schema.display_labels = ["abc__value"]
-        original_node_schema.order_by = ["abc__value"]
+        original_node_schema.order_by = ["xyz__color__value"]
         original_uniqueness_constraints = original_node_schema.uniqueness_constraints
         original_human_friendly_id = original_node_schema.human_friendly_id
         original_display_labels = original_node_schema.display_labels
@@ -100,12 +103,15 @@ class TestNodeUpdate:
         new_node_schema: BaseNodeSchema,
     ):
         attribute_id = str(uuid4())
+        relationship_id = str(uuid4())
         original_node_schema.attributes = [AttributeSchema(id=attribute_id, name="abc", kind="Text")]
-        original_node_schema.uniqueness_constraints = [["abc__value"]]
-        original_node_schema.human_friendly_id = ["abc__value"]
-        original_node_schema.display_labels = ["abc__value"]
-        original_node_schema.order_by = ["abc__value"]
+        original_node_schema.relationships = [RelationshipSchema(id=relationship_id, name="xyz", peer="TestingXyz")]
+        original_node_schema.uniqueness_constraints = [["abc__value"], ["xyz__name__value"]]
+        original_node_schema.human_friendly_id = ["xyz__color__value"]
+        original_node_schema.display_labels = ["abc__value", "xyz__height__value"]
+        original_node_schema.order_by = ["xyz__name__value", "jkl__value"]
         new_node_schema.attributes = [AttributeSchema(id=attribute_id, name="def", kind="Text")]
+        new_node_schema.relationships = [RelationshipSchema(id=relationship_id, name="qrs", peer="TestingQrs")]
         new_node_schema.uniqueness_constraints = None
         new_node_schema.human_friendly_id = None
         new_node_schema.display_labels = None
@@ -113,12 +119,38 @@ class TestNodeUpdate:
 
         original_node_schema.update(other=new_node_schema)
 
-        assert original_node_schema.uniqueness_constraints == [["def__value"]]
-        assert original_node_schema.human_friendly_id == ["def__value"]
-        assert original_node_schema.display_labels == ["def__value"]
-        assert original_node_schema.order_by == ["def__value"]
+        assert original_node_schema.uniqueness_constraints == [["def__value"], ["qrs__name__value"]]
+        assert original_node_schema.human_friendly_id == ["qrs__color__value"]
+        assert original_node_schema.display_labels == ["def__value", "qrs__height__value"]
+        assert original_node_schema.order_by == ["qrs__name__value", "jkl__value"]
 
+    def test_deleting_fields(
+        self,
+        original_node_schema: BaseNodeSchema,
+        new_node_schema: BaseNodeSchema,
+    ):
+        attribute_id = str(uuid4())
+        relationship_id = str(uuid4())
+        original_node_schema.attributes = [AttributeSchema(id=attribute_id, name="abc", kind="Text")]
+        original_node_schema.relationships = [RelationshipSchema(id=relationship_id, name="xyz", peer="TestingXyz")]
+        original_node_schema.uniqueness_constraints = [["abc__value"], ["xyz__name__value"]]
+        original_node_schema.human_friendly_id = ["xyz__color__value"]
+        original_node_schema.display_labels = ["abc__value", "xyz__height__value"]
+        original_node_schema.order_by = ["xyz__name__value", "jkl__value"]
+        new_node_schema.attributes = [
+            AttributeSchema(id=attribute_id, state=HashableModelState.ABSENT, name="abc", kind="Text")
+        ]
+        new_node_schema.relationships = [
+            RelationshipSchema(id=relationship_id, state=HashableModelState.ABSENT, name="xyz", peer="TestingXyz")
+        ]
+        new_node_schema.uniqueness_constraints = None
+        new_node_schema.human_friendly_id = None
+        new_node_schema.display_labels = None
+        new_node_schema.order_by = None
 
-# TODO: test updating rel
-# TODO: test deleting attr
-# TODO: test deleting rel
+        original_node_schema.update(other=new_node_schema)
+
+        assert original_node_schema.uniqueness_constraints == []
+        assert original_node_schema.human_friendly_id == []
+        assert original_node_schema.display_labels == []
+        assert original_node_schema.order_by == ["jkl__value"]

--- a/backend/tests/unit/core/schema/schema_branch/test_schema_hfid.py
+++ b/backend/tests/unit/core/schema/schema_branch/test_schema_hfid.py
@@ -94,7 +94,8 @@ async def test_schema_constraints(human_friendly_id, uniqueness_constraints, sho
 
     if should_raise:
         with pytest.raises(
-            ValidationError, match=r"HFID of TestCar refers peer TestPerson with a non-unique combination of attributes"
+            ValidationError,
+            match=r"HFID of TestCar refers to peer TestPerson with a non-unique combination of attributes",
         ):
             schema_branch.load_schema(schema=schema_root)
             schema_branch.process()

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -1034,13 +1034,14 @@ async def test_validate_uniqueness_constraints_success(schema_all_in_one, unique
     ["uniqueness_constraints", "unique_attributes", "expected_constraints", "expected_unique_attributes"],
     [
         (None, [], None, []),
-        (None, ["name"], [["name__value"]], ["name"]),
+        # name is on the generic and we don't add inherited unique attribute to the uniqueness constraints
+        (None, ["name"], None, ["name"]),
         ([["name__value"]], ["name"], [["name__value"]], ["name"]),
         ([["name__value"]], [], [["name__value"]], ["name"]),
         ([["name__value"]], ["breed"], [["name__value"], ["breed__value"]], ["name", "breed"]),
         ([["name__value", "owner"]], ["breed"], [["name__value", "owner"], ["breed__value"]], ["breed"]),
-        ([["owner"]], ["name"], [["owner"], ["name__value"]], ["name"]),
-        (None, ["name", "color"], [["color__value"], ["name__value"]], ["name", "color"]),
+        ([["owner"]], ["name"], [["owner"]], ["name"]),
+        (None, ["name", "color"], [["color__value"]], ["name", "color"]),
         ([["color__value"], ["name__value"]], [], [["color__value"], ["name__value"]], ["name", "color"]),
     ],
 )

--- a/changelog/6147.fixed.md
+++ b/changelog/6147.fixed.md
@@ -1,0 +1,1 @@
+Fix bug that could prevent renaming a unique attribute on a schema


### PR DESCRIPTION
fixes #6147

if you load a schema that includes a unique attribute (let's assume it is called `name`), we automatically add that unique attribute to the uniqueness constraints of the schema (ie `[["name__value"]]`) and, if there is no human friendly ID, we also might use the unique attribute as a human_friendly_id

if you then try to rename the unique attribute from above, you would get an error. something like `Requested unique constraint not found within node. (name__value)`. it is possible to resolve on your own by updating the uniqueness_constraints or human_friendly_id within the schema you are trying to load, but the error message doesn't really explain this.

If we are going to make automatic updates to `uniqueness_constraints` and `human_friendly_id` when a schema is loaded or updated, then we should also make the complementary automatic updates when an attribute is removed or renamed.

