### PR TITLE
command to clean up incorrect inheritance/database labels

### DIFF
--- a/backend/infrahub/cli/db.py
+++ b/backend/infrahub/cli/db.py
@@ -56,6 +56,7 @@ from infrahub.services.adapters.message_bus.local import BusSimulator
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 
 from .constants import ERROR_BADGE, FAILED_BADGE, SUCCESS_BADGE
+from .db_commands.check_inheritance import check_inheritance
 from .patch import patch_app
 
 
@@ -174,6 +175,28 @@ async def migrate_cmd(
     dbdriver = await context.init_db(retry=1)
 
     await migrate_database(db=dbdriver, initialize=True, check=check, migration_number=migration_number)
+
+    await dbdriver.close()
+
+
+@app.command(name="check-inheritance")
+async def check_inheritance_cmd(
+    ctx: typer.Context,
+    fix: bool = typer.Option(False, help="Fix the inheritance of any invalid nodes."),
+    config_file: str = typer.Argument("infrahub.toml", envvar="INFRAHUB_CONFIG"),
+) -> None:
+    """Check the database for any vertices with incorrect inheritance"""
+    logging.getLogger("infrahub").setLevel(logging.WARNING)
+    logging.getLogger("neo4j").setLevel(logging.ERROR)
+    logging.getLogger("prefect").setLevel(logging.ERROR)
+
+    config.load_and_exit(config_file_name=config_file)
+
+    context: CliContext = ctx.obj
+    dbdriver = await context.init_db(retry=1)
+    await initialize_registry(db=dbdriver)
+
+    await check_inheritance(db=dbdriver, fix=fix)
 
     await dbdriver.close()
 

--- a/backend/infrahub/cli/db.py
+++ b/backend/infrahub/cli/db.py
@@ -196,7 +196,9 @@ async def check_inheritance_cmd(
     dbdriver = await context.init_db(retry=1)
     await initialize_registry(db=dbdriver)
 
-    await check_inheritance(db=dbdriver, fix=fix)
+    success = await check_inheritance(db=dbdriver, fix=fix)
+    if not success:
+        raise typer.Exit(code=1)
 
     await dbdriver.close()
 

--- a/backend/infrahub/cli/db_commands/check_inheritance.py
+++ b/backend/infrahub/cli/db_commands/check_inheritance.py
@@ -26,6 +26,89 @@ if TYPE_CHECKING:
 log = get_logger()
 
 
+class GetSchemaWithUpdatedInheritance(Query):
+    """
+    Get the name, namespace, and branch of any SchemaNodes with _updated_ inheritance
+    This query will only return schemas that have had `inherit_from` updated after they were created
+    """
+
+    name = "get_schema_with_updated_inheritance"
+    type = QueryType.READ
+    insert_return = False
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
+        query = """
+// find inherit_from attributes that have been updated
+MATCH p = (schema_node:SchemaNode)-[has_attr_e:HAS_ATTRIBUTE {status: "active"}]->(a:Attribute {name: "inherit_from"})
+WHERE has_attr_e.to IS NULL
+CALL (a) {
+  // only get branches on which the value was updated, we can ignore the initial create
+  MATCH (a)-[e:HAS_VALUE]->(:AttributeValue)
+  ORDER BY e.from ASC
+  // tail leaves out the earliest one, which is the initial create
+  RETURN tail(collect(e.branch)) AS branches
+}
+WITH schema_node, a, branches
+WHERE size(branches) > 0
+UNWIND branches AS branch
+WITH DISTINCT schema_node, a, branch
+
+//get branch details
+CALL (branch) {
+  MATCH (b:Branch {name: branch})
+  RETURN b.branched_from AS branched_from, b.hierarchy_level AS branch_level
+}
+
+// get the namespace for the schema
+CALL (schema_node, a, branch, branched_from, branch_level) {
+  MATCH (schema_node)-[e1:HAS_ATTRIBUTE]-(:Attribute {name: "namespace"})-[e2:HAS_VALUE]->(av)
+  WHERE (
+    e1.branch = branch OR
+    (e1.branch_level < branch_level AND e1.from <= branched_from)
+  ) AND e1.to IS NULL
+  AND e1.status = "active"
+  AND (
+    e2.branch = branch OR
+    (e2.branch_level < branch_level AND e2.from <= branched_from)
+  ) AND e2.to IS NULL
+  AND e2.status = "active"
+  ORDER BY e2.branch_level DESC, e1.branch_level DESC, e2.from DESC, e1.from DESC
+  RETURN av.value AS namespace
+  LIMIT 1
+}
+
+// get the name for the schema
+CALL (schema_node, a, branch, branched_from, branch_level) {
+  MATCH (schema_node)-[e1:HAS_ATTRIBUTE]-(:Attribute {name: "name"})-[e2:HAS_VALUE]->(av)
+  WHERE (
+    e1.branch = branch OR
+    (e1.branch_level < branch_level AND e1.from <= branched_from)
+  ) AND e1.to IS NULL
+  AND e1.status = "active"
+  AND (
+    e2.branch = branch OR
+    (e2.branch_level < branch_level AND e2.from <= branched_from)
+  ) AND e2.to IS NULL
+  AND e2.status = "active"
+  ORDER BY e2.branch_level DESC, e1.branch_level DESC, e2.from DESC, e1.from DESC
+  RETURN av.value AS name
+  LIMIT 1
+}
+RETURN name, namespace, branch
+"""
+        self.return_labels = ["name", "namespace", "branch"]
+        self.add_to_query(query)
+
+    def get_updated_inheritance_kinds_by_branch(self) -> dict[str, list[str]]:
+        kinds_by_branch: dict[str, list[str]] = defaultdict(list)
+        for result in self.results:
+            name = result.get_as_type(label="name", return_type=str)
+            namespace = result.get_as_type(label="namespace", return_type=str)
+            branch = result.get_as_type(label="branch", return_type=str)
+            kinds_by_branch[branch].append(f"{namespace}{name}")
+        return kinds_by_branch
+
+
 @dataclass
 class KindLabelCount:
     kind: str
@@ -39,21 +122,36 @@ class KindLabelCountCorrected(KindLabelCount):
 
 
 class GetAllKindsAndLabels(Query):
+    """
+    Get the kind, labels, and number of nodes for the given kinds and branch
+    """
+
     name = "get_all_kinds_and_labels"
     type = QueryType.READ
     insert_return = False
 
+    def __init__(self, kinds: list[str] | None = None, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.kinds = kinds
+
     async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
         self.params["branch_name"] = self.branch.name
         self.params["branched_from"] = self.branch.get_branched_from()
+        self.params["branch_level"] = self.branch.hierarchy_level
+        kinds_str = "Node"
+        if self.kinds:
+            kinds_str = "|".join(self.kinds)
         query = """
-MATCH (n:Node)-[r:IS_PART_OF {branch: $branch_name}]->(:Root)
-WHERE r.from >= $branched_from
+MATCH (n:%(kinds_str)s)-[r:IS_PART_OF]->(:Root)
+WHERE (
+    r.branch = $branch_name OR
+    (r.branch_level < $branch_level AND r.from <= $branched_from)
+)
 AND r.to IS NULL
 AND r.status = "active"
 RETURN DISTINCT n.kind AS kind, labels(n) AS labels, count(*) AS num_nodes
 ORDER BY kind ASC
-        """
+        """ % {"kinds_str": kinds_str}
         self.return_labels = ["kind", "labels", "num_nodes"]
         self.add_to_query(query)
 
@@ -88,27 +186,39 @@ def display_kind_label_counts(kind_label_counts_by_branch: dict[str, list[KindLa
     console.print(table)
 
 
-async def check_inheritance(db: InfrahubDatabase, fix: bool = False) -> None:
+async def check_inheritance(db: InfrahubDatabase, fix: bool = False) -> bool:
+    """
+    Run migrations to update the inheritance of any nodes with incorrect inheritance from a failed migration
+    1. Identifies node schemas that have had their inheritance updated after they were created
+        a. includes the kind and branch of the inheritance update
+    2. Checks nodes of the given kinds on the given branch to verify their inheritance is correct
+    3. Displays counts of any kinds with incorrect inheritance on the given branch
+    4. If fix is True, runs migrations to update the inheritance of any nodes with incorrect inheritance
+        on the correct branch
+    """
+
+    updated_inheritance_query = await GetSchemaWithUpdatedInheritance.init(db=db)
+    await updated_inheritance_query.execute(db=db)
+    updated_inheritance_kinds_by_branch = updated_inheritance_query.get_updated_inheritance_kinds_by_branch()
+
+    if not updated_inheritance_kinds_by_branch:
+        rprint(f"{SUCCESS_BADGE} No schemas have had their inheritance updated")
+        return True
+
     schema_manager = SchemaManager()
     registry.schema = schema_manager
     schema = SchemaRoot(**internal_schema)
     schema_manager.register_schema(schema=schema)
     branches_by_name = {b.name: b for b in await Branch.get_list(db=db)}
-    kind_label_counts_by_branch: dict[str, list[KindLabelCountCorrected]] = defaultdict(list)
-    for branch in branches_by_name.values():
-        if not branch.is_default:
-            continue
 
-        rprint(f"Checking branch: {branch.name}", end="...")
-        # get the kind and labels for every node on the database
-        kind_label_query = await GetAllKindsAndLabels.init(db=db, branch=branch)
+    kind_label_counts_by_branch: dict[str, list[KindLabelCountCorrected]] = defaultdict(list)
+    for branch_name, kinds in updated_inheritance_kinds_by_branch.items():
+        rprint(f"Checking branch: {branch_name}", end="...")
+        branch = branches_by_name[branch_name]
+        schema_branch = await schema_manager.load_schema_from_db(db=db, branch=branch)
+        kind_label_query = await GetAllKindsAndLabels.init(db=db, branch=branch, kinds=kinds)
         await kind_label_query.execute(db=db)
         kind_label_counts = kind_label_query.get_kind_label_counts()
-
-        if branch.is_global:
-            schema_branch = await schema_manager.load_schema_from_db(db=db, branch=registry.default_branch)
-        else:
-            schema_branch = await schema_manager.load_schema_from_db(db=db, branch=branch)
 
         for kind_label_count in kind_label_counts:
             node_schema = schema_branch.get_node(name=kind_label_count.kind, duplicate=False)
@@ -116,7 +226,7 @@ async def check_inheritance(db: InfrahubDatabase, fix: bool = False) -> None:
             if kind_label_count.labels == correct_labels:
                 continue
 
-            kind_label_counts_by_branch[branch.name].append(
+            kind_label_counts_by_branch[branch_name].append(
                 KindLabelCountCorrected(
                     kind=kind_label_count.kind,
                     labels=kind_label_count.labels,
@@ -128,13 +238,13 @@ async def check_inheritance(db: InfrahubDatabase, fix: bool = False) -> None:
 
     if not kind_label_counts_by_branch:
         rprint(f"{SUCCESS_BADGE} All nodes have the correct inheritance")
-        return
+        return True
 
     display_kind_label_counts(kind_label_counts_by_branch)
 
     if not fix:
         rprint(f"{FAILED_BADGE} Use the --fix flag to fix the inheritance of any invalid nodes")
-        return
+        return False
 
     for branch_name, kind_label_counts_corrected in kind_label_counts_by_branch.items():
         for kind_label_count in kind_label_counts_corrected:
@@ -162,3 +272,13 @@ async def check_inheritance(db: InfrahubDatabase, fix: bool = False) -> None:
             rprint("done")
 
     rprint(f"{SUCCESS_BADGE} All nodes have the correct inheritance")
+
+    if registry.default_branch in kind_label_counts_by_branch:
+        kinds = [kind_label_count.kind for kind_label_count in kind_label_counts_by_branch[registry.default_branch]]
+        rprint(
+            "[bold cyan]Note that migrations were run on the default branch for the following schema kinds: "
+            f"{', '.join(kinds)}. You should rebase any branches that include/will include changes using "
+            "the migrated schemas[/bold cyan]"
+        )
+
+    return True

--- a/backend/infrahub/cli/db_commands/check_inheritance.py
+++ b/backend/infrahub/cli/db_commands/check_inheritance.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from rich import print as rprint
+from rich.console import Console
+from rich.table import Table
+
+from infrahub.core import registry
+from infrahub.core.branch.models import Branch
+from infrahub.core.constants import InfrahubKind
+from infrahub.core.migrations.query.node_duplicate import NodeDuplicateQuery, SchemaNodeInfo
+from infrahub.core.query import Query, QueryType
+from infrahub.core.schema import SchemaRoot, internal_schema
+from infrahub.core.schema.manager import SchemaManager
+from infrahub.log import get_logger
+
+from ..constants import FAILED_BADGE, SUCCESS_BADGE
+
+if TYPE_CHECKING:
+    from infrahub.core.schema.node_schema import NodeSchema
+    from infrahub.database import InfrahubDatabase
+
+log = get_logger()
+
+
+@dataclass
+class KindLabelCount:
+    kind: str
+    labels: frozenset[str]
+    num_nodes: int
+
+
+@dataclass
+class KindLabelCountCorrected(KindLabelCount):
+    node_schema: NodeSchema
+
+
+class GetAllKindsAndLabels(Query):
+    name = "get_all_kinds_and_labels"
+    type = QueryType.READ
+    insert_return = False
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
+        self.params["branch_name"] = self.branch.name
+        self.params["branched_from"] = self.branch.get_branched_from()
+        query = """
+MATCH (n:Node)-[r:IS_PART_OF {branch: $branch_name}]->(:Root)
+WHERE r.from >= $branched_from
+AND r.to IS NULL
+AND r.status = "active"
+RETURN DISTINCT n.kind AS kind, labels(n) AS labels, count(*) AS num_nodes
+ORDER BY kind ASC
+        """
+        self.return_labels = ["kind", "labels", "num_nodes"]
+        self.add_to_query(query)
+
+    def get_kind_label_counts(self) -> list[KindLabelCount]:
+        kind_label_counts: list[KindLabelCount] = []
+        for result in self.results:
+            kind = result.get_as_type(label="kind", return_type=str)
+            num_nodes = result.get_as_type(label="num_nodes", return_type=int)
+            labels: list[str] = result.get_as_type(label="labels", return_type=list)
+            # we can ignore the Node label and the label that matches the kind
+            cleaned_labels = frozenset(str(lbl) for lbl in labels if lbl not in ["Node", "CoreNode", kind])
+            kind_label_counts.append(KindLabelCount(kind=kind, labels=cleaned_labels, num_nodes=num_nodes))
+        return kind_label_counts
+
+
+def display_kind_label_counts(kind_label_counts_by_branch: dict[str, list[KindLabelCountCorrected]]) -> None:
+    console = Console()
+
+    table = Table(title="Incorrect Inheritance Nodes")
+
+    table.add_column("Branch")
+    table.add_column("Kind")
+    table.add_column("Incorrect Labels")
+    table.add_column("Num Nodes")
+
+    for branch_name, kind_label_counts in kind_label_counts_by_branch.items():
+        for kind_label_count in kind_label_counts:
+            table.add_row(
+                branch_name, kind_label_count.kind, str(list(kind_label_count.labels)), str(kind_label_count.num_nodes)
+            )
+
+    console.print(table)
+
+
+async def check_inheritance(db: InfrahubDatabase, fix: bool = False) -> None:
+    schema_manager = SchemaManager()
+    registry.schema = schema_manager
+    schema = SchemaRoot(**internal_schema)
+    schema_manager.register_schema(schema=schema)
+    branches_by_name = {b.name: b for b in await Branch.get_list(db=db)}
+    kind_label_counts_by_branch: dict[str, list[KindLabelCountCorrected]] = defaultdict(list)
+    for branch in branches_by_name.values():
+        if not branch.is_default:
+            continue
+
+        rprint(f"Checking branch: {branch.name}", end="...")
+        # get the kind and labels for every node on the database
+        kind_label_query = await GetAllKindsAndLabels.init(db=db, branch=branch)
+        await kind_label_query.execute(db=db)
+        kind_label_counts = kind_label_query.get_kind_label_counts()
+
+        if branch.is_global:
+            schema_branch = await schema_manager.load_schema_from_db(db=db, branch=registry.default_branch)
+        else:
+            schema_branch = await schema_manager.load_schema_from_db(db=db, branch=branch)
+
+        for kind_label_count in kind_label_counts:
+            node_schema = schema_branch.get_node(name=kind_label_count.kind, duplicate=False)
+            correct_labels = frozenset(node_schema.inherit_from)
+            if kind_label_count.labels == correct_labels:
+                continue
+
+            kind_label_counts_by_branch[branch.name].append(
+                KindLabelCountCorrected(
+                    kind=kind_label_count.kind,
+                    labels=kind_label_count.labels,
+                    num_nodes=kind_label_count.num_nodes,
+                    node_schema=node_schema,
+                )
+            )
+        rprint("done")
+
+    if not kind_label_counts_by_branch:
+        rprint(f"{SUCCESS_BADGE} All nodes have the correct inheritance")
+        return
+
+    display_kind_label_counts(kind_label_counts_by_branch)
+
+    if not fix:
+        rprint(f"{FAILED_BADGE} Use the --fix flag to fix the inheritance of any invalid nodes")
+        return
+
+    for branch_name, kind_label_counts_corrected in kind_label_counts_by_branch.items():
+        for kind_label_count in kind_label_counts_corrected:
+            rprint(f"Fixing kind {kind_label_count.kind} on branch {branch_name}", end="...")
+            node_schema = kind_label_count.node_schema
+            migration_query = await NodeDuplicateQuery.init(
+                db=db,
+                branch=branches_by_name[branch_name],
+                previous_node=SchemaNodeInfo(
+                    name=node_schema.name,
+                    namespace=node_schema.namespace,
+                    branch_support=node_schema.branch.value,
+                    labels=list(kind_label_count.labels) + [kind_label_count.kind, InfrahubKind.NODE],
+                    kind=kind_label_count.kind,
+                ),
+                new_node=SchemaNodeInfo(
+                    name=node_schema.name,
+                    namespace=node_schema.namespace,
+                    branch_support=node_schema.branch.value,
+                    labels=list(node_schema.inherit_from) + [kind_label_count.kind, InfrahubKind.NODE],
+                    kind=kind_label_count.kind,
+                ),
+            )
+            await migration_query.execute(db=db)
+            rprint("done")
+
+    rprint(f"{SUCCESS_BADGE} All nodes have the correct inheritance")

--- a/backend/infrahub/core/migrations/query/node_duplicate.py
+++ b/backend/infrahub/core/migrations/query/node_duplicate.py
@@ -38,11 +38,23 @@ class NodeDuplicateQuery(Query):
 
     def render_match(self) -> str:
         labels_str = ":".join(self.previous_node.labels)
-        query = f"""
+        query = """
         // Find all the active nodes
-        MATCH (node:{labels_str})
+        MATCH (node:%(labels_str)s)
         WITH DISTINCT node
-        """
+        CALL (node) {
+            WITH labels(node) AS node_labels
+            UNWIND node_labels AS n_label
+            ORDER BY n_label ASC
+            WITH collect(n_label) AS sorted_labels
+
+            RETURN (
+                node.kind = $new_node.kind AND
+                sorted_labels = $new_sorted_labels
+            ) AS already_migrated
+        }
+        WITH node WHERE already_migrated = FALSE
+        """ % {"labels_str": labels_str}
 
         return query
 
@@ -111,6 +123,7 @@ class NodeDuplicateQuery(Query):
 
         self.params["new_node"] = self.new_node.model_dump()
         self.params["previous_node"] = self.previous_node.model_dump()
+        self.params["new_sorted_labels"] = sorted(self.new_node.labels + ["Node"])
 
         self.params["current_time"] = self.at.to_string()
         self.params["branch"] = self.branch.name

--- a/backend/infrahub/core/migrations/query/node_duplicate.py
+++ b/backend/infrahub/core/migrations/query/node_duplicate.py
@@ -21,6 +21,13 @@ class SchemaNodeInfo(BaseModel):
 
 
 class NodeDuplicateQuery(Query):
+    """
+    Duplicates a Node to use a new kind or inheritance.
+    Creates a copy of each affected Node and sets the new kind/inheritance.
+    Adds duplicate edges to the new Node that match all the active edges on the old Node.
+    Sets all the edges on the old Node to deleted.
+    """
+
     name = "node_duplicate"
     type = QueryType.WRITE
     insert_return: bool = False
@@ -42,6 +49,9 @@ class NodeDuplicateQuery(Query):
         // Find all the active nodes
         MATCH (node:%(labels_str)s)
         WITH DISTINCT node
+        // ----------------
+        // Filter out nodes that have already been migrated
+        // ----------------
         CALL (node) {
             WITH labels(node) AS node_labels
             UNWIND node_labels AS n_label

--- a/backend/tests/unit/core/schema/test_check_inheritance_cmd.py
+++ b/backend/tests/unit/core/schema/test_check_inheritance_cmd.py
@@ -1,0 +1,164 @@
+from dataclasses import dataclass
+
+from infrahub.cli.db_commands.check_inheritance import check_inheritance
+from infrahub.core import registry
+from infrahub.core.branch.models import Branch
+from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
+from infrahub.core.schema.attribute_schema import AttributeSchema
+from infrahub.core.schema.generic_schema import GenericSchema
+from infrahub.database import InfrahubDatabase
+
+
+@dataclass
+class DatabaseNodeWithLabels:
+    n_uuid: str
+    n_labels: set[str]
+    branch: str
+    status: str
+
+    def __hash__(self) -> int:
+        return hash((self.n_uuid, frozenset(self.n_labels)))
+
+
+class TestCheckInheritance:
+    async def get_database_nodes_with_labels(self, db: InfrahubDatabase):
+        query = """
+MATCH (n:TestPerson)-[e:IS_PART_OF]->(:Root)
+WITH DISTINCT n, e.branch AS branch
+CALL (n, branch) {
+    MATCH (n)-[e:IS_PART_OF {branch: branch}]->(:Root)
+    ORDER BY e.from DESC
+    RETURN e
+    LIMIT 1
+}
+RETURN n.uuid AS n_uuid, labels(n) AS n_labels, e.branch AS branch, e.status AS status
+        """
+        results = await db.execute_query(query=query)
+        return {
+            DatabaseNodeWithLabels(
+                n_uuid=result.get("n_uuid"),
+                n_labels=set(result.get("n_labels")),
+                branch=result.get("branch"),
+                status=result.get("status"),
+            )
+            for result in results
+        }
+
+    async def test_identify_and_fix_inheritance_issues(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        car_accord_main: Node,
+        person_john_main: Node,
+        register_internal_models_schema,
+    ) -> None:
+        main_schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+        await registry.schema.load_schema_to_db(db=db, branch=default_branch, schema=main_schema_branch)
+        main_schema_branch = await registry.schema.load_schema_from_db(db=db, branch=default_branch)
+        registry.schema.set_schema_branch(name=default_branch.name, schema=main_schema_branch)
+
+        # verify no inheritance problems to start with
+        result = await check_inheritance(db=db, fix=False)
+        assert result is True
+
+        # add a generic to the schema
+        main_schema_branch = await registry.schema.load_schema_from_db(db=db, branch=default_branch)
+        registry.schema.set_schema_branch(name=default_branch.name, schema=main_schema_branch)
+        schema_generic = GenericSchema(
+            name="FoodPerson",
+            namespace="Test",
+            attributes=[AttributeSchema(name="favorite_food", kind="Text", optional=True)],
+        )
+        registry.schema.set(name="TestFoodPerson", branch=default_branch.name, schema=schema_generic)
+        person_schema = registry.schema.get_node_schema(name="TestPerson", branch=default_branch)
+        person_schema.inherit_from = ["TestFoodPerson"]
+        registry.schema.set(name=person_schema.kind, branch=default_branch.name, schema=person_schema)
+        registry.schema.process_schema_branch(name=default_branch.name)
+        updated_main_schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+        await registry.schema.load_schema_to_db(db=db, branch=default_branch, schema=updated_main_schema_branch)
+
+        # verify inheritance problems exist
+        result = await check_inheritance(db=db, fix=False)
+        assert result is False
+
+        # fix the inheritance problems
+        result = await check_inheritance(db=db, fix=True)
+        assert result is True
+
+        # verify inheritance is updated
+        db_nodes_with_labels = await self.get_database_nodes_with_labels(db=db)
+        assert db_nodes_with_labels == {
+            DatabaseNodeWithLabels(
+                n_uuid=person_john_main.id,
+                n_labels={"TestPerson", "CoreNode", "Node"},
+                branch=default_branch.name,
+                status="deleted",
+            ),
+            DatabaseNodeWithLabels(
+                n_uuid=person_john_main.id,
+                n_labels={"TestPerson", "TestFoodPerson", "CoreNode", "Node"},
+                branch=default_branch.name,
+                status="active",
+            ),
+        }
+
+        # un-update the inheritance on a branch
+        main_schema_branch = await registry.schema.load_schema_from_db(db=db, branch=default_branch)
+        registry.schema.set_schema_branch(name=default_branch.name, schema=main_schema_branch)
+        branch = await create_branch(db=db, branch_name="mulligan-branch")
+        registry.schema.set_schema_branch(name=branch.name, schema=main_schema_branch)
+        person_schema = registry.schema.get_node_schema(name="TestPerson", branch=branch)
+        person_schema.inherit_from = []
+        registry.schema.set(name=person_schema.kind, branch=branch.name, schema=person_schema)
+        registry.schema.process_schema_branch(name=branch.name)
+        updated_main_schema_branch = registry.schema.get_schema_branch(name=branch.name)
+        await registry.schema.load_schema_to_db(db=db, branch=branch, schema=updated_main_schema_branch)
+
+        # verify inheritance problems exist
+        result = await check_inheritance(db=db, fix=False)
+        assert result is False
+
+        # fix the inheritance problems
+        result = await check_inheritance(db=db, fix=True)
+        assert result is True
+
+        # verify inheritance is updated
+        db_nodes_with_labels = await self.get_database_nodes_with_labels(db=db)
+        assert db_nodes_with_labels == {
+            DatabaseNodeWithLabels(
+                n_uuid=person_john_main.id,
+                n_labels={"TestPerson", "CoreNode", "Node"},
+                branch=default_branch.name,
+                status="deleted",
+            ),
+            DatabaseNodeWithLabels(
+                n_uuid=person_john_main.id,
+                n_labels={"TestPerson", "TestFoodPerson", "CoreNode", "Node"},
+                branch=default_branch.name,
+                status="active",
+            ),
+            DatabaseNodeWithLabels(
+                n_uuid=person_john_main.id,
+                n_labels={"TestPerson", "TestFoodPerson", "CoreNode", "Node"},
+                branch=branch.name,
+                status="deleted",
+            ),
+            DatabaseNodeWithLabels(
+                n_uuid=person_john_main.id,
+                n_labels={"TestPerson", "CoreNode", "Node"},
+                branch=branch.name,
+                status="active",
+            ),
+        }
+
+        main_schema_branch = await registry.schema.load_schema_from_db(db=db, branch=default_branch)
+        registry.schema.set_schema_branch(name=default_branch.name, schema=main_schema_branch)
+        main_person = await NodeManager.get_one(db=db, branch=default_branch, id=person_john_main.id)
+        assert main_person.favorite_food.value is None
+
+        branch_schema_branch = await registry.schema.load_schema_from_db(db=db, branch=branch)
+        registry.schema.set_schema_branch(name=branch.name, schema=branch_schema_branch)
+        branch_person = await NodeManager.get_one(db=db, branch=branch, id=person_john_main.id)
+        assert not hasattr(branch_person, "favorite_food")

--- a/changelog/+inheritance-fix-command.added.md
+++ b/changelog/+inheritance-fix-command.added.md
@@ -1,0 +1,1 @@
+Add the `infrahub db check-inheritance` command to validate and fix any schemas that have had their inheritance updated and a failed migration.

--- a/docs/docs/reference/infrahub-cli/infrahub-db.mdx
+++ b/docs/docs/reference/infrahub-cli/infrahub-db.mdx
@@ -17,6 +17,7 @@ $ infrahub db [OPTIONS] COMMAND [ARGS]...
 **Commands**:
 
 * `check`: Run database sanity checks and output the...
+* `check-inheritance`: Check the database for any vertices with...
 * `constraint`: Manage Database Constraints
 * `index`: Manage Database Indexes
 * `init`: Erase the content of the database and...
@@ -41,6 +42,25 @@ $ infrahub db check [OPTIONS]
 
 * `--output-dir PATH`: Directory to save detailed check results (defaults to infrahub_db_check_YYYYMMDD-HHMMSS)
 * `--config-file TEXT`: Location of the configuration file to use for Infrahub  [env var: INFRAHUB_CONFIG; default: infrahub.toml]
+* `--help`: Show this message and exit.
+
+## `infrahub db check-inheritance`
+
+Check the database for any vertices with incorrect inheritance
+
+**Usage**:
+
+```console
+$ infrahub db check-inheritance [OPTIONS] [CONFIG_FILE]
+```
+
+**Arguments**:
+
+* `[CONFIG_FILE]`: [env var: INFRAHUB_CONFIG;default: infrahub.toml]
+
+**Options**:
+
+* `--fix / --no-fix`: Fix the inheritance of any invalid nodes.  [default: no-fix]
 * `--help`: Show this message and exit.
 
 ## `infrahub db constraint`


### PR DESCRIPTION
IFC-1691

new `infrahub db check-inheritance [--fix/--no-fix]` to check and clean up any incorrect inheritance at the database level
the root cause of the problem remains unidentified, but it is somehow possible to have the Node vertices with labels that do not match their current inheritance structure. for example, if I try to migrate the `NodeOne` schema to inherit from `CoreArtifactTarget` and that migration silently fails in some way then the schema on the database will indicate that all active `NodeOne` vertices should also have the `CoreArtifactTarget` label, but that will not actually be true

this command can be used to identify schemas with this problem and correct them

this version only works for inheritance misalignment. it does not identify or correct schema name/namespace/kind misalignment (mostly because that was going to be a harder problem to solve and I do not know if it is necessary)

TODO

- [x] unit tests (manual testing on a database dump with the problem is successful)
- [x] check if we can wait to save inheritance updates until the migration has completed successfully. made a new issue for it #6948 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new CLI command, infrahub db check-inheritance, to detect and optionally fix schema inheritance inconsistencies in the database.
* **Documentation**
  * Added detailed documentation for the new check-inheritance command, including usage instructions and options.
* **Tests**
  * Added comprehensive tests to verify the detection and correction of inheritance issues across schema branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->