### PR TITLE
Adding service catalog to the getting started doc

### DIFF
--- a/docs/docs/getting-started/quick-start.mdx
+++ b/docs/docs/getting-started/quick-start.mdx
@@ -58,6 +58,12 @@ The DC Fabric demo highlights Infrahub's capabilities in a data center environme
 
 <ReferenceLink title="Demo DC Fabric" url="https://docs.infrahub.app/demo/demo-dc-fabric" openInNewTab />
 
+- **Demo Service Catalog**
+
+The Service Catalog demo demonstrates how Infrahub can be used to manage and deploy services within an ISP environment. It walks through the process of creating a service catalog using Infrahub and Streamlit. From modeling services in the schema, codifying them in Generator, to making these capabilities accessible across the organization via a Streamlit app. This demo provides a comprehensive, end-to-end overview of the workflow.
+
+<ReferenceLink title="Demo Service Catalog" url="https://docs.infrahub.app/demo-service-catalog" openInNewTab />
+
 ## Meeting OpsMill
 
 If you are interested in Infrahub and would like to discuss your use case with OpsMill, please book a meeting with us.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Demo Service Catalog" section to the documentation, showcasing how Infrahub can manage and deploy services in an ISP environment with an end-to-end workflow overview and a reference link to the demo page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->