### PR TITLE
fix Migration033 minimum version

### DIFF
--- a/backend/infrahub/core/migrations/graph/m033_deduplicate_relationship_vertices.py
+++ b/backend/infrahub/core/migrations/graph/m033_deduplicate_relationship_vertices.py
@@ -89,7 +89,7 @@ class Migration033(GraphMigration):
     """
 
     name: str = "033_deduplicate_relationship_vertices"
-    minimum_version: int = 31
+    minimum_version: int = 32
     queries: Sequence[type[Query]] = [DeduplicateRelationshipVerticesQuery]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Raised the minimum supported version for a database migration to 32, aligning with the latest platform baseline.
  * This may affect upgrade sequencing: environments below the minimum must upgrade to the required baseline before applying this release.
  * No user-facing functionality changes; operational behavior remains unchanged once the migration prerequisites are met.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->