### PR TITLE
schema update migration for attribute kind update to/from JSON/List/TextArea

### DIFF
--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -680,6 +680,12 @@ class String(BaseAttribute):
     type = str
     value: str
 
+    @classmethod
+    def validate_content(cls, value: Any, name: str, schema: AttributeSchema) -> None:
+        if value is not None and not is_large_attribute_type(schema.kind):
+            validate_string_length(value=str(value))
+        super().validate_content(value=value, name=name, schema=schema)
+
 
 class StringOptional(String):
     value: str | None

--- a/backend/infrahub/core/migrations/__init__.py
+++ b/backend/infrahub/core/migrations/__init__.py
@@ -1,5 +1,5 @@
-from .schema.attribute_name_update import AttributeNameUpdateMigration
 from .schema.attribute_kind_update import AttributeKindUpdateMigration
+from .schema.attribute_name_update import AttributeNameUpdateMigration
 from .schema.node_attribute_add import NodeAttributeAddMigration
 from .schema.node_attribute_remove import NodeAttributeRemoveMigration
 from .schema.node_kind_update import NodeKindUpdateMigration

--- a/backend/infrahub/core/migrations/__init__.py
+++ b/backend/infrahub/core/migrations/__init__.py
@@ -1,4 +1,5 @@
 from .schema.attribute_name_update import AttributeNameUpdateMigration
+from .schema.attribute_kind_update import AttributeKindUpdateMigration
 from .schema.node_attribute_add import NodeAttributeAddMigration
 from .schema.node_attribute_remove import NodeAttributeRemoveMigration
 from .schema.node_kind_update import NodeKindUpdateMigration
@@ -17,6 +18,7 @@ MIGRATION_MAP: dict[str, type[SchemaMigration] | None] = {
     "node.relationship.remove": PlaceholderDummyMigration,
     "attribute.name.update": AttributeNameUpdateMigration,
     "attribute.branch.update": None,
+    "attribute.kind.update": AttributeKindUpdateMigration,
     "relationship.branch.update": None,
     "relationship.direction.update": None,
     "relationship.identifier.update": PlaceholderDummyMigration,

--- a/backend/infrahub/core/migrations/schema/attribute_kind_update.py
+++ b/backend/infrahub/core/migrations/schema/attribute_kind_update.py
@@ -29,38 +29,61 @@ class AttributeKindUpdateMigrationQuery(AttributeMigrationQuery):
         new_attr_value_labels = "AttributeValue"
         if needs_index:
             new_attr_value_labels += ":AttributeValueIndexed"
+        # ruff: noqa: S608
         query = """
+// ------------
+// start with all the Attribute vertices we might care about
+// ------------
 MATCH (n:%(schema_kind)s)-[:HAS_ATTRIBUTE]->(attr:Attribute)
 WHERE attr.name = $attr_name
 WITH DISTINCT n, attr
+
+// ------------
+// for each Attribute, find the most recent active edge and AttributeValue vertex that needs to be [un]indexed
+// ------------
 CALL (n, attr) {
     MATCH (n)-[r1:HAS_ATTRIBUTE]->(attr:Attribute)-[r2:HAS_VALUE]->(av)
     WHERE all(r IN [r1, r2] WHERE %(branch_filter)s)
     WITH r2, av, r1.status = "active" AND r2.status = "active" AS is_active
-    ORDER BY r2.branch_level DESC, r2.from DESC, r1.branch_level DESC, r1.from DESC
+    ORDER BY r2.branch_level DESC, r2.from DESC, r2.status = "active" DESC, r1.branch_level DESC, r1.from DESC, r1.status = "active" DESC
     LIMIT 1
     WITH r2 AS has_value_e, av, "AttributeValueIndexed" IN labels(av) AS is_indexed
     WHERE is_active AND is_indexed <> $needs_index
     RETURN has_value_e, av
 }
 
+// ------------
+// check if the correct AttributeValue vertex to use exists
+// ------------
 CALL (av) {
     OPTIONAL MATCH (existing_av:AttributeValue {is_default: av.is_default, value: av.value})
     WHERE "AttributeValueIndexed" IN labels(existing_av) = $needs_index
     RETURN existing_av IS NOT NULL AS av_exists
     LIMIT 1
 }
+// ------------
+// create the AttributeValue vertex if it does not exist
+// ------------
 CALL (av, av_exists) {
     WITH av_exists
     WHERE NOT av_exists
     CREATE (:%(new_attr_value_labels)s {is_default: av.is_default, value: av.value})
 }
 
+// ------------
+// create and update the HAS_VALUE edges
+// ------------
 CALL (attr, has_value_e, av) {
+    // ------------
+    // get the correct AttributeValue vertex b/c it definitely exists now
+    // ------------
     MATCH (new_av:%(new_attr_value_labels)s {is_default: av.is_default, value: av.value})
     WHERE "AttributeValueIndexed" IN labels(new_av) = $needs_index
     LIMIT 1
 
+    // ------------
+    // create the new HAS_VALUE edge
+    // ------------
     CREATE (attr)-[new_has_value_e:HAS_VALUE]->(new_av)
     SET new_has_value_e = properties(has_value_e)
     SET new_has_value_e.status = "active"
@@ -69,6 +92,10 @@ CALL (attr, has_value_e, av) {
     SET new_has_value_e.from = $at
     SET new_has_value_e.to = NULL
 
+    // ------------
+    // if we are updating on a branch and the existing edge is on the default branch,
+    // then create a new deleted edge on this branch
+    // ------------
     WITH attr, has_value_e, av
     WHERE has_value_e.branch <> $branch
     CREATE (attr)-[deleted_has_value_e:HAS_VALUE]->(av)
@@ -79,6 +106,11 @@ CALL (attr, has_value_e, av) {
     SET deleted_has_value_e.from = $at
     SET deleted_has_value_e.to = NULL
 }
+
+// ------------
+// if the existing edge is on the same branch as the update,
+// then set its "to" time
+// ------------
 CALL (has_value_e) {
     WITH has_value_e
     WHERE has_value_e.branch = $branch

--- a/backend/infrahub/core/migrations/schema/attribute_kind_update.py
+++ b/backend/infrahub/core/migrations/schema/attribute_kind_update.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+from ..query import AttributeMigrationQuery
+from ..query.attribute_rename import AttributeInfo, AttributeRenameQuery
+from ..shared import AttributeSchemaMigration
+
+
+class AttributeKindUpdateMigration(AttributeSchemaMigration):
+    name: str = "attribute.kind.update"
+    queries: Sequence[type[AttributeMigrationQuery]] = []  # type: ignore[assignment]

--- a/backend/infrahub/core/migrations/schema/attribute_kind_update.py
+++ b/backend/infrahub/core/migrations/schema/attribute_kind_update.py
@@ -54,21 +54,40 @@ CALL (n, attr) {
 
 // ------------
 // check if the correct AttributeValue vertex to use exists
+// create it if not
 // ------------
-CALL (av) {
-    OPTIONAL MATCH (existing_av:AttributeValue {is_default: av.is_default, value: av.value})
+WITH DISTINCT av.is_default AS av_is_default, av.value AS av_value
+CALL (av_is_default, av_value) {
+    OPTIONAL MATCH (existing_av:AttributeValue {is_default: av_is_default, value: av_value})
     WHERE "AttributeValueIndexed" IN labels(existing_av) = $needs_index
-    RETURN existing_av IS NOT NULL AS av_exists
+    WITH existing_av WHERE existing_av IS NULL
     LIMIT 1
+    CREATE (:%(new_attr_value_labels)s {is_default: av_is_default, value: av_value})
 }
+
 // ------------
-// create the AttributeValue vertex if it does not exist
+// get all the AttributeValue vertices that need to be updated again and run the updates
 // ------------
-CALL (av, av_exists) {
-    WITH av_exists
-    WHERE NOT av_exists
-    CREATE (:%(new_attr_value_labels)s {is_default: av.is_default, value: av.value})
+WITH 1 AS one
+LIMIT 1
+MATCH (n:%(schema_kind)s)-[:HAS_ATTRIBUTE]->(attr:Attribute)
+WHERE attr.name = $attr_name
+WITH DISTINCT n, attr
+
+// ------------
+// for each Attribute, find the most recent active edge and AttributeValue vertex that needs to be [un]indexed
+// ------------
+CALL (n, attr) {
+    MATCH (n)-[r1:HAS_ATTRIBUTE]->(attr:Attribute)-[r2:HAS_VALUE]->(av)
+    WHERE all(r IN [r1, r2] WHERE %(branch_filter)s)
+    WITH r2, av, r1.status = "active" AND r2.status = "active" AS is_active
+    ORDER BY r2.branch_level DESC, r2.from DESC, r2.status = "active" DESC, r1.branch_level DESC, r1.from DESC, r1.status = "active" DESC
+    LIMIT 1
+    WITH r2 AS has_value_e, av, "AttributeValueIndexed" IN labels(av) AS is_indexed
+    WHERE is_active AND is_indexed <> $needs_index
+    RETURN has_value_e, av
 }
+
 
 // ------------
 // create and update the HAS_VALUE edges

--- a/backend/infrahub/core/migrations/schema/attribute_kind_update.py
+++ b/backend/infrahub/core/migrations/schema/attribute_kind_update.py
@@ -1,12 +1,105 @@
 from __future__ import annotations
 
-from typing import Any, Sequence
+from typing import TYPE_CHECKING, Any, Sequence
+
+from infrahub.types import is_large_attribute_type
 
 from ..query import AttributeMigrationQuery
-from ..query.attribute_rename import AttributeInfo, AttributeRenameQuery
-from ..shared import AttributeSchemaMigration
+from ..shared import AttributeSchemaMigration, MigrationResult
+
+if TYPE_CHECKING:
+    from infrahub.core.branch.models import Branch
+    from infrahub.core.timestamp import Timestamp
+    from infrahub.database import InfrahubDatabase
+
+
+class AttributeKindUpdateMigrationQuery(AttributeMigrationQuery):
+    name = "migration_attribute_kind"
+    insert_return = False
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
+        branch_filter, branch_params = self.branch.get_query_filter_path(at=self.at)
+        self.params.update(branch_params)
+        needs_index = not is_large_attribute_type(self.migration.new_attribute_schema.kind)
+        self.params["needs_index"] = needs_index
+        self.params["branch"] = self.branch.name
+        self.params["branch_level"] = self.branch.hierarchy_level
+        self.params["at"] = self.at.to_string()
+        self.params["attr_name"] = self.migration.previous_attribute_schema.name
+        new_attr_value_labels = "AttributeValue"
+        if needs_index:
+            new_attr_value_labels += ":AttributeValueIndexed"
+        query = """
+MATCH (n:%(schema_kind)s)-[:HAS_ATTRIBUTE]->(attr:Attribute)
+WHERE attr.name = $attr_name
+WITH DISTINCT n, attr
+CALL (n, attr) {
+    MATCH (n)-[r1:HAS_ATTRIBUTE]->(attr:Attribute)-[r2:HAS_VALUE]->(av)
+    WHERE all(r IN [r1, r2] WHERE %(branch_filter)s)
+    WITH r2, av, r1.status = "active" AND r2.status = "active" AS is_active
+    ORDER BY r2.branch_level DESC, r2.from DESC, r1.branch_level DESC, r1.from DESC
+    LIMIT 1
+    WITH r2 AS has_value_e, av, "AttributeValueIndexed" IN labels(av) AS is_indexed
+    WHERE is_active AND is_indexed <> $needs_index
+    RETURN has_value_e, av
+}
+
+CALL (av) {
+    OPTIONAL MATCH (existing_av:AttributeValue {is_default: av.is_default, value: av.value})
+    WHERE "AttributeValueIndexed" IN labels(existing_av) = $needs_index
+    RETURN existing_av IS NOT NULL AS av_exists
+    LIMIT 1
+}
+CALL (av, av_exists) {
+    WITH av_exists
+    WHERE NOT av_exists
+    CREATE (:%(new_attr_value_labels)s {is_default: av.is_default, value: av.value})
+}
+
+CALL (attr, has_value_e, av) {
+    MATCH (new_av:%(new_attr_value_labels)s {is_default: av.is_default, value: av.value})
+    WHERE "AttributeValueIndexed" IN labels(new_av) = $needs_index
+    LIMIT 1
+
+    CREATE (attr)-[new_has_value_e:HAS_VALUE]->(new_av)
+    SET new_has_value_e = properties(has_value_e)
+    SET new_has_value_e.status = "active"
+    SET new_has_value_e.branch = $branch
+    SET new_has_value_e.branch_level = $branch_level
+    SET new_has_value_e.from = $at
+    SET new_has_value_e.to = NULL
+
+    WITH attr, has_value_e, av
+    WHERE has_value_e.branch <> $branch
+    CREATE (attr)-[deleted_has_value_e:HAS_VALUE]->(av)
+    SET deleted_has_value_e = properties(has_value_e)
+    SET deleted_has_value_e.status = "deleted"
+    SET deleted_has_value_e.branch = $branch
+    SET deleted_has_value_e.branch_level = $branch_level
+    SET deleted_has_value_e.from = $at
+    SET deleted_has_value_e.to = NULL
+}
+CALL (has_value_e) {
+    WITH has_value_e
+    WHERE has_value_e.branch = $branch
+    SET has_value_e.to = $at
+}
+        """ % {
+            "schema_kind": self.migration.previous_schema.kind,
+            "branch_filter": branch_filter,
+            "new_attr_value_labels": new_attr_value_labels,
+        }
+        self.add_to_query(query)
 
 
 class AttributeKindUpdateMigration(AttributeSchemaMigration):
     name: str = "attribute.kind.update"
-    queries: Sequence[type[AttributeMigrationQuery]] = []  # type: ignore[assignment]
+    queries: Sequence[type[AttributeMigrationQuery]] = [AttributeKindUpdateMigrationQuery]  # type: ignore[assignment]
+
+    async def execute(self, db: InfrahubDatabase, branch: Branch, at: Timestamp | str | None = None) -> MigrationResult:
+        is_indexed_previous = is_large_attribute_type(self.previous_attribute_schema.kind)
+        is_indexed_new = is_large_attribute_type(self.new_attribute_schema.kind)
+        if is_indexed_previous is is_indexed_new:
+            return MigrationResult()
+
+        return await super().execute(db=db, branch=branch, at=at)

--- a/backend/infrahub/core/models.py
+++ b/backend/infrahub/core/models.py
@@ -569,7 +569,10 @@ class HashableModel(BaseModel):
 
         for field_name in other.model_fields.keys():
             if not hasattr(self, field_name):
-                setattr(self, field_name, getattr(other, field_name))
+                try:
+                    setattr(self, field_name, getattr(other, field_name))
+                except ValueError:
+                    pass
                 continue
 
             attr_other = getattr(other, field_name)

--- a/backend/infrahub/core/models.py
+++ b/backend/infrahub/core/models.py
@@ -572,6 +572,7 @@ class HashableModel(BaseModel):
                 try:
                     setattr(self, field_name, getattr(other, field_name))
                 except ValueError:
+                    # handles the case where self and other are different types and other has fields that self does not
                     pass
                 continue
 

--- a/backend/infrahub/core/schema/definitions/internal.py
+++ b/backend/infrahub/core/schema/definitions/internal.py
@@ -487,7 +487,7 @@ attribute_schema = SchemaNode(
             kind="Text",
             description="Defines the type of the attribute.",
             enum=ATTRIBUTE_KIND_LABELS,
-            extra={"update": UpdateSupport.VALIDATE_CONSTRAINT},
+            extra={"update": UpdateSupport.MIGRATION_REQUIRED},
         ),
         SchemaAttribute(
             name="enum",

--- a/backend/infrahub/core/schema/generated/attribute_schema.py
+++ b/backend/infrahub/core/schema/generated/attribute_schema.py
@@ -31,7 +31,7 @@ class GeneratedAttributeSchema(HashableModel):
         json_schema_extra={"update": "migration_required"},
     )
     kind: str = Field(
-        ..., description="Defines the type of the attribute.", json_schema_extra={"update": "validate_constraint"}
+        ..., description="Defines the type of the attribute.", json_schema_extra={"update": "migration_required"}
     )
     enum: list | None = Field(
         default=None,

--- a/backend/infrahub/core/validators/attribute/kind.py
+++ b/backend/infrahub/core/validators/attribute/kind.py
@@ -65,8 +65,12 @@ class AttributeKindUpdateValidatorQuery(AttributeSchemaValidatorQuery):
             if value in (None, NULL_VALUE):
                 continue
             try:
+                attr_value = result.get("attribute_value")
                 infrahub_attribute_class.validate_format(
-                    value=result.get("attribute_value"), name=self.attribute_schema.name, schema=self.attribute_schema
+                    value=attr_value, name=self.attribute_schema.name, schema=self.attribute_schema
+                )
+                infrahub_attribute_class.validate_content(
+                    value=attr_value, name=self.attribute_schema.name, schema=self.attribute_schema
                 )
             except ValidationError:
                 grouped_data_paths.add_data_path(

--- a/backend/infrahub/core/validators/determiner.py
+++ b/backend/infrahub/core/validators/determiner.py
@@ -98,7 +98,10 @@ class ConstraintValidatorDeterminer:
                 continue
 
             prop_field_update = prop_field_info.json_schema_extra.get("update")
-            if prop_field_update != UpdateSupport.VALIDATE_CONSTRAINT.value:
+            if prop_field_update not in (
+                UpdateSupport.VALIDATE_CONSTRAINT.value,
+                UpdateSupport.MIGRATION_REQUIRED.value,
+            ):
                 continue
 
             if getattr(schema, prop_name) is None:
@@ -111,6 +114,13 @@ class ConstraintValidatorDeterminer:
                 property_name=prop_name,
             )
             constraint_name = f"node.{prop_name}.update"
+
+            do_constraint_validation = prop_field_update == UpdateSupport.VALIDATE_CONSTRAINT.value or (
+                prop_field_update == UpdateSupport.MIGRATION_REQUIRED.value
+                and CONSTRAINT_VALIDATOR_MAP.get(constraint_name)
+            )
+            if not do_constraint_validation:
+                continue
 
             constraints.append(SchemaUpdateConstraintInfo(constraint_name=constraint_name, path=schema_path))
         return constraints
@@ -154,7 +164,10 @@ class ConstraintValidatorDeterminer:
                 continue
 
             prop_field_update = prop_field_info.json_schema_extra.get("update")
-            if prop_field_update != UpdateSupport.VALIDATE_CONSTRAINT.value:
+            if prop_field_update not in (
+                UpdateSupport.VALIDATE_CONSTRAINT.value,
+                UpdateSupport.MIGRATION_REQUIRED.value,
+            ):
                 continue
 
             if prop_value is None:
@@ -167,6 +180,13 @@ class ConstraintValidatorDeterminer:
                     continue
                 path_type = SchemaPathType.RELATIONSHIP
                 constraint_name = f"relationship.{prop_name}.update"
+
+            do_constraint_validation = prop_field_update == UpdateSupport.VALIDATE_CONSTRAINT.value or (
+                prop_field_update == UpdateSupport.MIGRATION_REQUIRED.value
+                and CONSTRAINT_VALIDATOR_MAP.get(constraint_name)
+            )
+            if not do_constraint_validation:
+                continue
 
             schema_path = SchemaPath(
                 schema_kind=schema.kind,

--- a/backend/tests/integration/schema_lifecycle/test_migration_attribute_kind.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_attribute_kind.py
@@ -204,7 +204,7 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
         await thing_one.new(
             db=db,
             text_value="ONE",
-            text_area_value="longer ONE",
+            text_area_value="a" * 5000,
             list_value=["a", "b"],
             url_value="https://infrahub.com",
         )
@@ -300,6 +300,20 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
         schema_step_04: dict[str, Any],
         client: InfrahubClient,
     ):
+        # first attempt fails because thing_one.text_area_value is too long
+        response = await client.schema.load(schemas=[schema_step_04], branch=branch.name)
+        assert response.errors
+        error_messages = response.errors["errors"][0]["message"].split("\n")
+        assert len(error_messages) == 1
+        error_message = error_messages[0]
+        thing_one_id = initial_objects["thing_one"].id
+        assert error_message.startswith("Attribute-level 'kind' constraint violation on schema 'TestingThing")
+        assert f"Node (TestingThing(ID: {thing_one_id})) is not compliant." in error_message
+
+        thing_one = await NodeManager.get_one(db=db, branch=branch, id=initial_objects["thing_one"].id)
+        thing_one.text_area_value.value = "longer ONE"
+        await thing_one.save(db=db)
+
         response = await client.schema.load(schemas=[schema_step_04], branch=branch.name)
         assert not response.errors
 

--- a/backend/tests/integration/schema_lifecycle/test_migration_attribute_kind.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_attribute_kind.py
@@ -74,6 +74,18 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
             )
         return attr_is_indexeds
 
+    async def validate_indexed_state(
+        self, db: InfrahubDatabase, branch: Branch, kind_index_map: dict[tuple[str, str], dict[str, bool]]
+    ):
+        kinds = {kind_and_uuid[0] for kind_and_uuid in kind_index_map.keys()}
+        num_expected_results = sum(len(attr_map) for attr_map in kind_index_map.values())
+        attr_is_indexeds = await self.get_indexed_state_for_attributes(db=db, branch=branch, kinds=list(kinds))
+        assert len(attr_is_indexeds) == num_expected_results
+        for attr_is_indexed in attr_is_indexeds:
+            kind_and_uuid = (attr_is_indexed.kind, attr_is_indexed.uuid)
+            assert kind_and_uuid in kind_index_map
+            assert attr_is_indexed.is_indexed == kind_index_map[kind_and_uuid][attr_is_indexed.attr_name]
+
     @pytest.fixture(scope="class")
     def schema_thing(self) -> dict[str, Any]:
         return {
@@ -82,6 +94,8 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
             "attributes": [
                 {"name": "text_value", "kind": "Text"},
                 {"name": "text_area_value", "kind": "TextArea"},
+                {"name": "list_value", "kind": "List"},
+                {"name": "url_value", "kind": "URL"},
             ],
         }
 
@@ -129,6 +143,54 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
         }
 
     @pytest.fixture(scope="class")
+    def schema_thing_text_area_to_text(self, schema_thing_text_to_text_area: dict[str, Any]) -> dict[str, Any]:
+        updated_schema = deepcopy(schema_thing_text_to_text_area)
+        updated_schema["attributes"][1]["kind"] = "Text"
+        return updated_schema
+
+    @pytest.fixture(scope="class")
+    def schema_step_04(
+        self,
+        schema_thing_text_area_to_text,
+    ) -> dict[str, Any]:
+        return {
+            "version": "1.0",
+            "nodes": [schema_thing_text_area_to_text],
+        }
+
+    @pytest.fixture(scope="class")
+    def schema_thing_url_to_text(self, schema_thing_text_area_to_text: dict[str, Any]) -> dict[str, Any]:
+        updated_schema = deepcopy(schema_thing_text_area_to_text)
+        updated_schema["attributes"][3]["kind"] = "Text"
+        return updated_schema
+
+    @pytest.fixture(scope="class")
+    def schema_step_05(
+        self,
+        schema_thing_url_to_text,
+    ) -> dict[str, Any]:
+        return {
+            "version": "1.0",
+            "nodes": [schema_thing_url_to_text],
+        }
+
+    @pytest.fixture(scope="class")
+    def schema_thing_text_area_revert(self, schema_thing_url_to_text: dict[str, Any]) -> dict[str, Any]:
+        updated_schema = deepcopy(schema_thing_url_to_text)
+        updated_schema["attributes"][1]["kind"] = "TextArea"
+        return updated_schema
+
+    @pytest.fixture(scope="class")
+    def schema_step_06(
+        self,
+        schema_thing_text_area_revert,
+    ) -> dict[str, Any]:
+        return {
+            "version": "1.0",
+            "nodes": [schema_thing_text_area_revert],
+        }
+
+    @pytest.fixture(scope="class")
     async def initial_objects(
         self,
         db: InfrahubDatabase,
@@ -139,11 +201,23 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
         await load_schema(db=db, schema=schema_step_01)
 
         thing_one = await Node.init(schema=THING_KIND, db=db)
-        await thing_one.new(db=db, text_value="ONE", text_area_value="longer ONE")
+        await thing_one.new(
+            db=db,
+            text_value="ONE",
+            text_area_value="longer ONE",
+            list_value=["a", "b"],
+            url_value="https://infrahub.com",
+        )
         await thing_one.save(db=db)
 
         thing_two = await Node.init(schema=THING_KIND, db=db)
-        await thing_two.new(db=db, text_value="TWO", text_area_value="longer TWO")
+        await thing_two.new(
+            db=db,
+            text_value="TWO",
+            text_area_value="longer TWO",
+            list_value=["c", "d"],
+            url_value="https://opsmill.com",
+        )
         await thing_two.save(db=db)
 
         objs = {
@@ -158,23 +232,21 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
         objects = await NodeManager.get_many(db=db, ids=object_ids)
         assert len(objects) == len(object_ids)
 
-        # check that indexing is correct to start with
-        attr_is_indexeds = await self.get_indexed_state_for_attributes(db=db, branch=branch, kinds=[THING_KIND])
-        assert len(attr_is_indexeds) == 4
-        assert set(attr_is_indexeds) == {
-            AttributeIsIndexed(
-                kind=THING_KIND, uuid=initial_objects["thing_one"].id, attr_name="text_value", is_indexed=True
-            ),
-            AttributeIsIndexed(
-                kind=THING_KIND, uuid=initial_objects["thing_one"].id, attr_name="text_area_value", is_indexed=False
-            ),
-            AttributeIsIndexed(
-                kind=THING_KIND, uuid=initial_objects["thing_two"].id, attr_name="text_value", is_indexed=True
-            ),
-            AttributeIsIndexed(
-                kind=THING_KIND, uuid=initial_objects["thing_two"].id, attr_name="text_area_value", is_indexed=False
-            ),
+        kind_index_map = {
+            (THING_KIND, initial_objects["thing_one"].id): {
+                "text_value": True,
+                "text_area_value": False,
+                "list_value": False,
+                "url_value": True,
+            },
+            (THING_KIND, initial_objects["thing_two"].id): {
+                "text_value": True,
+                "text_area_value": False,
+                "list_value": False,
+                "url_value": True,
+            },
         }
+        await self.validate_indexed_state(db=db, branch=branch, kind_index_map=kind_index_map)
 
     async def test_step_02_illegal_kind_updates(
         self,
@@ -204,23 +276,99 @@ RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIn
         response = await client.schema.load(schemas=[schema_step_03], branch=branch.name)
         assert not response.errors
 
-        attr_is_indexeds = await self.get_indexed_state_for_attributes(db=db, branch=branch, kinds=[THING_KIND])
-        assert len(attr_is_indexeds) == 4
-        assert set(attr_is_indexeds) == {
-            AttributeIsIndexed(
-                kind=THING_KIND, uuid=initial_objects["thing_one"].id, attr_name="text_value", is_indexed=False
-            ),
-            AttributeIsIndexed(
-                kind=THING_KIND, uuid=initial_objects["thing_one"].id, attr_name="text_area_value", is_indexed=False
-            ),
-            AttributeIsIndexed(
-                kind=THING_KIND, uuid=initial_objects["thing_two"].id, attr_name="text_value", is_indexed=False
-            ),
-            AttributeIsIndexed(
-                kind=THING_KIND, uuid=initial_objects["thing_two"].id, attr_name="text_area_value", is_indexed=False
-            ),
+        kind_index_map = {
+            (THING_KIND, initial_objects["thing_one"].id): {
+                "text_value": False,
+                "text_area_value": False,
+                "list_value": False,
+                "url_value": True,
+            },
+            (THING_KIND, initial_objects["thing_two"].id): {
+                "text_value": False,
+                "text_area_value": False,
+                "list_value": False,
+                "url_value": True,
+            },
         }
+        await self.validate_indexed_state(db=db, branch=branch, kind_index_map=kind_index_map)
 
+    async def test_step_04_text_area_to_text_update(
+        self,
+        db: InfrahubDatabase,
+        initial_objects: dict[str, Node],
+        branch: Branch,
+        schema_step_04: dict[str, Any],
+        client: InfrahubClient,
+    ):
+        response = await client.schema.load(schemas=[schema_step_04], branch=branch.name)
+        assert not response.errors
 
-# TODO: why are 4 migrations running in the step 03 test?
-# TODO: test for allowed kind update that does not change indexing
+        kind_index_map = {
+            (THING_KIND, initial_objects["thing_one"].id): {
+                "text_value": False,
+                "text_area_value": True,
+                "list_value": False,
+                "url_value": True,
+            },
+            (THING_KIND, initial_objects["thing_two"].id): {
+                "text_value": False,
+                "text_area_value": True,
+                "list_value": False,
+                "url_value": True,
+            },
+        }
+        await self.validate_indexed_state(db=db, branch=branch, kind_index_map=kind_index_map)
+
+    async def test_step_05_url_to_text_update(
+        self,
+        db: InfrahubDatabase,
+        initial_objects: dict[str, Node],
+        branch: Branch,
+        schema_step_05: dict[str, Any],
+        client: InfrahubClient,
+    ):
+        response = await client.schema.load(schemas=[schema_step_05], branch=branch.name)
+        assert not response.errors
+
+        kind_index_map = {
+            (THING_KIND, initial_objects["thing_one"].id): {
+                "text_value": False,
+                "text_area_value": True,
+                "list_value": False,
+                "url_value": True,
+            },
+            (THING_KIND, initial_objects["thing_two"].id): {
+                "text_value": False,
+                "text_area_value": True,
+                "list_value": False,
+                "url_value": True,
+            },
+        }
+        await self.validate_indexed_state(db=db, branch=branch, kind_index_map=kind_index_map)
+
+    async def test_step_06_text_area_revert(
+        self,
+        db: InfrahubDatabase,
+        initial_objects: dict[str, Node],
+        branch: Branch,
+        schema_step_06: dict[str, Any],
+        client: InfrahubClient,
+    ):
+        response = await client.schema.load(schemas=[schema_step_06], branch=branch.name)
+        assert not response.errors
+
+        kind_index_map = {
+            (THING_KIND, initial_objects["thing_one"].id): {
+                "text_value": False,
+                "text_area_value": False,
+                "list_value": False,
+                "url_value": True,
+            },
+            (THING_KIND, initial_objects["thing_two"].id): {
+                "text_value": False,
+                "text_area_value": False,
+                "list_value": False,
+                "url_value": True,
+            },
+        }
+        await self.validate_indexed_state(db=db, branch=branch, kind_index_map=kind_index_map)

--- a/backend/tests/integration/schema_lifecycle/test_migration_attribute_kind.py
+++ b/backend/tests/integration/schema_lifecycle/test_migration_attribute_kind.py
@@ -1,0 +1,226 @@
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from infrahub_sdk.client import InfrahubClient
+
+from infrahub.core import registry
+from infrahub.core.branch.models import Branch
+from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
+from infrahub.core.node import Node
+from infrahub.database import InfrahubDatabase
+from infrahub.exceptions import BranchNotFoundError
+from tests.helpers.test_app import TestInfrahubApp
+
+from ..shared import load_schema
+
+THING_KIND = "TestingThing"
+
+
+@dataclass
+class AttributeIsIndexed:
+    kind: str
+    uuid: str
+    attr_name: str
+    is_indexed: bool
+
+    def __hash__(self) -> int:
+        return hash((self.kind, self.uuid, self.attr_name, self.is_indexed))
+
+
+class TestMigrationAttributeKind(TestInfrahubApp):
+    @pytest.fixture(params=[True, False])
+    async def branch(self, request, db: InfrahubDatabase, default_branch: Branch) -> Branch:
+        if request.param:
+            return default_branch
+        branch_name = "branch-attr-kind-update"
+        try:
+            return await registry.get_branch(db=db, branch=branch_name)
+        except BranchNotFoundError:
+            return await create_branch(db=db, branch_name=branch_name)
+
+    async def get_indexed_state_for_attributes(
+        self, db: InfrahubDatabase, branch: Branch, kinds: list[str]
+    ) -> list[AttributeIsIndexed]:
+        branch_filter, branch_params = branch.get_query_filter_path()
+        labels_filter = "|".join(kinds)
+        query = """
+MATCH (n:%(labels_filter)s)-[:HAS_ATTRIBUTE]->(attr:Attribute)
+WITH DISTINCT n, attr
+CALL (n, attr) {
+    MATCH (n)-[r1:HAS_ATTRIBUTE]->(attr:Attribute)-[r2:HAS_VALUE]->(av)
+    WHERE all(r IN [r1, r2] WHERE %(branch_filter)s)
+    WITH av, r1.status = "active" AND r2.status = "active" AS is_active
+    ORDER BY r2.branch_level DESC, r2.from DESC, r2.status = "active" DESC, r1.branch_level DESC, r1.from DESC, r1.status = "active" DESC
+    LIMIT 1
+    WITH av
+    WHERE is_active
+    RETURN av
+}
+RETURN n.kind AS kind, n.uuid AS uuid, attr.name AS attr_name, "AttributeValueIndexed" IN labels(av) AS is_indexed
+        """ % {"labels_filter": labels_filter, "branch_filter": branch_filter}
+        results = await db.execute_query(query=query, params=branch_params)
+        attr_is_indexeds = []
+        for result in results:
+            attr_is_indexeds.append(
+                AttributeIsIndexed(
+                    kind=result.get("kind"),
+                    uuid=result.get("uuid"),
+                    attr_name=result.get("attr_name"),
+                    is_indexed=result.get("is_indexed"),
+                )
+            )
+        return attr_is_indexeds
+
+    @pytest.fixture(scope="class")
+    def schema_thing(self) -> dict[str, Any]:
+        return {
+            "name": "Thing",
+            "namespace": "Testing",
+            "attributes": [
+                {"name": "text_value", "kind": "Text"},
+                {"name": "text_area_value", "kind": "TextArea"},
+            ],
+        }
+
+    @pytest.fixture(scope="class")
+    def schema_step_01(
+        self,
+        schema_thing,
+    ) -> dict[str, Any]:
+        return {
+            "version": "1.0",
+            "nodes": [schema_thing],
+        }
+
+    @pytest.fixture(scope="class")
+    def schema_thing_illegal_updates(self, schema_thing: dict[str, Any]) -> dict[str, Any]:
+        updated_schema = deepcopy(schema_thing)
+        updated_schema["attributes"][0]["kind"] = "JSON"
+        updated_schema["attributes"][1]["kind"] = "List"
+        return updated_schema
+
+    @pytest.fixture(scope="class")
+    def schema_step_02(
+        self,
+        schema_thing_illegal_updates,
+    ) -> dict[str, Any]:
+        return {
+            "version": "1.0",
+            "nodes": [schema_thing_illegal_updates],
+        }
+
+    @pytest.fixture(scope="class")
+    def schema_thing_text_to_text_area(self, schema_thing: dict[str, Any]) -> dict[str, Any]:
+        updated_schema = deepcopy(schema_thing)
+        updated_schema["attributes"][0]["kind"] = "TextArea"
+        return updated_schema
+
+    @pytest.fixture(scope="class")
+    def schema_step_03(
+        self,
+        schema_thing_text_to_text_area,
+    ) -> dict[str, Any]:
+        return {
+            "version": "1.0",
+            "nodes": [schema_thing_text_to_text_area],
+        }
+
+    @pytest.fixture(scope="class")
+    async def initial_objects(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        initialize_registry,
+        schema_step_01,
+    ) -> dict[str, Node]:
+        await load_schema(db=db, schema=schema_step_01)
+
+        thing_one = await Node.init(schema=THING_KIND, db=db)
+        await thing_one.new(db=db, text_value="ONE", text_area_value="longer ONE")
+        await thing_one.save(db=db)
+
+        thing_two = await Node.init(schema=THING_KIND, db=db)
+        await thing_two.new(db=db, text_value="TWO", text_area_value="longer TWO")
+        await thing_two.save(db=db)
+
+        objs = {
+            "thing_one": thing_one,
+            "thing_two": thing_two,
+        }
+
+        return objs
+
+    async def test_step01_baseline(self, db: InfrahubDatabase, initial_objects: dict[str, Node], branch: Branch):
+        object_ids = [obj.id for obj in initial_objects.values()]
+        objects = await NodeManager.get_many(db=db, ids=object_ids)
+        assert len(objects) == len(object_ids)
+
+        # check that indexing is correct to start with
+        attr_is_indexeds = await self.get_indexed_state_for_attributes(db=db, branch=branch, kinds=[THING_KIND])
+        assert len(attr_is_indexeds) == 4
+        assert set(attr_is_indexeds) == {
+            AttributeIsIndexed(
+                kind=THING_KIND, uuid=initial_objects["thing_one"].id, attr_name="text_value", is_indexed=True
+            ),
+            AttributeIsIndexed(
+                kind=THING_KIND, uuid=initial_objects["thing_one"].id, attr_name="text_area_value", is_indexed=False
+            ),
+            AttributeIsIndexed(
+                kind=THING_KIND, uuid=initial_objects["thing_two"].id, attr_name="text_value", is_indexed=True
+            ),
+            AttributeIsIndexed(
+                kind=THING_KIND, uuid=initial_objects["thing_two"].id, attr_name="text_area_value", is_indexed=False
+            ),
+        }
+
+    async def test_step_02_illegal_kind_updates(
+        self,
+        db: InfrahubDatabase,
+        initial_objects: dict[str, Node],
+        branch: Branch,
+        schema_step_02: dict[str, Any],
+        client: InfrahubClient,
+    ):
+        response = await client.schema.load(schemas=[schema_step_02], branch=branch.name)
+        assert response.errors
+        error_messages = response.errors["errors"][0]["message"].split("\n")
+        assert len(error_messages) == 4
+        assert all(
+            em.startswith("Attribute-level 'kind' constraint violation on schema 'TestingThing")
+            for em in error_messages
+        )
+
+    async def test_step_03_text_to_text_area_update(
+        self,
+        db: InfrahubDatabase,
+        initial_objects: dict[str, Node],
+        branch: Branch,
+        schema_step_03: dict[str, Any],
+        client: InfrahubClient,
+    ):
+        response = await client.schema.load(schemas=[schema_step_03], branch=branch.name)
+        assert not response.errors
+
+        attr_is_indexeds = await self.get_indexed_state_for_attributes(db=db, branch=branch, kinds=[THING_KIND])
+        assert len(attr_is_indexeds) == 4
+        assert set(attr_is_indexeds) == {
+            AttributeIsIndexed(
+                kind=THING_KIND, uuid=initial_objects["thing_one"].id, attr_name="text_value", is_indexed=False
+            ),
+            AttributeIsIndexed(
+                kind=THING_KIND, uuid=initial_objects["thing_one"].id, attr_name="text_area_value", is_indexed=False
+            ),
+            AttributeIsIndexed(
+                kind=THING_KIND, uuid=initial_objects["thing_two"].id, attr_name="text_value", is_indexed=False
+            ),
+            AttributeIsIndexed(
+                kind=THING_KIND, uuid=initial_objects["thing_two"].id, attr_name="text_area_value", is_indexed=False
+            ),
+        }
+
+
+# TODO: why are 4 migrations running in the step 03 test?
+# TODO: test for allowed kind update that does not change indexing

--- a/backend/tests/unit/core/constraint_validators/test_attribute_kind_update.py
+++ b/backend/tests/unit/core/constraint_validators/test_attribute_kind_update.py
@@ -1,9 +1,11 @@
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import PathType, SchemaPathType
+from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.path import DataPath, SchemaPath
+from infrahub.core.schema.node_schema import NodeSchema
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.validators.attribute.kind import AttributeKindChecker, AttributeKindUpdateValidatorQuery
 from infrahub.core.validators.model import SchemaConstraintValidatorRequest
@@ -74,9 +76,13 @@ async def test_query_failure(db: InfrahubDatabase, default_branch: Branch, car_a
 
 
 async def test_query_update_on_branch(
-    db: InfrahubDatabase, branch: Branch, default_branch: Branch, car_accord_main, car_camry_main, car_volt_main
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_accord_main,
+    car_camry_main,
+    car_volt_main,
+    branch: Branch,
 ):
-    await branch.rebase(db=db)
     car_accord = await NodeManager.get_one(db=db, branch=branch, id=car_accord_main.id)
     car_accord.name.value = "http://www.accord.com"
     await car_accord.save(db=db)
@@ -123,10 +129,111 @@ async def test_query_update_on_branch(
     )
 
 
-async def test_query_delete_on_branch(
-    db: InfrahubDatabase, branch: Branch, default_branch: Branch, car_accord_main, car_camry_main, car_volt_main
+async def test_query_update_on_branch_with_too_large_value(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    all_attribute_types_schema: NodeSchema,
 ):
-    await branch.rebase(db=db)
+    main_node = await Node.init(db=db, schema=all_attribute_types_schema.kind, branch=default_branch)
+    await main_node.new(db=db, name="number_one", mystring="abc", mytextarea="abcdef")
+    await main_node.save(db=db)
+
+    branch = await create_branch(db=db, branch_name="branch-too-large")
+
+    branch_node = await NodeManager.get_one(db=db, branch=branch, id=main_node.id)
+    branch_node.mytextarea.value = "abcdef" * 1000
+    await branch_node.save(db=db)
+
+    node_schema = registry.schema.get_node_schema(name=all_attribute_types_schema.kind, branch=branch)
+    name_attr = node_schema.get_attribute(name="mytextarea")
+    name_attr.kind = "Text"
+    registry.schema.set(name=all_attribute_types_schema.kind, schema=node_schema, branch=default_branch.name)
+
+    schema_path = SchemaPath(
+        path_type=SchemaPathType.ATTRIBUTE, schema_kind=all_attribute_types_schema.kind, field_name="mytextarea"
+    )
+
+    query = await AttributeKindUpdateValidatorQuery.init(
+        db=db, branch=branch, node_schema=node_schema, schema_path=schema_path
+    )
+
+    await query.execute(db=db)
+
+    grouped_paths = await query.get_paths()
+    all_data_paths = grouped_paths.get_all_data_paths()
+    assert len(all_data_paths) == 1
+    assert next(iter(all_data_paths)) == DataPath(
+        branch=branch.name,
+        path_type=PathType.ATTRIBUTE,
+        node_id=main_node.id,
+        kind=all_attribute_types_schema.kind,
+        field_name="mytextarea",
+        value="abcdef" * 1000,
+    )
+
+
+async def test_query_update_on_branch_with_parameters_violation(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_accord_main,
+    car_camry_main,
+    car_volt_main,
+    branch: Branch,
+):
+    car_accord = await NodeManager.get_one(db=db, branch=branch, id=car_accord_main.id)
+    car_accord.name.value = "ACCORD"
+    await car_accord.save(db=db)
+    car_volt = await NodeManager.get_one(db=db, branch=branch, id=car_volt_main.id)
+    car_volt.name.value = "VOLT"
+    await car_volt.save(db=db)
+    car_schema = registry.schema.get(name="TestCar", branch=branch)
+    name_attr = car_schema.get_attribute(name="name")
+    name_attr.parameters.regex = "^[a-z]+$"
+    registry.schema.set(name="TestCar", schema=car_schema, branch=default_branch.name)
+
+    schema_path = SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCar", field_name="name")
+
+    query = await AttributeKindUpdateValidatorQuery.init(
+        db=db, branch=branch, node_schema=car_schema, schema_path=schema_path
+    )
+
+    await query.execute(db=db)
+
+    grouped_paths = await query.get_paths()
+    all_data_paths = grouped_paths.get_all_data_paths()
+    assert len(all_data_paths) == 2
+    assert (
+        DataPath(
+            branch=branch.name,
+            path_type=PathType.ATTRIBUTE,
+            node_id=car_accord_main.id,
+            kind="TestCar",
+            field_name="name",
+            value=car_accord.name.value,
+        )
+        in all_data_paths
+    )
+    assert (
+        DataPath(
+            branch=branch.name,
+            path_type=PathType.ATTRIBUTE,
+            node_id=car_volt_main.id,
+            kind="TestCar",
+            field_name="name",
+            value=car_volt.name.value,
+        )
+        in all_data_paths
+    )
+
+
+async def test_query_delete_on_branch(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_accord_main,
+    car_camry_main,
+    car_volt_main,
+    branch: Branch,
+):
     car_accord = await NodeManager.get_one(db=db, branch=branch, id=car_accord_main.id)
     car_accord.name.value = "1234"
     await car_accord.save(db=db)
@@ -173,9 +280,13 @@ async def test_query_delete_on_branch(
 
 
 async def test_validator(
-    db: InfrahubDatabase, branch: Branch, default_branch: Branch, car_accord_main, car_camry_main, car_prius_main
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_accord_main,
+    car_camry_main,
+    car_prius_main,
+    branch: Branch,
 ):
-    await branch.rebase(db=db)
     car = await NodeManager.get_one(id=car_accord_main.id, db=db, branch=branch)
     car.name.value = "http://www.accord.com"
     await car.save(db=db)

--- a/backend/tests/unit/core/migrations/graph/test_037.py
+++ b/backend/tests/unit/core/migrations/graph/test_037.py
@@ -275,6 +275,14 @@ class TestMigration037:
         schema_branch = schema_branch.duplicate(name=branch_1.name)
         node_schema = schema_branch.get_node(name=all_attribute_types_schema.kind)
 
+        # we would prevent updating the schema from TextArea to Text if any nodes using the schema have
+        # an attribute value that is too large, so we change their data here before the schema
+        nodes = await NodeManager.query(db=db, branch=branch_1, schema=all_attribute_types_schema)
+        for node in nodes:
+            if node.mytextarea.value and len(node.mytextarea.value) > MAX_STRING_LENGTH:
+                node.mytextarea.value = node.mytextarea.value[:1000]
+                await node.save(db=db)
+
         name_attr_schema = node_schema.get_attribute(name="mytextarea")
         name_attr_schema.kind = "Text"
         schema_branch.set(name=all_attribute_types_schema.kind, schema=node_schema)
@@ -499,6 +507,9 @@ REMOVE avi:AttributeValueIndexed
                 # this one went from a list to a text attribute
                 if branch.name == "branch_2" and attr_name == "mylist":
                     assert str(original_attr_value).replace("'", '"').replace(" ", "") == retrieved_attr_value
+                # these ones might have been shortened to become Text attributes
+                elif branch.name == "branch_1" and attr_name == "mytextarea":
+                    assert original_attr_value.startswith(retrieved_attr_value)
                 else:
                     assert original_attr_value == retrieved_attr_value
 

--- a/backend/tests/unit/core/test_attribute.py
+++ b/backend/tests/unit/core/test_attribute.py
@@ -748,9 +748,15 @@ async def test_attribute_size(db: InfrahubDatabase, default_branch: Branch, all_
 
     large_string = "a" * 9_000  # It's over 9000!!!!
 
-    await obj.new(db=db, name="obj1", mystring=large_string)
-
     # Text field
+    with pytest.raises(
+        ValidationError, match=f"Text attribute length should be less than {MAX_STRING_LENGTH} characters."
+    ):
+        await obj.new(db=db, name="obj1", mystring=large_string)
+
+    # Updated text field
+    await obj.new(db=db, name="obj1")
+    obj.mystring.value = large_string
     with pytest.raises(
         ValidationError, match=f"Text attribute length should be less than {MAX_STRING_LENGTH} characters."
     ):

--- a/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
+++ b/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
@@ -296,11 +296,12 @@ async def test_schema_integrity(
         await run_proposed_change_schema_integrity_check(model=schema_integrity_01)
 
         checks = await registry.manager.query(db=db, schema=InfrahubKind.SCHEMACHECK)
-        assert len(checks) == 1
-        check = checks[0]
-        assert check.conclusion.value.value == "failure"
+        assert len(checks) == 2
+        assert checks[0].conclusion.value.value == "failure"
+        assert checks[1].conclusion.value.value == "failure"
 
-        assert check.conflicts.value == [
+        all_conflicts = [c.conflicts.value for c in checks]
+        assert [
             {
                 "branch": "placeholder",
                 "id": person_john_main.id,
@@ -308,7 +309,23 @@ async def test_schema_integrity(
                 "name": "schema/TestPerson/name/parameters.regex",
                 "path": "schema/TestPerson/name/parameters.regex",
                 "type": ConstraintIdentifier.ATTRIBUTE_PARAMETERS_REGEX_UPDATE.value,
-                # ruff: noqa: E501
-                "value": f"Attribute-level 'regex' constraint violation on schema 'TestPerson'. Node (TestPerson: {person_john_main.id}) is not compliant. The error relates to field name='{person_john_main.name.value}'.",
+                "value": (
+                    f"Attribute-level 'regex' constraint violation on schema 'TestPerson'. Node (TestPerson: {person_john_main.id})"
+                    f" is not compliant. The error relates to field name='{person_john_main.name.value}'."
+                ),
             }
-        ]
+        ] in all_conflicts
+        assert [
+            {
+                "branch": "placeholder",
+                "id": person_john_main.id,
+                "kind": "TestPerson",
+                "name": "schema/TestPerson/name/kind",
+                "path": "schema/TestPerson/name/kind",
+                "type": "attribute.kind.update",
+                "value": (
+                    f"Attribute-level 'kind' constraint violation on schema 'TestPerson'. Node (TestPerson: {person_john_main.id})"
+                    f" is not compliant. The error relates to field name='{person_john_main.name.value}'."
+                ),
+            }
+        ] in all_conflicts

--- a/docs/docs/reference/schema/validator-migration.mdx
+++ b/docs/docs/reference/schema/validator-migration.mdx
@@ -53,7 +53,7 @@ In this context, an element represent either a Node, a Generic, an Attribute or 
 | Name | Status |
 | ---- | ---- |
 | **name** | migration_required |
-| **kind** | validate_constraint |
+| **kind** | migration_required |
 | **enum** | validate_constraint |
 | **computed_attribute** | allowed |
 | **choices** | validate_constraint |


### PR DESCRIPTION
IFC-1734

add a schema update migration (the kind that runs when a new schema is loaded, not a database upgrade migration) to handle correctly updating `AttributeValue[Indexed]` vertices so that "large" attribute types (`JSON` / `List` / `TextArea`) are _not_ indexed and all other attribute types _are_ indexed.

also fixes a couple of other issues noted in my comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Per-branch migration for attribute-kind changes with automatic reindexing of attribute values.

- Bug Fixes
  - Safer model updates: incompatible field assignments are skipped.
  - String content validation enforces length limits for non-large text attributes.
  - Constraint validation now accepts migration-required rules when a validator exists.
  - Pre-migration truncation to avoid oversize data failures.

- Documentation
  - Validator docs: attribute "kind" status changed to migration_required.

- Tests
  - New and updated integration/unit tests covering migrations, indexing state, truncation, and validator edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->