### PR TITLE
Refactor generator actions to execute generator directly

### DIFF
--- a/backend/infrahub/actions/tasks.py
+++ b/backend/infrahub/actions/tasks.py
@@ -1,16 +1,107 @@
 from __future__ import annotations
 
-from infrahub_sdk.graphql import Mutation
+from collections import defaultdict
+from typing import TYPE_CHECKING, Any
+
+from infrahub_sdk.graphql import Mutation, Query
+from infrahub_sdk.types import Order
 from prefect import flow
 
 from infrahub.context import InfrahubContext  # noqa: TC001  needed for prefect flow
+from infrahub.core.constants import InfrahubKind
+from infrahub.generators.models import (
+    GeneratorDefinitionModel,
+    RequestGeneratorRun,
+)
 from infrahub.services import InfrahubServices  # noqa: TC001  needed for prefect flow
 from infrahub.trigger.models import TriggerType
 from infrahub.trigger.setup import setup_triggers_specific
+from infrahub.workers.dependencies import get_client, get_workflow
+from infrahub.workflows.catalogue import REQUEST_GENERATOR_RUN
 from infrahub.workflows.utils import add_tags
 
 from .gather import gather_trigger_action_rules
 from .models import EventGroupMember  # noqa: TC001  needed for prefect flow
+
+if TYPE_CHECKING:
+    from infrahub_sdk.client import InfrahubClient
+    from infrahub_sdk.node import InfrahubNode
+
+
+def get_generator_run_query(definition_id: str, target_ids: list[str]) -> Query:
+    return Query(
+        name=InfrahubKind.GENERATORDEFINITION,
+        query={
+            InfrahubKind.GENERATORDEFINITION: {
+                "@filters": {
+                    "ids": [definition_id],
+                },
+                "edges": {
+                    "node": {
+                        "id": None,
+                        "name": {
+                            "value": None,
+                        },
+                        "class_name": {
+                            "value": None,
+                        },
+                        "file_path": {
+                            "value": None,
+                        },
+                        "query": {
+                            "node": {
+                                "name": {
+                                    "value": None,
+                                },
+                            },
+                        },
+                        "convert_query_response": {
+                            "value": None,
+                        },
+                        "parameters": {
+                            "value": None,
+                        },
+                        "targets": {
+                            "node": {
+                                "id": None,
+                                "members": {
+                                    "@filters": {
+                                        "ids": target_ids,
+                                    },
+                                    "edges": {
+                                        "node": {
+                                            "__typename": None,
+                                            "id": None,
+                                            "display_label": None,
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                        "repository": {
+                            "node": {
+                                "__typename": None,
+                                "id": None,
+                                "name": {
+                                    "value": None,
+                                },
+                                f"... on {InfrahubKind.REPOSITORY}": {
+                                    "commit": {
+                                        "value": None,
+                                    },
+                                },
+                                f"... on {InfrahubKind.READONLYREPOSITORY}": {
+                                    "commit": {
+                                        "value": None,
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    )
 
 
 @flow(
@@ -65,12 +156,19 @@ async def run_generator(
     branch_name: str,
     node_ids: list[str],
     generator_definition_id: str,
-    context: InfrahubContext,  # noqa: ARG001
-    service: InfrahubServices,
+    context: InfrahubContext,
+    service: InfrahubServices,  # noqa: ARG001
 ) -> None:
     await add_tags(branches=[branch_name], nodes=node_ids + [generator_definition_id])
-    await _run_generator(
-        branch_name=branch_name, generator_definition_id=generator_definition_id, node_ids=node_ids, service=service
+
+    client = get_client()
+
+    await _run_generators(
+        branch_name=branch_name,
+        node_ids=node_ids,
+        generator_definition_id=generator_definition_id,
+        client=client,
+        context=context,
     )
 
 
@@ -82,13 +180,20 @@ async def run_generator_group_event(
     branch_name: str,
     members: list[EventGroupMember],
     generator_definition_id: str,
-    context: InfrahubContext,  # noqa: ARG001
-    service: InfrahubServices,
+    context: InfrahubContext,
+    service: InfrahubServices,  # noqa: ARG001
 ) -> None:
     node_ids = [node.id for node in members]
     await add_tags(branches=[branch_name], nodes=node_ids + [generator_definition_id])
-    await _run_generator(
-        branch_name=branch_name, generator_definition_id=generator_definition_id, node_ids=node_ids, service=service
+
+    client = get_client()
+
+    await _run_generators(
+        branch_name=branch_name,
+        node_ids=node_ids,
+        generator_definition_id=generator_definition_id,
+        client=client,
+        context=context,
     )
 
 
@@ -104,16 +209,95 @@ async def configure_action_rules(
     )  # type: ignore[misc]
 
 
-async def _run_generator(
+async def _get_targets(
+    branch_name: str,
+    targets: list[dict[str, Any]],
+    client: InfrahubClient,
+) -> dict[str, dict[str, InfrahubNode]]:
+    """Get the targets per kind in order to extract the variables."""
+
+    targets_per_kind: dict[str, dict[str, InfrahubNode]] = defaultdict(dict)
+
+    for target in targets:
+        targets_per_kind[target["node"]["__typename"]][target["node"]["id"]] = None
+
+    for kind, values in targets_per_kind.items():
+        nodes = await client.filters(
+            kind=kind, branch=branch_name, ids=list(values.keys()), populate_store=False, order=Order(disable=True)
+        )
+        for node in nodes:
+            targets_per_kind[kind][node.id] = node
+
+    return targets_per_kind
+
+
+async def _run_generators(
     branch_name: str,
     node_ids: list[str],
     generator_definition_id: str,
-    service: InfrahubServices,
+    client: InfrahubClient,
+    context: InfrahubContext | None = None,
 ) -> None:
-    mutation = Mutation(
-        mutation="CoreGeneratorDefinitionRun",
-        input_data={"data": {"id": generator_definition_id, "nodes": node_ids}},
-        query={"ok": None},
-    )
+    """Fetch generator metadata and submit per-target runs.
 
-    await service.client.execute_graphql(query=mutation.render(), branch_name=branch_name)
+    Args:
+        branch_name: Branch on which to execute.
+        node_ids: Node IDs to run against (restricts selection if provided).
+        generator_definition_id: Generator definition to execute.
+        client: InfrahubClient to query additional data.
+        context: Execution context passed to downstream workflow submissions.
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If the generator definition is not found or none of the requested
+            targets are members of the target group.
+    """
+    response = await client.execute_graphql(
+        query=get_generator_run_query(definition_id=generator_definition_id, target_ids=node_ids).render(),
+        branch_name=branch_name,
+    )
+    if not response[InfrahubKind.GENERATORDEFINITION]["edges"]:
+        raise ValueError(f"Generator definition {generator_definition_id} not found")
+
+    data = response[InfrahubKind.GENERATORDEFINITION]["edges"][0]["node"]
+
+    if not data["targets"]["node"]["members"]["edges"]:
+        raise ValueError(f"Target {node_ids[0]} is not part of the group {data['targets']['node']['id']}")
+
+    targets = data["targets"]["node"]["members"]["edges"]
+
+    targets_per_kind = await _get_targets(branch_name=branch_name, targets=targets, client=client)
+
+    workflow = get_workflow()
+
+    for target in targets:
+        node: InfrahubNode | None = None
+        if data["parameters"]["value"]:
+            node = targets_per_kind[target["node"]["__typename"]][target["node"]["id"]]
+
+        request_generator_run_model = RequestGeneratorRun(
+            generator_definition=GeneratorDefinitionModel(
+                definition_id=generator_definition_id,
+                definition_name=data["name"]["value"],
+                class_name=data["class_name"]["value"],
+                file_path=data["file_path"]["value"],
+                query_name=data["query"]["node"]["name"]["value"],
+                convert_query_response=data["convert_query_response"]["value"],
+                group_id=data["targets"]["node"]["id"],
+                parameters=data["parameters"]["value"],
+            ),
+            commit=data["repository"]["node"]["commit"]["value"],
+            repository_id=data["repository"]["node"]["id"],
+            repository_name=data["repository"]["node"]["name"]["value"],
+            repository_kind=data["repository"]["node"]["__typename"],
+            branch_name=branch_name,
+            query=data["query"]["node"]["name"]["value"],
+            variables=await node.extract(params=data["parameters"]["value"]) if node else {},
+            target_id=target["node"]["id"],
+            target_name=target["node"]["display_label"],
+        )
+        await workflow.submit_workflow(
+            workflow=REQUEST_GENERATOR_RUN, context=context, parameters={"model": request_generator_run_model}
+        )

--- a/backend/infrahub/generators/models.py
+++ b/backend/infrahub/generators/models.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, ConfigDict, Field
 class RequestGeneratorRun(BaseModel):
     """Runs a generator."""
 
-    generator_definition: ProposedChangeGeneratorDefinition = Field(..., description="The Generator definition")
+    generator_definition: GeneratorDefinitionModel = Field(..., description="The Generator definition")
     generator_instance: str | None = Field(
         default=None, description="The id of the generator instance if it previously existed"
     )
@@ -31,14 +31,33 @@ class RequestGeneratorDefinitionRun(BaseModel):
     target_members: list[str] = Field(default_factory=list, description="List of targets to run the generator for")
 
 
-class ProposedChangeGeneratorDefinition(BaseModel):
-    definition_id: str
-    definition_name: str
-    query_name: str
-    convert_query_response: bool
-    query_models: list[str]
-    repository_id: str
-    class_name: str
-    file_path: str
-    parameters: dict
-    group_id: str
+class GeneratorDefinitionModel(BaseModel):
+    definition_id: str = Field(..., description="The id of the generator definition.")
+    definition_name: str = Field(..., description="The name of the generator definition.")
+    query_name: str = Field(..., description="The name of the query to use when collecting data.")
+    convert_query_response: bool = Field(
+        ...,
+        description="Decide if the generator should convert the result of the GraphQL query to SDK InfrahubNode objects.",
+    )
+    class_name: str = Field(..., description="The name of the generator class to run.")
+    file_path: str = Field(..., description="The file path of the generator in the repository.")
+    group_id: str = Field(..., description="The group to target when running this generator")
+    parameters: dict = Field(..., description="The input parameters required to run this check")
+
+    @classmethod
+    def from_pc_generator_definition(cls, model: ProposedChangeGeneratorDefinition) -> GeneratorDefinitionModel:
+        return GeneratorDefinitionModel(
+            definition_id=model.definition_id,
+            definition_name=model.definition_name,
+            query_name=model.query_name,
+            convert_query_response=model.convert_query_response,
+            class_name=model.class_name,
+            file_path=model.file_path,
+            group_id=model.group_id,
+            parameters=model.parameters,
+        )
+
+
+class ProposedChangeGeneratorDefinition(GeneratorDefinitionModel):
+    query_models: list[str] = Field(..., description="The models to use when collecting data.")
+    repository_id: str = Field(..., description="The id of the repository.")

--- a/backend/infrahub/generators/tasks.py
+++ b/backend/infrahub/generators/tasks.py
@@ -15,6 +15,7 @@ from infrahub import lock
 from infrahub.context import InfrahubContext  # noqa: TC001 needed for prefect flow
 from infrahub.core.constants import GeneratorInstanceStatus, InfrahubKind
 from infrahub.generators.models import (
+    GeneratorDefinitionModel,
     ProposedChangeGeneratorDefinition,
     RequestGeneratorDefinitionRun,
     RequestGeneratorRun,
@@ -52,6 +53,7 @@ async def run_generator(model: RequestGeneratorRun) -> None:
         name=model.generator_definition.definition_name,
         class_name=model.generator_definition.class_name,
         file_path=model.generator_definition.file_path,
+        parameters=model.generator_definition.parameters,
         query=model.generator_definition.query_name,
         targets=model.generator_definition.group_id,
         convert_query_response=model.generator_definition.convert_query_response,
@@ -213,7 +215,7 @@ async def request_generator_definition_run(
 
         generator_instance = instance_by_member.get(member.id)
         request_generator_run_model = RequestGeneratorRun(
-            generator_definition=model.generator_definition,
+            generator_definition=GeneratorDefinitionModel.from_pc_generator_definition(model.generator_definition),
             commit=repository.commit.value,
             generator_instance=generator_instance,
             repository_id=repository.id,

--- a/backend/infrahub/workflows/catalogue.py
+++ b/backend/infrahub/workflows/catalogue.py
@@ -18,14 +18,14 @@ ACTION_ADD_NODE_TO_GROUP = WorkflowDefinition(
 
 ACTION_RUN_GENERATOR = WorkflowDefinition(
     name="action-run-generator",
-    type=WorkflowType.CORE,
+    type=WorkflowType.INTERNAL,
     module="infrahub.actions.tasks",
     function="run_generator",
 )
 
 ACTION_RUN_GENERATOR_GROUP_EVENT = WorkflowDefinition(
     name="action-run-generator-group-event",
-    type=WorkflowType.CORE,
+    type=WorkflowType.INTERNAL,
     module="infrahub.actions.tasks",
     function="run_generator_group_event",
 )
@@ -84,7 +84,7 @@ TRIGGER_ARTIFACT_DEFINITION_GENERATE = WorkflowDefinition(
 
 TRIGGER_GENERATOR_DEFINITION_RUN = WorkflowDefinition(
     name="generator-definition-run",
-    type=WorkflowType.CORE,
+    type=WorkflowType.INTERNAL,
     module="infrahub.generators.tasks",
     function="run_generator_definition",
     tags=[WorkflowTag.DATABASE_CHANGE],

--- a/backend/tests/functional/generator/test_mutation_generator.py
+++ b/backend/tests/functional/generator/test_mutation_generator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
+from fast_depends import dependency_provider
 from infrahub_sdk.graphql import Mutation
 from infrahub_sdk.protocols import CoreGeneratorDefinition
 from tests.constants import TestKind
@@ -10,8 +11,10 @@ from tests.helpers.file_repo import FileRepo
 from tests.helpers.schema import CAR_SCHEMA, load_schema
 from tests.helpers.test_app import TestInfrahubApp
 
+from infrahub.actions.tasks import _run_generators
 from infrahub.core.constants import InfrahubKind
 from infrahub.core.node import Node
+from infrahub.workers.dependencies import build_client
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -78,6 +81,9 @@ class TestMutationGenerator(TestInfrahubApp):
         response = await client.execute_graphql(query=mutation.render(), branch_name="branch1")
         assert response["CoreGeneratorDefinitionRun"]["ok"]
 
+        tags = await client.all(kind="BuiltinTag", branch="branch1")
+        assert "john-jesko" in [tag.name.value for tag in tags]
+
     async def test_execute_generator_background(
         self, db: InfrahubDatabase, initial_dataset: None, client: InfrahubClient
     ) -> None:
@@ -90,3 +96,24 @@ class TestMutationGenerator(TestInfrahubApp):
         response = await client.execute_graphql(query=mutation.render(), branch_name="branch1")
         assert response["CoreGeneratorDefinitionRun"]["ok"]
         assert response["CoreGeneratorDefinitionRun"]["task"]["id"]
+
+    async def test_execute_generator_action(
+        self, db: InfrahubDatabase, initial_dataset: None, client: InfrahubClient
+    ) -> None:
+        generator = await client.get(kind=CoreGeneratorDefinition, branch="branch1", name__value="cartags")
+
+        person_john = await client.get(kind=TestKind.PERSON, branch="branch1", name__value="John")
+        person_john.name.value = "Bill"
+        await person_john.save(allow_upsert=True)
+
+        with dependency_provider.scope(build_client, lambda: client):
+            await _run_generators(
+                branch_name="branch1",
+                node_ids=[person_john.id],
+                generator_definition_id=generator.id,
+                client=client,
+                context=None,
+            )
+
+        tags = await client.all(kind="BuiltinTag", branch="branch1")
+        assert "bill-jesko" in [tag.name.value for tag in tags]

--- a/backend/tests/integration_docker/test_triggered_actions.py
+++ b/backend/tests/integration_docker/test_triggered_actions.py
@@ -3,7 +3,17 @@ from pathlib import Path
 
 import pytest
 from infrahub_sdk import InfrahubClient
-from infrahub_sdk.protocols import CoreGenericRepository
+from infrahub_sdk.protocols import (
+    BuiltinTag,
+    CoreGeneratorAction,
+    CoreGeneratorDefinition,
+    CoreGenericRepository,
+    CoreGroupAction,
+    CoreGroupTriggerRule,
+    CoreNodeTriggerAttributeMatch,
+    CoreNodeTriggerRule,
+    CoreStandardGroup,
+)
 from infrahub_sdk.schema import NodeSchema, SchemaRoot
 from infrahub_sdk.testing.docker import TestInfrahubDockerClient
 from infrahub_sdk.testing.repository import GitRepo
@@ -100,19 +110,20 @@ class TestTriggeredActions(TestInfrahubDockerClient, SchemaCarPerson):
     async def test_create_main_triggers(
         self, client: InfrahubClient, default_branch: str, prefect_client: PrefectClient, load_initial_data: None
     ) -> None:
-        group_people = await client.get(
-            kind="CoreStandardGroup", id="people", prefetch_relationships=True, populate_store=True
-        )
         description_trigger_value = "right-stuff"
 
-        group_action = await client.create(kind="CoreGroupAction", name="add-to-people", group=group_people)
+        group_people = await client.get(
+            kind=CoreStandardGroup, name__value="people", prefetch_relationships=True, populate_store=True
+        )
+
+        group_action = await client.create(kind=CoreGroupAction, name="add-to-people", group=group_people)
         await group_action.save()
 
-        tags_original = await client.all(kind="BuiltinTag")
+        tags_original = await client.all(kind=BuiltinTag)
         tag_names_original = [tag.name.value for tag in tags_original]
 
         node_trigger = await client.create(
-            kind="CoreNodeTriggerRule",
+            kind=CoreNodeTriggerRule,
             name="trigger-add-to-people",
             active=False,
             node_kind=TESTING_PERSON,
@@ -122,7 +133,7 @@ class TestTriggeredActions(TestInfrahubDockerClient, SchemaCarPerson):
         await node_trigger.save()
 
         attribute_match = await client.create(
-            kind="CoreNodeTriggerAttributeMatch",
+            kind=CoreNodeTriggerAttributeMatch,
             attribute_name="description",
             value=description_trigger_value,
             value_match="value",
@@ -134,14 +145,14 @@ class TestTriggeredActions(TestInfrahubDockerClient, SchemaCarPerson):
         await node_trigger.save()
 
         # Get the generator definition defined in the car-dealership repository
-        generator_definition = await client.get(kind="CoreGeneratorDefinition", id="cartags")
+        generator_definition = await client.get(kind=CoreGeneratorDefinition, name__value="cartags")
         generator_action = await client.create(
-            kind="CoreGeneratorAction", name="run-cartags-generator", generator=generator_definition
+            kind=CoreGeneratorAction, name="run-cartags-generator", generator=generator_definition
         )
         await generator_action.save()
 
         group_trigger = await client.create(
-            kind="CoreGroupTriggerRule",
+            kind=CoreGroupTriggerRule,
             name="run-generator-for-new-members",
             branch_scope="all_branches",
             members_added=True,
@@ -151,7 +162,7 @@ class TestTriggeredActions(TestInfrahubDockerClient, SchemaCarPerson):
         await group_trigger.save()
 
         group_people = await client.get(
-            kind="CoreStandardGroup", id="people", prefetch_relationships=True, populate_store=True
+            kind=CoreStandardGroup, name__value="people", prefetch_relationships=True, populate_store=True
         )
 
         await group_people.members.fetch()
@@ -173,19 +184,19 @@ class TestTriggeredActions(TestInfrahubDockerClient, SchemaCarPerson):
         await laura.save()
 
         group_people = await client.get(
-            kind="CoreStandardGroup", id="people", prefetch_relationships=True, populate_store=True
+            kind=CoreStandardGroup, name__value="people", prefetch_relationships=True, populate_store=True
         )
 
         await group_people.members.fetch()
         for _ in range(30):
-            tags_updated = await client.all(kind="BuiltinTag")
+            tags_updated = await client.all(kind=BuiltinTag)
             tag_names_updated = [tag.name.value for tag in tags_updated]
             if len(tag_names_updated) > len(tag_names_original):
                 break
             await asyncio.sleep(1)
 
         group_people = await client.get(
-            kind="CoreStandardGroup", id="people", prefetch_relationships=True, populate_store=True
+            kind=CoreStandardGroup, name__value="people", prefetch_relationships=True, populate_store=True
         )
 
         await group_people.members.fetch()

--- a/changelog/+action-generator.housekeeping.md
+++ b/changelog/+action-generator.housekeeping.md
@@ -1,0 +1,1 @@
+Refactor Generator execution triggered by an action.


### PR DESCRIPTION
This PR refactor the flow `run_generator_group_event` and `run_generator` to execute the generators directly instead of calling the `CoreGeneratorDefinitionRun` mutation.

In the current implementation, the mutation is not async and as a result the execution could fail if the execution time is bigger than the timeout of the GraphQL API

Also in order to improve the performance of this workflow, the implementation is not using the SDK and instead it's using a single GraphQL query to pull all the information necessary from the backend.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generator runs now execute per-target: system fetches generator and target metadata and submits a dedicated run per target.

* **Improvements**
  * Generator definitions surface parameters consistently and validate target membership before execution.
  * Some generator-related workflows reclassified to internal handling.

* **Bug Fixes**
  * Clear errors when a generator definition is missing or requested targets don’t apply.

* **Refactor**
  * Switched to a workflow-driven, per-target orchestration for generator execution.

* **Tests**
  * Added functional and integration tests for generator and action-triggered runs.

* **Chores**
  * Added housekeeping changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->