### PR TITLE
Fix Resource Pool utilization query for large IPv6 prefix resource

### DIFF
--- a/backend/infrahub/graphql/queries/resource_manager.py
+++ b/backend/infrahub/graphql/queries/resource_manager.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from graphene import Field, Float, Int, List, NonNull, ObjectType, String
+from graphene import BigInt, Field, Float, Int, List, NonNull, ObjectType, String
 from infrahub_sdk.utils import extract_fields_first_node
 
 from infrahub.core import registry
@@ -33,7 +33,7 @@ class IPPoolUtilizationResource(ObjectType):
     id = Field(String, required=True, description="The ID of the current resource")
     display_label = Field(String, required=True, description="The common name of the resource")
     kind = Field(String, required=True, description="The resource kind")
-    weight = Field(Int, required=True, description="The relative weight of this resource.")
+    weight = Field(BigInt, required=True, description="The relative weight of this resource.")
     utilization = Field(Float, required=True, description="The overall utilization of the resource.")
     utilization_branches = Field(
         Float, required=True, description="The utilization of the resource on all non default branches."
@@ -70,7 +70,7 @@ def _validate_pool_type(pool_id: str, pool: CoreNode | None = None) -> CoreNode:
 
 
 class PoolAllocated(ObjectType):
-    count = Field(Int, required=True, description="The number of allocations within the selected pool.")
+    count = Field(BigInt, required=True, description="The number of allocations within the selected pool.")
     edges = Field(List(of_type=NonNull(PoolAllocatedEdge), required=True), required=True)
 
     @staticmethod
@@ -174,7 +174,7 @@ class PoolAllocated(ObjectType):
 
 
 class PoolUtilization(ObjectType):
-    count = Field(Int, required=True, description="The number of resources within the selected pool.")
+    count = Field(BigInt, required=True, description="The number of resources within the selected pool.")
     utilization = Field(Float, required=True, description="The overall utilization of the pool.")
     utilization_branches = Field(Float, required=True, description="The utilization in all non default branches.")
     utilization_default_branch = Field(

--- a/backend/tests/unit/graphql/queries/test_resource_pool.py
+++ b/backend/tests/unit/graphql/queries/test_resource_pool.py
@@ -254,6 +254,40 @@ async def test_create_ipv6_prefix_and_read_allocations(db: InfrahubDatabase, def
     assert site2_prefix in prefixes
     assert site3_prefix in prefixes
 
+    # ------------------------------------------------------------
+    # Validate the utilization query in the main Branch
+    # ------------------------------------------------------------
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    utilization_result = await graphql(
+        schema=gql_params.schema,
+        source=POOL_UTILIZATION,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"pool_id": ipv6_prefix_pool.id},
+    )
+
+    assert not utilization_result.errors
+    assert utilization_result.data
+    assert utilization_result.data["InfrahubResourcePoolUtilization"] == {
+        "edges": [
+            {
+                "node": {
+                    "display_label": "2001:db8::/48",
+                    "id": ipv6_prefix_resource.id,
+                    "kind": "IpamIPPrefix",
+                    "utilization": 0.0,
+                    "utilization_branches": 0.0,
+                    "utilization_default_branch": 0.0,
+                    "weight": 1208925819614629174706176,
+                },
+            },
+        ],
+        "count": 1,
+        "utilization": 0.0,
+        "utilization_branches": 0.0,
+        "utilization_default_branch": 0.0,
+    }
+
 
 async def test_create_ipv4_prefix_and_read_allocations(db: InfrahubDatabase, default_branch: Branch, prefix_pools_02):
     ipv4_prefix_resource = prefix_pools_02["ipv4_prefix_resource"]

--- a/changelog/6855.fixed.md
+++ b/changelog/6855.fixed.md
@@ -1,0 +1,1 @@
+Fix Resource Pool utilization query for large IPv6 prefix resource


### PR DESCRIPTION
Fixes #6855 

Use `BitInt` instead of `Int` for `InfrahubResourcePoolUtilization` query in GraphQL