### PR TITLE
Split actions in two for review and state

### DIFF
--- a/frontend/app/src/entities/proposed-changes/ui/action-button/pc-action-button.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/action-button/pc-action-button.tsx
@@ -1,13 +1,11 @@
 import { useAuth } from "@/entities/authentication/ui/useAuth";
 import { useGetProposedChangeAvailableActions } from "@/entities/proposed-changes/domain/get-proposed-change-available-actions.query";
 import { proposedChangedState } from "@/entities/proposed-changes/stores/proposedChanges.atom";
-import { ActionComboboxList } from "@/entities/proposed-changes/ui/action-button/pc-actions-combobox-list";
-import { ApproveButton } from "@/entities/proposed-changes/ui/action-button/pc-approve-button";
+import { ActionComboboxList } from "@/entities/proposed-changes/ui/action-button/pc-action-combobox-list";
 import { CloseButton } from "@/entities/proposed-changes/ui/action-button/pc-close-button";
 import { DraftButton } from "@/entities/proposed-changes/ui/action-button/pc-draft-button";
 import { MergeButton } from "@/entities/proposed-changes/ui/action-button/pc-merge-button";
 import { PcPlaceholderButton } from "@/entities/proposed-changes/ui/action-button/pc-placeholder-button";
-import { RejectButton } from "@/entities/proposed-changes/ui/action-button/pc-reject-button";
 import { ProposedChangeActionButtonProps } from "@/entities/proposed-changes/ui/action-button/types";
 import { PcActionsContext } from "@/entities/proposed-changes/ui/pc-actions-permissions-context";
 import { LoadingIndicator } from "@/shared/components/loading/loading-indicator";
@@ -20,11 +18,9 @@ import { ReactElement, useState } from "react";
 
 type ActionButtonComponent = (props: ProposedChangeActionButtonProps) => ReactElement;
 
-type Action = "approve" | "reject" | "merge" | "close" | "draft";
+type Action = "merge" | "close" | "draft";
 
 const actionsListMapping: Record<Action, ActionButtonComponent> = {
-  approve: ({ setOpen }) => <ApproveButton setOpen={setOpen} />,
-  reject: ({ setOpen }) => <RejectButton setOpen={setOpen} />,
   merge: ({ setOpen }) => <MergeButton setOpen={setOpen} />,
   close: ({ setOpen }) => <CloseButton setOpen={setOpen} />,
   draft: ({ setOpen }) => <DraftButton setOpen={setOpen} />,
@@ -45,7 +41,7 @@ export const PcActionButton = () => {
     <PcActionsContext value={data}>
       <Combobox open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
-          <div className={classNames(inputStyle, "flex p-0 border-0 w-40")}>
+          <div className={classNames(inputStyle, "flex p-0 border-0")}>
             {isPending && <LoadingIndicator />}
             {!isPending && auth?.user?.id ? (
               actionsListMapping?.[action]?.({ setOpen })

--- a/frontend/app/src/entities/proposed-changes/ui/action-button/pc-action-combobox-list.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/action-button/pc-action-combobox-list.tsx
@@ -1,0 +1,78 @@
+import { proposedChangedState } from "@/entities/proposed-changes/stores/proposedChanges.atom";
+import { usePcActionsContext } from "@/entities/proposed-changes/ui/pc-actions-permissions-context";
+import { ComboboxItem, ComboboxList } from "@/shared/components/ui/combobox";
+import { Tooltip } from "@/shared/components/ui/tooltip";
+import { useAtomValue } from "jotai";
+import { forwardRef } from "react";
+
+type ActionItem = { value: string; name: string; isDisabled?: boolean; message: string | null };
+
+export interface ActionComboboxListProps {
+  onSelect: (value: string) => void;
+  value?: string | null;
+}
+
+export const ActionComboboxList = forwardRef<HTMLDivElement, ActionComboboxListProps>(
+  ({ value, onSelect }, ref) => {
+    const { setDraft, unsetDraft, close, merge } = usePcActionsContext();
+    const proposedChangesDetails = useAtomValue(proposedChangedState);
+
+    const actionsList: Record<string, ActionItem> = {
+      merge: {
+        value: "merge",
+        name: "Merge",
+        isDisabled: !merge.available,
+        message: merge.unavailability_reason,
+      },
+      close: {
+        value: "close",
+        name: "Close",
+        isDisabled: !close.available,
+        message: close.unavailability_reason,
+      },
+      draft: {
+        value: "draft",
+        name: proposedChangesDetails.is_draft?.value ? "Open" : "Move to draft",
+        isDisabled: proposedChangesDetails.is_draft?.value
+          ? !unsetDraft.available
+          : !setDraft.available,
+        message: proposedChangesDetails.is_draft?.value
+          ? unsetDraft.unavailability_reason
+          : setDraft.unavailability_reason,
+      },
+    };
+
+    return (
+      <ComboboxList ref={ref}>
+        {Object.entries(actionsList).map(([, action]) => {
+          if (action.isDisabled) {
+            return (
+              <Tooltip
+                enabled
+                content={action.message}
+                className="whitespace-pre"
+                key={action.value}
+              >
+                <span className="flex items-center gap-2 cursor-default select-none rounded-md px-2 py-1.5 ml-5 text-sm outline-hidden truncate opacity-50">
+                  {action.name}
+                </span>
+              </Tooltip>
+            );
+          }
+
+          return (
+            <ComboboxItem
+              key={action.value}
+              value={action.value}
+              selectedValue={value}
+              onSelect={() => onSelect(action.value)}
+              className="cursor-pointer"
+            >
+              <span className="truncate">{action.name}</span>
+            </ComboboxItem>
+          );
+        })}
+      </ComboboxList>
+    );
+  }
+);

--- a/frontend/app/src/entities/proposed-changes/ui/action-button/pc-draft-button.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/action-button/pc-draft-button.tsx
@@ -69,7 +69,7 @@ export const DraftButton = ({ setOpen }: ProposedChangeActionButtonProps) => {
         <Button
           className="grow flex flex-wrap gap-2 h-full rounded-r-none border-r-white"
           onClick={handleAction}
-          variant={"primary"}
+          variant={"outline"}
           isLoading={isPending}
           disabled={tooltipEnabled || isPending}
         >
@@ -79,7 +79,7 @@ export const DraftButton = ({ setOpen }: ProposedChangeActionButtonProps) => {
 
       <Button
         className="h-full rounded-l-none border-l-0"
-        variant={"primary"}
+        variant={"outline"}
         size={"sm"}
         onClick={() => {
           setOpen(true);

--- a/frontend/app/src/entities/proposed-changes/ui/action-button/pc-review-button.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/action-button/pc-review-button.tsx
@@ -1,0 +1,63 @@
+import { useAuth } from "@/entities/authentication/ui/useAuth";
+import { useGetProposedChangeAvailableActions } from "@/entities/proposed-changes/domain/get-proposed-change-available-actions.query";
+import { proposedChangedState } from "@/entities/proposed-changes/stores/proposedChanges.atom";
+import { ApproveButton } from "@/entities/proposed-changes/ui/action-button/pc-approve-button";
+import { PcPlaceholderButton } from "@/entities/proposed-changes/ui/action-button/pc-placeholder-button";
+import { RejectButton } from "@/entities/proposed-changes/ui/action-button/pc-reject-button";
+import { ReviewComboboxList } from "@/entities/proposed-changes/ui/action-button/pc-review-combobox-list";
+import { ProposedChangeActionButtonProps } from "@/entities/proposed-changes/ui/action-button/types";
+import { PcActionsContext } from "@/entities/proposed-changes/ui/pc-actions-permissions-context";
+import { LoadingIndicator } from "@/shared/components/loading/loading-indicator";
+import { Combobox, ComboboxContent } from "@/shared/components/ui/combobox";
+import { PopoverTrigger } from "@/shared/components/ui/popover";
+import { inputStyle } from "@/shared/components/ui/style";
+import { classNames } from "@/shared/utils/common";
+import { useAtomValue } from "jotai";
+import { ReactElement, useState } from "react";
+
+type ReviewButtonComponent = (props: ProposedChangeActionButtonProps) => ReactElement;
+
+type Review = "approve" | "reject";
+
+const actionsListMapping: Record<Review, ReviewButtonComponent> = {
+  approve: ({ setOpen }) => <ApproveButton setOpen={setOpen} />,
+  reject: ({ setOpen }) => <RejectButton setOpen={setOpen} />,
+};
+
+export const PcReviewButton = () => {
+  const auth = useAuth();
+  const proposedChange = useAtomValue(proposedChangedState);
+
+  const { data, isPending } = useGetProposedChangeAvailableActions({
+    proposedChangeId: proposedChange.id,
+  });
+
+  const [open, setOpen] = useState(false);
+  const [action, setReview] = useState<Review>("approve");
+
+  return (
+    <PcActionsContext value={data}>
+      <Combobox open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <div className={classNames(inputStyle, "flex p-0 border-0")}>
+            {isPending && <LoadingIndicator />}
+            {!isPending && auth?.user?.id ? (
+              actionsListMapping?.[action]?.({ setOpen })
+            ) : (
+              <PcPlaceholderButton />
+            )}
+          </div>
+        </PopoverTrigger>
+        <ComboboxContent fitTriggerWidth={false}>
+          <ReviewComboboxList
+            value={action}
+            onSelect={(action) => {
+              setOpen(false);
+              setReview(action as Review);
+            }}
+          />
+        </ComboboxContent>
+      </Combobox>
+    </PcActionsContext>
+  );
+};

--- a/frontend/app/src/entities/proposed-changes/ui/action-button/pc-review-combobox-list.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/action-button/pc-review-combobox-list.tsx
@@ -10,15 +10,15 @@ import { forwardRef } from "react";
 
 type ActionItem = { value: string; name: string; isDisabled?: boolean; message: string | null };
 
-export interface ActionComboboxListProps {
+export interface ReviewComboboxListProps {
   onSelect: (value: string) => void;
   value?: string | null;
 }
 
-export const ActionComboboxList = forwardRef<HTMLDivElement, ActionComboboxListProps>(
+export const ReviewComboboxList = forwardRef<HTMLDivElement, ReviewComboboxListProps>(
   ({ value, onSelect }, ref) => {
     const auth = useAuth();
-    const { setDraft, unsetDraft, close, merge, approve, reject } = usePcActionsContext();
+    const { approve, reject } = usePcActionsContext();
     const proposedChangesDetails = useAtomValue(proposedChangedState);
 
     const actionsList: Record<string, ActionItem> = {
@@ -39,28 +39,6 @@ export const ActionComboboxList = forwardRef<HTMLDivElement, ActionComboboxListP
             : "Reject",
         isDisabled: !reject.available,
         message: reject.unavailability_reason,
-      },
-      merge: {
-        value: "merge",
-        name: "Merge",
-        isDisabled: !merge.available,
-        message: merge.unavailability_reason,
-      },
-      close: {
-        value: "close",
-        name: "Close",
-        isDisabled: !close.available,
-        message: close.unavailability_reason,
-      },
-      draft: {
-        value: "draft",
-        name: proposedChangesDetails.is_draft?.value ? "Open" : "Move to draft",
-        isDisabled: proposedChangesDetails.is_draft?.value
-          ? !unsetDraft.available
-          : !setDraft.available,
-        message: proposedChangesDetails.is_draft?.value
-          ? unsetDraft.unavailability_reason
-          : setDraft.unavailability_reason,
       },
     };
 

--- a/frontend/app/src/entities/proposed-changes/ui/proposed-change-details.tsx
+++ b/frontend/app/src/entities/proposed-changes/ui/proposed-change-details.tsx
@@ -1,10 +1,13 @@
 import { TASK_OBJECT } from "@/config/constants";
 import { proposedChangedState } from "@/entities/proposed-changes/stores/proposedChanges.atom";
-import { PcActionButton } from "@/entities/proposed-changes/ui/action-button/pc-actions-button";
+import { PcActionButton } from "@/entities/proposed-changes/ui/action-button/pc-action-button";
+import { PcReviewButton } from "@/entities/proposed-changes/ui/action-button/pc-review-button";
 import { Overview } from "@/entities/proposed-changes/ui/overview";
 import { ProposedChangeEditTrigger } from "@/entities/proposed-changes/ui/proposed-change-edit-trigger";
 import { getProposedChangesStateBadgeType } from "@/entities/proposed-changes/utils/proposed-changes";
 import { TASK_DETAILS_CHECK } from "@/entities/tasks/api/checkTasksItemDetails";
+import { PROPOSED_CHANGE_MERGE_WORKFLOW, TASK_ONGOING_STATES } from "@/entities/tasks/constants";
+import { TaskDisplay } from "@/entities/tasks/ui/task-display";
 import useQuery from "@/shared/api/graphql/useQuery";
 import { constructPath } from "@/shared/api/rest/fetch";
 import Accordion from "@/shared/components/display/accordion";
@@ -20,8 +23,6 @@ import { Icon } from "@iconify-icon/react";
 import { useAtomValue } from "jotai";
 import { HTMLAttributes } from "react";
 import { useNavigate, useParams } from "react-router";
-import { PROPOSED_CHANGE_MERGE_WORKFLOW, TASK_ONGOING_STATES } from "../../tasks/constants";
-import { TaskDisplay } from "../../tasks/ui/task-display";
 
 export const ProposedChangeDetails = ({ className, ...props }: HTMLAttributes<HTMLDivElement>) => {
   const { proposedChangeId } = useParams();
@@ -135,14 +136,6 @@ export const ProposedChangeDetails = ({ className, ...props }: HTMLAttributes<HT
       name: "Updated",
       value: <DateDisplay date={proposedChangesDetails?._updated_at} />,
     },
-    {
-      name: "Actions",
-      value: (
-        <div className="flex flex-wrap gap-2">
-          <PcActionButton />
-        </div>
-      ),
-    },
   ];
 
   return (
@@ -198,6 +191,11 @@ export const ProposedChangeDetails = ({ className, ...props }: HTMLAttributes<HT
           </CardWithBorder.Title>
 
           <PropertyList properties={proposedChangeProperties} />
+
+          <div className="flex flex-grow gap-2 p-2">
+            <PcReviewButton />
+            <PcActionButton />
+          </div>
         </CardWithBorder>
       </div>
     </div>


### PR DESCRIPTION
<img width="1465" height="901" alt="image" src="https://github.com/user-attachments/assets/ad227c6a-c913-4eb6-930b-61c8b63d4427" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a dedicated Review dropdown for approving or rejecting proposed changes.
  - Added a contextual Actions menu for merge/close/draft with dynamic availability and tooltips explaining unavailable actions.
  - Consolidated actions into a new action row on the details page, pairing Review and Actions buttons.

- Style
  - Updated draft-related buttons to an outline style for visual consistency.
  - Improved layout by removing fixed width from the action trigger for better responsiveness.
  - Streamlined the details view by removing the inline “Actions” property block.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->