### PR TITLE
revert CALL subquery deprecation ignore

### DIFF
--- a/backend/infrahub/database/__init__.py
+++ b/backend/infrahub/database/__init__.py
@@ -498,7 +498,6 @@ async def get_db(retry: int = 0) -> AsyncDriver:
         trusted_certificates=trusted_certificates,
         notifications_disabled_categories=[
             NotificationDisabledCategory.UNRECOGNIZED,
-            NotificationDisabledCategory.DEPRECATION,  # TODO: Remove me with 1.3
         ],
         notifications_min_severity=NotificationMinimumSeverity.WARNING,
     )


### PR DESCRIPTION
IFC-1482

remove `DEPRECATION` from the list of disabled neo4j warnings

all the existing `CALL` subqueries have been migrated to the new format, so we should not get any errors in the logs