### PR TITLE
fix(docs): many broken links

### DIFF
--- a/docs/_templates/infrahub_config.j2
+++ b/docs/_templates/infrahub_config.j2
@@ -13,7 +13,7 @@ The Infrahub containers have a number of environmental variables available at ru
 Here are a few common methods of setting environmental variables:
 
 - Exporting in a shell, example: `export INFRAHUB_ADDRESS="http://localhost:8000"`
-- Using a [`.env` file](https://docs.docker.com/compose/environment-variables/set-environment-variables/#substitute-with-an-env-file)
+- Using a [`.env` file](https://docs.docker.com/compose/how-tos/environment-variables/variable-interpolation/#env-file)
 - Using [direnv](https://direnv.net/)
 
 :::note

--- a/docs/docs/development/docs.mdx
+++ b/docs/docs/development/docs.mdx
@@ -253,7 +253,7 @@ Here are questions to ask when deciding where to place a new document:
 - Are you providing background information, explanation, or abstract concepts? Select **Topics**.
 - Are you providing APIs, command references, or concise reference information? Select **Reference**.
 
-If you're unsure where something goes, diátaxis offers a [map](https://diataxis.fr/needs/) and [compass](https://diataxis.fr/compass/) to help.
+If you're unsure where something goes, diátaxis offers a [map](https://diataxis.fr/map/) and [compass](https://diataxis.fr/compass/) to help.
 
 When creating a new page in the documentation, in addition to creating the `.mdx` file containing the documentation itself, you must also add the page to the relevant section of the `sidebars.ts` file.
 

--- a/docs/docs/reference/configuration.mdx
+++ b/docs/docs/reference/configuration.mdx
@@ -13,7 +13,7 @@ The Infrahub containers have a number of environmental variables available at ru
 Here are a few common methods of setting environmental variables:
 
 - Exporting in a shell, example: `export INFRAHUB_ADDRESS="http://localhost:8000"`
-- Using a [`.env` file](https://docs.docker.com/compose/environment-variables/set-environment-variables/#substitute-with-an-env-file)
+- Using a [`.env` file](https://docs.docker.com/compose/how-tos/environment-variables/variable-interpolation/#env-file)
 - Using [direnv](https://direnv.net/)
 
 :::note

--- a/docs/docs/reference/schema-validation.mdx
+++ b/docs/docs/reference/schema-validation.mdx
@@ -60,6 +60,6 @@ schemas:
 
 :::note
 
-The schema of the Infrahub external repository configuration file has been published on [JSON Schema store](https://www.schemastore.org/json/). It allows an editor, like Visual Studio Code to download the correct schema validation file. Visual Studio Code will automatically validate a file named `.infrahub.y(a)ml` with this schema, if the Red Hat YAML Language server is installed.
+The schema of the Infrahub external repository configuration file has been published on [JSON Schema store](https://www.schemastore.org/). It allows an editor, like Visual Studio Code to download the correct schema validation file. Visual Studio Code will automatically validate a file named `.infrahub.y(a)ml` with this schema, if the Red Hat YAML Language server is installed.
 
 :::

--- a/docs/docs/release-notes/infrahub/release-1_2_1.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_2_1.mdx
@@ -47,7 +47,7 @@ If you current schema is not valid anymore with Infrahub 1.2 our recommendation 
 
 In 1.2, we introduced a new command to upgrade Infrahub `infrahub upgrade`, unfortunately due to a bug the command was missing in Infrahub Enterprise.
 
-The issue has been fixed in 1.2.1 and the documentation has been updated to include more information regarding the upgrade procedure for Infrahub [Community](https://docs.infrahub.app/guides/upgrade) & [Enterprise](https://docs.infrahub.app/guides/upgrade-enterprise)
+The issue has been fixed in 1.2.1 and the documentation has been updated to include more information regarding the upgrade procedure for Infrahub [Community](https://docs.infrahub.app/guides/upgrade) & [Enterprise](https://docs.infrahub.app/guides/upgrade#enterprise)
 
 ## Main changes
 

--- a/docs/docs/topics/database-backup.mdx
+++ b/docs/docs/topics/database-backup.mdx
@@ -94,7 +94,7 @@ The first option is probably easier. The second option can be achieved by ensuri
 
 You must specify the directory containing the backup files you wish to restore on the Infrahub database in the `backup_directory` argument to the `db_backup neo4j restore` command. This directory should contain `.backup` files produced by the `db_backup neo4j backup` command. The files must be of the format `<database_name>-2024-02-07T22-12-16.backup`. Given the default database configuration, a backup will produce two `.backup` files: one for the `neo4j` database and one for the `system` database.
 
-The `backup` utility produces a `.backup` file for the `system` database, but the `restore` utility will not attempt to restore a `system` database backup. This should not cause any problems for you unless your Infrahub database has suffered a catastrophic failure. Neo4j provides documentation on this process [here](https://neo4j.com/docs/operations-manual/current/clustering/disaster-recovery/#_restore_the_system_database), but it is beyond the scope of what this utility is intended to do.
+The `backup` utility produces a `.backup` file for the `system` database, but the `restore` utility will not attempt to restore a `system` database backup. This should not cause any problems for you unless your Infrahub database has suffered a catastrophic failure. Neo4j provides documentation on this process [here](https://neo4j.com/docs/operations-manual/5/clustering/disaster-recovery/#make-the-system-database-write-available), but it is beyond the scope of what this utility is intended to do.
 
 ### Downtime
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated links for Diátaxis map, Docker Compose .env guidance, Neo4j disaster recovery (restore section), and Enterprise upgrade in 1.2.1 notes.
  * Cleaned up formatting in schema validation notes (removed unnecessary bullet points).
  * Updated template reference for env-file guidance to align docs with the new Docker Compose variable-interpolation link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->