### PR TITLE
make proposed change `created_by` relationship read_only

### DIFF
--- a/backend/infrahub/core/schema/definitions/core/propose_change.py
+++ b/backend/infrahub/core/schema/definitions/core/propose_change.py
@@ -66,6 +66,7 @@ core_proposed_change = NodeSchema(
             kind=RelKind.ATTRIBUTE,
             branch=BranchSupportType.AGNOSTIC,
             identifier="coreaccount__proposedchange_created_by",
+            read_only=True,
         ),
         Rel(
             name="comments",

--- a/backend/infrahub/graphql/mutations/action.py
+++ b/backend/infrahub/graphql/mutations/action.py
@@ -46,11 +46,14 @@ class InfrahubTriggerRuleMutation(InfrahubMutationMixin, Mutation):
         data: InputObjectType,
         branch: Branch,
         database: InfrahubDatabase | None = None,
+        override_data: dict[str, Any] | None = None,
     ) -> tuple[Node, Self]:
         graphql_context: GraphqlContext = info.context
         db = database or graphql_context.db
         _validate_node_kind(data=data, db=db)
-        trigger_rule_definition, result = await super().mutate_create(info=info, data=data, branch=branch, database=db)
+        trigger_rule_definition, result = await super().mutate_create(
+            info=info, data=data, branch=branch, database=db, override_data=override_data
+        )
 
         return trigger_rule_definition, result
 
@@ -93,11 +96,14 @@ class InfrahubTriggerRuleMatchMutation(InfrahubMutationMixin, Mutation):
         data: InputObjectType,
         branch: Branch,
         database: InfrahubDatabase | None = None,  # noqa: ARG003
+        override_data: dict[str, Any] | None = None,
     ) -> tuple[Node, Self]:
         graphql_context: GraphqlContext = info.context
 
         async with graphql_context.db.start_transaction() as dbt:
-            trigger_match, result = await super().mutate_create(info=info, data=data, branch=branch, database=dbt)
+            trigger_match, result = await super().mutate_create(
+                info=info, data=data, branch=branch, database=dbt, override_data=override_data
+            )
             trigger_match_model = cast(CoreNodeTriggerAttributeMatch | CoreNodeTriggerRelationshipMatch, trigger_match)
             node_trigger_rule = await trigger_match_model.trigger.get_peer(db=dbt, raise_on_error=True)
             node_trigger_rule_model = cast(CoreNodeTriggerRule, node_trigger_rule)

--- a/backend/infrahub/graphql/mutations/artifact_definition.py
+++ b/backend/infrahub/graphql/mutations/artifact_definition.py
@@ -49,10 +49,13 @@ class InfrahubArtifactDefinitionMutation(InfrahubMutationMixin, Mutation):
         data: InputObjectType,
         branch: Branch,
         database: InfrahubDatabase | None = None,  # noqa: ARG003
+        override_data: dict[str, Any] | None = None,
     ) -> tuple[Node, Self]:
         graphql_context: GraphqlContext = info.context
 
-        artifact_definition, result = await super().mutate_create(info=info, data=data, branch=branch)
+        artifact_definition, result = await super().mutate_create(
+            info=info, data=data, branch=branch, override_data=override_data
+        )
 
         if graphql_context.service:
             model = RequestArtifactDefinitionGenerate(

--- a/backend/infrahub/graphql/mutations/graphql_query.py
+++ b/backend/infrahub/graphql/mutations/graphql_query.py
@@ -68,6 +68,7 @@ class InfrahubGraphQLQueryMutation(InfrahubMutationMixin, Mutation):
         data: InputObjectType,
         branch: Branch,
         database: InfrahubDatabase | None = None,  # noqa: ARG003
+        override_data: dict[str, Any] | None = None,
     ) -> tuple[Node, Self]:
         graphql_context: GraphqlContext = info.context
 
@@ -75,7 +76,7 @@ class InfrahubGraphQLQueryMutation(InfrahubMutationMixin, Mutation):
             await cls.extract_query_info(info=info, data=data, branch=graphql_context.branch, db=graphql_context.db)
         )
 
-        obj, result = await super().mutate_create(info=info, data=data, branch=branch)
+        obj, result = await super().mutate_create(info=info, data=data, branch=branch, override_data=override_data)
 
         return obj, result
 

--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -146,7 +146,9 @@ class InfrahubMutationMixin:
         return mutation
 
     @classmethod
-    async def _call_mutate_create_object(cls, data: InputObjectType, db: InfrahubDatabase, branch: Branch) -> Node:
+    async def _call_mutate_create_object(
+        cls, data: InputObjectType, db: InfrahubDatabase, branch: Branch, override_data: dict[str, Any] | None = None
+    ) -> Node:
         """
         Wrapper around mutate_create_object to potentially activate locking.
         """
@@ -156,9 +158,9 @@ class InfrahubMutationMixin:
         )
         if lock_names:
             async with InfrahubMultiLock(lock_registry=lock.registry, locks=lock_names):
-                return await cls.mutate_create_object(data=data, db=db, branch=branch)
+                return await cls.mutate_create_object(data=data, db=db, branch=branch, extra_data=override_data)
 
-        return await cls.mutate_create_object(data=data, db=db, branch=branch)
+        return await cls.mutate_create_object(data=data, db=db, branch=branch, extra_data=override_data)
 
     @classmethod
     async def mutate_create(
@@ -167,10 +169,11 @@ class InfrahubMutationMixin:
         data: InputObjectType,
         branch: Branch,
         database: InfrahubDatabase | None = None,
+        override_data: dict[str, Any] | None = None,
     ) -> tuple[Node, Self]:
         graphql_context: GraphqlContext = info.context
         db = database or graphql_context.db
-        obj = await cls._call_mutate_create_object(data=data, db=db, branch=branch)
+        obj = await cls._call_mutate_create_object(data=data, db=db, branch=branch, override_data=override_data)
         result = await cls.mutate_create_to_graphql(info=info, db=db, obj=obj)
         return obj, result
 
@@ -181,12 +184,15 @@ class InfrahubMutationMixin:
         data: InputObjectType,
         db: InfrahubDatabase,
         branch: Branch,
+        override_data: dict[str, Any] | None = None,
     ) -> Node:
         schema = cls._meta.active_schema
         if isinstance(schema, GenericSchema):
             raise ValueError(f"Node of generic schema `{schema.name=}` can not be instantiated.")
+        create_data = dict(data)
+        create_data.update(override_data or {})
         return await create_node(
-            data=dict(data),
+            data=create_data,
             db=db,
             branch=branch,
             schema=schema,

--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -158,9 +158,9 @@ class InfrahubMutationMixin:
         )
         if lock_names:
             async with InfrahubMultiLock(lock_registry=lock.registry, locks=lock_names):
-                return await cls.mutate_create_object(data=data, db=db, branch=branch, extra_data=override_data)
+                return await cls.mutate_create_object(data=data, db=db, branch=branch, override_data=override_data)
 
-        return await cls.mutate_create_object(data=data, db=db, branch=branch, extra_data=override_data)
+        return await cls.mutate_create_object(data=data, db=db, branch=branch, override_data=override_data)
 
     @classmethod
     async def mutate_create(

--- a/backend/infrahub/graphql/mutations/menu.py
+++ b/backend/infrahub/graphql/mutations/menu.py
@@ -54,10 +54,11 @@ class InfrahubCoreMenuMutation(InfrahubMutationMixin, Mutation):
         data: InputObjectType,
         branch: Branch,
         database: InfrahubDatabase | None = None,  # noqa: ARG003
+        override_data: dict[str, Any] | None = None,
     ) -> tuple[Node, Self]:
         validate_namespace(data=data)
 
-        obj, result = await super().mutate_create(info=info, data=data, branch=branch)
+        obj, result = await super().mutate_create(info=info, data=data, branch=branch, override_data=override_data)
 
         return obj, result
 

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -52,11 +52,16 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
         data: InputObjectType,
         branch: Branch,
         database: InfrahubDatabase | None = None,  # noqa: ARG003
+        override_data: dict[str, Any] | None = None,
     ) -> tuple[Node, Self]:
         graphql_context: GraphqlContext = info.context
 
+        override_data = {"created_by": {"id": graphql_context.active_account_session.account_id}}
+
         async with graphql_context.db.start_transaction() as dbt:
-            proposed_change, result = await super().mutate_create(info=info, data=data, branch=branch, database=dbt)
+            proposed_change, result = await super().mutate_create(
+                info=info, data=data, branch=branch, database=dbt, override_data=override_data
+            )
             destination_branch = proposed_change.destination_branch.value
             source_branch = await _get_source_branch(db=dbt, name=proposed_change.source_branch.value)
             if destination_branch == source_branch.name:

--- a/backend/infrahub/graphql/mutations/repository.py
+++ b/backend/infrahub/graphql/mutations/repository.py
@@ -64,12 +64,13 @@ class InfrahubRepositoryMutation(InfrahubMutationMixin, Mutation):
         data: InputObjectType,
         branch: Branch,
         database: InfrahubDatabase | None = None,  # noqa: ARG003
+        override_data: dict[str, Any] | None = None,
     ) -> tuple[Node, Self]:
         graphql_context: GraphqlContext = info.context
 
         cleanup_payload(data)
         # Create the object in the database
-        obj, result = await super().mutate_create(info, data, branch)
+        obj, result = await super().mutate_create(info, data, branch, override_data=override_data)
         obj = cast(CoreGenericRepository, obj)
 
         # First check the connectivity to the remote repository

--- a/backend/infrahub/graphql/mutations/webhook.py
+++ b/backend/infrahub/graphql/mutations/webhook.py
@@ -67,6 +67,7 @@ class InfrahubWebhookMutation(InfrahubMutationMixin, Mutation):
         data: InputObjectType,
         branch: Branch,
         database: InfrahubDatabase | None = None,
+        override_data: dict[str, Any] | None = None,
     ) -> tuple[Node, Self]:
         graphql_context: GraphqlContext = info.context
 
@@ -74,7 +75,9 @@ class InfrahubWebhookMutation(InfrahubMutationMixin, Mutation):
 
         _validate_input(graphql_context=graphql_context, branch=branch, input_data=input_data)
 
-        obj, result = await super().mutate_create(info=info, data=data, branch=branch, database=database)
+        obj, result = await super().mutate_create(
+            info=info, data=data, branch=branch, database=database, override_data=override_data
+        )
 
         return obj, result
 

--- a/backend/tests/integration/message_bus/operations/request/test_proposed_change.py
+++ b/backend/tests/integration/message_bus/operations/request/test_proposed_change.py
@@ -10,6 +10,7 @@ from infrahub import config
 from infrahub.auth import AccountSession, AuthType
 from infrahub.context import BranchContext, InfrahubContext
 from infrahub.core.constants import InfrahubKind
+from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.git import InfrahubRepository
 from infrahub.message_bus.types import ProposedChangeBranchDiff
@@ -74,6 +75,11 @@ mutation ProposedChange(
   ) {
     object {
       id
+      created_by {
+        node {
+          id
+        }
+      }
     }
   }
 }
@@ -82,10 +88,17 @@ mutation ProposedChange(
 
 class TestProposedChange(TestInfrahubApp):
     @pytest.fixture(scope="class")
-    async def context(self) -> InfrahubContext:
+    async def user_account(self, db: InfrahubDatabase) -> Node:
+        account = await Node.init(db=db, schema=InfrahubKind.ACCOUNT)
+        await account.new(db=db, name="user", password="password")
+        await account.save(db=db)
+        return account
+
+    @pytest.fixture(scope="class")
+    async def context(self, user_account: Node) -> InfrahubContext:
         """Placeholder context for now, would be good to implement some auth and permissions here"""
         return InfrahubContext(
-            account=AccountSession(authenticated=False, account_id="placeholder", auth_type=AuthType.NONE),
+            account=AccountSession(authenticated=False, account_id=user_account.get_id(), auth_type=AuthType.NONE),
             branch=BranchContext(name="main", id="placeholder"),
         )
 
@@ -98,6 +111,7 @@ class TestProposedChange(TestInfrahubApp):
         init_db_base,
         client: InfrahubClient,
         redis,
+        user_account: Node,
         context: InfrahubContext,
     ) -> str:
         source_dir = tmp_path_module_scope / "sources"
@@ -132,7 +146,14 @@ class TestProposedChange(TestInfrahubApp):
         )
         assert not result.errors
         assert result.data
-        return result.data["CoreProposedChangeCreate"]["object"]["id"]
+        assert result.data["CoreProposedChangeCreate"]["object"]["created_by"]["node"]["id"] == user_account.get_id()
+        proposed_change_id = result.data["CoreProposedChangeCreate"]["object"]["id"]
+
+        pc = await NodeManager.get_one(db=db, id=proposed_change_id)
+        created_by = await pc.created_by.get_peer(db=db)
+        assert created_by.get_id() == user_account.get_id()
+
+        return proposed_change_id
 
     async def test_run_pipeline_validate_requested_jobs(
         self,

--- a/backend/tests/unit/graphql/mutations/test_proposed_change.py
+++ b/backend/tests/unit/graphql/mutations/test_proposed_change.py
@@ -89,7 +89,16 @@ async def test_create_invalid_branch_combinations(db: InfrahubDatabase, default_
     source_branch = Branch(name=branch_name)
     await source_branch.save(db=db)
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    account = await Node.init(db=db, schema=InfrahubKind.ACCOUNT)
+    await account.new(db=db, name="user", password="password")
+    await account.save(db=db)
+
+    gql_params = await prepare_graphql_params(
+        db=db,
+        include_subscription=False,
+        branch=default_branch,
+        account_session=AccountSession(authenticated=False, account_id=account.get_id(), auth_type=AuthType.NONE),
+    )
     no_source = await graphql(
         schema=gql_params.schema,
         source=CREATE_PROPOSED_CHANGE,

--- a/changelog/+ifc1650.added.md
+++ b/changelog/+ifc1650.added.md
@@ -1,0 +1,3 @@
+<!-- vale off -->
+Make created_by relationship of CoreProposedChange read-only. Set the relationship server-side during the CoreProposedChangeCreate mutation.
+<!-- vale on -->

--- a/frontend/app/src/entities/proposed-changes/api/createProposedChange.ts
+++ b/frontend/app/src/entities/proposed-changes/api/createProposedChange.ts
@@ -7,7 +7,6 @@ export const CREATE_PROPOSED_CHANGE = gql`
     $source_branch: String!
     $destination_branch: String!
     $reviewers: [RelatedNodeInput!]
-    $created_by: RelatedNodeInput!
   ) {
     CoreProposedChangeCreate(
       data: {
@@ -16,7 +15,6 @@ export const CREATE_PROPOSED_CHANGE = gql`
         source_branch: { value: $source_branch }
         destination_branch: { value: $destination_branch }
         reviewers: $reviewers
-        created_by: $created_by
       }
     ) {
       object {

--- a/frontend/app/src/entities/proposed-changes/ui/create-form.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/create-form.tsx
@@ -1,6 +1,5 @@
 import { PROPOSED_CHANGES_OBJECT } from "@/config/constants";
 import { QSP } from "@/config/qsp";
-import { useAuth } from "@/entities/authentication/ui/useAuth";
 import { branchesState } from "@/entities/branches/stores";
 import { branchesToSelectOptions } from "@/entities/branches/utils";
 import { Node } from "@/entities/nodes/getObjectItemDisplayValue";
@@ -37,7 +36,6 @@ import { toast } from "react-toastify";
 import { StringParam, useQueryParam } from "use-query-params";
 
 export const ProposedChangeCreateForm = () => {
-  const { user } = useAuth();
   const [sourceBranch] = useQueryParam(QSP.SOURCE_BRANCH, StringParam);
   const branches = useAtomValue(branchesState);
   const defaultBranch = branches.find((branch) => branch.is_default);
@@ -61,9 +59,6 @@ export const ProposedChangeCreateForm = () => {
             name,
             description,
             reviewers: reviewers?.map((node: Node) => ({ id: node.id })) || [],
-            created_by: {
-              id: user?.id,
-            },
           },
         });
 


### PR DESCRIPTION
IFC-1650

make CoreProposedChange.created_by a read-only relationship
set the `created_by` relationship to the logged-in user during the `CoreProposedChangeCreate` mutation