### PR TITLE
Release note for 1.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 ### Fixed
 
-- Fix repository objects view when there is no group tied to the repository ([#repo-objects](https://github.com/opsmill/infrahub/issues/repo-objects))
+- Fix repository objects view when there is no group tied to the repository [repository-objects](https://github.com/opsmill/infrahub/issues/repo-objects)
 - Prevent Python keywords from being used as attribute/relationship names in schemas. Schema validation now rejects Python keywords (like `from`, `class`, `import`) as attribute or relationship names, preventing 500 errors during GraphQL schema generation. ([#6730](https://github.com/opsmill/infrahub/issues/6730))
 - Fix bug in diff calculation logic that could prevent the diff from generating if the peer of a deleted node had its kind or inheritance changed on multiple branches ([#6928](https://github.com/opsmill/infrahub/issues/6928))
 - Fix an issue in a cypher query to get the peers of a node that has been migrated for a kind or inheritance update.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
+## [Infrahub - v1.3.5](https://github.com/opsmill/infrahub/tree/infrahub-v1.3.5) - 2025-08-05
+
+### Added
+
+- Add a new check for orphaned Relationship vertices to `infrahub db check`
+
+### Fixed
+
+- Fix repository objects view when there is no group tied to the repository ([#repo-objects](https://github.com/opsmill/infrahub/issues/repo-objects))
+- Prevent Python keywords from being used as attribute/relationship names in schemas. Schema validation now rejects Python keywords (like `from`, `class`, `import`) as attribute or relationship names, preventing 500 errors during GraphQL schema generation. ([#6730](https://github.com/opsmill/infrahub/issues/6730))
+- Fix bug in diff calculation logic that could prevent the diff from generating if the peer of a deleted node had its kind or inheritance changed on multiple branches ([#6928](https://github.com/opsmill/infrahub/issues/6928))
+- Fix an issue in a cypher query to get the peers of a node that has been migrated for a kind or inheritance update.
+- Fix an issue in the diff calculation that could double count properties of a node that has been migrated for a kind or inheritance update.
+
 ## [Infrahub - v1.3.4](https://github.com/opsmill/infrahub/tree/infrahub-v1.3.4) - 2025-07-22
 
 ### Fixed

--- a/changelog/+migrated-kind-diff.fixed.md
+++ b/changelog/+migrated-kind-diff.fixed.md
@@ -1,2 +1,0 @@
-Fix an issue in a cypher query to get the peers of a node that has been migrated for a kind or inheritance update.
-Fix an issue in the diff calculation that could double count properties of a node that has been migrated for a kind or inheritance update.

--- a/changelog/+orphaned-relationship-check.added.md
+++ b/changelog/+orphaned-relationship-check.added.md
@@ -1,1 +1,0 @@
-Add a new check for orphaned Relationship vertices to `infrahub db check`

--- a/changelog/6730.fixed.md
+++ b/changelog/6730.fixed.md
@@ -1,1 +1,0 @@
-Prevent Python keywords from being used as attribute/relationship names in schemas. Schema validation now rejects Python keywords (like `from`, `class`, `import`) as attribute or relationship names, preventing 500 errors during GraphQL schema generation.

--- a/changelog/6928.fixed.md
+++ b/changelog/6928.fixed.md
@@ -1,1 +1,0 @@
-Fix bug in diff calculation logic that could prevent the diff from generating if the peer of a deleted node had its kind or inheritance changed on multiple branches

--- a/changelog/repo-objects.fixed.md
+++ b/changelog/repo-objects.fixed.md
@@ -1,1 +1,0 @@
-Fix repository objects view when there is no group tied to the repository

--- a/docs/docs/release-notes/infrahub/release-1_3_5.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_3_5.mdx
@@ -1,0 +1,31 @@
+---
+title: Release 1.3.5
+---
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.3.5</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>August 5th, 2025</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[infrahub-v1.3.5](https://github.com/opsmill/infrahub/releases/tag/infrahub-v1.3.5)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Added
+
+- Add a new check for orphaned Relationship vertices to `infrahub db check`
+
+### Fixed
+
+- Fix repository objects view when there is no group tied to the repository ([#repo-objects](https://github.com/opsmill/infrahub/issues/repo-objects))
+- Prevent Python keywords from being used as attribute/relationship names in schemas. Schema validation now rejects Python keywords (like `from`, `class`, `import`) as attribute or relationship names, preventing 500 errors during GraphQL schema generation. ([#6730](https://github.com/opsmill/infrahub/issues/6730))
+- Fix bug in diff calculation logic that could prevent the diff from generating if the peer of a deleted node had its kind or inheritance changed on multiple branches ([#6928](https://github.com/opsmill/infrahub/issues/6928))
+- Fix an issue in a cypher query to get the peers of a node that has been migrated for a kind or inheritance update.
+- Fix an issue in the diff calculation that could double count properties of a node that has been migrated for a kind or inheritance update.

--- a/docs/docs/release-notes/infrahub/release-1_3_5.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_3_5.mdx
@@ -24,7 +24,7 @@ title: Release 1.3.5
 
 ### Fixed
 
-- Fix repository objects view when there is no group tied to the repository ([#repo-objects](https://github.com/opsmill/infrahub/issues/repo-objects))
+- Fix repository objects view when there is no group tied to the repository [repository-objects](https://github.com/opsmill/infrahub/issues/repo-objects)
 - Prevent Python keywords from being used as attribute/relationship names in schemas. Schema validation now rejects Python keywords (like `from`, `class`, `import`) as attribute or relationship names, preventing 500 errors during GraphQL schema generation. ([#6730](https://github.com/opsmill/infrahub/issues/6730))
 - Fix bug in diff calculation logic that could prevent the diff from generating if the peer of a deleted node had its kind or inheritance changed on multiple branches ([#6928](https://github.com/opsmill/infrahub/issues/6928))
 - Fix an issue in a cypher query to get the peers of a node that has been migrated for a kind or inheritance update.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "infrahub-server"
-version = "1.3.4"
+version = "1.3.5"
 description = "Infrahub is taking a new approach to Infrastructure Management by providing a new generation of datastore to organize and control all the data that defines how an infrastructure should run."
 authors = ["OpsMill <info@opsmill.com>"]
 readme = "README.md"

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = ">=3.9"
 
 [tool.poetry]
 name = "infrahub-testcontainers"
-version =  "1.3.4"
+version =  "1.3.5"
 description = "Testcontainers instance for Infrahub to easily build integration tests"
 authors = ["OpsMill <info@opsmill.com>"]
 readme = "README.md"

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-testcontainers"
-version =  "1.3.4"
+version =  "1.3.5"
 requires-python = ">=3.9"
 
 [tool.poetry]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added release notes for Infrahub version 1.3.5, detailing new features and bug fixes.  
* **New Features**
  * Introduced a database check for orphaned Relationship vertices in the database check command.  
* **Bug Fixes**
  * Corrected repository objects view when no group is associated.  
  * Improved schema validation to reject Python keywords as attribute or relationship names.  
  * Fixed diff calculation logic for nodes with changes in kind or inheritance across branches.  
  * Resolved issues with property counting and peer retrieval for migrated nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->