### PR TITLE
import yml or yaml

### DIFF
--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -437,10 +437,18 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
         branch_wt = self.get_worktree(identifier=commit or branch_name)
         log = get_run_logger()
 
-        config_file_name = ".infrahub.yml"
-        config_file = branch_wt.directory / config_file_name
-        if not config_file.is_file():
-            log.debug(f"Unable to find the configuration file {config_file_name}, skipping")
+        # Check for both .infrahub.yml and .infrahub.yaml, prefer .yml if both exist
+        config_file_yml = branch_wt.directory / ".infrahub.yml"
+        config_file_yaml = branch_wt.directory / ".infrahub.yaml"
+
+        if config_file_yml.is_file():
+            config_file = config_file_yml
+            config_file_name = ".infrahub.yml"
+        elif config_file_yaml.is_file():
+            config_file = config_file_yaml
+            config_file_name = ".infrahub.yaml"
+        else:
+            log.debug("Unable to find the configuration file (.infrahub.yml or .infrahub.yaml), skipping")
             return None
 
         config_file_content = config_file.read_text(encoding="utf-8")

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -532,7 +532,16 @@ async def run_proposed_change_user_tests(model: RequestProposedChangeUserTests) 
     def _execute(
         directory: Path, repository: ProposedChangeRepository, proposed_change: InfrahubNode
     ) -> int | pytest.ExitCode:
-        config_file = str(directory / ".infrahub.yml")
+        # Check for both .infrahub.yml and .infrahub.yaml, prefer .yml if both exist
+        config_file_yml = directory / ".infrahub.yml"
+        config_file_yaml = directory / ".infrahub.yaml"
+
+        if config_file_yml.is_file():
+            config_file = str(config_file_yml)
+        elif config_file_yaml.is_file():
+            config_file = str(config_file_yaml)
+        else:
+            config_file = str(config_file_yml)  # Default to .yml for error messages
         test_directory = directory / "tests"
         log = get_logger()
 

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -554,6 +554,16 @@ async def run_proposed_change_user_tests(model: RequestProposedChangeUserTests) 
             )
             return 1
 
+        # Check if config file exists and log error if neither extension is found
+        if not config_file_yml.is_file() and not config_file_yaml.is_file():
+            log.error(
+                event="repository_tests_failed",
+                proposed_change=proposed_change,
+                repository=repository.repository_name,
+                message="Configuration file not found (.infrahub.yml or .infrahub.yaml)",
+            )
+            return 1
+
         # Redirect stdout/stderr to avoid showing pytest lines in the git agent
         old_out = sys.stdout
         old_err = sys.stderr


### PR DESCRIPTION
discovery of the repository configuration file named either .infrahub.yml or .infrahub.yaml 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of repository configuration files by supporting both `.infrahub.yml` and `.infrahub.yaml` formats, with preference given to `.infrahub.yml` when both are present. This affects both repository configuration loading and user test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->