### PR TITLE
Initial instructions for Github Copilot

### DIFF
--- a/.github/instructions/python-docstring.instructions.md
+++ b/.github/instructions/python-docstring.instructions.md
@@ -7,9 +7,9 @@ Follow these guidelines for writing clear and consistent Python docstrings:
 - Always use triple quotes (""") for docstrings
 - Follow Google-style docstring format
 - Include these sections when applicable:
-   - Brief one-line description
-   - Detailed description (if needed)
-   - Args/Parameters without typing
-   - Returns
-   - Raises
-   - Examples
+  - Brief one-line description
+  - Detailed description (if needed)
+  - Args/Parameters without typing
+  - Returns
+  - Raises
+  - Examples

--- a/.github/instructions/python-docstring.instructions.md
+++ b/.github/instructions/python-docstring.instructions.md
@@ -1,0 +1,15 @@
+---
+applyTo: '**/*.py'
+---
+
+Follow these guidelines for writing clear and consistent Python docstrings:
+
+- Always use triple quotes (""") for docstrings
+- Follow Google-style docstring format
+- Include these sections when applicable:
+   - Brief one-line description
+   - Detailed description (if needed)
+   - Args/Parameters without typing
+   - Returns
+   - Raises
+   - Examples

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -11,11 +11,9 @@ applyTo: '**/*.py'
 - Use Pydantic models for dataclasses
 - All python functions should have a docstring
 
-# Formatting and Linting
+## Formatting and Linting
 
 The project is using Use ruff and mypy for type checking and validations.
 
-you can format all python files by running `poetry run invoke format` 
-and you can validate that all files are formatted correctly by running `poetry run invoke lint` 
-
-
+you can format all python files by running `poetry run invoke format`
+and you can validate that all files are formatted correctly by running `poetry run invoke lint`

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -1,0 +1,21 @@
+---
+applyTo: '**/*.py'
+---
+
+# Python rules
+
+- Use type hints for all function parameters and return values
+- Use Async whenever possible
+- Use `async def` for asynchronous functions
+- Use `await` for asynchronous calls
+- Use Pydantic models for dataclasses
+- All python functions should have a docstring
+
+# Formatting and Linting
+
+The project is using Use ruff and mypy for type checking and validations.
+
+you can format all python files by running `poetry run invoke format` 
+and you can validate that all files are formatted correctly by running `poetry run invoke lint` 
+
+

--- a/.github/instructions/tooling.instructions.md
+++ b/.github/instructions/tooling.instructions.md
@@ -1,0 +1,11 @@
+---
+applyTo: '*'
+---
+
+# Tooling rules
+
+- Prefer Github Actions for automated validation when user commit to the repository
+- Don't use Git precommit
+- Use ruff and mypy to validate and lint python files
+- Use yamllint to validate yaml files
+- Use poetry to manage the python project and its dependencies


### PR DESCRIPTION
This PR adds a few instructions for Github Copilot in `.github/instructions/`

This is mainly an experiment for now to see how these instructions influence the behavior of Copilot agent but I can see a lot of value for us to consolidate all the instructions and rules properly for both humans and AI Agent to use.

