### PR TITLE
IFC-1718 Add specific events for threads in proposed change

### DIFF
--- a/backend/infrahub/core/constants/__init__.py
+++ b/backend/infrahub/core/constants/__init__.py
@@ -67,6 +67,8 @@ class EventType(InfrahubStringEnum):
     PROPOSED_CHANGE_REJECTED = f"{EVENT_NAMESPACE}.proposed_change.rejected"
     PROPOSED_CHANGE_APPROVAL_REVOKED = f"{EVENT_NAMESPACE}.proposed_change.approval_revoked"
     PROPOSED_CHANGE_REJECTION_REVOKED = f"{EVENT_NAMESPACE}.proposed_change.rejection_revoked"
+    PROPOSED_CHANGE_THREAD_CREATED = f"{EVENT_NAMESPACE}.proposed_change_thread.created"
+    PROPOSED_CHANGE_THREAD_UPDATED = f"{EVENT_NAMESPACE}.proposed_change_thread.updated"
 
     REPOSITORY_UPDATE_COMMIT = f"{EVENT_NAMESPACE}.repository.update_commit"
 

--- a/backend/infrahub/events/__init__.py
+++ b/backend/infrahub/events/__init__.py
@@ -10,6 +10,8 @@ from .proposed_change_action import (
     ProposedChangeRejectedEvent,
     ProposedChangeRejectionRevokedEvent,
     ProposedChangeReviewRequestedEvent,
+    ProposedChangeThreadCreatedEvent,
+    ProposedChangeThreadUpdatedEvent,
 )
 from .repository_action import CommitUpdatedEvent
 from .validator_action import ValidatorFailedEvent, ValidatorPassedEvent, ValidatorStartedEvent
@@ -35,6 +37,8 @@ __all__ = [
     "ProposedChangeRejectedEvent",
     "ProposedChangeRejectionRevokedEvent",
     "ProposedChangeReviewRequestedEvent",
+    "ProposedChangeThreadCreatedEvent",
+    "ProposedChangeThreadUpdatedEvent",
     "ValidatorFailedEvent",
     "ValidatorPassedEvent",
     "ValidatorStartedEvent",

--- a/backend/infrahub/events/generator.py
+++ b/backend/infrahub/events/generator.py
@@ -1,14 +1,16 @@
 from infrahub.context import InfrahubContext
 from infrahub.core.branch import Branch
 from infrahub.core.changelog.models import RelationshipChangelogGetter
-from infrahub.core.constants import MutationAction
+from infrahub.core.constants import InfrahubKind, MutationAction
 from infrahub.core.node import Node
+from infrahub.core.protocols import CoreProposedChange
 from infrahub.database import InfrahubDatabase
 from infrahub.events.node_action import NodeDeletedEvent, NodeMutatedEvent, NodeUpdatedEvent, get_node_event
 from infrahub.groups.parsers import GroupNodeMutationParser
 from infrahub.worker import WORKER_IDENTITY
 
 from .models import EventMeta, InfrahubEvent
+from .proposed_change_action import ProposedChangeThreadCreatedEvent, ProposedChangeThreadUpdatedEvent
 
 
 async def generate_node_mutation_events(
@@ -68,4 +70,29 @@ async def generate_node_mutation_events(
 
     group_parser = GroupNodeMutationParser(db=db, branch=branch)
     group_events = await group_parser.group_events_from_node_actions(events=events)
-    return events + group_events
+
+    specific_events: list[InfrahubEvent] = []
+    if (kind := node.get_kind()) in [
+        InfrahubKind.CHANGETHREAD,
+        InfrahubKind.OBJECTTHREAD,
+        InfrahubKind.ARTIFACTTHREAD,
+        InfrahubKind.FILETHREAD,
+    ]:
+        proposed_change: CoreProposedChange = await node.change.get_peer(db=db, peer_type=CoreProposedChange)  # type: ignore[attr-defined]
+        action_to_event_map = {
+            MutationAction.CREATED: ProposedChangeThreadCreatedEvent,
+            MutationAction.UPDATED: ProposedChangeThreadUpdatedEvent,
+        }
+        if action in action_to_event_map:
+            specific_events.append(
+                action_to_event_map[action](
+                    proposed_change_id=proposed_change.id,
+                    proposed_change_name=proposed_change.name.value,
+                    proposed_change_state=proposed_change.state.value,
+                    thread_id=node.id,
+                    thread_kind=kind,
+                    meta=EventMeta.from_context(context=context),
+                )
+            )
+
+    return events + group_events + specific_events

--- a/backend/infrahub/events/proposed_change_action.py
+++ b/backend/infrahub/events/proposed_change_action.py
@@ -2,7 +2,7 @@ from typing import ClassVar
 
 from pydantic import Field
 
-from infrahub.core.constants import InfrahubKind
+from infrahub.core.constants import InfrahubKind, MutationAction
 
 from .constants import EVENT_NAMESPACE
 from .models import InfrahubEvent
@@ -148,3 +148,34 @@ class ProposedChangeRejectionRevokedEvent(ProposedChangeReviewRevokedEvent):
     """Event generated when a proposed change rejection has been revoked"""
 
     event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.proposed_change.rejection_revoked"
+
+
+class ProposedChangeThreadEevent(ProposedChangeEvent):
+    thread_id: str = Field(..., description="The ID of the thread that was created or updated")
+    thread_kind: str = Field(..., description="The name of the thread that was created or updated")
+
+    def get_related(self) -> list[dict[str, str]]:
+        related = super().get_related()
+        related.append(
+            {
+                "prefect.resource.id": self.thread_id,
+                "prefect.resource.role": "infrahub.related.node",
+                "infrahub.node.kind": self.thread_kind,
+                "infrahub.node.id": self.thread_id,
+            }
+        )
+        return related
+
+
+class ProposedChangeThreadCreatedEvent(ProposedChangeThreadEevent):
+    """Event generated when a thread has been created in a proposed change"""
+
+    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.proposed_change_thread.created"
+    action: MutationAction = MutationAction.CREATED
+
+
+class ProposedChangeThreadUpdatedEvent(ProposedChangeThreadEevent):
+    """Event generated when a thead has been updated in a proposed change"""
+
+    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.proposed_change_thread.updated"
+    action: MutationAction = MutationAction.UPDATED

--- a/backend/infrahub/events/proposed_change_action.py
+++ b/backend/infrahub/events/proposed_change_action.py
@@ -175,7 +175,7 @@ class ProposedChangeThreadCreatedEvent(ProposedChangeThreadEevent):
 
 
 class ProposedChangeThreadUpdatedEvent(ProposedChangeThreadEevent):
-    """Event generated when a thead has been updated in a proposed change"""
+    """Event generated when a thread has been updated in a proposed change"""
 
     event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.proposed_change_thread.updated"
     action: MutationAction = MutationAction.UPDATED

--- a/backend/infrahub/events/proposed_change_action.py
+++ b/backend/infrahub/events/proposed_change_action.py
@@ -150,7 +150,7 @@ class ProposedChangeRejectionRevokedEvent(ProposedChangeReviewRevokedEvent):
     event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.proposed_change.rejection_revoked"
 
 
-class ProposedChangeThreadEevent(ProposedChangeEvent):
+class ProposedChangeThreadEvent(ProposedChangeEvent):
     thread_id: str = Field(..., description="The ID of the thread that was created or updated")
     thread_kind: str = Field(..., description="The name of the thread that was created or updated")
 
@@ -167,14 +167,14 @@ class ProposedChangeThreadEevent(ProposedChangeEvent):
         return related
 
 
-class ProposedChangeThreadCreatedEvent(ProposedChangeThreadEevent):
+class ProposedChangeThreadCreatedEvent(ProposedChangeThreadEvent):
     """Event generated when a thread has been created in a proposed change"""
 
     event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.proposed_change_thread.created"
     action: MutationAction = MutationAction.CREATED
 
 
-class ProposedChangeThreadUpdatedEvent(ProposedChangeThreadEevent):
+class ProposedChangeThreadUpdatedEvent(ProposedChangeThreadEvent):
     """Event generated when a thread has been updated in a proposed change"""
 
     event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.proposed_change_thread.updated"

--- a/backend/infrahub/graphql/types/event.py
+++ b/backend/infrahub/graphql/types/event.py
@@ -158,6 +158,13 @@ class ProposedChangeMergedEvent(ObjectType):
     payload = Field(GenericScalar, required=True)
 
 
+class ProposedChangeThreadEvent(ObjectType):
+    class Meta:
+        interfaces = (EventNodeInterface,)
+
+    payload = Field(GenericScalar, required=True)
+
+
 # ---------------------------------------
 # Node/Object events
 # ---------------------------------------
@@ -214,5 +221,7 @@ EVENT_TYPES: dict[str, type[ObjectType]] = {
     events.ProposedChangeRejectionRevokedEvent.event_name: ProposedChangeReviewRevokedEvent,
     events.ProposedChangeReviewRequestedEvent.event_name: ProposedChangeReviewRequestedEvent,
     events.ProposedChangeMergedEvent.event_name: ProposedChangeMergedEvent,
+    events.ProposedChangeThreadCreatedEvent.event_name: ProposedChangeThreadEvent,
+    events.ProposedChangeThreadUpdatedEvent.event_name: ProposedChangeThreadEvent,
     "undefined": StandardEvent,
 }

--- a/backend/tests/functional/proposed_change/test_review.py
+++ b/backend/tests/functional/proposed_change/test_review.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 
 import pytest
 from infrahub_sdk.exceptions import GraphQLError
+from prefect import get_client
+from tests.helpers.events import query_events_by_name
 from tests.helpers.test_app import TestInfrahubApp
 
 from infrahub.core.constants.infrahubkind import PROPOSEDCHANGE
@@ -12,6 +15,8 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.protocols import CoreAccountGroup
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
     from infrahub_sdk import InfrahubClient
     from prefect.client.orchestration import PrefectClient
 
@@ -27,6 +32,11 @@ class TestProposedChangeReview(TestInfrahubApp):
         }
     }
     """
+
+    @pytest.fixture(scope="class")
+    async def prefect_client(self, prefect_test_fixture) -> AsyncGenerator[PrefectClient, None]:
+        async with get_client(sync_client=False) as client:
+            yield client
 
     async def test_approve_then_reject(
         self,

--- a/backend/tests/functional/proposed_change/test_review.py
+++ b/backend/tests/functional/proposed_change/test_review.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-import asyncio
 from typing import TYPE_CHECKING
 
 import pytest
 from infrahub_sdk.exceptions import GraphQLError
-from prefect import get_client
-from tests.helpers.events import query_events_by_name
 from tests.helpers.test_app import TestInfrahubApp
 
 from infrahub.core.constants.infrahubkind import PROPOSEDCHANGE
@@ -15,8 +12,6 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.protocols import CoreAccountGroup
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator
-
     from infrahub_sdk import InfrahubClient
     from prefect.client.orchestration import PrefectClient
 
@@ -32,20 +27,6 @@ class TestProposedChangeReview(TestInfrahubApp):
         }
     }
     """
-
-    @pytest.fixture(scope="class")
-    async def prefect_client(self, prefect_test_fixture) -> AsyncGenerator[PrefectClient, None]:
-        async with get_client(sync_client=False) as client:
-            yield client
-
-    async def assert_event(self, prefect_client: PrefectClient, event_name: str) -> None:
-        for _ in range(10):
-            events = await query_events_by_name(client=prefect_client, event_name=event_name)
-            if len(events) == 1:
-                return
-            await asyncio.sleep(1)
-
-        pytest.fail(f"unable to find prefect event '{event_name}'")
 
     async def test_approve_then_reject(
         self,

--- a/backend/tests/functional/proposed_change/test_review.py
+++ b/backend/tests/functional/proposed_change/test_review.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-import asyncio
 from typing import TYPE_CHECKING
 
 import pytest
 from infrahub_sdk.exceptions import GraphQLError
 from prefect import get_client
-from tests.helpers.events import query_events_by_name
 from tests.helpers.test_app import TestInfrahubApp
 
 from infrahub.core.constants.infrahubkind import PROPOSEDCHANGE

--- a/backend/tests/functional/proposed_change/test_thread_events.py
+++ b/backend/tests/functional/proposed_change/test_thread_events.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
+from prefect import get_client
 from tests.helpers.test_app import TestInfrahubApp
 
 from infrahub import config
@@ -10,6 +11,8 @@ from infrahub.core.constants.infrahubkind import CHANGETHREAD, PROPOSEDCHANGE, T
 from infrahub.core.initialization import create_branch
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
     from infrahub_sdk import InfrahubClient
     from prefect.client.orchestration import PrefectClient
 
@@ -21,6 +24,11 @@ class TestProposedChangeThreadEvents(TestInfrahubApp):
     @pytest.fixture(scope="class", autouse=True)
     def enable_broker_settings(self) -> None:
         config.SETTINGS.broker.enable = True
+
+    @pytest.fixture(scope="class")
+    async def prefect_client(self, prefect_test_fixture) -> AsyncGenerator[PrefectClient, None]:
+        async with get_client(sync_client=False) as client:
+            yield client
 
     async def test_thread_events(
         self,

--- a/backend/tests/functional/proposed_change/test_thread_events.py
+++ b/backend/tests/functional/proposed_change/test_thread_events.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from tests.helpers.test_app import TestInfrahubApp
+
+from infrahub import config
+from infrahub.core.constants.infrahubkind import CHANGETHREAD, PROPOSEDCHANGE, THREADCOMMENT
+from infrahub.core.initialization import create_branch
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClient
+    from prefect.client.orchestration import PrefectClient
+
+    from infrahub.core.schema.schema_branch import SchemaBranch
+    from infrahub.database import InfrahubDatabase
+
+
+class TestProposedChangeThreadEvents(TestInfrahubApp):
+    @pytest.fixture(scope="class", autouse=True)
+    def enable_broker_settings(self) -> None:
+        config.SETTINGS.broker.enable = True
+
+    async def test_thread_events(
+        self,
+        enable_broker_settings: None,
+        client: InfrahubClient,
+        db: InfrahubDatabase,
+        car_person_schema: SchemaBranch,
+        unprivileged_client: InfrahubClient,
+        prefect_client: PrefectClient,
+    ) -> None:
+        """
+        Create a proposed change thread and then mark it as resolved all of this while asserting that events are being fired.
+        """
+        source_branch = await create_branch(branch_name="branch-proposed-change", db=db)
+        proposed_change = await client.create(
+            kind=PROPOSEDCHANGE,
+            data={"source_branch": source_branch.name, "destination_branch": "main", "name": "test-pc"},
+        )
+        await proposed_change.save()
+
+        pc_thread = await client.create(kind=CHANGETHREAD, data={"change": proposed_change.id})
+        await pc_thread.save()
+
+        pc_thread_comment = await client.create(kind=THREADCOMMENT, data={"thread": pc_thread.id, "text": "A comment"})
+        await pc_thread_comment.save()
+
+        await self.assert_event(prefect_client=prefect_client, event_name="infrahub.proposed_change_thread.created")
+
+        pc_thread.resolved.value = True
+        await pc_thread.save()
+
+        await self.assert_event(prefect_client=prefect_client, event_name="infrahub.proposed_change_thread.updated")

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -7,7 +7,6 @@ from fast_depends import Provider
 from fast_depends import dependency_provider as provider
 from infrahub_sdk import Config, InfrahubClient
 from infrahub_sdk.uuidt import UUIDT
-from prefect import get_client
 from prefect.client.orchestration import PrefectClient
 
 from infrahub import config

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -213,11 +213,6 @@ class TestInfrahubApp(TestInfrahub):
         # This call emits a warning related to the fact database index manager has not been initialized.
         await initialization(db=db)
 
-    @pytest.fixture(scope="class")
-    async def prefect_client(self, prefect_test_fixture) -> AsyncGenerator[PrefectClient, None]:
-        async with get_client(sync_client=False) as client:
-            yield client
-
     async def assert_event(self, prefect_client: PrefectClient, event_name: str) -> None:
         for _ in range(10):
             events = await query_events_by_name(client=prefect_client, event_name=event_name)

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -1,3 +1,4 @@
+import asyncio
 from pathlib import Path
 from typing import AsyncGenerator, Generator
 
@@ -6,6 +7,8 @@ from fast_depends import Provider
 from fast_depends import dependency_provider as provider
 from infrahub_sdk import Config, InfrahubClient
 from infrahub_sdk.uuidt import UUIDT
+from prefect import get_client
+from prefect.client.orchestration import PrefectClient
 
 from infrahub import config
 from infrahub.core import registry
@@ -30,6 +33,7 @@ from infrahub.workers.dependencies import build_cache, build_client, build_messa
 from infrahub.workflows.initialization import setup_task_manager
 from tests.adapters.cache import MemoryCache
 from tests.adapters.message_bus import BusSimulator
+from tests.helpers.events import query_events_by_name
 
 from .test_client import InfrahubTestClient
 
@@ -208,3 +212,17 @@ class TestInfrahubApp(TestInfrahub):
 
         # This call emits a warning related to the fact database index manager has not been initialized.
         await initialization(db=db)
+
+    @pytest.fixture(scope="class")
+    async def prefect_client(self, prefect_test_fixture) -> AsyncGenerator[PrefectClient, None]:
+        async with get_client(sync_client=False) as client:
+            yield client
+
+    async def assert_event(self, prefect_client: PrefectClient, event_name: str) -> None:
+        for _ in range(10):
+            events = await query_events_by_name(client=prefect_client, event_name=event_name)
+            if len(events) == 1:
+                return
+            await asyncio.sleep(1)
+
+        pytest.fail(f"unable to find prefect event '{event_name}'")

--- a/docs/docs/reference/infrahub-events.mdx
+++ b/docs/docs/reference/infrahub-events.mdx
@@ -551,7 +551,7 @@ For more detailed explanations on how these events are used within Infrahub, see
 <!-- vale on -->
 
 **Type**: infrahub.proposed_change_thread.updated
-**Description**: Event generated when a thead has been updated in a proposed change
+**Description**: Event generated when a thread has been updated in a proposed change
 <!-- vale off -->
 **Uses node_kind filter for webhooks**: `false`
 <!-- vale on -->

--- a/docs/docs/reference/infrahub-events.mdx
+++ b/docs/docs/reference/infrahub-events.mdx
@@ -516,6 +516,66 @@ For more detailed explanations on how these events are used within Infrahub, see
 | **requested_by_account_id** | The ID of the user who requested the proposed change to be reviewed |
 | **requested_by_account_name** | The name of the user who requested the proposed change to be reviewed |
 <!-- vale on -->
+<!-- vale off -->
+### Proposed Change Thread Created Event
+<!-- vale on -->
+
+**Type**: infrahub.proposed_change_thread.created
+**Description**: Event generated when a thread has been created in a proposed change
+<!-- vale off -->
+**Uses node_kind filter for webhooks**: `false`
+<!-- vale on -->
+
+<!-- vale off -->
+| Key | Description |
+|-----|-------------|
+| **meta.branch** | The branch on which originate this event |
+| **meta.request_id** | N/A |
+| **meta.account_id** | The ID of the account triggering this event |
+| **meta.initiator_id** | The worker identity of the initial sender of this message |
+| **meta.context** | The context used when originating this event |
+| **meta.level** | N/A |
+| **meta.has_children** | Indicates if this event might potentially have child events under it. |
+| **meta.id** | UUID of the event |
+| **meta.parent** | The UUID of the parent event if applicable |
+| **meta.ancestors** | Any event used to trigger this event |
+| **proposed_change_id** | The ID of the proposed change |
+| **proposed_change_name** | The name of the proposed change |
+| **proposed_change_state** | The state of the proposed change |
+| **thread_id** | The ID of the thread that was created or updated |
+| **thread_kind** | The name of the thread that was created or updated |
+| **action** | N/A |
+<!-- vale on -->
+<!-- vale off -->
+### Proposed Change Thread Updated Event
+<!-- vale on -->
+
+**Type**: infrahub.proposed_change_thread.updated
+**Description**: Event generated when a thead has been updated in a proposed change
+<!-- vale off -->
+**Uses node_kind filter for webhooks**: `false`
+<!-- vale on -->
+
+<!-- vale off -->
+| Key | Description |
+|-----|-------------|
+| **meta.branch** | The branch on which originate this event |
+| **meta.request_id** | N/A |
+| **meta.account_id** | The ID of the account triggering this event |
+| **meta.initiator_id** | The worker identity of the initial sender of this message |
+| **meta.context** | The context used when originating this event |
+| **meta.level** | N/A |
+| **meta.has_children** | Indicates if this event might potentially have child events under it. |
+| **meta.id** | UUID of the event |
+| **meta.parent** | The UUID of the parent event if applicable |
+| **meta.ancestors** | Any event used to trigger this event |
+| **proposed_change_id** | The ID of the proposed change |
+| **proposed_change_name** | The name of the proposed change |
+| **proposed_change_state** | The state of the proposed change |
+| **thread_id** | The ID of the thread that was created or updated |
+| **thread_kind** | The name of the thread that was created or updated |
+| **action** | N/A |
+<!-- vale on -->
 ## Commit events
 
 <!-- vale off -->


### PR DESCRIPTION
This change adds a couple of events that are triggered when a thread is created or updated in a proposed change.

These events are triggered in addition to the classic node mutation events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced support for events when a proposed change thread is created or updated, enabling improved tracking of thread lifecycle actions.
  * Added corresponding event types to the user-facing event stream and GraphQL API.

* **Documentation**
  * Updated event reference documentation to describe the new "Proposed Change Thread Created" and "Proposed Change Thread Updated" events, including their payload structure and usage.

* **Tests**
  * Added functional tests to verify correct event firing for creation and update of proposed change threads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->