### PR TITLE
Remove branch parameter from ConvertObjectType mutation

### DIFF
--- a/backend/infrahub/core/convert_object_type/conversion.py
+++ b/backend/infrahub/core/convert_object_type/conversion.py
@@ -101,6 +101,8 @@ async def convert_object_type(
         deleted_node_out_rels_peer_ids = await get_out_rels_peers_ids(node=node, db=dbt)
         deleted_node_unidir_rels_peer_ids = await get_unidirectional_rels_peers_ids(node=node, db=dbt, branch=branch)
 
+        # Delete the node, so we delete relationships with peers as well, which might temporarily break cardinality constraints
+        # but they should be restored when creating the new node.
         deleted_nodes = await NodeManager.delete(db=dbt, branch=branch, nodes=[node], cascade_delete=False)
         if len(deleted_nodes) != 1:
             raise ValueError(f"Deleted {len(deleted_nodes)} nodes instead of 1")

--- a/backend/infrahub/graphql/mutations/convert_object_type.py
+++ b/backend/infrahub/graphql/mutations/convert_object_type.py
@@ -16,7 +16,6 @@ class ConvertObjectTypeInput(InputObjectType):
     node_id = String(required=True)
     target_kind = String(required=True)
     fields_mapping = GenericScalar(required=True)  # keys are destination attributes/relationships names.
-    branch = String(required=True)
 
 
 class ConvertObjectType(Mutation):
@@ -45,9 +44,9 @@ class ConvertObjectType(Mutation):
             fields_mapping[field] = InputForDestField(**input_for_dest_field_str)
 
         node_to_convert = await NodeManager.get_one(
-            id=str(data.node_id), db=graphql_context.db, branch=str(data.branch)
+            id=str(data.node_id), db=graphql_context.db, branch=graphql_context.branch
         )
-        target_schema = registry.get_node_schema(name=str(data.target_kind), branch=data.branch)
+        target_schema = registry.get_node_schema(name=str(data.target_kind), branch=graphql_context.branch)
         new_node = await convert_object_type(
             node=node_to_convert,
             target_schema=target_schema,

--- a/backend/infrahub/graphql/mutations/convert_object_type.py
+++ b/backend/infrahub/graphql/mutations/convert_object_type.py
@@ -6,6 +6,7 @@ from graphql import GraphQLResolveInfo
 
 from infrahub.core import registry
 from infrahub.core.convert_object_type.conversion import InputForDestField, convert_object_type
+from infrahub.core.convert_object_type.schema_mapping import get_schema_mapping
 from infrahub.core.manager import NodeManager
 
 if TYPE_CHECKING:
@@ -36,17 +37,26 @@ class ConvertObjectType(Mutation):
 
         graphql_context: GraphqlContext = info.context
 
+        node_to_convert = await NodeManager.get_one(
+            id=str(data.node_id), db=graphql_context.db, branch=graphql_context.branch
+        )
+
+        source_schema = registry.get_node_schema(name=node_to_convert.get_kind(), branch=graphql_context.branch)
+        target_schema = registry.get_node_schema(name=str(data.target_kind), branch=graphql_context.branch)
+
         fields_mapping: dict[str, InputForDestField] = {}
         if not isinstance(data.fields_mapping, dict):
             raise ValueError(f"Expected `fields_mapping` to be a `dict`, got {type(fields_mapping)}")
 
-        for field, input_for_dest_field_str in data.fields_mapping.items():
-            fields_mapping[field] = InputForDestField(**input_for_dest_field_str)
+        for field_name, input_for_dest_field_str in data.fields_mapping.items():
+            fields_mapping[field_name] = InputForDestField(**input_for_dest_field_str)
 
-        node_to_convert = await NodeManager.get_one(
-            id=str(data.node_id), db=graphql_context.db, branch=graphql_context.branch
-        )
-        target_schema = registry.get_node_schema(name=str(data.target_kind), branch=graphql_context.branch)
+        # Complete fields mapping with auto-mapping.
+        mapping = get_schema_mapping(source_schema=source_schema, target_schema=target_schema)
+        for field_name, mapping_value in mapping.items():
+            if mapping_value.source_field_name is not None and field_name not in fields_mapping:
+                fields_mapping[field_name] = InputForDestField(source_field=mapping_value.source_field_name)
+
         new_node = await convert_object_type(
             node=node_to_convert,
             target_schema=target_schema,

--- a/backend/infrahub/graphql/queries/convert_object_type_mapping.py
+++ b/backend/infrahub/graphql/queries/convert_object_type_mapping.py
@@ -12,13 +12,12 @@ class FieldsMapping(ObjectType):
 
 async def fields_mapping_type_conversion_resolver(
     root: dict,  # noqa: ARG001
-    info: GraphQLResolveInfo,  # noqa: ARG001
+    info: GraphQLResolveInfo,
     source_kind: str,
     target_kind: str,
-    branch: str,
 ) -> dict:
-    source_schema = registry.get_node_schema(name=source_kind, branch=branch)
-    target_schema = registry.get_node_schema(name=target_kind, branch=branch)
+    source_schema = registry.get_node_schema(name=source_kind, branch=info.context.branch)
+    target_schema = registry.get_node_schema(name=target_kind, branch=info.context.branch)
 
     mapping = get_schema_mapping(source_schema=source_schema, target_schema=target_schema)
     mapping_dict = {field_name: model.model_dump(mode="json") for field_name, model in mapping.items()}
@@ -29,7 +28,6 @@ FieldsMappingTypeConversion = Field(
     FieldsMapping,
     source_kind=String(),
     target_kind=String(),
-    branch=String(),
     description="Retrieve fields mapping for converting object type",
     resolver=fields_mapping_type_conversion_resolver,
     required=True,

--- a/backend/tests/functional/convert_object_type/test_convert_object_type.py
+++ b/backend/tests/functional/convert_object_type/test_convert_object_type.py
@@ -111,9 +111,7 @@ class TestConvertObjectType(TestInfrahubApp):
 
         mapping = {
             "name": InputForDestField(source_field="name"),
-            "height": InputForDestField(source_field="height"),
             "age": InputForDestField(data=InputDataForDestField(attribute_value=25)),
-            "favorite_car": InputForDestField(source_field="favorite_car"),
             "worst_car": InputForDestField(data=InputDataForDestField(peer_id=car_1.id)),
             "fastest_cars": InputForDestField(source_field="fastest_cars"),
             "slowest_cars": InputForDestField(data=InputDataForDestField(peers_ids=[car_1.id])),

--- a/backend/tests/functional/convert_object_type/test_convert_object_type.py
+++ b/backend/tests/functional/convert_object_type/test_convert_object_type.py
@@ -14,8 +14,8 @@ class TestGetConversionSchemaMapping(TestInfrahubApp):
         response = await client.schema.load(schemas=[schemas_conversion])
         assert len(response.errors) == 0, response.errors
 
-        query = """ query($source_kind: String!, $target_kind: String!, $branch: String!) {
-                FieldsMappingTypeConversion(source_kind: $source_kind, target_kind: $target_kind, branch: $branch) {
+        query = """ query($source_kind: String!, $target_kind: String!) {
+                FieldsMappingTypeConversion(source_kind: $source_kind, target_kind: $target_kind) {
                     mapping
                 }
             }
@@ -24,10 +24,10 @@ class TestGetConversionSchemaMapping(TestInfrahubApp):
         response = await client.execute_graphql(
             query=query,
             variables={
-                "branch": "main",
                 "source_kind": "TestconvPerson1",
                 "target_kind": "TestconvPerson2",
             },
+            branch_name="main",
         )
 
         assert response == {
@@ -97,11 +97,10 @@ class TestConvertObjectType(TestInfrahubApp):
         await jack_1.save()
 
         query = """
-            mutation($node_id: String!, $target_kind: String!, $branch: String!, $fields_mapping: GenericScalar!) {
+            mutation($node_id: String!, $target_kind: String!, $fields_mapping: GenericScalar!) {
                 ConvertObjectType(data: {
                         node_id: $node_id,
                         target_kind: $target_kind,
-                        branch: $branch,
                         fields_mapping: $fields_mapping
                     }) {
                         ok
@@ -126,11 +125,11 @@ class TestConvertObjectType(TestInfrahubApp):
         response = await client.execute_graphql(
             query=query,
             variables={
-                "branch": "main",
                 "node_id": str(jack_1.id),
                 "fields_mapping": mapping_dict,
                 "target_kind": "TestconvPerson2",
             },
+            branch_name="main",
         )
         assert response["ConvertObjectType"]["ok"] is True
         res_node = response["ConvertObjectType"]["node"]

--- a/backend/tests/unit/core/convert_object_type/test_convert_object_type.py
+++ b/backend/tests/unit/core/convert_object_type/test_convert_object_type.py
@@ -144,46 +144,40 @@ class TestConvertObjectType(TestInfrahubApp):
             )
 
     async def test_raise_on_break_mandatory_relationship(
-        self, db: InfrahubDatabase, client: InfrahubClient, schema_conversion_mandatory_owner, default_branch
+        self, db: InfrahubDatabase, client: InfrahubClient, schema_conversion_mandatory_owner, branch
     ) -> None:
         # Add a mandatory relationship between TestPerson1 and TestCar, that would no longer exist after converting a TestPerson1 to a TestPerson2.
-        res = await client.schema.load(schemas=[schema_conversion_mandatory_owner], branch=default_branch.name)
+        res = await client.schema.load(schemas=[schema_conversion_mandatory_owner], branch=branch.name)
         assert len(res.errors) == 0, res.errors
 
         jack_1 = await create_and_save(
             db=db,
             schema="TestmoPerson1",
-            name=f"Jack-{default_branch.name}",
-            branch=default_branch,
+            name=f"Jack-{branch.name}",
+            branch=branch,
         )
 
-        car_1 = await create_and_save(
-            db=db, schema="TestmoCar", name="car_1", branch=default_branch, mandatory_owner=jack_1
-        )
+        car_1 = await create_and_save(db=db, schema="TestmoCar", name="car_1", branch=branch, mandatory_owner=jack_1)
 
         # Refresh jack_1 now that we added a bag
         jack_1 = await NodeManager.get_one_by_id_or_default_filter(
-            db=db, id=jack_1.id, kind="TestmoPerson1", prefetch_relationships=True, branch=default_branch
+            db=db, id=jack_1.id, kind="TestmoPerson1", prefetch_relationships=True, branch=branch
         )
 
         mapping = {
             "name": InputForDestField(source_field="name"),
         }
 
-        person_2_schema = registry.get_node_schema(name="TestmoPerson2", branch=default_branch)
+        person_2_schema = registry.get_node_schema(name="TestmoPerson2", branch=branch)
         with pytest.raises(ValidationError, match=r"Too few relationships, min 1 at mandatory_owner"):
-            await convert_object_type(
-                node=jack_1, target_schema=person_2_schema, mapping=mapping, db=db, branch=default_branch
-            )
+            await convert_object_type(node=jack_1, target_schema=person_2_schema, mapping=mapping, db=db, branch=branch)
 
         # And make sure it works when setting a new owner to the car
         mapping = {
             "name": InputForDestField(source_field="name"),
             "my_car": InputForDestField(data=InputDataForDestField(peer_id=car_1.id)),
         }
-        await convert_object_type(
-            node=jack_1, target_schema=person_2_schema, mapping=mapping, db=db, branch=default_branch
-        )
+        await convert_object_type(node=jack_1, target_schema=person_2_schema, mapping=mapping, db=db, branch=branch)
 
     async def test_raise_on_break_mandatory_unidirectional_relationship(
         self,


### PR DESCRIPTION
This was leading to some bugs when specified branch was different than the branch specified within the graphql context.