### PR TITLE
docs: add testing instructions for Jinja2 computed attributes using Pytest

### DIFF
--- a/docs/docs/guides/computed-attributes.mdx
+++ b/docs/docs/guides/computed-attributes.mdx
@@ -268,3 +268,30 @@ You need to commit these files to a Git repository and link the repository to In
 The circuit's description is now automatically computed (this process may take a few seconds). Any changes to related attributes (i.e., endpoint name) will trigger a reevaluation and update the value accordingly.
 
 :::
+
+## How to Test Jinja2 Computed Attributes Locally
+
+When developing Jinja2 computed attributes, it can be difficult to get the filter syntax right, especially if you need to push the schema every time to test a change. Instead, you can test your Jinja2 computed attribute logic locally using Pytest and the `Jinja2Template` class from the Infrahub Python SDK.
+
+Example:
+
+```python
+import pytest
+from infrahub_sdk.template import Jinja2Template
+
+INTF_INDEX_JINJA2 = "{{ \"%03d\"| format(name__value | split_interface | last | int) }}"
+
+@pytest.mark.parametrize(
+    "intf_name,expected",
+    [
+        ("Ethernet12", "012"),
+        ("Ethernet4", "004"),
+    ]
+)
+async def test_intf_index(intf_name, expected):
+    tpl = Jinja2Template(template=INTF_INDEX_JINJA2)
+    rendered = await tpl.render(variables={"name__value": intf_name})
+    assert rendered == expected
+```
+
+This approach allows you to quickly iterate and validate your computed attribute logic without needing to push changes to the schema. Adjust the template and test cases as needed to cover different scenarios.

--- a/docs/docs/topics/computed-attributes.mdx
+++ b/docs/docs/topics/computed-attributes.mdx
@@ -33,6 +33,33 @@ See the [guide](../guides/computed-attributes) for instructions on creating Jinj
 
 ::::
 
+### How to Test Jinja2 Computed Attributes Locally
+
+When developing Jinja2 computed attributes, it can be difficult to get the filter syntax right, especially if you need to push the schema every time to test a change. Instead, you can test your Jinja2 computed attribute logic locally using Pytest and the `Jinja2Template` class from the Infrahub Python SDK.
+
+Example:
+
+```python
+import pytest
+from infrahub_sdk.template import Jinja2Template
+
+INTF_INDEX_JINJA2 = "{{ \"%03d\"| format(name__value | split_interface | last | int) }}"
+
+@pytest.mark.parametrize(
+    "intf_name,expected",
+    [
+        ("Ethernet12", "012"),
+        ("Ethernet4", "004"),
+    ]
+)
+async def test_intf_index(intf_name, expected):
+    tpl = Jinja2Template(template=INTF_INDEX_JINJA2)
+    rendered = await tpl.render(variables={"name__value": intf_name})
+    assert rendered == expected
+```
+
+This approach allows you to quickly iterate and validate your computed attribute logic without needing to push changes to the schema. Adjust the template and test cases as needed to cover different scenarios.
+
 ## Python computed attributes {#python-computed-attribute}
 
 Python computed attributes leverage Infrahub's [Python transform](./transformation.mdx) feature. Users can define which transformation to apply directly within the schema. The computation of the value is delegated to workers as asynchronous tasks, which may cause the value to take a few seconds to update.

--- a/docs/docs/topics/computed-attributes.mdx
+++ b/docs/docs/topics/computed-attributes.mdx
@@ -33,33 +33,6 @@ See the [guide](../guides/computed-attributes) for instructions on creating Jinj
 
 ::::
 
-### How to Test Jinja2 Computed Attributes Locally
-
-When developing Jinja2 computed attributes, it can be difficult to get the filter syntax right, especially if you need to push the schema every time to test a change. Instead, you can test your Jinja2 computed attribute logic locally using Pytest and the `Jinja2Template` class from the Infrahub Python SDK.
-
-Example:
-
-```python
-import pytest
-from infrahub_sdk.template import Jinja2Template
-
-INTF_INDEX_JINJA2 = "{{ \"%03d\"| format(name__value | split_interface | last | int) }}"
-
-@pytest.mark.parametrize(
-    "intf_name,expected",
-    [
-        ("Ethernet12", "012"),
-        ("Ethernet4", "004"),
-    ]
-)
-async def test_intf_index(intf_name, expected):
-    tpl = Jinja2Template(template=INTF_INDEX_JINJA2)
-    rendered = await tpl.render(variables={"name__value": intf_name})
-    assert rendered == expected
-```
-
-This approach allows you to quickly iterate and validate your computed attribute logic without needing to push changes to the schema. Adjust the template and test cases as needed to cover different scenarios.
-
 ## Python computed attributes {#python-computed-attribute}
 
 Python computed attributes leverage Infrahub's [Python transform](./transformation.mdx) feature. Users can define which transformation to apply directly within the schema. The computation of the value is delegated to workers as asynchronous tasks, which may cause the value to take a few seconds to update.


### PR DESCRIPTION
Incorporate Damiens tip of the day into the docs. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added a new guide: “How to Test Jinja2 Computed Attributes Locally.”
  - Includes a step-by-step example using the SDK and Pytest to render templates asynchronously and assert expected outputs.
  - Demonstrates validating computed-attribute logic locally without pushing schema changes.
  - Provides guidance on adapting the tests to your environment and inputs, plus notes on best practices and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->