### PR TITLE
Fix repository validator state

### DIFF
--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -696,6 +696,7 @@ async def trigger_internal_checks(
         if (
             existing_validator.typename == InfrahubKind.REPOSITORYVALIDATOR
             and existing_validator.repository.id == model.repository
+            and existing_validator.label.value == validator_name
         ):
             previous_validator = existing_validator
 


### PR DESCRIPTION
Fixes #6614

Currently we have two kind of tests ran linked to repository:
- user defined tests
- merge conflict tests

These tests are ran simultaneously and might reuse the same validator. So if user defined tests first fail, merge conflict tests might reuse this validator and override failure state with successful state, leading to wrong state.

This fix ensures the validator used for merge conflict tests is not the one used by user defined tests.