### PR TITLE
prep release 1.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
+## [Infrahub - v1.4.4](https://github.com/opsmill/infrahub/tree/infrahub-v1.4.4) - 2025-09-03
+
+### Fixed
+
+- Fix HTTP 403 when trying to fetch object metadata in changelog without being allowed to manage permissions ([#ifc1760](https://github.com/opsmill/infrahub/issues/ifc1760))
+- Fix HTTP 403 when trying to fetch nodes though a `CoreNode` query, this could prevent users to select nodes in various places with the user interface ([#6733](https://github.com/opsmill/infrahub/issues/6733))
+- Re-run Migration026 in case it failed during an upgrade from 1.2.4 or earlier to 1.4.x or later. Root cause of the migration failure has already been addressed. ([#7112](https://github.com/opsmill/infrahub/issues/7112))
+- Fixed rebase bug by ensuring rebase operations with data only changes correctly set the .branched_from property of the branch within the registry. ([#7113](https://github.com/opsmill/infrahub/issues/7113))
+- UI requests for proposed change objects are now branch-agnostic, preventing errors when a branch is deleted
+
+### Housekeeping
+
+- Internal UI: Decouple config fetching from usage
+
 ## [Infrahub - v1.4.3](https://github.com/opsmill/infrahub/tree/infrahub-v1.4.3) - 2025-08-29
 
 ### Fixed

--- a/changelog/+pc-branch.fixed.md
+++ b/changelog/+pc-branch.fixed.md
@@ -1,1 +1,0 @@
-UI requests for proposed change objects are now branch-agnostic, preventing errors when a branch is deleted

--- a/changelog/+ui-fetching.fixed.md
+++ b/changelog/+ui-fetching.fixed.md
@@ -1,1 +1,0 @@
-- Internal UI: Decouple config fetching from usage

--- a/changelog/6733.fixed.md
+++ b/changelog/6733.fixed.md
@@ -1,1 +1,0 @@
-Fix HTTP 403 when trying to fetch nodes though a `CoreNode` query, this could prevent users to select nodes in various places with the user interface

--- a/changelog/7112.fixed.md
+++ b/changelog/7112.fixed.md
@@ -1,1 +1,0 @@
-Re-run Migration026 in case it failed during an upgrade from 1.2.4 or earlier to 1.4.x or later. Root cause of the migration failure has already been addressed.

--- a/changelog/7113.fixed.md
+++ b/changelog/7113.fixed.md
@@ -1,1 +1,0 @@
-Fixed rebase bug by ensuring rebase operations with data only changes correctly set the .branched_from property of the branch within the registry.

--- a/changelog/ifc1760.fixed.md
+++ b/changelog/ifc1760.fixed.md
@@ -1,1 +1,0 @@
-Fix HTTP 403 when trying to fetch object metadata in changelog without being allowed to manage permissions

--- a/docs/docs/release-notes/infrahub/release-1_4_4.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_4_4.mdx
@@ -1,0 +1,31 @@
+---
+title: Release 1.4.4
+---
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.4.4</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>September 3rd, 2025</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[infrahub-v1.4.4](https://github.com/opsmill/infrahub/releases/tag/infrahub-v1.4.4)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Fixed
+
+- Fix HTTP 403 when trying to fetch object metadata in changelog without being allowed to manage permissions ([#ifc1760](https://github.com/opsmill/infrahub/issues/ifc1760))
+- Fix HTTP 403 when trying to fetch nodes though a `CoreNode` query, this could prevent users to select nodes in various places with the user interface ([#6733](https://github.com/opsmill/infrahub/issues/6733))
+- Re-run Migration026 in case it failed during an upgrade from 1.2.4 or earlier to 1.4.x or later. Root cause of the migration failure has already been addressed. ([#7112](https://github.com/opsmill/infrahub/issues/7112))
+- Fixed rebase bug by ensuring rebase operations with data only changes correctly set the .branched_from property of the branch within the registry. ([#7113](https://github.com/opsmill/infrahub/issues/7113))
+- UI requests for proposed change objects are now branch-agnostic, preventing errors when a branch is deleted
+
+### Housekeeping
+
+- Internal UI: Decouple config fetching from usage

--- a/docs/docs/release-notes/infrahub/release-1_4_4.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_4_4.mdx
@@ -28,4 +28,4 @@ title: Release 1.4.4
 
 ### Housekeeping
 
-- Internal UI: Decouple config fetching from usage
+- Internal UI: Decouple configuration fetching from usage

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -391,6 +391,7 @@ const sidebars: SidebarsConfig = {
             slug: 'release-notes/infrahub',
           },
           items: [
+            'release-notes/infrahub/release-1_4_4',
             'release-notes/infrahub/release-1_4_3',
             'release-notes/infrahub/release-1_4_2',
             'release-notes/infrahub/release-1_4_1',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "infrahub-server"
-version = "1.4.3"
+version = "1.4.4"
 description = "Infrahub is taking a new approach to Infrastructure Management by providing a new generation of datastore to organize and control all the data that defines how an infrastructure should run."
 authors = ["OpsMill <info@opsmill.com>"]
 readme = "README.md"

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "infrahub-testcontainers"
-version = "1.4.3"
+version = "1.4.4"
 requires-python = ">=3.9"
 
 [tool.poetry]
 name = "infrahub-testcontainers"
-version = "1.4.3"
+version = "1.4.4"
 description = "Testcontainers instance for Infrahub to easily build integration tests"
 authors = ["OpsMill <info@opsmill.com>"]
 readme = "README.md"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Bug Fixes
  * Resolved HTTP 403 when fetching object metadata without permissions.
  * Fixed HTTP 403 when querying nodes, restoring UI node selection.
  * Automatically re-run Migration026 if it failed during upgrades from 1.2.4 or earlier to 1.4.x+.
  * Corrected rebase behavior so data-only rebases set branched_from properly.
  * Made UI requests for proposed changes branch-agnostic to avoid errors after branch deletion.
* Documentation
  * Added release notes for version 1.4.4 and updated navigation.
* Chores
  * Bumped version to 1.4.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->