### PR TITLE
IFC-1695 Prune git old remote references on fetch

### DIFF
--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -716,7 +716,7 @@ class InfrahubRepositoryBase(BaseModel, ABC):
 
         repo = self.get_git_repo_main()
         try:
-            repo.remotes.origin.fetch()
+            repo.remotes.origin.fetch(prune=True)
         except GitCommandError as exc:
             await self._raise_enriched_error(error=exc)
 

--- a/backend/tests/unit/git/conftest.py
+++ b/backend/tests/unit/git/conftest.py
@@ -80,7 +80,7 @@ def git_upstream_repo_01(git_sources_dir: Path) -> dict[str, str | Path]:
     # Extract the fixture package in the source directory
 
     with tarfile.open(fixture_repo) as file:
-        file.extractall(git_sources_dir)
+        file.extractall(git_sources_dir, filter="data")
 
     return {"name": name, "path": git_sources_dir / name}
 

--- a/changelog/6884.fixed.md
+++ b/changelog/6884.fixed.md
@@ -1,0 +1,1 @@
+Use the prune flag when fetching updates from remote git reposities to clear deletd remote references locally

--- a/changelog/6884.fixed.md
+++ b/changelog/6884.fixed.md
@@ -1,1 +1,1 @@
-Use the prune flag when fetching updates from remote git reposities to clear deletd remote references locally
+Use the prune flag when fetching updates from remote git reposities to clear deleted remote references locally


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Git fetch now prunes stale remote-tracking branches to avoid outdated local references.
- Tests
  - Test fixture setup tightened to extract only intended archive entries for safer repository setup.
- Documentation
  - Added changelog entry describing the new pruning behavior during Git fetch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->