### PR TITLE
fix link to the approval workflow guide in the 1.4.0 release notes

### DIFF
--- a/docs/docs/release-notes/infrahub/release-1_4_0.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_4_0.mdx
@@ -88,7 +88,7 @@ With this change multiple improvements have been made to the overall proposed ch
 - Added the ability to set a proposed change to be a draft, allowing you to more easily indicate the state of a certain change
 - The overview tab of a proposed change now contains a more detailed timeline of all the actions/state changes that happened in a proposed change.
 
-Please refer to the documentation for a guide that explains how to setup a change approval workflow: https://develop.infrahub.pages.dev/guides/change-approval-workflow
+Please refer to the documentation for a guide that explains how to setup a change approval workflow: https://docs.infrahub.app/guides/change-approval-workflow
 
 ![Proposed change approval workflow](../../media/release_notes/infrahub_1_4/proposed_change.png)
 

--- a/docs/docs/release-notes/infrahub/release-1_4_0.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_4_0.mdx
@@ -161,7 +161,7 @@ Below are some example ways to get the latest version of Infrahub in your enviro
 - For deployments via Docker Compose, download the updated Docker Compose file
   - `curl https://infrahub.opsmill.io -o docker-compose.yml`
 - Set the `VERSION` environment variable and start the environment
-  - `export VERSION="1.4.0rc0"; docker compose pull && docker compose up -d`
+  - `export VERSION="1.4.0"; docker compose pull && docker compose up -d`
 - For deployments via Kubernetes, utilize the latest version of the Helm chart supplied with this release
 
 **Second**, once you have gotten the desired version of Infrahub in your environment, please run the following command.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the Enterprise “Proposed change approval workflow” link to the current docs site (https://docs.infrahub.app/guides/change-approval-workflow).
  - Updated Docker Compose guidance to reference version 1.4.0 instead of the release-candidate version.
  - Clarified navigation consistency within the Infrahub 1.4.0 release notes.
  - No changes to product behavior, UI, APIs, or error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->