### PR TITLE
Adds fields auto-mapping within conversion mutation

### DIFF
--- a/backend/infrahub/graphql/mutations/convert_object_type.py
+++ b/backend/infrahub/graphql/mutations/convert_object_type.py
@@ -6,6 +6,7 @@ from graphql import GraphQLResolveInfo
 
 from infrahub.core import registry
 from infrahub.core.convert_object_type.conversion import InputForDestField, convert_object_type
+from infrahub.core.convert_object_type.schema_mapping import get_schema_mapping
 from infrahub.core.manager import NodeManager
 
 if TYPE_CHECKING:
@@ -36,17 +37,26 @@ class ConvertObjectType(Mutation):
 
         graphql_context: GraphqlContext = info.context
 
+        node_to_convert = await NodeManager.get_one(
+            id=str(data.node_id), db=graphql_context.db, branch=graphql_context.branch
+        )
+
+        source_schema = registry.get_node_schema(name=node_to_convert.get_kind(), branch=graphql_context.branch)
+        target_schema = registry.get_node_schema(name=str(data.target_kind), branch=graphql_context.branch)
+
         fields_mapping: dict[str, InputForDestField] = {}
         if not isinstance(data.fields_mapping, dict):
             raise ValueError(f"Expected `fields_mapping` to be a `dict`, got {type(fields_mapping)}")
 
-        for field, input_for_dest_field_str in data.fields_mapping.items():
-            fields_mapping[field] = InputForDestField(**input_for_dest_field_str)
+        for field_name, input_for_dest_field_str in data.fields_mapping.items():
+            fields_mapping[field_name] = InputForDestField(**input_for_dest_field_str)
 
-        node_to_convert = await NodeManager.get_one(
-            id=str(data.node_id), db=graphql_context.db, branch=graphql_context.branch
-        )
-        target_schema = registry.get_node_schema(name=str(data.target_kind), branch=graphql_context.branch)
+        # Complete fields mapping with auto-mapping.
+        mapping = get_schema_mapping(source_schema=source_schema, target_schema=target_schema)
+        for field_name, mapping_value in mapping.items():
+            if mapping_value.source_field_name is not None and field_name not in fields_mapping:
+                fields_mapping[field_name] = InputForDestField(source_field=mapping_value.source_field_name)
+
         new_node = await convert_object_type(
             node=node_to_convert,
             target_schema=target_schema,

--- a/backend/tests/functional/convert_object_type/test_convert_object_type.py
+++ b/backend/tests/functional/convert_object_type/test_convert_object_type.py
@@ -111,9 +111,7 @@ class TestConvertObjectType(TestInfrahubApp):
 
         mapping = {
             "name": InputForDestField(source_field="name"),
-            "height": InputForDestField(source_field="height"),
             "age": InputForDestField(data=InputDataForDestField(attribute_value=25)),
-            "favorite_car": InputForDestField(source_field="favorite_car"),
             "worst_car": InputForDestField(data=InputDataForDestField(peer_id=car_1.id)),
             "fastest_cars": InputForDestField(source_field="fastest_cars"),
             "slowest_cars": InputForDestField(data=InputDataForDestField(peers_ids=[car_1.id])),


### PR DESCRIPTION
So it avoids users to specify fields that both exist in source and target schemas. It was supported initially as the primary use for these APIs was to be called by the frontend.