### PR TITLE
Ignore keyword scan for dependabot push

### DIFF
--- a/.github/workflows/keyword-scan.yml
+++ b/.github/workflows/keyword-scan.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   scan:
     if: |
-      github.event_name == 'push' ||
+      (github.event_name == 'push' && github.actor != 'dependabot[bot]') ||
       (github.event_name == 'pull_request' &&
        github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]')
     runs-on: ubuntu-latest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated keyword scanning workflow to skip scans triggered by automated dependency updates, while continuing to run on user pushes and qualifying pull requests. This reduces unnecessary CI runs and noise from automated changes, improving signal-to-noise for alerts. No impact on application functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->