### PR TITLE
Add hfid and uniqueness constraint to Attribute and Relationship Match for NodeTrigger

### DIFF
--- a/.github/workflows/version-upgrade.yml
+++ b/.github/workflows/version-upgrade.yml
@@ -40,6 +40,9 @@ jobs:
           - name: From 1.1.0
             source_version: 1.1.0
             neo4j_image: "neo4j:5.20.0-enterprise"
+          - name: From 1.3.6
+            source_version: 1.3.6
+            neo4j_image: "neo4j:2025.03.0-enterprise"
     name: ${{ matrix.name }}
     runs-on:
       group: huge-runners

--- a/.github/workflows/version-upgrade.yml
+++ b/.github/workflows/version-upgrade.yml
@@ -37,11 +37,11 @@ jobs:
       max-parallel: 4
       matrix:
         include:
-          - name: From 1.1.0
-            source_version: 1.1.0
-            neo4j_image: "neo4j:5.20.0-enterprise"
-          - name: From 1.3.6
-            source_version: 1.3.6
+          # - name: From 1.1.0
+          #   source_version: 1.1.0
+          #   neo4j_image: "neo4j:5.20.0-enterprise"
+          - name: From 1.3.0
+            source_version: 1.3.0
             neo4j_image: "neo4j:2025.03.0-enterprise"
     name: ${{ matrix.name }}
     runs-on:

--- a/backend/infrahub/actions/schema.py
+++ b/backend/infrahub/actions/schema.py
@@ -50,7 +50,7 @@ core_trigger_rule = GenericSchema(
             description="Indicates if this trigger is enabled or if it's just prepared, could be useful as you are setting up a trigger",
             optional=False,
             default_value=True,
-            order_weight=200,
+            order_weight=250,
         ),
         Attr(
             name="branch_scope",
@@ -59,7 +59,7 @@ core_trigger_rule = GenericSchema(
             choices=BranchScope.available_types(),
             default_value=BranchScope.DEFAULT_BRANCH.value.name,
             optional=False,
-            order_weight=200,
+            order_weight=260,
             allow_override=AllowOverrideType.NONE,
         ),
     ],
@@ -270,8 +270,10 @@ core_node_trigger_attribute_match = NodeSchema(
     label="Node Trigger Attribute Match",
     branch=BranchSupportType.AGNOSTIC,
     generate_profile=False,
-    inherit_from=["CoreNodeTriggerMatch"],
+    inherit_from=[core_node_trigger_match.kind],
     display_labels=["attribute_name__value"],
+    uniqueness_constraints=[["trigger", "attribute_name__value"]],
+    human_friendly_id=["trigger__name__value", "attribute_name__value"],
     attributes=[
         Attr(
             name="attribute_name",
@@ -319,8 +321,10 @@ core_node_trigger_relationship_match = NodeSchema(
     label="Node Trigger Relationship Match",
     branch=BranchSupportType.AGNOSTIC,
     generate_profile=False,
-    inherit_from=["CoreNodeTriggerMatch"],
+    inherit_from=[core_node_trigger_match.kind],
     display_labels=["relationship_name__value", "modification_type__value"],
+    uniqueness_constraints=[["trigger", "relationship_name__value"]],
+    human_friendly_id=["trigger__name__value", "relationship_name__value"],
     attributes=[
         Attr(
             name="relationship_name",

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -119,9 +119,8 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
         return "__".join(hfid)
 
     async def get_path_value(self, db: InfrahubDatabase, path: str) -> str:
-        schema_path = self._schema.parse_schema_path(
-            path=path, schema=db.schema.get_schema_branch(name=self._branch.name)
-        )
+        branch_name = self._branch.name if self._branch.name != GLOBAL_BRANCH_NAME else registry.default_branch
+        schema_path = self._schema.parse_schema_path(path=path, schema=db.schema.get_schema_branch(name=branch_name))
 
         if not schema_path.has_property:
             raise ValueError(f"Unable to retrieve the value of a path without property {path!r} on {self.get_kind()!r}")

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -119,8 +119,10 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
         return "__".join(hfid)
 
     async def get_path_value(self, db: InfrahubDatabase, path: str) -> str:
-        branch_name = self._branch.name if self._branch.name != GLOBAL_BRANCH_NAME else registry.default_branch
-        schema_path = self._schema.parse_schema_path(path=path, schema=db.schema.get_schema_branch(name=branch_name))
+        # branch_name = self._branch.name if self._branch.name != GLOBAL_BRANCH_NAME else registry.default_branch
+        schema_path = self._schema.parse_schema_path(
+            path=path, schema=db.schema.get_schema_branch(name=self._branch.name)
+        )
 
         if not schema_path.has_property:
             raise ValueError(f"Unable to retrieve the value of a path without property {path!r} on {self.get_kind()!r}")

--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -119,7 +119,6 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
         return "__".join(hfid)
 
     async def get_path_value(self, db: InfrahubDatabase, path: str) -> str:
-        # branch_name = self._branch.name if self._branch.name != GLOBAL_BRANCH_NAME else registry.default_branch
         schema_path = self._schema.parse_schema_path(
             path=path, schema=db.schema.get_schema_branch(name=self._branch.name)
         )

--- a/backend/infrahub/database/__init__.py
+++ b/backend/infrahub/database/__init__.py
@@ -28,6 +28,9 @@ from typing_extensions import Self
 from infrahub import config, lock
 from infrahub.constants.database import DatabaseType, Neo4jRuntime
 from infrahub.core import registry
+from infrahub.core.constants import (
+    GLOBAL_BRANCH_NAME,
+)
 from infrahub.core.query import QueryType
 from infrahub.exceptions import DatabaseError
 from infrahub.log import get_logger
@@ -129,10 +132,10 @@ class DatabaseSchemaManager:
 
         If the branch is the global one, the default branch will be returned.
         """
-        # branch_name = registry.default_branch if name == GLOBAL_BRANCH_NAME else name
-        if name not in self._db._schemas:
-            return registry.schema.get_schema_branch(name=name)
-        return self._db._schemas[name]
+        branch_name = registry.default_branch if name == GLOBAL_BRANCH_NAME else name
+        if branch_name not in self._db._schemas:
+            return registry.schema.get_schema_branch(name=branch_name)
+        return self._db._schemas[branch_name]
 
 
 class InfrahubDatabase:

--- a/backend/infrahub/database/__init__.py
+++ b/backend/infrahub/database/__init__.py
@@ -28,9 +28,6 @@ from typing_extensions import Self
 from infrahub import config, lock
 from infrahub.constants.database import DatabaseType, Neo4jRuntime
 from infrahub.core import registry
-from infrahub.core.constants import (
-    GLOBAL_BRANCH_NAME,
-)
 from infrahub.core.query import QueryType
 from infrahub.exceptions import DatabaseError
 from infrahub.log import get_logger
@@ -132,11 +129,10 @@ class DatabaseSchemaManager:
 
         If the branch is the global one, the default branch will be returned.
         """
-        branch_name = registry.default_branch if name == GLOBAL_BRANCH_NAME else name
-
-        if branch_name not in self._db._schemas:
-            return registry.schema.get_schema_branch(name=branch_name)
-        return self._db._schemas[branch_name]
+        # branch_name = registry.default_branch if name == GLOBAL_BRANCH_NAME else name
+        if name not in self._db._schemas:
+            return registry.schema.get_schema_branch(name=name)
+        return self._db._schemas[name]
 
 
 class InfrahubDatabase:

--- a/backend/infrahub/database/__init__.py
+++ b/backend/infrahub/database/__init__.py
@@ -28,6 +28,9 @@ from typing_extensions import Self
 from infrahub import config, lock
 from infrahub.constants.database import DatabaseType, Neo4jRuntime
 from infrahub.core import registry
+from infrahub.core.constants import (
+    GLOBAL_BRANCH_NAME,
+)
 from infrahub.core.query import QueryType
 from infrahub.exceptions import DatabaseError
 from infrahub.log import get_logger
@@ -125,9 +128,15 @@ class DatabaseSchemaManager:
         return self.get_full(branch=branch, duplicate=duplicate)
 
     def get_schema_branch(self, name: str) -> SchemaBranch:
-        if name not in self._db._schemas:
-            return registry.schema.get_schema_branch(name=name)
-        return self._db._schemas[name]
+        """Return a schema branch object based on its name.
+
+        If the branch is the global one, the default branch will be returned.
+        """
+        branch_name = registry.default_branch if name == GLOBAL_BRANCH_NAME else name
+
+        if branch_name not in self._db._schemas:
+            return registry.schema.get_schema_branch(name=branch_name)
+        return self._db._schemas[branch_name]
 
 
 class InfrahubDatabase:

--- a/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
+++ b/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
@@ -129,7 +129,7 @@ async def test_get_proposed_change_schema_integrity_constraints(
     non_generate_profile_constraints = [c for c in constraints if c.constraint_name != "node.generate_profile.update"]
     # should be updated/removed when ConstraintValidatorDeterminer is updated (#2592)
     assert len(constraints) == 219
-    assert len(non_generate_profile_constraints) == 130
+    assert len(non_generate_profile_constraints) == 132
     dumped_constraints = [c.model_dump() for c in non_generate_profile_constraints]
     assert {
         "constraint_name": "relationship.optional.update",

--- a/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
+++ b/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
@@ -128,7 +128,7 @@ async def test_get_proposed_change_schema_integrity_constraints(
     )
     non_generate_profile_constraints = [c for c in constraints if c.constraint_name != "node.generate_profile.update"]
     # should be updated/removed when ConstraintValidatorDeterminer is updated (#2592)
-    assert len(constraints) == 217
+    assert len(constraints) == 219
     assert len(non_generate_profile_constraints) == 130
     dumped_constraints = [c.model_dump() for c in non_generate_profile_constraints]
     assert {

--- a/changelog/+global_branch.fixed.md
+++ b/changelog/+global_branch.fixed.md
@@ -1,0 +1,1 @@
+Ensure the default branch is used when a node is part of the global branch

--- a/changelog/6713.fixed.md
+++ b/changelog/6713.fixed.md
@@ -1,0 +1,1 @@
+Add an HFID for Attribute and Relationship matches for a Node Trigger Rule


### PR DESCRIPTION
Fixes #6713, #7206

This PR add an HFID and a unique uniqueness constraint to both 
- CoreNodeTriggerRelationshipMatch
- CoreNodeTriggerAttributeMatch

With this fix it's now possible to manage Rule, Matches and Action with an object file.

This PR also include a fix to `get_schema_branch` to ensure that it's returning the schema of the default branch if the global branch is provided

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added human-friendly IDs for node trigger attribute and relationship matches, improving readability in UI and logs.

* **Bug Fixes**
  * Ensured items on the global branch correctly use the default branch, preventing branch mismatches.
  * Improved consistency of trigger rule ordering.

* **Documentation**
  * Added changelog entries describing the new IDs and branch handling fix.

* **Chores**
  * Updated CI migration matrix to start from 1.3.0 and use a newer Neo4j image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->