### PR TITLE
Remove delete option for node trigger rules (for now)

### DIFF
--- a/backend/infrahub/actions/constants.py
+++ b/backend/infrahub/actions/constants.py
@@ -10,7 +10,6 @@ from infrahub.utils import InfrahubStringEnum
 
 class NodeAction(InfrahubStringEnum):
     CREATED = "created"
-    DELETED = "deleted"
     UPDATED = "updated"
 
 

--- a/backend/tests/unit/actions/test_gather.py
+++ b/backend/tests/unit/actions/test_gather.py
@@ -270,7 +270,7 @@ async def test_gather_trigger_gather_trigger_action_rules_node_relationship(
     )
 
     main_node_trigger_rule.branch_scope.value = "other_branches"
-    main_node_trigger_rule.mutation_action.value = "deleted"
+    main_node_trigger_rule.mutation_action.value = "updated"
     await main_node_trigger_rule.save(db=db)
 
     triggers = await gather_trigger_action_rules(db=db)
@@ -278,7 +278,7 @@ async def test_gather_trigger_gather_trigger_action_rules_node_relationship(
     automation = triggers[0]
 
     assert automation.trigger == EventTrigger(
-        events={"infrahub.node.deleted"},
+        events={"infrahub.node.updated"},
         match={"infrahub.node.kind": "TestCar", "infrahub.branch.name": "!main"},
         match_related=[
             {


### PR DESCRIPTION
After talking with Benoit we decided to remove the DELETED option in the Node trigger rules. Mostly because there are no actions where it makes sense to match against this today. It might be more relevant to add back once we can tie webhooks into this system.

As an example it doesn't make sense to match against a deleted node and have it run an "add to group" action or a "run generator" action as none of those would work for deleted nodes.