### PR TITLE
IFC-1690 Fix available prefixes when parent prefix is empty

### DIFF
--- a/backend/infrahub/graphql/resolvers/ipam.py
+++ b/backend/infrahub/graphql/resolvers/ipam.py
@@ -12,6 +12,7 @@ from infrahub.core.constants import InfrahubKind
 from infrahub.core.ipam.constants import PrefixMemberType
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
+from infrahub.core.protocols import BuiltinIPNamespace, BuiltinIPPrefix
 from infrahub.graphql.parser import extract_selection
 from infrahub.graphql.permissions import get_permissions
 
@@ -47,8 +48,8 @@ async def _build_ip_range_node(
     schema: NodeSchema,
     address: IPvAnyAddress,
     last_address: IPvAnyAddress,
-    ip_namespace: Node,
-    ip_prefix: Node,
+    ip_namespace: BuiltinIPNamespace,
+    ip_prefix: BuiltinIPPrefix,
 ) -> Node:
     n = await Node.init(schema=schema, db=db, branch=branch)
     await n.new(
@@ -62,7 +63,7 @@ async def _build_ip_range_node(
     return n
 
 
-def _include_first_and_last_ips(ip_prefix: Node) -> bool:
+def _include_first_and_last_ips(ip_prefix: BuiltinIPPrefix) -> bool:
     if ip_prefix.prefix.version == 6 or ip_prefix.is_pool.value:
         return True
 
@@ -72,14 +73,14 @@ def _include_first_and_last_ips(ip_prefix: Node) -> bool:
 async def _resolve_available_address_nodes(
     db: InfrahubDatabase,
     branch: Branch,
-    prefix: Node,
+    prefix: BuiltinIPPrefix,
     existing_nodes: Sequence[Node],
     first_node_context: Node | None = None,
     last_node_context: Node | None = None,
 ) -> list[Node]:
     """Annotate a list of IP addresses node with available ranges within a prefix."""
     ip_prefix: IPvAnyNetwork = prefix.prefix.obj
-    ip_namespace = await prefix.ip_namespace.get_peer(db=db)
+    ip_namespace = await prefix.ip_namespace.get_peer(db=db, peer_type=BuiltinIPNamespace, raise_on_error=True)
     ip_range_schema = registry.get_node_schema(name=InfrahubKind.IPRANGEAVAILABLE, branch=branch)
 
     # Make sure nodes are ordered by addresses
@@ -172,7 +173,7 @@ async def _resolve_available_address_nodes(
 async def _resolve_available_prefix_nodes(
     db: InfrahubDatabase,
     branch: Branch,
-    prefix: Node,
+    prefix: BuiltinIPPrefix,
     existing_nodes: Sequence[Node],
     first_node_context: Node | None = None,
     last_node_context: Node | None = None,
@@ -229,7 +230,7 @@ async def _annotate_result(
     branch: Branch,
     resolve_available: bool,
     schema: NodeSchema,
-    parent_prefix: Node | None,
+    parent_prefix: BuiltinIPPrefix | None,
     result: list[Node],
     first_node_context: Node | None = None,
     last_node_context: Node | None = None,
@@ -307,10 +308,10 @@ async def ipam_paginated_list_resolver(  # noqa: PLR0915
         if schema.is_ip_prefix and "parent__ids" in filters:
             parent_prefix_id = next(iter(filters["parent__ids"]))
 
-        parent_prefix: Node | None = None
+        parent_prefix: BuiltinIPPrefix | None = None
         if parent_prefix_id:
             parent_prefix = await NodeManager.get_one(
-                db=db, id=parent_prefix_id, at=graphql_context.at, branch=graphql_context.branch
+                db=db, kind=BuiltinIPPrefix, id=parent_prefix_id, at=graphql_context.at, branch=graphql_context.branch
             )
 
         first_node_context: Node | None = None

--- a/backend/infrahub/graphql/resolvers/ipam.py
+++ b/backend/infrahub/graphql/resolvers/ipam.py
@@ -205,7 +205,23 @@ async def _resolve_available_prefix_nodes(
         available_nodes.append(node)
 
     # Properly sort existing nodes with available prefixes
-    return sorted(existing_nodes + available_nodes, key=lambda n: n.prefix.obj)
+    with_available_prefixes = sorted(existing_nodes + available_nodes, key=lambda n: n.prefix.obj)
+
+    # If the only available prefix is the same as the container prefix, this means the container prefix is empty and we should therefore at least
+    # offer two smaller prefixes allocatable within it
+    if len(with_available_prefixes) == 1 and next(iter(with_available_prefixes)).prefix.obj == prefix.prefix.obj:
+        available_nodes.clear()
+
+        for subnet in prefix.prefix.obj.subnets():
+            node = await Node.init(schema=ip_prefix_schema, db=db, branch=branch)
+            await node.new(
+                db=db, prefix=str(subnet), ip_namespace=await prefix.ip_namespace.get_peer(db=db), parent=prefix
+            )
+            available_nodes.append(node)
+
+        return available_nodes
+
+    return with_available_prefixes
 
 
 async def _annotate_result(

--- a/backend/infrahub/graphql/resolvers/ipam.py
+++ b/backend/infrahub/graphql/resolvers/ipam.py
@@ -208,21 +208,19 @@ async def _resolve_available_prefix_nodes(
     # Properly sort existing nodes with available prefixes
     with_available_prefixes = sorted(existing_nodes + available_nodes, key=lambda n: n.prefix.obj)
 
+    if len(with_available_prefixes) > 1 or with_available_prefixes[0].prefix.obj != prefix.prefix.obj:
+        return with_available_prefixes
+
     # If the only available prefix is the same as the container prefix, this means the container prefix is empty and we should therefore at least
     # offer two smaller prefixes allocatable within it
-    if len(with_available_prefixes) == 1 and next(iter(with_available_prefixes)).prefix.obj == prefix.prefix.obj:
-        available_nodes.clear()
+    available_nodes.clear()
 
-        for subnet in prefix.prefix.obj.subnets():
-            node = await Node.init(schema=ip_prefix_schema, db=db, branch=branch)
-            await node.new(
-                db=db, prefix=str(subnet), ip_namespace=await prefix.ip_namespace.get_peer(db=db), parent=prefix
-            )
-            available_nodes.append(node)
+    for subnet in prefix.prefix.obj.subnets():
+        node = await Node.init(schema=ip_prefix_schema, db=db, branch=branch)
+        await node.new(db=db, prefix=str(subnet), ip_namespace=await prefix.ip_namespace.get_peer(db=db), parent=prefix)
+        available_nodes.append(node)
 
-        return available_nodes
-
-    return with_available_prefixes
+    return available_nodes
 
 
 async def _annotate_result(

--- a/backend/tests/unit/graphql/queries/test_ipam.py
+++ b/backend/tests/unit/graphql/queries/test_ipam.py
@@ -594,7 +594,10 @@ class TestIpamAvailableNodes(TestInfrahubApp):
     @pytest.mark.parametrize(
         "prefix,result",
         [
-            ("net_empty", [("InternalIPPrefixAvailable", "10.0.0.0/24")]),
+            (
+                "net_empty",
+                [("InternalIPPrefixAvailable", "10.0.0.0/25"), ("InternalIPPrefixAvailable", "10.0.0.128/25")],
+            ),
             (
                 "net_free_end",
                 [


### PR DESCRIPTION
This change makes sure that we return subnets of the container prefix
for which we asked the available space. When a container prefix has no
space reserved, the next 2 smaller subnets that fit inside the container
must be returned. For instance, if 192.0.2.0/24 has no subnets, the
available space query must report 192.0.2.0/25 and 192.0.2.128/25.