### PR TITLE
fix(ci): add missing step for integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,8 +401,10 @@ jobs:
           echo INFRAHUB_IMAGE_VER=local-${{ runner.name }}-${{ github.sha }} >> $GITHUB_ENV
           echo INFRAHUB_TESTING_IMAGE_VER=local-${{ runner.name }}-${{ github.sha }} >> $GITHUB_ENV
           echo INFRAHUB_TESTING_DOCKER_IMAGE="opsmill/infrahub" >> $GITHUB_ENV
+      - name: Install Invoke
+        run: pip install invoke toml
       - name: "Build container"
-        run: "inv dev.build"
+        run: "invoke dev.build"
       - name: "Setup Python environment"
         run: |
           poetry config virtualenvs.create true --local


### PR DESCRIPTION
We were not properly installing invoke before using it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI pipeline to install required tooling and use the canonical task runner for container builds, improving build consistency and reliability across jobs.
  * Ensured tooling is available before build steps to reduce CI failures.

* **Notes**
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->