### PR TITLE
Fix filters for opened / draft / closed proposed changes views and improve ui

### DIFF
--- a/frontend/app/src/entities/proposed-changes/api/get-proposed-changes-counts-from-api.ts
+++ b/frontend/app/src/entities/proposed-changes/api/get-proposed-changes-counts-from-api.ts
@@ -27,16 +27,6 @@ export const getProposedChangesCountsFromApi = async ({
           __args: {
             ...(filters ? addFiltersToRequest(filters) : {}),
             state__values: PROPOSED_CHANGE_STATES.opened,
-            is_draft__value: false,
-          },
-          count: true,
-        },
-        draft: {
-          __aliasFor: PROPOSED_CHANGE_OBJECT,
-          __args: {
-            ...(filters ? addFiltersToRequest(filters) : {}),
-            is_draft__value: true,
-            state__values: PROPOSED_CHANGE_STATES.draft,
           },
           count: true,
         },

--- a/frontend/app/src/entities/proposed-changes/api/get-proposed-changes-counts-from-api.ts
+++ b/frontend/app/src/entities/proposed-changes/api/get-proposed-changes-counts-from-api.ts
@@ -21,6 +21,7 @@ export const getProposedChangesCountsFromApi = async ({
   const query = gql(
     jsonToGraphQLQuery({
       query: {
+        __name: "GET_PROPOSED_CHANGE_COUNTS",
         opened: {
           __aliasFor: PROPOSED_CHANGE_OBJECT,
           __args: {
@@ -35,6 +36,7 @@ export const getProposedChangesCountsFromApi = async ({
           __args: {
             ...(filters ? addFiltersToRequest(filters) : {}),
             is_draft__value: true,
+            state__values: PROPOSED_CHANGE_STATES.draft,
           },
           count: true,
         },

--- a/frontend/app/src/entities/proposed-changes/constants.ts
+++ b/frontend/app/src/entities/proposed-changes/constants.ts
@@ -14,7 +14,6 @@ export const PROPOSED_CHANGE_OBJECT = "CoreProposedChange";
 
 export const PROPOSED_CHANGE_STATES = {
   opened: [OPEN_STATE, MERGING_STATE],
-  draft: [OPEN_STATE, MERGE_STATE, "canceled"],
   closed: [CLOSE_STATE, MERGE_STATE, "canceled"],
 };
 

--- a/frontend/app/src/entities/proposed-changes/constants.ts
+++ b/frontend/app/src/entities/proposed-changes/constants.ts
@@ -14,7 +14,7 @@ export const PROPOSED_CHANGE_OBJECT = "CoreProposedChange";
 
 export const PROPOSED_CHANGE_STATES = {
   opened: [OPEN_STATE, MERGING_STATE],
-  draft: [MERGE_STATE, "canceled"],
+  draft: [OPEN_STATE, MERGE_STATE, "canceled"],
   closed: [CLOSE_STATE, MERGE_STATE, "canceled"],
 };
 

--- a/frontend/app/src/entities/proposed-changes/constants.ts
+++ b/frontend/app/src/entities/proposed-changes/constants.ts
@@ -14,6 +14,7 @@ export const PROPOSED_CHANGE_OBJECT = "CoreProposedChange";
 
 export const PROPOSED_CHANGE_STATES = {
   opened: [OPEN_STATE, MERGING_STATE],
+  draft: [MERGE_STATE, "canceled"],
   closed: [CLOSE_STATE, MERGE_STATE, "canceled"],
 };
 

--- a/frontend/app/src/entities/proposed-changes/constants.ts
+++ b/frontend/app/src/entities/proposed-changes/constants.ts
@@ -10,11 +10,12 @@ export const MERGE_STATE = "merged";
 export const MERGING_STATE = "merging";
 export const CLOSE_STATE = "closed";
 export const DRAFT_STATE = "draft";
+export const CANCEL_STATE = "canceled";
 export const PROPOSED_CHANGE_OBJECT = "CoreProposedChange";
 
 export const PROPOSED_CHANGE_STATES = {
   opened: [OPEN_STATE, MERGING_STATE],
-  closed: [CLOSE_STATE, MERGE_STATE, "canceled"],
+  closed: [CLOSE_STATE, MERGE_STATE, CANCEL_STATE],
 };
 
 export const PROPOSED_CHANGE_MERGED = "infrahub.proposed_change.merged";

--- a/frontend/app/src/entities/proposed-changes/domain/get-proposed-changes-counts.ts
+++ b/frontend/app/src/entities/proposed-changes/domain/get-proposed-changes-counts.ts
@@ -19,7 +19,6 @@ export async function getProposedChangesCounts(
 
   return {
     opened: data.opened.count ?? 0,
-    draft: data.draft.count ?? 0,
     closed: data.closed.count ?? 0,
   };
 }

--- a/frontend/app/src/entities/proposed-changes/ui/proposed-change-item.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/proposed-change-item.tsx
@@ -77,10 +77,7 @@ const ProposedChangesInfo = ({
         <span className="flex items-center space-x-4">
           <Link
             to={constructPath(`/proposed-changes/${id}`)}
-            className={classNames(
-              "hover:text-gray-500 transition-all text-lg font-semibold",
-              isDraft && "text-gray-500"
-            )}
+            className={classNames("hover:text-gray-500 transition-all text-lg font-semibold")}
           >
             <Icon
               icon={"mdi:file-replace-outline"}

--- a/frontend/app/src/entities/proposed-changes/ui/proposed-change-item.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/proposed-change-item.tsx
@@ -76,21 +76,24 @@ const ProposedChangesInfo = ({
   return (
     <div>
       <div className="flex flex-col gap-2">
-        <span className="space-x-2">
-          <Badge variant={getProposedChangesStateBadgeType(state)}>{state}</Badge>
-          {isDraft && <Badge variant={"gray"}>draft</Badge>}
+        <span className="flex items-center space-x-4">
           <Link
             to={constructPath(`/proposed-changes/${id}`)}
-            className="hover:text-gray-500 transition-all"
+            className="hover:text-gray-500 transition-all text-lg font-semibold"
           >
-            {name}
+            <Icon icon={"mdi:file-replace-outline"} className="text-base" /> {name}
           </Link>
+
+          <div className="space-x-2">
+            <Badge variant={getProposedChangesStateBadgeType(state)}>{state}</Badge>
+            {isDraft && <Badge variant={"gray-outline"}>draft</Badge>}
+          </div>
         </span>
         <span className="flex items-center gap-1 text-xs">
-          <Badge className="flex items-center gap-1">
+          <span className="flex items-center gap-1 font-semibold">
             <Icon icon={"mdi:source-branch"} />
             {branchName}
-          </Badge>
+          </span>
           Opened <DateDisplay date={createdAt} /> by {author}
         </span>
       </div>

--- a/frontend/app/src/entities/proposed-changes/ui/proposed-change-item.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/proposed-change-item.tsx
@@ -1,16 +1,15 @@
 import { ARTIFACT_OBJECT, CHECK_OBJECT, TASK_OBJECT } from "@/config/constants";
 import { useObjectsCount } from "@/entities/nodes/object/domain/get-objects-count.query";
 import { useObjectTableContext } from "@/entities/nodes/object/ui/object-table/object-table-context";
-import { NodeCore } from "@/entities/nodes/types";
 import { ProposedChangeItem } from "@/entities/proposed-changes/domain/get-proposed-changes";
 import { ProposedChangeDiffSummary } from "@/entities/proposed-changes/ui/diff-summary";
 import { ProposedChangesActionCell } from "@/entities/proposed-changes/ui/proposed-changes-actions-cell";
-import { getProposedChangesStateBadgeType } from "@/entities/proposed-changes/utils/proposed-changes";
 import { useSchema } from "@/entities/schema/ui/hooks/useSchema";
 import { constructPath } from "@/shared/api/rest/fetch";
 import { DateDisplay } from "@/shared/components/display/date-display";
 import { Badge } from "@/shared/components/ui/badge";
 import { Tooltip } from "@/shared/components/ui/tooltip";
+import { classNames } from "@/shared/utils/common";
 import { Icon } from "@iconify-icon/react";
 import { Link } from "react-router";
 
@@ -30,6 +29,7 @@ export const ProposedChangesItem = ({ node }: ProposedChangesItemProps) => {
           author={node.created_by.node?.display_label}
           state={node.state?.value}
           isDraft={!!node.is_draft?.value}
+          isApproved={!!node.approved_by.edges.length}
           createdAt={node._updated_at}
           branchName={node.source_branch?.value}
         />
@@ -37,9 +37,6 @@ export const ProposedChangesItem = ({ node }: ProposedChangesItemProps) => {
         <ProposedChangesData
           id={node.id}
           branchName={node.source_branch?.value}
-          approvers={node.approved_by.edges.map((edge: { node: NodeCore }) => {
-            return edge.node;
-          })}
           comments={node.total_comments.value ?? 0}
           validations={node.validations.count}
         />
@@ -60,6 +57,7 @@ type ProposedChangesInfoProps = {
   author: string;
   state: string;
   isDraft: boolean;
+  isApproved: boolean;
   createdAt: string;
   branchName?: string;
 };
@@ -68,8 +66,8 @@ const ProposedChangesInfo = ({
   id,
   name,
   author,
-  state,
   isDraft,
+  isApproved,
   createdAt,
   branchName,
 }: ProposedChangesInfoProps) => {
@@ -79,14 +77,26 @@ const ProposedChangesInfo = ({
         <span className="flex items-center space-x-4">
           <Link
             to={constructPath(`/proposed-changes/${id}`)}
-            className="hover:text-gray-500 transition-all text-lg font-semibold"
+            className={classNames(
+              "hover:text-gray-500 transition-all text-lg font-semibold",
+              isDraft && "text-gray-500"
+            )}
           >
-            <Icon icon={"mdi:file-replace-outline"} className="text-base" /> {name}
+            <Icon
+              icon={"mdi:file-replace-outline"}
+              className={classNames(
+                "text-base",
+                "text-green-700",
+                isDraft && "text-gray-500",
+                isApproved && "text-custom-blue-500"
+              )}
+            />{" "}
+            {name}
           </Link>
 
           <div className="space-x-2">
-            <Badge variant={getProposedChangesStateBadgeType(state)}>{state}</Badge>
             {isDraft && <Badge variant={"gray-outline"}>draft</Badge>}
+            {isApproved && <Badge variant={"blue-outline"}>approved</Badge>}
           </div>
         </span>
         <span className="flex items-center gap-1 text-xs">
@@ -104,7 +114,6 @@ const ProposedChangesInfo = ({
 type ProposedChangesDataProps = {
   id: string;
   branchName: string;
-  approvers: Array<NodeCore>;
   comments: number;
   validations: number;
 };
@@ -112,7 +121,6 @@ type ProposedChangesDataProps = {
 const ProposedChangesData = ({
   id,
   branchName,
-  approvers,
   comments,
   validations,
 }: ProposedChangesDataProps) => {
@@ -126,23 +134,7 @@ const ProposedChangesData = ({
           <ProposedChangesArtifacts id={id} />
           <ProposedChangesComments comments={comments} />
         </div>
-        <ProposedChangesApprovers approvers={approvers} />
       </div>
-    </div>
-  );
-};
-
-const ProposedChangesApprovers = ({ approvers }: { approvers: Array<NodeCore> }) => {
-  return (
-    <div className="flex flex-col gap-2 text-xs">
-      {!!approvers.length && (
-        <div className="flex items-center gap-2">
-          Approved by:{" "}
-          {approvers.map((approver) => {
-            return <span key={approver.id}>{approver.display_label}</span>;
-          })}
-        </div>
-      )}
     </div>
   );
 };

--- a/frontend/app/src/entities/proposed-changes/ui/proposed-change-table-filter.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/proposed-change-table-filter.tsx
@@ -13,11 +13,13 @@ import { useState } from "react";
 export interface TableColumnHeaderProps extends PopoverTriggerProps {
   schema: ModelSchema;
   columnSchema: AttributeSchema | RelationshipSchema;
+  customLabel?: string;
 }
 
 export function ProposedChangeTableFilter({
   schema,
   columnSchema,
+  customLabel,
   ...props
 }: TableColumnHeaderProps) {
   const [filters] = useFilters();
@@ -36,7 +38,9 @@ export function ProposedChangeTableFilter({
       >
         <TableColumnHeaderIcon fieldSchema={columnSchema} />
 
-        <span className="truncate mr-1">{columnSchema.label ?? columnSchema.name}</span>
+        <span className="truncate mr-1">
+          {customLabel ?? columnSchema.label ?? columnSchema.name}
+        </span>
         <Icon
           icon="mdi:filter-variant"
           className={classNames(

--- a/frontend/app/src/entities/proposed-changes/ui/proposed-changes-table-header.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/proposed-changes-table-header.tsx
@@ -69,7 +69,11 @@ export function ProposedChangesTableHeader({ schema }: ProposedChangesTableHeade
           <ProposedChangeTableFilter schema={schema} columnSchema={sourceBranchAttribute} />
         )}
         {authorRelationship && (
-          <ProposedChangeTableFilter schema={schema} columnSchema={authorRelationship} />
+          <ProposedChangeTableFilter
+            schema={schema}
+            columnSchema={authorRelationship}
+            customLabel={"Author"}
+          />
         )}
         {reviewersRelationship && (
           <ProposedChangeTableFilter schema={schema} columnSchema={reviewersRelationship} />

--- a/frontend/app/src/entities/proposed-changes/ui/proposed-changes-table-header.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/proposed-changes-table-header.tsx
@@ -20,6 +20,10 @@ export function ProposedChangesTableHeader({ schema }: ProposedChangesTableHeade
 
   const { data } = useGetProposedChangesCounts({ filters });
 
+  const draftAttribute = schema.attributes?.find((attribute) => {
+    return attribute.name === "is_draft";
+  });
+
   const stateAttribute = schema.attributes?.find((attribute) => {
     return attribute.name === "state";
   });
@@ -62,12 +66,18 @@ export function ProposedChangesTableHeader({ schema }: ProposedChangesTableHeade
         </ProposedChangeTableFilterLink>
       </div>
       <div className="flex items-center">
+        {draftAttribute && (
+          <ProposedChangeTableFilter schema={schema} columnSchema={draftAttribute} />
+        )}
+
         {stateAttribute && (
           <ProposedChangeTableFilter schema={schema} columnSchema={stateAttribute} />
         )}
+
         {sourceBranchAttribute && (
           <ProposedChangeTableFilter schema={schema} columnSchema={sourceBranchAttribute} />
         )}
+
         {authorRelationship && (
           <ProposedChangeTableFilter
             schema={schema}
@@ -75,9 +85,11 @@ export function ProposedChangesTableHeader({ schema }: ProposedChangesTableHeade
             customLabel={"Author"}
           />
         )}
+
         {reviewersRelationship && (
           <ProposedChangeTableFilter schema={schema} columnSchema={reviewersRelationship} />
         )}
+
         {approversRelationship && (
           <ProposedChangeTableFilter schema={schema} columnSchema={approversRelationship} />
         )}

--- a/frontend/app/src/entities/proposed-changes/ui/proposed-changes-table-header.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/proposed-changes-table-header.tsx
@@ -1,5 +1,5 @@
 import { QSP } from "@/config/qsp";
-import { CLOSE_STATE, DRAFT_STATE } from "@/entities/proposed-changes/constants";
+import { CLOSE_STATE } from "@/entities/proposed-changes/constants";
 import { useGetProposedChangesCounts } from "@/entities/proposed-changes/domain/get-proposed-changes-counts.query";
 import { ProposedChangeTableFilter } from "@/entities/proposed-changes/ui/proposed-change-table-filter";
 import { ProposedChangeTableFilterLink } from "@/entities/proposed-changes/ui/proposed-change-table-filter-link";
@@ -50,15 +50,6 @@ export function ProposedChangesTableHeader({ schema }: ProposedChangesTableHeade
           }}
         >
           Opened {data?.opened ? `(${data.opened})` : null}
-        </ProposedChangeTableFilterLink>
-
-        <ProposedChangeTableFilterLink
-          isActive={proposedChangeState === DRAFT_STATE}
-          onClick={() => {
-            setProposedChangeState(DRAFT_STATE);
-          }}
-        >
-          Draft {data?.draft ? `(${data.draft})` : null}
         </ProposedChangeTableFilterLink>
 
         <ProposedChangeTableFilterLink

--- a/frontend/app/src/entities/proposed-changes/utils/compute-proposed-change-filters.ts
+++ b/frontend/app/src/entities/proposed-changes/utils/compute-proposed-change-filters.ts
@@ -1,5 +1,5 @@
 import { Filter } from "@/shared/hooks/useFilters";
-import { DRAFT_STATE, PROPOSED_CHANGE_STATES } from "../constants";
+import { PROPOSED_CHANGE_STATES } from "../constants";
 
 export const computeProposedChangeFilters = ({
   filters,
@@ -8,16 +8,10 @@ export const computeProposedChangeFilters = ({
   const stateFilter: Filter = {
     name: "state__values",
     value:
-      qsp && qsp !== DRAFT_STATE && qsp in PROPOSED_CHANGE_STATES
+      qsp && qsp in PROPOSED_CHANGE_STATES
         ? PROPOSED_CHANGE_STATES[qsp as keyof typeof PROPOSED_CHANGE_STATES]
         : PROPOSED_CHANGE_STATES.opened,
   };
 
-  const draftFilter: Filter | null = !qsp
-    ? { name: "is_draft__value", value: false }
-    : qsp === DRAFT_STATE
-      ? { name: "is_draft__value", value: true }
-      : null;
-
-  return [...filters, stateFilter, ...(draftFilter ? [draftFilter] : [])];
+  return [...filters, stateFilter];
 };

--- a/frontend/app/src/entities/proposed-changes/utils/compute-proposed-change-filters.ts
+++ b/frontend/app/src/entities/proposed-changes/utils/compute-proposed-change-filters.ts
@@ -5,30 +5,19 @@ export const computeProposedChangeFilters = ({
   filters,
   qsp,
 }: { filters: Array<Filter>; qsp: keyof typeof PROPOSED_CHANGE_STATES | string }) => {
-  return [
-    ...filters,
-    {
-      name: "state__values",
-      value:
-        qsp && qsp in PROPOSED_CHANGE_STATES
-          ? PROPOSED_CHANGE_STATES[qsp as keyof typeof PROPOSED_CHANGE_STATES]
-          : PROPOSED_CHANGE_STATES.opened,
-    } as Filter,
-    ...(!qsp
-      ? [
-          {
-            name: "is_draft__value",
-            value: false,
-          } as Filter,
-        ]
-      : []),
-    ...(qsp === DRAFT_STATE
-      ? [
-          {
-            name: "is_draft__value",
-            value: true,
-          } as Filter,
-        ]
-      : []),
-  ];
+  const stateFilter: Filter = {
+    name: "state__values",
+    value:
+      qsp && qsp !== DRAFT_STATE && qsp in PROPOSED_CHANGE_STATES
+        ? PROPOSED_CHANGE_STATES[qsp as keyof typeof PROPOSED_CHANGE_STATES]
+        : PROPOSED_CHANGE_STATES.opened,
+  };
+
+  const draftFilter: Filter | null = !qsp
+    ? { name: "is_draft__value", value: false }
+    : qsp === DRAFT_STATE
+      ? { name: "is_draft__value", value: true }
+      : null;
+
+  return [...filters, stateFilter, ...(draftFilter ? [draftFilter] : [])];
 };

--- a/frontend/app/src/entities/proposed-changes/utils/proposed-changes.ts
+++ b/frontend/app/src/entities/proposed-changes/utils/proposed-changes.ts
@@ -5,16 +5,16 @@ export const getProposedChangesStateBadgeType = (
 ): BadgeProps["variant"] | undefined => {
   switch (state) {
     case "open": {
-      return "green";
+      return "green-outline";
     }
     case "closed": {
-      return "red";
+      return "red-outline";
     }
     case "merged": {
-      return "yellow";
+      return "yellow-outline";
     }
     case "canceled": {
-      return "gray";
+      return "gray-outline";
     }
     default: {
       return undefined;

--- a/frontend/app/src/shared/components/ui/badge.tsx
+++ b/frontend/app/src/shared/components/ui/badge.tsx
@@ -15,7 +15,7 @@ const badgeVariants = cva(
         blue: "border-transparent bg-custom-blue-700/10 text-custom-blue-700",
         yellow: "border-transparent bg-yellow-100 text-yellow-900",
         purple: "border-transparent bg-purple-50 text-purple-900",
-        "gray-outline": "bg-white border-gray-400 text-gray-900",
+        "gray-outline": "bg-white border-gray-400 text-gray-700",
         "blue-outline": "bg-white border-custom-blue-700 text-custom-blue-700",
         "yellow-outline": "bg-white border-yellow-100 text-yellow-900",
         "green-outline": "border-2 text-green-700 border-green-500",


### PR DESCRIPTION
* Add draft filter
* Remove draft tab
* Improve ui to differentiate states

<img width="1465" height="901" alt="Capture d’écran 2025-08-12 à 16 40 21" src="https://github.com/user-attachments/assets/9e07399e-2e3e-4076-bafe-c610abe31cfa" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-item Approved status with dynamic icon colors and inline Approved/Draft badges.
  * Header names use larger typography and branch shown inline; “Author” filter label customizable.

* **Changes**
  * Draft handling simplified: draft-specific counts and draft return value removed; draft filter rendered only when schema provides is_draft.
  * GraphQL query shape changed; filter construction simplified.
  * New CANCEL_STATE constant and state mapping adjustment.

* **Style**
  * Adjusted gray-outline badge text color for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->