### PR TITLE
Fix artifacts generation validation

### DIFF
--- a/backend/infrahub/generators/tasks.py
+++ b/backend/infrahub/generators/tasks.py
@@ -168,6 +168,15 @@ async def request_generator_definition_run(
 
     client = get_client()
 
+    # Needs to be fetched before fetching group members otherwise `object` relationship would override
+    # existing node in client store without the `name` attribute due to #521
+    existing_instances = await client.filters(
+        kind=InfrahubKind.GENERATORINSTANCE,
+        definition__ids=[model.generator_definition.definition_id],
+        include=["object"],
+        branch=model.branch,
+    )
+
     group = await client.get(
         kind=InfrahubKind.GENERICGROUP,
         prefetch_relationships=True,
@@ -177,12 +186,6 @@ async def request_generator_definition_run(
     )
     await group.members.fetch()
 
-    existing_instances = await client.filters(
-        kind=InfrahubKind.GENERATORINSTANCE,
-        definition__ids=[model.generator_definition.definition_id],
-        include=["object"],
-        branch=model.branch,
-    )
     instance_by_member = {}
     for instance in existing_instances:
         instance_by_member[instance.object.peer.id] = instance.id

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -310,6 +310,15 @@ async def generate_request_artifact_definition(
 
     client = get_client()
 
+    # Needs to be fetched before fetching group members otherwise `object` relationship would override
+    # existing node in client store without the `name` attribute due to #521
+    existing_artifacts = await client.filters(
+        kind=CoreArtifact,
+        definition__ids=[model.artifact_definition_id],
+        include=["object"],
+        branch=model.branch,
+    )
+
     artifact_definition = await client.get(
         kind=CoreArtifactDefinition, id=model.artifact_definition_id, branch=model.branch
     )
@@ -319,12 +328,6 @@ async def generate_request_artifact_definition(
     await group.members.fetch()
     current_members = [member.id for member in group.members.peers]
 
-    existing_artifacts = await client.filters(
-        kind=CoreArtifact,
-        definition__ids=[model.artifact_definition_id],
-        include=["object"],
-        branch=model.branch,
-    )
     artifacts_by_member = {}
     for artifact in existing_artifacts:
         if artifact.object.id in current_members:

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -646,16 +646,19 @@ async def validate_artifacts_generation(model: RequestArtifactDefinitionCheck, c
         context=context,
     )
 
-    await artifact_definition.targets.fetch()
-    group = artifact_definition.targets.peer
-    await group.members.fetch()
-
+    # Needs to be fetched before fetching group members otherwise `object` relationship would override
+    # existing node in client store without the `name` attribute due to #521
     existing_artifacts = await client.filters(
         kind=InfrahubKind.ARTIFACT,
         definition__ids=[model.artifact_definition.definition_id],
         include=["object"],
         branch=model.source_branch,
     )
+
+    await artifact_definition.targets.fetch()
+    group = artifact_definition.targets.peer
+    await group.members.fetch()
+
     artifacts_by_member = {}
     for artifact in existing_artifacts:
         artifacts_by_member[artifact.object.peer.id] = artifact.id
@@ -907,6 +910,15 @@ async def request_generator_definition_check(model: RequestGeneratorDefinitionCh
         context=context,
     )
 
+    # Needs to be fetched before fetching group members otherwise `object` relationship would override
+    # existing node in client store without the `name` attribute due to #521
+    existing_instances = await client.filters(
+        kind=InfrahubKind.GENERATORINSTANCE,
+        definition__ids=[model.generator_definition.definition_id],
+        include=["object"],
+        branch=model.source_branch,
+    )
+
     group = await client.get(
         kind=InfrahubKind.GENERICGROUP,
         prefetch_relationships=True,
@@ -916,12 +928,6 @@ async def request_generator_definition_check(model: RequestGeneratorDefinitionCh
     )
     await group.members.fetch()
 
-    existing_instances = await client.filters(
-        kind=InfrahubKind.GENERATORINSTANCE,
-        definition__ids=[model.generator_definition.definition_id],
-        include=["object"],
-        branch=model.source_branch,
-    )
     instance_by_member = {}
     for instance in existing_instances:
         instance_by_member[instance.object.peer.id] = instance.id


### PR DESCRIPTION
Fixes https://github.com/opsmill/infrahub/issues/6976

Issue is that `artifact.object` was not fetched as `include` does not work, so if the node was not in store, it wouldn't work. This PR relies on fixing sdk `include` here: https://github.com/opsmill/infrahub-sdk-python/pull/513

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed intermittent UI/data inconsistencies by changing data-loading order for generators, artifacts, and validations to preserve object relationships.

* **Performance**
  * Eliminated redundant data fetches during generator and artifact processing to reduce network calls and improve responsiveness.

* **Refactor**
  * Reordered internal fetch logic for generators, artifacts, and validation flows without altering public APIs or behavior.

* **Chores**
  * Updated Python SDK submodule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->