### PR TITLE
Preserve selected kind in IPAM object table when navigating

### DIFF
--- a/frontend/app/src/entities/ipam/utils.ts
+++ b/frontend/app/src/entities/ipam/utils.ts
@@ -1,5 +1,7 @@
+import { QSP } from "@/config/qsp";
 import { IPAM_QSP } from "@/entities/ipam/constants";
 import { constructPath, overrideQueryParams } from "@/shared/api/rest/fetch";
 
-export const constructPathForIpam = (path: string, overrideParams?: overrideQueryParams[]) =>
-  constructPath(path, overrideParams, [IPAM_QSP.NAMESPACE]);
+export function constructPathForIpam(path: string, overrideParams?: overrideQueryParams[]): string {
+  return constructPath(path, overrideParams, [IPAM_QSP.NAMESPACE, QSP.KIND]);
+}

--- a/frontend/app/src/entities/nodes/object/ui/object-table/hooks/use-schema-selected-in-object-table.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/hooks/use-schema-selected-in-object-table.tsx
@@ -12,7 +12,7 @@ export const useSchemaSelectedInObjectTable = (schema: ModelSchema) => {
     if (!isGenericSchema(schema) || !schema.used_by?.find((kind) => kind === kindInQsp)) {
       return setKindInQsp(undefined, "replaceIn");
     }
-  }, [kindInQsp]);
+  }, [kindInQsp, schema.hash]);
 
   return React.useMemo<ModelSchema>(() => {
     if (!isGenericSchema(schema)) return schema;
@@ -32,5 +32,5 @@ export const useSchemaSelectedInObjectTable = (schema: ModelSchema) => {
     if (!schemaOfInheritingKindInQsp) return schema;
 
     return schemaOfInheritingKindInQsp;
-  }, [kindInQsp, schema]);
+  }, [kindInQsp, schema.hash]);
 };

--- a/frontend/app/src/entities/nodes/object/ui/object-table/hooks/use-schema-selected-in-object-table.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/hooks/use-schema-selected-in-object-table.tsx
@@ -6,7 +6,7 @@ import React from "react";
 import { StringParam, useQueryParam } from "use-query-params";
 
 export const useSchemaSelectedInObjectTable = (schema: ModelSchema) => {
-  const [kindInQsp] = useQueryParam(QSP.KIND, StringParam);
+  const [kindInQsp, setKindInQsp] = useQueryParam(QSP.KIND, StringParam);
 
   return React.useMemo<ModelSchema>(() => {
     if (!isGenericSchema(schema)) return schema;
@@ -20,7 +20,10 @@ export const useSchemaSelectedInObjectTable = (schema: ModelSchema) => {
     if (!kindInQsp) return schema;
 
     const inheritingKindInQsp = schema.used_by?.find((kind) => kind === kindInQsp);
-    if (!inheritingKindInQsp) return schema;
+    if (!inheritingKindInQsp) {
+      setKindInQsp(undefined, "replaceIn");
+      return schema;
+    }
 
     const { schema: schemaOfInheritingKindInQsp } = getSchema(inheritingKindInQsp);
     if (!schemaOfInheritingKindInQsp) return schema;

--- a/frontend/app/src/entities/nodes/object/ui/object-table/hooks/use-schema-selected-in-object-table.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/hooks/use-schema-selected-in-object-table.tsx
@@ -8,6 +8,12 @@ import { StringParam, useQueryParam } from "use-query-params";
 export const useSchemaSelectedInObjectTable = (schema: ModelSchema) => {
   const [kindInQsp, setKindInQsp] = useQueryParam(QSP.KIND, StringParam);
 
+  React.useEffect(() => {
+    if (!isGenericSchema(schema) || !schema.used_by?.find((kind) => kind === kindInQsp)) {
+      return setKindInQsp(undefined, "replaceIn");
+    }
+  }, [kindInQsp]);
+
   return React.useMemo<ModelSchema>(() => {
     if (!isGenericSchema(schema)) return schema;
 
@@ -20,10 +26,7 @@ export const useSchemaSelectedInObjectTable = (schema: ModelSchema) => {
     if (!kindInQsp) return schema;
 
     const inheritingKindInQsp = schema.used_by?.find((kind) => kind === kindInQsp);
-    if (!inheritingKindInQsp) {
-      setKindInQsp(undefined, "replaceIn");
-      return schema;
-    }
+    if (!inheritingKindInQsp) return schema;
 
     const { schema: schemaOfInheritingKindInQsp } = getSchema(inheritingKindInQsp);
     if (!schemaOfInheritingKindInQsp) return schema;


### PR DESCRIPTION
IPAM feedback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of query parameters to ensure both namespace and kind are consistently included in generated paths.
  * Enhanced object table behavior to automatically clear invalid kind selections in the query parameters, preventing mismatches with the current schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->