### PR TITLE
Add support for nested GraphQL fragments

### DIFF
--- a/backend/infrahub/graphql/field_extractor.py
+++ b/backend/infrahub/graphql/field_extractor.py
@@ -1,0 +1,69 @@
+from typing import Any
+
+from graphql import (
+    FieldNode,
+    FragmentSpreadNode,
+    GraphQLResolveInfo,
+    InlineFragmentNode,
+    SelectionSetNode,
+)
+
+
+class GraphQLFieldExtractor:
+    """Class to extract fields from a GraphQL selection set."""
+
+    def __init__(self, info: GraphQLResolveInfo):
+        self.info = info
+        self.fragments = info.fragments
+
+    def get_fields(self) -> dict[str, Any]:
+        """Extract fields from the GraphQL selection set."""
+        fields = self._extract_fields(selection_set=self.info.field_nodes[0].selection_set)
+        return fields or {}
+
+    def _extract_fields(self, selection_set: SelectionSetNode | None) -> dict[str, dict] | None:
+        """This function extract all the requested fields in a tree of Dict from a SelectionSetNode
+
+        The goal of this function is to limit the fields that we need to query from the backend.
+
+        Currently the function support Fields and InlineFragments but in a combined tree where the fragments are merged together
+        This implementation may seam counter intuitive but in the current implementation
+        it's better to have slightly more information at time passed to the query manager.
+
+        In the future we'll probably need to redesign how we read GraphQL queries to generate better Database query.
+        """
+
+        if not selection_set:
+            return None
+
+        fields: dict[str, dict | Any] = {}
+        for node in selection_set.selections:
+            sub_selection_set = getattr(node, "selection_set", None)
+            if isinstance(node, FieldNode):
+                value = self._extract_fields(sub_selection_set)
+                if node.name.value not in fields:
+                    fields[node.name.value] = value
+                elif isinstance(fields[node.name.value], dict) and isinstance(value, dict):
+                    fields[node.name.value].update(value)
+
+            elif isinstance(node, InlineFragmentNode):
+                for sub_node in node.selection_set.selections:
+                    sub_sub_selection_set = getattr(sub_node, "selection_set", None)
+                    value = self._extract_fields(sub_sub_selection_set)
+                    sub_node_name = getattr(sub_node, "name", "")
+                    sub_node_name_value = getattr(sub_node_name, "value", "")
+                    if sub_node_name_value not in fields:
+                        fields[sub_node_name_value] = self._extract_fields(sub_sub_selection_set)
+                    elif isinstance(fields[sub_node_name_value], dict) and isinstance(value, dict):
+                        fields[sub_node_name_value].update(value)
+            elif isinstance(node, FragmentSpreadNode):
+                if node.name.value in self.info.fragments:
+                    if fragment_fields := self._extract_fields(self.info.fragments[node.name.value].selection_set):
+                        fields.update(fragment_fields)
+
+        return fields
+
+
+def extract_graphql_fields(info: GraphQLResolveInfo) -> dict[str, Any]:
+    graphql_extractor = GraphQLFieldExtractor(info=info)
+    return graphql_extractor.get_fields()

--- a/backend/infrahub/graphql/mutations/account.py
+++ b/backend/infrahub/graphql/mutations/account.py
@@ -2,7 +2,6 @@ from typing import TYPE_CHECKING, Any
 
 from graphene import Boolean, Field, InputField, InputObjectType, Mutation, String
 from graphql import GraphQLResolveInfo
-from infrahub_sdk.utils import extract_fields
 from infrahub_sdk.uuidt import UUIDT
 from typing_extensions import Self
 
@@ -14,6 +13,7 @@ from infrahub.core.protocols import CoreAccount, CoreNode, InternalAccountToken
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase, retry_db_transaction
 from infrahub.exceptions import NodeNotFoundError, PermissionDeniedError
+from infrahub.graphql.field_extractor import extract_graphql_fields
 
 from ..models import OrderModel
 from ..types import InfrahubObjectType
@@ -101,7 +101,7 @@ class AccountMixin:
         async with db.start_transaction() as dbt:
             await obj.save(db=dbt)
 
-        fields = await extract_fields(info.field_nodes[0].selection_set)
+        fields = extract_graphql_fields(info=info)
         return cls(object=await obj.to_graphql(db=db, fields=fields.get("object", {})), ok=True)  # type: ignore[call-arg]
 
     @classmethod

--- a/backend/infrahub/graphql/mutations/branch.py
+++ b/backend/infrahub/graphql/mutations/branch.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from graphene import Boolean, Field, InputField, InputObjectType, Mutation, String
-from infrahub_sdk.utils import extract_fields, extract_fields_first_node
 from opentelemetry import trace
 from typing_extensions import Self
 
 from infrahub.core.branch import Branch
 from infrahub.database import retry_db_transaction
 from infrahub.graphql.context import apply_external_context
+from infrahub.graphql.field_extractor import extract_graphql_fields
 from infrahub.graphql.types.context import ContextInput
 from infrahub.log import get_logger
 from infrahub.workflows.catalogue import (
@@ -84,7 +84,7 @@ class BranchCreate(Mutation):
 
         # Retrieve created branch
         obj = await Branch.get_by_name(db=graphql_context.db, name=model.name)
-        fields = await extract_fields(info.field_nodes[0].selection_set)
+        fields = extract_graphql_fields(info=info)
         return cls(object=await obj.to_graphql(fields=fields.get("object", {})), ok=True, task=task)
 
 
@@ -202,7 +202,7 @@ class BranchRebase(Mutation):
             )
             task = {"id": workflow.id}
 
-        fields = await extract_fields_first_node(info=info)
+        fields = extract_graphql_fields(info=info)
         ok = True
 
         return cls(object=await obj.to_graphql(fields=fields.get("object", {})), ok=ok, task=task)
@@ -245,7 +245,7 @@ class BranchValidate(Mutation):
             )
             task = {"id": workflow.id}
 
-        fields = await extract_fields_first_node(info=info)
+        fields = extract_graphql_fields(info=info)
 
         return cls(object=await obj.to_graphql(fields=fields.get("object", {})), ok=ok, task=task)
 
@@ -291,7 +291,7 @@ class BranchMerge(Mutation):
         # Pull the latest information about the branch from the database directly
         obj = await Branch.get_by_name(db=graphql_context.db, name=branch_name)
 
-        fields = await extract_fields(info.field_nodes[0].selection_set)
+        fields = extract_graphql_fields(info=info)
         ok = True
 
         return cls(object=await obj.to_graphql(fields=fields.get("object", {})), ok=ok, task=task)

--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any
 
 from graphene import InputObjectType, Mutation
 from graphene.types.mutation import MutationOptions
-from infrahub_sdk.utils import extract_fields
 from typing_extensions import Self
 
 from infrahub import config, lock
@@ -27,6 +26,7 @@ from infrahub.dependencies.registry import get_component_registry
 from infrahub.events.generator import generate_node_mutation_events
 from infrahub.exceptions import HFIDViolatedError, InitializationError, NodeNotFoundError
 from infrahub.graphql.context import apply_external_context
+from infrahub.graphql.field_extractor import extract_graphql_fields
 from infrahub.lock import InfrahubMultiLock, build_object_lock_name
 from infrahub.log import get_log_data, get_logger
 
@@ -200,7 +200,7 @@ class InfrahubMutationMixin:
 
     @classmethod
     async def mutate_create_to_graphql(cls, info: GraphQLResolveInfo, db: InfrahubDatabase, obj: Node) -> Self:
-        fields = await extract_fields(info.field_nodes[0].selection_set)
+        fields = extract_graphql_fields(info=info)
         result: dict[str, Any] = {"ok": True}
         if "object" in fields:
             result["object"] = await obj.to_graphql(db=db, fields=fields.get("object", {}))
@@ -320,7 +320,7 @@ class InfrahubMutationMixin:
         info: GraphQLResolveInfo,
         obj: Node,
     ) -> Self:
-        fields_object = await extract_fields(info.field_nodes[0].selection_set)
+        fields_object = extract_graphql_fields(info=info)
         fields_object = fields_object.get("object", {})
         result: dict[str, Any] = {"ok": True}
         if fields_object:

--- a/backend/infrahub/graphql/parser.py
+++ b/backend/infrahub/graphql/parser.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from graphql.language import (
     DirectiveNode,
     FieldNode,
+    FragmentSpreadNode,
     InlineFragmentNode,
     ListValueNode,
     NameNode,
@@ -15,6 +16,8 @@ from graphql.language import (
 from infrahub_sdk.utils import deep_merge_dict
 
 if TYPE_CHECKING:
+    from graphql import GraphQLResolveInfo
+
     from infrahub.core.schema import NodeSchema
 
 
@@ -26,14 +29,14 @@ class FieldEnricher:
     fields: dict = field(default_factory=dict)
 
 
-async def extract_selection(field_node: FieldNode, schema: NodeSchema) -> dict:
-    graphql_extractor = GraphQLExtractor(field_node=field_node, schema=schema)
+async def extract_selection(info: GraphQLResolveInfo, schema: NodeSchema) -> dict:
+    graphql_extractor = GraphQLExtractor(info=info, schema=schema)
     return await graphql_extractor.get_fields()
 
 
 class GraphQLExtractor:
-    def __init__(self, field_node: FieldNode, schema: NodeSchema) -> None:
-        self.field_node = field_node
+    def __init__(self, info: GraphQLResolveInfo, schema: NodeSchema) -> None:
+        self.info = info
         self.schema = schema
         self.typename_paths: dict[str, list[FieldEnricher]] = {}
         self.node_path: dict[str, list[FieldEnricher]] = {}
@@ -43,7 +46,7 @@ class GraphQLExtractor:
             self.node_path[path] = []
 
     async def get_fields(self) -> dict:
-        return await self.extract_fields(selection_set=self.field_node.selection_set) or {}
+        return await self.extract_fields(selection_set=self.info.field_nodes[0].selection_set) or {}
 
     def _process_expand_directive(self, path: str, directive: DirectiveNode) -> None:
         excluded_fields = []
@@ -203,6 +206,12 @@ class GraphQLExtractor:
                             )
                         elif isinstance(fields[sub_node.name.value], dict) and isinstance(value, dict):
                             fields[sub_node.name.value].update(value)  # type: ignore[union-attr]
+
+            elif isinstance(node, FragmentSpreadNode):
+                if node.name.value in self.info.fragments:
+                    fragment_fields = await self.extract_fields(self.info.fragments[node.name.value].selection_set)
+                    if fragment_fields:
+                        fields.update(fragment_fields)
 
         return self.apply_directives(selection_set=selection_set, fields=fields, path=path)
 

--- a/backend/infrahub/graphql/queries/account.py
+++ b/backend/infrahub/graphql/queries/account.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from graphene import Field, Int, List, NonNull, ObjectType, String
-from infrahub_sdk.utils import extract_fields_first_node
 
 from infrahub.core.manager import NodeManager
 from infrahub.core.protocols import InternalAccountToken
 from infrahub.exceptions import PermissionDeniedError
+from infrahub.graphql.field_extractor import extract_graphql_fields
 
 if TYPE_CHECKING:
     from graphql import GraphQLResolveInfo
@@ -44,7 +44,7 @@ async def resolve_account_tokens(
     if not graphql_context.account_session.authenticated_by_jwt:
         raise PermissionDeniedError("This operation requires authentication with a JWT token")
 
-    fields = await extract_fields_first_node(info)
+    fields = extract_graphql_fields(info)
 
     filters = {"account__ids": [graphql_context.account_session.account_id]}
     response: dict[str, Any] = {}
@@ -121,7 +121,7 @@ async def resolve_account_permissions(
     if not graphql_context.account_session:
         raise ValueError("An account_session is mandatory to execute this query")
 
-    fields = await extract_fields_first_node(info)
+    fields = extract_graphql_fields(info)
 
     response: dict[str, dict[str, Any]] = {}
     if "global_permissions" in fields:

--- a/backend/infrahub/graphql/queries/branch.py
+++ b/backend/infrahub/graphql/queries/branch.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from graphene import ID, Field, List, NonNull, String
-from infrahub_sdk.utils import extract_fields_first_node
 
+from infrahub.graphql.field_extractor import extract_graphql_fields
 from infrahub.graphql.types import BranchType
 
 if TYPE_CHECKING:
@@ -16,7 +16,7 @@ async def branch_resolver(
     info: GraphQLResolveInfo,
     **kwargs: Any,
 ) -> list[dict[str, Any]]:
-    fields = await extract_fields_first_node(info)
+    fields = extract_graphql_fields(info)
     return await BranchType.get_list(graphql_context=info.context, fields=fields, **kwargs)
 
 

--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any
 
 from graphene import Argument, Boolean, DateTime, Field, InputObjectType, Int, List, NonNull, ObjectType, String
 from graphene import Enum as GrapheneEnum
-from infrahub_sdk.utils import extract_fields
 
 from infrahub.core import registry
 from infrahub.core.constants import DiffAction, RelationshipCardinality
@@ -16,6 +15,7 @@ from infrahub.core.query.diff import DiffCountChanges
 from infrahub.core.timestamp import Timestamp
 from infrahub.dependencies.registry import get_component_registry
 from infrahub.graphql.enums import ConflictSelection as GraphQLConflictSelection
+from infrahub.graphql.field_extractor import extract_graphql_fields
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -438,7 +438,7 @@ class DiffTreeResolver:
         else:
             enriched_diff = enriched_diffs[0]
 
-        full_fields = await extract_fields(info.field_nodes[0].selection_set)
+        full_fields = extract_graphql_fields(info=info)
         diff_tree = await self.to_diff_tree(enriched_diff_root=enriched_diff, graphql_context=graphql_context)
         need_base_changes = "num_untracked_base_changes" in full_fields
         need_branch_changes = "num_untracked_diff_changes" in full_fields
@@ -495,7 +495,7 @@ class DiffTreeResolver:
             to_time=summary.to_time.to_datetime(),
             **summary.model_dump(exclude={"from_time", "to_time"}),
         )
-        full_fields = await extract_fields(info.field_nodes[0].selection_set)
+        full_fields = extract_graphql_fields(info=info)
         need_base_changes = "num_untracked_base_changes" in full_fields
         need_branch_changes = "num_untracked_diff_changes" in full_fields
         if need_base_changes or need_branch_changes:

--- a/backend/infrahub/graphql/queries/event.py
+++ b/backend/infrahub/graphql/queries/event.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from graphene import Argument, Boolean, DateTime, Enum, Field, Int, List, NonNull, ObjectType, String
-from infrahub_sdk.utils import extract_fields_first_node
 
 from infrahub.events.constants import EventSortOrder
 from infrahub.exceptions import ValidationError
+from infrahub.graphql.field_extractor import extract_graphql_fields
 from infrahub.graphql.types.event import EventNodes, EventTypeFilter
 from infrahub.task_manager.event import PrefectEvent
 from infrahub.task_manager.models import InfrahubEventFilter
@@ -79,7 +79,7 @@ class Events(ObjectType):
         limit: int,
         offset: int | None = None,
     ) -> dict[str, Any]:
-        fields = await extract_fields_first_node(info)
+        fields = extract_graphql_fields(info)
 
         prefect_tasks = await PrefectEvent.query(
             fields=fields,

--- a/backend/infrahub/graphql/queries/relationship.py
+++ b/backend/infrahub/graphql/queries/relationship.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from graphene import Field, Int, List, NonNull, ObjectType, String
-from infrahub_sdk.utils import extract_fields_first_node
 
 from infrahub.core.query.relationship import RelationshipGetByIdentifierQuery
+from infrahub.graphql.field_extractor import extract_graphql_fields
 from infrahub.graphql.types import RelationshipNode
 
 if TYPE_CHECKING:
@@ -29,7 +29,7 @@ class Relationships(ObjectType):
     ) -> dict[str, Any]:
         graphql_context: GraphqlContext = info.context
 
-        fields = await extract_fields_first_node(info)
+        fields = extract_graphql_fields(info)
         excluded_namespaces = excluded_namespaces or []
 
         response: dict[str, Any] = {"edges": [], "count": None}

--- a/backend/infrahub/graphql/queries/resource_manager.py
+++ b/backend/infrahub/graphql/queries/resource_manager.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from graphene import BigInt, Field, Float, Int, List, NonNull, ObjectType, String
-from infrahub_sdk.utils import extract_fields_first_node
 
 from infrahub.core import registry
 from infrahub.core.constants import InfrahubKind
@@ -16,6 +15,7 @@ from infrahub.core.query.resource_manager import (
     PrefixPoolGetIdentifiers,
 )
 from infrahub.exceptions import NodeNotFoundError, SchemaNotFoundError, ValidationError
+from infrahub.graphql.field_extractor import extract_graphql_fields
 from infrahub.pools.number import NumberUtilizationGetter
 
 if TYPE_CHECKING:
@@ -87,7 +87,7 @@ class PoolAllocated(ObjectType):
             id=pool_id, db=graphql_context.db, branch=graphql_context.branch
         )
 
-        fields = await extract_fields_first_node(info=info)
+        fields = extract_graphql_fields(info=info)
 
         allocated_kinds: list[str] = []
         pool = _validate_pool_type(pool_id=pool_id, pool=pool)
@@ -207,7 +207,7 @@ class PoolUtilization(ObjectType):
         utilization_getter = PrefixUtilizationGetter(
             db=db, ip_prefixes=list(resources_map.values()), at=graphql_context.at
         )
-        fields = await extract_fields_first_node(info=info)
+        fields = extract_graphql_fields(info=info)
         response: dict[str, Any] = {}
         total_utilization = None
         default_branch_utilization = None

--- a/backend/infrahub/graphql/queries/search.py
+++ b/backend/infrahub/graphql/queries/search.py
@@ -4,10 +4,11 @@ import ipaddress
 from typing import TYPE_CHECKING, Any
 
 from graphene import Boolean, Field, Int, List, NonNull, ObjectType, String
-from infrahub_sdk.utils import extract_fields_first_node, is_valid_uuid
+from infrahub_sdk.utils import is_valid_uuid
 
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.manager import NodeManager
+from infrahub.graphql.field_extractor import extract_graphql_fields
 
 if TYPE_CHECKING:
     from graphql import GraphQLResolveInfo
@@ -107,7 +108,7 @@ async def search_resolver(
     response: dict[str, Any] = {}
     results: list[CoreNode] = []
 
-    fields = await extract_fields_first_node(info)
+    fields = extract_graphql_fields(info=info)
 
     if is_valid_uuid(q):
         matching: CoreNode | None = await NodeManager.get_one(

--- a/backend/infrahub/graphql/queries/status.py
+++ b/backend/infrahub/graphql/queries/status.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from graphene import Boolean, Field, List, NonNull, ObjectType, String
-from infrahub_sdk.utils import extract_fields_first_node
+
+from infrahub.graphql.field_extractor import extract_graphql_fields
 
 if TYPE_CHECKING:
     from graphql import GraphQLResolveInfo
@@ -45,7 +46,7 @@ async def resolve_status(
     if service is None:
         raise ValueError("GraphqlContext.service is None")
 
-    fields = await extract_fields_first_node(info)
+    fields = extract_graphql_fields(info=info)
     response: dict[str, Any] = {}
     workers = await service.component.list_workers(
         branch=str(graphql_context.branch.uuid) or graphql_context.branch.name, schema_hash=True

--- a/backend/infrahub/graphql/queries/task.py
+++ b/backend/infrahub/graphql/queries/task.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from graphene import Field, Int, List, NonNull, ObjectType, String
-from infrahub_sdk.utils import extract_fields_first_node
 from prefect.client.schemas.objects import StateType
 
+from infrahub.graphql.field_extractor import extract_graphql_fields
 from infrahub.graphql.types.task import TaskNodes, TaskState
 from infrahub.task_manager.task import PrefectTask
 from infrahub.workflows.constants import WorkflowTag
@@ -79,7 +79,7 @@ class Tasks(ObjectType):
         log_offset: int | None = None,
     ) -> dict[str, Any]:
         graphql_context: GraphqlContext = info.context
-        fields = await extract_fields_first_node(info)
+        fields = extract_graphql_fields(info=info)
 
         prefect_tasks = await PrefectTask.query(
             db=graphql_context.db,

--- a/backend/infrahub/graphql/resolvers/ipam.py
+++ b/backend/infrahub/graphql/resolvers/ipam.py
@@ -281,7 +281,7 @@ async def ipam_paginated_list_resolver(  # noqa: PLR0915
         else info.return_type.graphene_type._meta.schema
     )
 
-    fields = await extract_selection(info.field_nodes[0], schema=schema)
+    fields = await extract_selection(info=info, schema=schema)
     resolve_available = bool(kwargs.pop("include_available", False))
 
     graphql_context: GraphqlContext = info.context

--- a/backend/infrahub/graphql/resolvers/many_relationship.py
+++ b/backend/infrahub/graphql/resolvers/many_relationship.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Any
 
 from graphql import GraphQLResolveInfo
-from infrahub_sdk.utils import deep_merge_dict, extract_fields
+from infrahub_sdk.utils import deep_merge_dict
 
 from infrahub.core.branch.models import Branch
 from infrahub.core.constants import BranchSupportType, RelationshipHierarchyDirection
@@ -11,6 +11,7 @@ from infrahub.core.schema.node_schema import NodeSchema
 from infrahub.core.schema.relationship_schema import RelationshipSchema
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
+from infrahub.graphql.field_extractor import extract_graphql_fields
 
 from ..loaders.peers import PeerRelationshipsDataLoader, QueryPeerParams
 from ..types import RELATIONS_PROPERTY_MAP, RELATIONS_PROPERTY_MAP_REVERSED
@@ -81,14 +82,14 @@ class ManyRelationshipResolver:
         This resolver is used for paginated responses and as such we redefined the requested
         fields by only reusing information below the 'node' key.
         """
-        # Extract the InfraHub schema by inspecting the GQL Schema
+        # Extract the Infrahub schema by inspecting the GQL Schema
 
         node_schema: MainSchemaTypes = info.parent_type.graphene_type._meta.schema  # type: ignore[attr-defined]
 
         graphql_context: GraphqlContext = info.context
 
         # Extract the name of the fields in the GQL query
-        fields = await extract_fields(info.field_nodes[0].selection_set)
+        fields = extract_graphql_fields(info=info)
         edges = fields.get("edges", {})
         node_fields = edges.get("node", {})
         property_fields = edges.get("properties", {})

--- a/backend/infrahub/graphql/resolvers/resolver.py
+++ b/backend/infrahub/graphql/resolvers/resolver.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from graphql.type.definition import GraphQLNonNull
-from infrahub_sdk.utils import extract_fields
 from opentelemetry import trace
 
 from infrahub.core.constants import BranchSupportType, InfrahubKind, RelationshipHierarchyDirection
 from infrahub.core.manager import NodeManager
 from infrahub.exceptions import NodeNotFoundError
+from infrahub.graphql.field_extractor import extract_graphql_fields
 
 from ..models import OrderModel
 from ..parser import extract_selection
@@ -26,7 +26,7 @@ async def account_resolver(
     root: dict,  # noqa: ARG001
     info: GraphQLResolveInfo,
 ) -> dict:
-    fields = await extract_fields(info.field_nodes[0].selection_set)
+    fields = extract_graphql_fields(info=info)
     graphql_context: GraphqlContext = info.context
 
     async with graphql_context.db.start_session(read_only=True) as db:
@@ -90,7 +90,7 @@ async def default_resolver(*args: Any, **kwargs) -> dict | list[dict] | None:
     graphql_context: GraphqlContext = info.context
 
     # Extract the name of the fields in the GQL query
-    fields = await extract_fields(info.field_nodes[0].selection_set)
+    fields = extract_graphql_fields(info=info)
 
     # Extract the schema of the node on the other end of the relationship from the GQL Schema
     node_rel = node_schema.get_relationship(info.field_name)
@@ -155,7 +155,7 @@ async def default_paginated_list_resolver(
         else info.return_type.graphene_type._meta.schema
     )
 
-    fields = await extract_selection(info.field_nodes[0], schema=schema)
+    fields = await extract_selection(info=info, schema=schema)
 
     graphql_context: GraphqlContext = info.context
     async with graphql_context.db.start_session(read_only=True) as db:
@@ -277,7 +277,7 @@ async def hierarchy_resolver(
     graphql_context: GraphqlContext = info.context
 
     # Extract the name of the fields in the GQL query
-    fields = await extract_fields(info.field_nodes[0].selection_set)
+    fields = extract_graphql_fields(info=info)
     edges = fields.get("edges", {})
     node_fields = edges.get("node", {})
 

--- a/backend/infrahub/graphql/resolvers/single_relationship.py
+++ b/backend/infrahub/graphql/resolvers/single_relationship.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, Any
 
 from graphql import GraphQLResolveInfo
 from graphql.type.definition import GraphQLNonNull
-from infrahub_sdk.utils import deep_merge_dict, extract_fields
+from infrahub_sdk.utils import deep_merge_dict
 
 from infrahub.core.branch.models import Branch
 from infrahub.core.constants import BranchSupportType
@@ -10,6 +10,7 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.schema.relationship_schema import RelationshipSchema
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
+from infrahub.graphql.field_extractor import extract_graphql_fields
 
 from ..loaders.node import GetManyParams, NodeDataLoader
 from ..types import RELATIONS_PROPERTY_MAP, RELATIONS_PROPERTY_MAP_REVERSED
@@ -42,7 +43,7 @@ class SingleRelationshipResolver:
         graphql_context: GraphqlContext = info.context
 
         # Extract the name of the fields in the GQL query
-        fields = await extract_fields(info.field_nodes[0].selection_set)
+        fields = extract_graphql_fields(info=info)
         node_fields = fields.get("node", {})
         property_fields = fields.get("properties", {})
         for key, value in property_fields.items():

--- a/backend/tests/unit/graphql/test_graphql_query.py
+++ b/backend/tests/unit/graphql/test_graphql_query.py
@@ -557,6 +557,118 @@ async def test_nested_query_single_relationship(
     assert result.data["InfraDevice"]["edges"][1]["node"]["location"] == expected_location_data
 
 
+async def test_nested_generic_query_many_relationship(
+    db: InfrahubDatabase, default_branch: Branch, node_group_schema: None, data_schema: None
+) -> None:
+    """Validates that nested GraphQL fragments work for cardinality=many relationships."""
+    raw_schema = {
+        "version": "1.0",
+        "generics": [
+            {
+                "name": "Generic",
+                "namespace": "Location",
+                "hierarchical": True,
+                "attributes": [{"name": "name", "optional": False, "kind": "Text"}],
+                "relationships": [{"name": "devices", "peer": "InfraDevice", "cardinality": "many", "optional": True}],
+            }
+        ],
+        "nodes": [
+            {
+                "name": "Device",
+                "namespace": "Infra",
+                "attributes": [{"name": "name", "kind": "Text", "optional": False}],
+                "relationships": [
+                    {"name": "location", "peer": "LocationGeneric", "optional": False, "cardinality": "one"}
+                ],
+            },
+            {
+                "name": "Site",
+                "namespace": "Location",
+                "inherit_from": ["LocationGeneric"],
+                "attributes": [{"name": "description", "optional": False, "kind": "Text"}],
+            },
+        ],
+    }
+    schema = SchemaRoot(**raw_schema)
+    schema_branch = registry.schema.register_schema(schema=schema, branch=default_branch.name)
+
+    site_schema = schema_branch.get_node(name="LocationSite")
+    device_schema = schema_branch.get_node(name="InfraDevice")
+
+    site1 = await Node.init(db=db, schema=site_schema, branch=default_branch)
+    await site1.new(db=db, name="site1", description="test")
+    await site1.save(db=db)
+
+    device1 = await Node.init(db=db, schema=device_schema, branch=default_branch)
+    await device1.new(db=db, name="device1", location=site1)
+    await device1.save(db=db)
+
+    device2 = await Node.init(db=db, schema=device_schema, branch=default_branch)
+    await device2.new(db=db, name="device2", location=site1)
+    await device2.save(db=db)
+
+    query = """
+    fragment DeviceData on InfraDevice {
+        name {
+            value
+        }
+    }
+
+    fragment LocationData on LocationSite {
+        name {
+            value
+        }
+        devices {
+            edges {
+            node {
+                ...DeviceData
+            }
+            }
+        }
+    }
+
+    query {
+        LocationSite {
+            edges {
+            node {
+                ...LocationData
+            }
+            }
+        }
+    }
+    """
+    gql_params = await prepare_graphql_params(
+        db=db, include_mutation=False, include_subscription=False, branch=default_branch
+    )
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
+
+    assert result.errors is None
+
+    assert result.data == {
+        "LocationSite": {
+            "edges": [
+                {
+                    "node": {
+                        "name": {"value": "site1"},
+                        "devices": {
+                            "edges": [
+                                {"node": {"name": {"value": "device1"}}},
+                                {"node": {"name": {"value": "device2"}}},
+                            ]
+                        },
+                    }
+                }
+            ]
+        }
+    }
+
+
 async def test_query_typename(db: InfrahubDatabase, default_branch: Branch, car_person_schema: SchemaBranch):
     car = registry.schema.get(name="TestCar")
     person = registry.schema.get(name="TestPerson")

--- a/changelog/5322.added.md
+++ b/changelog/5322.added.md
@@ -1,0 +1,1 @@
+Add support for nested named GraphQL fragments for cardinality=many relationships.


### PR DESCRIPTION
Changes in this PR:

* Add / fix support for nested graphql fragments so that they also work for cardinality=many relationships
* The change involves changing the extract_fields and fields_first_node function to a class within Infrahub, the reason for this is that we need to keep track of the fragments which would have been convoluted in a recursive function.
* The _extract_fields method of the class is pretty much an exact replica of what we had before as I didn't want to touch the implementation the only new part is the `elif isinstance(node, FragmentSpreadNode):` part.
* If there is a need we might move the class back to the SDK but I'm not sure it's useful there at the moment
* As the previous `extract_fields()` returned an optional dict that lead to some typing issues which is the reason why `extract_fields_first_node()` (that only returns a dict) was introduced. The new function extract_graphql_fields always returns a dict so that should fix some other typing issues.
* I've also updated the parser for our GraphQL directive in this PR. I think we need to rewrite that feature all together later and manage the directives in the GraphQLQuery Analyzer but at least it's in place there for now.

As the extract_fields function only lived in the SDK we didn't have proper code coverage on that function, we didn't have any tests that cover the lines `elif isinstance(fields[node.name.value], dict) and isinstance(value, dict):` in the SDK and with all of the additional tests with GraphQL we run in Infrahub we don't hit those lines here either. Just looking at that code I'd be sceptical that we'd ever be able to reach that condition and I'm not sure why they might have been added in the first place but I didn't want to remove them as I wasn't 100% sure.

Fixes #5322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for nested named GraphQL fragments in queries involving relationships with cardinality "many", allowing for more flexible and powerful queries.
* **Bug Fixes**
  * Improved handling of GraphQL fragments and fragment spreads in field extraction, ensuring accurate resolution of requested fields in complex queries.
* **Tests**
  * Added a new test to validate nested fragments on many-cardinality relationships in generic schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->