### PR TITLE
Add Infrahub namespace to get resource mutations

### DIFF
--- a/backend/infrahub/graphql/schema.py
+++ b/backend/infrahub/graphql/schema.py
@@ -94,8 +94,14 @@ class InfrahubBaseMutation(ObjectType):
     CoreProposedChangeMerge = ProposedChangeMerge.Field()
     CoreGeneratorDefinitionRun = GeneratorDefinitionRequestRun.Field()
 
-    IPPrefixPoolGetResource = IPPrefixPoolGetResource.Field()
-    IPAddressPoolGetResource = IPAddressPoolGetResource.Field()
+    InfrahubIPPrefixPoolGetResource = IPPrefixPoolGetResource.Field()
+    InfrahubIPAddressPoolGetResource = IPAddressPoolGetResource.Field()
+    IPPrefixPoolGetResource = IPPrefixPoolGetResource.Field(
+        deprecation_reason="This mutation has been renamed to 'InfrahubIPPrefixPoolGetResource'. It will be removed in the next version of Infrahub."
+    )
+    IPAddressPoolGetResource = IPAddressPoolGetResource.Field(
+        deprecation_reason="This mutation has been renamed to 'InfrahubIPAddressPoolGetResource'. It will be removed in the next version of Infrahub."
+    )
 
     BranchCreate = BranchCreate.Field()
     BranchDelete = BranchDelete.Field()

--- a/backend/tests/unit/graphql/mutations/test_resource_manager.py
+++ b/backend/tests/unit/graphql/mutations/test_resource_manager.py
@@ -280,7 +280,7 @@ async def test_prefix_pool_get_resource(
     query = (
         """
     mutation {
-        IPPrefixPoolGetResource(data: {
+        InfrahubIPPrefixPoolGetResource(data: {
             id: "%s"
         }) {
             ok
@@ -305,8 +305,8 @@ async def test_prefix_pool_get_resource(
 
     assert not result.errors
     assert result.data
-    assert result.data["IPPrefixPoolGetResource"]["ok"]
-    assert result.data["IPPrefixPoolGetResource"]["node"] == {
+    assert result.data["InfrahubIPPrefixPoolGetResource"]["ok"]
+    assert result.data["InfrahubIPPrefixPoolGetResource"]["node"] == {
         "display_label": "10.10.0.0/24",
         "kind": "IpamIPPrefix",
     }
@@ -341,7 +341,7 @@ async def test_prefix_pool_get_resource_with_identifier(
     query = (
         """
     mutation {
-        IPPrefixPoolGetResource(data: {
+        InfrahubIPPrefixPoolGetResource(data: {
             id: "%s"
             identifier: "myidentifier"
         }) {
@@ -369,8 +369,8 @@ async def test_prefix_pool_get_resource_with_identifier(
 
     assert not result.errors
     assert result.data
-    assert result.data["IPPrefixPoolGetResource"]["ok"]
-    assert result.data["IPPrefixPoolGetResource"]["node"] == {
+    assert result.data["InfrahubIPPrefixPoolGetResource"]["ok"]
+    assert result.data["InfrahubIPPrefixPoolGetResource"]["node"] == {
         "id": resource.id,
         "display_label": "10.10.0.0/24",
         "kind": "IpamIPPrefix",
@@ -405,7 +405,7 @@ async def test_prefix_pool_get_resource_with_prefix_length(
     query = (
         """
     mutation {
-        IPPrefixPoolGetResource(data: {
+        InfrahubIPPrefixPoolGetResource(data: {
             id: "%s"
             prefix_length: 31
         }) {
@@ -431,8 +431,11 @@ async def test_prefix_pool_get_resource_with_prefix_length(
 
     assert not result.errors
     assert result.data
-    assert result.data["IPPrefixPoolGetResource"]["ok"]
-    assert result.data["IPPrefixPoolGetResource"]["node"] == {"display_label": "10.10.0.0/31", "kind": "IpamIPPrefix"}
+    assert result.data["InfrahubIPPrefixPoolGetResource"]["ok"]
+    assert result.data["InfrahubIPPrefixPoolGetResource"]["node"] == {
+        "display_label": "10.10.0.0/31",
+        "kind": "IpamIPPrefix",
+    }
 
 
 async def test_address_pool_get_resource(
@@ -461,7 +464,7 @@ async def test_address_pool_get_resource(
     query = (
         """
     mutation {
-        IPAddressPoolGetResource(data: {
+        InfrahubIPAddressPoolGetResource(data: {
             id: "%s"
         }) {
             ok
@@ -486,8 +489,11 @@ async def test_address_pool_get_resource(
 
     assert not result.errors
     assert result.data
-    assert result.data["IPAddressPoolGetResource"]["ok"]
-    assert result.data["IPAddressPoolGetResource"]["node"] == {"display_label": "10.10.3.2/27", "kind": "IpamIPAddress"}
+    assert result.data["InfrahubIPAddressPoolGetResource"]["ok"]
+    assert result.data["InfrahubIPAddressPoolGetResource"]["node"] == {
+        "display_label": "10.10.3.2/27",
+        "kind": "IpamIPAddress",
+    }
 
 
 async def test_address_pool_get_resource_with_identifier(
@@ -518,7 +524,7 @@ async def test_address_pool_get_resource_with_identifier(
     query = (
         """
     mutation {
-        IPAddressPoolGetResource(data: {
+        InfrahubIPAddressPoolGetResource(data: {
             id: "%s"
             identifier: "myidentifier"
         }) {
@@ -546,8 +552,8 @@ async def test_address_pool_get_resource_with_identifier(
 
     assert not result.errors
     assert result.data
-    assert result.data["IPAddressPoolGetResource"]["ok"]
-    assert result.data["IPAddressPoolGetResource"]["node"] == {
+    assert result.data["InfrahubIPAddressPoolGetResource"]["ok"]
+    assert result.data["InfrahubIPAddressPoolGetResource"]["node"] == {
         "id": resource.id,
         "display_label": "10.10.3.2/27",
         "kind": "IpamIPAddress",
@@ -581,7 +587,7 @@ async def test_address_pool_get_resource_with_prefix_length(
     query = (
         """
     mutation {
-        IPAddressPoolGetResource(data: {
+        InfrahubIPAddressPoolGetResource(data: {
             id: "%s"
             prefix_length: 32
         }) {
@@ -607,8 +613,11 @@ async def test_address_pool_get_resource_with_prefix_length(
 
     assert not result.errors
     assert result.data
-    assert result.data["IPAddressPoolGetResource"]["ok"]
-    assert result.data["IPAddressPoolGetResource"]["node"] == {"display_label": "10.10.3.2/32", "kind": "IpamIPAddress"}
+    assert result.data["InfrahubIPAddressPoolGetResource"]["ok"]
+    assert result.data["InfrahubIPAddressPoolGetResource"]["node"] == {
+        "display_label": "10.10.3.2/32",
+        "kind": "IpamIPAddress",
+    }
 
 
 CREATE_NUMBER_POOL = """

--- a/changelog/+ifc1601.changed.md
+++ b/changelog/+ifc1601.changed.md
@@ -1,1 +1,1 @@
-Deprecate `IPAddressGetNextAvailable` and `IPPrefixGetNextAvailable` in favour of `InfrahubIPAddressGetNextAvailable` and `InfrahubIPPrefixGetNextAvailable` respectively
+Deprecate `IPAddressGetNextAvailable` and `IPPrefixGetNextAvailable` in favour of `InfrahubIPAddressGetNextAvailable` and `InfrahubIPPrefixGetNextAvailable` respectively. Also deprecate mutations `IPPrefixPoolGetResource` and `IPAddressPoolGetResource` in favour of `IPPrefixPoolGetResource` and `InfrahubIPAddressPoolGetResource`.

--- a/docs/docs/guides/resource-manager.mdx
+++ b/docs/docs/guides/resource-manager.mdx
@@ -230,7 +230,7 @@ Execute the following mutation to allocate an IP address out of the pool. Replac
 
   ```graphql
     mutation {
-      IPAddressPoolGetResource(
+      InfrahubIPAddressPoolGetResource(
         data: {
           id: "<id of resource pool>",
           data: {
@@ -264,7 +264,7 @@ Execute this mutation twice, note the identifier. The resulting IP address shoul
 
   ```graphql
     mutation {
-      IPAddressPoolGetResource(data: {
+      InfrahubIPAddressPoolGetResource(data: {
         id: "<id of resource pool>",
         identifier: "my-allocated-ip",
       })
@@ -430,7 +430,7 @@ Execute the following mutation to allocate an IP prefix out of the pool. Replace
 
   ```graphql
     mutation {
-      IPPrefixPoolGetResource(data: {
+      InfrahubIPPrefixPoolGetResource(data: {
         id: "<id of resource pool>",
         data: {
           description: "prefix allocated to point to point connection"
@@ -502,7 +502,7 @@ Execute this mutation twice, note the identifier. The resulting IP prefix should
 
   ```graphql
     mutation {
-      IPPrefixPoolGetResource(data: {
+      InfrahubIPPrefixPoolGetResource(data: {
         id: "<id of resource pool>",
         identifier: "my-allocated-prefix",
       })
@@ -664,7 +664,7 @@ Allocate a new IP address in the `test` branch using this mutation. Replace the 
 
   ```graphql
     mutation {
-      IPAddressPoolGetResource(
+      InfrahubIPAddressPoolGetResource(
         data: {
           id: "<id of resource pool>",
       })


### PR DESCRIPTION
Keep the old ones for now but mark them as deprecated like we did for
queries in original IFC-1601.