### PR TITLE
IP Prefix details page now show the list of members first instead of full details

### DIFF
--- a/changelog/+ifc1586.added.md
+++ b/changelog/+ifc1586.added.md
@@ -1,3 +1,4 @@
 New on IPAM:
 
+- IP Prefix details page now show the list of members first instead of full details.
 - When viewing a prefix's children list, you can now see the available sub-prefixes.

--- a/changelog/+ifc1586.added.md
+++ b/changelog/+ifc1586.added.md
@@ -1,4 +1,4 @@
 New on IPAM:
 
-- IP Prefix details page now show the list of members first instead of full details.
+- IP Prefix details page now shows the list of members first instead of full details.
 - When viewing a prefix's children list, you can now see the available sub-prefixes.

--- a/frontend/app/src/app/router.tsx
+++ b/frontend/app/src/app/router.tsx
@@ -459,11 +459,15 @@ export const router = createBrowserRouter([
                     children: [
                       {
                         index: true,
-                        lazy: () => import("@/pages/ipam/ipam-details-page"),
+                        lazy: () => import("@/pages/ipam/ipam-details-index-page"),
                       },
                       {
                         path: ":relationshipName",
                         lazy: () => import("@/pages/ipam/ipam-details-relationship-page"),
+                      },
+                      {
+                        path: "details",
+                        lazy: () => import("@/pages/ipam/ipam-details-page"),
                       },
                     ],
                   },

--- a/frontend/app/src/entities/ipam/ip-addresses/ui/ip-address-table.tsx
+++ b/frontend/app/src/entities/ipam/ip-addresses/ui/ip-address-table.tsx
@@ -34,6 +34,7 @@ export function IpAddressTable({ baseFilters = [] }: IpAddressTableProps) {
         data={flatData}
         isLoading={isPending || isFetchingNextPage}
         renderEmpty={() => <ObjectTableEmpty schema={selectedSchema} />}
+        data-testid="ip-address-table"
       />
     </InfiniteScroll>
   );

--- a/frontend/app/src/entities/ipam/ip-namespaces/ui/ip-namespace-tabs.tsx
+++ b/frontend/app/src/entities/ipam/ip-namespaces/ui/ip-namespace-tabs.tsx
@@ -30,6 +30,7 @@ export function IpNamespaceTabs({ objectId, schema }: IpNamespaceTabsProps) {
           parentKind={schema.kind!}
           parentId={objectId}
           relationship={relationshipSchemaWithIpAddress}
+          href="/ipam/ip_addresses"
         />
       )}
     </div>

--- a/frontend/app/src/entities/ipam/ipam-details-tabs.tsx
+++ b/frontend/app/src/entities/ipam/ipam-details-tabs.tsx
@@ -1,0 +1,37 @@
+import { constructPathForIpam } from "@/entities/ipam/utils";
+import { ObjectDetailsTab } from "@/entities/nodes/object/ui/object-details/object-details-tab";
+import { getRelationshipsVisibleInTab } from "@/entities/nodes/object/utils/get-relationships-visible-in-tab";
+import { NodeObject } from "@/entities/nodes/types";
+import { ModelSchema } from "@/entities/schema/types";
+import { Row } from "@/shared/components/container";
+import { LinkTab } from "@/shared/components/ui/link";
+import { IdCardIcon } from "lucide-react";
+
+export interface IpamDetailsTabsProps {
+  objectSchema: ModelSchema;
+  objectData: NodeObject;
+}
+
+export function IpamDetailsTabs({ objectSchema, objectData }: IpamDetailsTabsProps) {
+  const relationshipVisible = getRelationshipsVisibleInTab(objectSchema.relationships ?? []);
+
+  return (
+    <Row className="border-b border-gray-200">
+      <LinkTab href={constructPathForIpam("details")}>
+        <IdCardIcon className="size-4" />
+        Details
+      </LinkTab>
+
+      {relationshipVisible.map((relationship) => {
+        return (
+          <ObjectDetailsTab
+            key={relationship.name}
+            parentKind={objectSchema.kind as string}
+            parentId={objectData.id}
+            relationship={relationship}
+          />
+        );
+      })}
+    </Row>
+  );
+}

--- a/frontend/app/src/pages/ipam/ipam-details-index-page.tsx
+++ b/frontend/app/src/pages/ipam/ipam-details-index-page.tsx
@@ -1,0 +1,36 @@
+import { IP_PREFIX_GENERIC } from "@/entities/ipam/constants";
+import { constructPathForIpam } from "@/entities/ipam/utils";
+import { NodeAttribute } from "@/entities/nodes/types";
+import { isOfKind } from "@/entities/schema/utils/is-of-kind";
+import ErrorScreen from "@/shared/components/errors/error-screen";
+import { useCurrentFormContext } from "@/shared/components/form/utils/form-context";
+import { Navigate, useParams } from "react-router";
+
+export const IpamDetailsIndexPage = () => {
+  const { objectKind, objectId } = useParams();
+  const { parentSchema, parentData } = useCurrentFormContext();
+
+  if (!parentSchema) {
+    return <ErrorScreen message={`Schema ${objectKind} not found`} />;
+  }
+
+  if (!parentData) {
+    return <ErrorScreen message={`${parentSchema.label} with id ${objectId} not found`} />;
+  }
+
+  if (isOfKind(IP_PREFIX_GENERIC, parentSchema)) {
+    const memberType = (parentData.member_type as NodeAttribute)?.value;
+
+    if (memberType === "prefix") {
+      return <Navigate to={constructPathForIpam("children")} replace />;
+    }
+
+    if (memberType === "address") {
+      return <Navigate to={constructPathForIpam("ip_addresses")} replace />;
+    }
+  }
+
+  return <Navigate to={constructPathForIpam("details")} replace />;
+};
+
+export const Component = IpamDetailsIndexPage;

--- a/frontend/app/src/pages/ipam/ipam-details-layout.tsx
+++ b/frontend/app/src/pages/ipam/ipam-details-layout.tsx
@@ -1,9 +1,7 @@
+import { IpamDetailsTabs } from "@/entities/ipam/ipam-details-tabs";
 import { useGetObject } from "@/entities/nodes/object/domain/get-object.query";
 import { ObjectDetailsMenu } from "@/entities/nodes/object/ui/object-details/object-details-menu";
-import { ObjectDetailsTab } from "@/entities/nodes/object/ui/object-details/object-details-tab";
 import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
-import { getRelationshipsVisibleInTab } from "@/entities/nodes/object/utils/get-relationships-visible-in-tab";
-import { getObjectDetailsUrl } from "@/entities/nodes/utils";
 import { Permission } from "@/entities/permission/types";
 import { RequireObjectPermissions } from "@/entities/permission/ui/require-object-permissions";
 import { ModelSchema } from "@/entities/schema/types";
@@ -11,10 +9,9 @@ import { useSchema } from "@/entities/schema/ui/hooks/useSchema";
 import { getSchemaIcon } from "@/entities/schema/utils/get-schema-icon";
 import { Col, Row } from "@/shared/components/container";
 import ErrorScreen from "@/shared/components/errors/error-screen";
+import { FormContext } from "@/shared/components/form/utils/form-context";
 import { LoadingIndicator } from "@/shared/components/loading/loading-indicator";
-import { LinkTab } from "@/shared/components/ui/link";
 import { Icon } from "@iconify-icon/react";
-import { IdCardIcon } from "lucide-react";
 import { Outlet, useParams } from "react-router";
 
 interface IpamDetailsPageProps {
@@ -35,37 +32,28 @@ function IpamDetailsLayout({ objectSchema, objectId, permission }: IpamDetailsPa
   }
 
   return (
-    <Col className="gap-0 overflow-hidden">
-      <Row className="text-xs py-2 px-2.5 gap-1.5 text-custom-blue-800">
-        <Icon icon={getSchemaIcon(objectSchema)} />
-        {objectSchema.label}
-      </Row>
+    <FormContext value={{ parentSchema: objectSchema, parentData: data }}>
+      <Col className="gap-0 overflow-hidden">
+        <Row className="text-xs py-2 px-2.5 gap-1.5 text-custom-blue-800">
+          <Icon icon={getSchemaIcon(objectSchema)} />
+          {objectSchema.label}
+        </Row>
 
-      <Row className="px-2">
-        <h2 className="font-semibold text-lg justify-between">{getNodeLabel(data)}</h2>
+        <Row className="px-2">
+          <h2 className="font-semibold text-lg justify-between">{getNodeLabel(data)}</h2>
 
-        <ObjectDetailsMenu objectSchema={objectSchema} objectData={data} permission={permission} />
-      </Row>
-      <Row className="border-b border-gray-200">
-        <LinkTab href={getObjectDetailsUrl(objectSchema.kind as string, objectId)}>
-          <IdCardIcon className="size-4" />
-          Details
-        </LinkTab>
+          <ObjectDetailsMenu
+            objectSchema={objectSchema}
+            objectData={data}
+            permission={permission}
+          />
+        </Row>
 
-        {getRelationshipsVisibleInTab(objectSchema.relationships ?? []).map((relationship) => {
-          return (
-            <ObjectDetailsTab
-              key={relationship.name}
-              parentKind={objectSchema.kind as string}
-              parentId={objectId}
-              relationship={relationship}
-            />
-          );
-        })}
-      </Row>
+        <IpamDetailsTabs objectSchema={objectSchema} objectData={data} />
 
-      <Outlet />
-    </Col>
+        <Outlet />
+      </Col>
+    </FormContext>
   );
 }
 

--- a/frontend/app/src/shared/components/ui/link.tsx
+++ b/frontend/app/src/shared/components/ui/link.tsx
@@ -1,5 +1,5 @@
 import { classNames } from "@/shared/utils/common";
-import { LinkProps, Link as RouterLink } from "react-router";
+import { LinkProps, NavLink, NavLinkProps, Link as RouterLink } from "react-router";
 
 export const Link = (props: LinkProps) => {
   const { children, className, ...propsToPass } = props;
@@ -14,21 +14,21 @@ export const Link = (props: LinkProps) => {
   );
 };
 
-interface LinkTabProps extends Omit<LinkProps, "to"> {
+interface LinkTabProps extends Omit<NavLinkProps, "to"> {
   href: string;
 }
 
 export function LinkTab({ href, className, ...props }: LinkTabProps) {
-  const isTabActive = location.pathname.endsWith(href.split("?")?.[0] as string);
-
   return (
-    <RouterLink
+    <NavLink
       to={href}
-      className={classNames(
-        "transition-all focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-custom-blue-600/25",
-        "px-3 py-2 border-b-2 border-transparent inline-flex items-center gap-2 text-sm truncate h-11",
-        isTabActive && "border-custom-blue-600"
-      )}
+      className={({ isActive }) =>
+        classNames(
+          "transition-all focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-custom-blue-600/25",
+          "px-3 py-2 border-b-2 border-transparent inline-flex items-center gap-2 text-sm truncate h-11",
+          isActive && "border-custom-blue-600"
+        )
+      }
       {...props}
     />
   );

--- a/frontend/app/src/shared/components/ui/link.tsx
+++ b/frontend/app/src/shared/components/ui/link.tsx
@@ -22,6 +22,7 @@ export function LinkTab({ href, className, ...props }: LinkTabProps) {
   return (
     <NavLink
       to={href}
+      end
       className={({ isActive }) =>
         classNames(
           "transition-all focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-custom-blue-600/25",

--- a/frontend/app/tests/e2e/ipam/ip-prefix-list.spec.ts
+++ b/frontend/app/tests/e2e/ipam/ip-prefix-list.spec.ts
@@ -8,6 +8,7 @@ test.describe("/ipam/ip_prefixes - Ip Prefix list", () => {
       .getByTestId("identifier-cell")
       .getByRole("link", { name: "203.111.0.0/16" })
       .click();
+    await page.getByRole("link", { name: "Details" }).click();
     await expect(page.getByRole("heading", { name: "Details" })).toBeVisible();
     await expect(page.getByRole("heading", { name: "Activities" })).toBeVisible();
     await expect(page.getByText("Prefix203.111.0.0/16")).toBeVisible();
@@ -21,13 +22,14 @@ test.describe("/ipam/ip_prefixes - Ip Prefix list", () => {
 
     await test.step("select a prefix to view all sub prefixes", async () => {
       await page.getByRole("treeitem", { name: "2001:db8::/100" }).click();
-      await expect(page.getByText("Prefix2001:db8::/100")).toBeVisible();
+      await expect(page.getByRole("heading", { name: "2001:db8::/100" })).toBeVisible();
+      await expect(page.getByTestId("ip-prefix-table")).toBeVisible();
     });
 
     await test.step("go to any sub prefix list of any children prefix", async () => {
-      await page.getByRole("link", { name: "Children" }).click();
       await page.getByRole("link", { name: "2001:db8::/110" }).click();
-      await expect(page.getByText("Prefix2001:db8::/110")).toBeVisible();
+      await expect(page.getByRole("heading", { name: "2001:db8::/110" })).toBeVisible();
+      await expect(page.getByTestId("ip-address-table")).toBeVisible();
     });
 
     await test.step("use breadcrumb to go back to parent prefix", async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a tabbed navigation interface on the IP Prefix details page, allowing users to easily switch between details and related information.
  * The IP Prefix details page now displays the list of members as the initial view.

* **Improvements**
  * Enhanced navigation logic to automatically redirect users to the most relevant tab based on the type of IPAM object.
  * Updated tab styling to better indicate the active section.
  * Improved routing configuration for smoother navigation within IPAM details.
  * Refined tab links for IP addresses and prefixes for clearer user paths.

* **Documentation**
  * Updated changelog to reflect the new tabbed interface and default view changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->