### PR TITLE
Revert the state to the PC if the merge check fails

### DIFF
--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -176,6 +176,9 @@ async def merge_proposed_change(
         try:
             await verify_proposed_change_is_mergeable(proposed_change=proposed_change, db=db)  # type: ignore[arg-type]
         except ValueError as exc:
+            await _proposed_change_transition_state(
+                proposed_change=proposed_change, state=ProposedChangeState.OPEN, database=db
+            )
             return Failed(message=str(exc))
 
         source_branch = await Branch.get_by_name(db=db, name=proposed_change.source_branch.value)


### PR DESCRIPTION
If `verify_proposed_change_is_mergeable` raises an error we need to revert the state of the PC just like the other failure scenarios in this function. Without that the PC is stuck in a "merging" state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of failed merge attempts by ensuring proposed changes remain in the "OPEN" state if mergeability verification fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->