### PR TITLE
Fix branched_from property during rebase operations

### DIFF
--- a/backend/infrahub/tasks/registry.py
+++ b/backend/infrahub/tasks/registry.py
@@ -42,7 +42,7 @@ async def create_branch_registry(db: InfrahubDatabase, branch: Branch) -> None:
 
 
 async def update_branch_registry(db: InfrahubDatabase, branch: Branch) -> None:
-    """Update the registry for a branch if the schema hash has changed."""
+    """Update the registry for a branch if the schema hash has changed or the branch was rebased."""
 
     existing_branch: Branch = registry.branch[branch.name]
 
@@ -50,13 +50,23 @@ async def update_branch_registry(db: InfrahubDatabase, branch: Branch) -> None:
         log.warning("Branch schema hash is not set, cannot update branch registry")
         return
 
-    if existing_branch.schema_hash and existing_branch.schema_hash.main == branch.active_schema_hash.main:
+    if existing_branch.schema_hash.main == branch.active_schema_hash.main:
         log.debug(
-            "Branch schema hash is the same, no need to update branch registry",
+            "Branch schema hash is the same, no need to refresh the GraphQL schema within the registry",
             branch=branch.name,
             hash=existing_branch.schema_hash.main,
             worker=WORKER_IDENTITY,
         )
+        if existing_branch.branched_from != branch.branched_from:
+            # If the hash is the same but the branched_from timestamp differs it means
+            # that the branch has been rebased and these timestamps need to be refreshed
+            # in the registry even though the schema doesn't need to be reloaded.
+            log.info(
+                "Updating branched_from property in registry for rebased branch",
+                branch=branch.name,
+                worker=WORKER_IDENTITY,
+            )
+            registry.branch[branch.name] = branch
         return
 
     log.info(

--- a/changelog/7113.fixed.md
+++ b/changelog/7113.fixed.md
@@ -1,0 +1,1 @@
+Fixed rebase bug by ensuring rebase operations with data only changes correctly set the .branched_from property of the branch within the registry.


### PR DESCRIPTION
Fixes #7113

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Correctly updates a branch’s origin after rebasing, even when only data changes occur.
  * Ensures branch state stays accurate and up to date after rebase, reducing inconsistencies users may see in branch information.
  * Improves reliability of branch metadata shown in tools and queries post-rebase.

* **Documentation**
  * Added a changelog entry describing the fix for rebase handling to ensure accurate branch origin tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->