### PR TITLE
fix(ci): do not run keyword scanner for dependabot

### DIFF
--- a/.github/workflows/keyword-scan.yml
+++ b/.github/workflows/keyword-scan.yml
@@ -11,7 +11,7 @@ jobs:
     if: |
       github.event_name == 'push' ||
       (github.event_name == 'pull_request' &&
-       github.event.pull_request.head.repo.full_name == github.repository)
+       github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted CI keyword-scan rules for pull requests: now runs only on non-fork contributions and excludes automated bot submissions; push-trigger behavior unchanged.
  * Added a new environment variable used by the version-upgrade workflow to support automated upgrade operations.

No user-facing changes; no action required from users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->