### PR TITLE
prep release 1.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
+## [Infrahub - v1.4.5](https://github.com/opsmill/infrahub/tree/infrahub-v1.4.5) - 2025-09-08
+
+### Fixed
+
+- Fixed an issue where switching between relationships to the same schema didn’t refresh the table correctly. ([#6418](https://github.com/opsmill/infrahub/issues/6418))
+- Add initialization instructions for Infrahub repository to docs. ([#7137](https://github.com/opsmill/infrahub/issues/7137))
+- Relationship properties now show a clearer loading indicator.
+- Standardize internal cache-key generation using factories to make request handling easier and more consistent.
+- Fixed a bug in the object table where the kind selector was not filtering its options correctly.
+
+### Housekeeping
+
+- Internal(frontend): Upgraded Biome to v2. Now use Ultracite to configure Biome
+- Internal(frontend): Cleaned up unused files and functions
+
 ## [Infrahub - v1.4.4](https://github.com/opsmill/infrahub/tree/infrahub-v1.4.4) - 2025-09-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,12 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 ## [Infrahub - v1.4.5](https://github.com/opsmill/infrahub/tree/infrahub-v1.4.5) - 2025-09-08
 
+### Security
+
+- Fixes bug in authentication logic that allowed expired and/or deleted API tokens to authenticate successfully.
+
 ### Fixed
 
-- API token validation bug
 - Fixed an issue where switching between relationships to the same schema didn’t refresh the table correctly. ([#6418](https://github.com/opsmill/infrahub/issues/6418))
 - Add initialization instructions for Infrahub repository to docs. ([#7137](https://github.com/opsmill/infrahub/issues/7137))
 - Relationship properties now show a clearer loading indicator.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 ### Fixed
 
+- API token validation bug
 - Fixed an issue where switching between relationships to the same schema didn’t refresh the table correctly. ([#6418](https://github.com/opsmill/infrahub/issues/6418))
 - Add initialization instructions for Infrahub repository to docs. ([#7137](https://github.com/opsmill/infrahub/issues/7137))
 - Relationship properties now show a clearer loading indicator.

--- a/changelog/+filter-kind.fixed.md
+++ b/changelog/+filter-kind.fixed.md
@@ -1,1 +1,0 @@
-Fixed a bug in the object table where the kind selector was not filtering its options correctly.

--- a/changelog/+frontend.housekeeping.md
+++ b/changelog/+frontend.housekeeping.md
@@ -1,2 +1,0 @@
-- Internal(frontend): Upgraded Biome to v2. Now use Ultracite to configure Biome
-- Internal(frontend): Cleaned up unused files and functions

--- a/changelog/+query-key.fixed.md
+++ b/changelog/+query-key.fixed.md
@@ -1,2 +1,0 @@
-- Relationship properties now show a clearer loading indicator.
-- Standardize internal cache-key generation using factories to make request handling easier and more consistent.

--- a/changelog/6418.fixed.md
+++ b/changelog/6418.fixed.md
@@ -1,1 +1,0 @@
-Fixed an issue where switching between relationships to the same schema didn’t refresh the table correctly.

--- a/changelog/7137.fixed.md
+++ b/changelog/7137.fixed.md
@@ -1,1 +1,0 @@
-Add initialization instructions for Infrahub repository to docs.

--- a/docs/docs/release-notes/infrahub/release-1_4_5.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_4_5.mdx
@@ -9,7 +9,7 @@ title: Release 1.4.5
     </tr>
     <tr>
       <th>Release Date</th>
-      <td>September 3rd, 2025</td>
+      <td>September 8th, 2025</td>
     </tr>
     <tr>
       <th>Tag</th>

--- a/docs/docs/release-notes/infrahub/release-1_4_5.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_4_5.mdx
@@ -18,9 +18,12 @@ title: Release 1.4.5
   </tbody>
 </table>
 
+### Security
+
+- Fixes bug in authentication logic that allowed expired and/or deleted API tokens to authenticate successfully.
+
 ### Fixed
 
-- API token validation bug
 - Fixed an issue where switching between relationships to the same schema didn’t refresh the table correctly. ([#6418](https://github.com/opsmill/infrahub/issues/6418))
 - Add initialization instructions for Infrahub repository to docs. ([#7137](https://github.com/opsmill/infrahub/issues/7137))
 - Relationship properties now show a clearer loading indicator.

--- a/docs/docs/release-notes/infrahub/release-1_4_5.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_4_5.mdx
@@ -20,6 +20,7 @@ title: Release 1.4.5
 
 ### Fixed
 
+- API token validation bug
 - Fixed an issue where switching between relationships to the same schema didn’t refresh the table correctly. ([#6418](https://github.com/opsmill/infrahub/issues/6418))
 - Add initialization instructions for Infrahub repository to docs. ([#7137](https://github.com/opsmill/infrahub/issues/7137))
 - Relationship properties now show a clearer loading indicator.

--- a/docs/docs/release-notes/infrahub/release-1_4_5.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_4_5.mdx
@@ -1,0 +1,34 @@
+---
+title: Release 1.4.5
+---
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.4.5</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>September 3rd, 2025</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[infrahub-v1.4.5](https://github.com/opsmill/infrahub/releases/tag/infrahub-v1.4.5)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Fixed
+
+- Fixed an issue where switching between relationships to the same schema didn’t refresh the table correctly. ([#6418](https://github.com/opsmill/infrahub/issues/6418))
+- Add initialization instructions for Infrahub repository to docs. ([#7137](https://github.com/opsmill/infrahub/issues/7137))
+- Relationship properties now show a clearer loading indicator.
+- Standardize internal cache-key generation using factories to make request handling easier and more consistent.
+- Fixed a bug in the object table where the kind selector was not filtering its options correctly.
+
+### Housekeeping
+
+<!-- vale off -->
+- Internal(frontend): Upgraded Biome to v2. Now use Ultracite to configure Biome
+- Internal(frontend): Cleaned up unused files and functions
+<!-- vale on -->

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -414,6 +414,7 @@ const sidebars: SidebarsConfig = {
             slug: 'release-notes/infrahub',
           },
           items: [
+            'release-notes/infrahub/release-1_4_5',
             'release-notes/infrahub/release-1_4_4',
             'release-notes/infrahub/release-1_4_3',
             'release-notes/infrahub/release-1_4_2',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "infrahub-server"
-version = "1.4.4"
+version = "1.4.5"
 description = "Infrahub is taking a new approach to Infrastructure Management by providing a new generation of datastore to organize and control all the data that defines how an infrastructure should run."
 authors = ["OpsMill <info@opsmill.com>"]
 readme = "README.md"

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "infrahub-testcontainers"
-version = "1.4.4"
+version = "1.4.5"
 requires-python = ">=3.9"
 
 [tool.poetry]
 name = "infrahub-testcontainers"
-version = "1.4.4"
+version = "1.4.5"
 description = "Testcontainers instance for Infrahub to easily build integration tests"
 authors = ["OpsMill <info@opsmill.com>"]
 readme = "README.md"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added Infrahub 1.4.5 release notes and updated docs navigation; included repository initialization instructions.

- Security
  - Fixed token-authentication issue preventing expired/deleted API tokens from authenticating.

- Fixed
  - Resolved table refresh when switching relationships to the same schema.
  - Improved loading indicators for relationship properties.
  - Corrected kind-selector filtering in object tables.
  - Standardized cache-key behavior for more consistent request handling.

- Chores
  - Bumped package versions to 1.4.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->