### PR TITLE
prep release 1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
+## [Infrahub - v0.13.0.dev0](https://github.com/opsmill/infrahub/tree/infrahub-v0.13.0.dev0) - 2025-06-30
+
+### Fixed
+
+- Improve performance of uniqueness constraint checks during create/update/upsert mutations by allowing ordering elements from more specific to less specific within a constraint group ([#6377](https://github.com/opsmill/infrahub/issues/6377))
+- Fixed: min/max constraints no longer trigger on empty values when the field is optional. ([#6671](https://github.com/opsmill/infrahub/issues/6671))
+- - Fixed "Kind" filter in object template list view.
+  - Fixed search in object template selector during creation form
+
+  ([#6724](https://github.com/opsmill/infrahub/issues/6724))
+- Improve performance when calculating a large diff with many added and/or deleted node (>2,000) ([#6751](https://github.com/opsmill/infrahub/issues/6751))
+
 ## [Infrahub - v1.3.1](https://github.com/opsmill/infrahub/tree/infrahub-v1.3.1) - 2025-06-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,15 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
-## [Infrahub - v0.13.0.dev0](https://github.com/opsmill/infrahub/tree/infrahub-v0.13.0.dev0) - 2025-06-30
+## [Infrahub - v1.3.2](https://github.com/opsmill/infrahub/tree/infrahub-v1.3.2) - 2025-06-30
 
 ### Fixed
 
 - Improve performance of uniqueness constraint checks during create/update/upsert mutations by allowing ordering elements from more specific to less specific within a constraint group ([#6377](https://github.com/opsmill/infrahub/issues/6377))
 - Fixed: min/max constraints no longer trigger on empty values when the field is optional. ([#6671](https://github.com/opsmill/infrahub/issues/6671))
-- - Fixed "Kind" filter in object template list view.
+- Object template ([#6724](https://github.com/opsmill/infrahub/issues/6724))
+  - Fixed "Kind" filter in object template list view.
   - Fixed search in object template selector during creation form
-
-  ([#6724](https://github.com/opsmill/infrahub/issues/6724))
 - Improve performance when calculating a large diff with many added and/or deleted node (>2,000) ([#6751](https://github.com/opsmill/infrahub/issues/6751))
 
 ## [Infrahub - v1.3.1](https://github.com/opsmill/infrahub/tree/infrahub-v1.3.1) - 2025-06-27

--- a/changelog/6377.fixed.md
+++ b/changelog/6377.fixed.md
@@ -1,1 +1,0 @@
-Improve performance of uniqueness constraint checks during create/update/upsert mutations by allowing ordering elements from more specific to less specific within a constraint group

--- a/changelog/6671.fixed.md
+++ b/changelog/6671.fixed.md
@@ -1,1 +1,0 @@
-Fixed: min/max constraints no longer trigger on empty values when the field is optional.

--- a/changelog/6724.fixed.md
+++ b/changelog/6724.fixed.md
@@ -1,2 +1,0 @@
-- Fixed "Kind" filter in object template list view.
-- Fixed search in object template selector during creation form

--- a/changelog/6751.fixed.md
+++ b/changelog/6751.fixed.md
@@ -1,1 +1,0 @@
-Improve performance when calculating a large diff with many added and/or deleted node (>2,000)

--- a/docs/docs/release-notes/infrahub/release-1_3_2.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_3_2.mdx
@@ -1,0 +1,32 @@
+---
+title: Release 1.3.2
+---
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.3.2</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>June 30th, 2025</td>
+    </tr>
+    <tr>
+      <th>Release Codename</th>
+      <td>Amsterdam</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[infrahub-v1.3.2](https://github.com/opsmill/infrahub/releases/tag/infrahub-v1.3.2)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Fixed
+
+- Improve performance of uniqueness constraint checks during create/update/upsert mutations by allowing ordering elements from more specific to less specific within a constraint group ([#6377](https://github.com/opsmill/infrahub/issues/6377))
+- Fixed: min/max constraints no longer trigger on empty values when the field is optional. ([#6671](https://github.com/opsmill/infrahub/issues/6671))
+- Object template ([#6724](https://github.com/opsmill/infrahub/issues/6724))
+  - Fixed "Kind" filter in object template list view.
+  - Fixed search in object template selector during creation form
+- Improve performance when calculating a large diff with many added and/or deleted node (>2,000) ([#6751](https://github.com/opsmill/infrahub/issues/6751))

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -187,6 +187,7 @@ const sidebars: SidebarsConfig = {
             slug: 'release-notes/infrahub',
           },
           items: [
+            'release-notes/infrahub/release-1_3_2',
             'release-notes/infrahub/release-1_3_1',
             'release-notes/infrahub/release-1_3_0',
             'release-notes/infrahub/release-1_2_12',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "infrahub-server"
-version = "1.3.1"
+version = "1.3.2"
 description = "Infrahub is taking a new approach to Infrastructure Management by providing a new generation of datastore to organize and control all the data that defines how an infrastructure should run."
 authors = ["OpsMill <info@opsmill.com>"]
 readme = "README.md"

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "infrahub-testcontainers"
-version =  "1.3.1"
+version =  "1.3.2"
 requires-python = ">=3.9"
 
 [tool.poetry]
 name = "infrahub-testcontainers"
-version =  "1.3.1"
+version =  "1.3.2"
 description = "Testcontainers instance for Infrahub to easily build integration tests"
 authors = ["OpsMill <info@opsmill.com>"]
 readme = "README.md"


### PR DESCRIPTION
bumps version to `1.3.2`
adds release notes
uses SDK version 1.13.3