### PR TITLE
IFC-1601 Add namespace to get next available queries

### DIFF
--- a/backend/infrahub/graphql/queries/__init__.py
+++ b/backend/infrahub/graphql/queries/__init__.py
@@ -1,7 +1,12 @@
 from .account import AccountPermissions, AccountToken
 from .branch import BranchQueryList
 from .internal import InfrahubInfo
-from .ipam import InfrahubIPAddressGetNextAvailable, InfrahubIPPrefixGetNextAvailable
+from .ipam import (
+    DeprecatedIPAddressGetNextAvailable,
+    DeprecatedIPPrefixGetNextAvailable,
+    InfrahubIPAddressGetNextAvailable,
+    InfrahubIPPrefixGetNextAvailable,
+)
 from .relationship import Relationship
 from .resource_manager import InfrahubResourcePoolAllocated, InfrahubResourcePoolUtilization
 from .search import InfrahubSearchAnywhere
@@ -12,6 +17,8 @@ __all__ = [
     "AccountPermissions",
     "AccountToken",
     "BranchQueryList",
+    "DeprecatedIPAddressGetNextAvailable",
+    "DeprecatedIPPrefixGetNextAvailable",
     "InfrahubIPAddressGetNextAvailable",
     "InfrahubIPPrefixGetNextAvailable",
     "InfrahubInfo",

--- a/backend/infrahub/graphql/queries/ipam.py
+++ b/backend/infrahub/graphql/queries/ipam.py
@@ -119,3 +119,25 @@ InfrahubIPPrefixGetNextAvailable = Field(
     resolver=IPPrefixGetNextAvailable.resolve,
     required=True,
 )
+
+# The following two query fields must be removed once we are sure that people are not using the old queries anymore. Those fields only exist to
+# expose a deprecation message.
+
+DeprecatedIPAddressGetNextAvailable = Field(
+    IPAddressGetNextAvailable,
+    prefix_id=String(required=True),
+    prefix_length=Int(required=False),
+    resolver=IPAddressGetNextAvailable.resolve,
+    required=True,
+    deprecation_reason="This query has been renamed to 'InfrahubIPAddressGetNextAvailable'. It will be removed in the next version of Infrahub.",
+)
+
+
+DeprecatedIPPrefixGetNextAvailable = Field(
+    IPPrefixGetNextAvailable,
+    prefix_id=String(required=True),
+    prefix_length=Int(required=False),
+    resolver=IPPrefixGetNextAvailable.resolve,
+    required=True,
+    deprecation_reason="This query has been renamed to 'InfrahubIPPrefixGetNextAvailable'. It will be removed in the next version of Infrahub.",
+)

--- a/backend/infrahub/graphql/schema.py
+++ b/backend/infrahub/graphql/schema.py
@@ -40,6 +40,8 @@ from .queries import (
     AccountPermissions,
     AccountToken,
     BranchQueryList,
+    DeprecatedIPAddressGetNextAvailable,
+    DeprecatedIPPrefixGetNextAvailable,
     InfrahubInfo,
     InfrahubIPAddressGetNextAvailable,
     InfrahubIPPrefixGetNextAvailable,
@@ -74,8 +76,10 @@ class InfrahubBaseQuery(ObjectType):
     InfrahubEvent = Event
     InfrahubTaskBranchStatus = TaskBranchStatus
 
-    IPAddressGetNextAvailable = InfrahubIPAddressGetNextAvailable
-    IPPrefixGetNextAvailable = InfrahubIPPrefixGetNextAvailable
+    IPAddressGetNextAvailable = DeprecatedIPAddressGetNextAvailable
+    IPPrefixGetNextAvailable = DeprecatedIPPrefixGetNextAvailable
+    InfrahubIPAddressGetNextAvailable = InfrahubIPAddressGetNextAvailable
+    InfrahubIPPrefixGetNextAvailable = InfrahubIPPrefixGetNextAvailable
     InfrahubResourcePoolAllocated = InfrahubResourcePoolAllocated
     InfrahubResourcePoolUtilization = InfrahubResourcePoolUtilization
 

--- a/backend/tests/unit/graphql/queries/test_ipam.py
+++ b/backend/tests/unit/graphql/queries/test_ipam.py
@@ -129,7 +129,7 @@ async def test_ipprefix_nextavailable(
 
     query = """
     query($prefix: String!, $prefix_length: Int) {
-        IPPrefixGetNextAvailable(prefix_id: $prefix, prefix_length: $prefix_length) {
+        InfrahubIPPrefixGetNextAvailable(prefix_id: $prefix, prefix_length: $prefix_length) {
             prefix
         }
     }
@@ -144,7 +144,7 @@ async def test_ipprefix_nextavailable(
 
     assert not result.errors
     assert result.data
-    assert result.data["IPPrefixGetNextAvailable"]["prefix"] == response
+    assert result.data["InfrahubIPPrefixGetNextAvailable"]["prefix"] == response
 
 
 @pytest.mark.parametrize(
@@ -170,7 +170,7 @@ async def test_ipaddress_nextavailable(
 
     query = """
     query($prefix: String!, $prefix_length: Int) {
-        IPAddressGetNextAvailable(prefix_id: $prefix, prefix_length: $prefix_length) {
+        InfrahubIPAddressGetNextAvailable(prefix_id: $prefix, prefix_length: $prefix_length) {
             address
         }
     }
@@ -185,4 +185,4 @@ async def test_ipaddress_nextavailable(
 
     assert not result.errors
     assert result.data
-    assert result.data["IPAddressGetNextAvailable"]["address"] == response
+    assert result.data["InfrahubIPAddressGetNextAvailable"]["address"] == response

--- a/changelog/+ifc1601.changed.md
+++ b/changelog/+ifc1601.changed.md
@@ -1,0 +1,1 @@
+Deprecate `IPAddressGetNextAvailable` and `IPPrefixGetNextAvailable` in favour of `InfrahubIPAddressGetNextAvailable` and `InfrahubIPPrefixGetNextAvailable` respectively


### PR DESCRIPTION
Rename existing queries and duplicate them to ensure that we can warn users about their deprecation when using the old ones.