### PR TITLE
clone POST requests to retry them after token refresh

### DIFF
--- a/frontend/app/src/shared/api/rest/client.ts
+++ b/frontend/app/src/shared/api/rest/client.ts
@@ -17,6 +17,9 @@ export const queryClient = new QueryClient({
 
 export const apiClient = createClient<paths>({ baseUrl: INFRAHUB_API_SERVER_URL });
 
+// Store cloned requests for retry purposes
+const requestClones = new WeakMap<Request, Request>();
+
 const authMiddleware: Middleware = {
   async onRequest({ request }) {
     const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
@@ -24,23 +27,40 @@ const authMiddleware: Middleware = {
     if (!accessToken) return request;
 
     request.headers.set("Authorization", `Bearer ${accessToken}`);
+
+    // Store a clone for potential retry to avoid "body already used" error
+    // This is necessary because Request bodies can only be consumed once
+    requestClones.set(request, request.clone());
+
     return request;
   },
   async onResponse({ request, response }) {
-    if (response.status === 401) {
-      try {
-        const newToken = await getNewToken();
+    if (response.status !== 401) {
+      requestClones.delete(request);
+      return response;
+    }
 
-        if (!newToken?.access_token) {
-          return response;
-        }
+    try {
+      const newToken = await getNewToken();
 
-        request.headers.set("Authorization", `Bearer ${newToken.access_token}`);
-        return fetch(request);
-      } catch (error) {
-        console.error(error);
+      if (!newToken?.access_token) {
+        requestClones.delete(request);
         return response;
       }
+
+      const clonedRequest = requestClones.get(request);
+      requestClones.delete(request);
+
+      if (!clonedRequest) {
+        return response;
+      }
+
+      clonedRequest.headers.set("Authorization", `Bearer ${newToken.access_token}`);
+      return fetch(clonedRequest);
+    } catch (error) {
+      requestClones.delete(request);
+      console.error("Token refresh failed:", error);
+      return response;
     }
   },
 };

--- a/frontend/app/src/shared/api/rest/client.ts
+++ b/frontend/app/src/shared/api/rest/client.ts
@@ -40,18 +40,18 @@ const authMiddleware: Middleware = {
       return response;
     }
 
+    const clonedRequest = requestClones.get(request);
+    requestClones.delete(request);
+
+    if (!clonedRequest) {
+      return response;
+    }
+
     try {
       const newToken = await getNewToken();
 
       if (!newToken?.access_token) {
         requestClones.delete(request);
-        return response;
-      }
-
-      const clonedRequest = requestClones.get(request);
-      requestClones.delete(request);
-
-      if (!clonedRequest) {
         return response;
       }
 

--- a/frontend/app/src/shared/api/rest/client.ts
+++ b/frontend/app/src/shared/api/rest/client.ts
@@ -22,8 +22,10 @@ const requestClones = new WeakMap<Request, Request>();
 
 const authMiddleware: Middleware = {
   async onRequest({ request }) {
-    const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
+    const hadAuth = request.headers.has("Authorization");
+    if (hadAuth) return request;
 
+    const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
     if (!accessToken) return request;
 
     request.headers.set("Authorization", `Bearer ${accessToken}`);
@@ -51,14 +53,12 @@ const authMiddleware: Middleware = {
       const newToken = await getNewToken();
 
       if (!newToken?.access_token) {
-        requestClones.delete(request);
         return response;
       }
 
       clonedRequest.headers.set("Authorization", `Bearer ${newToken.access_token}`);
       return fetch(clonedRequest);
     } catch (error) {
-      requestClones.delete(request);
       console.error("Token refresh failed:", error);
       return response;
     }


### PR DESCRIPTION
Issue:
- https://github.com/opsmill/infrahub/issues/6659

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatic token refresh with seamless retry of failed requests, reducing interruptions when sessions expire.
  - Requests now proceed with the correct authorization header without manual re-authentication.

- Bug Fixes
  - Fewer unexpected 401 errors and failed actions due to expired tokens.
  - Improved session stability over long usage periods, minimizing the need to re-login.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->