### PR TITLE
Prevent generic relationship peer to be overridden

### DIFF
--- a/backend/infrahub/core/schema/node_schema.py
+++ b/backend/infrahub/core/schema/node_schema.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from infrahub.core.constants import AllowOverrideType, InfrahubKind
+from infrahub.core.constants import AllowOverrideType, InfrahubKind, RelationshipKind
 
 from .generated.node_schema import GeneratedNodeSchema
 from .generic_schema import GenericSchema
@@ -70,14 +70,17 @@ class NodeSchema(GeneratedNodeSchema):
                     )
 
         for relationship in self.relationships:
-            if (
-                relationship.name in interface.relationship_names
-                and not relationship.inherited
-                and interface.get_relationship(relationship.name).allow_override == AllowOverrideType.NONE
-            ):
-                raise ValueError(
-                    f"{self.kind}'s relationship {relationship.name} inherited from {interface.kind} cannot be overriden"
-                )
+            if relationship.name in interface.relationship_names and not relationship.inherited:
+                interface_relationship = interface.get_relationship(relationship.name)
+                if interface_relationship.allow_override == AllowOverrideType.NONE:
+                    raise ValueError(
+                        f"{self.kind}'s relationship {relationship.name} inherited from {interface.kind} cannot be overriden"
+                    )
+                if relationship.kind != RelationshipKind.HIERARCHY and relationship.peer != interface_relationship.peer:
+                    raise ValueError(
+                        f"{self.kind}'s relationship {relationship.name} inherited from {interface.kind} must have the same peer "
+                        f"({interface_relationship.peer} != {relationship.peer})"
+                    )
 
     def inherit_from_interface(self, interface: GenericSchema) -> None:
         existing_inherited_attributes: dict[str, int] = {

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -517,6 +517,50 @@ async def test_schema_branch_cleanup_inherited_elements(schema_all_in_one):
             },
             "TestCriticality's relationship status inherited from InfraGenericInterface cannot be overriden",
         ),
+        (
+            {
+                "nodes": [
+                    {
+                        "name": "Criticality",
+                        "namespace": "Test",
+                        "inherit_from": ["InfraGenericInterface"],
+                        "default_filter": "name__value",
+                        "branch": BranchSupportType.AGNOSTIC.value,
+                        "relationships": [
+                            {"name": "status", "peer": "TestState", "optional": True, "cardinality": "one"}
+                        ],
+                    },
+                    {
+                        "name": "Status",
+                        "namespace": "Test",
+                        "branch": BranchSupportType.AGNOSTIC.value,
+                        "attributes": [{"name": "name", "kind": "Text", "label": "Name", "unique": True}],
+                    },
+                    {
+                        "name": "State",
+                        "namespace": "Test",
+                        "branch": BranchSupportType.AGNOSTIC.value,
+                        "attributes": [{"name": "name", "kind": "Text", "label": "Name", "unique": True}],
+                    },
+                ],
+                "generics": [
+                    {
+                        "name": "GenericInterface",
+                        "namespace": "Infra",
+                        "attributes": [{"name": "name", "kind": "Text"}],
+                        "relationships": [
+                            {
+                                "name": "status",
+                                "peer": "TestStatus",
+                                "optional": True,
+                                "cardinality": "one",
+                            }
+                        ],
+                    },
+                ],
+            },
+            "TestCriticality's relationship status inherited from InfraGenericInterface must have the same peer (TestStatus != TestState)",
+        ),
     ],
 )
 async def test_schema_protected_generics(schema_dict, expected_error):

--- a/changelog/6699.fixed.md
+++ b/changelog/6699.fixed.md
@@ -1,0 +1,1 @@
+Raise error on schema load if someone tries to override the peer of a generic relationship as the GraphQL schema doesn't allow for that.


### PR DESCRIPTION
Fixes #6699

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema validation to ensure that inherited relationships cannot override the peer attribute of a generic relationship. An error is now raised during schema loading if this rule is violated.

* **Tests**
  * Added a new test case to verify that overriding the peer of an inherited generic relationship correctly raises an error.

* **Documentation**
  * Updated the changelog to reflect the stricter validation for inherited relationship peers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->