### PR TITLE
Disallow creating a PC in any state other than "open"

### DIFF
--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -77,6 +77,9 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
         graphql_context: GraphqlContext = info.context
 
         override_data = {"created_by": {"id": graphql_context.active_account_session.account_id}}
+        state = data.get("state", {}).get("value")
+        if state and state != ProposedChangeState.OPEN.value:
+            raise ValidationError(input_value="A proposed change has to be in the open state during creation")
 
         async with graphql_context.db.start_transaction() as dbt:
             proposed_change, result = await super().mutate_create(

--- a/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
+++ b/backend/tests/integration/proposed_change/test_proposed_change_conflict.py
@@ -203,9 +203,16 @@ class TestProposedChangePipelineConflict(TestInfrahubApp):
 
     async def test_happy_pipeline(self, db: InfrahubDatabase, happy_data_branch: str, client: InfrahubClient) -> None:
         proposed_change_user = await create_account(db=db, name="jimmy-change-user", password="Password123")
+        # The state=open part here is to validate that the state check during creation of a
+        # proposed change still works if the default "open" state is manually specified
         proposed_change_create = await client.create(
             kind=CoreProposedChange,
-            data={"source_branch": happy_data_branch, "destination_branch": "main", "name": "happy-test"},
+            data={
+                "source_branch": happy_data_branch,
+                "destination_branch": "main",
+                "name": "happy-test",
+                "state": "open",
+            },
         )
         await proposed_change_create.save(
             request_context=RequestContext(account=ContextAccount(id=proposed_change_user.id))

--- a/backend/tests/unit/graphql/mutations/test_proposed_change.py
+++ b/backend/tests/unit/graphql/mutations/test_proposed_change.py
@@ -34,12 +34,14 @@ mutation ProposedChange(
   $destination: String!,
   $name: String!,
   $source: String!
+  $state: String
   ) {
   CoreProposedChangeCreate(
     data: {
       name: {value: $name},
       source_branch: {value: $source},
       destination_branch: {value: $destination}
+      state: {value: $state}
     }
   ) {
     ok
@@ -141,6 +143,62 @@ async def test_create_invalid_branch_combinations(db: InfrahubDatabase, default_
     assert "Currently only the 'main' branch is supported as a destination for a proposed change" in str(
         invalid_destination.errors
     )
+
+
+async def test_create_invalid_state_combinations(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None
+) -> None:
+    """Validate that we can't create a PC in an invalid state.
+
+    While this wouldn't actually do anything it looks weird from an auditing point of view to have a
+    proposed change that looks like it has been merged even though it never was.
+    """
+    branch_name = str(uuid4().hex)
+    source_branch = Branch(name=branch_name)
+    await source_branch.save(db=db)
+
+    account = await Node.init(db=db, schema=InfrahubKind.ACCOUNT)
+    await account.new(db=db, name="user", password="password")
+    await account.save(db=db)
+
+    gql_params = await prepare_graphql_params(
+        db=db,
+        include_subscription=False,
+        branch=default_branch,
+        account_session=AccountSession(authenticated=False, account_id=account.get_id(), auth_type=AuthType.NONE),
+    )
+    closed = await graphql(
+        schema=gql_params.schema,
+        source=CREATE_PROPOSED_CHANGE,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={
+            "source": source_branch.name,
+            "destination": "main",
+            "name": "invalid-state",
+            "state": "closed",
+        },
+    )
+    assert closed.errors
+    assert "A proposed change has to be in the open state during creation" in str(closed.errors)
+
+    merged = await graphql(
+        schema=gql_params.schema,
+        source=CREATE_PROPOSED_CHANGE,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={
+            "source": source_branch.name,
+            "destination": "main",
+            "name": "invalid-state",
+            "state": "merged",
+        },
+    )
+
+    assert closed.errors
+    assert "A proposed change has to be in the open state during creation" in str(closed.errors)
+    assert merged.errors
+    assert "A proposed change has to be in the open state during creation" in str(merged.errors)
 
 
 class TestTriggerProposedChange(TestInfrahubApp):


### PR DESCRIPTION
The purpose of this is to create weird audit issues later as the only valid way to create a PC should be in the "open" state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure proposed changes are created only in the "open" state.

* **Tests**
  * Added tests confirming that proposed changes cannot be created with invalid initial states such as "closed" or "merged".
  * Updated existing tests to explicitly specify the "open" state during proposed change creation for validation purposes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->