### PR TITLE
Update relationships of cardinality many in bulk edit IFC-1744

### DIFF
--- a/frontend/app/src/entities/nodes/object/api/update-object-from-api.ts
+++ b/frontend/app/src/entities/nodes/object/api/update-object-from-api.ts
@@ -1,5 +1,10 @@
+import { getRelationshipMutation } from "@/entities/nodes/object/utils/get-relationship-mutations";
 import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
 import { BranchContextParams } from "@/shared/api/types";
+import {
+  RELATIONSHIP_BULK_ADD_PREFIX,
+  RELATIONSHIP_BULK_REMOVE_PREFIX,
+} from "@/shared/components/form/constants";
 import { gql } from "@apollo/client";
 import { jsonToGraphQLQuery } from "json-to-graphql-query";
 
@@ -15,24 +20,84 @@ export function updateObjectFromApi({
   profileIds = [],
   branchName,
 }: UpdateObjectFromApiParams) {
-  const mutation = jsonToGraphQLQuery({
-    mutation: {
-      [`${objectKind}Update`]: {
-        __args: {
-          data: {
-            ...data,
-            ...(profileIds?.length
-              ? { profiles: profileIds.map((profileId) => ({ id: profileId })) }
-              : {}),
-          },
-        },
-        object: {
-          id: true,
-          display_label: true,
-          hfid: true,
-          __typename: true,
+  const objectData = Object.entries(data).reduce((acc, [key, value]) => {
+    if (
+      key.startsWith(RELATIONSHIP_BULK_ADD_PREFIX) ||
+      key.startsWith(RELATIONSHIP_BULK_REMOVE_PREFIX)
+    ) {
+      return acc;
+    }
+
+    return {
+      ...acc,
+      [key]: value,
+    };
+  }, {});
+
+  const relationshipAddData = Object.entries(data).reduce((acc, [key, value]) => {
+    if (key.startsWith(RELATIONSHIP_BULK_ADD_PREFIX)) {
+      return {
+        ...acc,
+        [key.replace(RELATIONSHIP_BULK_ADD_PREFIX, "")]: value,
+      };
+    }
+
+    return acc;
+  }, {});
+
+  const relationshipRemoveData = Object.entries(data).reduce((acc, [key, value]) => {
+    if (key.startsWith(RELATIONSHIP_BULK_REMOVE_PREFIX)) {
+      return {
+        ...acc,
+        [key.replace(RELATIONSHIP_BULK_REMOVE_PREFIX, "")]: value,
+      };
+    }
+
+    return acc;
+  }, {});
+
+  const objectMutation = {
+    [`${objectKind}Update`]: {
+      __args: {
+        data: {
+          ...objectData,
+          ...(profileIds?.length
+            ? { profiles: profileIds.map((profileId) => ({ id: profileId })) }
+            : {}),
         },
       },
+      object: {
+        id: true,
+        display_label: true,
+        hfid: true,
+        __typename: true,
+      },
+    },
+  };
+
+  const relationshipAddMutation =
+    objectData?.id && Object.entries(relationshipAddData)?.length
+      ? getRelationshipMutation({
+          id: objectData.id,
+          data: relationshipAddData,
+          mutation: "RelationshipAdd",
+        })
+      : {};
+
+  const relationshipRemoveMutation =
+    objectData?.id && Object.entries(relationshipRemoveData)?.length
+      ? getRelationshipMutation({
+          id: objectData.id,
+          data: relationshipRemoveData,
+          mutation: "RelationshipAdd",
+        })
+      : {};
+
+  const mutation = jsonToGraphQLQuery({
+    mutation: {
+      ...objectMutation,
+      ...relationshipAddMutation,
+      ...relationshipRemoveMutation,
     },
   });
 

--- a/frontend/app/src/entities/nodes/object/api/update-object-from-api.ts
+++ b/frontend/app/src/entities/nodes/object/api/update-object-from-api.ts
@@ -89,7 +89,7 @@ export function updateObjectFromApi({
       ? getRelationshipMutation({
           id: objectData.id,
           data: relationshipRemoveData,
-          mutation: "RelationshipAdd",
+          mutation: "RelationshipRemove",
         })
       : {};
 

--- a/frontend/app/src/entities/nodes/object/utils/get-relationship-mutations.ts
+++ b/frontend/app/src/entities/nodes/object/utils/get-relationship-mutations.ts
@@ -1,0 +1,24 @@
+interface GetRelationshipMutationParams {
+  id: string;
+  data: Record<string, Array<{ id: string }>>;
+  mutation: string;
+}
+
+export const getRelationshipMutation = ({ id, data, mutation }: GetRelationshipMutationParams) => {
+  return Object.entries(data).reduce((acc, [fieldName, fieldValue]) => {
+    return {
+      ...acc,
+      [`ADD_${fieldName}_RELATIONSHIP`]: {
+        __aliasFor: mutation,
+        __args: {
+          data: {
+            id,
+            name: fieldName,
+            nodes: fieldValue,
+          },
+        },
+        ok: true,
+      },
+    };
+  }, {});
+};

--- a/frontend/app/src/entities/nodes/object/utils/get-relationship-mutations.ts
+++ b/frontend/app/src/entities/nodes/object/utils/get-relationship-mutations.ts
@@ -8,7 +8,7 @@ export const getRelationshipMutation = ({ id, data, mutation }: GetRelationshipM
   return Object.entries(data).reduce((acc, [fieldName, fieldValue]) => {
     return {
       ...acc,
-      [`ADD_${fieldName}_RELATIONSHIP`]: {
+      [`${mutation}_${fieldName}`]: {
         __aliasFor: mutation,
         __args: {
           data: {

--- a/frontend/app/src/shared/components/form/constants.ts
+++ b/frontend/app/src/shared/components/form/constants.ts
@@ -4,3 +4,6 @@ export const DEFAULT_FORM_FIELD_VALUE: EmptyFieldValue = {
   source: null,
   value: null,
 };
+
+export const RELATIONSHIP_BULK_ADD_PREFIX = "__add_";
+export const RELATIONSHIP_BULK_REMOVE_PREFIX = "__remove_";

--- a/frontend/app/src/shared/components/form/dynamic-form.tsx
+++ b/frontend/app/src/shared/components/form/dynamic-form.tsx
@@ -41,7 +41,7 @@ const DynamicForm = forwardRef<FormRef, DynamicFormProps>(
     return (
       <Form ref={ref} {...props} defaultValues={formDefaultValues}>
         {fields.map((field) => (
-          <DynamicInput key={field.name} {...field} />
+          <DynamicInput key={`${field.type}_${field.name}`} {...field} />
         ))}
 
         <div className="text-right">
@@ -119,6 +119,8 @@ export const DynamicInput = (props: DynamicFieldProps) => {
       const { type, ...otherProps } = props;
       return <SelectField {...otherProps} />;
     }
+    case "relationship-add":
+    case "relationship-remove":
     case "relationship": {
       const { schema: peerSchema } = getSchema(props.relationship.peer);
 

--- a/frontend/app/src/shared/components/form/type.ts
+++ b/frontend/app/src/shared/components/form/type.ts
@@ -176,8 +176,10 @@ export type DynamicAttributeFieldProps =
   | DynamicSelectFieldProps
   | DynamicKindFieldProps;
 
+export type RelationshipFieldType = "relationship" | "relationship-add" | "relationship-remove";
+
 export type DynamicRelationshipFieldProps = Omit<FormFieldProps, "defaultValue"> & {
-  type: "relationship";
+  type: RelationshipFieldType;
   defaultValue?: FormRelationshipValue;
   peer?: string;
   parent?: string;

--- a/frontend/app/src/shared/components/form/utils/getFormFieldFromRelationship.ts
+++ b/frontend/app/src/shared/components/form/utils/getFormFieldFromRelationship.ts
@@ -6,16 +6,38 @@ import { validateRelationshipMany } from "@/entities/schema/utils/validation/val
 import type {
   DynamicRelationshipFieldProps,
   FormRelationshipValue,
+  RelationshipFieldType,
 } from "@/shared/components/form/type";
 import { getRelationshipDefaultValue } from "@/shared/components/form/utils/getRelationshipDefaultValue";
 import { getRelationshipParent } from "@/shared/components/form/utils/getRelationshipParent";
 import { isFieldDisabled } from "@/shared/components/form/utils/isFieldDisabled";
 import { isRequired } from "@/shared/components/form/utils/validation";
 
+interface GetFieldLabelParams {
+  type?: RelationshipFieldType;
+  relationshipSchema: RelationshipSchema;
+}
+
+const getFieldLabel = ({ type, relationshipSchema }: GetFieldLabelParams) => {
+  const label = relationshipSchema.label ?? relationshipSchema.name;
+
+  if (type === "relationship-add") {
+    return `Add ${label}`;
+  }
+
+  if (type === "relationship-remove") {
+    return `Remove ${label}`;
+  }
+
+  return label;
+};
+
 interface GetFormFieldFromRelationshipParams {
+  type?: RelationshipFieldType;
+  name?: string;
   auth?: AuthContextType;
   isFilterForm: boolean;
-  isBulkUpdate: boolean;
+  isBulkUpdate?: boolean;
   relationshipSchema: RelationshipSchema;
   relationshipData?: RelationshipType;
   objectTemplate?: NodeObject | null;
@@ -25,6 +47,8 @@ interface GetFormFieldFromRelationshipParams {
 }
 
 export const getFormFieldFromRelationship = ({
+  type,
+  name,
   relationshipSchema,
   relationshipData,
   objectTemplate,
@@ -35,13 +59,15 @@ export const getFormFieldFromRelationship = ({
   parentData,
   auth,
 }: GetFormFieldFromRelationshipParams): DynamicRelationshipFieldProps => {
-  const label = relationshipSchema.label ?? relationshipSchema.name;
+  const label = getFieldLabel({ type, relationshipSchema });
+
   const relationshipTemplate = objectTemplate?.[relationshipSchema.name] as
     | NodeRelationship
     | undefined;
+
   return {
-    type: "relationship",
-    name: relationshipSchema.name,
+    type: type ?? "relationship",
+    name: name ?? relationshipSchema.name,
     label,
     defaultValue: getRelationshipDefaultValue({
       relationshipData,

--- a/frontend/app/src/shared/components/form/utils/getFormFieldsFromSchema.test.ts
+++ b/frontend/app/src/shared/components/form/utils/getFormFieldsFromSchema.test.ts
@@ -734,4 +734,21 @@ describe("getFormFieldsFromSchema", () => {
     expect(fields[0]?.rules?.required).to.equal(false);
     expect(fields[1]?.rules?.required).to.equal(false);
   });
+
+  it("should display add and remvoe fields for relationship of cardinality many in bulk edit", () => {
+    const schema = {
+      relationships: [
+        generateRelationshipSchema({ name: "cardinality_many", cardinality: "many" }),
+        generateRelationshipSchema({ name: "cardinality_one", cardinality: "one" }),
+      ],
+    } as ModelSchema;
+
+    // WHEN
+    const fields = getFormFieldsFromSchema({ schema, isBulkUpdate: true });
+
+    // THEN
+    expect(fields[0]?.name).to.equal("__add_cardinality_many");
+    expect(fields[1]?.name).to.equal("__remove_cardinality_many");
+    expect(fields[2]?.name).to.equal("cardinality_one");
+  });
 });

--- a/frontend/app/src/shared/components/form/utils/getFormFieldsFromSchema.test.ts
+++ b/frontend/app/src/shared/components/form/utils/getFormFieldsFromSchema.test.ts
@@ -9,6 +9,7 @@ import {
   generateAttributeSchema,
   generateRelationshipSchema,
 } from "../../../../../tests/fake/schema";
+import { RELATIONSHIP_BULK_ADD_PREFIX, RELATIONSHIP_BULK_REMOVE_PREFIX } from "../constants";
 
 describe("getFormFieldsFromSchema", () => {
   it("returns no fields if schema has no attributes nor relationships", () => {
@@ -738,8 +739,16 @@ describe("getFormFieldsFromSchema", () => {
   it("should display add and remvoe fields for relationship of cardinality many in bulk edit", () => {
     const schema = {
       relationships: [
-        generateRelationshipSchema({ name: "cardinality_many", cardinality: "many" }),
-        generateRelationshipSchema({ name: "cardinality_one", cardinality: "one" }),
+        generateRelationshipSchema({
+          name: "cardinality_many",
+          cardinality: "many",
+          order_weight: 1,
+        }),
+        generateRelationshipSchema({
+          name: "cardinality_one",
+          cardinality: "one",
+          order_weight: 2,
+        }),
       ],
     } as ModelSchema;
 
@@ -747,8 +756,10 @@ describe("getFormFieldsFromSchema", () => {
     const fields = getFormFieldsFromSchema({ schema, isBulkUpdate: true });
 
     // THEN
-    expect(fields[0]?.name).to.equal("__add_cardinality_many");
-    expect(fields[1]?.name).to.equal("__remove_cardinality_many");
+    expect(fields[0]?.name).to.equal(`${RELATIONSHIP_BULK_ADD_PREFIX}cardinality_many`);
+    expect(fields[0]?.type).to.equal("relationship-add");
+    expect(fields[1]?.name).to.equal(`${RELATIONSHIP_BULK_REMOVE_PREFIX}cardinality_many`);
+    expect(fields[1]?.type).to.equal("relationship-remove");
     expect(fields[2]?.name).to.equal("cardinality_one");
   });
 });

--- a/frontend/app/src/shared/components/form/utils/getFormFieldsFromSchema.ts
+++ b/frontend/app/src/shared/components/form/utils/getFormFieldsFromSchema.ts
@@ -88,6 +88,7 @@ export const getFormFieldsFromSchema = ({
           relationshipData: initialObject?.[field.name] as RelationshipType | undefined,
           objectTemplate,
           isFilterForm: !!isFilterForm,
+          isBulkUpdate: !!isBulkUpdate,
           schema,
           parentSchema,
           parentData,

--- a/frontend/app/src/shared/components/form/utils/getFormFieldsFromSchema.ts
+++ b/frontend/app/src/shared/components/form/utils/getFormFieldsFromSchema.ts
@@ -42,32 +42,69 @@ export const getFormFieldsFromSchema = ({
   ].filter((attribute) => !attribute.read_only);
   const orderedFields: typeof unorderedFields = sortByOrderWeight(unorderedFields);
 
-  return orderedFields.map((field) => {
+  return orderedFields.reduce((acc: Array<DynamicFieldProps>, field) => {
     if ("peer" in field) {
-      return getFormFieldFromRelationship({
+      if (isBulkUpdate) {
+        return [
+          ...acc,
+          getFormFieldFromRelationship({
+            type: "relationship-add",
+            name: `add_${field.name}`,
+            auth,
+            relationshipSchema: field,
+            relationshipData: initialObject?.[field.name] as RelationshipType | undefined,
+            objectTemplate,
+            isFilterForm: !!isFilterForm,
+            isBulkUpdate: !!isBulkUpdate,
+            schema,
+            parentSchema,
+            parentData,
+          }),
+          getFormFieldFromRelationship({
+            type: "relationship-remove",
+            name: `remove_${field.name}`,
+            auth,
+            relationshipSchema: field,
+            relationshipData: initialObject?.[field.name] as RelationshipType | undefined,
+            objectTemplate,
+            isFilterForm: !!isFilterForm,
+            isBulkUpdate: !!isBulkUpdate,
+            schema,
+            parentSchema,
+            parentData,
+          }),
+        ];
+      }
+
+      return [
+        ...acc,
+        getFormFieldFromRelationship({
+          auth,
+          relationshipSchema: field,
+          relationshipData: initialObject?.[field.name] as RelationshipType | undefined,
+          objectTemplate,
+          isFilterForm: !!isFilterForm,
+          schema,
+          parentSchema,
+          parentData,
+        }),
+      ];
+    }
+
+    return [
+      ...acc,
+      getFormFieldFromAttribute({
         auth,
-        relationshipSchema: field,
-        relationshipData: initialObject?.[field.name] as RelationshipType | undefined,
+        attributeSchema: field,
+        currentObject: initialObject as Record<string, AttributeType>,
         objectTemplate,
         isFilterForm: !!isFilterForm,
         isBulkUpdate: !!isBulkUpdate,
+        isUpdate: !!isUpdate,
         schema,
-        parentSchema,
-        parentData,
-      });
-    }
-
-    return getFormFieldFromAttribute({
-      auth,
-      attributeSchema: field,
-      currentObject: initialObject as Record<string, AttributeType>,
-      objectTemplate,
-      isFilterForm: !!isFilterForm,
-      isBulkUpdate: !!isBulkUpdate,
-      isUpdate: !!isUpdate,
-      schema,
-      pools,
-      profiles,
-    });
-  });
+        pools,
+        profiles,
+      }),
+    ];
+  }, []);
 };

--- a/frontend/app/src/shared/components/form/utils/getFormFieldsFromSchema.ts
+++ b/frontend/app/src/shared/components/form/utils/getFormFieldsFromSchema.ts
@@ -3,6 +3,10 @@ import { AttributeType, RelationshipType } from "@/entities/nodes/getObjectItemD
 import { NodeObject } from "@/entities/nodes/types";
 import { NumberPool } from "@/entities/resource-manager/domain/type";
 import { AttributeSchema, ModelSchema, RelationshipSchema } from "@/entities/schema/types";
+import {
+  RELATIONSHIP_BULK_ADD_PREFIX,
+  RELATIONSHIP_BULK_REMOVE_PREFIX,
+} from "@/shared/components/form/constants";
 import { ProfileData } from "@/shared/components/form/object-form";
 import { DynamicFieldProps } from "@/shared/components/form/type";
 import { FormContextType } from "@/shared/components/form/utils/form-context";
@@ -44,12 +48,12 @@ export const getFormFieldsFromSchema = ({
 
   return orderedFields.reduce((acc: Array<DynamicFieldProps>, field) => {
     if ("peer" in field) {
-      if (isBulkUpdate) {
+      if (isBulkUpdate && field.cardinality === "many") {
         return [
           ...acc,
           getFormFieldFromRelationship({
             type: "relationship-add",
-            name: `add_${field.name}`,
+            name: `${RELATIONSHIP_BULK_ADD_PREFIX}${field.name}`,
             auth,
             relationshipSchema: field,
             relationshipData: initialObject?.[field.name] as RelationshipType | undefined,
@@ -62,7 +66,7 @@ export const getFormFieldsFromSchema = ({
           }),
           getFormFieldFromRelationship({
             type: "relationship-remove",
-            name: `remove_${field.name}`,
+            name: `${RELATIONSHIP_BULK_REMOVE_PREFIX}${field.name}`,
             auth,
             relationshipSchema: field,
             relationshipData: initialObject?.[field.name] as RelationshipType | undefined,


### PR DESCRIPTION
* For relationships of cardinality many, 2 fields will be used in order to add or remove relationships independently the current objects values

<img width="1465" height="901" alt="Capture d’écran 2025-08-20 à 16 27 16" src="https://github.com/user-attachments/assets/1574deaa-b815-47e4-a721-5e4d562e6e34" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Bulk relationship editing: separate Add and Remove fields for many-valued relationships with clearer Add/Remove labels.
* Bug Fixes
  * Ensures unique input keys to avoid collisions for fields with identical names across types.
* Refactor
  * Save flow now sends object updates and relationship add/remove changes together while handling adds and removes distinctly.
* Tests
  * Added unit test validating bulk-edit add/remove field generation and ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->