### PR TITLE
Run build and register component registry in 'infrahub upgrade'

### DIFF
--- a/backend/infrahub/cli/upgrade.py
+++ b/backend/infrahub/cli/upgrade.py
@@ -14,6 +14,7 @@ from infrahub import config
 from infrahub.core.initialization import create_anonymous_role, create_default_account_groups, initialize_registry
 from infrahub.core.manager import NodeManager
 from infrahub.core.protocols import CoreAccount, CoreObjectPermission
+from infrahub.dependencies.registry import build_component_registry
 from infrahub.menu.menu import default_menu
 from infrahub.menu.models import MenuDict
 from infrahub.menu.repository import MenuRepository
@@ -53,6 +54,8 @@ async def upgrade_cmd(
     dbdriver = await context.init_db(retry=1)
 
     await initialize_registry(db=dbdriver)
+
+    build_component_registry()
 
     # NOTE add step to validate if the database and the task manager are reachable
 


### PR DESCRIPTION
Run and register the components within `infrahub upgrade` so that component required for schema migrations are available to the upgrade command as is done when we are starting the API server or the Prefect worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - The upgrade command now initializes the component registry before running, ensuring all components are discovered and ready. This improves reliability and consistency of upgrades across environments and reduces edge-case failures related to missing components. No changes to flags or output; behavior remains the same for typical users. No action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->