### PR TITLE
fix(backend): batch peers fetch only for many cardinality

### DIFF
--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -157,19 +157,21 @@ class NodeCreateAllQuery(NodeQuery):
         relationships: list[RelationshipCreateData] = []
         for rel_name in self.node._relationships:
             rel_manager: RelationshipManager = getattr(self.node, rel_name)
-            # Fetch all relationship peers through a single database call for performances.
-            peers = await rel_manager.get_peers(db=db, branch_agnostic=self.branch_agnostic)
+            if rel_manager.schema.cardinality == "many":
+                # Fetch all relationship peers through a single database call for performances.
+                peers = await rel_manager.get_peers(db=db, branch_agnostic=self.branch_agnostic)
 
             for rel in rel_manager._relationships:
-                try:
-                    rel.set_peer(value=peers[rel.get_peer_id()])
-                except KeyError:
-                    pass
-                except ValueError:
-                    # Relationship has not been initialized yet, it means the peer does not exist in db yet
-                    # typically because it will be allocated from a ressource pool. In that case, the peer
-                    # will be fetched using `rel.resolve` later.
-                    pass
+                if rel_manager.schema.cardinality == "many":
+                    try:
+                        rel.set_peer(value=peers[rel.get_peer_id()])
+                    except KeyError:
+                        pass
+                    except ValueError:
+                        # Relationship has not been initialized yet, it means the peer does not exist in db yet
+                        # typically because it will be allocated from a ressource pool. In that case, the peer
+                        # will be fetched using `rel.resolve` later.
+                        pass
 
                 rel_create_data = await rel.get_create_data(db=db, at=at)
                 if rel_create_data.peer_branch_level > deepest_branch_level or (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized relationship handling during node creation by skipping unnecessary peer lookups for single-valued relationships, reducing database calls and improving performance.
  * Preserves existing behavior for multi-valued relationships, including current error handling for missing peers.
  * No changes to public APIs; no configuration updates required.
  * Delivers more efficient node creation workflows, especially in projects with many single-valued links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->