### PR TITLE
Add migration for Attribute NumberPool on existing nodes

### DIFF
--- a/backend/infrahub/core/migrations/schema/node_attribute_add.py
+++ b/backend/infrahub/core/migrations/schema/node_attribute_add.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Sequence
 from infrahub.core import registry
 from infrahub.core.node import Node
 from infrahub.exceptions import PoolExhaustedError
+from infrahub.tasks.registry import refresh_branches
 
 from ..query import AttributeMigrationQuery
 from ..query.attribute_add import AttributeAddQuery
@@ -55,6 +56,8 @@ class NodeAttributeAddMigration(AttributeSchemaMigration):
             db=db, branch=branch, schema_node=self.new_schema, schema_attribute=self.new_attribute_schema
         )
 
+        await refresh_branches(db=db)
+
         # To do, implement pagination for large number pools
         nodes: list[Node] = await registry.manager.query(
             db=db, branch=branch, schema=self.new_schema, fields={"id": True, self.new_attribute_schema.name: True}
@@ -71,9 +74,9 @@ class NodeAttributeAddMigration(AttributeSchemaMigration):
             result.errors.append(str(exc))
             return result
 
-        for node, number in zip(nodes, numbers, strict=False):
+        for node, number in zip(nodes, numbers, strict=True):
             await number_pool.reserve(db=db, number=number, identifier=node.get_id())
             getattr(node, self.new_attribute_schema.name).value = number
-            await node.save(db=db)
+            await node.save(db=db, fields=[self.new_attribute_schema.name])
 
         return result

--- a/backend/infrahub/core/migrations/schema/node_attribute_add.py
+++ b/backend/infrahub/core/migrations/schema/node_attribute_add.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Sequence
 from infrahub.core import registry
 from infrahub.core.node import Node
 from infrahub.exceptions import PoolExhaustedError
-from infrahub.tasks.registry import refresh_branches
+from infrahub.tasks.registry import update_branch_registry
 
 from ..query import AttributeMigrationQuery
 from ..query.attribute_add import AttributeAddQuery
@@ -56,9 +56,8 @@ class NodeAttributeAddMigration(AttributeSchemaMigration):
             db=db, branch=branch, schema_node=self.new_schema, schema_attribute=self.new_attribute_schema
         )
 
-        await refresh_branches(db=db)
+        await update_branch_registry(db=db, branch=branch)
 
-        # To do, implement pagination for large number pools
         nodes: list[Node] = await registry.manager.query(
             db=db, branch=branch, schema=self.new_schema, fields={"id": True, self.new_attribute_schema.name: True}
         )

--- a/backend/infrahub/core/migrations/schema/node_attribute_add.py
+++ b/backend/infrahub/core/migrations/schema/node_attribute_add.py
@@ -75,7 +75,10 @@ class NodeAttributeAddMigration(AttributeSchemaMigration):
 
         for node, number in zip(nodes, numbers, strict=True):
             await number_pool.reserve(db=db, number=number, identifier=node.get_id())
-            getattr(node, self.new_attribute_schema.name).value = number
+            attr = getattr(node, self.new_attribute_schema.name)
+            attr.value = number
+            attr.source = number_pool.id
+
             await node.save(db=db, fields=[self.new_attribute_schema.name])
 
         return result

--- a/backend/infrahub/core/migrations/schema/node_attribute_add.py
+++ b/backend/infrahub/core/migrations/schema/node_attribute_add.py
@@ -11,6 +11,7 @@ from ..query.attribute_add import AttributeAddQuery
 from ..shared import AttributeSchemaMigration, MigrationResult
 
 if TYPE_CHECKING:
+    from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
     from infrahub.database import InfrahubDatabase
 
     from ...branch import Branch
@@ -50,13 +51,13 @@ class NodeAttributeAddMigration(AttributeSchemaMigration):
         if self.new_attribute_schema.kind != "NumberPool":
             return result
 
-        number_pool = await Node.fetch_or_create_number_pool(
-            db=db, branch=branch, schema_node=self.new_node_schema, schema_attribute=self.new_attribute_schema
+        number_pool: CoreNumberPool = await Node.fetch_or_create_number_pool(  # type: ignore[assignment]
+            db=db, branch=branch, schema_node=self.new_schema, schema_attribute=self.new_attribute_schema
         )
 
         # To do, implement pagination for large number pools
         nodes: list[Node] = await registry.manager.query(
-            db=db, branch=branch, schema=self.new_node_schema, fields={"id": True, self.new_attribute_schema.name: True}
+            db=db, branch=branch, schema=self.new_schema, fields={"id": True, self.new_attribute_schema.name: True}
         )
 
         try:
@@ -71,6 +72,8 @@ class NodeAttributeAddMigration(AttributeSchemaMigration):
             return result
 
         for node, number in zip(nodes, numbers, strict=False):
-            number_pool.reserve(db=db, number=number, identifier=node.get_id())
+            await number_pool.reserve(db=db, number=number, identifier=node.get_id())
             getattr(node, self.new_attribute_schema.name).value = number
             await node.save(db=db)
+
+        return result

--- a/backend/infrahub/core/migrations/schema/node_attribute_add.py
+++ b/backend/infrahub/core/migrations/schema/node_attribute_add.py
@@ -1,10 +1,20 @@
 from __future__ import annotations
 
-from typing import Any, Sequence
+from typing import TYPE_CHECKING, Any, Sequence
+
+from infrahub.core import registry
+from infrahub.core.node import Node
+from infrahub.exceptions import PoolExhaustedError
 
 from ..query import AttributeMigrationQuery
 from ..query.attribute_add import AttributeAddQuery
-from ..shared import AttributeSchemaMigration
+from ..shared import AttributeSchemaMigration, MigrationResult
+
+if TYPE_CHECKING:
+    from infrahub.database import InfrahubDatabase
+
+    from ...branch import Branch
+    from ...timestamp import Timestamp
 
 
 class NodeAttributeAddMigrationQuery01(AttributeMigrationQuery, AttributeAddQuery):
@@ -29,3 +39,38 @@ class NodeAttributeAddMigrationQuery01(AttributeMigrationQuery, AttributeAddQuer
 class NodeAttributeAddMigration(AttributeSchemaMigration):
     name: str = "node.attribute.add"
     queries: Sequence[type[AttributeMigrationQuery]] = [NodeAttributeAddMigrationQuery01]  # type: ignore[assignment]
+
+    async def execute_post_queries(
+        self,
+        db: InfrahubDatabase,
+        result: MigrationResult,
+        branch: Branch,
+        at: Timestamp,  # noqa: ARG002
+    ) -> MigrationResult:
+        if self.new_attribute_schema.kind != "NumberPool":
+            return result
+
+        number_pool = await Node.fetch_or_create_number_pool(
+            db=db, branch=branch, schema_node=self.new_node_schema, schema_attribute=self.new_attribute_schema
+        )
+
+        # To do, implement pagination for large number pools
+        nodes: list[Node] = await registry.manager.query(
+            db=db, branch=branch, schema=self.new_node_schema, fields={"id": True, self.new_attribute_schema.name: True}
+        )
+
+        try:
+            numbers = await number_pool.get_next_many(
+                db=db,
+                branch=branch,
+                quantity=len(nodes),
+                attribute=self.new_attribute_schema,
+            )
+        except PoolExhaustedError as exc:
+            result.errors.append(str(exc))
+            return result
+
+        for node, number in zip(nodes, numbers, strict=False):
+            number_pool.reserve(db=db, number=number, identifier=node.get_id())
+            getattr(node, self.new_attribute_schema.name).value = number
+            await node.save(db=db)

--- a/backend/infrahub/core/migrations/shared.py
+++ b/backend/infrahub/core/migrations/shared.py
@@ -82,7 +82,7 @@ class SchemaMigration(BaseModel):
     async def execute(self, db: InfrahubDatabase, branch: Branch, at: Timestamp | str | None = None) -> MigrationResult:
         async with db.start_transaction() as ts:
             result = MigrationResult()
-            at = at or Timestamp()
+            at = Timestamp(at)
 
             await self.execute_pre_queries(db=ts, result=result, branch=branch, at=at)
             await self.execute_queries(db=ts, result=result, branch=branch, at=at)

--- a/backend/infrahub/core/migrations/shared.py
+++ b/backend/infrahub/core/migrations/shared.py
@@ -16,13 +16,13 @@ from infrahub.core.schema import (
     SchemaRoot,
     internal_schema,
 )
+from infrahub.core.timestamp import Timestamp
 
 from .query import MigrationQuery  # noqa: TC001
 
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
     from infrahub.core.schema.schema_branch import SchemaBranch
-    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
@@ -47,18 +47,46 @@ class SchemaMigration(BaseModel):
     previous_node_schema: NodeSchema | GenericSchema | None = None
     schema_path: SchemaPath
 
+    async def execute_pre_queries(
+        self,
+        db: InfrahubDatabase,  # noqa: ARG002
+        result: MigrationResult,
+        branch: Branch,  # noqa: ARG002
+        at: Timestamp,  # noqa: ARG002
+    ) -> MigrationResult:
+        return result
+
+    async def execute_post_queries(
+        self,
+        db: InfrahubDatabase,  # noqa: ARG002
+        result: MigrationResult,
+        branch: Branch,  # noqa: ARG002
+        at: Timestamp,  # noqa: ARG002
+    ) -> MigrationResult:
+        return result
+
+    async def execute_queries(
+        self, db: InfrahubDatabase, result: MigrationResult, branch: Branch, at: Timestamp
+    ) -> MigrationResult:
+        for migration_query in self.queries:
+            try:
+                query = await migration_query.init(db=db, branch=branch, at=at, migration=self)
+                await query.execute(db=db)
+                result.nbr_migrations_executed += query.get_nbr_migrations_executed()
+            except Exception as exc:
+                result.errors.append(str(exc))
+                return result
+
+        return result
+
     async def execute(self, db: InfrahubDatabase, branch: Branch, at: Timestamp | str | None = None) -> MigrationResult:
         async with db.start_transaction() as ts:
             result = MigrationResult()
+            at = at or Timestamp()
 
-            for migration_query in self.queries:
-                try:
-                    query = await migration_query.init(db=ts, branch=branch, at=at, migration=self)
-                    await query.execute(db=ts)
-                    result.nbr_migrations_executed += query.get_nbr_migrations_executed()
-                except Exception as exc:
-                    result.errors.append(str(exc))
-                    return result
+            await self.execute_pre_queries(db=ts, result=result, branch=branch, at=at)
+            await self.execute_queries(db=ts, result=result, branch=branch, at=at)
+            await self.execute_post_queries(db=ts, result=result, branch=branch, at=at)
 
         return result
 

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -26,6 +26,7 @@ from infrahub.core.protocols import CoreNumberPool, CoreObjectTemplate
 from infrahub.core.query.node import NodeCheckIDQuery, NodeCreateAllQuery, NodeDeleteQuery, NodeGetListQuery
 from infrahub.core.schema import (
     AttributeSchema,
+    GenericSchema,
     NodeSchema,
     NonGenericSchemaTypes,
     ProfileSchema,
@@ -315,7 +316,10 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
 
     @staticmethod
     async def fetch_or_create_number_pool(
-        db: InfrahubDatabase, schema_node: NodeSchema, schema_attribute: AttributeSchema, branch: Branch | None = None
+        db: InfrahubDatabase,
+        schema_node: NodeSchema | GenericSchema,
+        schema_attribute: AttributeSchema,
+        branch: Branch | None = None,
     ) -> CoreNumberPool:
         """Fetch or create a number pool based on the schema attribute parameters.
 

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -263,11 +263,9 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
         within the create code.
         """
 
-        number_pool_parameters: NumberPoolParameters | None = None
         if attribute.schema.kind == "NumberPool" and isinstance(attribute.schema.parameters, NumberPoolParameters):
             attribute.from_pool = {"id": attribute.schema.parameters.number_pool_id}
             attribute.is_default = False
-            number_pool_parameters = attribute.schema.parameters
 
         if not attribute.from_pool:
             return
@@ -277,9 +275,9 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
                 db=db, id=attribute.from_pool["id"], kind=CoreNumberPool
             )
         except NodeNotFoundError:
-            if number_pool_parameters:
-                number_pool = await self._fetch_or_create_number_pool(
-                    db=db, attribute=attribute, number_pool_parameters=number_pool_parameters
+            if attribute.schema.kind == "NumberPool" and isinstance(attribute.schema.parameters, NumberPoolParameters):
+                number_pool = await self.fetch_or_create_number_pool(
+                    db=db, schema_node=self._schema, schema_attribute=attribute.schema, branch=self._branch
                 )
 
             else:
@@ -295,7 +293,9 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
             and number_pool.node_attribute.value == attribute.name
         ):
             try:
-                next_free = await number_pool.get_resource(db=db, branch=self._branch, node=self, attribute=attribute)
+                next_free = await number_pool.get_resource(
+                    db=db, branch=self._branch, node=self, attribute=attribute.schema
+                )
             except PoolExhaustedError:
                 errors.append(
                     ValidationError({f"{attribute.name}.from_pool": f"The pool {number_pool.node.value} is exhausted."})
@@ -313,10 +313,25 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
                 )
             )
 
-    async def _fetch_or_create_number_pool(
-        self, db: InfrahubDatabase, attribute: BaseAttribute, number_pool_parameters: NumberPoolParameters
+    @staticmethod
+    async def fetch_or_create_number_pool(
+        db: InfrahubDatabase, schema_node: NodeSchema, schema_attribute: AttributeSchema, branch: Branch | None = None
     ) -> CoreNumberPool:
+        """Fetch or create a number pool based on the schema attribute parameters.
+
+        Warning, ideally this method should be outside of the Node class, but it is itself using the Node class to create the pool node.
+        """
+
+        if (
+            schema_attribute.kind != "NumberPool"
+            or not schema_attribute.parameters
+            or not isinstance(schema_attribute.parameters, NumberPoolParameters)
+        ):
+            raise ValueError("Attribute is not of type NumberPool")
+
         number_pool_from_db: CoreNumberPool | None = None
+        number_pool_parameters: NumberPoolParameters = schema_attribute.parameters
+
         lock_definition = NumberPoolLockDefinition(pool_id=str(number_pool_parameters.number_pool_id))
         async with lock.registry.get(
             name=lock_definition.lock_name, namespace=lock_definition.namespace_name, local=False
@@ -328,22 +343,21 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
             except NodeNotFoundError:
                 schema = db.schema.get_node_schema(name="CoreNumberPool", duplicate=False)
 
-                pool_node = self._schema.kind
-                schema_attribute = self._schema.get_attribute(attribute.schema.name)
+                pool_node = schema.kind
                 if schema_attribute.inherited:
-                    for generic_name in self._schema.inherit_from:
+                    for generic_name in schema_node.inherit_from:
                         generic_node = db.schema.get_generic_schema(name=generic_name, duplicate=False)
-                        if attribute.schema.name in generic_node.attribute_names:
+                        if schema_attribute.name in generic_node.attribute_names:
                             pool_node = generic_node.kind
                             break
 
-                number_pool = await Node.init(db=db, schema=schema, branch=self._branch)
+                number_pool = await Node.init(db=db, schema=schema, branch=branch)
                 await number_pool.new(
                     db=db,
                     id=number_pool_parameters.number_pool_id,
-                    name=f"{pool_node}.{attribute.schema.name} [{number_pool_parameters.number_pool_id}]",
+                    name=f"{pool_node}.{schema_attribute.name} [{number_pool_parameters.number_pool_id}]",
                     node=pool_node,
-                    node_attribute=attribute.schema.name,
+                    node_attribute=schema_attribute.name,
                     start_range=number_pool_parameters.start_range,
                     end_range=number_pool_parameters.end_range,
                     pool_type=NumberPoolType.SCHEMA.value,

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -344,10 +344,12 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
                 number_pool_from_db = await registry.manager.get_one_by_id_or_default_filter(
                     db=db, id=str(number_pool_parameters.number_pool_id), kind=CoreNumberPool
                 )
+                return number_pool_from_db  # type: ignore[return-value]
+
             except NodeNotFoundError:
                 schema = db.schema.get_node_schema(name="CoreNumberPool", duplicate=False)
 
-                pool_node = schema.kind
+                pool_node = schema_node.kind
                 if schema_attribute.inherited:
                     for generic_name in schema_node.inherit_from:
                         generic_node = db.schema.get_generic_schema(name=generic_name, duplicate=False)
@@ -368,12 +370,15 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
                 )
                 await number_pool.save(db=db)
 
-        # Do a lookup of the number pool to get the correct mapped type from the registry
-        # without this we don't get access to the .get_resource() method.
-        created_pool: CoreNumberPool = number_pool_from_db or await registry.manager.get_one_by_id_or_default_filter(
-            db=db, id=number_pool.id, kind=CoreNumberPool
-        )
-        return created_pool
+                # Do a lookup of the number pool to get the correct mapped type from the registry
+                # without this we don't get access to the .get_resource() method.
+                created_pool: CoreNumberPool = (
+                    number_pool_from_db
+                    or await registry.manager.get_one_by_id_or_default_filter(
+                        db=db, id=number_pool.id, kind=CoreNumberPool
+                    )
+                )
+                return created_pool
 
     async def handle_object_template(self, fields: dict, db: InfrahubDatabase, errors: list) -> None:
         """Fill the `fields` parameters with values from an object template if one is in use."""

--- a/backend/infrahub/core/node/resource_manager/number_pool.py
+++ b/backend/infrahub/core/node/resource_manager/number_pool.py
@@ -11,8 +11,8 @@ from .. import Node
 
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
-    from infrahub.core.timestamp import Timestamp
     from infrahub.core.schema import AttributeSchema
+    from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
@@ -48,7 +48,9 @@ class CoreNumberPool(Node):
     async def reserve(self, db: InfrahubDatabase, number: int, identifier: str, at: Timestamp | None = None) -> None:
         """Reserve a number in the pool for a specific identifier."""
 
-        query = await NumberPoolSetReserved.init(db=db, pool_id=self.get_id(), identifier=identifier, reserved=number, at=at)
+        query = await NumberPoolSetReserved.init(
+            db=db, pool_id=self.get_id(), identifier=identifier, reserved=number, at=at
+        )
         await query.execute(db=db)
 
     async def get_resource(

--- a/backend/infrahub/core/node/resource_manager/number_pool.py
+++ b/backend/infrahub/core/node/resource_manager/number_pool.py
@@ -42,7 +42,8 @@ class CoreNumberPool(Node):
 
         query = await NumberPoolGetUsed.init(db=db, branch=branch, pool=self, branch_agnostic=True)
         await query.execute(db=db)
-        return [result.get_as_optional_type("value", return_type=int) for result in query.results]
+        used = [result.get_as_optional_type("value", return_type=int) for result in query.results]
+        return [item for item in used if item is not None]
 
     async def reserve(self, db: InfrahubDatabase, number: int, identifier: str, at: Timestamp | None = None) -> None:
         """Reserve a number in the pool for a specific identifier."""
@@ -75,7 +76,7 @@ class CoreNumberPool(Node):
 
         # If we have not returned a value we need to find one if avaiable
         number = await self.get_next(db=db, branch=branch, attribute=attribute)
-        self.reserve(db=db, number=number, identifier=identifier, at=at)
+        await self.reserve(db=db, number=number, identifier=identifier, at=at)
         return number
 
     async def get_next(self, db: InfrahubDatabase, branch: Branch, attribute: AttributeSchema) -> int:
@@ -103,7 +104,7 @@ class CoreNumberPool(Node):
             next_number = find_next_free(
                 start=self.start_range.value,  # type: ignore[attr-defined]
                 end=self.end_range.value,  # type: ignore[attr-defined]
-                taken=taken + allocated,
+                taken=list(set(taken) | set(allocated)),
                 parameters=attribute.parameters
                 if isinstance(attribute.parameters, NumberAttributeParameters)
                 else None,
@@ -118,11 +119,8 @@ class CoreNumberPool(Node):
         return allocated
 
 
-def find_next_free(
-    start: int, end: int, taken: list[int | None], parameters: NumberAttributeParameters | None
-) -> int | None:
-    used_numbers = [number for number in taken if number is not None]
-    used_set = set(used_numbers)
+def find_next_free(start: int, end: int, taken: list[int], parameters: NumberAttributeParameters | None) -> int | None:
+    used_set = set(taken)
 
     for num in range(start, end + 1):
         if num not in used_set:

--- a/backend/infrahub/core/node/resource_manager/number_pool.py
+++ b/backend/infrahub/core/node/resource_manager/number_pool.py
@@ -10,17 +10,15 @@ from infrahub.exceptions import PoolExhaustedError
 from .. import Node
 
 if TYPE_CHECKING:
-    from infrahub.core.attribute import BaseAttribute
     from infrahub.core.branch import Branch
     from infrahub.core.timestamp import Timestamp
+    from infrahub.core.schema import AttributeSchema
     from infrahub.database import InfrahubDatabase
 
 
 class CoreNumberPool(Node):
     def get_attribute_nb_excluded_values(self) -> int:
-        """
-        Returns the number of excluded values for the attribute of the number pool.
-        """
+        """Returns the number of excluded values for the attribute of the number pool."""
 
         pool_node = registry.schema.get(name=self.node.value)  # type: ignore [attr-defined]
         attribute = [attribute for attribute in pool_node.attributes if attribute.name == self.node_attribute.value][0]  # type: ignore [attr-defined]
@@ -35,18 +33,39 @@ class CoreNumberPool(Node):
         res = len(attribute.parameters.get_excluded_single_values()) + sum_excluded_values
         return res
 
+    async def get_used(
+        self,
+        db: InfrahubDatabase,
+        branch: Branch,
+    ) -> list[int]:
+        """Returns a list of used numbers in the pool."""
+
+        query = await NumberPoolGetUsed.init(db=db, branch=branch, pool=self, branch_agnostic=True)
+        await query.execute(db=db)
+        return [result.get_as_optional_type("value", return_type=int) for result in query.results]
+
+    async def reserve(self, db: InfrahubDatabase, number: int, identifier: str, at: Timestamp | None = None) -> None:
+        """Reserve a number in the pool for a specific identifier."""
+
+        query = await NumberPoolSetReserved.init(db=db, pool_id=self.get_id(), identifier=identifier, reserved=number, at=at)
+        await query.execute(db=db)
+
     async def get_resource(
         self,
         db: InfrahubDatabase,
         branch: Branch,
         node: Node,
-        attribute: BaseAttribute,
+        attribute: AttributeSchema,
         identifier: str | None = None,
         at: Timestamp | None = None,
     ) -> int:
+        # NOTE: ideally we should use the HFID as the identifier (if available)
+        # one of the challenge with using the HFID is that it might change over time
+        # so we need to ensure that the identifier is stable, or we need to handle the case where the identifier changes
         identifier = identifier or node.get_id()
+
         # Check if there is already a resource allocated with this identifier
-        # if not, pull all existing prefixes and allocated the next available
+        # if not, pull all existing number and allocate the next available
         # TODO add support for branch, if the node is reserved with this id in another branch we should return an error
         query_get = await NumberPoolGetReserved.init(db=db, branch=branch, pool_id=self.id, identifier=identifier)
         await query_get.execute(db=db)
@@ -56,28 +75,47 @@ class CoreNumberPool(Node):
 
         # If we have not returned a value we need to find one if avaiable
         number = await self.get_next(db=db, branch=branch, attribute=attribute)
-
-        query_set = await NumberPoolSetReserved.init(
-            db=db, pool_id=self.get_id(), identifier=identifier, reserved=number, at=at
-        )
-        await query_set.execute(db=db)
+        self.reserve(db=db, number=number, identifier=identifier, at=at)
         return number
 
-    async def get_next(self, db: InfrahubDatabase, branch: Branch, attribute: BaseAttribute) -> int:
-        query = await NumberPoolGetUsed.init(db=db, branch=branch, pool=self, branch_agnostic=True)
-        await query.execute(db=db)
-        taken = [result.get_as_optional_type("av.value", return_type=int) for result in query.results]
-        parameters = attribute.schema.parameters
+    async def get_next(self, db: InfrahubDatabase, branch: Branch, attribute: AttributeSchema) -> int:
+        taken = await self.get_used(db=db, branch=branch)
+
         next_number = find_next_free(
             start=self.start_range.value,  # type: ignore[attr-defined]
             end=self.end_range.value,  # type: ignore[attr-defined]
             taken=taken,
-            parameters=parameters if isinstance(parameters, NumberAttributeParameters) else None,
+            parameters=attribute.parameters if isinstance(attribute.parameters, NumberAttributeParameters) else None,
         )
         if next_number is None:
             raise PoolExhaustedError("There are no more values available in this pool.")
 
         return next_number
+
+    async def get_next_many(
+        self, db: InfrahubDatabase, quantity: int, branch: Branch, attribute: AttributeSchema
+    ) -> list[int]:
+        taken = await self.get_used(db=db, branch=branch)
+
+        allocated: list[int] = []
+
+        for _ in range(quantity):
+            next_number = find_next_free(
+                start=self.start_range.value,  # type: ignore[attr-defined]
+                end=self.end_range.value,  # type: ignore[attr-defined]
+                taken=taken + allocated,
+                parameters=attribute.parameters
+                if isinstance(attribute.parameters, NumberAttributeParameters)
+                else None,
+            )
+            if next_number is None:
+                raise PoolExhaustedError(
+                    f"There are no more values available in this pool, couldn't allocate {quantity} values, only {len(allocated)} available."
+                )
+
+            allocated.append(next_number)
+
+        return allocated
 
 
 def find_next_free(

--- a/backend/infrahub/core/query/resource_manager.py
+++ b/backend/infrahub/core/query/resource_manager.py
@@ -218,6 +218,9 @@ class NumberPoolGetUsed(Query):
         self.params.update(branch_params)
         self.params["attribute_name"] = self.pool.node_attribute.value
 
+        # NOTE, there is a bug with IS_RESERVED that is affecting this query
+        # Currently the workaround is to use DISTINCT to avoid duplicates but overtime the query could become slower than expected
+        # This should be fixed in the future
         query = """
         MATCH (pool:%(number_pool)s { uuid: $pool_id })
         CALL (pool) {
@@ -237,8 +240,8 @@ class NumberPoolGetUsed(Query):
             "number_pool": InfrahubKind.NUMBERPOOL,
         }
         self.add_to_query(query)
-        self.return_labels = ["av.value"]
-        self.order_by = ["av.value"]
+        self.return_labels = ["DISTINCT(av.value) as value"]
+        self.order_by = ["value"]
 
 
 class NumberPoolSetReserved(Query):

--- a/backend/infrahub/core/schema/__init__.py
+++ b/backend/infrahub/core/schema/__init__.py
@@ -46,6 +46,7 @@ class SchemaExtension(HashableModel):
 
 class SchemaRoot(BaseModel):
     model_config = ConfigDict(extra="forbid")
+
     version: str | None = Field(default=None)
     generics: list[GenericSchema] = Field(default_factory=list)
     nodes: list[NodeSchema] = Field(default_factory=list)
@@ -92,6 +93,10 @@ class SchemaRoot(BaseModel):
     def merge(self, schema: SchemaRoot) -> SchemaRoot:
         """Return a new `SchemaRoot` after merging `self` with `schema`."""
         return SchemaRoot.model_validate(deep_merge_dict(dicta=self.model_dump(), dictb=schema.model_dump()))
+
+    def duplicate(self) -> SchemaRoot:
+        """Return a duplicate of the current schema."""
+        return SchemaRoot.model_validate(self.model_dump())
 
 
 internal_schema = internal.to_dict()

--- a/backend/infrahub/core/schema/attribute_parameters.py
+++ b/backend/infrahub/core/schema/attribute_parameters.py
@@ -165,3 +165,9 @@ class NumberPoolParameters(AttributeParameters):
         if self.start_range > self.end_range:
             raise ValueError("`start_range` can't be less than `end_range`")
         return self
+
+    def get_pool_size(self) -> int:
+        """
+        Returns the size of the pool based on the defined ranges.
+        """
+        return self.end_range - self.start_range + 1

--- a/backend/infrahub/core/validators/node/attribute.py
+++ b/backend/infrahub/core/validators/node/attribute.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from infrahub.core import registry
+
 from ..interface import ConstraintCheckerInterface
 from ..query import NodeNotPresentValidatorQuery
 
@@ -31,8 +33,20 @@ class NodeAttributeAddChecker(ConstraintCheckerInterface):
         grouped_data_paths_list: list[GroupedDataPaths] = []
         if not request.schema_path.field_name:
             raise ValueError("field_name is not defined")
+
         attribute_schema = request.node_schema.get_attribute(name=request.schema_path.field_name)
         if attribute_schema.optional is True or attribute_schema.default_value is not None:
+            return grouped_data_paths_list
+
+        # If the attribute is a NumberPool, we need to ensure that the pool is big enough for all existing nodes
+        if attribute_schema.kind == "NumberPool":
+            nbr_nodes = await registry.manager.count(db=self.db, branch=self.branch, schema=request.node_schema)
+            pool_size = attribute_schema.parameters.get_pool_size()
+
+            if pool_size < nbr_nodes:
+                raise ValueError(
+                    f"The size of the NumberPool is smaller than the number of existing nodes {pool_size} < {nbr_nodes}."
+                )
             return grouped_data_paths_list
 
         for query_class in self.query_classes:

--- a/backend/infrahub/core/validators/node/attribute.py
+++ b/backend/infrahub/core/validators/node/attribute.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from infrahub.core import registry
+from infrahub.core.schema.attribute_parameters import NumberPoolParameters
 
 from ..interface import ConstraintCheckerInterface
 from ..query import NodeNotPresentValidatorQuery
@@ -39,7 +40,7 @@ class NodeAttributeAddChecker(ConstraintCheckerInterface):
             return grouped_data_paths_list
 
         # If the attribute is a NumberPool, we need to ensure that the pool is big enough for all existing nodes
-        if attribute_schema.kind == "NumberPool":
+        if attribute_schema.kind == "NumberPool" and isinstance(attribute_schema.parameters, NumberPoolParameters):
             nbr_nodes = await registry.manager.count(db=self.db, branch=self.branch, schema=request.node_schema)
             pool_size = attribute_schema.parameters.get_pool_size()
 

--- a/backend/infrahub/core/validators/tasks.py
+++ b/backend/infrahub/core/validators/tasks.py
@@ -11,9 +11,7 @@ from infrahub.core.branch import Branch  # noqa: TC001
 from infrahub.core.path import SchemaPath  # noqa: TC001
 from infrahub.core.schema import GenericSchema, NodeSchema
 from infrahub.core.validators.aggregated_checker import AggregatedConstraintChecker
-from infrahub.core.validators.model import (
-    SchemaConstraintValidatorRequest,
-)
+from infrahub.core.validators.model import SchemaConstraintValidatorRequest, SchemaViolation
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.services import InfrahubServices  # noqa: TC001  needed for prefect flow
 from infrahub.workflows.utils import add_tags
@@ -84,7 +82,17 @@ async def schema_path_validate(
         aggregated_constraint_checker = await component_registry.get_component(
             AggregatedConstraintChecker, db=db, branch=branch
         )
-        violations = await aggregated_constraint_checker.run_constraints(constraint_request)
+        try:
+            violations = await aggregated_constraint_checker.run_constraints(constraint_request)
+        except Exception as exc:
+            violation = SchemaViolation(
+                node_id="unknown",
+                node_kind=node_schema.kind,
+                display_label=f"Error validating {constraint_name} on {node_schema.kind}",
+                full_display_label=f"Error validating {constraint_name} on {node_schema.kind}",
+                message=str(exc),
+            )
+            violations = [violation]
 
         return SchemaValidatorPathResponseData(
             violations=violations, constraint_name=constraint_name, schema_path=schema_path

--- a/backend/infrahub/tasks/registry.py
+++ b/backend/infrahub/tasks/registry.py
@@ -1,15 +1,75 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from infrahub import lock
 from infrahub.core import registry
-from infrahub.database import InfrahubDatabase
 from infrahub.log import get_logger
 from infrahub.worker import WORKER_IDENTITY
 
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
+    from infrahub.core.schema.schema_branch import SchemaBranch
+    from infrahub.database import InfrahubDatabase
 
 log = get_logger()
+
+
+def update_graphql_schema(branch: Branch, schema_branch: SchemaBranch) -> None:
+    """
+    Update the GraphQL schema for the given branch.
+    """
+    from infrahub.graphql.manager import GraphQLSchemaManager
+
+    gqlm = GraphQLSchemaManager.get_manager_for_branch(branch=branch, schema_branch=schema_branch)
+    gqlm.get_graphql_schema(
+        include_query=True,
+        include_mutation=True,
+        include_subscription=True,
+        include_types=True,
+    )
+
+
+async def create_branch_registry(db: InfrahubDatabase, branch: Branch) -> None:
+    """Create a new entry in the registry for a given branch."""
+
+    log.info("New branch detected, pulling schema", branch=branch.name, worker=WORKER_IDENTITY)
+    await registry.schema.load_schema(db=db, branch=branch)
+    registry.branch[branch.name] = branch
+    schema_branch = registry.schema.get_schema_branch(name=branch.name)
+    update_graphql_schema(branch=branch, schema_branch=schema_branch)
+
+
+async def update_branch_registry(db: InfrahubDatabase, branch: Branch) -> None:
+    """Update the registry for a branch if the schema hash has changed."""
+
+    existing_branch: Branch = registry.branch[branch.name]
+
+    if not existing_branch.schema_hash:
+        log.warning("Branch schema hash is not set, cannot update branch registry")
+        return
+
+    if existing_branch.schema_hash and existing_branch.schema_hash.main == branch.active_schema_hash.main:
+        log.debug(
+            "Branch schema hash is the same, no need to update branch registry",
+            branch=branch.name,
+            hash=existing_branch.schema_hash.main,
+            worker=WORKER_IDENTITY,
+        )
+        return
+
+    log.info(
+        "New hash detected",
+        branch=branch.name,
+        hash_current=existing_branch.schema_hash.main,
+        hash_new=branch.active_schema_hash.main,
+        worker=WORKER_IDENTITY,
+    )
+    await registry.schema.load_schema(db=db, branch=branch)
+    registry.branch[branch.name] = branch
+    schema_branch = registry.schema.get_schema_branch(name=branch.name)
+
+    update_graphql_schema(branch=branch, schema_branch=schema_branch)
 
 
 async def refresh_branches(db: InfrahubDatabase) -> None:
@@ -24,41 +84,9 @@ async def refresh_branches(db: InfrahubDatabase) -> None:
         branches = await registry.branch_object.get_list(db=db)
         for new_branch in branches:
             if new_branch.name in registry.branch:
-                branch_registry: Branch = registry.branch[new_branch.name]
-                if (
-                    branch_registry.schema_hash
-                    and branch_registry.schema_hash.main != new_branch.active_schema_hash.main
-                ):
-                    log.info(
-                        "New hash detected",
-                        branch=new_branch.name,
-                        hash_current=branch_registry.schema_hash.main,
-                        hash_new=new_branch.active_schema_hash.main,
-                        worker=WORKER_IDENTITY,
-                    )
-                    await registry.schema.load_schema(db=db, branch=new_branch)
-                    registry.branch[new_branch.name] = new_branch
-                    schema_branch = registry.schema.get_schema_branch(name=new_branch.name)
-                    gqlm = GraphQLSchemaManager.get_manager_for_branch(branch=new_branch, schema_branch=schema_branch)
-                    gqlm.get_graphql_schema(
-                        include_query=True,
-                        include_mutation=True,
-                        include_subscription=True,
-                        include_types=True,
-                    )
-
+                await update_branch_registry(db=db, branch=new_branch)
             else:
-                log.info("New branch detected, pulling schema", branch=new_branch.name, worker=WORKER_IDENTITY)
-                await registry.schema.load_schema(db=db, branch=new_branch)
-                registry.branch[new_branch.name] = new_branch
-                schema_branch = registry.schema.get_schema_branch(name=new_branch.name)
-                gqlm = GraphQLSchemaManager.get_manager_for_branch(branch=new_branch, schema_branch=schema_branch)
-                gqlm.get_graphql_schema(
-                    include_query=True,
-                    include_mutation=True,
-                    include_subscription=True,
-                    include_types=True,
-                )
+                await create_branch_registry(db=db, branch=new_branch)
 
         purged_branches = await registry.purge_inactive_branches(db=db, active_branches=branches)
         purged_branches.update(

--- a/backend/tests/functional/pools/test_numberpool_lifecycle.py
+++ b/backend/tests/functional/pools/test_numberpool_lifecycle.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import pytest
 
 from infrahub.auth import AccountSession, AuthType
 from infrahub.context import InfrahubContext
+from infrahub.core.constants import HashableModelState
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.protocols import CoreNumberPool
 from infrahub.core.registry import registry
+from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot
 from infrahub.core.schema.attribute_parameters import NumberPoolParameters
 from infrahub.exceptions import NodeNotFoundError
 from infrahub.pools.registration import get_branches_with_schema_number_pool
@@ -27,24 +29,33 @@ if TYPE_CHECKING:
     from infrahub.database import InfrahubDatabase
     from tests.adapters.message_bus import BusSimulator
 
-node_schema_definition: dict[str, Any] = {
-    "name": "NumberAttribute",
-    "namespace": "Test",
-    "attributes": [
-        {"name": "name", "kind": "Text", "unique": True},
-        {
-            "name": "assigned_number",
-            "kind": "NumberPool",
-            "optional": False,
-            "unique": True,
-            "read_only": True,
-            "parameters": {"start_range": 10, "end_range": 25},
-        },
+node_schema_definition = NodeSchema(
+    name="NumberAttribute",
+    namespace="Test",
+    attributes=[
+        AttributeSchema(name="name", kind="Text", unique=True),
+        AttributeSchema(
+            name="assigned_number",
+            kind="NumberPool",
+            optional=False,
+            unique=True,
+            read_only=True,
+            parameters={"start_range": 10, "end_range": 25},
+        ),
     ],
-}
+)
 
 
 class TestAttributeNumberPoolLifecycle(TestInfrahubApp):
+    @pytest.fixture(scope="class")
+    def initial_schema(self) -> SchemaRoot:
+        schema = SchemaRoot(
+            version="1.0",
+            generics=[SNOW_TASK],
+            nodes=[node_schema_definition, SNOW_INCIDENT, SNOW_REQUEST],
+        )
+        return schema
+
     @pytest.fixture(scope="class")
     async def initial_dataset(
         self,
@@ -54,15 +65,13 @@ class TestAttributeNumberPoolLifecycle(TestInfrahubApp):
         client: InfrahubClient,
         bus_simulator: BusSimulator,
         prefect_test_fixture,
+        initial_schema: SchemaRoot,
     ) -> None:
         bus_simulator.service._cache = RedisCache()
 
-        schema = {
-            "version": "1.0",
-            "generics": [SNOW_TASK.to_dict()],
-            "nodes": [node_schema_definition, SNOW_INCIDENT.to_dict(), SNOW_REQUEST.to_dict()],
-        }
-        schema_load_response = await client.schema.load(schemas=[schema], wait_until_converged=True)
+        schema_load_response = await client.schema.load(
+            schemas=[initial_schema.model_dump()], wait_until_converged=True
+        )
         assert not schema_load_response.errors
 
     async def test_numberpool_assignment_direct_node(
@@ -97,9 +106,9 @@ class TestAttributeNumberPoolLifecycle(TestInfrahubApp):
         )
 
         assert initial_branches == ["main"]
-        node_schema_definition["state"] = "absent"
-        schema = {"version": "1.0", "nodes": [node_schema_definition]}
-        schema_load_response = await client.schema.load(schemas=[schema], wait_until_converged=True)
+        node_schema_definition.state = HashableModelState.ABSENT
+        schema = SchemaRoot(version="1.0", nodes=[node_schema_definition])
+        schema_load_response = await client.schema.load(schemas=[schema.model_dump()], wait_until_converged=True)
         assert not schema_load_response.errors
 
         after_purge = get_branches_with_schema_number_pool(kind="TestNumberAttribute", attribute_name="assigned_number")
@@ -144,14 +153,14 @@ class TestAttributeNumberPoolLifecycle(TestInfrahubApp):
         initial_branches = get_branches_with_schema_number_pool(kind="SnowTask", attribute_name="number")
 
         assert initial_branches == ["main"]
-        snow_task = SNOW_TASK.to_dict()
-        snow_task["state"] = "absent"
-        snow_request = SNOW_REQUEST.to_dict()
-        snow_request["state"] = "absent"
-        snow_incident = SNOW_INCIDENT.to_dict()
-        snow_incident["state"] = "absent"
-        schema = {"version": "1.0", "generics": [snow_task], "nodes": [snow_request, snow_incident]}
-        schema_load_response = await client.schema.load(schemas=[schema], wait_until_converged=True)
+        snow_task = SNOW_TASK.duplicate()
+        snow_task.state = HashableModelState.ABSENT
+        snow_request = SNOW_REQUEST.duplicate()
+        snow_request.state = HashableModelState.ABSENT
+        snow_incident = SNOW_INCIDENT.duplicate()
+        snow_incident.state = HashableModelState.ABSENT
+        schema = SchemaRoot(version="1.0", generics=[snow_task], nodes=[snow_request, snow_incident])
+        schema_load_response = await client.schema.load(schemas=[schema.model_dump()], wait_until_converged=True)
         assert not schema_load_response.errors
 
         after_purge = get_branches_with_schema_number_pool(kind="SnowTask", attribute_name="number")
@@ -165,3 +174,70 @@ class TestAttributeNumberPoolLifecycle(TestInfrahubApp):
                 kind=CoreNumberPool,
                 id=number_pool_id,
             )
+
+    async def test_numberpool_existing_nodes(
+        self, db: InfrahubDatabase, client: InfrahubClient, default_branch, initial_schema: SchemaRoot
+    ) -> None:
+        service = await InfrahubServices.new(database=db)
+        context = InfrahubContext.init(
+            branch=default_branch,
+            account=AccountSession(auth_type=AuthType.NONE, authenticated=False, account_id=""),
+        )
+
+        schema_load_response = await client.schema.load(
+            schemas=[initial_schema.model_dump()], wait_until_converged=True
+        )
+        assert not schema_load_response.errors
+
+        # Create incidents to ensure there are some data into the database
+        for idx in range(1, 6):
+            incident = await Node.init(db=db, schema=SNOW_INCIDENT.kind)
+            await incident.new(db=db, title=f"Incident #{idx}")
+            await incident.save(db=db)
+
+        # Add a new attribute to the existing schema with a large pool
+        new_schema = initial_schema.duplicate()
+        incident_schema = new_schema.get(name=SNOW_INCIDENT.kind)
+        incident_schema.attributes.append(
+            AttributeSchema(
+                name="new_number",
+                kind="NumberPool",
+                optional=False,
+                read_only=True,
+                parameters=NumberPoolParameters(start_range=10, end_range=30),
+            ),
+        )
+
+        schema_load_response = await client.schema.load(schemas=[new_schema.model_dump()], wait_until_converged=True)
+        assert not schema_load_response.errors
+
+        incidents = await registry.manager.query(db=db, branch=default_branch, schema=incident_schema)
+        assert incidents[0].new_number.value == 10
+
+        await validate_schema_number_pools(branch_name=registry.default_branch, context=context, service=service)
+
+        # NOTE : to be investigated, this should work but it does not right now
+        # incident_zz = await Node.init(db=db, schema=SNOW_INCIDENT.kind)
+        # await incident_zz.new(db=db, title=f"Incident ZZZ")
+        # await incident_zz.save(db=db)
+        # assert incident_zz.new_number.value == 20
+
+        # Add a new attribute to the existing schema with a large pool
+        new_schema2 = initial_schema.duplicate()
+        incident_schema = new_schema2.get(name=SNOW_INCIDENT.kind)
+        incident_schema.attributes.append(
+            AttributeSchema(
+                name="new_number2",
+                kind="NumberPool",
+                optional=False,
+                read_only=True,
+                parameters=NumberPoolParameters(start_range=2, end_range=4),
+            ),
+        )
+
+        schema_load_response = await client.schema.load(schemas=[new_schema2.model_dump()], wait_until_converged=True)
+        assert schema_load_response.errors
+        assert len(schema_load_response.errors["errors"]) == 1
+        assert schema_load_response.errors["errors"][0]["message"] == (
+            "The size of the NumberPool is smaller than the number of existing nodes 3 < 5."
+        )

--- a/backend/tests/functional/pools/test_numberpool_lifecycle.py
+++ b/backend/tests/functional/pools/test_numberpool_lifecycle.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
+from infrahub_sdk.graphql import Query
 
 from infrahub.auth import AccountSession, AuthType
 from infrahub.context import InfrahubContext
@@ -44,6 +45,13 @@ node_schema_definition = NodeSchema(
             parameters=NumberPoolParameters(start_range=10, end_range=25),
         ),
     ],
+)
+
+number_pool_allocation_query = Query(
+    query={
+        "InfrahubResourcePoolAllocated": {"@filters": {"pool_id": "$pool_id", "resource_id": "$pool_id"}, "count": None}
+    },
+    variables={"pool_id": str},
 )
 
 
@@ -217,11 +225,21 @@ class TestAttributeNumberPoolLifecycle(TestInfrahubApp):
         incidents = await registry.manager.query(db=db, branch=default_branch, schema=incident_schema)
         assert incidents[0].new_number.value == 10
 
-        pools_after2 = await client.all(kind="CoreNumberPool", branch=default_branch.name)
-        assert len(pools_after2) == 2
-
         incident10 = await client.create(kind=SNOW_INCIDENT.kind, title="Incident #10", branch=default_branch.name)
         await incident10.save()
+
+        # Ensure the calculated allocation is correct for both pools
+        number_pool = [pool for pool in pools_after if pool.node_attribute.value == "number"][0]
+        number_allocation = await client.execute_graphql(
+            query=number_pool_allocation_query.render(), variables={"pool_id": number_pool.id}
+        )
+        assert number_allocation["InfrahubResourcePoolAllocated"]["count"] == 6
+
+        new_number_pool = [pool for pool in pools_after if pool.node_attribute.value == "new_number"][0]
+        new_number_allocation = await client.execute_graphql(
+            query=number_pool_allocation_query.render(), variables={"pool_id": new_number_pool.id}
+        )
+        assert new_number_allocation["InfrahubResourcePoolAllocated"]["count"] == 6
 
         # Add a new attribute to the existing schema with a large pool
         new_schema2 = initial_schema.duplicate()

--- a/backend/tests/functional/pools/test_numberpool_lifecycle.py
+++ b/backend/tests/functional/pools/test_numberpool_lifecycle.py
@@ -40,7 +40,7 @@ node_schema_definition = NodeSchema(
             optional=False,
             unique=True,
             read_only=True,
-            parameters={"start_range": 10, "end_range": 25},
+            parameters=NumberPoolParameters(start_range=10, end_range=25),
         ),
     ],
 )

--- a/backend/tests/functional/pools/test_numberpool_lifecycle.py
+++ b/backend/tests/functional/pools/test_numberpool_lifecycle.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 
     from infrahub_sdk import InfrahubClient
 
+    from infrahub.core.branch import Branch
     from infrahub.database import InfrahubDatabase
     from tests.adapters.message_bus import BusSimulator
 
@@ -75,7 +76,7 @@ class TestAttributeNumberPoolLifecycle(TestInfrahubApp):
         assert not schema_load_response.errors
 
     async def test_numberpool_assignment_direct_node(
-        self, db: InfrahubDatabase, initial_dataset: None, client: InfrahubClient, default_branch
+        self, db: InfrahubDatabase, initial_dataset: None, client: InfrahubClient, default_branch: Branch
     ) -> None:
         service = await InfrahubServices.new(database=db)
         context = InfrahubContext.init(
@@ -176,7 +177,7 @@ class TestAttributeNumberPoolLifecycle(TestInfrahubApp):
             )
 
     async def test_numberpool_existing_nodes(
-        self, db: InfrahubDatabase, client: InfrahubClient, redis, default_branch, initial_schema: SchemaRoot
+        self, db: InfrahubDatabase, client: InfrahubClient, redis, default_branch: Branch, initial_schema: SchemaRoot
     ) -> None:
         schema_load_response = await client.schema.load(
             schemas=[initial_schema.model_dump()], wait_until_converged=True
@@ -188,6 +189,9 @@ class TestAttributeNumberPoolLifecycle(TestInfrahubApp):
             incident = await Node.init(db=db, schema=SNOW_INCIDENT.kind)
             await incident.new(db=db, title=f"Incident #{idx}")
             await incident.save(db=db)
+
+        pools_before = await client.all(kind="CoreNumberPool", branch=default_branch.name)
+        assert len(pools_before) == 1
 
         # Add a new attribute to the existing schema with a large pool
         new_schema = initial_schema.duplicate()
@@ -205,8 +209,19 @@ class TestAttributeNumberPoolLifecycle(TestInfrahubApp):
         schema_load_response = await client.schema.load(schemas=[new_schema.model_dump()], wait_until_converged=True)
         assert not schema_load_response.errors
 
+        # Validate that the new pool has been created
+        pools_after = await client.all(kind="CoreNumberPool", branch=default_branch.name)
+        assert len(pools_after) == 2
+
+        # Validate that the existing incidents have been updated with the new number
         incidents = await registry.manager.query(db=db, branch=default_branch, schema=incident_schema)
         assert incidents[0].new_number.value == 10
+
+        pools_after2 = await client.all(kind="CoreNumberPool", branch=default_branch.name)
+        assert len(pools_after2) == 2
+
+        incident10 = await client.create(kind=SNOW_INCIDENT.kind, title="Incident #10", branch=default_branch.name)
+        await incident10.save()
 
         # Add a new attribute to the existing schema with a large pool
         new_schema2 = initial_schema.duplicate()
@@ -225,5 +240,5 @@ class TestAttributeNumberPoolLifecycle(TestInfrahubApp):
         assert schema_load_response.errors
         assert len(schema_load_response.errors["errors"]) == 1
         assert schema_load_response.errors["errors"][0]["message"] == (
-            "The size of the NumberPool is smaller than the number of existing nodes 3 < 5."
+            "The size of the NumberPool is smaller than the number of existing nodes 3 < 6."
         )

--- a/backend/tests/functional/pools/test_numberpool_lifecycle.py
+++ b/backend/tests/functional/pools/test_numberpool_lifecycle.py
@@ -176,14 +176,8 @@ class TestAttributeNumberPoolLifecycle(TestInfrahubApp):
             )
 
     async def test_numberpool_existing_nodes(
-        self, db: InfrahubDatabase, client: InfrahubClient, default_branch, initial_schema: SchemaRoot
+        self, db: InfrahubDatabase, client: InfrahubClient, redis, default_branch, initial_schema: SchemaRoot
     ) -> None:
-        service = await InfrahubServices.new(database=db)
-        context = InfrahubContext.init(
-            branch=default_branch,
-            account=AccountSession(auth_type=AuthType.NONE, authenticated=False, account_id=""),
-        )
-
         schema_load_response = await client.schema.load(
             schemas=[initial_schema.model_dump()], wait_until_converged=True
         )
@@ -213,14 +207,6 @@ class TestAttributeNumberPoolLifecycle(TestInfrahubApp):
 
         incidents = await registry.manager.query(db=db, branch=default_branch, schema=incident_schema)
         assert incidents[0].new_number.value == 10
-
-        await validate_schema_number_pools(branch_name=registry.default_branch, context=context, service=service)
-
-        # NOTE : to be investigated, this should work but it does not right now
-        # incident_zz = await Node.init(db=db, schema=SNOW_INCIDENT.kind)
-        # await incident_zz.new(db=db, title=f"Incident ZZZ")
-        # await incident_zz.save(db=db)
-        # assert incident_zz.new_number.value == 20
 
         # Add a new attribute to the existing schema with a large pool
         new_schema2 = initial_schema.duplicate()

--- a/backend/tests/unit/core/resource_manager/test_number_pool.py
+++ b/backend/tests/unit/core/resource_manager/test_number_pool.py
@@ -1,6 +1,7 @@
 from infrahub.core.branch import Branch
 from infrahub.core.initialization import initialize_registry
 from infrahub.core.node import Node
+from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
 from infrahub.core.schema import SchemaRoot
 from infrahub.core.schema.attribute_parameters import NumberAttributeParameters
 from infrahub.core.schema.attribute_schema import AttributeSchema, NumberAttributeSchema
@@ -16,7 +17,7 @@ async def test_allocate_from_number_pool(db: InfrahubDatabase, default_branch: B
     await load_schema(db=db, schema=SchemaRoot(nodes=[TICKET]))
     await initialize_registry(db=db)
 
-    np1 = await Node.init(db=db, schema="CoreNumberPool")
+    np1 = await CoreNumberPool.init(db=db, schema="CoreNumberPool")
     await np1.new(db=db, name="pool1", node="TestingTicket", node_attribute="ticket_id", start_range=1, end_range=10)
     await np1.save(db=db)
 
@@ -38,6 +39,9 @@ async def test_allocate_from_number_pool(db: InfrahubDatabase, default_branch: B
     await recreated_ticket2.save(db=db)
     assert recreated_ticket2.ticket_id.value == 2
 
+    # Validate methods at the pool level
+    assert await np1.get_used(db=db, branch=default_branch) == [1, 2]
+
 
 async def test_resource_utilization(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema):
     """
@@ -50,7 +54,7 @@ async def test_resource_utilization(db: InfrahubDatabase, default_branch: Branch
     await load_schema(db=db, schema=SchemaRoot(nodes=[TICKET]))
     await initialize_registry(db=db)
 
-    np1 = await Node.init(db=db, schema="CoreNumberPool")
+    np1 = await CoreNumberPool.init(db=db, schema="CoreNumberPool")
     await np1.new(db=db, name="pool1", node="TestingTicket", node_attribute="ticket_id", start_range=1, end_range=10)
     await np1.save(db=db)
 
@@ -58,7 +62,7 @@ async def test_resource_utilization(db: InfrahubDatabase, default_branch: Branch
     await ticket1_np1.new(db=db, title="ticket1_np1", ticket_id={"from_pool": {"id": np1.id}})
     await ticket1_np1.save(db=db)
 
-    np2 = await Node.init(db=db, schema="CoreNumberPool")
+    np2 = await CoreNumberPool.init(db=db, schema="CoreNumberPool")
     await np2.new(db=db, name="pool2", node="TestingTicket", node_attribute="ticket_id", start_range=1, end_range=10)
     await np2.save(db=db)
 
@@ -148,7 +152,7 @@ async def test_allocate_from_number_pool_for_generic(
     await load_schema(db=db, schema=SchemaRoot(generics=[ticket], nodes=[speeding_ticket, parking_ticket]))
     await initialize_registry(db=db)
 
-    np1 = await Node.init(db=db, schema="CoreNumberPool")
+    np1 = await CoreNumberPool.init(db=db, schema="CoreNumberPool")
     await np1.new(db=db, name="pool1", node=ticket.kind, node_attribute="ticket_id", start_range=1, end_range=10)
     await np1.save(db=db)
 
@@ -199,11 +203,17 @@ async def test_allocate_from_number_pool_with_excluded_values(
     await load_schema(db=db, schema=SchemaRoot(nodes=[speeding_ticket]))
     await initialize_registry(db=db)
 
-    np1 = await Node.init(db=db, schema="CoreNumberPool")
+    np1 = await CoreNumberPool.init(db=db, schema="CoreNumberPool")
     await np1.new(
         db=db, name="pool1", node=speeding_ticket.kind, node_attribute="ticket_id", start_range=10, end_range=30
     )
     await np1.save(db=db)
+
+    # Validate that get_next_many return the correct values
+    next_many = await np1.get_next_many(
+        db=db, branch=default_branch, quantity=5, attribute=speeding_ticket.get_attribute("ticket_id")
+    )
+    assert next_many == [10, 11, 13, 17, 18]
 
     tickets = []
     for _ in range(5):

--- a/backend/tests/unit/core/schema/test_attribute_parameters.py
+++ b/backend/tests/unit/core/schema/test_attribute_parameters.py
@@ -1,3 +1,4 @@
+import sys
 from copy import deepcopy
 from typing import Any
 
@@ -61,6 +62,12 @@ def test_number_pool_invalid_range() -> None:
     }
     with pytest.raises(pydantic.ValidationError, match="`start_range` can't be less than `end_range`"):
         NodeSchema(**node_schema)
+
+
+def test_number_pool_get_pool_size() -> None:
+    assert NumberPoolParameters(start_range=10, end_range=25).get_pool_size() == 16
+    assert NumberPoolParameters(start_range=10).get_pool_size() == sys.maxsize - 9
+    assert NumberPoolParameters(end_range=25).get_pool_size() == 25
 
 
 def test_number_pool_optional() -> None:

--- a/changelog/6802.fixed.md
+++ b/changelog/6802.fixed.md
@@ -1,0 +1,1 @@
+Add migration for Attribute of kind NumberPool on existing nodes


### PR DESCRIPTION
Fixes #6802

This PR add a new validator and migration for NumberPool attribute to properly allocate a value to all existing nodes.
In order to apply this logic, this PR introduced 2 new hooks as part of the migration framework to execute some migration specific code before and/or after executing the normal queries. 

- The validator will ensure that the size of the pool is enough to provide a Number to all existing nodes, if the pool is smaller than the number of objects in the database it will fail
- The migration will assign a value to all attributes based on the pool, in order to minimize the load on the database, a new `get_next_many` has been introduced to easily pull multiple values at once.
