### PR TITLE
Auto-suggest Ip address/prefix when opening a children creation form

### DIFF
--- a/frontend/app/src/entities/ipam/ip-addresses/api/get-next-ip-address-available-from-api.ts
+++ b/frontend/app/src/entities/ipam/ip-addresses/api/get-next-ip-address-available-from-api.ts
@@ -1,0 +1,40 @@
+import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
+import { ContextParams } from "@/shared/api/types";
+import { gql } from "@apollo/client";
+
+export const NEXT_IP_ADDRESS_QUERY = gql`
+  query getNextIPAddressAvailable($parentPrefixId: String!) {
+    InfrahubIPAddressGetNextAvailable(prefix_id: $parentPrefixId) {
+      address
+    }
+  }
+`;
+
+export interface NextIPAddressAvailableData {
+  InfrahubIPAddressGetNextAvailable: {
+    address: string;
+  };
+}
+
+export interface NextIPAddressAvailableVars {
+  parentPrefixId: string;
+}
+
+export interface GetNextIPAddressAvailableFromApiParams
+  extends NextIPAddressAvailableVars,
+    ContextParams {}
+
+export const getNextIpAddressAvailableFromApi = ({
+  branchName,
+  atDate,
+  ...variables
+}: GetNextIPAddressAvailableFromApiParams) => {
+  return graphqlClient.query<NextIPAddressAvailableData, NextIPAddressAvailableVars>({
+    query: NEXT_IP_ADDRESS_QUERY,
+    variables,
+    context: {
+      branch: branchName,
+      date: atDate,
+    },
+  });
+};

--- a/frontend/app/src/entities/ipam/ip-addresses/domain/get-next-ip-address-available.query.ts
+++ b/frontend/app/src/entities/ipam/ip-addresses/domain/get-next-ip-address-available.query.ts
@@ -1,0 +1,44 @@
+import { useCurrentBranch } from "@/entities/branches/ui/branches-provider";
+import { ContextParams, QueryConfig } from "@/shared/api/types";
+import { datetimeAtom } from "@/shared/stores/time.atom";
+import { queryOptions, skipToken, useQuery } from "@tanstack/react-query";
+import { useAtomValue } from "jotai/index";
+import { getNextIpAddressAvailable } from "./get-next-ip-address-available";
+
+export interface GetNextIpAddressAvailableQueryOptionsParams extends ContextParams {
+  parentPrefixId?: string;
+}
+
+export function getNextIpAddressAvailableQueryOptions({
+  branchName,
+  atDate,
+  parentPrefixId,
+}: GetNextIpAddressAvailableQueryOptionsParams) {
+  return queryOptions({
+    queryKey: [branchName, atDate, "nextIpAddressAvailable", parentPrefixId],
+    queryFn: parentPrefixId
+      ? () => getNextIpAddressAvailable({ branchName, atDate, parentPrefixId })
+      : skipToken,
+  });
+}
+
+export type UseGetNextIpAddressAvailableOptions = QueryConfig<
+  typeof getNextIpAddressAvailableQueryOptions
+>;
+
+export function useGetNextIpAddressAvailable(
+  params: Omit<GetNextIpAddressAvailableQueryOptionsParams, keyof ContextParams>,
+  config?: UseGetNextIpAddressAvailableOptions
+) {
+  const { currentBranch } = useCurrentBranch();
+  const atDate = useAtomValue(datetimeAtom);
+
+  return useQuery({
+    ...getNextIpAddressAvailableQueryOptions({
+      branchName: currentBranch.name,
+      atDate,
+      ...params,
+    }),
+    ...config,
+  });
+}

--- a/frontend/app/src/entities/ipam/ip-addresses/domain/get-next-ip-address-available.ts
+++ b/frontend/app/src/entities/ipam/ip-addresses/domain/get-next-ip-address-available.ts
@@ -1,0 +1,20 @@
+import {
+  GetNextIPAddressAvailableFromApiParams,
+  getNextIpAddressAvailableFromApi,
+} from "@/entities/ipam/ip-addresses/api/get-next-ip-address-available-from-api";
+
+export type GetNextIpAddressAvailableParams = GetNextIPAddressAvailableFromApiParams;
+
+export type GetNextIpAddressAvailable = (
+  params: GetNextIpAddressAvailableParams
+) => Promise<string>;
+
+export const getNextIpAddressAvailable: GetNextIpAddressAvailable = async (params) => {
+  const { data, errors } = await getNextIpAddressAvailableFromApi(params);
+
+  if (errors) {
+    throw new Error(errors.map((e) => e.message).join("; "));
+  }
+
+  return data.InfrahubIPAddressGetNextAvailable.address;
+};

--- a/frontend/app/src/entities/ipam/ip-addresses/utils/get-ip-address-table-columns.tsx
+++ b/frontend/app/src/entities/ipam/ip-addresses/utils/get-ip-address-table-columns.tsx
@@ -46,7 +46,7 @@ export const getIpAddressTableColumns = (
 
           return (
             <>
-              <StickyLeftCell isMuted className="p-0.5">
+              <StickyLeftCell isMuted className="p-0.5" data-testid="ip-address-available">
                 <IpAddressAvailableCreateFormTrigger
                   ipAddressAvailableNode={ipAddressAvailableNode}
                 />

--- a/frontend/app/src/entities/ipam/ip-prefixes/api/get-next-ip-prefix-available-from-api.ts
+++ b/frontend/app/src/entities/ipam/ip-prefixes/api/get-next-ip-prefix-available-from-api.ts
@@ -1,0 +1,42 @@
+import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
+import { ContextParams } from "@/shared/api/types";
+import { gql } from "@apollo/client";
+
+export const NEXT_IP_PREFIX_QUERY = gql`
+  query getNextIPPrefixAvailable($parentPrefixId: String!) {
+    InfrahubIPPrefixGetNextAvailable(prefix_id: $parentPrefixId) {
+      prefix
+    }
+  }
+`;
+
+export interface NextIPPrefixAvailableData {
+  InfrahubIPPrefixGetNextAvailable: {
+    prefix: string;
+  };
+}
+
+export interface NextIPPrefixAvailableQueryVars {
+  parentPrefixId: string;
+}
+
+export interface GetNextIPPrefixGetNextAvailableFromApiParams
+  extends NextIPPrefixAvailableQueryVars,
+    ContextParams {}
+
+export const getNextIpPrefixAvailableFromApi = ({
+  parentPrefixId,
+  branchName,
+  atDate,
+}: GetNextIPPrefixGetNextAvailableFromApiParams) => {
+  return graphqlClient.query<NextIPPrefixAvailableData, NextIPPrefixAvailableQueryVars>({
+    query: NEXT_IP_PREFIX_QUERY,
+    variables: {
+      parentPrefixId,
+    },
+    context: {
+      branch: branchName,
+      date: atDate,
+    },
+  });
+};

--- a/frontend/app/src/entities/ipam/ip-prefixes/domain/get-next-ip-prefix-available.query.ts
+++ b/frontend/app/src/entities/ipam/ip-prefixes/domain/get-next-ip-prefix-available.query.ts
@@ -1,0 +1,44 @@
+import { useCurrentBranch } from "@/entities/branches/ui/branches-provider";
+import { getNextIpPrefixAvailable } from "@/entities/ipam/ip-prefixes/domain/get-next-ip-prefix-available";
+import { ContextParams, QueryConfig } from "@/shared/api/types";
+import { datetimeAtom } from "@/shared/stores/time.atom";
+import { queryOptions, skipToken, useQuery } from "@tanstack/react-query";
+import { useAtomValue } from "jotai/index";
+
+export interface GetNextIpPrefixAvailableQueryOptionsParams extends ContextParams {
+  parentPrefixId?: string;
+}
+
+export function getNextIpPrefixAvailableQueryOptions({
+  branchName,
+  atDate,
+  parentPrefixId,
+}: GetNextIpPrefixAvailableQueryOptionsParams) {
+  return queryOptions({
+    queryKey: [branchName, atDate, "nextIpPrefixAvailable", parentPrefixId],
+    queryFn: parentPrefixId
+      ? () => getNextIpPrefixAvailable({ branchName, atDate, parentPrefixId })
+      : skipToken,
+  });
+}
+
+export type UseGetNextIpPrefixAvailableOptions = QueryConfig<
+  typeof getNextIpPrefixAvailableQueryOptions
+>;
+
+export function useGetNextIpPrefixAvailable(
+  params: Omit<GetNextIpPrefixAvailableQueryOptionsParams, keyof ContextParams>,
+  config?: UseGetNextIpPrefixAvailableOptions
+) {
+  const { currentBranch } = useCurrentBranch();
+  const atDate = useAtomValue(datetimeAtom);
+
+  return useQuery({
+    ...getNextIpPrefixAvailableQueryOptions({
+      branchName: currentBranch.name,
+      atDate,
+      ...params,
+    }),
+    ...config,
+  });
+}

--- a/frontend/app/src/entities/ipam/ip-prefixes/domain/get-next-ip-prefix-available.ts
+++ b/frontend/app/src/entities/ipam/ip-prefixes/domain/get-next-ip-prefix-available.ts
@@ -1,0 +1,18 @@
+import {
+  GetNextIPPrefixGetNextAvailableFromApiParams,
+  getNextIpPrefixAvailableFromApi,
+} from "@/entities/ipam/ip-prefixes/api/get-next-ip-prefix-available-from-api";
+
+export type GetNextIpPrefixAvailableParams = GetNextIPPrefixGetNextAvailableFromApiParams;
+
+export type GetNextIpPrefixAvailable = (params: GetNextIpPrefixAvailableParams) => Promise<string>;
+
+export const getNextIpPrefixAvailable: GetNextIpPrefixAvailable = async (params) => {
+  const { data, errors } = await getNextIpPrefixAvailableFromApi(params);
+
+  if (errors) {
+    throw new Error(errors.map((e) => e.message).join("; "));
+  }
+
+  return data.InfrahubIPPrefixGetNextAvailable.prefix;
+};

--- a/frontend/app/src/entities/ipam/ip-prefixes/ui/ipam-creation-form.tsx
+++ b/frontend/app/src/entities/ipam/ip-prefixes/ui/ipam-creation-form.tsx
@@ -1,8 +1,14 @@
+import { IP_ADDRESS_GENERIC, IP_PREFIX_GENERIC } from "@/entities/ipam/constants";
+import { useGetNextIpAddressAvailable } from "@/entities/ipam/ip-addresses/domain/get-next-ip-address-available.query";
+import { useGetNextIpPrefixAvailable } from "@/entities/ipam/ip-prefixes/domain/get-next-ip-prefix-available.query";
 import { useCreateObjectMutation } from "@/entities/nodes/object/domain/create-object.mutation";
 import { useAllocateResourceMutation } from "@/entities/resource-manager/domain/allocate-resource.mutation";
 import { getAllocateMutationNameFromSchema } from "@/entities/resource-manager/utils/get-allocate-mutation-name-from-schema";
+import { isOfKind } from "@/entities/schema/utils/is-of-kind";
 import { NodeForm, NodeFormProps } from "@/shared/components/form/node-form";
+import { useCurrentFormContext } from "@/shared/components/form/utils/form-context";
 import { getCreateMutationFromFormData } from "@/shared/components/form/utils/mutations/getCreateMutationFromFormData";
+import { LoadingIndicator } from "@/shared/components/loading/loading-indicator";
 import { ALERT_TYPES, Alert } from "@/shared/components/ui/alert";
 import { toast } from "react-toastify";
 
@@ -11,6 +17,35 @@ export interface IpamCreationFormProps extends NodeFormProps {}
 function IpamCreationForm(props: IpamCreationFormProps) {
   const allocateResource = useAllocateResourceMutation();
   const createObject = useCreateObjectMutation();
+  const { parentData } = useCurrentFormContext();
+
+  const isIpPrefixSchema = isOfKind(IP_PREFIX_GENERIC, props.schema);
+  const isIpAddressSchema = isOfKind(IP_ADDRESS_GENERIC, props.schema);
+
+  const ipFieldName = isIpPrefixSchema ? "prefix" : "address";
+
+  const { data: nextIpAddress, isLoading: isIpAddressLoading } = useGetNextIpAddressAvailable(
+    { parentPrefixId: parentData?.id },
+    // Enable fetching the next available IP address only if:
+    // - The current schema is for an IP address
+    // - The current object does NOT already have an address set
+    { enabled: isIpAddressSchema && !props.currentObject?.address }
+  );
+  const { data: nextIpPrefix, isLoading: isIpPrefixLoading } = useGetNextIpPrefixAvailable(
+    { parentPrefixId: parentData?.id },
+    {
+      // Enable fetching the next available IP prefix only if:
+      // - The current schema is for an IP prefix
+      // - The current object does NOT already have a prefix set
+      enabled: isIpPrefixSchema && !props.currentObject?.prefix,
+    }
+  );
+
+  if (parentData && (isIpAddressLoading || isIpPrefixLoading)) {
+    return <LoadingIndicator className="mt-4" />;
+  }
+
+  const nextIpValue = isIpPrefixSchema ? nextIpPrefix : nextIpAddress;
 
   const onSuccess: NodeFormProps["onSuccess"] = (newNode) => {
     toast(
@@ -24,7 +59,6 @@ function IpamCreationForm(props: IpamCreationFormProps) {
         toastId: `alert-success-${props.schema.name}-created`,
       }
     );
-
     props.onSuccess?.(newNode);
   };
 
@@ -35,15 +69,20 @@ function IpamCreationForm(props: IpamCreationFormProps) {
   return (
     <NodeForm
       {...props}
+      currentObject={
+        nextIpValue
+          ? {
+              ...props.currentObject,
+              [ipFieldName]: { value: nextIpValue },
+            }
+          : props.currentObject
+      }
       onSubmit={async ({ fields, formData }) => {
-        // prefix and address are fields that pool allocates
-        const formFieldsWithoutIpField = fields.filter(
-          ({ name }) => name !== "prefix" && name !== "address"
-        );
-
-        const fieldDataForIpField = formData.prefix ?? formData.address;
-
+        // Remove the IP field if it's being allocated from a pool
+        const formFieldsWithoutIpField = fields.filter(({ name }) => name !== ipFieldName);
+        const fieldDataForIpField = formData[ipFieldName];
         const allocateMutationName = getAllocateMutationNameFromSchema(props.schema);
+
         if (fieldDataForIpField?.source?.type === "pool" && allocateMutationName) {
           await allocateResource.mutateAsync(
             {

--- a/frontend/app/src/entities/ipam/ip-prefixes/utils/get-ip-prefix-table-columns.tsx
+++ b/frontend/app/src/entities/ipam/ip-prefixes/utils/get-ip-prefix-table-columns.tsx
@@ -48,7 +48,7 @@ export const getIpPrefixTableColumns = (schema: ModelSchema): ColumnDef<NodeCore
         if (ipPrefixNode.__typename === IP_PREFIX_AVAILABLE_KIND) {
           return (
             <>
-              <StickyLeftCell isMuted className="pl-0.5">
+              <StickyLeftCell isMuted className="pl-0.5" data-testid="ip-prefix-available">
                 <IpPrefixAvailableIdentifier ipPrefixNode={row.original} />
               </StickyLeftCell>
 

--- a/frontend/app/tests/e2e/ipam/ip-prefix-create.spec.ts
+++ b/frontend/app/tests/e2e/ipam/ip-prefix-create.spec.ts
@@ -69,7 +69,7 @@ test.describe("/ipam - Allocate an ip prefix with pool", () => {
       ).toBeVisible();
     });
 
-    await test.step("Creation form should suggested a  available ip address", async () => {
+    await test.step("Creation form should suggest an available IP address within parent prefix", async () => {
       await page.getByTestId("create-object-button").click();
       await expect(page.getByLabel("Address *")).toHaveValue("11.0.0.2/9");
       await page.getByRole("button", { name: "Save" }).click();

--- a/frontend/app/tests/e2e/ipam/ip-prefix-create.spec.ts
+++ b/frontend/app/tests/e2e/ipam/ip-prefix-create.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from "@playwright/test";
+import { ACCOUNT_STATE_PATH } from "../../constants";
+import { generateRandomBranchName } from "../../utils";
+import { createBranchAPI, deleteBranchAPI } from "../utils/graphql";
+
+test.describe("/ipam - Allocate an ip prefix with pool", () => {
+  test.use({ storageState: ACCOUNT_STATE_PATH.ADMIN });
+
+  const BRANCH_NAME = generateRandomBranchName("ip-prefix-create");
+
+  test.beforeAll(async ({ request }) => {
+    await createBranchAPI(request, BRANCH_NAME);
+  });
+
+  test.afterAll(async ({ request }) => {
+    await deleteBranchAPI(request, BRANCH_NAME);
+  });
+
+  test("should create an IP prefix at IPAM root, allocate a child prefix, and allocate IP addresses from the pool", async ({
+    page,
+  }) => {
+    await test.step("Navigate to IPAM root and open create prefix form", async () => {
+      await page.goto(`ipam?branch=${BRANCH_NAME}`);
+      await page.getByTestId("create-object-button").click();
+    });
+
+    await test.step("Create a root IP prefix 11.0.0.0/8 manually", async () => {
+      await page.getByLabel("Prefix *").fill("11.0.0.0/8");
+      await page.getByLabel("Member Type").click();
+      await page.getByRole("option", { name: "Prefix Prefix serves as" }).click();
+      await page.getByRole("button", { name: "Save" }).click();
+      await expect(page.getByText("IP Prefix 11.0.0.0/8 created")).toBeVisible();
+    });
+
+    await test.step("Allocate the available child prefix 11.0.0.0/9 from the root prefix", async () => {
+      await page.getByTestId("identifier-cell").getByRole("link", { name: "11.0.0.0/8" }).click();
+      await page
+        .getByTestId("ip-prefix-available")
+        .getByRole("button", { name: "11.0.0.0/9" })
+        .click();
+      await expect(page.getByLabel("Prefix *")).toHaveValue("11.0.0.0/9");
+      await page.getByRole("button", { name: "Save" }).click();
+      await expect(page.getByText("IP Prefix 11.0.0.0/9 created")).toBeVisible();
+    });
+
+    await test.step("Verify child prefix 11.0.0.0/9 details and available ip addresses", async () => {
+      await page.getByTestId("identifier-cell").getByRole("link", { name: "11.0.0.0/9" }).click();
+      await expect(
+        page
+          .getByTestId("ip-address-available")
+          .getByRole("button", { name: "11.0.0.1/9 11.127.255.254/9" })
+      ).toBeVisible();
+      await expect(page.getByText("More than 65536 IP addresses")).toBeVisible();
+    });
+
+    await test.step("Allocate the first IP address (11.0.0.1/9) from the table", async () => {
+      await page
+        .getByTestId("ip-address-available")
+        .getByRole("button", { name: "11.0.0.1/9 11.127.255.254/9" })
+        .click();
+      await expect(page.getByLabel("Address *")).toHaveValue("11.0.0.1/9");
+      await page.getByRole("button", { name: "Save" }).click();
+      await expect(page.getByText("IP Address 11.0.0.1/9 created")).toBeVisible();
+      await expect(
+        page.getByTestId("identifier-cell").getByRole("link", { name: "11.0.0.1/9" })
+      ).toBeVisible();
+      await expect(
+        page.getByTestId("ip-address-available").getByRole("button", { name: "11.0.0.2/9" })
+      ).toBeVisible();
+    });
+
+    await test.step("Creation form should suggested a  available ip address", async () => {
+      await page.getByTestId("create-object-button").click();
+      await expect(page.getByLabel("Address *")).toHaveValue("11.0.0.2/9");
+      await page.getByRole("button", { name: "Save" }).click();
+      await expect(page.getByText("IP Address 11.0.0.2/9 created")).toBeVisible();
+    });
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic fetching and pre-filling of the next available IP address or prefix in creation forms, streamlining allocation workflows.
  * Introduced hooks and utilities to support dynamic retrieval of available IP addresses and prefixes based on context.
  * Added end-to-end tests to validate IP prefix and address allocation flows.

* **Style**
  * Added test identifiers to specific table cells for improved UI testability.

* **Tests**
  * Implemented comprehensive automated tests covering IP prefix and address creation and allocation scenarios in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->