### PR TITLE
fix for unlikely diff bug

### DIFF
--- a/backend/infrahub/core/query/diff.py
+++ b/backend/infrahub/core/query/diff.py
@@ -148,7 +148,14 @@ CALL (diff_path) {
         OR type(base_r_node) <> "IS_RELATED" OR type(base_r_prop) <> "IS_RELATED"
     )
     WITH latest_base_path, base_r_root, base_r_node, base_r_prop
-    ORDER BY base_r_prop.from DESC, base_r_node.from DESC, base_r_root.from DESC
+    // status="active" ordering is for tie-breaking edges added and deleted at the same time, we want the active one
+    ORDER BY
+        base_r_prop.from DESC,
+        base_r_prop.status = "active" DESC,
+        base_r_node.from DESC,
+        base_r_node.status = "active" DESC,
+        base_r_root.from DESC,
+        base_r_root.status = "active" DESC
     LIMIT 1
     RETURN latest_base_path
 }
@@ -172,8 +179,10 @@ CALL (penultimate_path) {
     AND %(id_func)s(peer_r_node) = %(id_func)s(r_node)
     AND [%(id_func)s(n), type(peer_r_node)] <> [%(id_func)s(peer), type(r_peer)]
     AND r_peer.from < $to_time
+
     // filter out paths where an earlier from time follows a later from time
-    AND peer_r_node.from <= r_peer.from
+    //AND peer_r_node.from <= r_peer.from
+
     // filter out paths where a base branch edge follows a branch edge
     AND (peer_r_node.branch = $base_branch_name OR r_peer.branch = $branch_name)
     // filter out paths where an active edge follows a deleted edge
@@ -661,8 +670,10 @@ AND ALL(
     WHERE ((r_pair[0]).branch = $base_branch_name OR (r_pair[1]).branch = $branch_name)
     // filter out paths where an active edge follows a deleted edge
     AND ((r_pair[0]).status = "active" OR (r_pair[1]).status = "deleted")
+
     // filter out paths where an earlier from time follows a later from time
-    AND (r_pair[0]).from <= (r_pair[1]).from
+    //AND (r_pair[0]).from <= (r_pair[1]).from
+
     // require adjacent edge pairs to have overlapping times, but only if on the same branch
     AND (
         (r_pair[0]).branch <> (r_pair[1]).branch

--- a/backend/infrahub/core/query/diff.py
+++ b/backend/infrahub/core/query/diff.py
@@ -179,10 +179,6 @@ CALL (penultimate_path) {
     AND %(id_func)s(peer_r_node) = %(id_func)s(r_node)
     AND [%(id_func)s(n), type(peer_r_node)] <> [%(id_func)s(peer), type(r_peer)]
     AND r_peer.from < $to_time
-
-    // filter out paths where an earlier from time follows a later from time
-    //AND peer_r_node.from <= r_peer.from
-
     // filter out paths where a base branch edge follows a branch edge
     AND (peer_r_node.branch = $base_branch_name OR r_peer.branch = $branch_name)
     // filter out paths where an active edge follows a deleted edge
@@ -670,10 +666,6 @@ AND ALL(
     WHERE ((r_pair[0]).branch = $base_branch_name OR (r_pair[1]).branch = $branch_name)
     // filter out paths where an active edge follows a deleted edge
     AND ((r_pair[0]).status = "active" OR (r_pair[1]).status = "deleted")
-
-    // filter out paths where an earlier from time follows a later from time
-    //AND (r_pair[0]).from <= (r_pair[1]).from
-
     // require adjacent edge pairs to have overlapping times, but only if on the same branch
     AND (
         (r_pair[0]).branch <> (r_pair[1]).branch

--- a/backend/tests/unit/core/diff/test_diff_calculator.py
+++ b/backend/tests/unit/core/diff/test_diff_calculator.py
@@ -4024,9 +4024,9 @@ async def test_migrated_kind_node_then_peer_delete(
     person_albert_main,
 ):
     # migrate TestPerson kind on main
-    schema = registry.schema.get_schema_branch(name=default_branch.name)
-    original_person_schema = schema.get_node(name="TestPerson")
-    person_schema = schema.get_node(name="TestPerson")
+    schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+    original_person_schema = schema_branch.get_node(name="TestPerson")
+    person_schema = schema_branch.get_node(name="TestPerson")
     person_schema.inherit_from = ["GenericThing"]
     registry.schema.set(name="TestPerson", schema=person_schema, branch=default_branch.name)
     migration = NodeKindUpdateMigration(
@@ -4039,9 +4039,10 @@ async def test_migrated_kind_node_then_peer_delete(
 
     # migrate TestPerson kind back to original on a different branch
     branch = await create_branch(db=db, branch_name="branch-undo-kind-migrate")
-    schema = registry.schema.get_schema_branch(name=default_branch.name)
-    original_person_schema = schema.get_node(name="TestPerson")
-    person_schema = schema.get_node(name="TestPerson")
+    schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+    registry.schema.set_schema_branch(name=branch.name, schema=schema_branch)
+    original_person_schema = schema_branch.get_node(name="TestPerson")
+    person_schema = schema_branch.get_node(name="TestPerson")
     person_schema.inherit_from = []
     registry.schema.set(name="TestPerson", schema=person_schema, branch=branch.name)
     migration = NodeKindUpdateMigration(
@@ -4054,12 +4055,14 @@ async def test_migrated_kind_node_then_peer_delete(
 
     # create a branch and delete a car on the branch
     branch = await create_branch(db=db, branch_name="branch-delete-car")
+    schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+    registry.schema.set_schema_branch(name=branch.name, schema=schema_branch)
     branch_accord = await NodeManager.get_one(db=db, branch=branch, id=car_accord_main.id)
     await branch_accord.delete(db=db)
 
     diff_calculator = DiffCalculator(db=db)
 
-    _ = await diff_calculator.calculate_diff(
+    calculated_diffs = await diff_calculator.calculate_diff(
         base_branch=default_branch,
         diff_branch=branch,
         from_time=Timestamp(branch.get_branched_from()),
@@ -4067,3 +4070,28 @@ async def test_migrated_kind_node_then_peer_delete(
         previous_node_specifiers=None,
         include_unchanged=True,
     )
+
+    base_diff = calculated_diffs.base_branch_diff
+    assert base_diff.nodes == []
+
+    branch_diff = calculated_diffs.diff_branch_diff
+    nodes_by_id = {n.uuid: n for n in branch_diff.nodes}
+    assert set(nodes_by_id.keys()) == {person_john_main.id, car_accord_main.id}
+
+    person_node = nodes_by_id[person_john_main.id]
+    assert person_node.action is DiffAction.UPDATED
+    assert person_node.is_node_kind_migration is False
+    assert len(person_node.attributes) == 0
+    rels_by_identifier = {r.identifier: r for r in person_node.relationships}
+    cars_identifier = person_schema.get_relationship(name="cars").get_identifier()
+    assert set(rels_by_identifier.keys()) == {cars_identifier}
+    cars_rel = rels_by_identifier[cars_identifier]
+    assert cars_rel.action is DiffAction.UPDATED
+    elements_by_id = {r.peer_id: r for r in cars_rel.relationships}
+    assert set(elements_by_id.keys()) == {car_accord_main.id}
+    element_diff = elements_by_id[car_accord_main.id]
+    assert element_diff.action is DiffAction.REMOVED
+
+    car_node = nodes_by_id[car_accord_main.id]
+    assert car_node.action is DiffAction.REMOVED
+    assert car_node.is_node_kind_migration is False

--- a/backend/tests/unit/core/diff/test_diff_calculator.py
+++ b/backend/tests/unit/core/diff/test_diff_calculator.py
@@ -4011,3 +4011,58 @@ async def test_calculate_with_renamed_relationships(
 
     base_diff = calculated_diffs.base_branch_diff
     assert len(base_diff.nodes) == 0
+
+async def test_migrated_kind_node_then_peer_delete(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_accord_main,
+    car_camry_main,
+    person_john_main,
+    person_jane_main,
+    person_alfred_main,
+    person_albert_main,
+):
+    # migrate TestPerson kind on main
+    schema = registry.schema.get_schema_branch(name=default_branch.name)
+    original_person_schema = schema.get_node(name="TestPerson")
+    person_schema = schema.get_node(name="TestPerson")
+    person_schema.inherit_from = ["GenericThing"]
+    registry.schema.set(name="TestPerson", schema=person_schema, branch=default_branch.name)
+    migration = NodeKindUpdateMigration(
+        previous_node_schema=original_person_schema,
+        new_node_schema=person_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="inherit_from"),
+    )
+    execution_result = await migration.execute(db=db, branch=default_branch)
+    assert not execution_result.errors
+  
+    # migrate TestPerson kind back to original on a different branch
+    branch = await create_branch(db=db, branch_name="branch-undo-kind-migrate")
+    schema = registry.schema.get_schema_branch(name=default_branch.name)
+    original_person_schema = schema.get_node(name="TestPerson")
+    person_schema = schema.get_node(name="TestPerson")
+    person_schema.inherit_from = []
+    registry.schema.set(name="TestPerson", schema=person_schema, branch=branch.name)
+    migration = NodeKindUpdateMigration(
+        previous_node_schema=original_person_schema,
+        new_node_schema=person_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="inherit_from"),
+    )
+    execution_result = await migration.execute(db=db, branch=branch)
+    assert not execution_result.errors
+
+    # create a branch and delete a car on the branch
+    branch = await create_branch(db=db, branch_name="branch-delete-car")
+    branch_accord = await NodeManager.get_one(db=db, branch=branch, id=car_accord_main.id)
+    await branch_accord.delete(db=db)
+
+    diff_calculator = DiffCalculator(db=db)
+
+    calculated_diffs = await diff_calculator.calculate_diff(
+        base_branch=default_branch,
+        diff_branch=branch,
+        from_time=Timestamp(branch.get_branched_from()),
+        to_time=Timestamp(),
+        previous_node_specifiers=None,
+        include_unchanged=True,
+    )

--- a/backend/tests/unit/core/diff/test_diff_calculator.py
+++ b/backend/tests/unit/core/diff/test_diff_calculator.py
@@ -4012,6 +4012,7 @@ async def test_calculate_with_renamed_relationships(
     base_diff = calculated_diffs.base_branch_diff
     assert len(base_diff.nodes) == 0
 
+
 async def test_migrated_kind_node_then_peer_delete(
     db: InfrahubDatabase,
     default_branch: Branch,
@@ -4035,7 +4036,7 @@ async def test_migrated_kind_node_then_peer_delete(
     )
     execution_result = await migration.execute(db=db, branch=default_branch)
     assert not execution_result.errors
-  
+
     # migrate TestPerson kind back to original on a different branch
     branch = await create_branch(db=db, branch_name="branch-undo-kind-migrate")
     schema = registry.schema.get_schema_branch(name=default_branch.name)
@@ -4058,7 +4059,7 @@ async def test_migrated_kind_node_then_peer_delete(
 
     diff_calculator = DiffCalculator(db=db)
 
-    calculated_diffs = await diff_calculator.calculate_diff(
+    _ = await diff_calculator.calculate_diff(
         base_branch=default_branch,
         diff_branch=branch,
         from_time=Timestamp(branch.get_branched_from()),

--- a/changelog/6928.fixed.md
+++ b/changelog/6928.fixed.md
@@ -1,0 +1,1 @@
+Fix bug in diff calculation logic that could prevent the diff from generating if the peer of a deleted node had its kind or inheritance changed on multiple branches


### PR DESCRIPTION
fixes #6928 

if a deleted node included in the diff for a given branch had a peer on one of its relationships that had gone through the NodeKindUpdate migration (changing its kind or inheritance) multiple times on different branches then the diff _could_ fail to generate depending on how results were ordered

the fix is
- to be more deterministic when ordering the results of certain queries to ensure that active edges are preferred over deleted edges with the same from time
- to allow deeper edges in a path to have an earlier from time than shallower edges, which can happen if the peer of a relationship had its kind/inheritance updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where diffs could not be generated if a peer of a deleted node had changes in its kind or inheritance across branches. Diffs now correctly reflect these changes.
* **Tests**
  * Added a new test to validate diff calculation when a node kind migration is reverted on a branch and a related node is deleted on a further branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->