### PR TITLE
updates and tests for Relationship queries to not return deleted rels

### DIFF
--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -871,6 +871,9 @@ class RelationshipGetQuery(RelationshipQuery):
         query = """
         MATCH (s)%s(rl:Relationship { name: $name })%s(d)
         WHERE %s
+        ORDER BY r1.branch_level DESC, r1.from DESC, r1.status ASC, r2.branch_level DESC, r2.from DESC, r2.status ASC
+        WITH *, r1.status = "active" AND r2.status = "active" AS is_active
+        LIMIT 1
         """ % (
             r1,
             r2,
@@ -880,7 +883,7 @@ class RelationshipGetQuery(RelationshipQuery):
         self.params["at"] = self.at.to_string()
 
         self.add_to_query(query)
-        self.return_labels = ["s", "d", "rl", "r1", "r2"]
+        self.return_labels = ["s", "d", "rl", "r2", "is_active"]
 
 
 class RelationshipGetByIdentifierQuery(Query):

--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -885,6 +885,19 @@ class RelationshipGetQuery(RelationshipQuery):
         self.add_to_query(query)
         self.return_labels = ["s", "d", "rl", "r2", "is_active"]
 
+    def is_already_deleted(self) -> bool:
+        result = self.get_result()
+        if not result:
+            return False
+        return result.get("is_active") is False
+
+    def get_relationships_ids_for_branch(self, branch_name: str) -> list[str] | None:
+        result = self.get_result()
+        if not result:
+            return None
+
+        return [rel.element_id for rel in result.get_rels() if rel.get("branch") == branch_name]
+
 
 class RelationshipGetByIdentifierQuery(Query):
     name = "relationship_get_identifier"

--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -410,6 +410,10 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin):
                 f"Unable to find the relationship to delete. id: {self.id}, source: {node.id}, destination: {peer.id}"
             )
 
+        # this Relationship has already been deleted
+        if result.get("is_active") is False:
+            return
+
         # when we remove a relationship we need to :
         # - Update the existing relationship if we are on the same branch
         # - Create a new rel of type DELETED in the right branch

--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -404,21 +404,21 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin):
             db=db, source=node, destination=peer, rel=self, branch=self.branch, at=delete_at
         )
         await get_query.execute(db=db)
-        result = get_query.get_result()
-        if not result:
+
+        rel_ids_to_update = get_query.get_relationships_ids_for_branch(branch_name=branch.name)
+        if rel_ids_to_update is None:
             raise Error(
                 f"Unable to find the relationship to delete. id: {self.id}, source: {node.id}, destination: {peer.id}"
             )
 
-        # this Relationship has already been deleted
-        if result.get("is_active") is False:
+        if get_query.is_already_deleted():
             return
 
         # when we remove a relationship we need to :
         # - Update the existing relationship if we are on the same branch
         # - Create a new rel of type DELETED in the right branch
 
-        if rel_ids_to_update := [rel.element_id for rel in result.get_rels() if rel.get("branch") == branch.name]:
+        if rel_ids_to_update:
             await update_relationships_to(rel_ids_to_update, to=delete_at, db=db)
 
         delete_query = await RelationshipDeleteQuery.init(

--- a/backend/tests/unit/core/test_relationship.py
+++ b/backend/tests/unit/core/test_relationship.py
@@ -483,3 +483,33 @@ async def test_relationship_timestamp_changes(
     tag_rels = await after_save_person_jack.tags.get_relationships(db=db)
     assert len(tag_rels) == 1
     assert [r.peer_id for r in tag_rels] == [tag_red_main.id]
+
+
+async def test_relationship_second_delete_is_ignored(
+    db: InfrahubDatabase, person_jack_main: Node, tag_blue_main: Node, branch: Branch
+):
+    person_jack = await NodeManager.get_one(db=db, branch=branch, id=person_jack_main.id)
+    await person_jack.tags.update(db=db, data=[tag_blue_main.id])
+    await person_jack.save(db=db)
+    rels = await person_jack.tags.get_relationships(db=db)
+
+    blue_tag_rel = rels[0]
+    await blue_tag_rel.delete(db=db)
+    await blue_tag_rel.delete(db=db)
+
+    # verify that only 1 delete path exists
+    query = """
+MATCH (s:Node {uuid: $source_id})-[r1:IS_RELATED {status: "deleted", branch: $branch}]-(:Relationship {name: $rel_name})
+    -[r2:IS_RELATED {status: "deleted", branch: $branch}]-(d:Node {uuid: $dest_id})
+RETURN count(*) AS num_paths
+    """
+    result = await db.execute_query(
+        query=query,
+        params={
+            "source_id": person_jack_main.id,
+            "branch": branch.name,
+            "rel_name": "builtintag__testperson",
+            "dest_id": tag_blue_main.id,
+        },
+    )
+    assert result[0].get("num_paths") == 1

--- a/backend/tests/unit/core/test_relationship_query.py
+++ b/backend/tests/unit/core/test_relationship_query.py
@@ -18,6 +18,7 @@ from infrahub.core.query.relationship import (
     RelationshipDeleteQuery,
     RelationshipGetByIdentifierQuery,
     RelationshipGetPeerQuery,
+    RelationshipGetQuery,
     RelationshipPeerData,
     RelationshipQuery,
     RelData,
@@ -1096,3 +1097,57 @@ async def test_query_RelationshipGetByIdentifierQuery(
     )
     await query.execute(db=db)
     assert await query.count(db=db) == 5
+
+    # test owner update on branch
+    branch_yaris = await NodeManager.get_one(db=db, branch=branch, id=car_yaris_main.id)
+    await branch_yaris.owner.update(db=db, data=person_jane_main)
+    await branch_yaris.save(db=db)
+    query = await RelationshipGetByIdentifierQuery.init(
+        db=db, branch=branch, identifiers=["testcar__testperson"], excluded_namespaces=[]
+    )
+    await query.execute(db=db)
+    assert await query.count(db=db) == 5
+
+    # test delete
+    branch_prius = await NodeManager.get_one(db=db, branch=branch, id=car_prius_main.id)
+    await branch_prius.delete(db=db)
+    query = await RelationshipGetByIdentifierQuery.init(
+        db=db, branch=branch, identifiers=["testcar__testperson"], excluded_namespaces=[]
+    )
+    await query.execute(db=db)
+    assert await query.count(db=db) == 4
+
+
+async def test_query_RelationshipGetQuery(
+    db: InfrahubDatabase,
+    car_prius_main: Node,
+    person_john_main: Node,
+    branch: Branch,
+):
+    person_john = await NodeManager.get_one(db=db, branch=branch, id=person_john_main.id)
+    car_prius = await NodeManager.get_one(db=db, branch=branch, id=car_prius_main.id)
+    owner_rels = await car_prius.owner.get_relationships(db=db)
+    owner_rel = owner_rels[0]
+
+    # test query on active Relationship
+    query = await RelationshipGetQuery.init(
+        db=db, branch=branch, source=car_prius, rel=owner_rel, destination=person_john
+    )
+    await query.execute(db=db)
+    results = list(query.get_results())
+    assert len(results) == 1
+    assert results[0].get("s").get("uuid") == car_prius_main.id
+    assert results[0].get("d").get("uuid") == person_john_main.id
+    assert results[0].get("is_active") is True
+
+    # test query on deleted Relationship
+    await owner_rel.delete(db=db)
+    query = await RelationshipGetQuery.init(
+        db=db, branch=branch, source=car_prius, rel=owner_rel, destination=person_john
+    )
+    await query.execute(db=db)
+    results = list(query.get_results())
+    assert len(results) == 1
+    assert results[0].get("s").get("uuid") == car_prius_main.id
+    assert results[0].get("d").get("uuid") == person_john_main.id
+    assert results[0].get("is_active") is False

--- a/changelog/+relationship-query.fixed.md
+++ b/changelog/+relationship-query.fixed.md
@@ -1,0 +1,1 @@
+Update a cypher query that did not correctly account for deleted Relationships. It was only used during a delete, so would not have caused any issues visible to the user.


### PR DESCRIPTION
found a couple of issues with a `Relationship`-related query while investigating IFC-1836 and looking at what other queries used `Branch.get_query_filter_relationships`

`RelationshipGetByIdentifierQuery` and `RelationshipGetQuery` both use that method. `RelationshipGetByIdentifierQuery` was correctly accounting for deleted edges, but `RelationshipGetQuery` could return deleted relationships. Fortunately, this query is only used when deleting things, so the worst case would be that something gets double-deleted, which is usually not a big deal

The updates to the query is to make sure we only get the latest Relationship path (ie `(Node)-[:IS_RELATED]-(:Relationship)-[:IS_RELATED]-(:Node)`) and then account for whether that path is deleted or not

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Fix handling of deleted relationships to avoid duplicate deletion paths and ensure accurate active status; deletions are now idempotent.

- Documentation
  - Added changelog entry describing the corrected query behavior for deleted relationships.

- Tests
  - Added tests for single active relationship retrieval, status after deletion, idempotent deletes, and additional query coverage when updating ownership and after node deletions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->