### PR TITLE
Use proper prefix for PC mutation

### DIFF
--- a/backend/infrahub/graphql/schema.py
+++ b/backend/infrahub/graphql/schema.py
@@ -131,4 +131,6 @@ class InfrahubBaseMutation(ObjectType):
     ResolveDiffConflict = ResolveDiffConflict.Field()
 
     ConvertObjectType = ConvertObjectType.Field()
+    CoreProposedChangeCheckForApprovalRevoke = ProposedChangeCheckForApprovalRevoke.Field()
+    # Remove the below line once the enterprise test has been renamed
     ProposedChangeCheckForApprovalRevoke = ProposedChangeCheckForApprovalRevoke.Field()

--- a/backend/tests/functional/proposed_change/test_check_for_approval_revoke.py
+++ b/backend/tests/functional/proposed_change/test_check_for_approval_revoke.py
@@ -10,8 +10,8 @@ class TestProposedChangeCheckForRevokeApprovals(TestInfrahubApp):
         client: InfrahubClient,
     ) -> None:
         mutation = """
-        mutation ProposedChangeCheckForApprovalRevoke($data: ProposedChangeCheckForApprovalRevokeInput!) {
-            ProposedChangeCheckForApprovalRevoke(data: $data) {
+        mutation CoreProposedChangeCheckForApprovalRevoke($data: ProposedChangeCheckForApprovalRevokeInput!) {
+            CoreProposedChangeCheckForApprovalRevoke(data: $data) {
                 ok
             }
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new GraphQL mutation for revoking approval checks on proposed changes.

* **Tests**
  * Updated test cases to use the new mutation name for approval revoke functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->