### PR TITLE
Add configuration for proposed change approval

### DIFF
--- a/backend/infrahub/api/internal.py
+++ b/backend/infrahub/api/internal.py
@@ -18,6 +18,7 @@ from infrahub.config import (  # noqa: TC001
 )
 from infrahub.core import registry
 from infrahub.exceptions import NodeNotFoundError
+from infrahub.workers.dependencies import get_installation_type
 
 if TYPE_CHECKING:
     from infrahub.auth import AccountSession
@@ -31,6 +32,8 @@ class ConfigAPI(BaseModel):
     analytics: AnalyticsSettings
     experimental_features: ExperimentalFeaturesSettings
     sso: config.SSOInfo
+    installation_type: str
+    policy: config.PolicySettings
 
 
 class InfoAPI(BaseModel):
@@ -46,6 +49,8 @@ async def get_config() -> ConfigAPI:
         analytics=config.SETTINGS.analytics,
         experimental_features=config.SETTINGS.experimental_features,
         sso=config.SETTINGS.security.public_sso_config,
+        installation_type=get_installation_type(),
+        policy=config.SETTINGS.policy,
     )
 
 

--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -48,6 +48,10 @@ def default_append_git_suffix_domains() -> list[str]:
     return ["github.com", "gitlab.com"]
 
 
+class EnterpriseFeatures(str, Enum):
+    PROPOSED_CHANGE_REQUIRE_APPROVAL = "proposed_change_require_approval"
+
+
 class UserInfoMethod(str, Enum):
     POST = "post"
     GET = "get"
@@ -315,6 +319,10 @@ class DevelopmentSettings(BaseSettings):
     frontend_redirect_sso: bool = Field(
         default=False,
         description="Indicates of the frontend should be responsible for the SSO redirection",
+    )
+    allow_enterprise_configuration: bool = Field(
+        default=False,
+        description="Allow enterprise configuration in development mode, this will not enable the features just allow the configuration.",
     )
 
 
@@ -766,6 +774,22 @@ class TraceSettings(BaseSettings):
     exporter_endpoint: str | None = Field(default=None, description="OTLP endpoint for exporting traces")
 
 
+class PolicySettings(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix="INFRAHUB_POLICY_")
+    required_proposed_change_approvals: int = Field(
+        default=0,
+        ge=0,
+        description="Number of approvals required for proposed changes. (Enterprise only: not available in the community version.)",
+    )
+
+    @property
+    def enterprise_features(self) -> list[EnterpriseFeatures]:
+        """Returns a list of enterprise features that are enabled based on the settings."""
+        if self.required_proposed_change_approvals > 0:
+            return [EnterpriseFeatures.PROPOSED_CHANGE_REQUIRE_APPROVAL]
+        return []
+
+
 @dataclass
 class Override:
     message_bus: InfrahubMessageBus | None = None
@@ -858,6 +882,10 @@ class ConfiguredSettings:
         return self.active_settings.analytics
 
     @property
+    def policy(self) -> PolicySettings:
+        return self.active_settings.policy
+
+    @property
     def security(self) -> SecuritySettings:
         return self.active_settings.security
 
@@ -872,6 +900,11 @@ class ConfiguredSettings:
     @property
     def experimental_features(self) -> ExperimentalFeaturesSettings:
         return self.active_settings.experimental_features
+
+    @property
+    def enterprise_features(self) -> list[EnterpriseFeatures]:
+        """Returns a list of enterprise features that are enabled based on the settings."""
+        return self.active_settings.enterprise_features
 
 
 class Settings(BaseSettings):
@@ -890,16 +923,22 @@ class Settings(BaseSettings):
     logging: LoggingSettings = LoggingSettings()
     analytics: AnalyticsSettings = AnalyticsSettings()
     initial: InitialSettings = InitialSettings()
+    policy: PolicySettings = PolicySettings()
     security: SecuritySettings = SecuritySettings()
     storage: StorageSettings = StorageSettings()
     trace: TraceSettings = TraceSettings()
     experimental_features: ExperimentalFeaturesSettings = ExperimentalFeaturesSettings()
 
+    @property
+    def enterprise_features(self) -> list[EnterpriseFeatures]:
+        """Returns a list of enterprise features that are enabled based on the settings."""
+        return self.policy.enterprise_features
+
 
 def load(config_file_name: Path | str = "infrahub.toml", config_data: dict[str, Any] | None = None) -> Settings:
     """Load configuration.
 
-    Configuration is loaded from a config file in toml format that contains the settings,
+    Configuration is loaded from a configuration file in toml format that contains the settings,
     or from a dictionary of those settings passed in as "config_data"
     """
     config_file = Path(config_file_name)

--- a/backend/infrahub/constants/environment.py
+++ b/backend/infrahub/constants/environment.py
@@ -1,0 +1,1 @@
+INSTALLATION_TYPE = "community"

--- a/backend/infrahub/server.py
+++ b/backend/infrahub/server.py
@@ -23,6 +23,7 @@ from infrahub import __version__, config
 from infrahub.api import router as api
 from infrahub.api.exception_handlers import generic_api_exception_handler
 from infrahub.components import ComponentType
+from infrahub.constants.environment import INSTALLATION_TYPE
 from infrahub.core.initialization import initialization
 from infrahub.dependencies.registry import build_component_registry
 from infrahub.exceptions import Error, ValidationError
@@ -37,6 +38,7 @@ from infrahub.workers.dependencies import (
     get_cache,
     get_component,
     get_database,
+    get_installation_type,
     get_message_bus,
     get_workflow,
     set_component_type,
@@ -47,6 +49,7 @@ CURRENT_DIRECTORY = Path(__file__).parent.resolve()
 
 async def app_initialization(application: FastAPI, enable_scheduler: bool = True) -> None:
     config.SETTINGS.initialize_and_exit()
+    _validate_feature_selection(configuration=config.SETTINGS.active_settings)
 
     # Initialize trace
     if config.SETTINGS.trace.enable:
@@ -212,3 +215,12 @@ async def documentation() -> RedirectResponse:
 @app.get("/{rest_of_path:path}", include_in_schema=False)
 async def react_app(req: Request, rest_of_path: str) -> Response:  # noqa: ARG001
     return templates.TemplateResponse("index.html", {"request": req})
+
+
+def _validate_feature_selection(configuration: config.Settings) -> None:
+    if configuration.enterprise_features and not configuration.dev.allow_enterprise_configuration:
+        installation_type = get_installation_type()
+        if installation_type == INSTALLATION_TYPE:
+            raise ValidationError(
+                f"Enterprise features [{','.join(configuration.enterprise_features)}] are not supported when running Infrahub 'community'."
+            )

--- a/backend/infrahub/workers/dependencies.py
+++ b/backend/infrahub/workers/dependencies.py
@@ -6,6 +6,7 @@ from infrahub_sdk.config import Config
 
 from infrahub import config
 from infrahub.components import ComponentType
+from infrahub.constants.environment import INSTALLATION_TYPE
 from infrahub.database import InfrahubDatabase, get_db
 from infrahub.services.adapters.cache import InfrahubCache
 from infrahub.services.adapters.event import InfrahubEventService
@@ -39,6 +40,15 @@ def build_client() -> InfrahubClient:
 @inject
 def get_client(client: InfrahubClient = Depends(build_client)) -> InfrahubClient:  # noqa: B008
     return client
+
+
+def build_installation_type() -> str:
+    return INSTALLATION_TYPE
+
+
+@inject
+def get_installation_type(installation_type: str = Depends(build_installation_type)) -> str:
+    return installation_type
 
 
 async def build_database() -> InfrahubDatabase:

--- a/backend/tests/unit/api/test_50_internals.py
+++ b/backend/tests/unit/api/test_50_internals.py
@@ -1,4 +1,5 @@
 import pytest
+from fastapi.testclient import TestClient
 
 from infrahub import config
 from infrahub.api import internal
@@ -7,7 +8,7 @@ from tests.helpers.fixtures import get_fixtures_dir
 
 
 async def test_config_endpoint(
-    db: InfrahubDatabase, client, client_headers, default_branch, register_core_models_schema: None
+    db: InfrahubDatabase, client: TestClient, client_headers, default_branch, register_core_models_schema: None
 ):
     with client:
         response = client.get("/api/config", headers=client_headers)
@@ -15,14 +16,26 @@ async def test_config_endpoint(
     assert response.status_code == 200
     assert response.json() is not None
 
-    result = response.json()
+    result: dict = response.json()
 
-    assert sorted(result.keys()) == ["analytics", "experimental_features", "logging", "main", "sso"]
+    assert sorted(result.keys()) == [
+        "analytics",
+        "experimental_features",
+        "installation_type",
+        "logging",
+        "main",
+        "policy",
+        "sso",
+    ]
 
 
 @pytest.mark.parametrize("allow_anonymous_access", [False, True])
 async def test_config_endpoint_anonymous_account(
-    db: InfrahubDatabase, client, default_branch, register_core_models_schema: None, allow_anonymous_access: bool
+    db: InfrahubDatabase,
+    client: TestClient,
+    default_branch,
+    register_core_models_schema: None,
+    allow_anonymous_access: bool,
 ):
     config.SETTINGS.main.allow_anonymous_access = allow_anonymous_access
 
@@ -33,7 +46,7 @@ async def test_config_endpoint_anonymous_account(
 
 
 async def test_info_endpoint(
-    db: InfrahubDatabase, client, client_headers, default_branch, register_core_models_schema: None
+    db: InfrahubDatabase, client: TestClient, client_headers, default_branch, register_core_models_schema: None
 ):
     with client:
         response = client.get("/api/info", headers=client_headers)


### PR DESCRIPTION
This PR adds a configuration option for the proposed change approval process, as it's an enterprise only feature I added some controls around the management of the configuration so that the server would fail to start when you do this using the community version. There's an option to disable this check using the development configuration. Disabling the check in this way won't actually enable the feature as the feature will come from the enterprise repository, instead the frontend team can use this flag in order to ignore the check if they want to observe the API response from the server.

With this enabled a /api/config endpoint could look like this:

```json
❯ curl http://localhost:8000/api/config -s | jq
{
  "main": {
    "docs_index_path": "/Users/patrick/Code/opsmill/infrahub/docs/build/search-index.json",
    "internal_address": "http://localhost:8000",
    "allow_anonymous_access": true,
    "anonymous_access_role": "Anonymous User",
    "telemetry_optout": true,
    "telemetry_endpoint": "https://telemetry.opsmill.cloud/infrahub",
    "permission_backends": [
      "infrahub.permissions.LocalPermissionBackend"
    ],
    "public_url": "http://localhost:8080/",
    "schema_strict_mode": true
  },
  "logging": {
    "remote": {
      "enable": false,
      "frontend_dsn": null,
      "api_server_dsn": null,
      "git_agent_dsn": null
    }
  },
  "analytics": {
    "enable": true,
    "address": null,
    "api_key": null
  },
  "experimental_features": {
    "graphql_enums": false,
    "value_db_index": false
  },
  "sso": {
    "providers": [],
    "enabled": false
  },
  "installation_type": "community",
  "policy": {
    "required_proposed_change_approvals": 3
  }
}
```

~I'm not sure if we need the "enterprise_features" flag or if we should instead just indicate the installation type "community" or "enterprise".~

Within the enterprise repo we'd something like this to inject the enterprise installation type.

```python
dependency_provider.override(build_installation_type, build_ent_installation_type)
```
