### PR TITLE
Create number pools within a lock

### DIFF
--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -7,6 +7,7 @@ from infrahub_sdk.template import Jinja2Template
 from infrahub_sdk.utils import is_valid_uuid
 from infrahub_sdk.uuidt import UUIDT
 
+from infrahub import lock
 from infrahub.core import registry
 from infrahub.core.changelog.models import NodeChangelog
 from infrahub.core.constants import (
@@ -34,6 +35,7 @@ from infrahub.core.schema import (
 from infrahub.core.schema.attribute_parameters import NumberPoolParameters
 from infrahub.core.timestamp import Timestamp
 from infrahub.exceptions import InitializationError, NodeNotFoundError, PoolExhaustedError, ValidationError
+from infrahub.pools.models import NumberPoolLockDefinition
 from infrahub.types import ATTRIBUTE_TYPES
 
 from ...graphql.constants import KIND_GRAPHQL_FIELD_NAME
@@ -271,7 +273,7 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
             )
         except NodeNotFoundError:
             if number_pool_parameters:
-                number_pool = await self._create_number_pool(
+                number_pool = await self._fetch_or_create_number_pool(
                     db=db, attribute=attribute, number_pool_parameters=number_pool_parameters
                 )
 
@@ -306,35 +308,49 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
                 )
             )
 
-    async def _create_number_pool(
+    async def _fetch_or_create_number_pool(
         self, db: InfrahubDatabase, attribute: BaseAttribute, number_pool_parameters: NumberPoolParameters
     ) -> CoreNumberPool:
-        schema = db.schema.get_node_schema(name="CoreNumberPool", duplicate=False)
+        number_pool_from_db: CoreNumberPool | None = None
+        lock_definition = NumberPoolLockDefinition(pool_id=str(number_pool_parameters.number_pool_id))
+        async with lock.registry.get(
+            name=lock_definition.lock_name, namespace=lock_definition.namespace_name, local=False
+        ):
+            try:
+                number_pool_from_db = await registry.manager.get_one_by_id_or_default_filter(
+                    db=db, id=str(number_pool_parameters.number_pool_id), kind=CoreNumberPool
+                )
+            except NodeNotFoundError:
+                schema = db.schema.get_node_schema(name="CoreNumberPool", duplicate=False)
 
-        pool_node = self._schema.kind
-        schema_attribute = self._schema.get_attribute(attribute.schema.name)
-        if schema_attribute.inherited:
-            for generic_name in self._schema.inherit_from:
-                generic_node = db.schema.get_generic_schema(name=generic_name, duplicate=False)
-                if attribute.schema.name in generic_node.attribute_names:
-                    pool_node = generic_node.kind
-                    break
+                pool_node = self._schema.kind
+                schema_attribute = self._schema.get_attribute(attribute.schema.name)
+                if schema_attribute.inherited:
+                    for generic_name in self._schema.inherit_from:
+                        generic_node = db.schema.get_generic_schema(name=generic_name, duplicate=False)
+                        if attribute.schema.name in generic_node.attribute_names:
+                            pool_node = generic_node.kind
+                            break
 
-        number_pool = await Node.init(db=db, schema=schema, branch=self._branch)
-        await number_pool.new(
-            db=db,
-            id=number_pool_parameters.number_pool_id,
-            name=f"{pool_node}.{attribute.schema.name} [{number_pool_parameters.number_pool_id}]",
-            node=pool_node,
-            node_attribute=attribute.schema.name,
-            start_range=number_pool_parameters.start_range,
-            end_range=number_pool_parameters.end_range,
-            pool_type=NumberPoolType.SCHEMA.value,
-        )
-        await number_pool.save(db=db)
+                number_pool = await Node.init(db=db, schema=schema, branch=self._branch)
+                await number_pool.new(
+                    db=db,
+                    id=number_pool_parameters.number_pool_id,
+                    name=f"{pool_node}.{attribute.schema.name} [{number_pool_parameters.number_pool_id}]",
+                    node=pool_node,
+                    node_attribute=attribute.schema.name,
+                    start_range=number_pool_parameters.start_range,
+                    end_range=number_pool_parameters.end_range,
+                    pool_type=NumberPoolType.SCHEMA.value,
+                )
+                await number_pool.save(db=db)
+
         # Do a lookup of the number pool to get the correct mapped type from the registry
         # without this we don't get access to the .get_resource() method.
-        return await registry.manager.get_one_by_id_or_default_filter(db=db, id=number_pool.id, kind=CoreNumberPool)
+        created_pool: CoreNumberPool = number_pool_from_db or await registry.manager.get_one_by_id_or_default_filter(
+            db=db, id=number_pool.id, kind=CoreNumberPool
+        )
+        return created_pool
 
     async def handle_object_template(self, fields: dict, db: InfrahubDatabase, errors: list) -> None:
         """Fill the `fields` parameters with values from an object template if one is in use."""

--- a/backend/infrahub/pools/models.py
+++ b/backend/infrahub/pools/models.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class NumberPoolLockDefinition:
+    pool_id: str
+
+    @property
+    def lock_name(self) -> str:
+        return f"number-pool-creation-{self.pool_id}"
+
+    @property
+    def namespace_name(self) -> str:
+        return "number-pool"

--- a/backend/infrahub/pools/tasks.py
+++ b/backend/infrahub/pools/tasks.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from prefect import flow
 from prefect.logging import get_run_logger
 
+from infrahub import lock
 from infrahub.context import InfrahubContext  # noqa: TC001  needed for prefect flow
 from infrahub.core.constants import InfrahubKind, NumberPoolType
 from infrahub.core.manager import NodeManager
@@ -10,6 +11,8 @@ from infrahub.core.node import Node
 from infrahub.core.protocols import CoreNumberPool
 from infrahub.core.registry import registry
 from infrahub.core.schema.attribute_parameters import NumberPoolParameters
+from infrahub.exceptions import NodeNotFoundError
+from infrahub.pools.models import NumberPoolLockDefinition
 from infrahub.pools.registration import get_branches_with_schema_number_pool
 from infrahub.services import InfrahubServices  # noqa: TC001  needed for prefect flow
 
@@ -101,16 +104,23 @@ async def _create_number_pool(
     start_range: int,
     end_range: int,
 ) -> None:
-    async with service.database.start_session() as dbs:
-        number_pool = await Node.init(db=dbs, schema=InfrahubKind.NUMBERPOOL, branch=registry.default_branch)
-        await number_pool.new(
-            db=dbs,
-            id=number_pool_id,
-            name=f"{pool_node}.{pool_attribute} [{number_pool_id}]",
-            node=pool_node,
-            node_attribute=pool_attribute,
-            start_range=start_range,
-            end_range=end_range,
-            pool_type=NumberPoolType.SCHEMA.value,
-        )
-        await number_pool.save(db=dbs)
+    lock_definition = NumberPoolLockDefinition(pool_id=number_pool_id)
+    async with lock.registry.get(name=lock_definition.lock_name, namespace=lock_definition.namespace_name, local=False):
+        async with service.database.start_session() as dbs:
+            try:
+                await registry.manager.get_one_by_id_or_default_filter(
+                    db=dbs, id=str(number_pool_id), kind=CoreNumberPool
+                )
+            except NodeNotFoundError:
+                number_pool = await Node.init(db=dbs, schema=InfrahubKind.NUMBERPOOL, branch=registry.default_branch)
+                await number_pool.new(
+                    db=dbs,
+                    id=number_pool_id,
+                    name=f"{pool_node}.{pool_attribute} [{number_pool_id}]",
+                    node=pool_node,
+                    node_attribute=pool_attribute,
+                    start_range=start_range,
+                    end_range=end_range,
+                    pool_type=NumberPoolType.SCHEMA.value,
+                )
+                await number_pool.save(db=dbs)


### PR DESCRIPTION
Create number pools within a lock to avoid timing situations where two pools of the same ID would have been created at the same time.