### PR TITLE
diff crash with double-deleted schemas

### DIFF
--- a/backend/infrahub/core/diff/enricher/hierarchy.py
+++ b/backend/infrahub/core/diff/enricher/hierarchy.py
@@ -7,6 +7,7 @@ from infrahub.core.query.node import NodeGetHierarchyQuery
 from infrahub.core.query.relationship import RelationshipGetPeerQuery, RelationshipPeerData
 from infrahub.core.schema import ProfileSchema, TemplateSchema
 from infrahub.database import InfrahubDatabase
+from infrahub.exceptions import SchemaNotFoundError
 from infrahub.log import get_logger
 
 from ..model.path import (
@@ -42,9 +43,12 @@ class DiffHierarchyEnricher(DiffEnricherInterface):
         node_hierarchy_map: dict[str, list[NodeIdentifier]] = defaultdict(list)
 
         for node in enriched_diff_root.nodes:
-            schema_node = self.db.schema.get(
-                name=node.kind, branch=enriched_diff_root.diff_branch_name, duplicate=False
-            )
+            try:
+                schema_node = self.db.schema.get(
+                    name=node.kind, branch=enriched_diff_root.diff_branch_name, duplicate=False
+                )
+            except SchemaNotFoundError:
+                continue
 
             if isinstance(schema_node, ProfileSchema | TemplateSchema):
                 continue

--- a/backend/infrahub/core/diff/query_parser.py
+++ b/backend/infrahub/core/diff/query_parser.py
@@ -13,6 +13,7 @@ from infrahub.core.constants import (
 )
 from infrahub.core.constants.database import DatabaseEdgeType
 from infrahub.core.timestamp import Timestamp
+from infrahub.exceptions import SchemaNotFoundError
 
 from .model.field_specifiers_map import NodeFieldSpecifierMap
 from .model.path import (
@@ -566,9 +567,12 @@ class DiffQueryParser:
         if database_path.deepest_branch == self.diff_branch_name:
             branches_to_check.append(self.base_branch_name)
         for schema_branch_name in branches_to_check:
-            node_schema = self.schema_manager.get(
-                name=database_path.node_kind, branch=schema_branch_name, duplicate=False
-            )
+            try:
+                node_schema = self.schema_manager.get(
+                    name=database_path.node_kind, branch=schema_branch_name, duplicate=False
+                )
+            except SchemaNotFoundError:
+                continue
             relationship_schemas = node_schema.get_relationships_by_identifier(id=database_path.attribute_name)
             if len(relationship_schemas) == 1:
                 return relationship_schemas[0]

--- a/backend/tests/integration/diff/test_diff_rebase.py
+++ b/backend/tests/integration/diff/test_diff_rebase.py
@@ -5,24 +5,33 @@ from typing import TYPE_CHECKING
 import pytest
 
 from infrahub import config, lock
-from infrahub.core.constants import DiffAction, InfrahubKind
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.constants import (
+    DiffAction,
+    HashableModelState,
+    InfrahubKind,
+    RelationshipCardinality,
+    RelationshipKind,
+)
 from infrahub.core.constants.database import DatabaseEdgeType
 from infrahub.core.diff.model.path import BranchTrackingId
 from infrahub.core.diff.repository.repository import DiffRepository
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
+from infrahub.core.schema import RelationshipSchema, SchemaRoot
 from infrahub.core.timestamp import Timestamp
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.services.adapters.cache.redis import RedisCache
 from tests.constants import TestKind
 from tests.helpers.schema import CAR_SCHEMA, load_schema
+from tests.helpers.schema.location import CONTINENT, LOCATION
 from tests.helpers.test_app import TestInfrahubApp
 
 if TYPE_CHECKING:
     from infrahub_sdk import InfrahubClient
 
-    from infrahub.core.branch import Branch
     from infrahub.database import InfrahubDatabase
     from tests.adapters.message_bus import BusSimulator
 
@@ -71,14 +80,39 @@ class TestDiffRebase(TestInfrahubApp):
         lock.initialize_lock(local_only=True)
 
     @pytest.fixture(scope="class")
+    def main_schema_root(self) -> SchemaRoot:
+        main_schema_root = CAR_SCHEMA.model_copy()
+        # add a Node and relationship to delete later
+        main_schema_root.generics.append(LOCATION)
+        continent_schema = CONTINENT.model_copy()
+        continent_schema.children = None
+        continent_schema.parent = None
+        main_schema_root.nodes.append(continent_schema)
+        manufacturer_schema = main_schema_root.get(TestKind.MANUFACTURER)
+        manufacturer_schema.relationships.append(
+            RelationshipSchema(
+                name="continents",
+                kind=RelationshipKind.GENERIC,
+                peer=TestKind.CONTINENT,
+                cardinality=RelationshipCardinality.MANY,
+                identifier="continent__manufacturer",
+            )
+        )
+        return main_schema_root
+
+    @pytest.fixture(scope="class")
     async def initial_dataset(
         self,
         db: InfrahubDatabase,
         default_branch,
+        main_schema_root: SchemaRoot,
         client: InfrahubClient,
         bus_simulator: BusSimulator,
     ) -> dict[str, Node]:
-        await load_schema(db, schema=CAR_SCHEMA, update_db=True)
+        await load_schema(db, schema=main_schema_root, update_db=True)
+        antarctica = await Node.init(schema=TestKind.CONTINENT, db=db)
+        await antarctica.new(db=db, name="Antarctica", shortname="ANT")
+        await antarctica.save(db=db)
         john = await Node.init(schema=TestKind.PERSON, db=db)
         await john.new(db=db, name="John", height=175, description="The famous Joe Doe")
         await john.save(db=db)
@@ -92,7 +126,7 @@ class TestDiffRebase(TestInfrahubApp):
         await koenigsegg.new(db=db, name="Koenigsegg", customers=[john])
         await koenigsegg.save(db=db)
         omnicorp = await Node.init(schema=TestKind.MANUFACTURER, db=db)
-        await omnicorp.new(db=db, name="Omnicorp", customers=[murphy])
+        await omnicorp.new(db=db, name="Omnicorp", customers=[murphy], continents=[antarctica])
         await omnicorp.save(db=db)
         cyberdyne = await Node.init(schema=TestKind.MANUFACTURER, db=db)
         await cyberdyne.new(db=db, name="Cyberdyne")
@@ -135,6 +169,7 @@ class TestDiffRebase(TestInfrahubApp):
         bus_simulator.service._cache = RedisCache()
 
         return {
+            "antarctica": antarctica,
             "john": john,
             "kara": kara,
             "murphy": murphy,
@@ -154,6 +189,10 @@ class TestDiffRebase(TestInfrahubApp):
     @pytest.fixture(scope="class")
     async def branch_2(self, db: InfrahubDatabase) -> Branch:
         return await create_branch(branch_name="branch_2", db=db)
+
+    @pytest.fixture(scope="class")
+    async def branch_3(self, db: InfrahubDatabase) -> Branch:
+        return await create_branch(branch_name="branch_3", db=db)
 
     @pytest.fixture(scope="class")
     async def diff_repository(self, db: InfrahubDatabase, default_branch: Branch) -> DiffRepository:
@@ -193,6 +232,32 @@ class TestDiffRebase(TestInfrahubApp):
 
         result = await client.execute_graphql(query=DIFF_UPDATE_QUERY, variables={"branch_name": branch_2.name})
         assert result["DiffUpdate"]["ok"]
+
+    @pytest.fixture(scope="class")
+    async def add_branch_3_changes(
+        self, db: InfrahubDatabase, client: InfrahubClient, default_branch: Branch, initial_dataset, branch_3: Branch
+    ):
+        antarctica_id = initial_dataset["antarctica"].id
+        antarctica_branch_1 = await NodeManager.get_one(db=db, id=antarctica_id, branch=branch_3)
+        await antarctica_branch_1.delete(db=db)
+
+        # delete a node schema with a relationship
+        branch_3_schema = await registry.schema.load_schema_from_db(db=db, branch=branch_3.name)
+
+        continent_schema = branch_3_schema.get(name=TestKind.CONTINENT, duplicate=True)
+        continent_schema.state = HashableModelState.ABSENT
+        manufacturer_schema = branch_3_schema.get(name=TestKind.MANUFACTURER, duplicate=True)
+        manufactuer_continent_rel = manufacturer_schema.get_relationship("continents")
+        manufactuer_continent_rel.state = HashableModelState.ABSENT
+        schemas_to_load = {"version": "1.0", "nodes": [continent_schema.model_dump(), manufacturer_schema.model_dump()]}
+        response = await client.schema.load(schemas=[schemas_to_load], branch=branch_3.name, wait_until_converged=True)
+        assert not response.errors
+        assert response.schema_updated
+
+        retrieved_branch_3_schema = await registry.schema.load_schema_from_db(db=db, branch=branch_3.name)
+        assert not retrieved_branch_3_schema.has(name=TestKind.CONTINENT)
+        manufacturer_schema = retrieved_branch_3_schema.get(name=TestKind.MANUFACTURER)
+        assert "continents" not in manufacturer_schema.relationship_names
 
     async def test_no_conflicts_before_merge(
         self,
@@ -481,3 +546,49 @@ class TestDiffRebase(TestInfrahubApp):
                 assert prop_diff.previous_value == (check_value if expected_action is DiffAction.REMOVED else None)
                 assert prop_diff.new_value == (check_value if expected_action is DiffAction.ADDED else None)
                 assert prop_diff.conflict is None
+
+    async def test_merge_and_rebase(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        initial_dataset,
+        client: InfrahubClient,
+        branch_3: Branch,
+        add_branch_3_changes,
+    ):
+        antarctica_id = initial_dataset["antarctica"].id
+
+        # add a node on main
+        main_jeb = await Node.init(db=db, branch=default_branch, schema=TestKind.PERSON)
+        await main_jeb.new(db=db, name="Jeb", height=160)
+        await main_jeb.save(db=db)
+
+        # check schema is correct on branch_3
+        branch_3_schema = await registry.schema.load_schema_from_db(db=db, branch=branch_3.name)
+        assert not branch_3_schema.has(name=TestKind.CONTINENT)
+        manufacturer_schema = branch_3_schema.get(name=TestKind.MANUFACTURER)
+        assert "continents" not in manufacturer_schema.relationship_names
+
+        # merge branch_3
+        result = await client.execute_graphql(query=BRANCH_MERGE, variables={"branch": branch_3.name})
+        assert result["BranchMerge"]["ok"]
+
+        # check schema is correct on default_branch
+        main_schema = await registry.schema.load_schema_from_db(db=db, branch=default_branch.name)
+        assert not main_schema.has(name=TestKind.CONTINENT)
+        manufacturer_schema = main_schema.get(name=TestKind.MANUFACTURER)
+        assert "continents" not in manufacturer_schema.relationship_names
+        no_antartica = await NodeManager.get_one(db=db, id=antarctica_id, branch=default_branch)
+        assert no_antartica is None
+
+        # rebase branch_3
+        result = await client.execute_graphql(query=BRANCH_REBASE, variables={"branch": branch_3.name})
+        assert result["BranchRebase"]["ok"]
+
+        # check branch_3 is updated
+        branch_3 = await Branch.get_by_name(db=db, name=branch_3.name)
+        no_antartica = await NodeManager.get_one(db=db, id=antarctica_id, branch=branch_3)
+        assert no_antartica is None
+        branch_3_jeb = await NodeManager.get_one(db=db, id=main_jeb.id, branch=branch_3)
+        assert branch_3_jeb.name.value == "Jeb"
+        assert branch_3_jeb.height.value == 160

--- a/backend/tests/unit/core/diff/test_coordinator.py
+++ b/backend/tests/unit/core/diff/test_coordinator.py
@@ -2,6 +2,7 @@ from typing import Any
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
+from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import DiffAction
 from infrahub.core.constants.database import DatabaseEdgeType
@@ -17,6 +18,7 @@ from infrahub.core.node import Node
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.dependencies.registry import get_component_registry
+from infrahub.exceptions import SchemaNotFoundError
 
 
 class TestDiffCoordinator:
@@ -366,3 +368,44 @@ class TestDiffCoordinator:
         assert rel_diffs == {("cars", DiffAction.UPDATED)}
         attr_diffs = {(a.name, a.action) for a in updated_person_diff.attributes}
         assert attr_diffs == {("height", DiffAction.UPDATED)}
+
+    async def test_schema_deleted_on_source_and_target_branches(
+        self,
+        db: InfrahubDatabase,
+        register_internal_models_schema,
+        default_branch: Branch,
+        person_john_main,
+    ) -> None:
+        branch = await create_branch(db=db, branch_name="branch1")
+        component_registry = get_component_registry()
+        diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=branch)
+        diff_repository = await component_registry.get_component(DiffRepository, db=db, branch=branch)
+
+        # delete john on the default branch
+        john_main = await NodeManager.get_one(db=db, id=person_john_main.id)
+        await john_main.delete(db=db)
+
+        # delete john on the branch
+        john_branch = await NodeManager.get_one(db=db, id=person_john_main.id, branch=branch)
+        await john_branch.delete(db=db)
+
+        # delete the schema on the default branch
+        main_schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+        main_schema_branch.delete(name="TestPerson")
+
+        # delete the schema on the branch, it might not exist b/c it was just deleted above
+        branch_schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+        try:
+            branch_schema_branch.delete(name="TestPerson")
+        except SchemaNotFoundError:
+            pass
+
+        # calculate the diff
+        diff_metadata = await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=branch)
+        enriched_diff = await diff_repository.get_one(diff_branch_name=branch.name, diff_id=diff_metadata.uuid)
+
+        assert len(enriched_diff.nodes) == 1
+        nodes_by_id = {n.uuid: n for n in enriched_diff.nodes}
+        assert set(nodes_by_id.keys()) == {person_john_main.id}
+        john_diff = nodes_by_id[person_john_main.id]
+        assert john_diff.action is DiffAction.REMOVED

--- a/changelog/6830.fixed.md
+++ b/changelog/6830.fixed.md
@@ -1,0 +1,1 @@
+Fix bug that would cause diff generation to fail if schema for a deleted Node was deleted on both source and target branches


### PR DESCRIPTION
fixes #6830 

diff generation would fail with `SchemaNotFoundError`s if node(s) were deleted with their schema on both the source and target branches

fix is to just catch and ignore the `SchemaNotFoundError`s.

another possible fix would be to add the ability to load a deleted schema, but that seems like overkill for this edge case

TODO:

- [x] integration test for the merge, rebase workflow that found the bug