### PR TITLE
IFC-1633 Add events related to proposed change actions

### DIFF
--- a/backend/infrahub/core/constants/__init__.py
+++ b/backend/infrahub/core/constants/__init__.py
@@ -61,6 +61,11 @@ class EventType(InfrahubStringEnum):
     GROUP_MEMBER_ADDED = f"{EVENT_NAMESPACE}.group.member_added"
     GROUP_MEMBER_REMOVED = f"{EVENT_NAMESPACE}.group.member_removed"
 
+    PROPOSED_CHANGE_MERGED = f"{EVENT_NAMESPACE}.proposed_change.merged"
+    PROPOSED_CHANGE_REVIEW_REQUESTED = f"{EVENT_NAMESPACE}.proposed_change.review_requested"
+    PROPOSED_CHANGE_REVIEWED = f"{EVENT_NAMESPACE}.proposed_change.reviewed"
+    PROPOSED_CHANGE_REVIEW_REVOKED = f"{EVENT_NAMESPACE}.proposed_change.review_revoked"
+
     REPOSITORY_UPDATE_COMMIT = f"{EVENT_NAMESPACE}.repository.update_commit"
 
     ARTIFACT_CREATED = f"{EVENT_NAMESPACE}.artifact.created"

--- a/backend/infrahub/core/constants/__init__.py
+++ b/backend/infrahub/core/constants/__init__.py
@@ -66,7 +66,7 @@ class EventType(InfrahubStringEnum):
     PROPOSED_CHANGE_APPROVED = f"{EVENT_NAMESPACE}.proposed_change.approved"
     PROPOSED_CHANGE_REJECTED = f"{EVENT_NAMESPACE}.proposed_change.rejected"
     PROPOSED_CHANGE_APPROVAL_REVOKED = f"{EVENT_NAMESPACE}.proposed_change.approval_revoked"
-    PROPOSED_CHANGE_REJECTION_REVOKED = f"{EVENT_NAMESPACE}.proposed_change.rejectin_revoked"
+    PROPOSED_CHANGE_REJECTION_REVOKED = f"{EVENT_NAMESPACE}.proposed_change.rejection_revoked"
 
     REPOSITORY_UPDATE_COMMIT = f"{EVENT_NAMESPACE}.repository.update_commit"
 

--- a/backend/infrahub/core/constants/__init__.py
+++ b/backend/infrahub/core/constants/__init__.py
@@ -63,8 +63,10 @@ class EventType(InfrahubStringEnum):
 
     PROPOSED_CHANGE_MERGED = f"{EVENT_NAMESPACE}.proposed_change.merged"
     PROPOSED_CHANGE_REVIEW_REQUESTED = f"{EVENT_NAMESPACE}.proposed_change.review_requested"
-    PROPOSED_CHANGE_REVIEWED = f"{EVENT_NAMESPACE}.proposed_change.reviewed"
-    PROPOSED_CHANGE_REVIEW_REVOKED = f"{EVENT_NAMESPACE}.proposed_change.review_revoked"
+    PROPOSED_CHANGE_APPROVED = f"{EVENT_NAMESPACE}.proposed_change.approved"
+    PROPOSED_CHANGE_REJECTED = f"{EVENT_NAMESPACE}.proposed_change.rejected"
+    PROPOSED_CHANGE_APPROVAL_REVOKED = f"{EVENT_NAMESPACE}.proposed_change.approval_revoked"
+    PROPOSED_CHANGE_REJECTION_REVOKED = f"{EVENT_NAMESPACE}.proposed_change.rejectin_revoked"
 
     REPOSITORY_UPDATE_COMMIT = f"{EVENT_NAMESPACE}.repository.update_commit"
 

--- a/backend/infrahub/events/__init__.py
+++ b/backend/infrahub/events/__init__.py
@@ -3,6 +3,12 @@ from .branch_action import BranchCreatedEvent, BranchDeletedEvent, BranchMergedE
 from .group_action import GroupMemberAddedEvent, GroupMemberRemovedEvent
 from .models import EventMeta, InfrahubEvent
 from .node_action import NodeCreatedEvent, NodeDeletedEvent, NodeUpdatedEvent
+from .proposed_change_action import (
+    ProposedChangeMergedEvent,
+    ProposedChangeReviewedEvent,
+    ProposedChangeReviewRequestedEvent,
+    ProposedChangeReviewRevokedEvent,
+)
 from .repository_action import CommitUpdatedEvent
 from .validator_action import ValidatorFailedEvent, ValidatorPassedEvent, ValidatorStartedEvent
 
@@ -21,6 +27,10 @@ __all__ = [
     "NodeCreatedEvent",
     "NodeDeletedEvent",
     "NodeUpdatedEvent",
+    "ProposedChangeMergedEvent",
+    "ProposedChangeReviewRequestedEvent",
+    "ProposedChangeReviewRevokedEvent",
+    "ProposedChangeReviewedEvent",
     "ValidatorFailedEvent",
     "ValidatorPassedEvent",
     "ValidatorStartedEvent",

--- a/backend/infrahub/events/__init__.py
+++ b/backend/infrahub/events/__init__.py
@@ -4,10 +4,12 @@ from .group_action import GroupMemberAddedEvent, GroupMemberRemovedEvent
 from .models import EventMeta, InfrahubEvent
 from .node_action import NodeCreatedEvent, NodeDeletedEvent, NodeUpdatedEvent
 from .proposed_change_action import (
+    ProposedChangeApprovalRevokedEvent,
+    ProposedChangeApprovedEvent,
     ProposedChangeMergedEvent,
-    ProposedChangeReviewedEvent,
+    ProposedChangeRejectedEvent,
+    ProposedChangeRejectionRevokedEvent,
     ProposedChangeReviewRequestedEvent,
-    ProposedChangeReviewRevokedEvent,
 )
 from .repository_action import CommitUpdatedEvent
 from .validator_action import ValidatorFailedEvent, ValidatorPassedEvent, ValidatorStartedEvent
@@ -27,10 +29,12 @@ __all__ = [
     "NodeCreatedEvent",
     "NodeDeletedEvent",
     "NodeUpdatedEvent",
+    "ProposedChangeApprovalRevokedEvent",
+    "ProposedChangeApprovedEvent",
     "ProposedChangeMergedEvent",
+    "ProposedChangeRejectedEvent",
+    "ProposedChangeRejectionRevokedEvent",
     "ProposedChangeReviewRequestedEvent",
-    "ProposedChangeReviewRevokedEvent",
-    "ProposedChangeReviewedEvent",
     "ValidatorFailedEvent",
     "ValidatorPassedEvent",
     "ValidatorStartedEvent",

--- a/backend/infrahub/events/proposed_change_action.py
+++ b/backend/infrahub/events/proposed_change_action.py
@@ -17,6 +17,7 @@ class ProposedChangeEvent(InfrahubEvent):
             "infrahub.proposed_change.id": self.proposed_change_id,
             "infrahub.proposed_change.name": self.proposed_change_name,
             "infrahub.proposed_change.state": self.proposed_change_state,
+            "infrahub.branch.name": self.meta.context.branch.name,
         }
 
 
@@ -31,7 +32,6 @@ class ProposedChangeReviewEvent(ProposedChangeEvent):
             "infrahub.proposed_change.reviewer_account_id": self.reviewer_account_id,
             "infrahub.proposed_change.reviewer_account_name": self.reviewer_account_name,
             "infrahub.proposed_change.reviewer_decision": self.reviewer_decision,
-            "infrahub.branch.name": self.meta.context.branch.name,
         }
 
 
@@ -46,7 +46,6 @@ class ProposedChangeReviewRevokedEvent(ProposedChangeEvent):
             "infrahub.proposed_change.reviewer_account_id": self.reviewer_account_id,
             "infrahub.proposed_change.reviewer_account_name": self.reviewer_account_name,
             "infrahub.proposed_change.reviewer_former_decision": self.reviewer_former_decision,
-            "infrahub.branch.name": self.meta.context.branch.name,
         }
 
 
@@ -63,7 +62,6 @@ class ProposedChangeMergedEvent(ProposedChangeEvent):
             **super().get_resource(),
             "infrahub.proposed_change.merged_by_account_id": self.merged_by_account_id,
             "infrahub.proposed_change.merged_by_account_name": self.merged_by_account_name,
-            "infrahub.branch.name": self.meta.context.branch.name,
         }
 
 
@@ -84,7 +82,6 @@ class ProposedChangeReviewRequestedEvent(ProposedChangeEvent):
             **super().get_resource(),
             "infrahub.proposed_change.review_requested_by_account_id": self.requested_by_account_id,
             "infrahub.proposed_change.review_requested_by_account_name": self.requested_by_account_name,
-            "infrahub.branch.name": self.meta.context.branch.name,
         }
 
 

--- a/backend/infrahub/events/proposed_change_action.py
+++ b/backend/infrahub/events/proposed_change_action.py
@@ -20,6 +20,23 @@ class ProposedChangeEvent(InfrahubEvent):
         }
 
 
+class ProposedChangeMergedEvent(ProposedChangeEvent):
+    """Event generated when a proposed change has been merged"""
+
+    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.proposed_change.merged"
+
+    merged_by_account_id: str = Field(..., description="The ID of the user who merged the proposed change")
+    merged_by_account_name: str = Field(..., description="The name of the user who merged the proposed change")
+
+    def get_resource(self) -> dict[str, str]:
+        return {
+            **super().get_resource(),
+            "infrahub.proposed_change.merged_by_account_id": self.merged_by_account_id,
+            "infrahub.proposed_change.merged_by_account_name": self.merged_by_account_name,
+            "infrahub.branch.name": self.meta.context.branch.name,
+        }
+
+
 class ProposedChangeReviewRequestedEvent(ProposedChangeEvent):
     """Event generated when a proposed change has been flagged for review"""
 
@@ -75,22 +92,5 @@ class ProposedChangeReviewRevokedEvent(ProposedChangeEvent):
             "infrahub.proposed_change.reviewer_account_id": self.reviewer_account_id,
             "infrahub.proposed_change.reviewer_account_name": self.reviewer_account_name,
             "infrahub.proposed_change.reviewer_former_decision": self.reviewer_former_decision,
-            "infrahub.branch.name": self.meta.context.branch.name,
-        }
-
-
-class ProposedChangeMergedEvent(ProposedChangeEvent):
-    """Event generated when a proposed change has been merged"""
-
-    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.proposed_change.merged"
-
-    merged_by_account_id: str = Field(..., description="The ID of the user who merged the proposed change")
-    merged_by_account_name: str = Field(..., description="The name of the user who merged the proposed change")
-
-    def get_resource(self) -> dict[str, str]:
-        return {
-            **super().get_resource(),
-            "infrahub.proposed_change.merged_by_account_id": self.merged_by_account_id,
-            "infrahub.proposed_change.merged_by_account_name": self.merged_by_account_name,
             "infrahub.branch.name": self.meta.context.branch.name,
         }

--- a/backend/infrahub/events/proposed_change_action.py
+++ b/backend/infrahub/events/proposed_change_action.py
@@ -1,0 +1,96 @@
+from typing import ClassVar
+
+from pydantic import Field
+
+from .constants import EVENT_NAMESPACE
+from .models import InfrahubEvent
+
+
+class ProposedChangeEvent(InfrahubEvent):
+    proposed_change_id: str = Field(..., description="The ID of the proposed change")
+    proposed_change_name: str = Field(..., description="The name of the proposed change")
+    proposed_change_state: str = Field(..., description="The state of the proposed change")
+
+    def get_resource(self) -> dict[str, str]:
+        return {
+            "prefect.resource.id": f"infrahub.proposed_change.{self.proposed_change_id}",
+            "infrahub.proposed_change.id": self.proposed_change_id,
+            "infrahub.proposed_change.name": self.proposed_change_name,
+            "infrahub.proposed_change.state": self.proposed_change_state,
+        }
+
+
+class ProposedChangeReviewRequestedEvent(ProposedChangeEvent):
+    """Event generated when a proposed change has been flagged for review"""
+
+    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.proposed_change.review_requested"
+
+    requested_by_account_id: str = Field(
+        ..., description="The ID of the user who requested the proposed change to be reviewed"
+    )
+    requested_by_account_name: str = Field(
+        ..., description="The name of the user who requested the proposed change to be reviewed"
+    )
+
+    def get_resource(self) -> dict[str, str]:
+        return {
+            **super().get_resource(),
+            "infrahub.proposed_change.review_requested_by_account_id": self.requested_by_account_id,
+            "infrahub.proposed_change.review_requested_by_account_name": self.requested_by_account_name,
+            "infrahub.branch.name": self.meta.context.branch.name,
+        }
+
+
+class ProposedChangeReviewedEvent(ProposedChangeEvent):
+    """Event generated when a proposed change has been reviewed"""
+
+    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.proposed_change.reviewed"
+
+    reviewer_account_id: str = Field(..., description="The ID of the user who reviewed the proposed change")
+    reviewer_account_name: str = Field(..., description="The name of the user who reviewed the proposed change")
+    reviewer_decision: str = Field(..., description="The decision made by the reviewer")
+
+    def get_resource(self) -> dict[str, str]:
+        return {
+            **super().get_resource(),
+            "infrahub.proposed_change.reviewer_account_id": self.reviewer_account_id,
+            "infrahub.proposed_change.reviewer_account_name": self.reviewer_account_name,
+            "infrahub.proposed_change.reviewer_decision": self.reviewer_decision,
+            "infrahub.branch.name": self.meta.context.branch.name,
+        }
+
+
+class ProposedChangeReviewRevokedEvent(ProposedChangeEvent):
+    """Event generated when a proposed change review has been revoked"""
+
+    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.proposed_change.review_revoked"
+
+    reviewer_account_id: str = Field(..., description="The ID of the user who reviewed the proposed change")
+    reviewer_account_name: str = Field(..., description="The name of the user who reviewed the proposed change")
+    reviewer_former_decision: str = Field(..., description="The former decision made by the reviewer")
+
+    def get_resource(self) -> dict[str, str]:
+        return {
+            **super().get_resource(),
+            "infrahub.proposed_change.reviewer_account_id": self.reviewer_account_id,
+            "infrahub.proposed_change.reviewer_account_name": self.reviewer_account_name,
+            "infrahub.proposed_change.reviewer_former_decision": self.reviewer_former_decision,
+            "infrahub.branch.name": self.meta.context.branch.name,
+        }
+
+
+class ProposedChangeMergedEvent(ProposedChangeEvent):
+    """Event generated when a proposed change has been merged"""
+
+    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.proposed_change.merged"
+
+    merged_by_account_id: str = Field(..., description="The ID of the user who merged the proposed change")
+    merged_by_account_name: str = Field(..., description="The name of the user who merged the proposed change")
+
+    def get_resource(self) -> dict[str, str]:
+        return {
+            **super().get_resource(),
+            "infrahub.proposed_change.merged_by_account_id": self.merged_by_account_id,
+            "infrahub.proposed_change.merged_by_account_name": self.merged_by_account_name,
+            "infrahub.branch.name": self.meta.context.branch.name,
+        }

--- a/backend/infrahub/events/proposed_change_action.py
+++ b/backend/infrahub/events/proposed_change_action.py
@@ -29,13 +29,21 @@ class ProposedChangeReviewEvent(ProposedChangeEvent):
     reviewer_account_name: str = Field(..., description="The name of the user who reviewed the proposed change")
     reviewer_decision: str = Field(..., description="The decision made by the reviewer")
 
+    def get_related(self) -> list[dict[str, str]]:
+        related = super().get_related()
+        related.append(
+            {
+                "prefect.resource.id": self.reviewer_account_id,
+                "prefect.resource.role": "infrahub.related.node",
+                "infrahub.node.kind": InfrahubKind.GENERICACCOUNT,
+                "infrahub.node.id": self.reviewer_account_id,
+                "infrahub.reviewer.account.name": self.reviewer_account_name,
+            }
+        )
+        return related
+
     def get_resource(self) -> dict[str, str]:
-        return {
-            **super().get_resource(),
-            "infrahub.proposed_change.reviewer_account_id": self.reviewer_account_id,
-            "infrahub.proposed_change.reviewer_account_name": self.reviewer_account_name,
-            "infrahub.proposed_change.reviewer_decision": self.reviewer_decision,
-        }
+        return {**super().get_resource(), "infrahub.proposed_change.reviewer_decision": self.reviewer_decision}
 
 
 class ProposedChangeReviewRevokedEvent(ProposedChangeEvent):
@@ -43,11 +51,22 @@ class ProposedChangeReviewRevokedEvent(ProposedChangeEvent):
     reviewer_account_name: str = Field(..., description="The name of the user who reviewed the proposed change")
     reviewer_former_decision: str = Field(..., description="The former decision made by the reviewer")
 
+    def get_related(self) -> list[dict[str, str]]:
+        related = super().get_related()
+        related.append(
+            {
+                "prefect.resource.id": self.reviewer_account_id,
+                "prefect.resource.role": "infrahub.related.node",
+                "infrahub.node.kind": InfrahubKind.GENERICACCOUNT,
+                "infrahub.node.id": self.reviewer_account_id,
+                "infrahub.reviewer.account.name": self.reviewer_account_name,
+            }
+        )
+        return related
+
     def get_resource(self) -> dict[str, str]:
         return {
             **super().get_resource(),
-            "infrahub.proposed_change.reviewer_account_id": self.reviewer_account_id,
-            "infrahub.proposed_change.reviewer_account_name": self.reviewer_account_name,
             "infrahub.proposed_change.reviewer_former_decision": self.reviewer_former_decision,
         }
 
@@ -59,6 +78,19 @@ class ProposedChangeMergedEvent(ProposedChangeEvent):
 
     merged_by_account_id: str = Field(..., description="The ID of the user who merged the proposed change")
     merged_by_account_name: str = Field(..., description="The name of the user who merged the proposed change")
+
+    def get_related(self) -> list[dict[str, str]]:
+        related = super().get_related()
+        related.append(
+            {
+                "prefect.resource.id": self.merged_by_account_id,
+                "prefect.resource.role": "infrahub.related.node",
+                "infrahub.node.kind": InfrahubKind.GENERICACCOUNT,
+                "infrahub.node.id": self.merged_by_account_id,
+                "infrahub.merged_by.account.name": self.merged_by_account_name,
+            }
+        )
+        return related
 
     def get_resource(self) -> dict[str, str]:
         return {
@@ -80,12 +112,18 @@ class ProposedChangeReviewRequestedEvent(ProposedChangeEvent):
         ..., description="The name of the user who requested the proposed change to be reviewed"
     )
 
-    def get_resource(self) -> dict[str, str]:
-        return {
-            **super().get_resource(),
-            "infrahub.proposed_change.review_requested_by_account_id": self.requested_by_account_id,
-            "infrahub.proposed_change.review_requested_by_account_name": self.requested_by_account_name,
-        }
+    def get_related(self) -> list[dict[str, str]]:
+        related = super().get_related()
+        related.append(
+            {
+                "prefect.resource.id": self.requested_by_account_id,
+                "prefect.resource.role": "infrahub.related.node",
+                "infrahub.node.kind": InfrahubKind.GENERICACCOUNT,
+                "infrahub.node.id": self.requested_by_account_id,
+                "infrahub.requested_by.account.name": self.requested_by_account_name,
+            }
+        )
+        return related
 
 
 class ProposedChangeApprovedEvent(ProposedChangeReviewEvent):

--- a/backend/infrahub/events/proposed_change_action.py
+++ b/backend/infrahub/events/proposed_change_action.py
@@ -2,6 +2,8 @@ from typing import ClassVar
 
 from pydantic import Field
 
+from infrahub.core.constants import InfrahubKind
+
 from .constants import EVENT_NAMESPACE
 from .models import InfrahubEvent
 
@@ -14,7 +16,8 @@ class ProposedChangeEvent(InfrahubEvent):
     def get_resource(self) -> dict[str, str]:
         return {
             "prefect.resource.id": f"infrahub.proposed_change.{self.proposed_change_id}",
-            "infrahub.proposed_change.id": self.proposed_change_id,
+            "infrahub.node.kind": InfrahubKind.PROPOSEDCHANGE,
+            "infrahub.node.id": self.proposed_change_id,
             "infrahub.proposed_change.name": self.proposed_change_name,
             "infrahub.proposed_change.state": self.proposed_change_state,
             "infrahub.branch.name": self.meta.context.branch.name,

--- a/backend/infrahub/events/proposed_change_action.py
+++ b/backend/infrahub/events/proposed_change_action.py
@@ -20,6 +20,36 @@ class ProposedChangeEvent(InfrahubEvent):
         }
 
 
+class ProposedChangeReviewEvent(ProposedChangeEvent):
+    reviewer_account_id: str = Field(..., description="The ID of the user who reviewed the proposed change")
+    reviewer_account_name: str = Field(..., description="The name of the user who reviewed the proposed change")
+    reviewer_decision: str = Field(..., description="The decision made by the reviewer")
+
+    def get_resource(self) -> dict[str, str]:
+        return {
+            **super().get_resource(),
+            "infrahub.proposed_change.reviewer_account_id": self.reviewer_account_id,
+            "infrahub.proposed_change.reviewer_account_name": self.reviewer_account_name,
+            "infrahub.proposed_change.reviewer_decision": self.reviewer_decision,
+            "infrahub.branch.name": self.meta.context.branch.name,
+        }
+
+
+class ProposedChangeReviewRevokedEvent(ProposedChangeEvent):
+    reviewer_account_id: str = Field(..., description="The ID of the user who reviewed the proposed change")
+    reviewer_account_name: str = Field(..., description="The name of the user who reviewed the proposed change")
+    reviewer_former_decision: str = Field(..., description="The former decision made by the reviewer")
+
+    def get_resource(self) -> dict[str, str]:
+        return {
+            **super().get_resource(),
+            "infrahub.proposed_change.reviewer_account_id": self.reviewer_account_id,
+            "infrahub.proposed_change.reviewer_account_name": self.reviewer_account_name,
+            "infrahub.proposed_change.reviewer_former_decision": self.reviewer_former_decision,
+            "infrahub.branch.name": self.meta.context.branch.name,
+        }
+
+
 class ProposedChangeMergedEvent(ProposedChangeEvent):
     """Event generated when a proposed change has been merged"""
 
@@ -58,39 +88,25 @@ class ProposedChangeReviewRequestedEvent(ProposedChangeEvent):
         }
 
 
-class ProposedChangeReviewedEvent(ProposedChangeEvent):
-    """Event generated when a proposed change has been reviewed"""
+class ProposedChangeApprovedEvent(ProposedChangeReviewEvent):
+    """Event generated when a proposed change has been approved"""
 
-    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.proposed_change.reviewed"
-
-    reviewer_account_id: str = Field(..., description="The ID of the user who reviewed the proposed change")
-    reviewer_account_name: str = Field(..., description="The name of the user who reviewed the proposed change")
-    reviewer_decision: str = Field(..., description="The decision made by the reviewer")
-
-    def get_resource(self) -> dict[str, str]:
-        return {
-            **super().get_resource(),
-            "infrahub.proposed_change.reviewer_account_id": self.reviewer_account_id,
-            "infrahub.proposed_change.reviewer_account_name": self.reviewer_account_name,
-            "infrahub.proposed_change.reviewer_decision": self.reviewer_decision,
-            "infrahub.branch.name": self.meta.context.branch.name,
-        }
+    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.proposed_change.approved"
 
 
-class ProposedChangeReviewRevokedEvent(ProposedChangeEvent):
-    """Event generated when a proposed change review has been revoked"""
+class ProposedChangeRejectedEvent(ProposedChangeReviewEvent):
+    """Event generated when a proposed change has been rejected"""
 
-    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.proposed_change.review_revoked"
+    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.proposed_change.rejected"
 
-    reviewer_account_id: str = Field(..., description="The ID of the user who reviewed the proposed change")
-    reviewer_account_name: str = Field(..., description="The name of the user who reviewed the proposed change")
-    reviewer_former_decision: str = Field(..., description="The former decision made by the reviewer")
 
-    def get_resource(self) -> dict[str, str]:
-        return {
-            **super().get_resource(),
-            "infrahub.proposed_change.reviewer_account_id": self.reviewer_account_id,
-            "infrahub.proposed_change.reviewer_account_name": self.reviewer_account_name,
-            "infrahub.proposed_change.reviewer_former_decision": self.reviewer_former_decision,
-            "infrahub.branch.name": self.meta.context.branch.name,
-        }
+class ProposedChangeApprovalRevokedEvent(ProposedChangeReviewRevokedEvent):
+    """Event generated when a proposed change approval has been revoked"""
+
+    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.proposed_change.approval_revoked"
+
+
+class ProposedChangeRejectionRevokedEvent(ProposedChangeReviewRevokedEvent):
+    """Event generated when a proposed change rejection has been revoked"""
+
+    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.proposed_change.rejection_revoked"

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -275,7 +275,7 @@ class ProposedChangeReview(Mutation):
                     decision=data.decision,
                     proposed_change=proposed_change,
                     current_user=current_user,
-                    graphql_context=graphql_context,
+                    context=graphql_context,
                 )
                 await proposed_change.save(db=db)
 

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -24,7 +24,6 @@ from infrahub.events import (
     ProposedChangeApprovedEvent,
     ProposedChangeRejectedEvent,
     ProposedChangeRejectionRevokedEvent,
-    ProposedChangeReviewRequestedEvent,
 )
 from infrahub.exceptions import BranchNotFoundError, PermissionDeniedError, ValidationError
 from infrahub.graphql.mutations.main import InfrahubMutationMixin
@@ -135,9 +134,6 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
             updated_state = ProposedChangeState(state_update)
             state.validate_state_transition(updated_state)
 
-        was_draft = obj.is_draft.value
-        still_draft = data.get("is_draft", {"value": was_draft}).get("value")
-
         # Check before starting a transaction, stopping in the middle of the transaction seems to break with memgraph
         if updated_state == ProposedChangeState.MERGED and graphql_context.account_session:
             try:
@@ -170,25 +166,6 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
             # from the overridden "merging" value, so here we change it back to reflect the
             # correct value for the event that will be generated.
             proposed_change.node_changelog.attributes["state"].value = ProposedChangeState.MERGED.value
-
-        # If the proposed change was in draft but isn't anymore, send the review requested event
-        if was_draft and not still_draft:
-            current_user = await NodeManager.get_one(
-                db=graphql_context.db,
-                kind=InfrahubKind.GENERICACCOUNT,
-                id=graphql_context.active_account_session.account_id,
-            )
-            event_service = await get_event_service()
-            await event_service.send(
-                event=ProposedChangeReviewRequestedEvent(
-                    proposed_change_id=proposed_change.id,
-                    proposed_change_name=proposed_change.name.value,
-                    proposed_change_state=proposed_change.state.value,
-                    requested_by_account_id=current_user.id,
-                    requested_by_account_name=current_user.name.value,
-                    meta=EventMeta.from_context(context=graphql_context.get_context()),
-                )
-            )
 
         return proposed_change, result
 

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -20,9 +20,11 @@ from infrahub.core.schema import NodeSchema
 from infrahub.database import InfrahubDatabase, retry_db_transaction
 from infrahub.events import (
     EventMeta,
-    ProposedChangeReviewedEvent,
+    ProposedChangeApprovalRevokedEvent,
+    ProposedChangeApprovedEvent,
+    ProposedChangeRejectedEvent,
+    ProposedChangeRejectionRevokedEvent,
     ProposedChangeReviewRequestedEvent,
-    ProposedChangeReviewRevokedEvent,
 )
 from infrahub.exceptions import BranchNotFoundError, PermissionDeniedError, ValidationError
 from infrahub.graphql.mutations.main import InfrahubMutationMixin
@@ -328,7 +330,7 @@ class ProposedChangeReview(Mutation):
                 if current_user.id in rejected_by_ids:
                     await proposed_change.rejected_by.remove_locally(db=db, peer_id=current_user.id)
 
-                event = ProposedChangeReviewedEvent(
+                event = ProposedChangeApprovedEvent(
                     proposed_change_id=proposed_change.id,
                     proposed_change_name=proposed_change.name.value,
                     proposed_change_state=proposed_change.state.value,
@@ -345,7 +347,7 @@ class ProposedChangeReview(Mutation):
                     )
                 await proposed_change.approved_by.remove_locally(db=db, peer_id=current_user.id)
 
-                event = ProposedChangeReviewRevokedEvent(
+                event = ProposedChangeApprovalRevokedEvent(
                     proposed_change_id=proposed_change.id,
                     proposed_change_name=proposed_change.name.value,
                     proposed_change_state=proposed_change.state.value,
@@ -362,7 +364,7 @@ class ProposedChangeReview(Mutation):
                 if current_user.id in approved_by_ids:
                     await proposed_change.approved_by.remove_locally(db=db, peer_id=current_user.id)
 
-                event = ProposedChangeReviewedEvent(
+                event = ProposedChangeRejectedEvent(
                     proposed_change_id=proposed_change.id,
                     proposed_change_name=proposed_change.name.value,
                     proposed_change_state=proposed_change.state.value,
@@ -379,7 +381,7 @@ class ProposedChangeReview(Mutation):
                     )
                 await proposed_change.rejected_by.remove_locally(db=db, peer_id=current_user.id)
 
-                event = ProposedChangeReviewRevokedEvent(
+                event = ProposedChangeRejectionRevokedEvent(
                     proposed_change_id=proposed_change.id,
                     proposed_change_name=proposed_change.name.value,
                     proposed_change_state=proposed_change.state.value,

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -134,7 +134,7 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
             state.validate_state_transition(updated_state)
 
         was_draft = obj.is_draft.value
-        still_draft = data.get("is_draft", was_draft).get("value")
+        still_draft = data.get("is_draft", {"value": was_draft}).get("value")
 
         # Check before starting a transaction, stopping in the middle of the transaction seems to break with memgraph
         if updated_state == ProposedChangeState.MERGED and graphql_context.account_session:

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -270,7 +270,7 @@ class ProposedChangeReview(Mutation):
             )
 
             async with graphql_context.db.start_session() as db:
-                await cls._handle_decision(
+                event = await cls._handle_decision(
                     db=db,
                     decision=data.decision,
                     proposed_change=proposed_change,
@@ -278,6 +278,10 @@ class ProposedChangeReview(Mutation):
                     graphql_context=graphql_context,
                 )
                 await proposed_change.save(db=db)
+
+                if event:
+                    event_service = await get_event_service()
+                    await event_service.send(event=event)
 
         return {"ok": True}
 
@@ -289,7 +293,7 @@ class ProposedChangeReview(Mutation):
         proposed_change: CoreProposedChange,
         current_user: Node,
         context: GraphqlContext,
-    ) -> None:
+    ) -> InfrahubEvent | None:
         """Modify approved_by and rejected_by relationships of the prpoposed change based on the decision."""
 
         approved_by = await proposed_change.approved_by.get_peers(db=db)
@@ -371,9 +375,7 @@ class ProposedChangeReview(Mutation):
             case _:
                 raise ValidationError(input_value=f"Invalid decision {decision}")
 
-        if event:
-            event_service = await get_event_service()
-            await event_service.send(event=event)
+        return event
 
 
 class ProposedChangeMergeInput(InputObjectType):

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Self
 
 from graphene import Boolean, Enum, Field, InputObjectType, List, Mutation, String
@@ -13,10 +15,15 @@ from infrahub.core.constants import (
     PermissionDecision,
 )
 from infrahub.core.manager import NodeManager
-from infrahub.core.node import Node
 from infrahub.core.protocols import CoreProposedChange
 from infrahub.core.schema import NodeSchema
 from infrahub.database import InfrahubDatabase, retry_db_transaction
+from infrahub.events import (
+    EventMeta,
+    ProposedChangeReviewedEvent,
+    ProposedChangeReviewRequestedEvent,
+    ProposedChangeReviewRevokedEvent,
+)
 from infrahub.exceptions import BranchNotFoundError, PermissionDeniedError, ValidationError
 from infrahub.graphql.mutations.main import InfrahubMutationMixin
 from infrahub.graphql.types.enums import CheckType as GraphQLCheckType
@@ -25,11 +32,17 @@ from infrahub.lock import InfrahubLock, build_object_lock_name
 from infrahub.proposed_change.approval_revoker import do_revoke_approvals_on_updated_pcs
 from infrahub.proposed_change.constants import ProposedChangeApprovalDecision, ProposedChangeState
 from infrahub.proposed_change.models import RequestProposedChangePipeline
+from infrahub.workers.dependencies import get_event_service
 from infrahub.workflows.catalogue import PROPOSED_CHANGE_MERGE, REQUEST_PROPOSED_CHANGE_PIPELINE
 
 from .main import InfrahubMutationOptions
 
 if TYPE_CHECKING:
+    from graphql import GraphQLResolveInfo
+
+    from infrahub.core.node import Node
+    from infrahub.events.models import InfrahubEvent
+
     from ..initialization import GraphqlContext
 
 ProposedChangeApprovalDecisionInput = Enum.from_enum(ProposedChangeApprovalDecision)
@@ -120,6 +133,9 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
             updated_state = ProposedChangeState(state_update)
             state.validate_state_transition(updated_state)
 
+        was_draft = obj.is_draft.value
+        still_draft = data.get("is_draft", was_draft).get("value")
+
         # Check before starting a transaction, stopping in the middle of the transaction seems to break with memgraph
         if updated_state == ProposedChangeState.MERGED and graphql_context.account_session:
             try:
@@ -152,6 +168,25 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
             # from the overridden "merging" value, so here we change it back to reflect the
             # correct value for the event that will be generated.
             proposed_change.node_changelog.attributes["state"].value = ProposedChangeState.MERGED.value
+
+        # If the proposed change was in draft but isn't anymore, send the review requested event
+        if was_draft and not still_draft:
+            current_user = await NodeManager.get_one(
+                db=graphql_context.db,
+                kind=InfrahubKind.GENERICACCOUNT,
+                id=graphql_context.active_account_session.account_id,
+            )
+            event_service = await get_event_service()
+            await event_service.send(
+                event=ProposedChangeReviewRequestedEvent(
+                    proposed_change_id=proposed_change.id,
+                    proposed_change_name=proposed_change.name.value,
+                    proposed_change_state=proposed_change.state.value,
+                    requested_by_account_id=current_user.id,
+                    requested_by_account_name=current_user.name.value,
+                    meta=EventMeta.from_context(context=graphql_context.get_context()),
+                )
+            )
 
         return proposed_change, result
 
@@ -261,6 +296,7 @@ class ProposedChangeReview(Mutation):
                     decision=data.decision,
                     proposed_change=proposed_change,
                     current_user=current_user,
+                    graphql_context=graphql_context,
                 )
                 await proposed_change.save(db=db)
 
@@ -273,6 +309,7 @@ class ProposedChangeReview(Mutation):
         decision: ProposedChangeApprovalDecision,
         proposed_change: CoreProposedChange,
         current_user: Node,
+        context: GraphqlContext,
     ) -> None:
         """Modify approved_by and rejected_by relationships of the prpoposed change based on the decision."""
 
@@ -280,6 +317,8 @@ class ProposedChangeReview(Mutation):
         rejected_by = await proposed_change.rejected_by.get_peers(db=db)
         approved_by_ids = [node.id for _, node in approved_by.items()]
         rejected_by_ids = [node.id for _, node in rejected_by.items()]
+        event: InfrahubEvent | None = None
+        event_meta = EventMeta.from_context(context=context.get_context())
 
         match decision:
             case ProposedChangeApprovalDecision.APPROVE:
@@ -289,12 +328,32 @@ class ProposedChangeReview(Mutation):
                 if current_user.id in rejected_by_ids:
                     await proposed_change.rejected_by.remove_locally(db=db, peer_id=current_user.id)
 
+                event = ProposedChangeReviewedEvent(
+                    proposed_change_id=proposed_change.id,
+                    proposed_change_name=proposed_change.name.value,
+                    proposed_change_state=proposed_change.state.value,
+                    reviewer_account_id=current_user.id,
+                    reviewer_account_name=current_user.name.value,
+                    reviewer_decision=decision.value,
+                    meta=event_meta,
+                )
+
             case ProposedChangeApprovalDecision.CANCEL_APPROVE:
                 if current_user.id not in approved_by_ids:
                     raise ValidationError(
                         input_value="You did not approve this proposed change yet, it can't be un-approved"
                     )
                 await proposed_change.approved_by.remove_locally(db=db, peer_id=current_user.id)
+
+                event = ProposedChangeReviewRevokedEvent(
+                    proposed_change_id=proposed_change.id,
+                    proposed_change_name=proposed_change.name.value,
+                    proposed_change_state=proposed_change.state.value,
+                    reviewer_account_id=current_user.id,
+                    reviewer_account_name=current_user.name.value,
+                    reviewer_former_decision=ProposedChangeApprovalDecision.APPROVE.value,
+                    meta=event_meta,
+                )
 
             case ProposedChangeApprovalDecision.REJECT:
                 if current_user.id in rejected_by_ids:
@@ -303,6 +362,16 @@ class ProposedChangeReview(Mutation):
                 if current_user.id in approved_by_ids:
                     await proposed_change.approved_by.remove_locally(db=db, peer_id=current_user.id)
 
+                event = ProposedChangeReviewedEvent(
+                    proposed_change_id=proposed_change.id,
+                    proposed_change_name=proposed_change.name.value,
+                    proposed_change_state=proposed_change.state.value,
+                    reviewer_account_id=current_user.id,
+                    reviewer_account_name=current_user.name.value,
+                    reviewer_decision=decision.value,
+                    meta=event_meta,
+                )
+
             case ProposedChangeApprovalDecision.CANCEL_REJECT:
                 if current_user.id not in rejected_by_ids:
                     raise ValidationError(
@@ -310,8 +379,22 @@ class ProposedChangeReview(Mutation):
                     )
                 await proposed_change.rejected_by.remove_locally(db=db, peer_id=current_user.id)
 
+                event = ProposedChangeReviewRevokedEvent(
+                    proposed_change_id=proposed_change.id,
+                    proposed_change_name=proposed_change.name.value,
+                    proposed_change_state=proposed_change.state.value,
+                    reviewer_account_id=current_user.id,
+                    reviewer_account_name=current_user.name.value,
+                    reviewer_former_decision=ProposedChangeApprovalDecision.REJECT.value,
+                    meta=event_meta,
+                )
+
             case _:
                 raise ValidationError(input_value=f"Invalid decision {decision}")
+
+        if event:
+            event_service = await get_event_service()
+            await event_service.send(event=event)
 
 
 class ProposedChangeMergeInput(InputObjectType):

--- a/backend/infrahub/graphql/types/event.py
+++ b/backend/infrahub/graphql/types/event.py
@@ -123,6 +123,7 @@ class ProposedChangeReviewEvent(ObjectType):
     reviewer_account_id = String(required=True, description="The ID of the user who reviewed the proposed change")
     reviewer_account_name = String(required=True, description="The name of the user who reviewed the proposed change")
     reviewer_decision = String(required=True, description="The decision made by the reviewer")
+    payload = Field(GenericScalar, required=True)
 
 
 class ProposedChangeReviewRevokedEvent(ObjectType):
@@ -132,6 +133,7 @@ class ProposedChangeReviewRevokedEvent(ObjectType):
     reviewer_account_id = String(required=True, description="The ID of the user who reviewed the proposed change")
     reviewer_account_name = String(required=True, description="The name of the user who reviewed the proposed change")
     reviewer_former_decision = String(required=True, description="The decision made by the reviewer")
+    payload = Field(GenericScalar, required=True)
 
 
 # ---------------------------------------

--- a/backend/infrahub/graphql/types/event.py
+++ b/backend/infrahub/graphql/types/event.py
@@ -136,6 +136,28 @@ class ProposedChangeReviewRevokedEvent(ObjectType):
     payload = Field(GenericScalar, required=True)
 
 
+class ProposedChangeReviewRequestedEvent(ObjectType):
+    class Meta:
+        interfaces = (EventNodeInterface,)
+
+    requested_by_account_id = String(
+        required=True, description="The ID of the user who requested the proposed change to be reviewed"
+    )
+    requested_by_account_name = String(
+        required=True, description="The name of the user who requested the proposed change to be reviewed"
+    )
+    payload = Field(GenericScalar, required=True)
+
+
+class ProposedChangeMergedEvent(ObjectType):
+    class Meta:
+        interfaces = (EventNodeInterface,)
+
+    merged_by_account_id = String(required=True, description="The ID of the user who merged the proposed change")
+    merged_by_account_name = String(required=True, description="The name of the user who merged the proposed change")
+    payload = Field(GenericScalar, required=True)
+
+
 # ---------------------------------------
 # Node/Object events
 # ---------------------------------------
@@ -190,5 +212,7 @@ EVENT_TYPES: dict[str, type[ObjectType]] = {
     events.ProposedChangeApprovalRevokedEvent.event_name: ProposedChangeReviewRevokedEvent,
     events.ProposedChangeRejectedEvent.event_name: ProposedChangeReviewEvent,
     events.ProposedChangeRejectionRevokedEvent.event_name: ProposedChangeReviewRevokedEvent,
+    events.ProposedChangeReviewRequestedEvent.event_name: ProposedChangeReviewRequestedEvent,
+    events.ProposedChangeMergedEvent.event_name: ProposedChangeMergedEvent,
     "undefined": StandardEvent,
 }

--- a/backend/infrahub/graphql/types/event.py
+++ b/backend/infrahub/graphql/types/event.py
@@ -114,6 +114,27 @@ class BranchDeletedEvent(ObjectType):
 
 
 # ---------------------------------------
+# Proposed change events
+# ---------------------------------------
+class ProposedChangeReviewEvent(ObjectType):
+    class Meta:
+        interfaces = (EventNodeInterface,)
+
+    reviewer_account_id = String(required=True, description="The ID of the user who reviewed the proposed change")
+    reviewer_account_name = String(required=True, description="The name of the user who reviewed the proposed change")
+    reviewer_decision = String(required=True, description="The decision made by the reviewer")
+
+
+class ProposedChangeReviewRevokedEvent(ObjectType):
+    class Meta:
+        interfaces = (EventNodeInterface,)
+
+    reviewer_account_id = String(required=True, description="The ID of the user who reviewed the proposed change")
+    reviewer_account_name = String(required=True, description="The name of the user who reviewed the proposed change")
+    reviewer_former_decision = String(required=True, description="The decision made by the reviewer")
+
+
+# ---------------------------------------
 # Node/Object events
 # ---------------------------------------
 class NodeMutatedEvent(ObjectType):
@@ -163,5 +184,9 @@ EVENT_TYPES: dict[str, type[ObjectType]] = {
     events.BranchDeletedEvent.event_name: BranchDeletedEvent,
     events.GroupMemberAddedEvent.event_name: GroupEvent,
     events.GroupMemberRemovedEvent.event_name: GroupEvent,
+    events.ProposedChangeApprovedEvent.event_name: ProposedChangeReviewEvent,
+    events.ProposedChangeApprovalRevokedEvent.event_name: ProposedChangeReviewRevokedEvent,
+    events.ProposedChangeRejectedEvent.event_name: ProposedChangeReviewEvent,
+    events.ProposedChangeRejectionRevokedEvent.event_name: ProposedChangeReviewRevokedEvent,
     "undefined": StandardEvent,
 }

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -43,6 +43,7 @@ from infrahub.core.diff.coordinator import DiffCoordinator
 from infrahub.core.diff.model.diff import DiffElementType, SchemaConflict
 from infrahub.core.diff.model.path import NodeDiffFieldSummary
 from infrahub.core.integrity.object_conflict.conflict_recorder import ObjectConflictValidatorRecorder
+from infrahub.core.manager import NodeManager
 from infrahub.core.protocols import CoreDataCheck, CoreValidator
 from infrahub.core.protocols import CoreProposedChange as InternalCoreProposedChange
 from infrahub.core.timestamp import Timestamp
@@ -51,6 +52,7 @@ from infrahub.core.validators.determiner import ConstraintValidatorDeterminer
 from infrahub.core.validators.models.validate_migration import SchemaValidateMigrationData
 from infrahub.core.validators.tasks import schema_validate_migrations
 from infrahub.dependencies.registry import get_component_registry
+from infrahub.events import EventMeta, ProposedChangeMergedEvent
 from infrahub.exceptions import MergeFailedError
 from infrahub.generators.models import ProposedChangeGeneratorDefinition
 from infrahub.git.base import extract_repo_file_information
@@ -214,6 +216,22 @@ async def merge_proposed_change(
         await _proposed_change_transition_state(
             proposed_change=proposed_change, state=ProposedChangeState.MERGED, database=db
         )
+
+        current_user = await NodeManager.get_one_by_id_or_default_filter(
+            id=context.account.account_id, kind=InfrahubKind.GENERICACCOUNT, db=db
+        )
+        event_service = await get_event_service()
+        await event_service.send(
+            event=ProposedChangeMergedEvent(
+                proposed_change_id=proposed_change.id,
+                proposed_change_name=proposed_change.name.value,
+                proposed_change_state=proposed_change.state.value,
+                merged_by_account_id=current_user.id,
+                merged_by_account_name=current_user.name.value,
+                meta=EventMeta.from_context(context=context),
+            )
+        )
+
         return Completed(message="proposed change merged successfully")
 
 

--- a/backend/infrahub/task_manager/event.py
+++ b/backend/infrahub/task_manager/event.py
@@ -172,29 +172,45 @@ class PrefectEventData(PrefectEventModel):
 
         return {"members": members, "ancestors": ancestors}
 
-    def _return_proposed_change_reviewer(self) -> dict[str, Any]:
-        return {
-            "reviewer_account_id": self.resource.get("infrahub.proposed_change.reviewer_account_id"),
-            "reviewer_account_name": self.resource.get("infrahub.proposed_change.reviewer_account_name"),
-        }
+    def _return_proposed_change_event(self) -> dict[str, Any]:
+        data = {}
+        for resource in self.related:
+            if resource.role != "infrahub.related.node":
+                continue
+            match self.event:
+                case "infrahub.proposed_change.merged":
+                    data.update(
+                        {
+                            "merged_by_account_id": resource.get("infrahub.node.id"),
+                            "merged_by_account_name": resource.get("infrahub.merged_by.account.name"),
+                        }
+                    )
+                case "infrahub.proposed_change.review_requested":
+                    data.update(
+                        {
+                            "requested_by_account_id": resource.get("infrahub.node.id"),
+                            "requested_by_account_name": resource.get("infrahub.requested_by.account.name"),
+                        }
+                    )
+                case (
+                    "infrahub.proposed_change.approved"
+                    | "infrahub.proposed_change.rejected"
+                    | "infrahub.proposed_change.approval_revoked"
+                    | "infrahub.proposed_change.rejection_revoked"
+                ):
+                    data.update(
+                        {
+                            "reviewer_account_id": resource.get("infrahub.node.id"),
+                            "reviewer_account_name": resource.get("infrahub.reviewer.account.name"),
+                        }
+                    )
+        return data
 
     def _return_proposed_change_reviewer_decision(self) -> dict[str, Any]:
         return {"reviewer_decision": self.resource.get("infrahub.proposed_change.reviewer_decision")}
 
     def _return_proposed_change_reviewer_former_decision(self) -> dict[str, Any]:
         return {"reviewer_former_decision": self.resource.get("infrahub.proposed_change.reviewer_former_decision")}
-
-    def _return_proposed_change_requested_by(self) -> dict[str, Any]:
-        return {
-            "requested_by_account_id": self.resource.get("infrahub.proposed_change.requested_by_account_id"),
-            "requested_by_account_name": self.resource.get("infrahub.proposed_change.requested_by_account_name"),
-        }
-
-    def _return_proposed_change_merged_by(self) -> dict[str, Any]:
-        return {
-            "merged_by_account_id": self.resource.get("infrahub.proposed_change.merged_by_account_id"),
-            "merged_by_account_name": self.resource.get("infrahub.proposed_change.merged_by_account_name"),
-        }
 
     def _return_event_specifics(self) -> dict[str, Any]:
         """Return event specific data based on the type of event being processed"""
@@ -218,18 +234,16 @@ class PrefectEventData(PrefectEventModel):
                 event_specifics = self._return_group_event()
             case "infrahub.proposed_change.approved" | "infrahub.proposed_change.rejected":
                 event_specifics = {
-                    **self._return_proposed_change_reviewer(),
+                    **self._return_proposed_change_event(),
                     **self._return_proposed_change_reviewer_decision(),
                 }
             case "infrahub.proposed_change.approval_revoked" | "infrahub.proposed_change.rejection_revoked":
                 event_specifics = {
-                    **self._return_proposed_change_reviewer(),
+                    **self._return_proposed_change_event(),
                     **self._return_proposed_change_reviewer_former_decision(),
                 }
-            case "infrahub.proposed_change.review_requested":
-                event_specifics = self._return_proposed_change_requested_by()
-            case "infrahub.proposed_change.merged":
-                event_specifics = self._return_proposed_change_merged_by()
+            case "infrahub.proposed_change.review_requested" | "infrahub.proposed_change.merged":
+                event_specifics = self._return_proposed_change_event()
 
         return event_specifics
 

--- a/backend/infrahub/task_manager/event.py
+++ b/backend/infrahub/task_manager/event.py
@@ -184,6 +184,18 @@ class PrefectEventData(PrefectEventModel):
     def _return_proposed_change_reviewer_former_decision(self) -> dict[str, Any]:
         return {"reviewer_former_decision": self.resource.get("infrahub.proposed_change.reviewer_former_decision")}
 
+    def _return_proposed_change_requested_by(self) -> dict[str, Any]:
+        return {
+            "requested_by_account_id": self.resource.get("infrahub.proposed_change.requested_by_account_id"),
+            "requested_by_account_name": self.resource.get("infrahub.proposed_change.requested_by_account_name"),
+        }
+
+    def _return_proposed_change_merged_by(self) -> dict[str, Any]:
+        return {
+            "merged_by_account_id": self.resource.get("infrahub.proposed_change.merged_by_account_id"),
+            "merged_by_account_name": self.resource.get("infrahub.proposed_change.merged_by_account_name"),
+        }
+
     def _return_event_specifics(self) -> dict[str, Any]:
         """Return event specific data based on the type of event being processed"""
 
@@ -214,6 +226,10 @@ class PrefectEventData(PrefectEventModel):
                     **self._return_proposed_change_reviewer(),
                     **self._return_proposed_change_reviewer_former_decision(),
                 }
+            case "infrahub.proposed_change.review_requested":
+                event_specifics = self._return_proposed_change_requested_by()
+            case "infrahub.proposed_change.merged":
+                event_specifics = self._return_proposed_change_merged_by()
 
         return event_specifics
 

--- a/backend/infrahub/task_manager/event.py
+++ b/backend/infrahub/task_manager/event.py
@@ -172,6 +172,18 @@ class PrefectEventData(PrefectEventModel):
 
         return {"members": members, "ancestors": ancestors}
 
+    def _return_proposed_change_reviewer(self) -> dict[str, Any]:
+        return {
+            "reviewer_account_id": self.resource.get("infrahub.proposed_change.reviewer_account_id"),
+            "reviewer_account_name": self.resource.get("infrahub.proposed_change.reviewer_account_name"),
+        }
+
+    def _return_proposed_change_reviewer_decision(self) -> dict[str, Any]:
+        return {"reviewer_decision": self.resource.get("infrahub.proposed_change.reviewer_decision")}
+
+    def _return_proposed_change_reviewer_former_decision(self) -> dict[str, Any]:
+        return {"reviewer_former_decision": self.resource.get("infrahub.proposed_change.reviewer_former_decision")}
+
     def _return_event_specifics(self) -> dict[str, Any]:
         """Return event specific data based on the type of event being processed"""
 
@@ -192,6 +204,16 @@ class PrefectEventData(PrefectEventModel):
                 event_specifics = self._return_branch_rebased()
             case "infrahub.group.member_added" | "infrahub.group.member_removed":
                 event_specifics = self._return_group_event()
+            case "infrahub.proposed_change.approved" | "infrahub.proposed_change.rejected":
+                event_specifics = {
+                    **self._return_proposed_change_reviewer(),
+                    **self._return_proposed_change_reviewer_decision(),
+                }
+            case "infrahub.proposed_change.approval_revoked" | "infrahub.proposed_change.rejection_revoked":
+                event_specifics = {
+                    **self._return_proposed_change_reviewer(),
+                    **self._return_proposed_change_reviewer_former_decision(),
+                }
 
         return event_specifics
 

--- a/backend/tests/functional/proposed_change/test_review.py
+++ b/backend/tests/functional/proposed_change/test_review.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 from infrahub_sdk.exceptions import GraphQLError
+from prefect import get_client
+from tests.helpers.events import query_events_by_name
 from tests.helpers.test_app import TestInfrahubApp
 
 from infrahub.core.constants.infrahubkind import PROPOSEDCHANGE
@@ -13,7 +15,10 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.protocols import CoreAccountGroup
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
     from infrahub_sdk import InfrahubClient
+    from prefect.client.orchestration import PrefectClient
 
     from infrahub.core.schema.schema_branch import SchemaBranch
     from infrahub.database import InfrahubDatabase
@@ -40,10 +45,10 @@ class TestProposedChangeReview(TestInfrahubApp):
     }
     """
 
-    async def query_events(self, client: InfrahubClient, event_type: str) -> dict:
-        # Not pretty, but wait for events to be processed before querying them
-        await asyncio.sleep(2)
-        return await client.execute_graphql(query=self.event_query, variables={"event_type": event_type})
+    @pytest.fixture(scope="class")
+    async def prefect_client(self, prefect_test_fixture) -> AsyncGenerator[PrefectClient, None]:
+        async with get_client(sync_client=False) as client:
+            yield client
 
     async def test_approve_then_reject(
         self,
@@ -51,6 +56,7 @@ class TestProposedChangeReview(TestInfrahubApp):
         db: InfrahubDatabase,
         car_person_schema: SchemaBranch,
         unprivileged_client: InfrahubClient,
+        prefect_client: PrefectClient,
     ) -> None:
         """Test the complete proposed change review flow including relationship updates."""
 
@@ -94,10 +100,9 @@ class TestProposedChangeReview(TestInfrahubApp):
         assert len(updated_pc.rejected_by.peers) == 0
 
         # Verify that an event has been logged
-        event_response = await self.query_events(client=client, event_type="infrahub.proposed_change.approved")
-        assert event_response["InfrahubEvent"]["edges"]
-        assert event_response["InfrahubEvent"]["edges"][0]["node"]["__typename"] == "ProposedChangeReviewEvent"
-        assert event_response["InfrahubEvent"]["edges"][0]["node"]["event"] == "infrahub.proposed_change.approved"
+        await asyncio.sleep(2)
+        events = await query_events_by_name(client=prefect_client, event_name="infrahub.proposed_change.approved")
+        assert len(events) == 1
 
         # Test the ProposedChangeReview mutation with REJECTED decision
         response = await unprivileged_client.execute_graphql(
@@ -119,10 +124,9 @@ class TestProposedChangeReview(TestInfrahubApp):
         assert rejected_by_peers == {reviewer["AccountProfile"]["id"]}
 
         # Verify that an event has been logged
-        event_response = await self.query_events(client=client, event_type="infrahub.proposed_change.rejected")
-        assert event_response["InfrahubEvent"]["edges"]
-        assert event_response["InfrahubEvent"]["edges"][0]["node"]["__typename"] == "ProposedChangeReviewEvent"
-        assert event_response["InfrahubEvent"]["edges"][0]["node"]["event"] == "infrahub.proposed_change.rejected"
+        await asyncio.sleep(2)
+        events = await query_events_by_name(client=prefect_client, event_name="infrahub.proposed_change.rejected")
+        assert len(events) == 1
 
     async def test_cancel_approve(
         self,
@@ -130,6 +134,7 @@ class TestProposedChangeReview(TestInfrahubApp):
         db: InfrahubDatabase,
         car_person_schema: SchemaBranch,
         unprivileged_client: InfrahubClient,
+        prefect_client: PrefectClient,
     ) -> None:
         """Test the complete proposed change review flow including relationship updates."""
 
@@ -183,12 +188,11 @@ class TestProposedChangeReview(TestInfrahubApp):
         assert len(updated_pc.rejected_by.peers) == 0
 
         # Verify that an event has been logged
-        event_response = await self.query_events(client=client, event_type="infrahub.proposed_change.approval_revoked")
-        assert event_response["InfrahubEvent"]["edges"]
-        assert event_response["InfrahubEvent"]["edges"][0]["node"]["__typename"] == "ProposedChangeReviewRevokedEvent"
-        assert (
-            event_response["InfrahubEvent"]["edges"][0]["node"]["event"] == "infrahub.proposed_change.approval_revoked"
+        await asyncio.sleep(2)
+        events = await query_events_by_name(
+            client=prefect_client, event_name="infrahub.proposed_change.approval_revoked"
         )
+        assert len(events) == 1
 
     async def test_cancel_reject(
         self,
@@ -196,6 +200,7 @@ class TestProposedChangeReview(TestInfrahubApp):
         db: InfrahubDatabase,
         car_person_schema: SchemaBranch,
         unprivileged_client: InfrahubClient,
+        prefect_client: PrefectClient,
     ) -> None:
         """Test the complete proposed change review flow including relationship updates."""
 
@@ -249,12 +254,11 @@ class TestProposedChangeReview(TestInfrahubApp):
         assert len(updated_pc.rejected_by.peers) == 0
 
         # Verify that an event has been logged
-        event_response = await self.query_events(client=client, event_type="infrahub.proposed_change.rejection_revoked")
-        assert event_response["InfrahubEvent"]["edges"]
-        assert event_response["InfrahubEvent"]["edges"][0]["node"]["__typename"] == "ProposedChangeReviewRevokedEvent"
-        assert (
-            event_response["InfrahubEvent"]["edges"][0]["node"]["event"] == "infrahub.proposed_change.rejection_revoked"
+        await asyncio.sleep(2)
+        events = await query_events_by_name(
+            client=prefect_client, event_name="infrahub.proposed_change.rejection_revoked"
         )
+        assert len(events) == 1
 
     async def test_missing_permission(
         self,

--- a/backend/tests/functional/proposed_change/test_review.py
+++ b/backend/tests/functional/proposed_change/test_review.py
@@ -50,6 +50,15 @@ class TestProposedChangeReview(TestInfrahubApp):
         async with get_client(sync_client=False) as client:
             yield client
 
+    async def assert_event(self, prefect_client: PrefectClient, event_name: str) -> None:
+        for _ in range(10):
+            events = await query_events_by_name(client=prefect_client, event_name=event_name)
+            if len(events) == 1:
+                return
+            await asyncio.sleep(1)
+
+        pytest.fail(f"unable to find prefect event '{event_name}'")
+
     async def test_approve_then_reject(
         self,
         client: InfrahubClient,
@@ -100,9 +109,7 @@ class TestProposedChangeReview(TestInfrahubApp):
         assert len(updated_pc.rejected_by.peers) == 0
 
         # Verify that an event has been logged
-        await asyncio.sleep(2)
-        events = await query_events_by_name(client=prefect_client, event_name="infrahub.proposed_change.approved")
-        assert len(events) == 1
+        await self.assert_event(prefect_client=prefect_client, event_name="infrahub.proposed_change.approved")
 
         # Test the ProposedChangeReview mutation with REJECTED decision
         response = await unprivileged_client.execute_graphql(
@@ -124,9 +131,7 @@ class TestProposedChangeReview(TestInfrahubApp):
         assert rejected_by_peers == {reviewer["AccountProfile"]["id"]}
 
         # Verify that an event has been logged
-        await asyncio.sleep(2)
-        events = await query_events_by_name(client=prefect_client, event_name="infrahub.proposed_change.rejected")
-        assert len(events) == 1
+        await self.assert_event(prefect_client=prefect_client, event_name="infrahub.proposed_change.rejected")
 
     async def test_cancel_approve(
         self,
@@ -188,11 +193,7 @@ class TestProposedChangeReview(TestInfrahubApp):
         assert len(updated_pc.rejected_by.peers) == 0
 
         # Verify that an event has been logged
-        await asyncio.sleep(2)
-        events = await query_events_by_name(
-            client=prefect_client, event_name="infrahub.proposed_change.approval_revoked"
-        )
-        assert len(events) == 1
+        await self.assert_event(prefect_client=prefect_client, event_name="infrahub.proposed_change.approval_revoked")
 
     async def test_cancel_reject(
         self,
@@ -254,11 +255,7 @@ class TestProposedChangeReview(TestInfrahubApp):
         assert len(updated_pc.rejected_by.peers) == 0
 
         # Verify that an event has been logged
-        await asyncio.sleep(2)
-        events = await query_events_by_name(
-            client=prefect_client, event_name="infrahub.proposed_change.rejection_revoked"
-        )
-        assert len(events) == 1
+        await self.assert_event(prefect_client=prefect_client, event_name="infrahub.proposed_change.rejection_revoked")
 
     async def test_missing_permission(
         self,

--- a/backend/tests/functional/proposed_change/test_review.py
+++ b/backend/tests/functional/proposed_change/test_review.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 
 import pytest
@@ -19,13 +20,30 @@ if TYPE_CHECKING:
 
 
 class TestProposedChangeReview(TestInfrahubApp):
-    review_query: str = """
-        mutation ProposedChangeReview($data: ProposedChangeReviewInput!) {
-            CoreProposedChangeReview(data: $data) {
-                ok
+    review_query = """
+    mutation ProposedChangeReview($data: ProposedChangeReviewInput!) {
+        CoreProposedChangeReview(data: $data) {
+            ok
+        }
+    }
+    """
+    event_query = """
+    query GetEvents($event_type: String!) {
+        InfrahubEvent(event_type: [$event_type]) {
+            edges {
+                node {
+                    __typename
+                    event
+                }
             }
         }
-        """
+    }
+    """
+
+    async def query_events(self, client: InfrahubClient, event_type: str) -> dict:
+        # Not pretty, but wait for events to be processed before querying them
+        await asyncio.sleep(2)
+        return await client.execute_graphql(query=self.event_query, variables={"event_type": event_type})
 
     async def test_approve_then_reject(
         self,
@@ -75,6 +93,12 @@ class TestProposedChangeReview(TestInfrahubApp):
         }
         assert len(updated_pc.rejected_by.peers) == 0
 
+        # Verify that an event has been logged
+        event_response = await self.query_events(client=client, event_type="infrahub.proposed_change.approved")
+        assert event_response["InfrahubEvent"]["edges"]
+        assert event_response["InfrahubEvent"]["edges"][0]["node"]["__typename"] == "ProposedChangeReviewEvent"
+        assert event_response["InfrahubEvent"]["edges"][0]["node"]["event"] == "infrahub.proposed_change.approved"
+
         # Test the ProposedChangeReview mutation with REJECTED decision
         response = await unprivileged_client.execute_graphql(
             query=self.review_query,
@@ -93,6 +117,12 @@ class TestProposedChangeReview(TestInfrahubApp):
         assert len(approved_by_peers) == 0
         rejected_by_peers = {related_node.peer.id for related_node in updated_pc.rejected_by.peers}
         assert rejected_by_peers == {reviewer["AccountProfile"]["id"]}
+
+        # Verify that an event has been logged
+        event_response = await self.query_events(client=client, event_type="infrahub.proposed_change.rejected")
+        assert event_response["InfrahubEvent"]["edges"]
+        assert event_response["InfrahubEvent"]["edges"][0]["node"]["__typename"] == "ProposedChangeReviewEvent"
+        assert event_response["InfrahubEvent"]["edges"][0]["node"]["event"] == "infrahub.proposed_change.rejected"
 
     async def test_cancel_approve(
         self,
@@ -152,6 +182,14 @@ class TestProposedChangeReview(TestInfrahubApp):
         assert len(updated_pc.approved_by.peers) == 0
         assert len(updated_pc.rejected_by.peers) == 0
 
+        # Verify that an event has been logged
+        event_response = await self.query_events(client=client, event_type="infrahub.proposed_change.approval_revoked")
+        assert event_response["InfrahubEvent"]["edges"]
+        assert event_response["InfrahubEvent"]["edges"][0]["node"]["__typename"] == "ProposedChangeReviewRevokedEvent"
+        assert (
+            event_response["InfrahubEvent"]["edges"][0]["node"]["event"] == "infrahub.proposed_change.approval_revoked"
+        )
+
     async def test_cancel_reject(
         self,
         client: InfrahubClient,
@@ -209,6 +247,14 @@ class TestProposedChangeReview(TestInfrahubApp):
         assert updated_pc.state.value == "open"
         assert len(updated_pc.approved_by.peers) == 0
         assert len(updated_pc.rejected_by.peers) == 0
+
+        # Verify that an event has been logged
+        event_response = await self.query_events(client=client, event_type="infrahub.proposed_change.rejection_revoked")
+        assert event_response["InfrahubEvent"]["edges"]
+        assert event_response["InfrahubEvent"]["edges"][0]["node"]["__typename"] == "ProposedChangeReviewRevokedEvent"
+        assert (
+            event_response["InfrahubEvent"]["edges"][0]["node"]["event"] == "infrahub.proposed_change.rejection_revoked"
+        )
 
     async def test_missing_permission(
         self,

--- a/backend/tests/functional/proposed_change/test_review.py
+++ b/backend/tests/functional/proposed_change/test_review.py
@@ -32,18 +32,6 @@ class TestProposedChangeReview(TestInfrahubApp):
         }
     }
     """
-    event_query = """
-    query GetEvents($event_type: String!) {
-        InfrahubEvent(event_type: [$event_type]) {
-            edges {
-                node {
-                    __typename
-                    event
-                }
-            }
-        }
-    }
-    """
 
     @pytest.fixture(scope="class")
     async def prefect_client(self, prefect_test_fixture) -> AsyncGenerator[PrefectClient, None]:

--- a/backend/tests/helpers/events.py
+++ b/backend/tests/helpers/events.py
@@ -2,7 +2,7 @@ import asyncio
 from uuid import UUID
 
 from prefect.client.orchestration import PrefectClient
-from prefect.events.filters import EventFilter, EventIDFilter
+from prefect.events.filters import EventFilter, EventIDFilter, EventNameFilter
 from prefect.events.schemas.events import Event, RelatedResource, Resource
 from pydantic import TypeAdapter
 
@@ -51,6 +51,15 @@ async def query_event(client: PrefectClient, event_id: UUID) -> Event:
         return events[0]
 
     raise Exception(f"No event found for id {event_id}")
+
+
+async def query_events_by_name(client: PrefectClient, event_name: str) -> list[Event]:
+    filters = EventFilter(event=EventNameFilter(name=[event_name]))  # type: ignore[call-arg]
+    body = {"filter": filters.model_dump(mode="json", exclude_unset=True)}
+
+    response = await client._client.post("/events/filter", json=body)
+    response.raise_for_status()
+    return TypeAdapter(list[Event]).validate_python(response.json().get("events"))
 
 
 def extract_expected_ids(data: dict[str, InfrahubEvent], expected_events: list[str]) -> list[str]:

--- a/changelog/+ifc1633.added.md
+++ b/changelog/+ifc1633.added.md
@@ -1,0 +1,1 @@
+Add events for proposed change reviews and merge

--- a/docs/docs/reference/infrahub-events.mdx
+++ b/docs/docs/reference/infrahub-events.mdx
@@ -336,6 +336,126 @@ For more detailed explanations on how these events are used within Infrahub, see
 | **changelog** | Data on modified object |
 | **fields** | Fields provided in the mutation |
 <!-- vale on -->
+## Proposed events
+
+<!-- vale off -->
+### Proposed Change Merged Event
+<!-- vale on -->
+
+**Type**: infrahub.proposed_change.merged
+**Description**: Event generated when a proposed change has been merged
+<!-- vale off -->
+**Uses node_kind filter for webhooks**: `false`
+<!-- vale on -->
+
+<!-- vale off -->
+| Key | Description |
+|-----|-------------|
+| **meta.branch** | The branch on which originate this event |
+| **meta.request_id** | N/A |
+| **meta.account_id** | The ID of the account triggering this event |
+| **meta.initiator_id** | The worker identity of the initial sender of this message |
+| **meta.context** | The context used when originating this event |
+| **meta.level** | N/A |
+| **meta.has_children** | Indicates if this event might potentially have child events under it. |
+| **meta.id** | UUID of the event |
+| **meta.parent** | The UUID of the parent event if applicable |
+| **meta.ancestors** | Any event used to trigger this event |
+| **proposed_change_id** | The ID of the proposed change |
+| **proposed_change_name** | The name of the proposed change |
+| **proposed_change_state** | The state of the proposed change |
+| **merged_by_account_id** | The ID of the user who merged the proposed change |
+| **merged_by_account_name** | The name of the user who merged the proposed change |
+<!-- vale on -->
+<!-- vale off -->
+### Proposed Change Review Requested Event
+<!-- vale on -->
+
+**Type**: infrahub.proposed_change.review_requested
+**Description**: Event generated when a proposed change has been flagged for review
+<!-- vale off -->
+**Uses node_kind filter for webhooks**: `false`
+<!-- vale on -->
+
+<!-- vale off -->
+| Key | Description |
+|-----|-------------|
+| **meta.branch** | The branch on which originate this event |
+| **meta.request_id** | N/A |
+| **meta.account_id** | The ID of the account triggering this event |
+| **meta.initiator_id** | The worker identity of the initial sender of this message |
+| **meta.context** | The context used when originating this event |
+| **meta.level** | N/A |
+| **meta.has_children** | Indicates if this event might potentially have child events under it. |
+| **meta.id** | UUID of the event |
+| **meta.parent** | The UUID of the parent event if applicable |
+| **meta.ancestors** | Any event used to trigger this event |
+| **proposed_change_id** | The ID of the proposed change |
+| **proposed_change_name** | The name of the proposed change |
+| **proposed_change_state** | The state of the proposed change |
+| **requested_by_account_id** | The ID of the user who requested the proposed change to be reviewed |
+| **requested_by_account_name** | The name of the user who requested the proposed change to be reviewed |
+<!-- vale on -->
+<!-- vale off -->
+### Proposed Change Review Revoked Event
+<!-- vale on -->
+
+**Type**: infrahub.proposed_change.review_revoked
+**Description**: Event generated when a proposed change review has been revoked
+<!-- vale off -->
+**Uses node_kind filter for webhooks**: `false`
+<!-- vale on -->
+
+<!-- vale off -->
+| Key | Description |
+|-----|-------------|
+| **meta.branch** | The branch on which originate this event |
+| **meta.request_id** | N/A |
+| **meta.account_id** | The ID of the account triggering this event |
+| **meta.initiator_id** | The worker identity of the initial sender of this message |
+| **meta.context** | The context used when originating this event |
+| **meta.level** | N/A |
+| **meta.has_children** | Indicates if this event might potentially have child events under it. |
+| **meta.id** | UUID of the event |
+| **meta.parent** | The UUID of the parent event if applicable |
+| **meta.ancestors** | Any event used to trigger this event |
+| **proposed_change_id** | The ID of the proposed change |
+| **proposed_change_name** | The name of the proposed change |
+| **proposed_change_state** | The state of the proposed change |
+| **reviewer_account_id** | The ID of the user who reviewed the proposed change |
+| **reviewer_account_name** | The name of the user who reviewed the proposed change |
+| **reviewer_former_decision** | The former decision made by the reviewer |
+<!-- vale on -->
+<!-- vale off -->
+### Proposed Change Reviewed Event
+<!-- vale on -->
+
+**Type**: infrahub.proposed_change.reviewed
+**Description**: Event generated when a proposed change has been reviewed
+<!-- vale off -->
+**Uses node_kind filter for webhooks**: `false`
+<!-- vale on -->
+
+<!-- vale off -->
+| Key | Description |
+|-----|-------------|
+| **meta.branch** | The branch on which originate this event |
+| **meta.request_id** | N/A |
+| **meta.account_id** | The ID of the account triggering this event |
+| **meta.initiator_id** | The worker identity of the initial sender of this message |
+| **meta.context** | The context used when originating this event |
+| **meta.level** | N/A |
+| **meta.has_children** | Indicates if this event might potentially have child events under it. |
+| **meta.id** | UUID of the event |
+| **meta.parent** | The UUID of the parent event if applicable |
+| **meta.ancestors** | Any event used to trigger this event |
+| **proposed_change_id** | The ID of the proposed change |
+| **proposed_change_name** | The name of the proposed change |
+| **proposed_change_state** | The state of the proposed change |
+| **reviewer_account_id** | The ID of the user who reviewed the proposed change |
+| **reviewer_account_name** | The name of the user who reviewed the proposed change |
+| **reviewer_decision** | The decision made by the reviewer |
+<!-- vale on -->
 ## Commit events
 
 <!-- vale off -->

--- a/docs/docs/reference/infrahub-events.mdx
+++ b/docs/docs/reference/infrahub-events.mdx
@@ -339,6 +339,66 @@ For more detailed explanations on how these events are used within Infrahub, see
 ## Proposed events
 
 <!-- vale off -->
+### Proposed Change Approval Revoked Event
+<!-- vale on -->
+
+**Type**: infrahub.proposed_change.approval_revoked
+**Description**: Event generated when a proposed change approval has been revoked
+<!-- vale off -->
+**Uses node_kind filter for webhooks**: `false`
+<!-- vale on -->
+
+<!-- vale off -->
+| Key | Description |
+|-----|-------------|
+| **meta.branch** | The branch on which originate this event |
+| **meta.request_id** | N/A |
+| **meta.account_id** | The ID of the account triggering this event |
+| **meta.initiator_id** | The worker identity of the initial sender of this message |
+| **meta.context** | The context used when originating this event |
+| **meta.level** | N/A |
+| **meta.has_children** | Indicates if this event might potentially have child events under it. |
+| **meta.id** | UUID of the event |
+| **meta.parent** | The UUID of the parent event if applicable |
+| **meta.ancestors** | Any event used to trigger this event |
+| **proposed_change_id** | The ID of the proposed change |
+| **proposed_change_name** | The name of the proposed change |
+| **proposed_change_state** | The state of the proposed change |
+| **reviewer_account_id** | The ID of the user who reviewed the proposed change |
+| **reviewer_account_name** | The name of the user who reviewed the proposed change |
+| **reviewer_former_decision** | The former decision made by the reviewer |
+<!-- vale on -->
+<!-- vale off -->
+### Proposed Change Approved Event
+<!-- vale on -->
+
+**Type**: infrahub.proposed_change.approved
+**Description**: Event generated when a proposed change has been approved
+<!-- vale off -->
+**Uses node_kind filter for webhooks**: `false`
+<!-- vale on -->
+
+<!-- vale off -->
+| Key | Description |
+|-----|-------------|
+| **meta.branch** | The branch on which originate this event |
+| **meta.request_id** | N/A |
+| **meta.account_id** | The ID of the account triggering this event |
+| **meta.initiator_id** | The worker identity of the initial sender of this message |
+| **meta.context** | The context used when originating this event |
+| **meta.level** | N/A |
+| **meta.has_children** | Indicates if this event might potentially have child events under it. |
+| **meta.id** | UUID of the event |
+| **meta.parent** | The UUID of the parent event if applicable |
+| **meta.ancestors** | Any event used to trigger this event |
+| **proposed_change_id** | The ID of the proposed change |
+| **proposed_change_name** | The name of the proposed change |
+| **proposed_change_state** | The state of the proposed change |
+| **reviewer_account_id** | The ID of the user who reviewed the proposed change |
+| **reviewer_account_name** | The name of the user who reviewed the proposed change |
+| **reviewer_decision** | The decision made by the reviewer |
+<!-- vale on -->
+<!-- vale off -->
 ### Proposed Change Merged Event
 <!-- vale on -->
 
@@ -368,6 +428,66 @@ For more detailed explanations on how these events are used within Infrahub, see
 | **merged_by_account_name** | The name of the user who merged the proposed change |
 <!-- vale on -->
 <!-- vale off -->
+### Proposed Change Rejected Event
+<!-- vale on -->
+
+**Type**: infrahub.proposed_change.rejected
+**Description**: Event generated when a proposed change has been rejected
+<!-- vale off -->
+**Uses node_kind filter for webhooks**: `false`
+<!-- vale on -->
+
+<!-- vale off -->
+| Key | Description |
+|-----|-------------|
+| **meta.branch** | The branch on which originate this event |
+| **meta.request_id** | N/A |
+| **meta.account_id** | The ID of the account triggering this event |
+| **meta.initiator_id** | The worker identity of the initial sender of this message |
+| **meta.context** | The context used when originating this event |
+| **meta.level** | N/A |
+| **meta.has_children** | Indicates if this event might potentially have child events under it. |
+| **meta.id** | UUID of the event |
+| **meta.parent** | The UUID of the parent event if applicable |
+| **meta.ancestors** | Any event used to trigger this event |
+| **proposed_change_id** | The ID of the proposed change |
+| **proposed_change_name** | The name of the proposed change |
+| **proposed_change_state** | The state of the proposed change |
+| **reviewer_account_id** | The ID of the user who reviewed the proposed change |
+| **reviewer_account_name** | The name of the user who reviewed the proposed change |
+| **reviewer_decision** | The decision made by the reviewer |
+<!-- vale on -->
+<!-- vale off -->
+### Proposed Change Rejection Revoked Event
+<!-- vale on -->
+
+**Type**: infrahub.proposed_change.rejection_revoked
+**Description**: Event generated when a proposed change rejection has been revoked
+<!-- vale off -->
+**Uses node_kind filter for webhooks**: `false`
+<!-- vale on -->
+
+<!-- vale off -->
+| Key | Description |
+|-----|-------------|
+| **meta.branch** | The branch on which originate this event |
+| **meta.request_id** | N/A |
+| **meta.account_id** | The ID of the account triggering this event |
+| **meta.initiator_id** | The worker identity of the initial sender of this message |
+| **meta.context** | The context used when originating this event |
+| **meta.level** | N/A |
+| **meta.has_children** | Indicates if this event might potentially have child events under it. |
+| **meta.id** | UUID of the event |
+| **meta.parent** | The UUID of the parent event if applicable |
+| **meta.ancestors** | Any event used to trigger this event |
+| **proposed_change_id** | The ID of the proposed change |
+| **proposed_change_name** | The name of the proposed change |
+| **proposed_change_state** | The state of the proposed change |
+| **reviewer_account_id** | The ID of the user who reviewed the proposed change |
+| **reviewer_account_name** | The name of the user who reviewed the proposed change |
+| **reviewer_former_decision** | The former decision made by the reviewer |
+<!-- vale on -->
+<!-- vale off -->
 ### Proposed Change Review Requested Event
 <!-- vale on -->
 
@@ -395,66 +515,6 @@ For more detailed explanations on how these events are used within Infrahub, see
 | **proposed_change_state** | The state of the proposed change |
 | **requested_by_account_id** | The ID of the user who requested the proposed change to be reviewed |
 | **requested_by_account_name** | The name of the user who requested the proposed change to be reviewed |
-<!-- vale on -->
-<!-- vale off -->
-### Proposed Change Review Revoked Event
-<!-- vale on -->
-
-**Type**: infrahub.proposed_change.review_revoked
-**Description**: Event generated when a proposed change review has been revoked
-<!-- vale off -->
-**Uses node_kind filter for webhooks**: `false`
-<!-- vale on -->
-
-<!-- vale off -->
-| Key | Description |
-|-----|-------------|
-| **meta.branch** | The branch on which originate this event |
-| **meta.request_id** | N/A |
-| **meta.account_id** | The ID of the account triggering this event |
-| **meta.initiator_id** | The worker identity of the initial sender of this message |
-| **meta.context** | The context used when originating this event |
-| **meta.level** | N/A |
-| **meta.has_children** | Indicates if this event might potentially have child events under it. |
-| **meta.id** | UUID of the event |
-| **meta.parent** | The UUID of the parent event if applicable |
-| **meta.ancestors** | Any event used to trigger this event |
-| **proposed_change_id** | The ID of the proposed change |
-| **proposed_change_name** | The name of the proposed change |
-| **proposed_change_state** | The state of the proposed change |
-| **reviewer_account_id** | The ID of the user who reviewed the proposed change |
-| **reviewer_account_name** | The name of the user who reviewed the proposed change |
-| **reviewer_former_decision** | The former decision made by the reviewer |
-<!-- vale on -->
-<!-- vale off -->
-### Proposed Change Reviewed Event
-<!-- vale on -->
-
-**Type**: infrahub.proposed_change.reviewed
-**Description**: Event generated when a proposed change has been reviewed
-<!-- vale off -->
-**Uses node_kind filter for webhooks**: `false`
-<!-- vale on -->
-
-<!-- vale off -->
-| Key | Description |
-|-----|-------------|
-| **meta.branch** | The branch on which originate this event |
-| **meta.request_id** | N/A |
-| **meta.account_id** | The ID of the account triggering this event |
-| **meta.initiator_id** | The worker identity of the initial sender of this message |
-| **meta.context** | The context used when originating this event |
-| **meta.level** | N/A |
-| **meta.has_children** | Indicates if this event might potentially have child events under it. |
-| **meta.id** | UUID of the event |
-| **meta.parent** | The UUID of the parent event if applicable |
-| **meta.ancestors** | Any event used to trigger this event |
-| **proposed_change_id** | The ID of the proposed change |
-| **proposed_change_name** | The name of the proposed change |
-| **proposed_change_state** | The state of the proposed change |
-| **reviewer_account_id** | The ID of the user who reviewed the proposed change |
-| **reviewer_account_name** | The name of the user who reviewed the proposed change |
-| **reviewer_decision** | The decision made by the reviewer |
 <!-- vale on -->
 ## Commit events
 


### PR DESCRIPTION
This change introduce events related to actions taken on a proposed change. For now, several new events are part of the PR:

- `infrahub.proposed_change.merged`
- `infrahub.proposed_change.approved`
- `infrahub.proposed_change.rejected`
- `infrahub.proposed_change.approval_revoked`
- `infrahub.proposed_change.rejection_revoked`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced new event types for proposed change reviews and merges, including approval, rejection, revocation, review requests, and merging actions.
  * Added corresponding GraphQL event types and extended event mapping for these new events.
  * Enabled asynchronous event dispatching after proposed change review decisions and merges.

* **Documentation**
  * Expanded event documentation to include detailed descriptions and payloads for all new proposed change events.

* **Bug Fixes**
  * Enhanced test coverage to verify that proposed change review and merge actions correctly emit the new events.

* **Chores**
  * Updated changelog to reflect the addition of proposed change review and merge events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->