### PR TITLE
new DiffRepository method to delete all diffs

### DIFF
--- a/backend/infrahub/core/diff/query/delete_query.py
+++ b/backend/infrahub/core/diff/query/delete_query.py
@@ -9,17 +9,21 @@ class EnrichedDiffDeleteQuery(Query):
     type = QueryType.WRITE
     insert_return = False
 
-    def __init__(self, enriched_diff_root_uuids: list[str], **kwargs: Any) -> None:
+    def __init__(self, enriched_diff_root_uuids: list[str] | None = None, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.enriched_diff_root_uuids = enriched_diff_root_uuids
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
-        self.params = {"diff_root_uuids": self.enriched_diff_root_uuids}
+        diff_filter = ""
+        if self.enriched_diff_root_uuids:
+            self.params = {"diff_root_uuids": self.enriched_diff_root_uuids}
+            diff_filter = "WHERE d_root.uuid IN $diff_root_uuids"
+
         query = """
         MATCH (d_root:DiffRoot)
-        WHERE d_root.uuid IN $diff_root_uuids
+        %(diff_filter)s
         OPTIONAL MATCH (d_root)-[*]->(diff_thing)
         DETACH DELETE diff_thing
         DETACH DELETE d_root
-        """
+        """ % {"diff_filter": diff_filter}
         self.add_to_query(query=query)

--- a/backend/infrahub/core/diff/repository/repository.py
+++ b/backend/infrahub/core/diff/repository/repository.py
@@ -377,6 +377,10 @@ class DiffRepository:
         await query.execute(db=self.db)
         return query.get_summary()
 
+    async def delete_all_diff_roots(self) -> None:
+        query = await EnrichedDiffDeleteQuery.init(db=self.db)
+        await query.execute(db=self.db)
+
     async def delete_diff_roots(self, diff_root_uuids: list[str]) -> None:
         query = await EnrichedDiffDeleteQuery.init(db=self.db, enriched_diff_root_uuids=diff_root_uuids)
         await query.execute(db=self.db)

--- a/backend/infrahub/core/migrations/graph/m015_diff_format_update.py
+++ b/backend/infrahub/core/migrations/graph/m015_diff_format_update.py
@@ -31,6 +31,5 @@ class Migration015(ArbitraryMigration):
         component_registry = get_component_registry()
         diff_repo = await component_registry.get_component(DiffRepository, db=db, branch=default_branch)
 
-        diff_roots = await diff_repo.get_roots_metadata()
-        await diff_repo.delete_diff_roots(diff_root_uuids=[d.uuid for d in diff_roots])
+        await diff_repo.delete_all_diff_roots()
         return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m016_diff_delete_bug_fix.py
+++ b/backend/infrahub/core/migrations/graph/m016_diff_delete_bug_fix.py
@@ -31,6 +31,5 @@ class Migration016(ArbitraryMigration):
         component_registry = get_component_registry()
         diff_repo = await component_registry.get_component(DiffRepository, db=db, branch=default_branch)
 
-        diff_roots = await diff_repo.get_roots_metadata()
-        await diff_repo.delete_diff_roots(diff_root_uuids=[d.uuid for d in diff_roots])
+        await diff_repo.delete_all_diff_roots()
         return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m028_delete_diffs.py
+++ b/backend/infrahub/core/migrations/graph/m028_delete_diffs.py
@@ -33,6 +33,5 @@ class Migration028(ArbitraryMigration):
         component_registry = get_component_registry()
         diff_repo = await component_registry.get_component(DiffRepository, db=db, branch=default_branch)
 
-        diff_roots = await diff_repo.get_roots_metadata()
-        await diff_repo.delete_diff_roots(diff_root_uuids=[d.uuid for d in diff_roots])
+        await diff_repo.delete_all_diff_roots()
         return MigrationResult()

--- a/backend/tests/unit/core/diff/repository/test_diff_repository.py
+++ b/backend/tests/unit/core/diff/repository/test_diff_repository.py
@@ -495,6 +495,24 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
             r.exists_on_database = False
         assert set(retrieved) == set(diffs)
 
+    async def test_delete_all_diffs(self, diff_repository: DiffRepository, reset_database):
+        diffs: list[EnrichedDiffRoot] = []
+        for _ in range(5):
+            nodes = self._build_nodes(num_nodes=2, num_sub_fields=1)
+            enriched_diff = EnrichedRootFactory.build(nodes=nodes)
+            await self._save_single_diff(
+                diff_repository=diff_repository, enriched_diff=enriched_diff, do_summary_counts=False
+            )
+            diffs.append(enriched_diff)
+
+        await diff_repository.delete_all_diff_roots()
+
+        retrieved = await diff_repository.get(
+            base_branch_name=self.base_branch_name,
+            diff_branch_names=[self.diff_branch_name],
+        )
+        assert len(retrieved) == 0
+
     async def test_get_by_tracking_id(self, diff_repository: DiffRepository, reset_database):
         branch_tracking_id = BranchTrackingId(name=self.diff_branch_name)
         name_tracking_id = NameTrackingId(name="an very cool diff")


### PR DESCRIPTION
new way to delete all diffs that does not require retrieving them from the database first

without this change, a user upgrading from `1.1` or earlier to latest might encounter an error during certain migrations that delete all diffs