### PR TITLE
Force branches data to be reloaded when the hash doesn't look healthy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
+## [Infrahub - v1.4.3](https://github.com/opsmill/infrahub/tree/infrahub-v1.4.3) - 2025-08-29
+
+### Fixed
+
+- Force branches data to be reloaded when the hash doesn't look healthy
+
 ## [Infrahub - v1.4.2](https://github.com/opsmill/infrahub/tree/infrahub-v1.4.2) - 2025-08-28
 
 ### Fixed

--- a/backend/infrahub/core/models.py
+++ b/backend/infrahub/core/models.py
@@ -73,6 +73,15 @@ class SchemaBranchHash(BaseModel):
     nodes: dict[str, str] = Field(default_factory=dict)
     generics: dict[str, str] = Field(default_factory=dict)
 
+    @property
+    def is_valid(self) -> bool:
+        """
+        TODO: This is a temporary solution to avoid comparing schema hashes if there are less than 2 nodes or generics.
+        """
+        if len(self.nodes) < 2 and len(self.generics) < 2:
+            return False
+        return True
+
     def compare(self, other: SchemaBranchHash) -> SchemaBranchDiff | None:
         if other.main == self.main:
             return None

--- a/backend/infrahub/core/schema/manager.py
+++ b/backend/infrahub/core/schema/manager.py
@@ -615,7 +615,9 @@ class SchemaManager(NodeManager):
                 return new_branch_schema
 
         current_schema = self.get_schema_branch(name=branch.name)
-        schema_diff = current_schema.get_hash_full().compare(branch.active_schema_hash)
+        schema_diff = None
+        if branch.active_schema_hash.is_valid and current_schema.get_hash_full().is_valid:
+            schema_diff = current_schema.get_hash_full().compare(branch.active_schema_hash)
         branch_schema = await self.load_schema_from_db(
             db=db, branch=branch, schema=current_schema, schema_diff=schema_diff
         )

--- a/changelog/+branch_schema.fixed.md
+++ b/changelog/+branch_schema.fixed.md
@@ -1,1 +1,0 @@
-Force branches data to be reloaded when the hash doesn't look healthy

--- a/changelog/+branch_schema.fixed.md
+++ b/changelog/+branch_schema.fixed.md
@@ -1,0 +1,1 @@
+Force branches data to be reloaded when the hash doesn't look healthy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "infrahub-server"
-version = "1.4.2"
+version = "1.4.3"
 description = "Infrahub is taking a new approach to Infrastructure Management by providing a new generation of datastore to organize and control all the data that defines how an infrastructure should run."
 authors = ["OpsMill <info@opsmill.com>"]
 readme = "README.md"

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "infrahub-testcontainers"
-version =  "1.4.2"
+version = "1.4.3"
 requires-python = ">=3.9"
 
 [tool.poetry]
 name = "infrahub-testcontainers"
-version =  "1.4.2"
+version = "1.4.3"
 description = "Testcontainers instance for Infrahub to easily build integration tests"
 authors = ["OpsMill <info@opsmill.com>"]
 readme = "README.md"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Prevented unreliable schema comparisons by skipping diffs when hashes appear invalid, triggering a safe full reload of branch data to avoid inconsistent state or load errors.

- Chores
  - Bumped version to 1.4.3.
  - Updated changelog with a fix entry describing the safer reload behavior when schema hashes look unhealthy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->