### PR TITLE
docs: add release notes for version 1.4.3

### DIFF
--- a/docs/docs/release-notes/infrahub/release-1_4_3.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_4_3.mdx
@@ -1,0 +1,23 @@
+---
+title: Release 1.4.3
+---
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.4.3</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>August 29th, 2025</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[infrahub-v1.4.3](https://github.com/opsmill/infrahub/releases/tag/infrahub-v1.4.3)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Fixed
+
+- Force branches data to be reloaded when the hash doesn't look healthy

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -391,6 +391,7 @@ const sidebars: SidebarsConfig = {
             slug: 'release-notes/infrahub',
           },
           items: [
+            'release-notes/infrahub/release-1_4_3',
             'release-notes/infrahub/release-1_4_2',
             'release-notes/infrahub/release-1_4_1',
             'release-notes/infrahub/release-1_4_0',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added Release Notes for InfraHub 1.4.3 with release date (Aug 29, 2025) and link to the corresponding GitHub tag.
  - Documented a fix: branches data now reloads automatically when the hash appears unhealthy.
  - Updated navigation to include the new 1.4.3 release notes at the top of the InfraHub section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->