### PR TITLE
Fix repository objects view

### DIFF
--- a/changelog/repo-objects.fixed.md
+++ b/changelog/repo-objects.fixed.md
@@ -1,0 +1,1 @@
+Fix repository objects view when there is no group tied to the repository

--- a/frontend/app/src/entities/repository/domain/get-repository-group.ts
+++ b/frontend/app/src/entities/repository/domain/get-repository-group.ts
@@ -5,13 +5,19 @@ export interface GetRepositoryGroupParams extends BranchContextParams {
   nodeId: string;
 }
 
-export type GetRepositoryGroup = (params: GetRepositoryGroupParams) => Promise<number>;
+export type GetRepositoryGroup = (
+  params: GetRepositoryGroupParams
+) => Promise<{ id: string | undefined }>;
 
 export const getRepositoryGroup: GetRepositoryGroup = async ({ branchName, nodeId }) => {
-  const { data } = await getRepositoryGroupFromApi({
+  const { data, errors } = await getRepositoryGroupFromApi({
     branchName,
     nodeIds: [nodeId],
   });
 
-  return data.CoreRepositoryGroup.edges?.[0]?.node?.id;
+  if (errors?.[0]?.message) {
+    throw new Error(errors[0].message);
+  }
+
+  return { id: data.CoreRepositoryGroup.edges?.[0]?.node?.id };
 };

--- a/frontend/app/src/entities/repository/ui/repository-objects-manager.tsx
+++ b/frontend/app/src/entities/repository/ui/repository-objects-manager.tsx
@@ -3,6 +3,7 @@ import { REPOSITORY_GROUP } from "@/entities/repository/constant";
 import { useGetRepositoryGroup } from "@/entities/repository/domain/get-repository-group.query";
 import { useSchema } from "@/entities/schema/ui/hooks/useSchema";
 import ErrorScreen from "@/shared/components/errors/error-screen";
+import NoDataFound from "@/shared/components/errors/no-data-found";
 import { Spinner } from "@/shared/components/ui/spinner";
 
 export interface RepositoryObjectsManagerProps {
@@ -10,7 +11,7 @@ export interface RepositoryObjectsManagerProps {
 }
 export function RepositoryObjectsManager({ parentNodeId }: RepositoryObjectsManagerProps) {
   const { schema } = useSchema(REPOSITORY_GROUP);
-  const { isPending, data: repositoryId, error } = useGetRepositoryGroup({ nodeId: parentNodeId });
+  const { isPending, data, error } = useGetRepositoryGroup({ nodeId: parentNodeId });
 
   const membersRelationship = schema?.relationships?.find((relationship) => {
     return relationship.name === "members";
@@ -26,10 +27,14 @@ export function RepositoryObjectsManager({ parentNodeId }: RepositoryObjectsMana
     return <ErrorScreen message={error.message} />;
   }
 
+  if (!data.id) {
+    return <NoDataFound message="No objects found for this repository" />;
+  }
+
   return (
     <RelationshipTable
       parentKind={REPOSITORY_GROUP}
-      parentId={repositoryId}
+      parentId={data.id}
       relationshipName={"members"}
       relationshipSchema={relationshipSchema}
     />

--- a/frontend/app/src/entities/repository/ui/repository-objects-tab.tsx
+++ b/frontend/app/src/entities/repository/ui/repository-objects-tab.tsx
@@ -28,7 +28,7 @@ export function RepositoryObjectsTab({ objectId, ...props }: TaskTabProps) {
       Objects
       {isPending && <Spinner />}
       {!isPending && (
-        <Badge className="font-medium rounded-full text-gray-80">{objectsCount}</Badge>
+        <Badge className="font-medium rounded-full text-gray-80">{objectsCount ?? 0}</Badge>
       )}
     </ObjectDetailsTab>
   );

--- a/frontend/app/src/shared/components/errors/no-data-found.tsx
+++ b/frontend/app/src/shared/components/errors/no-data-found.tsx
@@ -12,11 +12,10 @@ export default function NoDataFound(props: tNoData) {
   const { message, icon } = props;
 
   return (
-    <div className="flex flex-col flex-1 items-center justify-center p-8 text-center gap-2">
-      <div className="bg-white rounded-full flex items-center justify-center p-2 text-custom-blue-green">
-        {icon || <Icon icon={"mdi:file-question-outline"} className="" />}
-      </div>
-      <div>{message ?? DEFAULT_MESSAGE}</div>
+    <div className="col-span-full flex flex-col items-center justify-center py-12 text-stone-500">
+      {icon ?? <Icon icon="mdi:table-off" className="mb-2 text-3xl" />}
+      <div className="text-lg font-medium">No data</div>
+      <div className="text-sm">{message ?? DEFAULT_MESSAGE}</div>
     </div>
   );
 }

--- a/frontend/app/tests/e2e/repository/repository-objects.spec.ts
+++ b/frontend/app/tests/e2e/repository/repository-objects.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/test";
+import { ACCOUNT_STATE_PATH } from "../../constants";
+import { generateRandomBranchName } from "../../utils";
+import { createBranchAPI, deleteBranchAPI } from "../utils/graphql";
+
+const GIT_REPO_URL = "https://github.com/opsmill/infrahub-demo-edge.git";
+const REPO_NAME = "test repository";
+
+test.describe("Repository - Creation and objects view", () => {
+  test.use({ storageState: ACCOUNT_STATE_PATH.ADMIN });
+
+  const BRANCH_NAME = generateRandomBranchName("repository-branch");
+
+  test.beforeAll(async ({ request }) => {
+    await createBranchAPI(request, BRANCH_NAME);
+  });
+
+  test.afterAll(async ({ request }) => {
+    await deleteBranchAPI(request, BRANCH_NAME);
+  });
+
+  test.beforeEach(async function ({ page }) {
+    page.on("response", async (response) => {
+      if (response.status() === 500) {
+        await expect(response.url()).toBe("This URL responded with a 500 status");
+      }
+    });
+  });
+
+  test("Create repository and access objects view", async ({ page }) => {
+    await page.goto("/objects/CoreGenericRepository");
+    await page.getByTestId("create-object-button").click();
+    await page.getByRole("combobox", { name: "Select an object type" }).click();
+    await page.getByRole("option", { name: "Read-Only Repository Core" }).click();
+    await page.getByRole("textbox", { name: "Repository location *" }).fill(GIT_REPO_URL);
+    await page.getByRole("textbox", { name: "Name *" }).fill(REPO_NAME);
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(page.getByRole("link", { name: REPO_NAME })).toBeVisible();
+    await page.getByRole("link", { name: REPO_NAME }).click();
+    await page.getByRole("link", { name: "Objects" }).click();
+    await expect(page.getByText("No objects found for this")).toBeVisible();
+  });
+});


### PR DESCRIPTION
Fix repository objects when there is no group tied to the repository

The group is created only if there is some objects, but if there is no object, there is no group

<img width="1465" height="901" alt="Capture d’écran 2025-07-25 à 09 25 47" src="https://github.com/user-attachments/assets/f9c4c707-ed36-4716-b2f6-509d4e34287b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the repository objects view did not handle cases with no associated group, now displaying a clear "No data" message when applicable.
  * The objects count badge now reliably displays "0" when no objects are present, instead of leaving the value blank.

* **Style**
  * Improved the appearance and layout of the "No data" message for a more minimal and structured look.

* **New Features**
  * Added an end-to-end test suite to validate repository creation and object view functionality, ensuring a smooth user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->