### PR TITLE
Add section to show how to access files stored in the Git repository when using a Python transform.

### DIFF
--- a/docs/docs/topics/transformation.mdx
+++ b/docs/docs/topics/transformation.mdx
@@ -75,6 +75,17 @@ A TransformPython must be written as a Python class that inherits from `Infrahub
 
 Please refer to the guide [Creating a Python transform](../guides/python-transform) for more information.
 
+##### Python transform accessing local files
+
+There may be times that you want to access files that are stored within the Git repository such as Jinja2 templates.
+
+This can be accomplished by using the `self.root_directory` that points to the root of the Git repository.
+
+```python
+    async def transform(self, data):
+        templates_path = f"{self.root_directory}/templates"
+```
+
 #### Render a TransformPython
 
 A TransformPython can be rendered with 2 different methods:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the Python transformation plugin documentation with guidance on accessing local files in the Git repository during a Python transform, including example usage for referencing repository files such as templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->