### PR TITLE
fixes for diffing and merging a branch into an emtpy default branch

### DIFF
--- a/backend/infrahub/core/diff/model/path.py
+++ b/backend/infrahub/core/diff/model/path.py
@@ -22,8 +22,6 @@ if TYPE_CHECKING:
     from neo4j.graph import Relationship as Neo4jRelationship
     from whenever import TimeDelta
 
-    from infrahub.graphql.initialization import GraphqlContext
-
 
 @dataclass
 class TimeRange:
@@ -315,12 +313,6 @@ class EnrichedDiffRelationship(BaseSummary):
 
 
 @dataclass
-class ParentNodeInfo:
-    node: EnrichedDiffNode
-    relationship_name: str = "undefined"
-
-
-@dataclass
 class EnrichedDiffNode(BaseSummary):
     identifier: NodeIdentifier
     label: str
@@ -363,37 +355,6 @@ class EnrichedDiffNode(BaseSummary):
         for rel in self.relationships:
             rel.clear_conflicts()
         self.conflict = None
-
-    def get_parent_info(self, graphql_context: GraphqlContext | None = None) -> ParentNodeInfo | None:
-        for r in self.relationships:
-            for n in r.nodes:
-                relationship_name: str = "undefined"
-
-                if not graphql_context:
-                    return ParentNodeInfo(node=n, relationship_name=relationship_name)
-
-                node_schema = graphql_context.db.schema.get(name=self.kind)
-                rel_schema = node_schema.get_relationship(name=r.name)
-
-                parent_schema = graphql_context.db.schema.get(name=n.kind)
-                rels_parent = parent_schema.get_relationships_by_identifier(id=rel_schema.get_identifier())
-
-                if rels_parent and len(rels_parent) == 1:
-                    relationship_name = rels_parent[0].name
-                elif rels_parent and len(rels_parent) > 1:
-                    for rel_parent in rels_parent:
-                        if (
-                            rel_schema.direction == RelationshipDirection.INBOUND
-                            and rel_parent.direction == RelationshipDirection.OUTBOUND
-                        ) or (
-                            rel_schema.direction == RelationshipDirection.OUTBOUND
-                            and rel_parent.direction == RelationshipDirection.INBOUND
-                        ):
-                            relationship_name = rel_parent.name
-                            break
-
-                return ParentNodeInfo(node=n, relationship_name=relationship_name)
-        return None
 
     def get_all_child_nodes(self) -> set[EnrichedDiffNode]:
         all_children = set()

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -226,8 +226,18 @@ class SchemaBranch:
     def update(self, schema: SchemaBranch) -> None:
         """Update another SchemaBranch into this one."""
 
-        local_kinds = list(self.nodes.keys()) + list(self.generics.keys())
-        other_kinds = list(schema.nodes.keys()) + list(schema.generics.keys())
+        local_kinds = (
+            list(self.nodes.keys())
+            + list(self.generics.keys())
+            + list(self.profiles.keys())
+            + list(self.templates.keys())
+        )
+        other_kinds = (
+            list(schema.nodes.keys())
+            + list(schema.generics.keys())
+            + list(schema.profiles.keys())
+            + list(schema.templates.keys())
+        )
 
         in_both, _, other_only = compare_lists(list1=local_kinds, list2=other_kinds)
 

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -226,18 +226,8 @@ class SchemaBranch:
     def update(self, schema: SchemaBranch) -> None:
         """Update another SchemaBranch into this one."""
 
-        local_kinds = (
-            list(self.nodes.keys())
-            + list(self.generics.keys())
-            + list(self.profiles.keys())
-            + list(self.templates.keys())
-        )
-        other_kinds = (
-            list(schema.nodes.keys())
-            + list(schema.generics.keys())
-            + list(schema.profiles.keys())
-            + list(schema.templates.keys())
-        )
+        local_kinds = self.all_names
+        other_kinds = schema.all_names
 
         in_both, _, other_only = compare_lists(list1=local_kinds, list2=other_kinds)
 

--- a/backend/infrahub/graphql/app.py
+++ b/backend/infrahub/graphql/app.py
@@ -231,6 +231,7 @@ class InfrahubGraphQLApp:
                 operation_name=operation_name,
                 branch=branch,
             )
+        impacted_models = analyzed_query.query_report.impacted_models
 
         await self._evaluate_permissions(
             db=db,
@@ -282,7 +283,7 @@ class InfrahubGraphQLApp:
         GRAPHQL_QUERY_HEIGHT_METRICS.labels(**labels).observe(await analyzed_query.calculate_height())
         # GRAPHQL_QUERY_VARS_METRICS.labels(**labels).observe(len(analyzed_query.variables))
         GRAPHQL_TOP_LEVEL_QUERIES_METRICS.labels(**labels).observe(analyzed_query.nbr_queries)
-        GRAPHQL_QUERY_OBJECTS_METRICS.labels(**labels).observe(len(analyzed_query.query_report.impacted_models))
+        GRAPHQL_QUERY_OBJECTS_METRICS.labels(**labels).observe(len(impacted_models))
 
         _, errors = analyzed_query.is_valid
         if errors:

--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -152,7 +152,7 @@ class DiffTreeSummary(DiffSummaryCounts):
 
 
 class DiffTreeResolver:
-    def __init__(self):
+    def __init__(self) -> None:
         self.source_branch_name: str | None = None
 
     def initialize(self, enriched_diff_root: EnrichedDiffRoot) -> None:

--- a/backend/infrahub/graphql/queries/diff/tree.py
+++ b/backend/infrahub/graphql/queries/diff/tree.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from graphene import Argument, Boolean, DateTime, Field, InputObjectType, Int, List, NonNull, ObjectType, String
@@ -7,7 +8,7 @@ from graphene import Enum as GrapheneEnum
 from infrahub_sdk.utils import extract_fields
 
 from infrahub.core import registry
-from infrahub.core.constants import DiffAction, RelationshipCardinality
+from infrahub.core.constants import DiffAction, RelationshipCardinality, RelationshipDirection
 from infrahub.core.constants.database import DatabaseEdgeType
 from infrahub.core.diff.model.path import NameTrackingId
 from infrahub.core.diff.query.filters import EnrichedDiffQueryFilters
@@ -36,6 +37,12 @@ if TYPE_CHECKING:
 
 GrapheneDiffActionEnum = GrapheneEnum.from_enum(DiffAction)
 GrapheneCardinalityEnum = GrapheneEnum.from_enum(RelationshipCardinality)
+
+
+@dataclass
+class ParentNodeInfo:
+    node: EnrichedDiffNode
+    relationship_name: str
 
 
 class ConflictDetails(ObjectType):
@@ -145,9 +152,16 @@ class DiffTreeSummary(DiffSummaryCounts):
 
 
 class DiffTreeResolver:
+    def __init__(self):
+        self.source_branch_name: str | None = None
+
+    def initialize(self, enriched_diff_root: EnrichedDiffRoot) -> None:
+        self.source_branch_name = enriched_diff_root.diff_branch_name
+
     async def to_diff_tree(
         self, enriched_diff_root: EnrichedDiffRoot, graphql_context: GraphqlContext | None = None
     ) -> DiffTree:
+        self.initialize(enriched_diff_root=enriched_diff_root)
         all_nodes = list(enriched_diff_root.nodes)
         tree_nodes = [self.to_diff_node(enriched_node=e_node, graphql_context=graphql_context) for e_node in all_nodes]
         name = None
@@ -166,6 +180,43 @@ class DiffTreeResolver:
             num_conflicts=enriched_diff_root.num_conflicts,
         )
 
+    def _get_parent_info(
+        self, diff_node: EnrichedDiffNode, graphql_context: GraphqlContext | None = None
+    ) -> ParentNodeInfo | None:
+        for r in diff_node.relationships:
+            for n in r.nodes:
+                relationship_name: str = "undefined"
+
+                if not graphql_context or not self.source_branch_name:
+                    return ParentNodeInfo(node=n, relationship_name=relationship_name)
+
+                node_schema = graphql_context.db.schema.get(
+                    name=diff_node.kind, branch=self.source_branch_name, duplicate=False
+                )
+                rel_schema = node_schema.get_relationship(name=r.name)
+
+                parent_schema = graphql_context.db.schema.get(
+                    name=n.kind, branch=self.source_branch_name, duplicate=False
+                )
+                rels_parent = parent_schema.get_relationships_by_identifier(id=rel_schema.get_identifier())
+
+                if rels_parent and len(rels_parent) == 1:
+                    relationship_name = rels_parent[0].name
+                elif rels_parent and len(rels_parent) > 1:
+                    for rel_parent in rels_parent:
+                        if (
+                            rel_schema.direction == RelationshipDirection.INBOUND
+                            and rel_parent.direction == RelationshipDirection.OUTBOUND
+                        ) or (
+                            rel_schema.direction == RelationshipDirection.OUTBOUND
+                            and rel_parent.direction == RelationshipDirection.INBOUND
+                        ):
+                            relationship_name = rel_parent.name
+                            break
+
+                return ParentNodeInfo(node=n, relationship_name=relationship_name)
+        return None
+
     def to_diff_node(self, enriched_node: EnrichedDiffNode, graphql_context: GraphqlContext | None = None) -> DiffNode:
         diff_attributes = [
             self.to_diff_attribute(enriched_attribute=e_attr, graphql_context=graphql_context)
@@ -181,7 +232,7 @@ class DiffTreeResolver:
             conflict = self.to_diff_conflict(enriched_conflict=enriched_node.conflict, graphql_context=graphql_context)
 
         parent = None
-        if parent_info := enriched_node.get_parent_info(graphql_context=graphql_context):
+        if parent_info := self._get_parent_info(diff_node=enriched_node, graphql_context=graphql_context):
             parent = DiffNodeParent(
                 uuid=parent_info.node.uuid,
                 kind=parent_info.node.kind,

--- a/backend/tests/integration/schema_lifecycle/test_empty_main_merge.py
+++ b/backend/tests/integration/schema_lifecycle/test_empty_main_merge.py
@@ -176,6 +176,8 @@ query GetDiffTree($branch: String){
 
 
 class TestProposedChangeOnEmptyMain(TestInfrahubApp):
+    """Test adding schema and data on branch and merging it into a fresh default branch"""
+
     @pytest.fixture(scope="class")
     async def branch(self, db: InfrahubDatabase) -> Branch:
         return await create_branch(db=db, branch_name="branch")

--- a/backend/tests/integration/schema_lifecycle/test_empty_main_merge.py
+++ b/backend/tests/integration/schema_lifecycle/test_empty_main_merge.py
@@ -1,0 +1,352 @@
+from typing import Any
+
+from infrahub.proposed_change.constants import ProposedChangeState
+import pytest
+from infrahub_sdk.client import InfrahubClient
+
+from infrahub.core.branch.models import Branch
+from infrahub.core.initialization import create_branch
+from infrahub.core.node import Node
+from infrahub.database import InfrahubDatabase
+from tests.constants import TestKind
+from tests.helpers.schema import DEVICE_SCHEMA, LOCATION_SCHEMA, load_schema
+from tests.helpers.test_app import TestInfrahubApp
+
+PROPOSED_CHANGE_CREATE = """
+mutation ProposedChange(
+  $name: String!,
+  $source_branch: String!,
+  $destination_branch: String!,
+	) {
+  CoreProposedChangeCreate(
+    data: {
+      name: {value: $name},
+      source_branch: {value: $source_branch},
+      destination_branch: {value: $destination_branch}
+    }
+  ) {
+    object {
+      id
+    }
+  }
+}
+"""
+
+PROPOSED_CHANGE_UPDATE = """
+mutation UpdateProposedChange(
+    $proposed_change_id: String!,
+    $state: String
+  ) {
+  CoreProposedChangeUpdate(data:
+    {
+      id: $proposed_change_id,
+      state: {value: $state}
+    }
+  ) {
+    ok
+  }
+}
+"""
+
+DIFF_TREE_QUERY = """
+query GetDiffTree($branch: String){
+    DiffTree (branch: $branch, filters: {status: {excludes: UNCHANGED}}) {
+        base_branch
+        diff_branch
+        from_time
+        to_time
+        num_added
+        num_removed
+        num_updated
+        num_conflicts
+        num_untracked_base_changes
+        num_untracked_diff_changes
+        nodes {
+            uuid
+            kind
+            label
+            last_changed_at
+            status
+            parent {
+              uuid
+              kind
+              relationship_name
+            }
+            contains_conflict
+            num_added
+            num_removed
+            num_updated
+            num_conflicts
+            attributes {
+                name
+                last_changed_at
+                status
+                num_added
+                num_removed
+                num_updated
+                num_conflicts
+                contains_conflict
+                conflict {
+                    uuid
+                    base_branch_action
+                    base_branch_value
+                    base_branch_changed_at
+                    base_branch_label
+                    diff_branch_action
+                    diff_branch_value
+                    diff_branch_changed_at
+                    diff_branch_label
+                    selected_branch
+                }
+                properties {
+                    property_type
+                    last_changed_at
+                    previous_value
+                    new_value
+                    previous_label
+                    new_label
+                    status
+                    conflict {
+                        uuid
+                        base_branch_action
+                        base_branch_value
+                        base_branch_changed_at
+                        base_branch_label
+                        diff_branch_action
+                        diff_branch_value
+                        diff_branch_changed_at
+                        diff_branch_label
+                        selected_branch
+                    }
+                }
+            }
+            relationships {
+                name
+                last_changed_at
+                status
+                cardinality
+                contains_conflict
+                elements {
+                    status
+                    peer_id
+                    last_changed_at
+                    contains_conflict
+                    conflict {
+                        uuid
+                        base_branch_action
+                        base_branch_changed_at
+                        base_branch_value
+                        base_branch_label
+                        diff_branch_action
+                        diff_branch_value
+                        diff_branch_changed_at
+                        diff_branch_label
+                        selected_branch
+                    }
+                    properties {
+                        property_type
+                        last_changed_at
+                        previous_value
+                        new_value
+                        previous_label
+                        new_label
+                        status
+                        conflict {
+                            uuid
+                            base_branch_action
+                            base_branch_value
+                            base_branch_changed_at
+                            base_branch_label
+                            diff_branch_action
+                            diff_branch_value
+                            diff_branch_changed_at
+                            diff_branch_label
+                            selected_branch
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+
+
+class TestProposedChangeOnEmptyMain(TestInfrahubApp):
+    @pytest.fixture(scope="class")
+    async def branch(self, db: InfrahubDatabase) -> Branch:
+        return await create_branch(db=db, branch_name="branch")
+
+    @pytest.fixture(scope="class")
+    async def branch_schema(self, db: InfrahubDatabase, branch: Branch) -> None:
+        combined_schema = DEVICE_SCHEMA.model_copy(deep=True)
+        combined_schema.nodes.extend(LOCATION_SCHEMA.nodes)
+        combined_schema.generics.extend(LOCATION_SCHEMA.generics)
+        await load_schema(db=db, schema=combined_schema, branch_name=branch.name, update_db=True)
+
+    @pytest.fixture(scope="class")
+    async def branch_data(self, db: InfrahubDatabase, branch: Branch, branch_schema: None) -> dict[str, Node]:
+        node_map: dict[str, Node] = {}
+
+        # load data using template
+        device_template: Node = await Node.init(schema=f"Template{TestKind.DEVICE}", db=db, branch=branch)
+        await device_template.new(
+            db=db, template_name="MX204 Router", manufacturer="Juniper", height=1, weight=6, airflow="Front to rear"
+        )
+        await device_template.save(db=db)
+        node_map["device_template"] = device_template
+
+        device: Node = await Node.init(db=db, schema=TestKind.DEVICE, branch=branch)
+        await device.new(db=db, name="device-01", object_template={"id": device_template.id})
+        await device.save(db=db)
+        node_map["device"] = device
+
+        # load data using profile
+        interface = await Node.init(db=db, branch=branch, schema=TestKind.PHYSICAL_INTERFACE)
+        await interface.new(db=db, name="interface1", device=device, phys_type="SFP (1GE)")
+        await interface.save(db=db)
+        node_map["interface"] = interface
+        sfp_profile = await Node.init(db=db, branch=branch, schema=f"Profile{TestKind.SFP}")
+        await sfp_profile.new(db=db, profile_name="sfp_part_number", part_number="12345")
+        await sfp_profile.save(db=db)
+        node_map["sfp_profile"] = sfp_profile
+        sfp = await Node.init(db=db, branch=branch, schema=TestKind.SFP)
+        await sfp.new(
+            db=db,
+            name="sfp1",
+            interface=interface,
+            phys_type="SFP (1GE)",
+            serial_number="54321",
+            profiles=[sfp_profile],
+        )
+        await sfp.save(db=db)
+        node_map["sfp"] = sfp
+
+        # load hierarchical data
+        continent_map = {"antartica": ["mcmurdough", "south_pole"], "pacific": ["midway", "bikini"]}
+        for continent, countries in continent_map.items():
+            continent_node = await Node.init(db=db, branch=branch, schema="TestingContinent")
+            await continent_node.new(db=db, name=continent, shortname=continent[:3].upper())
+            await continent_node.save(db=db)
+            node_map[continent] = continent_node
+
+            for country in countries:
+                country_node = await Node.init(db=db, branch=branch, schema="TestingCountry")
+                await country_node.new(db=db, name=country, shortname=country[:3].upper(), parent=continent)
+                await country_node.save(db=db)
+                node_map[f"{continent}-{country}"] = country_node
+
+                site_name = f"{continent}-{country}-r1"
+                site_node = await Node.init(db=db, branch=branch, schema="TestingSite")
+                await site_node.new(
+                    db=db, name=site_name, shortname=f"{continent[:2]}-{country[:2]}-r1", parent=country
+                )
+                await site_node.save(db=db)
+                node_map[site_name] = site_node
+
+        return node_map
+
+    @pytest.fixture(scope="class")
+    async def proposed_change_id(
+        self,
+        db: InfrahubDatabase,
+        client: InfrahubClient,
+        default_branch: Branch,
+        branch: Branch,
+        branch_data: dict[str, Node],
+    ) -> str:
+        result = await client.execute_graphql(
+            query=PROPOSED_CHANGE_CREATE,
+            variables={
+                "name": "pc1",
+                "source_branch": branch.name,
+                "destination_branch": default_branch.name,
+            },
+        )
+        proposed_change_id = result["CoreProposedChangeCreate"]["object"]["id"]
+        return proposed_change_id
+
+    def _get_diff_node_attribute_values(self, diff_node: dict[str, Any]) -> dict[str, Any]:
+        diff_attribute_values_by_name = {}
+        for diff_attribute in diff_node["attributes"]:
+            name = diff_attribute["name"]
+            for diff_property in diff_attribute["properties"]:
+                if diff_property["property_type"] == "HAS_VALUE":
+                    diff_attribute_values_by_name[name] = diff_property["new_value"]
+        return diff_attribute_values_by_name
+
+    async def test_retrieve_diff(
+        self, client: InfrahubClient, default_branch: Branch, branch: Branch, branch_data: dict[str, Node], proposed_change_id: str
+    ):
+        result = await client.execute_graphql(
+            query=DIFF_TREE_QUERY,
+            variables={"branch": branch.name},
+        )
+
+        assert result["DiffTree"]
+        diff_nodes_by_uuid = {n["uuid"]: n for n in result["DiffTree"]["nodes"]}
+        branch_data_uuids = {n.id: n for n in branch_data.values()}
+        assert set(branch_data_uuids.keys()) <= set(diff_nodes_by_uuid.keys())
+
+        # verify device created with template
+        device_uuid = branch_data["device"].id
+        device_attr_values = self._get_diff_node_attribute_values(diff_nodes_by_uuid[device_uuid])
+        assert device_attr_values == {
+            "name": "device-01",
+            "manufacturer": "Juniper",
+            "height": "1",
+            "weight": "6",
+            "part_number": "NULL",
+            "airflow": "Front to rear",
+        }
+
+        # verify sfp created with profile
+        sfp_uuid = branch_data["sfp"].id
+        sfp_attr_values = self._get_diff_node_attribute_values(diff_nodes_by_uuid[sfp_uuid])
+        assert sfp_attr_values == {
+            "phys_type": "SFP (1GE)",
+            "serial_number": "54321",
+            # no part number here because it only exists in the profile at the database level
+            "part_number": "NULL",
+        }
+
+        # verify hierarchy data
+        continent_map = {
+            "antartica": ["antartica-mcmurdough", "antartica-south_pole"],
+            "pacific": ["pacific-midway", "pacific-bikini"],
+        }
+        for continent_name, country_names in continent_map.items():
+            continent_uuid = branch_data[continent_name].id
+            continent_node = diff_nodes_by_uuid[continent_uuid]
+            assert continent_node["parent"] is None
+
+            for country_name in country_names:
+                country_uuid = branch_data[country_name].id
+                country_node = diff_nodes_by_uuid[country_uuid]
+                assert country_node["parent"] == {
+                    "uuid": continent_uuid,
+                    "kind": TestKind.CONTINENT,
+                    "relationship_name": "children",
+                }
+
+                site_name = f"{country_name}-r1"
+                site_uuid = branch_data[site_name].id
+                site_node = diff_nodes_by_uuid[site_uuid]
+                assert site_node["parent"] == {
+                    "uuid": country_uuid,
+                    "kind": TestKind.COUNTRY,
+                    "relationship_name": "children",
+                }
+
+    async def test_merge_proposed_change(self, client: InfrahubClient, default_branch: Branch, branch: Branch, branch_data: dict[str, Node], proposed_change_id: str):
+        result = await client.execute_graphql(
+            query=PROPOSED_CHANGE_UPDATE,
+            variables={
+                "proposed_change_id": proposed_change_id,
+                "state": ProposedChangeState.MERGED.value,
+            },
+        )
+        assert result["CoreProposedChangeUpdate"]["ok"]
+
+
+# TODO: verify schema/data on main

--- a/backend/tests/integration/schema_lifecycle/test_empty_main_merge.py
+++ b/backend/tests/integration/schema_lifecycle/test_empty_main_merge.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-from infrahub.proposed_change.constants import ProposedChangeState
 import pytest
 from infrahub_sdk.client import InfrahubClient
 
@@ -8,6 +7,7 @@ from infrahub.core.branch.models import Branch
 from infrahub.core.initialization import create_branch
 from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
+from infrahub.proposed_change.constants import ProposedChangeState
 from tests.constants import TestKind
 from tests.helpers.schema import DEVICE_SCHEMA, LOCATION_SCHEMA, load_schema
 from tests.helpers.test_app import TestInfrahubApp
@@ -276,7 +276,12 @@ class TestProposedChangeOnEmptyMain(TestInfrahubApp):
         return diff_attribute_values_by_name
 
     async def test_retrieve_diff(
-        self, client: InfrahubClient, default_branch: Branch, branch: Branch, branch_data: dict[str, Node], proposed_change_id: str
+        self,
+        client: InfrahubClient,
+        default_branch: Branch,
+        branch: Branch,
+        branch_data: dict[str, Node],
+        proposed_change_id: str,
     ):
         result = await client.execute_graphql(
             query=DIFF_TREE_QUERY,
@@ -338,7 +343,14 @@ class TestProposedChangeOnEmptyMain(TestInfrahubApp):
                     "relationship_name": "children",
                 }
 
-    async def test_merge_proposed_change(self, client: InfrahubClient, default_branch: Branch, branch: Branch, branch_data: dict[str, Node], proposed_change_id: str):
+    async def test_merge_proposed_change(
+        self,
+        client: InfrahubClient,
+        default_branch: Branch,
+        branch: Branch,
+        branch_data: dict[str, Node],
+        proposed_change_id: str,
+    ):
         result = await client.execute_graphql(
             query=PROPOSED_CHANGE_UPDATE,
             variables={

--- a/backend/tests/integration/schema_lifecycle/test_empty_main_merge.py
+++ b/backend/tests/integration/schema_lifecycle/test_empty_main_merge.py
@@ -1,10 +1,13 @@
+from enum import Enum
 from typing import Any
 
 import pytest
 from infrahub_sdk.client import InfrahubClient
 
+from infrahub.core import registry
 from infrahub.core.branch.models import Branch
 from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
 from infrahub.proposed_change.constants import ProposedChangeState
@@ -213,7 +216,6 @@ class TestProposedChangeOnEmptyMain(TestInfrahubApp):
         sfp = await Node.init(db=db, branch=branch, schema=TestKind.SFP)
         await sfp.new(
             db=db,
-            name="sfp1",
             interface=interface,
             phys_type="SFP (1GE)",
             serial_number="54321",
@@ -345,12 +347,14 @@ class TestProposedChangeOnEmptyMain(TestInfrahubApp):
 
     async def test_merge_proposed_change(
         self,
+        db: InfrahubDatabase,
         client: InfrahubClient,
         default_branch: Branch,
         branch: Branch,
         branch_data: dict[str, Node],
         proposed_change_id: str,
     ):
+        # merge proposed change
         result = await client.execute_graphql(
             query=PROPOSED_CHANGE_UPDATE,
             variables={
@@ -360,5 +364,38 @@ class TestProposedChangeOnEmptyMain(TestInfrahubApp):
         )
         assert result["CoreProposedChangeUpdate"]["ok"]
 
+        # verify schema hashes match
+        branch_schema_branch = await registry.schema.load_schema_from_db(db=db, branch=branch)
+        branch_schema_hash = branch_schema_branch.get_hash()
+        default_schema_branch = await registry.schema.load_schema_from_db(db=db, branch=default_branch)
+        default_schema_hash = default_schema_branch.get_hash()
+        assert branch_schema_hash == default_schema_hash
 
-# TODO: verify schema/data on main
+        # verify data on main
+        node_uuids = [n.id for n in branch_data.values()]
+        branch_node_map = await NodeManager.get_many(db=db, branch=branch, ids=node_uuids, prefetch_relationships=True)
+        assert len(branch_node_map) == len(node_uuids)
+        main_node_map = await NodeManager.get_many(
+            db=db, branch=default_branch, ids=node_uuids, prefetch_relationships=True
+        )
+        assert len(main_node_map) == len(node_uuids)
+
+        for node_uuid, branch_node in branch_node_map.items():
+            main_node = main_node_map[node_uuid]
+            for attr_name in branch_node.get_schema().attribute_names:
+                branch_attr_value = getattr(branch_node, attr_name).value
+                if isinstance(branch_attr_value, Enum):
+                    branch_attr_value = branch_attr_value.value
+                main_attr_value = getattr(main_node, attr_name).value
+                if isinstance(main_attr_value, Enum):
+                    main_attr_value = main_attr_value.value
+                assert branch_attr_value == main_attr_value
+
+            for rel_name in branch_node.get_schema().relationship_names:
+                branch_rel_manager = getattr(branch_node, rel_name)
+                main_rel_manager = getattr(main_node, rel_name)
+                branch_rels = await branch_rel_manager.get_relationships(db=db)
+                main_rels = await main_rel_manager.get_relationships(db=db)
+                branch_peer_ids = {rel.peer_id for rel in branch_rels}
+                main_peer_ids = {rel.peer_id for rel in main_rels}
+                assert branch_peer_ids == main_peer_ids

--- a/backend/tests/integration/schema_lifecycle/test_empty_main_merge.py
+++ b/backend/tests/integration/schema_lifecycle/test_empty_main_merge.py
@@ -311,12 +311,19 @@ class TestProposedChangeOnEmptyMain(TestInfrahubApp):
 
         # verify sfp created with profile
         sfp_uuid = branch_data["sfp"].id
-        sfp_attr_values = self._get_diff_node_attribute_values(diff_nodes_by_uuid[sfp_uuid])
+        sfp_diff_node = diff_nodes_by_uuid[sfp_uuid]
+        sfp_attr_values = self._get_diff_node_attribute_values(sfp_diff_node)
         assert sfp_attr_values == {
             "phys_type": "SFP (1GE)",
             "serial_number": "54321",
             # no part number here because it only exists in the profile at the database level
             "part_number": "NULL",
+        }
+        # verify parent relationship
+        assert sfp_diff_node["parent"] == {
+            "uuid": branch_data["interface"].id,
+            "kind": TestKind.PHYSICAL_INTERFACE,
+            "relationship_name": "sfp",
         }
 
         # verify hierarchy data

--- a/changelog/6484.fixed.md
+++ b/changelog/6484.fixed.md
@@ -1,0 +1,1 @@
+Fix bugs that would prevent generating a diff for and merging a branch with new schema and data into a fresh instance of Infrahub.


### PR DESCRIPTION
fixes #6484 

there were a few small bugs that would prevent retrieving a diff of and merging a branch with new schema and data on a fresh instance of Infrahub
- update `SchemaBranch.update` to include `Profile` and `Template` schemas, otherwise adding a new schema and new instance of a `Profile` or `Template` schema would fail
- update logic for retrieving a diff to use the correct branch when getting information about parents of nodes in the diff
- add a big old test to make sure this does not regress

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Expanded schema updates to include profiles and templates during diff/merge.
  - Improved diff tree to determine parent relationship names with branch-aware context.

- Bug Fixes
  - Fixed failures when generating diffs and merging a branch that introduces new schema and data into a fresh instance.

- Tests
  - Added end-to-end integration tests covering proposed changes, diff tree inspection, and merge verification.

- Refactor
  - Minor internal metrics and request-handling cleanup; removed an obsolete public helper for parent-relationship info.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->