### PR TITLE
new `infrahub db check` query for orphaned Relationships

### DIFF
--- a/backend/infrahub/cli/db.py
+++ b/backend/infrahub/cli/db.py
@@ -916,5 +916,39 @@ async def run_database_checks(db: InfrahubDatabase, output_dir: Path) -> None:
     else:
         rprint(f"{SUCCESS_BADGE} No duplicated edges found")
 
+    # Check 4: Orphaned Relationships
+    rprint("\n[bold cyan]Check 4: Orphaned Relationships[/bold cyan]")
+    orphaned_rels_query = """
+    MATCH (r:Relationship)-[:IS_RELATED]-(peer:Node)
+    WITH DISTINCT r, peer
+    WITH r, count(*) AS num_peers
+    WHERE num_peers < 2
+    MATCH (r)-[e:IS_RELATED]-(peer:Node)
+    RETURN DISTINCT
+        r.name AS r_name,
+        e.branch AS branch,
+        e.status AS status,
+        e.from AS from_time,
+        e.to AS to_time,
+        peer.uuid AS peer_uuid,
+        peer.kind AS peer_kind
+    """
+    results = await db.execute_query(query=orphaned_rels_query)
+    if results:
+        rprint(f"[red]Found {len(results)} orphaned Relationships[/red]")
+        # Write detailed results to file
+        output_file = output_dir / "orphaned_relationships.csv"
+        with output_file.open(mode="w", newline="") as f:
+            writer = DictWriter(
+                f,
+                fieldnames=["r_name", "branch", "status", "from_time", "to_time", "peer_uuid", "peer_kind"],
+            )
+            writer.writeheader()
+            for result in results:
+                writer.writerow(dict(result))
+        rprint(f"  Detailed results written to: {output_file}")
+    else:
+        rprint(f"{SUCCESS_BADGE} No orphaned relationships found")
+
     rprint(f"\n{SUCCESS_BADGE} Database health checks completed")
     rprint(f"Detailed results saved to: {output_dir.absolute()}")

--- a/changelog/+orphaned-relationship-check.added.md
+++ b/changelog/+orphaned-relationship-check.added.md
@@ -1,0 +1,1 @@
+Add a new check for orphaned Relationship vertices to `infrahub db check`


### PR DESCRIPTION
recently encountered various orphaned Relationship problems while troubleshooting/debugging, so that it would be good to capture them in the `infrahub db check` command

example CSV output
```
r_name,branch,status,from_time,to_time,peer_uuid,peer_kind
parent__child,cool-branch,active,2025-07-01T22:09:27.949913Z,2025-07-01T22:09:27.949913Z,18272d9c-744e-7deb-30e7-1065fe7367f9,IpamPrefix
parent__child,cool-branch,deleted,2025-07-01T22:09:27.949913Z,,18272d9c-744e-7deb-30e7-1065fe7367f9,IpamPrefix
parent__child,cool-branch,active,2025-07-01T22:05:31.139287Z,2025-07-01T22:09:27.949913Z,18272d9c-744e-7deb-30e7-1065fe7367f9,IpamPrefix

```