### PR TITLE
Switch order weights in action schema

### DIFF
--- a/backend/infrahub/actions/schema.py
+++ b/backend/infrahub/actions/schema.py
@@ -28,14 +28,14 @@ core_trigger_rule = GenericSchema(
             kind="Text",
             description="The name of the trigger rule",
             unique=True,
-            order_weight=1000,
+            order_weight=100,
         ),
         Attr(
             name="description",
             kind="Text",
             description="A longer description to define the purpose of this trigger",
             optional=True,
-            order_weight=2000,
+            order_weight=200,
         ),
         Attr(
             name="active",
@@ -43,7 +43,7 @@ core_trigger_rule = GenericSchema(
             description="Indicates if this trigger is enabled or if it's just prepared, could be useful as you are setting up a trigger",
             optional=False,
             default_value=True,
-            order_weight=2000,
+            order_weight=200,
         ),
         Attr(
             name="branch_scope",
@@ -52,7 +52,7 @@ core_trigger_rule = GenericSchema(
             choices=BranchScope.available_types(),
             default_value=BranchScope.DEFAULT_BRANCH.value.name,
             optional=False,
-            order_weight=2000,
+            order_weight=200,
             allow_override=AllowOverrideType.NONE,
         ),
     ],
@@ -65,7 +65,7 @@ core_trigger_rule = GenericSchema(
             kind=RelKind.ATTRIBUTE,
             cardinality=Cardinality.ONE,
             optional=False,
-            order_weight=10000,
+            order_weight=1000,
         ),
     ],
 )
@@ -89,14 +89,14 @@ core_action = GenericSchema(
             description="Short descriptive name",
             kind="Text",
             unique=True,
-            order_weight=1000,
+            order_weight=100,
         ),
         Attr(
             name="description",
             description="A detailed description of the action",
             kind="Text",
             optional=True,
-            order_weight=2000,
+            order_weight=200,
         ),
     ],
     relationships=[
@@ -108,7 +108,7 @@ core_action = GenericSchema(
             cardinality=Cardinality.MANY,
             identifier="core_action__core_triggerrule",
             optional=True,
-            order_weight=10000,
+            order_weight=1000,
         ),
     ],
 )
@@ -132,7 +132,7 @@ core_node_trigger_match = GenericSchema(
             cardinality=Cardinality.ONE,
             optional=False,
             identifier="core_node_trigger_match__core_trigger_rule",
-            order_weight=10000,
+            order_weight=1000,
         ),
     ],
 )
@@ -161,7 +161,7 @@ core_generator_action = NodeSchema(
             cardinality=Cardinality.ONE,
             identifier="core_generator_action__generator_definition",
             optional=False,
-            order_weight=4000,
+            order_weight=400,
         ),
     ],
 )
@@ -188,7 +188,7 @@ core_group_action = NodeSchema(
             unique=False,
             optional=False,
             default_value=True,
-            order_weight=3000,
+            order_weight=300,
         ),
     ],
     relationships=[
@@ -200,7 +200,7 @@ core_group_action = NodeSchema(
             cardinality=Cardinality.ONE,
             identifier="core_action__group",
             optional=False,
-            order_weight=4000,
+            order_weight=400,
         ),
     ],
 )
@@ -227,7 +227,7 @@ core_node_trigger_rule = NodeSchema(
             description="The kind of node to match against",
             unique=False,
             optional=False,
-            order_weight=3000,
+            order_weight=300,
         ),
         Attr(
             name="mutation_action",
@@ -236,7 +236,7 @@ core_node_trigger_rule = NodeSchema(
             enum=NodeAction.available_types(),
             unique=False,
             optional=False,
-            order_weight=4000,
+            order_weight=400,
         ),
     ],
     relationships=[
@@ -248,7 +248,7 @@ core_node_trigger_rule = NodeSchema(
             cardinality=Cardinality.MANY,
             optional=True,
             identifier="core_node_trigger_match__core_trigger_rule",
-            order_weight=8000,
+            order_weight=800,
         ),
     ],
 )
@@ -270,7 +270,7 @@ core_node_trigger_attribute_match = NodeSchema(
             description="The attribue to match against",
             unique=False,
             optional=False,
-            order_weight=1000,
+            order_weight=100,
         ),
         Attr(
             name="value",
@@ -278,7 +278,7 @@ core_node_trigger_attribute_match = NodeSchema(
             description="The value the attribute is updated to",
             unique=False,
             optional=True,
-            order_weight=2000,
+            order_weight=200,
         ),
         Attr(
             name="value_previous",
@@ -286,7 +286,7 @@ core_node_trigger_attribute_match = NodeSchema(
             description="The previous value of the targeted attribute",
             unique=False,
             optional=True,
-            order_weight=3000,
+            order_weight=300,
         ),
         Attr(
             name="value_match",
@@ -295,7 +295,7 @@ core_node_trigger_attribute_match = NodeSchema(
             choices=ValueMatch.available_types(),
             default_value=ValueMatch.VALUE.value.name,
             optional=False,
-            order_weight=5000,
+            order_weight=500,
         ),
     ],
     relationships=[],
@@ -318,7 +318,7 @@ core_node_trigger_relationship_match = NodeSchema(
             description="The name of the relationship to match against",
             unique=False,
             optional=False,
-            order_weight=1000,
+            order_weight=100,
         ),
         Attr(
             name="added",
@@ -327,7 +327,7 @@ core_node_trigger_relationship_match = NodeSchema(
             unique=False,
             optional=False,
             default_value=True,
-            order_weight=2000,
+            order_weight=200,
         ),
         Attr(
             name="peer",
@@ -335,7 +335,7 @@ core_node_trigger_relationship_match = NodeSchema(
             description="The node_id of the relationship peer to match against",
             unique=False,
             optional=True,
-            order_weight=3000,
+            order_weight=300,
         ),
     ],
     relationships=[],
@@ -364,7 +364,7 @@ core_group_trigger_rule = NodeSchema(
             unique=False,
             optional=False,
             default_value=True,
-            order_weight=3000,
+            order_weight=300,
         ),
     ],
     relationships=[
@@ -376,7 +376,7 @@ core_group_trigger_rule = NodeSchema(
             cardinality=Cardinality.ONE,
             identifier="core_group_trigger__group",
             optional=False,
-            order_weight=4000,
+            order_weight=400,
         ),
     ],
 )


### PR DESCRIPTION
Lowering the order_weight within the action schemas to avoid having "member of groups" show up in between other entries.

Before:

![Screenshot 2025-06-03 at 09 06 31](https://github.com/user-attachments/assets/718558ed-393f-4706-afee-b98a27a181ee)


After:

![Screenshot 2025-06-03 at 09 12 02](https://github.com/user-attachments/assets/f2b3ebf5-8191-4e6b-96d7-c06c21a45003)


