### PR TITLE
Cleanup references to infrahub.toml

### DIFF
--- a/docs/docs/guides/installation.mdx
+++ b/docs/docs/guides/installation.mdx
@@ -276,7 +276,6 @@ infrahubServer:
     env:
       INFRAHUB_ALLOW_ANONYMOUS_ACCESS: "true"
       INFRAHUB_CACHE_PORT: 6379
-      INFRAHUB_CONFIG: /config/infrahub.toml
       INFRAHUB_DB_TYPE: neo4j
       INFRAHUB_LOG_LEVEL: INFO
       INFRAHUB_PRODUCTION: "true"
@@ -425,7 +424,6 @@ infrahub:
       env:
         INFRAHUB_ALLOW_ANONYMOUS_ACCESS: "true"
         INFRAHUB_CACHE_PORT: 6379
-        INFRAHUB_CONFIG: /config/infrahub.toml
         INFRAHUB_DB_TYPE: neo4j
         INFRAHUB_LOG_LEVEL: INFO
         INFRAHUB_PRODUCTION: "true"

--- a/docs/docs/guides/sso.mdx
+++ b/docs/docs/guides/sso.mdx
@@ -43,35 +43,15 @@ Aside from the display label and icon all the other entries will be provided by 
 
 An example of what the configuration could look like:
 
-<Tabs groupId="provider1-configuration">
-  <TabItem value="Environment Variables" default>
-
-  ```bash
-  export INFRAHUB_OAUTH2_PROVIDER1_CLIENT_ID=infrahub-sso
-  export INFRAHUB_OAUTH2_PROVIDER1_CLIENT_SECRET=edPf4IaquQaqns7t3s95mLhKKYdwL1up
-  export INFRAHUB_OAUTH2_PROVIDER1_AUTHORIZATION_URL=http://localhost:8180/realms/infrahub/protocol/openid-connect/auth
-  export INFRAHUB_OAUTH2_PROVIDER1_TOKEN_URL=http://localhost:8180/realms/infrahub/protocol/openid-connect/token
-  export INFRAHUB_OAUTH2_PROVIDER1_USERINFO_URL=http://localhost:8180/realms/infrahub/protocol/openid-connect/userinfo
-  export INFRAHUB_OAUTH2_PROVIDER1_DISPLAY_LABEL="Internal Server (Keycloak)"
-  export INFRAHUB_OAUTH2_PROVIDER1_ICON="mdi:security-lock-outline"
-  ```
-
-  </TabItem>
-  <TabItem value="infrahub.toml" default>
-
-  ```toml
-  [security.oauth2_provider_settings.provider1]
-  client_id = "infrahub-sso"
-  client_secret = "edPf4IaquQaqns7t3s95mLhKKYdwL1up"
-  authorization_url = "http://localhost:8180/realms/infrahub/protocol/openid-connect/auth"
-  token_url = "http://localhost:8180/realms/infrahub/protocol/openid-connect/token"
-  userinfo_url = "http://localhost:8180/realms/infrahub/protocol/openid-connect/userinfo"
-  display_label = "Internal Server (Keycloak)"
-  icon = "mdi:security-lock-outline"
-  ```
-
-  </TabItem>
-</Tabs>
+```bash
+export INFRAHUB_OAUTH2_PROVIDER1_CLIENT_ID=infrahub-sso
+export INFRAHUB_OAUTH2_PROVIDER1_CLIENT_SECRET=edPf4IaquQaqns7t3s95mLhKKYdwL1up
+export INFRAHUB_OAUTH2_PROVIDER1_AUTHORIZATION_URL=http://localhost:8180/realms/infrahub/protocol/openid-connect/auth
+export INFRAHUB_OAUTH2_PROVIDER1_TOKEN_URL=http://localhost:8180/realms/infrahub/protocol/openid-connect/token
+export INFRAHUB_OAUTH2_PROVIDER1_USERINFO_URL=http://localhost:8180/realms/infrahub/protocol/openid-connect/userinfo
+export INFRAHUB_OAUTH2_PROVIDER1_DISPLAY_LABEL="Internal Server (Keycloak)"
+export INFRAHUB_OAUTH2_PROVIDER1_ICON="mdi:security-lock-outline"
+```
 
 This could be the configuration of a Keycloak provider, please refer to the documentation of your intended provider for guides on how to create a client and access the required information.
 
@@ -79,43 +59,15 @@ This could be the configuration of a Keycloak provider, please refer to the docu
 
 In order to activate the above provider we need to add it to the list of active OAuth2 providers.
 
-<Tabs groupId="provider1-configuration">
-  <TabItem value="Environment Variables" default>
-
-  ```bash
-  export INFRAHUB_SECURITY_OAUTH2_PROVIDERS='["provider1"]'
-  ```
-
-  </TabItem>
-  <TabItem value="infrahub.toml" default>
-
-  ```toml
-  [security]
-  oauth2_providers = ["provider1"]
-  ```
-
-  </TabItem>
-</Tabs>
+```bash
+export INFRAHUB_SECURITY_OAUTH2_PROVIDERS='["provider1"]'
+```
 
 Alternatively if you are setting up multiple providers each with their different settings:
 
-<Tabs groupId="provider1-configuration">
-  <TabItem value="Environment Variables" default>
-
-  ```bash
-  export INFRAHUB_SECURITY_OAUTH2_PROVIDERS='["provider1","provider2"]'
-  ```
-
-  </TabItem>
-  <TabItem value="infrahub.toml" default>
-
-  ```toml
-  [security]
-  oauth2_providers = ["provider1", "provider2"]
-  ```
-
-  </TabItem>
-</Tabs>
+```bash
+export INFRAHUB_SECURITY_OAUTH2_PROVIDERS='["provider1","provider2"]'
+```
 
 ## Setting up OIDC in Infrahub
 
@@ -140,31 +92,13 @@ Aside from the display label and icon all the other entries will be provided by 
 
 An example of what the configuration could look like:
 
-<Tabs groupId="provider1-configuration">
-  <TabItem value="Environment Variables" default>
-
-  ```bash
-  export INFRAHUB_OIDC_PROVIDER1_CLIENT_ID=infrahub-sso
-  export INFRAHUB_OIDC_PROVIDER1_CLIENT_SECRET=edPf4IaquQaqns7t3s95mLhKKYdwL1up
-  export INFRAHUB_OIDC_PROVIDER1_DISCOVERY_URL=http://localhost:8180/realms/infrahub/.well-known/openid-configuration
-  export INFRAHUB_OIDC_PROVIDER1_DISPLAY_LABEL="Internal Server (Keycloak)"
-  export INFRAHUB_OIDC_PROVIDER1_ICON="mdi:security-lock-outline"
-  ```
-
-  </TabItem>
-  <TabItem value="infrahub.toml" default>
-
-  ```toml
-  [security.oidc_provider_settings.provider1]
-  client_id = "infrahub-sso"
-  client_secret = "edPf4IaquQaqns7t3s95mLhKKYdwL1up"
-  discovery_url = "http://localhost:8180/realms/infrahub/.well-known/openid-configuration"
-  display_label = "Internal Server (Keycloak)"
-  icon = "mdi:security-lock-outline"
-  ```
-
-  </TabItem>
-</Tabs>
+```bash
+export INFRAHUB_OIDC_PROVIDER1_CLIENT_ID=infrahub-sso
+export INFRAHUB_OIDC_PROVIDER1_CLIENT_SECRET=edPf4IaquQaqns7t3s95mLhKKYdwL1up
+export INFRAHUB_OIDC_PROVIDER1_DISCOVERY_URL=http://localhost:8180/realms/infrahub/.well-known/openid-configuration
+export INFRAHUB_OIDC_PROVIDER1_DISPLAY_LABEL="Internal Server (Keycloak)"
+export INFRAHUB_OIDC_PROVIDER1_ICON="mdi:security-lock-outline"
+```
 
 This could be the configuration of a Keycloak provider, please refer to the documentation of your intended provider for guides on how to create a client and access the required information.
 
@@ -172,43 +106,15 @@ This could be the configuration of a Keycloak provider, please refer to the docu
 
 In order to activate the above provider we need to add it to the list of active OIDC providers.
 
-<Tabs groupId="provider1-configuration">
-  <TabItem value="Environment Variables" default>
-
-  ```bash
-  export INFRAHUB_SECURITY_OIDC_PROVIDERS='["provider1"]'
-  ```
-
-  </TabItem>
-  <TabItem value="infrahub.toml" default>
-
-  ```toml
-  [security]
-  oidc_providers = ["provider1"]
-  ```
-
-  </TabItem>
-</Tabs>
+```bash
+export INFRAHUB_SECURITY_OIDC_PROVIDERS='["provider1"]'
+```
 
 Alternatively if you are setting up multiple providers each with their different settings:
 
-<Tabs groupId="provider1-configuration">
-  <TabItem value="Environment Variables" default>
-
-  ```bash
-  export INFRAHUB_SECURITY_OIDC_PROVIDERS='["provider1","provider2"]'
-  ```
-
-  </TabItem>
-  <TabItem value="infrahub.toml" default>
-
-  ```toml
-  [security]
-  oidc_providers = ["provider1", "provider2"]
-  ```
-
-  </TabItem>
-</Tabs>
+```bash
+export INFRAHUB_SECURITY_OIDC_PROVIDERS='["provider1","provider2"]'
+```
 
 ## Configuring the redirect URI in the identity provider
 


### PR DESCRIPTION
Cleanup based on this PR: https://github.com/opsmill/infrahub/pull/4582

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guide by removing references to a deprecated environment variable in Helm chart examples.
  * Simplified SSO configuration guide by displaying only environment variable examples and removing tabbed TOML configuration sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->