### PR TITLE
Restrict Python keywords for attribute and relationship names

### DIFF
--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import hashlib
+import keyword
 from collections import defaultdict
 from itertools import chain, combinations
 from typing import Any
@@ -518,6 +519,7 @@ class SchemaBranch:
 
     def process_validate(self) -> None:
         self.validate_names()
+        self.validate_python_keywords()
         self.validate_kinds()
         self.validate_computed_attributes()
         self.validate_attribute_parameters()
@@ -986,6 +988,26 @@ class SchemaBranch:
                     isinstance(node, GenericSchema) and rel.name in RESERVED_ATTR_GEN_NAMES
                 ):
                     raise ValueError(f"{node.kind}: {rel.name} isn't allowed as a relationship name.")
+
+    def validate_python_keywords(self) -> None:
+        """Validate that attribute and relationship names don't use Python keywords."""
+        for name in self.all_names:
+            node = self.get(name=name, duplicate=False)
+
+            # Check for Python keywords in attribute names
+            for attribute in node.attributes:
+                if keyword.iskeyword(attribute.name):
+                    raise ValueError(
+                        f"Python keyword '{attribute.name}' cannot be used as an attribute name on '{node.kind}'"
+                    )
+
+            # Check for Python keywords in relationship names
+            if config.SETTINGS.main.schema_strict_mode:
+                for relationship in node.relationships:
+                    if keyword.iskeyword(relationship.name):
+                        raise ValueError(
+                            f"Python keyword '{relationship.name}' cannot be used as a relationship name on '{node.kind}' when using strict mode"
+                        )
 
     def _validate_common_parent(self, node: NodeSchema, rel: RelationshipSchema) -> None:
         if not rel.common_parent:

--- a/backend/tests/fixtures/schemas/python_keyword_from.json
+++ b/backend/tests/fixtures/schemas/python_keyword_from.json
@@ -1,0 +1,42 @@
+{
+    "version": "1.0",
+    "nodes": [
+        {
+            "name": "RoutingPolicy",
+            "namespace": "Infra",
+            "default_filter": "name__value",
+            "display_labels": [
+                "name__value"
+            ],
+            "attributes": [
+                {
+                    "name": "name",
+                    "kind": "Text",
+                    "unique": true,
+                    "optional": false
+                },
+                {
+                    "name": "description",
+                    "kind": "Text",
+                    "unique": false,
+                    "optional": false
+                },
+                {
+                    "name": "from",
+                    "label": "From",
+                    "description": "Specifies the match conditions for the policy term.",
+                    "kind": "Dropdown",
+                    "state": "absent",
+                    "choices": [
+                        {
+                            "name": "default",
+                            "label": "Default"
+                        }
+                    ],
+                    "optional": true
+                }
+            ],
+            "relationships": []
+        }
+    ]
+}

--- a/backend/tests/unit/api/test_40_schema.py
+++ b/backend/tests/unit/api/test_40_schema.py
@@ -338,6 +338,29 @@ async def test_schema_load_endpoint_not_valid_with_generics_02(
     assert response.status_code == 422
 
 
+async def test_schema_load_endpoint_python_keyword_attribute(
+    db: InfrahubDatabase,
+    client: TestClient,
+    admin_headers,
+    default_branch: Branch,
+    authentication_base,
+    helper,
+):
+    """Test that loading a schema with Python keyword as attribute name fails with proper error."""
+    with client:
+        response = client.post(
+            "/api/schema/load",
+            headers=admin_headers,
+            json={"schemas": [helper.schema_file("python_keyword_from.json")]},
+        )
+
+    assert response.status_code == 422
+    assert (
+        "Python keyword 'from' cannot be used as an attribute name on 'InfraRoutingPolicy'"
+        in response.json()["errors"][0]["message"]
+    )
+
+
 async def test_schema_load_endpoint_constraints_not_valid(
     db: InfrahubDatabase,
     client: TestClient,

--- a/backend/tests/unit/core/test_schema.py
+++ b/backend/tests/unit/core/test_schema.py
@@ -1,4 +1,4 @@
-from typing import Hashable
+from typing import Any, Hashable
 
 import pytest
 from pydantic import ValidationError
@@ -16,6 +16,7 @@ from infrahub.core.schema import (
 )
 from infrahub.core.schema.attribute_parameters import TextAttributeParameters
 from infrahub.core.schema.attribute_schema import TextAttributeSchema
+from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
 
 
@@ -226,7 +227,7 @@ async def test_attribute_schema_choices_invalid_kind():
 
 
 async def test_attribute_schema_dropdown_missing_choices():
-    SCHEMA = {"name": "name", "kind": "Dropdown"}
+    SCHEMA: dict[str, Any] = {"name": "name", "kind": "Dropdown"}
 
     with pytest.raises(ValidationError) as exc:
         AttributeSchema(**SCHEMA)
@@ -247,3 +248,197 @@ def test_dropdown_choice_sort():
     active = DropdownChoice(name="active", color="#AAbb0f")
     passive = DropdownChoice(name="passive", color="#AAbb0f")
     assert active < passive
+
+
+def test_validate_python_keywords_with_attribute_and_relationship():
+    """Test that validate_python_keywords rejects Python keywords in attribute and relationship names."""
+    # Test schema with 'from' keyword as attribute name
+    SCHEMA_WITH_KEYWORD_ATTR: dict[str, Any] = {
+        "nodes": [
+            {
+                "name": "RoutingPolicy",
+                "namespace": "Infra",
+                "default_filter": "name__value",
+                "branch": BranchSupportType.AWARE.value,
+                "attributes": [
+                    {"name": "name", "kind": "Text", "unique": True},
+                    {"name": "from", "kind": "Text"},  # Python keyword
+                ],
+            }
+        ]
+    }
+
+    schema_root = SchemaRoot(**SCHEMA_WITH_KEYWORD_ATTR)
+    schema_branch = SchemaBranch(cache={}, name="test")
+    schema_branch.load_schema(schema=schema_root)
+
+    with pytest.raises(ValueError) as exc:
+        schema_branch.process_validate()
+
+    assert "Python keyword 'from' cannot be used as an attribute name on 'InfraRoutingPolicy'" in str(exc.value)
+
+    # Test schema with 'class' keyword as relationship name
+    SCHEMA_WITH_KEYWORD_REL: dict[str, Any] = {
+        "nodes": [
+            {
+                "name": "Device",
+                "namespace": "Test",
+                "default_filter": "name__value",
+                "branch": BranchSupportType.AWARE.value,
+                "attributes": [
+                    {"name": "name", "kind": "Text", "unique": True},
+                ],
+                "relationships": [
+                    {"name": "class", "peer": "TestType", "cardinality": "one", "optional": True},  # Python keyword
+                ],
+            },
+            {
+                "name": "Type",
+                "namespace": "Test",
+                "default_filter": "name__value",
+                "attributes": [
+                    {"name": "name", "kind": "Text", "unique": True},
+                ],
+            },
+        ]
+    }
+
+    schema_root = SchemaRoot(**SCHEMA_WITH_KEYWORD_REL)
+    schema_branch = SchemaBranch(cache={}, name="test")
+    schema_branch.load_schema(schema=schema_root)
+
+    with pytest.raises(ValueError) as exc:
+        schema_branch.process_validate()
+
+    assert "Python keyword 'class' cannot be used as a relationship name on 'TestDevice' when using strict mode" in str(
+        exc.value
+    )
+
+    # Test schema with valid names (no keywords)
+    SCHEMA_VALID: dict[str, Any] = {
+        "nodes": [
+            {
+                "name": "ValidSchema",
+                "namespace": "Test",
+                "default_filter": "name__value",
+                "branch": BranchSupportType.AWARE.value,
+                "attributes": [
+                    {"name": "name", "kind": "Text", "unique": True},
+                    {"name": "source", "kind": "Text"},  # Not a keyword
+                ],
+                "relationships": [
+                    {"name": "parent", "peer": "TestType", "cardinality": "one", "optional": True},  # Not a keyword
+                ],
+            },
+            {
+                "name": "Type",
+                "namespace": "Test",
+                "default_filter": "name__value",
+                "attributes": [
+                    {"name": "name", "kind": "Text", "unique": True},
+                ],
+            },
+        ]
+    }
+
+    schema_root = SchemaRoot(**SCHEMA_VALID)
+    schema_branch = SchemaBranch(cache={}, name="test")
+    schema_branch.load_schema(schema=schema_root)
+
+    # This should not raise any exception
+    schema_branch.process_validate()
+
+
+def test_validate_python_keywords_multiple_keywords():
+    """Test that validate_python_keywords catches multiple Python keywords."""
+    SCHEMA_WITH_MULTIPLE_KEYWORDS: dict[str, Any] = {
+        "nodes": [
+            {
+                "name": "TestNode",
+                "namespace": "Test",
+                "default_filter": "name__value",
+                "branch": BranchSupportType.AWARE.value,
+                "attributes": [
+                    {"name": "name", "kind": "Text", "unique": True},
+                    {"name": "from", "kind": "Text"},  # Python keyword
+                    {"name": "import", "kind": "Text"},  # Python keyword
+                ],
+                "relationships": [
+                    {"name": "class", "peer": "TestType", "cardinality": "one", "optional": True},  # Python keyword
+                    {"name": "def", "peer": "TestType", "cardinality": "one", "optional": True},  # Python keyword
+                ],
+            }
+        ]
+    }
+
+    schema_root = SchemaRoot(**SCHEMA_WITH_MULTIPLE_KEYWORDS)
+    schema_branch = SchemaBranch(cache={}, name="test")
+    schema_branch.load_schema(schema=schema_root)
+
+    # Should raise ValueError on the first Python keyword encountered
+    with pytest.raises(ValueError) as exc:
+        schema_branch.process_validate()
+
+    # Check that at least one Python keyword error is caught
+    error_message = str(exc.value)
+    keyword_found = False
+    for keyword in ["from", "import", "class", "def"]:
+        if f"Python keyword '{keyword}' cannot be used as a" in error_message:
+            keyword_found = True
+            break
+
+    assert keyword_found, f"Expected Python keyword error, got: {error_message}"
+
+
+def test_validate_namespaces_and_keyword_separation():
+    """Test that namespace and Python keyword validation work separately in their proper contexts."""
+    # Test that SchemaRoot.validate_namespaces() only catches namespace issues
+    SCHEMA_WITH_NAMESPACE_ISSUE: dict[str, Any] = {
+        "nodes": [
+            {
+                "name": "TestNode",
+                "namespace": "Internal",  # Restricted namespace
+                "default_filter": "name__value",
+                "branch": BranchSupportType.AWARE.value,
+                "attributes": [
+                    {"name": "name", "kind": "Text", "unique": True},
+                    {"name": "from", "kind": "Text"},  # Python keyword (not caught by SchemaRoot.validate)
+                ],
+            }
+        ]
+    }
+
+    schema_root = SchemaRoot(**SCHEMA_WITH_NAMESPACE_ISSUE)
+    errors = schema_root.validate_namespaces()
+    assert len(errors) == 1
+    assert "Restricted namespace 'Internal' used on 'TestNode'" in errors[0]
+
+    # Test that SchemaBranch validation catches Python keywords when namespace is valid
+    SCHEMA_WITH_KEYWORD_ISSUE: dict[str, Any] = {
+        "nodes": [
+            {
+                "name": "TestNode",
+                "namespace": "Test",  # Valid namespace
+                "default_filter": "name__value",
+                "branch": BranchSupportType.AWARE.value,
+                "attributes": [
+                    {"name": "name", "kind": "Text", "unique": True},
+                    {"name": "from", "kind": "Text"},  # Python keyword
+                ],
+            }
+        ]
+    }
+
+    schema_root = SchemaRoot(**SCHEMA_WITH_KEYWORD_ISSUE)
+    # SchemaRoot validation should pass (no namespace issues)
+    errors = schema_root.validate_namespaces()
+    assert len(errors) == 0
+
+    # But SchemaBranch validation should catch the Python keyword
+    schema_branch = SchemaBranch(cache={}, name="test")
+    schema_branch.load_schema(schema=schema_root)
+
+    with pytest.raises(ValueError) as exc:
+        schema_branch.process_validate()
+
+    assert "Python keyword 'from' cannot be used as an attribute name" in str(exc.value)

--- a/changelog/6730.fixed.md
+++ b/changelog/6730.fixed.md
@@ -1,0 +1,1 @@
+Prevent Python keywords from being used as attribute/relationship names in schemas. Schema validation now rejects Python keywords (like `from`, `class`, `import`) as attribute or relationship names, preventing 500 errors during GraphQL schema generation.


### PR DESCRIPTION
This PR restricts Python keywords from being used as attribute names (as they break the GraphQL server). The relationships have also been added though only for strict mode as they don't break the GraphQL server. However using reserved Python keywords for relationship names still breaks the SDK when trying to use those names. As such the recommendation would be to avoid doing that.

Replaces #6767

Fixes #6730

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Schema validation now prevents the use of Python reserved keywords as attribute or relationship names, ensuring better compatibility and error prevention.

* **Bug Fixes**
  * Eliminated potential runtime errors during schema processing by enforcing keyword restrictions.

* **Tests**
  * Added comprehensive tests to verify that schemas using Python keywords as names are correctly rejected.

* **Documentation**
  * Updated changelog to reflect the new validation behavior for schema definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->