### PR TITLE
Fix ability to run invoke commands under Python 3.10

### DIFF
--- a/tasks/performance.py
+++ b/tasks/performance.py
@@ -1,4 +1,3 @@
-from datetime import UTC, datetime
 from pathlib import Path
 
 from invoke import Context, task
@@ -10,6 +9,9 @@ from .utils import git_info
 def run(context: Context, directory: str = "utilities", dataset: str = "dataset03") -> None:
     """Launch a performance test using Locust. Gunicorn must be running"""
     PERFORMANCE_FILE_PREFIX = "locust_"
+    # Fix ability to run any invoke command under Python 3.10 (datetime.UTC was added in Python 3.11)
+    from datetime import UTC, datetime
+
     NOW = datetime.now(tz=UTC)
     date_format = NOW.strftime("%Y-%m-%d-%H-%M-%S")
 


### PR DESCRIPTION
Due to a recent change to get the bulk of the repo up to date with code standards of Python 3.12 an issue with the invoke commands was encountered.

```python
root@1a2be83cddfa:/source# inv -l
Traceback (most recent call last):
  File "/usr/local/bin/inv", line 8, in <module>
    sys.exit(program.run())
  File "/usr/local/lib/python3.10/site-packages/invoke/program.py", line 387, in run
    self.parse_collection()
  File "/usr/local/lib/python3.10/site-packages/invoke/program.py", line 479, in parse_collection
    self.load_collection()
  File "/usr/local/lib/python3.10/site-packages/invoke/program.py", line 716, in load_collection
    module, parent = loader.load(coll_name)
  File "/usr/local/lib/python3.10/site-packages/invoke/loader.py", line 91, in load
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/source/tasks/__init__.py", line 5, in <module>
    from . import backend, bundle, demo, dev, docs, main, performance, release, schema, sdk
  File "/source/tasks/performance.py", line 1, in <module>
    from datetime import UTC, datetime
ImportError: cannot import name 'UTC' from 'datetime' (/usr/local/lib/python3.10/datetime.py)
```

This small fix is to ensure that people still on Python 3.10 can still use commands such as `invoke demo.start` etc. For Infrahub specific commands used for development it's still assumed that Python 3.12 will be used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.
- Bug Fixes
  - Improved reliability on Python 3.10 by deferring timezone initialization during task execution, eliminating import-related crashes.
  - Ensures performance tasks run consistently across different runtime versions, reducing unexpected failures during scheduled runs and manual invocations.
  - Enhances cross-version compatibility without altering workflows or requiring configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->