### PR TITLE
Fix total comments count in proposed changes list view

### DIFF
--- a/frontend/app/src/entities/proposed-changes/api/get-proposed-changes-from-api.ts
+++ b/frontend/app/src/entities/proposed-changes/api/get-proposed-changes-from-api.ts
@@ -56,8 +56,8 @@ export const getProposedChangesFromApi = async ({
             display_label: true,
             hfid: true,
             _updated_at: true,
-            comments: {
-              count: true,
+            total_comments: {
+              value: true,
             },
             validations: {
               count: true,

--- a/frontend/app/src/entities/proposed-changes/domain/get-proposed-changes.ts
+++ b/frontend/app/src/entities/proposed-changes/domain/get-proposed-changes.ts
@@ -14,7 +14,7 @@ export type ProposedChangeItem = {
   _updated_at: string;
   source_branch: { value: string };
   approved_by: { edges: Array<{ node: NodeCore }> };
-  comments: { count: number };
+  total_comments: { value: number };
   validations: { count: number };
 };
 

--- a/frontend/app/src/entities/proposed-changes/ui/proposed-change-item.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/proposed-change-item.tsx
@@ -40,7 +40,7 @@ export const ProposedChangesItem = ({ node }: ProposedChangesItemProps) => {
           approvers={node.approved_by.edges.map((edge: { node: NodeCore }) => {
             return edge.node;
           })}
-          comments={node.comments.count}
+          comments={node.total_comments.value ?? 0}
           validations={node.validations.count}
         />
       </div>


### PR DESCRIPTION
Use the new property to display correctly the total comments count in proposed changes list view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated how comment counts are retrieved and displayed for proposed changes, ensuring accurate totals are shown to users. The comment count now reflects the new data structure from the backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->