### PR TITLE
IFC-1600 Fix next prefix query when length is none

### DIFF
--- a/backend/infrahub/graphql/queries/ipam.py
+++ b/backend/infrahub/graphql/queries/ipam.py
@@ -74,7 +74,7 @@ class IPPrefixGetNextAvailable(ObjectType):
         root: dict,  # noqa: ARG004
         info: GraphQLResolveInfo,
         prefix_id: str,
-        prefix_length: int,
+        prefix_length: int | None = None,
     ) -> dict[str, str]:
         graphql_context: GraphqlContext = info.context
 

--- a/backend/infrahub/pools/prefix.py
+++ b/backend/infrahub/pools/prefix.py
@@ -9,7 +9,9 @@ if TYPE_CHECKING:
     from infrahub.core.ipam.constants import IPNetworkType
 
 
-def get_next_available_prefix(pool: IPSet, prefix_length: int, prefix_ver: Literal[4, 6] = 4) -> IPNetworkType:
+def get_next_available_prefix(
+    pool: IPSet, prefix_length: int | None = None, prefix_ver: Literal[4, 6] = 4
+) -> IPNetworkType:
     """Get the next available prefix of a given prefix length from an IPSet.
 
     Args:
@@ -20,10 +22,7 @@ def get_next_available_prefix(pool: IPSet, prefix_length: int, prefix_ver: Liter
     Raises:
         ValueError: If there are no available subnets in the pool
     """
-    prefix_ver_map = {
-        4: ipaddress.IPv4Network,
-        6: ipaddress.IPv6Network,
-    }
+    prefix_ver_map = {4: ipaddress.IPv4Network, 6: ipaddress.IPv6Network}
 
     filtered_pool = IPSet([])
     for subnet in pool.iter_cidrs():
@@ -31,6 +30,9 @@ def get_next_available_prefix(pool: IPSet, prefix_length: int, prefix_ver: Liter
             filtered_pool.add(subnet)
 
     for cidr in filtered_pool.iter_cidrs():
+        if prefix_length is None:
+            return cidr
+
         if cidr.prefixlen <= prefix_length:
             next_available = ipaddress.ip_network(f"{cidr.network}/{prefix_length}")
             return next_available

--- a/backend/tests/unit/graphql/queries/test_ipam.py
+++ b/backend/tests/unit/graphql/queries/test_ipam.py
@@ -110,7 +110,7 @@ async def ip_dataset_02(
         ("net146", 16, "10.0.0.0/16"),
         ("net146", 24, "10.0.0.0/24"),
         ("net142", 26, "10.10.1.64/26"),
-        ("net142", 27, "10.10.1.32/27"),
+        ("net142", None, "10.10.1.32/27"),
     ],
 )
 async def test_ipprefix_nextavailable(
@@ -128,7 +128,7 @@ async def test_ipprefix_nextavailable(
     gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
 
     query = """
-    query($prefix: String!, $prefix_length: Int!) {
+    query($prefix: String!, $prefix_length: Int) {
         IPPrefixGetNextAvailable(prefix_id: $prefix, prefix_length: $prefix_length) {
             prefix
         }

--- a/changelog/+ifc1600.changed.md
+++ b/changelog/+ifc1600.changed.md
@@ -1,0 +1,1 @@
+Allow `prefix_length` to be omitted when using `IPPrefixGetNextAvailable` GraphQL query to return the first next available prefix


### PR DESCRIPTION
Return the first available prefix if prefix length is not provided. We could also try to lookup the next largest prefix available but I think that most people expect to just have the next prefix disregarding its actual size.