### PR TITLE
update final CALL subqueries for new format

### DIFF
--- a/backend/infrahub/core/diff/query/field_specifiers.py
+++ b/backend/infrahub/core/diff/query/field_specifiers.py
@@ -15,7 +15,7 @@ class EnrichedDiffFieldSpecifiersQuery(Query):
     async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
         self.params["diff_id"] = self.diff_id
         query = """
-CALL {
+CALL () {
     MATCH (root:DiffRoot {uuid: $diff_id})-[:DIFF_HAS_NODE]->(node:DiffNode)-[:DIFF_HAS_ATTRIBUTE]->(attr:DiffAttribute)
     WHERE (root.is_merged IS NULL OR root.is_merged <> TRUE)
     RETURN node.uuid AS node_uuid, node.kind AS node_kind, attr.name AS field_name

--- a/backend/infrahub/core/diff/query/merge.py
+++ b/backend/infrahub/core/diff/query/merge.py
@@ -710,14 +710,14 @@ class DiffMergeRollbackQuery(Query):
         // ---------------------------
         // reset to times on target branch
         // ---------------------------
-        CALL {
+        CALL () {
             OPTIONAL MATCH ()-[r_to {to: $at, branch: $target_branch}]-()
             SET r_to.to = NULL
         }
         // ---------------------------
         // reset from times on target branch
         // ---------------------------
-        CALL {
+        CALL () {
             OPTIONAL MATCH ()-[r_from {from: $at, branch: $target_branch}]-()
             DELETE r_from
         }

--- a/backend/infrahub/core/migrations/graph/m012_convert_account_generic.py
+++ b/backend/infrahub/core/migrations/graph/m012_convert_account_generic.py
@@ -61,7 +61,7 @@ class Migration012RenameTypeAttributeData(AttributeRenameQuery):
     def render_match(self) -> str:
         query = """
         // Find all the active nodes
-        CALL {
+        CALL () {
             MATCH (node:%(node_kind)s)
             WHERE exists((node)-[:HAS_ATTRIBUTE]-(:Attribute { name: $prev_attr.name }))
                 AND NOT exists((node)-[:HAS_ATTRIBUTE]-(:Attribute { name: $new_attr.name }))

--- a/backend/infrahub/core/migrations/graph/m023_deduplicate_cardinality_one_relationships.py
+++ b/backend/infrahub/core/migrations/graph/m023_deduplicate_cardinality_one_relationships.py
@@ -52,7 +52,7 @@ class DedupCardinalityOneRelsQuery(Query):
         # of a one-to-many BIDIR relationship.
         query = """
 
-        CALL {
+        CALL () {
             MATCH (rel_node: Relationship)-[edge:IS_RELATED]->(n: Node)<-[edge_2:IS_RELATED]-(rel_node_2: Relationship {name: rel_node.name})
             WHERE rel_node.name in $rel_one_identifiers_inbound[n.kind]
                 AND edge.branch = edge_2.branch
@@ -64,7 +64,7 @@ class DedupCardinalityOneRelsQuery(Query):
             DETACH DELETE rel_node
         }
 
-        CALL {
+        CALL () {
             MATCH (rel_node_3: Relationship)<-[edge_3:IS_RELATED]-(n: Node)-[edge_4:IS_RELATED]->(rel_node_4: Relationship {name: rel_node_3.name})
             WHERE rel_node_3.name in $rel_one_identifiers_outbound[n.kind]
                 AND edge_3.branch = edge_4.branch

--- a/backend/infrahub/core/migrations/graph/m029_duplicates_cleanup.py
+++ b/backend/infrahub/core/migrations/graph/m029_duplicates_cleanup.py
@@ -535,12 +535,12 @@ class PerformHardDeletes(Query):
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
         query = """
-CALL {
+CALL () {
     MATCH (n)
     WHERE n.to_delete = TRUE
     DETACH DELETE n
 }
-CALL {
+CALL () {
     MATCH ()-[e]-()
     WHERE e.to_delete = TRUE
     DELETE e

--- a/backend/infrahub/core/migrations/query/attribute_rename.py
+++ b/backend/infrahub/core/migrations/query/attribute_rename.py
@@ -38,7 +38,7 @@ class AttributeRenameQuery(Query):
     def render_match(self) -> str:
         query = """
         // Find all the active nodes
-        CALL {
+        CALL () {
             MATCH (node:%(node_kind)s)
             WHERE exists((node)-[:HAS_ATTRIBUTE]-(:Attribute { name: $prev_attr.name }))
             RETURN node

--- a/backend/infrahub/core/query/delete.py
+++ b/backend/infrahub/core/query/delete.py
@@ -21,7 +21,7 @@ class DeleteAfterTimeQuery(Query):
         // ---------------------
         // Reset edges with to time after timestamp
         // ---------------------
-        CALL {
+        CALL () {
             OPTIONAL MATCH (p)-[r]-(q)
             WHERE r.to > $timestamp
             SET r.to = NULL
@@ -33,7 +33,7 @@ class DeleteAfterTimeQuery(Query):
             // ---------------------
             // Delete edges with from time after timestamp timestamp
             // ---------------------
-            CALL {
+            CALL () {
                 OPTIONAL MATCH (p)-[r]->(q)
                 WHERE r.from > $timestamp
                 DELETE r
@@ -49,7 +49,7 @@ class DeleteAfterTimeQuery(Query):
             // ---------------------
             // Delete edges with from time after timestamp timestamp
             // ---------------------
-            CALL {
+            CALL () {
                 OPTIONAL MATCH (p)-[r]->(q)
                 WHERE r.from > $timestamp
                 DELETE r

--- a/backend/tests/unit/core/diff/repository/test_diff_repository.py
+++ b/backend/tests/unit/core/diff/repository/test_diff_repository.py
@@ -1037,7 +1037,7 @@ class TestDiffRepositorySaveAndLoad(DiffRepositoryTestBase):
 async def verify_no_orphaned_nodes(db: InfrahubDatabase) -> None:
     """Verify that no diff elements have been orphaned"""
     query = """
-CALL {
+CALL () {
     MATCH (d:DiffNode)
     WHERE not exists((:DiffRoot)-[]->(d))
     RETURN d

--- a/backend/tests/unit/core/migrations/graph/test_029/test_029.py
+++ b/backend/tests/unit/core/migrations/graph/test_029/test_029.py
@@ -29,7 +29,7 @@ CREATE (:Branch {name: "branch-9176", is_default: FALSE, is_global: FALSE, branc
         await db.execute_query(query=query)
         # export does not include AttributeValue.value or Boolean.value, we need to set those for the snapshot
         query = """
-CALL {
+CALL () {
     MATCH (a:AttributeValue)
     RETURN a
     UNION


### PR DESCRIPTION
I thought `CALL {...}` subqueries that did not use any outer variable were still allowed, but I was wrong. they still need to be `CALL () {...}`