### PR TITLE
Fix duplicate `member_type` arg for prefix pool

### DIFF
--- a/backend/infrahub/core/node/resource_manager/ip_prefix_pool.py
+++ b/backend/infrahub/core/node/resource_manager/ip_prefix_pool.py
@@ -68,11 +68,12 @@ class CoreIPPrefixPool(Node):
             )
 
         member_type = member_type or data.get("member_type", None) or self.default_member_type.value.value  # type: ignore[attr-defined]
+        data["member_type"] = member_type
 
         target_schema = registry.get_node_schema(name=prefix_type, branch=branch)
         node = await Node.init(db=db, schema=target_schema, branch=branch)
         try:
-            await node.new(db=db, prefix=str(next_prefix), member_type=member_type, ip_namespace=ip_namespace, **data)
+            await node.new(db=db, prefix=str(next_prefix), ip_namespace=ip_namespace, **data)
         except ValidationError as exc:
             raise ValueError(f"IPPrefixPool: {self.name.value} | {exc!s}") from exc  # type: ignore[attr-defined]
         await node.save(db=db)

--- a/changelog/+prefixpool-member_type.fixed.md
+++ b/changelog/+prefixpool-member_type.fixed.md
@@ -1,0 +1,1 @@
+Fix an issue where prefixes could not be allocated from a pool when passing `member_type` inside the data parameter


### PR DESCRIPTION
When passing `member_type` inside the `data` parameter of the mutation, the mutation code was sending the `member_type` keyword argument twice. This change should fix the issue by having the `member_type` value only inside the `data` dict, which will get unpacked when creating the prefix node.