### PR TITLE
Fix error when filtering by node fields in IPAM, hide available IPs when filters are applied

### DIFF
--- a/frontend/app/src/entities/ipam/ip-addresses/api/get-ip-address-list-from-api.ts
+++ b/frontend/app/src/entities/ipam/ip-addresses/api/get-ip-address-list-from-api.ts
@@ -18,7 +18,7 @@ export interface GetIpAddressListGraphQLQueryParams extends PaginationParams {
   relationships: Array<RelationshipSchema>;
 }
 
-export function getIpAddressListGraphQLQuery({
+export function getIpAddressListWithAvailabilityGraphQLQuery({
   limit,
   offset,
   filters,
@@ -68,16 +68,63 @@ export function getIpAddressListGraphQLQuery({
   });
 }
 
+export function getIpAddressListWithoutAvailabilityGraphQLQuery({
+  limit,
+  offset,
+  filters,
+  objectKind,
+  attributes,
+  relationships,
+}: GetIpAddressListGraphQLQueryParams) {
+  return jsonToGraphQLQuery({
+    query: {
+      __name: `GetObjects${objectKind}`,
+      [objectKind]: {
+        __args: {
+          limit,
+          offset,
+          ...(filters ? addFiltersToRequest(filters) : {}),
+        },
+        edges: {
+          node: {
+            id: true,
+            display_label: true,
+            hfid: true,
+            ...addAttributesToRequest(attributes),
+            ...addRelationshipsToRequest(relationships),
+          },
+        },
+      },
+    },
+  });
+}
+
 export interface getIpAddressListFromApiParams
   extends ContextParams,
     GetIpAddressListGraphQLQueryParams {}
 
-export function getIpAddressListFromApi({
+export function getIpAddressListWithAvailabilityFromApi({
   branchName,
   atDate,
   ...params
 }: getIpAddressListFromApiParams) {
-  const graphqlQuery = getIpAddressListGraphQLQuery(params);
+  const graphqlQuery = getIpAddressListWithAvailabilityGraphQLQuery(params);
+
+  return graphqlClient.query({
+    query: gql(graphqlQuery),
+    context: {
+      branch: branchName,
+      date: atDate,
+    },
+  });
+}
+
+export function getIpAddressListWithoutAvailabilityFromApi({
+  branchName,
+  atDate,
+  ...params
+}: getIpAddressListFromApiParams) {
+  const graphqlQuery = getIpAddressListWithoutAvailabilityGraphQLQuery(params);
 
   return graphqlClient.query({
     query: gql(graphqlQuery),

--- a/frontend/app/src/entities/ipam/ip-addresses/domain/get-ip-address-list.ts
+++ b/frontend/app/src/entities/ipam/ip-addresses/domain/get-ip-address-list.ts
@@ -6,6 +6,7 @@ import {
 import { IpAddressAvailableNode } from "@/entities/ipam/ip-addresses/domain/types";
 import { getIpAddressAttributesVisibleInListView } from "@/entities/ipam/ip-addresses/utils/get-ip-address-attributes-visible-in-list-view";
 import { getIpAddressRelationshipsVisibleInListView } from "@/entities/ipam/ip-addresses/utils/get-ip-address-relationships-visible-in-list-view";
+import { hasIncompatibleFiltersForIpAvailability } from "@/entities/ipam/utils";
 import { OBJECTS_PER_PAGE } from "@/entities/nodes/object/domain/get-objects";
 import { NodeObject } from "@/entities/nodes/types";
 import { ModelSchema } from "@/entities/schema/types";
@@ -34,10 +35,10 @@ export const getIpAddressList: GetIpAddressList = async ({
     schema.relationships ?? []
   );
 
-  const isFiltered = filters.some(({ name }) => name !== "ip_prefix__ids");
+  const excludeIpAvailability = hasIncompatibleFiltersForIpAvailability(filters);
   const schemaKind = schema.kind as string;
 
-  const getIpAddressListFromApi = isFiltered
+  const getIpAddressListFromApi = excludeIpAvailability
     ? getIpAddressListWithoutAvailabilityFromApi
     : getIpAddressListWithAvailabilityFromApi;
 
@@ -57,7 +58,7 @@ export const getIpAddressList: GetIpAddressList = async ({
   }
 
   return (
-    data[isFiltered ? schemaKind : IP_ADDRESS_GENERIC]?.edges?.map(
+    data[excludeIpAvailability ? schemaKind : IP_ADDRESS_GENERIC]?.edges?.map(
       (edge: { node: NodeObject | IpAddressAvailableNode }) => edge.node
     ) ?? []
   );

--- a/frontend/app/src/entities/ipam/ip-addresses/domain/get-ip-address-list.ts
+++ b/frontend/app/src/entities/ipam/ip-addresses/domain/get-ip-address-list.ts
@@ -1,5 +1,8 @@
 import { IP_ADDRESS_GENERIC } from "@/entities/ipam/constants";
-import { getIpAddressListFromApi } from "@/entities/ipam/ip-addresses/api/get-ip-address-list-from-api";
+import {
+  getIpAddressListWithAvailabilityFromApi,
+  getIpAddressListWithoutAvailabilityFromApi,
+} from "@/entities/ipam/ip-addresses/api/get-ip-address-list-from-api";
 import { IpAddressAvailableNode } from "@/entities/ipam/ip-addresses/domain/types";
 import { getIpAddressAttributesVisibleInListView } from "@/entities/ipam/ip-addresses/utils/get-ip-address-attributes-visible-in-list-view";
 import { getIpAddressRelationshipsVisibleInListView } from "@/entities/ipam/ip-addresses/utils/get-ip-address-relationships-visible-in-list-view";
@@ -24,14 +27,19 @@ export const getIpAddressList: GetIpAddressList = async ({
   offset,
   branchName,
   atDate,
-  filters,
+  filters = [],
 }) => {
   const attributesVisible = getIpAddressAttributesVisibleInListView(schema.attributes ?? []);
   const relationshipsVisible = getIpAddressRelationshipsVisibleInListView(
     schema.relationships ?? []
   );
 
+  const isFiltered = filters.some(({ name }) => name !== "ip_prefix__ids");
   const schemaKind = schema.kind as string;
+
+  const getIpAddressListFromApi = isFiltered
+    ? getIpAddressListWithoutAvailabilityFromApi
+    : getIpAddressListWithAvailabilityFromApi;
 
   const { data, errors } = await getIpAddressListFromApi({
     branchName,
@@ -49,7 +57,7 @@ export const getIpAddressList: GetIpAddressList = async ({
   }
 
   return (
-    data[IP_ADDRESS_GENERIC]?.edges?.map(
+    data[isFiltered ? schemaKind : IP_ADDRESS_GENERIC]?.edges?.map(
       (edge: { node: NodeObject | IpAddressAvailableNode }) => edge.node
     ) ?? []
   );

--- a/frontend/app/src/entities/ipam/ip-addresses/ui/ip-address-availability-filter-tag.tsx
+++ b/frontend/app/src/entities/ipam/ip-addresses/ui/ip-address-availability-filter-tag.tsx
@@ -15,6 +15,9 @@ export function IpAddressAvailabilityFilterTag({ ...props }: TagProps) {
 
   if (!objectId) return null; // to hide it on IPAM homepage
 
+  const isFiltered = filters.some(({ name }) => name !== "ip_prefix__ids"); // exclude this because compatible with ip availability
+  if (isFiltered) return null;
+
   const currentIpAvailabilityFilter = filters.find(
     (filter) => filter.name === AVAILABLE_IP_FILTER_NAME
   );

--- a/frontend/app/src/entities/ipam/ip-addresses/ui/ip-address-availability-filter-tag.tsx
+++ b/frontend/app/src/entities/ipam/ip-addresses/ui/ip-address-availability-filter-tag.tsx
@@ -3,6 +3,7 @@ import {
   HIDE_AVAILABLE_IP,
   SHOW_AVAILABLE_IP,
 } from "@/entities/ipam/constants";
+import { hasIncompatibleFiltersForIpAvailability } from "@/entities/ipam/utils";
 import { FilterSuggestionTag } from "@/entities/nodes/object/ui/filters/filter-suggestion-tag";
 import { FilterTag } from "@/entities/nodes/object/ui/filters/filter-tag";
 import useFilters from "@/shared/hooks/useFilters";
@@ -14,9 +15,7 @@ export function IpAddressAvailabilityFilterTag({ ...props }: TagProps) {
   const { objectId } = useParams();
 
   if (!objectId) return null; // to hide it on IPAM homepage
-
-  const isFiltered = filters.some(({ name }) => name !== "ip_prefix__ids"); // exclude this because compatible with ip availability
-  if (isFiltered) return null;
+  if (hasIncompatibleFiltersForIpAvailability(filters)) return null;
 
   const currentIpAvailabilityFilter = filters.find(
     (filter) => filter.name === AVAILABLE_IP_FILTER_NAME

--- a/frontend/app/src/entities/ipam/ip-prefixes/api/get-ip-prefix-list-from-api.ts
+++ b/frontend/app/src/entities/ipam/ip-prefixes/api/get-ip-prefix-list-from-api.ts
@@ -20,7 +20,52 @@ export interface BuildGetIpPrefixListQueryParams extends PaginationParams {
   relationships: Array<RelationshipSchema>;
 }
 
-export function buildGetIpPrefixListQuery({
+// Common fields reused across IP Prefix queries
+export const IP_PREFIX_KIND_DETAILS_FRAGMENT = {
+  ancestors: {
+    count: true,
+  },
+  children: {
+    count: true,
+  },
+  ip_addresses: {
+    count: true,
+  },
+};
+
+export function buildGetIpPrefixListWithoutAvailabilityQuery({
+  limit,
+  offset,
+  filters,
+  objectKind,
+  attributes,
+  relationships,
+}: BuildGetIpPrefixListQueryParams) {
+  return jsonToGraphQLQuery({
+    query: {
+      __name: `GetObjects${objectKind}`,
+      [objectKind]: {
+        __args: {
+          limit,
+          offset,
+          ...(filters ? addFiltersToRequest(filters) : {}),
+        },
+        edges: {
+          node: {
+            id: true,
+            display_label: true,
+            hfid: true,
+            ...IP_PREFIX_KIND_DETAILS_FRAGMENT,
+            ...addAttributesToRequest(attributes),
+            ...addRelationshipsToRequest(relationships),
+          },
+        },
+      },
+    },
+  });
+}
+
+export function buildGetIpPrefixListWithAvailabilityQuery({
   limit,
   offset,
   filters,
@@ -47,34 +92,19 @@ export function buildGetIpPrefixListQuery({
             __on: [
               {
                 __typeName: objectKind,
+                ...IP_PREFIX_KIND_DETAILS_FRAGMENT,
                 ...addAttributesToRequest(attributes),
                 ...addRelationshipsToRequest(relationships),
-                ip_namespace: {
-                  node: {
-                    id: true,
-                    display_label: true,
-                    hfid: true,
-                  },
-                },
-                ancestors: {
-                  count: true,
-                },
-                children: {
-                  count: true,
-                },
-                ip_addresses: {
-                  count: true,
-                },
               },
               {
-                __typeName: IP_PREFIX_AVAILABLE_KIND, // Ancestors are not available on this kind. Instead, we do parent ancestors + 1
+                __typeName: IP_PREFIX_AVAILABLE_KIND,
                 parent: {
                   node: {
                     id: true,
                     display_label: true,
                     hfid: true,
                     ancestors: {
-                      count: true,
+                      count: true, // Ancestors are not available on this kind. Instead, we do parent ancestors + 1
                     },
                   },
                 },

--- a/frontend/app/src/entities/ipam/ip-prefixes/domain/get-ip-prefix-list.ts
+++ b/frontend/app/src/entities/ipam/ip-prefixes/domain/get-ip-prefix-list.ts
@@ -1,5 +1,8 @@
 import { IP_PREFIX_GENERIC } from "@/entities/ipam/constants";
-import { buildGetIpPrefixListQuery } from "@/entities/ipam/ip-prefixes/api/get-ip-prefix-list-from-api";
+import {
+  buildGetIpPrefixListWithAvailabilityQuery,
+  buildGetIpPrefixListWithoutAvailabilityQuery,
+} from "@/entities/ipam/ip-prefixes/api/get-ip-prefix-list-from-api";
 import { IpPrefixNode } from "@/entities/ipam/ip-prefixes/types";
 import { getPrefixAttributesVisibleInListView } from "@/entities/ipam/ip-prefixes/utils/get-prefix-attributes-visible-in-list-view";
 import { OBJECTS_PER_PAGE } from "@/entities/nodes/object/domain/get-objects";
@@ -28,9 +31,14 @@ export const getIpPrefixList: GetIpPrefixList = async ({
   const attributesVisible = getPrefixAttributesVisibleInListView(schema.attributes ?? []);
   const relationshipsVisible = getRelationshipsVisibleInListView(schema.relationships ?? []);
 
+  const isFiltered = filters?.some((filter) => filter.name !== "parent__ids");
   const schemaKind = schema.kind as string;
 
-  const queryString = buildGetIpPrefixListQuery({
+  const queryString = (
+    isFiltered
+      ? buildGetIpPrefixListWithoutAvailabilityQuery
+      : buildGetIpPrefixListWithAvailabilityQuery
+  )({
     limit,
     offset,
     filters,
@@ -48,5 +56,7 @@ export const getIpPrefixList: GetIpPrefixList = async ({
     },
   });
 
-  return data[IP_PREFIX_GENERIC]?.edges?.map((edge: any) => edge.node) ?? [];
+  return (
+    data[isFiltered ? schemaKind : IP_PREFIX_GENERIC]?.edges?.map((edge: any) => edge.node) ?? []
+  );
 };

--- a/frontend/app/src/entities/ipam/ip-prefixes/domain/get-ip-prefix-list.ts
+++ b/frontend/app/src/entities/ipam/ip-prefixes/domain/get-ip-prefix-list.ts
@@ -5,6 +5,7 @@ import {
 } from "@/entities/ipam/ip-prefixes/api/get-ip-prefix-list-from-api";
 import { IpPrefixNode } from "@/entities/ipam/ip-prefixes/types";
 import { getPrefixAttributesVisibleInListView } from "@/entities/ipam/ip-prefixes/utils/get-prefix-attributes-visible-in-list-view";
+import { hasIncompatibleFiltersForIpAvailability } from "@/entities/ipam/utils";
 import { OBJECTS_PER_PAGE } from "@/entities/nodes/object/domain/get-objects";
 import { getRelationshipsVisibleInListView } from "@/entities/nodes/object/utils/get-relationships-visible-in-list-view";
 import { ModelSchema } from "@/entities/schema/types";
@@ -26,16 +27,16 @@ export const getIpPrefixList: GetIpPrefixList = async ({
   offset,
   branchName,
   atDate,
-  filters,
+  filters = [],
 }) => {
   const attributesVisible = getPrefixAttributesVisibleInListView(schema.attributes ?? []);
   const relationshipsVisible = getRelationshipsVisibleInListView(schema.relationships ?? []);
 
-  const isFiltered = filters?.some((filter) => filter.name !== "parent__ids");
+  const excludeIpAvailability = hasIncompatibleFiltersForIpAvailability(filters);
   const schemaKind = schema.kind as string;
 
   const queryString = (
-    isFiltered
+    excludeIpAvailability
       ? buildGetIpPrefixListWithoutAvailabilityQuery
       : buildGetIpPrefixListWithAvailabilityQuery
   )({
@@ -57,6 +58,8 @@ export const getIpPrefixList: GetIpPrefixList = async ({
   });
 
   return (
-    data[isFiltered ? schemaKind : IP_PREFIX_GENERIC]?.edges?.map((edge: any) => edge.node) ?? []
+    data[excludeIpAvailability ? schemaKind : IP_PREFIX_GENERIC]?.edges?.map(
+      (edge: any) => edge.node
+    ) ?? []
   );
 };

--- a/frontend/app/src/entities/ipam/ip-prefixes/ui/ip-prefix-availability-filter-tag.tsx
+++ b/frontend/app/src/entities/ipam/ip-prefixes/ui/ip-prefix-availability-filter-tag.tsx
@@ -15,6 +15,9 @@ export function IpPrefixAvailabilityFilterTag({ ...props }: TagProps) {
 
   if (!objectId) return null; // to hide it on IPAM homepage
 
+  const isFiltered = filters.some((filter) => filter.name !== "parent__ids");
+  if (isFiltered) return null;
+
   const currentIpAvailabilityFilter = filters.find(
     (filter) => filter.name === AVAILABLE_IP_FILTER_NAME
   );

--- a/frontend/app/src/entities/ipam/ip-prefixes/ui/ip-prefix-availability-filter-tag.tsx
+++ b/frontend/app/src/entities/ipam/ip-prefixes/ui/ip-prefix-availability-filter-tag.tsx
@@ -3,6 +3,7 @@ import {
   HIDE_AVAILABLE_IP,
   SHOW_AVAILABLE_IP,
 } from "@/entities/ipam/constants";
+import { hasIncompatibleFiltersForIpAvailability } from "@/entities/ipam/utils";
 import { FilterSuggestionTag } from "@/entities/nodes/object/ui/filters/filter-suggestion-tag";
 import { FilterTag } from "@/entities/nodes/object/ui/filters/filter-tag";
 import useFilters from "@/shared/hooks/useFilters";
@@ -14,9 +15,7 @@ export function IpPrefixAvailabilityFilterTag({ ...props }: TagProps) {
   const { objectId } = useParams();
 
   if (!objectId) return null; // to hide it on IPAM homepage
-
-  const isFiltered = filters.some((filter) => filter.name !== "parent__ids");
-  if (isFiltered) return null;
+  if (hasIncompatibleFiltersForIpAvailability(filters)) return null;
 
   const currentIpAvailabilityFilter = filters.find(
     (filter) => filter.name === AVAILABLE_IP_FILTER_NAME

--- a/frontend/app/src/entities/ipam/ip-prefixes/ui/ip-prefix-details.tsx
+++ b/frontend/app/src/entities/ipam/ip-prefixes/ui/ip-prefix-details.tsx
@@ -40,7 +40,10 @@ export function IpPrefixDetails({ prefixSchema, prefixId }: IpPrefixDetailsProps
     ...(prefixSchema.attributes ?? []).map((schemaAttribute) => {
       const attributeData = data[schemaAttribute.name] as NodeAttribute | undefined;
 
-      if (!attributeData || (!attributeData.value && attributeData.value !== 0)) {
+      if (
+        !attributeData ||
+        (!attributeData.value && attributeData.value !== 0 && attributeData.value !== false)
+      ) {
         return {
           name: schemaAttribute.label || schemaAttribute.name,
           value: "-",

--- a/frontend/app/src/entities/ipam/utils.ts
+++ b/frontend/app/src/entities/ipam/utils.ts
@@ -1,7 +1,18 @@
 import { QSP } from "@/config/qsp";
-import { IPAM_QSP } from "@/entities/ipam/constants";
+import { AVAILABLE_IP_FILTER_NAME, IPAM_QSP } from "@/entities/ipam/constants";
 import { constructPath, overrideQueryParams } from "@/shared/api/rest/fetch";
+import { Filter } from "@/shared/hooks/useFilters";
 
 export function constructPathForIpam(path: string, overrideParams?: overrideQueryParams[]): string {
   return constructPath(path, overrideParams, [IPAM_QSP.NAMESPACE, QSP.KIND]);
+}
+
+const allowedFiltersWithIpAvailability: Array<Filter["name"]> = [
+  "parent__ids",
+  "ip_prefix__ids",
+  AVAILABLE_IP_FILTER_NAME,
+];
+
+export function hasIncompatibleFiltersForIpAvailability(filters: Filter[]) {
+  return filters.some(({ name }) => !allowedFiltersWithIpAvailability.includes(name));
 }

--- a/frontend/app/src/entities/nodes/getObjectItemDisplayValue.tsx
+++ b/frontend/app/src/entities/nodes/getObjectItemDisplayValue.tsx
@@ -175,7 +175,9 @@ export const ObjectAttributeValue = ({
   attributeSchema: FieldSchema;
   attributeValue: AttributeType;
 }) => {
-  if (!attributeValue.value && attributeValue.value !== 0) return "-";
+  if (!attributeValue.value && attributeValue.value !== 0 && attributeValue.value !== false) {
+    return "-";
+  }
 
   switch (attributeSchema.kind as AttributeKind) {
     case ATTRIBUTE_KIND.ID:

--- a/frontend/app/src/entities/nodes/object/ui/filters/attribute-filter-form.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/filters/attribute-filter-form.tsx
@@ -27,7 +27,7 @@ export function AttributeFilterForm({ attributeSchema, onSuccess }: AttributeFil
     if (condition === FILTER_CONDITION.CONTAINS) {
       const { attribute } = formData;
 
-      if (!attribute && attribute !== 0) {
+      if (!attribute && attribute !== 0 && attribute !== false) {
         return setFilters(filters.filter((f) => !f.name.startsWith(attributeSchema.name)));
       }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to fetch IP address and IP prefix lists with or without availability data, depending on applied filters.
  * Improved filtering logic for IP address and prefix lists, providing more accurate data retrieval based on filter selection.

* **Bug Fixes**
  * Availability filter tags for IP addresses and prefixes are now hidden when filters other than the default are applied, ensuring correct UI behavior.
  * Display logic updated to correctly show `false` as a valid attribute value instead of a placeholder.

* **Refactor**
  * Streamlined and modularized GraphQL query construction for IP address and prefix data, improving maintainability and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->