### PR TITLE
Add `common_parent` relationship attribute

### DIFF
--- a/backend/infrahub/core/constraint/node/runner.py
+++ b/backend/infrahub/core/constraint/node/runner.py
@@ -38,4 +38,6 @@ class NodeConstraintRunner:
                 relationship_manager: RelationshipManager = getattr(node, relationship_name)
                 await relationship_manager.fetch_relationship_ids(db=db, force_refresh=True)
                 for relationship_constraint in self.relationship_manager_constraints:
-                    await relationship_constraint.check(relm=relationship_manager, node_schema=node.get_schema())
+                    await relationship_constraint.check(
+                        relm=relationship_manager, node_schema=node.get_schema(), node=node
+                    )

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -962,3 +962,12 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
         for name in self._relationships:
             relm: RelationshipManager = getattr(self, name)
             relm.validate()
+
+    async def get_parent_relationship_peer(self, db: InfrahubDatabase, name: str) -> Node | None:
+        """When a node has a parent relationship of a given name, this method returns the peer of that relationship."""
+        relationship = self.get_schema().get_relationship(name=name)
+        if relationship.kind != RelationshipKind.PARENT:
+            raise ValueError(f"Relationship '{name}' is not of kind 'parent'")
+
+        relm: RelationshipManager = getattr(self, name)
+        return await relm.get_peer(db=db)

--- a/backend/infrahub/core/relationship/constraints/count.py
+++ b/backend/infrahub/core/relationship/constraints/count.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import RelationshipCardinality, RelationshipDirection
+from infrahub.core.node import Node
 from infrahub.core.query.relationship import RelationshipCountPerNodeQuery
 from infrahub.core.schema import MainSchemaTypes
 from infrahub.database import InfrahubDatabase
@@ -25,7 +26,7 @@ class RelationshipCountConstraint(RelationshipManagerConstraintInterface):
         self.db = db
         self.branch = branch
 
-    async def check(self, relm: RelationshipManager, node_schema: MainSchemaTypes) -> None:  # noqa: ARG002
+    async def check(self, relm: RelationshipManager, node_schema: MainSchemaTypes, node: Node) -> None:  # noqa: ARG002
         branch = await registry.get_branch(db=self.db) if not self.branch else self.branch
 
         # NOTE adding resolve here because we need to retrieve the real ID
@@ -63,7 +64,7 @@ class RelationshipCountConstraint(RelationshipManagerConstraintInterface):
 
         query = await RelationshipCountPerNodeQuery.init(
             db=self.db,
-            node_ids=[node.uuid for node in nodes_to_validate],
+            node_ids=[n.uuid for n in nodes_to_validate],
             identifier=relm.schema.identifier,
             direction=relm.schema.direction.neighbor_direction,
             branch=branch,
@@ -74,14 +75,14 @@ class RelationshipCountConstraint(RelationshipManagerConstraintInterface):
         # Need to adjust the number based on what we will add / remove
         #  +1 for max_count
         #  -1 for min_count
-        for node in nodes_to_validate:
-            if node.max_count and count_per_peer[node.uuid] + 1 > node.max_count:
+        for node_to_validate in nodes_to_validate:
+            if node_to_validate.max_count and count_per_peer[node_to_validate.uuid] + 1 > node_to_validate.max_count:
                 raise ValidationError(
-                    f"Node {node.uuid} has {count_per_peer[node.uuid] + 1} peers "
-                    f"for {relm.schema.identifier}, maximum of {node.max_count} allowed",
+                    f"Node {node_to_validate.uuid} has {count_per_peer[node_to_validate.uuid] + 1} peers "
+                    f"for {relm.schema.identifier}, maximum of {node_to_validate.max_count} allowed",
                 )
-            if node.min_count and count_per_peer[node.uuid] - 1 < node.min_count:
+            if node_to_validate.min_count and count_per_peer[node_to_validate.uuid] - 1 < node_to_validate.min_count:
                 raise ValidationError(
-                    f"Node {node.uuid} has {count_per_peer[node.uuid] - 1} peers "
-                    f"for {relm.schema.identifier}, no fewer than {node.min_count} allowed",
+                    f"Node {node_to_validate.uuid} has {count_per_peer[node_to_validate.uuid] - 1} peers "
+                    f"for {relm.schema.identifier}, no fewer than {node_to_validate.min_count} allowed",
                 )

--- a/backend/infrahub/core/relationship/constraints/interface.py
+++ b/backend/infrahub/core/relationship/constraints/interface.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 
+from infrahub.core.node import Node
 from infrahub.core.schema import MainSchemaTypes
 
 from ..model import RelationshipManager
@@ -7,4 +8,4 @@ from ..model import RelationshipManager
 
 class RelationshipManagerConstraintInterface(ABC):
     @abstractmethod
-    async def check(self, relm: RelationshipManager, node_schema: MainSchemaTypes) -> None: ...
+    async def check(self, relm: RelationshipManager, node_schema: MainSchemaTypes, node: Node) -> None: ...

--- a/backend/infrahub/core/relationship/constraints/peer_kind.py
+++ b/backend/infrahub/core/relationship/constraints/peer_kind.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import RelationshipCardinality
+from infrahub.core.node import Node
 from infrahub.core.query.node import NodeListGetInfoQuery
 from infrahub.core.schema import MainSchemaTypes
 from infrahub.core.schema.generic_schema import GenericSchema
@@ -26,7 +27,7 @@ class RelationshipPeerKindConstraint(RelationshipManagerConstraintInterface):
         self.db = db
         self.branch = branch
 
-    async def check(self, relm: RelationshipManager, node_schema: MainSchemaTypes) -> None:  # noqa: ARG002
+    async def check(self, relm: RelationshipManager, node_schema: MainSchemaTypes, node: Node) -> None:  # noqa: ARG002
         branch = await registry.get_branch(db=self.db) if not self.branch else self.branch
         peer_schema = registry.schema.get(name=relm.schema.peer, branch=branch, duplicate=False)
         if isinstance(peer_schema, GenericSchema):

--- a/backend/infrahub/core/relationship/constraints/peer_parent.py
+++ b/backend/infrahub/core/relationship/constraints/peer_parent.py
@@ -38,7 +38,7 @@ class RelationshipPeerParentConstraint(RelationshipManagerConstraintInterface):
         if len(parents) != 1:
             raise ValidationError(
                 f"All the elements of the '{relm.name}' relationship on node {node.id} ({node.get_kind()}) must have the same parent "
-                "for the node"
+                "as the node"
             )
 
     async def check(self, relm: RelationshipManager, node_schema: MainSchemaTypes, node: Node) -> None:  # noqa: ARG002

--- a/backend/infrahub/core/relationship/constraints/peer_parent.py
+++ b/backend/infrahub/core/relationship/constraints/peer_parent.py
@@ -26,12 +26,14 @@ class RelationshipPeerParentConstraint(RelationshipManagerConstraintInterface):
         """Validate that all peers of a given `relm` have the same parent for the given `relationship_name`."""
         node_parent = await node.get_parent_relationship_peer(db=self.db, name=parent_rel_name)
         if not node_parent:
+            # If the schema is properly validated we are not expecting this to happen
             raise ValidationError(f"Node {node.id} ({node.get_kind()}) does not have a parent peer")
 
         parents: set[str] = {node_parent.id}
         for peer in peers.values():
             parent = await peer.get_parent_relationship_peer(db=self.db, name=parent_rel_name)
             if not parent:
+                # If the schema is properly validated we are not expecting this to happen
                 raise ValidationError(f"Peer {peer.id} ({peer.get_kind()}) does not have a parent peer")
             parents.add(parent.id)
 

--- a/backend/infrahub/core/relationship/constraints/peer_parent.py
+++ b/backend/infrahub/core/relationship/constraints/peer_parent.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Mapping
+
+from infrahub.exceptions import ValidationError
+
+from .interface import RelationshipManagerConstraintInterface
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.core.node import Node
+    from infrahub.core.schema import MainSchemaTypes
+    from infrahub.database import InfrahubDatabase
+
+    from ..model import RelationshipManager
+
+
+class RelationshipPeerParentConstraint(RelationshipManagerConstraintInterface):
+    def __init__(self, db: InfrahubDatabase, branch: Branch | None = None):
+        self.db = db
+        self.branch = branch
+
+    async def _check_relationship_peers_parent(
+        self, relm: RelationshipManager, parent_rel_name: str, node: Node, peers: Mapping[str, Node]
+    ) -> None:
+        """Validate that all peers of a given `relm` have the same parent for the given `relationship_name`."""
+        node_parent = await node.get_parent_relationship_peer(db=self.db, name=parent_rel_name)
+        if not node_parent:
+            raise ValidationError(f"Node {node.id} ({node.get_kind()}) does not have a parent peer")
+
+        parents: set[str] = {node_parent.id}
+        for peer in peers.values():
+            parent = await peer.get_parent_relationship_peer(db=self.db, name=parent_rel_name)
+            if not parent:
+                raise ValidationError(f"Peer {peer.id} ({peer.get_kind()}) does not have a parent peer")
+            parents.add(parent.id)
+
+        if len(parents) != 1:
+            raise ValidationError(
+                f"All the elements of the '{relm.name}' relationship on node {node.id} ({node.get_kind()}) must have the same parent "
+                "for the node"
+            )
+
+    async def check(self, relm: RelationshipManager, node_schema: MainSchemaTypes, node: Node) -> None:  # noqa: ARG002
+        if not relm.schema.common_parent:
+            return
+
+        peers = await relm.get_peers(db=self.db)
+        if not peers:
+            return
+
+        await self._check_relationship_peers_parent(
+            relm=relm, parent_rel_name=relm.schema.common_parent, node=node, peers=peers
+        )

--- a/backend/infrahub/core/relationship/constraints/peer_relatives.py
+++ b/backend/infrahub/core/relationship/constraints/peer_relatives.py
@@ -58,7 +58,7 @@ class RelationshipPeerRelativesConstraint(RelationshipManagerConstraintInterface
                     f"for their '{node.schema.kind}.{relationship_name}' relationship"
                 )
 
-    async def check(self, relm: RelationshipManager, node_schema: MainSchemaTypes) -> None:
+    async def check(self, relm: RelationshipManager, node_schema: MainSchemaTypes, node: Node) -> None:  # noqa: ARG002
         if relm.schema.cardinality != RelationshipCardinality.MANY or not relm.schema.common_relatives:
             return
 

--- a/backend/infrahub/core/relationship/constraints/profiles_kind.py
+++ b/backend/infrahub/core/relationship/constraints/profiles_kind.py
@@ -23,7 +23,7 @@ class RelationshipProfilesKindConstraint(RelationshipManagerConstraintInterface)
         self.branch = branch
         self.schema_branch = registry.schema.get_schema_branch(branch.name if branch else registry.default_branch)
 
-    async def check(self, relm: RelationshipManager, node_schema: MainSchemaTypes) -> None:
+    async def check(self, relm: RelationshipManager, node_schema: MainSchemaTypes, node: Node) -> None:  # noqa: ARG002
         if relm.name != "profiles" or not isinstance(node_schema, NodeSchema):
             return
 

--- a/backend/infrahub/core/schema/definitions/internal.py
+++ b/backend/infrahub/core/schema/definitions/internal.py
@@ -755,6 +755,13 @@ relationship_schema = SchemaNode(
             extra={"update": UpdateSupport.VALIDATE_CONSTRAINT},
         ),
         SchemaAttribute(
+            name="common_parent",
+            kind="Text",
+            optional=True,
+            description="Name of a parent relationship on the peer schema that must share the same related object with the object's parent.",
+            extra={"update": UpdateSupport.VALIDATE_CONSTRAINT},
+        ),
+        SchemaAttribute(
             name="common_relatives",
             kind="List",
             internal_kind=str,

--- a/backend/infrahub/core/schema/definitions/internal.py
+++ b/backend/infrahub/core/schema/definitions/internal.py
@@ -759,7 +759,7 @@ relationship_schema = SchemaNode(
             kind="Text",
             optional=True,
             description="Name of a parent relationship on the peer schema that must share the same related object with the object's parent.",
-            extra={"update": UpdateSupport.VALIDATE_CONSTRAINT},
+            extra={"update": UpdateSupport.ALLOWED},
         ),
         SchemaAttribute(
             name="common_relatives",
@@ -767,7 +767,7 @@ relationship_schema = SchemaNode(
             internal_kind=str,
             optional=True,
             description="List of relationship names on the peer schema for which all objects must share the same set of peers.",
-            extra={"update": UpdateSupport.VALIDATE_CONSTRAINT},
+            extra={"update": UpdateSupport.ALLOWED},
         ),
         SchemaAttribute(
             name="order_weight",

--- a/backend/infrahub/core/schema/generated/relationship_schema.py
+++ b/backend/infrahub/core/schema/generated/relationship_schema.py
@@ -76,12 +76,12 @@ class GeneratedRelationshipSchema(HashableModel):
     common_parent: str | None = Field(
         default=None,
         description="Name of a parent relationship on the peer schema that must share the same related object with the object's parent.",
-        json_schema_extra={"update": "validate_constraint"},
+        json_schema_extra={"update": "allowed"},
     )
     common_relatives: list[str] | None = Field(
         default=None,
         description="List of relationship names on the peer schema for which all objects must share the same set of peers.",
-        json_schema_extra={"update": "validate_constraint"},
+        json_schema_extra={"update": "allowed"},
     )
     order_weight: int | None = Field(
         default=None,

--- a/backend/infrahub/core/schema/generated/relationship_schema.py
+++ b/backend/infrahub/core/schema/generated/relationship_schema.py
@@ -73,6 +73,11 @@ class GeneratedRelationshipSchema(HashableModel):
         description="Defines the maximum objects allowed on the other side of the relationship.",
         json_schema_extra={"update": "validate_constraint"},
     )
+    common_parent: str | None = Field(
+        default=None,
+        description="Name of a parent relationship on the peer schema that must share the same related object with the object parent.",
+        json_schema_extra={"update": "validate_constraint"},
+    )
     common_relatives: list[str] | None = Field(
         default=None,
         description="List of relationship names on the peer schema for which all objects must share the same set of peers.",

--- a/backend/infrahub/core/schema/generated/relationship_schema.py
+++ b/backend/infrahub/core/schema/generated/relationship_schema.py
@@ -75,7 +75,7 @@ class GeneratedRelationshipSchema(HashableModel):
     )
     common_parent: str | None = Field(
         default=None,
-        description="Name of a parent relationship on the peer schema that must share the same related object with the object parent.",
+        description="Name of a parent relationship on the peer schema that must share the same related object with the object's parent.",
         json_schema_extra={"update": "validate_constraint"},
     )
     common_relatives: list[str] | None = Field(

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -975,6 +975,28 @@ class SchemaBranch:
                 ):
                     raise ValueError(f"{node.kind}: {rel.name} isn't allowed as a relationship name.")
 
+    def _validate_common_parent(self, node: NodeSchema, rel: RelationshipSchema) -> None:
+        if not rel.common_parent:
+            return
+
+        peer_schema = self.get(name=rel.peer, duplicate=False)
+        if not node.has_parent_relationship:
+            raise ValueError(
+                f"{node.kind}: Relationship {rel.name!r} defines 'common_parent' but node does not have a parent relationship"
+            ) from None
+
+        try:
+            parent_rel = peer_schema.get_relationship(name=rel.common_parent)
+        except ValueError as exc:
+            raise ValueError(
+                f"{node.kind}: Relationship {rel.name!r} defines 'common_parent' but '{rel.peer}.{rel.common_parent}' does not exist"
+            ) from exc
+
+        if parent_rel.kind != RelationshipKind.PARENT:
+            raise ValueError(
+                f"{node.kind}: Relationship {rel.name!r} defines 'common_parent' but '{rel.peer}.{rel.common_parent} is not of kind 'parent'"
+            ) from None
+
     def validate_kinds(self) -> None:
         for name in list(self.nodes.keys()):
             node = self.get_node(name=name, duplicate=False)
@@ -997,6 +1019,9 @@ class SchemaBranch:
                     raise ValueError(
                         f"{node.kind}: Relationship {rel.name!r} is referring an invalid peer {rel.peer!r}"
                     ) from None
+
+                self._validate_common_parent(node=node, rel=rel)
+
                 if rel.common_relatives:
                     peer_schema = self.get(name=rel.peer, duplicate=False)
                     for common_relatives_rel_name in rel.common_relatives:

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -983,7 +983,7 @@ class SchemaBranch:
         if not node.has_parent_relationship:
             raise ValueError(
                 f"{node.kind}: Relationship {rel.name!r} defines 'common_parent' but node does not have a parent relationship"
-            ) from None
+            )
 
         try:
             parent_rel = peer_schema.get_relationship(name=rel.common_parent)
@@ -995,7 +995,7 @@ class SchemaBranch:
         if parent_rel.kind != RelationshipKind.PARENT:
             raise ValueError(
                 f"{node.kind}: Relationship {rel.name!r} defines 'common_parent' but '{rel.peer}.{rel.common_parent} is not of kind 'parent'"
-            ) from None
+            )
 
     def validate_kinds(self) -> None:
         for name in list(self.nodes.keys()):

--- a/backend/infrahub/dependencies/builder/constraint/grouped/node_runner.py
+++ b/backend/infrahub/dependencies/builder/constraint/grouped/node_runner.py
@@ -4,6 +4,7 @@ from infrahub.dependencies.interface import DependencyBuilder, DependencyBuilder
 from ..node.grouped_uniqueness import NodeGroupedUniquenessConstraintDependency
 from ..relationship_manager.count import RelationshipCountConstraintDependency
 from ..relationship_manager.peer_kind import RelationshipPeerKindConstraintDependency
+from ..relationship_manager.peer_parent import RelationshipPeerParentConstraintDependency
 from ..relationship_manager.peer_relatives import RelationshipPeerRelativesConstraintDependency
 from ..relationship_manager.profiles_kind import RelationshipProfilesKindConstraintDependency
 
@@ -19,6 +20,7 @@ class NodeConstraintRunnerDependency(DependencyBuilder[NodeConstraintRunner]):
                 RelationshipPeerKindConstraintDependency.build(context=context),
                 RelationshipCountConstraintDependency.build(context=context),
                 RelationshipProfilesKindConstraintDependency.build(context=context),
+                RelationshipPeerParentConstraintDependency.build(context=context),
                 RelationshipPeerRelativesConstraintDependency.build(context=context),
             ],
         )

--- a/backend/infrahub/dependencies/builder/constraint/relationship_manager/peer_parent.py
+++ b/backend/infrahub/dependencies/builder/constraint/relationship_manager/peer_parent.py
@@ -1,0 +1,8 @@
+from infrahub.core.relationship.constraints.peer_parent import RelationshipPeerParentConstraint
+from infrahub.dependencies.interface import DependencyBuilder, DependencyBuilderContext
+
+
+class RelationshipPeerParentConstraintDependency(DependencyBuilder[RelationshipPeerParentConstraint]):
+    @classmethod
+    def build(cls, context: DependencyBuilderContext) -> RelationshipPeerParentConstraint:
+        return RelationshipPeerParentConstraint(db=context.db, branch=context.branch)

--- a/backend/infrahub/dependencies/registry.py
+++ b/backend/infrahub/dependencies/registry.py
@@ -3,6 +3,7 @@ from .builder.constraint.node.grouped_uniqueness import NodeGroupedUniquenessCon
 from .builder.constraint.node.uniqueness import NodeAttributeUniquenessConstraintDependency
 from .builder.constraint.relationship_manager.count import RelationshipCountConstraintDependency
 from .builder.constraint.relationship_manager.peer_kind import RelationshipPeerKindConstraintDependency
+from .builder.constraint.relationship_manager.peer_parent import RelationshipPeerParentConstraintDependency
 from .builder.constraint.relationship_manager.peer_relatives import RelationshipPeerRelativesConstraintDependency
 from .builder.constraint.relationship_manager.profiles_kind import RelationshipProfilesKindConstraintDependency
 from .builder.constraint.schema.aggregated import AggregatedSchemaConstraintsDependency
@@ -38,6 +39,7 @@ def build_component_registry() -> ComponentDependencyRegistry:
     component_registry.track_dependency(RelationshipCountConstraintDependency)
     component_registry.track_dependency(RelationshipProfilesKindConstraintDependency)
     component_registry.track_dependency(RelationshipPeerKindConstraintDependency)
+    component_registry.track_dependency(RelationshipPeerParentConstraintDependency)
     component_registry.track_dependency(RelationshipPeerRelativesConstraintDependency)
     component_registry.track_dependency(NodeConstraintRunnerDependency)
     component_registry.track_dependency(NodeDeleteValidatorDependency)

--- a/backend/infrahub/graphql/mutations/relationship.py
+++ b/backend/infrahub/graphql/mutations/relationship.py
@@ -421,12 +421,14 @@ async def _validate_peer_parents(
         db=graphql_context.db, name=rel_schema.common_parent
     )
     if not source_node_parent:
+        # If the schema is properly validated we are not expecting this to happen
         raise ValidationError(f"Node {source_node.id} ({source_node.get_kind()!r}) does not have a parent peer")
 
     parents: set[str] = {source_node_parent.id}
     for peer in peers.values():
         peer_parent = await peer.get_parent_relationship_peer(db=graphql_context.db, name=rel_schema.common_parent)
         if not peer_parent:
+            # If the schema is properly validated we are not expecting this to happen
             raise ValidationError(f"Peer {peer.id} ({peer.get_kind()!r}) does not have a parent peer")
         parents.add(peer_parent.id)
 

--- a/backend/infrahub/graphql/mutations/relationship.py
+++ b/backend/infrahub/graphql/mutations/relationship.py
@@ -85,6 +85,7 @@ class RelationshipAdd(Mutation):
         nodes = await _validate_peers(info=info, data=data)
         await _validate_permissions(info=info, source_node=source, peers=nodes)
         await _validate_peer_types(info=info, data=data, source_node=source, peers=nodes)
+        await _validate_peer_parents(info=info, data=data, source_node=source, peers=nodes)
 
         # This has to be done after validating the permissions
         await apply_external_context(graphql_context=graphql_context, context_input=context)
@@ -404,6 +405,35 @@ async def _validate_peer_types(
                     raise ValidationError(
                         f"{node_id!r} {node.get_kind()!r} is already related to another peer on '{peer_relationships[0].name}'"
                     )
+
+
+async def _validate_peer_parents(
+    info: GraphQLResolveInfo, data: RelationshipNodesInput, source_node: Node, peers: dict[str, Node]
+) -> None:
+    relationship_name = str(data.name)
+    rel_schema = source_node.get_schema().get_relationship(name=relationship_name)
+    if not rel_schema.common_parent:
+        return
+
+    graphql_context: GraphqlContext = info.context
+
+    source_node_parent = await source_node.get_parent_relationship_peer(
+        db=graphql_context.db, name=rel_schema.common_parent
+    )
+    if not source_node_parent:
+        raise ValidationError(f"Node {source_node.id} ({source_node.get_kind()!r}) does not have a parent peer")
+
+    parents: set[str] = {source_node_parent.id}
+    for peer in peers.values():
+        peer_parent = await peer.get_parent_relationship_peer(db=graphql_context.db, name=rel_schema.common_parent)
+        if not peer_parent:
+            raise ValidationError(f"Peer {peer.id} ({peer.get_kind()!r}) does not have a parent peer")
+        parents.add(peer_parent.id)
+
+    if len(parents) > 1:
+        raise ValidationError(
+            f"Cannot relate {source_node.id!r} to '{relationship_name}' peers that do not have the same parent"
+        )
 
 
 async def _collect_current_peers(

--- a/backend/tests/functional/constraints/peer_parent.py
+++ b/backend/tests/functional/constraints/peer_parent.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import copy
+from typing import TYPE_CHECKING
+
+import pytest
+from infrahub_sdk.exceptions import GraphQLError
+
+from infrahub.core.node import Node
+from tests.constants import TestKind
+from tests.helpers.schema import DEVICE_SCHEMA, load_schema
+from tests.helpers.schema.device import LAG_INTERFACE
+from tests.helpers.test_app import TestInfrahubApp
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClient
+
+    from infrahub.core.branch import Branch
+    from infrahub.core.schema import SchemaRoot
+    from infrahub.core.schema.schema_branch import SchemaBranch
+    from infrahub.database import InfrahubDatabase
+
+
+class TestPeerParentConstraint(TestInfrahubApp):
+    @pytest.fixture(scope="class", autouse=True)
+    def schema(self, default_branch: Branch, register_internal_schema: SchemaBranch) -> SchemaRoot:
+        schema_with_lag = copy.deepcopy(DEVICE_SCHEMA)
+        schema_with_lag.nodes[0].generate_template = False
+        schema_with_lag.nodes.append(LAG_INTERFACE)
+        return schema_with_lag
+
+    @pytest.fixture(scope="class")
+    async def data(
+        self,
+        db: InfrahubDatabase,
+        initialize_registry: None,
+        client: InfrahubClient,
+        default_branch: Branch,
+        schema: SchemaRoot,
+    ) -> dict[str, Node]:
+        await load_schema(db, schema=schema, update_db=True)
+
+        device_1 = await Node.init(db=db, schema=TestKind.DEVICE)
+        await device_1.new(db=db, name="Foo", manufacturer="Foo Inc.", weight=10, airflow="Front to rear")
+
+        interfaces_1: list[Node] = []
+        interfaces_1_ids: list[str] = []
+        for if_name in ["et-0/0/0", "et-0/0/1", "et-0/0/2", "et-0/0/3"]:
+            interface = await Node.init(db=db, schema=TestKind.PHYSICAL_INTERFACE)
+            await interface.new(db=db, name=if_name, phys_type="QSFP28 (100GE)", device=device_1)
+            await interface.save(db=db)
+            interfaces_1.append(interface)
+            interfaces_1_ids.append(interface.id)
+
+        await device_1.interfaces.update(db=db, data=interfaces_1)  # type: ignore[attr-defined]
+        await device_1.save(db=db)
+
+        device_2 = await Node.init(db=db, schema=TestKind.DEVICE)
+        await device_2.new(db=db, name="Bar", manufacturer="Bar Inc.", weight=10, airflow="Front to rear")
+
+        interfaces_2: list[Node] = []
+        interfaces_2_ids: list[str] = []
+        for if_name in ["et-0/0/0", "et-0/0/1", "et-0/0/2", "et-0/0/3"]:
+            interface = await Node.init(db=db, schema=TestKind.PHYSICAL_INTERFACE)
+            await interface.new(db=db, name=if_name, phys_type="QSFP28 (100GE)", device=device_2)
+            await interface.save(db=db)
+            interfaces_2.append(interface)
+            interfaces_2_ids.append(interface.id)
+
+        await device_2.interfaces.update(db=db, data=interfaces_2)  # type: ignore[attr-defined]
+        await device_2.save(db=db)
+
+        return {"device_1": device_1, "device_2": device_2}
+
+    async def test_create_lag_main(
+        self, db: InfrahubDatabase, data: dict[str, Node], client: InfrahubClient, default_branch: Branch
+    ) -> None:
+        device = await client.get(kind=TestKind.DEVICE, id=data["device_1"].id, branch=default_branch.name)
+        await device.interfaces.fetch()
+
+        lag = await client.create(
+            kind=TestKind.LAG_INTERFACE,
+            name="ae0",
+            device=device,
+            members=[i.peer for i in device.interfaces],  # type: ignore[attr-defined]
+            branch=default_branch.name,
+        )
+        await lag.save()
+
+        assert len(lag.members.peers) == 4
+        assert sorted(lag.members.peer_ids) == sorted([i.id for i in device.interfaces])
+
+    async def test_create_incorrect_lag_main(
+        self, db: InfrahubDatabase, data: dict[str, Node], client: InfrahubClient, default_branch: Branch
+    ) -> None:
+        device_1 = await client.get(kind=TestKind.DEVICE, id=data["device_1"].id, branch=default_branch.name)
+        await device_1.interfaces.fetch()
+        device_2 = await client.get(kind=TestKind.DEVICE, id=data["device_2"].id, branch=default_branch.name)
+        await device_2.interfaces.fetch()
+
+        lag = await client.create(
+            kind=TestKind.LAG_INTERFACE,
+            name="ae1",
+            device=device_1,
+            members=[i.peer for i in list(device_1.interfaces)[:-1] + list(device_2.interfaces)],  # type: ignore[attr-defined]
+            branch=default_branch.name,
+        )
+
+        with pytest.raises(GraphQLError) as exc:
+            await lag.save()
+        assert "must have the same parent as the node" in exc.value.errors[0]["message"]
+
+    async def test_create_lag_branch(
+        self, db: InfrahubDatabase, data: dict[str, Node], client: InfrahubClient, default_branch: Branch
+    ) -> None:
+        branch = await client.branch.create(branch_name="test-lag")
+
+        device = await client.get(kind=TestKind.DEVICE, id=data["device_2"].id, branch=branch.name)
+        await device.interfaces.fetch()
+
+        lag = await client.create(
+            kind=TestKind.LAG_INTERFACE,
+            name="ae0",
+            device=device,
+            members=[i.peer for i in device.interfaces],  # type: ignore[attr-defined]
+            branch=branch.name,
+        )
+        await lag.save()
+
+        assert len(lag.members.peers) == 4
+        assert sorted(lag.members.peer_ids) == sorted([i.id for i in device.interfaces])
+
+    async def test_create_incorrect_lag_branch(
+        self, db: InfrahubDatabase, data: dict[str, Node], client: InfrahubClient, default_branch: Branch
+    ) -> None:
+        branch = await client.branch.create(branch_name="test-lag-incorrect")
+
+        device_1 = await client.get(kind=TestKind.DEVICE, id=data["device_1"].id, branch=branch.name)
+        await device_1.interfaces.fetch()
+        device_2 = await client.get(kind=TestKind.DEVICE, id=data["device_2"].id, branch=branch.name)
+        await device_2.interfaces.fetch()
+
+        lag = await client.create(
+            kind=TestKind.LAG_INTERFACE,
+            name="ae1",
+            device=device_2,
+            members=[i.peer for i in list(device_1.interfaces)[:-1] + list(device_2.interfaces)[:-1]],  # type: ignore[attr-defined]
+            branch=branch.name,
+        )
+
+        with pytest.raises(GraphQLError) as exc:
+            await lag.save()
+        assert "must have the same parent as the node" in exc.value.errors[0]["message"]

--- a/backend/tests/functional/constraints/peer_relatives.py
+++ b/backend/tests/functional/constraints/peer_relatives.py
@@ -26,7 +26,12 @@ class TestPeerRelativesConstraint(TestInfrahubApp):
     def schema(self, default_branch: Branch, register_internal_schema: SchemaBranch) -> SchemaRoot:
         schema_with_lag = copy.deepcopy(DEVICE_SCHEMA)
         schema_with_lag.nodes[0].generate_template = False
-        schema_with_lag.nodes.append(LAG_INTERFACE)
+
+        lag_node_schema = copy.deepcopy(LAG_INTERFACE)
+        lag_node_schema.relationships[0].common_parent = None
+        lag_node_schema.relationships[0].common_relatives = ["device"]
+        schema_with_lag.nodes.append(lag_node_schema)
+
         return schema_with_lag
 
     @pytest.fixture(scope="class")

--- a/backend/tests/helpers/schema/device.py
+++ b/backend/tests/helpers/schema/device.py
@@ -132,7 +132,7 @@ LAG_INTERFACE = NodeSchema(
             optional=True,
             peer=TestKind.PHYSICAL_INTERFACE,
             cardinality=RelationshipCardinality.MANY,
-            common_relatives=["device"],
+            common_parent="device",
         )
     ],
 )

--- a/backend/tests/unit/core/constraint_validators/test_relationship_manager.py
+++ b/backend/tests/unit/core/constraint_validators/test_relationship_manager.py
@@ -15,7 +15,7 @@ async def test_node_validate_constraint_relationship_count_failure(
     await person.new(db=db, name="Alfred", height=160, cars=[car_accord_main.id])
 
     with pytest.raises(ValidationError) as exc:
-        await constraint.check(relm=person.cars, node_schema=person.get_schema())
+        await constraint.check(relm=person.cars, node_schema=person.get_schema(), node=person)
 
     assert "has 2 peers for testcar__testperson, maximum of 1 allowed" in exc.value.message
 
@@ -25,4 +25,4 @@ async def test_node_validate_constraint_relationship_count_success(
 ):
     constraint = RelationshipCountConstraint(db=db, branch=default_branch)
 
-    await constraint.check(relm=person_john_main.cars, node_schema=person_john_main.get_schema())
+    await constraint.check(relm=person_john_main.cars, node_schema=person_john_main.get_schema(), node=person_john_main)

--- a/backend/tests/unit/core/constraint_validators/test_relationship_peer_relatives.py
+++ b/backend/tests/unit/core/constraint_validators/test_relationship_peer_relatives.py
@@ -5,6 +5,7 @@ import pytest
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.node import Node
+from infrahub.core.relationship.constraints.peer_parent import RelationshipPeerParentConstraint
 from infrahub.core.relationship.constraints.peer_relatives import RelationshipPeerRelativesConstraint
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
@@ -15,12 +16,88 @@ from tests.helpers.schema.device import LAG_INTERFACE
 from tests.helpers.test_app import TestInfrahubApp
 
 
-class TestRelationshipPeerRelativesConstraint(TestInfrahubApp):
+class TestRelationshipPeerParentConstraint(TestInfrahubApp):
     @pytest.fixture(scope="class", autouse=True)
     def schema(self, default_branch: Branch, register_internal_schema: SchemaBranch) -> None:
         schema_with_lag = copy.deepcopy(DEVICE_SCHEMA)
         schema_with_lag.nodes[0].generate_template = False
         schema_with_lag.nodes.append(LAG_INTERFACE)
+        return registry.schema.register_schema(schema=schema_with_lag, branch=registry.default_branch)
+
+    @pytest.fixture
+    async def device_1(self, db: InfrahubDatabase, schema) -> Node:
+        device = await Node.init(db=db, schema=TestKind.DEVICE)
+        await device.new(db=db, name="Foo", manufacturer="Foo Inc.", weight=10, airflow="Front to rear")
+
+        interfaces: list[Node] = []
+        for if_name in ["et-0/0/0", "et-0/0/1", "et-0/0/2", "et-0/0/3"]:
+            interface = await Node.init(db=db, schema=TestKind.PHYSICAL_INTERFACE)
+            await interface.new(db=db, name=if_name, phys_type="QSFP28 (100GE)", device=device)
+            await interface.save(db=db)
+            interfaces.append(interface)
+
+        await device.interfaces.update(db=db, data=interfaces)
+        await device.save(db=db)
+
+        return device
+
+    @pytest.fixture
+    async def device_2(self, db: InfrahubDatabase, schema) -> Node:
+        device = await Node.init(db=db, schema=TestKind.DEVICE)
+        await device.new(db=db, name="Bar", manufacturer="Bar Inc.", weight=10, airflow="Front to rear")
+
+        interfaces: list[Node] = []
+        for if_name in ["et-0/0/0", "et-0/0/1", "et-0/0/2", "et-0/0/3"]:
+            interface = await Node.init(db=db, schema=TestKind.PHYSICAL_INTERFACE)
+            await interface.new(db=db, name=if_name, phys_type="QSFP28 (100GE)", device=device)
+            await interface.save(db=db)
+            interfaces.append(interface)
+
+        await device.interfaces.update(db=db, data=interfaces)
+        await device.save(db=db)
+
+        return device
+
+    async def test_same_parent(self, db: InfrahubDatabase, device_1: Node):
+        lag_schema = registry.schema.get_node_schema(name=TestKind.LAG_INTERFACE, duplicate=False)
+
+        constraint = RelationshipPeerParentConstraint(db=db)
+
+        interfaces = await device_1.interfaces.get_peers(db=db)
+
+        lag = await Node.init(db=db, schema=TestKind.LAG_INTERFACE)
+        await lag.new(db=db, name="ae0", device=device_1, members=list(interfaces.values()))
+        await lag.save(db=db)
+
+        await constraint.check(relm=lag.members, node_schema=lag_schema, node=lag)
+
+    async def test_different_parent(self, db: InfrahubDatabase, device_1: Node, device_2: Node):
+        lag_schema = registry.schema.get_node_schema(name=TestKind.LAG_INTERFACE, duplicate=False)
+
+        constraint = RelationshipPeerParentConstraint(db=db)
+
+        interfaces_1 = await device_1.interfaces.get_peers(db=db)
+        interfaces_2 = await device_2.interfaces.get_peers(db=db)
+        interfaces = list(interfaces_1.values()) + list(interfaces_2.values())
+
+        lag = await Node.init(db=db, schema=TestKind.LAG_INTERFACE)
+        await lag.new(db=db, name="ae0", device=device_1, members=interfaces)
+        await lag.save(db=db)
+
+        with pytest.raises(ValidationError, match=r"must have the same parent"):
+            await constraint.check(relm=lag.members, node_schema=lag_schema, node=lag)
+
+
+class TestRelationshipPeerRelativesConstraint(TestInfrahubApp):
+    @pytest.fixture(scope="class", autouse=True)
+    def schema(self, default_branch: Branch, register_internal_schema: SchemaBranch) -> None:
+        lag = copy.deepcopy(LAG_INTERFACE)
+        lag.relationships[0].common_parent = None
+        lag.relationships[0].common_relatives = ["device"]
+
+        schema_with_lag = copy.deepcopy(DEVICE_SCHEMA)
+        schema_with_lag.nodes[0].generate_template = False
+        schema_with_lag.nodes.append(lag)
         return registry.schema.register_schema(schema=schema_with_lag, branch=registry.default_branch)
 
     @pytest.fixture
@@ -68,7 +145,7 @@ class TestRelationshipPeerRelativesConstraint(TestInfrahubApp):
         await lag.new(db=db, name="ae0", device=device_1, members=list(interfaces.values()))
         await lag.save(db=db)
 
-        await constraint.check(relm=lag.members, node_schema=lag_schema)
+        await constraint.check(relm=lag.members, node_schema=lag_schema, node=lag)
 
     async def test_common_relatives_disallowed(self, db: InfrahubDatabase, device_1: Node, device_2: Node):
         lag_schema = registry.schema.get_node_schema(name=TestKind.LAG_INTERFACE, duplicate=False)
@@ -87,4 +164,4 @@ class TestRelationshipPeerRelativesConstraint(TestInfrahubApp):
             ValidationError,
             match=r"must have the same set of peers for their 'TestingPhysicalInterface.device' relationship",
         ):
-            await constraint.check(relm=lag.members, node_schema=lag_schema)
+            await constraint.check(relm=lag.members, node_schema=lag_schema, node=lag)

--- a/backend/tests/unit/core/constraint_validators/test_relationship_profiles_kind.py
+++ b/backend/tests/unit/core/constraint_validators/test_relationship_profiles_kind.py
@@ -80,7 +80,7 @@ class TestRelationshipProfilesKindConstraint(TestInfrahubApp):
         ship_schema = registry.schema.get_node_schema(name="TestShip", duplicate=False)
 
         constraint = RelationshipProfilesKindConstraint(db=db)
-        await constraint.check(relm=ship_one.profiles, node_schema=ship_schema)
+        await constraint.check(relm=ship_one.profiles, node_schema=ship_schema, node=ship_one)
 
     async def test_profile_for_schema_allowed(self, db: InfrahubDatabase, ship_one: Node, ship_profile: Node):
         ship_schema = registry.schema.get_node_schema(name="TestShip", duplicate=False)
@@ -89,7 +89,7 @@ class TestRelationshipProfilesKindConstraint(TestInfrahubApp):
         await ship_one.profiles.add(db=db, data=ship_profile)
         await ship_one.profiles.resolve(db=db)
 
-        await constraint.check(relm=ship_one.profiles, node_schema=ship_schema)
+        await constraint.check(relm=ship_one.profiles, node_schema=ship_schema, node=ship_one)
 
     async def test_generic_profile_allowed(self, db: InfrahubDatabase, ship_one: Node, space_object_profile: Node):
         ship_schema = registry.schema.get_node_schema(name="TestShip", duplicate=False)
@@ -98,7 +98,7 @@ class TestRelationshipProfilesKindConstraint(TestInfrahubApp):
         await ship_one.profiles.add(db=db, data=space_object_profile)
         await ship_one.profiles.resolve(db=db)
 
-        await constraint.check(relm=ship_one.profiles, node_schema=ship_schema)
+        await constraint.check(relm=ship_one.profiles, node_schema=ship_schema, node=ship_one)
 
     async def test_wrong_profile_not_allowed(self, db: InfrahubDatabase, ship_one: Node):
         wrong_profile = await Node.init(db=db, schema="ProfileTestOtherGeneric")
@@ -111,7 +111,7 @@ class TestRelationshipProfilesKindConstraint(TestInfrahubApp):
         await ship_one.profiles.resolve(db=db)
 
         with pytest.raises(ValidationError) as exc:
-            await constraint.check(relm=ship_one.profiles, node_schema=ship_schema)
+            await constraint.check(relm=ship_one.profiles, node_schema=ship_schema, node=ship_one)
 
         assert "is of kind ProfileTestOtherGeneric" in exc.value.message
         assert "only ['ProfileTestGenericSpaceObject', 'ProfileTestShip'] are allowed" in exc.value.message
@@ -128,7 +128,7 @@ class TestRelationshipProfilesKindConstraint(TestInfrahubApp):
         await ship_one.profiles.resolve(db=db)
 
         with pytest.raises(ValidationError) as exc:
-            await constraint.check(relm=ship_one.profiles, node_schema=ship_schema)
+            await constraint.check(relm=ship_one.profiles, node_schema=ship_schema, node=ship_one)
 
         assert "is of kind ProfileTestGenericSpaceObject" in exc.value.message
         assert "only ['ProfileTestShip'] are allowed" in exc.value.message
@@ -144,4 +144,4 @@ class TestRelationshipProfilesKindConstraint(TestInfrahubApp):
         await ship_one.profiles.resolve(db=db)
 
         with pytest.raises(ValidationError, match="TestShip does not allow profiles"):
-            await constraint.check(relm=ship_one.profiles, node_schema=ship_schema)
+            await constraint.check(relm=ship_one.profiles, node_schema=ship_schema, node=ship_one)

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -946,6 +946,7 @@ async def test_schema_branch_validate_kinds_peer():
 async def test_schema_branch_validate_kinds_common_relatives():
     schema_with_lag = copy.deepcopy(DEVICE_SCHEMA)
     lag_interface_schema = copy.deepcopy(LAG_INTERFACE)
+    lag_interface_schema.relationships[0].common_parent = None
     lag_interface_schema.relationships[0].common_relatives = ["doesnotexist"]
     schema_with_lag.nodes.append(lag_interface_schema)
 

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -961,6 +961,76 @@ async def test_schema_branch_validate_kinds_common_relatives():
     )
 
 
+async def test_schema_branch_validate_common_parent():
+    schema_with_lag = copy.deepcopy(DEVICE_SCHEMA)
+    lag_interface_schema = copy.deepcopy(LAG_INTERFACE)
+    lag_interface_schema.relationships[0].common_parent = "device"
+    schema_with_lag.nodes.append(lag_interface_schema)
+
+    schema = SchemaBranch(cache={}, name="test")
+    schema.load_schema(schema=schema_with_lag)
+    schema.process_inheritance()
+    schema.validate_kinds()
+
+
+async def test_schema_branch_validate_common_parent_without_valid_parent():
+    schema_with_lag = copy.deepcopy(DEVICE_SCHEMA)
+    lag_interface_schema = copy.deepcopy(LAG_INTERFACE)
+    lag_interface_schema.relationships[0].common_parent = "device"
+    schema_with_lag.nodes.append(lag_interface_schema)
+
+    schema = SchemaBranch(cache={}, name="test")
+    schema.load_schema(schema=schema_with_lag)
+    schema.process_inheritance()
+    schema.get(name=TestKind.LAG_INTERFACE, duplicate=False).get_relationship("device").kind = RelationshipKind.GENERIC
+
+    with pytest.raises(ValueError) as exc:
+        schema.validate_kinds()
+
+    assert str(exc.value) == (
+        "TestingLinkAggegrationInterface: Relationship 'members' defines 'common_parent' but node does not have a parent relationship"
+    )
+
+
+async def test_schema_branch_validate_common_parent_invalid_relationship_name():
+    schema_with_lag = copy.deepcopy(DEVICE_SCHEMA)
+    lag_interface_schema = copy.deepcopy(LAG_INTERFACE)
+    lag_interface_schema.relationships[0].common_parent = "foo"
+    schema_with_lag.nodes.append(lag_interface_schema)
+
+    schema = SchemaBranch(cache={}, name="test")
+    schema.load_schema(schema=schema_with_lag)
+    schema.process_inheritance()
+
+    with pytest.raises(ValueError) as exc:
+        schema.validate_kinds()
+
+    assert str(exc.value) == (
+        "TestingLinkAggegrationInterface: Relationship 'members' defines 'common_parent' but 'TestingPhysicalInterface.foo' does not exist"
+    )
+
+
+async def test_schema_branch_validate_common_parent_invalid_relationship_kind():
+    schema_with_lag = copy.deepcopy(DEVICE_SCHEMA)
+    lag_interface_schema = copy.deepcopy(LAG_INTERFACE)
+    lag_interface_schema.relationships[0].common_parent = "device"
+    schema_with_lag.nodes.append(lag_interface_schema)
+
+    schema = SchemaBranch(cache={}, name="test")
+    schema.load_schema(schema=schema_with_lag)
+    schema.process_inheritance()
+    schema.get(name=TestKind.PHYSICAL_INTERFACE, duplicate=False).get_relationship(
+        "device"
+    ).kind = RelationshipKind.GENERIC
+
+    with pytest.raises(ValueError) as exc:
+        schema.validate_kinds()
+
+    assert str(exc.value) == (
+        "TestingLinkAggegrationInterface: Relationship 'members' defines 'common_parent' but 'TestingPhysicalInterface.device is not of kind 'parent'"
+    )
+
+
 async def test_schema_branch_validate_kinds_inherit():
     SCHEMA1 = {
         "name": "Criticality",

--- a/docs/docs/reference/schema/relationship.mdx
+++ b/docs/docs/reference/schema/relationship.mdx
@@ -18,7 +18,7 @@ Below is the list of all available options to define a Relationship in the schem
 | [**allow_override**](#allow_override) | Attribute | Type of allowed override for the relationship. | False |
 | [**branch**](#branch) | Attribute | Type of branch support for the relatioinship, if not defined it will be determine based both peers. | False |
 | [**cardinality**](#cardinality) | Attribute | Defines how many objects are expected on the other side of the relationship. | False |
-| [**common_parent**](#common_parent) | Attribute | Name of a parent relationship on the peer schema that must share the same related object with the object parent. | False |
+| [**common_parent**](#common_parent) | Attribute | Name of a parent relationship on the peer schema that must share the same related object with the object's parent. | False |
 | [**common_relatives**](#common_relatives) | Attribute | List of relationship names on the peer schema for which all objects must share the same set of peers. | False |
 | [**deprecation**](#deprecation) | Attribute | Mark relationship as deprecated and provide a user-friendly message to display | False |
 | [**description**](#description) | Attribute | Short description of the relationship. | False |
@@ -81,7 +81,7 @@ Below is the list of all available options to define a Relationship in the schem
 | ---- | --------------- |
 | **Name** | common_parent |
 | **Kind** | `Text` |
-| **Description** | Name of a parent relationship on the peer schema that must share the same related object with the object parent. |
+| **Description** | Name of a parent relationship on the peer schema that must share the same related object with the object's parent. |
 | **Optional** | True |
 | **Default Value** |  |
 | **Constraints** |  |

--- a/docs/docs/reference/schema/relationship.mdx
+++ b/docs/docs/reference/schema/relationship.mdx
@@ -18,6 +18,7 @@ Below is the list of all available options to define a Relationship in the schem
 | [**allow_override**](#allow_override) | Attribute | Type of allowed override for the relationship. | False |
 | [**branch**](#branch) | Attribute | Type of branch support for the relatioinship, if not defined it will be determine based both peers. | False |
 | [**cardinality**](#cardinality) | Attribute | Defines how many objects are expected on the other side of the relationship. | False |
+| [**common_parent**](#common_parent) | Attribute | Name of a parent relationship on the peer schema that must share the same related object with the object parent. | False |
 | [**common_relatives**](#common_relatives) | Attribute | List of relationship names on the peer schema for which all objects must share the same set of peers. | False |
 | [**deprecation**](#deprecation) | Attribute | Mark relationship as deprecated and provide a user-friendly message to display | False |
 | [**description**](#description) | Attribute | Short description of the relationship. | False |
@@ -73,6 +74,17 @@ Below is the list of all available options to define a Relationship in the schem
 | **Default Value** | many |
 | **Constraints** |  |
 | **Accepted Values** | `one` `many`  |
+
+### common_parent
+
+| Key | Value |
+| ---- | --------------- |
+| **Name** | common_parent |
+| **Kind** | `Text` |
+| **Description** | Name of a parent relationship on the peer schema that must share the same related object with the object parent. |
+| **Optional** | True |
+| **Default Value** |  |
+| **Constraints** |  |
 
 ### common_relatives
 

--- a/docs/docs/reference/schema/validator-migration.mdx
+++ b/docs/docs/reference/schema/validator-migration.mdx
@@ -86,8 +86,8 @@ In this context, an element represent either a Node, a Generic, an Attribute or 
 | **cardinality** | validate_constraint |
 | **min_count** | validate_constraint |
 | **max_count** | validate_constraint |
-| **common_parent** | validate_constraint |
-| **common_relatives** | validate_constraint |
+| **common_parent** | allowed |
+| **common_relatives** | allowed |
 | **order_weight** | allowed |
 | **optional** | validate_constraint |
 | **branch** | not_supported |

--- a/docs/docs/reference/schema/validator-migration.mdx
+++ b/docs/docs/reference/schema/validator-migration.mdx
@@ -86,6 +86,7 @@ In this context, an element represent either a Node, a Generic, an Attribute or 
 | **cardinality** | validate_constraint |
 | **min_count** | validate_constraint |
 | **max_count** | validate_constraint |
+| **common_parent** | validate_constraint |
 | **common_relatives** | validate_constraint |
 | **order_weight** | allowed |
 | **optional** | validate_constraint |


### PR DESCRIPTION
This relationship attribute is used to specify that peers of a given
relationship must share a common parent with the source object. While
the parent of the source object is infered automatically (as there is
only one parent per object), the `common_parent` value must be set to
the name of the parent relationship of the peer schema.