### PR TITLE
Replace new_branch variable and ignore updates for -global- branch

### DIFF
--- a/backend/infrahub/tasks/registry.py
+++ b/backend/infrahub/tasks/registry.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from infrahub import lock
 from infrahub.core import registry
+from infrahub.core.constants import GLOBAL_BRANCH_NAME
 from infrahub.log import get_logger
 from infrahub.worker import WORKER_IDENTITY
 
@@ -81,16 +82,21 @@ async def refresh_branches(db: InfrahubDatabase) -> None:
     from infrahub.graphql.manager import GraphQLSchemaManager
 
     async with lock.registry.local_schema_lock():
-        branches = await registry.branch_object.get_list(db=db)
-        for new_branch in branches:
-            if new_branch.name in registry.branch:
-                await update_branch_registry(db=db, branch=new_branch)
-            else:
-                await create_branch_registry(db=db, branch=new_branch)
+        active_branches = await registry.branch_object.get_list(db=db)
+        for active_branch in active_branches:
+            if active_branch.name == GLOBAL_BRANCH_NAME:
+                # Avoid processing updates for the global branch as it doesn't
+                # have an associated schema
+                continue
 
-        purged_branches = await registry.purge_inactive_branches(db=db, active_branches=branches)
+            if active_branch.name in registry.branch:
+                await update_branch_registry(db=db, branch=active_branch)
+            else:
+                await create_branch_registry(db=db, branch=active_branch)
+
+        purged_branches = await registry.purge_inactive_branches(db=db, active_branches=active_branches)
         purged_branches.update(
-            GraphQLSchemaManager.purge_inactive(active_branches=[branch.name for branch in branches])
+            GraphQLSchemaManager.purge_inactive(active_branches=[branch.name for branch in active_branches])
         )
         for branch_name in sorted(purged_branches):
             log.info(f"Removed branch {branch_name!r} from the registry", branch=branch_name, worker=WORKER_IDENTITY)

--- a/changelog/+3cdf0ab8.fixed.md
+++ b/changelog/+3cdf0ab8.fixed.md
@@ -1,0 +1,1 @@
+Removed incorrect log warning about 'Branch schema hash is not set, cannot update branch registry' due to including the '-global-' branch when processing branch updates.


### PR DESCRIPTION
The variable name was confusing as all of the branches weren't new, switching to active_branch for clarity.

Due to a recent refactoring we were logging the warning message:

"Branch schema hash is not set, cannot update branch registry"

The root cause of this was that we didn't have a schema_hash on the '-global-' branch which we never was supposed to have.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevents processing of the global branch during branch updates.
  - Processes only active branches to avoid stale or inactive data handling.
  - Removes an incorrect warning about missing branch schema hashes.
  - Reduces noisy logs and improves reliability of branch registry updates.

- **Documentation**
  - Added changelog entry describing the removal of the incorrect log warning and improved branch processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->