### PR TITLE
Fixed filtering options in object table schema selector

### DIFF
--- a/changelog/+filter-kind.fixed.md
+++ b/changelog/+filter-kind.fixed.md
@@ -1,0 +1,1 @@
+Fixed a bug in the object table where the kind selector was not filtering its options correctly.

--- a/frontend/app/src/entities/nodes/object/ui/object-table/object-table-schema-selector.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-table/object-table-schema-selector.tsx
@@ -48,7 +48,7 @@ export function ObjectTableSchemaSelector() {
       </ComboboxTrigger>
 
       <ComboboxContent portal fitTriggerWidth={false}>
-        <ComboboxList>
+        <ComboboxList shouldFilter>
           <ComboboxItem
             value={baseSchema.hash}
             selectedValue={selectedSchema.hash}
@@ -66,6 +66,7 @@ export function ObjectTableSchemaSelector() {
           {items.map((schema) => {
             return (
               <ComboboxItem
+                keywords={[schema.label!, schema.kind!]}
                 key={schema.hash}
                 value={schema.hash}
                 selectedValue={selectedSchema.hash}

--- a/frontend/app/tests/e2e/objects/object-filters.spec.ts
+++ b/frontend/app/tests/e2e/objects/object-filters.spec.ts
@@ -96,8 +96,24 @@ test.describe("Object filters", () => {
     await expect(page.getByTestId("object-items")).toContainText("Interface L3");
     await expect(page.getByTestId("object-schema-schema-selector")).toContainText("All Interface");
 
-    await test.step("filter using kind", async () => {
+    await test.step("filter target kind", async () => {
       await page.getByTestId("object-schema-schema-selector").click();
+      await expect(
+        page.getByRole("option", { name: "Interface L2 Infra", exact: true })
+      ).toBeVisible();
+      await expect(
+        page.getByRole("option", { name: "Interface L3 Infra", exact: true })
+      ).toBeVisible();
+      await page.getByPlaceholder("Filter...").fill("l3");
+      await expect(
+        page.getByRole("option", { name: "Interface L2 Infra", exact: true })
+      ).toBeHidden();
+      await expect(
+        page.getByRole("option", { name: "Interface L3 Infra", exact: true })
+      ).toBeVisible();
+    });
+
+    await test.step("filter using kind", async () => {
       await page.getByRole("option", { name: "Interface L3 Infra", exact: true }).click();
 
       await expect(page.getByTestId("object-schema-schema-selector")).toContainText(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added client-side filtering to the object schema selector dropdown, enabling type-to-filter and keyword-based matching for faster option discovery.

* **Bug Fixes**
  * Resolved an issue where the kind selector did not filter its options correctly, ensuring accurate results when narrowing down object kinds.

* **Tests**
  * Expanded end-to-end coverage to validate substring-based filtering behavior in the schema selector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->