### PR TITLE
Add mutation to review a proposed change

### DIFF
--- a/backend/infrahub/core/protocols.py
+++ b/backend/infrahub/core/protocols.py
@@ -481,6 +481,7 @@ class CoreProposedChange(CoreTaskTarget):
     destination_branch: String
     state: Enum
     approved_by: RelationshipManager
+    rejected_by: RelationshipManager
     reviewers: RelationshipManager
     created_by: RelationshipManager
     comments: RelationshipManager

--- a/backend/infrahub/core/schema/definitions/core/propose_change.py
+++ b/backend/infrahub/core/schema/definitions/core/propose_change.py
@@ -50,6 +50,15 @@ core_proposed_change = NodeSchema(
             identifier="coreaccount__proposedchange_approved_by",
         ),
         Rel(
+            name="rejected_by",
+            peer=InfrahubKind.GENERICACCOUNT,
+            optional=True,
+            cardinality=Cardinality.MANY,
+            kind=RelKind.ATTRIBUTE,
+            branch=BranchSupportType.AGNOSTIC,
+            identifier="coreaccount__proposedchange_rejected_by",
+        ),
+        Rel(
             name="reviewers",
             peer=InfrahubKind.GENERICACCOUNT,
             optional=True,

--- a/backend/infrahub/core/schema/definitions/core/propose_change.py
+++ b/backend/infrahub/core/schema/definitions/core/propose_change.py
@@ -48,6 +48,7 @@ core_proposed_change = NodeSchema(
             kind=RelKind.ATTRIBUTE,
             branch=BranchSupportType.AGNOSTIC,
             identifier="coreaccount__proposedchange_approved_by",
+            read_only=True,
         ),
         Rel(
             name="rejected_by",
@@ -57,6 +58,7 @@ core_proposed_change = NodeSchema(
             kind=RelKind.ATTRIBUTE,
             branch=BranchSupportType.AGNOSTIC,
             identifier="coreaccount__proposedchange_rejected_by",
+            read_only=True,
         ),
         Rel(
             name="reviewers",

--- a/backend/infrahub/core/schema/definitions/core/propose_change.py
+++ b/backend/infrahub/core/schema/definitions/core/propose_change.py
@@ -48,7 +48,6 @@ core_proposed_change = NodeSchema(
             kind=RelKind.ATTRIBUTE,
             branch=BranchSupportType.AGNOSTIC,
             identifier="coreaccount__proposedchange_approved_by",
-            read_only=True,
         ),
         Rel(
             name="rejected_by",
@@ -58,7 +57,6 @@ core_proposed_change = NodeSchema(
             kind=RelKind.ATTRIBUTE,
             branch=BranchSupportType.AGNOSTIC,
             identifier="coreaccount__proposedchange_rejected_by",
-            read_only=True,
         ),
         Rel(
             name="reviewers",

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -106,7 +106,7 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
             include_source=True,
         )
         state = ProposedChangeState(obj.state.value.value)
-        state.validate_editability()
+        state.validate_updatable()
 
         updated_state = None
         if state_update := data.get("state", {}).get("value"):
@@ -222,11 +222,56 @@ class ProposedChangeReview(Mutation):
             id=str(data.id), kind=CoreProposedChange, db=graphql_context.db, prefetch_relationships=True
         )
         state = ProposedChangeState(proposed_change.state.value.value)
-        state.validate_review()
+        state.validate_reviewable()
 
         created_by = await proposed_change.created_by.get_peer(db=graphql_context.db)
         if created_by and created_by.id == graphql_context.active_account_session.account_id:
             raise ValidationError(input_value="You cannot review your own proposed changes")
+
+        current_user = await NodeManager.get_one_by_id_or_default_filter(
+            id=graphql_context.active_account_session.account_id,
+            kind=InfrahubKind.GENERICACCOUNT,
+            db=graphql_context.db,
+        )
+
+        approved_by = await proposed_change.approved_by.get_peers(db=graphql_context.db)
+        rejected_by = await proposed_change.rejected_by.get_peers(db=graphql_context.db)
+        approved_by_ids = [node.id for _, node in approved_by.items()]
+        rejected_by_ids = [node.id for _, node in rejected_by.items()]
+
+        async with graphql_context.db.start_session() as db:
+            if data.decision == proposed_change_constants.ProposedChangeApprovalDecision.APPROVE:
+                if current_user.id in approved_by_ids:
+                    raise ValidationError(input_value="You have already approved this proposed change")
+                await proposed_change.approved_by.add(db=db, data=current_user)
+                if current_user.id in rejected_by_ids:
+                    await proposed_change.rejected_by.remove_locally(db=db, peer_id=current_user.id)
+
+            elif data.decision == proposed_change_constants.ProposedChangeApprovalDecision.UNDO_APPROVE:
+                if current_user.id not in approved_by_ids:
+                    raise ValidationError(
+                        input_value="You did not approve this proposed change yet, it can't be un-approved"
+                    )
+                await proposed_change.approved_by.remove_locally(db=db, peer_id=current_user.id)
+
+            elif data.decision == proposed_change_constants.ProposedChangeApprovalDecision.REJECT:
+                if current_user.id in rejected_by_ids:
+                    raise ValidationError(input_value="You have already rejected this proposed change")
+                await proposed_change.rejected_by.add(db=db, data=current_user)
+                if current_user.id in approved_by_ids:
+                    await proposed_change.approved_by.remove_locally(db=db, peer_id=current_user.id)
+
+            elif data.decision == proposed_change_constants.ProposedChangeApprovalDecision.UNDO_REJECT:
+                if current_user.id not in rejected_by_ids:
+                    raise ValidationError(
+                        input_value="You did not reject this proposed change yet, it can't be un-rejected"
+                    )
+                await proposed_change.rejected_by.remove_locally(db=db, peer_id=current_user.id)
+
+            else:
+                raise ValidationError(input_value=f"Invalid decision {data.decision}")
+
+            await proposed_change.save(db=db)
 
         return {"ok": True}
 

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -274,7 +274,7 @@ class ProposedChangeReview(Mutation):
                 if current_user.id in rejected_by_ids:
                     await proposed_change.rejected_by.remove_locally(db=db, peer_id=current_user.id)
 
-            case ProposedChangeApprovalDecision.UNDO_APPROVE:
+            case ProposedChangeApprovalDecision.CANCEL_APPROVE:
                 if current_user.id not in approved_by_ids:
                     raise ValidationError(
                         input_value="You did not approve this proposed change yet, it can't be un-approved"
@@ -288,7 +288,7 @@ class ProposedChangeReview(Mutation):
                 if current_user.id in approved_by_ids:
                     await proposed_change.approved_by.remove_locally(db=db, peer_id=current_user.id)
 
-            case ProposedChangeApprovalDecision.UNDO_REJECT:
+            case ProposedChangeApprovalDecision.CANCEL_REJECT:
                 if current_user.id not in rejected_by_ids:
                     raise ValidationError(
                         input_value="You did not reject this proposed change yet, it can't be un-rejected"

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -19,8 +19,7 @@ from infrahub.database import InfrahubDatabase, retry_db_transaction
 from infrahub.exceptions import BranchNotFoundError, PermissionDeniedError, ValidationError
 from infrahub.graphql.mutations.main import InfrahubMutationMixin
 from infrahub.graphql.types.enums import CheckType as GraphQLCheckType
-from infrahub.proposed_change import constants as proposed_change_constants
-from infrahub.proposed_change.constants import ProposedChangeState
+from infrahub.proposed_change.constants import ProposedChangeApprovalDecision, ProposedChangeState
 from infrahub.workflows.catalogue import PROPOSED_CHANGE_MERGE, REQUEST_PROPOSED_CHANGE_PIPELINE
 
 from ...proposed_change.models import RequestProposedChangePipeline
@@ -30,7 +29,7 @@ from .main import InfrahubMutationOptions
 if TYPE_CHECKING:
     from ..initialization import GraphqlContext
 
-ProposedChangeApprovalDecision = Enum.from_enum(proposed_change_constants.ProposedChangeApprovalDecision)
+ProposedChangeApprovalDecisionInput = Enum.from_enum(ProposedChangeApprovalDecision)
 
 
 class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
@@ -200,7 +199,9 @@ class ProposedChangeRequestRunCheck(Mutation):
 
 class ProposedChangeReviewInput(InputObjectType):
     id = String(required=True, description="The ID of the proposed change to review.")
-    decision = ProposedChangeApprovalDecision(required=True, description="The decision for the proposed change review.")
+    decision = ProposedChangeApprovalDecisionInput(
+        required=True, description="The decision for the proposed change review."
+    )
 
 
 class ProposedChangeReview(Mutation):
@@ -216,6 +217,11 @@ class ProposedChangeReview(Mutation):
         info: GraphQLResolveInfo,
         data: ProposedChangeReviewInput,
     ) -> dict[str, bool]:
+        """
+        This mutation is used to approve or reject a proposed change.
+        It can also be used to undo an approval or rejection.
+        """
+
         graphql_context: GraphqlContext = info.context
 
         proposed_change = await NodeManager.get_one_by_id_or_default_filter(
@@ -234,46 +240,63 @@ class ProposedChangeReview(Mutation):
             db=graphql_context.db,
         )
 
-        approved_by = await proposed_change.approved_by.get_peers(db=graphql_context.db)
-        rejected_by = await proposed_change.rejected_by.get_peers(db=graphql_context.db)
+        async with graphql_context.db.start_session() as db:
+            await cls._handle_decision(
+                db=db,
+                decision=data.decision,
+                proposed_change=proposed_change,
+                current_user=current_user,
+            )
+            await proposed_change.save(db=db)
+
+        return {"ok": True}
+
+    @classmethod
+    async def _handle_decision(
+        cls,
+        db: InfrahubDatabase,
+        decision: ProposedChangeApprovalDecision,
+        proposed_change: CoreProposedChange,
+        current_user: Node,
+    ) -> None:
+        """Modify approved_by and rejected_by relationships of the prpoposed change based on the decision."""
+
+        approved_by = await proposed_change.approved_by.get_peers(db=db)
+        rejected_by = await proposed_change.rejected_by.get_peers(db=db)
         approved_by_ids = [node.id for _, node in approved_by.items()]
         rejected_by_ids = [node.id for _, node in rejected_by.items()]
 
-        async with graphql_context.db.start_session() as db:
-            if data.decision == proposed_change_constants.ProposedChangeApprovalDecision.APPROVE:
+        match decision:
+            case ProposedChangeApprovalDecision.APPROVE:
                 if current_user.id in approved_by_ids:
                     raise ValidationError(input_value="You have already approved this proposed change")
                 await proposed_change.approved_by.add(db=db, data=current_user)
                 if current_user.id in rejected_by_ids:
                     await proposed_change.rejected_by.remove_locally(db=db, peer_id=current_user.id)
 
-            elif data.decision == proposed_change_constants.ProposedChangeApprovalDecision.UNDO_APPROVE:
+            case ProposedChangeApprovalDecision.UNDO_APPROVE:
                 if current_user.id not in approved_by_ids:
                     raise ValidationError(
                         input_value="You did not approve this proposed change yet, it can't be un-approved"
                     )
                 await proposed_change.approved_by.remove_locally(db=db, peer_id=current_user.id)
 
-            elif data.decision == proposed_change_constants.ProposedChangeApprovalDecision.REJECT:
+            case ProposedChangeApprovalDecision.REJECT:
                 if current_user.id in rejected_by_ids:
                     raise ValidationError(input_value="You have already rejected this proposed change")
                 await proposed_change.rejected_by.add(db=db, data=current_user)
                 if current_user.id in approved_by_ids:
                     await proposed_change.approved_by.remove_locally(db=db, peer_id=current_user.id)
 
-            elif data.decision == proposed_change_constants.ProposedChangeApprovalDecision.UNDO_REJECT:
+            case ProposedChangeApprovalDecision.UNDO_REJECT:
                 if current_user.id not in rejected_by_ids:
                     raise ValidationError(
                         input_value="You did not reject this proposed change yet, it can't be un-rejected"
                     )
                 await proposed_change.rejected_by.remove_locally(db=db, peer_id=current_user.id)
 
-            else:
-                raise ValidationError(input_value=f"Invalid decision {data.decision}")
-
-            await proposed_change.save(db=db)
-
-        return {"ok": True}
+            case _:
+                raise ValidationError(input_value=f"Invalid decision {decision}")
 
 
 class ProposedChangeMergeInput(InputObjectType):

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Any, Self
 
-from graphene import Boolean, Field, InputObjectType, Mutation, String
+from graphene import Boolean, Enum, Field, InputObjectType, Mutation, String
 from graphql import GraphQLResolveInfo
 
 from infrahub.core.account import GlobalPermission
@@ -13,11 +13,13 @@ from infrahub.core.constants import (
 )
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
+from infrahub.core.protocols import CoreProposedChange
 from infrahub.core.schema import NodeSchema
 from infrahub.database import InfrahubDatabase, retry_db_transaction
 from infrahub.exceptions import BranchNotFoundError, PermissionDeniedError, ValidationError
 from infrahub.graphql.mutations.main import InfrahubMutationMixin
 from infrahub.graphql.types.enums import CheckType as GraphQLCheckType
+from infrahub.proposed_change import constants as proposed_change_constants
 from infrahub.proposed_change.constants import ProposedChangeState
 from infrahub.workflows.catalogue import PROPOSED_CHANGE_MERGE, REQUEST_PROPOSED_CHANGE_PIPELINE
 
@@ -27,6 +29,8 @@ from .main import InfrahubMutationOptions
 
 if TYPE_CHECKING:
     from ..initialization import GraphqlContext
+
+ProposedChangeApprovalDecision = Enum.from_enum(proposed_change_constants.ProposedChangeApprovalDecision)
 
 
 class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
@@ -190,6 +194,39 @@ class ProposedChangeRequestRunCheck(Mutation):
                 parameters={"model": request_proposed_change_model},
                 context=graphql_context.get_context(),
             )
+
+        return {"ok": True}
+
+
+class ProposedChangeReviewInput(InputObjectType):
+    id = String(required=True, description="The ID of the proposed change to review.")
+    decision = ProposedChangeApprovalDecision(required=True, description="The decision for the proposed change review.")
+
+
+class ProposedChangeReview(Mutation):
+    class Arguments:
+        data = ProposedChangeReviewInput(required=True)
+
+    ok = Boolean()
+
+    @classmethod
+    async def mutate(
+        cls,
+        root: dict,  # noqa: ARG003
+        info: GraphQLResolveInfo,
+        data: ProposedChangeReviewInput,
+    ) -> dict[str, bool]:
+        graphql_context: GraphqlContext = info.context
+
+        proposed_change = await NodeManager.get_one_by_id_or_default_filter(
+            id=str(data.id), kind=CoreProposedChange, db=graphql_context.db, prefetch_relationships=True
+        )
+        state = ProposedChangeState(proposed_change.state.value.value)
+        state.validate_review()
+
+        created_by = await proposed_change.created_by.get_peer(db=graphql_context.db)
+        if created_by and created_by.id == graphql_context.active_account_session.account_id:
+            raise ValidationError(input_value="You cannot review your own proposed changes")
 
         return {"ok": True}
 

--- a/backend/infrahub/graphql/schema.py
+++ b/backend/infrahub/graphql/schema.py
@@ -20,7 +20,7 @@ from .mutations.convert_object_type import ConvertObjectType
 from .mutations.diff import DiffUpdateMutation
 from .mutations.diff_conflict import ResolveDiffConflict
 from .mutations.generator import GeneratorDefinitionRequestRun
-from .mutations.proposed_change import ProposedChangeMerge, ProposedChangeRequestRunCheck
+from .mutations.proposed_change import ProposedChangeMerge, ProposedChangeRequestRunCheck, ProposedChangeReview
 from .mutations.relationship import (
     RelationshipAdd,
     RelationshipRemove,
@@ -92,6 +92,7 @@ class InfrahubBaseMutation(ObjectType):
     InfrahubAccountTokenDelete = InfrahubAccountTokenDelete.Field()
     CoreProposedChangeRunCheck = ProposedChangeRequestRunCheck.Field()
     CoreProposedChangeMerge = ProposedChangeMerge.Field()
+    CoreProposedChangeReview = ProposedChangeReview.Field()
     CoreGeneratorDefinitionRun = GeneratorDefinitionRequestRun.Field()
 
     InfrahubIPPrefixPoolGetResource = IPPrefixPoolGetResource.Field()

--- a/backend/infrahub/proposed_change/constants.py
+++ b/backend/infrahub/proposed_change/constants.py
@@ -6,9 +6,9 @@ from infrahub.utils import InfrahubStringEnum
 
 class ProposedChangeApprovalDecision(InfrahubStringEnum):
     APPROVE = "approve"
-    UNDO_APPROVE = "undo-approve"
+    CANCEL_APPROVE = "cancel-approve"
     REJECT = "reject"
-    UNDO_REJECT = "undo-reject"
+    CANCEL_REJECT = "cancel-reject"
 
 
 class ProposedChangeState(InfrahubStringEnum):

--- a/backend/infrahub/proposed_change/constants.py
+++ b/backend/infrahub/proposed_change/constants.py
@@ -5,8 +5,10 @@ from infrahub.utils import InfrahubStringEnum
 
 
 class ProposedChangeApprovalDecision(InfrahubStringEnum):
-    APPROVED = "approved"
-    REJECTED = "rejected"
+    APPROVE = "approve"
+    UNDO_APPROVE = "undo-approve"
+    REJECT = "reject"
+    UNDO_REJECT = "undo-reject"
 
 
 class ProposedChangeState(InfrahubStringEnum):
@@ -19,7 +21,7 @@ class ProposedChangeState(InfrahubStringEnum):
     @property
     def is_completed(self) -> bool:
         """Check if the proposed change is in a completed state."""
-        return self in [ProposedChangeState.CANCELED, ProposedChangeState.MERGED, ProposedChangeState.MERGING]
+        return self != ProposedChangeState.OPEN
 
     def validate_state_check_run(self) -> None:
         if self == ProposedChangeState.OPEN:
@@ -27,13 +29,13 @@ class ProposedChangeState(InfrahubStringEnum):
 
         raise ValidationError(input_value="Unable to trigger check on proposed changes that aren't in the open state")
 
-    def validate_editability(self) -> None:
+    def validate_updatable(self) -> None:
         if self.is_completed:
             raise ValidationError(
                 input_value=f"A proposed change in the {self.value} state is not allowed to be updated"
             )
 
-    def validate_review(self) -> None:
+    def validate_reviewable(self) -> None:
         if self.is_completed:
             raise ValidationError(
                 input_value=f"A proposed change in the {self.value} state is not allowed to be reviewed"

--- a/backend/infrahub/proposed_change/constants.py
+++ b/backend/infrahub/proposed_change/constants.py
@@ -4,12 +4,22 @@ from infrahub.exceptions import ValidationError
 from infrahub.utils import InfrahubStringEnum
 
 
+class ProposedChangeApprovalDecision(InfrahubStringEnum):
+    APPROVED = "approved"
+    REJECTED = "rejected"
+
+
 class ProposedChangeState(InfrahubStringEnum):
     OPEN = "open"
     MERGED = "merged"
     MERGING = "merging"
     CLOSED = "closed"
     CANCELED = "canceled"
+
+    @property
+    def is_completed(self) -> bool:
+        """Check if the proposed change is in a completed state."""
+        return self in [ProposedChangeState.CANCELED, ProposedChangeState.MERGED, ProposedChangeState.MERGING]
 
     def validate_state_check_run(self) -> None:
         if self == ProposedChangeState.OPEN:
@@ -18,9 +28,15 @@ class ProposedChangeState(InfrahubStringEnum):
         raise ValidationError(input_value="Unable to trigger check on proposed changes that aren't in the open state")
 
     def validate_editability(self) -> None:
-        if self in [ProposedChangeState.CANCELED, ProposedChangeState.MERGED, ProposedChangeState.MERGED]:
+        if self.is_completed:
             raise ValidationError(
                 input_value=f"A proposed change in the {self.value} state is not allowed to be updated"
+            )
+
+    def validate_review(self) -> None:
+        if self.is_completed:
+            raise ValidationError(
+                input_value=f"A proposed change in the {self.value} state is not allowed to be reviewed"
             )
 
     def validate_state_transition(self, updated_state: ProposedChangeState) -> None:

--- a/backend/tests/functional/proposed_change/test_proposed_change_review.py
+++ b/backend/tests/functional/proposed_change/test_proposed_change_review.py
@@ -20,7 +20,9 @@ class TestProposedChangeReview(TestInfrahubApp):
         }
         """
 
-    async def test_approve_then_reject(self, client: InfrahubClient, db, car_person_schema) -> None:
+    async def test_approve_then_reject(
+        self, client: InfrahubClient, db, car_person_schema, unprivileged_client
+    ) -> None:
         """Test the complete proposed change review flow including relationship updates."""
 
         # Create a branch for the proposed change
@@ -43,28 +45,30 @@ class TestProposedChangeReview(TestInfrahubApp):
 
         # Test the ProposedChangeReview mutation with APPROVED decision
 
-        response = await client.execute_graphql(
+        response = await unprivileged_client.execute_graphql(
             query=self.review_query,
             variables={"data": {"id": str(proposed_change.id), "decision": "APPROVE"}},
-            branch_name="main",
+            branch_name=source_branch.name,
         )
 
         assert response["CoreProposedChangeReview"]["ok"] is True
 
-        user = await client.get_user()
+        reviewer = await unprivileged_client.get_user()
 
         # Verify the proposed change still exists and is in the correct state
         updated_pc = await client.get(kind=PROPOSEDCHANGE, id=proposed_change.id, prefetch_relationships=True)
         assert updated_pc is not None
         assert updated_pc.state.value == "open"  # Should still be open after review
-        assert {related_node.peer.id for related_node in updated_pc.approved_by.peers} == {user["AccountProfile"]["id"]}
+        assert {related_node.peer.id for related_node in updated_pc.approved_by.peers} == {
+            reviewer["AccountProfile"]["id"]
+        }
         assert len(updated_pc.rejected_by.peers) == 0
 
         # Test the ProposedChangeReview mutation with REJECTED decision
-        response = await client.execute_graphql(
+        response = await unprivileged_client.execute_graphql(
             query=self.review_query,
             variables={"data": {"id": str(proposed_change.id), "decision": "REJECT"}},
-            branch_name="main",
+            branch_name=source_branch.name,
         )
 
         assert response["CoreProposedChangeReview"]["ok"] is True
@@ -77,9 +81,9 @@ class TestProposedChangeReview(TestInfrahubApp):
         approved_by_peers = {related_node.peer.id for related_node in updated_pc.approved_by.peers}
         assert len(approved_by_peers) == 0
         rejected_by_peers = {related_node.peer.id for related_node in updated_pc.rejected_by.peers}
-        assert rejected_by_peers == {user["AccountProfile"]["id"]}
+        assert rejected_by_peers == {reviewer["AccountProfile"]["id"]}
 
-    async def test_cancel_approve(self, client: InfrahubClient, db, car_person_schema) -> None:
+    async def test_cancel_approve(self, client: InfrahubClient, db, car_person_schema, unprivileged_client) -> None:
         """Test the complete proposed change review flow including relationship updates."""
 
         # Create a branch for the proposed change
@@ -101,24 +105,26 @@ class TestProposedChangeReview(TestInfrahubApp):
         assert len(rejected_by_peers) == 0
 
         # Approve the PC
-        await client.execute_graphql(
+        await unprivileged_client.execute_graphql(
             query=self.review_query,
             variables={"data": {"id": str(proposed_change.id), "decision": "APPROVE"}},
-            branch_name="main",
+            branch_name=source_branch.name,
         )
 
         # Verify the proposed change still exists and is in the correct state
         updated_pc = await client.get(kind=PROPOSEDCHANGE, id=proposed_change.id, prefetch_relationships=True)
         assert updated_pc is not None
-        user = await client.get_user()
-        assert {related_node.peer.id for related_node in updated_pc.approved_by.peers} == {user["AccountProfile"]["id"]}
+        reviewer = await unprivileged_client.get_user()
+        assert {related_node.peer.id for related_node in updated_pc.approved_by.peers} == {
+            reviewer["AccountProfile"]["id"]
+        }
         assert len(updated_pc.rejected_by.peers) == 0
 
         # Un-approve the PC
-        response = await client.execute_graphql(
+        response = await unprivileged_client.execute_graphql(
             query=self.review_query,
             variables={"data": {"id": str(proposed_change.id), "decision": "CANCEL_APPROVE"}},
-            branch_name="main",
+            branch_name=source_branch.name,
         )
 
         assert response["CoreProposedChangeReview"]["ok"] is True
@@ -129,7 +135,7 @@ class TestProposedChangeReview(TestInfrahubApp):
         assert len(updated_pc.approved_by.peers) == 0
         assert len(updated_pc.rejected_by.peers) == 0
 
-    async def test_cancel_reject(self, client: InfrahubClient, db, car_person_schema) -> None:
+    async def test_cancel_reject(self, client: InfrahubClient, db, car_person_schema, unprivileged_client) -> None:
         """Test the complete proposed change review flow including relationship updates."""
 
         # Create a branch for the proposed change
@@ -151,24 +157,26 @@ class TestProposedChangeReview(TestInfrahubApp):
         assert len(rejected_by_peers) == 0
 
         # Reject the PC
-        await client.execute_graphql(
+        await unprivileged_client.execute_graphql(
             query=self.review_query,
             variables={"data": {"id": str(proposed_change.id), "decision": "REJECT"}},
-            branch_name="main",
+            branch_name=source_branch.name,
         )
 
         # Verify the proposed change still exists and is in the correct state
         updated_pc = await client.get(kind=PROPOSEDCHANGE, id=proposed_change.id, prefetch_relationships=True)
         assert updated_pc is not None
-        user = await client.get_user()
-        assert {related_node.peer.id for related_node in updated_pc.rejected_by.peers} == {user["AccountProfile"]["id"]}
+        reviewer = await unprivileged_client.get_user()
+        assert {related_node.peer.id for related_node in updated_pc.rejected_by.peers} == {
+            reviewer["AccountProfile"]["id"]
+        }
         assert len(updated_pc.approved_by.peers) == 0
 
         # Un-reject the PC
-        response = await client.execute_graphql(
+        response = await unprivileged_client.execute_graphql(
             query=self.review_query,
             variables={"data": {"id": str(proposed_change.id), "decision": "CANCEL_REJECT"}},
-            branch_name="main",
+            branch_name=source_branch.name,
         )
 
         assert response["CoreProposedChangeReview"]["ok"] is True

--- a/backend/tests/functional/proposed_change/test_proposed_change_review.py
+++ b/backend/tests/functional/proposed_change/test_proposed_change_review.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tests.helpers.test_app import TestInfrahubApp
+
+from infrahub.core.constants.infrahubkind import PROPOSEDCHANGE
+from infrahub.core.initialization import create_branch
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClient
+
+
+class TestProposedChangeReview(TestInfrahubApp):
+    async def test_approve_then_reject(self, client: InfrahubClient, db, car_person_schema) -> None:
+        """Test the complete proposed change review flow including relationship updates."""
+
+        # Create a branch for the proposed change
+        source_branch = await create_branch(branch_name="branch-proposed-change", db=db)
+
+        # Create a proposed change
+        proposed_change = await client.create(
+            kind=PROPOSEDCHANGE,
+            data={"source_branch": source_branch.name, "destination_branch": "main", "name": "test-pc"},
+        )
+        await proposed_change.save()
+
+        # Get the proposed change to verify initial state
+        pc = await client.get(kind=PROPOSEDCHANGE, id=proposed_change.id)
+        assert pc is not None
+        approved_by_peers = {related_node.peer for related_node in pc.approved_by.peers}
+        assert len(approved_by_peers) == 0
+        rejected_by_peers = {related_node.peer for related_node in pc.rejected_by.peers}
+        assert len(rejected_by_peers) == 0
+
+        # Test the ProposedChangeReview mutation with APPROVED decision
+        review_query = """
+        mutation ProposedChangeReview($data: ProposedChangeReviewInput!) {
+            CoreProposedChangeReview(data: $data) {
+                ok
+            }
+        }
+        """
+
+        response = await client.execute_graphql(
+            query=review_query,
+            variables={"data": {"id": str(proposed_change.id), "decision": "APPROVE"}},
+            branch_name="main",
+        )
+
+        assert response["CoreProposedChangeReview"]["ok"] is True
+
+        user = await client.get_user()
+
+        # Verify the proposed change still exists and is in the correct state
+        updated_pc = await client.get(kind=PROPOSEDCHANGE, id=proposed_change.id, prefetch_relationships=True)
+        assert updated_pc is not None
+        assert updated_pc.state.value == "open"  # Should still be open after review
+        assert {related_node.peer.id for related_node in updated_pc.approved_by.peers} == {user["AccountProfile"]["id"]}
+        assert len(updated_pc.rejected_by.peers) == 0
+
+        # Test the ProposedChangeReview mutation with REJECTED decision
+        response = await client.execute_graphql(
+            query=review_query,
+            variables={"data": {"id": str(proposed_change.id), "decision": "REJECT"}},
+            branch_name="main",
+        )
+
+        assert response["CoreProposedChangeReview"]["ok"] is True
+
+        # Verify user has been removed from `approved_by` and added to `rejected_by`
+        updated_pc = await client.get(kind=PROPOSEDCHANGE, id=proposed_change.id, prefetch_relationships=True)
+        assert updated_pc is not None
+        assert updated_pc.state.value == "open"  # Should still be open after review
+
+        approved_by_peers = {related_node.peer.id for related_node in updated_pc.approved_by.peers}
+        assert len(approved_by_peers) == 0
+        rejected_by_peers = {related_node.peer.id for related_node in updated_pc.rejected_by.peers}
+        assert rejected_by_peers == {user["AccountProfile"]["id"]}
+
+    async def test_undo_approve(self, client: InfrahubClient, db, car_person_schema) -> None:
+        """Test the complete proposed change review flow including relationship updates."""
+
+        # Create a branch for the proposed change
+        source_branch = await create_branch(branch_name="branch-pc-2", db=db)
+
+        # Create a proposed change
+        proposed_change = await client.create(
+            kind=PROPOSEDCHANGE,
+            data={"source_branch": source_branch.name, "destination_branch": "main", "name": "test-pc-2"},
+        )
+        await proposed_change.save()
+
+        # Get the proposed change to verify initial state
+        pc = await client.get(kind=PROPOSEDCHANGE, id=proposed_change.id)
+        assert pc is not None
+        approved_by_peers = {related_node.peer for related_node in pc.approved_by.peers}
+        assert len(approved_by_peers) == 0
+        rejected_by_peers = {related_node.peer for related_node in pc.rejected_by.peers}
+        assert len(rejected_by_peers) == 0
+
+        # Approve the PC
+        review_query = """
+        mutation ProposedChangeReview($data: ProposedChangeReviewInput!) {
+            CoreProposedChangeReview(data: $data) {
+                ok
+            }
+        }
+        """
+
+        await client.execute_graphql(
+            query=review_query,
+            variables={"data": {"id": str(proposed_change.id), "decision": "APPROVE"}},
+            branch_name="main",
+        )
+
+        # Verify the proposed change still exists and is in the correct state
+        updated_pc = await client.get(kind=PROPOSEDCHANGE, id=proposed_change.id, prefetch_relationships=True)
+        assert updated_pc is not None
+        user = await client.get_user()
+        assert {related_node.peer.id for related_node in updated_pc.approved_by.peers} == {user["AccountProfile"]["id"]}
+        assert len(updated_pc.rejected_by.peers) == 0
+
+        # Un-approve the PC
+        response = await client.execute_graphql(
+            query=review_query,
+            variables={"data": {"id": str(proposed_change.id), "decision": "UNDO_APPROVE"}},
+            branch_name="main",
+        )
+
+        assert response["CoreProposedChangeReview"]["ok"] is True
+
+        updated_pc = await client.get(kind=PROPOSEDCHANGE, id=proposed_change.id, prefetch_relationships=True)
+        assert updated_pc is not None
+        assert updated_pc.state.value == "open"
+        assert len(updated_pc.approved_by.peers) == 0
+        assert len(updated_pc.rejected_by.peers) == 0
+
+    async def test_undo_reject(self, client: InfrahubClient, db, car_person_schema) -> None:
+        """Test the complete proposed change review flow including relationship updates."""
+
+        # Create a branch for the proposed change
+        source_branch = await create_branch(branch_name="branch-pc-3", db=db)
+
+        # Create a proposed change
+        proposed_change = await client.create(
+            kind=PROPOSEDCHANGE,
+            data={"source_branch": source_branch.name, "destination_branch": "main", "name": "test-pc-3"},
+        )
+        await proposed_change.save()
+
+        # Get the proposed change to verify initial state
+        pc = await client.get(kind=PROPOSEDCHANGE, id=proposed_change.id)
+        assert pc is not None
+        approved_by_peers = {related_node.peer for related_node in pc.approved_by.peers}
+        assert len(approved_by_peers) == 0
+        rejected_by_peers = {related_node.peer for related_node in pc.rejected_by.peers}
+        assert len(rejected_by_peers) == 0
+
+        # Reject the PC
+        review_query = """
+        mutation ProposedChangeReview($data: ProposedChangeReviewInput!) {
+            CoreProposedChangeReview(data: $data) {
+                ok
+            }
+        }
+        """
+
+        await client.execute_graphql(
+            query=review_query,
+            variables={"data": {"id": str(proposed_change.id), "decision": "REJECT"}},
+            branch_name="main",
+        )
+
+        # Verify the proposed change still exists and is in the correct state
+        updated_pc = await client.get(kind=PROPOSEDCHANGE, id=proposed_change.id, prefetch_relationships=True)
+        assert updated_pc is not None
+        user = await client.get_user()
+        assert {related_node.peer.id for related_node in updated_pc.rejected_by.peers} == {user["AccountProfile"]["id"]}
+        assert len(updated_pc.approved_by.peers) == 0
+
+        # Un-reject the PC
+        response = await client.execute_graphql(
+            query=review_query,
+            variables={"data": {"id": str(proposed_change.id), "decision": "UNDO_REJECT"}},
+            branch_name="main",
+        )
+
+        assert response["CoreProposedChangeReview"]["ok"] is True
+
+        updated_pc = await client.get(kind=PROPOSEDCHANGE, id=proposed_change.id, prefetch_relationships=True)
+        assert updated_pc is not None
+        assert updated_pc.state.value == "open"
+        assert len(updated_pc.approved_by.peers) == 0
+        assert len(updated_pc.rejected_by.peers) == 0

--- a/backend/tests/functional/proposed_change/test_proposed_change_review.py
+++ b/backend/tests/functional/proposed_change/test_proposed_change_review.py
@@ -79,7 +79,7 @@ class TestProposedChangeReview(TestInfrahubApp):
         rejected_by_peers = {related_node.peer.id for related_node in updated_pc.rejected_by.peers}
         assert rejected_by_peers == {user["AccountProfile"]["id"]}
 
-    async def test_undo_approve(self, client: InfrahubClient, db, car_person_schema) -> None:
+    async def test_cancel_approve(self, client: InfrahubClient, db, car_person_schema) -> None:
         """Test the complete proposed change review flow including relationship updates."""
 
         # Create a branch for the proposed change
@@ -117,7 +117,7 @@ class TestProposedChangeReview(TestInfrahubApp):
         # Un-approve the PC
         response = await client.execute_graphql(
             query=self.review_query,
-            variables={"data": {"id": str(proposed_change.id), "decision": "UNDO_APPROVE"}},
+            variables={"data": {"id": str(proposed_change.id), "decision": "CANCEL_APPROVE"}},
             branch_name="main",
         )
 
@@ -129,7 +129,7 @@ class TestProposedChangeReview(TestInfrahubApp):
         assert len(updated_pc.approved_by.peers) == 0
         assert len(updated_pc.rejected_by.peers) == 0
 
-    async def test_undo_reject(self, client: InfrahubClient, db, car_person_schema) -> None:
+    async def test_cancel_reject(self, client: InfrahubClient, db, car_person_schema) -> None:
         """Test the complete proposed change review flow including relationship updates."""
 
         # Create a branch for the proposed change
@@ -167,7 +167,7 @@ class TestProposedChangeReview(TestInfrahubApp):
         # Un-reject the PC
         response = await client.execute_graphql(
             query=self.review_query,
-            variables={"data": {"id": str(proposed_change.id), "decision": "UNDO_REJECT"}},
+            variables={"data": {"id": str(proposed_change.id), "decision": "CANCEL_REJECT"}},
             branch_name="main",
         )
 

--- a/backend/tests/functional/proposed_change/test_proposed_change_review.py
+++ b/backend/tests/functional/proposed_change/test_proposed_change_review.py
@@ -12,6 +12,14 @@ if TYPE_CHECKING:
 
 
 class TestProposedChangeReview(TestInfrahubApp):
+    review_query: str = """
+        mutation ProposedChangeReview($data: ProposedChangeReviewInput!) {
+            CoreProposedChangeReview(data: $data) {
+                ok
+            }
+        }
+        """
+
     async def test_approve_then_reject(self, client: InfrahubClient, db, car_person_schema) -> None:
         """Test the complete proposed change review flow including relationship updates."""
 
@@ -34,16 +42,9 @@ class TestProposedChangeReview(TestInfrahubApp):
         assert len(rejected_by_peers) == 0
 
         # Test the ProposedChangeReview mutation with APPROVED decision
-        review_query = """
-        mutation ProposedChangeReview($data: ProposedChangeReviewInput!) {
-            CoreProposedChangeReview(data: $data) {
-                ok
-            }
-        }
-        """
 
         response = await client.execute_graphql(
-            query=review_query,
+            query=self.review_query,
             variables={"data": {"id": str(proposed_change.id), "decision": "APPROVE"}},
             branch_name="main",
         )
@@ -61,7 +62,7 @@ class TestProposedChangeReview(TestInfrahubApp):
 
         # Test the ProposedChangeReview mutation with REJECTED decision
         response = await client.execute_graphql(
-            query=review_query,
+            query=self.review_query,
             variables={"data": {"id": str(proposed_change.id), "decision": "REJECT"}},
             branch_name="main",
         )
@@ -100,16 +101,8 @@ class TestProposedChangeReview(TestInfrahubApp):
         assert len(rejected_by_peers) == 0
 
         # Approve the PC
-        review_query = """
-        mutation ProposedChangeReview($data: ProposedChangeReviewInput!) {
-            CoreProposedChangeReview(data: $data) {
-                ok
-            }
-        }
-        """
-
         await client.execute_graphql(
-            query=review_query,
+            query=self.review_query,
             variables={"data": {"id": str(proposed_change.id), "decision": "APPROVE"}},
             branch_name="main",
         )
@@ -123,7 +116,7 @@ class TestProposedChangeReview(TestInfrahubApp):
 
         # Un-approve the PC
         response = await client.execute_graphql(
-            query=review_query,
+            query=self.review_query,
             variables={"data": {"id": str(proposed_change.id), "decision": "UNDO_APPROVE"}},
             branch_name="main",
         )
@@ -158,16 +151,8 @@ class TestProposedChangeReview(TestInfrahubApp):
         assert len(rejected_by_peers) == 0
 
         # Reject the PC
-        review_query = """
-        mutation ProposedChangeReview($data: ProposedChangeReviewInput!) {
-            CoreProposedChangeReview(data: $data) {
-                ok
-            }
-        }
-        """
-
         await client.execute_graphql(
-            query=review_query,
+            query=self.review_query,
             variables={"data": {"id": str(proposed_change.id), "decision": "REJECT"}},
             branch_name="main",
         )
@@ -181,7 +166,7 @@ class TestProposedChangeReview(TestInfrahubApp):
 
         # Un-reject the PC
         response = await client.execute_graphql(
-            query=review_query,
+            query=self.review_query,
             variables={"data": {"id": str(proposed_change.id), "decision": "UNDO_REJECT"}},
             branch_name="main",
         )

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -61,7 +61,11 @@ class TestInfrahub:
 
 class TestInfrahubApp(TestInfrahub):
     @pytest.fixture(scope="class")
-    def api_token(self) -> str:
+    def api_admin_token(self) -> str:
+        return str(UUIDT())
+
+    @pytest.fixture(scope="class")
+    def api_unprivileged_token(self) -> str:
         return str(UUIDT())
 
     @pytest.fixture(scope="class")
@@ -140,13 +144,13 @@ class TestInfrahubApp(TestInfrahub):
     async def client(
         self,
         test_client: InfrahubTestClient,
-        api_token: str,
+        api_admin_token: str,
         bus_simulator: BusSimulator,
         service: InfrahubServices,
         dependency_provider: Provider,
     ) -> InfrahubClient:
         config = Config(
-            api_token=api_token,
+            api_token=api_admin_token,
             requester=test_client.async_request,
             sync_requester=test_client.sync_request,
             schema_converge_timeout=5,
@@ -167,12 +171,43 @@ class TestInfrahubApp(TestInfrahub):
             yield sdk_client
 
     @pytest.fixture(scope="class")
-    async def initialize_registry(
-        self, db: InfrahubDatabase, register_core_schema: SchemaBranch, bus_simulator: BusSimulator, api_token: str
-    ) -> None:
-        admin_account = await create_account(
-            db=db, name="admin", password=config.SETTINGS.initial.admin_password, token_value=api_token
+    async def unprivileged_client(
+        self,
+        test_client: InfrahubTestClient,
+        api_unprivileged_token: str,
+        bus_simulator: BusSimulator,
+        service: InfrahubServices,
+        dependency_provider: Provider,
+    ) -> InfrahubClient:
+        config = Config(
+            api_token=api_unprivileged_token,
+            requester=test_client.async_request,
+            sync_requester=test_client.sync_request,
+            schema_converge_timeout=5,
         )
+
+        sdk_client = InfrahubClient(config=config)
+        return sdk_client
+
+    @pytest.fixture(scope="class")
+    async def initialize_registry(
+        self,
+        db: InfrahubDatabase,
+        register_core_schema: SchemaBranch,
+        bus_simulator: BusSimulator,
+        api_admin_token: str,
+        api_unprivileged_token: str,
+    ) -> None:
+        _ = await create_account(
+            db=db,
+            name="unprivileged",
+            password="testing_unprivileged_password",
+            token_value=api_unprivileged_token,
+        )
+        admin_account = await create_account(
+            db=db, name="admin", password=config.SETTINGS.initial.admin_password, token_value=api_admin_token
+        )
+
         administrator_role = await create_super_administrator_role(db=db)
         await create_super_administrators_group(db=db, role=administrator_role, admin_accounts=[admin_account])
 


### PR DESCRIPTION
This is a start of a PR for adding a new mutation to review or reject a proposed change.

It would have to be updated in order to add the current user to the list of approvers (currently the approved_by relationship) and we also need another relationship to track those that have rejected the proposed change.

When a user approves a proposed change their relationship to the rejected_by field should be removed and vice versa. Potentially we could introduce a configuration option which would allow users to approve their own proposed changes.