### PR TITLE
IFC-1499 Check schema permission for dropdown/enum operations

### DIFF
--- a/backend/infrahub/api/schema.py
+++ b/backend/infrahub/api/schema.py
@@ -36,6 +36,7 @@ from infrahub.events import EventMeta
 from infrahub.events.schema_action import SchemaUpdatedEvent
 from infrahub.exceptions import MigrationError
 from infrahub.log import get_log_data, get_logger
+from infrahub.permissions import define_global_permission_from_branch
 from infrahub.types import ATTRIBUTE_PYTHON_TYPES
 from infrahub.worker import WORKER_IDENTITY
 from infrahub.workflows.catalogue import SCHEMA_APPLY_MIGRATION, SCHEMA_VALIDATE_MIGRATION
@@ -287,13 +288,8 @@ async def load_schema(
     context: InfrahubContext = Depends(get_context),
 ) -> SchemaUpdate:
     permission_manager.raise_for_permission(
-        permission=GlobalPermission(
-            action=GlobalPermissions.MANAGE_SCHEMA.value,
-            decision=(
-                PermissionDecision.ALLOW_DEFAULT
-                if branch.name in (GLOBAL_BRANCH_NAME, registry.default_branch)
-                else PermissionDecision.ALLOW_OTHER
-            ).value,
+        permission=define_global_permission_from_branch(
+            permission=GlobalPermissions.MANAGE_SCHEMA, branch_name=branch.name
         )
     )
 

--- a/backend/infrahub/graphql/context.py
+++ b/backend/infrahub/graphql/context.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from infrahub.core.constants import GlobalPermissions, InfrahubKind
 from infrahub.core.manager import NodeManager
 from infrahub.exceptions import NodeNotFoundError, ValidationError
-from infrahub.permissions.globals import define_global_permission_from_branch
+from infrahub.permissions import define_global_permission_from_branch
 
 if TYPE_CHECKING:
     from .initialization import GraphqlContext

--- a/backend/infrahub/graphql/mutations/schema.py
+++ b/backend/infrahub/graphql/mutations/schema.py
@@ -6,7 +6,7 @@ from graphene import Boolean, Field, InputObjectType, Mutation, String
 
 from infrahub import lock
 from infrahub.core import registry
-from infrahub.core.constants import RESTRICTED_NAMESPACES
+from infrahub.core.constants import RESTRICTED_NAMESPACES, GlobalPermissions
 from infrahub.core.manager import NodeManager
 from infrahub.core.schema import DropdownChoice, GenericSchema, NodeSchema
 from infrahub.database import InfrahubDatabase, retry_db_transaction
@@ -16,6 +16,7 @@ from infrahub.exceptions import ValidationError
 from infrahub.graphql.context import apply_external_context
 from infrahub.graphql.types.context import ContextInput
 from infrahub.log import get_log_data, get_logger
+from infrahub.permissions import define_global_permission_from_branch
 from infrahub.worker import WORKER_IDENTITY
 
 from ..types import DropdownFields
@@ -30,6 +31,14 @@ if TYPE_CHECKING:
     from ..initialization import GraphqlContext
 
 log = get_logger()
+
+
+def _validate_schema_permission(graphql_context: GraphqlContext) -> None:
+    graphql_context.active_permissions.raise_for_permission(
+        permission=define_global_permission_from_branch(
+            permission=GlobalPermissions.MANAGE_SCHEMA, branch_name=graphql_context.branch.name
+        )
+    )
 
 
 class SchemaEnumInput(InputObjectType):
@@ -69,6 +78,7 @@ class SchemaDropdownAdd(Mutation):
     ) -> Self:
         graphql_context: GraphqlContext = info.context
 
+        _validate_schema_permission(graphql_context=graphql_context)
         await apply_external_context(graphql_context=graphql_context, context_input=context)
 
         kind = graphql_context.db.schema.get(name=str(data.kind), branch=graphql_context.branch.name)
@@ -130,6 +140,7 @@ class SchemaDropdownRemove(Mutation):
     ) -> dict[str, bool]:
         graphql_context: GraphqlContext = info.context
 
+        _validate_schema_permission(graphql_context=graphql_context)
         kind = graphql_context.db.schema.get(name=str(data.kind), branch=graphql_context.branch.name)
         await apply_external_context(graphql_context=graphql_context, context_input=context)
 
@@ -185,6 +196,7 @@ class SchemaEnumAdd(Mutation):
     ) -> dict[str, bool]:
         graphql_context: GraphqlContext = info.context
 
+        _validate_schema_permission(graphql_context=graphql_context)
         kind = graphql_context.db.schema.get(name=str(data.kind), branch=graphql_context.branch.name)
         await apply_external_context(graphql_context=graphql_context, context_input=context)
 
@@ -230,6 +242,7 @@ class SchemaEnumRemove(Mutation):
     ) -> dict[str, bool]:
         graphql_context: GraphqlContext = info.context
 
+        _validate_schema_permission(graphql_context=graphql_context)
         kind = graphql_context.db.schema.get(name=str(data.kind), branch=graphql_context.branch.name)
         await apply_external_context(graphql_context=graphql_context, context_input=context)
 

--- a/backend/infrahub/graphql/schema.py
+++ b/backend/infrahub/graphql/schema.py
@@ -21,21 +21,10 @@ from .mutations.diff import DiffUpdateMutation
 from .mutations.diff_conflict import ResolveDiffConflict
 from .mutations.generator import GeneratorDefinitionRequestRun
 from .mutations.proposed_change import ProposedChangeMerge, ProposedChangeRequestRunCheck
-from .mutations.relationship import (
-    RelationshipAdd,
-    RelationshipRemove,
-)
-from .mutations.repository import (
-    ProcessRepository,
-    ValidateRepositoryConnectivity,
-)
+from .mutations.relationship import RelationshipAdd, RelationshipRemove
+from .mutations.repository import ProcessRepository, ValidateRepositoryConnectivity
 from .mutations.resource_manager import IPAddressPoolGetResource, IPPrefixPoolGetResource
-from .mutations.schema import (
-    SchemaDropdownAdd,
-    SchemaDropdownRemove,
-    SchemaEnumAdd,
-    SchemaEnumRemove,
-)
+from .mutations.schema import SchemaDropdownAdd, SchemaDropdownRemove, SchemaEnumAdd, SchemaEnumRemove
 from .queries import (
     AccountPermissions,
     AccountToken,

--- a/backend/infrahub/permissions/__init__.py
+++ b/backend/infrahub/permissions/__init__.py
@@ -1,4 +1,5 @@
 from infrahub.permissions.backend import PermissionBackend
+from infrahub.permissions.globals import define_global_permission_from_branch
 from infrahub.permissions.local_backend import LocalPermissionBackend
 from infrahub.permissions.manager import PermissionManager
 from infrahub.permissions.report import report_schema_permissions
@@ -9,6 +10,7 @@ __all__ = [
     "LocalPermissionBackend",
     "PermissionBackend",
     "PermissionManager",
+    "define_global_permission_from_branch",
     "get_global_permission_for_kind",
     "report_schema_permissions",
 ]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -44,6 +44,7 @@ from infrahub.database import InfrahubDatabase, get_db
 from infrahub.lock import initialize_lock
 from infrahub.message_bus import InfrahubMessage, InfrahubResponse
 from infrahub.message_bus.types import MessageTTL
+from infrahub.permissions import LocalPermissionBackend
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.message_bus import InfrahubMessageBus
 from tests.adapters.log import FakeLogger
@@ -165,6 +166,14 @@ async def default_ipnamespace(db: InfrahubDatabase, register_core_models_schema)
         registry.default_ipnamespace = ip_namespace.id
         return ip_namespace
     return None
+
+
+@pytest.fixture
+def default_permission_backend() -> Generator[None, Any, Any]:
+    if not registry.permission_backends:
+        registry.permission_backends = [LocalPermissionBackend()]
+    yield
+    registry.permission_backends = []
 
 
 @pytest.fixture

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -170,10 +170,10 @@ async def default_ipnamespace(db: InfrahubDatabase, register_core_models_schema)
 
 @pytest.fixture
 def default_permission_backend() -> Generator[None, Any, Any]:
-    if not registry.permission_backends:
-        registry.permission_backends = [LocalPermissionBackend()]
+    previous_backends = registry.permission_backends
+    registry.permission_backends = [LocalPermissionBackend()]
     yield
-    registry.permission_backends = []
+    registry.permission_backends = previous_backends
 
 
 @pytest.fixture

--- a/backend/tests/helpers/permissions.py
+++ b/backend/tests/helpers/permissions.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from infrahub.core import registry
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.node import Node
 from infrahub.core.protocols import CoreAccountGroup
 from infrahub.database import InfrahubDatabase
-from infrahub.permissions import LocalPermissionBackend
 
 if TYPE_CHECKING:
     from infrahub.core.account import GlobalPermission, ObjectPermission
@@ -20,8 +18,6 @@ async def define_permissions(
     object_permissions: list[ObjectPermission] | None = None,
     global_permissions: list[GlobalPermission] | None = None,
 ) -> None:
-    registry.permission_backends = [LocalPermissionBackend()]
-
     object_permissions = object_permissions or []
     global_permissions = global_permissions or []
     permissions = []

--- a/backend/tests/unit/core/constraint_validators/test_uniqueness_checker.py
+++ b/backend/tests/unit/core/constraint_validators/test_uniqueness_checker.py
@@ -225,7 +225,7 @@ class TestUniquenessChecker:
             in all_data_paths
         )
 
-    @pytest.mark.skip("We technically don't support unqiueness constraints on properties of relationships")
+    @pytest.mark.skip("We technically don't support uniqueness constraints on properties of relationships")
     async def test_combined_uniqueness_constraints_with_violations(
         self,
         db: InfrahubDatabase,
@@ -357,7 +357,7 @@ class TestUniquenessChecker:
             in all_data_paths
         )
 
-    @pytest.mark.skip("We technically don't support unqiueness constraints on properties of relationships")
+    @pytest.mark.skip("We technically don't support uniqueness constraints on properties of relationships")
     async def test_generic_unique_attribute_multiple_relationship_violations_to_same_node(
         self,
         db: InfrahubDatabase,
@@ -440,7 +440,7 @@ class TestUniquenessChecker:
             in all_data_paths
         )
 
-    @pytest.mark.skip("We technically don't support unqiueness constraints on properties of relationships")
+    @pytest.mark.skip("We technically don't support uniqueness constraints on properties of relationships")
     async def test_generic_unique_constraint_relationship_with_and_without_attr(
         self,
         db: InfrahubDatabase,

--- a/backend/tests/unit/graphql/auth/query_permission_checker/test_default_branch_checker.py
+++ b/backend/tests/unit/graphql/auth/query_permission_checker/test_default_branch_checker.py
@@ -76,11 +76,7 @@ class TestDefaultBranchPermission:
         [(True, "main"), (False, "main"), (True, "not_default_branch"), (False, "not_default_branch")],
     )
     async def test_account_with_permission(
-        self,
-        db: InfrahubDatabase,
-        permissions_helper: PermissionsHelper,
-        contains_mutation: bool,
-        branch_name: str,
+        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper, contains_mutation: bool, branch_name: str
     ):
         checker = DefaultBranchPermissionChecker()
         session = AccountSession(
@@ -120,11 +116,7 @@ class TestDefaultBranchPermission:
         [(True, "main"), (False, "main"), (True, "not_default_branch"), (False, "not_default_branch")],
     )
     async def test_account_without_permission(
-        self,
-        db: InfrahubDatabase,
-        permissions_helper: PermissionsHelper,
-        contains_mutation: bool,
-        branch_name: str,
+        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper, contains_mutation: bool, branch_name: str
     ):
         checker = DefaultBranchPermissionChecker()
         session = AccountSession(

--- a/backend/tests/unit/graphql/auth/query_permission_checker/test_default_branch_checker.py
+++ b/backend/tests/unit/graphql/auth/query_permission_checker/test_default_branch_checker.py
@@ -9,13 +9,12 @@ import pytest
 from infrahub.auth import AccountSession, AuthType
 from infrahub.core.constants import GlobalPermissions, InfrahubKind, PermissionDecision
 from infrahub.core.node import Node
-from infrahub.core.registry import registry
 from infrahub.exceptions import PermissionDeniedError
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 from infrahub.graphql.auth.query_permission_checker.default_branch_checker import DefaultBranchPermissionChecker
 from infrahub.graphql.auth.query_permission_checker.interface import CheckerResolution
 from infrahub.graphql.initialization import GraphqlContext, GraphqlParams
-from infrahub.permissions import LocalPermissionBackend, PermissionManager
+from infrahub.permissions import PermissionManager
 
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
@@ -34,7 +33,6 @@ class TestDefaultBranchPermission:
         second_account: CoreAccount,
         permissions_helper: PermissionsHelper,
     ):
-        registry.permission_backends = [LocalPermissionBackend()]
         permissions_helper._default_branch = default_branch
 
         permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
@@ -77,7 +75,12 @@ class TestDefaultBranchPermission:
         [(True, "main"), (False, "main"), (True, "not_default_branch"), (False, "not_default_branch")],
     )
     async def test_account_with_permission(
-        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper, contains_mutation: bool, branch_name: str
+        self,
+        db: InfrahubDatabase,
+        default_permission_backend: None,
+        permissions_helper: PermissionsHelper,
+        contains_mutation: bool,
+        branch_name: str,
     ):
         checker = DefaultBranchPermissionChecker()
         session = AccountSession(
@@ -117,7 +120,12 @@ class TestDefaultBranchPermission:
         [(True, "main"), (False, "main"), (True, "not_default_branch"), (False, "not_default_branch")],
     )
     async def test_account_without_permission(
-        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper, contains_mutation: bool, branch_name: str
+        self,
+        db: InfrahubDatabase,
+        default_permission_backend: None,
+        permissions_helper: PermissionsHelper,
+        contains_mutation: bool,
+        branch_name: str,
     ):
         checker = DefaultBranchPermissionChecker()
         session = AccountSession(

--- a/backend/tests/unit/graphql/auth/query_permission_checker/test_default_branch_checker.py
+++ b/backend/tests/unit/graphql/auth/query_permission_checker/test_default_branch_checker.py
@@ -27,6 +27,7 @@ class TestDefaultBranchPermission:
     async def test_setup(
         self,
         db: InfrahubDatabase,
+        default_permission_backend: None,
         register_core_models_schema: None,
         default_branch: Branch,
         first_account: CoreAccount,
@@ -77,7 +78,6 @@ class TestDefaultBranchPermission:
     async def test_account_with_permission(
         self,
         db: InfrahubDatabase,
-        default_permission_backend: None,
         permissions_helper: PermissionsHelper,
         contains_mutation: bool,
         branch_name: str,
@@ -122,7 +122,6 @@ class TestDefaultBranchPermission:
     async def test_account_without_permission(
         self,
         db: InfrahubDatabase,
-        default_permission_backend: None,
         permissions_helper: PermissionsHelper,
         contains_mutation: bool,
         branch_name: str,

--- a/backend/tests/unit/graphql/auth/query_permission_checker/test_merge_operation_checker.py
+++ b/backend/tests/unit/graphql/auth/query_permission_checker/test_merge_operation_checker.py
@@ -9,13 +9,12 @@ import pytest
 from infrahub.auth import AccountSession, AuthType
 from infrahub.core.constants import GlobalPermissions, InfrahubKind, PermissionDecision
 from infrahub.core.node import Node
-from infrahub.core.registry import registry
 from infrahub.exceptions import PermissionDeniedError
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 from infrahub.graphql.auth.query_permission_checker.interface import CheckerResolution
 from infrahub.graphql.auth.query_permission_checker.merge_operation_checker import MergeBranchPermissionChecker
 from infrahub.graphql.initialization import GraphqlContext, GraphqlParams
-from infrahub.permissions import LocalPermissionBackend, PermissionManager
+from infrahub.permissions import PermissionManager
 
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
@@ -34,7 +33,6 @@ class TestMergeBranchPermission:
         first_account: CoreAccount,
         second_account: CoreAccount,
     ):
-        registry.permission_backends = [LocalPermissionBackend()]
         permissions_helper._default_branch = default_branch
 
         permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
@@ -81,6 +79,7 @@ class TestMergeBranchPermission:
         operation_name: str,
         checker_resolution: CheckerResolution | None,
         db: InfrahubDatabase,
+        default_permission_backend: None,
         permissions_helper: PermissionsHelper,
     ):
         checker = MergeBranchPermissionChecker()
@@ -118,6 +117,7 @@ class TestMergeBranchPermission:
         operation_name: str,
         checker_resolution: CheckerResolution | None,
         db: InfrahubDatabase,
+        default_permission_backend: None,
         permissions_helper: PermissionsHelper,
     ):
         checker = MergeBranchPermissionChecker()

--- a/backend/tests/unit/graphql/auth/query_permission_checker/test_merge_operation_checker.py
+++ b/backend/tests/unit/graphql/auth/query_permission_checker/test_merge_operation_checker.py
@@ -27,6 +27,7 @@ class TestMergeBranchPermission:
     async def test_setup(
         self,
         db: InfrahubDatabase,
+        default_permission_backend: None,
         register_core_models_schema: None,
         default_branch: Branch,
         permissions_helper: PermissionsHelper,
@@ -79,7 +80,6 @@ class TestMergeBranchPermission:
         operation_name: str,
         checker_resolution: CheckerResolution | None,
         db: InfrahubDatabase,
-        default_permission_backend: None,
         permissions_helper: PermissionsHelper,
     ):
         checker = MergeBranchPermissionChecker()
@@ -117,7 +117,6 @@ class TestMergeBranchPermission:
         operation_name: str,
         checker_resolution: CheckerResolution | None,
         db: InfrahubDatabase,
-        default_permission_backend: None,
         permissions_helper: PermissionsHelper,
     ):
         checker = MergeBranchPermissionChecker()

--- a/backend/tests/unit/graphql/auth/query_permission_checker/test_object_permission_checker.py
+++ b/backend/tests/unit/graphql/auth/query_permission_checker/test_object_permission_checker.py
@@ -215,6 +215,7 @@ class TestObjectPermissions:
     async def test_setup(
         self,
         db: InfrahubDatabase,
+        default_permission_backend: None,
         register_core_models_schema: None,
         default_branch: Branch,
         permissions_helper: PermissionsHelper,
@@ -261,9 +262,7 @@ class TestObjectPermissions:
 
         permissions_helper._first = first_account
 
-    async def test_first_account_tags(
-        self, db: InfrahubDatabase, default_permission_backend: None, permissions_helper: PermissionsHelper
-    ) -> None:
+    async def test_first_account_tags(self, db: InfrahubDatabase, permissions_helper: PermissionsHelper) -> None:
         checker = ObjectPermissionChecker()
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
@@ -288,9 +287,7 @@ class TestObjectPermissions:
             query_parameters=gql_params,
         )
 
-    async def test_first_account_repos(
-        self, db: InfrahubDatabase, default_permission_backend: None, permissions_helper: PermissionsHelper
-    ) -> None:
+    async def test_first_account_repos(self, db: InfrahubDatabase, permissions_helper: PermissionsHelper) -> None:
         checker = ObjectPermissionChecker()
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
@@ -316,9 +313,7 @@ class TestObjectPermissions:
                 query_parameters=gql_params,
             )
 
-    async def test_first_account_graphql(
-        self, db: InfrahubDatabase, default_permission_backend: None, permissions_helper: PermissionsHelper
-    ) -> None:
+    async def test_first_account_graphql(self, db: InfrahubDatabase, permissions_helper: PermissionsHelper) -> None:
         """The user should have permissions to list GraphQLQueries."""
         checker = ObjectPermissionChecker()
         session = AccountSession(
@@ -345,7 +340,7 @@ class TestObjectPermissions:
         )
 
     async def test_first_account_graphql_and_repos(
-        self, db: InfrahubDatabase, default_permission_backend: None, permissions_helper: PermissionsHelper
+        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper
     ) -> None:
         """The user should have permissions to list GraphQLQueries but not repositories linked to them"""
         checker = ObjectPermissionChecker()
@@ -378,6 +373,7 @@ class TestAccountManagerPermissions:
     async def test_setup(
         self,
         db: InfrahubDatabase,
+        default_permission_backend: None,
         register_core_models_schema: None,
         default_branch: Branch,
         permissions_helper: PermissionsHelper,
@@ -423,11 +419,7 @@ class TestAccountManagerPermissions:
 
     @pytest.mark.parametrize("operation", [MUTATION_ACCOUNT, MUTATION_ACCOUNT_GROUP, MUTATION_ACCOUNT_ROLE])
     async def test_account_with_permission(
-        self,
-        db: InfrahubDatabase,
-        default_permission_backend: None,
-        permissions_helper: PermissionsHelper,
-        operation: str,
+        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper, operation: str
     ):
         checker = AccountManagerPermissionChecker()
         session = AccountSession(
@@ -465,12 +457,7 @@ class TestAccountManagerPermissions:
         ],
     )
     async def test_account_without_permission(
-        self,
-        db: InfrahubDatabase,
-        default_permission_backend: None,
-        permissions_helper: PermissionsHelper,
-        operation: str,
-        must_raise: bool,
+        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper, operation: str, must_raise: bool
     ):
         checker = AccountManagerPermissionChecker()
         session = AccountSession(
@@ -514,6 +501,7 @@ class TestPermissionManagerPermissions:
     async def test_setup(
         self,
         db: InfrahubDatabase,
+        default_permission_backend: None,
         register_core_models_schema: None,
         default_branch: Branch,
         permissions_helper: PermissionsHelper,
@@ -561,11 +549,7 @@ class TestPermissionManagerPermissions:
         "operation", [MUTATION_GLOBAL_PERMISSION, MUTATION_OBJECT_PERMISSION, QUERY_ACCOUNT_PERMISSIONS]
     )
     async def test_account_with_permission(
-        self,
-        db: InfrahubDatabase,
-        default_permission_backend: None,
-        permissions_helper: PermissionsHelper,
-        operation: str,
+        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper, operation: str
     ):
         checker = PermissionManagerPermissionChecker()
         session = AccountSession(
@@ -602,12 +586,7 @@ class TestPermissionManagerPermissions:
         ],
     )
     async def test_account_without_permission(
-        self,
-        db: InfrahubDatabase,
-        default_permission_backend: None,
-        permissions_helper: PermissionsHelper,
-        operation: str,
-        must_raise: bool,
+        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper, operation: str, must_raise: bool
     ):
         checker = PermissionManagerPermissionChecker()
         session = AccountSession(
@@ -649,6 +628,7 @@ class TestRepositoryManagerPermissions:
     async def test_setup(
         self,
         db: InfrahubDatabase,
+        default_permission_backend: None,
         register_core_models_schema: None,
         default_branch: Branch,
         permissions_helper: PermissionsHelper,
@@ -696,11 +676,7 @@ class TestRepositoryManagerPermissions:
         "operation", [MUTATION_REPOSITORY, MUTATION_READONLY_REPOSITORY, MUTATION_GENERIC_REPOSITORY]
     )
     async def test_account_with_permission(
-        self,
-        db: InfrahubDatabase,
-        default_permission_backend: None,
-        permissions_helper: PermissionsHelper,
-        operation: str,
+        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper, operation: str
     ):
         checker = RepositoryManagerPermissionChecker()
         session = AccountSession(
@@ -737,12 +713,7 @@ class TestRepositoryManagerPermissions:
         ],
     )
     async def test_account_without_permission(
-        self,
-        db: InfrahubDatabase,
-        default_permission_backend: None,
-        permissions_helper: PermissionsHelper,
-        operation: str,
-        must_raise: bool,
+        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper, operation: str, must_raise: bool
     ):
         checker = RepositoryManagerPermissionChecker()
         session = AccountSession(

--- a/backend/tests/unit/graphql/auth/query_permission_checker/test_object_permission_checker.py
+++ b/backend/tests/unit/graphql/auth/query_permission_checker/test_object_permission_checker.py
@@ -21,7 +21,6 @@ from infrahub.graphql.auth.query_permission_checker.object_permission_checker im
     RepositoryManagerPermissionChecker,
 )
 from infrahub.graphql.initialization import prepare_graphql_params
-from infrahub.permissions.local_backend import LocalPermissionBackend
 
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch

--- a/backend/tests/unit/graphql/auth/query_permission_checker/test_object_permission_checker.py
+++ b/backend/tests/unit/graphql/auth/query_permission_checker/test_object_permission_checker.py
@@ -221,7 +221,6 @@ class TestObjectPermissions:
         permissions_helper: PermissionsHelper,
         first_account: CoreAccount,
     ):
-        registry.permission_backends = [LocalPermissionBackend()]
         permissions_helper._default_branch = default_branch
 
         permissions = []
@@ -263,7 +262,9 @@ class TestObjectPermissions:
 
         permissions_helper._first = first_account
 
-    async def test_first_account_tags(self, db: InfrahubDatabase, permissions_helper: PermissionsHelper) -> None:
+    async def test_first_account_tags(
+        self, db: InfrahubDatabase, default_permission_backend: None, permissions_helper: PermissionsHelper
+    ) -> None:
         checker = ObjectPermissionChecker()
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
@@ -288,7 +289,9 @@ class TestObjectPermissions:
             query_parameters=gql_params,
         )
 
-    async def test_first_account_repos(self, db: InfrahubDatabase, permissions_helper: PermissionsHelper) -> None:
+    async def test_first_account_repos(
+        self, db: InfrahubDatabase, default_permission_backend: None, permissions_helper: PermissionsHelper
+    ) -> None:
         checker = ObjectPermissionChecker()
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
@@ -314,7 +317,9 @@ class TestObjectPermissions:
                 query_parameters=gql_params,
             )
 
-    async def test_first_account_graphql(self, db: InfrahubDatabase, permissions_helper: PermissionsHelper) -> None:
+    async def test_first_account_graphql(
+        self, db: InfrahubDatabase, default_permission_backend: None, permissions_helper: PermissionsHelper
+    ) -> None:
         """The user should have permissions to list GraphQLQueries."""
         checker = ObjectPermissionChecker()
         session = AccountSession(
@@ -341,7 +346,7 @@ class TestObjectPermissions:
         )
 
     async def test_first_account_graphql_and_repos(
-        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper
+        self, db: InfrahubDatabase, default_permission_backend: None, permissions_helper: PermissionsHelper
     ) -> None:
         """The user should have permissions to list GraphQLQueries but not repositories linked to them"""
         checker = ObjectPermissionChecker()
@@ -380,7 +385,6 @@ class TestAccountManagerPermissions:
         first_account: CoreAccount,
         second_account: CoreAccount,
     ):
-        registry.permission_backends = [LocalPermissionBackend()]
         permissions_helper._default_branch = default_branch
 
         permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
@@ -420,7 +424,11 @@ class TestAccountManagerPermissions:
 
     @pytest.mark.parametrize("operation", [MUTATION_ACCOUNT, MUTATION_ACCOUNT_GROUP, MUTATION_ACCOUNT_ROLE])
     async def test_account_with_permission(
-        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper, operation: str
+        self,
+        db: InfrahubDatabase,
+        default_permission_backend: None,
+        permissions_helper: PermissionsHelper,
+        operation: str,
     ):
         checker = AccountManagerPermissionChecker()
         session = AccountSession(
@@ -458,7 +466,12 @@ class TestAccountManagerPermissions:
         ],
     )
     async def test_account_without_permission(
-        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper, operation: str, must_raise: bool
+        self,
+        db: InfrahubDatabase,
+        default_permission_backend: None,
+        permissions_helper: PermissionsHelper,
+        operation: str,
+        must_raise: bool,
     ):
         checker = AccountManagerPermissionChecker()
         session = AccountSession(
@@ -508,7 +521,6 @@ class TestPermissionManagerPermissions:
         first_account: CoreAccount,
         second_account: CoreAccount,
     ):
-        registry.permission_backends = [LocalPermissionBackend()]
         permissions_helper._default_branch = default_branch
 
         permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
@@ -550,7 +562,11 @@ class TestPermissionManagerPermissions:
         "operation", [MUTATION_GLOBAL_PERMISSION, MUTATION_OBJECT_PERMISSION, QUERY_ACCOUNT_PERMISSIONS]
     )
     async def test_account_with_permission(
-        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper, operation: str
+        self,
+        db: InfrahubDatabase,
+        default_permission_backend: None,
+        permissions_helper: PermissionsHelper,
+        operation: str,
     ):
         checker = PermissionManagerPermissionChecker()
         session = AccountSession(
@@ -587,7 +603,12 @@ class TestPermissionManagerPermissions:
         ],
     )
     async def test_account_without_permission(
-        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper, operation: str, must_raise: bool
+        self,
+        db: InfrahubDatabase,
+        default_permission_backend: None,
+        permissions_helper: PermissionsHelper,
+        operation: str,
+        must_raise: bool,
     ):
         checker = PermissionManagerPermissionChecker()
         session = AccountSession(
@@ -635,7 +656,6 @@ class TestRepositoryManagerPermissions:
         first_account: CoreAccount,
         second_account: CoreAccount,
     ):
-        registry.permission_backends = [LocalPermissionBackend()]
         permissions_helper._default_branch = default_branch
 
         permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
@@ -677,7 +697,11 @@ class TestRepositoryManagerPermissions:
         "operation", [MUTATION_REPOSITORY, MUTATION_READONLY_REPOSITORY, MUTATION_GENERIC_REPOSITORY]
     )
     async def test_account_with_permission(
-        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper, operation: str
+        self,
+        db: InfrahubDatabase,
+        default_permission_backend: None,
+        permissions_helper: PermissionsHelper,
+        operation: str,
     ):
         checker = RepositoryManagerPermissionChecker()
         session = AccountSession(
@@ -714,7 +738,12 @@ class TestRepositoryManagerPermissions:
         ],
     )
     async def test_account_without_permission(
-        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper, operation: str, must_raise: bool
+        self,
+        db: InfrahubDatabase,
+        default_permission_backend: None,
+        permissions_helper: PermissionsHelper,
+        operation: str,
+        must_raise: bool,
     ):
         checker = RepositoryManagerPermissionChecker()
         session = AccountSession(

--- a/backend/tests/unit/graphql/auth/query_permission_checker/test_super_admin_checker.py
+++ b/backend/tests/unit/graphql/auth/query_permission_checker/test_super_admin_checker.py
@@ -26,6 +26,7 @@ class TestSuperAdminPermission:
     async def test_setup(
         self,
         db: InfrahubDatabase,
+        default_permission_backend: None,
         register_core_models_schema: None,
         default_branch: Branch,
         first_account: CoreAccount,
@@ -69,9 +70,7 @@ class TestSuperAdminPermission:
             is_supported = await checker.supports(db=db, account_session=user, branch=permissions_helper.default_branch)
             assert is_supported == user.authenticated
 
-    async def test_account_with_permission(
-        self, db: InfrahubDatabase, default_permission_backend: None, permissions_helper: PermissionsHelper
-    ):
+    async def test_account_with_permission(self, db: InfrahubDatabase, permissions_helper: PermissionsHelper):
         checker = SuperAdminPermissionChecker()
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
@@ -93,9 +92,7 @@ class TestSuperAdminPermission:
         )
         assert resolution == CheckerResolution.TERMINATE
 
-    async def test_account_without_permission(
-        self, db: InfrahubDatabase, default_permission_backend: None, permissions_helper: PermissionsHelper
-    ):
+    async def test_account_without_permission(self, db: InfrahubDatabase, permissions_helper: PermissionsHelper):
         checker = SuperAdminPermissionChecker()
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.second.id, session_id=str(uuid4()), auth_type=AuthType.JWT

--- a/backend/tests/unit/graphql/auth/query_permission_checker/test_super_admin_checker.py
+++ b/backend/tests/unit/graphql/auth/query_permission_checker/test_super_admin_checker.py
@@ -9,12 +9,11 @@ import pytest
 from infrahub.auth import AccountSession, AuthType
 from infrahub.core.constants import GlobalPermissions, InfrahubKind, PermissionDecision
 from infrahub.core.node import Node
-from infrahub.core.registry import registry
 from infrahub.graphql.analyzer import InfrahubGraphQLQueryAnalyzer
 from infrahub.graphql.auth.query_permission_checker.interface import CheckerResolution
 from infrahub.graphql.auth.query_permission_checker.super_admin_checker import SuperAdminPermissionChecker
 from infrahub.graphql.initialization import GraphqlContext, GraphqlParams
-from infrahub.permissions import LocalPermissionBackend, PermissionManager
+from infrahub.permissions import PermissionManager
 
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
@@ -33,7 +32,6 @@ class TestSuperAdminPermission:
         second_account: CoreAccount,
         permissions_helper: PermissionsHelper,
     ):
-        registry.permission_backends = [LocalPermissionBackend()]
         permissions_helper._default_branch = default_branch
 
         permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
@@ -71,7 +69,9 @@ class TestSuperAdminPermission:
             is_supported = await checker.supports(db=db, account_session=user, branch=permissions_helper.default_branch)
             assert is_supported == user.authenticated
 
-    async def test_account_with_permission(self, db: InfrahubDatabase, permissions_helper: PermissionsHelper):
+    async def test_account_with_permission(
+        self, db: InfrahubDatabase, default_permission_backend: None, permissions_helper: PermissionsHelper
+    ):
         checker = SuperAdminPermissionChecker()
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
@@ -93,7 +93,9 @@ class TestSuperAdminPermission:
         )
         assert resolution == CheckerResolution.TERMINATE
 
-    async def test_account_without_permission(self, db: InfrahubDatabase, permissions_helper: PermissionsHelper):
+    async def test_account_without_permission(
+        self, db: InfrahubDatabase, default_permission_backend: None, permissions_helper: PermissionsHelper
+    ):
         checker = SuperAdminPermissionChecker()
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.second.id, session_id=str(uuid4()), auth_type=AuthType.JWT

--- a/backend/tests/unit/graphql/mutations/test_mutation_context.py
+++ b/backend/tests/unit/graphql/mutations/test_mutation_context.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 async def test_add_context_invalid_account(
     db: InfrahubDatabase,
     default_branch: Branch,
+    default_permission_backend: None,
     car_person_schema: None,
     first_account: Node,
     session_first_account: AccountSession,
@@ -66,6 +67,7 @@ async def test_add_context_invalid_account(
 async def test_add_context_valid_account(
     db: InfrahubDatabase,
     default_branch: Branch,
+    default_permission_backend: None,
     car_person_schema: None,
     enable_broker_config: None,
     session_first_account: AccountSession,
@@ -120,6 +122,7 @@ async def test_add_context_valid_account(
 async def test_add_context_missing_permissions(
     db: InfrahubDatabase,
     default_branch: Branch,
+    default_permission_backend: None,
     car_person_schema: None,
     session_second_account: AccountSession,
     first_account: Node,

--- a/backend/tests/unit/graphql/mutations/test_proposed_change.py
+++ b/backend/tests/unit/graphql/mutations/test_proposed_change.py
@@ -9,12 +9,10 @@ from infrahub.core.branch import Branch
 from infrahub.core.constants import CheckType, InfrahubKind
 from infrahub.core.initialization import create_branch
 from infrahub.core.node import Node
-from infrahub.core.registry import registry
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.message_bus.types import KVTTL
-from infrahub.permissions.local_backend import LocalPermissionBackend
 from infrahub.proposed_change.models import RequestProposedChangePipeline
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
@@ -265,6 +263,7 @@ class TestMergeProposedChangePermissionFailure(TestInfrahubApp):
     async def test_merge_proposed_change_permission_failure(
         self,
         db: InfrahubDatabase,
+        default_permission_backend: None,
         register_core_models_schema: None,
         session_first_account: AccountSession,
         session_admin: AccountSession,
@@ -280,8 +279,6 @@ class TestMergeProposedChangePermissionFailure(TestInfrahubApp):
         async with get_client(sync_client=False) as prefect_client:
             await setup_worker_pools(client=prefect_client)
             await setup_deployments(prefect_client)
-
-        registry.permission_backends = [LocalPermissionBackend()]
 
         branch_name = "merge-proposed-change-perm"
         branch = await create_branch(branch_name=branch_name, db=db)

--- a/backend/tests/unit/graphql/mutations/test_schema.py
+++ b/backend/tests/unit/graphql/mutations/test_schema.py
@@ -9,7 +9,7 @@ from tests.helpers.graphql import graphql
 
 
 async def test_delete_last_dropdown_option(
-    db: InfrahubDatabase, default_permission_backend, default_branch, choices_schema
+    db: InfrahubDatabase, default_permission_backend, default_branch, choices_schema, session_admin
 ):
     query = """
     mutation {
@@ -18,7 +18,9 @@ async def test_delete_last_dropdown_option(
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    gql_params = await prepare_graphql_params(
+        db=db, include_subscription=False, branch=default_branch, account_session=session_admin
+    )
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -32,7 +34,7 @@ async def test_delete_last_dropdown_option(
 
 
 async def test_delete_last_enum_option(
-    db: InfrahubDatabase, default_permission_backend, default_branch, choices_schema
+    db: InfrahubDatabase, default_permission_backend, default_branch, choices_schema, session_admin
 ):
     query = """
     mutation {
@@ -41,7 +43,9 @@ async def test_delete_last_enum_option(
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    gql_params = await prepare_graphql_params(
+        db=db, include_subscription=False, branch=default_branch, account_session=session_admin
+    )
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -55,7 +59,7 @@ async def test_delete_last_enum_option(
 
 
 async def test_delete_enum_option_that_does_not_exist(
-    db: InfrahubDatabase, default_permission_backend, default_branch, choices_schema
+    db: InfrahubDatabase, default_permission_backend, default_branch, choices_schema, session_admin
 ):
     query = """
     mutation {
@@ -64,7 +68,9 @@ async def test_delete_enum_option_that_does_not_exist(
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    gql_params = await prepare_graphql_params(
+        db=db, include_subscription=False, branch=default_branch, account_session=session_admin
+    )
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -78,7 +84,7 @@ async def test_delete_enum_option_that_does_not_exist(
 
 
 async def test_delete_drop_option_that_does_not_exist(
-    db: InfrahubDatabase, default_permission_backend, default_branch, choices_schema
+    db: InfrahubDatabase, default_permission_backend, default_branch, choices_schema, session_admin
 ):
     query = """
     mutation {
@@ -87,7 +93,9 @@ async def test_delete_drop_option_that_does_not_exist(
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    gql_params = await prepare_graphql_params(
+        db=db, include_subscription=False, branch=default_branch, account_session=session_admin
+    )
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -101,7 +109,7 @@ async def test_delete_drop_option_that_does_not_exist(
 
 
 async def test_add_enum_option_that_exist(
-    db: InfrahubDatabase, default_permission_backend, default_branch, choices_schema
+    db: InfrahubDatabase, default_permission_backend, default_branch, choices_schema, session_admin
 ):
     query = """
     mutation {
@@ -110,7 +118,9 @@ async def test_add_enum_option_that_exist(
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    gql_params = await prepare_graphql_params(
+        db=db, include_subscription=False, branch=default_branch, account_session=session_admin
+    )
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -124,7 +134,7 @@ async def test_add_enum_option_that_exist(
 
 
 async def test_delete_dropdown_option_in_use(
-    db: InfrahubDatabase, default_permission_backend, default_branch, choices_schema
+    db: InfrahubDatabase, default_permission_backend, default_branch, choices_schema, session_admin
 ):
     obj1 = await Node.init(db=db, schema="TestChoice")
     await obj1.new(db=db, name="test-passive-01", status="passive", temperature_scale="celsius")
@@ -137,7 +147,9 @@ async def test_delete_dropdown_option_in_use(
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    gql_params = await prepare_graphql_params(
+        db=db, include_subscription=False, branch=default_branch, account_session=session_admin
+    )
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -151,7 +163,7 @@ async def test_delete_dropdown_option_in_use(
 
 
 async def test_delete_enum_option_in_use(
-    db: InfrahubDatabase, default_permission_backend, default_branch, choices_schema
+    db: InfrahubDatabase, default_permission_backend, default_branch, choices_schema, session_admin
 ):
     obj1 = await Node.init(db=db, schema="TestChoice")
     await obj1.new(db=db, name="test-passive-01", status="passive")
@@ -164,7 +176,9 @@ async def test_delete_enum_option_in_use(
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    gql_params = await prepare_graphql_params(
+        db=db, include_subscription=False, branch=default_branch, account_session=session_admin
+    )
     result = await graphql(
         schema=gql_params.schema,
         source=query,

--- a/backend/tests/unit/graphql/mutations/test_schema.py
+++ b/backend/tests/unit/graphql/mutations/test_schema.py
@@ -8,7 +8,9 @@ from infrahub.graphql.mutations.schema import validate_kind, validate_kind_dropd
 from tests.helpers.graphql import graphql
 
 
-async def test_delete_last_dropdown_option(db: InfrahubDatabase, default_branch, choices_schema):
+async def test_delete_last_dropdown_option(
+    db: InfrahubDatabase, default_permission_backend, default_branch, choices_schema
+):
     query = """
     mutation {
         SchemaDropdownRemove(data: {kind: "TestChoice", attribute: "temperature_scale", dropdown: "celsius"}) {
@@ -29,7 +31,9 @@ async def test_delete_last_dropdown_option(db: InfrahubDatabase, default_branch,
     assert "Unable to remove the last dropdown on TestChoice in attribute temperature_scale" in str(result.errors[0])
 
 
-async def test_delete_last_enum_option(db: InfrahubDatabase, default_branch, choices_schema):
+async def test_delete_last_enum_option(
+    db: InfrahubDatabase, default_permission_backend, default_branch, choices_schema
+):
     query = """
     mutation {
         SchemaEnumRemove(data: {kind: "BaseChoice", attribute: "measuring_system", enum: "metric"}) {
@@ -50,7 +54,9 @@ async def test_delete_last_enum_option(db: InfrahubDatabase, default_branch, cho
     assert "Unable to remove the last enum on BaseChoice in attribute measuring_system" in str(result.errors[0])
 
 
-async def test_delete_enum_option_that_does_not_exist(db: InfrahubDatabase, default_branch, choices_schema):
+async def test_delete_enum_option_that_does_not_exist(
+    db: InfrahubDatabase, default_permission_backend, default_branch, choices_schema
+):
     query = """
     mutation {
         SchemaEnumRemove(data: {kind: "BaseChoice", attribute: "color", enum: "yellow"}) {
@@ -71,7 +77,9 @@ async def test_delete_enum_option_that_does_not_exist(db: InfrahubDatabase, defa
     assert "The enum value yellow does not exists on BaseChoice in attribute color" in str(result.errors[0])
 
 
-async def test_delete_drop_option_that_does_not_exist(db: InfrahubDatabase, default_branch, choices_schema):
+async def test_delete_drop_option_that_does_not_exist(
+    db: InfrahubDatabase, default_permission_backend, default_branch, choices_schema
+):
     query = """
     mutation {
         SchemaDropdownRemove(data: {kind: "BaseChoice", attribute: "section", dropdown: "ci"}) {
@@ -92,7 +100,9 @@ async def test_delete_drop_option_that_does_not_exist(db: InfrahubDatabase, defa
     assert "The dropdown value ci does not exists on BaseChoice in attribute section" in str(result.errors[0])
 
 
-async def test_add_enum_option_that_exist(db: InfrahubDatabase, default_branch, choices_schema):
+async def test_add_enum_option_that_exist(
+    db: InfrahubDatabase, default_permission_backend, default_branch, choices_schema
+):
     query = """
     mutation {
         SchemaEnumAdd(data: {kind: "BaseChoice", attribute: "color", enum: "red"}) {
@@ -113,7 +123,9 @@ async def test_add_enum_option_that_exist(db: InfrahubDatabase, default_branch, 
     assert "The enum value red already exists on BaseChoice in attribute color" in str(result.errors[0])
 
 
-async def test_delete_dropdown_option_in_use(db: InfrahubDatabase, default_branch, choices_schema):
+async def test_delete_dropdown_option_in_use(
+    db: InfrahubDatabase, default_permission_backend, default_branch, choices_schema
+):
     obj1 = await Node.init(db=db, schema="TestChoice")
     await obj1.new(db=db, name="test-passive-01", status="passive", temperature_scale="celsius")
     await obj1.save(db=db)
@@ -138,7 +150,9 @@ async def test_delete_dropdown_option_in_use(db: InfrahubDatabase, default_branc
     assert "There are still TestChoice objects using this dropdown" in str(result.errors[0])
 
 
-async def test_delete_enum_option_in_use(db: InfrahubDatabase, default_branch, choices_schema):
+async def test_delete_enum_option_in_use(
+    db: InfrahubDatabase, default_permission_backend, default_branch, choices_schema
+):
     obj1 = await Node.init(db=db, schema="TestChoice")
     await obj1.new(db=db, name="test-passive-01", status="passive")
     await obj1.save(db=db)

--- a/backend/tests/unit/graphql/queries/test_list_permissions.py
+++ b/backend/tests/unit/graphql/queries/test_list_permissions.py
@@ -10,9 +10,7 @@ from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.protocols import CoreAccountRole
-from infrahub.core.registry import registry
 from infrahub.graphql.initialization import prepare_graphql_params
-from infrahub.permissions import LocalPermissionBackend
 from infrahub.permissions.constants import BranchRelativePermissionDecision, PermissionDecisionFlag
 from tests.helpers.graphql import graphql
 
@@ -99,7 +97,6 @@ class TestObjectPermissions:
     ):
         permissions_helper._first = first_account
         permissions_helper._default_branch = default_branch
-        registry.permission_backends = [LocalPermissionBackend()]
 
         permissions = []
         for object_permission in [
@@ -168,7 +165,9 @@ class TestObjectPermissions:
         await group.members.add(db=db, data={"id": first_account.id})
         await group.members.save(db=db)
 
-    async def test_first_account_tags(self, db: InfrahubDatabase, permissions_helper: PermissionsHelper) -> None:
+    async def test_first_account_tags(
+        self, db: InfrahubDatabase, default_permission_backend: None, permissions_helper: PermissionsHelper
+    ) -> None:
         """In the main branch the first account doesn't have the permission to make changes, but it has in the other branches"""
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
@@ -193,7 +192,7 @@ class TestObjectPermissions:
         }
 
     async def test_first_account_tags_non_main_branch(
-        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper
+        self, db: InfrahubDatabase, default_permission_backend: None, permissions_helper: PermissionsHelper
     ) -> None:
         """In other branches the permissions for the first account is less restrictive"""
         branch2 = await create_branch(branch_name="pr-12345", db=db)
@@ -216,7 +215,7 @@ class TestObjectPermissions:
         }
 
     async def test_first_account_list_permissions_for_generics(
-        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper
+        self, db: InfrahubDatabase, default_permission_backend: None, permissions_helper: PermissionsHelper
     ) -> None:
         """In the main branch the first account doesn't have the permission to make changes"""
         session = AccountSession(
@@ -255,7 +254,7 @@ class TestObjectPermissions:
         } in result.data["BuiltinIPNamespace"]["permissions"]["edges"]
 
     async def test_first_account_ipprefix_pool(
-        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper
+        self, db: InfrahubDatabase, default_permission_backend: None, permissions_helper: PermissionsHelper
     ) -> None:
         """In the main branch the first account doesn't have the permission to make changes, but it has in the other branches"""
         session = AccountSession(
@@ -281,7 +280,7 @@ class TestObjectPermissions:
         }
 
     async def test_first_account_tags_non_main_branch_non_isolated(
-        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper
+        self, db: InfrahubDatabase, default_permission_backend: None, permissions_helper: PermissionsHelper
     ) -> None:
         """In other branches the permissions for the first account should be updated if we modify the main branch"""
 
@@ -370,7 +369,6 @@ class TestAttributePermissions:
     ):
         permissions_helper._first = first_account
         permissions_helper._default_branch = default_branch
-        registry.permission_backends = [LocalPermissionBackend()]
 
         permissions = []
         for object_permission in [
@@ -426,7 +424,7 @@ class TestAttributePermissions:
         await tag.save(db=db)
 
     async def test_first_account_tags_main_branch(
-        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper
+        self, db: InfrahubDatabase, default_permission_backend: None, permissions_helper: PermissionsHelper
     ) -> None:
         """In the main branch the first account doesn't have the permission to make changes, so attribute cannot be changed"""
         session = AccountSession(
@@ -449,7 +447,7 @@ class TestAttributePermissions:
         }
 
     async def test_first_account_tags_non_main_branch(
-        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper
+        self, db: InfrahubDatabase, default_permission_backend: None, permissions_helper: PermissionsHelper
     ) -> None:
         """In other branches the permissions for the first account is less restrictive, attribute should be updatable"""
         branch2 = await create_branch(branch_name="pr-12345", db=db)

--- a/backend/tests/unit/graphql/queries/test_list_permissions.py
+++ b/backend/tests/unit/graphql/queries/test_list_permissions.py
@@ -90,6 +90,7 @@ class TestObjectPermissions:
     async def test_setup(
         self,
         db: InfrahubDatabase,
+        default_permission_backend: None,
         register_core_models_schema: SchemaBranch,
         default_branch: Branch,
         permissions_helper: PermissionsHelper,
@@ -165,9 +166,7 @@ class TestObjectPermissions:
         await group.members.add(db=db, data={"id": first_account.id})
         await group.members.save(db=db)
 
-    async def test_first_account_tags(
-        self, db: InfrahubDatabase, default_permission_backend: None, permissions_helper: PermissionsHelper
-    ) -> None:
+    async def test_first_account_tags(self, db: InfrahubDatabase, permissions_helper: PermissionsHelper) -> None:
         """In the main branch the first account doesn't have the permission to make changes, but it has in the other branches"""
         session = AccountSession(
             authenticated=True, account_id=permissions_helper.first.id, session_id=str(uuid4()), auth_type=AuthType.JWT
@@ -192,7 +191,7 @@ class TestObjectPermissions:
         }
 
     async def test_first_account_tags_non_main_branch(
-        self, db: InfrahubDatabase, default_permission_backend: None, permissions_helper: PermissionsHelper
+        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper
     ) -> None:
         """In other branches the permissions for the first account is less restrictive"""
         branch2 = await create_branch(branch_name="pr-12345", db=db)
@@ -215,7 +214,7 @@ class TestObjectPermissions:
         }
 
     async def test_first_account_list_permissions_for_generics(
-        self, db: InfrahubDatabase, default_permission_backend: None, permissions_helper: PermissionsHelper
+        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper
     ) -> None:
         """In the main branch the first account doesn't have the permission to make changes"""
         session = AccountSession(
@@ -254,7 +253,7 @@ class TestObjectPermissions:
         } in result.data["BuiltinIPNamespace"]["permissions"]["edges"]
 
     async def test_first_account_ipprefix_pool(
-        self, db: InfrahubDatabase, default_permission_backend: None, permissions_helper: PermissionsHelper
+        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper
     ) -> None:
         """In the main branch the first account doesn't have the permission to make changes, but it has in the other branches"""
         session = AccountSession(
@@ -280,7 +279,7 @@ class TestObjectPermissions:
         }
 
     async def test_first_account_tags_non_main_branch_non_isolated(
-        self, db: InfrahubDatabase, default_permission_backend: None, permissions_helper: PermissionsHelper
+        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper
     ) -> None:
         """In other branches the permissions for the first account should be updated if we modify the main branch"""
 
@@ -362,6 +361,7 @@ class TestAttributePermissions:
     async def test_setup(
         self,
         db: InfrahubDatabase,
+        default_permission_backend: None,
         register_core_models_schema: SchemaBranch,
         default_branch: Branch,
         permissions_helper: PermissionsHelper,
@@ -424,7 +424,7 @@ class TestAttributePermissions:
         await tag.save(db=db)
 
     async def test_first_account_tags_main_branch(
-        self, db: InfrahubDatabase, default_permission_backend: None, permissions_helper: PermissionsHelper
+        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper
     ) -> None:
         """In the main branch the first account doesn't have the permission to make changes, so attribute cannot be changed"""
         session = AccountSession(
@@ -447,7 +447,7 @@ class TestAttributePermissions:
         }
 
     async def test_first_account_tags_non_main_branch(
-        self, db: InfrahubDatabase, default_permission_backend: None, permissions_helper: PermissionsHelper
+        self, db: InfrahubDatabase, permissions_helper: PermissionsHelper
     ) -> None:
         """In other branches the permissions for the first account is less restrictive, attribute should be updatable"""
         branch2 = await create_branch(branch_name="pr-12345", db=db)

--- a/backend/tests/unit/graphql/test_core_account.py
+++ b/backend/tests/unit/graphql/test_core_account.py
@@ -1,14 +1,12 @@
 import bcrypt
 
 from infrahub.auth import AccountSession, AuthType
-from infrahub.core import registry
 from infrahub.core.account import GlobalPermission, ObjectPermission
 from infrahub.core.branch import Branch
 from infrahub.core.constants import GlobalPermissions, PermissionAction, PermissionDecision
 from infrahub.core.manager import NodeManager
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
-from infrahub.permissions.local_backend import LocalPermissionBackend
 from tests.helpers.graphql import graphql
 
 
@@ -48,9 +46,13 @@ async def test_everyone_can_update_password(db: InfrahubDatabase, default_branch
 
 
 async def test_permissions(
-    db: InfrahubDatabase, default_branch: Branch, authentication_base, session_admin, first_account
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    default_permission_backend: None,
+    authentication_base,
+    session_admin,
+    first_account,
 ):
-    registry.permission_backends = [LocalPermissionBackend()]
     query = """
     query {
         InfrahubPermissions {

--- a/backend/tests/unit/graphql/test_mutation_relationship.py
+++ b/backend/tests/unit/graphql/test_mutation_relationship.py
@@ -24,7 +24,6 @@ from infrahub.events.group_action import GroupMemberAddedEvent, GroupMemberRemov
 from infrahub.events.models import EventNode
 from infrahub.events.node_action import NodeMutatedEvent
 from infrahub.graphql.initialization import prepare_graphql_params
-from infrahub.permissions import LocalPermissionBackend
 from infrahub.services import InfrahubServices
 from tests.adapters.event import MemoryInfrahubEvent
 from tests.helpers.graphql import graphql
@@ -38,6 +37,7 @@ if TYPE_CHECKING:
 
 async def test_relationship_add(
     db: InfrahubDatabase,
+    default_permission_backend: None,
     person_jack_main: Node,
     tag_blue_main: Node,
     tag_red_main: Node,
@@ -180,6 +180,7 @@ async def test_relationship_add(
 
 async def test_relationship_remove(
     db: InfrahubDatabase,
+    default_permission_backend: None,
     person_jack_tags_main: Node,
     tag_blue_main: Node,
     tag_red_main: Node,
@@ -391,6 +392,7 @@ async def test_relationship_wrong_node(
 
 async def test_relationship_groups_add(
     db: InfrahubDatabase,
+    default_permission_backend: None,
     default_branch: Branch,
     car_person_generics_data: dict[str, Node],
     enable_broker_config: None,
@@ -538,6 +540,7 @@ async def test_relationship_groups_add(
 
 async def test_relationship_groups_remove(
     db: InfrahubDatabase,
+    default_permission_backend: None,
     default_branch: Branch,
     car_person_generics_data,
     enable_broker_config: None,
@@ -1154,14 +1157,13 @@ async def test_add_generic_related_node_with_hfid(
 
 async def test_with_permissions(
     db: InfrahubDatabase,
+    default_permission_backend: None,
     register_core_models_schema: None,
     default_branch: Branch,
     first_account: CoreAccount,
     person_jack_main: Node,
     tag_blue_main: Node,
 ):
-    registry.permission_backends = [LocalPermissionBackend()]
-
     permissions = []
     for object_permission in [
         ObjectPermission(
@@ -1231,14 +1233,13 @@ async def test_with_permissions(
 
 async def test_without_permissions(
     db: InfrahubDatabase,
+    default_permission_backend: None,
     register_core_models_schema: None,
     default_branch: Branch,
     first_account: CoreAccount,
     person_jack_main: Node,
     tag_red_main: Node,
 ):
-    registry.permission_backends = [LocalPermissionBackend()]
-
     first_session = AccountSession(
         authenticated=True, account_id=first_account.id, session_id=str(uuid4()), auth_type=AuthType.JWT
     )

--- a/backend/tests/unit/permissions/test_manager.py
+++ b/backend/tests/unit/permissions/test_manager.py
@@ -8,7 +8,7 @@ from infrahub.core.constants import GlobalPermissions, InfrahubKind, PermissionA
 from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import PermissionDeniedError
-from infrahub.permissions import AssignedPermissions, LocalPermissionBackend, PermissionBackend, PermissionManager
+from infrahub.permissions import AssignedPermissions, PermissionBackend, PermissionManager
 from infrahub.permissions.constants import PermissionDecisionFlag
 
 
@@ -33,10 +33,12 @@ class DummyBackendDeny(PermissionBackend):
 
 
 async def test_load_permissions(
-    db: InfrahubDatabase, default_branch: Branch, session_admin: AccountSession, session_first_account: AccountSession
+    db: InfrahubDatabase,
+    default_permission_backend: None,
+    default_branch: Branch,
+    session_admin: AccountSession,
+    session_first_account: AccountSession,
 ):
-    registry.permission_backends = [LocalPermissionBackend()]
-
     permission_manager = PermissionManager(account_session=session_admin)
     await permission_manager.load_permissions(db=db, branch=default_branch)
 
@@ -78,13 +80,12 @@ async def test_load_permissions_multiple_backends(
 async def test_has_permission_global(
     db: InfrahubDatabase,
     default_branch: Branch,
+    default_permission_backend: None,
     register_core_models_schema: None,
     session_admin: AccountSession,
     session_first_account: AccountSession,
     session_second_account: AccountSession,
 ):
-    registry.permission_backends = [LocalPermissionBackend()]
-
     allow_default_branch_edition = GlobalPermission(
         action=GlobalPermissions.EDIT_DEFAULT_BRANCH.value, decision=PermissionDecision.ALLOW_ALL.value
     )
@@ -145,13 +146,12 @@ async def test_has_permission_global(
 async def test_has_permission_object(
     db: InfrahubDatabase,
     default_branch: Branch,
+    default_permission_backend: None,
     register_core_models_schema: None,
     session_admin: AccountSession,
     session_first_account: AccountSession,
     session_second_account: AccountSession,
 ):
-    registry.permission_backends = [LocalPermissionBackend()]
-
     role1_permissions = []
     for p in [
         ObjectPermission(
@@ -230,13 +230,12 @@ async def test_has_permission_object(
 async def test_has_permissions_object(
     db: InfrahubDatabase,
     default_branch: Branch,
+    default_permission_backend: None,
     register_core_models_schema: None,
     session_admin: AccountSession,
     session_first_account: AccountSession,
     session_second_account: AccountSession,
 ):
-    registry.permission_backends = [LocalPermissionBackend()]
-
     role1_permissions = []
     for p in [
         ObjectPermission(
@@ -335,13 +334,12 @@ async def test_has_permissions_object(
 async def test_report_permission_object(
     db: InfrahubDatabase,
     default_branch: Branch,
+    default_permission_backend: None,
     register_core_models_schema: None,
     session_admin: AccountSession,
     session_first_account: AccountSession,
     session_second_account: AccountSession,
 ):
-    registry.permission_backends = [LocalPermissionBackend()]
-
     role1_permissions = []
     for p in [
         ObjectPermission(

--- a/backend/tests/unit/permissions/test_manager.py
+++ b/backend/tests/unit/permissions/test_manager.py
@@ -76,6 +76,8 @@ async def test_load_permissions_multiple_backends(
     assert "object_permissions" in permission_manager.permissions
     assert len(permission_manager.permissions["object_permissions"]) == 2
 
+    registry.permission_backends.clear()
+
 
 async def test_has_permission_global(
     db: InfrahubDatabase,

--- a/backend/tests/unit/permissions/test_manager.py
+++ b/backend/tests/unit/permissions/test_manager.py
@@ -76,8 +76,6 @@ async def test_load_permissions_multiple_backends(
     assert "object_permissions" in permission_manager.permissions
     assert len(permission_manager.permissions["object_permissions"]) == 2
 
-    registry.permission_backends.clear()
-
 
 async def test_has_permission_global(
     db: InfrahubDatabase,

--- a/changelog/6410.fixed.md
+++ b/changelog/6410.fixed.md
@@ -1,0 +1,1 @@
+Ensure that only users with "manage schema" permissions can add or remove dropdown and enum values


### PR DESCRIPTION
This change ensures that the `MANAGE_SCHEMA` global permission is checked when trying to add or remove a dropdown/enum value.

Unit tests involving permissions have been slightly changed to use a fixture to set the permission backend to use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Enforced that only users with the "Manage schema" permission can add or remove dropdown and enum values via GraphQL.
  - Schema enum mutations now require an explicit enum name in the input.

- Documentation
  - Changelog updated to note the "Manage schema" permission requirement for dropdown/enum changes.

- Tests
  - Test suite switched to a fixture-driven permission backend and updated test signatures to rely on the default permission fixture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->