### PR TITLE
handle overridden choice attributes on generics during schema integrity check

### DIFF
--- a/backend/infrahub/core/validators/attribute/choices.py
+++ b/backend/infrahub/core/validators/attribute/choices.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from infrahub.core.constants import NULL_VALUE, PathType
 from infrahub.core.path import DataPath, GroupedDataPaths
+from infrahub.core.schema.generic_schema import GenericSchema
 
 from ..interface import ConstraintCheckerInterface
 from ..shared import AttributeSchemaValidatorQuery
@@ -18,6 +19,14 @@ if TYPE_CHECKING:
 class AttributeChoicesUpdateValidatorQuery(AttributeSchemaValidatorQuery):
     name: str = "attribute_constraints_choices_validator"
 
+    def __init__(
+        self,
+        excluded_kinds: list[str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.excluded_kinds: list[str] = excluded_kinds or []
+        super().__init__(**kwargs)
+
     async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
         if self.attribute_schema.choices is None:
             return
@@ -28,9 +37,11 @@ class AttributeChoicesUpdateValidatorQuery(AttributeSchemaValidatorQuery):
         self.params["attr_name"] = self.attribute_schema.name
         self.params["allowed_values"] = [choice.name for choice in self.attribute_schema.choices]
         self.params["null_value"] = NULL_VALUE
+        self.params["excluded_kinds"] = self.excluded_kinds
 
         query = """
-        MATCH p = (n:%(node_kind)s)
+        MATCH (n:%(node_kind)s)
+        WHERE size($excluded_kinds) = 0 OR NOT n.kind IN $excluded_kinds
         CALL (n) {
             MATCH path = (root:Root)<-[rr:IS_PART_OF]-(n)-[ra:HAS_ATTRIBUTE]-(:Attribute { name: $attr_name } )-[rv:HAS_VALUE]-(av:AttributeValue)
             WHERE all(
@@ -92,10 +103,24 @@ class AttributeChoicesChecker(ConstraintCheckerInterface):
         if attribute_schema.choices is None:
             return grouped_data_paths_list
 
+        # skip inheriting schemas that override the attribute being checked
+        excluded_kinds: list[str] = []
+        if request.node_schema.is_generic_schema:
+            request.node_schema = cast(GenericSchema, request.node_schema)
+            for inheriting_kind in request.node_schema.used_by:
+                inheriting_schema = request.schema_branch.get_node(name=inheriting_kind, duplicate=False)
+                inheriting_schema_attribute = inheriting_schema.get_attribute(name=request.schema_path.field_name)
+                if not inheriting_schema_attribute.inherited:
+                    excluded_kinds.append(inheriting_kind)
+
         for query_class in self.query_classes:
             # TODO add exception handling
             query = await query_class.init(
-                db=self.db, branch=self.branch, node_schema=request.node_schema, schema_path=request.schema_path
+                db=self.db,
+                branch=self.branch,
+                node_schema=request.node_schema,
+                schema_path=request.schema_path,
+                excluded_kinds=excluded_kinds,
             )
             await query.execute(db=self.db)
             grouped_data_paths_list.append(await query.get_paths())

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -1784,7 +1784,7 @@ async def all_attribute_default_types_schema(
 
 
 @pytest.fixture
-async def criticality_schema(db: InfrahubDatabase, default_branch: Branch, group_schema, data_schema) -> NodeSchema:
+async def criticality_schema_root() -> SchemaRoot:
     generic_schema: dict[str, Any] = {
         "name": "GenericCriticality",
         "namespace": "Test",
@@ -1824,11 +1824,18 @@ async def criticality_schema(db: InfrahubDatabase, default_branch: Branch, group
         ],
     }
     node = NodeSchema(**node_schema)
+    return SchemaRoot(nodes=[node], generics=[generic])
 
-    registry.schema.set(name=node.kind, schema=node, branch=default_branch.name)
-    registry.schema.set(name=generic.kind, schema=generic, branch=default_branch.name)
+
+@pytest.fixture
+async def criticality_schema(
+    db: InfrahubDatabase, default_branch: Branch, group_schema, data_schema, criticality_schema_root: SchemaRoot
+) -> NodeSchema:
+    registry.schema.register_schema(schema=criticality_schema_root, branch=default_branch.name)
     registry.schema.process_schema_branch(name=default_branch.name)
-    return registry.schema.get(name=node.kind, branch=default_branch.name)
+    return registry.schema.get_node_schema(
+        name=criticality_schema_root.nodes[0].kind, branch=default_branch.name, duplicate=False
+    )
 
 
 @pytest.fixture

--- a/backend/tests/unit/core/constraint_validators/test_attribute_choices_update.py
+++ b/backend/tests/unit/core/constraint_validators/test_attribute_choices_update.py
@@ -13,7 +13,7 @@ from infrahub.core.validators.model import SchemaConstraintValidatorRequest
 from infrahub.database import InfrahubDatabase
 
 
-async def test_query_new_choice_value(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_new_choice_value(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
     crit_low = await Node.init(db=db, schema=criticality_schema)
     await crit_low.new(db=db, name="low", level=4, status="active")
     await crit_low.save(db=db)
@@ -41,7 +41,7 @@ async def test_query_new_choice_value(db: InfrahubDatabase, default_branch: Bran
     assert len(all_data_paths) == 0
 
 
-async def test_query_remove_choice(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_remove_choice(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
     crit_low = await Node.init(db=db, schema=criticality_schema)
     await crit_low.new(db=db, name="low", level=4, status="active")
     await crit_low.save(db=db)
@@ -78,7 +78,7 @@ async def test_query_remove_choice(db: InfrahubDatabase, default_branch: Branch,
     ]
 
 
-async def test_query_convert_to_choice(db: InfrahubDatabase, branch: Branch, criticality_schema):
+async def test_convert_to_choice(db: InfrahubDatabase, branch: Branch, criticality_schema):
     crit_low = await Node.init(db=db, schema=criticality_schema, branch=branch)
     await crit_low.new(db=db, name="low", level=4, status="active")
     await crit_low.save(db=db)
@@ -129,7 +129,7 @@ async def test_query_convert_to_choice(db: InfrahubDatabase, branch: Branch, cri
     )
 
 
-async def test_query_attribute_update_on_branch(
+async def test_attribute_update_on_branch(
     db: InfrahubDatabase, branch: Branch, criticality_schema, criticality_low, criticality_medium
 ):
     criticality_low.status.value = "passive"
@@ -188,7 +188,7 @@ async def test_query_attribute_update_on_branch(
     )
 
 
-async def test_query_node_delete_on_branch(
+async def test_node_delete_on_branch(
     db: InfrahubDatabase, branch: Branch, criticality_schema, criticality_low, criticality_medium
 ):
     criticality_low.status.value = "passive"

--- a/backend/tests/unit/core/constraint_validators/test_attribute_choices_update.py
+++ b/backend/tests/unit/core/constraint_validators/test_attribute_choices_update.py
@@ -4,9 +4,11 @@ from infrahub.core.constants import PathType, SchemaPathType
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.path import DataPath, SchemaPath
-from infrahub.core.schema import DropdownChoice
+from infrahub.core.schema import DropdownChoice, SchemaRoot
+from infrahub.core.schema.attribute_schema import AttributeSchema
+from infrahub.core.schema.node_schema import NodeSchema
 from infrahub.core.schema.schema_branch import SchemaBranch
-from infrahub.core.validators.attribute.choices import AttributeChoicesChecker, AttributeChoicesUpdateValidatorQuery
+from infrahub.core.validators.attribute.choices import AttributeChoicesChecker
 from infrahub.core.validators.model import SchemaConstraintValidatorRequest
 from infrahub.database import InfrahubDatabase
 
@@ -23,17 +25,19 @@ async def test_query_new_choice_value(db: InfrahubDatabase, default_branch: Bran
     status_attr = crit_schema.get_attribute(name="status")
     status_attr.choices.append(DropdownChoice(name="another-thing"))
 
-    node_schema = crit_schema
-    schema_path = SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCriticality", field_name="status")
-
-    query = await AttributeChoicesUpdateValidatorQuery.init(
-        db=db, branch=default_branch, node_schema=node_schema, schema_path=schema_path
+    request = SchemaConstraintValidatorRequest(
+        branch=default_branch,
+        constraint_name="attribute.choices.update",
+        node_schema=crit_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCriticality", field_name="status"),
+        schema_branch=SchemaBranch(cache={}),
     )
 
-    await query.execute(db=db)
+    constraint_checker = AttributeChoicesChecker(db=db, branch=default_branch)
+    grouped_data_paths = await constraint_checker.check(request)
 
-    grouped_paths = await query.get_paths()
-    all_data_paths = grouped_paths.get_all_data_paths()
+    assert len(grouped_data_paths) == 1
+    all_data_paths = grouped_data_paths[0].get_all_data_paths()
     assert len(all_data_paths) == 0
 
 
@@ -49,17 +53,19 @@ async def test_query_remove_choice(db: InfrahubDatabase, default_branch: Branch,
     status_attr = crit_schema.get_attribute(name="status")
     status_attr.choices = [DropdownChoice(name="active", color="#00ff00", description="Online things")]
 
-    node_schema = crit_schema
-    schema_path = SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCriticality", field_name="status")
-
-    query = await AttributeChoicesUpdateValidatorQuery.init(
-        db=db, branch=default_branch, node_schema=node_schema, schema_path=schema_path
+    request = SchemaConstraintValidatorRequest(
+        branch=default_branch,
+        constraint_name="attribute.choices.update",
+        node_schema=crit_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCriticality", field_name="status"),
+        schema_branch=SchemaBranch(cache={}),
     )
 
-    await query.execute(db=db)
+    constraint_checker = AttributeChoicesChecker(db=db, branch=default_branch)
+    grouped_data_paths = await constraint_checker.check(request)
 
-    grouped_paths = await query.get_paths()
-    all_data_paths = grouped_paths.get_all_data_paths()
+    assert len(grouped_data_paths) == 1
+    all_data_paths = grouped_data_paths[0].get_all_data_paths()
     assert all_data_paths == [
         DataPath(
             branch=default_branch.name,
@@ -85,17 +91,19 @@ async def test_query_convert_to_choice(db: InfrahubDatabase, branch: Branch, cri
     name_attr.choices = [DropdownChoice(name="nothing")]
     name_attr.kind = "Dropdown"
 
-    node_schema = crit_schema
-    schema_path = SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCriticality", field_name="name")
-
-    query = await AttributeChoicesUpdateValidatorQuery.init(
-        db=db, branch=branch, node_schema=node_schema, schema_path=schema_path
+    request = SchemaConstraintValidatorRequest(
+        branch=branch,
+        constraint_name="attribute.choices.update",
+        node_schema=crit_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCriticality", field_name="name"),
+        schema_branch=SchemaBranch(cache={}),
     )
 
-    await query.execute(db=db)
+    constraint_checker = AttributeChoicesChecker(db=db, branch=branch)
+    grouped_data_paths = await constraint_checker.check(request)
 
-    grouped_paths = await query.get_paths()
-    all_data_paths = grouped_paths.get_all_data_paths()
+    assert len(grouped_data_paths) == 1
+    all_data_paths = grouped_data_paths[0].get_all_data_paths()
     assert len(all_data_paths) == 2
     assert (
         DataPath(
@@ -141,16 +149,20 @@ async def test_query_attribute_update_on_branch(
     crit_schema = registry.schema.get(name="TestCriticality", branch=branch)
     status_attr = crit_schema.get_attribute(name="status")
     status_attr.choices = [DropdownChoice(name="active", color="#00ff00", description="Online things")]
-    schema_path = SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCriticality", field_name="status")
 
-    query = await AttributeChoicesUpdateValidatorQuery.init(
-        db=db, branch=branch, node_schema=crit_schema, schema_path=schema_path
+    request = SchemaConstraintValidatorRequest(
+        branch=branch,
+        constraint_name="attribute.choices.update",
+        node_schema=crit_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCriticality", field_name="status"),
+        schema_branch=SchemaBranch(cache={}),
     )
 
-    await query.execute(db=db)
+    constraint_checker = AttributeChoicesChecker(db=db, branch=branch)
+    grouped_data_paths = await constraint_checker.check(request)
 
-    grouped_paths = await query.get_paths()
-    all_data_paths = grouped_paths.get_all_data_paths()
+    assert len(grouped_data_paths) == 1
+    all_data_paths = grouped_data_paths[0].get_all_data_paths()
     assert len(all_data_paths) == 2
     assert (
         DataPath(
@@ -195,16 +207,20 @@ async def test_query_node_delete_on_branch(
     crit_schema = registry.schema.get(name="TestCriticality", branch=branch)
     status_attr = crit_schema.get_attribute(name="status")
     status_attr.choices = [DropdownChoice(name="active", color="#00ff00", description="Online things")]
-    schema_path = SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCriticality", field_name="status")
 
-    query = await AttributeChoicesUpdateValidatorQuery.init(
-        db=db, branch=branch, node_schema=crit_schema, schema_path=schema_path
+    request = SchemaConstraintValidatorRequest(
+        branch=branch,
+        constraint_name="attribute.choices.update",
+        node_schema=crit_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCriticality", field_name="status"),
+        schema_branch=SchemaBranch(cache={}),
     )
 
-    await query.execute(db=db)
+    constraint_checker = AttributeChoicesChecker(db=db, branch=branch)
+    grouped_data_paths = await constraint_checker.check(request)
 
-    grouped_paths = await query.get_paths()
-    all_data_paths = grouped_paths.get_all_data_paths()
+    assert len(grouped_data_paths) == 1
+    all_data_paths = grouped_data_paths[0].get_all_data_paths()
     assert len(all_data_paths) == 2
     assert (
         DataPath(
@@ -282,3 +298,82 @@ async def test_validator(db: InfrahubDatabase, branch: Branch, criticality_schem
         )
         in data_paths
     )
+
+
+async def test_validator_generic_and_node_have_different_choices(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    criticality_schema_root: SchemaRoot,
+    criticality_low: Node,
+    criticality_medium: Node,
+    branch: Branch,
+):
+    # add different choices to the status attribute on the generic
+    criticality_schema_root.generics[0].attributes.append(
+        AttributeSchema(
+            name="status",
+            kind="Dropdown",
+            optional=True,
+            choices=[DropdownChoice(name="generic_active"), DropdownChoice(name="generic_passive")],
+        )
+    )
+    # add another schema that inherits from the generic, but does not override the status attribute
+    criticality_schema_root.nodes.append(
+        NodeSchema(
+            name="CriticalityTwo",
+            namespace="Test",
+            inherit_from=["TestGenericCriticality"],
+        )
+    )
+    registry.schema.register_schema(schema=criticality_schema_root, branch=default_branch.name)
+    registry.schema.process_schema_branch(name=default_branch.name)
+    schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+    registry.schema.set_schema_branch(name=branch.name, schema=schema_branch)
+
+    # create TestCriticalityTwo nodes
+    crit_two_status = await Node.init(db=db, schema="TestCriticalityTwo", branch=branch)
+    await crit_two_status.new(db=db, status="generic_active")
+    await crit_two_status.save(db=db)
+    crit_two_no_status = await Node.init(db=db, schema="TestCriticalityTwo", branch=branch)
+    await crit_two_no_status.new(db=db)
+    await crit_two_no_status.save(db=db)
+
+    # update TestCriticality nodes
+    crit_low = await NodeManager.get_one(id=criticality_low.id, db=db, branch=branch)
+    crit_low.status.value = None
+    await crit_low.save(db=db)
+    crit_med = await NodeManager.get_one(id=criticality_medium.id, db=db, branch=branch)
+    crit_med.status.value = "passive"
+    await crit_med.save(db=db)
+
+    # verify that no errors are raised for TestGenericCriticality
+    constraint_checker = AttributeChoicesChecker(db=db, branch=branch)
+
+    generic_crit_schema = registry.schema.get(name="TestGenericCriticality", branch=branch)
+    request = SchemaConstraintValidatorRequest(
+        branch=branch,
+        constraint_name="attribute.choices.update",
+        node_schema=generic_crit_schema,
+        schema_path=SchemaPath(
+            path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestGenericCriticality", field_name="status"
+        ),
+        schema_branch=schema_branch,
+    )
+    grouped_data_paths = await constraint_checker.check(request)
+    assert len(grouped_data_paths) == 1
+    data_paths = grouped_data_paths[0].get_all_data_paths()
+    assert len(data_paths) == 0
+
+    # verify that no errors are raised for TestCriticality
+    node_crit_schema = registry.schema.get_node_schema(name="TestCriticality", branch=branch)
+    request = SchemaConstraintValidatorRequest(
+        branch=branch,
+        constraint_name="attribute.choices.update",
+        node_schema=node_crit_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="TestCriticality", field_name="status"),
+        schema_branch=schema_branch,
+    )
+    grouped_data_paths = await constraint_checker.check(request)
+    assert len(grouped_data_paths) == 1
+    data_paths = grouped_data_paths[0].get_all_data_paths()
+    assert len(data_paths) == 0

--- a/changelog/7086.fixed.md
+++ b/changelog/7086.fixed.md
@@ -1,0 +1,1 @@
+Fix bug in schema validation that would incorrectly flag Dropdown attributes of node schema that override a generic attribute as having illegal values


### PR DESCRIPTION
fixes #7086 

there is a bug in the `AttributeChoicesChecker` that we use during schema validation to check if the values of a choice-type attribute (`Dropdown`) that incorrectly checks the allowed values of a generic schema for inheriting schema that have overridden the generic attribute with their own choices.

For example, say I have this schema
- a generic schema `GenericA` with a `role` attribute that allows these values: [`one`, `two`]
- a node schema `NodeB` that inherits from `GenericA` and has overridden the `role` attribute to allow these values [`three`, `four`]
when schema validation runs, it will incorrectly identify instances of `NodeB` as having invalid `role` values b/c the role is not `one` or `two`

the fix is to update `AttributeChoicesChecker` to ignore Nodes that have overridden the attribute being checked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed validation for dropdown/choice attributes when node schemas override a generic attribute, preventing false “illegal value” errors.
  * Improved handling of schema inheritance so generic and node-specific choices can differ without triggering validation issues.
  * Ensures accurate validation results across branches during attribute updates and deletions.

* **Documentation**
  * Added changelog entry describing the fix for dropdown attribute validation on overridden generic attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->