### PR TITLE
fix(tests): flaky integration docker on enterprise

### DIFF
--- a/backend/tests/integration_docker/test_computed_attributes.py
+++ b/backend/tests/integration_docker/test_computed_attributes.py
@@ -83,7 +83,7 @@ class TestComputedAttributes(TestInfrahubDockerClient):
         )
         await color1_initial.save()
 
-        for _ in range(10):
+        for _ in range(20):
             # Give the computed attribute triggers a little while to run
             tshirt1_updated = await client.get(kind="TestingTShirt", id=tshirt1.id)
             if tshirt1_updated.description.value != first_desc:
@@ -100,7 +100,7 @@ class TestComputedAttributes(TestInfrahubDockerClient):
             "A Ember Glow Explorer t-shirt. A deep, fiery red-orange reminiscent of smoldering embers at dusk."
         )
 
-        for _ in range(10):
+        for _ in range(20):
             # Give the computed attribute triggers a little while to run
             tshirt1_second_update_result = await client.get(kind="TestingTShirt", id=tshirt1.id)
             if tshirt1_second_update_result.description.value == expected_description:
@@ -112,7 +112,7 @@ class TestComputedAttributes(TestInfrahubDockerClient):
         await tshirt1_second_update_result.save()
 
         expected_name_code = "WEARABLE-GARDENER"
-        for _ in range(10):
+        for _ in range(20):
             # Give the computed attribute triggers a little while to run
             tshirt1_last_update_result = await client.get(kind="TestingTShirt", id=tshirt1.id)
             if tshirt1_last_update_result.name_code.value == expected_name_code:
@@ -201,7 +201,7 @@ class TestComputedAttributes(TestInfrahubDockerClient):
         await sweden_name_update.save()
 
         swe_name_router_1 = "swe-sth-router-1"
-        for _ in range(10):
+        for _ in range(20):
             # Give the computed attribute triggers a little while to run
             sth_router_1_swe = await client.get(kind="InfraDevice", id=sth_router_1.id, include=["name"])
             if sth_router_1_swe.name.value == swe_name_router_1:


### PR DESCRIPTION
When running the integration tests with Infrahub Enterprise, we make use of the new distributed task manager mode. This mode may introduce some delay in message processing (default of 10s), which in turns make some integration tests flaky.

Increase the wait time above 10s, and also make it consistent with other places where we wait 20s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved stability of integration tests by extending polling duration for asynchronous computed-attribute and transform-based scenarios. This reduces flakiness by allowing more time for updates to appear while preserving early exit when conditions are met. No impact on user-facing functionality or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->