### PR TITLE
Fix Number min/max_value not restricting values

### DIFF
--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -31,6 +31,7 @@ from infrahub.helpers import hash_password
 
 from ..types import ATTRIBUTE_TYPES, LARGE_ATTRIBUTE_TYPES
 from .constants.relationship_label import RELATIONSHIP_TO_NODE_LABEL, RELATIONSHIP_TO_VALUE_LABEL
+from .schema.attribute_parameters import NumberAttributeParameters
 
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
@@ -254,6 +255,14 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin):
         if max_length := schema.get_max_length():
             if len(value) > max_length:
                 raise ValidationError({name: f"{value} must have a maximum length of {max_length!r}"})
+
+        if isinstance(schema.parameters, NumberAttributeParameters):
+            min_value = schema.parameters.min_value
+            if min_value is not None and value < min_value:
+                raise ValidationError({name: f"{value} is lower than the minimum allowed value {min_value!r}"})
+            max_value = schema.parameters.max_value
+            if max_value is not None and value > max_value:
+                raise ValidationError({name: f"{value} is higher than the maximum allowed value {max_value!r}"})
 
         if schema.enum:
             try:

--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -257,12 +257,7 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin):
                 raise ValidationError({name: f"{value} must have a maximum length of {max_length!r}"})
 
         if isinstance(schema.parameters, NumberAttributeParameters):
-            min_value = schema.parameters.min_value
-            if min_value is not None and value < min_value:
-                raise ValidationError({name: f"{value} is lower than the minimum allowed value {min_value!r}"})
-            max_value = schema.parameters.max_value
-            if max_value is not None and value > max_value:
-                raise ValidationError({name: f"{value} is higher than the maximum allowed value {max_value!r}"})
+            schema.parameters.check_valid_value(value=value, name=name)
 
         if schema.enum:
             try:

--- a/backend/infrahub/core/schema/attribute_parameters.py
+++ b/backend/infrahub/core/schema/attribute_parameters.py
@@ -8,6 +8,7 @@ from pydantic import ConfigDict, Field, model_validator
 from infrahub import config
 from infrahub.core.constants.schema import UpdateSupport
 from infrahub.core.models import HashableModel
+from infrahub.exceptions import ValidationError
 
 
 def get_attribute_parameters_class_for_kind(kind: str) -> type[AttributeParameters]:
@@ -124,16 +125,22 @@ class NumberAttributeParameters(AttributeParameters):
         return ranges
 
     def is_valid_value(self, value: int) -> bool:
+        try:
+            self.check_valid_value(value=value, name="UNUSED")
+        except ValidationError:
+            return False
+        return True
+
+    def check_valid_value(self, value: int, name: str) -> None:
         if self.min_value is not None and value < self.min_value:
-            return False
+            raise ValidationError({name: f"{value} is lower than the minimum allowed value {self.min_value!r}"})
         if self.max_value is not None and value > self.max_value:
-            return False
+            raise ValidationError({name: f"{value} is higher than the maximum allowed value {self.max_value!r}"})
         if value in self.get_excluded_single_values():
-            return False
+            raise ValidationError({name: f"{value} is in the excluded values"})
         for start, end in self.get_excluded_ranges():
             if start <= value <= end:
-                return False
-        return True
+                raise ValidationError({name: f"{value} is in an the excluded range {start}-{end}"})
 
 
 class NumberPoolParameters(AttributeParameters):

--- a/backend/tests/functional/schemas/test_load_number_parameters.py
+++ b/backend/tests/functional/schemas/test_load_number_parameters.py
@@ -22,7 +22,7 @@ schema_number_parameters = {
                 {
                     "name": "size",
                     "kind": "Number",
-                    "parameters": {"min_value": 10, "max_value": 4094},
+                    "parameters": {"min_value": 10, "max_value": 4094, "excluded_values": "12,14-16"},
                     "optional": False,
                 }
             ],
@@ -32,10 +32,12 @@ schema_number_parameters = {
 
 
 class TestNbParameters(TestInfrahubApp):
-    async def test_min_max_value(self, client: InfrahubClient) -> None:
+    @pytest.fixture(scope="class")
+    async def load_schema(self, client: InfrahubClient) -> None:
         response = await client.schema.load(schemas=[schema_number_parameters])
         assert len(response.errors) == 0, response.errors
 
+    async def test_min_max_value(self, client: InfrahubClient, load_schema) -> None:
         node = await client.create(kind="RandomApplication", size=5)
         with pytest.raises(GraphQLError) as exc:
             await node.save()
@@ -45,3 +47,23 @@ class TestNbParameters(TestInfrahubApp):
         with pytest.raises(GraphQLError) as exc:
             await node.save()
             assert r"10000 is higher than the maximum allowed value 4096 at size" in exc.value.message
+
+    async def test_excluded_values(self, client: InfrahubClient, load_schema) -> None:
+        node = await client.create(kind="RandomApplication", size=12)
+        with pytest.raises(GraphQLError) as exc:
+            await node.save()
+            assert "12 is in the excluded values at size" in exc.value.message
+
+        node = await client.create(kind="RandomApplication", size=14)
+        with pytest.raises(GraphQLError) as exc:
+            await node.save()
+            assert "14 is in the excluded range 14-16 at size" in exc.value.message
+
+        node = await client.create(kind="RandomApplication", size=16)
+        with pytest.raises(GraphQLError) as exc:
+            await node.save()
+            assert "16 is in the excluded range 14-16 at size" in exc.value.message
+
+    async def test_create_attribute_successfully(self, client: InfrahubClient, load_schema) -> None:
+        node = await client.create(kind="RandomApplication", size=13)
+        await node.save()

--- a/backend/tests/functional/schemas/test_load_number_parameters.py
+++ b/backend/tests/functional/schemas/test_load_number_parameters.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from infrahub_sdk.exceptions import GraphQLError
+
+from tests.helpers.test_app import TestInfrahubApp
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClient
+
+
+schema_number_parameters = {
+    "version": "1.0",
+    "nodes": [
+        {
+            "name": "Application",
+            "namespace": "Random",
+            "include_in_menu": True,
+            "attributes": [
+                {
+                    "name": "size",
+                    "kind": "Number",
+                    "parameters": {"min_value": 10, "max_value": 4094},
+                    "optional": False,
+                }
+            ],
+        },
+    ],
+}
+
+
+class TestNbParameters(TestInfrahubApp):
+    async def test_min_max_value(self, client: InfrahubClient) -> None:
+        response = await client.schema.load(schemas=[schema_number_parameters])
+        assert len(response.errors) == 0, response.errors
+
+        node = await client.create(kind="RandomApplication", size=5)
+        with pytest.raises(GraphQLError) as exc:
+            await node.save()
+            assert "5 is lower than the minimum allowed value 10 at size" in exc.value.message
+
+        node = await client.create(kind="RandomApplication", size=10_000)
+        with pytest.raises(GraphQLError) as exc:
+            await node.save()
+            assert r"10000 is higher than the maximum allowed value 4096 at size" in exc.value.message


### PR DESCRIPTION
Fixes https://github.com/opsmill/infrahub/issues/6714

Currently, constraints are checked only during a schema update, and not during a node update.