### PR TITLE
IFC-1686 Add support for `kinds` filter for generic IP query

### DIFF
--- a/backend/infrahub/graphql/manager.py
+++ b/backend/infrahub/graphql/manager.py
@@ -914,6 +914,7 @@ class GraphQLSchemaManager:
             if schema.kind in [InfrahubKind.IPADDRESS, InfrahubKind.IPPREFIX]:
                 # This is only available for IPAM generics
                 filters["include_available"] = graphene.Boolean()
+                filters["kinds"] = graphene.List(graphene.NonNull(graphene.String))
 
         if not top_level:
             return filters

--- a/backend/infrahub/graphql/parser.py
+++ b/backend/infrahub/graphql/parser.py
@@ -18,7 +18,7 @@ from infrahub_sdk.utils import deep_merge_dict
 if TYPE_CHECKING:
     from graphql import GraphQLResolveInfo
 
-    from infrahub.core.schema import NodeSchema
+    from infrahub.core.schema import GenericSchema, NodeSchema
 
 
 @dataclass
@@ -29,13 +29,13 @@ class FieldEnricher:
     fields: dict = field(default_factory=dict)
 
 
-async def extract_selection(info: GraphQLResolveInfo, schema: NodeSchema) -> dict:
+async def extract_selection(info: GraphQLResolveInfo, schema: NodeSchema | GenericSchema) -> dict:
     graphql_extractor = GraphQLExtractor(info=info, schema=schema)
     return await graphql_extractor.get_fields()
 
 
 class GraphQLExtractor:
-    def __init__(self, info: GraphQLResolveInfo, schema: NodeSchema) -> None:
+    def __init__(self, info: GraphQLResolveInfo, schema: NodeSchema | GenericSchema) -> None:
         self.info = info
         self.schema = schema
         self.typename_paths: dict[str, list[FieldEnricher]] = {}

--- a/backend/infrahub/graphql/resolvers/ipam.py
+++ b/backend/infrahub/graphql/resolvers/ipam.py
@@ -231,6 +231,23 @@ async def _resolve_available_prefix_nodes(
     return available_nodes
 
 
+def _filter_kinds(nodes: list[Node], kinds: list[str], limit: int | None) -> list[Node]:
+    filtered: list[Node] = []
+    available_node_kinds = [InfrahubKind.IPPREFIXAVAILABLE, InfrahubKind.IPRANGEAVAILABLE]
+    kinds += available_node_kinds
+
+    limit_with_available = limit
+    for node in nodes:
+        if node.get_schema().kind not in kinds:
+            continue
+        # Adapt the limit of nodes to return by always including available ones
+        if node.get_schema().kind in available_node_kinds:
+            limit_with_available += 1
+        filtered.append(node)
+
+    return filtered[:limit_with_available] if limit else filtered
+
+
 async def _annotate_result(
     db: InfrahubDatabase,
     branch: Branch,
@@ -240,29 +257,32 @@ async def _annotate_result(
     result: list[Node],
     first_node_context: Node | None = None,
     last_node_context: Node | None = None,
+    kinds_to_filter: list[str] | None = None,
+    limit: int | None = None,
 ) -> list[Node]:
-    if not resolve_available or not parent_prefix:
-        return result
+    nodes: list[Node] = result
 
-    return (
-        await _resolve_available_address_nodes(
-            db=db,
-            branch=branch,
-            prefix=parent_prefix,
-            existing_nodes=result,
-            first_node_context=first_node_context,
-            last_node_context=last_node_context,
-        )
-        if schema.is_ip_address
-        else await _resolve_available_prefix_nodes(
-            db=db,
-            branch=branch,
-            prefix=parent_prefix,
-            existing_nodes=result,
-            first_node_context=first_node_context,
-            last_node_context=last_node_context,
-        )
-    )
+    if resolve_available and parent_prefix:
+        if schema.is_ip_address:
+            nodes = await _resolve_available_address_nodes(
+                db=db,
+                branch=branch,
+                prefix=parent_prefix,
+                existing_nodes=result,
+                first_node_context=first_node_context,
+                last_node_context=last_node_context,
+            )
+        else:
+            nodes = await _resolve_available_prefix_nodes(
+                db=db,
+                branch=branch,
+                prefix=parent_prefix,
+                existing_nodes=result,
+                first_node_context=first_node_context,
+                last_node_context=last_node_context,
+            )
+
+    return _filter_kinds(nodes=nodes, kinds=kinds_to_filter, limit=limit) if kinds_to_filter else nodes
 
 
 @trace.get_tracer(__name__).start_as_current_span("ipam_paginated_list_resolver")
@@ -283,6 +303,12 @@ async def ipam_paginated_list_resolver(  # noqa: PLR0915
 
     fields = await extract_selection(info=info, schema=schema)
     resolve_available = bool(kwargs.pop("include_available", False))
+    kinds_to_filter: list[str] = kwargs.pop("kinds", [])  # type: ignore[assignment]
+
+    # Since we are going to narrow down the number of nodes in the end, we will query for a larger set in the first place to make sure that we will
+    # fill in the page to its maximum
+    if kinds_to_filter and limit:
+        limit *= len(kinds_to_filter)
 
     graphql_context: GraphqlContext = info.context
     async with graphql_context.db.start_session(read_only=True) as db:
@@ -379,6 +405,8 @@ async def ipam_paginated_list_resolver(  # noqa: PLR0915
             result=objs,
             first_node_context=first_node_context,
             last_node_context=last_node_context,
+            kinds_to_filter=kinds_to_filter,
+            limit=limit,
         )
 
         if result:

--- a/backend/infrahub/graphql/resolvers/ipam.py
+++ b/backend/infrahub/graphql/resolvers/ipam.py
@@ -14,6 +14,7 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.protocols import BuiltinIPNamespace, BuiltinIPPrefix
 from infrahub.core.schema.generic_schema import GenericSchema
+from infrahub.exceptions import ValidationError
 from infrahub.graphql.parser import extract_selection
 from infrahub.graphql.permissions import get_permissions
 
@@ -305,6 +306,11 @@ async def ipam_paginated_list_resolver(  # noqa: PLR0915
     fields = await extract_selection(info=info, schema=schema)
     resolve_available = bool(kwargs.pop("include_available", False))
     kinds_to_filter: list[str] = kwargs.pop("kinds", [])  # type: ignore[assignment]
+
+    if isinstance(schema, GenericSchema):
+        for kind in kinds_to_filter:
+            if kind not in schema.used_by:
+                raise ValidationError(f"{kind} is not a node inheriting from {schema.kind}")
 
     graphql_context: GraphqlContext = info.context
     async with graphql_context.db.start_session(read_only=True) as db:

--- a/backend/infrahub/graphql/resolvers/ipam.py
+++ b/backend/infrahub/graphql/resolvers/ipam.py
@@ -303,14 +303,16 @@ async def ipam_paginated_list_resolver(  # noqa: PLR0915
         else info.return_type.graphene_type._meta.schema
     )
 
+    if not isinstance(schema, GenericSchema) or schema.kind not in [InfrahubKind.IPADDRESS, InfrahubKind.IPPREFIX]:
+        raise ValidationError(f"{schema.kind} is not {InfrahubKind.IPADDRESS} or {InfrahubKind.IPPREFIX}")
+
     fields = await extract_selection(info=info, schema=schema)
     resolve_available = bool(kwargs.pop("include_available", False))
     kinds_to_filter: list[str] = kwargs.pop("kinds", [])  # type: ignore[assignment]
 
-    if isinstance(schema, GenericSchema):
-        for kind in kinds_to_filter:
-            if kind not in schema.used_by:
-                raise ValidationError(f"{kind} is not a node inheriting from {schema.kind}")
+    for kind in kinds_to_filter:
+        if kind not in schema.used_by:
+            raise ValidationError(f"{kind} is not a node inheriting from {schema.kind}")
 
     graphql_context: GraphqlContext = info.context
     async with graphql_context.db.start_session(read_only=True) as db:
@@ -363,7 +365,7 @@ async def ipam_paginated_list_resolver(  # noqa: PLR0915
         # Since we are going to narrow down the number of nodes in the end, we will query for a larger set (that can potentially include all kinds of
         # implementations) in the first place to make sure that we will fill in the page to its maximum
         query_limit = limit
-        if kinds_to_filter and limit and isinstance(schema, GenericSchema):
+        if kinds_to_filter and limit:
             query_limit *= len(schema.used_by)
 
         objs = []

--- a/backend/infrahub/graphql/resolvers/ipam.py
+++ b/backend/infrahub/graphql/resolvers/ipam.py
@@ -235,14 +235,14 @@ async def _resolve_available_prefix_nodes(
 def _filter_kinds(nodes: list[Node], kinds: list[str], limit: int | None) -> list[Node]:
     filtered: list[Node] = []
     available_node_kinds = [InfrahubKind.IPPREFIXAVAILABLE, InfrahubKind.IPRANGEAVAILABLE]
-    kinds += available_node_kinds
+    kinds_with_available = kinds + available_node_kinds
 
     limit_with_available = limit
     for node in nodes:
-        if node.get_schema().kind not in kinds:
+        if node.get_schema().kind not in kinds_with_available:
             continue
         # Adapt the limit of nodes to return by always including available ones
-        if node.get_schema().kind in available_node_kinds:
+        if limit and node.get_schema().kind in available_node_kinds:
             limit_with_available += 1
         filtered.append(node)
 

--- a/backend/infrahub/graphql/resolvers/ipam.py
+++ b/backend/infrahub/graphql/resolvers/ipam.py
@@ -13,6 +13,7 @@ from infrahub.core.ipam.constants import PrefixMemberType
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.protocols import BuiltinIPNamespace, BuiltinIPPrefix
+from infrahub.core.schema.generic_schema import GenericSchema
 from infrahub.graphql.parser import extract_selection
 from infrahub.graphql.permissions import get_permissions
 
@@ -252,7 +253,7 @@ async def _annotate_result(
     db: InfrahubDatabase,
     branch: Branch,
     resolve_available: bool,
-    schema: NodeSchema,
+    schema: NodeSchema | GenericSchema,
     parent_prefix: BuiltinIPPrefix | None,
     result: list[Node],
     first_node_context: Node | None = None,
@@ -295,7 +296,7 @@ async def ipam_paginated_list_resolver(  # noqa: PLR0915
     partial_match: bool = False,
     **kwargs: dict[str, Any],
 ) -> dict[str, Any]:
-    schema: NodeSchema = (
+    schema: NodeSchema | GenericSchema = (
         info.return_type.of_type.graphene_type._meta.schema
         if isinstance(info.return_type, GraphQLNonNull)
         else info.return_type.graphene_type._meta.schema
@@ -304,11 +305,6 @@ async def ipam_paginated_list_resolver(  # noqa: PLR0915
     fields = await extract_selection(info=info, schema=schema)
     resolve_available = bool(kwargs.pop("include_available", False))
     kinds_to_filter: list[str] = kwargs.pop("kinds", [])  # type: ignore[assignment]
-
-    # Since we are going to narrow down the number of nodes in the end, we will query for a larger set in the first place to make sure that we will
-    # fill in the page to its maximum
-    if kinds_to_filter and limit:
-        limit *= len(kinds_to_filter)
 
     graphql_context: GraphqlContext = info.context
     async with graphql_context.db.start_session(read_only=True) as db:
@@ -358,6 +354,12 @@ async def ipam_paginated_list_resolver(  # noqa: PLR0915
             limit += 1
             fetch_last_node_context = True
 
+        # Since we are going to narrow down the number of nodes in the end, we will query for a larger set (that can potentially include all kinds of
+        # implementations) in the first place to make sure that we will fill in the page to its maximum
+        query_limit = limit
+        if kinds_to_filter and limit and isinstance(schema, GenericSchema):
+            query_limit *= len(schema.used_by)
+
         objs = []
         if edges or "hfid" in filters:
             objs = await NodeManager.query(
@@ -367,7 +369,7 @@ async def ipam_paginated_list_resolver(  # noqa: PLR0915
                 fields=node_fields,
                 at=graphql_context.at,
                 branch=graphql_context.branch,
-                limit=limit,
+                limit=query_limit,
                 offset=offset,
                 account=graphql_context.account_session,
                 include_source=True,

--- a/backend/tests/unit/graphql/queries/test_ipam.py
+++ b/backend/tests/unit/graphql/queries/test_ipam.py
@@ -425,16 +425,24 @@ class TestIpamAvailableNodes(TestInfrahubApp):
         await net.new(db=db, prefix="192.0.2.0/24", ip_namespace=ns, is_pool=False, member_type="address")
         await net.save(db=db)
 
+        ipamipaddress_count = 0
+        testipaddress_count = 0
         for i in range(1, 32):
             await self._create_address(db, address_schema, f"192.0.2.{i}/24", ns, net)
-
+            ipamipaddress_count += 1
         for i in range(64, 96):
             await self._create_address(db, alternative_address_schema, f"192.0.2.{i}/24", ns, net)
-
+            testipaddress_count += 1
         for i in range(96, 128):
             await self._create_address(db, address_schema, f"192.0.2.{i}/24", ns, net)
+            ipamipaddress_count += 1
 
-        return {"ns": ns, "net": net}
+        return {
+            "ns": ns,
+            "net": net,
+            "ipamipaddress_count": ipamipaddress_count,
+            "testipaddress_count": testipaddress_count,
+        }
 
     @pytest.mark.parametrize(
         "prefix,result",
@@ -545,7 +553,17 @@ class TestIpamAvailableNodes(TestInfrahubApp):
             for node in response.data["BuiltinIPAddress"]["edges"]
         ]
 
-    @pytest.mark.parametrize("limit", [0, 10, 60])
+    @pytest.mark.parametrize(
+        "limit,kinds",
+        [
+            (0, ["IpamIPAddress"]),
+            (0, ["IpamIPAddress", "TestIPAddress"]),
+            (10, ["IpamIPAddress"]),
+            (10, ["IpamIPAddress", "TestIPAddress"]),
+            (60, ["IpamIPAddress"]),
+            (60, ["IpamIPAddress", "TestIPAddress"]),
+        ],
+    )
     async def test_ip_address_include_available_filtered_by_kind(
         self,
         db: InfrahubDatabase,
@@ -554,12 +572,13 @@ class TestIpamAvailableNodes(TestInfrahubApp):
         register_ipam_schema: SchemaBranch,
         ip_dataset_range_various_kinds: dict[str, Node],
         limit: int,
+        kinds: list[str],
     ):
         gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
 
         query = """
-        query($prefix: ID!, $limit: Int!) {
-            BuiltinIPAddress(ip_prefix__ids: [$prefix], include_available: true, kinds: ["IpamIPAddress"], limit: $limit) {
+        query($prefix: ID!, $limit: Int!, $kinds: [String!]) {
+            BuiltinIPAddress(ip_prefix__ids: [$prefix], include_available: true, kinds: $kinds, limit: $limit) {
                 edges {
                     node {
                         id
@@ -575,19 +594,32 @@ class TestIpamAvailableNodes(TestInfrahubApp):
             schema=gql_params.schema,
             source=query,
             context_value=gql_params.context,
-            variable_values={"prefix": ip_dataset_range_various_kinds["net"].id, "limit": limit},
+            variable_values={"prefix": ip_dataset_range_various_kinds["net"].id, "limit": limit, "kinds": kinds},
         )
         assert not response.errors
         assert response.data
         assert response.data["BuiltinIPAddress"]["edges"]
-        # There should be only one kind if we exclude available range
-        assert {node["node"]["__typename"] for node in response.data["BuiltinIPAddress"]["edges"]} - {
-            "InternalIPRangeAvailable"
-        } == {"IpamIPAddress"}
+
+        if len(kinds) == 1 or (limit > 0 and limit < 32):
+            # There should be only one kind if we exclude available range
+            assert {node["node"]["__typename"] for node in response.data["BuiltinIPAddress"]["edges"]} - {
+                "InternalIPRangeAvailable"
+            } == {"IpamIPAddress"}
+        else:
+            assert {node["node"]["__typename"] for node in response.data["BuiltinIPAddress"]["edges"]} - {
+                "InternalIPRangeAvailable"
+            } == set(kinds)
+
+        expected_ipaddress_count = ip_dataset_range_various_kinds["ipamipaddress_count"]
+        if len(kinds) == 2:
+            expected_ipaddress_count += ip_dataset_range_various_kinds["testipaddress_count"]
 
         # Given the used fixture, only 0, 1 or 2 available ranges can be in the result
         if limit:
-            assert len(response.data["BuiltinIPAddress"]["edges"]) - limit <= 2
+            assert len(response.data["BuiltinIPAddress"]["edges"]) - limit in [0, 1, 2]
+        else:
+            # If we query for all addresses, we'll have 2 available ranges too
+            assert len(response.data["BuiltinIPAddress"]["edges"]) == expected_ipaddress_count + 2
 
     @pytest.mark.parametrize(
         "limit,offset,result",

--- a/backend/tests/unit/graphql/queries/test_ipam.py
+++ b/backend/tests/unit/graphql/queries/test_ipam.py
@@ -1,8 +1,10 @@
+from typing import Any
+
 import pytest
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
-from infrahub.core.constants import InfrahubKind
+from infrahub.core.constants import BranchSupportType, InfrahubKind
 from infrahub.core.node import Node
 from infrahub.core.schema import SchemaRoot
 from infrahub.core.schema.node_schema import NodeSchema
@@ -191,6 +193,34 @@ async def test_ipaddress_nextavailable(
     assert result.data["InfrahubIPAddressGetNextAvailable"]["address"] == response
 
 
+@pytest.fixture(scope="class")
+def alternative_ipam_schema() -> SchemaRoot:
+    SCHEMA: dict[str, Any] = {
+        "nodes": [
+            {
+                "name": "IPPrefix",
+                "namespace": "Test",
+                "default_filter": "prefix__value",
+                "order_by": ["prefix__value"],
+                "display_labels": ["prefix__value"],
+                "branch": BranchSupportType.AWARE.value,
+                "inherit_from": [InfrahubKind.IPPREFIX, InfrahubKind.WEIGHTED_POOL_RESOURCE],
+            },
+            {
+                "name": "IPAddress",
+                "namespace": "Test",
+                "default_filter": "address__value",
+                "order_by": ["address__value"],
+                "display_labels": ["address__value"],
+                "branch": BranchSupportType.AWARE.value,
+                "inherit_from": [InfrahubKind.IPADDRESS],
+            },
+        ],
+    }
+
+    return SchemaRoot(**SCHEMA)
+
+
 class TestIpamAvailableNodes(TestInfrahubApp):
     async def _create_address(
         self, db: InfrahubDatabase, schema: NodeSchema, address: str, ns: Node, prefix: Node
@@ -208,9 +238,15 @@ class TestIpamAvailableNodes(TestInfrahubApp):
 
     @pytest.fixture(scope="class")
     async def register_ipam_schema(
-        self, initialize_registry: None, default_branch: Branch, ipam_schema: SchemaRoot
+        self,
+        initialize_registry: None,
+        default_branch: Branch,
+        ipam_schema: SchemaRoot,
+        alternative_ipam_schema: SchemaRoot,
     ) -> SchemaBranch:
-        schema_branch = registry.schema.register_schema(schema=ipam_schema, branch=default_branch.name)
+        schema_branch = registry.schema.register_schema(
+            schema=ipam_schema.merge(alternative_ipam_schema), branch=default_branch.name
+        )
         default_branch.update_schema_hash()
         return schema_branch
 
@@ -372,6 +408,34 @@ class TestIpamAvailableNodes(TestInfrahubApp):
             "net6": net6,
         }
 
+    @pytest.fixture(scope="class")
+    async def ip_dataset_range_various_kinds(
+        self, db: InfrahubDatabase, default_branch: Branch, register_ipam_schema: SchemaBranch
+    ):
+        prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch)
+        address_schema = registry.schema.get_node_schema(name="IpamIPAddress", branch=default_branch)
+        alternative_address_schema = registry.schema.get_node_schema(name="TestIPAddress", branch=default_branch)
+
+        ns = await Node.init(db=db, schema=InfrahubKind.NAMESPACE)
+        await ns.new(db=db, name="multi-kinds")
+        await ns.save(db=db)
+
+        # Prefix with all IP available
+        net = await Node.init(db=db, schema=prefix_schema)
+        await net.new(db=db, prefix="192.0.2.0/24", ip_namespace=ns, is_pool=False, member_type="address")
+        await net.save(db=db)
+
+        for i in range(1, 32):
+            await self._create_address(db, address_schema, f"192.0.2.{i}/24", ns, net)
+
+        for i in range(64, 96):
+            await self._create_address(db, alternative_address_schema, f"192.0.2.{i}/24", ns, net)
+
+        for i in range(96, 128):
+            await self._create_address(db, address_schema, f"192.0.2.{i}/24", ns, net)
+
+        return {"ns": ns, "net": net}
+
     @pytest.mark.parametrize(
         "prefix,result",
         [
@@ -480,6 +544,50 @@ class TestIpamAvailableNodes(TestInfrahubApp):
             (node["node"]["__typename"], node["node"]["display_label"])
             for node in response.data["BuiltinIPAddress"]["edges"]
         ]
+
+    @pytest.mark.parametrize("limit", [0, 10, 60])
+    async def test_ip_address_include_available_filtered_by_kind(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        default_ipnamespace: Node,
+        register_ipam_schema: SchemaBranch,
+        ip_dataset_range_various_kinds: dict[str, Node],
+        limit: int,
+    ):
+        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+
+        query = """
+        query($prefix: ID!, $limit: Int!) {
+            BuiltinIPAddress(ip_prefix__ids: [$prefix], include_available: true, kinds: ["IpamIPAddress"], limit: $limit) {
+                edges {
+                    node {
+                        id
+                        display_label
+                        __typename
+                    }
+                }
+            }
+        }
+        """
+
+        response = await graphql(
+            schema=gql_params.schema,
+            source=query,
+            context_value=gql_params.context,
+            variable_values={"prefix": ip_dataset_range_various_kinds["net"].id, "limit": limit},
+        )
+        assert not response.errors
+        assert response.data
+        assert response.data["BuiltinIPAddress"]["edges"]
+        # There should be only one kind if we exclude available range
+        assert {node["node"]["__typename"] for node in response.data["BuiltinIPAddress"]["edges"]} - {
+            "InternalIPRangeAvailable"
+        } == {"IpamIPAddress"}
+
+        # Given the used fixture, only 0, 1 or 2 available ranges can be in the result
+        if limit:
+            assert len(response.data["BuiltinIPAddress"]["edges"]) - limit <= 2
 
     @pytest.mark.parametrize(
         "limit,offset,result",

--- a/backend/tests/unit/graphql/queries/test_ipam.py
+++ b/backend/tests/unit/graphql/queries/test_ipam.py
@@ -575,7 +575,6 @@ class TestIpamAvailableNodes(TestInfrahubApp):
         kinds: list[str],
     ):
         gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
-
         query = """
         query($prefix: ID!, $limit: Int!, $kinds: [String!]) {
             BuiltinIPAddress(ip_prefix__ids: [$prefix], include_available: true, kinds: $kinds, limit: $limit) {
@@ -620,6 +619,39 @@ class TestIpamAvailableNodes(TestInfrahubApp):
         else:
             # If we query for all addresses, we'll have 2 available ranges too
             assert len(response.data["BuiltinIPAddress"]["edges"]) == expected_ipaddress_count + 2
+
+    async def test_ip_address_include_available_filtered_by_kind_invalid(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        default_ipnamespace: Node,
+        register_ipam_schema: SchemaBranch,
+        ip_dataset_range_various_kinds: dict[str, Node],
+    ):
+        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+        query = """
+        query($prefix: ID!, $kinds: [String!]) {
+            BuiltinIPAddress(ip_prefix__ids: [$prefix], include_available: true, kinds: $kinds) {
+                edges {
+                    node {
+                        id
+                        display_label
+                        __typename
+                    }
+                }
+            }
+        }
+        """
+
+        response = await graphql(
+            schema=gql_params.schema,
+            source=query,
+            context_value=gql_params.context,
+            variable_values={"prefix": ip_dataset_range_various_kinds["net"].id, "kinds": ["NotAnIPAddress"]},
+        )
+
+        assert response.errors
+        assert response.errors[0].message == "NotAnIPAddress is not a node inheriting from BuiltinIPAddress"
 
     @pytest.mark.parametrize(
         "limit,offset,result",


### PR DESCRIPTION
This change adds a `kinds` filter to the generic IPAM queries in order to only get nodes which kinds are matching a filter provided one.

When performing the database query, if a limit is given and kinds must be filtered, we query for a larger dataset to be able to fill in the return page as much as possible with the kinds that need to be in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for filtering IP address and prefix results by specific kinds in GraphQL queries, allowing more precise queries.
* **Bug Fixes**
  * Ensured that available IP prefix and range nodes are always included in filtered results.
* **Tests**
  * Introduced comprehensive tests to verify correct filtering and inclusion of nodes by kind and limit in query results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->