### PR TITLE
fix branch-support bugs in IP reconciliation

### DIFF
--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -673,8 +673,6 @@ class IPPrefixReconcileQuery(Query):
             "ip_prefix_kind": InfrahubKind.IPPREFIX,
             "ip_address_kind": InfrahubKind.IPADDRESS,
             "branch_filter": branch_filter,
-            "ip_prefix_kind": InfrahubKind.IPPREFIX,
-            "ip_address_kind": InfrahubKind.IPADDRESS,
             "ip_prefix_attribute_kind": PREFIX_ATTRIBUTE_LABEL,
             "ip_address_attribute_kind": ADDRESS_ATTRIBUTE_LABEL,
         }

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -377,6 +377,8 @@ class IPPrefixReconcileQuery(Query):
         WHERE %(branch_filter)s
         ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
         LIMIT 1
+        WITH ip_namespace
+        WHERE r.status = "active"
         """ % {"branch_filter": branch_filter, "namespace_kind": self.params["namespace_kind"]}
         self.add_to_query(namespace_query)
 
@@ -386,8 +388,13 @@ class IPPrefixReconcileQuery(Query):
             // ------------------
             // Get IP Prefix node by UUID
             // ------------------
-            MATCH (ip_node:%(ip_kind)s {uuid: $node_uuid})
+            OPTIONAL MATCH (ip_node:%(ip_kind)s {uuid: $node_uuid})-[r:IS_PART_OF]->(:Root)
+            WHERE %(branch_filter)s
+            ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+            LIMIT 1
+            WITH ip_namespace, ip_node
             """ % {
+                "branch_filter": branch_filter,
                 "ip_kind": InfrahubKind.IPADDRESS
                 if isinstance(self.ip_value, IPAddressType)
                 else InfrahubKind.IPPREFIX,

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -397,9 +397,9 @@ class IPPrefixReconcileQuery(Query):
         else:
             get_node_by_prefix_query = """
             // ------------------
-            // Get IP nodes with the correct value on this branch
+            // Get IP node with the correct value on this branch
             // ------------------
-            MATCH (:Root)<-[r1:IS_PART_OF]-(ip_node:%(ip_kind)s)
+            OPTIONAL MATCH (:Root)<-[r1:IS_PART_OF]-(ip_node:%(ip_kind)s)
                 -[r2:HAS_ATTRIBUTE]->(a:Attribute)-[r3:HAS_VALUE]->(aipn:%(ip_attribute_kind)s)
             WHERE aipn.binary_address = $prefix_binary_full
             AND aipn.prefixlen = $prefixlen
@@ -409,19 +409,23 @@ class IPPrefixReconcileQuery(Query):
                 r2.branch_level DESC, r2.from DESC, r2.status ASC,
                 r1.branch_level DESC, r1.from DESC, r1.status ASC
             LIMIT 1
-            WITH ip_namespace, ip_node
-            WHERE r1.status = "active" AND r2.status = "active" AND r3.status = "active"
+            WITH ip_namespace, CASE
+                WHEN ip_node IS NOT NULL AND r1.status = "active" AND r2.status = "active" AND r3.status = "active" THEN ip_node
+                ELSE NULL
+            END AS ip_node
             // ------------------
             // Filter to only those that are in the correct namespace
             // ------------------
-            MATCH (ip_namespace)-[r1:IS_RELATED]-(nsr:Relationship)-[r2:IS_RELATED]-(ip_node)
+            OPTIONAL MATCH (ip_namespace)-[r1:IS_RELATED]-(nsr:Relationship)-[r2:IS_RELATED]-(ip_node)
             WHERE nsr.name IN ["ip_namespace__ip_prefix", "ip_namespace__ip_address"]
             AND all(r IN [r1, r2] WHERE (%(branch_filter)s))
             ORDER BY r1.branch_level DESC, r1.from DESC, r1.status ASC,
                 r2.branch_level DESC, r2.from DESC, r2.status ASC
             LIMIT 1
-            WITH ip_namespace, ip_node
-            WHERE r1.status = "active" AND r2.status = "active"
+            WITH ip_namespace, CASE
+                WHEN ip_node IS NOT NULL AND r1.status = "active" AND r2.status = "active" THEN ip_node
+                ELSE NULL
+            END as ip_node
             """ % {
                 "branch_filter": branch_filter,
                 "ip_kind": InfrahubKind.IPADDRESS

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -375,6 +375,8 @@ class IPPrefixReconcileQuery(Query):
         // ------------------
         MATCH (ip_namespace:%(namespace_kind)s {uuid: $namespace_id})-[r:IS_PART_OF]->(root:Root)
         WHERE %(branch_filter)s
+        ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+        LIMIT 1
         """ % {"branch_filter": branch_filter, "namespace_kind": self.params["namespace_kind"]}
         self.add_to_query(namespace_query)
 
@@ -395,17 +397,31 @@ class IPPrefixReconcileQuery(Query):
         else:
             get_node_by_prefix_query = """
             // ------------------
-            // Get IP Prefix node by prefix value
+            // Get IP nodes with the correct value on this branch
             // ------------------
-            OPTIONAL MATCH ip_node_path = (:Root)<-[:IS_PART_OF]-(ip_node:%(ip_kind)s)
-            -[:HAS_ATTRIBUTE]->(a:Attribute)-[:HAS_VALUE]->(aipn:%(ip_attribute_kind)s),
-            (ip_namespace)-[:IS_RELATED]-(nsr:Relationship)
-            -[:IS_RELATED]-(ip_node)
-            WHERE nsr.name IN ["ip_namespace__ip_prefix", "ip_namespace__ip_address"]
-            AND aipn.binary_address = $prefix_binary_full
+            MATCH (:Root)<-[r1:IS_PART_OF]-(ip_node:%(ip_kind)s)
+                -[r2:HAS_ATTRIBUTE]->(a:Attribute)-[r3:HAS_VALUE]->(aipn:%(ip_attribute_kind)s)
+            WHERE aipn.binary_address = $prefix_binary_full
             AND aipn.prefixlen = $prefixlen
             AND aipn.version = $ip_version
-            AND all(r IN relationships(ip_node_path) WHERE (%(branch_filter)s) and r.status = "active")
+            AND all(r IN [r1, r2, r3] WHERE (%(branch_filter)s))
+            ORDER BY r3.branch_level DESC, r3.from DESC, r3.status ASC,
+                r2.branch_level DESC, r2.from DESC, r2.status ASC,
+                r1.branch_level DESC, r1.from DESC, r1.status ASC
+            LIMIT 1
+            WITH ip_namespace, ip_node
+            WHERE r1.status = "active" AND r2.status = "active" AND r3.status = "active"
+            // ------------------
+            // Filter to only those that are in the correct namespace
+            // ------------------
+            MATCH (ip_namespace)-[r1:IS_RELATED]-(nsr:Relationship)-[r2:IS_RELATED]-(ip_node)
+            WHERE nsr.name IN ["ip_namespace__ip_prefix", "ip_namespace__ip_address"]
+            AND all(r IN [r1, r2] WHERE (%(branch_filter)s))
+            ORDER BY r1.branch_level DESC, r1.from DESC, r1.status ASC,
+                r2.branch_level DESC, r2.from DESC, r2.status ASC
+            LIMIT 1
+            WITH ip_namespace, ip_node
+            WHERE r1.status = "active" AND r2.status = "active"
             """ % {
                 "branch_filter": branch_filter,
                 "ip_kind": InfrahubKind.IPADDRESS
@@ -498,7 +514,7 @@ class IPPrefixReconcileQuery(Query):
             OPTIONAL MATCH (ip_namespace)-[r1:IS_RELATED]-(:Relationship {name: "ip_namespace__ip_prefix"})-[r2:IS_RELATED]-(maybe_new_parent)
             WHERE all(r IN [r1, r2] WHERE (%(branch_filter)s))
             WITH maybe_new_parent, r1, r2, r1.status = "active" AND r2.status = "active" AS is_active
-            ORDER BY elementId(maybe_new_parent), r1.branch_level DESC, r1.from DESC, r1.status DESC, r2.branch_level DESC, r2.from DESC, r2.status DESC
+            ORDER BY elementId(maybe_new_parent), r1.branch_level DESC, r1.from DESC, r1.status ASC, r2.branch_level DESC, r2.from DESC, r2.status ASC
             WITH maybe_new_parent, head(collect(is_active)) AS is_active
             RETURN is_active = TRUE AS parent_in_namespace
         }
@@ -509,7 +525,7 @@ class IPPrefixReconcileQuery(Query):
             OPTIONAL MATCH (maybe_new_parent)-[r1:HAS_ATTRIBUTE]->(:Attribute {name: "prefix"})-[r2:HAS_VALUE]->(av:AttributeValue)
             WHERE all(r IN [r1, r2] WHERE (%(branch_filter)s))
             WITH maybe_new_parent, av, r1, r2, r1.status = "active" AND r2.status = "active" AS is_active
-            ORDER BY elementId(maybe_new_parent), r1.branch_level DESC, r1.from DESC, r1.status DESC, r2.branch_level DESC, r2.from DESC, r2.status DESC
+            ORDER BY elementId(maybe_new_parent), r1.branch_level DESC, r1.from DESC, r1.status ASC, r2.branch_level DESC, r2.from DESC, r2.status ASC
             // ------------------
             // get the latest active attribute value for the maybe_new_parent
             // ------------------
@@ -549,19 +565,18 @@ class IPPrefixReconcileQuery(Query):
         // Identify the correct children, if any, for the prefix node
         // ------------------
         CALL (ip_namespace, ip_node) {
+            // ------------------
             // Get ALL possible children for the prefix node
-            OPTIONAL MATCH child_path = (
-                 (ip_namespace)-[r1:IS_RELATED]
-                 -(ns_rel:Relationship)-[r2:IS_RELATED]
-                 -(maybe_new_child:%(ip_prefix_kind)s|%(ip_address_kind)s)-[har:HAS_ATTRIBUTE]
-                 ->(a:Attribute)-[hvr:HAS_VALUE]
-                 ->(av:%(ip_prefix_attribute_kind)s|%(ip_address_attribute_kind)s)
+            // ------------------
+            OPTIONAL MATCH (
+                 (ip_namespace)-[:IS_RELATED]-(ns_rel:Relationship)-[:IS_RELATED]
+                 -(maybe_new_child:%(ip_prefix_kind)s|%(ip_address_kind)s)-[:HAS_ATTRIBUTE]
+                 ->(a:Attribute)-[:HAS_VALUE]->(av:%(ip_prefix_attribute_kind)s|%(ip_address_attribute_kind)s)
             )
             USING INDEX av:%(ip_prefix_attribute_kind)s(binary_address)
             USING INDEX av:%(ip_address_attribute_kind)s(binary_address)
             WHERE $is_prefix  // only prefix nodes can have children
             AND ns_rel.name IN ["ip_namespace__ip_prefix", "ip_namespace__ip_address"]
-            AND any(child_kind IN [$ip_prefix_kind, $ip_address_kind] WHERE child_kind IN labels(maybe_new_child))
             AND a.name in ["prefix", "address"]
             AND (ip_node IS NULL OR maybe_new_child.uuid <> ip_node.uuid)
             AND (
@@ -570,22 +585,58 @@ class IPPrefixReconcileQuery(Query):
             )
             AND av.version = $ip_version
             AND av.binary_address STARTS WITH $prefix_binary_host
-            AND all(r IN relationships(child_path) WHERE (%(branch_filter)s))
-            WITH
-                maybe_new_child,
-                av AS mnc_attribute,
-                r1,
-                r2,
-                har,
-                hvr,
-                all(r in relationships(child_path) WHERE r.status = "active") AS is_active,
-                reduce(br_lvl = 0, r in relationships(child_path) | br_lvl + r.branch_level) AS branch_level
-            ORDER BY maybe_new_child.uuid, branch_level DESC, hvr.from DESC, har.from DESC, r2.from DESC, r1.from DESC
-            WITH maybe_new_child, head(collect([mnc_attribute, is_active])) AS latest_mnc_details
-            RETURN maybe_new_child, latest_mnc_details[0] AS latest_mnc_attribute, latest_mnc_details[1] AS mnc_is_active
+            RETURN DISTINCT maybe_new_child
         }
-        WITH ip_namespace, ip_node, current_parent, current_children, new_parent, latest_mnc_attribute,
-            CASE WHEN mnc_is_active IN [TRUE, NULL] THEN maybe_new_child ELSE NULL END AS maybe_new_child
+        CALL (ip_namespace, maybe_new_child) {
+            // ------------------
+            // filter to only active maybe_new_child Nodes in the correct namespace
+            // ------------------
+            OPTIONAL MATCH (ip_namespace)-[r1:IS_RELATED]-(ns_rel:Relationship)-[r2:IS_RELATED]-(maybe_new_child)
+            WHERE ns_rel.name IN ["ip_namespace__ip_prefix", "ip_namespace__ip_address"]
+            AND all(r IN [r1, r2] WHERE (%(branch_filter)s))
+            WITH maybe_new_child, r1, r2, r1.status = "active" AND r2.status = "active" AS is_active
+            ORDER BY elementId(maybe_new_child), r1.branch_level DESC, r1.from DESC, r1.status ASC, r2.branch_level DESC, r2.from DESC, r2.status ASC
+            WITH maybe_new_child, head(collect(is_active)) AS is_active
+            RETURN is_active = TRUE AS child_in_namespace
+        }
+        CALL (maybe_new_child) {
+            // ------------------
+            // filter to only active maybe_new_child Nodes currently linked to a possible child AttributeValue
+            // ------------------
+            OPTIONAL MATCH (maybe_new_child:%(ip_prefix_kind)s|%(ip_address_kind)s)-[r1:HAS_ATTRIBUTE]->(a:Attribute)-[r2:HAS_VALUE]->(av:AttributeValue)
+            WHERE a.name in ["prefix", "address"]
+            AND all(r IN [r1, r2] WHERE (%(branch_filter)s))
+            WITH maybe_new_child, av, r1, r2, r1.status = "active" AND r2.status = "active" AS is_active
+            ORDER BY elementId(maybe_new_child), r1.branch_level DESC, r1.from DESC, r1.status ASC, r2.branch_level DESC, r2.from DESC, r2.status ASC
+            // ------------------
+            // get the latest active attribute value for the maybe_new_child
+            // ------------------
+            WITH maybe_new_child, head(collect([av, is_active])) AS av_is_active
+            WITH
+                av_is_active[0] AS av,
+                av_is_active[1] AS is_active
+            // ------------------
+            // return NULL if the value is not allowed or if it is not active
+            // ------------------
+            WITH av, is_active, (
+                (
+                    ($ip_prefix_kind IN labels(maybe_new_child) AND av.prefixlen > $prefixlen)
+                    OR ($ip_address_kind IN labels(maybe_new_child) AND av.prefixlen >= $prefixlen)
+                )
+                AND av.version = $ip_version
+                AND av.binary_address STARTS WITH $prefix_binary_host
+            ) AS is_allowed_value
+            RETURN CASE WHEN is_active = TRUE AND is_allowed_value = TRUE THEN av ELSE NULL END AS latest_mnc_attribute
+        }
+        // ------------------
+        // set inactive/illegal value/wrong namespace maybe_new_children to NULL
+        // ------------------
+        WITH ip_namespace, ip_node, current_parent, current_children, new_parent,
+            CASE
+                WHEN child_in_namespace = TRUE AND latest_mnc_attribute IS NOT NULL THEN maybe_new_child
+                ELSE NULL
+            END AS maybe_new_child,
+            CASE WHEN child_in_namespace = TRUE THEN latest_mnc_attribute ELSE NULL END AS latest_mnc_attribute
         WITH ip_namespace, ip_node, current_parent, current_children, new_parent, collect([maybe_new_child, latest_mnc_attribute]) AS maybe_children_ips
         WITH ip_namespace, ip_node, current_parent, current_children, new_parent, maybe_children_ips, range(0, size(maybe_children_ips) - 1) AS child_indices
         UNWIND child_indices as ind
@@ -619,6 +670,8 @@ class IPPrefixReconcileQuery(Query):
             new_parent,
             collect(new_child) as new_children
         """ % {
+            "ip_prefix_kind": InfrahubKind.IPPREFIX,
+            "ip_address_kind": InfrahubKind.IPADDRESS,
             "branch_filter": branch_filter,
             "ip_prefix_kind": InfrahubKind.IPPREFIX,
             "ip_address_kind": InfrahubKind.IPADDRESS,

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -452,7 +452,7 @@ class IPPrefixReconcileQuery(Query):
             OPTIONAL MATCH parent_prefix_path = (ip_node)-[r1:IS_RELATED]->(:Relationship {name: "parent__child"})-[r2:IS_RELATED]->(current_parent:%(ip_prefix_kind)s)
             WHERE all(r IN relationships(parent_prefix_path) WHERE (%(branch_filter)s))
             RETURN current_parent, (r1.status = "active" AND r2.status = "active") AS parent_is_active
-            ORDER BY r1.branch_level DESC, r2.branch_level DESC, r1.from DESC, r2.from DESC
+            ORDER BY r1.branch_level DESC, r1.from DESC, r1.status ASC, r2.branch_level DESC, r2.from DESC, r2.status ASC
             LIMIT 1
         }
         WITH ip_namespace, ip_node, CASE WHEN parent_is_active THEN current_parent ELSE NULL END as current_parent

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -474,28 +474,66 @@ class IPPrefixReconcileQuery(Query):
         // Identify the correct parent, if any, for the prefix node
         // ------------------
         CALL (ip_namespace) {
-            OPTIONAL MATCH parent_path = (ip_namespace)-[pr1:IS_RELATED {status: "active"}]-(ns_rel:Relationship {name: "ip_namespace__ip_prefix"})
-            -[pr2:IS_RELATED {status: "active"}]-(maybe_new_parent:%(ip_prefix_kind)s)
-            -[har:HAS_ATTRIBUTE]->(:Attribute {name: "prefix"})
-            -[hvr:HAS_VALUE]->(av:%(ip_prefix_attribute_kind)s)
-            USING INDEX av:%(ip_prefix_attribute_kind)s(binary_address)
-            WHERE all(r IN relationships(parent_path) WHERE (%(branch_filter)s))
-            AND av.version = $ip_version
+            // ------------------
+            // start with just the AttributeValue vertices b/c we have an index on them
+            // ------------------
+            OPTIONAL MATCH (av:%(ip_prefix_attribute_kind)s)
+            WHERE av.version = $ip_version
             AND av.binary_address IN $possible_prefix_list
             AND any(prefix_and_length IN $possible_prefix_and_length_list WHERE av.binary_address = prefix_and_length[0] AND av.prefixlen <= prefix_and_length[1])
-            WITH
-                maybe_new_parent,
-                har,
-                hvr,
-                av.prefixlen as prefixlen,
-                (har.status = "active" AND hvr.status = "active") AS is_active,
-                har.branch_level + hvr.branch_level AS branch_level
-            ORDER BY branch_level DESC, har.from DESC, hvr.from DESC
-            WITH maybe_new_parent, prefixlen, is_active
-            RETURN maybe_new_parent, head(collect(prefixlen)) AS mnp_prefixlen, head(collect(is_active)) AS mnp_is_active
+            // ------------------
+            // now get all the possible IPPrefix nodes for these AttributeValues
+            // ------------------
+            OPTIONAL MATCH parent_path = (ip_namespace)-[:IS_RELATED]-(:Relationship {name: "ip_namespace__ip_prefix"})
+            -[:IS_RELATED]-(maybe_new_parent:%(ip_prefix_kind)s)
+            -[:HAS_ATTRIBUTE]->(:Attribute {name: "prefix"})
+            -[:HAS_VALUE]->(av:AttributeValue)
+            WHERE all(r IN relationships(parent_path) WHERE (%(branch_filter)s))
+            RETURN DISTINCT maybe_new_parent
         }
-        WITH ip_namespace, ip_node, current_parent, current_children, mnp_prefixlen,
-            CASE WHEN mnp_is_active THEN maybe_new_parent ELSE NULL END AS maybe_new_parent
+        CALL (ip_namespace, maybe_new_parent) {
+            // ------------------
+            // filter to only active maybe_new_parent Nodes in the correct namespace
+            // ------------------
+            OPTIONAL MATCH (ip_namespace)-[r1:IS_RELATED]-(:Relationship {name: "ip_namespace__ip_prefix"})-[r2:IS_RELATED]-(maybe_new_parent)
+            WHERE all(r IN [r1, r2] WHERE (%(branch_filter)s))
+            WITH maybe_new_parent, r1, r2, r1.status = "active" AND r2.status = "active" AS is_active
+            ORDER BY elementId(maybe_new_parent), r1.branch_level DESC, r1.from DESC, r1.status DESC, r2.branch_level DESC, r2.from DESC, r2.status DESC
+            WITH maybe_new_parent, head(collect(is_active)) AS is_active
+            RETURN is_active = TRUE AS parent_in_namespace
+        }
+        CALL (maybe_new_parent) {
+            // ------------------
+            // filter to only active maybe_new_parent Nodes currently linked to one of the allowed AttributeValues
+            // ------------------
+            OPTIONAL MATCH (maybe_new_parent)-[r1:HAS_ATTRIBUTE]->(:Attribute {name: "prefix"})-[r2:HAS_VALUE]->(av:AttributeValue)
+            WHERE all(r IN [r1, r2] WHERE (%(branch_filter)s))
+            WITH maybe_new_parent, av, r1, r2, r1.status = "active" AND r2.status = "active" AS is_active
+            ORDER BY elementId(maybe_new_parent), r1.branch_level DESC, r1.from DESC, r1.status DESC, r2.branch_level DESC, r2.from DESC, r2.status DESC
+            // ------------------
+            // get the latest active attribute value for the maybe_new_parent
+            // ------------------
+            WITH maybe_new_parent, head(collect([av, is_active])) AS av_is_active
+            WITH
+                av_is_active[0] AS av,
+                av_is_active[1] AS is_active
+            // ------------------
+            // return NULL if the value is not allowed or if it is not active
+            // ------------------
+            WITH av, is_active, (
+                av.version = $ip_version
+                AND av.binary_address IN $possible_prefix_list
+                AND any(prefix_and_length IN $possible_prefix_and_length_list WHERE av.binary_address = prefix_and_length[0] AND av.prefixlen <= prefix_and_length[1])
+            ) AS is_allowed_value
+            RETURN CASE WHEN is_active = TRUE AND is_allowed_value = TRUE THEN av ELSE NULL END AS allowed_av
+        }
+        // ------------------
+        // set inactive maybe_new_parents to NULL
+        // ------------------
+        WITH ip_namespace, ip_node, current_parent, current_children, allowed_av.prefixlen AS mnp_prefixlen,
+            CASE WHEN parent_in_namespace = TRUE AND allowed_av IS NOT NULL
+                THEN maybe_new_parent ELSE NULL
+            END AS maybe_new_parent
         WITH ip_namespace, ip_node, current_parent, current_children, maybe_new_parent, mnp_prefixlen
         ORDER BY ip_node.uuid, mnp_prefixlen DESC
         WITH ip_namespace, ip_node, current_parent, current_children, head(collect(maybe_new_parent)) as new_parent

--- a/backend/tests/unit/core/ipam/test_ipam_reconcile_query.py
+++ b/backend/tests/unit/core/ipam/test_ipam_reconcile_query.py
@@ -2,10 +2,12 @@ import ipaddress
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
-from infrahub.core.constants import InfrahubKind
+from infrahub.core.constants import InfrahubKind, SchemaPathType
 from infrahub.core.initialization import create_branch, get_default_ipnamespace
 from infrahub.core.manager import NodeManager
+from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration
 from infrahub.core.node import Node
+from infrahub.core.path import SchemaPath
 from infrahub.core.query.ipam import IPPrefixReconcileQuery
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
@@ -605,3 +607,53 @@ async def test_root_ip_prefix_added_reconcile(
     await query.execute(db=db)
     assert query.get_calculated_parent_uuid() is None
     assert query.get_calculated_children_uuids() == [child_prefix_node.id]
+
+
+async def test_reconcile_query_on_migrated_kind_node(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
+    default_ipnamespace = await get_default_ipnamespace(db=db)
+    registry.default_ipnamespace = default_ipnamespace.id
+    prefix_140 = ip_dataset_01["net140"]
+    namespace = ip_dataset_01["ns1"]
+
+    branch = await create_branch(db=db, branch_name="migrated-branch")
+
+    # update IpamIPPrefix schema name
+    prefix_schema = registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch, duplicate=True)
+    prefix_schema.name = "IPPrefixTwo"
+    assert prefix_schema.kind == "IpamIPPrefixTwo"
+    migration = NodeKindUpdateMigration(
+        previous_node_schema=registry.schema.get_node_schema(name="IpamIPPrefix", branch=default_branch),
+        new_node_schema=prefix_schema,
+        schema_path=SchemaPath(path_type=SchemaPathType.ATTRIBUTE, schema_kind="IpamIPPrefixTwo", field_name="name"),
+    )
+    execution_result = await migration.execute(db=db, branch=branch)
+    assert not execution_result.errors
+
+    registry.schema.set(name="IpamIPPrefixTwo", schema=prefix_schema, branch=branch.name)
+    wrong_parent = await Node.init(db=db, schema=prefix_schema, branch=branch)
+    await wrong_parent.new(db=db, prefix="192.168.0.0/16", ip_namespace=namespace)
+    await wrong_parent.save(db=db)
+    wrong_child = await Node.init(db=db, schema=prefix_schema, branch=branch)
+    await wrong_child.new(db=db, prefix="192.168.0.0/24", ip_namespace=namespace)
+    await wrong_child.save(db=db)
+    branch_net_140 = await NodeManager.get_one(db=db, branch=branch, id=prefix_140.id)
+    await branch_net_140.parent.update(db=db, data=wrong_parent.id)
+    await branch_net_140.children.update(db=db, data=[wrong_child.id])
+    await branch_net_140.ip_addresses.update(db=db, data=[None])
+    await branch_net_140.save(db=db)
+
+    ip_network = ipaddress.ip_network(prefix_140.prefix.value)
+    query = await IPPrefixReconcileQuery.init(db=db, branch=branch, ip_value=ip_network, namespace=namespace)
+    await query.execute(db=db)
+
+    assert query.get_ip_node_uuid() == prefix_140.id
+    # the wrong parent and wrong child confirm that we retrieved the correct Node from the database: the IpamIPPrefixTwo instance
+    assert query.get_current_parent_uuid() == wrong_parent.id
+    assert set(query.get_current_children_uuids()) == {wrong_child.id}
+    assert query.get_calculated_parent_uuid() == ip_dataset_01["net146"].id
+    assert set(query.get_calculated_children_uuids()) == {
+        ip_dataset_01["net142"].id,
+        ip_dataset_01["net144"].id,
+        ip_dataset_01["net145"].id,
+        ip_dataset_01["address10"].id,
+    }

--- a/backend/tests/unit/core/ipam/test_ipam_reconciler.py
+++ b/backend/tests/unit/core/ipam/test_ipam_reconciler.py
@@ -5,6 +5,7 @@ import pytest
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.initialization import (
+    create_branch,
     get_default_ipnamespace,
 )
 from infrahub.core.ipam.reconciler import IpamReconciler
@@ -248,3 +249,36 @@ async def test_ipprefix_reconciler_prefix_value_update(db: InfrahubDatabase, def
         child_parent_rels = await child.ip_prefix.get_relationships(db=db)
         assert len(child_parent_rels) == 1
         assert child_parent_rels[0].peer_id == updated_prefix.id
+
+
+async def test_ipprefix_reconciler_prefix_value_update_on_branch(
+    db: InfrahubDatabase, default_branch: Branch, ip_dataset_01
+):
+    default_ipnamespace = await get_default_ipnamespace(db=db)
+    registry.default_ipnamespace = default_ipnamespace.id
+    namespace = ip_dataset_01["ns1"]
+    net_143 = ip_dataset_01["net143"]
+
+    branch = await create_branch(db=db, branch_name="branch-prefix-update")
+    net_143_branch = await NodeManager.get_one(db=db, branch=branch, id=net_143.id)
+    net_143_branch.prefix.value = "10.10.1.0/28"
+    await net_143_branch.save(db=db)
+
+    ip_network = ipaddress.ip_network(net_143_branch.prefix.value)
+    reconciler = IpamReconciler(db=db, branch=branch)
+    await reconciler.reconcile(ip_value=ip_network, namespace=namespace)
+
+    # check prefix is updated
+    updated_prefix = await NodeManager.get_one(db=db, branch=branch, id=net_143.id)
+    assert updated_prefix.prefix.value == "10.10.1.0/28"
+    # check children are correct
+    updated_prefix_child_rels = await updated_prefix.children.get_relationships(db=db)
+    assert len(updated_prefix_child_rels) == 0
+    # check addresses are correct
+    updated_address_rels = await updated_prefix.ip_addresses.get_relationships(db=db)
+    assert len(updated_address_rels) == 1
+    assert updated_address_rels[0].peer_id == ip_dataset_01["address11"].id
+    # check parent is correct
+    updated_parent_rel = await updated_prefix.parent.get_relationships(db=db)
+    assert len(updated_parent_rel) == 1
+    assert updated_parent_rel[0].peer_id == ip_dataset_01["net140"].id

--- a/backend/tests/unit/core/ipam/test_ipam_reconciler.py
+++ b/backend/tests/unit/core/ipam/test_ipam_reconciler.py
@@ -4,6 +4,7 @@ import pytest
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
+from infrahub.core.constants import InfrahubKind
 from infrahub.core.initialization import (
     create_branch,
     get_default_ipnamespace,
@@ -13,6 +14,15 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import NodeNotFoundError
+
+
+async def test_missing_value_raises_error(db: InfrahubDatabase, default_branch: Branch, default_ipnamespace: Node):
+    reconciler = IpamReconciler(db=db, branch=default_branch)
+    with pytest.raises(NodeNotFoundError) as exc_info:
+        await reconciler.reconcile(ip_value=ipaddress.ip_network("10.10.0.0/24"), namespace=default_ipnamespace)
+
+    assert exc_info.value.node_type == InfrahubKind.IPPREFIX
+    assert exc_info.value.identifier == "10.10.0.0/24"
 
 
 async def test_first_prefix(
@@ -322,7 +332,7 @@ async def test_ipprefix_reconciler_decrement_prefix_length_on_branch(
     # check parent is correct
     updated_parent_rel = await updated_prefix.parent.get_relationships(db=db)
     assert len(updated_parent_rel) == 1
-    assert updated_parent_rel[0].peer_id == ip_dataset_01["net140"].id
+    assert updated_parent_rel[0].peer_id == net_143_branch.id
 
 
 async def test_namespace_change_on_branch(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
@@ -361,3 +371,58 @@ async def test_namespace_change_on_branch(db: InfrahubDatabase, default_branch: 
     updated_parent_rel = await updated_prefix.parent.get_relationships(db=db)
     assert len(updated_parent_rel) == 1
     assert updated_parent_rel[0].peer_id == ip_dataset_01["net146"].id
+
+
+async def test_ipprefix_swap_values_on_branch(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
+    default_ipnamespace = await get_default_ipnamespace(db=db)
+    registry.default_ipnamespace = default_ipnamespace.id
+    namespace = ip_dataset_01["ns1"]
+    net_140 = ip_dataset_01["net140"]
+    net_143 = ip_dataset_01["net143"]
+
+    branch = await create_branch(db=db, branch_name="branch-prefix-update")
+    # update from 10.10.0.0/16 to 8.8.0.0/16 and delete parent and children relationships
+    net_140_branch = await NodeManager.get_one(db=db, branch=branch, id=net_140.id)
+    net_140_branch.prefix.value = "8.8.0.0/16"
+    await net_140_branch.parent.update(db=db, data=[None])
+    await net_140_branch.children.update(db=db, data=[None])
+    await net_140_branch.save(db=db)
+    # update from 10.10.1.0/27 to 10.10.0.0/16
+    net_143_branch = await NodeManager.get_one(db=db, branch=branch, id=net_143.id)
+    net_143_branch.prefix.value = "10.10.0.0/16"
+    await net_143_branch.save(db=db)
+
+    reconciler = IpamReconciler(db=db, branch=branch)
+
+    ip_network = ipaddress.ip_network(net_143_branch.prefix.value)
+    await reconciler.reconcile(ip_value=ip_network, namespace=namespace)
+
+    # check new 10.10.0.0/16 prefix is updated
+    updated_prefix = await NodeManager.get_one(db=db, branch=branch, id=net_143.id)
+    assert updated_prefix.prefix.value == "10.10.0.0/16"
+    # check children are correct
+    updated_prefix_child_rels = await updated_prefix.children.get_relationships(db=db)
+    assert len(updated_prefix_child_rels) == 3
+    child_peer_ids = {rel.peer_id for rel in updated_prefix_child_rels}
+    assert child_peer_ids == {ip_dataset_01["net142"].id, ip_dataset_01["net144"].id, ip_dataset_01["net145"].id}
+    # check addresses are correct
+    updated_address_rels = await updated_prefix.ip_addresses.get_relationships(db=db)
+    assert len(updated_address_rels) == 1
+    assert updated_address_rels[0].peer_id == ip_dataset_01["address10"].id
+    # check parent is correct
+    updated_parent_rel = await updated_prefix.parent.get_relationships(db=db)
+    assert len(updated_parent_rel) == 1
+    assert updated_parent_rel[0].peer_id == ip_dataset_01["net146"].id
+
+    # check new 8.8.0.0/16 is unchanged
+    updated_prefix = await NodeManager.get_one(db=db, branch=branch, id=net_140.id)
+    assert updated_prefix.prefix.value == "8.8.0.0/16"
+    # check children are correct
+    updated_prefix_child_rels = await updated_prefix.children.get_relationships(db=db)
+    assert len(updated_prefix_child_rels) == 0
+    # check addresses are correct
+    updated_address_rels = await updated_prefix.ip_addresses.get_relationships(db=db)
+    assert len(updated_address_rels) == 0
+    # check parent is correct
+    updated_parent_rel = await updated_prefix.parent.get_relationships(db=db)
+    assert len(updated_parent_rel) == 0

--- a/backend/tests/unit/core/ipam/test_ipam_reconciler.py
+++ b/backend/tests/unit/core/ipam/test_ipam_reconciler.py
@@ -281,4 +281,4 @@ async def test_ipprefix_reconciler_prefix_value_update_on_branch(
     # check parent is correct
     updated_parent_rel = await updated_prefix.parent.get_relationships(db=db)
     assert len(updated_parent_rel) == 1
-    assert updated_parent_rel[0].peer_id == ip_dataset_01["net140"].id
+    assert updated_parent_rel[0].peer_id == ip_dataset_01["net142"].id

--- a/backend/tests/unit/core/ipam/test_ipam_reconciler.py
+++ b/backend/tests/unit/core/ipam/test_ipam_reconciler.py
@@ -251,7 +251,7 @@ async def test_ipprefix_reconciler_prefix_value_update(db: InfrahubDatabase, def
         assert child_parent_rels[0].peer_id == updated_prefix.id
 
 
-async def test_ipprefix_reconciler_prefix_value_update_on_branch(
+async def test_ipprefix_reconciler_increment_prefix_length_on_branch(
     db: InfrahubDatabase, default_branch: Branch, ip_dataset_01
 ):
     default_ipnamespace = await get_default_ipnamespace(db=db)
@@ -261,6 +261,7 @@ async def test_ipprefix_reconciler_prefix_value_update_on_branch(
 
     branch = await create_branch(db=db, branch_name="branch-prefix-update")
     net_143_branch = await NodeManager.get_one(db=db, branch=branch, id=net_143.id)
+    # update from 10.10.1.0/27 to 10.10.1.0/28
     net_143_branch.prefix.value = "10.10.1.0/28"
     await net_143_branch.save(db=db)
 
@@ -282,3 +283,81 @@ async def test_ipprefix_reconciler_prefix_value_update_on_branch(
     updated_parent_rel = await updated_prefix.parent.get_relationships(db=db)
     assert len(updated_parent_rel) == 1
     assert updated_parent_rel[0].peer_id == ip_dataset_01["net142"].id
+
+
+async def test_ipprefix_reconciler_decrement_prefix_length_on_branch(
+    db: InfrahubDatabase, default_branch: Branch, ip_dataset_01
+):
+    default_ipnamespace = await get_default_ipnamespace(db=db)
+    registry.default_ipnamespace = default_ipnamespace.id
+    namespace = ip_dataset_01["ns1"]
+    net_142 = ip_dataset_01["net142"]
+    net_143 = ip_dataset_01["net143"]
+
+    branch = await create_branch(db=db, branch_name="branch-prefix-update")
+    # update from 10.10.1.0/27 to 10.10.0.0/23
+    net_143_branch = await NodeManager.get_one(db=db, branch=branch, id=net_143.id)
+    net_143_branch.prefix.value = "10.10.0.0/23"
+    await net_143_branch.save(db=db)
+    # update from 10.10.1.0/24 to 10.10.1.0/26
+    net_142_branch = await NodeManager.get_one(db=db, branch=branch, id=net_142.id)
+    net_142_branch.prefix.value = "10.10.1.0/26"
+    await net_142_branch.save(db=db)
+    # so net142 should not be a parent of net143 on this branch
+
+    ip_network = ipaddress.ip_network(net_142_branch.prefix.value)
+    reconciler = IpamReconciler(db=db, branch=branch)
+    await reconciler.reconcile(ip_value=ip_network, namespace=namespace)
+
+    # check prefix is updated
+    updated_prefix = await NodeManager.get_one(db=db, branch=branch, id=net_142.id)
+    assert updated_prefix.prefix.value == "10.10.1.0/26"
+    # check children are correct
+    updated_prefix_child_rels = await updated_prefix.children.get_relationships(db=db)
+    assert len(updated_prefix_child_rels) == 0
+    # check addresses are correct
+    updated_address_rels = await updated_prefix.ip_addresses.get_relationships(db=db)
+    assert len(updated_address_rels) == 1
+    assert updated_address_rels[0].peer_id == ip_dataset_01["address11"].id
+    # check parent is correct
+    updated_parent_rel = await updated_prefix.parent.get_relationships(db=db)
+    assert len(updated_parent_rel) == 1
+    assert updated_parent_rel[0].peer_id == ip_dataset_01["net140"].id
+
+
+async def test_namespace_change_on_branch(db: InfrahubDatabase, default_branch: Branch, ip_dataset_01):
+    default_ipnamespace = await get_default_ipnamespace(db=db)
+    registry.default_ipnamespace = default_ipnamespace.id
+    namespace = ip_dataset_01["ns1"]
+    namespace_2 = ip_dataset_01["ns2"]
+    net_140 = ip_dataset_01["net140"]
+    net_142 = ip_dataset_01["net142"]
+    net_143 = ip_dataset_01["net143"]
+
+    branch = await create_branch(db=db, branch_name="branch-prefix-update")
+    # update namespaces for parent and child on branch
+    net_140_branch = await NodeManager.get_one(db=db, branch=branch, id=net_140.id)
+    await net_140_branch.ip_namespace.update(db=db, data=namespace_2)
+    await net_140_branch.save(db=db)
+    net_143_branch = await NodeManager.get_one(db=db, branch=branch, id=net_143.id)
+    await net_143_branch.ip_namespace.update(db=db, data=namespace_2)
+    await net_143_branch.save(db=db)
+
+    ip_network = ipaddress.ip_network(net_142.prefix.value)
+    reconciler = IpamReconciler(db=db, branch=branch)
+    await reconciler.reconcile(ip_value=ip_network, namespace=namespace)
+
+    # check prefix is updated
+    updated_prefix = await NodeManager.get_one(db=db, branch=branch, id=net_142.id)
+    assert updated_prefix.prefix.value == "10.10.1.0/24"
+    # check children are correct
+    updated_prefix_child_rels = await updated_prefix.children.get_relationships(db=db)
+    assert len(updated_prefix_child_rels) == 0
+    # check addresses are correct
+    updated_address_rels = await updated_prefix.ip_addresses.get_relationships(db=db)
+    assert len(updated_address_rels) == 1
+    assert updated_address_rels[0].peer_id == ip_dataset_01["address11"].id
+    # check parent is correct
+    updated_parent_rel = await updated_prefix.parent.get_relationships(db=db)
+    assert len(updated_parent_rel) == 1
+    assert updated_parent_rel[0].peer_id == ip_dataset_01["net146"].id

--- a/changelog/6934.fixed.md
+++ b/changelog/6934.fixed.md
@@ -1,0 +1,1 @@
+Fix bug in IP reconciliation that could cause prefixes or addresses updated on a branch to have incorrect parents or children.


### PR DESCRIPTION
part of #6934 
IFC-1712

there were a few bugs in the IP reconciliation cypher query that could cause prefixes or addresses to have incorrect parents/children if their address/prefix/namespace/parent/children were updated on a branch
good news is that the bug(s) were not an issue when running on the default branch AND we always run IP reconciliation for any updated IP nodes when merging a branch

the bugs were that we were only checking if edges were active in a few places instead of selecting only the latest active value for a given attribute or relationship. for example, if I have a prefix `10.10.0.0/16` on main and I create a branch and update this prefix to `10.10.0.0/15` on the branch, then the IP reconciliation logic _could_ still consider this node as having the value `10.10.0.0/16` in certain circumstances.

The fixes are to update the query to do an initial wider filter to get all the possible correct nodes for each stage and then filter them to make sure that their latest value and namespace are the correct ones.

TODO:

will need a migration in a follow-up PR to identify prefix/address nodes that have been updated on a branch that has not been merged back into the default branch and reconcile them on the branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect parent/child assignment during branched IP prefix/address updates; reconciliation now respects branch-specific state and active relationships.

* **Improvements**
  * More robust and modular IP lookup, namespace selection, and parent/child reconciliation with unified handling for prefixes and addresses and stricter status/branch filtering.

* **Tests**
  * Added branch-focused reconciliation tests, migration-aware reconciliation test, and a missing-prefix error test.

* **Documentation**
  * Changelog updated to reflect the IP reconciliation fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->