### PR TITLE
fix(docs): add full backup and restore process

### DIFF
--- a/docs/docs/guides/database-backup.mdx
+++ b/docs/docs/guides/database-backup.mdx
@@ -17,7 +17,9 @@ An alternative to avoid cloning the Infrahub repository is to directly run it th
 docker run --rm -v /var/run/docker.sock:/var/run/docker.sock registry.opsmill.io/opsmill/infrahub python -m utilities.db_backup
 ```
 
-## Backup a remote Infrahub database
+## Backup tool usage
+
+### Backup a remote Infrahub database
 
 ```python
 python -m utilities.db_backup neo4j backup --database-url=172.28.64.1 /infrahub_backups
@@ -30,7 +32,7 @@ Since the tool starts a helper container, the database may not be directly acces
 python -m utilities.db_backup neo4j backup --host-network --database-url=172.28.64.1 /infrahub_backups
 ```
 
-## Backup a local Infrahub database with a non-default backup port
+### Backup a local Infrahub database with a non-default backup port
 
 ```python
 python -m utilities.db_backup neo4j backup --database-backup-port=12345 /infrahub_backups
@@ -38,13 +40,44 @@ python -m utilities.db_backup neo4j backup --database-backup-port=12345 /infrahu
 
 In this example, I am running the backup command on the same machine that is running the Infrahub Docker containers. In this case, port `12345` must also have been set using the `NEO4J_server_backup_listen__address` environment variable in the Infrahub database container.
 
-## Restore a backup on a non-default cypher port
+### Restore a backup on a non-default cypher port
 
 ```python
 python -m utilities.db_backup neo4j restore /infrahub_backups --database-cypher-port=9876
 ```
 
 In this example, I am restoring `.backup` files that exist in the `/infrahub_backups` directory and my Infrahub database container uses a non-standard port for cypher access: `9876` instead of `7687`.
+
+## Full backup and restore procedure
+
+Backing Infrahub up consists of:
+
+1. Backup the Neo4j database, as described in this guide.
+2. Backup the artifact store
+
+  Either the S3 bucket or the local filesystem, accordingly.
+
+3. Backup the Prefect database (task logs, etc)
+
+  You can use standard PostgreSQL tools like `pg_dump`
+  For example, when running using Docker compose:
+
+`docker exec infrahub-task-manager-db-1 pg_dump -Fc -d prefect -U postgres > prefect.dump`
+
+Restoring Infrahub consists of:
+
+1. Starting Infrahub
+2. Restoring the Neo4j database
+3. Restoring the artifact store
+4. Restoring the Prefect database
+
+  For example, when running using Docker Compose:
+
+  `docker exec infrahub-task-manager-db-1 pg_restore -d prefect -U postgres --clean --create prefect.dump`
+
+  Then restart the task manager (Prefect server)
+
+5. Restarting Infrahub (API servers, then task workers)
 
 # Cluster Database backup and restore examples  
 

--- a/docs/docs/release-notes/infrahub/release-1_2_0.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_2_0.mdx
@@ -171,7 +171,7 @@ The top menu has also been made more compact, to provide a cleaner look.
 
 Users of Neo4j-enterprise and infrahub-enterprise already had the capability to backup the Neo4j database following the process in our [documentation](https://docs.infrahub.app/guides/database-backup).
 
-With Infrahub 1.2.0 there's a new requirement to also backup the PostgreSQL database that is used for Infrahub's internal task and event system. More information can be found in the [Installing Infrahub Enterprise guide](https://docs.infrahub.app/guides/installation-enterprise#backup-and-restore-infrahub-enterprise).
+With Infrahub 1.2.0 there's a new requirement to also backup the PostgreSQL database that is used for Infrahub's internal task and event system. More information can be found in the [Database backup and restore guide](https://docs.infrahub.app/guides/database-backup#full-backup-and-restore-procedure).
 
 ## Changelog
 


### PR DESCRIPTION
Fixes #6951

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Reworked database backup guide with a new “Backup tool usage” section, including remote backup via --database-url and a --host-network example.
  - Added a comprehensive “Full backup and restore procedure” covering Neo4j, artifact store, and Prefect (PostgreSQL) with concrete pg_dump/pg_restore examples.
  - Adjusted heading levels for clearer structure.
  - Updated release notes link to point to the Database backup and restore guide with the appropriate anchor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->