### PR TITLE
Replace deprecated app parameter to httpx in tests

### DIFF
--- a/backend/tests/helpers/test_client.py
+++ b/backend/tests/helpers/test_client.py
@@ -17,7 +17,7 @@ async def dummy_async_request(
 class InfrahubTestClient(httpx.AsyncClient):
     def __init__(self, app: FastAPI, base_url: str = "") -> None:
         self.loop = asyncio.get_event_loop()
-        super().__init__(app=app, base_url=base_url)
+        super().__init__(transport=httpx.ASGITransport(app=app), base_url=base_url)
 
     async def _request(
         self, url: str, method: HTTPMethod, headers: dict[str, Any], timeout: int, payload: dict | None = None


### PR DESCRIPTION
When running tests we're constantly seeing errors like this:

```python
backend/tests/unit/core/convert_object_type/test_convert_object_type.py::TestSchemaConversionMapping::test_schema_conversion_mapping[main]
  /Users/patrick/.virtualenvs/infrahub/lib/python3.12/site-packages/httpx/_client.py:1437: DeprecationWarning: The 'app' shortcut is now deprecated. Use the explicit style 'transport=ASGITransport(app=...)' instead.
    warnings.warn(message, DeprecationWarning)
```