### PR TITLE
Added preview of current IP attributes/rels in IPAM details page header

### DIFF
--- a/frontend/app/src/entities/ipam/ip-namespaces/ui/ip-namespace-tabs.tsx
+++ b/frontend/app/src/entities/ipam/ip-namespaces/ui/ip-namespace-tabs.tsx
@@ -1,3 +1,4 @@
+import { constructPathForIpam } from "@/entities/ipam/utils";
 import { ObjectDetailsTab } from "@/entities/nodes/object/ui/object-details/object-details-tab";
 import { ModelSchema } from "@/entities/schema/types";
 
@@ -21,7 +22,7 @@ export function IpNamespaceTabs({ objectId, schema }: IpNamespaceTabsProps) {
           parentKind={schema.kind!}
           parentId={objectId}
           relationship={relationshipSchemaWithIpPrefix}
-          href="/ipam"
+          href={constructPathForIpam("/ipam")}
         />
       )}
 
@@ -30,7 +31,7 @@ export function IpNamespaceTabs({ objectId, schema }: IpNamespaceTabsProps) {
           parentKind={schema.kind!}
           parentId={objectId}
           relationship={relationshipSchemaWithIpAddress}
-          href="/ipam/ip_addresses"
+          href={constructPathForIpam("/ipam/ip_addresses")}
         />
       )}
     </div>

--- a/frontend/app/src/entities/ipam/ip-prefixes/ui/ipam-details-header.tsx
+++ b/frontend/app/src/entities/ipam/ip-prefixes/ui/ipam-details-header.tsx
@@ -1,0 +1,145 @@
+import { getPrefixAttributesVisibleInListView } from "@/entities/ipam/ip-prefixes/utils/get-prefix-attributes-visible-in-list-view";
+import { ObjectDetailsMenu } from "@/entities/nodes/object/ui/object-details/object-details-menu";
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
+import { getRelationshipsVisibleInListView } from "@/entities/nodes/object/utils/get-relationships-visible-in-list-view";
+import {
+  NodeAttribute,
+  NodeCore,
+  NodeObject,
+  NodeRelationshipMany,
+  NodeRelationshipOne,
+} from "@/entities/nodes/types";
+import { getObjectDetailsUrl } from "@/entities/nodes/utils";
+import { Permission } from "@/entities/permission/types";
+import { AttributeSchema, ModelSchema, RelationshipSchema } from "@/entities/schema/types";
+import { Row, RowProps } from "@/shared/components/container";
+import { classNames, sortByOrderWeight } from "@/shared/utils/common";
+import React from "react";
+import { Link, LinkProps } from "react-router";
+
+interface IpPrefixDetailsHeaderProps extends RowProps {
+  ipPrefixSchema: ModelSchema;
+  ipPrefixNode: NodeObject;
+  permission: Permission;
+}
+
+export function IpamDetailsHeader({
+  ipPrefixNode,
+  ipPrefixSchema,
+  permission,
+  className,
+  ...props
+}: IpPrefixDetailsHeaderProps) {
+  const attributesVisible = getPrefixAttributesVisibleInListView(
+    ipPrefixSchema.attributes ?? []
+  ).filter((rel) => rel.name !== "address");
+  const relationshipsVisible = getRelationshipsVisibleInListView(
+    ipPrefixSchema.relationships ?? []
+  ).filter((rel) => rel.name !== "parent");
+
+  const orderedFields: Array<AttributeSchema | RelationshipSchema> = sortByOrderWeight([
+    ...attributesVisible,
+    ...relationshipsVisible,
+  ]);
+
+  return (
+    <Row className={classNames("relative", className)} {...props}>
+      <Row>
+        <h2 className="font-semibold text-lg">{getNodeLabel(ipPrefixNode)}</h2>
+
+        <ObjectDetailsMenu
+          objectSchema={ipPrefixSchema}
+          objectData={ipPrefixNode}
+          permission={permission}
+        />
+      </Row>
+
+      <Row>
+        <Fade />
+        {orderedFields.map((field, index) => {
+          let displayValue: React.ReactNode = "-";
+
+          if ("peer" in field) {
+            if (field.cardinality === "many") {
+              const relData = ipPrefixNode[field.name] as NodeRelationshipMany | undefined;
+              if (relData && relData.edges?.length > 0) {
+                displayValue = relData.edges.map(({ node }, index) =>
+                  node ? (
+                    <>
+                      {index > 0 && ", "}
+                      <RelationshipDisplay key={node.id} node={node} />
+                    </>
+                  ) : null
+                );
+              }
+            } else {
+              const relData = ipPrefixNode[field.name] as NodeRelationshipOne | undefined;
+              displayValue = relData?.node ? <RelationshipDisplay node={relData.node} /> : "-";
+            }
+          } else {
+            const attributeData = ipPrefixNode[field.name] as NodeAttribute | undefined;
+            const attributeValue = attributeData?.value?.toString();
+            displayValue =
+              attributeValue && field.name === "utilization"
+                ? `${attributeValue}%`
+                : (attributeValue ?? "-");
+          }
+
+          return (
+            <React.Fragment key={field.name}>
+              {index > 0 && <Divider />}
+              <Group>
+                <Title>{field.label}</Title>
+                <Value>{displayValue}</Value>
+              </Group>
+            </React.Fragment>
+          );
+        })}
+      </Row>
+    </Row>
+  );
+}
+
+const Divider = () => <div className="w-px bg-gray-200 h-5" />;
+
+const Group = ({ className, children, ...props }: React.HTMLProps<HTMLDivElement>) => (
+  <div className={classNames("text-xs not-last:max-w-50", className)} {...props}>
+    {children}
+  </div>
+);
+
+const Title = ({ className, children, ...props }: React.HTMLProps<HTMLDivElement>) => (
+  <div className={classNames("text-custom-blue-800 truncate", className)} {...props}>
+    {children}
+  </div>
+);
+
+const Value = ({ className, children, ...props }: React.HTMLProps<HTMLDivElement>) => (
+  <div className={classNames("text-gray-600 font-medium truncate", className)} {...props}>
+    {children}
+  </div>
+);
+
+const Fade = ({ className, ...props }: React.HTMLProps<HTMLDivElement>) => (
+  <div
+    className={classNames(
+      "absolute right-0 top-0 bottom-0 w-40 bg-gradient-to-r from-transparent via-white/70 to-white pointer-events-none",
+      className
+    )}
+    {...props}
+  />
+);
+
+interface RelationshipDisplayProps extends Omit<LinkProps, "to"> {
+  node: NodeCore;
+}
+
+const RelationshipDisplay = ({ className, node, ...props }: RelationshipDisplayProps) => (
+  <Link
+    to={getObjectDetailsUrl(node.__typename, node.id)}
+    className={classNames("underline decoration-dotted inline-flex", className)}
+    {...props}
+  >
+    {node.display_label}
+  </Link>
+);

--- a/frontend/app/src/entities/ipam/ip-prefixes/utils/get-prefix-attributes-visible-in-list-view.ts
+++ b/frontend/app/src/entities/ipam/ip-prefixes/utils/get-prefix-attributes-visible-in-list-view.ts
@@ -1,6 +1,7 @@
 import { AttributeSchema } from "@/entities/schema/types";
 
 const PREFIX_ATTRIBUTES_EXCLUDED_IN_LIST = [
+  "prefix",
   "network_address",
   "hostmask",
   "is_top_level",

--- a/frontend/app/src/entities/nodes/object/ui/object-details/object-details-menu.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-details/object-details-menu.tsx
@@ -181,6 +181,7 @@ export function ObjectDetailsMenu({
             await queryClient.invalidateQueries({
               predicate: (query) => query.queryKey.includes("objects"),
             });
+            setIsEditModalOpen(false);
           }}
           objectid={objectData.id!}
           objectname={objectSchema.kind!}

--- a/frontend/app/src/pages/ipam/ipam-details-layout.tsx
+++ b/frontend/app/src/pages/ipam/ipam-details-layout.tsx
@@ -1,7 +1,6 @@
+import { IpamDetailsHeader } from "@/entities/ipam/ip-prefixes/ui/ipam-details-header";
 import { IpamDetailsTabs } from "@/entities/ipam/ipam-details-tabs";
 import { useGetObject } from "@/entities/nodes/object/domain/get-object.query";
-import { ObjectDetailsMenu } from "@/entities/nodes/object/ui/object-details/object-details-menu";
-import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { Permission } from "@/entities/permission/types";
 import { RequireObjectPermissions } from "@/entities/permission/ui/require-object-permissions";
 import { ModelSchema } from "@/entities/schema/types";
@@ -33,24 +32,20 @@ function IpamDetailsLayout({ objectSchema, objectId, permission }: IpamDetailsPa
 
   return (
     <FormContext value={{ parentSchema: objectSchema, parentData: data }}>
-      <Col className="gap-0 overflow-hidden">
-        <Row className="text-xs py-2 px-2.5 gap-1.5 text-custom-blue-800">
+      <Col className="gap-0 overflow-hidden pt-2">
+        <Row className="text-xs px-2.5 gap-1.5 text-custom-blue-800">
           <Icon icon={getSchemaIcon(objectSchema)} />
           {objectSchema.label}
         </Row>
 
-        <Row className="px-2">
-          <h2 className="font-semibold text-lg justify-between">{getNodeLabel(data)}</h2>
-
-          <ObjectDetailsMenu
-            objectSchema={objectSchema}
-            objectData={data}
-            permission={permission}
-          />
-        </Row>
+        <IpamDetailsHeader
+          ipPrefixSchema={objectSchema}
+          ipPrefixNode={data}
+          permission={permission}
+          className="px-2.5 mb-2"
+        />
 
         <IpamDetailsTabs objectSchema={objectSchema} objectData={data} />
-
         <Outlet />
       </Col>
     </FormContext>

--- a/frontend/app/src/shared/components/container.tsx
+++ b/frontend/app/src/shared/components/container.tsx
@@ -1,9 +1,7 @@
 import { classNames } from "@/shared/utils/common";
 import React from "react";
 
-export interface RowProps extends React.HTMLAttributes<HTMLDivElement> {
-  children: React.ReactNode;
-}
+export interface RowProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export function Row({ className, ...props }: RowProps) {
   return <div className={classNames("flex items-center gap-2", className)} {...props} />;

--- a/frontend/app/tests/e2e/ipam/ip-prefix-list.spec.ts
+++ b/frontend/app/tests/e2e/ipam/ip-prefix-list.spec.ts
@@ -12,7 +12,7 @@ test.describe("/ipam/ip_prefixes - Ip Prefix list", () => {
     await expect(page.getByRole("heading", { name: "Details" })).toBeVisible();
     await expect(page.getByRole("heading", { name: "Activities" })).toBeVisible();
     await expect(page.getByText("Prefix203.111.0.0/16")).toBeVisible();
-    await expect(page.getByText("Utilization0%")).toBeVisible();
+    await expect(page.getByRole("row", { name: "Utilization 0%" })).toBeVisible();
     await expect(page.getByRole("progressbar")).toBeVisible();
     await expect(page.getByRole("row", { name: "IP Namespace default" })).toBeVisible();
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a detailed header view for IP prefix entities, providing enhanced display of attributes and relationships with improved styling and navigation links.

* **Improvements**
  * Updated the IPAM details layout to use the new header component for a more consistent and informative presentation.
  * Navigation links within IP namespace tabs are now dynamically generated for improved flexibility.
  * The edit modal in object details now closes automatically after updates for a smoother user experience.
  * Excluded the "prefix" attribute from the list view of IP prefixes for a cleaner display.
  * Improved accessibility in IP prefix utilization display on details page.

* **Refactor**
  * Simplified component prop interfaces for improved maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->