### PR TITLE
Add "lock." prefix to global locks, include worker ID to lock value

### DIFF
--- a/backend/infrahub/lock.py
+++ b/backend/infrahub/lock.py
@@ -13,6 +13,7 @@ from redis.asyncio.lock import Lock as GlobalLock
 
 from infrahub import config
 from infrahub.core.timestamp import current_timestamp
+from infrahub.worker import WORKER_IDENTITY
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -92,7 +93,7 @@ class NATSLock:
         await self.release()
 
     async def acquire(self) -> None:
-        token = current_timestamp()
+        token = f"{current_timestamp()}::{WORKER_IDENTITY}"
         while True:
             if await self.do_acquire(token):
                 self.token = token
@@ -138,9 +139,9 @@ class InfrahubLock:
         if self.use_local:
             self.local = LocalLock()
         elif config.SETTINGS.cache.driver == config.CacheDriver.Redis:
-            self.remote = GlobalLock(redis=self.connection, name=self.name)
+            self.remote = GlobalLock(redis=self.connection, name=f"lock.{self.name}")
         else:
-            self.remote = NATSLock(service=self.connection, name=self.name)
+            self.remote = NATSLock(service=self.connection, name=f"lock.{self.name}")
 
     async def __aenter__(self):
         await self.acquire()
@@ -156,7 +157,7 @@ class InfrahubLock:
     async def acquire(self) -> None:
         with LOCK_ACQUIRE_TIME_METRICS.labels(self.name, self.lock_type).time():
             if not self.use_local:
-                await self.remote.acquire(token=current_timestamp())
+                await self.remote.acquire(token=f"{current_timestamp()}::{WORKER_IDENTITY}")
             else:
                 await self.local.acquire()
         self.acquire_time = time.time_ns()


### PR DESCRIPTION
This PR adds a `lock.` prefix to the name of global locks with the goal of being able to list all global locks using a simple filter i.e. `locks.*`, the second change is that the worker ID has been included in the payload of the lock. The purpose is to identify the worker that created the lock so that we can later release stale locks if the worker is offline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced lock key collisions by standardizing remote lock key prefixes across backends.
  * Improved reliability of distributed operations by including worker identity in lock tokens.
  * Ensured clearer lock acquisition outcomes for remote locks, reducing intermittent failures and timeouts.

* **Chores**
  * Unified token format and key naming for remote locks to improve traceability and consistency in clustered deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->