### PR TITLE
Refresh GraphQL schema after a branch rebase operation

### DIFF
--- a/backend/infrahub/message_bus/operations/refresh/registry.py
+++ b/backend/infrahub/message_bus/operations/refresh/registry.py
@@ -1,5 +1,3 @@
-from infrahub import lock
-from infrahub.core.registry import registry
 from infrahub.message_bus import messages
 from infrahub.services import InfrahubServices
 from infrahub.tasks.registry import refresh_branches
@@ -24,8 +22,7 @@ async def rebased_branch(message: messages.RefreshRegistryRebasedBranch, service
         )
         return
 
-    async with lock.registry.local_schema_lock():
-        service.log.info("Refreshing rebased branch")
+    async with service.database.start_session(read_only=True) as db:
+        await refresh_branches(db=db)
 
-        async with service.database.start_session(read_only=True) as db:
-            registry.branch[message.branch] = await registry.branch_object.get_by_name(name=message.branch, db=db)
+    await service.component.refresh_schema_hash()

--- a/changelog/6561.fixed.md
+++ b/changelog/6561.fixed.md
@@ -1,0 +1,1 @@
+Ensure GraphQL schema is refreshed after a branch rebase


### PR DESCRIPTION
The change here is that we ensure to refresh the branch properly. The main issue here was that during a rebase we only refreshed the branch object in the registry but we didn't refresh the GraphQL schema on the API workers. The change means that we manage a branch rebase in the same way as any other schema change where we refresh the local registry branches as required.

A follow up step to this could be to combine the two messages into a single branch refresh one and potentially include the name of a branch as an argument to avoid refreshing all of the branches.

Fixes #6561