### PR TITLE
feat(docs): add config preset for enterprise install

### DIFF
--- a/docs/docs/guides/installation.mdx
+++ b/docs/docs/guides/installation.mdx
@@ -334,6 +334,11 @@ You can also specify a specific version in the URL:
 
 - [https://infrahub.opsmill.io/enterprise/1.3.5](https://infrahub.opsmill.io/enterprise/1.3.5)
 
+You can also specify a sizing preset in the URL. This will automatically configure replica count for each component according to your sizing plan:
+
+- [https://infrahub.opsmill.io/enterprise?size=medium](https://infrahub.opsmill.io/enterprise?size=medium)
+- [https://infrahub.opsmill.io/enterprise/1.3.5?size=small](https://infrahub.opsmill.io/enterprise/1.3.5?size=small)
+
 #### Prerequisites
 
 - [Docker](https://docs.docker.com/engine/install/) (version 24.x minimum)
@@ -474,6 +479,13 @@ infrahub:
 :::warning
 Be sure to replace the placeholder values with your actual values.
 :::
+
+You can also use the configuration preset values.yaml file. This will automatically configure replica count for each component according to your sizing plan.
+They are available here:
+
+<ReferenceLink title="Small size config preset" url="https://github.com/opsmill/infrahub-helm/blob/stable/charts/infrahub-enterprise/values.small.yaml" openInNewTab />
+<ReferenceLink title="Medium size config preset" url="https://github.com/opsmill/infrahub-helm/blob/stable/charts/infrahub-enterprise/values.medium.yaml" openInNewTab />
+<ReferenceLink title="Large size config preset" url="https://github.com/opsmill/infrahub-helm/blob/stable/charts/infrahub-enterprise/values.large.yaml" openInNewTab />
 
 #### Step 2: install the chart
 

--- a/docs/docs/guides/installation.mdx
+++ b/docs/docs/guides/installation.mdx
@@ -336,8 +336,9 @@ You can also specify a specific version in the URL:
 
 You can also specify a sizing preset in the URL. This will automatically configure replica count for each component according to your sizing plan:
 
-- [https://infrahub.opsmill.io/enterprise?size=medium](https://infrahub.opsmill.io/enterprise?size=medium)
-- [https://infrahub.opsmill.io/enterprise/1.3.5?size=small](https://infrahub.opsmill.io/enterprise/1.3.5?size=small)
+- [https://infrahub.opsmill.io/enterprise?size=small](https://infrahub.opsmill.io/enterprise?size=small) (requires 8 GB of RAM)
+- [https://infrahub.opsmill.io/enterprise/1.3.5?size=medium](https://infrahub.opsmill.io/enterprise/1.3.5?size=medium) (requires 24 GB of RAM)
+- [https://infrahub.opsmill.io/enterprise?size=large](https://infrahub.opsmill.io/enterprise/1.3.5?size=large) (requires 64 GB of RAM)
 
 #### Prerequisites
 
@@ -483,9 +484,9 @@ Be sure to replace the placeholder values with your actual values.
 You can also use the configuration preset values.yaml file. This will automatically configure replica count for each component according to your sizing plan.
 They are available here:
 
-<ReferenceLink title="Small size config preset" url="https://github.com/opsmill/infrahub-helm/blob/stable/charts/infrahub-enterprise/values.small.yaml" openInNewTab />
-<ReferenceLink title="Medium size config preset" url="https://github.com/opsmill/infrahub-helm/blob/stable/charts/infrahub-enterprise/values.medium.yaml" openInNewTab />
-<ReferenceLink title="Large size config preset" url="https://github.com/opsmill/infrahub-helm/blob/stable/charts/infrahub-enterprise/values.large.yaml" openInNewTab />
+<ReferenceLink title="Small size config preset (requires 8 GB of RAM)" url="https://github.com/opsmill/infrahub-helm/blob/stable/charts/infrahub-enterprise/values.small.yaml" openInNewTab />
+<ReferenceLink title="Medium size config preset (requires 24 GB of RAM)" url="https://github.com/opsmill/infrahub-helm/blob/stable/charts/infrahub-enterprise/values.medium.yaml" openInNewTab />
+<ReferenceLink title="Large size config preset (requires 64 GB of RAM)" url="https://github.com/opsmill/infrahub-helm/blob/stable/charts/infrahub-enterprise/values.large.yaml" openInNewTab />
 
 #### Step 2: install the chart
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added sizing preset guidance across installation guides with small/medium/large examples and RAM recommendations.
  * Community (Docker Compose): documented URL-based ?size presets that auto-configure replicas.
  * Enterprise (Docker Compose via curl): mirrored URL-based presets and examples.
  * Enterprise (Kubernetes/Helm): added preset values file guidance, updated values.yaml structure, example links to preset YAMLs, and support notes for OCI/registry-based installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->