### PR TITLE
Store GraphQL schemas by schema hash instead of branch name

### DIFF
--- a/backend/infrahub/graphql/manager.py
+++ b/backend/infrahub/graphql/manager.py
@@ -101,7 +101,6 @@ def get_attr_kind(node_schema: MainSchemaTypes, attr_schema: AttributeSchema) ->
 
 @dataclass
 class BranchDetails:
-    branch_name: str
     schema_changed_at: Timestamp
     schema_hash: str
     gql_manager: GraphQLSchemaManager
@@ -109,62 +108,68 @@ class BranchDetails:
 
 class GraphQLSchemaManager:
     _extra_types: dict[str, GraphQLTypes] = {}
-    _branch_details_by_name: dict[str, BranchDetails] = {}
+    _branch_details_by_hash: dict[str, BranchDetails] = {}
+    _branch_name_by_hash: dict[str, set[str]] = {}
+    _branch_hash_activation_by_branch_name: dict[str, dict[str, str]] = {}
 
     @classmethod
     def clear_cache(cls) -> None:
-        cls._branch_details_by_name = {}
+        cls._branch_details_by_hash = {}
+        cls._branch_name_by_hash = {}
 
     @classmethod
     def purge_inactive(cls, active_branches: list[str]) -> set[str]:
         """Return inactive branches that were purged"""
         inactive_branches: set[str] = set()
-        for branch_name in list(cls._branch_details_by_name):
-            if branch_name not in active_branches:
-                inactive_branches.add(branch_name)
-                del cls._branch_details_by_name[branch_name]
+        for schema_hash in list(cls._branch_name_by_hash.keys()):
+            branches = list(cls._branch_name_by_hash[schema_hash])
+            for branch in branches:
+                if branch not in active_branches and branch in cls._branch_name_by_hash[schema_hash]:
+                    inactive_branches.add(branch)
+                    cls._branch_name_by_hash[schema_hash].discard(branch)
+
+        for schema_hash in list(cls._branch_name_by_hash.keys()):
+            if not cls._branch_name_by_hash[schema_hash]:
+                # If no remaining branch is using the schema remove it completely
+                del cls._branch_name_by_hash[schema_hash]
+                del cls._branch_details_by_hash[schema_hash]
+
         return inactive_branches
 
     @classmethod
-    def _cache_branch(
-        cls, branch: Branch, schema_branch: SchemaBranch, schema_hash: str | None = None
-    ) -> BranchDetails:
-        if not schema_hash:
-            if branch.schema_hash:
-                schema_hash = branch.schema_hash.main
-            else:
-                schema_hash = schema_branch.get_hash()
+    def _cache_branch(cls, branch: Branch, schema_branch: SchemaBranch, schema_hash: str) -> BranchDetails:
         branch_details = BranchDetails(
-            branch_name=branch.name,
             schema_changed_at=Timestamp(branch.schema_changed_at) if branch.schema_changed_at else Timestamp(),
             schema_hash=schema_hash,
             gql_manager=cls(schema=schema_branch),
         )
-        cls._branch_details_by_name[branch.name] = branch_details
+
+        cls._branch_details_by_hash[schema_hash] = branch_details
+
         return branch_details
 
     @classmethod
     def get_manager_for_branch(cls, branch: Branch, schema_branch: SchemaBranch) -> GraphQLSchemaManager:
-        if branch.name not in cls._branch_details_by_name:
-            branch_details = cls._cache_branch(branch=branch, schema_branch=schema_branch)
-            return branch_details.gql_manager
-        cached_branch_details = cls._branch_details_by_name[branch.name]
-        # try to use the schema_changed_at time b/c it is faster than checking the hash
-        if branch.schema_changed_at:
-            changed_at_time = Timestamp(branch.schema_changed_at)
-            if changed_at_time > cached_branch_details.schema_changed_at:
-                cached_branch_details = cls._cache_branch(branch=branch, schema_branch=schema_branch)
-            return cached_branch_details.gql_manager
         if branch.schema_hash:
-            current_hash = branch.active_schema_hash.main
+            schema_hash = branch.schema_hash.main
         else:
-            current_hash = schema_branch.get_hash()
-        if cached_branch_details.schema_hash != current_hash:
-            cached_branch_details = cls._cache_branch(
-                branch=branch, schema_branch=schema_branch, schema_hash=current_hash
-            )
+            schema_hash = schema_branch.get_hash()
 
-        return cached_branch_details.gql_manager
+        if schema_hash in cls._branch_details_by_hash:
+            branch_details = cls._branch_details_by_hash[schema_hash]
+        else:
+            branch_details = cls._cache_branch(branch=branch, schema_branch=schema_branch, schema_hash=schema_hash)
+
+        cls._add_branch_hash(branch_name=branch.name, schema_hash=schema_hash)
+
+        return branch_details.gql_manager
+
+    @classmethod
+    def _add_branch_hash(cls, branch_name: str, schema_hash: str) -> None:
+        if schema_hash not in cls._branch_name_by_hash:
+            cls._branch_name_by_hash[schema_hash] = set()
+
+        cls._branch_name_by_hash[schema_hash].add(branch_name)
 
     def __init__(self, schema: SchemaBranch) -> None:
         self.schema = schema

--- a/backend/infrahub/graphql/manager.py
+++ b/backend/infrahub/graphql/manager.py
@@ -116,6 +116,7 @@ class GraphQLSchemaManager:
     def clear_cache(cls) -> None:
         cls._branch_details_by_hash = {}
         cls._branch_name_by_hash = {}
+        cls._branch_hash_activation_by_branch_name = {}
 
     @classmethod
     def purge_inactive(cls, active_branches: list[str]) -> set[str]:

--- a/backend/tests/helpers/graphql.py
+++ b/backend/tests/helpers/graphql.py
@@ -15,6 +15,7 @@ from graphql import graphql as graphql_core
 
 from infrahub.core.branch import Branch
 from infrahub.graphql.initialization import prepare_graphql_params
+from infrahub.graphql.manager import GraphQLSchemaManager
 from infrahub.log import get_logger
 
 if TYPE_CHECKING:
@@ -95,9 +96,13 @@ async def graphql_query(
     service: InfrahubServices | None = None,
     variables: dict[str, Any] | None = None,
     account_session: AccountSession | None = None,
+    refresh_schema: bool = False,
 ) -> ExecutionResult:
     branch = branch or await Branch.get_by_name(name="main", db=db)
     variables = variables or {}
+    if refresh_schema:
+        GraphQLSchemaManager.clear_cache()
+
     gql_params = await prepare_graphql_params(
         db=db,
         include_subscription=False,

--- a/backend/tests/helpers/graphql.py
+++ b/backend/tests/helpers/graphql.py
@@ -15,7 +15,6 @@ from graphql import graphql as graphql_core
 
 from infrahub.core.branch import Branch
 from infrahub.graphql.initialization import prepare_graphql_params
-from infrahub.graphql.manager import GraphQLSchemaManager
 from infrahub.log import get_logger
 
 if TYPE_CHECKING:
@@ -96,12 +95,9 @@ async def graphql_query(
     service: InfrahubServices | None = None,
     variables: dict[str, Any] | None = None,
     account_session: AccountSession | None = None,
-    refresh_schema: bool = False,
 ) -> ExecutionResult:
     branch = branch or await Branch.get_by_name(name="main", db=db)
     variables = variables or {}
-    if refresh_schema:
-        GraphQLSchemaManager.clear_cache()
 
     gql_params = await prepare_graphql_params(
         db=db,

--- a/backend/tests/unit/api/test_20_graphql.py
+++ b/backend/tests/unit/api/test_20_graphql.py
@@ -1,14 +1,22 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
 
 from infrahub import config
-from infrahub.core.branch import Branch
 from infrahub.core.initialization import create_branch
 from infrahub.core.timestamp import Timestamp
-from infrahub.database import InfrahubDatabase
+
+if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
+
+    from infrahub.core.branch import Branch
+    from infrahub.database import InfrahubDatabase
 
 
 async def test_graphql_endpoint(
-    db: InfrahubDatabase, client, admin_headers, default_branch: Branch, create_test_admin, car_person_data
+    db: InfrahubDatabase, client: TestClient, admin_headers, default_branch: Branch, create_test_admin, car_person_data
 ):
     query = """
     query {
@@ -50,7 +58,7 @@ async def test_graphql_endpoint(
 
 
 async def test_graphql_endpoint_with_timestamp(
-    db: InfrahubDatabase, client, admin_headers, default_branch: Branch, create_test_admin, car_person_data
+    db: InfrahubDatabase, client: TestClient, admin_headers, default_branch: Branch, create_test_admin, car_person_data
 ):
     time_before = Timestamp()
 

--- a/backend/tests/unit/graphql/test_graphql_partial_match.py
+++ b/backend/tests/unit/graphql/test_graphql_partial_match.py
@@ -134,7 +134,8 @@ async def test_query_filter_relationships_with_generic_filter_partial_match(
         }
     }
     """
-    result = await graphql_query(query=query, db=db, branch=default_branch, refresh_schema=True)
+    default_branch.update_schema_hash()
+    result = await graphql_query(query=query, db=db, branch=default_branch)
 
     assert result.errors is None
     assert result.data

--- a/backend/tests/unit/graphql/test_graphql_partial_match.py
+++ b/backend/tests/unit/graphql/test_graphql_partial_match.py
@@ -134,7 +134,7 @@ async def test_query_filter_relationships_with_generic_filter_partial_match(
         }
     }
     """
-    result = await graphql_query(query=query, db=db, branch=default_branch)
+    result = await graphql_query(query=query, db=db, branch=default_branch, refresh_schema=True)
 
     assert result.errors is None
     assert result.data

--- a/backend/tests/unit/graphql/test_graphql_query.py
+++ b/backend/tests/unit/graphql/test_graphql_query.py
@@ -14,6 +14,7 @@ from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
+from infrahub.graphql.manager import GraphQLSchemaManager
 from tests.helpers.graphql import graphql
 
 
@@ -1027,6 +1028,7 @@ async def test_query_filter_on_enum(
         }
     }
     """ % (enum_value)
+    GraphQLSchemaManager.clear_cache()
     gql_params = await prepare_graphql_params(
         db=db, include_mutation=False, include_subscription=False, branch=default_branch
     )
@@ -1975,6 +1977,7 @@ async def test_query_attribute_node_property_source(
         }
     }
     """
+    GraphQLSchemaManager.clear_cache()
     gql_params = await prepare_graphql_params(
         db=db, include_mutation=False, include_subscription=False, branch=default_branch
     )
@@ -2033,6 +2036,7 @@ async def test_query_attribute_node_property_owner(
         }
     }
     """
+    GraphQLSchemaManager.clear_cache()
     gql_params = await prepare_graphql_params(
         db=db, include_mutation=False, include_subscription=False, branch=default_branch
     )
@@ -2045,6 +2049,7 @@ async def test_query_attribute_node_property_owner(
     )
 
     assert result1.errors is None
+    assert result1.data
     assert result1.data["TestPerson"]["edges"][0]["node"]["name"]["owner"]
     assert result1.data["TestPerson"]["edges"][0]["node"]["name"]["owner"]["id"] == first_account.id
     assert result1.data["TestPerson"]["edges"][0]["node"]["name"]["owner"][
@@ -2092,6 +2097,7 @@ async def test_query_attribute_node_property_owner(
 
     assert result2.errors is None
 
+    assert result2.data
     assert result2.data["TestCar"]["edges"][0]["node"]["owner"]["node"]["name"]["owner"]
     assert result2.data["TestCar"]["edges"][0]["node"]["owner"]["node"]["name"]["owner"]["id"] == first_account.id
     assert result2.data["TestCar"]["edges"][0]["node"]["owner"]["node"]["name"]["owner"][
@@ -2466,6 +2472,7 @@ async def test_query_attribute_flag_property(
         }
     }
     """
+    GraphQLSchemaManager.clear_cache()
     gql_params = await prepare_graphql_params(
         db=db, include_mutation=False, include_subscription=False, branch=default_branch
     )
@@ -2478,6 +2485,7 @@ async def test_query_attribute_flag_property(
     )
 
     assert result1.errors is None
+    assert result1.data
     assert result1.data["TestPerson"]["edges"][0]["node"]["firstname"]["is_protected"] is True
     assert result1.data["TestPerson"]["edges"][0]["node"]["lastname"]["is_visible"] is False
 
@@ -2781,6 +2789,7 @@ async def test_generic_root_with_pagination(
         }
     }
     """
+    GraphQLSchemaManager.clear_cache()
     gql_params = await prepare_graphql_params(
         db=db, include_mutation=False, include_subscription=False, branch=default_branch
     )
@@ -2822,7 +2831,7 @@ async def test_generic_root_with_filters(
         }
     }
     """
-
+    GraphQLSchemaManager.clear_cache()
     gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
@@ -2882,6 +2891,7 @@ async def test_member_of_groups(
         }
     }
     """
+    GraphQLSchemaManager.clear_cache()
     gql_params = await prepare_graphql_params(
         db=db, include_mutation=False, include_subscription=False, branch=default_branch
     )

--- a/backend/tests/unit/graphql/test_manager.py
+++ b/backend/tests/unit/graphql/test_manager.py
@@ -1,12 +1,10 @@
 import inspect
-from copy import deepcopy
 
 import graphene
 import pytest
 
 from infrahub.core import registry
 from infrahub.core.branch import Branch
-from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.manager import GraphQLSchemaManager
 from infrahub.graphql.types import InfrahubObject
@@ -291,23 +289,18 @@ async def test_branch_caching_hit(
     assert manager1 is manager2
 
 
-@pytest.mark.parametrize("schema_changed_at_new,schema_hash_updated", [(True, False), (False, True), (True, True)])
 async def test_branch_caching_miss(
     db: InfrahubDatabase,
     default_branch: Branch,
     data_schema,
     car_person_schema_generics,
-    schema_changed_at_new: bool,
-    schema_hash_updated: bool,
 ):
     default_branch.update_schema_hash()
     same_branch = default_branch.model_copy()
     schema_branch = registry.schema.get_schema_branch(default_branch.name)
-    if schema_changed_at_new:
-        same_branch.schema_changed_at = Timestamp().to_string()
-    if schema_hash_updated:
-        default_branch.schema_hash.main = "abc"
-        same_branch.update_schema_hash()
+
+    default_branch.active_schema_hash.main = "abc"
+    same_branch.update_schema_hash()
 
     manager1 = GraphQLSchemaManager.get_manager_for_branch(branch=default_branch, schema_branch=schema_branch)
     manager2 = GraphQLSchemaManager.get_manager_for_branch(branch=same_branch, schema_branch=schema_branch)
@@ -328,18 +321,16 @@ async def test_branch_purge(
 
     GraphQLSchemaManager.get_manager_for_branch(branch=default_branch, schema_branch=schema_branch)
     GraphQLSchemaManager.purge_inactive(active_branches=[default_branch.name])
-    GraphQLSchemaManager._branch_details_by_name[active_branch] = deepcopy(
-        GraphQLSchemaManager._branch_details_by_name[default_branch.name]
-    )
-    GraphQLSchemaManager._branch_details_by_name[purged_branch] = deepcopy(
-        GraphQLSchemaManager._branch_details_by_name[default_branch.name]
-    )
+    GraphQLSchemaManager._add_branch_hash(branch_name=active_branch, schema_hash=default_branch.active_schema_hash.main)
+    GraphQLSchemaManager._add_branch_hash(branch_name=purged_branch, schema_hash=default_branch.active_schema_hash.main)
 
-    assert default_branch.name in GraphQLSchemaManager._branch_details_by_name.keys()
-    assert active_branch in GraphQLSchemaManager._branch_details_by_name.keys()
-    assert purged_branch in GraphQLSchemaManager._branch_details_by_name.keys()
+    assert default_branch.active_schema_hash.main in GraphQLSchemaManager._branch_details_by_hash.keys()
+    assert default_branch.active_schema_hash.main in GraphQLSchemaManager._branch_name_by_hash.keys()
+
+    assert active_branch in GraphQLSchemaManager._branch_name_by_hash[default_branch.active_schema_hash.main]
+    assert purged_branch in GraphQLSchemaManager._branch_name_by_hash[default_branch.active_schema_hash.main]
     purged_branches = GraphQLSchemaManager.purge_inactive(active_branches=[active_branch, default_branch.name])
-    assert default_branch.name in GraphQLSchemaManager._branch_details_by_name.keys()
-    assert active_branch in GraphQLSchemaManager._branch_details_by_name.keys()
-    assert purged_branch not in GraphQLSchemaManager._branch_details_by_name.keys()
+    assert active_branch in GraphQLSchemaManager._branch_name_by_hash[default_branch.active_schema_hash.main]
+    assert purged_branch not in GraphQLSchemaManager._branch_name_by_hash[default_branch.active_schema_hash.main]
+
     assert purged_branches == {purged_branch}

--- a/backend/tests/unit/graphql/test_mutation_artifact_definition.py
+++ b/backend/tests/unit/graphql/test_mutation_artifact_definition.py
@@ -101,9 +101,8 @@ async def test_create_artifact_definition(
     account_session = AccountSession(
         authenticated=True, account_id=create_test_admin.id, session_id=None, auth_type=AuthType.API
     )
-    gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=branch, service=service, account_session=account_session
-    )
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch, service=service, account_session=account_session)
 
     with patch(
         "infrahub.services.adapters.workflow.local.WorkflowLocalExecution.submit_workflow"
@@ -175,6 +174,7 @@ async def test_update_artifact_definition(
     account_session = AccountSession(
         authenticated=True, account_id=create_test_admin.id, session_id=None, auth_type=AuthType.API
     )
+    branch.update_schema_hash()
     gql_params = await prepare_graphql_params(
         db=db, include_subscription=False, branch=branch, service=service, account_session=account_session
     )

--- a/backend/tests/unit/graphql/test_mutation_create.py
+++ b/backend/tests/unit/graphql/test_mutation_create.py
@@ -15,6 +15,7 @@ from infrahub.core.schema.node_schema import NodeSchema
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
+from infrahub.graphql.manager import GraphQLSchemaManager
 from tests.constants import TestKind
 from tests.helpers.graphql import graphql
 from tests.helpers.schema import DEVICE_SCHEMA
@@ -1281,6 +1282,7 @@ async def test_create_with_object_template(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch, branch: Branch
 ):
     registry.schema.register_schema(schema=DEVICE_SCHEMA, branch=branch.name)
+    branch.update_schema_hash()
 
     query = """
     mutation NewDevice($device_name: String!, $template_id: String!) {
@@ -1295,7 +1297,7 @@ async def test_create_with_object_template(
       }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
 
     # Random non-existing ID for template
     result = await graphql(
@@ -1358,6 +1360,7 @@ async def test_create_with_object_template(
         variable_values={"device_name": "th2.par.asbr02", "template_id": device_template.id},
     )
     assert not result.errors
+    assert result.data
 
     device = await NodeManager.get_one(
         db=db, kind=TestKind.DEVICE, branch=branch, id=result.data[f"{TestKind.DEVICE}Create"]["object"]["id"]
@@ -1396,6 +1399,7 @@ async def test_create_with_object_template(
     )
     assert not result.errors
 
+    assert result.data
     device = await NodeManager.get_one(
         db=db, kind=TestKind.DEVICE, branch=branch, id=result.data[f"{TestKind.DEVICE}Create"]["object"]["id"]
     )
@@ -1418,6 +1422,7 @@ async def test_create_without_object_template(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch, branch: Branch
 ):
     registry.schema.register_schema(schema=DEVICE_SCHEMA, branch=branch.name)
+    branch.update_schema_hash()
 
     query = """
     mutation NewDevice($device_name: String!, $manufacturer: String!) {
@@ -1435,7 +1440,7 @@ async def test_create_without_object_template(
       }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
 
     result = await graphql(
         schema=gql_params.schema,
@@ -1460,6 +1465,7 @@ async def test_create_sub_object_template_by_hfid(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch, branch: Branch
 ):
     registry.schema.register_schema(schema=DEVICE_SCHEMA, branch=branch.name)
+    branch.update_schema_hash()
 
     device_template = await Node.init(db=db, schema=f"Template{TestKind.DEVICE}", branch=branch)
     await device_template.new(
@@ -1491,7 +1497,7 @@ async def test_create_sub_object_template_by_hfid(
     }
     """
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1549,6 +1555,7 @@ async def test_create_simple_object_with_enum(
         }
     }
     """ % (enum_value)
+    GraphQLSchemaManager.clear_cache()
     gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
@@ -1559,6 +1566,7 @@ async def test_create_simple_object_with_enum(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestCarCreate"]["ok"] is True
     assert result.data["TestCarCreate"]["object"]["transmission"]["value"] == response_value
 
@@ -1632,6 +1640,7 @@ async def test_create_string_when_enums_on_fails(
         }
     }
     """
+    GraphQLSchemaManager.clear_cache()
     gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
@@ -1641,5 +1650,6 @@ async def test_create_string_when_enums_on_fails(
         variable_values={},
     )
 
+    assert result.errors
     assert len(result.errors) == 1
     assert "'TestCarTransmissionValue' cannot represent non-enum value" in result.errors[0].message

--- a/backend/tests/unit/graphql/test_parser.py
+++ b/backend/tests/unit/graphql/test_parser.py
@@ -147,9 +147,8 @@ async def test_directive_merge_fields(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,

--- a/backend/tests/unit/graphql/test_query_analyzer.py
+++ b/backend/tests/unit/graphql/test_query_analyzer.py
@@ -7,6 +7,7 @@ from infrahub.core.schema import SchemaRoot
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.analyzer import GraphQLArgument, GraphQLVariable, InfrahubGraphQLQueryAnalyzer, MutateAction
 from infrahub.graphql.initialization import prepare_graphql_params
+from infrahub.graphql.manager import GraphQLSchemaManager
 from tests.helpers.schema.color import COLOR
 from tests.helpers.schema.tshirt import TSHIRT
 
@@ -34,6 +35,7 @@ async def test_is_valid_simple_schema(
     car_person_schema_generics,
 ):
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
+    GraphQLSchemaManager.clear_cache()
     gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
     gqa = InfrahubGraphQLQueryAnalyzer(
         query=query_01, schema=gql_params.schema, branch=default_branch, schema_branch=schema_branch


### PR DESCRIPTION
The goal of this PR is to lower the memory consumption of Infrahub when you have multiple branches within your database. The improvements impact both the API server and the background worker.

Previously the GraphQL schema was generated for each branch and stored within the local registry of each worker (api & background worker) this was done within a dictionary (`_branch_details_by_name` within `GraphQLSchemaManager`). Due to how this worked each individual branch got its own GraphQL schema. Each GraphQL schema we store will consume memory. Due to this the memory consumption was excessive if two branches shared the same schema.


## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Migrated GraphQL schema caching to a hash-based model for clearer cache semantics.
- Performance
  - Reduced cache bloat and more efficient purge of inactive schemas.
- Reliability
  - Improved cache consistency to reduce stale/incorrect GraphQL schema responses after branch changes.
- Tests
  - Tests now explicitly refresh/clear schema cache to ensure deterministic GraphQL test outcomes.
- Chores
  - Cleaned up test typing and imports for clearer diagnostics and faster test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
The main change within this PR is to refactor the internal storage of GraphQL schemas and instead store the schemas within `GraphQLSchemaManager._branch_details_by_hash`. So instead of storing each schema by name we store each schema by the schema_hash value which leads to less memory consumption provided that there is more than one branch that use exactly the same schema.

After this work was done I did a brief test by looking at memory consumption as reported on my Macbook with `docker stats`.

### On `develop` after loading the basic infrastructure schema

```
CONTAINER ID   NAME                         CPU %     MEM USAGE / LIMIT     MEM %     NET I/O           BLOCK I/O         PIDS
cc69655e2be4   infrahub-task-worker-1       0.24%     449MiB / 9.704GiB     4.52%     33.5MB / 478kB    254kB / 53MB      26
49a2613b1ad1   infrahub-task-worker-2       0.15%     445MiB / 9.704GiB     4.48%     33.3MB / 669kB    225kB / 53.3MB    29
e970d926e0cf   infrahub-server-1            1.19%     1.464GiB / 9.704GiB   15.09%    124MB / 19.9MB    4.29MB / 69.3MB   32
d6b9c80bcf22   infrahub-task-manager-1      22.36%    541.8MiB / 9.704GiB   5.45%     33MB / 12.2MB     0B / 71.6MB       18
55cf98b50995   infrahub-task-manager-db-1   0.18%     80.24MiB / 9.704GiB   0.81%     10.8MB / 30.1MB   4.1kB / 153MB     12
71f4c3d1bdda   infrahub-cache-1             0.13%     9.285MiB / 9.704GiB   0.09%     426kB / 159kB     0B / 4.1kB        5
8a447a9b351c   infrahub-message-queue-1     26.30%    189.9MiB / 9.704GiB   1.91%     41.9kB / 33.8kB   0B / 840kB        92
813dccc0d531   infrahub-git-server-1        0.00%     40.59MiB / 9.704GiB   0.41%     3.22kB / 126B     0B / 57.3kB       17
c4f06a9831b7   infrahub-database-1          4.50%     1.433GiB / 9.704GiB   14.77%    15.8MB / 188MB    90.1kB / 416MB    121
```

After creating 10 branches (where all of them share the same schema)

```
CONTAINER ID   NAME                         CPU %     MEM USAGE / LIMIT     MEM %     NET I/O           BLOCK I/O         PIDS
cc69655e2be4   infrahub-task-worker-1       35.31%    1.039GiB / 9.704GiB   10.70%    35.6MB / 798kB    254kB / 53.2MB    34
49a2613b1ad1   infrahub-task-worker-2       2.41%     575.3MiB / 9.704GiB   5.79%     34.4MB / 1.02MB   225kB / 53.5MB    31
e970d926e0cf   infrahub-server-1            143.07%   3.921GiB / 9.704GiB   40.41%    135MB / 25.3MB    7.62MB / 74.5MB   36
d6b9c80bcf22   infrahub-task-manager-1      8.97%     543MiB / 9.704GiB     5.46%     37MB / 18.8MB     3.21MB / 71.6MB   19
55cf98b50995   infrahub-task-manager-db-1   6.90%     85.13MiB / 9.704GiB   0.86%     17MB / 33.5MB     1.31MB / 225MB    12
71f4c3d1bdda   infrahub-cache-1             0.22%     10.4MiB / 9.704GiB    0.10%     682kB / 244kB     1.11MB / 16.4kB   5
8a447a9b351c   infrahub-message-queue-1     1.43%     150.4MiB / 9.704GiB   1.51%     54.8kB / 57.8kB   1.19MB / 840kB    49
813dccc0d531   infrahub-git-server-1        0.00%     42.11MiB / 9.704GiB   0.42%     3.26kB / 126B     1.78MB / 57.3kB   17
c4f06a9831b7   infrahub-database-1          71.55%    1.46GiB / 9.704GiB    15.04%    19MB / 200MB      6.2MB / 434MB     122
```

Of note here is that the API server increased its memory consumption from `1.464GiB` to `3.921GiB`.

### On `pog-per-hash-graphql-schema-IFC-1784` after loading the basic infrastructure schema

```
CONTAINER ID   NAME                         CPU %     MEM USAGE / LIMIT     MEM %     NET I/O           BLOCK I/O         PIDS
543fb903d0ff   infrahub-task-worker-2       0.25%     482.3MiB / 9.704GiB   4.85%     33.6MB / 651kB    201kB / 53.3MB    28
ea01f1b9a564   infrahub-task-worker-1       0.47%     462.2MiB / 9.704GiB   4.65%     33.2MB / 414kB    1.36MB / 53MB     26
6821aa5828ec   infrahub-server-1            1.49%     1.521GiB / 9.704GiB   15.67%    122MB / 18.2MB    3.33MB / 71.2MB   27
08c7e39071b6   infrahub-task-manager-1      8.02%     556.8MiB / 9.704GiB   5.60%     32.1MB / 10.5MB   87.5MB / 71.6MB   18
49020ccdbe5e   infrahub-message-queue-1     2.08%     153MiB / 9.704GiB     1.54%     37.9kB / 29.5kB   35.4MB / 840kB    49
4dba15ac19bd   infrahub-cache-1             0.29%     12.66MiB / 9.704GiB   0.13%     355kB / 153kB     3.15MB / 0B       5
91181be40c62   infrahub-task-manager-db-1   0.95%     84.48MiB / 9.704GiB   0.85%     9.15MB / 29.2MB   8.27MB / 132MB    12
90186cf9353b   infrahub-git-server-1        0.00%     46.45MiB / 9.704GiB   0.47%     3.16kB / 126B     6.25MB / 57.3kB   18
31027e3813a1   infrahub-database-1          2.05%     1.524GiB / 9.704GiB   15.71%    15.7MB / 186MB    374MB / 412MB     126
```

After creating 10 branches (where all of them share the same schema)

```
CONTAINER ID   NAME                         CPU %     MEM USAGE / LIMIT     MEM %     NET I/O           BLOCK I/O         PIDS
543fb903d0ff   infrahub-task-worker-2       1.34%     522.3MiB / 9.704GiB   5.26%     34.6MB / 928kB    201kB / 53.5MB    31
ea01f1b9a564   infrahub-task-worker-1       10.46%    556.1MiB / 9.704GiB   5.60%     34.7MB / 709kB    1.36MB / 53.2MB   32
6821aa5828ec   infrahub-server-1            4.95%     1.569GiB / 9.704GiB   16.16%    134MB / 22.7MB    3.33MB / 75.6MB   33
08c7e39071b6   infrahub-task-manager-1      5.45%     556.8MiB / 9.704GiB   5.60%     35.5MB / 16MB     87.5MB / 71.6MB   18
49020ccdbe5e   infrahub-message-queue-1     0.88%     158.2MiB / 9.704GiB   1.59%     49.3kB / 52.5kB   35.4MB / 840kB    49
4dba15ac19bd   infrahub-cache-1             1.63%     12.28MiB / 9.704GiB   0.12%     597kB / 233kB     3.15MB / 4.1kB    5
91181be40c62   infrahub-task-manager-db-1   0.49%     93.11MiB / 9.704GiB   0.94%     14.3MB / 32.2MB   8.27MB / 199MB    12
90186cf9353b   infrahub-git-server-1        0.02%     46.49MiB / 9.704GiB   0.47%     3.16kB / 126B     6.25MB / 57.3kB   18
31027e3813a1   infrahub-database-1          3.64%     1.543GiB / 9.704GiB   15.90%    18.6MB / 199MB    374MB / 428MB     126
```

In this test the memory of the API container increased from `1.521GiB` to `1.569GiB`. Note that the initial memory consumption was a bit higher on the second run. I think this could be due to the somewhat clunky nature of the test setup.

## Follow up work

This PR would help to reduce the memory footprint in a multi branch database provided that the schema is the same between at least some of the branches. We also have additional work that needs to be done with regards to garbage collection (IFC-1783) and reviewing caching bashed on hashes for GraphQL schema types themselves (IFC-1800).

Noted while working on this PR was that we don't regenerate the GraphQL schema when querying information in the past which could lead to incorrect schema given that point in time. Further the `/api/schema` endpoint doesn't support the `at` query argument so I'm unsure how the frontend would present a previous schema. A problematic aspect here could be if a node kind existed in the past but has been either removed or modified with regards to renaming attributes or similar.

## Changes of note

* The BranchDetails dataclass has lost its `branch_name` attribute which doesn't make sense when we store the schema by hash. Also the attribute wasn't used.
* Refactor `GraphQLSchemaManager.purge_inactive()` to fit new structure. This method will need to be refactored again in the next step with the garbage collection.
* Updated logic for `GraphQLSchemaManager.get_manager_for_branch()`. The change is to focus on the hash of a branch and ignore the `schema_changed_at` field as we didn't use it to generate a new GraphQL schema regardless.
* A number of tests have been updated, these are purely unittests that weren't using the system in a proper way and instead had a hand-wavy approach to schema updates. Some other changes include clarification for typing issues to avoid warnings in the editor such as `assert response.data` before a `assert response.data["blah"]` since the .data attribute is an optional dictionary
* Refactoring of the `test_branch_caching_miss()` test. As this test had a matrix where we considered the `.schema_changed_at` attribute with regards to the GraphQLSchemaManager and this doesn't work correctly I removed the test parameters and modified the test to only account for the current logic (in a follow up work we'll instead evaluate the hash of the branch when the .schema_changed_at is later that the requested timestamp of the user. Such an action will then lead to the regeneration of a new GraphQL schema using the hash of the requested schema (eventually those schemas will be garbage collected to reclaim memory).
