### PR TITLE
fix(testcontainers): fix prefect redis config bis

### DIFF
--- a/python_testcontainers/infrahub_testcontainers/docker-compose-cluster.test.yml
+++ b/python_testcontainers/infrahub_testcontainers/docker-compose-cluster.test.yml
@@ -217,6 +217,7 @@ services:
       cache:
         condition: service_healthy
     environment:
+      PREFECT_UI_ENABLED: "${INFRAHUB_TESTING_PREFECT_UI_ENABLED}" # This might be required because triggers actions service depends on an in-memory API server
       PREFECT_API_DATABASE_CONNECTION_URL: postgresql+asyncpg://postgres:postgres@task-manager-db:5432/prefect
 
       PREFECT_API_DATABASE_MIGRATE_ON_START: "false"

--- a/python_testcontainers/infrahub_testcontainers/docker-compose.test.yml
+++ b/python_testcontainers/infrahub_testcontainers/docker-compose.test.yml
@@ -128,6 +128,7 @@ services:
       cache:
         condition: service_healthy
     environment:
+      PREFECT_UI_ENABLED: "${INFRAHUB_TESTING_PREFECT_UI_ENABLED}" # This might be required because triggers actions service depends on an in-memory API server
       PREFECT_API_DATABASE_CONNECTION_URL: postgresql+asyncpg://postgres:postgres@task-manager-db:5432/prefect
 
       PREFECT_API_DATABASE_MIGRATE_ON_START: "false"


### PR DESCRIPTION
This is a silly one, the RunDeployment actions depend on a special in-memory API server instance to create the triggered deployment. When running as non-root we may hit the permission denied error due to the UI generation stuff.
Allow disabling the UI when running the background services container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new environment variable configuration for the task manager background service in test Docker Compose files to enhance environment setup flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->