### PR TITLE
Add option Any to Trigger Attribute Match

### DIFF
--- a/backend/infrahub/actions/constants.py
+++ b/backend/infrahub/actions/constants.py
@@ -118,6 +118,12 @@ class ValueMatch(DropdownEnum):
         description="Match against both the current and previous values",
         color="#5ac8fa",
     )
+    ANY = DropdownChoice(
+        name="any",
+        label="Any",
+        description="Match against any value",
+        color="#276cc2",
+    )
 
 
 NODES_THAT_TRIGGER_ACTION_RULES_SETUP = [

--- a/backend/tests/unit/actions/test_gather.py
+++ b/backend/tests/unit/actions/test_gather.py
@@ -125,8 +125,30 @@ async def test_gather_trigger_gather_trigger_action_rules_node_attribute(
         ],
     )
 
+    attribute_match.value_match.value = "any"
+    await attribute_match.save(db=db)
+
+    triggers = await gather_trigger_action_rules(db=db)
+    assert len(triggers) == 1
+    automation = triggers[0]
+
+    assert automation.trigger == EventTrigger(
+        events={"infrahub.node.updated"},
+        match={"infrahub.node.kind": "BuiltinTag", "infrahub.branch.name": "main"},
+        match_related=[
+            {
+                "prefect.resource.role": "infrahub.node.attribute_update",
+                "infrahub.field.name": "description",
+                "infrahub.attribute.action": ["added", "updated", "removed"],
+            }
+        ],
+    )
+
     main_node_trigger_rule.branch_scope.value = "other_branches"
     await main_node_trigger_rule.save(db=db)
+
+    attribute_match.value_match.value = "value_full"
+    await attribute_match.save(db=db)
 
     triggers = await gather_trigger_action_rules(db=db)
     assert len(triggers) == 1

--- a/changelog/+match-attr.added.md
+++ b/changelog/+match-attr.added.md
@@ -1,0 +1,1 @@
+Add an option to match trigger action any attribute value


### PR DESCRIPTION
Add an option for `CoreNodeTriggerAttributeMatch` to match on Any attribute values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Any” option to value-matching dropdowns, allowing triggers to match against any attribute value where value-match criteria apply.

* **Documentation**
  * Added a changelog entry announcing the new “Any” matching option.

* **Tests**
  * Expanded unit tests to validate attribute-based triggers across different value-match modes, branch-scoping (including not-main branches), multiple attribute matches, and trigger activation states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->