### PR TITLE
Autofix linting issues targeting Python 3.12

### DIFF
--- a/backend/infrahub/auth.py
+++ b/backend/infrahub/auth.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from enum import Enum
 from typing import TYPE_CHECKING
 
@@ -76,7 +76,7 @@ async def authenticate_with_password(
     if not valid_credentials:
         raise AuthorizationError("Incorrect password")
 
-    now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=UTC)
     refresh_expires = now + timedelta(seconds=config.SETTINGS.security.refresh_token_lifetime)
 
     session_id = await create_db_refresh_token(db=db, account_id=account.id, expiration=refresh_expires)
@@ -137,7 +137,7 @@ async def signin_sso_account(db: InfrahubDatabase, account_name: str, sso_groups
                 await group.members.add(db=db, data=account)
                 await group.members.save(db=db)
 
-    now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=UTC)
     refresh_expires = now + timedelta(seconds=config.SETTINGS.security.refresh_token_lifetime)
     session_id = await create_db_refresh_token(db=db, account_id=account.id, expiration=refresh_expires)
     access_token = generate_access_token(account_id=account.id, session_id=session_id)
@@ -146,7 +146,7 @@ async def signin_sso_account(db: InfrahubDatabase, account_name: str, sso_groups
 
 
 def generate_access_token(account_id: str, session_id: uuid.UUID) -> str:
-    now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=UTC)
 
     access_expires = now + timedelta(seconds=config.SETTINGS.security.access_token_lifetime)
     access_data = {
@@ -163,7 +163,7 @@ def generate_access_token(account_id: str, session_id: uuid.UUID) -> str:
 
 
 def generate_refresh_token(account_id: str, session_id: uuid.UUID, expiration: datetime) -> str:
-    now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=UTC)
 
     refresh_data = {
         "sub": account_id,

--- a/backend/infrahub/cli/db.py
+++ b/backend/infrahub/cli/db.py
@@ -5,7 +5,7 @@ import logging
 import os
 from collections import defaultdict
 from csv import DictReader, DictWriter
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Sequence
@@ -59,7 +59,7 @@ from .patch import patch_app
 
 def get_timestamp_string() -> str:
     """Generate a timestamp string in the format YYYYMMDD-HHMMSS."""
-    return datetime.now(tz=timezone.utc).strftime("%Y%m%d-%H%M%S")
+    return datetime.now(tz=UTC).strftime("%Y%m%d-%H%M%S")
 
 
 if TYPE_CHECKING:

--- a/backend/infrahub/patch/plan_writer.py
+++ b/backend/infrahub/patch/plan_writer.py
@@ -1,6 +1,6 @@
 import json
 from dataclasses import asdict
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -10,7 +10,7 @@ from .models import EdgeToAdd, EdgeToDelete, EdgeToUpdate, PatchPlan, VertexToAd
 
 class PatchPlanWriter:
     def write(self, patches_directory: Path, patch_plan: PatchPlan) -> Path:
-        timestamp_str = datetime.now(tz=timezone.utc).strftime("%Y%m%d-%H%M%S")
+        timestamp_str = datetime.now(tz=UTC).strftime("%Y%m%d-%H%M%S")
         patch_name = f"patch-{patch_plan.name}-{timestamp_str}"
         patch_plan_directory = patches_directory / Path(patch_name)
         if not patch_plan_directory.exists():

--- a/backend/tests/unit/graphql/diff/test_diff_tree_query.py
+++ b/backend/tests/unit/graphql/diff/test_diff_tree_query.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
 import pytest
@@ -20,8 +20,6 @@ from infrahub.dependencies.registry import get_component_registry
 from infrahub.graphql.enums import ConflictSelection as GraphQLConfictSelection
 from infrahub.graphql.initialization import prepare_graphql_params
 from tests.helpers.graphql import graphql
-
-UTC = timezone.utc  # Required for older versions of Python
 
 ADDED_ACTION = "ADDED"
 UPDATED_ACTION = "UPDATED"

--- a/python_testcontainers/infrahub_testcontainers/models.py
+++ b/python_testcontainers/infrahub_testcontainers/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 
@@ -27,7 +27,7 @@ class InfrahubResultContext(BaseModel):
 
 class InfrahubActiveMeasurementItem(BaseModel):
     definition: MeasurementDefinition
-    start_time: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    start_time: datetime = Field(default_factory=lambda: datetime.now(UTC))
     context: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/python_testcontainers/infrahub_testcontainers/performance_test.py
+++ b/python_testcontainers/infrahub_testcontainers/performance_test.py
@@ -1,6 +1,6 @@
 import hashlib
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from types import TracebackType
 from typing import Any
 
@@ -35,7 +35,7 @@ class InfrahubPerformanceTest:
         self.env_vars = {}
         self.project_name = ""
         self.test_info = {}
-        self.start_time = datetime.now(timezone.utc)
+        self.start_time = datetime.now(UTC)
         self.end_time: datetime | None = None
         self.results_url = results_url
         self.scraper_endpoint = ""
@@ -57,7 +57,7 @@ class InfrahubPerformanceTest:
 
     def finalize(self, session: pytest.Session) -> None:
         if self.initialized:
-            self.end_time = datetime.now(timezone.utc)
+            self.end_time = datetime.now(UTC)
             self.extract_test_session_information(session)
             self.send_results()
 
@@ -129,7 +129,7 @@ class InfrahubPerformanceTest:
         if not exc_type and self.active_measurements:
             self.add_measurement(
                 definition=self.active_measurements.definition,
-                value=(datetime.now(timezone.utc) - self.active_measurements.start_time).total_seconds() * 1000,
+                value=(datetime.now(UTC) - self.active_measurements.start_time).total_seconds() * 1000,
                 context=self.active_measurements.context,
             )
 

--- a/tasks/performance.py
+++ b/tasks/performance.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 from invoke import Context, task
@@ -10,7 +10,7 @@ from .utils import git_info
 def run(context: Context, directory: str = "utilities", dataset: str = "dataset03") -> None:
     """Launch a performance test using Locust. Gunicorn must be running"""
     PERFORMANCE_FILE_PREFIX = "locust_"
-    NOW = datetime.now(tz=timezone.utc)
+    NOW = datetime.now(tz=UTC)
     date_format = NOW.strftime("%Y-%m-%d-%H-%M-%S")
 
     local_dir = Path(__file__).parent.resolve()

--- a/utilities/db_backup/__main__.py
+++ b/utilities/db_backup/__main__.py
@@ -3,7 +3,7 @@ import os
 import sys
 from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Generator
 
@@ -127,7 +127,7 @@ class Neo4jBackupRestoreBase:
             return
         if not with_timestamp:
             print(message)
-        right_now = datetime.now(timezone.utc).astimezone()
+        right_now = datetime.now(UTC).astimezone()
         right_now_str = right_now.strftime("%H:%M:%S")
         print(f"{right_now_str} - {message}")
 
@@ -138,7 +138,7 @@ class Neo4jBackupRestoreBase:
         end = "" if completion_message else "\n"
         to_print = start
         if with_timestamp:
-            right_now = datetime.now(timezone.utc).astimezone()
+            right_now = datetime.now(UTC).astimezone()
             right_now_str = right_now.strftime("%H:%M:%S")
             to_print = f"{right_now_str} - {start}"
         print(to_print, end=end, flush=True)


### PR DESCRIPTION
Correct autofixable errors when specifying Python 3.12 as the target version for ruff.

```diff
diff --git a/pyproject.toml b/pyproject.toml
index 08e741caa..a1d514a28 100644
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -457,7 +457,7 @@ disable_error_code = [

 [tool.ruff]
 line-length = 120
-target-version = "py310"
+target-version = "py312"

 exclude = [
     ".git",
```

Aside from these fixes there are a number of others that will need to be addressed but won't be included in this PR.

```python
❯ ruff check .
backend/infrahub/auth.py:26:7: UP042 Class AuthType inherits from both `str` and `enum.Enum`
   |
26 | class AuthType(str, Enum):
   |       ^^^^^^^^ UP042
27 |     NONE = "none"
28 |     JWT = "jwt"
   |
   = help: Inherit from `enum.StrEnum`

backend/infrahub/cli/db.py:77:7: UP042 Class ConstraintAction inherits from both `str` and `enum.Enum`
   |
77 | class ConstraintAction(str, Enum):
   |       ^^^^^^^^^^^^^^^^ UP042
78 |     SHOW = "show"
79 |     ADD = "add"
   |
   = help: Inherit from `enum.StrEnum`

backend/infrahub/cli/db.py:83:7: UP042 Class IndexAction inherits from both `str` and `enum.Enum`
   |
83 | class IndexAction(str, Enum):
   |       ^^^^^^^^^^^ UP042
84 |     SHOW = "show"
85 |     ADD = "add"
   |
   = help: Inherit from `enum.StrEnum`

backend/infrahub/config.py:51:7: UP042 Class EnterpriseFeatures inherits from both `str` and `enum.Enum`
   |
51 | class EnterpriseFeatures(str, Enum):
   |       ^^^^^^^^^^^^^^^^^^ UP042
52 |     PROPOSED_CHANGE_REQUIRE_APPROVAL = "proposed_change_require_approval"
53 |     REVOKE_PROPOSED_CHANGE_APPROVALS = "revoke_proposed_change_approvals"
   |
   = help: Inherit from `enum.StrEnum`

backend/infrahub/config.py:56:7: UP042 Class UserInfoMethod inherits from both `str` and `enum.Enum`
   |
56 | class UserInfoMethod(str, Enum):
   |       ^^^^^^^^^^^^^^ UP042
57 |     POST = "post"
58 |     GET = "get"
   |
   = help: Inherit from `enum.StrEnum`

backend/infrahub/config.py:61:7: UP042 Class SSOProtocol inherits from both `str` and `enum.Enum`
   |
61 | class SSOProtocol(str, Enum):
   |       ^^^^^^^^^^^ UP042
62 |     OAUTH2 = "oauth2"
63 |     OIDC = "oidc"
   |
   = help: Inherit from `enum.StrEnum`

backend/infrahub/config.py:66:7: UP042 Class Oauth2Provider inherits from both `str` and `enum.Enum`
   |
66 | class Oauth2Provider(str, Enum):
   |       ^^^^^^^^^^^^^^ UP042
67 |     GOOGLE = "google"
68 |     PROVIDER1 = "provider1"
   |
   = help: Inherit from `enum.StrEnum`

backend/infrahub/config.py:72:7: UP042 Class OIDCProvider inherits from both `str` and `enum.Enum`
   |
72 | class OIDCProvider(str, Enum):
   |       ^^^^^^^^^^^^ UP042
73 |     GOOGLE = "google"
74 |     PROVIDER1 = "provider1"
   |
   = help: Inherit from `enum.StrEnum`

backend/infrahub/config.py:101:7: UP042 Class StorageDriver inherits from both `str` and `enum.Enum`
    |
101 | class StorageDriver(str, Enum):
    |       ^^^^^^^^^^^^^ UP042
102 |     FileSystemStorage = "local"
103 |     InfrahubS3ObjectStorage = "s3"
    |
    = help: Inherit from `enum.StrEnum`

backend/infrahub/config.py:106:7: UP042 Class TraceExporterType inherits from both `str` and `enum.Enum`
    |
106 | class TraceExporterType(str, Enum):
    |       ^^^^^^^^^^^^^^^^^ UP042
107 |     CONSOLE = "console"
108 |     OTLP = "otlp"
    |
    = help: Inherit from `enum.StrEnum`

backend/infrahub/config.py:113:7: UP042 Class TraceTransportProtocol inherits from both `str` and `enum.Enum`
    |
113 | class TraceTransportProtocol(str, Enum):
    |       ^^^^^^^^^^^^^^^^^^^^^^ UP042
114 |     GRPC = "grpc"
115 |     HTTP_PROTOBUF = "http/protobuf"
    |
    = help: Inherit from `enum.StrEnum`

backend/infrahub/config.py:119:7: UP042 Class BrokerDriver inherits from both `str` and `enum.Enum`
    |
119 | class BrokerDriver(str, Enum):
    |       ^^^^^^^^^^^^ UP042
120 |     RabbitMQ = "rabbitmq"
121 |     NATS = "nats"
    |
    = help: Inherit from `enum.StrEnum`

backend/infrahub/config.py:140:7: UP042 Class CacheDriver inherits from both `str` and `enum.Enum`
    |
140 | class CacheDriver(str, Enum):
    |       ^^^^^^^^^^^ UP042
141 |     Redis = "redis"
142 |     NATS = "nats"
    |
    = help: Inherit from `enum.StrEnum`

backend/infrahub/config.py:161:7: UP042 Class WorkflowDriver inherits from both `str` and `enum.Enum`
    |
161 | class WorkflowDriver(str, Enum):
    |       ^^^^^^^^^^^^^^ UP042
162 |     LOCAL = "local"
163 |     WORKER = "worker"
    |
    = help: Inherit from `enum.StrEnum`

backend/infrahub/config.py:166:7: UP042 Class ExtraLogLevel inherits from both `str` and `enum.Enum`
    |
166 | class ExtraLogLevel(str, Enum):
    |       ^^^^^^^^^^^^^ UP042
167 |     CRITICAL = "CRITICAL"
168 |     ERROR = "ERROR"
    |
    = help: Inherit from `enum.StrEnum`

backend/infrahub/constants/database.py:4:7: UP042 Class DatabaseType inherits from both `str` and `enum.Enum`
  |
4 | class DatabaseType(str, Enum):
  |       ^^^^^^^^^^^^ UP042
5 |     NEO4J = "neo4j"
6 |     MEMGRAPH = "memgraph"
  |
  = help: Inherit from `enum.StrEnum`

backend/infrahub/constants/database.py:9:7: UP042 Class Neo4jRuntime inherits from both `str` and `enum.Enum`
   |
 9 | class Neo4jRuntime(str, Enum):
   |       ^^^^^^^^^^^^ UP042
10 |     DEFAULT = "default"
11 |     INTERPRETED = "interpreted"
   |
   = help: Inherit from `enum.StrEnum`

backend/infrahub/constants/database.py:18:7: UP042 Class IndexType inherits from both `str` and `enum.Enum`
   |
18 | class IndexType(str, Enum):
   |       ^^^^^^^^^ UP042
19 |     TEXT = "text"
20 |     RANGE = "range"
   |
   = help: Inherit from `enum.StrEnum`

backend/infrahub/constants/database.py:25:7: UP042 Class EntityType inherits from both `str` and `enum.Enum`
   |
25 | class EntityType(str, Enum):
   |       ^^^^^^^^^^ UP042
26 |     NODE = "node"
27 |     RELATIONSHIP = "relationship"
   |
   = help: Inherit from `enum.StrEnum`

backend/infrahub/core/diff/model/diff.py:274:7: UP042 Class DiffElementType inherits from both `str` and `enum.Enum`
    |
274 | class DiffElementType(str, Enum):
    |       ^^^^^^^^^^^^^^^ UP042
275 |     ATTRIBUTE = "Attribute"
276 |     RELATIONSHIP_ONE = "RelationshipOne"
    |
    = help: Inherit from `enum.StrEnum`

backend/infrahub/core/graph/constraints.py:15:7: UP042 Class GraphPropertyType inherits from both `str` and `enum.Enum`
   |
15 | class GraphPropertyType(str, Enum):
   |       ^^^^^^^^^^^^^^^^^ UP042
16 |     BOOLEAN = "BOOLEAN"
17 |     STRING = "STRING"
   |
   = help: Inherit from `enum.StrEnum`

backend/infrahub/core/manager.py:65:5: UP047 Generic function `get_schema` should use type parameters
   |
65 |   def get_schema(
   |  _____^
66 | |     db: InfrahubDatabase, branch: Branch, node_schema: type[SchemaProtocol] | MainSchemaTypes | str
67 | | ) -> MainSchemaTypes:
   | |_^ UP047
68 |       if isinstance(node_schema, str):
69 |           return db.schema.get(name=node_schema, branch=branch.name)
   |
   = help: Use type parameters

backend/infrahub/core/schema/__init__.py:24:1: UP040 Type alias `NonGenericSchemaTypes` uses `TypeAlias` annotation instead of the `type` keyword
   |
22 | from .template_schema import TemplateSchema
23 |
24 | NonGenericSchemaTypes: TypeAlias = NodeSchema | ProfileSchema | TemplateSchema
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
25 | MainSchemaTypes: TypeAlias = NonGenericSchemaTypes | GenericSchema
   |
   = help: Use the `type` keyword

backend/infrahub/core/schema/__init__.py:25:1: UP040 Type alias `MainSchemaTypes` uses `TypeAlias` annotation instead of the `type` keyword
   |
24 | NonGenericSchemaTypes: TypeAlias = NodeSchema | ProfileSchema | TemplateSchema
25 | MainSchemaTypes: TypeAlias = NonGenericSchemaTypes | GenericSchema
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP040
   |
   = help: Use the `type` keyword

backend/infrahub/core/validators/enum.py:4:7: UP042 Class ConstraintIdentifier inherits from both `str` and `enum.Enum`
  |
4 | class ConstraintIdentifier(str, Enum):
  |       ^^^^^^^^^^^^^^^^^^^^ UP042
5 |     ATTRIBUTE_PARAMETERS_REGEX_UPDATE = "attribute.parameters.regex.update"
6 |     ATTRIBUTE_PARAMETERS_MIN_LENGTH_UPDATE = "attribute.parameters.min_length.update"
  |
  = help: Inherit from `enum.StrEnum`

backend/infrahub/dependencies/interface.py:17:30: UP046 Generic class `DependencyBuilder` uses `Generic` subclass instead of type parameters
   |
17 | class DependencyBuilder(ABC, Generic[T]):
   |                              ^^^^^^^^^^ UP046
18 |     @classmethod
19 |     @abstractmethod
   |
   = help: Use type parameters

backend/infrahub/events/constants.py:6:7: UP042 Class EventSortOrder inherits from both `str` and `enum.Enum`
  |
6 | class EventSortOrder(str, Enum):
  |       ^^^^^^^^^^^^^^ UP042
7 |     ASC = "asc"
8 |     DESC = "desc"
  |
  = help: Inherit from `enum.StrEnum`

backend/infrahub/graphql/analyzer.py:52:7: UP042 Class MutateAction inherits from both `str` and `enum.Enum`
   |
52 | class MutateAction(str, Enum):
   |       ^^^^^^^^^^^^ UP042
53 |     CREATE = "create"
54 |     DELETE = "delete"
   |
   = help: Inherit from `enum.StrEnum`

backend/infrahub/graphql/analyzer.py:58:7: UP042 Class ContextType inherits from both `str` and `enum.Enum`
   |
58 | class ContextType(str, Enum):
   |       ^^^^^^^^^^^ UP042
59 |     EDGE = "edge"
60 |     NODE = "node"
   |
   = help: Inherit from `enum.StrEnum`

backend/infrahub/graphql/analyzer.py:83:7: UP042 Class GraphQLOperation inherits from both `str` and `enum.Enum`
   |
83 | class GraphQLOperation(str, Enum):
   |       ^^^^^^^^^^^^^^^^ UP042
84 |     QUERY = "query"
85 |     MUTATION = "mutation"
   |
   = help: Inherit from `enum.StrEnum`

backend/infrahub/graphql/mutations/relationship.py:51:7: UP042 Class GroupUpdateType inherits from both `str` and `enum.Enum`
   |
51 | class GroupUpdateType(str, Enum):
   |       ^^^^^^^^^^^^^^^ UP042
52 |     NONE = "none"
53 |     MEMBERS = "members"
   |
   = help: Inherit from `enum.StrEnum`

backend/infrahub/patch/constants.py:4:7: UP042 Class PatchPlanFilename inherits from both `str` and `enum.Enum`
  |
4 | class PatchPlanFilename(str, Enum):
  |       ^^^^^^^^^^^^^^^^^ UP042
5 |     VERTICES_TO_ADD = "vertices_to_add.json"
6 |     VERTICES_TO_UPDATE = "vertices_to_update.json"
  |
  = help: Inherit from `enum.StrEnum`

backend/infrahub/telemetry/constants.py:7:7: UP042 Class InfrahubType inherits from both `str` and `enum.Enum`
  |
7 | class InfrahubType(str, Enum):
  |       ^^^^^^^^^^^^ UP042
8 |     COMMUNITY = "community"
9 |     ENTERPRISE = "enterprise"
  |
  = help: Inherit from `enum.StrEnum`

backend/infrahub/trigger/models.py:33:7: UP042 Class TriggerType inherits from both `str` and `enum.Enum`
   |
33 | class TriggerType(str, Enum):
   |       ^^^^^^^^^^^ UP042
34 |     ACTION_TRIGGER_RULE = "action_trigger_rule"
35 |     BUILTIN = "builtin"
   |
   = help: Inherit from `enum.StrEnum`

backend/infrahub/utils.py:79:5: UP047 Generic function `get_all_subclasses` should use type parameters
   |
79 | def get_all_subclasses(cls: AnyClass) -> list[AnyClass]:
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP047
80 |     """Recursively get all subclasses of the given class."""
81 |     subclasses: list[AnyClass] = []
   |
   = help: Use type parameters

backend/infrahub/validators/tasks.py:15:11: UP047 Generic function `start_validator` should use type parameters
   |
15 |   async def start_validator(
   |  ___________^
16 | |     client: InfrahubClient,
17 | |     validator: CoreValidator | None,
18 | |     validator_type: type[ValidatorType],
19 | |     proposed_change: str,
20 | |     context: InfrahubContext,
21 | |     data: dict[str, Any],
22 | | ) -> ValidatorType:
   | |_^ UP047
23 |       if validator:
24 |           validator.conclusion.value = ValidatorConclusion.UNKNOWN.value
   |
   = help: Use type parameters

backend/tests/helpers/test_client.py:11:60: ASYNC109 Async function definition with a `timeout` parameter
   |
10 | async def dummy_async_request(
11 |     url: str, method: HTTPMethod, headers: dict[str, Any], timeout: int, payload: dict | None = None
   |                                                            ^^^^^^^^^^^^ ASYNC109
12 | ) -> httpx.Response:
13 |     """Return an empty response and to pretend that the git commit was updated successfully"""
   |
   = help: Use `asyncio.timeout` instead

backend/tests/helpers/test_client.py:23:70: ASYNC109 Async function definition with a `timeout` parameter
   |
22 |     async def _request(
23 |         self, url: str, method: HTTPMethod, headers: dict[str, Any], timeout: int, payload: dict | None = None
   |                                                                      ^^^^^^^^^^^^ ASYNC109
24 |     ) -> httpx.Response:
25 |         content = None
   |
   = help: Use `asyncio.timeout` instead

backend/tests/helpers/test_client.py:31:70: ASYNC109 Async function definition with a `timeout` parameter
   |
30 |     async def async_request(
31 |         self, url: str, method: HTTPMethod, headers: dict[str, Any], timeout: int, payload: dict | None = None
   |                                                                      ^^^^^^^^^^^^ ASYNC109
32 |     ) -> httpx.Response:
33 |         return await self._request(url=url, method=method, headers=headers, timeout=timeout, payload=payload)
   |
   = help: Use `asyncio.timeout` instead

backend/tests/helpers/test_worker.py:32:76: ASYNC109 Async function definition with a `timeout` parameter
   |
30 |     @classmethod
31 |     async def wait_for_flow(
32 |         cls, client: PrefectClient, work_pool_id: UUID, interval: int = 1, timeout: int = 10
   |                                                                            ^^^^^^^^^^^^^^^^^ ASYNC109
33 |     ) -> FlowRun:
34 |         while timeout:
   |
   = help: Use `asyncio.timeout` instead

models/infrastructure_edge.py:447:7: UP042 Class DevicePatternName inherits from both `str` and `enum.Enum`
    |
447 | class DevicePatternName(str, Enum):
    |       ^^^^^^^^^^^^^^^^^ UP042
448 |     LEAF = "LEAF"
449 |     CORE = "CORE"
    |
    = help: Inherit from `enum.StrEnum`

python_testcontainers/infrahub_testcontainers/models.py:8:7: UP042 Class ContextUnit inherits from both `str` and `enum.Enum`
   |
 8 | class ContextUnit(str, Enum):
   |       ^^^^^^^^^^^ UP042
 9 |     COUNT = "count"
10 |     TIME = "msec"  # time in milliseconds
   |
   = help: Inherit from `enum.StrEnum`

tasks/shared.py:20:7: UP042 Class DatabaseType inherits from both `str` and `enum.Enum`
   |
20 | class DatabaseType(str, Enum):
   |       ^^^^^^^^^^^^ UP042
21 |     NEO4J = "neo4j"
22 |     MEMGRAPH = "memgraph"
   |
   = help: Inherit from `enum.StrEnum`

tasks/shared.py:25:7: UP042 Class Namespace inherits from both `str` and `enum.Enum`
   |
25 | class Namespace(str, Enum):
   |       ^^^^^^^^^ UP042
26 |     DEFAULT = "default"  # aka demo
27 |     DEV = "dev"
   |
   = help: Inherit from `enum.StrEnum`

Found 44 errors.
No fixes available (40 hidden fixes can be enabled with the `--unsafe-fixes` option).
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized UTC handling across the app, ensuring consistent UTC-aware timestamps in authentication, CLI timestamps, patch plans, performance metrics, and backups. No behavior changes expected.
- Tests
  - Updated tests to use the new UTC import without altering test behavior.
- Chores
  - Aligned imports and time initialization across modules for consistency and future compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->