### PR TITLE
IFC-1745 Prevent draft proposed change merged via mutation

### DIFF
--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -137,6 +137,9 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
             updated_state = ProposedChangeState(state_update)
             state.validate_state_transition(updated_state)
 
+        # Check if the draft state will change (defaults to current draft state)
+        will_be_draft = data.get("is_draft", {}).get("value", obj.is_draft.value)
+
         # Check before starting a transaction, stopping in the middle of the transaction seems to break with memgraph
         if updated_state == ProposedChangeState.MERGED and graphql_context.account_session:
             try:
@@ -150,7 +153,7 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
                 raise ValidationError(str(exc)) from exc
 
         if updated_state == ProposedChangeState.MERGED:
-            if obj.is_draft.value:
+            if obj.is_draft.value or will_be_draft:
                 raise ValidationError("A draft proposed change is not allowed to be merged")
             data["state"]["value"] = ProposedChangeState.MERGING.value
 

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -153,7 +153,7 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
                 raise ValidationError(str(exc)) from exc
 
         if updated_state == ProposedChangeState.MERGED:
-            if obj.is_draft.value or will_be_draft:
+            if will_be_draft:
                 raise ValidationError("A draft proposed change is not allowed to be merged")
             data["state"]["value"] = ProposedChangeState.MERGING.value
 

--- a/backend/infrahub/graphql/mutations/proposed_change.py
+++ b/backend/infrahub/graphql/mutations/proposed_change.py
@@ -150,6 +150,8 @@ class InfrahubProposedChangeMutation(InfrahubMutationMixin, Mutation):
                 raise ValidationError(str(exc)) from exc
 
         if updated_state == ProposedChangeState.MERGED:
+            if obj.is_draft.value:
+                raise ValidationError("A draft proposed change is not allowed to be merged")
             data["state"]["value"] = ProposedChangeState.MERGING.value
 
         proposed_change, result = await super().mutate_update(

--- a/backend/infrahub/permissions/constants.py
+++ b/backend/infrahub/permissions/constants.py
@@ -25,6 +25,7 @@ GLOBAL_PERMISSION_DENIAL_MESSAGE = {
     GlobalPermissions.EDIT_DEFAULT_BRANCH.value: "You are not allowed to change data in the default branch",
     GlobalPermissions.MERGE_BRANCH.value: "You are not allowed to merge a branch",
     GlobalPermissions.MERGE_PROPOSED_CHANGE.value: "You are not allowed to merge proposed changes",
+    GlobalPermissions.REVIEW_PROPOSED_CHANGE.value: "You are not allowed to review proposed changes",
     GlobalPermissions.MANAGE_SCHEMA.value: "You are not allowed to manage the schema",
     GlobalPermissions.MANAGE_ACCOUNTS.value: "You are not allowed to manage user accounts, groups or roles",
     GlobalPermissions.MANAGE_PERMISSIONS.value: "You are not allowed to manage permissions",

--- a/backend/tests/functional/proposed_change/test_review.py
+++ b/backend/tests/functional/proposed_change/test_review.py
@@ -274,10 +274,7 @@ class TestProposedChangeReview(TestInfrahubApp):
                 raise_for_error=False,
             )
 
-        assert (
-            exc.value.errors[0]["message"]
-            == "You do not have the following permission: global:review_proposed_change:allow_all"
-        )
+        assert exc.value.errors[0]["message"] == "You are not allowed to review proposed changes"
 
         # Verify the proposed change still exists and is in the correct state
         updated_pc = await client.get(kind=PROPOSEDCHANGE, id=proposed_change.id, prefetch_relationships=True)

--- a/backend/tests/unit/graphql/mutations/test_proposed_change.py
+++ b/backend/tests/unit/graphql/mutations/test_proposed_change.py
@@ -81,6 +81,23 @@ mutation UpdateProposedChange(
   }
 }
 """
+UPDATE_PROPOSED_CHANGE_WITH_DRAFT = """
+mutation UpdateProposedChange(
+    $proposed_change: String!,
+    $state: String
+    $draft: Boolean
+  ) {
+  CoreProposedChangeUpdate(data:
+    {
+      id: $proposed_change,
+      state: {value: $state},
+      is_draft: {value: $draft}
+    }
+  ) {
+    ok
+  }
+}
+"""
 
 
 async def test_create_invalid_branch_combinations(db: InfrahubDatabase, default_branch, register_core_models_schema):
@@ -346,6 +363,19 @@ async def test_merge_draft_proposed_change(db: InfrahubDatabase, register_core_m
         query=UPDATE_PROPOSED_CHANGE,
         db=db,
         variables={"proposed_change": proposed_change.id, "state": "merged"},
+        service=service,
+    )
+
+    assert update_status.errors
+    assert "A draft proposed change is not allowed to be merged" in str(update_status.errors[0])
+
+    proposed_change.is_draft.value = False
+    await proposed_change.save(db=db)
+
+    update_status = await graphql_mutation(
+        query=UPDATE_PROPOSED_CHANGE_WITH_DRAFT,
+        db=db,
+        variables={"proposed_change": proposed_change.id, "state": "merged", "draft": True},
         service=service,
     )
 

--- a/backend/tests/unit/graphql/mutations/test_proposed_change.py
+++ b/backend/tests/unit/graphql/mutations/test_proposed_change.py
@@ -329,6 +329,30 @@ async def test_update_merged_proposed_change(db: InfrahubDatabase, register_core
     assert "A proposed change in the merged state is not allowed to be updated" in str(update_status.errors[0])
 
 
+async def test_merge_draft_proposed_change(db: InfrahubDatabase, register_core_models_schema: None):
+    branch_name = "draft-proposed-change"
+    source_branch = Branch(name=branch_name)
+    await source_branch.save(db=db)
+
+    proposed_change = await Node.init(db=db, schema=InfrahubKind.PROPOSEDCHANGE)
+    await proposed_change.new(
+        db=db, name="draft-pc-1234", destination_branch="main", source_branch=branch_name, state="open", is_draft=True
+    )
+    await proposed_change.save(db=db)
+
+    service = await InfrahubServices.new(database=db, message_bus=BusSimulator())
+
+    update_status = await graphql_mutation(
+        query=UPDATE_PROPOSED_CHANGE,
+        db=db,
+        variables={"proposed_change": proposed_change.id, "state": "merged"},
+        service=service,
+    )
+
+    assert update_status.errors
+    assert "A draft proposed change is not allowed to be merged" in str(update_status.errors[0])
+
+
 class TestMergeProposedChangePermissionFailure(TestInfrahubApp):
     async def test_merge_proposed_change_permission_failure(
         self,


### PR DESCRIPTION
This change prevents a proposed change that is marked as a draft to be merged by using the proposed change update mutation.

There is also a slight change to an permission error message, to make it a bit more friendly, which is so small I think it can go inside that PR too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents merging proposed changes that are drafts or would become drafts during merge.
  * Improves permission error message for users lacking review rights on proposed changes.
* **Tests**
  * Added unit tests verifying draft proposed changes cannot be merged.
  * Updated functional tests to expect the new review permission denial message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->