### PR TITLE
Add graphiql workers at build time for offline use IFC-1766

### DIFF
--- a/changelog/7046.fixed.md
+++ b/changelog/7046.fixed.md
@@ -1,0 +1,1 @@
+Add graphiql workers at build time for offline use

--- a/frontend/app/src/modules.d.ts
+++ b/frontend/app/src/modules.d.ts
@@ -1,1 +1,16 @@
 declare module "react-datetime";
+
+declare module "monaco-editor/esm/vs/editor/editor.worker?worker&module" {
+  const EditorWorker: { new (): Worker };
+  export default EditorWorker;
+}
+
+declare module "monaco-editor/esm/vs/language/json/json.worker?worker&module" {
+  const JsonWorker: { new (): Worker };
+  export default JsonWorker;
+}
+
+declare module "@/vendor/monaco-graphql/graphql.worker?worker&module" {
+  const GraphQLWorker: { new (): Worker };
+  export default GraphQLWorker;
+}

--- a/frontend/app/src/pages/graphql/index.tsx
+++ b/frontend/app/src/pages/graphql/index.tsx
@@ -9,7 +9,11 @@ import { GraphiQL, HISTORY_PLUGIN } from "graphiql";
 import { useAtomValue } from "jotai";
 import { StringParam, useQueryParam } from "use-query-params";
 
-import "graphiql/setup-workers/esm.sh";
+import GraphQLWorker from "@/vendor/monaco-graphql/graphql.worker?worker";
+// Bundle Monaco workers locally so build works offline and avoids dep pre-bundling issues
+// with ?worker imports inside node_modules.
+import EditorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
+import JsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
 import "graphiql/style.css";
 import "@graphiql/plugin-explorer/style.css";
 
@@ -38,6 +42,20 @@ const GraphqlSandboxPage = () => {
   const [query] = useQueryParam(QSP.QUERY, StringParam);
   const branch = useAtomValue(currentBranchAtom);
   const waybackMachineDate = useAtomValue(datetimeAtom);
+
+  // Ensure Monaco workers are available when running offline
+  (globalThis as any).MonacoEnvironment = {
+    getWorker(_workerId: unknown, label: string) {
+      switch (label) {
+        case "json":
+          return new (JsonWorker as unknown as { new (): Worker })();
+        case "graphql":
+          return new (GraphQLWorker as unknown as { new (): Worker })();
+        default:
+          return new (EditorWorker as unknown as { new (): Worker })();
+      }
+    },
+  };
 
   return (
     <GraphiQL

--- a/frontend/app/src/pages/graphql/index.tsx
+++ b/frontend/app/src/pages/graphql/index.tsx
@@ -9,11 +9,11 @@ import { GraphiQL, HISTORY_PLUGIN } from "graphiql";
 import { useAtomValue } from "jotai";
 import { StringParam, useQueryParam } from "use-query-params";
 
-import GraphQLWorker from "@/vendor/monaco-graphql/graphql.worker?worker";
+import GraphQLWorker from "@/vendor/monaco-graphql/graphql.worker?worker&module";
 // Bundle Monaco workers locally so build works offline and avoids dep pre-bundling issues
 // with ?worker imports inside node_modules.
-import EditorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
-import JsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
+import EditorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker&module";
+import JsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker&module";
 import "graphiql/style.css";
 import "@graphiql/plugin-explorer/style.css";
 

--- a/frontend/app/src/vendor/monaco-graphql/graphql.worker.ts
+++ b/frontend/app/src/vendor/monaco-graphql/graphql.worker.ts
@@ -1,0 +1,8 @@
+import { initialize } from "monaco-editor/esm/vs/editor/editor.worker";
+import { GraphQLWorker } from "monaco-graphql/esm/GraphQLWorker";
+
+// Minimal worker bootstrap without sourcemap footer
+globalThis.onmessage = () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  initialize((ctx: any, createData: any) => new GraphQLWorker(ctx, createData));
+};

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -15,6 +15,9 @@ export default defineConfig({
     port: 3000,
     host: "0.0.0.0",
   },
+  worker: {
+    format: "es",
+  },
   plugins: [tailwindcss(), react(), svgr(), tsconfigPaths()],
   test: {
     browser: {


### PR DESCRIPTION
Issue https://github.com/opsmill/infrahub/issues/7046

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GraphQL editor now runs offline by bundling editor workers locally.

* **Bug Fixes**
  * Fixed intermittent failures where the GraphQL IDE wouldn’t load.
  * Improved reliability of syntax highlighting, IntelliSense, and JSON handling.

* **Chores**
  * Updated worker bootstrapping and build configuration to produce ES-module workers and streamline initialization.

* **Documentation**
  * Added changelog entry documenting offline GraphiQL worker support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->