### PR TITLE
fix duplicate relationships added during node creation

### DIFF
--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -82,6 +82,9 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
     def get_schema(self) -> NonGenericSchemaTypes:
         return self._schema
 
+    def get_branch(self) -> Branch:
+        return self._branch
+
     def get_kind(self) -> str:
         """Return the main Kind of the Object."""
         return self._schema.kind

--- a/backend/infrahub/core/node/resource_manager/ip_address_pool.py
+++ b/backend/infrahub/core/node/resource_manager/ip_address_pool.py
@@ -18,6 +18,7 @@ from .. import Node
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
     from infrahub.core.ipam.constants import IPAddressType
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
@@ -30,6 +31,7 @@ class CoreIPAddressPool(Node):
         data: dict[str, Any] | None = None,
         address_type: str | None = None,
         prefixlen: int | None = None,
+        at: Timestamp | None = None,
     ) -> Node:
         # Check if there is already a resource allocated with this identifier
         # if not, pull all existing prefixes and allocated the next available
@@ -63,18 +65,18 @@ class CoreIPAddressPool(Node):
         next_address = await self.get_next(db=db, prefixlen=prefixlen)
 
         target_schema = registry.get_node_schema(name=address_type, branch=branch)
-        node = await Node.init(db=db, schema=target_schema, branch=branch)
+        node = await Node.init(db=db, schema=target_schema, branch=branch, at=at)
         try:
             await node.new(db=db, address=str(next_address), ip_namespace=ip_namespace, **data)
         except ValidationError as exc:
             raise ValueError(f"IPAddressPool: {self.name.value} | {exc!s}") from exc  # type: ignore[attr-defined]
-        await node.save(db=db)
+        await node.save(db=db, at=at)
         reconciler = IpamReconciler(db=db, branch=branch)
         await reconciler.reconcile(ip_value=next_address, namespace=ip_namespace.id, node_uuid=node.get_id())
 
         if identifier:
             query_set = await IPAddressPoolSetReserved.init(
-                db=db, pool_id=self.id, identifier=identifier, address_id=node.id
+                db=db, pool_id=self.id, identifier=identifier, address_id=node.id, at=at
             )
             await query_set.execute(db=db)
 

--- a/backend/infrahub/core/node/resource_manager/ip_prefix_pool.py
+++ b/backend/infrahub/core/node/resource_manager/ip_prefix_pool.py
@@ -20,6 +20,7 @@ from .. import Node
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
     from infrahub.core.ipam.constants import IPNetworkType
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
@@ -33,6 +34,7 @@ class CoreIPPrefixPool(Node):
         prefixlen: int | None = None,
         member_type: str | None = None,
         prefix_type: str | None = None,
+        at: Timestamp | None = None,
     ) -> Node:
         # Check if there is already a resource allocated with this identifier
         # if not, pull all existing prefixes and allocated the next available
@@ -71,18 +73,18 @@ class CoreIPPrefixPool(Node):
         data["member_type"] = member_type
 
         target_schema = registry.get_node_schema(name=prefix_type, branch=branch)
-        node = await Node.init(db=db, schema=target_schema, branch=branch)
+        node = await Node.init(db=db, schema=target_schema, branch=branch, at=at)
         try:
             await node.new(db=db, prefix=str(next_prefix), ip_namespace=ip_namespace, **data)
         except ValidationError as exc:
             raise ValueError(f"IPPrefixPool: {self.name.value} | {exc!s}") from exc  # type: ignore[attr-defined]
-        await node.save(db=db)
+        await node.save(db=db, at=at)
         reconciler = IpamReconciler(db=db, branch=branch)
         await reconciler.reconcile(ip_value=next_prefix, namespace=ip_namespace.id, node_uuid=node.get_id())
 
         if identifier:
             query_set = await PrefixPoolSetReserved.init(
-                db=db, pool_id=self.id, identifier=identifier, prefix_id=node.id
+                db=db, pool_id=self.id, identifier=identifier, prefix_id=node.id, at=at
             )
             await query_set.execute(db=db)
 

--- a/backend/infrahub/core/node/resource_manager/number_pool.py
+++ b/backend/infrahub/core/node/resource_manager/number_pool.py
@@ -12,6 +12,7 @@ from .. import Node
 if TYPE_CHECKING:
     from infrahub.core.attribute import BaseAttribute
     from infrahub.core.branch import Branch
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
@@ -41,6 +42,7 @@ class CoreNumberPool(Node):
         node: Node,
         attribute: BaseAttribute,
         identifier: str | None = None,
+        at: Timestamp | None = None,
     ) -> int:
         identifier = identifier or node.get_id()
         # Check if there is already a resource allocated with this identifier
@@ -56,7 +58,7 @@ class CoreNumberPool(Node):
         number = await self.get_next(db=db, branch=branch, attribute=attribute)
 
         query_set = await NumberPoolSetReserved.init(
-            db=db, pool_id=self.get_id(), identifier=identifier, reserved=number
+            db=db, pool_id=self.get_id(), identifier=identifier, reserved=number, at=at
         )
         await query_set.execute(db=db)
         return number

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, AsyncIterator, Generator
 from infrahub import config
 from infrahub.core import registry
 from infrahub.core.constants import (
+    GLOBAL_BRANCH_NAME,
     AttributeDBNodeType,
     RelationshipDirection,
     RelationshipHierarchyDirection,
@@ -286,15 +287,44 @@ class NodeCreateAllQuery(NodeQuery):
 
         branch_filter, branch_params = self.branch.get_query_filter_path(at=self.at)
         self.params.update(branch_params)
+        self.params["global_branch_name"] = GLOBAL_BRANCH_NAME
+        self.params["default_branch_name"] = registry.default_branch
+
+        dest_node_subquery = """
+        CALL (rel) {
+            MATCH (dest_node:Node { uuid: rel.destination_id })-[r:IS_PART_OF]->(root:Root)
+            WHERE (
+                (rel.peer_branch_level = 2 AND %(branch_filter)s)
+                OR (
+                    rel.peer_branch_level = 1
+                    AND rel.peer_branch = $global_branch_name
+                    AND r.branch = $global_branch_name
+                    AND r.from < $at AND (r.to IS NULL or r.to > $at)
+                )
+                OR (
+                    rel.peer_branch_level = 1 AND
+                    rel.peer_branch = $default_branch_name AND
+                    r.branch IN [$default_branch_name, $global_branch_name]
+                    AND r.from < $at AND (r.to IS NULL or r.to > $at)
+                )
+            )
+            ORDER BY r.branch_level DESC, r.from DESC
+            WITH dest_node, r
+            LIMIT 1
+            WITH dest_node, r
+            WHERE r.status = "active"
+            RETURN dest_node
+        }
+        """ % {"branch_filter": branch_filter}
+
         rels_bidir_query = """
         WITH distinct n
         UNWIND $rels_bidir AS rel
-        CALL (n, rel) {
-            MATCH (d:Node { uuid: rel.destination_id })-[r:IS_PART_OF]->(root:Root)
-            WHERE %(branch_filter)s
+        %(dest_node_subquery)s
+        CALL (n, rel, dest_node) {
             CREATE (rl:Relationship { uuid: rel.uuid, name: rel.name, branch_support: rel.branch_support })
             CREATE (n)-[:IS_RELATED %(rel_prop)s ]->(rl)
-            CREATE (d)-[:IS_RELATED %(rel_prop)s ]->(rl)
+            CREATE (dest_node)-[:IS_RELATED %(rel_prop)s ]->(rl)
             MERGE (ip:Boolean { value: rel.is_protected })
             MERGE (iv:Boolean { value: rel.is_visible })
             WITH rl, ip, iv
@@ -310,17 +340,16 @@ class NodeCreateAllQuery(NodeQuery):
                 CREATE (rl)-[:HAS_OWNER { branch: rel.branch, branch_level: rel.branch_level, status: rel.status, from: $at }]->(peer)
             )
         }
-        """ % {"rel_prop": rel_prop_str, "branch_filter": branch_filter}
+        """ % {"rel_prop": rel_prop_str, "dest_node_subquery": dest_node_subquery}
 
         rels_out_query = """
         WITH distinct n
         UNWIND $rels_out AS rel
-        CALL (n, rel) {
-            MATCH (d:Node { uuid: rel.destination_id })-[r:IS_PART_OF]->(root:Root)
-            WHERE %(branch_filter)s
+        %(dest_node_subquery)s
+        CALL (n, rel, dest_node) {
             CREATE (rl:Relationship { uuid: rel.uuid, name: rel.name, branch_support: rel.branch_support })
             CREATE (n)-[:IS_RELATED %(rel_prop)s ]->(rl)
-            CREATE (d)<-[:IS_RELATED %(rel_prop)s ]-(rl)
+            CREATE (dest_node)<-[:IS_RELATED %(rel_prop)s ]-(rl)
             MERGE (ip:Boolean { value: rel.is_protected })
             MERGE (iv:Boolean { value: rel.is_visible })
             WITH rl, ip, iv
@@ -336,17 +365,16 @@ class NodeCreateAllQuery(NodeQuery):
                 CREATE (rl)-[:HAS_OWNER { branch: rel.branch, branch_level: rel.branch_level, status: rel.status, from: $at }]->(peer)
             )
         }
-        """ % {"rel_prop": rel_prop_str, "branch_filter": branch_filter}
+        """ % {"rel_prop": rel_prop_str, "dest_node_subquery": dest_node_subquery}
 
         rels_in_query = """
         WITH distinct n
         UNWIND $rels_in AS rel
-        CALL (n, rel) {
-            MATCH (d:Node { uuid: rel.destination_id })-[r:IS_PART_OF]->(root:Root)
-            WHERE %(branch_filter)s
+        %(dest_node_subquery)s
+        CALL (n, rel, dest_node) {
             CREATE (rl:Relationship { uuid: rel.uuid, name: rel.name, branch_support: rel.branch_support })
             CREATE (n)<-[:IS_RELATED %(rel_prop)s ]-(rl)
-            CREATE (d)-[:IS_RELATED %(rel_prop)s ]->(rl)
+            CREATE (dest_node)-[:IS_RELATED %(rel_prop)s ]->(rl)
             MERGE (ip:Boolean { value: rel.is_protected })
             MERGE (iv:Boolean { value: rel.is_visible })
             WITH rl, ip, iv
@@ -362,7 +390,7 @@ class NodeCreateAllQuery(NodeQuery):
                 CREATE (rl)-[:HAS_OWNER { branch: rel.branch, branch_level: rel.branch_level, status: rel.status, from: $at }]->(peer)
             )
         }
-        """ % {"rel_prop": rel_prop_str, "branch_filter": branch_filter}
+        """ % {"rel_prop": rel_prop_str, "dest_node_subquery": dest_node_subquery}
 
         query = f"""
         MATCH (root:Root)

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -129,7 +129,7 @@ class NodeCreateAllQuery(NodeQuery):
 
     raise_error_if_empty: bool = True
 
-    async def query_init(self, db: InfrahubDatabase, **kwargs) -> None:  # noqa: ARG002
+    async def query_init(self, db: InfrahubDatabase, **kwargs) -> None:  # noqa: ARG002, PLR0915
         at = self.at or self.node._at
         self.params["uuid"] = self.node.id
         self.params["branch"] = self.branch.name
@@ -152,11 +152,19 @@ class NodeCreateAllQuery(NodeQuery):
             else:
                 attributes.append(attr_data)
 
+        deepest_branch_name = self.branch.name
+        deepest_branch_level = self.branch.hierarchy_level
         relationships: list[RelationshipCreateData] = []
         for rel_name in self.node._relationships:
             rel_manager: RelationshipManager = getattr(self.node, rel_name)
             for rel in rel_manager._relationships:
-                relationships.append(await rel.get_create_data(db=db))
+                rel_create_data = await rel.get_create_data(db=db, at=at)
+                if rel_create_data.peer_branch_level > deepest_branch_level or (
+                    deepest_branch_name == GLOBAL_BRANCH_NAME and rel_create_data.peer_branch == registry.default_branch
+                ):
+                    deepest_branch_name = rel_create_data.peer_branch
+                    deepest_branch_level = rel_create_data.peer_branch_level
+                relationships.append(rel_create_data)
 
         self.params["attrs"] = [attr.model_dump() for attr in attributes]
         self.params["attrs_iphost"] = [attr.model_dump() for attr in attributes_iphost]
@@ -285,7 +293,8 @@ class NodeCreateAllQuery(NodeQuery):
         }
         """ % {"ipnetwork_prop": ", ".join(ipnetwork_prop_list)}
 
-        branch_filter, branch_params = self.branch.get_query_filter_path(at=self.at)
+        deepest_branch = await registry.get_branch(db=db, branch=deepest_branch_name)
+        branch_filter, branch_params = deepest_branch.get_query_filter_path(at=self.at)
         self.params.update(branch_params)
         self.params["global_branch_name"] = GLOBAL_BRANCH_NAME
         self.params["default_branch_name"] = registry.default_branch
@@ -299,16 +308,16 @@ class NodeCreateAllQuery(NodeQuery):
                     rel.peer_branch_level = 1
                     AND rel.peer_branch = $global_branch_name
                     AND r.branch = $global_branch_name
-                    AND r.from < $at AND (r.to IS NULL or r.to > $at)
+                    AND r.from <= $at AND (r.to IS NULL or r.to > $at)
                 )
                 OR (
                     rel.peer_branch_level = 1 AND
                     rel.peer_branch = $default_branch_name AND
                     r.branch IN [$default_branch_name, $global_branch_name]
-                    AND r.from < $at AND (r.to IS NULL or r.to > $at)
+                    AND r.from <= $at AND (r.to IS NULL or r.to > $at)
                 )
             )
-            ORDER BY r.branch_level DESC, r.from DESC
+            ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
             WITH dest_node, r
             LIMIT 1
             WITH dest_node, r

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -303,13 +303,16 @@ class NodeCreateAllQuery(NodeQuery):
         CALL (rel) {
             MATCH (dest_node:Node { uuid: rel.destination_id })-[r:IS_PART_OF]->(root:Root)
             WHERE (
+                // if the relationship is on a branch, use the regular filter
                 (rel.peer_branch_level = 2 AND %(branch_filter)s)
+                // simplified filter for the global branch
                 OR (
                     rel.peer_branch_level = 1
                     AND rel.peer_branch = $global_branch_name
                     AND r.branch = $global_branch_name
                     AND r.from <= $at AND (r.to IS NULL or r.to > $at)
                 )
+                // simplified filter for the default branch
                 OR (
                     rel.peer_branch_level = 1 AND
                     rel.peer_branch = $default_branch_name AND
@@ -317,6 +320,7 @@ class NodeCreateAllQuery(NodeQuery):
                     AND r.from <= $at AND (r.to IS NULL or r.to > $at)
                 )
             )
+            // r.status is a tie-breaker when there are nodes with the same UUID added/deleted at the same time
             ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
             WITH dest_node, r
             LIMIT 1

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -232,9 +232,8 @@ class NodeCreateAllQuery(NodeQuery):
 
         attrs_iphost_query = """
         WITH distinct n
-        UNWIND $attrs_iphost AS attr_iphost
-        CALL (n, attr_iphost) {
-            WITH n, attr_iphost AS attr
+        UNWIND $attrs_iphost AS attr
+        CALL (n, attr) {
             CREATE (a:Attribute { uuid: attr.uuid, name: attr.name, branch_support: attr.branch_support })
             CREATE (n)-[:HAS_ATTRIBUTE { branch: attr.branch, branch_level: attr.branch_level, status: attr.status, from: $at }]->(a)
             MERGE (av:AttributeValue:AttributeIPHost { %(iphost_prop)s })
@@ -260,9 +259,8 @@ class NodeCreateAllQuery(NodeQuery):
 
         attrs_ipnetwork_query = """
         WITH distinct n
-        UNWIND $attrs_ipnetwork AS attr_ipnetwork
-        CALL (n, attr_ipnetwork) {
-            WITH n, attr_ipnetwork AS attr
+        UNWIND $attrs_ipnetwork AS attr
+        CALL (n, attr) {
             CREATE (a:Attribute { uuid: attr.uuid, name: attr.name, branch_support: attr.branch_support })
             CREATE (n)-[:HAS_ATTRIBUTE { branch: attr.branch, branch_level: attr.branch_level, status: attr.status, from: $at }]->(a)
             MERGE (av:AttributeValue:AttributeIPNetwork { %(ipnetwork_prop)s })
@@ -286,12 +284,14 @@ class NodeCreateAllQuery(NodeQuery):
         }
         """ % {"ipnetwork_prop": ", ".join(ipnetwork_prop_list)}
 
+        branch_filter, branch_params = self.branch.get_query_filter_path(at=self.at)
+        self.params.update(branch_params)
         rels_bidir_query = """
         WITH distinct n
         UNWIND $rels_bidir AS rel
         CALL (n, rel) {
-            MATCH (d:Node { uuid: rel.destination_id })-[is_part_of_e:IS_PART_OF {status: "active", branch: rel.branch}]->(root:Root)
-            WHERE is_part_of_e.from <= $at AND (is_part_of_e.to >= $at OR is_part_of_e.to IS NULL)
+            MATCH (d:Node { uuid: rel.destination_id })-[r:IS_PART_OF]->(root:Root)
+            WHERE %(branch_filter)s
             CREATE (rl:Relationship { uuid: rel.uuid, name: rel.name, branch_support: rel.branch_support })
             CREATE (n)-[:IS_RELATED %(rel_prop)s ]->(rl)
             CREATE (d)-[:IS_RELATED %(rel_prop)s ]->(rl)
@@ -310,14 +310,14 @@ class NodeCreateAllQuery(NodeQuery):
                 CREATE (rl)-[:HAS_OWNER { branch: rel.branch, branch_level: rel.branch_level, status: rel.status, from: $at }]->(peer)
             )
         }
-        """ % {"rel_prop": rel_prop_str}
+        """ % {"rel_prop": rel_prop_str, "branch_filter": branch_filter}
 
         rels_out_query = """
         WITH distinct n
         UNWIND $rels_out AS rel
         CALL (n, rel) {
-            MATCH (d:Node { uuid: rel.destination_id })-[is_part_of_e:IS_PART_OF {status: "active", branch: rel.branch}]->(root:Root)
-            WHERE is_part_of_e.from <= $at AND (is_part_of_e.to >= $at OR is_part_of_e.to IS NULL)
+            MATCH (d:Node { uuid: rel.destination_id })-[r:IS_PART_OF]->(root:Root)
+            WHERE %(branch_filter)s
             CREATE (rl:Relationship { uuid: rel.uuid, name: rel.name, branch_support: rel.branch_support })
             CREATE (n)-[:IS_RELATED %(rel_prop)s ]->(rl)
             CREATE (d)<-[:IS_RELATED %(rel_prop)s ]-(rl)
@@ -336,14 +336,14 @@ class NodeCreateAllQuery(NodeQuery):
                 CREATE (rl)-[:HAS_OWNER { branch: rel.branch, branch_level: rel.branch_level, status: rel.status, from: $at }]->(peer)
             )
         }
-        """ % {"rel_prop": rel_prop_str}
+        """ % {"rel_prop": rel_prop_str, "branch_filter": branch_filter}
 
         rels_in_query = """
         WITH distinct n
         UNWIND $rels_in AS rel
         CALL (n, rel) {
-            MATCH (d:Node { uuid: rel.destination_id })-[is_part_of_e:IS_PART_OF {status: "active", branch: rel.branch}]->(root:Root)
-            WHERE is_part_of_e.from <= $at AND (is_part_of_e.to >= $at OR is_part_of_e.to IS NULL)
+            MATCH (d:Node { uuid: rel.destination_id })-[r:IS_PART_OF]->(root:Root)
+            WHERE %(branch_filter)s
             CREATE (rl:Relationship { uuid: rel.uuid, name: rel.name, branch_support: rel.branch_support })
             CREATE (n)<-[:IS_RELATED %(rel_prop)s ]-(rl)
             CREATE (d)-[:IS_RELATED %(rel_prop)s ]->(rl)
@@ -362,7 +362,7 @@ class NodeCreateAllQuery(NodeQuery):
                 CREATE (rl)-[:HAS_OWNER { branch: rel.branch, branch_level: rel.branch_level, status: rel.status, from: $at }]->(peer)
             )
         }
-        """ % {"rel_prop": rel_prop_str}
+        """ % {"rel_prop": rel_prop_str, "branch_filter": branch_filter}
 
         query = f"""
         MATCH (root:Root)

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -216,6 +216,8 @@ class NodeCreateAllQuery(NodeQuery):
             CREATE (a)-[:HAS_VALUE { branch: attr.branch, branch_level: attr.branch_level, status: attr.status, from: $at }]->(av)
             MERGE (ip:Boolean { value: attr.is_protected })
             MERGE (iv:Boolean { value: attr.is_visible })
+            WITH a, ip, iv
+            LIMIT 1
             CREATE (a)-[:IS_PROTECTED { branch: attr.branch, branch_level: attr.branch_level, status: attr.status, from: $at }]->(ip)
             CREATE (a)-[:IS_VISIBLE { branch: attr.branch, branch_level: attr.branch_level, status: attr.status, from: $at }]->(iv)
             FOREACH ( prop IN attr.source_prop |
@@ -241,6 +243,8 @@ class NodeCreateAllQuery(NodeQuery):
             CREATE (a)-[:HAS_VALUE { branch: attr.branch, branch_level: attr.branch_level, status: attr.status, from: $at }]->(av)
             MERGE (ip:Boolean { value: attr.is_protected })
             MERGE (iv:Boolean { value: attr.is_visible })
+            WITH a, ip, iv
+            LIMIT 1
             CREATE (a)-[:IS_PROTECTED { branch: attr.branch, branch_level: attr.branch_level, status: attr.status, from: $at }]->(ip)
             CREATE (a)-[:IS_VISIBLE { branch: attr.branch, branch_level: attr.branch_level, status: attr.status, from: $at }]->(iv)
             FOREACH ( prop IN attr.source_prop |
@@ -267,6 +271,8 @@ class NodeCreateAllQuery(NodeQuery):
             CREATE (a)-[:HAS_VALUE { branch: attr.branch, branch_level: attr.branch_level, status: attr.status, from: $at }]->(av)
             MERGE (ip:Boolean { value: attr.is_protected })
             MERGE (iv:Boolean { value: attr.is_visible })
+            WITH a, ip, iv
+            LIMIT 1
             CREATE (a)-[:IS_PROTECTED { branch: attr.branch, branch_level: attr.branch_level, status: attr.status, from: $at }]->(ip)
             CREATE (a)-[:IS_VISIBLE { branch: attr.branch, branch_level: attr.branch_level, status: attr.status, from: $at }]->(iv)
             FOREACH ( prop IN attr.source_prop |
@@ -284,12 +290,15 @@ class NodeCreateAllQuery(NodeQuery):
         WITH distinct n
         UNWIND $rels_bidir AS rel
         CALL (n, rel) {
-            MERGE (d:Node { uuid: rel.destination_id })
+            MATCH (d:Node { uuid: rel.destination_id })-[is_part_of_e:IS_PART_OF {status: "active", branch: rel.branch}]->(root:Root)
+            WHERE is_part_of_e.from <= $at AND (is_part_of_e.to >= $at OR is_part_of_e.to IS NULL)
             CREATE (rl:Relationship { uuid: rel.uuid, name: rel.name, branch_support: rel.branch_support })
             CREATE (n)-[:IS_RELATED %(rel_prop)s ]->(rl)
             CREATE (d)-[:IS_RELATED %(rel_prop)s ]->(rl)
             MERGE (ip:Boolean { value: rel.is_protected })
             MERGE (iv:Boolean { value: rel.is_visible })
+            WITH rl, ip, iv
+            LIMIT 1
             CREATE (rl)-[:IS_PROTECTED { branch: rel.branch, branch_level: rel.branch_level, status: rel.status, from: $at }]->(ip)
             CREATE (rl)-[:IS_VISIBLE { branch: rel.branch, branch_level: rel.branch_level, status: rel.status, from: $at }]->(iv)
             FOREACH ( prop IN rel.source_prop |
@@ -305,15 +314,17 @@ class NodeCreateAllQuery(NodeQuery):
 
         rels_out_query = """
         WITH distinct n
-        UNWIND $rels_out AS rel_out
-        CALL (n, rel_out) {
-            WITH n, rel_out as rel
-            MERGE (d:Node { uuid: rel.destination_id })
+        UNWIND $rels_out AS rel
+        CALL (n, rel) {
+            MATCH (d:Node { uuid: rel.destination_id })-[is_part_of_e:IS_PART_OF {status: "active", branch: rel.branch}]->(root:Root)
+            WHERE is_part_of_e.from <= $at AND (is_part_of_e.to >= $at OR is_part_of_e.to IS NULL)
             CREATE (rl:Relationship { uuid: rel.uuid, name: rel.name, branch_support: rel.branch_support })
             CREATE (n)-[:IS_RELATED %(rel_prop)s ]->(rl)
             CREATE (d)<-[:IS_RELATED %(rel_prop)s ]-(rl)
             MERGE (ip:Boolean { value: rel.is_protected })
             MERGE (iv:Boolean { value: rel.is_visible })
+            WITH rl, ip, iv
+            LIMIT 1
             CREATE (rl)-[:IS_PROTECTED { branch: rel.branch, branch_level: rel.branch_level, status: rel.status, from: $at }]->(ip)
             CREATE (rl)-[:IS_VISIBLE { branch: rel.branch, branch_level: rel.branch_level, status: rel.status, from: $at }]->(iv)
             FOREACH ( prop IN rel.source_prop |
@@ -329,15 +340,17 @@ class NodeCreateAllQuery(NodeQuery):
 
         rels_in_query = """
         WITH distinct n
-        UNWIND $rels_in AS rel_in
-        CALL (n, rel_in) {
-            WITH n, rel_in AS rel
-            MERGE (d:Node { uuid: rel.destination_id })
+        UNWIND $rels_in AS rel
+        CALL (n, rel) {
+            MATCH (d:Node { uuid: rel.destination_id })-[is_part_of_e:IS_PART_OF {status: "active", branch: rel.branch}]->(root:Root)
+            WHERE is_part_of_e.from <= $at AND (is_part_of_e.to >= $at OR is_part_of_e.to IS NULL)
             CREATE (rl:Relationship { uuid: rel.uuid, name: rel.name, branch_support: rel.branch_support })
             CREATE (n)<-[:IS_RELATED %(rel_prop)s ]-(rl)
             CREATE (d)-[:IS_RELATED %(rel_prop)s ]->(rl)
             MERGE (ip:Boolean { value: rel.is_protected })
             MERGE (iv:Boolean { value: rel.is_visible })
+            WITH rl, ip, iv
+            LIMIT 1
             CREATE (rl)-[:IS_PROTECTED { branch: rel.branch, branch_level: rel.branch_level, status: rel.status, from: $at }]->(ip)
             CREATE (rl)-[:IS_VISIBLE { branch: rel.branch, branch_level: rel.branch_level, status: rel.status, from: $at }]->(iv)
             FOREACH ( prop IN rel.source_prop |

--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -206,16 +206,18 @@ class RelationshipQuery(Query):
         self.params["source_id"] = self.source_id or self.source.get_id()
         if source_branch.is_global or source_branch.is_default:
             source_query_match = """
-            MATCH (s:Node { uuid: $source_id })
+            MATCH (s:Node { uuid: $source_id })-[source_e:IS_PART_OF {branch: $source_branch, status: "active"}]->(:Root)
+            WHERE source_e.from <= $at AND (source_e.to IS NULL OR source_e.to > $at)
             OPTIONAL MATCH (s)-[delete_edge:IS_PART_OF {status: "deleted", branch: $source_branch}]->(:Root)
             WHERE delete_edge.from <= $at
             WITH *, s WHERE delete_edge IS NULL
             """
             self.params["source_branch"] = source_branch.name
-        source_filter, source_filter_params = source_branch.get_query_filter_path(
-            at=self.at, variable_name="r", params_prefix="src_"
-        )
-        source_query_match = """
+        else:
+            source_filter, source_filter_params = source_branch.get_query_filter_path(
+                at=self.at, variable_name="r", params_prefix="src_"
+            )
+            source_query_match = """
             MATCH (s:Node { uuid: $source_id })
             CALL (s) {
                 MATCH (s)-[r:IS_PART_OF]->(:Root)
@@ -225,15 +227,16 @@ class RelationshipQuery(Query):
                 LIMIT 1
             }
             WITH *, s WHERE s_is_active = TRUE
-            """ % {"source_filter": source_filter}
-        self.params.update(source_filter_params)
+                """ % {"source_filter": source_filter}
+            self.params.update(source_filter_params)
         self.add_to_query(source_query_match)
 
     def add_dest_match_to_query(self, destination_branch: Branch, destination_id: str) -> None:
         self.params["destination_id"] = destination_id
         if destination_branch.is_global or destination_branch.is_default:
             destination_query_match = """
-            MATCH (d:Node { uuid: $destination_id })
+            MATCH (d:Node { uuid: $destination_id })-[dest_e:IS_PART_OF {branch: $destination_branch, status: "active"}]->(:Root)
+            WHERE dest_e.from <= $at AND (dest_e.to IS NULL OR dest_e.to > $at)
             OPTIONAL MATCH (d)-[delete_edge:IS_PART_OF {status: "deleted", branch: $destination_branch}]->(:Root)
             WHERE delete_edge.from <= $at
             WITH *, d WHERE delete_edge IS NULL

--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -422,7 +422,7 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin):
         )
         await delete_query.execute(db=db)
 
-    async def resolve(self, db: InfrahubDatabase) -> None:
+    async def resolve(self, db: InfrahubDatabase, at: Timestamp | None = None) -> None:
         """Resolve the peer of the relationship."""
 
         if self._peer is not None:
@@ -472,7 +472,7 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin):
                 if hfid_str:
                     data_from_pool["identifier"] = f"hfid={hfid_str} rel={self.name}"
 
-            assigned_peer: Node = await pool.get_resource(db=db, branch=self.branch, **data_from_pool)  # type: ignore[attr-defined]
+            assigned_peer: Node = await pool.get_resource(db=db, branch=self.branch, at=at, **data_from_pool)  # type: ignore[attr-defined]
             await self.set_peer(value=assigned_peer)
             self.set_source(value=pool.id)
 
@@ -528,10 +528,10 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin):
 
         return response
 
-    async def get_create_data(self, db: InfrahubDatabase) -> RelationshipCreateData:
+    async def get_create_data(self, db: InfrahubDatabase, at: Timestamp | None = None) -> RelationshipCreateData:
         branch = self.get_branch_based_on_support_type()
 
-        await self.resolve(db=db)
+        await self.resolve(db=db, at=at)
 
         peer = await self.get_peer(db=db)
         peer_branch = peer.get_branch()

--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -63,9 +63,11 @@ class RelationshipCreateData(BaseModel):
     uuid: str
     name: str
     destination_id: str
-    branch: str | None = None
+    branch: str
     branch_level: int
     branch_support: str | None = None
+    peer_branch: str
+    peer_branch_level: int
     direction: str
     status: str
     is_protected: bool
@@ -532,10 +534,13 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin):
         await self.resolve(db=db)
 
         peer = await self.get_peer(db=db)
+        peer_branch = peer.get_branch()
         data = RelationshipCreateData(
             uuid=str(UUIDT()),
             name=self.schema.get_identifier(),
             branch=branch.name,
+            peer_branch=peer_branch.name,
+            peer_branch_level=peer_branch.hierarchy_level,
             destination_id=peer.id,
             status="active",
             direction=self.schema.direction.value,

--- a/backend/tests/unit/core/constraint_validators/test_node_uniqueness.py
+++ b/backend/tests/unit/core/constraint_validators/test_node_uniqueness.py
@@ -55,7 +55,7 @@ async def test_hierarchical_uniqueness_constraint(
     await fr.save(db=db)
     uk = await Node.init(db=db, schema="LocationSite", branch=default_branch)
     await uk.new(db=db, name="United Kingdom", parent=eu)
-    await fr.save(db=db)
+    await uk.save(db=db)
 
     th2 = await Node.init(db=db, schema="LocationRack", branch=default_branch)
     await th2.new(db=db, name="th2-par", parent=fr)

--- a/backend/tests/unit/core/constraint_validators/test_relationship_peer_relatives.py
+++ b/backend/tests/unit/core/constraint_validators/test_relationship_peer_relatives.py
@@ -28,6 +28,7 @@ class TestRelationshipPeerParentConstraint(TestInfrahubApp):
     async def device_1(self, db: InfrahubDatabase, schema) -> Node:
         device = await Node.init(db=db, schema=TestKind.DEVICE)
         await device.new(db=db, name="Foo", manufacturer="Foo Inc.", weight=10, airflow="Front to rear")
+        await device.save(db=db)
 
         interfaces: list[Node] = []
         for if_name in ["et-0/0/0", "et-0/0/1", "et-0/0/2", "et-0/0/3"]:
@@ -37,7 +38,6 @@ class TestRelationshipPeerParentConstraint(TestInfrahubApp):
             interfaces.append(interface)
 
         await device.interfaces.update(db=db, data=interfaces)
-        await device.save(db=db)
 
         return device
 
@@ -45,6 +45,7 @@ class TestRelationshipPeerParentConstraint(TestInfrahubApp):
     async def device_2(self, db: InfrahubDatabase, schema) -> Node:
         device = await Node.init(db=db, schema=TestKind.DEVICE)
         await device.new(db=db, name="Bar", manufacturer="Bar Inc.", weight=10, airflow="Front to rear")
+        await device.save(db=db)
 
         interfaces: list[Node] = []
         for if_name in ["et-0/0/0", "et-0/0/1", "et-0/0/2", "et-0/0/3"]:
@@ -54,7 +55,6 @@ class TestRelationshipPeerParentConstraint(TestInfrahubApp):
             interfaces.append(interface)
 
         await device.interfaces.update(db=db, data=interfaces)
-        await device.save(db=db)
 
         return device
 
@@ -104,6 +104,7 @@ class TestRelationshipPeerRelativesConstraint(TestInfrahubApp):
     async def device_1(self, db: InfrahubDatabase, schema) -> Node:
         device = await Node.init(db=db, schema=TestKind.DEVICE)
         await device.new(db=db, name="Foo", manufacturer="Foo Inc.", weight=10, airflow="Front to rear")
+        await device.save(db=db)
 
         interfaces: list[Node] = []
         for if_name in ["et-0/0/0", "et-0/0/1", "et-0/0/2", "et-0/0/3"]:
@@ -113,7 +114,6 @@ class TestRelationshipPeerRelativesConstraint(TestInfrahubApp):
             interfaces.append(interface)
 
         await device.interfaces.update(db=db, data=interfaces)
-        await device.save(db=db)
 
         return device
 
@@ -121,6 +121,7 @@ class TestRelationshipPeerRelativesConstraint(TestInfrahubApp):
     async def device_2(self, db: InfrahubDatabase, schema) -> Node:
         device = await Node.init(db=db, schema=TestKind.DEVICE)
         await device.new(db=db, name="Bar", manufacturer="Bar Inc.", weight=10, airflow="Front to rear")
+        await device.save(db=db)
 
         interfaces: list[Node] = []
         for if_name in ["et-0/0/0", "et-0/0/1", "et-0/0/2", "et-0/0/3"]:
@@ -130,7 +131,6 @@ class TestRelationshipPeerRelativesConstraint(TestInfrahubApp):
             interfaces.append(interface)
 
         await device.interfaces.update(db=db, data=interfaces)
-        await device.save(db=db)
 
         return device
 

--- a/backend/tests/unit/core/test_relationship_query.py
+++ b/backend/tests/unit/core/test_relationship_query.py
@@ -197,7 +197,12 @@ async def test_query_RelationshipCreateQuery_w_node_property(
 
 
 async def test_query_RelationshipCreateQuery_for_node_with_migrated_kind(
-    db: InfrahubDatabase, tag_blue_main: Node, person_jack_main: Node, branch: Branch
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    tag_blue_main: Node,
+    tag_red_main: Node,
+    person_jack_main: Node,
+    branch: Branch,
 ):
     schema = registry.schema.get_schema_branch(name=branch.name)
     person_schema = schema.get(name="TestPerson")
@@ -245,6 +250,36 @@ async def test_query_RelationshipCreateQuery_for_node_with_migrated_kind(
         relationships=["IS_RELATED"],
     )
     assert len(paths) == 0
+    query = await RelationshipCreateQuery.init(
+        db=db,
+        source=person_jack_main,
+        destination=tag_red_main,
+        schema=rel_schema,
+        rel=Relationship,
+        branch=default_branch,
+        at=Timestamp(),
+    )
+    await query.execute(db=db)
+    # check paths between tag_red and person_jack_main
+    paths = await get_paths_between_nodes(
+        db=db,
+        source_id=tag_red_main.db_id,
+        destination_id=person_jack_main.db_id,
+        max_length=2,
+        relationships=["IS_RELATED"],
+    )
+    assert len(paths) == (0 if branch.name == default_branch.name else 1)
+
+    # check paths between tag_red and migrated_person_jack
+    paths = await get_paths_between_nodes(
+        db=db,
+        source_id=tag_red_main.db_id,
+        destination_id=migrated_person_jack.db_id,
+        max_length=2,
+        relationships=["IS_RELATED"],
+    )
+    assert len(paths) == (1 if branch.name == default_branch.name else 0)
+
     await verify_no_duplicate_paths(db=db)
 
 

--- a/backend/tests/unit/graphql/test_mutation_create.py
+++ b/backend/tests/unit/graphql/test_mutation_create.py
@@ -3,10 +3,14 @@ import pytest
 from infrahub import config
 from infrahub.core import registry
 from infrahub.core.branch.models import Branch
-from infrahub.core.constants import InfrahubKind
+from infrahub.core.constants import InfrahubKind, SchemaPathType
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
+from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration
 from infrahub.core.node import Node
+from infrahub.core.path import SchemaPath
+from infrahub.core.schema import SchemaRoot
+from infrahub.core.schema.definitions.core.group import core_group, core_standard_group
 from infrahub.core.schema.node_schema import NodeSchema
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
@@ -831,6 +835,186 @@ async def test_create_object_with_multiple_relationships_flag_property(
     assert rels[0].is_protected is True
     assert rels[1].is_protected is True
     assert rels[2].is_protected is True
+
+
+async def test_create_relationship_for_node_with_migrated_kind(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_internal_models_schema,
+    car_person_schema: Node,
+    person_alfred_main: Node,
+):
+    schema = SchemaRoot(generics=[core_group], nodes=[core_standard_group])
+    registry.schema.register_schema(schema=schema, branch=default_branch.name)
+    default_branch.update_schema_hash()
+
+    branch = await create_branch(db=db, branch_name="migrated-branch")
+    schema = registry.schema.get_schema_branch(name=branch.name)
+    person_schema = schema.get(name="TestPerson")
+    person_schema.name = "GreatPerson"
+    new_person_kind = "TestGreatPerson"
+    assert person_schema.kind == new_person_kind
+    registry.schema.set(name=new_person_kind, schema=person_schema, branch=branch.name)
+    migration = NodeKindUpdateMigration(
+        previous_node_schema=schema.get(name="TestPerson"),
+        new_node_schema=person_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind=new_person_kind, field_name="name"),
+    )
+    execution_result = await migration.execute(db=db, branch=branch)
+    assert not execution_result.errors
+    core_node_schema = schema.get_generic(name="CoreNode")
+    core_node_schema.used_by.append(new_person_kind)
+    schema.set(name="CoreNode", schema=core_node_schema)
+    await registry.schema.load_schema_to_db(db=db, schema=schema, branch=branch)
+
+    # create group on main
+    group_create_query = """
+    mutation ($id: String!, $name: String!) {
+        CoreStandardGroupCreate(data: {
+            name: { value: $name},
+            group_type: { value: "internal" },
+            members: { id: $id }
+        }) {
+            ok
+            object {
+                id
+            }
+        }
+    }
+    """
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=group_create_query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"id": person_alfred_main.id, "name": "main-group"},
+    )
+    assert not result.errors
+    assert result.data
+    main_group_id = result.data["CoreStandardGroupCreate"]["object"]["id"]
+
+    # create group on branch
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=group_create_query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"id": person_alfred_main.id, "name": "branch-group"},
+    )
+    assert not result.errors
+    assert result.data
+    branch_group_id = result.data["CoreStandardGroupCreate"]["object"]["id"]
+
+    # check relationship count on main
+    group_members_query = """
+    query getRelationshipCount_CoreStandardGroup_members ($ids: [ID!]!) {
+        CoreStandardGroup(
+            ids: $ids
+        ) {
+            edges {
+                node {
+                    members {
+                        count
+                    }
+                }
+            }
+        }
+    }
+    """
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=group_members_query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"ids": [main_group_id]},
+    )
+    assert not result.errors
+    assert result.data
+    assert result.data["CoreStandardGroup"]["edges"][0]["node"]["members"]["count"] == 1
+
+    # check relationship count on branch
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=group_members_query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"ids": [branch_group_id]},
+    )
+    assert not result.errors
+    assert result.data
+    assert result.data["CoreStandardGroup"]["edges"][0]["node"]["members"]["count"] == 1
+
+    # check person-side relationship on main
+    person_main = await NodeManager.get_one(db=db, id=person_alfred_main.id, branch=default_branch)
+    groups = await person_main.member_of_groups.get(db=db)
+    assert len(groups) == 1
+    assert groups[0].peer_id == main_group_id
+    main_person_schema = registry.schema.get(name="TestPerson", branch=default_branch, duplicate=False)
+    members_rel_schema = main_person_schema.get_relationship("member_of_groups")
+    peer_count = await NodeManager.count_peers(
+        db=db,
+        ids=[person_alfred_main.id],
+        source_kind="TestPerson",
+        schema=members_rel_schema,
+        filters={},
+        branch=default_branch,
+    )
+    assert peer_count == 1
+
+    # check group-side relationship on main
+    group_main = await NodeManager.get_one(db=db, id=main_group_id, branch=default_branch)
+    members = await group_main.members.get(db=db)
+    assert len(members) == 1
+    assert members[0].peer_id == person_alfred_main.id
+    main_group_schema = registry.schema.get(name="CoreStandardGroup", branch=default_branch, duplicate=False)
+    members_rel_schema = main_group_schema.get_relationship("members")
+    peer_count = await NodeManager.count_peers(
+        db=db,
+        ids=[main_group_id],
+        source_kind="CoreStandardGroup",
+        schema=members_rel_schema,
+        filters={},
+        branch=default_branch,
+    )
+    assert peer_count == 1
+
+    # check person-side relationship on branch
+    alfred_branch = await NodeManager.get_one(db=db, id=person_alfred_main.id, branch=branch)
+    groups = await alfred_branch.member_of_groups.get(db=db)
+    assert len(groups) == 1
+    assert groups[0].peer_id == branch_group_id
+    branch_person_schema = registry.schema.get(name="TestGreatPerson", branch=branch, duplicate=False)
+    members_rel_schema = branch_person_schema.get_relationship("member_of_groups")
+    peer_count = await NodeManager.count_peers(
+        db=db,
+        ids=[person_alfred_main.id],
+        source_kind="TestGreatPerson",
+        schema=members_rel_schema,
+        filters={},
+        branch=branch,
+    )
+    assert peer_count == 1
+
+    # check group-side relationship on branch
+    group_branch = await NodeManager.get_one(db=db, id=branch_group_id, branch=branch)
+    members = await group_branch.members.get(db=db)
+    assert len(members) == 1
+    assert members[0].peer_id == person_alfred_main.id
+    branch_group_schema = registry.schema.get(name="CoreStandardGroup", branch=branch, duplicate=False)
+    members_rel_schema = branch_group_schema.get_relationship("members")
+    peer_count = await NodeManager.count_peers(
+        db=db,
+        ids=[branch_group_id],
+        source_kind="CoreStandardGroup",
+        schema=members_rel_schema,
+        filters={},
+        branch=branch,
+    )
+    assert peer_count == 1
 
 
 async def test_create_person_not_valid(db: InfrahubDatabase, default_branch, car_person_schema):

--- a/backend/tests/unit/graphql/test_mutation_relationship.py
+++ b/backend/tests/unit/graphql/test_mutation_relationship.py
@@ -10,9 +10,14 @@ from infrahub.core import registry
 from infrahub.core.account import ObjectPermission
 from infrahub.core.branch import Branch
 from infrahub.core.changelog.models import RelationshipCardinalityManyChangelog
-from infrahub.core.constants import InfrahubKind, PermissionAction, PermissionDecision
+from infrahub.core.constants import InfrahubKind, PermissionAction, PermissionDecision, SchemaPathType
+from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
+from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration
 from infrahub.core.node import Node
+from infrahub.core.path import SchemaPath
+from infrahub.core.schema import SchemaRoot
+from infrahub.core.schema.definitions.core.group import core_group, core_standard_group
 from infrahub.core.utils import count_relationships
 from infrahub.database import InfrahubDatabase
 from infrahub.events.group_action import GroupMemberAddedEvent, GroupMemberRemovedEvent
@@ -863,6 +868,194 @@ async def test_relationship_add_busy(db: InfrahubDatabase, default_branch: Branc
     )
     assert result.errors
     assert "'TestElectricCar' is already related to another peer on 'owner'" in str(result.errors[0])
+
+
+async def test_relationship_add_for_node_with_migrated_kind(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_internal_models_schema,
+    car_person_schema: Node,
+    person_alfred_main: Node,
+):
+    schema = SchemaRoot(generics=[core_group], nodes=[core_standard_group])
+    registry.schema.register_schema(schema=schema, branch=default_branch.name)
+    default_branch.update_schema_hash()
+
+    branch = await create_branch(db=db, branch_name="migrated-branch")
+    schema = registry.schema.get_schema_branch(name=branch.name)
+    person_schema = schema.get(name="TestPerson")
+    person_schema.name = "GreatPerson"
+    new_person_kind = "TestGreatPerson"
+    assert person_schema.kind == new_person_kind
+    registry.schema.set(name=new_person_kind, schema=person_schema, branch=branch.name)
+    migration = NodeKindUpdateMigration(
+        previous_node_schema=schema.get(name="TestPerson"),
+        new_node_schema=person_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind=new_person_kind, field_name="name"),
+    )
+    execution_result = await migration.execute(db=db, branch=branch)
+    assert not execution_result.errors
+    core_node_schema = schema.get_generic(name="CoreNode")
+    core_node_schema.used_by.append(new_person_kind)
+    schema.set(name="CoreNode", schema=core_node_schema)
+    await registry.schema.load_schema_to_db(db=db, schema=schema, branch=branch)
+
+    # create group on main
+    main_group = await Node.init(db=db, schema=InfrahubKind.STANDARDGROUP)
+    await main_group.new(
+        db=db,
+        name="main-group",
+    )
+    await main_group.save(db=db)
+    # create group on branch
+    branch_group = await Node.init(db=db, branch=branch, schema=InfrahubKind.STANDARDGROUP)
+    await branch_group.new(
+        db=db,
+        name="branch-group",
+    )
+    await branch_group.save(db=db)
+
+    # add person to group on main
+    add_members_query = """
+    mutation ($group_id: String!, $members: [RelatedNodeInput]) {
+        RelationshipAdd(data: {
+            id: $group_id,
+            name: "members",
+            nodes: $members,
+        }) {
+            ok
+        }
+    }
+    """
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=add_members_query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"group_id": main_group.id, "members": [{"id": person_alfred_main.id}]},
+    )
+    assert not result.errors
+
+    # add person to group on branch
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=add_members_query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"group_id": branch_group.id, "members": [{"id": person_alfred_main.id}]},
+    )
+    assert not result.errors
+
+    # check relationship count on main
+    group_members_query = """
+    query getRelationshipCount_CoreStandardGroup_members ($ids: [ID!]!) {
+        CoreStandardGroup(
+            ids: $ids
+        ) {
+            edges {
+                node {
+                    members {
+                        count
+                    }
+                }
+            }
+        }
+    }
+    """
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=group_members_query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"ids": [main_group.id]},
+    )
+    assert not result.errors
+    assert result.data
+    assert result.data["CoreStandardGroup"]["edges"][0]["node"]["members"]["count"] == 1
+
+    # check relationship count on branch
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=group_members_query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"ids": [branch_group.id]},
+    )
+    assert not result.errors
+    assert result.data
+    assert result.data["CoreStandardGroup"]["edges"][0]["node"]["members"]["count"] == 1
+
+    # check person-side relationship on main
+    person_main = await NodeManager.get_one(db=db, id=person_alfred_main.id, branch=default_branch)
+    groups = await person_main.member_of_groups.get(db=db)
+    assert len(groups) == 1
+    assert groups[0].peer_id == main_group.id
+    main_person_schema = registry.schema.get(name="TestPerson", branch=default_branch, duplicate=False)
+    members_rel_schema = main_person_schema.get_relationship("member_of_groups")
+    peer_count = await NodeManager.count_peers(
+        db=db,
+        ids=[person_alfred_main.id],
+        source_kind="TestPerson",
+        schema=members_rel_schema,
+        filters={},
+        branch=default_branch,
+    )
+    assert peer_count == 1
+
+    # check group-side relationship on main
+    group_main = await NodeManager.get_one(db=db, id=main_group.id, branch=default_branch)
+    members = await group_main.members.get(db=db)
+    assert len(members) == 1
+    assert members[0].peer_id == person_alfred_main.id
+    main_group_schema = registry.schema.get(name="CoreStandardGroup", branch=default_branch, duplicate=False)
+    members_rel_schema = main_group_schema.get_relationship("members")
+    peer_count = await NodeManager.count_peers(
+        db=db,
+        ids=[main_group.id],
+        source_kind="CoreStandardGroup",
+        schema=members_rel_schema,
+        filters={},
+        branch=default_branch,
+    )
+    assert peer_count == 1
+
+    # check person-side relationship on branch
+    alfred_branch = await NodeManager.get_one(db=db, id=person_alfred_main.id, branch=branch)
+    groups = await alfred_branch.member_of_groups.get(db=db)
+    assert len(groups) == 1
+    assert groups[0].peer_id == branch_group.id
+    branch_person_schema = registry.schema.get(name="TestGreatPerson", branch=branch, duplicate=False)
+    members_rel_schema = branch_person_schema.get_relationship("member_of_groups")
+    peer_count = await NodeManager.count_peers(
+        db=db,
+        ids=[person_alfred_main.id],
+        source_kind="TestGreatPerson",
+        schema=members_rel_schema,
+        filters={},
+        branch=branch,
+    )
+    assert peer_count == 1
+
+    # check group-side relationship on branch
+    group_branch = await NodeManager.get_one(db=db, id=branch_group.id, branch=branch)
+    members = await group_branch.members.get(db=db)
+    assert len(members) == 1
+    assert members[0].peer_id == person_alfred_main.id
+    branch_group_schema = registry.schema.get(name="CoreStandardGroup", branch=branch, duplicate=False)
+    members_rel_schema = branch_group_schema.get_relationship("members")
+    peer_count = await NodeManager.count_peers(
+        db=db,
+        ids=[branch_group.id],
+        source_kind="CoreStandardGroup",
+        schema=members_rel_schema,
+        filters={},
+        branch=branch,
+    )
+    assert peer_count == 1
 
 
 async def test_relationship_add_from_pool(

--- a/backend/tests/unit/graphql/test_mutation_update.py
+++ b/backend/tests/unit/graphql/test_mutation_update.py
@@ -5,9 +5,14 @@ from infrahub.auth import AccountSession
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.changelog.models import RelationshipCardinalityManyChangelog, RelationshipCardinalityOneChangelog
-from infrahub.core.constants import DiffAction
+from infrahub.core.constants import DiffAction, InfrahubKind, SchemaPathType
+from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
+from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration
 from infrahub.core.node import Node
+from infrahub.core.path import SchemaPath
+from infrahub.core.schema import SchemaRoot
+from infrahub.core.schema.definitions.core.group import core_group, core_standard_group
 from infrahub.database import InfrahubDatabase
 from infrahub.events.node_action import NodeMutatedEvent
 from infrahub.graphql.initialization import prepare_graphql_params
@@ -1164,6 +1169,193 @@ async def test_update_relationship_previously_deleted(
     p13 = await NodeManager.get_one(db=db, id=person_jack_main.id, branch=branch)
     tags = await p13.tags.get(db=db)
     assert sorted([tag.peer.name.value for tag in tags]) == ["Black", "Blue"]
+
+
+async def test_update_for_node_with_migrated_kind(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    register_internal_models_schema,
+    car_person_schema: Node,
+    person_alfred_main: Node,
+):
+    schema = SchemaRoot(generics=[core_group], nodes=[core_standard_group])
+    registry.schema.register_schema(schema=schema, branch=default_branch.name)
+    default_branch.update_schema_hash()
+
+    branch = await create_branch(db=db, branch_name="migrated-branch")
+    schema = registry.schema.get_schema_branch(name=branch.name)
+    person_schema = schema.get(name="TestPerson")
+    person_schema.name = "GreatPerson"
+    new_person_kind = "TestGreatPerson"
+    assert person_schema.kind == new_person_kind
+    registry.schema.set(name=new_person_kind, schema=person_schema, branch=branch.name)
+    migration = NodeKindUpdateMigration(
+        previous_node_schema=schema.get(name="TestPerson"),
+        new_node_schema=person_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind=new_person_kind, field_name="name"),
+    )
+    execution_result = await migration.execute(db=db, branch=branch)
+    assert not execution_result.errors
+    core_node_schema = schema.get_generic(name="CoreNode")
+    core_node_schema.used_by.append(new_person_kind)
+    schema.set(name="CoreNode", schema=core_node_schema)
+    await registry.schema.load_schema_to_db(db=db, schema=schema, branch=branch)
+
+    # create group on main
+    main_group = await Node.init(db=db, schema=InfrahubKind.STANDARDGROUP)
+    await main_group.new(
+        db=db,
+        name="main-group",
+    )
+    await main_group.save(db=db)
+    # create group on branch
+    branch_group = await Node.init(db=db, branch=branch, schema=InfrahubKind.STANDARDGROUP)
+    await branch_group.new(
+        db=db,
+        name="branch-group",
+    )
+    await branch_group.save(db=db)
+
+    # add person to group on main
+    update_group_query = """
+    mutation ($group_id: String!, $members: [RelatedNodeInput]) {
+        CoreStandardGroupUpdate(data: {
+            id: $group_id,
+            members: $members,
+        }) {
+            ok
+        }
+    }
+    """
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=update_group_query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"group_id": main_group.id, "members": [{"id": person_alfred_main.id}]},
+    )
+    assert not result.errors
+
+    # add person to group on branch
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=update_group_query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"group_id": branch_group.id, "members": [{"id": person_alfred_main.id}]},
+    )
+    assert not result.errors
+
+    # check relationship count on main
+    group_members_query = """
+    query getRelationshipCount_CoreStandardGroup_members ($ids: [ID!]!) {
+        CoreStandardGroup(
+            ids: $ids
+        ) {
+            edges {
+                node {
+                    members {
+                        count
+                    }
+                }
+            }
+        }
+    }
+    """
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=group_members_query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"ids": [main_group.id]},
+    )
+    assert not result.errors
+    assert result.data
+    assert result.data["CoreStandardGroup"]["edges"][0]["node"]["members"]["count"] == 1
+
+    # check relationship count on branch
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=group_members_query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"ids": [branch_group.id]},
+    )
+    assert not result.errors
+    assert result.data
+    assert result.data["CoreStandardGroup"]["edges"][0]["node"]["members"]["count"] == 1
+
+    # check person-side relationship on main
+    person_main = await NodeManager.get_one(db=db, id=person_alfred_main.id, branch=default_branch)
+    groups = await person_main.member_of_groups.get(db=db)
+    assert len(groups) == 1
+    assert groups[0].peer_id == main_group.id
+    main_person_schema = registry.schema.get(name="TestPerson", branch=default_branch, duplicate=False)
+    members_rel_schema = main_person_schema.get_relationship("member_of_groups")
+    peer_count = await NodeManager.count_peers(
+        db=db,
+        ids=[person_alfred_main.id],
+        source_kind="TestPerson",
+        schema=members_rel_schema,
+        filters={},
+        branch=default_branch,
+    )
+    assert peer_count == 1
+
+    # check group-side relationship on main
+    group_main = await NodeManager.get_one(db=db, id=main_group.id, branch=default_branch)
+    members = await group_main.members.get(db=db)
+    assert len(members) == 1
+    assert members[0].peer_id == person_alfred_main.id
+    main_group_schema = registry.schema.get(name="CoreStandardGroup", branch=default_branch, duplicate=False)
+    members_rel_schema = main_group_schema.get_relationship("members")
+    peer_count = await NodeManager.count_peers(
+        db=db,
+        ids=[main_group.id],
+        source_kind="CoreStandardGroup",
+        schema=members_rel_schema,
+        filters={},
+        branch=default_branch,
+    )
+    assert peer_count == 1
+
+    # check person-side relationship on branch
+    alfred_branch = await NodeManager.get_one(db=db, id=person_alfred_main.id, branch=branch)
+    groups = await alfred_branch.member_of_groups.get(db=db)
+    assert len(groups) == 1
+    assert groups[0].peer_id == branch_group.id
+    branch_person_schema = registry.schema.get(name="TestGreatPerson", branch=branch, duplicate=False)
+    members_rel_schema = branch_person_schema.get_relationship("member_of_groups")
+    peer_count = await NodeManager.count_peers(
+        db=db,
+        ids=[person_alfred_main.id],
+        source_kind="TestGreatPerson",
+        schema=members_rel_schema,
+        filters={},
+        branch=branch,
+    )
+    assert peer_count == 1
+
+    # check group-side relationship on branch
+    group_branch = await NodeManager.get_one(db=db, id=branch_group.id, branch=branch)
+    members = await group_branch.members.get(db=db)
+    assert len(members) == 1
+    assert members[0].peer_id == person_alfred_main.id
+    branch_group_schema = registry.schema.get(name="CoreStandardGroup", branch=branch, duplicate=False)
+    members_rel_schema = branch_group_schema.get_relationship("members")
+    peer_count = await NodeManager.count_peers(
+        db=db,
+        ids=[branch_group.id],
+        source_kind="CoreStandardGroup",
+        schema=members_rel_schema,
+        filters={},
+        branch=branch,
+    )
+    assert peer_count == 1
 
 
 async def test_update_with_uniqueness_constraint_violation(db: InfrahubDatabase, default_branch, car_person_schema):

--- a/changelog/+prevent_dup_rels.fixed.md
+++ b/changelog/+prevent_dup_rels.fixed.md
@@ -1,0 +1,1 @@
+Fix a bug in node creating that could cause duplicate relationships if the node being created included a relationship to a node of a schema that had its kind or inheritance updated in the past


### PR DESCRIPTION
IFC-1648
relates to #6812 

root cause of this bug is that when creating a node, if that node includes relationships to a node that has had its kind/inheritance updated (resulting in 2 nodes with the same UUID), then the `NodeCreateAllQuery` will create illegal relationships to all nodes with the given UUID instead of just the active one

solving this problem completely required adding a new subquery to the `NodeCreateAllQuery` query that identifies the correct vertex in the database for the given peer of each relationship

### a few notes
- I had to remove the MERGE statement from the subqueries to create relationships. it has been replaced with a new MATCH subquery. this means that the `NodeCreateAllQuery` will no longer create a vertex for the peer of a relationship if that peer cannot be found. I think this is an improvement because we should not be creating nodes before their dependent peers are created. for example, creating an interface before creating the interface's device should not be allowed
- the `NodeCreateAllQuery` contains sneaky (and unfortunate) recursive logic that can end up calling the `NodeCreateAllQuery` for a different node within the instantiation of the `NodeCreateAllQuery`. I think this can only occur when creating a node that includes an IP item from a pool. This did not work well with the new subquery to get a relationship's peer b/c the peer could have been created with a timestamp _later than_ that of the first `NodeCreateAllQuery`. I chose to pass the `at` kwarg down into the logic to create a pool, but the better fix would be to rewrite this to remove the surprise recursion