### PR TITLE
simpler uniqueness query for node constraints

### DIFF
--- a/backend/infrahub/core/node/constraints/grouped_uniqueness.py
+++ b/backend/infrahub/core/node/constraints/grouped_uniqueness.py
@@ -1,26 +1,19 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING
 
 from infrahub.core import registry
 from infrahub.core.constants import NULL_VALUE
-from infrahub.core.schema import (
-    MainSchemaTypes,
-    SchemaAttributePath,
-    SchemaAttributePathValue,
-)
 from infrahub.core.schema.basenode_schema import (
-    SchemaUniquenessConstraintPath,
     UniquenessConstraintType,
     UniquenessConstraintViolation,
 )
-from infrahub.core.validators.uniqueness.index import UniquenessQueryResultsIndex
 from infrahub.core.validators.uniqueness.model import (
-    NodeUniquenessQueryRequest,
-    QueryAttributePath,
-    QueryRelationshipAttributePath,
+    NodeUniquenessQueryRequestValued,
+    QueryAttributePathValued,
+    QueryRelationshipPathValued,
 )
-from infrahub.core.validators.uniqueness.query import NodeUniqueAttributeConstraintQuery
+from infrahub.core.validators.uniqueness.query import UniquenessValidationQuery
 from infrahub.exceptions import HFIDViolatedError, ValidationError
 
 from .interface import NodeConstraintInterface
@@ -28,8 +21,11 @@ from .interface import NodeConstraintInterface
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
     from infrahub.core.node import Node
-    from infrahub.core.query import QueryResult
     from infrahub.core.relationship.model import RelationshipManager
+    from infrahub.core.schema import (
+        MainSchemaTypes,
+        SchemaAttributePath,
+    )
     from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
@@ -40,72 +36,38 @@ class NodeGroupedUniquenessConstraint(NodeConstraintInterface):
         self.branch = branch
         self.schema_branch = registry.schema.get_schema_branch(branch.name)
 
-    async def _build_query_request(
-        self,
-        updated_node: Node,
-        node_schema: MainSchemaTypes,
-        uniqueness_constraint_paths: list[SchemaUniquenessConstraintPath],
-        filters: list[str] | None = None,
-    ) -> NodeUniquenessQueryRequest:
-        query_request = NodeUniquenessQueryRequest(kind=node_schema.kind)
-        for uniqueness_constraint_path in uniqueness_constraint_paths:
-            include_in_query = not filters
-            query_relationship_paths: set[QueryRelationshipAttributePath] = set()
-            query_attribute_paths: set[QueryAttributePath] = set()
-            for attribute_path in uniqueness_constraint_path.attributes_paths:
-                if attribute_path.related_schema and attribute_path.relationship_schema:
-                    if filters and attribute_path.relationship_schema.name in filters:
-                        include_in_query = True
-
-                    relationship_manager: RelationshipManager = getattr(
-                        updated_node, attribute_path.relationship_schema.name
-                    )
-                    related_node = await relationship_manager.get_peer(db=self.db)
-                    related_node_id = related_node.get_id() if related_node else None
-                    query_relationship_paths.add(
-                        QueryRelationshipAttributePath(
-                            identifier=attribute_path.relationship_schema.get_identifier(),
-                            value=related_node_id,
-                        )
-                    )
-                    continue
-                if attribute_path.attribute_schema:
-                    if filters and attribute_path.attribute_schema.name in filters:
-                        include_in_query = True
-                    attribute_name = attribute_path.attribute_schema.name
-                    attribute = getattr(updated_node, attribute_name)
-                    if attribute.is_enum and attribute.value:
-                        attribute_value = attribute.value.value
-                    else:
-                        attribute_value = attribute.value
-                    if attribute_value is None:
-                        attribute_value = NULL_VALUE
-                    query_attribute_paths.add(
-                        QueryAttributePath(
-                            attribute_name=attribute_name,
-                            property_name=attribute_path.attribute_property_name or "value",
-                            value=attribute_value,
-                        )
-                    )
-            if include_in_query:
-                query_request.relationship_attribute_paths |= query_relationship_paths
-                query_request.unique_attribute_paths |= query_attribute_paths
-        return query_request
-
-    async def _get_node_attribute_path_values(
+    async def _get_unique_valued_paths(
         self,
         updated_node: Node,
         path_group: list[SchemaAttributePath],
-    ) -> list[SchemaAttributePathValue]:
-        node_value_combination = []
+        filters: list[str],
+    ) -> list[QueryAttributePathValued | QueryRelationshipPathValued]:
+        # if filters are provided, we need to check if the path group is relevant to the filters
+        if filters:
+            field_names: list[str] = []
+            for schema_attribute_path in path_group:
+                if schema_attribute_path.relationship_schema:
+                    field_names.append(schema_attribute_path.relationship_schema.name)
+                elif schema_attribute_path.attribute_schema:
+                    field_names.append(schema_attribute_path.attribute_schema.name)
+
+            if not set(field_names) & set(filters):
+                return []
+
+        valued_paths: list[QueryAttributePathValued | QueryRelationshipPathValued] = []
         for schema_attribute_path in path_group:
             if schema_attribute_path.relationship_schema:
                 relationship_name = schema_attribute_path.relationship_schema.name
                 relationship_manager: RelationshipManager = getattr(updated_node, relationship_name)
                 related_node = await relationship_manager.get_peer(db=self.db)
                 related_node_id = related_node.get_id() if related_node else None
-                node_value_combination.append(
-                    SchemaAttributePathValue.from_schema_attribute_path(schema_attribute_path, value=related_node_id)
+                valued_paths.append(
+                    QueryRelationshipPathValued(
+                        relationship_schema=schema_attribute_path.relationship_schema,
+                        peer_id=related_node_id,
+                        attribute_name=None,
+                        attribute_value=None,
+                    )
                 )
             elif schema_attribute_path.attribute_schema:
                 attribute_name = schema_attribute_path.attribute_schema.name
@@ -115,85 +77,78 @@ class NodeGroupedUniquenessConstraint(NodeConstraintInterface):
                     attribute_value = attribute_value.value
                 elif attribute_value is None:
                     attribute_value = NULL_VALUE
-                node_value_combination.append(
-                    SchemaAttributePathValue.from_schema_attribute_path(
-                        schema_attribute_path,
+                valued_paths.append(
+                    QueryAttributePathValued(
+                        attribute_name=attribute_name,
                         value=attribute_value,
                     )
                 )
-        return node_value_combination
-
-    async def _get_violations(
-        self,
-        updated_node: Node,
-        uniqueness_constraint_paths: list[SchemaUniquenessConstraintPath],
-        query_results: Iterable[QueryResult],
-    ) -> list[UniquenessConstraintViolation]:
-        results_index = UniquenessQueryResultsIndex(
-            query_results=query_results, exclude_node_ids={updated_node.get_id()}
-        )
-        violations = []
-        for uniqueness_constraint_path in uniqueness_constraint_paths:
-            # path_group = one constraint (that can contain multiple items)
-            schema_attribute_path_values = await self._get_node_attribute_path_values(
-                updated_node=updated_node, path_group=uniqueness_constraint_path.attributes_paths
-            )
-
-            # constraint cannot be violated if this node is missing any values
-            if any(sapv.value is None for sapv in schema_attribute_path_values):
-                continue
-
-            matching_node_ids = results_index.get_node_ids_for_value_group(schema_attribute_path_values)
-            if not matching_node_ids:
-                continue
-
-            uniqueness_constraint_fields = []
-            for sapv in schema_attribute_path_values:
-                if sapv.relationship_schema:
-                    uniqueness_constraint_fields.append(sapv.relationship_schema.name)
-                elif sapv.attribute_schema:
-                    uniqueness_constraint_fields.append(sapv.attribute_schema.name)
-
-            violations.append(
-                UniquenessConstraintViolation(
-                    nodes_ids=matching_node_ids,
-                    fields=uniqueness_constraint_fields,
-                    typ=uniqueness_constraint_path.typ,
-                )
-            )
-
-        return violations
+        return valued_paths
 
     async def _get_single_schema_violations(
         self,
         node: Node,
         node_schema: MainSchemaTypes,
+        filters: list[str],
         at: Timestamp | None = None,
-        filters: list[str] | None = None,
     ) -> list[UniquenessConstraintViolation]:
         schema_branch = self.db.schema.get_schema_branch(name=self.branch.name)
 
         uniqueness_constraint_paths = node_schema.get_unique_constraint_schema_attribute_paths(
             schema_branch=schema_branch
         )
-        query_request = await self._build_query_request(
-            updated_node=node,
-            node_schema=node_schema,
-            uniqueness_constraint_paths=uniqueness_constraint_paths,
-            filters=filters,
-        )
-        if not query_request:
-            return []
 
-        query = await NodeUniqueAttributeConstraintQuery.init(
-            db=self.db, branch=self.branch, at=at, query_request=query_request, min_count_required=0
-        )
-        await query.execute(db=self.db)
-        return await self._get_violations(
-            updated_node=node,
-            uniqueness_constraint_paths=uniqueness_constraint_paths,
-            query_results=query.get_results(),
-        )
+        violations: list[UniquenessConstraintViolation] = []
+        for uniqueness_constraint_path in uniqueness_constraint_paths:
+            valued_paths = await self._get_unique_valued_paths(
+                updated_node=node,
+                path_group=uniqueness_constraint_path.attributes_paths,
+                filters=filters,
+            )
+
+            if not valued_paths:
+                continue
+
+            # Create the valued query request for this constraint
+            valued_query_request = NodeUniquenessQueryRequestValued(
+                kind=node_schema.kind,
+                unique_valued_paths=valued_paths,
+            )
+
+            # Execute the query
+            query = await UniquenessValidationQuery.init(
+                db=self.db,
+                branch=self.branch,
+                at=at,
+                query_request=valued_query_request,
+                node_ids_to_exclude=[node.get_id()],
+            )
+            await query.execute(db=self.db)
+
+            # Get violation nodes from the query results
+            violation_nodes = query.get_violation_nodes()
+            if not violation_nodes:
+                continue
+
+            # Create violation object
+            uniqueness_constraint_fields = []
+            for valued_path in valued_paths:
+                if isinstance(valued_path, QueryRelationshipPathValued):
+                    uniqueness_constraint_fields.append(valued_path.relationship_schema.name)
+                elif isinstance(valued_path, QueryAttributePathValued):
+                    uniqueness_constraint_fields.append(valued_path.attribute_name)
+
+            matching_node_ids = {node_id for node_id, _ in violation_nodes}
+            if matching_node_ids:
+                violations.append(
+                    UniquenessConstraintViolation(
+                        nodes_ids=matching_node_ids,
+                        fields=uniqueness_constraint_fields,
+                        typ=uniqueness_constraint_path.typ,
+                    )
+                )
+
+        return violations
 
     async def check(self, node: Node, at: Timestamp | None = None, filters: list[str] | None = None) -> None:
         def _frozen_constraints(schema: MainSchemaTypes) -> frozenset[frozenset[str]]:
@@ -218,7 +173,8 @@ class NodeGroupedUniquenessConstraint(NodeConstraintInterface):
         if include_node_schema:
             schemas_to_check.append(node_schema)
 
-        violations = []
+        violations: list[UniquenessConstraintViolation] = []
+
         for schema in schemas_to_check:
             schema_filters = list(filters) if filters is not None else []
             for attr_schema in schema.attributes:

--- a/backend/infrahub/core/validators/uniqueness/model.py
+++ b/backend/infrahub/core/validators/uniqueness/model.py
@@ -59,6 +59,23 @@ class NodeUniquenessQueryRequest(BaseModel):
         )
 
 
+class QueryRelationshipPathValued(BaseModel):
+    relationship_schema: RelationshipSchema
+    peer_id: str | None
+    attribute_name: str | None
+    attribute_value: str | bool | int | float | None
+
+
+class QueryAttributePathValued(BaseModel):
+    attribute_name: str
+    value: str | bool | int | float
+
+
+class NodeUniquenessQueryRequestValued(BaseModel):
+    kind: str
+    unique_valued_paths: list[QueryAttributePathValued | QueryRelationshipPathValued]
+
+
 class NonUniqueRelatedAttribute(BaseModel):
     relationship: RelationshipSchema
     attribute_name: str

--- a/backend/infrahub/core/validators/uniqueness/query.py
+++ b/backend/infrahub/core/validators/uniqueness/query.py
@@ -5,10 +5,12 @@ from typing import TYPE_CHECKING, Any
 from infrahub.core.constants.relationship_label import RELATIONSHIP_TO_VALUE_LABEL
 from infrahub.core.query import Query, QueryType
 
+from .model import QueryAttributePathValued, QueryRelationshipPathValued
+
 if TYPE_CHECKING:
     from infrahub.database import InfrahubDatabase
 
-    from .model import NodeUniquenessQueryRequest
+    from .model import NodeUniquenessQueryRequest, NodeUniquenessQueryRequestValued
 
 
 class NodeUniqueAttributeConstraintQuery(Query):
@@ -244,3 +246,154 @@ class NodeUniqueAttributeConstraintQuery(Query):
             "attr_value",
             "relationship_identifier",
         ]
+
+
+class UniquenessValidationQuery(Query):
+    name = "uniqueness_constraint_validation"
+    type = QueryType.READ
+
+    def __init__(
+        self,
+        query_request: NodeUniquenessQueryRequestValued,
+        **kwargs: Any,
+    ) -> None:
+        self.query_request = query_request
+        super().__init__(**kwargs)
+
+    def _build_attr_subquery(
+        self, attr_path: QueryAttributePathValued, index: int, branch_filter: str
+    ) -> tuple[str, dict[str, str | int | float | bool]]:
+        attr_name_var = f"attr_name_{index}"
+        attr_value_var = f"attr_value_{index}"
+        attribute_query = """
+CALL (node) {
+    MATCH (node)-[r:HAS_ATTRIBUTE]->(attr:Attribute {name: $%(attr_name_var)s})
+    WHERE %(branch_filter)s
+    WITH attr, r.status = "active" AS is_active
+    ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+    WITH attr, is_active
+    LIMIT 1
+    WITH attr, is_active
+    WHERE is_active = TRUE
+    MATCH (attr)-[r:HAS_VALUE]->(:AttributeValue {value: $%(attr_value_var)s})
+    WHERE %(branch_filter)s
+    WITH r
+    ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+    LIMIT 1
+    WITH r
+    WHERE r.status = "active"
+    RETURN 1 AS is_match_%(index)s
+}
+        """ % {
+            "attr_name_var": attr_name_var,
+            "attr_value_var": attr_value_var,
+            "branch_filter": branch_filter,
+            "index": index,
+        }
+        params: dict[str, str | int | float | bool] = {
+            attr_name_var: attr_path.attribute_name,
+            attr_value_var: attr_path.value,
+        }
+        return attribute_query, params
+
+    def _build_rel_subquery(
+        self, rel_path: QueryRelationshipPathValued, index: int, branch_filter: str
+    ) -> tuple[str, dict[str, str | int | float | bool]]:
+        params: dict[str, str | int | float | bool] = {}
+        rel_attr_query = ""
+        if rel_path.attribute_name and rel_path.attribute_value:
+            attr_name_var = f"attr_name_{index}"
+            attr_value_var = f"attr_value_{index}"
+            rel_attr_query = """
+    MATCH (peer)-[r:HAS_ATTRIBUTE]->(attr:Attribute {name: $%(attr_name_var)s})
+    WHERE %(branch_filter)s
+    WITH attr, r.status = "active" AS is_active
+    ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+    WITH attr, is_active
+    LIMIT 1
+    WITH attr, is_active
+    WHERE is_active = TRUE
+    MATCH (attr)-[r:HAS_VALUE]->(:AttributeValue {value: $%(attr_value_var)s})
+    WHERE %(branch_filter)s
+    WITH r
+    ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+    LIMIT 1
+    WITH r
+    WHERE r.status = "active"
+            """ % {"attr_name_var": attr_name_var, "attr_value_var": attr_value_var, "branch_filter": branch_filter}
+            params[attr_name_var] = rel_path.attribute_name
+            params[attr_value_var] = rel_path.attribute_value
+        query_arrows = rel_path.relationship_schema.get_query_arrows()
+        rel_name_var = f"rel_name_{index}"
+        peer_where = f"WHERE {branch_filter}"
+        if rel_path.peer_id:
+            peer_id_var = f"peer_id_{index}"
+            peer_where += f"AND peer.uuid = ${peer_id_var}"
+            params[peer_id_var] = rel_path.peer_id
+        relationship_query = """
+CALL (node) {
+    MATCH (node)%(lstart)s[r:IS_RELATED]%(lend)s(rel:Relationship {name: $%(rel_name_var)s})
+    WHERE %(branch_filter)s
+    WITH rel, r.status = "active" AS is_active
+    ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+    WITH rel, is_active
+    LIMIT 1
+    WITH rel, is_active
+    WHERE is_active = TRUE
+    MATCH (rel)%(rstart)s[r:IS_RELATED]%(rend)s(peer:Node)
+    %(peer_where)s
+    WITH peer, r.status = "active" AS is_active
+    ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+    WITH peer, is_active
+    LIMIT 1
+    WITH peer, is_active
+    WHERE is_active = TRUE
+%(rel_attr_query)s
+    RETURN 1 AS is_match_%(index)s
+    LIMIT 1
+}
+        """ % {
+            "rel_name_var": rel_name_var,
+            "lstart": query_arrows.left.start,
+            "lend": query_arrows.left.end,
+            "rstart": query_arrows.right.start,
+            "rend": query_arrows.right.end,
+            "peer_where": peer_where,
+            "rel_attr_query": rel_attr_query,
+            "branch_filter": branch_filter,
+            "index": index,
+        }
+        params[rel_name_var] = rel_path.relationship_schema.get_identifier()
+        return relationship_query, params
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
+        branch_filter, branch_params = self.branch.get_query_filter_path(at=self.at.to_string())
+        self.params.update(branch_params)
+
+        subqueries = []
+        for index, schema_path in enumerate(self.query_request.unique_valued_paths):
+            if isinstance(schema_path, QueryAttributePathValued):
+                subquery, params = self._build_attr_subquery(
+                    attr_path=schema_path, index=index, branch_filter=branch_filter
+                )
+            else:
+                subquery, params = self._build_rel_subquery(
+                    rel_path=schema_path, index=index, branch_filter=branch_filter
+                )
+            subqueries.append(subquery)
+            self.params.update(params)
+
+        full_query = """
+MATCH(node:%(kind)s)
+%(subqueries)s
+        """ % {"kind": self.query_request.kind, "subqueries": "\n".join(subqueries)}
+        self.add_to_query(full_query)
+        self.return_labels = ["node.uuid AS node_uuid", "node.kind AS node_kind"]
+
+    def get_violation_nodes(self) -> list[tuple[str, str]]:
+        violation_tuples = []
+        for result in self.results:
+            violation_tuples.append(
+                (result.get_as_type("node_uuid", return_type=str), result.get_as_type("node_kind", return_type=str))
+            )
+        return violation_tuples

--- a/backend/infrahub/core/validators/uniqueness/query.py
+++ b/backend/infrahub/core/validators/uniqueness/query.py
@@ -263,11 +263,18 @@ class UniquenessValidationQuery(Query):
         super().__init__(**kwargs)
 
     def _build_attr_subquery(
-        self, attr_path: QueryAttributePathValued, index: int, branch_filter: str
+        self, node_kind: str, attr_path: QueryAttributePathValued, index: int, branch_filter: str, is_first_query: bool
     ) -> tuple[str, dict[str, str | int | float | bool]]:
         attr_name_var = f"attr_name_{index}"
         attr_value_var = f"attr_value_{index}"
+        if is_first_query:
+            first_query_filter = "WHERE $node_ids_to_exclude IS NULL OR NOT node.uuid IN $node_ids_to_exclude"
+        else:
+            first_query_filter = ""
         attribute_query = """
+MATCH (node:%(node_kind)s)-[:HAS_ATTRIBUTE]->(attr:Attribute {name: $%(attr_name_var)s})-[:HAS_VALUE]->(:AttributeValue {value: $%(attr_value_var)s})
+%(first_query_filter)s
+WITH DISTINCT node
 CALL (node) {
     MATCH (node)-[r:HAS_ATTRIBUTE]->(attr:Attribute {name: $%(attr_name_var)s})
     WHERE %(branch_filter)s
@@ -287,6 +294,8 @@ CALL (node) {
     RETURN 1 AS is_match_%(index)s
 }
         """ % {
+            "first_query_filter": first_query_filter,
+            "node_kind": node_kind,
             "attr_name_var": attr_name_var,
             "attr_value_var": attr_value_var,
             "branch_filter": branch_filter,
@@ -299,10 +308,16 @@ CALL (node) {
         return attribute_query, params
 
     def _build_rel_subquery(
-        self, rel_path: QueryRelationshipPathValued, index: int, branch_filter: str
+        self,
+        node_kind: str,
+        rel_path: QueryRelationshipPathValued,
+        index: int,
+        branch_filter: str,
+        is_first_query: bool,
     ) -> tuple[str, dict[str, str | int | float | bool]]:
         params: dict[str, str | int | float | bool] = {}
         rel_attr_query = ""
+        rel_attr_match = ""
         if rel_path.attribute_name and rel_path.attribute_value:
             attr_name_var = f"attr_name_{index}"
             attr_value_var = f"attr_value_{index}"
@@ -323,16 +338,47 @@ CALL (node) {
     WITH r
     WHERE r.status = "active"
             """ % {"attr_name_var": attr_name_var, "attr_value_var": attr_value_var, "branch_filter": branch_filter}
+            rel_attr_match = (
+                "-[r:HAS_VALUE]->(:AttributeValue {value: $%(attr_value_var)s})-[:HAS_VALUE]->(:AttributeValue {value: $%(attr_value_var)s})"
+                % {
+                    "attr_value_var": attr_value_var,
+                }
+            )
             params[attr_name_var] = rel_path.attribute_name
             params[attr_value_var] = rel_path.attribute_value
         query_arrows = rel_path.relationship_schema.get_query_arrows()
         rel_name_var = f"rel_name_{index}"
+        first_match = (
+            "MATCH (node:%(node_kind)s)%(lstart)s[:IS_RELATED]%(lend)s(:Relationship {name: $%(rel_name_var)s})%(rstart)s[:IS_RELATED]%(rend)s"
+            % {
+                "node_kind": node_kind,
+                "lstart": query_arrows.left.start,
+                "lend": query_arrows.left.end,
+                "rstart": query_arrows.right.start,
+                "rend": query_arrows.right.end,
+                "rel_name_var": rel_name_var,
+            }
+        )
         peer_where = f"WHERE {branch_filter}"
         if rel_path.peer_id:
             peer_id_var = f"peer_id_{index}"
             peer_where += f"AND peer.uuid = ${peer_id_var}"
             params[peer_id_var] = rel_path.peer_id
-        relationship_query = """
+            first_match += "(:Node {uuid: $%(peer_id_var)s})" % {"peer_id_var": peer_id_var}
+        else:
+            first_match += "(:Node)"
+        if rel_attr_match:
+            first_match += rel_attr_match
+        if is_first_query:
+            first_query_filter = "WHERE $node_ids_to_exclude IS NULL OR NOT node.uuid IN $node_ids_to_exclude"
+        else:
+            first_query_filter = ""
+        relationship_query = f"""
+{first_match}
+{first_query_filter}
+WITH DISTINCT node
+        """
+        relationship_query += """
 CALL (node) {
     MATCH (node)%(lstart)s[r:IS_RELATED]%(lend)s(rel:Relationship {name: $%(rel_name_var)s})
     WHERE %(branch_filter)s
@@ -375,22 +421,27 @@ CALL (node) {
 
         subqueries = []
         for index, schema_path in enumerate(self.query_request.unique_valued_paths):
+            is_first_query = index == 0
             if isinstance(schema_path, QueryAttributePathValued):
                 subquery, params = self._build_attr_subquery(
-                    attr_path=schema_path, index=index, branch_filter=branch_filter
+                    node_kind=self.query_request.kind,
+                    attr_path=schema_path,
+                    index=index,
+                    branch_filter=branch_filter,
+                    is_first_query=is_first_query,
                 )
             else:
                 subquery, params = self._build_rel_subquery(
-                    rel_path=schema_path, index=index, branch_filter=branch_filter
+                    node_kind=self.query_request.kind,
+                    rel_path=schema_path,
+                    index=index,
+                    branch_filter=branch_filter,
+                    is_first_query=is_first_query,
                 )
             subqueries.append(subquery)
             self.params.update(params)
 
-        full_query = """
-MATCH(node:%(kind)s)
-WHERE $node_ids_to_exclude IS NULL OR NOT node.uuid IN $node_ids_to_exclude
-%(subqueries)s
-        """ % {"kind": self.query_request.kind, "subqueries": "\n".join(subqueries)}
+        full_query = "\n".join(subqueries)
         self.add_to_query(full_query)
         self.return_labels = ["node.uuid AS node_uuid", "node.kind AS node_kind"]
 

--- a/backend/infrahub/core/validators/uniqueness/query.py
+++ b/backend/infrahub/core/validators/uniqueness/query.py
@@ -349,6 +349,7 @@ CALL (node) {
             params[attr_value_var] = rel_path.attribute_value
         query_arrows = rel_path.relationship_schema.get_query_arrows()
         rel_name_var = f"rel_name_{index}"
+        # long path MATCH is required to hit an index on the peer or AttributeValue of the peer
         first_match = (
             "MATCH (node:%(node_kind)s)%(lstart)s[:IS_RELATED]%(lend)s(:Relationship {name: $%(rel_name_var)s})%(rstart)s[:IS_RELATED]%(rend)s"
             % {

--- a/backend/infrahub/core/validators/uniqueness/query.py
+++ b/backend/infrahub/core/validators/uniqueness/query.py
@@ -370,7 +370,7 @@ CALL (node) {
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
         self.params["node_ids_to_exclude"] = self.node_ids_to_exclude
-        branch_filter, branch_params = self.branch.get_query_filter_path(at=self.at.to_string())
+        branch_filter, branch_params = self.branch.get_query_filter_path(at=self.at.to_string(), is_isolated=False)
         self.params.update(branch_params)
 
         subqueries = []

--- a/backend/infrahub/core/validators/uniqueness/query.py
+++ b/backend/infrahub/core/validators/uniqueness/query.py
@@ -339,8 +339,9 @@ CALL (node) {
     WHERE r.status = "active"
             """ % {"attr_name_var": attr_name_var, "attr_value_var": attr_value_var, "branch_filter": branch_filter}
             rel_attr_match = (
-                "-[r:HAS_VALUE]->(:AttributeValue {value: $%(attr_value_var)s})-[:HAS_VALUE]->(:AttributeValue {value: $%(attr_value_var)s})"
+                "-[r:HAS_ATTRIBUTE]->(attr:Attribute {name: $%(attr_name_var)s})-[:HAS_VALUE]->(:AttributeValue {value: $%(attr_value_var)s})"
                 % {
+                    "attr_name_var": attr_name_var,
                     "attr_value_var": attr_value_var,
                 }
             )

--- a/backend/infrahub/core/validators/uniqueness/query.py
+++ b/backend/infrahub/core/validators/uniqueness/query.py
@@ -363,10 +363,11 @@ CALL (node) {
         peer_where = f"WHERE {branch_filter}"
         if rel_path.peer_id:
             peer_id_var = f"peer_id_{index}"
-            peer_where += f"AND peer.uuid = ${peer_id_var}"
+            peer_where += f" AND peer.uuid = ${peer_id_var}"
             params[peer_id_var] = rel_path.peer_id
             first_match += "(:Node {uuid: $%(peer_id_var)s})" % {"peer_id_var": peer_id_var}
         else:
+            peer_where += " AND peer.uuid <> node.uuid"
             first_match += "(:Node)"
         if rel_attr_match:
             first_match += rel_attr_match

--- a/backend/infrahub/core/validators/uniqueness/query.py
+++ b/backend/infrahub/core/validators/uniqueness/query.py
@@ -255,9 +255,11 @@ class UniquenessValidationQuery(Query):
     def __init__(
         self,
         query_request: NodeUniquenessQueryRequestValued,
+        node_ids_to_exclude: list[str] | None = None,
         **kwargs: Any,
     ) -> None:
         self.query_request = query_request
+        self.node_ids_to_exclude = node_ids_to_exclude
         super().__init__(**kwargs)
 
     def _build_attr_subquery(
@@ -367,6 +369,7 @@ CALL (node) {
         return relationship_query, params
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: Any) -> None:  # noqa: ARG002
+        self.params["node_ids_to_exclude"] = self.node_ids_to_exclude
         branch_filter, branch_params = self.branch.get_query_filter_path(at=self.at.to_string())
         self.params.update(branch_params)
 
@@ -385,6 +388,7 @@ CALL (node) {
 
         full_query = """
 MATCH(node:%(kind)s)
+WHERE $node_ids_to_exclude IS NULL OR NOT node.uuid IN $node_ids_to_exclude
 %(subqueries)s
         """ % {"kind": self.query_request.kind, "subqueries": "\n".join(subqueries)}
         self.add_to_query(full_query)

--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -25,7 +25,7 @@ from infrahub.core.timestamp import Timestamp
 from infrahub.database import retry_db_transaction
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.events.generator import generate_node_mutation_events
-from infrahub.exceptions import HFIDViolatedError, InitializationError
+from infrahub.exceptions import HFIDViolatedError, InitializationError, NodeNotFoundError
 from infrahub.graphql.context import apply_external_context
 from infrahub.lock import InfrahubMultiLock, build_object_lock_name
 from infrahub.log import get_log_data, get_logger
@@ -384,7 +384,23 @@ class InfrahubMutationMixin:
             if len(exc.matching_nodes_ids) > 1:
                 raise RuntimeError(f"Multiple {schema_name} nodes have the same hfid") from exc
             node_id = list(exc.matching_nodes_ids)[0]
-            node = await NodeManager.get_one(db=db, id=node_id, kind=schema_name, branch=branch, raise_on_error=True)
+
+            try:
+                node = await NodeManager.get_one(
+                    db=db, id=node_id, kind=schema_name, branch=branch, raise_on_error=True
+                )
+            except NodeNotFoundError as exc:
+                if branch.is_default:
+                    raise
+                raise NodeNotFoundError(
+                    node_type=exc.node_type,
+                    identifier=exc.identifier,
+                    branch_name=branch.name,
+                    message=(
+                        f"Node {exc.identifier} / {exc.node_type} uses this human-friendly ID, but does not exist on"
+                        f" this branch. Please rebase this branch to access {exc.identifier} / {exc.node_type}"
+                    ),
+                ) from exc
             updated_obj, mutation = await cls._call_mutate_update(
                 info=info,
                 data=data,

--- a/backend/tests/unit/core/constraint_validators/test_node_grouped_uniqueness.py
+++ b/backend/tests/unit/core/constraint_validators/test_node_grouped_uniqueness.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from unittest.mock import patch
 
 import pytest
@@ -6,7 +7,7 @@ from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.node import Node
 from infrahub.core.node.constraints.grouped_uniqueness import NodeGroupedUniquenessConstraint
-from infrahub.core.validators.uniqueness.query import NodeUniqueAttributeConstraintQuery
+from infrahub.core.validators.uniqueness.query import UniquenessValidationQuery
 from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import HFIDViolatedError, ValidationError
 from tests.node_creation import create_and_save
@@ -202,7 +203,7 @@ class TestNodeGroupedUniquenessConstraint:
         await self.__call_system_under_test(db=db, branch=default_branch, node=car_node)
 
     @pytest.mark.parametrize(
-        ["node_constraints", "parent_constraints", "node_query_should_run"],
+        ["node_constraints", "parent_constraints", "expected_number_calls_by_kind"],
         [
             (
                 [
@@ -213,7 +214,7 @@ class TestNodeGroupedUniquenessConstraint:
                     ["nbr_seats__value", "name__value"],
                     ["previous_owner", "nbr_seats__value"],
                 ],
-                False,
+                {"TestCar": 2},
             ),
             (
                 [
@@ -223,7 +224,7 @@ class TestNodeGroupedUniquenessConstraint:
                     ["nbr_seats__value", "name__value"],
                     ["previous_owner", "nbr_seats__value"],
                 ],
-                False,
+                {"TestCar": 2},
             ),
             (
                 [
@@ -233,7 +234,7 @@ class TestNodeGroupedUniquenessConstraint:
                     ["nbr_seats__value", "name__value"],
                     ["previous_owner", "nbr_seats__value"],
                 ],
-                True,
+                {"TestCar": 2, "TestElectricCar": 1},
             ),
             (
                 [
@@ -244,7 +245,7 @@ class TestNodeGroupedUniquenessConstraint:
                     ["nbr_seats__value", "name__value"],
                     ["previous_owner", "nbr_seats__value"],
                 ],
-                True,
+                {"TestCar": 2, "TestElectricCar": 2},
             ),
         ],
     )
@@ -255,7 +256,7 @@ class TestNodeGroupedUniquenessConstraint:
         car_person_generics_data_simple,
         node_constraints: list[list[str]],
         parent_constraints: list[list[str]],
-        node_query_should_run: bool,
+        expected_number_calls_by_kind: dict[str, int],
     ):
         car_node: Node = car_person_generics_data_simple["c1"]
         car_schema = car_node.get_schema()
@@ -267,19 +268,13 @@ class TestNodeGroupedUniquenessConstraint:
 
         # make sure we only use this query once if the constraints overlap
         with patch(
-            "infrahub.core.node.constraints.grouped_uniqueness.NodeUniqueAttributeConstraintQuery",
-            wraps=NodeUniqueAttributeConstraintQuery,
+            "infrahub.core.node.constraints.grouped_uniqueness.UniquenessValidationQuery",
+            wraps=UniquenessValidationQuery,
         ) as wrapped_query:
             await self.__call_system_under_test(db=db, branch=default_branch, node=car_node)
-            if node_query_should_run:
-                assert len(wrapped_query.init.call_args_list) == 2
-            else:
-                assert len(wrapped_query.init.call_args_list) == 1
-            query_kinds = {init_call[1]["query_request"].kind for init_call in wrapped_query.init.call_args_list}
-            if node_query_should_run:
-                assert query_kinds == {car_schema.kind, parent_kind}
-            else:
-                assert query_kinds == {parent_kind}
+            query_kinds = [init_call[1]["query_request"].kind for init_call in wrapped_query.init.call_args_list]
+            number_runs_by_kind = Counter(query_kinds)
+            assert number_runs_by_kind == expected_number_calls_by_kind
 
     async def test_uniqueness_constraint_conflict_relationship_and_attribute(
         self, db: InfrahubDatabase, default_branch: Branch, car_person_generics_data_simple

--- a/backend/tests/unit/core/constraint_validators/test_node_uniqueness.py
+++ b/backend/tests/unit/core/constraint_validators/test_node_uniqueness.py
@@ -3,7 +3,6 @@ import pytest
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.node import Node
-from infrahub.core.node.constraints.attribute_uniqueness import NodeAttributeUniquenessConstraint
 from infrahub.core.node.constraints.grouped_uniqueness import NodeGroupedUniquenessConstraint
 from infrahub.core.schema import SchemaRoot
 from infrahub.database import InfrahubDatabase
@@ -13,20 +12,20 @@ from infrahub.exceptions import ValidationError
 async def test_node_validate_constraint_node_uniqueness_failure(
     db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node, car_volt_main: Node, person_john_main
 ):
-    constraint = NodeAttributeUniquenessConstraint(db=db, branch=default_branch)
+    constraint = NodeGroupedUniquenessConstraint(db=db, branch=default_branch)
     new_john = await Node.init(db=db, schema="TestPerson", branch=default_branch)
     await new_john.new(db=db, name="John", height=160)
 
     with pytest.raises(ValidationError) as exc:
         await constraint.check(new_john)
 
-    assert "An object already exist with this value" in exc.value.message
+    assert "Violates uniqueness constraint 'name'" in exc.value.message
 
 
 async def test_node_validate_constraint_node_uniqueness_success(
     db: InfrahubDatabase, default_branch: Branch, car_accord_main: Node, car_volt_main: Node, person_john_main
 ):
-    constraint = NodeAttributeUniquenessConstraint(db=db, branch=default_branch)
+    constraint = NodeGroupedUniquenessConstraint(db=db, branch=default_branch)
     alfred = await Node.init(db=db, schema="TestPerson", branch=default_branch)
 
     await alfred.new(db=db, name="Alfred", height=160)

--- a/backend/tests/unit/core/constraint_validators/test_uniqueness_validation_query.py
+++ b/backend/tests/unit/core/constraint_validators/test_uniqueness_validation_query.py
@@ -1,0 +1,709 @@
+from infrahub.core.branch import Branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.validators.uniqueness.model import NodeUniquenessQueryRequestValued
+from infrahub.core.validators.uniqueness.query import QueryAttributePathValued, UniquenessValidationQuery
+from infrahub.database import InfrahubDatabase
+
+
+async def test_query_uniqueness_no_violations(
+    db: InfrahubDatabase,
+    car_accord_main,
+    car_camry_main,
+    car_volt_main,
+    car_yaris_main,
+    car_prius_main,
+    branch: Branch,
+):
+    query = await UniquenessValidationQuery.init(
+        db=db,
+        branch=branch,
+        query_request=NodeUniquenessQueryRequestValued(
+            kind="TestCar", unique_valued_paths=[QueryAttributePathValued(attribute_name="name", value="notacar")]
+        ),
+    )
+    query_result = await query.execute(db=db)
+
+    assert not query_result.results
+
+
+async def test_query_uniqueness_one_attr_violation(
+    db: InfrahubDatabase, car_accord_main, car_prius_main, branch: Branch, default_branch: Branch
+):
+    query_request = NodeUniquenessQueryRequestValued(
+        kind="TestCar",
+        unique_valued_paths=[QueryAttributePathValued(attribute_name="nbr_seats", value=5)],
+    )
+    query = await UniquenessValidationQuery.init(db=db, branch=branch, query_request=query_request)
+    await query.execute(db=db)
+    violation_tuples = query.get_violation_nodes()
+    assert set(violation_tuples) == {(car_accord_main.id, "TestCar"), (car_prius_main.id, "TestCar")}
+
+    query_request.unique_valued_paths.append(QueryAttributePathValued(attribute_name="name", value="prius"))
+    query = await UniquenessValidationQuery.init(db=db, branch=branch, query_request=query_request)
+    await query.execute(db=db)
+    violation_tuples = query.get_violation_nodes()
+    assert violation_tuples == [(car_prius_main.id, "TestCar")]
+
+    query_request.unique_valued_paths.append(QueryAttributePathValued(attribute_name="color", value="#000000"))
+    query = await UniquenessValidationQuery.init(db=db, branch=branch, query_request=query_request)
+    await query.execute(db=db)
+    violation_tuples = query.get_violation_nodes()
+    assert violation_tuples == []
+
+
+async def test_query_uniqueness_deleted_node_ignored(
+    db: InfrahubDatabase,
+    car_accord_main,
+    car_prius_main,
+    branch: Branch,
+):
+    node_to_delete = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
+    await node_to_delete.delete(db=db)
+
+    query_request = NodeUniquenessQueryRequestValued(
+        kind="TestCar",
+        unique_valued_paths=[QueryAttributePathValued(attribute_name="nbr_seats", value=5)],
+    )
+    query = await UniquenessValidationQuery.init(db=db, branch=branch, query_request=query_request)
+    await query.execute(db=db)
+
+    violation_nodes = query.get_violation_nodes()
+    assert violation_nodes == [(car_prius_main.id, "TestCar")]
+
+
+# async def test_query_uniqueness_get_latest_update(
+#     db: InfrahubDatabase,
+#     car_accord_main,
+#     car_prius_main,
+#     branch: Branch,
+# ):
+#     car_to_update = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
+#     car_to_update.nbr_seats.value = 3
+#     await car_to_update.save(db=db)
+
+#     query = await NodeUniqueAttributeConstraintQuery.init(
+#         db=db,
+#         branch=branch,
+#         query_request=NodeUniquenessQueryRequest(
+#             kind="TestCar",
+#             unique_attribute_paths=[
+#                 {"attribute_name": "name", "property_name": "value"},
+#                 {"attribute_name": "nbr_seats", "property_name": "value"},
+#             ],
+#         ),
+#     )
+#     query_result = await query.execute(db=db)
+
+#     assert not query_result.results
+
+
+# async def test_query_uniqueness_cross_branch_conflict(
+#     db: InfrahubDatabase,
+#     car_accord_main,
+#     car_prius_main,
+#     person_john_main,
+#     default_branch: Branch,
+# ):
+#     branch_2 = await create_branch(branch_name="branch2", db=db)
+#     new_car_main = await Node.init(db=db, schema="TestCar", branch=default_branch)
+#     await new_car_main.new(db=db, name="Thunderbolt", nbr_seats=2, is_electric=True, owner=person_john_main)
+#     await new_car_main.save(db=db)
+#     new_car_branch = await Node.init(db=db, schema="TestCar", branch=branch_2)
+#     await new_car_branch.new(db=db, name="Thunderbolt", nbr_seats=4, is_electric=True, owner=person_john_main)
+#     await new_car_branch.save(db=db)
+
+#     query = await NodeUniqueAttributeConstraintQuery.init(
+#         db=db,
+#         branch=branch_2,
+#         query_request=NodeUniquenessQueryRequest(
+#             kind="TestCar", unique_attribute_paths=[{"attribute_name": "name", "property_name": "value"}]
+#         ),
+#     )
+#     query_result = await query.execute(db=db)
+
+#     assert len(query_result.results) == 2
+#     expected_result_dicts = [
+#         {
+#             "attr_name": "name",
+#             "node_id": new_car_main.id,
+#             "node_count": 2,
+#             "attr_value": "Thunderbolt",
+#             "relationship_identifier": None,
+#             "deepest_branch_name": default_branch.name,
+#         },
+#         {
+#             "attr_name": "name",
+#             "node_id": new_car_branch.id,
+#             "node_count": 2,
+#             "attr_value": "Thunderbolt",
+#             "relationship_identifier": None,
+#             "deepest_branch_name": "branch2",
+#         },
+#     ]
+#     for result in query_result.results:
+#         serial_result = dict(result.data)
+#         assert serial_result in expected_result_dicts
+
+
+# async def test_query_uniqueness_multiple_attribute_violations(
+#     db: InfrahubDatabase,
+#     car_accord_main,
+#     car_prius_main,
+#     car_volt_main,
+#     car_camry_main,
+#     branch: Branch,
+#     default_branch: Branch,
+# ):
+#     for car_id in (car_volt_main.id, car_camry_main.id):
+#         car_to_update = await NodeManager.get_one(id=car_id, db=db, branch=branch)
+#         car_to_update.color.value = "#ffffff"
+#         await car_to_update.save(db=db)
+
+#     expected_result_dicts = [
+#         {
+#             "attr_name": "nbr_seats",
+#             "node_id": node_id,
+#             "node_count": 3,
+#             "attr_value": 5,
+#             "relationship_identifier": None,
+#             "deepest_branch_name": default_branch.name,
+#         }
+#         for node_id in (car_accord_main.id, car_prius_main.id, car_camry_main.id)
+#     ]
+#     expected_result_dicts += [
+#         {
+#             "attr_name": "color",
+#             "node_id": node_id,
+#             "node_count": 2,
+#             "attr_value": "#ffffff",
+#             "relationship_identifier": None,
+#             "deepest_branch_name": branch.name,
+#         }
+#         for node_id in (car_volt_main.id, car_camry_main.id)
+#     ]
+#     expected_result_dicts += [
+#         {
+#             "attr_name": "color",
+#             "node_id": node_id,
+#             "node_count": 2,
+#             "attr_value": "#444444",
+#             "relationship_identifier": None,
+#             "deepest_branch_name": default_branch.name,
+#         }
+#         for node_id in (car_accord_main.id, car_prius_main.id)
+#     ]
+
+#     query = await NodeUniqueAttributeConstraintQuery.init(
+#         db=db,
+#         branch=branch,
+#         query_request=NodeUniquenessQueryRequest(
+#             kind="TestCar",
+#             unique_attribute_paths=[
+#                 {"attribute_name": "name", "property_name": "value"},
+#                 {"attribute_name": "color", "property_name": "value"},
+#                 {"attribute_name": "nbr_seats", "property_name": "value"},
+#             ],
+#         ),
+#     )
+#     query_result = await query.execute(db=db)
+
+#     assert len(query_result.results) == 7
+#     for result in query_result.results:
+#         serial_result = dict(result.data)
+#         assert serial_result in expected_result_dicts
+
+
+# async def test_query_relationship_uniqueness_no_violations(
+#     db: InfrahubDatabase,
+#     car_accord_main,
+#     car_prius_main,
+#     person_jane_main,
+#     person_john_main,
+#     branch: Branch,
+# ):
+#     car_to_update = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
+#     await car_to_update.owner.update(data=person_jane_main, db=db)
+#     await car_to_update.save(db=db)
+
+#     person_to_update = await NodeManager.get_one(id=person_jane_main.id, db=db, branch=branch)
+#     person_to_update.height.value = person_john_main.height.value - 1
+#     await person_to_update.save(db=db)
+
+#     query = await NodeUniqueAttributeConstraintQuery.init(
+#         db=db,
+#         branch=branch,
+#         query_request=NodeUniquenessQueryRequest(
+#             kind="TestCar",
+#             unique_attribute_paths=[{"attribute_name": "name", "property_name": "value"}],
+#             relationship_attribute_paths=[{"identifier": "testcar__testperson", "attribute_name": "height"}],
+#         ),
+#     )
+#     query_result = await query.execute(db=db)
+
+#     assert not query_result.results
+
+
+# async def test_query_relationship_uniqueness_one_violation(
+#     db: InfrahubDatabase,
+#     car_accord_main,
+#     car_prius_main,
+#     person_jane_main,
+#     person_john_main,
+#     branch: Branch,
+#     default_branch: Branch,
+# ):
+#     car_to_update = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
+#     await car_to_update.owner.update(data=person_jane_main, db=db)
+#     await car_to_update.save(db=db)
+#     person_to_update = await NodeManager.get_one(id=person_jane_main.id, db=db, branch=branch)
+#     person_to_update.height.value = person_john_main.height.value
+#     await person_to_update.save(db=db)
+
+#     query = await NodeUniqueAttributeConstraintQuery.init(
+#         db=db,
+#         branch=branch,
+#         query_request=NodeUniquenessQueryRequest(
+#             kind="TestCar",
+#             unique_attribute_paths=[{"attribute_name": "name", "property_name": "value"}],
+#             relationship_attribute_paths=[{"identifier": "testcar__testperson", "attribute_name": "height"}],
+#         ),
+#     )
+#     query_result = await query.execute(db=db)
+
+#     assert len(query_result.results) == 2
+#     expected_result_dicts = [
+#         {
+#             "attr_name": "height",
+#             "node_id": car_accord_main.id,
+#             "node_count": 2,
+#             "attr_value": 180,
+#             "relationship_identifier": "testcar__testperson",
+#             "deepest_branch_name": branch.name,
+#         },
+#         {
+#             "attr_name": "height",
+#             "node_id": car_prius_main.id,
+#             "node_count": 2,
+#             "attr_value": 180,
+#             "relationship_identifier": "testcar__testperson",
+#             "deepest_branch_name": default_branch.name,
+#         },
+#     ]
+#     for result in query_result.results:
+#         serial_result = dict(result.data)
+#         assert serial_result in expected_result_dicts
+
+
+# async def test_query_relationship_and_attribute_uniqueness_violations(
+#     db: InfrahubDatabase,
+#     car_accord_main,
+#     car_prius_main,
+#     person_jane_main,
+#     person_john_main,
+#     branch: Branch,
+#     default_branch: Branch,
+# ):
+#     car_to_update = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
+#     await car_to_update.owner.update(data=person_jane_main, db=db)
+#     await car_to_update.save(db=db)
+#     person_to_update = await NodeManager.get_one(id=person_jane_main.id, db=db, branch=branch)
+#     person_to_update.height.value = person_john_main.height.value
+#     await person_to_update.save(db=db)
+#     expected_result_dicts = [
+#         {
+#             "attr_name": "nbr_seats",
+#             "node_id": car_accord_main.id,
+#             "node_count": 2,
+#             "attr_value": 5,
+#             "relationship_identifier": None,
+#             "deepest_branch_name": default_branch.name,
+#         },
+#         {
+#             "attr_name": "nbr_seats",
+#             "node_id": car_prius_main.id,
+#             "node_count": 2,
+#             "attr_value": 5,
+#             "relationship_identifier": None,
+#             "deepest_branch_name": default_branch.name,
+#         },
+#         {
+#             "attr_name": "height",
+#             "node_id": car_accord_main.id,
+#             "node_count": 2,
+#             "attr_value": 180,
+#             "relationship_identifier": "testcar__testperson",
+#             "deepest_branch_name": branch.name,
+#         },
+#         {
+#             "attr_name": "height",
+#             "node_id": car_prius_main.id,
+#             "node_count": 2,
+#             "attr_value": 180,
+#             "relationship_identifier": "testcar__testperson",
+#             "deepest_branch_name": default_branch.name,
+#         },
+#     ]
+
+#     query = await NodeUniqueAttributeConstraintQuery.init(
+#         db=db,
+#         branch=branch,
+#         query_request=NodeUniquenessQueryRequest(
+#             kind="TestCar",
+#             unique_attribute_paths=[
+#                 {"attribute_name": "name", "property_name": "value"},
+#                 {"attribute_name": "nbr_seats", "property_name": "value"},
+#             ],
+#             relationship_attribute_paths=[{"identifier": "testcar__testperson", "attribute_name": "height"}],
+#         ),
+#     )
+#     query_result = await query.execute(db=db)
+
+#     assert len(query_result.results) == 4
+#     for result in query_result.results:
+#         serial_result = dict(result.data)
+#         assert serial_result in expected_result_dicts
+
+
+# async def test_query_relationship_violation_no_attribute(
+#     db: InfrahubDatabase,
+#     car_accord_main,
+#     car_prius_main,
+#     car_camry_main,
+#     person_john_main,
+#     branch: Branch,
+#     default_branch: Branch,
+# ):
+#     car_to_update = await NodeManager.get_one(id=car_camry_main.id, db=db, branch=branch)
+#     await car_to_update.owner.update(data=person_john_main, db=db)
+#     await car_to_update.save(db=db)
+#     expected_result_dicts = [
+#         {
+#             "attr_name": "id",
+#             "node_id": car_accord_main.id,
+#             "node_count": 3,
+#             "attr_value": person_john_main.id,
+#             "relationship_identifier": "testcar__testperson",
+#             "deepest_branch_name": default_branch.name,
+#         },
+#         {
+#             "attr_name": "id",
+#             "node_id": car_prius_main.id,
+#             "node_count": 3,
+#             "attr_value": person_john_main.id,
+#             "relationship_identifier": "testcar__testperson",
+#             "deepest_branch_name": default_branch.name,
+#         },
+#         {
+#             "attr_name": "id",
+#             "node_id": car_camry_main.id,
+#             "node_count": 3,
+#             "attr_value": person_john_main.id,
+#             "relationship_identifier": "testcar__testperson",
+#             "deepest_branch_name": branch.name,
+#         },
+#     ]
+
+#     query = await NodeUniqueAttributeConstraintQuery.init(
+#         db=db,
+#         branch=branch,
+#         query_request=NodeUniquenessQueryRequest(
+#             kind="TestCar", relationship_attribute_paths=[{"identifier": "testcar__testperson", "attribute_name": None}]
+#         ),
+#     )
+#     query_result = await query.execute(db=db)
+
+#     assert len(query_result.results) == 3
+#     for result in query_result.results:
+#         serial_result = dict(result.data)
+#         assert serial_result in expected_result_dicts
+
+
+# async def test_query_relationship_no_violation_same_peer_different_rels(
+#     db: InfrahubDatabase, default_branch: Branch, animal_person_schema: SchemaBranch
+# ):
+#     john = await Node.init(schema="TestPerson", db=db)
+#     await john.new(db=db, name="John", height=175)
+#     await john.save(db=db)
+#     jane = await Node.init(schema="TestPerson", db=db)
+#     await jane.new(db=db, name="Jane", height=165)
+#     await jane.save(db=db)
+#     johns_dog = await Node.init(schema="TestDog", db=db)
+#     await johns_dog.new(db=db, name="J-dog", breed="mixed", owner=john, best_friend=jane)
+#     await johns_dog.save(db=db)
+#     jane_dog = await Node.init(schema="TestDog", db=db)
+#     await jane_dog.new(db=db, name="Jane-dog", breed="mixed", owner=jane, best_friend=jane)
+#     await jane_dog.save(db=db)
+
+#     branch = await create_branch(db=db, branch_name="branch")
+#     joe = await Node.init(schema="TestPerson", db=db, branch=branch)
+#     await joe.new(db=db, name="Joe", height=175)
+#     await joe.save(db=db)
+#     joes_dog = await Node.init(schema="TestDog", db=db, branch=branch)
+#     await joes_dog.new(db=db, name="Joe-dog", breed="mixed", owner=joe, best_friend=jane)
+#     await joes_dog.save(db=db)
+
+#     expected_best_friend_result_dicts = [
+#         {
+#             "attr_name": "id",
+#             "node_id": johns_dog.id,
+#             "node_count": 3,
+#             "attr_value": jane.id,
+#             "relationship_identifier": "person__animal_friend",
+#             "deepest_branch_name": default_branch.name,
+#         },
+#         {
+#             "attr_name": "id",
+#             "node_id": jane_dog.id,
+#             "node_count": 3,
+#             "attr_value": jane.id,
+#             "relationship_identifier": "person__animal_friend",
+#             "deepest_branch_name": default_branch.name,
+#         },
+#         {
+#             "attr_name": "id",
+#             "node_id": joes_dog.id,
+#             "node_count": 3,
+#             "attr_value": jane.id,
+#             "relationship_identifier": "person__animal_friend",
+#             "deepest_branch_name": branch.name,
+#         },
+#     ]
+
+#     owner_query = await NodeUniqueAttributeConstraintQuery.init(
+#         db=db,
+#         branch=branch,
+#         query_request=NodeUniquenessQueryRequest(
+#             kind="TestDog", relationship_attribute_paths=[{"identifier": "person__animal", "value": jane.id}]
+#         ),
+#     )
+#     owner_query_result = await owner_query.execute(db=db)
+#     assert len(owner_query_result.results) == 0
+
+#     best_friend_query = await NodeUniqueAttributeConstraintQuery.init(
+#         db=db,
+#         branch=branch,
+#         query_request=NodeUniquenessQueryRequest(
+#             kind="TestDog", relationship_attribute_paths=[{"identifier": "person__animal_friend", "value": jane.id}]
+#         ),
+#     )
+#     best_friend_query_result = await best_friend_query.execute(db=db)
+#     assert len(best_friend_query_result.results) == 3
+#     for result in best_friend_query_result.results:
+#         serial_result = dict(result.data)
+#         assert serial_result in expected_best_friend_result_dicts
+
+
+# async def test_query_response_min_count_0_attribute_paths(
+#     db: InfrahubDatabase, car_accord_main, car_prius_main, branch: Branch, default_branch: Branch
+# ):
+#     expected_result_dicts = [
+#         {
+#             "attr_name": "nbr_seats",
+#             "node_id": car_accord_main.id,
+#             "node_count": 2,
+#             "attr_value": 5,
+#             "relationship_identifier": None,
+#             "deepest_branch_name": default_branch.name,
+#         },
+#         {
+#             "attr_name": "nbr_seats",
+#             "node_id": car_prius_main.id,
+#             "node_count": 2,
+#             "attr_value": 5,
+#             "relationship_identifier": None,
+#             "deepest_branch_name": default_branch.name,
+#         },
+#         {
+#             "attr_name": "name",
+#             "node_id": car_accord_main.id,
+#             "node_count": 1,
+#             "attr_value": car_accord_main.name.value,
+#             "relationship_identifier": None,
+#             "deepest_branch_name": default_branch.name,
+#         },
+#         {
+#             "attr_name": "name",
+#             "node_id": car_prius_main.id,
+#             "node_count": 1,
+#             "attr_value": car_prius_main.name.value,
+#             "relationship_identifier": None,
+#             "deepest_branch_name": default_branch.name,
+#         },
+#     ]
+
+#     query = await NodeUniqueAttributeConstraintQuery.init(
+#         db=db,
+#         branch=branch,
+#         query_request=NodeUniquenessQueryRequest(
+#             kind="TestCar",
+#             unique_attribute_paths=[
+#                 {"attribute_name": "name", "property_name": "value"},
+#                 {"attribute_name": "nbr_seats", "property_name": "value"},
+#             ],
+#         ),
+#         min_count_required=0,
+#     )
+#     query_result = await query.execute(db=db)
+
+#     assert len(query_result.results) == 4
+#     for result in query_result.results:
+#         serial_result = dict(result.data)
+#         assert serial_result in expected_result_dicts
+
+
+# async def test_query_response_min_count_0_relationship_paths(
+#     db: InfrahubDatabase, car_camry_main, car_prius_main, branch: Branch, default_branch: Branch
+# ):
+#     expected_result_dicts = [
+#         {
+#             "attr_name": "name",
+#             "node_id": car_camry_main.id,
+#             "node_count": 1,
+#             "attr_value": "Jane",
+#             "relationship_identifier": "testcar__testperson",
+#             "deepest_branch_name": default_branch.name,
+#         },
+#         {
+#             "attr_name": "name",
+#             "node_id": car_prius_main.id,
+#             "node_count": 1,
+#             "attr_value": "John",
+#             "relationship_identifier": "testcar__testperson",
+#             "deepest_branch_name": default_branch.name,
+#         },
+#         {
+#             "attr_name": "height",
+#             "node_id": car_camry_main.id,
+#             "node_count": 2,
+#             "attr_value": 180,
+#             "relationship_identifier": "testcar__testperson",
+#             "deepest_branch_name": default_branch.name,
+#         },
+#         {
+#             "attr_name": "height",
+#             "node_id": car_prius_main.id,
+#             "node_count": 2,
+#             "attr_value": 180,
+#             "relationship_identifier": "testcar__testperson",
+#             "deepest_branch_name": default_branch.name,
+#         },
+#     ]
+
+#     query = await NodeUniqueAttributeConstraintQuery.init(
+#         db=db,
+#         branch=branch,
+#         query_request=NodeUniquenessQueryRequest(
+#             kind="TestCar",
+#             relationship_attribute_paths=[
+#                 {"identifier": "testcar__testperson", "attribute_name": "height"},
+#                 {"identifier": "testcar__testperson", "attribute_name": "name"},
+#             ],
+#         ),
+#         min_count_required=0,
+#     )
+#     query_result = await query.execute(db=db)
+
+#     assert len(query_result.results) == 4
+#     for result in query_result.results:
+#         serial_result = dict(result.data)
+#         assert serial_result in expected_result_dicts
+
+
+# async def test_query_response_min_count_0_attribute_paths_with_value(
+#     db: InfrahubDatabase, car_accord_main, car_prius_main, branch: Branch, default_branch: Branch
+# ):
+#     expected_result_dicts = [
+#         {
+#             "attr_name": "nbr_seats",
+#             "node_id": car_accord_main.id,
+#             "node_count": 2,
+#             "attr_value": 5,
+#             "relationship_identifier": None,
+#             "deepest_branch_name": default_branch.name,
+#         },
+#         {
+#             "attr_name": "nbr_seats",
+#             "node_id": car_prius_main.id,
+#             "node_count": 2,
+#             "attr_value": 5,
+#             "relationship_identifier": None,
+#             "deepest_branch_name": default_branch.name,
+#         },
+#         {
+#             "attr_name": "name",
+#             "node_id": car_accord_main.id,
+#             "node_count": 1,
+#             "attr_value": car_accord_main.name.value,
+#             "relationship_identifier": None,
+#             "deepest_branch_name": default_branch.name,
+#         },
+#     ]
+
+#     query = await NodeUniqueAttributeConstraintQuery.init(
+#         db=db,
+#         branch=branch,
+#         query_request=NodeUniquenessQueryRequest(
+#             kind="TestCar",
+#             unique_attribute_paths=[
+#                 {"attribute_name": "name", "property_name": "value", "value": "accord"},
+#                 {"attribute_name": "nbr_seats", "property_name": "value"},
+#             ],
+#         ),
+#         min_count_required=0,
+#     )
+#     query_result = await query.execute(db=db)
+
+#     assert len(query_result.results) == 3
+#     for result in query_result.results:
+#         serial_result = dict(result.data)
+#         assert serial_result in expected_result_dicts
+
+
+# async def test_query_response_min_count_0_relationship_paths_with_value(
+#     db: InfrahubDatabase, car_camry_main, car_prius_main, branch: Branch, default_branch: Branch
+# ):
+#     expected_result_dicts = [
+#         {
+#             "attr_name": "name",
+#             "node_id": car_camry_main.id,
+#             "node_count": 1,
+#             "attr_value": "Jane",
+#             "relationship_identifier": "testcar__testperson",
+#             "deepest_branch_name": default_branch.name,
+#         },
+#         {
+#             "attr_name": "height",
+#             "node_id": car_camry_main.id,
+#             "node_count": 2,
+#             "attr_value": 180,
+#             "relationship_identifier": "testcar__testperson",
+#             "deepest_branch_name": default_branch.name,
+#         },
+#         {
+#             "attr_name": "height",
+#             "node_id": car_prius_main.id,
+#             "node_count": 2,
+#             "attr_value": 180,
+#             "relationship_identifier": "testcar__testperson",
+#             "deepest_branch_name": default_branch.name,
+#         },
+#     ]
+
+#     query = await NodeUniqueAttributeConstraintQuery.init(
+#         db=db,
+#         branch=branch,
+#         query_request=NodeUniquenessQueryRequest(
+#             kind="TestCar",
+#             relationship_attribute_paths=[
+#                 {"identifier": "testcar__testperson", "attribute_name": "height"},
+#                 {"identifier": "testcar__testperson", "attribute_name": "name", "value": "Jane"},
+#             ],
+#         ),
+#         min_count_required=0,
+#     )
+#     query_result = await query.execute(db=db)
+
+#     assert len(query_result.results) == 3
+#     for result in query_result.results:
+#         serial_result = dict(result.data)
+#         assert serial_result in expected_result_dicts

--- a/backend/tests/unit/core/constraint_validators/test_uniqueness_validation_query.py
+++ b/backend/tests/unit/core/constraint_validators/test_uniqueness_validation_query.py
@@ -1,7 +1,14 @@
 from infrahub.core.branch import Branch
+from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.validators.uniqueness.model import NodeUniquenessQueryRequestValued
-from infrahub.core.validators.uniqueness.query import QueryAttributePathValued, UniquenessValidationQuery
+from infrahub.core.validators.uniqueness.query import (
+    QueryAttributePathValued,
+    QueryRelationshipPathValued,
+    UniquenessValidationQuery,
+)
 from infrahub.database import InfrahubDatabase
 
 
@@ -71,639 +78,279 @@ async def test_query_uniqueness_deleted_node_ignored(
     assert violation_nodes == [(car_prius_main.id, "TestCar")]
 
 
-# async def test_query_uniqueness_get_latest_update(
-#     db: InfrahubDatabase,
-#     car_accord_main,
-#     car_prius_main,
-#     branch: Branch,
-# ):
-#     car_to_update = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
-#     car_to_update.nbr_seats.value = 3
-#     await car_to_update.save(db=db)
+async def test_query_uniqueness_get_latest_update(
+    db: InfrahubDatabase,
+    car_accord_main,
+    car_prius_main,
+    branch: Branch,
+):
+    car_to_update = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
+    car_to_update.nbr_seats.value = 3
+    await car_to_update.save(db=db)
 
-#     query = await NodeUniqueAttributeConstraintQuery.init(
-#         db=db,
-#         branch=branch,
-#         query_request=NodeUniquenessQueryRequest(
-#             kind="TestCar",
-#             unique_attribute_paths=[
-#                 {"attribute_name": "name", "property_name": "value"},
-#                 {"attribute_name": "nbr_seats", "property_name": "value"},
-#             ],
-#         ),
-#     )
-#     query_result = await query.execute(db=db)
-
-#     assert not query_result.results
+    query_request = NodeUniquenessQueryRequestValued(
+        kind="TestCar",
+        unique_valued_paths=[QueryAttributePathValued(attribute_name="nbr_seats", value=3)],
+    )
+    query = await UniquenessValidationQuery.init(db=db, branch=branch, query_request=query_request)
+    await query.execute(db=db)
+    violation_nodes = query.get_violation_nodes()
+    assert violation_nodes == [(car_accord_main.id, "TestCar")]
 
 
-# async def test_query_uniqueness_cross_branch_conflict(
-#     db: InfrahubDatabase,
-#     car_accord_main,
-#     car_prius_main,
-#     person_john_main,
-#     default_branch: Branch,
-# ):
-#     branch_2 = await create_branch(branch_name="branch2", db=db)
-#     new_car_main = await Node.init(db=db, schema="TestCar", branch=default_branch)
-#     await new_car_main.new(db=db, name="Thunderbolt", nbr_seats=2, is_electric=True, owner=person_john_main)
-#     await new_car_main.save(db=db)
-#     new_car_branch = await Node.init(db=db, schema="TestCar", branch=branch_2)
-#     await new_car_branch.new(db=db, name="Thunderbolt", nbr_seats=4, is_electric=True, owner=person_john_main)
-#     await new_car_branch.save(db=db)
+async def test_query_uniqueness_multiple_attribute_violations(
+    db: InfrahubDatabase,
+    car_accord_main,
+    car_prius_main,
+    car_volt_main,
+    car_camry_main,
+    branch: Branch,
+    default_branch: Branch,
+):
+    for car_id in (car_volt_main.id, car_camry_main.id, car_accord_main.id):
+        car_to_update = await NodeManager.get_one(id=car_id, db=db, branch=branch)
+        car_to_update.color.value = "#ffffff"
+        await car_to_update.save(db=db)
 
-#     query = await NodeUniqueAttributeConstraintQuery.init(
-#         db=db,
-#         branch=branch_2,
-#         query_request=NodeUniquenessQueryRequest(
-#             kind="TestCar", unique_attribute_paths=[{"attribute_name": "name", "property_name": "value"}]
-#         ),
-#     )
-#     query_result = await query.execute(db=db)
-
-#     assert len(query_result.results) == 2
-#     expected_result_dicts = [
-#         {
-#             "attr_name": "name",
-#             "node_id": new_car_main.id,
-#             "node_count": 2,
-#             "attr_value": "Thunderbolt",
-#             "relationship_identifier": None,
-#             "deepest_branch_name": default_branch.name,
-#         },
-#         {
-#             "attr_name": "name",
-#             "node_id": new_car_branch.id,
-#             "node_count": 2,
-#             "attr_value": "Thunderbolt",
-#             "relationship_identifier": None,
-#             "deepest_branch_name": "branch2",
-#         },
-#     ]
-#     for result in query_result.results:
-#         serial_result = dict(result.data)
-#         assert serial_result in expected_result_dicts
+    query_request = NodeUniquenessQueryRequestValued(
+        kind="TestCar",
+        unique_valued_paths=[
+            QueryAttributePathValued(attribute_name="nbr_seats", value=5),
+            QueryAttributePathValued(attribute_name="color", value="#ffffff"),
+        ],
+    )
+    query = await UniquenessValidationQuery.init(db=db, branch=branch, query_request=query_request)
+    await query.execute(db=db)
+    violation_nodes = query.get_violation_nodes()
+    assert set(violation_nodes) == {(car_camry_main.id, "TestCar"), (car_accord_main.id, "TestCar")}
 
 
-# async def test_query_uniqueness_multiple_attribute_violations(
-#     db: InfrahubDatabase,
-#     car_accord_main,
-#     car_prius_main,
-#     car_volt_main,
-#     car_camry_main,
-#     branch: Branch,
-#     default_branch: Branch,
-# ):
-#     for car_id in (car_volt_main.id, car_camry_main.id):
-#         car_to_update = await NodeManager.get_one(id=car_id, db=db, branch=branch)
-#         car_to_update.color.value = "#ffffff"
-#         await car_to_update.save(db=db)
+async def test_query_relationship_uniqueness_no_violations(
+    db: InfrahubDatabase,
+    car_accord_main,
+    car_prius_main,
+    person_jane_main,
+    person_john_main,
+    person_albert_main,
+    branch: Branch,
+):
+    car_to_update = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
+    await car_to_update.owner.update(data=person_jane_main, db=db)
+    await car_to_update.save(db=db)
 
-#     expected_result_dicts = [
-#         {
-#             "attr_name": "nbr_seats",
-#             "node_id": node_id,
-#             "node_count": 3,
-#             "attr_value": 5,
-#             "relationship_identifier": None,
-#             "deepest_branch_name": default_branch.name,
-#         }
-#         for node_id in (car_accord_main.id, car_prius_main.id, car_camry_main.id)
-#     ]
-#     expected_result_dicts += [
-#         {
-#             "attr_name": "color",
-#             "node_id": node_id,
-#             "node_count": 2,
-#             "attr_value": "#ffffff",
-#             "relationship_identifier": None,
-#             "deepest_branch_name": branch.name,
-#         }
-#         for node_id in (car_volt_main.id, car_camry_main.id)
-#     ]
-#     expected_result_dicts += [
-#         {
-#             "attr_name": "color",
-#             "node_id": node_id,
-#             "node_count": 2,
-#             "attr_value": "#444444",
-#             "relationship_identifier": None,
-#             "deepest_branch_name": default_branch.name,
-#         }
-#         for node_id in (car_accord_main.id, car_prius_main.id)
-#     ]
+    person_to_update = await NodeManager.get_one(id=person_jane_main.id, db=db, branch=branch)
+    person_to_update.height.value = person_john_main.height.value - 1
+    await person_to_update.save(db=db)
 
-#     query = await NodeUniqueAttributeConstraintQuery.init(
-#         db=db,
-#         branch=branch,
-#         query_request=NodeUniquenessQueryRequest(
-#             kind="TestCar",
-#             unique_attribute_paths=[
-#                 {"attribute_name": "name", "property_name": "value"},
-#                 {"attribute_name": "color", "property_name": "value"},
-#                 {"attribute_name": "nbr_seats", "property_name": "value"},
-#             ],
-#         ),
-#     )
-#     query_result = await query.execute(db=db)
+    car_schema = db.schema.get("TestCar", branch=branch, duplicate=False)
+    owner_rel_schema = car_schema.get_relationship(name="owner")
 
-#     assert len(query_result.results) == 7
-#     for result in query_result.results:
-#         serial_result = dict(result.data)
-#         assert serial_result in expected_result_dicts
+    # relationship peer only
+    query_request = NodeUniquenessQueryRequestValued(
+        kind="TestCar",
+        unique_valued_paths=[
+            QueryRelationshipPathValued(
+                relationship_schema=owner_rel_schema,
+                peer_id=person_albert_main.id,
+                attribute_name=None,
+                attribute_value=None,
+            )
+        ],
+    )
+    query = await UniquenessValidationQuery.init(db=db, branch=branch, query_request=query_request)
+    await query.execute(db=db)
+    violation_nodes = query.get_violation_nodes()
+    assert violation_nodes == []
 
+    # relationship attribute value only
+    query_request = NodeUniquenessQueryRequestValued(
+        kind="TestCar",
+        unique_valued_paths=[
+            QueryRelationshipPathValued(
+                relationship_schema=owner_rel_schema, peer_id=None, attribute_name="height", attribute_value=5000
+            )
+        ],
+    )
+    query = await UniquenessValidationQuery.init(db=db, branch=branch, query_request=query_request)
+    await query.execute(db=db)
+    violation_nodes = query.get_violation_nodes()
+    assert violation_nodes == []
 
-# async def test_query_relationship_uniqueness_no_violations(
-#     db: InfrahubDatabase,
-#     car_accord_main,
-#     car_prius_main,
-#     person_jane_main,
-#     person_john_main,
-#     branch: Branch,
-# ):
-#     car_to_update = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
-#     await car_to_update.owner.update(data=person_jane_main, db=db)
-#     await car_to_update.save(db=db)
+    # attr and relationship peer
+    query_request = NodeUniquenessQueryRequestValued(
+        kind="TestCar",
+        unique_valued_paths=[
+            QueryAttributePathValued(attribute_name="name", value=person_to_update.height.value),
+            QueryRelationshipPathValued(
+                relationship_schema=owner_rel_schema,
+                peer_id=person_john_main.id,
+                attribute_name=None,
+                attribute_value=None,
+            ),
+        ],
+    )
+    query = await UniquenessValidationQuery.init(db=db, branch=branch, query_request=query_request)
+    await query.execute(db=db)
+    violation_nodes = query.get_violation_nodes()
+    assert violation_nodes == []
 
-#     person_to_update = await NodeManager.get_one(id=person_jane_main.id, db=db, branch=branch)
-#     person_to_update.height.value = person_john_main.height.value - 1
-#     await person_to_update.save(db=db)
-
-#     query = await NodeUniqueAttributeConstraintQuery.init(
-#         db=db,
-#         branch=branch,
-#         query_request=NodeUniquenessQueryRequest(
-#             kind="TestCar",
-#             unique_attribute_paths=[{"attribute_name": "name", "property_name": "value"}],
-#             relationship_attribute_paths=[{"identifier": "testcar__testperson", "attribute_name": "height"}],
-#         ),
-#     )
-#     query_result = await query.execute(db=db)
-
-#     assert not query_result.results
+    # attr and relationship value
+    query_request = NodeUniquenessQueryRequestValued(
+        kind="TestCar",
+        unique_valued_paths=[
+            QueryAttributePathValued(attribute_name="name", value=person_to_update.height.value),
+            QueryRelationshipPathValued(
+                relationship_schema=owner_rel_schema, peer_id=None, attribute_name="height", attribute_value=5000
+            ),
+        ],
+    )
+    query = await UniquenessValidationQuery.init(db=db, branch=branch, query_request=query_request)
+    await query.execute(db=db)
+    violation_nodes = query.get_violation_nodes()
+    assert violation_nodes == []
 
 
-# async def test_query_relationship_uniqueness_one_violation(
-#     db: InfrahubDatabase,
-#     car_accord_main,
-#     car_prius_main,
-#     person_jane_main,
-#     person_john_main,
-#     branch: Branch,
-#     default_branch: Branch,
-# ):
-#     car_to_update = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
-#     await car_to_update.owner.update(data=person_jane_main, db=db)
-#     await car_to_update.save(db=db)
-#     person_to_update = await NodeManager.get_one(id=person_jane_main.id, db=db, branch=branch)
-#     person_to_update.height.value = person_john_main.height.value
-#     await person_to_update.save(db=db)
+async def test_query_relationship_uniqueness_one_violation(
+    db: InfrahubDatabase,
+    car_accord_main,
+    car_prius_main,
+    person_jane_main,
+    person_john_main,
+    person_albert_main,
+    branch: Branch,
+):
+    car_accord_branch = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
+    await car_accord_branch.owner.update(data=person_jane_main, db=db)
+    await car_accord_branch.save(db=db)
 
-#     query = await NodeUniqueAttributeConstraintQuery.init(
-#         db=db,
-#         branch=branch,
-#         query_request=NodeUniquenessQueryRequest(
-#             kind="TestCar",
-#             unique_attribute_paths=[{"attribute_name": "name", "property_name": "value"}],
-#             relationship_attribute_paths=[{"identifier": "testcar__testperson", "attribute_name": "height"}],
-#         ),
-#     )
-#     query_result = await query.execute(db=db)
+    person_jane_branch = await NodeManager.get_one(id=person_jane_main.id, db=db, branch=branch)
+    person_jane_branch.height.value = person_john_main.height.value - 1
+    await person_jane_branch.save(db=db)
 
-#     assert len(query_result.results) == 2
-#     expected_result_dicts = [
-#         {
-#             "attr_name": "height",
-#             "node_id": car_accord_main.id,
-#             "node_count": 2,
-#             "attr_value": 180,
-#             "relationship_identifier": "testcar__testperson",
-#             "deepest_branch_name": branch.name,
-#         },
-#         {
-#             "attr_name": "height",
-#             "node_id": car_prius_main.id,
-#             "node_count": 2,
-#             "attr_value": 180,
-#             "relationship_identifier": "testcar__testperson",
-#             "deepest_branch_name": default_branch.name,
-#         },
-#     ]
-#     for result in query_result.results:
-#         serial_result = dict(result.data)
-#         assert serial_result in expected_result_dicts
+    car_schema = db.schema.get("TestCar", branch=branch, duplicate=False)
+    owner_rel_schema = car_schema.get_relationship(name="owner")
 
+    # relationship peer only
+    query_request = NodeUniquenessQueryRequestValued(
+        kind="TestCar",
+        unique_valued_paths=[
+            QueryRelationshipPathValued(
+                relationship_schema=owner_rel_schema,
+                peer_id=person_jane_main.id,
+                attribute_name=None,
+                attribute_value=None,
+            )
+        ],
+    )
+    query = await UniquenessValidationQuery.init(db=db, branch=branch, query_request=query_request)
+    await query.execute(db=db)
+    violation_nodes = query.get_violation_nodes()
+    assert violation_nodes == [(car_accord_main.id, "TestCar")]
 
-# async def test_query_relationship_and_attribute_uniqueness_violations(
-#     db: InfrahubDatabase,
-#     car_accord_main,
-#     car_prius_main,
-#     person_jane_main,
-#     person_john_main,
-#     branch: Branch,
-#     default_branch: Branch,
-# ):
-#     car_to_update = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
-#     await car_to_update.owner.update(data=person_jane_main, db=db)
-#     await car_to_update.save(db=db)
-#     person_to_update = await NodeManager.get_one(id=person_jane_main.id, db=db, branch=branch)
-#     person_to_update.height.value = person_john_main.height.value
-#     await person_to_update.save(db=db)
-#     expected_result_dicts = [
-#         {
-#             "attr_name": "nbr_seats",
-#             "node_id": car_accord_main.id,
-#             "node_count": 2,
-#             "attr_value": 5,
-#             "relationship_identifier": None,
-#             "deepest_branch_name": default_branch.name,
-#         },
-#         {
-#             "attr_name": "nbr_seats",
-#             "node_id": car_prius_main.id,
-#             "node_count": 2,
-#             "attr_value": 5,
-#             "relationship_identifier": None,
-#             "deepest_branch_name": default_branch.name,
-#         },
-#         {
-#             "attr_name": "height",
-#             "node_id": car_accord_main.id,
-#             "node_count": 2,
-#             "attr_value": 180,
-#             "relationship_identifier": "testcar__testperson",
-#             "deepest_branch_name": branch.name,
-#         },
-#         {
-#             "attr_name": "height",
-#             "node_id": car_prius_main.id,
-#             "node_count": 2,
-#             "attr_value": 180,
-#             "relationship_identifier": "testcar__testperson",
-#             "deepest_branch_name": default_branch.name,
-#         },
-#     ]
+    # relationship attribute value only
+    query_request = NodeUniquenessQueryRequestValued(
+        kind="TestCar",
+        unique_valued_paths=[
+            QueryRelationshipPathValued(
+                relationship_schema=owner_rel_schema,
+                peer_id=None,
+                attribute_name="height",
+                attribute_value=person_jane_branch.height.value,
+            )
+        ],
+    )
+    query = await UniquenessValidationQuery.init(db=db, branch=branch, query_request=query_request)
+    await query.execute(db=db)
+    violation_nodes = query.get_violation_nodes()
+    assert violation_nodes == [(car_accord_main.id, "TestCar")]
 
-#     query = await NodeUniqueAttributeConstraintQuery.init(
-#         db=db,
-#         branch=branch,
-#         query_request=NodeUniquenessQueryRequest(
-#             kind="TestCar",
-#             unique_attribute_paths=[
-#                 {"attribute_name": "name", "property_name": "value"},
-#                 {"attribute_name": "nbr_seats", "property_name": "value"},
-#             ],
-#             relationship_attribute_paths=[{"identifier": "testcar__testperson", "attribute_name": "height"}],
-#         ),
-#     )
-#     query_result = await query.execute(db=db)
+    # attr and relationship peer
+    query_request = NodeUniquenessQueryRequestValued(
+        kind="TestCar",
+        unique_valued_paths=[
+            QueryAttributePathValued(attribute_name="name", value=car_prius_main.name.value),
+            QueryRelationshipPathValued(
+                relationship_schema=owner_rel_schema,
+                peer_id=person_john_main.id,
+                attribute_name=None,
+                attribute_value=None,
+            ),
+        ],
+    )
+    query = await UniquenessValidationQuery.init(db=db, branch=branch, query_request=query_request)
+    await query.execute(db=db)
+    violation_nodes = query.get_violation_nodes()
+    assert violation_nodes == [(car_prius_main.id, "TestCar")]
 
-#     assert len(query_result.results) == 4
-#     for result in query_result.results:
-#         serial_result = dict(result.data)
-#         assert serial_result in expected_result_dicts
+    # attr and relationship value
+    query_request = NodeUniquenessQueryRequestValued(
+        kind="TestCar",
+        unique_valued_paths=[
+            QueryAttributePathValued(attribute_name="name", value=car_accord_main.name.value),
+            QueryRelationshipPathValued(
+                relationship_schema=owner_rel_schema,
+                peer_id=None,
+                attribute_name="height",
+                attribute_value=person_jane_branch.height.value,
+            ),
+        ],
+    )
+    query = await UniquenessValidationQuery.init(db=db, branch=branch, query_request=query_request)
+    await query.execute(db=db)
+    violation_nodes = query.get_violation_nodes()
+    assert violation_nodes == [(car_accord_main.id, "TestCar")]
 
 
-# async def test_query_relationship_violation_no_attribute(
-#     db: InfrahubDatabase,
-#     car_accord_main,
-#     car_prius_main,
-#     car_camry_main,
-#     person_john_main,
-#     branch: Branch,
-#     default_branch: Branch,
-# ):
-#     car_to_update = await NodeManager.get_one(id=car_camry_main.id, db=db, branch=branch)
-#     await car_to_update.owner.update(data=person_john_main, db=db)
-#     await car_to_update.save(db=db)
-#     expected_result_dicts = [
-#         {
-#             "attr_name": "id",
-#             "node_id": car_accord_main.id,
-#             "node_count": 3,
-#             "attr_value": person_john_main.id,
-#             "relationship_identifier": "testcar__testperson",
-#             "deepest_branch_name": default_branch.name,
-#         },
-#         {
-#             "attr_name": "id",
-#             "node_id": car_prius_main.id,
-#             "node_count": 3,
-#             "attr_value": person_john_main.id,
-#             "relationship_identifier": "testcar__testperson",
-#             "deepest_branch_name": default_branch.name,
-#         },
-#         {
-#             "attr_name": "id",
-#             "node_id": car_camry_main.id,
-#             "node_count": 3,
-#             "attr_value": person_john_main.id,
-#             "relationship_identifier": "testcar__testperson",
-#             "deepest_branch_name": branch.name,
-#         },
-#     ]
+async def test_query_relationship_no_violation_same_peer_different_rels(
+    db: InfrahubDatabase, default_branch: Branch, animal_person_schema: SchemaBranch
+):
+    john = await Node.init(schema="TestPerson", db=db)
+    await john.new(db=db, name="John", height=175)
+    await john.save(db=db)
+    jane = await Node.init(schema="TestPerson", db=db)
+    await jane.new(db=db, name="Jane", height=165)
+    await jane.save(db=db)
+    johns_dog = await Node.init(schema="TestDog", db=db)
+    await johns_dog.new(db=db, name="J-dog", breed="mixed", owner=john, best_friend=jane)
+    await johns_dog.save(db=db)
+    jane_dog = await Node.init(schema="TestDog", db=db)
+    await jane_dog.new(db=db, name="Jane-dog", breed="mixed", owner=jane, best_friend=jane)
+    await jane_dog.save(db=db)
 
-#     query = await NodeUniqueAttributeConstraintQuery.init(
-#         db=db,
-#         branch=branch,
-#         query_request=NodeUniquenessQueryRequest(
-#             kind="TestCar", relationship_attribute_paths=[{"identifier": "testcar__testperson", "attribute_name": None}]
-#         ),
-#     )
-#     query_result = await query.execute(db=db)
+    branch = await create_branch(db=db, branch_name="branch")
+    joe = await Node.init(schema="TestPerson", db=db, branch=branch)
+    await joe.new(db=db, name="Joe", height=175)
+    await joe.save(db=db)
+    joes_dog = await Node.init(schema="TestDog", db=db, branch=branch)
+    await joes_dog.new(db=db, name="Joe-dog", breed="mixed", owner=joe, best_friend=jane)
+    await joes_dog.save(db=db)
 
-#     assert len(query_result.results) == 3
-#     for result in query_result.results:
-#         serial_result = dict(result.data)
-#         assert serial_result in expected_result_dicts
+    dog_schema = db.schema.get("TestDog", duplicate=False)
+    owner_rel_schema = dog_schema.get_relationship("owner")
+    best_friend_rel_schema = dog_schema.get_relationship("best_friend")
 
+    query_request = NodeUniquenessQueryRequestValued(
+        kind="TestDog",
+        unique_valued_paths=[
+            QueryRelationshipPathValued(
+                relationship_schema=owner_rel_schema, peer_id=jane.id, attribute_name=None, attribute_value=None
+            )
+        ],
+    )
+    query = await UniquenessValidationQuery.init(db=db, branch=branch, query_request=query_request)
+    await query.execute(db=db)
+    violation_nodes = query.get_violation_nodes()
+    assert violation_nodes == [(jane_dog.id, "TestDog")]
 
-# async def test_query_relationship_no_violation_same_peer_different_rels(
-#     db: InfrahubDatabase, default_branch: Branch, animal_person_schema: SchemaBranch
-# ):
-#     john = await Node.init(schema="TestPerson", db=db)
-#     await john.new(db=db, name="John", height=175)
-#     await john.save(db=db)
-#     jane = await Node.init(schema="TestPerson", db=db)
-#     await jane.new(db=db, name="Jane", height=165)
-#     await jane.save(db=db)
-#     johns_dog = await Node.init(schema="TestDog", db=db)
-#     await johns_dog.new(db=db, name="J-dog", breed="mixed", owner=john, best_friend=jane)
-#     await johns_dog.save(db=db)
-#     jane_dog = await Node.init(schema="TestDog", db=db)
-#     await jane_dog.new(db=db, name="Jane-dog", breed="mixed", owner=jane, best_friend=jane)
-#     await jane_dog.save(db=db)
-
-#     branch = await create_branch(db=db, branch_name="branch")
-#     joe = await Node.init(schema="TestPerson", db=db, branch=branch)
-#     await joe.new(db=db, name="Joe", height=175)
-#     await joe.save(db=db)
-#     joes_dog = await Node.init(schema="TestDog", db=db, branch=branch)
-#     await joes_dog.new(db=db, name="Joe-dog", breed="mixed", owner=joe, best_friend=jane)
-#     await joes_dog.save(db=db)
-
-#     expected_best_friend_result_dicts = [
-#         {
-#             "attr_name": "id",
-#             "node_id": johns_dog.id,
-#             "node_count": 3,
-#             "attr_value": jane.id,
-#             "relationship_identifier": "person__animal_friend",
-#             "deepest_branch_name": default_branch.name,
-#         },
-#         {
-#             "attr_name": "id",
-#             "node_id": jane_dog.id,
-#             "node_count": 3,
-#             "attr_value": jane.id,
-#             "relationship_identifier": "person__animal_friend",
-#             "deepest_branch_name": default_branch.name,
-#         },
-#         {
-#             "attr_name": "id",
-#             "node_id": joes_dog.id,
-#             "node_count": 3,
-#             "attr_value": jane.id,
-#             "relationship_identifier": "person__animal_friend",
-#             "deepest_branch_name": branch.name,
-#         },
-#     ]
-
-#     owner_query = await NodeUniqueAttributeConstraintQuery.init(
-#         db=db,
-#         branch=branch,
-#         query_request=NodeUniquenessQueryRequest(
-#             kind="TestDog", relationship_attribute_paths=[{"identifier": "person__animal", "value": jane.id}]
-#         ),
-#     )
-#     owner_query_result = await owner_query.execute(db=db)
-#     assert len(owner_query_result.results) == 0
-
-#     best_friend_query = await NodeUniqueAttributeConstraintQuery.init(
-#         db=db,
-#         branch=branch,
-#         query_request=NodeUniquenessQueryRequest(
-#             kind="TestDog", relationship_attribute_paths=[{"identifier": "person__animal_friend", "value": jane.id}]
-#         ),
-#     )
-#     best_friend_query_result = await best_friend_query.execute(db=db)
-#     assert len(best_friend_query_result.results) == 3
-#     for result in best_friend_query_result.results:
-#         serial_result = dict(result.data)
-#         assert serial_result in expected_best_friend_result_dicts
-
-
-# async def test_query_response_min_count_0_attribute_paths(
-#     db: InfrahubDatabase, car_accord_main, car_prius_main, branch: Branch, default_branch: Branch
-# ):
-#     expected_result_dicts = [
-#         {
-#             "attr_name": "nbr_seats",
-#             "node_id": car_accord_main.id,
-#             "node_count": 2,
-#             "attr_value": 5,
-#             "relationship_identifier": None,
-#             "deepest_branch_name": default_branch.name,
-#         },
-#         {
-#             "attr_name": "nbr_seats",
-#             "node_id": car_prius_main.id,
-#             "node_count": 2,
-#             "attr_value": 5,
-#             "relationship_identifier": None,
-#             "deepest_branch_name": default_branch.name,
-#         },
-#         {
-#             "attr_name": "name",
-#             "node_id": car_accord_main.id,
-#             "node_count": 1,
-#             "attr_value": car_accord_main.name.value,
-#             "relationship_identifier": None,
-#             "deepest_branch_name": default_branch.name,
-#         },
-#         {
-#             "attr_name": "name",
-#             "node_id": car_prius_main.id,
-#             "node_count": 1,
-#             "attr_value": car_prius_main.name.value,
-#             "relationship_identifier": None,
-#             "deepest_branch_name": default_branch.name,
-#         },
-#     ]
-
-#     query = await NodeUniqueAttributeConstraintQuery.init(
-#         db=db,
-#         branch=branch,
-#         query_request=NodeUniquenessQueryRequest(
-#             kind="TestCar",
-#             unique_attribute_paths=[
-#                 {"attribute_name": "name", "property_name": "value"},
-#                 {"attribute_name": "nbr_seats", "property_name": "value"},
-#             ],
-#         ),
-#         min_count_required=0,
-#     )
-#     query_result = await query.execute(db=db)
-
-#     assert len(query_result.results) == 4
-#     for result in query_result.results:
-#         serial_result = dict(result.data)
-#         assert serial_result in expected_result_dicts
-
-
-# async def test_query_response_min_count_0_relationship_paths(
-#     db: InfrahubDatabase, car_camry_main, car_prius_main, branch: Branch, default_branch: Branch
-# ):
-#     expected_result_dicts = [
-#         {
-#             "attr_name": "name",
-#             "node_id": car_camry_main.id,
-#             "node_count": 1,
-#             "attr_value": "Jane",
-#             "relationship_identifier": "testcar__testperson",
-#             "deepest_branch_name": default_branch.name,
-#         },
-#         {
-#             "attr_name": "name",
-#             "node_id": car_prius_main.id,
-#             "node_count": 1,
-#             "attr_value": "John",
-#             "relationship_identifier": "testcar__testperson",
-#             "deepest_branch_name": default_branch.name,
-#         },
-#         {
-#             "attr_name": "height",
-#             "node_id": car_camry_main.id,
-#             "node_count": 2,
-#             "attr_value": 180,
-#             "relationship_identifier": "testcar__testperson",
-#             "deepest_branch_name": default_branch.name,
-#         },
-#         {
-#             "attr_name": "height",
-#             "node_id": car_prius_main.id,
-#             "node_count": 2,
-#             "attr_value": 180,
-#             "relationship_identifier": "testcar__testperson",
-#             "deepest_branch_name": default_branch.name,
-#         },
-#     ]
-
-#     query = await NodeUniqueAttributeConstraintQuery.init(
-#         db=db,
-#         branch=branch,
-#         query_request=NodeUniquenessQueryRequest(
-#             kind="TestCar",
-#             relationship_attribute_paths=[
-#                 {"identifier": "testcar__testperson", "attribute_name": "height"},
-#                 {"identifier": "testcar__testperson", "attribute_name": "name"},
-#             ],
-#         ),
-#         min_count_required=0,
-#     )
-#     query_result = await query.execute(db=db)
-
-#     assert len(query_result.results) == 4
-#     for result in query_result.results:
-#         serial_result = dict(result.data)
-#         assert serial_result in expected_result_dicts
-
-
-# async def test_query_response_min_count_0_attribute_paths_with_value(
-#     db: InfrahubDatabase, car_accord_main, car_prius_main, branch: Branch, default_branch: Branch
-# ):
-#     expected_result_dicts = [
-#         {
-#             "attr_name": "nbr_seats",
-#             "node_id": car_accord_main.id,
-#             "node_count": 2,
-#             "attr_value": 5,
-#             "relationship_identifier": None,
-#             "deepest_branch_name": default_branch.name,
-#         },
-#         {
-#             "attr_name": "nbr_seats",
-#             "node_id": car_prius_main.id,
-#             "node_count": 2,
-#             "attr_value": 5,
-#             "relationship_identifier": None,
-#             "deepest_branch_name": default_branch.name,
-#         },
-#         {
-#             "attr_name": "name",
-#             "node_id": car_accord_main.id,
-#             "node_count": 1,
-#             "attr_value": car_accord_main.name.value,
-#             "relationship_identifier": None,
-#             "deepest_branch_name": default_branch.name,
-#         },
-#     ]
-
-#     query = await NodeUniqueAttributeConstraintQuery.init(
-#         db=db,
-#         branch=branch,
-#         query_request=NodeUniquenessQueryRequest(
-#             kind="TestCar",
-#             unique_attribute_paths=[
-#                 {"attribute_name": "name", "property_name": "value", "value": "accord"},
-#                 {"attribute_name": "nbr_seats", "property_name": "value"},
-#             ],
-#         ),
-#         min_count_required=0,
-#     )
-#     query_result = await query.execute(db=db)
-
-#     assert len(query_result.results) == 3
-#     for result in query_result.results:
-#         serial_result = dict(result.data)
-#         assert serial_result in expected_result_dicts
-
-
-# async def test_query_response_min_count_0_relationship_paths_with_value(
-#     db: InfrahubDatabase, car_camry_main, car_prius_main, branch: Branch, default_branch: Branch
-# ):
-#     expected_result_dicts = [
-#         {
-#             "attr_name": "name",
-#             "node_id": car_camry_main.id,
-#             "node_count": 1,
-#             "attr_value": "Jane",
-#             "relationship_identifier": "testcar__testperson",
-#             "deepest_branch_name": default_branch.name,
-#         },
-#         {
-#             "attr_name": "height",
-#             "node_id": car_camry_main.id,
-#             "node_count": 2,
-#             "attr_value": 180,
-#             "relationship_identifier": "testcar__testperson",
-#             "deepest_branch_name": default_branch.name,
-#         },
-#         {
-#             "attr_name": "height",
-#             "node_id": car_prius_main.id,
-#             "node_count": 2,
-#             "attr_value": 180,
-#             "relationship_identifier": "testcar__testperson",
-#             "deepest_branch_name": default_branch.name,
-#         },
-#     ]
-
-#     query = await NodeUniqueAttributeConstraintQuery.init(
-#         db=db,
-#         branch=branch,
-#         query_request=NodeUniquenessQueryRequest(
-#             kind="TestCar",
-#             relationship_attribute_paths=[
-#                 {"identifier": "testcar__testperson", "attribute_name": "height"},
-#                 {"identifier": "testcar__testperson", "attribute_name": "name", "value": "Jane"},
-#             ],
-#         ),
-#         min_count_required=0,
-#     )
-#     query_result = await query.execute(db=db)
-
-#     assert len(query_result.results) == 3
-#     for result in query_result.results:
-#         serial_result = dict(result.data)
-#         assert serial_result in expected_result_dicts
+    query_request = NodeUniquenessQueryRequestValued(
+        kind="TestDog",
+        unique_valued_paths=[
+            QueryRelationshipPathValued(
+                relationship_schema=best_friend_rel_schema, peer_id=jane.id, attribute_name=None, attribute_value=None
+            )
+        ],
+    )
+    query = await UniquenessValidationQuery.init(db=db, branch=branch, query_request=query_request)
+    await query.execute(db=db)
+    violation_nodes = query.get_violation_nodes()
+    assert set(violation_nodes) == {(jane_dog.id, "TestDog"), (joes_dog.id, "TestDog"), (johns_dog.id, "TestDog")}

--- a/backend/tests/unit/graphql/test_mutation_upsert.py
+++ b/backend/tests/unit/graphql/test_mutation_upsert.py
@@ -239,7 +239,7 @@ async def test_update_by_id_to_nonunique_value_raises_error(
 
 
 async def test_non_unique_value_raises_error(db: InfrahubDatabase, person_schema_unique_attr_non_hfid, branch: Branch):
-    _ = await create_and_save(db=db, schema="TestPerson", name="Jack", bag="bag-jacks")
+    _ = await create_and_save(db=db, branch=branch, schema="TestPerson", name="Jack", bag="bag-jacks")
 
     # Make sure correct raised error is raised while violating uniqueness constraint of a non hfid-related attribute.
     query = """

--- a/backend/tests/unit/graphql/test_mutation_upsert.py
+++ b/backend/tests/unit/graphql/test_mutation_upsert.py
@@ -1,5 +1,6 @@
 from infrahub.auth import AccountSession
 from infrahub.core.branch import Branch
+from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.registry import registry
@@ -638,3 +639,37 @@ async def test_with_constructed_hfid_with_numbers(
         "description": {"value": "Here is the update"},
         "id": first_ticket.id,
     }
+
+
+async def test_upsert_node_on_branch_with_hfid_on_default(db: InfrahubDatabase, default_branch, car_person_schema):
+    # create a node on the default branch after the branch is created
+    branch = await create_branch(branch_name="test-branch", db=db)
+    person = await create_and_save(db=db, branch=default_branch, schema="TestPerson", name="John", height=182)
+
+    # try to upsert a node on the branch with a matching hfid
+    query = """
+    mutation {
+        TestPersonUpsert(data: {name: { value: "John"}, height: {value: 183}}) {
+            ok
+            object {
+                id
+            }
+        }
+    }
+    """
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
+
+    assert result.errors
+    assert len(result.errors) == 1
+    assert (
+        f"Node {person.id} / TestPerson uses this human-friendly ID, but does not exist on this branch"
+        in result.errors[0].message
+    )
+    assert f"Please rebase this branch to access {person.id} / TestPerson" in result.errors[0].message

--- a/backend/tests/unit/graphql/test_mutation_upsert.py
+++ b/backend/tests/unit/graphql/test_mutation_upsert.py
@@ -240,7 +240,7 @@ async def test_update_by_id_to_nonunique_value_raises_error(
 
 
 async def test_non_unique_value_raises_error(db: InfrahubDatabase, person_schema_unique_attr_non_hfid, branch: Branch):
-    _ = await create_and_save(db=db, branch=branch, schema="TestPerson", name="Jack", bag="bag-jacks")
+    _ = await create_and_save(db=db, schema="TestPerson", name="Jack", bag="bag-jacks")
 
     # Make sure correct raised error is raised while violating uniqueness constraint of a non hfid-related attribute.
     query = """

--- a/changelog/6377.fixed.md
+++ b/changelog/6377.fixed.md
@@ -1,0 +1,1 @@
+Improve performance of uniqueness constraint checks during create/update/upsert mutations

--- a/changelog/6377.fixed.md
+++ b/changelog/6377.fixed.md
@@ -1,1 +1,1 @@
-Improve performance of uniqueness constraint checks during create/update/upsert mutations
+Improve performance of uniqueness constraint checks during create/update/upsert mutations by allowing ordering elements from more specific to less specific within a constraint group


### PR DESCRIPTION
part of #6377

We use the `NodeUniqueAttributeConstraintQuery` cypher query in two places:
1.  when creating/updating a node via a mutation
2. when running schema integrity checks as part of a proposed change pipeline

this query checks for any attributes/relationships that match any part of uniqueness constraint and returns all of them, where they are then processed in memory using Python

this PR only affects use case `1` above. it uses a new query `UniquenessValidationQuery` in place of `NodeUniqueAttributeConstraintQuery`. the new query is simpler and returns a much simpler result, but it must be run once for every element of a uniqueness constraint on the node and any parents it may have (although if the node-level uniqueness constraints are a subset of the generic-level uniqueness constraints, then we just run the generic-level ones). the new query also supports ordering of uniqueness constraints and filters out nodes as it runs. this allows ordering uniqueness_constraints from more-specific to less-specific in order to increase performance.

for example, if you have an IP schema with `uniqueness_constraints=[["address__value", "ip_namespace"]]`, this new query will filter by `address__value` (fewer results) before filtering by `ip_namespace` (more results)

the new `UniquenessValidationQuery` query requires specific values, so it is not suitable for checking if _any_ duplicate nodes exist during the schema integrity check, but it may be possible to update it for this case later

### one more thing
also adds a better error message for this specific corner-ish case
 - create a branch (say `branch-test`)
 - add a `blue` tag on `main`
 - try to upsert a `blue` tag on `branch-test`, where the `blue` tag does not actually exist b/c it was created after the branch
 - uniqueness constraints raise an error indicating that the existing `blue` tag on `main` matches this HFID
 - mutation logic tries to retrieve the `blue` tag on `branch-test` and fails with a generic `NodeNotFound` error  
the error message in the final step is now enhanced to give a little more information
```
"Node {tag.id} / BuiltinTag uses this human-friendly ID, but does not exist on this branch. Please rebase this branch to access {tag.id} / BuiltinTag"
```

TODO:

- [x] query needs to handle finding a duplicate node on main for an upsert on a branch when the branch was created before the node on main
- [x] better error message for the above
- [x] test for the above
