### PR TITLE
Wrap resource pool assignments within a lock context

### DIFF
--- a/backend/infrahub/core/node/resource_manager/ip_address_pool.py
+++ b/backend/infrahub/core/node/resource_manager/ip_address_pool.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ipaddress
 from typing import TYPE_CHECKING, Any
 
+from infrahub import lock
 from infrahub.core import registry
 from infrahub.core.ipam.reconciler import IpamReconciler
 from infrahub.core.query.ipam import get_ip_addresses
@@ -33,54 +34,55 @@ class CoreIPAddressPool(Node):
         prefixlen: int | None = None,
         at: Timestamp | None = None,
     ) -> Node:
-        # Check if there is already a resource allocated with this identifier
-        # if not, pull all existing prefixes and allocated the next available
+        async with lock.registry.get(name=self.get_id(), namespace="resource_pool"):
+            # Check if there is already a resource allocated with this identifier
+            # if not, pull all existing prefixes and allocated the next available
 
-        if identifier:
-            query_get = await IPAddressPoolGetReserved.init(db=db, pool_id=self.id, identifier=identifier)
-            await query_get.execute(db=db)
-            result = query_get.get_result()
+            if identifier:
+                query_get = await IPAddressPoolGetReserved.init(db=db, pool_id=self.id, identifier=identifier)
+                await query_get.execute(db=db)
+                result = query_get.get_result()
 
-            if result:
-                address = result.get_node("address")
-                # TODO add support for branch, if the node is reserved with this id in another branch we should return an error
-                node = await registry.manager.get_one(db=db, id=address.get("uuid"), branch=branch)
+                if result:
+                    address = result.get_node("address")
+                    # TODO add support for branch, if the node is reserved with this id in another branch we should return an error
+                    node = await registry.manager.get_one(db=db, id=address.get("uuid"), branch=branch)
 
-                if node:
-                    return node
+                    if node:
+                        return node
 
-        data = data or {}
+            data = data or {}
 
-        address_type = address_type or data.get("address_type") or self.default_address_type.value  # type: ignore[attr-defined]
-        if not address_type:
-            raise ValueError(
-                f"IPAddressPool: {self.name.value} | "  # type: ignore[attr-defined]
-                "An address_type or a default_value type must be provided to allocate a new IP address"
-            )
+            address_type = address_type or data.get("address_type") or self.default_address_type.value  # type: ignore[attr-defined]
+            if not address_type:
+                raise ValueError(
+                    f"IPAddressPool: {self.name.value} | "  # type: ignore[attr-defined]
+                    "An address_type or a default_value type must be provided to allocate a new IP address"
+                )
 
-        ip_namespace = await self.ip_namespace.get_peer(db=db)  # type: ignore[attr-defined]
+            ip_namespace = await self.ip_namespace.get_peer(db=db)  # type: ignore[attr-defined]
 
-        prefixlen = prefixlen or data.get("prefixlen") or self.default_prefix_length.value  # type: ignore[attr-defined]
+            prefixlen = prefixlen or data.get("prefixlen") or self.default_prefix_length.value  # type: ignore[attr-defined]
 
-        next_address = await self.get_next(db=db, prefixlen=prefixlen)
+            next_address = await self.get_next(db=db, prefixlen=prefixlen)
 
-        target_schema = registry.get_node_schema(name=address_type, branch=branch)
-        node = await Node.init(db=db, schema=target_schema, branch=branch, at=at)
-        try:
-            await node.new(db=db, address=str(next_address), ip_namespace=ip_namespace, **data)
-        except ValidationError as exc:
-            raise ValueError(f"IPAddressPool: {self.name.value} | {exc!s}") from exc  # type: ignore[attr-defined]
-        await node.save(db=db, at=at)
-        reconciler = IpamReconciler(db=db, branch=branch)
-        await reconciler.reconcile(ip_value=next_address, namespace=ip_namespace.id, node_uuid=node.get_id())
+            target_schema = registry.get_node_schema(name=address_type, branch=branch)
+            node = await Node.init(db=db, schema=target_schema, branch=branch, at=at)
+            try:
+                await node.new(db=db, address=str(next_address), ip_namespace=ip_namespace, **data)
+            except ValidationError as exc:
+                raise ValueError(f"IPAddressPool: {self.name.value} | {exc!s}") from exc  # type: ignore[attr-defined]
+            await node.save(db=db, at=at)
+            reconciler = IpamReconciler(db=db, branch=branch)
+            await reconciler.reconcile(ip_value=next_address, namespace=ip_namespace.id, node_uuid=node.get_id())
 
-        if identifier:
-            query_set = await IPAddressPoolSetReserved.init(
-                db=db, pool_id=self.id, identifier=identifier, address_id=node.id, at=at
-            )
-            await query_set.execute(db=db)
+            if identifier:
+                query_set = await IPAddressPoolSetReserved.init(
+                    db=db, pool_id=self.id, identifier=identifier, address_id=node.id, at=at
+                )
+                await query_set.execute(db=db)
 
-        return node
+            return node
 
     async def get_next(self, db: InfrahubDatabase, prefixlen: int | None = None) -> IPAddressType:
         resources = await self.resources.get_peers(db=db)  # type: ignore[attr-defined]

--- a/backend/infrahub/core/node/resource_manager/ip_prefix_pool.py
+++ b/backend/infrahub/core/node/resource_manager/ip_prefix_pool.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any
 
 from netaddr import IPSet
 
+from infrahub import lock
 from infrahub.core import registry
 from infrahub.core.ipam.reconciler import IpamReconciler
 from infrahub.core.query.ipam import get_subnets
@@ -36,59 +37,60 @@ class CoreIPPrefixPool(Node):
         prefix_type: str | None = None,
         at: Timestamp | None = None,
     ) -> Node:
-        # Check if there is already a resource allocated with this identifier
-        # if not, pull all existing prefixes and allocated the next available
-        if identifier:
-            query_get = await PrefixPoolGetReserved.init(db=db, pool_id=self.id, identifier=identifier)
-            await query_get.execute(db=db)
-            result = query_get.get_result()
-            if result:
-                prefix = result.get_node("prefix")
-                # TODO add support for branch, if the node is reserved with this id in another branch we should return an error
-                node = await registry.manager.get_one(db=db, id=prefix.get("uuid"), branch=branch)
-                if node:
-                    return node
+        async with lock.registry.get(name=self.get_id(), namespace="resource_pool"):
+            # Check if there is already a resource allocated with this identifier
+            # if not, pull all existing prefixes and allocated the next available
+            if identifier:
+                query_get = await PrefixPoolGetReserved.init(db=db, pool_id=self.id, identifier=identifier)
+                await query_get.execute(db=db)
+                result = query_get.get_result()
+                if result:
+                    prefix = result.get_node("prefix")
+                    # TODO add support for branch, if the node is reserved with this id in another branch we should return an error
+                    node = await registry.manager.get_one(db=db, id=prefix.get("uuid"), branch=branch)
+                    if node:
+                        return node
 
-        ip_namespace = await self.ip_namespace.get_peer(db=db)  # type: ignore[attr-defined]
+            ip_namespace = await self.ip_namespace.get_peer(db=db)  # type: ignore[attr-defined]
 
-        data = data or {}
+            data = data or {}
 
-        prefixlen = prefixlen or data.get("prefixlen", None) or self.default_prefix_length.value  # type: ignore[attr-defined]
-        if not prefixlen:
-            raise ValueError(
-                f"IPPrefixPool: {self.name.value} | "  # type: ignore[attr-defined]
-                "A prefixlen or a default_value must be provided to allocate a new prefix"
-            )
+            prefixlen = prefixlen or data.get("prefixlen", None) or self.default_prefix_length.value  # type: ignore[attr-defined]
+            if not prefixlen:
+                raise ValueError(
+                    f"IPPrefixPool: {self.name.value} | "  # type: ignore[attr-defined]
+                    "A prefixlen or a default_value must be provided to allocate a new prefix"
+                )
 
-        next_prefix = await self.get_next(db=db, prefixlen=prefixlen)
+            next_prefix = await self.get_next(db=db, prefixlen=prefixlen)
 
-        prefix_type = prefix_type or data.get("prefix_type", None) or self.default_prefix_type.value  # type: ignore[attr-defined]
-        if not prefix_type:
-            raise ValueError(
-                f"IPPrefixPool: {self.name.value} | "  # type: ignore[attr-defined]
-                "A prefix_type or a default_value type must be provided to allocate a new prefix"
-            )
+            prefix_type = prefix_type or data.get("prefix_type", None) or self.default_prefix_type.value  # type: ignore[attr-defined]
+            if not prefix_type:
+                raise ValueError(
+                    f"IPPrefixPool: {self.name.value} | "  # type: ignore[attr-defined]
+                    "A prefix_type or a default_value type must be provided to allocate a new prefix"
+                )
 
-        member_type = member_type or data.get("member_type", None) or self.default_member_type.value.value  # type: ignore[attr-defined]
-        data["member_type"] = member_type
+            member_type = member_type or data.get("member_type", None) or self.default_member_type.value.value  # type: ignore[attr-defined]
+            data["member_type"] = member_type
 
-        target_schema = registry.get_node_schema(name=prefix_type, branch=branch)
-        node = await Node.init(db=db, schema=target_schema, branch=branch, at=at)
-        try:
-            await node.new(db=db, prefix=str(next_prefix), ip_namespace=ip_namespace, **data)
-        except ValidationError as exc:
-            raise ValueError(f"IPPrefixPool: {self.name.value} | {exc!s}") from exc  # type: ignore[attr-defined]
-        await node.save(db=db, at=at)
-        reconciler = IpamReconciler(db=db, branch=branch)
-        await reconciler.reconcile(ip_value=next_prefix, namespace=ip_namespace.id, node_uuid=node.get_id())
+            target_schema = registry.get_node_schema(name=prefix_type, branch=branch)
+            node = await Node.init(db=db, schema=target_schema, branch=branch, at=at)
+            try:
+                await node.new(db=db, prefix=str(next_prefix), ip_namespace=ip_namespace, **data)
+            except ValidationError as exc:
+                raise ValueError(f"IPPrefixPool: {self.name.value} | {exc!s}") from exc  # type: ignore[attr-defined]
+            await node.save(db=db, at=at)
+            reconciler = IpamReconciler(db=db, branch=branch)
+            await reconciler.reconcile(ip_value=next_prefix, namespace=ip_namespace.id, node_uuid=node.get_id())
 
-        if identifier:
-            query_set = await PrefixPoolSetReserved.init(
-                db=db, pool_id=self.id, identifier=identifier, prefix_id=node.id, at=at
-            )
-            await query_set.execute(db=db)
+            if identifier:
+                query_set = await PrefixPoolSetReserved.init(
+                    db=db, pool_id=self.id, identifier=identifier, prefix_id=node.id, at=at
+                )
+                await query_set.execute(db=db)
 
-        return node
+            return node
 
     async def get_next(self, db: InfrahubDatabase, prefixlen: int) -> IPNetworkType:
         resources = await self.resources.get_peers(db=db)  # type: ignore[attr-defined]

--- a/backend/infrahub/core/node/resource_manager/number_pool.py
+++ b/backend/infrahub/core/node/resource_manager/number_pool.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from infrahub import lock
 from infrahub.core import registry
 from infrahub.core.query.resource_manager import NumberPoolGetReserved, NumberPoolGetUsed, NumberPoolSetReserved
 from infrahub.core.schema.attribute_parameters import NumberAttributeParameters
@@ -62,24 +63,25 @@ class CoreNumberPool(Node):
         identifier: str | None = None,
         at: Timestamp | None = None,
     ) -> int:
-        # NOTE: ideally we should use the HFID as the identifier (if available)
-        # one of the challenge with using the HFID is that it might change over time
-        # so we need to ensure that the identifier is stable, or we need to handle the case where the identifier changes
-        identifier = identifier or node.get_id()
+        async with lock.registry.get(name=self.get_id(), namespace="resource_pool"):
+            # NOTE: ideally we should use the HFID as the identifier (if available)
+            # one of the challenge with using the HFID is that it might change over time
+            # so we need to ensure that the identifier is stable, or we need to handle the case where the identifier changes
+            identifier = identifier or node.get_id()
 
-        # Check if there is already a resource allocated with this identifier
-        # if not, pull all existing number and allocate the next available
-        # TODO add support for branch, if the node is reserved with this id in another branch we should return an error
-        query_get = await NumberPoolGetReserved.init(db=db, branch=branch, pool_id=self.id, identifier=identifier)
-        await query_get.execute(db=db)
-        reservation = query_get.get_reservation()
-        if reservation is not None:
-            return reservation
+            # Check if there is already a resource allocated with this identifier
+            # if not, pull all existing number and allocate the next available
+            # TODO add support for branch, if the node is reserved with this id in another branch we should return an error
+            query_get = await NumberPoolGetReserved.init(db=db, branch=branch, pool_id=self.id, identifier=identifier)
+            await query_get.execute(db=db)
+            reservation = query_get.get_reservation()
+            if reservation is not None:
+                return reservation
 
-        # If we have not returned a value we need to find one if avaiable
-        number = await self.get_next(db=db, branch=branch, attribute=attribute)
-        await self.reserve(db=db, number=number, identifier=identifier, at=at)
-        return number
+            # If we have not returned a value we need to find one if avaiable
+            number = await self.get_next(db=db, branch=branch, attribute=attribute)
+            await self.reserve(db=db, number=number, identifier=identifier, at=at)
+            return number
 
     async def get_next(self, db: InfrahubDatabase, branch: Branch, attribute: AttributeSchema) -> int:
         taken = await self.get_used(db=db, branch=branch)

--- a/changelog/+a97e7d93.fixed.md
+++ b/changelog/+a97e7d93.fixed.md
@@ -1,0 +1,1 @@
+Fix resource pool allocation on concurrent mutations. Assignments from the resource pools are now done within a lock to prevent invalid assignments that might occur during concurrent requests.


### PR DESCRIPTION
Due to timing issues we might end up with the same resource from a pool if multiple requests come in at once. Due to this we're wrapping the resource allocations within a global lock to prevent this behaviour.

(replaces #7014 due to lack of coffee and git force push)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Improved reliability of resource pool allocations by making them atomic, preventing duplicate or invalid assignments during simultaneous requests. Applies to IP address, IP prefix, and numeric resource pools, ensuring consistent results under high concurrency.

- Documentation
  - Added changelog entry noting the fix for concurrent allocation issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->