### PR TITLE
Add proposed change event when multiple approvals are revoked

### DIFF
--- a/backend/infrahub/core/constants/__init__.py
+++ b/backend/infrahub/core/constants/__init__.py
@@ -66,6 +66,7 @@ class EventType(InfrahubStringEnum):
     PROPOSED_CHANGE_APPROVED = f"{EVENT_NAMESPACE}.proposed_change.approved"
     PROPOSED_CHANGE_REJECTED = f"{EVENT_NAMESPACE}.proposed_change.rejected"
     PROPOSED_CHANGE_APPROVAL_REVOKED = f"{EVENT_NAMESPACE}.proposed_change.approval_revoked"
+    PROPOSED_CHANGE_APPROVALS_REVOKED = f"{EVENT_NAMESPACE}.proposed_change.approvals_revoked"
     PROPOSED_CHANGE_REJECTION_REVOKED = f"{EVENT_NAMESPACE}.proposed_change.rejection_revoked"
     PROPOSED_CHANGE_THREAD_CREATED = f"{EVENT_NAMESPACE}.proposed_change_thread.created"
     PROPOSED_CHANGE_THREAD_UPDATED = f"{EVENT_NAMESPACE}.proposed_change_thread.updated"

--- a/backend/infrahub/events/__init__.py
+++ b/backend/infrahub/events/__init__.py
@@ -5,6 +5,7 @@ from .models import EventMeta, InfrahubEvent
 from .node_action import NodeCreatedEvent, NodeDeletedEvent, NodeUpdatedEvent
 from .proposed_change_action import (
     ProposedChangeApprovalRevokedEvent,
+    ProposedChangeApprovalsRevokedEvent,
     ProposedChangeApprovedEvent,
     ProposedChangeMergedEvent,
     ProposedChangeRejectedEvent,
@@ -32,6 +33,7 @@ __all__ = [
     "NodeDeletedEvent",
     "NodeUpdatedEvent",
     "ProposedChangeApprovalRevokedEvent",
+    "ProposedChangeApprovalsRevokedEvent",
     "ProposedChangeApprovedEvent",
     "ProposedChangeMergedEvent",
     "ProposedChangeRejectedEvent",

--- a/backend/infrahub/events/proposed_change_action.py
+++ b/backend/infrahub/events/proposed_change_action.py
@@ -1,6 +1,6 @@
-from typing import ClassVar
+from typing import ClassVar, Self
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from infrahub.core.constants import InfrahubKind, MutationAction
 
@@ -148,6 +148,33 @@ class ProposedChangeRejectionRevokedEvent(ProposedChangeReviewRevokedEvent):
     """Event generated when a proposed change rejection has been revoked"""
 
     event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.proposed_change.rejection_revoked"
+
+
+class ProposedChangeApprovalsRevokedEvent(ProposedChangeEvent):
+    reviewer_account_ids: list[str] = Field(..., description="IDs of accounts whose approval was revoked")
+    reviewer_account_names: list[str] = Field(..., description="Names of accounts whose approval was revoked")
+
+    event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.proposed_change.approvals_revoked"
+
+    @model_validator(mode="after")
+    def check_same_length(self) -> Self:
+        if len(self.reviewer_account_ids) != len(self.reviewer_account_names):
+            raise ValueError("reviewer_account_ids and reviewer_account_names must have the same number of items")
+        return self
+
+    def get_related(self) -> list[dict[str, str]]:
+        related = super().get_related()
+        for i, account_id in enumerate(self.reviewer_account_ids):
+            related.append(
+                {
+                    "prefect.resource.id": account_id,
+                    "prefect.resource.role": "infrahub.related.node",
+                    "infrahub.node.kind": InfrahubKind.GENERICACCOUNT,
+                    "infrahub.node.id": account_id,
+                    "infrahub.reviewer.account.name": self.reviewer_account_names[i],
+                }
+            )
+        return related
 
 
 class ProposedChangeThreadEvent(ProposedChangeEvent):

--- a/backend/infrahub/events/proposed_change_action.py
+++ b/backend/infrahub/events/proposed_change_action.py
@@ -1,6 +1,6 @@
-from typing import ClassVar, Self
+from typing import ClassVar
 
-from pydantic import Field, model_validator
+from pydantic import Field
 
 from infrahub.core.constants import InfrahubKind, MutationAction
 
@@ -151,31 +151,22 @@ class ProposedChangeRejectionRevokedEvent(ProposedChangeReviewRevokedEvent):
 
 
 class ProposedChangeApprovalsRevokedEvent(ProposedChangeEvent):
-    reviewer_account_ids: list[str] = Field(
-        default_factory=list, description="IDs of accounts whose approval was revoked"
-    )
-    reviewer_account_names: list[str] = Field(
-        default_factory=list, description="Names of accounts whose approval was revoked"
+    reviewer_accounts: dict[str, str] = Field(
+        default_factory=dict, description="ID to name map of accounts whose approval was revoked"
     )
 
     event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.proposed_change.approvals_revoked"
 
-    @model_validator(mode="after")
-    def check_same_length(self) -> Self:
-        if len(self.reviewer_account_ids) != len(self.reviewer_account_names):
-            raise ValueError("reviewer_account_ids and reviewer_account_names must have the same number of items")
-        return self
-
     def get_related(self) -> list[dict[str, str]]:
         related = super().get_related()
-        for i, account_id in enumerate(self.reviewer_account_ids):
+        for account_id, account_name in self.reviewer_accounts.items():
             related.append(
                 {
                     "prefect.resource.id": account_id,
                     "prefect.resource.role": "infrahub.related.node",
                     "infrahub.node.kind": InfrahubKind.GENERICACCOUNT,
                     "infrahub.node.id": account_id,
-                    "infrahub.reviewer.account.name": self.reviewer_account_names[i],
+                    "infrahub.reviewer.account.name": account_name,
                 }
             )
         return related

--- a/backend/infrahub/events/proposed_change_action.py
+++ b/backend/infrahub/events/proposed_change_action.py
@@ -151,8 +151,12 @@ class ProposedChangeRejectionRevokedEvent(ProposedChangeReviewRevokedEvent):
 
 
 class ProposedChangeApprovalsRevokedEvent(ProposedChangeEvent):
-    reviewer_account_ids: list[str] = Field(..., description="IDs of accounts whose approval was revoked")
-    reviewer_account_names: list[str] = Field(..., description="Names of accounts whose approval was revoked")
+    reviewer_account_ids: list[str] = Field(
+        default_factory=list, description="IDs of accounts whose approval was revoked"
+    )
+    reviewer_account_names: list[str] = Field(
+        default_factory=list, description="Names of accounts whose approval was revoked"
+    )
 
     event_name: ClassVar[str] = f"{EVENT_NAMESPACE}.proposed_change.approvals_revoked"
 

--- a/backend/infrahub/graphql/types/event.py
+++ b/backend/infrahub/graphql/types/event.py
@@ -140,12 +140,6 @@ class ProposedChangeApprovalsRevokedEvent(ObjectType):
     class Meta:
         interfaces = (EventNodeInterface,)
 
-    reviewer_account_ids = List(
-        NonNull(String), required=True, description="IDs of accounts whose approvals were revoked"
-    )
-    reviewer_account_names = List(
-        NonNull(String), required=True, description="Names of accounts whose approvals were revoked"
-    )
     payload = Field(GenericScalar, required=True)
 
 

--- a/backend/infrahub/graphql/types/event.py
+++ b/backend/infrahub/graphql/types/event.py
@@ -136,6 +136,19 @@ class ProposedChangeReviewRevokedEvent(ObjectType):
     payload = Field(GenericScalar, required=True)
 
 
+class ProposedChangeApprovalsRevokedEvent(ObjectType):
+    class Meta:
+        interfaces = (EventNodeInterface,)
+
+    reviewer_account_ids = List(
+        NonNull(String), required=True, description="IDs of accounts whose approvals were revoked"
+    )
+    reviewer_account_names = List(
+        NonNull(String), required=True, description="Names of accounts whose approvals were revoked"
+    )
+    payload = Field(GenericScalar, required=True)
+
+
 class ProposedChangeReviewRequestedEvent(ObjectType):
     class Meta:
         interfaces = (EventNodeInterface,)
@@ -220,6 +233,7 @@ EVENT_TYPES: dict[str, type[ObjectType]] = {
     events.ProposedChangeRejectedEvent.event_name: ProposedChangeReviewEvent,
     events.ProposedChangeRejectionRevokedEvent.event_name: ProposedChangeReviewRevokedEvent,
     events.ProposedChangeReviewRequestedEvent.event_name: ProposedChangeReviewRequestedEvent,
+    events.ProposedChangeApprovalsRevokedEvent.event_name: ProposedChangeApprovalsRevokedEvent,
     events.ProposedChangeMergedEvent.event_name: ProposedChangeMergedEvent,
     events.ProposedChangeThreadCreatedEvent.event_name: ProposedChangeThreadEvent,
     events.ProposedChangeThreadUpdatedEvent.event_name: ProposedChangeThreadEvent,

--- a/backend/infrahub/task_manager/event.py
+++ b/backend/infrahub/task_manager/event.py
@@ -253,10 +253,7 @@ class PrefectEventData(PrefectEventModel):
                     **self._return_proposed_change_reviewer_former_decision(),
                 }
             case "infrahub.proposed_change.approvals_revoked":
-                event_specifics = {
-                    **self._return_proposed_change_event(),
-                    **self._return_reviewers_of_revoked_approvals(),
-                }
+                event_specifics = self._return_proposed_change_event()
             case "infrahub.proposed_change.review_requested" | "infrahub.proposed_change.merged":
                 event_specifics = self._return_proposed_change_event()
 

--- a/backend/infrahub/task_manager/event.py
+++ b/backend/infrahub/task_manager/event.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
 from prefect.client.orchestration import PrefectClient, get_client

--- a/backend/infrahub/task_manager/event.py
+++ b/backend/infrahub/task_manager/event.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
 from prefect.client.orchestration import PrefectClient, get_client
@@ -212,6 +213,15 @@ class PrefectEventData(PrefectEventModel):
     def _return_proposed_change_reviewer_former_decision(self) -> dict[str, Any]:
         return {"reviewer_former_decision": self.resource.get("infrahub.proposed_change.reviewer_former_decision")}
 
+    def _return_reviewers_of_revoked_approvals(self) -> dict[str, Any]:
+        data = defaultdict(list)
+        for resource in self.related:
+            if resource.role != "infrahub.related.node":
+                continue
+            data["reviewer_account_ids"].append(resource.get("infrahub.node.id"))
+            data["reviewer_account_names"].append(resource.get("infrahub.reviewer.account.name"))
+        return data
+
     def _return_event_specifics(self) -> dict[str, Any]:
         """Return event specific data based on the type of event being processed"""
 
@@ -241,6 +251,11 @@ class PrefectEventData(PrefectEventModel):
                 event_specifics = {
                     **self._return_proposed_change_event(),
                     **self._return_proposed_change_reviewer_former_decision(),
+                }
+            case "infrahub.proposed_change.approvals_revoked":
+                event_specifics = {
+                    **self._return_proposed_change_event(),
+                    **self._return_reviewers_of_revoked_approvals(),
                 }
             case "infrahub.proposed_change.review_requested" | "infrahub.proposed_change.merged":
                 event_specifics = self._return_proposed_change_event()

--- a/backend/infrahub/task_manager/event.py
+++ b/backend/infrahub/task_manager/event.py
@@ -213,15 +213,6 @@ class PrefectEventData(PrefectEventModel):
     def _return_proposed_change_reviewer_former_decision(self) -> dict[str, Any]:
         return {"reviewer_former_decision": self.resource.get("infrahub.proposed_change.reviewer_former_decision")}
 
-    def _return_reviewers_of_revoked_approvals(self) -> dict[str, Any]:
-        data = defaultdict(list)
-        for resource in self.related:
-            if resource.role != "infrahub.related.node":
-                continue
-            data["reviewer_account_ids"].append(resource.get("infrahub.node.id"))
-            data["reviewer_account_names"].append(resource.get("infrahub.reviewer.account.name"))
-        return data
-
     def _return_event_specifics(self) -> dict[str, Any]:
         """Return event specific data based on the type of event being processed"""
 
@@ -252,9 +243,11 @@ class PrefectEventData(PrefectEventModel):
                     **self._return_proposed_change_event(),
                     **self._return_proposed_change_reviewer_former_decision(),
                 }
-            case "infrahub.proposed_change.approvals_revoked":
-                event_specifics = self._return_proposed_change_event()
-            case "infrahub.proposed_change.review_requested" | "infrahub.proposed_change.merged":
+            case (
+                "infrahub.proposed_change.approvals_revoked"
+                | "infrahub.proposed_change.review_requested"
+                | "infrahub.proposed_change.merged"
+            ):
                 event_specifics = self._return_proposed_change_event()
 
         return event_specifics

--- a/docs/docs/reference/infrahub-events.mdx
+++ b/docs/docs/reference/infrahub-events.mdx
@@ -369,6 +369,33 @@ For more detailed explanations on how these events are used within Infrahub, see
 | **reviewer_former_decision** | The former decision made by the reviewer |
 <!-- vale on -->
 <!-- vale off -->
+### Proposed Change Approvals Revoked Event
+<!-- vale on -->
+
+**Type**: infrahub.proposed_change.approvals_revoked
+<!-- vale off -->
+**Uses node_kind filter for webhooks**: `false`
+<!-- vale on -->
+
+<!-- vale off -->
+| Key | Description |
+|-----|-------------|
+| **meta.branch** | The branch on which originate this event |
+| **meta.request_id** | N/A |
+| **meta.account_id** | The ID of the account triggering this event |
+| **meta.initiator_id** | The worker identity of the initial sender of this message |
+| **meta.context** | The context used when originating this event |
+| **meta.level** | N/A |
+| **meta.has_children** | Indicates if this event might potentially have child events under it. |
+| **meta.id** | UUID of the event |
+| **meta.parent** | The UUID of the parent event if applicable |
+| **meta.ancestors** | Any event used to trigger this event |
+| **proposed_change_id** | The ID of the proposed change |
+| **proposed_change_name** | The name of the proposed change |
+| **proposed_change_state** | The state of the proposed change |
+| **reviewer_accounts** | ID to name map of accounts whose approval was revoked |
+<!-- vale on -->
+<!-- vale off -->
 ### Proposed Change Approved Event
 <!-- vale on -->
 


### PR DESCRIPTION
This change adds a new event to be raised when multiple approvals were revoked during a single transaction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Approvals Revoked” event for proposed changes that records revoked approvals as a map of reviewer IDs to names and is exposed via the public events API and GraphQL.

* **Improvements**
  * Task processing now includes the new event in proposed-change grouping and aggregates per-reviewer related data for multi-review revocations.

* **Chores**
  * Registered the new event type in enums and exported it publicly; updated documentation and event mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->