### PR TITLE
Revert upsert mutation to use InputObjectType instead of a dict

### DIFF
--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -376,8 +376,8 @@ class InfrahubMutationMixin:
             return updated_obj, mutation, False
 
         try:
-            dict_data.pop("hfid", "unused")  # `hfid` is invalid for creation.
-            created_obj, mutation = await cls.mutate_create(info=info, data=dict_data, branch=branch)
+            data.pop("hfid", None)  # `hfid` is invalid for creation.
+            created_obj, mutation = await cls.mutate_create(info=info, data=data, branch=branch)
             return created_obj, mutation, True
         except HFIDViolatedError as exc:
             # Only the HFID constraint has been violated, it means the node exists and we can update without rerunning constraints

--- a/backend/tests/unit/graphql/mutations/test_webhook.py
+++ b/backend/tests/unit/graphql/mutations/test_webhook.py
@@ -219,6 +219,43 @@ async def test_update_description_only(
     assert updated_webhook.event_type.value.value == "infrahub.node.created"
 
 
+async def test_upsert_webhook(db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch) -> None:
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=UPSERT_WEBHOOK,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={
+            "name": "my-upserted-webhook",
+            "description": "I was created",
+            "url": "http://localhost:8200/webhook",
+            "shared_key": "very-secret",
+        },
+    )
+    assert not result.errors
+    assert result.data
+
+    result = await graphql(
+        schema=gql_params.schema,
+        source=UPSERT_WEBHOOK,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={
+            "name": "my-upserted-webhook",
+            "description": "I was updated",
+            "url": "http://localhost:8200/webhook",
+            "shared_key": "very-secret",
+        },
+    )
+    assert not result.errors
+    assert result.data
+    webhook_id = result.data["CoreStandardWebhookUpsert"]["object"]["id"]
+    webhook = await NodeManager.get_one_by_id_or_default_filter(db=db, id=webhook_id, kind=CoreStandardWebhook)
+    assert webhook.name.value == "my-upserted-webhook"
+    assert webhook.description.value == "I was updated"
+
+
 CREATE_WEBHOOK = """
 mutation CreateWebhook(
     $event_type: String
@@ -260,5 +297,43 @@ mutation UpdateWebhook(
       id
     }
   }
+}
+"""
+
+UPSERT_WEBHOOK = """
+mutation UpsertWebhook(
+    $shared_key: String
+    $description: String
+    $name: String!
+    $url: String
+
+)   {
+    CoreStandardWebhookUpsert(
+        data: {
+            shared_key: {
+                value: $shared_key
+            }
+            description: {
+                value: $description
+            }
+            name: {
+                value: $name
+            }
+            url: {
+                value: $url
+            }
+        }
+    ){
+        ok
+        object {
+            id
+            name {
+                value
+            }
+            description {
+                value
+            }
+        }
+    }
 }
 """

--- a/changelog/6641.fixed.md
+++ b/changelog/6641.fixed.md
@@ -1,0 +1,1 @@
+Fix upsert mutation for webhooks


### PR DESCRIPTION
This PR changes how the upsert mutations are handled when creating new objects the problem with the bug was that the previous behaviour was that we converted the `InputObjectType` object into a `dict` then within the webhook mutations we tried to access attributes directly under the object which failed for dictionary objects (i.e. trying `my_object.my_attribute` instead of `my_object["my_attribute"]`). It appears that the reason for this conversion in the first place was to remove the "hfid" of an object as we didn't want this if the object was being created. I updated the code to instead remove "hfid" directly from the data object.

Fixes #6641