### PR TITLE
duplicate Relationships cleanup migration

### DIFF
--- a/backend/infrahub/core/migrations/graph/__init__.py
+++ b/backend/infrahub/core/migrations/graph/__init__.py
@@ -34,6 +34,7 @@ from .m029_duplicates_cleanup import Migration029
 from .m030_illegal_edges import Migration030
 from .m031_check_number_attributes import Migration031
 from .m032_cleanup_orphaned_branch_relationships import Migration032
+from .m033_deduplicate_relationship_vertices import Migration033
 
 if TYPE_CHECKING:
     from infrahub.core.root import Root
@@ -73,6 +74,7 @@ MIGRATIONS: list[type[GraphMigration | InternalSchemaMigration | ArbitraryMigrat
     Migration030,
     Migration031,
     Migration032,
+    Migration033,
 ]
 
 

--- a/backend/infrahub/core/migrations/graph/m033_deduplicate_relationship_vertices.py
+++ b/backend/infrahub/core/migrations/graph/m033_deduplicate_relationship_vertices.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Sequence
+
+from infrahub.core.migrations.shared import GraphMigration, MigrationResult
+from infrahub.log import get_logger
+
+from ...query import Query, QueryType
+
+if TYPE_CHECKING:
+    from infrahub.database import InfrahubDatabase
+
+log = get_logger()
+
+
+class DeduplicateRelationshipVerticesQuery(Query):
+    """
+    For each group of duplicate Relationships with the same UUID, delete any Relationship that meets the following criteria:
+    - is linked to a deleted node (only if the delete time is before the Relationship's from time)
+    - is linked to a node on an incorrect branch (ie Relationship added on main, but Node is on a branch)
+    """
+
+    name = "deduplicate_relationship_vertices"
+    type = QueryType.WRITE
+    insert_return = False
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
+        query = """
+MATCH (root:Root)
+WITH root.default_branch AS default_branch_name
+// ------------
+// Find all Relationship vertices with duplicate UUIDs
+// ------------
+MATCH (r:Relationship)
+WITH r.uuid AS r_uuid, default_branch_name, count(*) AS num_dups
+WHERE num_dups > 1
+WITH DISTINCT r_uuid, default_branch_name
+// ------------
+// get the branched_from time for each relationship edge and node
+// ------------
+MATCH (rel:Relationship {uuid: r_uuid})
+CALL (rel) {
+    MATCH (rel)-[is_rel_e:IS_RELATED {status: "active"}]-(n:Node)
+    MATCH (rel_branch:Branch {name: is_rel_e.branch})
+    RETURN is_rel_e, rel_branch.branched_from AS rel_branched_from, n
+}
+// ------------
+// for each IS_RELATED edge of the relationship, check the IS_PART_OF edges of the Node vertex
+// to determine if this side of the relationship is legal
+// ------------
+CALL (n, is_rel_e, rel_branched_from, default_branch_name) {
+    OPTIONAL MATCH (n)-[is_part_of_e:IS_PART_OF {status: "active"}]->(:Root)
+    WHERE (
+        // the Node's create time must precede the Relationship's create time
+        is_part_of_e.from <= is_rel_e.from AND (is_part_of_e.to >= is_rel_e.from OR is_part_of_e.to IS NULL)
+        // the Node must have been created on a branch of equal or lesser depth than the Relationship
+        AND is_part_of_e.branch_level <= is_rel_e.branch_level
+        // if the Node and Relationships were created on branch_level = 2, then they must be on the same branch
+        AND (
+            is_part_of_e.branch_level = 1
+            OR is_part_of_e.branch = is_rel_e.branch
+        )
+        // if the Node was created on the default branch, and the Relationship was created on a branch,
+        // then the Node must have been created after the branched_from time of the Relationship's branch
+        AND (
+            is_part_of_e.branch <> default_branch_name
+            OR is_rel_e.branch_level = 1
+            OR is_part_of_e.from <= rel_branched_from
+        )
+    )
+    WITH is_part_of_e IS NOT NULL AS is_legal
+    ORDER BY is_legal DESC
+    RETURN is_legal
+    LIMIT 1
+}
+WITH rel, is_legal
+ORDER BY rel, is_legal ASC
+WITH rel, head(collect(is_legal)) AS is_legal
+WHERE is_legal = false
+DETACH DELETE rel
+        """
+        self.add_to_query(query)
+
+
+class Migration033(GraphMigration):
+    """
+    Identifies duplicate Relationship vertices that have the same UUID property. Deletes any duplicates that
+    are linked to deleted nodes or nodes on in incorrect branch.
+    """
+
+    name: str = "032_deduplicate_relationship_vertices"
+    minimum_version: int = 31
+    queries: Sequence[type[Query]] = [DeduplicateRelationshipVerticesQuery]
+
+    async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
+        result = MigrationResult()
+        return result

--- a/backend/tests/unit/core/migrations/graph/test_033.py
+++ b/backend/tests/unit/core/migrations/graph/test_033.py
@@ -1,0 +1,329 @@
+import pytest
+
+from infrahub.core.constants import GLOBAL_BRANCH_NAME
+from infrahub.core.migrations.graph.m033_deduplicate_relationship_vertices import Migration033
+from infrahub.core.utils import delete_all_nodes
+from infrahub.database import InfrahubDatabase
+
+
+class TestMigration033:
+    @pytest.fixture(scope="class")
+    async def legal_relationship_dicts(self) -> list[dict[str, str | int]]:
+        return [
+            # node on main, rel on main created after node
+            {
+                "uuid": "legal_main_main",
+                "source_uuid": "main_node_zero",
+                "dest_uuid": "main_node",
+                "branch": "main",
+                "branch_level": 1,
+                "from_time": "2025-01-02T00:00:01Z",
+            },
+            # node on main, rel on branch (created before node) created after node
+            {
+                "uuid": "legal_main_branch",
+                "source_uuid": "main_node_zero",
+                "dest_uuid": "branch_a_node_one",
+                "branch": "branch_a",
+                "branch_level": 2,
+                "from_time": "2025-01-03T00:00:02Z",
+            },
+            # node on main, rel on global created after node
+            {
+                "uuid": "legal_main_global",
+                "source_uuid": "main_node_zero",
+                "dest_uuid": "global_node",
+                "branch": GLOBAL_BRANCH_NAME,
+                "branch_level": 1,
+                "from_time": "2025-01-01T00:00:01Z",
+            },
+            # node on global, rel on main created after node
+            {
+                "uuid": "legal_global_main",
+                "source_uuid": "global_node",
+                "dest_uuid": "main_node",
+                "branch": "main",
+                "branch_level": 1,
+                "from_time": "2025-01-02T00:00:02Z",
+            },
+            # node on global, rel on branch created after node
+            {
+                "uuid": "legal_global_branch",
+                "source_uuid": "global_node",
+                "dest_uuid": "branch_a_node_one",
+                "branch": "branch_a",
+                "branch_level": 2,
+                "from_time": "2025-01-03T00:00:02Z",
+            },
+            # node on global, rel on global created after node
+            {
+                "uuid": "legal_global_global",
+                "source_uuid": "global_node",
+                "dest_uuid": "global_node_zero",
+                "branch": GLOBAL_BRANCH_NAME,
+                "branch_level": 1,
+                "from_time": "2025-01-01T00:00:03Z",
+            },
+            # node on branch, rel on same branch created after node
+            {
+                "uuid": "legal_branch_branch",
+                "source_uuid": "branch_a_node_one",
+                "dest_uuid": "branch_a_node_two",
+                "branch": "branch_a",
+                "branch_level": 2,
+                "from_time": "2025-01-04T00:00:02Z",
+            },
+        ]
+
+    @pytest.fixture(scope="class")
+    async def illegal_relationship_dicts(self) -> list[dict[str, str | int]]:
+        return [
+            # node on main, rel on global created before node
+            {
+                "uuid": "illegal_main_global",
+                "source_uuid": "main_node",
+                "dest_uuid": "global_node",
+                "branch": "main",
+                "branch_level": 1,
+                "from_time": "2024-12-31T00:00:01Z",
+            },
+            # node on main, rel on main created before node
+            {
+                "uuid": "illegal_main_main",
+                "source_uuid": "main_node_zero",
+                "dest_uuid": "main_node",
+                "branch": "main",
+                "branch_level": 1,
+                "from_time": "2024-12-31T00:00:0Z",
+            },
+            # node on main, rel on branch (created before node) created before node
+            {
+                "uuid": "illegal_main_branch_one",
+                "source_uuid": "main_node_last",
+                "dest_uuid": "branch_a_node_one",
+                "branch": "branch_a",
+                "branch_level": 2,
+                "from_time": "2024-01-31T00:00:00Z",
+            },
+            # node on main, rel on branch (created before node) created after node
+            {
+                "uuid": "illegal_main_branch_two",
+                "source_uuid": "main_node_last",
+                "dest_uuid": "branch_a_node_one",
+                "branch": "branch_a",
+                "branch_level": 2,
+                "from_time": "2025-01-31T00:00:00Z",
+            },
+            # node on global, rel on global created before node
+            {
+                "uuid": "illegal_global_global",
+                "source_uuid": "global_node",
+                "dest_uuid": "global_node_zero",
+                "branch": GLOBAL_BRANCH_NAME,
+                "branch_level": 1,
+                "from_time": "2024-12-31T00:00:01Z",
+            },
+            # node on global, rel on main created before node
+            {
+                "uuid": "illegal_global_main",
+                "source_uuid": "global_node",
+                "dest_uuid": "main_node",
+                "branch": "main",
+                "branch_level": 1,
+                "from_time": "2024-12-31T00:00:0Z",
+            },
+            # node on global, rel on branch (created before node) created before node
+            {
+                "uuid": "illegal_global_branch_one",
+                "source_uuid": "global_node_last",
+                "dest_uuid": "branch_a_node_one",
+                "branch": "branch_a",
+                "branch_level": 2,
+                "from_time": "2024-01-31T00:00:00Z",
+            },
+            # node on global, rel on branch (created before node) created after node
+            {
+                "uuid": "illegal_global_branch_two",
+                "source_uuid": "global_node_last",
+                "dest_uuid": "branch_a_node_one",
+                "branch": "branch_a",
+                "branch_level": 2,
+                "from_time": "2025-01-31T00:00:00Z",
+            },
+            # node on branch, rel on different branch created before node
+            {
+                "uuid": "illegal_branch_branch_one",
+                "source_uuid": "branch_a_node_one",
+                "dest_uuid": "branch_b_node_one",
+                "branch": "branch_a",
+                "branch_level": 2,
+                "from_time": "2024-01-31T00:00:00Z",
+            },
+            # node on branch, rel on different branch created after node
+            {
+                "uuid": "illegal_branch_branch_two",
+                "source_uuid": "branch_a_node_one",
+                "dest_uuid": "branch_b_node_one",
+                "branch": "branch_a",
+                "branch_level": 2,
+                "from_time": "2025-01-31T00:00:00Z",
+            },
+            # node on branch, rel on same branch created before node
+            {
+                "uuid": "illegal_branch_branch_three",
+                "source_uuid": "branch_a_node_one",
+                "dest_uuid": "branch_a_node_two",
+                "branch": "branch_a",
+                "branch_level": 2,
+                "from_time": "2024-01-31T00:00:00Z",
+            },
+        ]
+
+    @pytest.fixture(scope="class")
+    async def load_bad_data(
+        self,
+        db: InfrahubDatabase,
+        legal_relationship_dicts: list[dict[str, str | int]],
+        illegal_relationship_dicts: list[dict[str, str | int]],
+    ):
+        await delete_all_nodes(db=db)
+        root_and_branch_query = """
+MERGE (root:Root {default_branch: "main"})
+MERGE (main:Branch {name: "main", branched_from: "2023-01-01T00:00:00"})
+MERGE (global:Branch {name: "-global-", branched_from: "2023-01-02T00:00:00"})
+MERGE (branch_a:Branch {name: "branch_a", branched_from: "2025-01-03T00:00:00"})
+MERGE (branch_b:Branch {name: "branch_b", branched_from: "2025-01-04T00:00:00"})
+        """
+        await db.execute_query(query=root_and_branch_query)
+
+        nodes = [
+            # main node zero - 2024-01-01
+            {
+                "labels": ["MainNode"],
+                "uuid": "main_node_zero",
+                "branch": "main",
+                "branch_level": 1,
+                "from_time": "2024-01-01T00:00:00Z",
+            },
+            # global node zero - 2024-01-02
+            {
+                "labels": ["GlobalNode"],
+                "uuid": "global_node_zero",
+                "branch": GLOBAL_BRANCH_NAME,
+                "branch_level": 1,
+                "from_time": "2024-01-02T00:00:00Z",
+            },
+            # main node - 2025-01-02
+            {
+                "labels": ["MainNode"],
+                "uuid": "main_node",
+                "branch": "main",
+                "branch_level": 1,
+                "from_time": "2025-01-02T00:00:00Z",
+            },
+            # main node last - 2026-01-01
+            {
+                "labels": ["MainNode"],
+                "uuid": "main_node_last",
+                "branch": "main",
+                "branch_level": 1,
+                "from_time": "2026-01-01T00:00:00Z",
+            },
+            # global node - 2025-01-01
+            {
+                "labels": ["GlobalNode"],
+                "uuid": "global_node",
+                "branch": GLOBAL_BRANCH_NAME,
+                "branch_level": 1,
+                "from_time": "2025-01-01T00:00:00Z",
+            },
+            # global node last - 2026-01-02
+            {
+                "labels": ["GlobalNode"],
+                "uuid": "global_node_last",
+                "branch": GLOBAL_BRANCH_NAME,
+                "branch_level": 1,
+                "from_time": "2026-01-02T00:00:00Z",
+            },
+            # branch A node one - 2025-01-03
+            {
+                "labels": ["BranchNode"],
+                "uuid": "branch_a_node_one",
+                "branch": "branch_a",
+                "branch_level": 2,
+                "from_time": "2025-01-03T00:00:01Z",
+            },
+            # branch A node two - 2025-01-03
+            {
+                "labels": ["BranchNode"],
+                "uuid": "branch_a_node_two",
+                "branch": "branch_a",
+                "branch_level": 2,
+                "from_time": "2025-01-03T01:00:01Z",
+            },
+            # branch B node one - 2025-01-04
+            {
+                "labels": ["BranchNode"],
+                "uuid": "branch_b_node_one",
+                "branch": "branch_b",
+                "branch_level": 2,
+                "from_time": "2025-01-04T00:00:01Z",
+            },
+            # branch node two - 2025-01-04
+            {
+                "labels": ["BranchNode"],
+                "uuid": "branch_b_node_two",
+                "branch": "branch_b",
+                "branch_level": 2,
+                "from_time": "2025-01-04T01:00:01Z",
+            },
+        ]
+
+        for node_dict in nodes:
+            create_node_query = """
+MATCH (root:Root)
+CREATE (n:Node:%(node_labels)s {uuid: "%(uuid)s"})
+CREATE (n)-[:IS_PART_OF {status: "active", branch: "%(branch)s", branch_level: %(branch_level)s, from: "%(from_time)s"}]->(root)
+            """ % {
+                "node_labels": " ".join(node_dict["labels"]),
+                "uuid": node_dict["uuid"],
+                "branch": node_dict["branch"],
+                "branch_level": node_dict["branch_level"],
+                "from_time": node_dict["from_time"],
+            }
+            await db.execute_query(query=create_node_query)
+
+        create_relationships_query = """
+UNWIND $relationships AS rel
+MATCH (source_node:Node {uuid: rel.source_uuid})
+MATCH (dest_node:Node {uuid: rel.dest_uuid})
+CREATE (rel_node_one:Relationship {uuid: rel.uuid})
+CREATE (source_node)-[:IS_RELATED {status: "active", branch: rel.branch, branch_level: rel.branch_level, from: rel.from_time}]->(rel_node_one)
+CREATE (rel_node_one)-[:IS_RELATED {status: "active", branch: rel.branch, branch_level: rel.branch_level, from: rel.from_time}]->(dest_node)
+// duplicate relationship so the migration will examine them
+CREATE (rel_node_two:Relationship {uuid: rel.uuid})
+CREATE (source_node)-[:IS_RELATED {status: "active", branch: rel.branch, branch_level: rel.branch_level, from: rel.from_time}]->(rel_node_two)
+CREATE (rel_node_two)-[:IS_RELATED {status: "active", branch: rel.branch, branch_level: rel.branch_level, from: rel.from_time}]->(dest_node)
+        """
+
+        await db.execute_query(
+            query=create_relationships_query,
+            params={"relationships": legal_relationship_dicts + illegal_relationship_dicts},
+        )
+
+    async def test_migration_033(self, db: InfrahubDatabase, load_bad_data, legal_relationship_dicts):
+        # Run the migration
+        migration = Migration033(db=db)
+        execution_result = await migration.execute(db=db)
+        assert not execution_result.errors
+        validation_result = await migration.validate_migration(db=db)
+        assert not validation_result.errors
+
+        all_relationships_query = """
+MATCH (r:Relationship)
+RETURN r.uuid AS uuid
+"""
+        results = await db.execute_query(query=all_relationships_query)
+        all_relationships = {r["uuid"] for r in results}
+        expected_relationships = {r["uuid"] for r in legal_relationship_dicts}
+        assert all_relationships == expected_relationships

--- a/backend/tests/unit/core/migrations/graph/test_033.py
+++ b/backend/tests/unit/core/migrations/graph/test_033.py
@@ -73,6 +73,15 @@ class TestMigration033:
                 "branch_level": 2,
                 "from_time": "2025-01-04T00:00:02Z",
             },
+            # node on branch deleted, rel on branch during node active time
+            {
+                "uuid": "legal_branch_branch_deleted",
+                "source_uuid": "branch_a_node_deleted",
+                "dest_uuid": "branch_a_node_one",
+                "branch": "branch_a",
+                "branch_level": 2,
+                "from_time": "2025-01-03T02:00:01Z",
+            },
         ]
 
     @pytest.fixture(scope="class")
@@ -177,6 +186,15 @@ class TestMigration033:
                 "branch_level": 2,
                 "from_time": "2024-01-31T00:00:00Z",
             },
+            # node on branch deleted, rel on same branch after node deleted
+            {
+                "uuid": "illegal_branch_branch_deleted",
+                "source_uuid": "branch_a_node_deleted",
+                "dest_uuid": "branch_a_node_one",
+                "branch": "branch_a",
+                "branch_level": 2,
+                "from_time": "2025-02-03T02:00:03Z",
+            },
         ]
 
     @pytest.fixture(scope="class")
@@ -261,6 +279,15 @@ MERGE (branch_b:Branch {name: "branch_b", branched_from: "2025-01-04T00:00:00"})
                 "branch_level": 2,
                 "from_time": "2025-01-03T01:00:01Z",
             },
+            # branch A node deleted - 2025-01-03
+            {
+                "labels": ["BranchNode"],
+                "uuid": "branch_a_node_deleted",
+                "branch": "branch_a",
+                "branch_level": 2,
+                "from_time": "2025-01-03T02:00:01Z",
+                "to_time": "2025-02-03T02:00:02Z",
+            },
             # branch B node one - 2025-01-04
             {
                 "labels": ["BranchNode"],
@@ -269,7 +296,7 @@ MERGE (branch_b:Branch {name: "branch_b", branched_from: "2025-01-04T00:00:00"})
                 "branch_level": 2,
                 "from_time": "2025-01-04T00:00:01Z",
             },
-            # branch node two - 2025-01-04
+            # branch B node two - 2025-01-04
             {
                 "labels": ["BranchNode"],
                 "uuid": "branch_b_node_two",
@@ -280,18 +307,15 @@ MERGE (branch_b:Branch {name: "branch_b", branched_from: "2025-01-04T00:00:00"})
         ]
 
         for node_dict in nodes:
+            # ruff: noqa: E501
             create_node_query = """
 MATCH (root:Root)
-CREATE (n:Node:%(node_labels)s {uuid: "%(uuid)s"})
-CREATE (n)-[:IS_PART_OF {status: "active", branch: "%(branch)s", branch_level: %(branch_level)s, from: "%(from_time)s"}]->(root)
+CREATE (n:Node:%(node_labels)s {uuid: $node_dict.uuid})
+CREATE (n)-[:IS_PART_OF {status: "active", branch: $node_dict.branch, branch_level: $node_dict.branch_level, from: $node_dict.from_time, to: $node_dict.to_time}]->(root)
             """ % {
                 "node_labels": " ".join(node_dict["labels"]),
-                "uuid": node_dict["uuid"],
-                "branch": node_dict["branch"],
-                "branch_level": node_dict["branch_level"],
-                "from_time": node_dict["from_time"],
             }
-            await db.execute_query(query=create_node_query)
+            await db.execute_query(query=create_node_query, params={"node_dict": node_dict})
 
         create_relationships_query = """
 UNWIND $relationships AS rel
@@ -313,7 +337,7 @@ CREATE (rel_node_two)-[:IS_RELATED {status: "active", branch: rel.branch, branch
 
     async def test_migration_033(self, db: InfrahubDatabase, load_bad_data, legal_relationship_dicts):
         # Run the migration
-        migration = Migration033(db=db)
+        migration = Migration033()
         execution_result = await migration.execute(db=db)
         assert not execution_result.errors
         validation_result = await migration.validate_migration(db=db)

--- a/changelog/+delete-dup-rels.fixed.md
+++ b/changelog/+delete-dup-rels.fixed.md
@@ -1,0 +1,1 @@
+Migration to clean up duplicated relationships


### PR DESCRIPTION
IFC-1648
relates to #6803 

the actual bug is addressed in #6803 

> root cause of this bug is that when creating a node, if that node includes relationships to a node that has had its kind/inheritance updated (resulting in 2 nodes with the same UUID), then the NodeCreateAllQuery will create illegal relationships to all nodes with the given UUID instead of just the active one

this PR adds a migration to remove these illegal duplicate Relationship vertexes