### PR TITLE
Lock on names for GraphQLQueryGroup

### DIFF
--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -152,7 +153,7 @@ class InfrahubMutationMixin:
         """
         schema_branch = db.schema.get_schema_branch(name=branch.name)
         lock_names = _get_kind_lock_names_on_object_mutation(
-            kind=cls._meta.active_schema.kind, branch=branch, schema_branch=schema_branch
+            kind=cls._meta.active_schema.kind, branch=branch, schema_branch=schema_branch, data=data
         )
         if lock_names:
             async with InfrahubMultiLock(lock_registry=lock.registry, locks=lock_names):
@@ -216,7 +217,7 @@ class InfrahubMutationMixin:
 
         schema_branch = db.schema.get_schema_branch(name=branch.name)
         lock_names = _get_kind_lock_names_on_object_mutation(
-            kind=cls._meta.active_schema.kind, branch=branch, schema_branch=schema_branch
+            kind=cls._meta.active_schema.kind, branch=branch, schema_branch=schema_branch, data=data
         )
 
         if db.is_transaction:
@@ -266,7 +267,6 @@ class InfrahubMutationMixin:
         obj = node or await NodeManager.find_object(
             db=db, kind=cls._meta.active_schema.kind, id=data.get("id"), hfid=data.get("hfid"), branch=branch
         )
-
         obj, result = await cls._call_mutate_update(info=info, data=data, db=db, branch=branch, obj=obj)
 
         return obj, result
@@ -517,14 +517,33 @@ def _should_kind_be_locked_on_any_branch(kind: str, schema_branch: SchemaBranch)
     return False
 
 
-def _get_kind_lock_names_on_object_mutation(kind: str, branch: Branch, schema_branch: SchemaBranch) -> list[str]:
+def _hash(value: str) -> str:
+    # Do not use builtin `hash` for lock names as due to randomization results would differ between
+    # different processes.
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def _get_kind_lock_names_on_object_mutation(
+    kind: str, branch: Branch, schema_branch: SchemaBranch, data: InputObjectType
+) -> list[str]:
     """
     Return objects kind for which we want to avoid concurrent mutation (create/update). Except for some specific kinds,
     concurrent mutations are only allowed on non-main branch as objects validations will be performed at least when merging in main branch.
     """
 
-    if not branch.is_default and not _should_kind_be_locked_on_any_branch(kind, schema_branch):
+    if not branch.is_default and not _should_kind_be_locked_on_any_branch(kind=kind, schema_branch=schema_branch):
         return []
+
+    if kind == InfrahubKind.GRAPHQLQUERYGROUP:
+        # Lock on name as well to improve performances
+        try:
+            name = data.name.value
+            return [build_object_lock_name(kind + "." + _hash(name))]
+        except AttributeError:
+            # We might reach here if we are updating a CoreGraphQLQueryGroup without updating the name,
+            # in which case we would not need to lock. This is not supposed to happen as current `update`
+            # logic first fetches the node with its name.
+            return []
 
     lock_kinds = _get_kinds_to_lock_on_object_mutation(kind, schema_branch)
     lock_names = [build_object_lock_name(kind) for kind in lock_kinds]

--- a/backend/tests/unit/core/test_get_kinds_lock.py
+++ b/backend/tests/unit/core/test_get_kinds_lock.py
@@ -1,9 +1,13 @@
+from unittest.mock import patch
+
+from infrahub import lock
 from infrahub.core import registry
+from infrahub.core.constants.infrahubkind import GRAPHQLQUERY, GRAPHQLQUERYGROUP
 from infrahub.core.initialization import create_branch
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.mutations.main import (
-    _get_kind_lock_names_on_object_mutation,
     _get_kinds_to_lock_on_object_mutation,
+    _hash,
 )
 from tests.helpers.test_app import TestInfrahubApp
 
@@ -32,15 +36,79 @@ class TestGetKindsLock(TestInfrahubApp):
         schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
         assert _get_kinds_to_lock_on_object_mutation(kind="BuiltinIPPrefix", schema_branch=schema_branch) == []
 
-    async def test_lock_graphql_query_group_other_branch(
+    async def test_lock_core_graphql_query_groups(
         self,
         db: InfrahubDatabase,
         default_branch,
         register_core_models_schema,
         client,
     ):
+        graphql_query = await client.create(
+            kind=GRAPHQLQUERY,
+            name="a_gql_query",
+            query="""mutation MyMutation {
+                        InfrahubAccountTokenDelete(data: {id: "%s"}) {
+                            ok
+                        }
+                    }""",
+        )
+        await graphql_query.save()
+
+        # Test create
+        with patch("infrahub.graphql.mutations.main.InfrahubMultiLock") as mock_infrahub_multi_lock:
+            group = await client.create(kind=GRAPHQLQUERYGROUP, name="a_gql_group", query=graphql_query)
+            await group.save()
+            mock_infrahub_multi_lock.assert_called_once_with(
+                lock_registry=lock.registry, locks=["global.object.CoreGraphQLQueryGroup." + _hash("a_gql_group")]
+            )
+
+        # Test upsert the same node
+        with patch("infrahub.graphql.mutations.main.InfrahubMultiLock") as mock_infrahub_multi_lock:
+            group = await client.create(kind=GRAPHQLQUERYGROUP, name="a_gql_group", query=graphql_query)
+            await group.save(allow_upsert=True)
+
+            mock_infrahub_multi_lock.assert_called_with(
+                lock_registry=lock.registry, locks=["global.object.CoreGraphQLQueryGroup." + _hash("a_gql_group")]
+            )
+
+        # Test updating group name
+        with patch("infrahub.graphql.mutations.main.InfrahubMultiLock") as mock_infrahub_multi_lock:
+            group.name = "new_group_name"
+            await group.save()
+
+            mock_infrahub_multi_lock.assert_called_once_with(
+                lock_registry=lock.registry, locks=["global.object.CoreGraphQLQueryGroup." + _hash("new_group_name")]
+            )
+
+        # Test updating other field not present in uniqueness constraint
+        with patch("infrahub.graphql.mutations.main.InfrahubMultiLock") as mock_infrahub_multi_lock:
+            query = (
+                """mutation {
+                CoreGraphQLQueryGroupUpdate(
+                    data: {
+                        id: "%s"
+                        label: { value: "new_label"}
+                    }
+                ){
+                    ok
+                }
+            }
+            """
+                % group.id
+            )
+
+            result = await client.execute_graphql(query=query)
+            assert result["CoreGraphQLQueryGroupUpdate"]["ok"] is True
+
+            mock_infrahub_multi_lock.assert_not_called()
+
+        # Test lock onanother branch
         other_branch = await create_branch(branch_name="other_branch", db=db)
-        schema_branch = registry.schema.get_schema_branch(name=other_branch.name)
-        assert _get_kind_lock_names_on_object_mutation(
-            kind="CoreGraphQLQueryGroup", branch=other_branch, schema_branch=schema_branch
-        ) == ["global.object.CoreGroup"]
+        with patch("infrahub.graphql.mutations.main.InfrahubMultiLock") as mock_infrahub_multi_lock:
+            group = await client.create(
+                kind=GRAPHQLQUERYGROUP, name="one_more_group", query=graphql_query, branch=other_branch.name
+            )
+            await group.save()
+            mock_infrahub_multi_lock.assert_called_once_with(
+                lock_registry=lock.registry, locks=["global.object.CoreGraphQLQueryGroup." + _hash("one_more_group")]
+            )


### PR DESCRIPTION
Should fix IFC-1642, where users are not able to run PC's because upserting many `CoreGraphQLQueryGroup` is too slow because of the lock. This PR adds the `name` value (only uniqueness constraint field) into the lock name so that concurrent upserts are not blocked.

Ideally we would implement a general fix as in https://github.com/opsmill/infrahub/pull/6888 but this would require more testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved locking mechanism for GraphQL query groups, providing more granular locks based on object names.
* **Bug Fixes**
  * Enhanced lock consistency by using a stable hash function for lock name generation.
* **Tests**
  * Expanded test coverage for locking behavior in GraphQL query group operations, including creation, updates, and branch-specific scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->