### PR TITLE
IFC-1750 Fix default PC Reviewer role permission set

### DIFF
--- a/backend/infrahub/core/initialization.py
+++ b/backend/infrahub/core/initialization.py
@@ -37,7 +37,7 @@ from infrahub.exceptions import DatabaseError
 from infrahub.graphql.manager import GraphQLSchemaManager
 from infrahub.log import get_logger
 from infrahub.menu.utils import create_default_menu
-from infrahub.permissions import PermissionBackend
+from infrahub.permissions import PermissionBackend, get_or_create_global_permission
 from infrahub.storage import InfrahubObjectStorage
 
 if TYPE_CHECKING:
@@ -371,20 +371,13 @@ async def create_default_role(db: InfrahubDatabase) -> CoreAccountRole:
     await proposed_change_permission.save(db=db)
 
     # Other permissions, created to keep references of them from the start
-    for permission_action, permission_description in (
-        (GlobalPermissions.EDIT_DEFAULT_BRANCH, "Allow a user to change data in the default branch"),
-        (GlobalPermissions.MANAGE_ACCOUNTS, "Allow a user to manage accounts, account roles and account groups"),
-        (GlobalPermissions.MANAGE_PERMISSIONS, "Allow a user to manage permissions"),
-        (GlobalPermissions.MERGE_BRANCH, "Allow a user to merge branches"),
+    for permission_action in (
+        GlobalPermissions.EDIT_DEFAULT_BRANCH,
+        GlobalPermissions.MANAGE_ACCOUNTS,
+        GlobalPermissions.MANAGE_PERMISSIONS,
+        GlobalPermissions.MERGE_BRANCH,
     ):
-        permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
-        await permission.new(
-            db=db,
-            action=permission_action.value,
-            decision=PermissionDecision.ALLOW_ALL.value,
-            description=permission_description,
-        )
-        await permission.save(db=db)
+        await get_or_create_global_permission(db=db, permission=permission_action)
 
     view_permission = await Node.init(db=db, schema=InfrahubKind.OBJECTPERMISSION)
     await view_permission.new(
@@ -428,18 +421,31 @@ async def create_default_role(db: InfrahubDatabase) -> CoreAccountRole:
 
 
 async def create_proposed_change_reviewer_role(db: InfrahubDatabase) -> CoreAccountRole:
-    reviewer_permission = await Node.init(db=db, schema=InfrahubKind.GLOBALPERMISSION)
-    await reviewer_permission.new(
-        db=db,
-        action=GlobalPermissions.REVIEW_PROPOSED_CHANGE.value,
-        decision=PermissionDecision.ALLOW_ALL.value,
-        description="Allow a user to approve or revoke proposed changes",
+    edit_default_branch_permission = await get_or_create_global_permission(
+        db=db, permission=GlobalPermissions.EDIT_DEFAULT_BRANCH
     )
-    await reviewer_permission.save(db=db)
+    reviewer_permission = await get_or_create_global_permission(
+        db=db, permission=GlobalPermissions.REVIEW_PROPOSED_CHANGE
+    )
+
+    proposed_change_update_permission = await Node.init(db=db, schema=InfrahubKind.OBJECTPERMISSION)
+    await proposed_change_update_permission.new(
+        db=db,
+        name="ProposedChange",
+        namespace="Core",
+        action=PermissionAction.UPDATE.value,
+        decision=PermissionDecision.ALLOW_ALL.value,
+        description="Allow a user to update proposed changes",
+    )
+    await proposed_change_update_permission.save(db=db)
 
     role_name = "Proposed Change Reviewer"
     role = await Node.init(db=db, schema=CoreAccountRole)
-    await role.new(db=db, name=role_name, permissions=[reviewer_permission])
+    await role.new(
+        db=db,
+        name=role_name,
+        permissions=[edit_default_branch_permission, reviewer_permission, proposed_change_update_permission],
+    )
     await role.save(db=db)
     log.info(f"Created account role: {role_name}")
 
@@ -497,7 +503,6 @@ async def create_default_account_groups(
 
     default_role = await create_default_role(db=db)
     proposed_change_reviewer_role = await create_proposed_change_reviewer_role(db=db)
-
     await create_accounts_group(
         db=db, name="Infrahub Users", roles=[default_role, proposed_change_reviewer_role], accounts=accounts or []
     )

--- a/backend/infrahub/permissions/__init__.py
+++ b/backend/infrahub/permissions/__init__.py
@@ -1,5 +1,5 @@
 from infrahub.permissions.backend import PermissionBackend
-from infrahub.permissions.globals import define_global_permission_from_branch
+from infrahub.permissions.globals import define_global_permission_from_branch, get_or_create_global_permission
 from infrahub.permissions.local_backend import LocalPermissionBackend
 from infrahub.permissions.manager import PermissionManager
 from infrahub.permissions.report import report_schema_permissions
@@ -12,5 +12,6 @@ __all__ = [
     "PermissionManager",
     "define_global_permission_from_branch",
     "get_global_permission_for_kind",
+    "get_or_create_global_permission",
     "report_schema_permissions",
 ]

--- a/backend/infrahub/permissions/constants.py
+++ b/backend/infrahub/permissions/constants.py
@@ -31,3 +31,15 @@ GLOBAL_PERMISSION_DENIAL_MESSAGE = {
     GlobalPermissions.MANAGE_PERMISSIONS.value: "You are not allowed to manage permissions",
     GlobalPermissions.MANAGE_REPOSITORIES.value: "You are not allowed to manage repositories",
 }
+
+GLOBAL_PERMISSION_DESCRIPTION = {
+    GlobalPermissions.EDIT_DEFAULT_BRANCH: "Allow a user to change data in the default branch",
+    GlobalPermissions.MERGE_BRANCH: "Allow a user to merge branches",
+    GlobalPermissions.MERGE_PROPOSED_CHANGE: "Allow a user to merge proposed changes",
+    GlobalPermissions.REVIEW_PROPOSED_CHANGE: "Allow a user to approve or reject proposed changes",
+    GlobalPermissions.MANAGE_SCHEMA: "Allow a user to manage the schema",
+    GlobalPermissions.MANAGE_ACCOUNTS: "Allow a user to manage accounts, account roles and account groups",
+    GlobalPermissions.MANAGE_PERMISSIONS: "Allow a user to manage permissions",
+    GlobalPermissions.MANAGE_REPOSITORIES: "Allow a user to manage repositories",
+    GlobalPermissions.SUPER_ADMIN: "Allow a user to do anything",
+}

--- a/backend/infrahub/permissions/globals.py
+++ b/backend/infrahub/permissions/globals.py
@@ -1,6 +1,18 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from infrahub.core.account import GlobalPermission
 from infrahub.core.constants import GLOBAL_BRANCH_NAME, GlobalPermissions, PermissionDecision
+from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
+from infrahub.core.protocols import CoreGlobalPermission
 from infrahub.core.registry import registry
+
+from .constants import GLOBAL_PERMISSION_DESCRIPTION
+
+if TYPE_CHECKING:
+    from infrahub.database import InfrahubDatabase
 
 
 def define_global_permission_from_branch(permission: GlobalPermissions, branch_name: str) -> GlobalPermission:
@@ -10,3 +22,23 @@ def define_global_permission_from_branch(permission: GlobalPermissions, branch_n
         decision = PermissionDecision.ALLOW_OTHER
 
     return GlobalPermission(action=permission.value, decision=decision.value)
+
+
+async def get_or_create_global_permission(db: InfrahubDatabase, permission: GlobalPermissions) -> CoreGlobalPermission:
+    permissions = await NodeManager.query(
+        db=db, schema=CoreGlobalPermission, filters={"action__value": permission.value}, limit=1
+    )
+
+    if permissions:
+        return permissions[0]
+
+    p = await Node.init(db=db, schema=CoreGlobalPermission)
+    await p.new(
+        db=db,
+        action=permission.value,
+        decision=PermissionDecision.ALLOW_ALL.value,
+        description=GLOBAL_PERMISSION_DESCRIPTION[permission],
+    )
+    await p.save(db=db)
+
+    return p

--- a/frontend/app/tests/e2e/role-management/read.spec.ts
+++ b/frontend/app/tests/e2e/role-management/read.spec.ts
@@ -25,8 +25,8 @@ test.describe("Role management - READ", () => {
     await test.step("check roles view", async () => {
       await page.getByRole("link", { name: "Roles" }).click();
       await expect(page.getByText("General Access")).toBeVisible();
-      await expect(page.getByText("Infrahub Users")).toBeVisible();
-      await expect(page.getByText("global:edit_default_branch:")).toBeVisible();
+      await expect(page.getByText("Infrahub Users").first()).toBeVisible();
+      await expect(page.getByText("global:edit_default_branch:").first()).toBeVisible();
       await expect(page.getByRole("cell", { name: "1" }).first()).toBeVisible();
     });
 


### PR DESCRIPTION
This change adds a couple of permissions to the "Proposed Change Reviewer" role that we ship when Infrahub is started for the first time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded Proposed Change Reviewer role to also allow updating proposed changes.
  - Clearer, human‑readable descriptions for global permissions in role management.

- Refactor
  - More reliable initialization of default global permissions to prevent duplicates and ensure consistent setups.

- Tests
  - Stabilized Roles view end‑to‑end test by scoping assertions to the first matching element for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->