### PR TITLE
Refactor 'infrahub shell'

### DIFF
--- a/backend/infrahub/cli/__init__.py
+++ b/backend/infrahub/cli/__init__.py
@@ -1,5 +1,3 @@
-from asyncio import run as aiorun
-
 import typer
 from infrahub_sdk.async_typer import AsyncTyper
 
@@ -43,18 +41,87 @@ async def _init_shell(config_file: str) -> None:
 
 
 @app.command()
-def shell(config_file: str = typer.Argument("infrahub.toml", envvar="INFRAHUB_CONFIG")) -> None:
-    """Start a python shell within Infrahub context."""
-    aiorun(_init_shell(config_file=config_file))
+def shell() -> None:
+    """Start a python shell within Infrahub context (requires IPython)."""
+    from infrahub_sdk import InfrahubClient
+    from IPython import start_ipython
+    from traitlets.config import Config
 
-    # TODO add check to properly exit of ipython is not installed
-    from IPython import embed
-    from rich import pretty
-    from traitlets.config import get_config
+    from infrahub import config
+    from infrahub.components import ComponentType
+    from infrahub.core.branch import Branch
+    from infrahub.core.initialization import initialization
+    from infrahub.core.manager import NodeManager
+    from infrahub.core.registry import registry
+    from infrahub.dependencies.registry import build_component_registry
+    from infrahub.lock import initialize_lock
+    from infrahub.services import InfrahubServices
+    from infrahub.workers.dependencies import (
+        get_cache,
+        get_component,
+        get_database,
+        get_workflow,
+        set_component_type,
+    )
 
-    pretty.install()
+    async def initialize_service() -> InfrahubServices:
+        config.load_and_exit()
+        client = InfrahubClient()
 
-    c = get_config()
-    c.InteractiveShellEmbed.colors = "Linux"
-    c.InteractiveShellApp.extensions.append("rich")
-    embed(config=c)
+        component_type = ComponentType.GIT_AGENT
+        set_component_type(component_type=component_type)
+
+        database = await get_database()
+
+        build_component_registry()
+
+        workflow = get_workflow()
+        cache = await get_cache()
+        component = await get_component()
+        service = await InfrahubServices.new(
+            cache=cache,
+            client=client,
+            database=database,
+            workflow=workflow,
+            component=component,
+            component_type=component_type,
+        )
+        initialize_lock(service=service)
+
+        async with service.database as db:
+            await initialization(db=db)
+        await service.component.refresh_schema_hash()
+
+        return service
+
+    def welcome() -> None:
+        print("--------------------------------------")
+        print("infrahub interactive shell initialized")
+        print("--------------------------------------")
+        print("Available objects:")
+        print("* db: InfrahubDatabase")
+        print("* Branch: Branch")
+        print("* NodeManager: NodeManager")
+        print("* registry: Registry")
+        print("* service: InfrahubServices")
+        print()
+        print("Example use:")
+        print("In [1] tags = await NodeManager.query(schema='BuiltinTag', db=db)")
+
+    c = Config()
+    c.InteractiveShellApp.exec_lines = [
+        "service = await initialize_service()",
+        "db = service.database",
+        "welcome()",
+    ]
+    c.TerminalInteractiveShell.colors = "Neutral"
+
+    user_ns = {
+        "initialize_service": initialize_service,
+        "welcome": welcome,
+        "NodeManager": NodeManager,
+        "Branch": Branch,
+        "registry": registry,
+    }
+
+    start_ipython(argv=[], config=c, user_ns=user_ns)


### PR DESCRIPTION
This PR refactors the `infrahub shell` command which currently isn't working at all. The command is meant to be used for local debugging or troubleshooting and provides access to internal components within Infrahub.

It uses IPython to you have access to asyncio directly from the shell without doing anything special. I.e. you can just run async code as if it was the sync version.

Note that this shell uses IPython which is a develop dependency of Infrahub and as such won't be included in a purely production build.

In order to test it you run `infrahub shell` it's using the same API as the other command line tools such as `infrahub server start`.

A few objects are made available from the start and more can be added.

Just after running the shell you can for example paste the code:

```python
>>> tags = await NodeManager.query(schema='BuiltinTag', db=db)
```

In order to query for all of the tags using the NodeManager class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Interactive shell now fully auto-initializes the runtime, preloads services and data access, and exposes helpful helpers for immediate interaction.
  - Improved user experience with a welcome message and a consistent Neutral theme.

- Refactor
  - Simplified, in-process startup sequence for faster, more reliable launches.

- Changes
  - Shell command is now parameterless and auto-loads configuration (no config-file argument).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->