### PR TITLE
fix(docs): add config preset sizing table

### DIFF
--- a/docs/docs/guides/installation.mdx
+++ b/docs/docs/guides/installation.mdx
@@ -350,7 +350,15 @@ You can also specify a sizing preset in the URL. This will automatically configu
 
 - [https://infrahub.opsmill.io/enterprise?size=small](https://infrahub.opsmill.io/enterprise?size=small) (requires 8 GB of RAM)
 - [https://infrahub.opsmill.io/enterprise/1.3.5?size=medium](https://infrahub.opsmill.io/enterprise/1.3.5?size=medium) (requires 24 GB of RAM)
-- [https://infrahub.opsmill.io/enterprise?size=large](https://infrahub.opsmill.io/enterprise/1.3.5?size=large) (requires 64 GB of RAM)
+- [https://infrahub.opsmill.io/enterprise/stable?size=large](https://infrahub.opsmill.io/enterprise/stable?size=large) (requires 64 GB of RAM)
+
+| Size   | Total required memory | API workers | Task workers | Task manager API workers | Task manager background workers | DB heap size | DB page cache size |
+| ----------- | ----- | - | - | - | - | --- | --- |
+| small       | 8 GB  | 4 | 2 | 1 | 1 | 8G  | 1G  |
+| medium      | 24 GB | 4 | 4 | 2 | 2 | 24G | 4G  |
+| medium-data | 24 GB | 4 | 2 | 1 | 1 | 24G | 4G  |
+| large       | 64 GB | 4 | 8 | 4 | 2 | 31G | 16G |
+| large-data  | 64 GB | 4 | 2 | 1 | 1 | 31G | 16G |
 
 #### Prerequisites
 
@@ -498,7 +506,9 @@ They are available here:
 
 <ReferenceLink title="Small size config preset (requires 8 GB of RAM)" url="https://github.com/opsmill/infrahub-helm/blob/stable/charts/infrahub-enterprise/values.small.yaml" openInNewTab />
 <ReferenceLink title="Medium size config preset (requires 24 GB of RAM)" url="https://github.com/opsmill/infrahub-helm/blob/stable/charts/infrahub-enterprise/values.medium.yaml" openInNewTab />
+<ReferenceLink title="Medium (data) size config preset (requires 24 GB of RAM)" url="https://github.com/opsmill/infrahub-helm/blob/stable/charts/infrahub-enterprise/values.medium-data.yaml" openInNewTab />
 <ReferenceLink title="Large size config preset (requires 64 GB of RAM)" url="https://github.com/opsmill/infrahub-helm/blob/stable/charts/infrahub-enterprise/values.large.yaml" openInNewTab />
+<ReferenceLink title="Large (data) size config preset (requires 64 GB of RAM)" url="https://github.com/opsmill/infrahub-helm/blob/stable/charts/infrahub-enterprise/values.large-data.yaml" openInNewTab />
 
 #### Step 2: install the chart
 

--- a/docs/docs/topics/hardware-requirements.mdx
+++ b/docs/docs/topics/hardware-requirements.mdx
@@ -33,11 +33,11 @@ For enterprise deployments, use these guidelines:
 
 | Enterprise Product | CPU Cores | RAM  | Storage / database (Neo4j) |
 |--------------------|-----------|------|----------------------------|
-| Small              | 4         | 12GB | SSD and/or >= 5000 IOPS    |
-| Medium Data        | 8         | 16GB | SSD and/or >= 5000 IOPS    |
-| Medium Action      | 8         | 16GB | SSD and/or >= 5000 IOPS    |
-| Large Data         | 16        | 32GB | SSD and/or >= 5000 IOPS    |
-| Large Action       | 16        | 32GB | SSD and/or >= 5000 IOPS    |
+| Small              | 8         | 16GB | SSD and/or >= 5000 IOPS    |
+| Medium Data        | 16        | 32GB | SSD and/or >= 5000 IOPS    |
+| Medium Action      | 16        | 32GB | SSD and/or >= 5000 IOPS    |
+| Large Data         | 32        | 64GB | SSD and/or >= 5000 IOPS    |
+| Large Action       | 32        | 64GB | SSD and/or >= 5000 IOPS    |
 
 ## Performance benchmark utility
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Enterprise sizing URL to include stable channel.
  * Added a comprehensive Enterprise sizing table (memory, workers, DB heap/page cache).
  * Introduced Medium (data) and Large (data) configuration presets.
  * Switched Enterprise chart installation to an OCI registry path.
  * Revised Kubernetes/Helm examples to use nested values under infrahub > infrahubServer.
  * Added data preset references to Enterprise Helm guidance.
  * Increased Enterprise hardware recommendations (CPU and RAM doubled for all sizes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->