### PR TITLE
prevent diff update and merge from running simultaneously

### DIFF
--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -15,6 +15,7 @@ from infrahub.core.branch import Branch
 from infrahub.core.changelog.diff import DiffChangelogCollector, MigrationTracker
 from infrahub.core.constants import MutationAction
 from infrahub.core.diff.coordinator import DiffCoordinator
+from infrahub.core.diff.diff_locker import DiffLocker
 from infrahub.core.diff.ipam_diff_parser import IpamDiffParser
 from infrahub.core.diff.merger.merger import DiffMerger
 from infrahub.core.diff.model.path import BranchTrackingId, EnrichedDiffRoot, EnrichedDiffRootMetadata
@@ -31,7 +32,7 @@ from infrahub.dependencies.registry import get_component_registry
 from infrahub.events.branch_action import BranchCreatedEvent, BranchDeletedEvent, BranchMergedEvent, BranchRebasedEvent
 from infrahub.events.models import EventMeta, InfrahubEvent
 from infrahub.events.node_action import get_node_event
-from infrahub.exceptions import BranchNotFoundError, MergeFailedError, ValidationError
+from infrahub.exceptions import BranchNotFoundError, ValidationError
 from infrahub.graphql.mutations.models import BranchCreateModel  # noqa: TC001
 from infrahub.services import InfrahubServices  # noqa: TC001  needed for prefect flow
 from infrahub.workflows.catalogue import (
@@ -65,6 +66,7 @@ async def rebase_branch(branch: str, context: InfrahubContext, service: Infrahub
             diff_merger=diff_merger,
             diff_repository=diff_repository,
             source_branch=obj,
+            diff_locker=DiffLocker(),
             service=service,
         )
 
@@ -221,14 +223,10 @@ async def merge_branch(
                 diff_merger=diff_merger,
                 diff_repository=diff_repository,
                 source_branch=obj,
+                diff_locker=DiffLocker(),
                 service=service,
             )
-            try:
-                branch_diff = await merger.merge()
-            except Exception as exc:
-                log.exception("Merge failed, beginning rollback")
-                await merger.rollback()
-                raise MergeFailedError(branch_name=branch) from exc
+            branch_diff = await merger.merge()
             await merger.update_schema()
 
         changelog_collector = DiffChangelogCollector(diff=branch_diff, branch=obj, db=db)

--- a/backend/infrahub/core/diff/coordinator.py
+++ b/backend/infrahub/core/diff/coordinator.py
@@ -118,7 +118,7 @@ class DiffCoordinator:
     async def update_branch_diff(self, base_branch: Branch, diff_branch: Branch) -> EnrichedDiffRootMetadata:
         tracking_id = BranchTrackingId(name=diff_branch.name)
         log.info(f"Received request to update branch diff for {base_branch.name} - {diff_branch.name}")
-        existing_incremental_lock = await self.diff_locker.get_existing_lock(
+        existing_incremental_lock = self.diff_locker.get_existing_lock(
             target_branch_name=base_branch.name, source_branch_name=diff_branch.name, is_incremental=True
         )
         if existing_incremental_lock and await existing_incremental_lock.locked():

--- a/backend/infrahub/core/diff/coordinator.py
+++ b/backend/infrahub/core/diff/coordinator.py
@@ -6,8 +6,7 @@ from uuid import uuid4
 
 from prefect import flow
 
-from infrahub import lock
-from infrahub.core.branch import Branch  # noqa: TC001
+from infrahub.core.branch import Branch
 from infrahub.core.timestamp import Timestamp
 from infrahub.exceptions import ValidationError
 from infrahub.log import get_logger
@@ -26,12 +25,14 @@ from .model.path import (
 
 if TYPE_CHECKING:
     from infrahub.core.node import Node
+    from infrahub.database import InfrahubDatabase
 
     from .calculator import DiffCalculator
     from .combiner import DiffCombiner
     from .conflict_transferer import DiffConflictTransferer
     from .conflicts_enricher import ConflictsEnricher
     from .data_check_synchronizer import DiffDataCheckSynchronizer
+    from .diff_locker import DiffLocker
     from .enricher.aggregated import AggregatedDiffEnricher
     from .enricher.labels import DiffLabelsEnricher
     from .repository.repository import DiffRepository
@@ -59,10 +60,9 @@ class EnrichedDiffRequest:
 
 
 class DiffCoordinator:
-    lock_namespace = "diff-update"
-
     def __init__(
         self,
+        db: InfrahubDatabase,
         diff_repo: DiffRepository,
         diff_calculator: DiffCalculator,
         diff_enricher: AggregatedDiffEnricher,
@@ -71,7 +71,9 @@ class DiffCoordinator:
         labels_enricher: DiffLabelsEnricher,
         data_check_synchronizer: DiffDataCheckSynchronizer,
         conflict_transferer: DiffConflictTransferer,
+        diff_locker: DiffLocker,
     ) -> None:
+        self.db = db
         self.diff_repo = diff_repo
         self.diff_calculator = diff_calculator
         self.diff_enricher = diff_enricher
@@ -80,7 +82,7 @@ class DiffCoordinator:
         self.labels_enricher = labels_enricher
         self.data_check_synchronizer = data_check_synchronizer
         self.conflict_transferer = conflict_transferer
-        self.lock_registry = lock.registry
+        self.diff_locker = diff_locker
 
     async def run_update(
         self,
@@ -113,37 +115,35 @@ class DiffCoordinator:
             name=name,
         )
 
-    def _get_lock_name(self, base_branch_name: str, diff_branch_name: str, is_incremental: bool) -> str:
-        lock_name = f"{base_branch_name}__{diff_branch_name}"
-        if is_incremental:
-            lock_name += "__incremental"
-        return lock_name
-
     async def update_branch_diff(self, base_branch: Branch, diff_branch: Branch) -> EnrichedDiffRootMetadata:
+        tracking_id = BranchTrackingId(name=diff_branch.name)
         log.info(f"Received request to update branch diff for {base_branch.name} - {diff_branch.name}")
-        incremental_lock_name = self._get_lock_name(
-            base_branch_name=base_branch.name, diff_branch_name=diff_branch.name, is_incremental=True
-        )
-        existing_incremental_lock = self.lock_registry.get_existing(
-            name=incremental_lock_name, namespace=self.lock_namespace
+        existing_incremental_lock = await self.diff_locker.get_existing_lock(
+            target_branch_name=base_branch.name, source_branch_name=diff_branch.name, is_incremental=True
         )
         if existing_incremental_lock and await existing_incremental_lock.locked():
             log.info(f"Branch diff update for {base_branch.name} - {diff_branch.name} already in progress")
-            async with self.lock_registry.get(name=incremental_lock_name, namespace=self.lock_namespace):
+            async with self.diff_locker.acquire_lock(
+                target_branch_name=base_branch.name, source_branch_name=diff_branch.name, is_incremental=True
+            ):
                 log.info(f"Existing branch diff update for {base_branch.name} - {diff_branch.name} complete")
-                return await self.diff_repo.get_one(
-                    tracking_id=BranchTrackingId(name=diff_branch.name), diff_branch_name=diff_branch.name
-                )
-        general_lock_name = self._get_lock_name(
-            base_branch_name=base_branch.name, diff_branch_name=diff_branch.name, is_incremental=False
-        )
+                return await self.diff_repo.get_one(tracking_id=tracking_id, diff_branch_name=diff_branch.name)
         from_time = Timestamp(diff_branch.get_branched_from())
         to_time = Timestamp()
-        tracking_id = BranchTrackingId(name=diff_branch.name)
         async with (
-            self.lock_registry.get(name=general_lock_name, namespace=self.lock_namespace),
-            self.lock_registry.get(name=incremental_lock_name, namespace=self.lock_namespace),
+            self.diff_locker.acquire_lock(
+                target_branch_name=base_branch.name, source_branch_name=diff_branch.name, is_incremental=True
+            ),
+            self.diff_locker.acquire_lock(
+                target_branch_name=base_branch.name, source_branch_name=diff_branch.name, is_incremental=False
+            ),
         ):
+            refreshed_branch = await Branch.get_by_name(db=self.db, name=diff_branch.name)
+            if refreshed_branch.get_branched_from() != diff_branch.get_branched_from():
+                log.info(
+                    f"Branch {diff_branch.name} was merged or rebased while waiting for lock, returning latest diff"
+                )
+                return await self.diff_repo.get_one(tracking_id=tracking_id, diff_branch_name=diff_branch.name)
             log.info(f"Acquired lock to run branch diff update for {base_branch.name} - {diff_branch.name}")
             enriched_diffs, node_identifiers_to_drop = await self._update_diffs(
                 base_branch=base_branch,
@@ -169,10 +169,9 @@ class DiffCoordinator:
         name: str,
     ) -> EnrichedDiffRootMetadata:
         tracking_id = NameTrackingId(name=name)
-        general_lock_name = self._get_lock_name(
-            base_branch_name=base_branch.name, diff_branch_name=diff_branch.name, is_incremental=False
-        )
-        async with self.lock_registry.get(name=general_lock_name, namespace=self.lock_namespace):
+        async with self.diff_locker.acquire_lock(
+            target_branch_name=base_branch.name, source_branch_name=diff_branch.name, is_incremental=False
+        ):
             log.info(f"Acquired lock to run arbitrary diff update for {base_branch.name} - {diff_branch.name}")
             enriched_diffs, node_identifiers_to_drop = await self._update_diffs(
                 base_branch=base_branch,
@@ -196,10 +195,9 @@ class DiffCoordinator:
         diff_branch: Branch,
         diff_id: str,
     ) -> EnrichedDiffRoot:
-        general_lock_name = self._get_lock_name(
-            base_branch_name=base_branch.name, diff_branch_name=diff_branch.name, is_incremental=False
-        )
-        async with self.lock_registry.get(name=general_lock_name, namespace=self.lock_namespace):
+        async with self.diff_locker.acquire_lock(
+            target_branch_name=base_branch.name, source_branch_name=diff_branch.name, is_incremental=False
+        ):
             log.info(f"Acquired lock to recalculate diff for {base_branch.name} - {diff_branch.name}")
             current_branch_diff = await self.diff_repo.get_one(diff_branch_name=diff_branch.name, diff_id=diff_id)
             current_base_diff = await self.diff_repo.get_one(

--- a/backend/infrahub/core/diff/diff_locker.py
+++ b/backend/infrahub/core/diff/diff_locker.py
@@ -13,7 +13,7 @@ class DiffLocker:
             lock_name += "__incremental"
         return lock_name
 
-    async def get_existing_lock(
+    def get_existing_lock(
         self, target_branch_name: str, source_branch_name: str, is_incremental: bool = False
     ) -> lock.InfrahubLock | None:
         name = self.get_lock_name(target_branch_name, source_branch_name, is_incremental)

--- a/backend/infrahub/core/diff/diff_locker.py
+++ b/backend/infrahub/core/diff/diff_locker.py
@@ -1,0 +1,26 @@
+from infrahub import lock
+
+
+class DiffLocker:
+    lock_namespace = "diff-update"
+
+    def __init__(self) -> None:
+        self.lock_registry = lock.registry
+
+    def get_lock_name(self, base_branch_name: str, diff_branch_name: str, is_incremental: bool) -> str:
+        lock_name = f"{base_branch_name}__{diff_branch_name}"
+        if is_incremental:
+            lock_name += "__incremental"
+        return lock_name
+
+    async def get_existing_lock(
+        self, target_branch_name: str, source_branch_name: str, is_incremental: bool = False
+    ) -> lock.InfrahubLock | None:
+        name = self.get_lock_name(target_branch_name, source_branch_name, is_incremental)
+        return self.lock_registry.get_existing(name=name, namespace=self.lock_namespace)
+
+    def acquire_lock(
+        self, target_branch_name: str, source_branch_name: str, is_incremental: bool = False
+    ) -> lock.InfrahubLock:
+        name = self.get_lock_name(target_branch_name, source_branch_name, is_incremental)
+        return self.lock_registry.get(name=name, namespace=self.lock_namespace)

--- a/backend/infrahub/core/merge.py
+++ b/backend/infrahub/core/merge.py
@@ -9,7 +9,7 @@ from infrahub.core.models import SchemaUpdateValidationResult
 from infrahub.core.protocols import CoreRepository
 from infrahub.core.registry import registry
 from infrahub.core.timestamp import Timestamp
-from infrahub.exceptions import ValidationError
+from infrahub.exceptions import MergeFailedError, ValidationError
 from infrahub.log import get_logger
 
 from ..git.models import GitRepositoryMerge
@@ -18,6 +18,7 @@ from ..workflows.catalogue import GIT_REPOSITORIES_MERGE
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
     from infrahub.core.diff.coordinator import DiffCoordinator
+    from infrahub.core.diff.diff_locker import DiffLocker
     from infrahub.core.diff.merger.merger import DiffMerger
     from infrahub.core.diff.model.path import EnrichedDiffRoot
     from infrahub.core.diff.repository.repository import DiffRepository
@@ -39,6 +40,7 @@ class BranchMerger:
         diff_coordinator: DiffCoordinator,
         diff_merger: DiffMerger,
         diff_repository: DiffRepository,
+        diff_locker: DiffLocker,
         destination_branch: Branch | None = None,
         service: InfrahubServices | None = None,
     ):
@@ -48,6 +50,7 @@ class BranchMerger:
         self.diff_coordinator = diff_coordinator
         self.diff_merger = diff_merger
         self.diff_repository = diff_repository
+        self.diff_locker = diff_locker
         self.migrations: list[SchemaUpdateMigrationInfo] = []
         self._merge_at = Timestamp()
 
@@ -185,22 +188,34 @@ class BranchMerger:
         )
         log.info("Diff updated for merge")
 
-        errors: list[str] = []
-        async for conflict_path, conflict in self.diff_repository.get_all_conflicts_for_diff(
-            diff_branch_name=self.source_branch.name, tracking_id=BranchTrackingId(name=self.source_branch.name)
+        log.info("Acquiring lock for merge")
+        async with self.diff_locker.acquire_lock(
+            target_branch_name=self.destination_branch.name,
+            source_branch_name=self.source_branch.name,
+            is_incremental=False,
         ):
-            if conflict.selected_branch is None or conflict.resolvable is False:
-                errors.append(conflict_path)
+            log.info("Lock acquired for merge")
+            try:
+                errors: list[str] = []
+                async for conflict_path, conflict in self.diff_repository.get_all_conflicts_for_diff(
+                    diff_branch_name=self.source_branch.name, tracking_id=BranchTrackingId(name=self.source_branch.name)
+                ):
+                    if conflict.selected_branch is None or conflict.resolvable is False:
+                        errors.append(conflict_path)
 
-        if errors:
-            raise ValidationError(
-                f"Unable to merge the branch '{self.source_branch.name}', conflict resolution missing: {', '.join(errors)}"
-            )
+                if errors:
+                    raise ValidationError(
+                        f"Unable to merge the branch '{self.source_branch.name}', conflict resolution missing: {', '.join(errors)}"
+                    )
 
-        # TODO need to find a way to properly communicate back to the user any issue that could come up during the merge
-        # From the Graph or From the repositories
-        self._merge_at = Timestamp(at)
-        branch_diff = await self.diff_merger.merge_graph(at=self._merge_at)
+                # TODO need to find a way to properly communicate back to the user any issue that could come up during the merge
+                # From the Graph or From the repositories
+                self._merge_at = Timestamp(at)
+                branch_diff = await self.diff_merger.merge_graph(at=self._merge_at)
+            except Exception as exc:
+                log.exception("Merge failed, beginning rollback")
+                await self.rollback()
+                raise MergeFailedError(branch_name=self.source_branch.name) from exc
         await self.merge_repositories()
         return branch_diff
 

--- a/backend/infrahub/dependencies/builder/diff/coordinator.py
+++ b/backend/infrahub/dependencies/builder/diff/coordinator.py
@@ -1,4 +1,5 @@
 from infrahub.core.diff.coordinator import DiffCoordinator
+from infrahub.dependencies.builder.diff.locker import DiffLockerDependency
 from infrahub.dependencies.interface import DependencyBuilder, DependencyBuilderContext
 
 from .calculator import DiffCalculatorDependency
@@ -15,6 +16,7 @@ class DiffCoordinatorDependency(DependencyBuilder[DiffCoordinator]):
     @classmethod
     def build(cls, context: DependencyBuilderContext) -> DiffCoordinator:
         return DiffCoordinator(
+            db=context.db,
             diff_repo=DiffRepositoryDependency.build(context=context),
             diff_calculator=DiffCalculatorDependency.build(context=context),
             diff_combiner=DiffCombinerDependency.build(context=context),
@@ -23,4 +25,5 @@ class DiffCoordinatorDependency(DependencyBuilder[DiffCoordinator]):
             labels_enricher=DiffLabelsEnricherDependency.build(context=context),
             data_check_synchronizer=DiffDataCheckSynchronizerDependency.build(context=context),
             conflict_transferer=DiffConflictTransfererDependency.build(context=context),
+            diff_locker=DiffLockerDependency.build(context=context),
         )

--- a/backend/infrahub/dependencies/builder/diff/locker.py
+++ b/backend/infrahub/dependencies/builder/diff/locker.py
@@ -1,0 +1,8 @@
+from infrahub.core.diff.diff_locker import DiffLocker
+from infrahub.dependencies.interface import DependencyBuilder, DependencyBuilderContext
+
+
+class DiffLockerDependency(DependencyBuilder[DiffLocker]):
+    @classmethod
+    def build(cls, context: DependencyBuilderContext) -> DiffLocker:  # noqa: ARG003
+        return DiffLocker()

--- a/backend/infrahub/graphql/mutations/tasks.py
+++ b/backend/infrahub/graphql/mutations/tasks.py
@@ -6,6 +6,7 @@ from infrahub.context import InfrahubContext  # noqa: TC001  needed for prefect 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.diff.coordinator import DiffCoordinator
+from infrahub.core.diff.diff_locker import DiffLocker
 from infrahub.core.diff.merger.merger import DiffMerger
 from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.merge import BranchMerger
@@ -50,6 +51,7 @@ async def merge_branch_mutation(branch: str, context: InfrahubContext, service: 
             diff_merger=diff_merger,
             diff_repository=diff_repository,
             source_branch=obj,
+            diff_locker=DiffLocker(),
             service=service,
         )
         candidate_schema = merger.get_candidate_schema()

--- a/backend/tests/integration/diff/test_diff_merge.py
+++ b/backend/tests/integration/diff/test_diff_merge.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 from infrahub_sdk import InfrahubClient
 
@@ -164,7 +166,7 @@ class TestDiffMerge(TestInfrahubApp):
         new_person = await Node.init(db=db, schema=PERSON_KIND)
         await new_person.new(db=db, name="Chuck Berry")
         await new_person.save(db=db)
-        diff_branch = await create_branch(db=db, branch_name="branch2")
+        diff_branch = await create_branch(db=db, branch_name=f"branch-{uuid.uuid4()}")
         if delete_on_branch:
             delete_branch = diff_branch
             update_branch = default_branch

--- a/backend/tests/integration/diff/test_merge_rollback.py
+++ b/backend/tests/integration/diff/test_merge_rollback.py
@@ -35,9 +35,13 @@ mutation($branch: String!) {
 class BrokenBranchMerger:
     def __init__(self, *args, **kwargs) -> None:
         self.real_merger = BranchMerger(*args, **kwargs)
+        self.real_merger.diff_merger.merge_graph = self.merge_graph  # type: ignore
 
     async def merge(self, at=None) -> None:
         await self.real_merger.merge(at=at)
+
+    async def merge_graph(self, at):
+        await self.real_merger.diff_merger.merge_graph(at=at)
         raise ValueError("This is broken on purpose")
 
     async def rollback(self) -> None:

--- a/backend/tests/unit/core/diff/test_coordinator_lock.py
+++ b/backend/tests/unit/core/diff/test_coordinator_lock.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 import pytest
 
 from infrahub import config, lock
+from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.diff.coordinator import DiffCoordinator
 from infrahub.core.diff.diff_locker import DiffLocker
@@ -14,6 +15,9 @@ from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.initialization import create_branch
 from infrahub.core.merge import BranchMerger
 from infrahub.core.node import Node
+from infrahub.core.schema import SchemaRoot
+from infrahub.core.schema.definitions.core.repository import core_repository
+from infrahub.core.schema.node_schema import NodeSchema
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase, get_db
 from infrahub.dependencies.registry import get_component_registry
@@ -39,6 +43,17 @@ class TestDiffCoordinatorLocks:
     async def diff_repository(self, db: InfrahubDatabase, default_branch: Branch) -> DiffRepository:
         component_registry = get_component_registry()
         return await component_registry.get_component(DiffRepository, db=db, branch=default_branch)
+
+    @pytest.fixture
+    async def dummy_repository_schema(self, db: InfrahubDatabase, default_branch: Branch) -> None:
+        dummy_repository = NodeSchema(
+            name=core_repository.name,
+            namespace=core_repository.namespace,
+        )
+        schema = SchemaRoot(nodes=[dummy_repository])
+        registry.schema.register_schema(schema=schema, branch=default_branch.name)
+        default_branch.update_schema_hash()
+        await default_branch.save(db=db)
 
     async def get_diff_coordinator(self, db: InfrahubDatabase, diff_branch: Branch) -> DiffCoordinator:
         config.SETTINGS.database.max_depth_search_hierarchy = 10
@@ -166,13 +181,13 @@ class TestDiffCoordinatorLocks:
         assert len(diff_coordinator.diff_calculator.calculate_diff.call_args_list) == 2
 
     async def test_diff_update_blocks_merge(
-        self, db: InfrahubDatabase, default_branch: Branch, diff_repository: DiffRepository, branch_with_data: Branch
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        diff_repository: DiffRepository,
+        branch_with_data: Branch,
+        dummy_repository_schema: None,
     ):
-        # schema = SchemaRoot(generics=[core_generic_repository])
-        # schema_branch = registry.schema.register_schema(schema=schema, branch=default_branch.name)
-        # default_branch.update_schema_hash()
-        # await default_branch.save(db=db)
-
         diff_branch = branch_with_data
         diff_coordinator = await self.get_diff_coordinator(db=db, diff_branch=diff_branch)
         branch_merger = BranchMerger(
@@ -201,27 +216,34 @@ class TestDiffCoordinatorLocks:
         assert results[0].tracking_id == results[1].tracking_id
 
     async def test_merge_blocks_diff_update(
-        self, db: InfrahubDatabase, default_branch: Branch, diff_repository: DiffRepository, branch_with_data: Branch
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        diff_repository: DiffRepository,
+        branch_with_data: Branch,
+        dummy_repository_schema: None,
     ):
-        # schema = SchemaRoot(generics=[core_generic_repository])
-        # schema_branch = registry.schema.register_schema(schema=schema, branch=default_branch.name)
-        # default_branch.update_schema_hash()
-        # await default_branch.save(db=db)
-
         diff_branch = branch_with_data
         diff_coordinator = await self.get_diff_coordinator(db=db, diff_branch=diff_branch)
+
+        # need a separate database connection or the driver raises an error
+        # which is fine, b/c this is closer to the real issue
         db2 = InfrahubDatabase(driver=await get_db(retry=5))
+        component_registry = get_component_registry()
+        diff_repository_2 = await component_registry.get_component(DiffRepository, db=db2, branch=default_branch)
+        diff_coordinator_2 = await self.get_diff_coordinator(db=db2, diff_branch=diff_branch)
+
         branch_merger = BranchMerger(
             db=db2,
-            diff_coordinator=diff_coordinator,
+            diff_coordinator=diff_coordinator_2,
             diff_merger=DiffMerger(
                 db=db,
                 source_branch=diff_branch,
                 destination_branch=default_branch,
-                diff_repository=diff_repository,
-                serializer=DiffMergeSerializer(db=db, max_batch_size=50),
+                diff_repository=diff_repository_2,
+                serializer=DiffMergeSerializer(db=db2, max_batch_size=50),
             ),
-            diff_repository=diff_repository,
+            diff_repository=diff_repository_2,
             source_branch=diff_branch,
             diff_locker=DiffLocker(),
         )

--- a/backend/tests/unit/core/diff/test_coordinator_lock.py
+++ b/backend/tests/unit/core/diff/test_coordinator_lock.py
@@ -7,11 +7,15 @@ import pytest
 from infrahub import config, lock
 from infrahub.core.branch import Branch
 from infrahub.core.diff.coordinator import DiffCoordinator
+from infrahub.core.diff.diff_locker import DiffLocker
+from infrahub.core.diff.merger.merger import DiffMerger
+from infrahub.core.diff.merger.serializer import DiffMergeSerializer
 from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.initialization import create_branch
+from infrahub.core.merge import BranchMerger
 from infrahub.core.node import Node
 from infrahub.core.timestamp import Timestamp
-from infrahub.database import InfrahubDatabase
+from infrahub.database import InfrahubDatabase, get_db
 from infrahub.dependencies.registry import get_component_registry
 
 
@@ -160,3 +164,74 @@ class TestDiffCoordinatorLocks:
         assert full_branch_diff.nodes == full_arbitrary_diff.nodes
         # arbitrary diff is calculated separately from the branch-tracking diff
         assert len(diff_coordinator.diff_calculator.calculate_diff.call_args_list) == 2
+
+    async def test_diff_update_blocks_merge(
+        self, db: InfrahubDatabase, default_branch: Branch, diff_repository: DiffRepository, branch_with_data: Branch
+    ):
+        # schema = SchemaRoot(generics=[core_generic_repository])
+        # schema_branch = registry.schema.register_schema(schema=schema, branch=default_branch.name)
+        # default_branch.update_schema_hash()
+        # await default_branch.save(db=db)
+
+        diff_branch = branch_with_data
+        diff_coordinator = await self.get_diff_coordinator(db=db, diff_branch=diff_branch)
+        branch_merger = BranchMerger(
+            db=db,
+            diff_coordinator=diff_coordinator,
+            diff_merger=DiffMerger(
+                db=db,
+                source_branch=diff_branch,
+                destination_branch=default_branch,
+                diff_repository=diff_repository,
+                serializer=DiffMergeSerializer(db=db, max_batch_size=50),
+            ),
+            diff_repository=diff_repository,
+            source_branch=diff_branch,
+            diff_locker=DiffLocker(),
+        )
+
+        results = await asyncio.gather(
+            diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=diff_branch),
+            branch_merger.merge(),
+        )
+        assert len(results) == 2
+        assert results[0].to_time == results[1].to_time
+        assert results[0].uuid == results[1].uuid
+        assert results[0].partner_uuid == results[1].partner_uuid
+        assert results[0].tracking_id == results[1].tracking_id
+
+    async def test_merge_blocks_diff_update(
+        self, db: InfrahubDatabase, default_branch: Branch, diff_repository: DiffRepository, branch_with_data: Branch
+    ):
+        # schema = SchemaRoot(generics=[core_generic_repository])
+        # schema_branch = registry.schema.register_schema(schema=schema, branch=default_branch.name)
+        # default_branch.update_schema_hash()
+        # await default_branch.save(db=db)
+
+        diff_branch = branch_with_data
+        diff_coordinator = await self.get_diff_coordinator(db=db, diff_branch=diff_branch)
+        db2 = InfrahubDatabase(driver=await get_db(retry=5))
+        branch_merger = BranchMerger(
+            db=db2,
+            diff_coordinator=diff_coordinator,
+            diff_merger=DiffMerger(
+                db=db,
+                source_branch=diff_branch,
+                destination_branch=default_branch,
+                diff_repository=diff_repository,
+                serializer=DiffMergeSerializer(db=db, max_batch_size=50),
+            ),
+            diff_repository=diff_repository,
+            source_branch=diff_branch,
+            diff_locker=DiffLocker(),
+        )
+
+        results = await asyncio.gather(
+            branch_merger.merge(),
+            diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=diff_branch),
+        )
+        assert len(results) == 2
+        assert results[0].to_time == results[1].to_time
+        assert results[0].uuid == results[1].uuid
+        assert results[0].partner_uuid == results[1].partner_uuid
+        assert results[0].tracking_id == results[1].tracking_id

--- a/backend/tests/unit/core/ipam/test_ipam_diff_parser.py
+++ b/backend/tests/unit/core/ipam/test_ipam_diff_parser.py
@@ -54,7 +54,7 @@ async def test_ipam_diff_parser_update(db: InfrahubDatabase, default_branch: Bra
 
 
 async def test_ipam_diff_parser_create(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
-    branch_2 = await create_branch(db=db, branch_name="branch_2")
+    branch_2 = await create_branch(db=db, branch_name="branch_22")
     prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
     address_schema = registry.schema.get_node_schema(name="IpamIPAddress", branch=default_branch)
 
@@ -99,7 +99,7 @@ async def test_ipam_diff_parser_create(db: InfrahubDatabase, default_branch: Bra
 
 
 async def test_ipam_diff_parser_delete(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
-    branch_2 = await create_branch(db=db, branch_name="branch_2")
+    branch_2 = await create_branch(db=db, branch_name="branch_222")
     net_140 = ip_dataset_01["net140"]
     net_143 = ip_dataset_01["net143"]
 

--- a/backend/tests/unit/core/test_branch_merge.py
+++ b/backend/tests/unit/core/test_branch_merge.py
@@ -2,6 +2,7 @@ from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.diff.coordinator import DiffCoordinator
+from infrahub.core.diff.diff_locker import DiffLocker
 from infrahub.core.diff.merger.merger import DiffMerger
 from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.initialization import create_branch
@@ -30,6 +31,7 @@ async def _get_branch_merger(
         diff_repository=diff_repository,
         source_branch=source_branch,
         destination_branch=destination_branch,
+        diff_locker=DiffLocker(),
     )
 
 

--- a/changelog/6704.fixed.md
+++ b/changelog/6704.fixed.md
@@ -1,0 +1,1 @@
+Prevent a merge operation and a diff update from running at the same time on the same branch


### PR DESCRIPTION
fixes #6704 

it is possible to run a diff update and a merge operation for the same branch at the same time. we need to prevent this because the merge operation expects a diff to be static as it is running. If the diff is changing as it is running the results of the merge will be unexpected.

the `DiffCoordinator` class already has logic for locking a diff when running so that two diffs on the same branch cannot run at the same time. This PR uses similar logic to prevent a merge and a diff update on the same branch from running at the same time. I tested this locally both starting the diff before the merge and vice versa.