### PR TITLE
make the assertion errors in db_snapshot.py more verbose in pytest

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -65,6 +65,8 @@ from tests.helpers.utils import get_exposed_port, start_neo4j_container, start_p
 ResponseClass = TypeVar("ResponseClass")
 DEFAULT_TESTING_LOG_LEVEL = "WARNING"
 
+pytest.register_assert_rewrite("tests.db_snapshot")
+
 
 def pytest_addoption(parser):
     parser.addoption("--neo4j", action="store_true", dest="neo4j", default=False, help="enable neo4j tests")


### PR DESCRIPTION
by default, pytest only does it's verbose assertion errors in failures in actual `test_xyz.py` files
if the assert is in a file not collected by pytest, you have to do this to get the helpful error

eg
```
>       assert these_branches == {1,2,3}
E       AssertionError: assert == failed. [pytest-clarity diff shown]
E         
E         LHS vs RHS shown below
E         
E         set(['main'])
E         set([1, 2, 3])
E         

backend/tests/db_snapshot.py:200: AssertionError
```

is better than 

```
>       assert these_branches == {1,2,3}
E       AssertionError

backend/tests/db_snapshot.py:200: AssertionError
```