### PR TITLE
Hide IPAM menu when there are no IP node kinds

### DIFF
--- a/backend/infrahub/core/schema/manager.py
+++ b/backend/infrahub/core/schema/manager.py
@@ -93,6 +93,15 @@ class SchemaManager(NodeManager):
 
         raise ValueError("The selected node is not of type NodeSchema")
 
+    def get_generic_schema(
+        self, name: str, branch: Branch | str | None = None, duplicate: bool = True
+    ) -> GenericSchema:
+        schema = self.get(name=name, branch=branch, duplicate=duplicate)
+        if isinstance(schema, GenericSchema):
+            return schema
+
+        raise ValueError("The selected node is not of type GenericSchema")
+
     def get_profile_schema(
         self, name: str, branch: Branch | str | None = None, duplicate: bool = True
     ) -> ProfileSchema:

--- a/backend/infrahub/menu/generator.py
+++ b/backend/infrahub/menu/generator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from infrahub.core import registry
+from infrahub.core.constants import InfrahubKind
 from infrahub.core.protocols import CoreMenuItem
 from infrahub.log import get_logger
 
@@ -132,5 +133,12 @@ async def generate_menu(db: InfrahubDatabase, branch: Branch, menu_items: list[C
         )
         default_menu.children[str(menu_item.identifier)] = menu_item
         items_to_add[item_name] = True
+
+    builtin_ipaddress = registry.schema.get_generic_schema(name=InfrahubKind.IPADDRESS, branch=branch, duplicate=False)
+    builtin_ipprefix = registry.schema.get_generic_schema(name=InfrahubKind.IPPREFIX, branch=branch, duplicate=False)
+    ipam_missing = len(builtin_ipaddress.used_by + builtin_ipprefix.used_by) == 0
+
+    if ipam_missing:
+        structure.data.pop("BuiltinIPAM")
 
     return structure

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -2451,6 +2451,32 @@ async def test_load_node_to_db_generic_schema(db: InfrahubDatabase, default_bran
     assert len(results) == 1
 
 
+async def test_get_incorrect_kinds(default_branch: Branch) -> None:
+    person_schema = NodeSchema(
+        name="Person",
+        namespace="Test",
+        default_filter="name__value",
+        attributes=[
+            AttributeSchema(name="name", kind="Text", unique=True),
+            AttributeSchema(name="description", kind="Text"),
+        ],
+    )
+
+    house_generic = GenericSchema(
+        name="House", namespace="Test", attributes=[AttributeSchema(name="name", kind="Text", unique=True)]
+    )
+    manager = SchemaManager()
+
+    manager.set(name="TestPerson", schema=person_schema, branch=default_branch.name)
+    manager.set(name="TestHouse", schema=house_generic, branch=default_branch.name)
+
+    with pytest.raises(ValueError, match="The selected node is not of type NodeSchema"):
+        manager.get_node_schema(name="TestHouse", branch=default_branch.name, duplicate=False)
+
+    with pytest.raises(ValueError, match="The selected node is not of type GenericSchema"):
+        manager.get_generic_schema(name="TestPerson", branch=default_branch.name, duplicate=False)
+
+
 async def test_update_node_in_db_node_schema(db: InfrahubDatabase, default_branch: Branch):
     SCHEMA = {
         "name": "Criticality",

--- a/backend/tests/unit/menu/test_generator.py
+++ b/backend/tests/unit/menu/test_generator.py
@@ -2,7 +2,7 @@ from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.initialization import create_default_menu
 from infrahub.core.protocols import CoreMenuItem
-from infrahub.core.schema import SchemaRoot
+from infrahub.core.schema import NodeSchema, SchemaRoot
 from infrahub.database import InfrahubDatabase
 from infrahub.menu.constants import FULL_DEFAULT_MENU, MenuSection
 from infrahub.menu.generator import generate_menu
@@ -104,3 +104,35 @@ async def test_generate_menu_default(
     assert menu
     assert "TestMenu0" in menu.data.keys()
     assert "TestCar" in menu.data[FULL_DEFAULT_MENU].children.keys()
+
+
+async def test_generate_ipam_menu(
+    db: InfrahubDatabase,
+    menu_repository: MenuRepository,
+    default_branch: Branch,
+    car_person_schema_generics: SchemaRoot,
+) -> None:
+    """Validate that the IPAM menu only shows up if IP nodes are defined in the schema"""
+    await create_default_menu(db=db)
+
+    new_menu_items = generate_menu_fixtures(nbr_item=2)
+    await menu_repository.create_menu(menu=new_menu_items)
+
+    menu_items = await registry.manager.query(db=db, schema=CoreMenuItem, branch=default_branch)
+    initial_menu = await generate_menu(db=db, branch=default_branch, menu_items=menu_items)
+
+    schema = SchemaRoot(
+        nodes=[
+            NodeSchema(
+                name="IPAddress",
+                namespace="Test",
+                inherit_from=["BuiltinIPAddress"],
+            )
+        ]
+    )
+    registry.schema.register_schema(schema=schema, branch=default_branch.name)
+
+    updated_menu = await generate_menu(db=db, branch=default_branch, menu_items=menu_items)
+
+    assert "BuiltinIPAM" not in initial_menu.data
+    assert "BuiltinIPAM" in updated_menu.data

--- a/changelog/+dbcd1be4.changed.md
+++ b/changelog/+dbcd1be4.changed.md
@@ -1,0 +1,1 @@
+Stopped the IPAM menu item from showing up if there are no nodes inheriting from BuiltinIPAddress or BuiltinIPPrefix


### PR DESCRIPTION
This PR reverts the menu to the previous behaviour where we only show the IPAM menu if there are IPAM node types declared in the database. This is determined by looking for any nodes that inherit from either BuiltinIPAddress or BuiltinIPPrefix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The "BuiltinIPAM" menu item is now only shown when related IP address or prefix nodes are present.
* **Bug Fixes**
  * Improved schema retrieval to ensure only the correct schema types can be accessed, with clear error messages for mismatches.
* **Tests**
  * Added tests to verify menu visibility for "BuiltinIPAM" and schema type validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->