### PR TITLE
Activate ruff builtin rule and set ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -503,7 +503,6 @@ ignore = [
     "G",        # flake8-logging-format
     "RSE",      # flake8-raise
     "BLE",      # flake8-blind-except (BLE)
-    "A",        # flake8-builtins
     "PD",       # pandas-vet
     "FAST002",  # FastAPI dependency without `Annotated`
 
@@ -587,6 +586,17 @@ quote-style = "double"
 indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "auto"
+
+[tool.ruff.lint.flake8-builtins]
+ignorelist = [
+    "id",
+    # Review and update builtin shadowing below this line
+    "filter",
+    "format",
+    "input",
+    "property",
+    "type",
+]
 
 [tool.ruff.lint.isort]
 known-first-party = ["infrahub"]


### PR DESCRIPTION
Avoid further builtin shadowing and set ignores for the current violations, some of them I think we could fix later others like `id` we can probably ignore.