### PR TITLE
refactor(api): update query variables type from str to Any

### DIFF
--- a/backend/infrahub/api/query.py
+++ b/backend/infrahub/api/query.py
@@ -40,7 +40,7 @@ router = APIRouter(prefix="/query")
 
 
 class QueryPayload(BaseModel):
-    variables: dict[str, str] = Field(default_factory=dict)
+    variables: dict[str, Any] = Field(default_factory=dict)
 
 
 async def execute_query(


### PR DESCRIPTION
Allow more flexible variable types in GraphQL queries by changing the type annotation from str to Any

Fixes https://github.com/opsmill/infrahub/issues/7119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded GraphQL variable support: You can now pass non-string values (numbers, booleans, lists, and objects) as variables in queries and mutations. This enables more flexible and expressive requests while remaining backward compatible with existing string-only usage. Default behavior for omitted variables remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->