### PR TITLE
docs: Add initialization instructions for Infrahub repository

### DIFF
--- a/changelog/7137.fixed.md
+++ b/changelog/7137.fixed.md
@@ -1,0 +1,1 @@
+Add initialization instructions for Infrahub repository to docs.

--- a/docs/docs/getting-started/next-steps.mdx
+++ b/docs/docs/getting-started/next-steps.mdx
@@ -84,11 +84,9 @@ The most important file is the `.infrahub.yml` file, which defines how Infrahub 
 
 You will need to push this repository to a remote location that Infrahub can access. It doesn't have to be a public repository as Infrahub supports authentication with private repositories. Depending on the provider you use (for example: GitHub, GitLab, Bitbucket), the process may vary slightly, but the general steps are the same:
 
-1. Create a new repository on your preferred git hosting service.
-2. Clone the repository to your local machine.
-3. Create a `.infrahub.yml` file in the root of the repository.
-4. Push the repository to the remote location.
-5. Create a "Infrahub" access token with the required permissions to access the repository.
+1. Create a new repository using the `infrahubctl repository init <directory>` command or manually.
+2. Push the repository to the remote location.
+3. Create a "Infrahub" access token with the required permissions to access the repository.
 
 Then you can connect the repository to Infrahub using the Infrahub CLI or the web interface!
 

--- a/docs/docs/getting-started/next-steps.mdx
+++ b/docs/docs/getting-started/next-steps.mdx
@@ -84,7 +84,7 @@ The most important file is the `.infrahub.yml` file, which defines how Infrahub 
 
 You will need to push this repository to a remote location that Infrahub can access. It doesn't have to be a public repository as Infrahub supports authentication with private repositories. Depending on the provider you use (for example: GitHub, GitLab, Bitbucket), the process may vary slightly, but the general steps are the same:
 
-1. Create a new repository using the `infrahubctl repository init <directory>` command or manually.
+1. Create a new repository using the `infrahubctl repository init <directory>` command or manually. More details in the [related topic](../topics/developer-guide#initializing-an-infrahub-repository).
 2. Push the repository to the remote location.
 3. Create a "Infrahub" access token with the required permissions to access the repository.
 

--- a/docs/docs/topics/developer-guide.mdx
+++ b/docs/docs/topics/developer-guide.mdx
@@ -31,6 +31,39 @@ When you run the command, the CLI will prompt you to specify what you would like
 
 The template being used is the [Infrahub Template Repository](https://github.com/opsmill/infrahub-template).
 
+<details>
+  <summary>Recommended file structure for manually creating an Infrahub repository</summary>
+
+If you prefer to create your Infrahub repository manually, use the following folder structure as a reference:
+
+```bash
+├── generators
+├── lib
+│   ├── __init__.py
+│   └── example.py
+├── menus
+├── objects
+│   └── example.yml
+├── pyproject.toml
+├── queries
+├── README.md
+├── schemas
+│   └── example.yml
+├── scripts
+│   └── example_script.py
+├── tasks.py
+├── tests
+│   ├── __init__.py
+│   └── integration
+│       ├── conftest.py
+│       └── test_infrahub.py
+├── transforms
+│   └── templates
+└── uv.lock
+```
+
+</details>
+
 ### Development
 
 #### Execute your code locally

--- a/docs/docs/topics/developer-guide.mdx
+++ b/docs/docs/topics/developer-guide.mdx
@@ -31,7 +31,6 @@ When you run the command, the CLI will prompt you to specify what you would like
 
 The template being used is the [Infrahub Template Repository](https://github.com/opsmill/infrahub-template).
 
-
 ### Development
 
 #### Execute your code locally

--- a/docs/docs/topics/developer-guide.mdx
+++ b/docs/docs/topics/developer-guide.mdx
@@ -37,6 +37,10 @@ The template being used is the [Infrahub Template Repository](https://github.com
 If you prefer to create your Infrahub repository manually, use the following folder structure as a reference:
 
 ```bash
+├── .gitignore
+├── .infrahub.yml
+├── .vscode
+│   └── extensions.json
 ├── generators
 ├── lib
 │   ├── __init__.py
@@ -51,7 +55,6 @@ If you prefer to create your Infrahub repository manually, use the following fol
 │   └── example.yml
 ├── scripts
 │   └── example_script.py
-├── tasks.py
 ├── tests
 │   ├── __init__.py
 │   └── integration

--- a/docs/docs/topics/developer-guide.mdx
+++ b/docs/docs/topics/developer-guide.mdx
@@ -13,6 +13,22 @@ The following features in Infrahub are based on user provided code :
 - [**Generators**](./generator.mdx): Automate complex tasks by generating outputs dynamically.
 - [**Checks**](./check.mdx): Validate your infrastructure with custom rules.
 
+### Initializing an Infrahub repository
+
+Before you start developing extensions or custom code for Infrahub, you need to initialize a repository. This sets up the directory structure and configuration files required for Infrahub to manage your infrastructure data.
+
+To initialize a new Infrahub repository, run the following command (replace `<directory>` with your desired path):
+
+```shell
+uv tool run --from 'infrahub-sdk[ctl]' infrahubctl repository init <directory>
+```
+
+This will create a new Infrahub repository in the specified directory, ready for you to add schemas, transforms, and generators.
+
+When you run the command, the CLI will prompt you to specify what you would like included in your repository (such as example generators, transforms, and scripts). This helps you tailor the repository to your needs from the start.
+
+The template being used is the [Infrahub Template Repository](https://github.com/opsmill/infrahub-template).
+
 ## Development lifecycle
 
 ### Development

--- a/docs/docs/topics/developer-guide.mdx
+++ b/docs/docs/topics/developer-guide.mdx
@@ -13,6 +13,8 @@ The following features in Infrahub are based on user provided code :
 - [**Generators**](./generator.mdx): Automate complex tasks by generating outputs dynamically.
 - [**Checks**](./check.mdx): Validate your infrastructure with custom rules.
 
+## Development lifecycle
+
 ### Initializing an Infrahub repository
 
 Before you start developing extensions or custom code for Infrahub, you need to initialize a repository. This sets up the directory structure and configuration files required for Infrahub to manage your infrastructure data.
@@ -29,7 +31,6 @@ When you run the command, the CLI will prompt you to specify what you would like
 
 The template being used is the [Infrahub Template Repository](https://github.com/opsmill/infrahub-template).
 
-## Development lifecycle
 
 ### Development
 


### PR DESCRIPTION
Fixes: #7137 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Simplified “Initialize a git repository” in Getting Started to a CLI-driven flow (infrahubctl repository init), reduced steps, and added links to the Developer Guide and connecting your repository to Infrahub.
  - Added a Developer Guide subsection on initializing an Infrahub repository, covering CLI workflow, template usage, and an optional manual folder structure.
  - Added a changelog entry noting the new initialization instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->