### PR TITLE
Refactor NumberPoolGetUsed query to account for deleted node and branch

### DIFF
--- a/backend/infrahub/core/convert_object_type/conversion.py
+++ b/backend/infrahub/core/convert_object_type/conversion.py
@@ -9,6 +9,7 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.node.create import create_node
 from infrahub.core.query.relationship import GetAllPeersIds
+from infrahub.core.query.resource_manager import PoolChangeReserved
 from infrahub.core.relationship import RelationshipManager
 from infrahub.core.schema import NodeSchema
 from infrahub.database import InfrahubDatabase
@@ -120,5 +121,14 @@ async def convert_object_type(
         peers = await NodeManager.get_many(ids=peers_ids, db=dbt, prefetch_relationships=True, branch=branch)
         for peer in peers.values():
             peer.validate_relationships()
+
+        # If the node had some value reserved in any Pools / Resource Manager, we need to change the identifier of the reservation(s)
+        query = await PoolChangeReserved.init(
+            db=dbt,
+            existing_identifier=node.get_id(),
+            new_identifier=node_created.get_id(),
+            branch=branch,
+        )
+        await query.execute(db=dbt)
 
         return node_created

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -372,13 +372,9 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
 
                 # Do a lookup of the number pool to get the correct mapped type from the registry
                 # without this we don't get access to the .get_resource() method.
-                created_pool: CoreNumberPool = (
-                    number_pool_from_db
-                    or await registry.manager.get_one_by_id_or_default_filter(
-                        db=db, id=number_pool.id, kind=CoreNumberPool
-                    )
+                return await registry.manager.get_one_by_id_or_default_filter(
+                    db=db, id=number_pool.id, kind=CoreNumberPool
                 )
-                return created_pool
 
     async def handle_object_template(self, fields: dict, db: InfrahubDatabase, errors: list) -> None:
         """Fill the `fields` parameters with values from an object template if one is in use."""
@@ -842,6 +838,7 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
 
         query = await NodeDeleteQuery.init(db=db, node=self, at=delete_at)
         await query.execute(db=db)
+
         self._node_changelog = node_changelog
 
     async def to_graphql(

--- a/backend/infrahub/core/node/resource_manager/number_pool.py
+++ b/backend/infrahub/core/node/resource_manager/number_pool.py
@@ -42,7 +42,7 @@ class CoreNumberPool(Node):
 
         query = await NumberPoolGetUsed.init(db=db, branch=branch, pool=self, branch_agnostic=True)
         await query.execute(db=db)
-        used = [result.get_as_optional_type("value", return_type=int) for result in query.results]
+        used = [result.value for result in query.iter_results()]
         return [item for item in used if item is not None]
 
     async def reserve(self, db: InfrahubDatabase, number: int, identifier: str, at: Timestamp | None = None) -> None:

--- a/backend/infrahub/core/query/resource_manager.py
+++ b/backend/infrahub/core/query/resource_manager.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, AsyncGenerator
+from typing import TYPE_CHECKING, Any, Generator
 
 from pydantic import BaseModel, ConfigDict
 
@@ -11,6 +11,13 @@ from infrahub.core.query import Query, QueryType
 if TYPE_CHECKING:
     from infrahub.core.protocols import CoreNumberPool
     from infrahub.database import InfrahubDatabase
+
+
+class NumberPoolIdentifierData(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    value: int
+    identifier: str
 
 
 class IPAddressPoolGetIdentifiers(Query):
@@ -160,7 +167,7 @@ class NumberPoolGetReserved(Query):
     def __init__(
         self,
         pool_id: str,
-        identifier: str,
+        identifier: str | None = None,
         **kwargs: dict[str, Any],
     ) -> None:
         self.pool_id = pool_id
@@ -178,28 +185,89 @@ class NumberPoolGetReserved(Query):
 
         self.params.update(branch_params)
 
+        # If identifier is not provided, we return all reservations for the pool
+        identifier_filter = ""
+        if self.identifier:
+            identifier_filter = "r.identifier = $identifier AND "
+            self.params["identifier"] = self.identifier
+
         query = """
         MATCH (pool:%(number_pool)s { uuid: $pool_id })-[r:IS_RESERVED]->(reservation:AttributeValue)
         WHERE
-            r.identifier = $identifier
-            AND
+            %(identifier_filter)s
             %(branch_filter)s
-        """ % {"branch_filter": branch_filter, "number_pool": InfrahubKind.NUMBERPOOL}
+        """ % {
+            "branch_filter": branch_filter,
+            "number_pool": InfrahubKind.NUMBERPOOL,
+            "identifier_filter": identifier_filter,
+        }
         self.add_to_query(query)
-        self.return_labels = ["reservation.value"]
+        self.return_labels = ["reservation.value AS value", "r.identifier AS identifier"]
 
     def get_reservation(self) -> int | None:
         result = self.get_result()
         if result:
-            return result.get_as_optional_type("reservation.value", return_type=int)
+            return result.get_as_optional_type("value", return_type=int)
         return None
 
+    def get_reservations(self) -> Generator[NumberPoolIdentifierData]:
+        for result in self.results:
+            yield NumberPoolIdentifierData.model_construct(
+                value=result.get_as_type("value", return_type=int),
+                identifier=result.get_as_type("identifier", return_type=str),
+            )
 
-class NumberPoolGetUsedData(BaseModel):
-    model_config = ConfigDict(frozen=True)
 
-    value: int
-    identifier: str
+class PoolChangeReserved(Query):
+    """Change the identifier on all pools.
+    This is useful when a node is being converted to a different type and its ID has changed
+    """
+
+    name = "pool_change_reserved"
+    type = QueryType.WRITE
+
+    def __init__(
+        self,
+        existing_identifier: str,
+        new_identifier: str,
+        **kwargs: dict[str, Any],
+    ) -> None:
+        self.existing_identifier = existing_identifier
+        self.new_identifier = new_identifier
+
+        super().__init__(**kwargs)  # type: ignore[arg-type]
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
+        self.params["new_identifier"] = self.new_identifier
+        self.params["existing_identifier"] = self.existing_identifier
+        self.params["at"] = self.at.to_string()
+
+        branch_filter, branch_params = self.branch.get_query_filter_path(
+            at=self.at.to_string(), branch_agnostic=self.branch_agnostic
+        )
+
+        self.params.update(branch_params)
+
+        global_branch = registry.get_global_branch()
+        self.params["rel_prop"] = {
+            "branch": global_branch.name,
+            "branch_level": global_branch.hierarchy_level,
+            "status": RelationshipStatus.ACTIVE.value,
+            "from": self.at.to_string(),
+            "identifier": self.new_identifier,
+        }
+
+        query = """
+        MATCH (pool:Node)-[r:IS_RESERVED]->(resource)
+        WHERE
+            r.identifier = $existing_identifier
+            AND
+            %(branch_filter)s
+        SET r.to = $at
+        CREATE (pool)-[new_rel:IS_RESERVED $rel_prop]->(resource)
+        """ % {"branch_filter": branch_filter}
+        self.add_to_query(query)
+        self.return_labels = ["pool.uuid AS pool_id", "r", "new_rel"]
 
 
 """
@@ -214,7 +282,7 @@ This will be especially important as we want to support upsert with NumberPool
 class NumberPoolGetUsed(Query):
     name = "number_pool_get_used"
     type = QueryType.READ
-    return_model = NumberPoolGetUsedData
+    return_model = NumberPoolIdentifierData
 
     def __init__(
         self,
@@ -262,7 +330,7 @@ class NumberPoolGetUsed(Query):
         self.return_labels = ["DISTINCT(av.value) as value", "res.identifier as identifier"]
         self.order_by = ["value"]
 
-    async def iter_results(self) -> AsyncGenerator[NumberPoolGetUsedData]:
+    def iter_results(self) -> Generator[NumberPoolIdentifierData]:
         for result in self.results:
             yield self.return_model.model_construct(
                 value=result.get_as_type("value", return_type=int),

--- a/backend/infrahub/core/query/resource_manager.py
+++ b/backend/infrahub/core/query/resource_manager.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, AsyncGenerator
+
+from pydantic import BaseModel, ConfigDict
 
 from infrahub.core import registry
 from infrahub.core.constants import InfrahubKind, RelationshipStatus
@@ -193,9 +195,26 @@ class NumberPoolGetReserved(Query):
         return None
 
 
+class NumberPoolGetUsedData(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    value: int
+    identifier: str
+
+
+"""
+Important!: The relationship IS_RESERVED for Number is not being cleaned up when the node or the branch is deleted
+I think this is something we should address in the future.
+It works for now because the query has been updated to match the identifier in IS_RESERVED with the UUID of the related node
+But in the future, if we need to use an identifier that is not the UUID, we will need to clean up the relationships
+This will be especially important as we want to support upsert with NumberPool
+"""
+
+
 class NumberPoolGetUsed(Query):
     name = "number_pool_get_used"
     type = QueryType.READ
+    return_model = NumberPoolGetUsedData
 
     def __init__(
         self,
@@ -218,30 +237,37 @@ class NumberPoolGetUsed(Query):
         self.params.update(branch_params)
         self.params["attribute_name"] = self.pool.node_attribute.value
 
-        # NOTE, there is a bug with IS_RESERVED that is affecting this query
-        # Currently the workaround is to use DISTINCT to avoid duplicates but overtime the query could become slower than expected
-        # This should be fixed in the future
         query = """
-        MATCH (pool:%(number_pool)s { uuid: $pool_id })
-        CALL (pool) {
-            MATCH (pool)-[res:IS_RESERVED]->(av:AttributeValue)<-[hv:HAS_VALUE]-(attr:Attribute)
+        MATCH (pool:%(number_pool)s { uuid: $pool_id })-[res:IS_RESERVED]->(av:AttributeValue)
+        WHERE toInteger(av.value) >= $start_range and toInteger(av.value) <= $end_range
+        CALL (pool, res, av) {
+            MATCH (pool)-[res]->(av)<-[hv:HAS_VALUE]-(attr:Attribute)<-[ha:HAS_ATTRIBUTE]-(n:%(node)s)
             WHERE
-                attr.name = $attribute_name
-                AND
-                toInteger(av.value) >= $start_range and toInteger(av.value) <= $end_range
-                AND
-                all(r in [res, hv] WHERE (%(branch_filter)s))
-            RETURN av, (res.status = "active" AND hv.status = "active") AS is_active
+                n.uuid = res.identifier AND
+                attr.name = $attribute_name AND
+                all(r in [res, hv, ha] WHERE (%(branch_filter)s))
+            ORDER BY res.branch_level DESC, hv.branch_level DESC, ha.branch_level DESC, res.from DESC, hv.from DESC, ha.from DESC
+            RETURN (res.status = "active" AND hv.status = "active" AND ha.status = "active") AS is_active
+            LIMIT 1
         }
-        WITH av, is_active
-        WHERE is_active = TRUE
+        WITH av, res, is_active
+        WHERE is_active = True
         """ % {
             "branch_filter": branch_filter,
             "number_pool": InfrahubKind.NUMBERPOOL,
+            "node": self.pool.node.value,
         }
+
         self.add_to_query(query)
-        self.return_labels = ["DISTINCT(av.value) as value"]
+        self.return_labels = ["DISTINCT(av.value) as value", "res.identifier as identifier"]
         self.order_by = ["value"]
+
+    async def iter_results(self) -> AsyncGenerator[NumberPoolGetUsedData]:
+        for result in self.results:
+            yield self.return_model.model_construct(
+                value=result.get_as_type("value", return_type=int),
+                identifier=result.get_as_type("identifier", return_type=str),
+            )
 
 
 class NumberPoolSetReserved(Query):

--- a/backend/tests/functional/convert_object_type/test_convert_object_type.py
+++ b/backend/tests/functional/convert_object_type/test_convert_object_type.py
@@ -2,11 +2,33 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
+from infrahub.core.constants import InfrahubKind
 from infrahub.core.convert_object_type.conversion import InputDataForDestField, InputForDestField
+from infrahub.core.query.resource_manager import NumberPoolGetReserved
+from infrahub.core.schema import AttributeSchema, GenericSchema, NodeSchema, SchemaRoot
 from tests.helpers.test_app import TestInfrahubApp
 
 if TYPE_CHECKING:
     from infrahub_sdk import InfrahubClient
+    from infrahub_sdk.node import InfrahubNode
+
+    from infrahub.core.branch import Branch
+    from infrahub.database import InfrahubDatabase
+
+CONVERT_OBJECT_MUTATION = """
+    mutation($node_id: String!, $target_kind: String!, $fields_mapping: GenericScalar!) {
+        ConvertObjectType(data: {
+                node_id: $node_id,
+                target_kind: $target_kind,
+                fields_mapping: $fields_mapping
+            }) {
+                ok
+                node
+        }
+    }
+"""
 
 
 class TestGetConversionSchemaMapping(TestInfrahubApp):
@@ -93,21 +115,7 @@ class TestConvertObjectType(TestInfrahubApp):
             favorite_car=car_1,
             fastest_cars=[car_1, car_2],
         )
-
         await jack_1.save()
-
-        query = """
-            mutation($node_id: String!, $target_kind: String!, $fields_mapping: GenericScalar!) {
-                ConvertObjectType(data: {
-                        node_id: $node_id,
-                        target_kind: $target_kind,
-                        fields_mapping: $fields_mapping
-                    }) {
-                        ok
-                        node
-                }
-            }
-        """
 
         mapping = {
             "name": InputForDestField(source_field="name"),
@@ -121,7 +129,7 @@ class TestConvertObjectType(TestInfrahubApp):
         mapping_dict = {field_name: model.model_dump(mode="json") for field_name, model in mapping.items()}
 
         response = await client.execute_graphql(
-            query=query,
+            query=CONVERT_OBJECT_MUTATION,
             variables={
                 "node_id": str(jack_1.id),
                 "fields_mapping": mapping_dict,
@@ -135,3 +143,78 @@ class TestConvertObjectType(TestInfrahubApp):
         assert res_node["age"]["value"] == 25
         assert res_node["name"]["value"] == "Jack"
         assert res_node["height"]["value"] == 170
+
+
+class TestConvertObjectTypeResourcePool(TestInfrahubApp):
+    @pytest.fixture
+    async def schemas_person(self, node_group_schema, data_schema) -> SchemaRoot:
+        person_generic = GenericSchema(
+            name="PersonGeneric",
+            namespace="Test",
+            human_friendly_id=["name__value"],
+            attributes=[
+                AttributeSchema(name="name", kind="Text", unique=True),
+                AttributeSchema(name="height", kind="Number", optional=True),
+                AttributeSchema(name="random_id", kind="NumberPool", read_only=True),
+            ],
+        )
+
+        person1 = NodeSchema(
+            name="Person1",
+            namespace="Test",
+            inherit_from=[person_generic.kind],
+        )
+
+        person2 = NodeSchema(
+            name="Person2",
+            namespace="Test",
+            inherit_from=[person_generic.kind],
+            attributes=[
+                AttributeSchema(name="age", kind="Number", default_value=25),
+                AttributeSchema(name="citizenship", kind="Text", optional=True),
+            ],
+        )
+
+        schema: SchemaRoot = SchemaRoot(version="1.0", generics=[person_generic], nodes=[person1, person2])
+        return schema
+
+    async def test_convert_number_pool(
+        self, db: InfrahubDatabase, client: InfrahubClient, schemas_person: SchemaRoot, default_branch: Branch
+    ) -> None:
+        response = await client.schema.load(schemas=[schemas_person.model_dump()])
+        assert len(response.errors) == 0, response.errors
+
+        # Create some objects
+        persons: dict[str, InfrahubNode] = {}
+        for name in ["jack", "paul", "pierre"]:
+            person = await client.create(kind="TestPerson1", name=name)
+            await person.save()
+            persons[name] = person
+
+        # Retrieve the pool used for the NumberPool attribute
+        pools = await client.all(kind=InfrahubKind.NUMBERPOOL)
+        assert len(pools) == 1
+        pool = pools[0]
+
+        # Check the state of the pool before converting the object
+        query1 = await NumberPoolGetReserved.init(db=db, pool_id=pool.id, branch=default_branch)
+        await query1.execute(db=db)
+        reservations_before = {item.identifier: item.value for item in query1.get_reservations()}
+
+        response = await client.execute_graphql(
+            query=CONVERT_OBJECT_MUTATION,
+            variables={
+                "node_id": str(persons["jack"].id),
+                "target_kind": "TestPerson2",
+                "fields_mapping": {},
+            },
+            branch_name="main",
+        )
+        assert response["ConvertObjectType"]["ok"] is True
+        new_id = response["ConvertObjectType"]["node"]["id"]
+
+        query1 = await NumberPoolGetReserved.init(db=db, pool_id=pool.id, branch=default_branch)
+        await query1.execute(db=db)
+        reservations_after = {item.identifier: item.value for item in query1.get_reservations()}
+
+        assert reservations_after[new_id] == reservations_before[str(persons["jack"].id)]

--- a/backend/tests/functional/pools/test_numberpool_branch.py
+++ b/backend/tests/functional/pools/test_numberpool_branch.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from infrahub_sdk.graphql import Query
+
+from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot
+from infrahub.services.adapters.cache.redis import RedisCache
+from tests.helpers.test_app import TestInfrahubApp
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from infrahub_sdk import InfrahubClient
+
+    from infrahub.core.branch import Branch
+    from infrahub.database import InfrahubDatabase
+    from tests.adapters.message_bus import BusSimulator
+
+
+REQUEST = NodeSchema(
+    name="Request",
+    namespace="Test",
+    label="Request",
+    attributes=[
+        AttributeSchema(name="title", kind="Text", unique=False, optional=False),
+        AttributeSchema(name="number", kind="NumberPool", optional=False, read_only=True, unique=True),
+    ],
+)
+
+INCIDENT = NodeSchema(
+    name="Incident",
+    namespace="Test",
+    label="Incident",
+    attributes=[
+        AttributeSchema(name="title", kind="Text", unique=False, optional=False),
+        AttributeSchema(name="number", kind="NumberPool", optional=False, read_only=True, unique=True),
+    ],
+)
+
+number_pool_allocation_query = Query(
+    query={
+        "InfrahubResourcePoolAllocated": {"@filters": {"pool_id": "$pool_id", "resource_id": "$pool_id"}, "count": None}
+    },
+    variables={"pool_id": str},
+)
+
+BRANCH2 = "branch2"
+
+
+class TestAttributeNumberPoolLifecycle(TestInfrahubApp):
+    @pytest.fixture(scope="class")
+    def initial_schema(self) -> SchemaRoot:
+        schema = SchemaRoot(
+            version="1.0",
+            nodes=[INCIDENT, REQUEST],
+        )
+        return schema
+
+    @pytest.fixture(scope="class")
+    async def initial_dataset(
+        self,
+        db: InfrahubDatabase,
+        initialize_registry: None,
+        git_repos_source_dir_module_scope: Path,
+        client: InfrahubClient,
+        bus_simulator: BusSimulator,
+        prefect_test_fixture,
+        initial_schema: SchemaRoot,
+        default_branch: Branch,
+    ) -> None:
+        bus_simulator.service._cache = RedisCache()
+
+        schema_load_response = await client.schema.load(
+            schemas=[initial_schema.model_dump()], wait_until_converged=True
+        )
+        assert not schema_load_response.errors
+
+        # Create incidents/requests to ensure there are some data into the database
+        for idx in range(1, 4):
+            incident = await client.create(kind=INCIDENT.kind, branch=default_branch.name, title=f"Incident #{idx}")
+            await incident.save()
+
+        for idx in range(1, 4):
+            requests = await client.create(kind=REQUEST.kind, branch=default_branch.name, title=f"Request #{idx}")
+            await requests.save()
+
+        incidents = await client.all(kind=INCIDENT.kind, branch=default_branch.name)
+        assert len(incidents) == 3
+        assert sorted([incident.number.value for incident in incidents]) == [1, 2, 3]
+
+        requests = await client.all(kind=REQUEST.kind, branch=default_branch.name)
+        assert len(requests) == 3
+        assert sorted([request.number.value for request in requests]) == [1, 2, 3]
+
+    async def test_numberpool_assign_in_branch(
+        self, db: InfrahubDatabase, initial_dataset: None, client: InfrahubClient, default_branch: Branch
+    ) -> None:
+        await client.branch.create(branch_name=BRANCH2, sync_with_git=False)
+
+        for idx in range(4, 7):
+            obj = await client.create(kind=REQUEST.kind, branch=BRANCH2, title=f"Request #{idx}")
+            await obj.save()
+
+        for idx in range(7, 10):
+            obj = await client.create(kind=REQUEST.kind, branch=default_branch.name, title=f"Request #{idx}")
+            await obj.save()
+
+        for idx in range(4, 10):
+            obj = await client.create(kind=INCIDENT.kind, branch=default_branch.name, title=f"Incident #{idx}")
+            await obj.save()
+
+        requests_main = await client.all(kind=REQUEST.kind, branch=default_branch.name)
+        assert sorted([request.number.value for request in requests_main]) == [1, 2, 3, 7, 8, 9]
+
+        requests_branch = await client.all(kind=REQUEST.kind, branch=BRANCH2)
+        assert sorted([request.number.value for request in requests_branch]) == [1, 2, 3, 4, 5, 6]
+
+        incidents = await client.all(kind=INCIDENT.kind, branch=default_branch.name)
+        assert sorted([incident.number.value for incident in incidents]) == [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+    async def test_numberpool_branch_delete(
+        self, db: InfrahubDatabase, initial_dataset: None, client: InfrahubClient, default_branch: Branch
+    ) -> None:
+        """Validate that after deleting BRANCH2, the numbers are reallocated correctly in the main branch."""
+        await client.branch.delete(branch_name=BRANCH2)
+
+        for idx in range(10, 14):
+            obj = await client.create(kind=REQUEST.kind, branch=default_branch.name, title=f"Request #{idx}")
+            await obj.save()
+
+        requests_main = await client.all(kind=REQUEST.kind, branch=default_branch.name)
+        assert sorted([request.number.value for request in requests_main]) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+    async def test_numberpool_node_delete(
+        self, db: InfrahubDatabase, initial_dataset: None, client: InfrahubClient, default_branch: Branch
+    ) -> None:
+        """Validate that after deleting BRANCH2, the numbers are reallocated correctly in the main branch."""
+        incidents = await client.all(kind=INCIDENT.kind, branch=default_branch.name)
+        for incident in incidents:
+            await incident.delete()
+
+        for idx in range(1, 4):
+            incident = await client.create(kind=INCIDENT.kind, branch=default_branch.name, title=f"Incident #1-{idx}")
+            await incident.save()
+
+        incidents = await client.all(kind=INCIDENT.kind, branch=default_branch.name)
+        assert sorted([incident.number.value for incident in incidents]) == [1, 2, 3]

--- a/backend/tests/unit/core/resource_manager/test_number_pool_query.py
+++ b/backend/tests/unit/core/resource_manager/test_number_pool_query.py
@@ -1,0 +1,107 @@
+import pytest
+
+from infrahub.core import registry
+from infrahub.core.branch import Branch
+from infrahub.core.constants import InfrahubKind
+from infrahub.core.initialization import create_branch
+from infrahub.core.node import Node
+from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
+from infrahub.core.query.resource_manager import NumberPoolGetUsed
+from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot
+from infrahub.core.schema.schema_branch import SchemaBranch
+from infrahub.database import InfrahubDatabase
+
+REQUEST = NodeSchema(
+    name="Request",
+    namespace="Test",
+    label="Request",
+    attributes=[
+        AttributeSchema(name="title", kind="Text", unique=False, optional=False),
+        AttributeSchema(name="number", kind="NumberPool", optional=False, read_only=True, unique=True),
+    ],
+)
+
+INCIDENT = NodeSchema(
+    name="Incident",
+    namespace="Test",
+    label="Incident",
+    attributes=[
+        AttributeSchema(name="title", kind="Text", unique=False, optional=False),
+        AttributeSchema(name="number", kind="NumberPool", optional=False, read_only=True, unique=True),
+    ],
+)
+
+
+@pytest.fixture
+async def register_test_schema(default_branch: Branch, register_core_models_schema) -> SchemaBranch:
+    registry.node[InfrahubKind.NUMBERPOOL] = CoreNumberPool
+
+    schema = SchemaRoot(
+        version="1.0",
+        nodes=[REQUEST, INCIDENT],
+    )
+    schema_branch = registry.schema.register_schema(schema=schema, branch=default_branch.name)
+    default_branch.update_schema_hash()
+
+    return schema_branch
+
+
+async def create_objects(db: InfrahubDatabase, schema: NodeSchema, branch: str, start: int, end: int) -> list[Node]:
+    """Helper function to create incidents."""
+    nodes = []
+    for idx in range(start, end + 1):
+        incident = await Node.init(db=db, schema=schema, branch=branch)
+        await incident.new(db=db, title=f"{schema.name} #{idx}")
+        await incident.save(db=db)
+        nodes.append(incident)
+    return nodes
+
+
+async def get_used_numbers_in_pool(db: InfrahubDatabase, pool: CoreNumberPool, branch: Branch) -> list[int]:
+    """Helper function to get used numbers in a pool."""
+    query = await NumberPoolGetUsed.init(db=db, branch=branch, pool=pool, branch_agnostic=True)
+    await query.execute(db=db)
+    return sorted([result.value async for result in query.iter_results()])
+
+
+async def test_NumberPoolGetUsed(
+    db: InfrahubDatabase, register_test_schema: SchemaBranch, default_branch: Branch
+) -> None:
+    incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
+    request_schema = registry.schema.get_node_schema(name=REQUEST.kind, branch=default_branch)
+
+    incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
+    await create_objects(db=db, schema=request_schema, branch=default_branch.name, start=1, end=6)
+
+    # Identify the NumberPool for each model
+    pools = await registry.schema.query(db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch.name)
+    assert len(pools) == 2
+    incident_pool = next((pool for pool in pools if pool.node.value == INCIDENT.kind), None)
+
+    # Validate that the incident NumberPool has 3 used values
+    assert await get_used_numbers_in_pool(db=db, pool=incident_pool, branch=default_branch) == [1, 2, 3]
+
+    # Create a new branch and add more incidents
+    # Ensure the query returns all used numbers across branches
+    branch2 = await create_branch(db=db, branch_name="branch2")
+    await create_objects(db=db, schema=incident_schema, branch=branch2.name, start=4, end=7)
+
+    assert await get_used_numbers_in_pool(db=db, pool=incident_pool, branch=default_branch) == [1, 2, 3, 4, 5, 6, 7]
+
+    # Delete the branch and validate that the numbers allocated previously are available
+    await branch2.delete(db=db)
+    assert await get_used_numbers_in_pool(db=db, pool=incident_pool, branch=default_branch) == [1, 2, 3]
+
+    # Create a new branch and add more incidents
+    # to ensure the query returns all used numbers across branches
+    branch3 = await create_branch(db=db, branch_name="branch3")
+    await create_objects(db=db, schema=incident_schema, branch=branch3.name, start=11, end=13)
+    assert await get_used_numbers_in_pool(db=db, pool=incident_pool, branch=default_branch) == [1, 2, 3, 4, 5, 6]
+
+    # Delete the branch and validate that the numbers allocated previously are available
+    await branch3.delete(db=db)
+    assert await get_used_numbers_in_pool(db=db, pool=incident_pool, branch=default_branch) == [1, 2, 3]
+
+    # Delete nodes in main and ensure the numbers are reallocated
+    await incidents[1].delete(db=db)
+    assert await get_used_numbers_in_pool(db=db, pool=incident_pool, branch=default_branch) == [1, 3]

--- a/backend/tests/unit/core/resource_manager/test_number_pool_query.py
+++ b/backend/tests/unit/core/resource_manager/test_number_pool_query.py
@@ -6,7 +6,7 @@ from infrahub.core.constants import InfrahubKind
 from infrahub.core.initialization import create_branch
 from infrahub.core.node import Node
 from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
-from infrahub.core.query.resource_manager import NumberPoolGetUsed
+from infrahub.core.query.resource_manager import NumberPoolGetReserved, NumberPoolGetUsed, PoolChangeReserved
 from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
@@ -61,7 +61,13 @@ async def get_used_numbers_in_pool(db: InfrahubDatabase, pool: CoreNumberPool, b
     """Helper function to get used numbers in a pool."""
     query = await NumberPoolGetUsed.init(db=db, branch=branch, pool=pool, branch_agnostic=True)
     await query.execute(db=db)
-    return sorted([result.value async for result in query.iter_results()])
+    return sorted([result.value for result in query.iter_results()])
+
+
+async def get_reservations(db: InfrahubDatabase, pool: CoreNumberPool, branch: Branch) -> dict[str, int]:
+    query1 = await NumberPoolGetReserved.init(db=db, pool_id=pool.get_id(), branch=branch)
+    await query1.execute(db=db)
+    return {item.identifier: item.value for item in query1.get_reservations()}
 
 
 async def test_NumberPoolGetUsed(
@@ -74,9 +80,11 @@ async def test_NumberPoolGetUsed(
     await create_objects(db=db, schema=request_schema, branch=default_branch.name, start=1, end=6)
 
     # Identify the NumberPool for each model
-    pools = await registry.schema.query(db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch.name)
+    pools: list[CoreNumberPool] = await registry.schema.query(
+        db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch.name
+    )
     assert len(pools) == 2
-    incident_pool = next((pool for pool in pools if pool.node.value == INCIDENT.kind), None)
+    incident_pool = next(pool for pool in pools if pool.node.value == INCIDENT.kind)
 
     # Validate that the incident NumberPool has 3 used values
     assert await get_used_numbers_in_pool(db=db, pool=incident_pool, branch=default_branch) == [1, 2, 3]
@@ -105,3 +113,33 @@ async def test_NumberPoolGetUsed(
     # Delete nodes in main and ensure the numbers are reallocated
     await incidents[1].delete(db=db)
     assert await get_used_numbers_in_pool(db=db, pool=incident_pool, branch=default_branch) == [1, 3]
+
+
+async def test_PoolChangeReserved(
+    db: InfrahubDatabase, register_test_schema: SchemaBranch, default_branch: Branch
+) -> None:
+    incident_schema = registry.schema.get_node_schema(name=INCIDENT.kind, branch=default_branch)
+    request_schema = registry.schema.get_node_schema(name=REQUEST.kind, branch=default_branch)
+
+    incidents = await create_objects(db=db, schema=incident_schema, branch=default_branch.name, start=1, end=3)
+    await create_objects(db=db, schema=request_schema, branch=default_branch.name, start=1, end=6)
+    incident = incidents[1]
+
+    pools: list[CoreNumberPool] = await registry.schema.query(
+        db=db, schema=InfrahubKind.NUMBERPOOL, branch=default_branch.name
+    )
+    assert len(pools) == 2
+    incident_pool = next(pool for pool in pools if pool.node.value == INCIDENT.kind)
+
+    reservations_before = await get_reservations(db=db, pool=incident_pool, branch=default_branch)
+    assert len(reservations_before) == 3
+    assert reservations_before[incident.get_id()] == 2
+
+    query = await PoolChangeReserved.init(
+        db=db, existing_identifier=incident.get_id(), new_identifier="new_id", branch=default_branch
+    )
+    await query.execute(db=db)
+
+    reservations_before = await get_reservations(db=db, pool=incident_pool, branch=default_branch)
+    assert len(reservations_before) == 3
+    assert reservations_before["new_id"] == 2

--- a/changelog/6865.fixed.md
+++ b/changelog/6865.fixed.md
@@ -1,0 +1,1 @@
+Fix number allocation for Number Pool to ensure that values that are not used anymore will get back into the pool


### PR DESCRIPTION
Fixes #6865 

This PR mainly refactor the query `NumberPoolGetUsed` and adds more tests around the query and around the NumberPool in general.

The main issues were that the query was matching only on the attribute name and not on the node id, also the query was not accounting properly for nodes that have been deleted. 

I've also added a query and some tests to ensure that all reservations will be updated when a node is being converted (and has a new id)

Side note, there is more work needed around the relationship `IS_RESERVED`, currently this relationship is not being deleted when a node or a branch is being deleted. It's working for now because we are using the UUID of the node as the identifier but this is currently preventing us to use Number Pool with Upsert.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved number pool allocation so that values no longer in use are now correctly returned to the pool for reuse.

* **New Features**
  * Enhanced support for updating and tracking reservations in number pools, including the ability to change reservation identifiers.
  * Added support for filtering and retrieving richer reservation data in number pools.

* **Tests**
  * Added comprehensive tests to verify number pool behavior across branches, object type conversions, and reservation updates, ensuring correct allocation, isolation, and reuse of numbers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->