### PR TITLE
Remove ProposedChangeCheckForApprovalRevoke mutation

### DIFF
--- a/backend/infrahub/graphql/schema.py
+++ b/backend/infrahub/graphql/schema.py
@@ -132,5 +132,3 @@ class InfrahubBaseMutation(ObjectType):
 
     ConvertObjectType = ConvertObjectType.Field()
     CoreProposedChangeCheckForApprovalRevoke = ProposedChangeCheckForApprovalRevoke.Field()
-    # Remove the below line once the enterprise test has been renamed
-    ProposedChangeCheckForApprovalRevoke = ProposedChangeCheckForApprovalRevoke.Field()


### PR DESCRIPTION
We will use CoreProposedChangeCheckForApprovalRevoke instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed redundant mutation field registration to streamline the backend schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->