### PR TITLE
Enable collapsing IPAM tree

### DIFF
--- a/frontend/app/src/config/localStorage.ts
+++ b/frontend/app/src/config/localStorage.ts
@@ -1,3 +1,3 @@
 export const ACCESS_TOKEN_KEY = "access_token";
-
 export const SIDEBAR_COLLAPSED_KEY = "sidebar_collapsed";
+export const IPAM_TREE_KEY = "ipam_tree_collapsed";

--- a/frontend/app/src/entities/ipam/ip-addresses/utils/get-ip-address-table-columns.tsx
+++ b/frontend/app/src/entities/ipam/ip-addresses/utils/get-ip-address-table-columns.tsx
@@ -75,7 +75,11 @@ export const getIpAddressTableColumns = (
           columnHelper.accessor("__typename", {
             id: "objectKind",
             header: () => <KindHeaderCell schema={schema} />,
-            cell: ({ cell }) => <KindBodyCell schemaKind={cell.getValue()} />,
+            cell: ({ cell }) => {
+              const schemaKind = cell.getValue();
+              if (schemaKind === IP_ADDRESS_AVAILABLE_KIND) return null;
+              return <KindBodyCell schemaKind={cell.getValue()} />;
+            },
           }),
         ]
       : ([] as Array<any>)),

--- a/frontend/app/src/entities/ipam/ip-namespaces/ip-namespace-selector.tsx
+++ b/frontend/app/src/entities/ipam/ip-namespaces/ip-namespace-selector.tsx
@@ -29,45 +29,44 @@ export default function IpNamespaceSelector({ className }: IpNamespaceSelectorPr
   const [isOpen, setIsOpen] = React.useState(false);
 
   return (
-    <div className={classNames("flex gap-2 items-center", className)}>
-      <PopoverTrigger isOpen={isOpen} onOpenChange={setIsOpen}>
-        <AriaButton
-          data-testid="namespace-select"
-          className={classNames(
-            focusVisibleStyle,
-            "flex flex-col w-full px-2 py-1",
-            "border border-transparent",
-            "hover:bg-gray-100"
-          )}
-        >
-          <Row className="text-xs text-gray-600">IP Namespace</Row>
-          <Row className="text-sm">
-            <span className="truncate">{getNodeLabel(currentIpNamespace)}</span>
-            <ChevronsUpDownIcon className="ml-auto text-gray-600 size-3.5" />
-          </Row>
-        </AriaButton>
+    <PopoverTrigger isOpen={isOpen} onOpenChange={setIsOpen}>
+      <AriaButton
+        data-testid="namespace-select"
+        className={classNames(
+          focusVisibleStyle,
+          "flex flex-col w-full px-1.5 py-0.5 h-10 rounded",
+          "border border-transparent",
+          "hover:bg-gray-100",
+          className
+        )}
+      >
+        <Row className="text-xs text-gray-600">IP Namespace</Row>
+        <Row className="text-sm gap-1.5">
+          <span className="truncate">{getNodeLabel(currentIpNamespace)}</span>
+          <ChevronsUpDownIcon className="ml-auto text-gray-600 size-3.5 shrink-0" />
+        </Row>
+      </AriaButton>
 
-        <Popover placement="bottom start" style={{ width: "var(--trigger-width)" }}>
-          <IpNamespaceComboboxList
-            onNamespaceSelection={(value) => {
-              setCurrentIpNamespace(value);
-              setIsOpen(false);
-            }}
-          />
+      <Popover placement="bottom start" style={{ width: "var(--trigger-width)" }}>
+        <IpNamespaceComboboxList
+          onNamespaceSelection={(value) => {
+            setCurrentIpNamespace(value);
+            setIsOpen(false);
+          }}
+        />
 
-          <Col className="border-t border-neutral-200">
-            <LinkButton
-              to={constructPath("/ipam/namespaces")}
-              variant="ghost"
-              size="sm"
-              className="text-xs justify-start m-2"
-            >
-              View all IP namespaces
-            </LinkButton>
-          </Col>
-        </Popover>
-      </PopoverTrigger>
-    </div>
+        <Col className="border-t border-neutral-200">
+          <LinkButton
+            to={constructPath("/ipam/namespaces")}
+            variant="ghost"
+            size="sm"
+            className="text-xs justify-start m-2"
+          >
+            View all IP namespaces
+          </LinkButton>
+        </Col>
+      </Popover>
+    </PopoverTrigger>
   );
 }
 

--- a/frontend/app/src/entities/ipam/ip-prefixes/ui/ipam-details-header.tsx
+++ b/frontend/app/src/entities/ipam/ip-prefixes/ui/ipam-details-header.tsx
@@ -54,7 +54,7 @@ export function IpamDetailsHeader({
         />
       </Row>
 
-      <Row>
+      <Row className="gap-2.5">
         <Fade />
         {orderedFields.map((field, index) => {
           let displayValue: React.ReactNode = "-";

--- a/frontend/app/src/entities/ipam/ip-prefixes/utils/get-ip-prefix-table-columns.tsx
+++ b/frontend/app/src/entities/ipam/ip-prefixes/utils/get-ip-prefix-table-columns.tsx
@@ -82,7 +82,11 @@ export const getIpPrefixTableColumns = (schema: ModelSchema): ColumnDef<NodeCore
           columnHelper.accessor("__typename", {
             id: "objectKind",
             header: () => <KindHeaderCell schema={schema} />,
-            cell: ({ cell }) => <KindBodyCell schemaKind={cell.getValue()} />,
+            cell: ({ cell }) => {
+              const schemaKind = cell.getValue();
+              if (schemaKind === IP_PREFIX_AVAILABLE_KIND) return null;
+              return <KindBodyCell schemaKind={schemaKind} />;
+            },
           }),
         ]
       : ([] as Array<any>)),

--- a/frontend/app/src/pages/ipam/ipam-layout.tsx
+++ b/frontend/app/src/pages/ipam/ipam-layout.tsx
@@ -1,33 +1,62 @@
+import { IPAM_TREE_KEY } from "@/config/localStorage";
 import IpNamespaceSelector from "@/entities/ipam/ip-namespaces/ip-namespace-selector";
 import { IpNamespaceProvider } from "@/entities/ipam/ip-namespaces/ui/ip-namespace-provider";
 import { IpamBreadcrumb } from "@/entities/ipam/ipam-breadcrumb";
 import IpamTree from "@/entities/ipam/ipam-tree/ipam-tree";
-import { Col } from "@/shared/components/container";
+import { Separator } from "@/shared/components/aria/separator";
+import { Button } from "@/shared/components/buttons/button-primitive";
+import { Col, Row } from "@/shared/components/container";
 import ErrorScreen from "@/shared/components/errors/error-screen";
 import { Card } from "@/shared/components/ui/card";
 import { ScrollArea } from "@/shared/components/ui/scroll-area";
+import { useLocalStorage } from "@/shared/hooks/useLocalStorage";
+import { SidebarIcon } from "lucide-react";
 import { ErrorBoundary } from "react-error-boundary";
 import { Outlet } from "react-router";
 
 export const Component = () => {
+  const [collapsed, setCollapsed] = useLocalStorage(IPAM_TREE_KEY);
+
+  const booleanCollapsed = collapsed === "true";
+
   return (
     <IpNamespaceProvider>
-      <Card className="p-0 flex items-stretch h-full w-full overflow-hidden">
-        <Col className="gap-0 w-60 shrink-0 border-r border-gray-200">
-          <IpNamespaceSelector className="border-b border-gray-200 h-12" />
+      <Card className="p-0 flex flex-col size-full overflow-hidden">
+        <Row className="h-11 gap-0 *:shrink-0">
+          <Button
+            variant="ghost"
+            size="square"
+            aria-label="toggle IPAM tree"
+            onClick={() => setCollapsed(JSON.stringify(!booleanCollapsed))}
+            className="m-1 text-gray-400 hover:text-neutral-600"
+          >
+            <SidebarIcon className="size-4" />
+          </Button>
+          <Separator orientation="vertical" />
+          <IpNamespaceSelector className="w-47 m-0.75" />
+          <Separator orientation="vertical" />
+          <IpamBreadcrumb className="grow px-2" />
+        </Row>
 
-          <ErrorBoundary fallbackRender={({ error }) => <ErrorScreen message={error.message} />}>
-            <ScrollArea scrollX>
-              <IpamTree className="w-full px-2" />
-            </ScrollArea>
-          </ErrorBoundary>
-        </Col>
+        <Separator />
 
-        <Col className="gap-0 grow overflow-hidden">
-          <IpamBreadcrumb className="h-12 shrink-0 border-b border-gray-200 px-2" />
+        <Row className="items-stretch overflow-hidden gap-0 grow">
+          {!booleanCollapsed && (
+            <Col className="gap-0 w-60 shrink-0 border-r border-gray-200">
+              <ErrorBoundary
+                fallbackRender={({ error }) => <ErrorScreen message={error.message} />}
+              >
+                <ScrollArea scrollX>
+                  <IpamTree className="w-full px-2" />
+                </ScrollArea>
+              </ErrorBoundary>
+            </Col>
+          )}
 
-          <Outlet />
-        </Col>
+          <Col className="gap-0 grow overflow-hidden">
+            <Outlet />
+          </Col>
+        </Row>
       </Card>
     </IpNamespaceProvider>
   );

--- a/frontend/app/src/shared/components/aria/separator.tsx
+++ b/frontend/app/src/shared/components/aria/separator.tsx
@@ -1,0 +1,20 @@
+import { classNames } from "@/shared/utils/common";
+import {
+  Separator as AriaSeparator,
+  SeparatorProps as AriaSeparatorProps,
+} from "react-aria-components";
+
+export interface SeparatorProps extends AriaSeparatorProps {}
+
+export function Separator({ orientation = "horizontal", className, ...props }: SeparatorProps) {
+  return (
+    <AriaSeparator
+      {...props}
+      className={classNames(
+        "bg-gray-200 text-gray-200 shrink-0",
+        orientation === "horizontal" ? "h-px w-full" : "h-full w-px",
+        className
+      )}
+    />
+  );
+}

--- a/frontend/app/tests/e2e/ipam/ipam-tree.spec.ts
+++ b/frontend/app/tests/e2e/ipam/ipam-tree.spec.ts
@@ -48,28 +48,36 @@ test.describe("/ipam - Ipam Tree", () => {
     await expect(page.getByRole("heading", { name: "10.0.0.0/8" })).toBeVisible();
   });
 
-  test.describe("IPAM search", () => {
-    test("search an IP Prefix", async ({ page }) => {
-      await page.goto("/ipam");
+  test("search an IP Prefix", async ({ page }) => {
+    await page.goto("/ipam");
 
-      await test.step("search on IPAM tree", async () => {
-        await expect(page.getByRole("treeitem", { name: "10.0.0.0/8" })).toBeVisible();
-        await page.getByPlaceholder("Filter...").fill("10.2");
-        await expect(page.getByRole("treeitem", { name: "10.2.0.0/16" })).toBeVisible();
-        expect(await page.getByRole("treeitem").count()).toEqual(1);
-      });
-
-      await test.step("search results are visible after navigation", async () => {
-        await page.getByRole("treeitem", { name: "10.2.0.0/16" }).click();
-        await expect(page.getByText("Prefix10.2.0.0/16")).toBeVisible();
-        await expect(page.getByRole("treeitem", { name: "10.2.0.0/16" })).toBeVisible();
-        expect(await page.getByRole("treeitem").count()).toEqual(1);
-      });
-
-      await test.step("reset IPAM search", async () => {
-        await page.getByPlaceholder("Filter...").fill("");
-        await expect(page.getByRole("treeitem", { name: "10.0.0.0/8" })).toBeVisible();
-      });
+    await test.step("search on IPAM tree", async () => {
+      await expect(page.getByRole("treeitem", { name: "10.0.0.0/8" })).toBeVisible();
+      await page.getByPlaceholder("Filter...").fill("10.2");
+      await expect(page.getByRole("treeitem", { name: "10.2.0.0/16" })).toBeVisible();
+      expect(await page.getByRole("treeitem").count()).toEqual(1);
     });
+
+    await test.step("search results are visible after navigation", async () => {
+      await page.getByRole("treeitem", { name: "10.2.0.0/16" }).click();
+      await expect(page.getByText("Prefix10.2.0.0/16")).toBeVisible();
+      await expect(page.getByRole("treeitem", { name: "10.2.0.0/16" })).toBeVisible();
+      expect(await page.getByRole("treeitem").count()).toEqual(1);
+    });
+
+    await test.step("reset IPAM search", async () => {
+      await page.getByPlaceholder("Filter...").fill("");
+      await expect(page.getByRole("treeitem", { name: "10.0.0.0/8" })).toBeVisible();
+    });
+  });
+
+  test("collapse IPAM tree", async ({ page }) => {
+    await page.goto("/ipam");
+
+    await expect(page.getByTestId("ipam-tree")).toBeVisible();
+    await page.getByRole("button", { name: "toggle IPAM tree" }).click();
+    await expect(page.getByTestId("ipam-tree")).toBeHidden();
+    await page.getByRole("button", { name: "toggle IPAM tree" }).click();
+    await expect(page.getByTestId("ipam-tree")).toBeVisible();
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a collapsible sidebar for the IPAM tree with state persisted between sessions.
  * Introduced a toggle button in the header to show or hide the IPAM tree sidebar.
  * Added a new separator component for consistent visual dividers.

* **Enhancements**
  * Improved spacing and layout in the IPAM details header and IP namespace selector for better usability.
  * Updated IP address and prefix tables to conditionally hide the object kind column for available entries.

* **Tests**
  * Added end-to-end test to verify collapsing and expanding the IPAM tree sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->