### PR TITLE
IFC-1801 Add mutation to trigger computed attribute re-computation

### DIFF
--- a/backend/infrahub/graphql/mutations/computed_attribute.py
+++ b/backend/infrahub/graphql/mutations/computed_attribute.py
@@ -177,7 +177,8 @@ class RecomputeComputedAttribute(Mutation):
                 message=f"The indicated node does not use a computed attribute for the specified attribute '{data.attribute}'"
             )
 
-        workflow = COMPUTED_ATTRIBUTE_PROCESS_JINJA2 if data.node_ids else TRIGGER_UPDATE_JINJA_COMPUTED_ATTRIBUTES
+        recalculate_single_workflow = COMPUTED_ATTRIBUTE_PROCESS_JINJA2
+        recalculate_all_workflow = TRIGGER_UPDATE_JINJA_COMPUTED_ATTRIBUTES
         if attribute.computed_attribute.kind == ComputedAttributeKind.TRANSFORM_PYTHON:
             if not await NodeManager.query(
                 db=graphql_context.db,
@@ -188,9 +189,9 @@ class RecomputeComputedAttribute(Mutation):
                 raise ProcessingError(
                     message=f"The transform for the indicated node computed attribute for the specified attribute '{data.attribute}' does not exist"
                 )
-            workflow = (
-                COMPUTED_ATTRIBUTE_PROCESS_TRANSFORM if data.node_ids else TRIGGER_UPDATE_PYTHON_COMPUTED_ATTRIBUTES
-            )
+
+            recalculate_single_workflow = COMPUTED_ATTRIBUTE_PROCESS_TRANSFORM
+            recalculate_all_workflow = TRIGGER_UPDATE_PYTHON_COMPUTED_ATTRIBUTES
 
         if data.node_ids:
             nodes = await NodeManager.get_many(
@@ -198,7 +199,7 @@ class RecomputeComputedAttribute(Mutation):
             )
             for node in nodes.values():
                 await get_workflow().submit_workflow(
-                    workflow=workflow,
+                    workflow=recalculate_single_workflow,
                     context=graphql_context.get_context(),
                     parameters={
                         "branch_name": graphql_context.branch.name,
@@ -211,7 +212,7 @@ class RecomputeComputedAttribute(Mutation):
                 )
         else:
             await get_workflow().submit_workflow(
-                workflow=workflow,
+                workflow=recalculate_all_workflow,
                 context=graphql_context.get_context(),
                 parameters={
                     "branch_name": graphql_context.branch.name,

--- a/backend/infrahub/graphql/mutations/computed_attribute.py
+++ b/backend/infrahub/graphql/mutations/computed_attribute.py
@@ -2,20 +2,28 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from graphene import Boolean, InputObjectType, Mutation, String
+from graphene import Boolean, InputObjectType, List, Mutation, NonNull, String
 
 from infrahub.core.account import ObjectPermission
 from infrahub.core.constants import ComputedAttributeKind, PermissionAction, PermissionDecision
 from infrahub.core.manager import NodeManager
+from infrahub.core.protocols import CoreTransformPython
 from infrahub.core.registry import registry
 from infrahub.database import retry_db_transaction
 from infrahub.events import EventMeta
 from infrahub.events.node_action import NodeUpdatedEvent
-from infrahub.exceptions import NodeNotFoundError, ValidationError
+from infrahub.exceptions import NodeNotFoundError, ProcessingError, ValidationError
 from infrahub.graphql.context import apply_external_context
 from infrahub.graphql.types.context import ContextInput
 from infrahub.log import get_log_data
 from infrahub.worker import WORKER_IDENTITY
+from infrahub.workers.dependencies import get_workflow
+from infrahub.workflows.catalogue import (
+    COMPUTED_ATTRIBUTE_PROCESS_JINJA2,
+    COMPUTED_ATTRIBUTE_PROCESS_TRANSFORM,
+    TRIGGER_UPDATE_JINJA_COMPUTED_ATTRIBUTES,
+    TRIGGER_UPDATE_PYTHON_COMPUTED_ATTRIBUTES,
+)
 
 if TYPE_CHECKING:
     from graphql import GraphQLResolveInfo
@@ -89,7 +97,7 @@ class UpdateComputedAttribute(Mutation):
             raise NodeNotFoundError(
                 node_type="target_node",
                 identifier=str(data.id),
-                message="The indicated not does not have the specified attribute_name",
+                message="The indicated node does not have the specified attribute_name",
             )
         if attribute_field.value != str(data.value):
             attribute_field.value = str(data.value)
@@ -116,4 +124,102 @@ class UpdateComputedAttribute(Mutation):
 
         result: dict[str, Any] = {"ok": True}
 
+        return cls(**result)
+
+
+class InfrahubComputedAttributeRecomputeInput(InputObjectType):
+    kind = String(required=True, description="Kind of the node to update")
+    attribute = String(required=True, description="Name of the computed attribute that must be recomputed")
+    node_ids = List(NonNull(String), description="ID of the nodes for which the attribute must be recomputed")
+
+
+class RecomputeComputedAttribute(Mutation):
+    class Arguments:
+        data = InfrahubComputedAttributeRecomputeInput(required=True)
+        context = ContextInput(required=False)
+
+    ok = Boolean()
+
+    @classmethod
+    @retry_db_transaction(name="update_computed_attribute")
+    async def mutate(
+        cls,
+        _: dict,
+        info: GraphQLResolveInfo,
+        data: InfrahubComputedAttributeRecomputeInput,
+        context: ContextInput | None = None,
+    ) -> RecomputeComputedAttribute:
+        graphql_context: GraphqlContext = info.context
+        node_schema = registry.schema.get_node_schema(
+            name=str(data.kind), branch=graphql_context.branch.name, duplicate=False
+        )
+
+        graphql_context.active_permissions.raise_for_permission(
+            permission=ObjectPermission(
+                namespace=node_schema.namespace,
+                name=node_schema.name,
+                action=PermissionAction.UPDATE.value,
+                decision=PermissionDecision.ALLOW_DEFAULT.value
+                if graphql_context.branch.name == registry.default_branch
+                else PermissionDecision.ALLOW_OTHER.value,
+            )
+        )
+        await apply_external_context(graphql_context=graphql_context, context_input=context)
+
+        attribute = node_schema.get_attribute(name=str(data.attribute))
+
+        if not attribute:
+            raise ProcessingError(
+                message=f"The indicated node does not have the specified attribute '{data.attribute}'"
+            )
+        if not attribute.computed_attribute:
+            raise ProcessingError(
+                message=f"The indicated node does not use a computed attribute for the specified attribute '{data.attribute}'"
+            )
+
+        workflow = COMPUTED_ATTRIBUTE_PROCESS_JINJA2 if data.node_ids else TRIGGER_UPDATE_JINJA_COMPUTED_ATTRIBUTES
+        if attribute.computed_attribute.kind == ComputedAttributeKind.TRANSFORM_PYTHON:
+            if not await NodeManager.query(
+                db=graphql_context.db,
+                branch=graphql_context.branch,
+                schema=CoreTransformPython,
+                filters={"name__value": attribute.computed_attribute.transform},
+            ):
+                raise ProcessingError(
+                    message=f"The transform for the indicated node computed attribute for the specified attribute '{data.attribute}' does not exist"
+                )
+            workflow = (
+                COMPUTED_ATTRIBUTE_PROCESS_TRANSFORM if data.node_ids else TRIGGER_UPDATE_PYTHON_COMPUTED_ATTRIBUTES
+            )
+
+        if data.node_ids:
+            nodes = await NodeManager.get_many(
+                db=graphql_context.db, branch=graphql_context.branch, ids=list(data.node_ids)
+            )
+            for node in nodes.values():
+                await get_workflow().submit_workflow(
+                    workflow=workflow,
+                    context=graphql_context.get_context(),
+                    parameters={
+                        "branch_name": graphql_context.branch.name,
+                        "computed_attribute_name": str(data.attribute),
+                        "computed_attribute_kind": node_schema.kind,
+                        "node_kind": node_schema.kind,
+                        "object_id": node.id,
+                        "context": context,
+                    },
+                )
+        else:
+            await get_workflow().submit_workflow(
+                workflow=workflow,
+                context=graphql_context.get_context(),
+                parameters={
+                    "branch_name": graphql_context.branch.name,
+                    "computed_attribute_name": str(data.attribute),
+                    "computed_attribute_kind": node_schema.kind,
+                    "context": context,
+                },
+            )
+
+        result: dict[str, Any] = {"ok": True}
         return cls(**result)

--- a/backend/infrahub/graphql/schema.py
+++ b/backend/infrahub/graphql/schema.py
@@ -15,7 +15,7 @@ from .mutations.branch import (
     BranchUpdate,
     BranchValidate,
 )
-from .mutations.computed_attribute import UpdateComputedAttribute
+from .mutations.computed_attribute import RecomputeComputedAttribute, UpdateComputedAttribute
 from .mutations.convert_object_type import ConvertObjectType
 from .mutations.diff import DiffUpdateMutation
 from .mutations.diff_conflict import ResolveDiffConflict
@@ -113,6 +113,7 @@ class InfrahubBaseMutation(ObjectType):
     InfrahubRepositoryProcess = ProcessRepository.Field()
     InfrahubRepositoryConnectivity = ValidateRepositoryConnectivity.Field()
     InfrahubUpdateComputedAttribute = UpdateComputedAttribute.Field()
+    InfrahubRecomputeComputedAttribute = RecomputeComputedAttribute.Field()
 
     RelationshipAdd = RelationshipAdd.Field()
     RelationshipRemove = RelationshipRemove.Field()

--- a/backend/tests/functional/computed_attributes/test_computed_attribute.py
+++ b/backend/tests/functional/computed_attributes/test_computed_attribute.py
@@ -5,12 +5,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from infrahub.auth import AccountSession, AuthType
-from infrahub.computed_attribute.tasks import (
-    gather_trigger_computed_attribute_python,
-    process_jinja2,
-    process_transform,
-    query_transform_targets,
-)
+from infrahub.computed_attribute.tasks import gather_trigger_computed_attribute_python, query_transform_targets
 from infrahub.context import BranchContext, InfrahubContext
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.node import Node
@@ -27,6 +22,15 @@ if TYPE_CHECKING:
     from infrahub.core.branch import Branch
     from infrahub.database import InfrahubDatabase
     from tests.adapters.message_bus import BusSimulator
+
+
+RECOMPUTE_COMPUTED_ATTRIBUTE_MUTATION = """
+mutation Recompute($kind: String!, $attribute: String!, $node_ids: [String!]) {
+  InfrahubRecomputeComputedAttribute(data: {kind: $kind, attribute: $attribute, node_ids: $node_ids}) {
+    ok
+  }
+}
+"""
 
 
 class TestComputedAttribute(TestInfrahubApp):
@@ -138,17 +142,12 @@ class TestComputedAttribute(TestInfrahubApp):
         tshirt_1.color = data["c2"].id
         await tshirt_1.save()
 
-        # As we currently don't have a way to trigger on events within these tests we fire the automated workflow
-        # manually
-        await process_jinja2(
-            branch_name=default_branch.name,
-            node_kind="TestingTShirt",
-            object_id=tshirt_1.id,
-            computed_attribute_kind="TestingTShirt",
-            computed_attribute_name="description",
-            updated_fields=["color"],
-            context=context,
+        response = await client.execute_graphql(
+            query=RECOMPUTE_COMPUTED_ATTRIBUTE_MUTATION,
+            variables={"kind": TSHIRT.kind, "attribute": "description", "node_ids": [tshirt_1.id]},
         )
+        assert "InfrahubRecomputeComputedAttribute" in response
+        assert response["InfrahubRecomputeComputedAttribute"]["ok"]
 
         tshirt_updated = await client.get(kind="TestingTShirt", id=data["t1"].id)
         assert (
@@ -163,21 +162,17 @@ class TestComputedAttribute(TestInfrahubApp):
         default_branch: Branch,
         context: InfrahubContext,
     ) -> None:
-        # As we currently don't have a way to trigger on events within these tests we fire the automated workflow
-        # manually
         tshirt_obj = data["t2"]
         color_obj = data["c3"]
 
         tshirt_initial = await client.get(kind="TestingTShirt", id=tshirt_obj.id)
 
-        await process_transform(
-            branch_name=default_branch.name,
-            object_id=tshirt_obj.id,
-            node_kind="TestingTShirt",
-            computed_attribute_name="pitch",
-            computed_attribute_kind="TestingTShirt",
-            context=context,
+        response = await client.execute_graphql(
+            query=RECOMPUTE_COMPUTED_ATTRIBUTE_MUTATION,
+            variables={"kind": TSHIRT.kind, "attribute": "pitch", "node_ids": [tshirt_obj.id]},
         )
+        assert "InfrahubRecomputeComputedAttribute" in response
+        assert response["InfrahubRecomputeComputedAttribute"]["ok"]
 
         tshirt_first_pitch_allocation = await client.get(kind="TestingTShirt", id=tshirt_obj.id)
 

--- a/changelog/+ifc1801.added.md
+++ b/changelog/+ifc1801.added.md
@@ -1,0 +1,1 @@
+Add `InfrahubRecomputeComputedAttribute` GraphQL mutation to trigger computed attribute re-computation on all nodes of a given kind or a subset of nodes given their IDs


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a GraphQL mutation to recompute computed attributes by kind or node IDs, supporting both Jinja- and Python-based computed attributes for targeted or bulk updates.

- Bug Fixes
  - Corrected a typo in the error message shown when a node lacks the specified attribute.

- Documentation
  - Changelog updated to describe the new recomputation mutation and its usage.

- Tests
  - Functional tests refactored to invoke the new mutation instead of triggering workflows directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->