### PR TITLE
Add support for authentication in custom webhooks

### DIFF
--- a/backend/infrahub/core/protocols.py
+++ b/backend/infrahub/core/protocols.py
@@ -319,6 +319,7 @@ class CoreCheckDefinition(CoreTaskTarget):
 
 
 class CoreCustomWebhook(CoreWebhook, CoreTaskTarget):
+    shared_key: StringOptional
     transformation: RelationshipManager
 
 

--- a/backend/infrahub/core/schema/definitions/core/webhook.py
+++ b/backend/infrahub/core/schema/definitions/core/webhook.py
@@ -120,6 +120,9 @@ core_custom_webhook = NodeSchema(
     branch=BranchSupportType.AGNOSTIC,
     generate_profile=False,
     inherit_from=[InfrahubKind.WEBHOOK, InfrahubKind.TASKTARGET],
+    attributes=[
+        Attr(name="shared_key", kind="Password", unique=False, optional=True, order_weight=4000),
+    ],
     relationships=[
         Rel(
             name="transformation",

--- a/backend/infrahub/webhook/models.py
+++ b/backend/infrahub/webhook/models.py
@@ -121,17 +121,38 @@ class Webhook(BaseModel):
     validate_certificates: bool = Field(...)
     _payload: Any = None
     _headers: dict[str, Any] | None = None
+    shared_key: str | None = Field(default=None, description="Shared key for signing the webhook requests")
 
     async def _prepare_payload(self, data: dict[str, Any], context: EventContext, client: InfrahubClient) -> None:  # noqa: ARG002
         self._payload = {"data": data, **context.model_dump()}
 
-    def _assign_headers(self) -> None:
-        self._headers = {}
+    def _assign_headers(self, uuid: UUID | None = None, at: Timestamp | None = None) -> None:
+        self._headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+        if self.shared_key:
+            message_id = f"msg_{uuid.hex}" if uuid else f"msg_{uuid4().hex}"
+            timestamp = str(at.to_timestamp()) if at else str(Timestamp().to_timestamp())
+            payload = json.dumps(self._payload or {})
+            unsigned_data = f"{message_id}.{timestamp}.{payload}".encode()
+            signature = self._sign(data=unsigned_data)
+            self._headers["webhook-id"] = message_id
+            self._headers["webhook-timestamp"] = timestamp
+            self._headers["webhook-signature"] = f"v1,{base64.b64encode(signature).decode('utf-8')}"
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def webhook_type(self) -> str:
         return self.__class__.__name__
+
+    @property
+    def signing_key(self) -> str:
+        """Return the signing key for the webhook."""
+        if self.shared_key:
+            return self.shared_key
+        raise ValueError("Shared key is not set for the webhook")
 
     async def prepare(self, data: dict[str, Any], context: EventContext, client: InfrahubClient) -> None:
         await self._prepare_payload(data=data, context=context, client=client)
@@ -153,6 +174,9 @@ class Webhook(BaseModel):
     def from_cache(cls, data: dict[str, Any]) -> Self:
         return cls(**data)
 
+    def _sign(self, data: bytes) -> bytes:
+        return hmac.new(key=self.signing_key.encode(), msg=data, digestmod=hashlib.sha256).digest()
+
 
 class CustomWebhook(Webhook):
     """Custom webhook"""
@@ -164,30 +188,11 @@ class CustomWebhook(Webhook):
             url=obj.url.value,
             event_type=obj.event_type.value,
             validate_certificates=obj.validate_certificates.value or False,
+            shared_key=obj.shared_key.value,
         )
 
 
 class StandardWebhook(Webhook):
-    shared_key: str = Field(...)
-
-    def _assign_headers(self, uuid: UUID | None = None, at: Timestamp | None = None) -> None:
-        message_id = f"msg_{uuid.hex}" if uuid else f"msg_{uuid4().hex}"
-        timestamp = str(at.to_timestamp()) if at else str(Timestamp().to_timestamp())
-        payload = json.dumps(self._payload or {})
-        unsigned_data = f"{message_id}.{timestamp}.{payload}".encode()
-        signature = self._sign(data=unsigned_data)
-
-        self._headers = {
-            "Accept": "application/json",
-            "Content-Type": "application/json",
-            "webhook-id": message_id,
-            "webhook-timestamp": timestamp,
-            "webhook-signature": f"v1,{base64.b64encode(signature).decode('utf-8')}",
-        }
-
-    def _sign(self, data: bytes) -> bytes:
-        return hmac.new(key=self.shared_key.encode(), msg=data, digestmod=hashlib.sha256).digest()
-
     @classmethod
     def from_object(cls, obj: CoreStandardWebhook) -> Self:
         return cls(
@@ -245,4 +250,5 @@ class TransformWebhook(Webhook):
             transform_file=transform.file_path.value,
             transform_timeout=transform.timeout.value,
             convert_query_response=transform.convert_query_response.value or False,
+            shared_key=obj.shared_key.value,
         )

--- a/backend/tests/functional/webhook/test_task.py
+++ b/backend/tests/functional/webhook/test_task.py
@@ -257,6 +257,7 @@ class TestWebhookTasks(TestInfrahubApp):
             "repository_kind": "CoreRepository",
             "repository_name": "car-dealership",
             "convert_query_response": False,
+            "shared_key": None,
             "transform_class": "WebhookTransformer",
             "transform_file": "transforms/webhook_transformer.py",
             "transform_name": "WebhookTransformer",

--- a/changelog/6521.added.md
+++ b/changelog/6521.added.md
@@ -1,0 +1,1 @@
+Added support for authentication / signing to custom webhooks. If using a transform it is assumed that the transform renders JSON data.


### PR DESCRIPTION
This PR adds support for an optional shared_key to custom webhooks.

Most of the work consists of just moving some data from the standard webhooks to the generic parent class so that they work in a similar way.


It currently assumes that the content_type of the transforms is JSON which is the only option now but will change in the future: https://github.com/opsmill/infrahub-sdk-python/issues/282 

Fixes #6521

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for authentication and signing mechanisms to custom webhooks using an optional shared key.
  * All webhook types can now optionally sign requests with a shared key for enhanced security.

* **Bug Fixes**
  * Updated tests to ensure the shared key attribute is properly handled in webhook conversions.

* **Documentation**
  * Added a changelog entry describing the new authentication and signing support for custom webhooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->