### PR TITLE
Store a reference to the return value of `asyncio.create_task`

### DIFF
--- a/backend/infrahub/graphql/app.py
+++ b/backend/infrahub/graphql/app.py
@@ -88,6 +88,8 @@ GQL_STOP = "stop"
 ContextValue = Any | Callable[[HTTPConnection], Any]
 RootValue = Any
 
+subscription_tasks = set()
+
 
 class InfrahubGraphQLApp:
     def __init__(
@@ -446,7 +448,9 @@ class InfrahubGraphQLApp:
 
         asyncgen = cast(AsyncGenerator[Any, None], result)
         subscriptions[operation_id] = asyncgen
-        asyncio.create_task(self._observe_subscription(asyncgen, operation_id, websocket))
+        task = asyncio.create_task(self._observe_subscription(asyncgen, operation_id, websocket))
+        subscription_tasks.add(task)
+        task.add_done_callback(subscription_tasks.discard)
         return []
 
     async def _observe_subscription(

--- a/backend/infrahub/services/adapters/message_bus/nats.py
+++ b/backend/infrahub/services/adapters/message_bus/nats.py
@@ -26,6 +26,8 @@ if TYPE_CHECKING:
 MessageFunction = Callable[[InfrahubMessage], Awaitable[None]]
 ResponseClass = TypeVar("ResponseClass")
 
+publish_tasks = set()
+
 
 async def _add_request_id(message: InfrahubMessage) -> None:
     log_data = get_log_data()
@@ -223,7 +225,9 @@ class NATSMessageBus(InfrahubMessageBus):
                     # Delayed retries are directly handled in the callback using Nack
                     return
                 # Use asyncio task for delayed publish since NATS does not support that out of the box
-                asyncio.create_task(self._publish_with_delay(message, routing_key, delay))
+                task = asyncio.create_task(self._publish_with_delay(message, routing_key, delay))
+                publish_tasks.add(task)
+                task.add_done_callback(publish_tasks.discard)
                 return
 
             for enricher in self.message_enrichers:

--- a/backend/infrahub/services/scheduler.py
+++ b/backend/infrahub/services/scheduler.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
 
 log = get_logger()
 
+background_tasks = set()
+
 
 @dataclass
 class Schedule:
@@ -56,7 +58,9 @@ class InfrahubScheduler:
 
     async def start_schedule(self) -> None:
         for schedule in self.schedules:
-            asyncio.create_task(self.run_schedule(schedule=schedule), name=f"scheduled_task_{schedule.name}")
+            task = asyncio.create_task(self.run_schedule(schedule=schedule), name=f"scheduled_task_{schedule.name}")
+            background_tasks.add(task)
+            task.add_done_callback(background_tasks.discard)
 
     async def shutdown(self) -> None:
         self.running = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -541,7 +541,6 @@ ignore = [
     "RET503",  # Missing explicit `return` at the end of function able to return non-`None` value
     "RET504",  # Unnecessary assignment before `return` statement
     "RUF005",  # Consider `[*list(peers.values()), rfc5735]` instead of concatenation
-    "RUF006",  # Store a reference to the return value of `asyncio.create_task`
     "RUF010",  # Use explicit conversion flag
     "RUF012",  # Mutable class attributes should be annotated with `typing.ClassVar`
     "RUF015",  # Prefer `next(...)` over single element slice


### PR DESCRIPTION
Fix to a linting issue reported by ruff that looks like something that might have caused some weird bugs in the past that would have been hard to troubleshoot.

A reference can be found here: https://textual.textualize.io/blog/2023/02/11/the-heisenbug-lurking-in-your-async-code/