### PR TITLE
IFC-1796 Add method to get changes between 2 commits

### DIFF
--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -977,13 +977,11 @@ class InfrahubRepositoryBase(BaseModel, ABC):
         """Return the changes between two commits in this repo."""
         files: dict[str, list[str | tuple[str, str]]] = {
             "added": [],
-            "modified": [],
+            "copied": [],
             "deleted": [],
             "renamed": [],
-            "copied": [],
+            "modified": [],
             "type_changed": [],
-            "unmerged": [],
-            "unknown": [],
         }
 
         repo = self.get_git_repo_main()

--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, NoReturn
 from uuid import UUID  # noqa: TC003
 
 import git
-from git import Blob, Repo
+from git import BadName, Blob, Repo
 from git.exc import GitCommandError, InvalidGitRepositoryError
 from git.refs.remote import RemoteReference
 from infrahub_sdk import InfrahubClient  # noqa: TC002
@@ -984,8 +984,12 @@ class InfrahubRepositoryBase(BaseModel, ABC):
         """Return the changes between two commits in this repo."""
         changes = RepoChangedFiles()
         repo = self.get_git_repo_main()
-        commit_a = repo.commit(first_commit)
-        commit_b = repo.commit(second_commit) if second_commit else repo.head.commit
+
+        try:
+            commit_a = repo.commit(first_commit)
+            commit_b = repo.commit(second_commit) if second_commit else repo.head.commit
+        except BadName as exc:
+            raise CommitNotFoundError(identifier=str(self.id), commit=exc.args[0]) from exc
 
         for diff in commit_a.diff(commit_b):
             match diff.change_type:

--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -67,6 +67,15 @@ class RepoFileInformation(BaseModel):
     """Extension of the file Example: py """
 
 
+class RepoChangedFiles(BaseModel):
+    added: list[str] = Field(default_factory=list)
+    copied: list[tuple[str, str]] = Field(default_factory=list)
+    deleted: list[str] = Field(default_factory=list)
+    renamed: list[tuple[str, str]] = Field(default_factory=list)
+    modified: list[str] = Field(default_factory=list)
+    type_changed: list[tuple[str, str]] = Field(default_factory=list)
+
+
 def extract_repo_file_information(
     full_filename: Path, repo_directory: Path, worktree_directory: Path | None = None
 ) -> RepoFileInformation:
@@ -971,19 +980,9 @@ class InfrahubRepositoryBase(BaseModel, ABC):
             return registry.default_branch
         return branch_name
 
-    def get_changed_files(
-        self, first_commit: str, second_commit: str | None = None
-    ) -> dict[str, list[str | tuple[str, str]]]:
+    def get_changed_files(self, first_commit: str, second_commit: str | None = None) -> RepoChangedFiles:
         """Return the changes between two commits in this repo."""
-        files: dict[str, list[str | tuple[str, str]]] = {
-            "added": [],
-            "copied": [],
-            "deleted": [],
-            "renamed": [],
-            "modified": [],
-            "type_changed": [],
-        }
-
+        changes = RepoChangedFiles()
         repo = self.get_git_repo_main()
         commit_a = repo.commit(first_commit)
         commit_b = repo.commit(second_commit) if second_commit else repo.head.commit
@@ -991,16 +990,16 @@ class InfrahubRepositoryBase(BaseModel, ABC):
         for diff in commit_a.diff(commit_b):
             match diff.change_type:
                 case "A":
-                    files["added"].append(diff.b_path)
+                    changes.added.append(diff.b_path)
                 case "C":
-                    files["copied"].append((diff.a_path, diff.b_path))
+                    changes.copied.append((diff.a_path, diff.b_path))
                 case "D":
-                    files["deleted"].append(diff.a_path)
+                    changes.deleted.append(diff.a_path)
                 case "R":
-                    files["renamed"].append((diff.a_path, diff.b_path))
+                    changes.renamed.append((diff.a_path, diff.b_path))
                 case "M":
-                    files["modified"].append(diff.b_path)
+                    changes.modified.append(diff.b_path)
                 case "T":
-                    files["type_changed"].append((diff.a_path, diff.b_path))
+                    changes.type_changed.append((diff.a_path, diff.b_path))
 
-        return files
+        return changes

--- a/backend/infrahub/git/base.py
+++ b/backend/infrahub/git/base.py
@@ -970,3 +970,39 @@ class InfrahubRepositoryBase(BaseModel, ABC):
         if branch_name == self.default_branch and branch_name != registry.default_branch:
             return registry.default_branch
         return branch_name
+
+    def get_changed_files(
+        self, first_commit: str, second_commit: str | None = None
+    ) -> dict[str, list[str | tuple[str, str]]]:
+        """Return the changes between two commits in this repo."""
+        files: dict[str, list[str | tuple[str, str]]] = {
+            "added": [],
+            "modified": [],
+            "deleted": [],
+            "renamed": [],
+            "copied": [],
+            "type_changed": [],
+            "unmerged": [],
+            "unknown": [],
+        }
+
+        repo = self.get_git_repo_main()
+        commit_a = repo.commit(first_commit)
+        commit_b = repo.commit(second_commit) if second_commit else repo.head.commit
+
+        for diff in commit_a.diff(commit_b):
+            match diff.change_type:
+                case "A":
+                    files["added"].append(diff.b_path)
+                case "C":
+                    files["copied"].append((diff.a_path, diff.b_path))
+                case "D":
+                    files["deleted"].append(diff.a_path)
+                case "R":
+                    files["renamed"].append((diff.a_path, diff.b_path))
+                case "M":
+                    files["modified"].append(diff.b_path)
+                case "T":
+                    files["type_changed"].append((diff.a_path, diff.b_path))
+
+        return files

--- a/backend/tests/fixtures/repos/changed-files/initial__main/commit1/test.gql
+++ b/backend/tests/fixtures/repos/changed-files/initial__main/commit1/test.gql
@@ -1,0 +1,10 @@
+query tags {
+  BuiltinTag {
+    edges {
+      node {
+    id
+    hfid
+     }
+   }
+ }
+}

--- a/backend/tests/fixtures/repos/changed-files/initial__main/commit2/test.gql
+++ b/backend/tests/fixtures/repos/changed-files/initial__main/commit2/test.gql
@@ -1,0 +1,10 @@
+ query tags_query {
+  BuiltinTag {
+    edges {
+      node {
+	      id
+	      hfid
+      }
+    }
+  }
+}

--- a/backend/tests/fixtures/repos/changed-files/initial__main/commit3/README.md
+++ b/backend/tests/fixtures/repos/changed-files/initial__main/commit3/README.md
@@ -1,0 +1,1 @@
+I'm just a README

--- a/backend/tests/integration/git/test_repository.py
+++ b/backend/tests/integration/git/test_repository.py
@@ -9,7 +9,7 @@ from git import GitCommandError
 from infrahub.core.constants import InfrahubKind, RepositoryOperationalStatus
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
-from infrahub.exceptions import RepositoryError
+from infrahub.exceptions import CommitNotFoundError, RepositoryError
 from infrahub.git.repository import get_initialized_repo
 from tests.constants import TestKind
 from tests.helpers.file_repo import FileRepo, MultipleStagesFileRepo
@@ -189,3 +189,6 @@ class TestRepositoryChangedFiles(TestInfrahubApp):
         diff_1_to_head = infrahub_repo.get_changed_files(first_commit=commits[0].hexsha)
         assert diff_1_to_head.added == ["README.md"]
         assert diff_1_to_head.modified == ["test.gql"]
+
+        with pytest.raises(CommitNotFoundError, match="Commit foo not found with GitRepository"):
+            infrahub_repo.get_changed_files(first_commit="foo")

--- a/backend/tests/integration/git/test_repository.py
+++ b/backend/tests/integration/git/test_repository.py
@@ -173,7 +173,7 @@ class TestRepositoryChangedFiles(TestInfrahubApp):
         )
 
         # Have commits from oldest to youngest
-        commits = list(reversed(list(infrahub_repo.cache_repo.iter_commits())))
+        commits = list(reversed(list(infrahub_repo.get_git_repo_main().iter_commits())))
         assert len(commits) == 3
 
         diff_1_to_3 = infrahub_repo.get_changed_files(first_commit=commits[0].hexsha, second_commit=commits[1].hexsha)

--- a/backend/tests/integration/git/test_repository.py
+++ b/backend/tests/integration/git/test_repository.py
@@ -176,8 +176,8 @@ class TestRepositoryChangedFiles(TestInfrahubApp):
         commits = list(reversed(list(infrahub_repo.get_git_repo_main().iter_commits())))
         assert len(commits) == 3
 
-        diff_1_to_3 = infrahub_repo.get_changed_files(first_commit=commits[0].hexsha, second_commit=commits[1].hexsha)
-        assert diff_1_to_3.modified == ["test.gql"]
+        diff_1_to_2 = infrahub_repo.get_changed_files(first_commit=commits[0].hexsha, second_commit=commits[1].hexsha)
+        assert diff_1_to_2.modified == ["test.gql"]
 
         diff_2_to_3 = infrahub_repo.get_changed_files(first_commit=commits[1].hexsha, second_commit=commits[2].hexsha)
         assert diff_2_to_3.added == ["README.md"]

--- a/backend/tests/integration/git/test_repository.py
+++ b/backend/tests/integration/git/test_repository.py
@@ -12,7 +12,7 @@ from infrahub.core.node import Node
 from infrahub.exceptions import RepositoryError
 from infrahub.git.repository import get_initialized_repo
 from tests.constants import TestKind
-from tests.helpers.file_repo import FileRepo
+from tests.helpers.file_repo import FileRepo, MultipleStagesFileRepo
 from tests.helpers.schema import CAR_SCHEMA, load_schema
 from tests.helpers.test_app import TestInfrahubApp
 from tests.integration.git.utils import check_repo_correctly_created
@@ -123,3 +123,73 @@ class TestCreateRepository(TestInfrahubApp):
                     db=db, id=client_repository.id, kind=InfrahubKind.REPOSITORY, raise_on_error=True
                 )
                 assert r.operational_status.value == expected_operational_status.value
+
+
+class TestRepositoryChangedFiles(TestInfrahubApp):
+    @pytest.fixture(scope="class")
+    async def initial_dataset(
+        self,
+        db: InfrahubDatabase,
+        tmp_path_module_scope,
+        initialize_registry: None,
+        git_repos_dir_module_scope: Path,
+        git_repos_source_dir_module_scope: Path,
+    ) -> None:
+        source_dir = tmp_path_module_scope / "sources"
+        source_dir.mkdir()
+        file_repo = MultipleStagesFileRepo(name="changed-files", sources_directory=source_dir)
+
+        obj = await Node.init(schema=InfrahubKind.REPOSITORY, db=db)
+        await obj.new(
+            db=db,
+            name=file_repo.name,
+            description="test repository",
+            location=file_repo.path,
+            commit=file_repo.repo.commit("main").hexsha,
+        )
+        await obj.save(db=db)
+
+    async def test_get_changed_files(
+        self,
+        db: InfrahubDatabase,
+        initial_dataset: None,
+        git_repos_source_dir_module_scope: Path,
+        client: InfrahubClient,
+        service: InfrahubServices,
+    ) -> None:
+        """Validate that we can create a repository, that it gets updated with the commit id and that objects are created."""
+        client_repository = await client.get(kind=InfrahubKind.REPOSITORY, name__value="changed-files")
+        repository: CoreRepository = await NodeManager.get_one(
+            db=db, id=client_repository.id, kind=InfrahubKind.REPOSITORY, raise_on_error=True
+        )
+
+        assert repository.commit.value
+
+        infrahub_repo = await get_initialized_repo(
+            client=client,
+            repository_id=repository.id,
+            name=repository.name.value,
+            repository_kind=InfrahubKind.REPOSITORY,
+        )
+
+        # Have commits from oldest to youngest
+        commits = list(reversed(list(infrahub_repo.cache_repo.iter_commits())))
+        assert len(commits) == 3
+
+        diff_1_to_3 = infrahub_repo.get_changed_files(first_commit=commits[0].hexsha, second_commit=commits[1].hexsha)
+        assert diff_1_to_3
+        assert diff_1_to_3["modified"] == ["test.gql"]
+
+        diff_2_to_3 = infrahub_repo.get_changed_files(first_commit=commits[1].hexsha, second_commit=commits[2].hexsha)
+        assert diff_2_to_3
+        assert diff_2_to_3["added"] == ["README.md"]
+
+        diff_1_to_3 = infrahub_repo.get_changed_files(first_commit=commits[0].hexsha, second_commit=commits[2].hexsha)
+        assert diff_1_to_3
+        assert diff_1_to_3["added"] == ["README.md"]
+        assert diff_1_to_3["modified"] == ["test.gql"]
+
+        diff_1_to_head = infrahub_repo.get_changed_files(first_commit=commits[0].hexsha)
+        assert diff_1_to_head
+        assert diff_1_to_head["added"] == ["README.md"]
+        assert diff_1_to_head["modified"] == ["test.gql"]

--- a/backend/tests/integration/git/test_repository.py
+++ b/backend/tests/integration/git/test_repository.py
@@ -177,19 +177,15 @@ class TestRepositoryChangedFiles(TestInfrahubApp):
         assert len(commits) == 3
 
         diff_1_to_3 = infrahub_repo.get_changed_files(first_commit=commits[0].hexsha, second_commit=commits[1].hexsha)
-        assert diff_1_to_3
-        assert diff_1_to_3["modified"] == ["test.gql"]
+        assert diff_1_to_3.modified == ["test.gql"]
 
         diff_2_to_3 = infrahub_repo.get_changed_files(first_commit=commits[1].hexsha, second_commit=commits[2].hexsha)
-        assert diff_2_to_3
-        assert diff_2_to_3["added"] == ["README.md"]
+        assert diff_2_to_3.added == ["README.md"]
 
         diff_1_to_3 = infrahub_repo.get_changed_files(first_commit=commits[0].hexsha, second_commit=commits[2].hexsha)
-        assert diff_1_to_3
-        assert diff_1_to_3["added"] == ["README.md"]
-        assert diff_1_to_3["modified"] == ["test.gql"]
+        assert diff_1_to_3.added == ["README.md"]
+        assert diff_1_to_3.modified == ["test.gql"]
 
         diff_1_to_head = infrahub_repo.get_changed_files(first_commit=commits[0].hexsha)
-        assert diff_1_to_head
-        assert diff_1_to_head["added"] == ["README.md"]
-        assert diff_1_to_head["modified"] == ["test.gql"]
+        assert diff_1_to_head.added == ["README.md"]
+        assert diff_1_to_head.modified == ["test.gql"]


### PR DESCRIPTION
This method takes a first commit parameter and an optional second commit parameter, if not set the repo's head will be used instead. It then computes a diff and returns a Pydantic model with list of filenames for fiels that have been changed, added or deleted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added the ability to list changed files between two commits, grouped as added, copied, deleted, renamed, modified, and type-changed.
  - Returns structured results and reports clear errors when a requested commit is not found.

- Tests
  - Added integration tests and fixtures to validate changed-file detection across multiple commits and error handling for unknown commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->