### PR TITLE
another fix for migrated kind nodes in the diff

### DIFF
--- a/backend/infrahub/core/query/diff.py
+++ b/backend/infrahub/core/query/diff.py
@@ -666,6 +666,17 @@ AND ALL(
     WHERE ((r_pair[0]).branch = $base_branch_name OR (r_pair[1]).branch = $branch_name)
     // filter out paths where an active edge follows a deleted edge
     AND ((r_pair[0]).status = "active" OR (r_pair[1]).status = "deleted")
+    // filter out paths where an earlier from time follows a later from time
+    AND (r_pair[0]).from <= (r_pair[1]).from
+    // if both are deleted, then the deeper edge must have been deleted first
+    AND ((r_pair[0]).status = "active" OR (r_pair[1]).status = "active" OR (r_pair[0]).from >= (r_pair[1].from))
+    AND (
+        (r_pair[0]).status = (r_pair[1]).status
+        OR (
+            (r_pair[0]).from <= (r_pair[1]).from
+            AND ((r_pair[0]).to IS NULL OR (r_pair[0]).to >= (r_pair[1]).from)
+        )
+    )
     // require adjacent edge pairs to have overlapping times, but only if on the same branch
     AND (
         (r_pair[0]).branch <> (r_pair[1]).branch

--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -643,12 +643,9 @@ class RelationshipGetPeerQuery(Query):
 
         arrows = self.schema.get_query_arrows()
 
-        path_str = (
-            f"{arrows.left.start}[:IS_RELATED]{arrows.left.end}(rl){arrows.right.start}[:IS_RELATED]{arrows.right.end}"
-        )
+        path_str = f"{arrows.left.start}[r1:IS_RELATED]{arrows.left.end}(rl){arrows.right.start}[r2:IS_RELATED]{arrows.right.end}"
 
         branch_level_str = "reduce(br_lvl = 0, r in relationships(path) | br_lvl + r.branch_level)"
-        froms_str = db.render_list_comprehension(items="relationships(path)", item_name="from")
         query = """
         MATCH (source_node:Node)%(arrow_left_start)s[:IS_RELATED]%(arrow_left_end)s(rl:Relationship { name: $rel_identifier })
         WHERE source_node.uuid IN $source_ids
@@ -659,24 +656,24 @@ class RelationshipGetPeerQuery(Query):
                 $source_kind IN LABELS(source_node) AND
                 peer.uuid <> source_node.uuid AND
                 $peer_kind IN LABELS(peer) AND
-                all(r IN relationships(path) WHERE (%(branch_filter)s))
-            WITH source_node, peer, rl, relationships(path) as rels, %(branch_level)s AS branch_level, %(froms)s AS froms
-            RETURN peer as peer, rels, rl as rl1
-            ORDER BY branch_level DESC, froms[-1] DESC, froms[-2] DESC
+                all(r IN [r1, r2] WHERE (%(branch_filter)s))
+            WITH source_node, peer, rl, r1, r2, %(branch_level)s AS branch_level
+            RETURN peer as peer, r1.status = "active" AND r2.status = "active" AS is_active, [r1, r2] AS rels
+            // status is required as a tiebreaker for migrated-kind nodes
+            ORDER BY branch_level DESC, r2.from DESC, r2.status ASC, r1.from DESC, r1.status ASC
             LIMIT 1
         }
-        WITH peer, rl1 as rl, rels, source_node
+        WITH peer, rl, is_active, rels, source_node
         """ % {
             "path": path_str,
             "branch_filter": branch_filter,
             "branch_level": branch_level_str,
-            "froms": froms_str,
             "arrow_left_start": arrows.left.start,
             "arrow_left_end": arrows.left.end,
         }
 
         self.add_to_query(query)
-        where_clause = ['all(r IN rels WHERE r.status = "active")']
+        where_clause = ["is_active = TRUE"]
         clean_filters = extract_field_filters(field_name=self.schema.name, filters=self.filters)
 
         if (clean_filters and "id" in clean_filters) or "ids" in clean_filters:

--- a/backend/tests/unit/core/diff/test_diff_calculator.py
+++ b/backend/tests/unit/core/diff/test_diff_calculator.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 import pytest
@@ -19,6 +21,9 @@ from infrahub.core.path import SchemaPath
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
+
+if TYPE_CHECKING:
+    from infrahub.core.diff.model.path import DiffNode
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -3235,6 +3240,7 @@ async def test_calculate_with_migrated_kind_node(
     base_diff = calculated_diffs.base_branch_diff
     assert len(base_diff.nodes) == 2
     nodes_by_id_and_kind = {(n.uuid, n.kind): n for n in base_diff.nodes}
+    assert len(base_diff.nodes) == 2
     assert set(nodes_by_id_and_kind.keys()) == {
         (car_camry_main.id, "TestCar"),
         (person_jane_main.id, person_jane_main.get_kind()),
@@ -4076,6 +4082,7 @@ async def test_migrated_kind_node_then_peer_delete(
 
     branch_diff = calculated_diffs.diff_branch_diff
     nodes_by_id = {n.uuid: n for n in branch_diff.nodes}
+    assert len(branch_diff.nodes) == 2
     assert set(nodes_by_id.keys()) == {person_john_main.id, car_accord_main.id}
 
     person_node = nodes_by_id[person_john_main.id]
@@ -4095,3 +4102,197 @@ async def test_migrated_kind_node_then_peer_delete(
     car_node = nodes_by_id[car_accord_main.id]
     assert car_node.action is DiffAction.REMOVED
     assert car_node.is_node_kind_migration is False
+
+
+async def test_migrated_kind_with_property_level_changes(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_accord_main,
+    car_camry_main,
+    person_john_main,
+    person_jane_main,
+    person_alfred_main,
+):
+    branch = await create_branch(db=db, branch_name="lets-migrate")
+
+    # property-level changes before migration
+    branch_john = await NodeManager.get_one(db=db, branch=branch, id=person_john_main.id)
+    branch_john.name.value = "John Branch"
+    await branch_john.save(db=db)
+    branch_accord = await NodeManager.get_one(db=db, branch=branch, id=car_accord_main.id)
+    await branch_accord.owner.update(db=db, data={"id": person_john_main.id, "_relation__is_visible": False})
+    await branch_accord.save(db=db)
+
+    # migrate TestPerson kind on branch
+    schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+    registry.schema.set_schema_branch(name=branch.name, schema=schema_branch)
+    original_person_schema = schema_branch.get_node(name="TestPerson")
+    person_schema = schema_branch.get_node(name="TestPerson")
+    person_schema.inherit_from = ["GenericThing"]
+    registry.schema.set(name="TestPerson", schema=person_schema, branch=branch.name)
+    migration = NodeKindUpdateMigration(
+        previous_node_schema=original_person_schema,
+        new_node_schema=person_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestPerson", field_name="inherit_from"),
+    )
+    execution_result = await migration.execute(db=db, branch=branch)
+    assert not execution_result.errors
+
+    # property-level change after migration
+    branch_jane = await NodeManager.get_one(db=db, branch=branch, id=person_jane_main.id)
+    branch_jane.name.value = "Jane Branch"
+    await branch_jane.save(db=db)
+    branch_camry = await NodeManager.get_one(db=db, branch=branch, id=car_camry_main.id)
+    await branch_camry.owner.update(db=db, data={"id": person_jane_main.id, "_relation__is_protected": True})
+    await branch_camry.save(db=db)
+
+    diff_calculator = DiffCalculator(db=db)
+
+    calculated_diffs = await diff_calculator.calculate_diff(
+        base_branch=default_branch,
+        diff_branch=branch,
+        from_time=Timestamp(branch.get_branched_from()),
+        to_time=Timestamp(),
+        previous_node_specifiers=None,
+        include_unchanged=True,
+    )
+
+    base_diff = calculated_diffs.base_branch_diff
+    assert base_diff.nodes == []
+
+    branch_diff = calculated_diffs.diff_branch_diff
+    nodes_by_id: dict[str, list[DiffNode]] = defaultdict(list)
+    for node in branch_diff.nodes:
+        nodes_by_id[node.uuid].append(node)
+    assert len(branch_diff.nodes) == 8
+    assert set(nodes_by_id.keys()) == {
+        person_john_main.id,
+        person_jane_main.id,
+        person_alfred_main.id,
+        car_accord_main.id,
+        car_camry_main.id,
+    }
+
+    # validate person_alfred_main migrated
+    alfred_previous_diff = [n for n in nodes_by_id[person_alfred_main.id] if n.action is DiffAction.REMOVED][0]
+    alfred_new_diff = [n for n in nodes_by_id[person_alfred_main.id] if n.action is DiffAction.ADDED][0]
+    assert alfred_previous_diff.is_node_kind_migration is True
+    assert alfred_previous_diff.attributes == []
+    assert alfred_previous_diff.relationships == []
+    assert alfred_new_diff.is_node_kind_migration is True
+    assert alfred_new_diff.attributes == []
+    assert alfred_new_diff.relationships == []
+
+    # validate person_john_main migrated
+    john_previous_diff = [n for n in nodes_by_id[person_john_main.id] if n.action is DiffAction.REMOVED][0]
+    john_new_diff = [n for n in nodes_by_id[person_john_main.id] if n.action is DiffAction.ADDED][0]
+    assert john_previous_diff.is_node_kind_migration is True
+    assert john_previous_diff.attributes == []
+    assert john_previous_diff.relationships == []
+    assert john_new_diff.is_node_kind_migration is True
+    attributes_by_name = {a.name: a for a in john_new_diff.attributes}
+    assert set(attributes_by_name.keys()) == {"name"}
+    name_attr = attributes_by_name["name"]
+    # it would be more correct if this was DiffAction.UPDATED, but ADDED is also technically correct for a node kind migration
+    assert name_attr.action is DiffAction.ADDED
+    properties_by_type = {p.property_type: p for p in name_attr.properties}
+    assert set(properties_by_type.keys()) == {DatabaseEdgeType.HAS_VALUE}
+    has_value_prop = properties_by_type[DatabaseEdgeType.HAS_VALUE]
+    assert has_value_prop.action is DiffAction.UPDATED
+    assert has_value_prop.new_value == "John Branch"
+    assert has_value_prop.previous_value == "John"
+    relationships_by_identifier = {r.identifier: r for r in john_new_diff.relationships}
+    assert set(relationships_by_identifier.keys()) == {"testcar__testperson"}
+    cars_rel = relationships_by_identifier["testcar__testperson"]
+    assert cars_rel.action is DiffAction.UPDATED
+    elements_by_id = {r.peer_id: r for r in cars_rel.relationships}
+    assert set(elements_by_id.keys()) == {car_accord_main.id}
+    element_diff = elements_by_id[car_accord_main.id]
+    assert element_diff.action is DiffAction.UPDATED
+    assert element_diff.peer_id == car_accord_main.id
+    properties_by_type = {p.property_type: p for p in element_diff.properties if p.action != DiffAction.UNCHANGED}
+    assert set(properties_by_type.keys()) == {DatabaseEdgeType.IS_VISIBLE}
+    is_visible_prop = properties_by_type[DatabaseEdgeType.IS_VISIBLE]
+    assert is_visible_prop.action is DiffAction.UPDATED
+    assert is_visible_prop.new_value is False
+    assert is_visible_prop.previous_value is True
+
+    # validate person_jane_main migrated
+    jane_previous_diff = [n for n in nodes_by_id[person_jane_main.id] if n.action is DiffAction.REMOVED][0]
+    jane_new_diff = [n for n in nodes_by_id[person_jane_main.id] if n.action is DiffAction.ADDED][0]
+    assert jane_previous_diff.is_node_kind_migration is True
+    assert jane_previous_diff.attributes == []
+    assert jane_previous_diff.relationships == []
+    assert jane_new_diff.is_node_kind_migration is True
+    attributes_by_name = {a.name: a for a in jane_new_diff.attributes}
+    assert set(attributes_by_name.keys()) == {"name"}
+    name_attr = attributes_by_name["name"]
+    # it would be more correct if this was DiffAction.UPDATED, but ADDED is also technically correct for a node kind migration
+    assert name_attr.action is DiffAction.ADDED
+    properties_by_type = {p.property_type: p for p in name_attr.properties}
+    assert set(properties_by_type.keys()) == {DatabaseEdgeType.HAS_VALUE}
+    has_value_prop = properties_by_type[DatabaseEdgeType.HAS_VALUE]
+    assert has_value_prop.action is DiffAction.UPDATED
+    assert has_value_prop.new_value == "Jane Branch"
+    assert has_value_prop.previous_value == "Jane"
+    relationships_by_identifier = {r.identifier: r for r in jane_new_diff.relationships}
+    assert set(relationships_by_identifier.keys()) == {"testcar__testperson"}
+    cars_rel = relationships_by_identifier["testcar__testperson"]
+    assert cars_rel.action is DiffAction.UPDATED
+    elements_by_id = {r.peer_id: r for r in cars_rel.relationships}
+    assert set(elements_by_id.keys()) == {car_camry_main.id}
+    element_diff = elements_by_id[car_camry_main.id]
+    assert element_diff.action is DiffAction.UPDATED
+    assert element_diff.peer_id == car_camry_main.id
+    properties_by_type = {p.property_type: p for p in element_diff.properties if p.action != DiffAction.UNCHANGED}
+    assert set(properties_by_type.keys()) == {DatabaseEdgeType.IS_PROTECTED}
+    is_protected_prop = properties_by_type[DatabaseEdgeType.IS_PROTECTED]
+    assert is_protected_prop.action is DiffAction.UPDATED
+    assert is_protected_prop.new_value is True
+    assert is_protected_prop.previous_value is False
+
+    # validate car_accord
+    car_diffs = nodes_by_id[car_accord_main.id]
+    assert len(car_diffs) == 1
+    car_diff = car_diffs[0]
+    assert car_diff.action is DiffAction.UPDATED
+    assert car_diff.is_node_kind_migration is False
+    assert car_diff.attributes == []
+    rels_by_identifier = {r.identifier: r for r in car_diff.relationships}
+    assert set(rels_by_identifier.keys()) == {"testcar__testperson"}
+    person_rel = rels_by_identifier["testcar__testperson"]
+    assert person_rel.action is DiffAction.UPDATED
+    elements_by_id = {r.peer_id: r for r in person_rel.relationships}
+    assert set(elements_by_id.keys()) == {person_john_main.id}
+    element_diff = elements_by_id[person_john_main.id]
+    assert element_diff.action is DiffAction.UPDATED
+    assert element_diff.peer_id == person_john_main.id
+    properties_by_type = {p.property_type: p for p in element_diff.properties if p.action != DiffAction.UNCHANGED}
+    assert set(properties_by_type.keys()) == {DatabaseEdgeType.IS_VISIBLE}
+    is_visible_prop = properties_by_type[DatabaseEdgeType.IS_VISIBLE]
+    assert is_visible_prop.action is DiffAction.UPDATED
+    assert is_visible_prop.new_value is False
+    assert is_visible_prop.previous_value is True
+
+    # validate car_camry
+    car_diffs = nodes_by_id[car_camry_main.id]
+    assert len(car_diffs) == 1
+    car_diff = car_diffs[0]
+    assert car_diff.action is DiffAction.UPDATED
+    assert car_diff.is_node_kind_migration is False
+    assert car_diff.attributes == []
+    rels_by_identifier = {r.identifier: r for r in car_diff.relationships}
+    assert set(rels_by_identifier.keys()) == {"testcar__testperson"}
+    person_rel = rels_by_identifier["testcar__testperson"]
+    assert person_rel.action is DiffAction.UPDATED
+    elements_by_id = {r.peer_id: r for r in person_rel.relationships}
+    assert set(elements_by_id.keys()) == {person_jane_main.id}
+    element_diff = elements_by_id[person_jane_main.id]
+    assert element_diff.action is DiffAction.UPDATED
+    assert element_diff.peer_id == person_jane_main.id
+    properties_by_type = {p.property_type: p for p in element_diff.properties if p.action != DiffAction.UNCHANGED}
+    assert set(properties_by_type.keys()) == {DatabaseEdgeType.IS_PROTECTED}
+    is_protected_prop = properties_by_type[DatabaseEdgeType.IS_PROTECTED]
+    assert is_protected_prop.action is DiffAction.UPDATED
+    assert is_protected_prop.new_value is True
+    assert is_protected_prop.previous_value is False

--- a/backend/tests/unit/core/test_relationship_query.py
+++ b/backend/tests/unit/core/test_relationship_query.py
@@ -837,6 +837,49 @@ async def test_query_RelationshipGetPeerQuery_with_multiple_filter(
     assert query.get_peer_ids() == [car_volt_main.id]
 
 
+async def test_query_RelationshipGetPeerQuery_with_migrated_kind(
+    db: InfrahubDatabase,
+    person_john_main,
+    car_accord_main,
+    car_camry_main,
+    car_volt_main,
+    car_prius_main,
+    car_yaris_main,
+    branch: Branch,
+):
+    person_schema = registry.schema.get_node_schema(name="TestPerson")
+    rel_schema = person_schema.get_relationship("cars")
+
+    # migrate person kind
+    person_schema.name = "NewPerson"
+    person_schema.namespace = "Test2"
+    assert person_schema.kind == "Test2NewPerson"
+    registry.schema.set(name="Test2NewPerson", schema=person_schema, branch=branch.name)
+    migration = NodeKindUpdateMigration(
+        previous_node_schema=registry.schema.get_node_schema(name="TestPerson", branch=branch),
+        new_node_schema=person_schema,
+        schema_path=SchemaPath(
+            path_type=SchemaPathType.ATTRIBUTE, schema_kind="Test2NewPerson", field_name="namespace"
+        ),
+    )
+    execution_result = await migration.execute(db=db, branch=branch)
+    assert not execution_result.errors
+
+    query = await RelationshipGetPeerQuery.init(
+        db=db,
+        source_ids=[person_john_main.id],
+        schema=rel_schema,
+        filters={"cars__is_electric__value": True, "cars__nbr_seats__value": 4},
+        rel=Relationship,
+        branch=branch,
+        at=Timestamp(),
+    )
+
+    await query.execute(db=db)
+
+    assert query.get_peer_ids() == [car_volt_main.id]
+
+
 async def test_query_RelationshipDataDeleteQuery(
     db: InfrahubDatabase, tag_blue_main: Node, person_jack_tags_main: Node, branch: Branch
 ):

--- a/changelog/+migrated-kind-diff.fixed.md
+++ b/changelog/+migrated-kind-diff.fixed.md
@@ -1,0 +1,2 @@
+Fix an issue in a cypher query to get the peers of a node that has been migrated for a kind or inheritance update.
+Fix an issue in the diff calculation that could double count properties of a node that has been migrated for a kind or inheritance update.


### PR DESCRIPTION
follow up to #6927 

- fix an issue in the diff calculation that could result in property-level changes being double-counted for a node with migrated kind/inheritance
- fix an issue in the `RelationshipGetPeerQuery` that could cause a relationship that exists on the database to be incorrectly ignored and then possible recreated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of peer retrieval and diff calculation for nodes that have undergone kind or inheritance migrations, preventing double counting of properties and ensuring correct peer identification.

* **Tests**
  * Added comprehensive tests to verify correct diff behavior and peer query results for migrated nodes and property-level changes.

* **Changelog**
  * Updated documentation to reflect fixes related to migrated node handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->