### PR TITLE
Store dynamic types for GraphQL schema by hash

### DIFF
--- a/backend/infrahub/graphql/manager.py
+++ b/backend/infrahub/graphql/manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Iterable
 
@@ -92,6 +93,24 @@ class GraphqlMutations:
     delete: type[InfrahubMutation]
 
 
+@dataclass
+class InterfaceReference:
+    reference: type[graphene.Interface]
+    reference_hash: str
+
+
+@dataclass
+class InfrahubObjectReference:
+    reference: type[InfrahubObject]
+    reference_hash: str
+
+
+@dataclass
+class InfrahubEdgedReference:
+    reference: type[InfrahubObject]
+    reference_hash: str
+
+
 def get_attr_kind(node_schema: MainSchemaTypes, attr_schema: AttributeSchema) -> str:
     if not config.SETTINGS.experimental_features.graphql_enums or not attr_schema.enum:
         return attr_schema.kind
@@ -101,6 +120,7 @@ def get_attr_kind(node_schema: MainSchemaTypes, attr_schema: AttributeSchema) ->
 class GraphQLSchemaManager:
     def __init__(self, schema: SchemaBranch) -> None:
         self.schema = schema
+        self.schema_hash = schema.get_hash()
 
         self._full_graphql_schema: GraphQLSchema | None = None
         self._graphql_types: dict[str, GraphQLTypes] = {}
@@ -273,7 +293,9 @@ class GraphQLSchemaManager:
             )
             ATTRIBUTE_TYPES[base_enum_name] = data_type_class
 
-    def _get_related_input_type(self, relationship: RelationshipSchema) -> type[RelatedNodeInput]:
+    def _get_related_input_type(
+        self, relationship: RelationshipSchema
+    ) -> type[RelatedNodeInput | RelatedIPPrefixNodeInput | RelatedIPAddressNodeInput]:
         peer_schema = self.schema.get(name=relationship.peer, duplicate=False)
         if peer_schema.is_ip_prefix:
             return RelatedIPPrefixNodeInput
@@ -331,12 +353,15 @@ class GraphQLSchemaManager:
         # Generate all GraphQL ObjectType, Nested, Paginated & NestedPaginated and store them in the registry
         for node_schema in full_schema.values():
             if isinstance(node_schema, NodeSchema | ProfileSchema | TemplateSchema):
-                node_type = self.generate_graphql_object(schema=node_schema, populate_cache=True)
+                node_object_type = self.generate_graphql_object(schema=node_schema, populate_cache=True)
                 node_type_edged = self.generate_graphql_edged_object(
-                    schema=node_schema, node=node_type, populate_cache=True
+                    schema=node_schema, node=node_object_type, populate_cache=True
                 )
                 nested_node_type_edged = self.generate_graphql_edged_object(
-                    schema=node_schema, node=node_type, relation_property=relationship_property, populate_cache=True
+                    schema=node_schema,
+                    node=node_object_type,
+                    relation_property=relationship_property,
+                    populate_cache=True,
                 )
 
                 self.generate_graphql_paginated_object(schema=node_schema, edge=node_type_edged, populate_cache=True)
@@ -488,13 +513,15 @@ class GraphQLSchemaManager:
 
         return type("MutationMixin", (object,), class_attrs)
 
-    def generate_graphql_object(self, schema: MainSchemaTypes, populate_cache: bool = False) -> type[InfrahubObject]:
+    def generate_graphql_object(self, schema: MainSchemaTypes, populate_cache: bool = False) -> InfrahubObjectReference:
         """Generate a GraphQL object Type from a Infrahub NodeSchema."""
 
         interfaces: set[type[InfrahubObject]] = set()
+        md5hash = hashlib.md5(usedforsecurity=False)
+        md5hash.update(f"{schema.kind}{schema.get_hash()}".encode())
 
         if isinstance(schema, NodeSchema | ProfileSchema | TemplateSchema) and schema.inherit_from:
-            for generic_name in schema.inherit_from:
+            for generic_name in sorted(schema.inherit_from):
                 generic = self.get_type(name=generic_name)
                 interfaces.add(generic)
 
@@ -528,20 +555,25 @@ class GraphQLSchemaManager:
             req = "" if attr.optional else " (required)"
             main_attrs[attr.name] = graphene.Field(attr_type, description=f"{attr.description}{req}")
 
+        object_hash = md5hash.hexdigest()
+
         graphql_object = type(schema.kind, (InfrahubObject,), main_attrs)
+        registry.set_object_type(reference=graphql_object, reference_hash=object_hash, schema_hash=self.schema_hash)
 
         if populate_cache:
             self.set_type(name=schema.kind, graphql_type=graphql_object)
 
-        return graphql_object
+        return InfrahubObjectReference(reference=graphql_object, reference_hash=object_hash)
 
-    def generate_interface_object(
-        self, schema: GenericSchema, populate_cache: bool = False
-    ) -> type[graphene.Interface]:
+    def generate_interface_object(self, schema: GenericSchema, populate_cache: bool = False) -> InterfaceReference:
         meta_attrs = {
             "name": schema.kind,
             "description": schema.description,
         }
+
+        md5hash = hashlib.md5(usedforsecurity=False)
+        md5hash.update(f"interface-{schema.kind}{schema.get_hash()}".encode())
+        interface_hash = md5hash.hexdigest()
 
         main_attrs = {
             "id": graphene.Field(graphene.String, required=False, description="Unique identifier"),
@@ -551,7 +583,6 @@ class GraphQLSchemaManager:
                 description="Human friendly identifier",
             ),
             "display_label": graphene.String(required=False),
-            "Meta": type("Meta", (object,), meta_attrs),
         }
 
         for attr in schema.attributes:
@@ -559,12 +590,18 @@ class GraphQLSchemaManager:
             attr_type = self.get_type(name=get_attribute_type(kind=attr_kind).get_graphql_type_name())
             main_attrs[attr.name] = graphene.Field(attr_type, description=attr.description)
 
-        interface_object = type(schema.kind, (InfrahubInterface,), main_attrs)
+        interface_object = registry.get_interface_type(reference_hash=interface_hash, schema_hash=self.schema_hash)
+        if not interface_object:
+            main_attrs["Meta"] = type("Meta", (object,), meta_attrs)
+            interface_object = type(schema.kind, (InfrahubInterface,), main_attrs)
+
+        interface_reference = InterfaceReference(reference=interface_object, reference_hash=interface_hash)
+        registry.set_interface_type(reference=interface_reference, schema_hash=self.schema_hash)
 
         if populate_cache:
             self.set_type(name=schema.kind, graphql_type=interface_object)
 
-        return interface_object
+        return interface_reference
 
     def define_relationship_property(self, data_source: type[InfrahubObject], data_owner: type[InfrahubObject]) -> None:
         type_name = "RelationshipProperty"
@@ -652,7 +689,18 @@ class GraphQLSchemaManager:
             elif rel.cardinality == RelationshipCardinality.MANY:
                 attrs[rel.name] = graphene.InputField(graphene.List(input_type), description=rel.description)
 
-        return type(f"{schema.kind}CreateInput", (graphene.InputObjectType,), attrs)
+        input_name = f"{schema.kind}CreateInput"
+        md5hash = hashlib.md5(usedforsecurity=False)
+        md5hash.update(f"{input_name}{schema.get_hash()}".encode())
+        input_hash = md5hash.hexdigest()
+        mutation_input_type = registry.get_input_type(reference_hash=input_hash, schema_hash=self.schema_hash)
+        if not mutation_input_type:
+            mutation_input_type = type(input_name, (graphene.InputObjectType,), attrs)
+            registry.set_input_type(
+                reference=mutation_input_type, reference_hash=input_hash, schema_hash=self.schema_hash
+            )
+
+        return mutation_input_type
 
     def generate_graphql_mutation_update_input(self, schema: MainSchemaTypes) -> type[graphene.InputObjectType]:
         """Generate an InputObjectType Object from a Infrahub NodeSchema
@@ -691,7 +739,18 @@ class GraphQLSchemaManager:
                     graphene.List(input_type), required=False, description=rel.description
                 )
 
-        return type(f"{schema.kind}UpdateInput", (graphene.InputObjectType,), attrs)
+        input_name = f"{schema.kind}UpdateInput"
+        md5hash = hashlib.md5(usedforsecurity=False)
+        md5hash.update(f"{input_name}{schema.get_hash()}".encode())
+        input_hash = md5hash.hexdigest()
+        mutation_input_type = registry.get_input_type(reference_hash=input_hash, schema_hash=self.schema_hash)
+        if not mutation_input_type:
+            mutation_input_type = type(input_name, (graphene.InputObjectType,), attrs)
+            registry.set_input_type(
+                reference=mutation_input_type, reference_hash=input_hash, schema_hash=self.schema_hash
+            )
+
+        return mutation_input_type
 
     def generate_graphql_mutation_upsert_input(
         self, schema: NodeSchema | ProfileSchema | TemplateSchema
@@ -737,8 +796,18 @@ class GraphQLSchemaManager:
                 attrs[rel.name] = graphene.InputField(
                     graphene.List(input_type), required=required, description=rel.description
                 )
+        input_name = f"{schema.kind}UpsertInput"
+        md5hash = hashlib.md5(usedforsecurity=False)
+        md5hash.update(f"{input_name}{schema.get_hash()}".encode())
+        input_hash = md5hash.hexdigest()
+        mutation_input_type = registry.get_input_type(reference_hash=input_hash, schema_hash=self.schema_hash)
+        if not mutation_input_type:
+            mutation_input_type = type(input_name, (graphene.InputObjectType,), attrs)
+            registry.set_input_type(
+                reference=mutation_input_type, reference_hash=input_hash, schema_hash=self.schema_hash
+            )
 
-        return type(f"{schema.kind}UpsertInput", (graphene.InputObjectType,), attrs)
+        return mutation_input_type
 
     def generate_graphql_mutation_create(
         self,
@@ -750,17 +819,27 @@ class GraphQLSchemaManager:
         """Generate a GraphQL Mutation to CREATE an object based on the specified NodeSchema."""
         name = f"{schema.kind}{mutation_type}"
 
-        object_type = self.generate_graphql_object(schema=schema)
+        md5hash = hashlib.md5(usedforsecurity=False)
+        md5hash.update(f"{name}{schema.get_hash()}".encode())
+        mutation_hash = md5hash.hexdigest()
 
-        main_attrs: dict[str, Any] = {"ok": graphene.Boolean(), "object": graphene.Field(object_type)}
+        mutation_object = registry.get_mutation_type(reference_hash=mutation_hash, schema_hash=self.schema_hash)
+        if not mutation_object:
+            object_type = self.generate_graphql_object(schema=schema)
 
-        meta_attrs: dict[str, Any] = {"schema": schema, "name": name, "description": schema.description}
-        main_attrs["Meta"] = type("Meta", (object,), meta_attrs)
+            main_attrs: dict[str, Any] = {"ok": graphene.Boolean(), "object": graphene.Field(object_type.reference)}
 
-        args_attrs = {"data": input_type(required=True), "context": ContextInput(required=False)}
-        main_attrs["Arguments"] = type("Arguments", (object,), args_attrs)
+            meta_attrs: dict[str, Any] = {"schema": schema, "name": name, "description": schema.description}
+            main_attrs["Meta"] = type("Meta", (object,), meta_attrs)
 
-        return type(name, (base_class,), main_attrs)
+            args_attrs = {"data": input_type(required=True), "context": ContextInput(required=False)}
+            main_attrs["Arguments"] = type("Arguments", (object,), args_attrs)
+            mutation_object = type(name, (base_class,), main_attrs)
+            registry.set_mutation_type(
+                reference=mutation_object, reference_hash=mutation_hash, schema_hash=self.schema_hash
+            )
+
+        return mutation_object
 
     def generate_graphql_mutation_update(
         self,
@@ -771,34 +850,50 @@ class GraphQLSchemaManager:
         """Generate a GraphQL Mutation to UPDATE an object based on the specified NodeSchema."""
         name = f"{schema.kind}Update"
 
-        object_type = self.generate_graphql_object(schema=schema)
+        md5hash = hashlib.md5(usedforsecurity=False)
+        md5hash.update(f"{name}{schema.get_hash()}".encode())
+        mutation_hash = md5hash.hexdigest()
 
-        main_attrs: dict[str, Any] = {"ok": graphene.Boolean(), "object": graphene.Field(object_type)}
+        mutation_object = registry.get_mutation_type(reference_hash=mutation_hash, schema_hash=self.schema_hash)
+        if not mutation_object:
+            object_type = self.generate_graphql_object(schema=schema)
 
-        meta_attrs: dict[str, Any] = {"schema": schema, "name": name, "description": schema.description}
-        main_attrs["Meta"] = type("Meta", (object,), meta_attrs)
+            main_attrs: dict[str, Any] = {"ok": graphene.Boolean(), "object": graphene.Field(object_type.reference)}
 
-        args_attrs = {"data": input_type(required=True), "context": ContextInput(required=False)}
-        main_attrs["Arguments"] = type("Arguments", (object,), args_attrs)
+            meta_attrs: dict[str, Any] = {"schema": schema, "name": name, "description": schema.description}
+            main_attrs["Meta"] = type("Meta", (object,), meta_attrs)
 
-        return type(name, (base_class,), main_attrs)
+            args_attrs = {"data": input_type(required=True), "context": ContextInput(required=False)}
+            main_attrs["Arguments"] = type("Arguments", (object,), args_attrs)
 
-    @staticmethod
+            mutation_object = type(name, (base_class,), main_attrs)
+            registry.set_mutation_type(
+                reference=mutation_object, reference_hash=mutation_hash, schema_hash=self.schema_hash
+            )
+
+        return mutation_object
+
     def generate_graphql_mutation_delete(
-        schema: NodeSchema | ProfileSchema | TemplateSchema, base_class: type[InfrahubMutation] = InfrahubMutation
+        self, schema: NodeSchema | ProfileSchema | TemplateSchema, base_class: type[InfrahubMutation] = InfrahubMutation
     ) -> type[InfrahubMutation]:
         """Generate a GraphQL Mutation to DELETE an object based on the specified NodeSchema."""
         name = f"{schema.kind}Delete"
+        md5hash = hashlib.md5(usedforsecurity=False)
+        md5hash.update(f"{name}{schema.get_hash()}".encode())
+        mutation_hash = md5hash.hexdigest()
+        mutation_object = registry.get_mutation_type(reference_hash=mutation_hash, schema_hash=self.schema_hash)
+        if not mutation_object:
+            main_attrs: dict[str, Any] = {"ok": graphene.Boolean()}
+            meta_attrs = {"schema": schema, "name": name, "description": schema.description}
+            main_attrs["Meta"] = type("Meta", (object,), meta_attrs)
+            args_attrs: dict[str, Any] = {"data": DeleteInput(required=True), "context": ContextInput(required=False)}
+            main_attrs["Arguments"] = type("Arguments", (object,), args_attrs)
+            mutation_object = type(name, (base_class,), main_attrs)
+            registry.set_mutation_type(
+                reference=mutation_object, reference_hash=mutation_hash, schema_hash=self.schema_hash
+            )
 
-        main_attrs: dict[str, Any] = {"ok": graphene.Boolean()}
-
-        meta_attrs = {"schema": schema, "name": name, "description": schema.description}
-        main_attrs["Meta"] = type("Meta", (object,), meta_attrs)
-
-        args_attrs: dict[str, Any] = {"data": DeleteInput(required=True), "context": ContextInput(required=False)}
-        main_attrs["Arguments"] = type("Arguments", (object,), args_attrs)
-
-        return type(name, (base_class,), main_attrs)
+        return mutation_object
 
     def generate_filters(
         self, schema: MainSchemaTypes, top_level: bool = False, include_properties: bool = True
@@ -871,15 +966,19 @@ class GraphQLSchemaManager:
     def generate_graphql_edged_object(
         self,
         schema: MainSchemaTypes,
-        node: type[InfrahubObject],
+        node: InterfaceReference | InfrahubObjectReference,
         relation_property: type[InfrahubObject] | None = None,
         populate_cache: bool = False,
-    ) -> type[InfrahubObject]:
+    ) -> InfrahubEdgedReference:
         """Generate a edged GraphQL object Type from a Infrahub NodeSchema for pagination."""
 
         object_name = f"Edged{schema.kind}"
         if relation_property:
             object_name = f"NestedEdged{schema.kind}"
+
+        md5hash = hashlib.md5(usedforsecurity=False)
+        md5hash.update(f"{object_name}{schema.get_hash()}{node.reference_hash}".encode())
+        edge_hash = md5hash.hexdigest()
 
         meta_attrs: dict[str, Any] = {
             "schema": schema,
@@ -889,28 +988,37 @@ class GraphQLSchemaManager:
         }
 
         main_attrs: dict[str, Any] = {
-            "node": graphene.Field(node, required=False),
+            "node": graphene.Field(node.reference, required=False),
             "Meta": type("Meta", (object,), meta_attrs),
         }
 
         if relation_property:
             main_attrs["properties"] = graphene.Field(relation_property, required=False)
 
-        graphql_edged_object = type(object_name, (InfrahubObject,), main_attrs)
+        graphql_edged_object = registry.get_edge_type(reference_hash=edge_hash, schema_hash=self.schema_hash)
+        if not graphql_edged_object:
+            graphql_edged_object = type(object_name, (InfrahubObject,), main_attrs)
+            registry.set_edge_type(
+                reference=graphql_edged_object, reference_hash=edge_hash, schema_hash=self.schema_hash
+            )
 
         if populate_cache:
             self.set_type(name=object_name, graphql_type=graphql_edged_object)
 
-        return graphql_edged_object
+        return InfrahubEdgedReference(reference=graphql_edged_object, reference_hash=edge_hash)
 
     def generate_graphql_paginated_object(
-        self, schema: MainSchemaTypes, edge: type[InfrahubObject], nested: bool = False, populate_cache: bool = False
+        self, schema: MainSchemaTypes, edge: InfrahubEdgedReference, nested: bool = False, populate_cache: bool = False
     ) -> type[InfrahubObject]:
         """Generate a paginated GraphQL object Type from a Infrahub NodeSchema."""
 
         object_name = f"Paginated{schema.kind}"
         if nested:
             object_name = f"NestedPaginated{schema.kind}"
+
+        md5hash = hashlib.md5(usedforsecurity=False)
+        md5hash.update(f"{object_name}{schema.get_hash()}{edge.reference_hash}".encode())
+        paginated_hash = md5hash.hexdigest()
 
         meta_attrs: dict[str, Any] = {
             "schema": schema,
@@ -922,14 +1030,21 @@ class GraphQLSchemaManager:
 
         main_attrs: dict[str, Any] = {
             "count": graphene.Int(required=True),
-            "edges": graphene.List(of_type=graphene.NonNull(edge), required=True),
+            "edges": graphene.List(of_type=graphene.NonNull(edge.reference), required=True),
             "permissions": graphene.Field(
                 PaginatedObjectPermission, required=True, resolver=parent_field_name_resolver
             ),
-            "Meta": type("Meta", (object,), meta_attrs),
         }
 
-        graphql_paginated_object = type(object_name, (InfrahubObject,), main_attrs)
+        graphql_paginated_object = registry.get_paginated_type(
+            reference_hash=paginated_hash, schema_hash=self.schema_hash
+        )
+        if not graphql_paginated_object:
+            main_attrs["Meta"] = type("Meta", (object,), meta_attrs)
+            graphql_paginated_object = type(object_name, (InfrahubObject,), main_attrs)
+            registry.set_paginated_type(
+                reference=graphql_paginated_object, reference_hash=paginated_hash, schema_hash=self.schema_hash
+            )
 
         if populate_cache:
             self.set_type(name=object_name, graphql_type=graphql_paginated_object)
@@ -959,30 +1074,53 @@ class GraphQLSchemaManager:
             main_attrs["properties"] = graphene.Field(relation_property, required=False)
 
         object_name = f"NestedEdged{schema.kind}"
-        nested_interface_object = type(object_name, (InfrahubObject,), main_attrs)
+        md5hash = hashlib.md5(usedforsecurity=False)
+        md5hash.update(f"{object_name}{schema.get_hash()}".encode())
+        paginated_hash = md5hash.hexdigest()
+        nested_interface_object = registry.get_paginated_type(
+            reference_hash=paginated_hash, schema_hash=self.schema_hash
+        )
+        if not nested_interface_object:
+            nested_interface_object = type(object_name, (InfrahubObject,), main_attrs)
+            registry.set_paginated_type(
+                reference=nested_interface_object, reference_hash=paginated_hash, schema_hash=self.schema_hash
+            )
 
         if populate_cache:
             self.set_type(name=object_name, graphql_type=nested_interface_object)
 
         return nested_interface_object
 
-    @staticmethod
     def generate_paginated_interface_object(
-        schema: GenericSchema, base_interface: type[graphene.ObjectType]
+        self, schema: GenericSchema, base_interface: type[graphene.ObjectType]
     ) -> type[InfrahubObject]:
-        meta_attrs: dict[str, Any] = {
-            "name": f"NestedPaginated{schema.kind}",
-            "schema": schema,
-            "description": schema.description,
-        }
+        object_name = f"NestedPaginated{schema.kind}"
+        md5hash = hashlib.md5(usedforsecurity=False)
+        md5hash.update(f"{object_name}{schema.get_hash()}".encode())
+        paginated_hash = md5hash.hexdigest()
 
-        main_attrs: dict[str, Any] = {
-            "count": graphene.Int(required=True),
-            "edges": graphene.List(of_type=graphene.NonNull(base_interface)),
-            "Meta": type("Meta", (object,), meta_attrs),
-        }
+        nested_interface_object = registry.get_paginated_type(
+            reference_hash=paginated_hash, schema_hash=self.schema_hash
+        )
+        if not nested_interface_object:
+            meta_attrs: dict[str, Any] = {
+                "name": object_name,
+                "schema": schema,
+                "description": schema.description,
+            }
 
-        return type(f"NestedPaginated{schema.kind}", (InfrahubObject,), main_attrs)
+            main_attrs: dict[str, Any] = {
+                "count": graphene.Int(required=True),
+                "edges": graphene.List(of_type=graphene.NonNull(base_interface)),
+                "Meta": type("Meta", (object,), meta_attrs),
+            }
+
+            nested_interface_object = type(object_name, (InfrahubObject,), main_attrs)
+            registry.set_paginated_type(
+                reference=nested_interface_object, reference_hash=paginated_hash, schema_hash=self.schema_hash
+            )
+
+        return nested_interface_object
 
 
 registry._register_manager(manager=GraphQLSchemaManager)

--- a/backend/infrahub/graphql/registry.py
+++ b/backend/infrahub/graphql/registry.py
@@ -7,9 +7,14 @@ from infrahub.core.timestamp import Timestamp
 from infrahub.exceptions import InitializationError
 
 if TYPE_CHECKING:
+    import graphene
+
     from infrahub.core.branch import Branch
     from infrahub.core.schema.schema_branch import SchemaBranch
-    from infrahub.graphql.manager import GraphQLSchemaManager
+    from infrahub.graphql.manager import GraphQLSchemaManager, InterfaceReference
+
+    from .mutations.main import InfrahubMutation
+    from .types import InfrahubObject
 
 
 @dataclass
@@ -21,16 +26,24 @@ class BranchDetails:
 
 @dataclass
 class GraphQLSchemaRegistry:
-    branch_details_by_hash: dict[str, BranchDetails] = field(default_factory=dict)
-    branch_name_by_hash: dict[str, set[str]] = field(default_factory=dict)
-    branch_hash_activation_by_branch_name: dict[str, dict[str, str]] = field(default_factory=dict)
+    _branch_details_by_hash: dict[str, BranchDetails] = field(default_factory=dict)
+    _branch_name_by_hash: dict[str, set[str]] = field(default_factory=dict)
+    _branch_hash_activation_by_branch_name: dict[str, dict[str, str]] = field(default_factory=dict)
+    _registered_interface_types: dict[str, type[graphene.Interface]] = field(default_factory=dict)
+    _reference_hash_schema_map: dict[str, set[str]] = field(default_factory=dict)
+    _registered_edge_types: dict[str, type[InfrahubObject]] = field(default_factory=dict)
+    _registered_paginated_types: dict[str, type[InfrahubObject]] = field(default_factory=dict)
+    _registered_input_types: dict[str, type[graphene.InputObjectType]] = field(default_factory=dict)
+    _registered_object_types: dict[str, type[InfrahubObject]] = field(default_factory=dict)
+    _registered_mutation_types: dict[str, type[InfrahubMutation]] = field(default_factory=dict)
+
     _manager_class: type[GraphQLSchemaManager] | None = None
 
     def _add_branch_hash(self, branch_name: str, schema_hash: str) -> None:
-        if schema_hash not in self.branch_name_by_hash:
-            self.branch_name_by_hash[schema_hash] = set()
+        if schema_hash not in self._branch_name_by_hash:
+            self._branch_name_by_hash[schema_hash] = set()
 
-        self.branch_name_by_hash[schema_hash].add(branch_name)
+        self._branch_name_by_hash[schema_hash].add(branch_name)
 
     def _register_manager(self, manager: type[GraphQLSchemaManager]) -> None:
         self._manager_class = manager
@@ -43,25 +56,90 @@ class GraphQLSchemaRegistry:
 
     def clear_cache(self) -> None:
         """Clear internal cache stored within this registry."""
-        self.branch_details_by_hash = {}
-        self.branch_name_by_hash = {}
-        self.branch_hash_activation_by_branch_name = {}
+        self._branch_details_by_hash = {}
+        self._branch_name_by_hash = {}
+        self._branch_hash_activation_by_branch_name = {}
+        self._registered_interface_types = {}
+        self._reference_hash_schema_map = {}
+        self._registered_edge_types = {}
+        self._registered_paginated_types = {}
+        self._registered_input_types = {}
+        self._registered_object_types = {}
+        self._registered_mutation_types = {}
+
+    def _add_schema_to_reference_hash(self, reference_hash: str, schema_hash: str) -> None:
+        """Add the schema hash to a map containing the referenced object.
+
+        The goal of this is to be able to see all schemas that use a given reference type,
+        once no schemas use a specific type it's safe to remove the type from the registry.
+        """
+        if reference_hash not in self._reference_hash_schema_map:
+            self._reference_hash_schema_map[reference_hash] = set()
+        self._reference_hash_schema_map[reference_hash].add(schema_hash)
+
+    def get_edge_type(self, reference_hash: str, schema_hash: str) -> type[InfrahubObject] | None:
+        self._add_schema_to_reference_hash(reference_hash=reference_hash, schema_hash=schema_hash)
+        return self._registered_edge_types.get(reference_hash)
+
+    def set_edge_type(self, reference: type[InfrahubObject], reference_hash: str, schema_hash: str) -> None:
+        self._add_schema_to_reference_hash(reference_hash=reference_hash, schema_hash=schema_hash)
+        self._registered_edge_types[reference_hash] = reference
+
+    def get_input_type(self, reference_hash: str, schema_hash: str) -> type[graphene.InputObjectType] | None:
+        self._add_schema_to_reference_hash(reference_hash=reference_hash, schema_hash=schema_hash)
+        return self._registered_input_types.get(reference_hash)
+
+    def set_input_type(self, reference: type[graphene.InputObjectType], reference_hash: str, schema_hash: str) -> None:
+        self._add_schema_to_reference_hash(reference_hash=reference_hash, schema_hash=schema_hash)
+        self._registered_input_types[reference_hash] = reference
+
+    def get_interface_type(self, reference_hash: str, schema_hash: str) -> type[graphene.Interface] | None:
+        self._add_schema_to_reference_hash(reference_hash=reference_hash, schema_hash=schema_hash)
+        return self._registered_interface_types.get(reference_hash)
+
+    def set_interface_type(self, reference: InterfaceReference, schema_hash: str) -> None:
+        self._add_schema_to_reference_hash(reference_hash=reference.reference_hash, schema_hash=schema_hash)
+        self._registered_interface_types[reference.reference_hash] = reference.reference
+
+    def get_mutation_type(self, reference_hash: str, schema_hash: str) -> type[InfrahubMutation] | None:
+        self._add_schema_to_reference_hash(reference_hash=reference_hash, schema_hash=schema_hash)
+        return self._registered_mutation_types.get(reference_hash)
+
+    def set_mutation_type(self, reference: type[InfrahubMutation], reference_hash: str, schema_hash: str) -> None:
+        self._add_schema_to_reference_hash(reference_hash=reference_hash, schema_hash=schema_hash)
+        self._registered_mutation_types[reference_hash] = reference
+
+    def get_object_type(self, reference_hash: str, schema_hash: str) -> type[InfrahubObject] | None:
+        self._add_schema_to_reference_hash(reference_hash=reference_hash, schema_hash=schema_hash)
+        return self._registered_object_types.get(reference_hash)
+
+    def set_object_type(self, reference: type[InfrahubObject], reference_hash: str, schema_hash: str) -> None:
+        self._add_schema_to_reference_hash(reference_hash=reference_hash, schema_hash=schema_hash)
+        self._registered_object_types[reference_hash] = reference
+
+    def get_paginated_type(self, reference_hash: str, schema_hash: str) -> type[InfrahubObject] | None:
+        self._add_schema_to_reference_hash(reference_hash=reference_hash, schema_hash=schema_hash)
+        return self._registered_paginated_types.get(reference_hash)
+
+    def set_paginated_type(self, reference: type[InfrahubObject], reference_hash: str, schema_hash: str) -> None:
+        self._add_schema_to_reference_hash(reference_hash=reference_hash, schema_hash=schema_hash)
+        self._registered_paginated_types[reference_hash] = reference
 
     def purge_inactive(self, active_branches: list[str]) -> set[str]:
         """Return inactive branches that were purged"""
         inactive_branches: set[str] = set()
-        for schema_hash in list(self.branch_name_by_hash.keys()):
-            branches = list(self.branch_name_by_hash[schema_hash])
+        for schema_hash in list(self._branch_name_by_hash.keys()):
+            branches = list(self._branch_name_by_hash[schema_hash])
             for branch in branches:
-                if branch not in active_branches and branch in self.branch_name_by_hash[schema_hash]:
+                if branch not in active_branches and branch in self._branch_name_by_hash[schema_hash]:
                     inactive_branches.add(branch)
-                    self.branch_name_by_hash[schema_hash].discard(branch)
+                    self._branch_name_by_hash[schema_hash].discard(branch)
 
-        for schema_hash in list(self.branch_name_by_hash.keys()):
-            if not self.branch_name_by_hash[schema_hash]:
+        for schema_hash in list(self._branch_name_by_hash.keys()):
+            if not self._branch_name_by_hash[schema_hash]:
                 # If no remaining branch is using the schema remove it completely
-                del self.branch_name_by_hash[schema_hash]
-                del self.branch_details_by_hash[schema_hash]
+                del self._branch_name_by_hash[schema_hash]
+                del self._branch_details_by_hash[schema_hash]
 
         return inactive_branches
 
@@ -72,7 +150,7 @@ class GraphQLSchemaRegistry:
             gql_manager=self.manager(schema=schema_branch),
         )
 
-        self.branch_details_by_hash[schema_hash] = branch_details
+        self._branch_details_by_hash[schema_hash] = branch_details
 
         return branch_details
 
@@ -82,8 +160,8 @@ class GraphQLSchemaRegistry:
         else:
             schema_hash = schema_branch.get_hash()
 
-        if schema_hash in self.branch_details_by_hash:
-            branch_details = self.branch_details_by_hash[schema_hash]
+        if schema_hash in self._branch_details_by_hash:
+            branch_details = self._branch_details_by_hash[schema_hash]
         else:
             branch_details = self.cache_branch(branch=branch, schema_branch=schema_branch, schema_hash=schema_hash)
 

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -1784,7 +1784,7 @@ async def all_attribute_default_types_schema(
 
 
 @pytest.fixture
-async def criticality_schema_root() -> SchemaRoot:
+async def criticality_schema_root(register_core_models_schema: None) -> SchemaRoot:
     generic_schema: dict[str, Any] = {
         "name": "GenericCriticality",
         "namespace": "Test",
@@ -1829,7 +1829,11 @@ async def criticality_schema_root() -> SchemaRoot:
 
 @pytest.fixture
 async def criticality_schema(
-    db: InfrahubDatabase, default_branch: Branch, group_schema, data_schema, criticality_schema_root: SchemaRoot
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    group_schema,
+    data_schema,
+    criticality_schema_root: SchemaRoot,
 ) -> NodeSchema:
     registry.schema.register_schema(schema=criticality_schema_root, branch=default_branch.name)
     registry.schema.process_schema_branch(name=default_branch.name)
@@ -1884,7 +1888,9 @@ async def criticality_high(db: InfrahubDatabase, default_branch: Branch, critica
 
 
 @pytest.fixture
-async def generic_vehicule_schema(db: InfrahubDatabase, default_branch: Branch) -> GenericSchema:
+async def generic_vehicule_schema(
+    db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None
+) -> GenericSchema:
     SCHEMA: dict[str, Any] = {
         "name": "Vehicule",
         "namespace": "Test",

--- a/backend/tests/unit/graphql/test_graphql_query.py
+++ b/backend/tests/unit/graphql/test_graphql_query.py
@@ -2630,9 +2630,8 @@ async def test_model_node_interface(db: InfrahubDatabase, default_branch: Branch
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -2642,6 +2641,7 @@ async def test_model_node_interface(db: InfrahubDatabase, default_branch: Branch
     )
 
     assert result.errors is None
+    assert result.data
     assert sorted([car["node"]["name"]["value"] for car in result.data["TestCar"]["edges"]]) == [
         "Porsche 911",
         "Renaud Clio",
@@ -2695,6 +2695,7 @@ async def test_model_rel_interface(db: InfrahubDatabase, default_branch: Branch,
         }
     }
     """
+    default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(
         db=db, include_mutation=False, include_subscription=False, branch=default_branch
     )
@@ -2707,6 +2708,7 @@ async def test_model_rel_interface(db: InfrahubDatabase, default_branch: Branch,
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data["TestPerson"]["edges"][0]["node"]["vehicules"]["edges"]) == 2
     expected_results = {
         "name": {"value": "John Doe"},
@@ -2756,6 +2758,7 @@ async def test_model_rel_interface_reverse(db: InfrahubDatabase, default_branch:
         }
     }
     """
+    default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(
         db=db, include_mutation=False, include_subscription=False, branch=default_branch
     )
@@ -2768,6 +2771,7 @@ async def test_model_rel_interface_reverse(db: InfrahubDatabase, default_branch:
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data["TestBoat"]["edges"][0]["node"]["owners"]["edges"]) == 1
 
 

--- a/backend/tests/unit/graphql/test_manager.py
+++ b/backend/tests/unit/graphql/test_manager.py
@@ -20,10 +20,10 @@ async def test_generate_interface_object(db: InfrahubDatabase, default_branch: B
     gqlm = GraphQLSchemaManager(schema=schema)
 
     result = gqlm.generate_interface_object(schema=generic_vehicule_schema)
-    assert inspect.isclass(result)
-    assert issubclass(result, graphene.Interface)
-    assert result._meta.name == "TestVehicule"
-    assert sorted(result._meta.fields.keys()) == ["description", "display_label", "hfid", "id", "name"]
+    assert inspect.isclass(result.reference)
+    assert issubclass(result.reference, graphene.Interface)
+    assert result.reference._meta.name == "TestVehicule"
+    assert sorted(result.reference._meta.fields.keys()) == ["description", "display_label", "hfid", "id", "name"]
 
 
 async def test_generate_graphql_object(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
@@ -33,10 +33,10 @@ async def test_generate_graphql_object(db: InfrahubDatabase, default_branch: Bra
     generic_schema = schema.get(name="TestGenericCriticality", duplicate=False)
     gqlm.generate_interface_object(schema=generic_schema, populate_cache=True)
     result = gqlm.generate_graphql_object(schema=criticality_schema)
-    assert inspect.isclass(result)
-    assert issubclass(result, InfrahubObject)
-    assert result._meta.name == "TestCriticality"
-    assert sorted(result._meta.fields.keys()) == [
+    assert inspect.isclass(result.reference)
+    assert issubclass(result.reference, InfrahubObject)
+    assert result.reference._meta.name == "TestCriticality"
+    assert sorted(result.reference._meta.fields.keys()) == [
         "_updated_at",
         "color",
         "description",
@@ -64,10 +64,10 @@ async def test_generate_graphql_object_with_interface(
     gqlm.generate_interface_object(schema=generic_vehicule_schema, populate_cache=True)
 
     result = gqlm.generate_graphql_object(schema=car_schema)
-    assert inspect.isclass(result)
-    assert issubclass(result, InfrahubObject)
-    assert result._meta.name == "TestCar"
-    assert sorted(result._meta.fields.keys()) == [
+    assert inspect.isclass(result.reference)
+    assert issubclass(result.reference, InfrahubObject)
+    assert result.reference._meta.name == "TestCar"
+    assert sorted(result.reference._meta.fields.keys()) == [
         "_updated_at",
         "description",
         "display_label",
@@ -325,13 +325,13 @@ async def test_branch_purge(
     graphql_registry._add_branch_hash(branch_name=active_branch, schema_hash=default_branch.active_schema_hash.main)
     graphql_registry._add_branch_hash(branch_name=purged_branch, schema_hash=default_branch.active_schema_hash.main)
 
-    assert default_branch.active_schema_hash.main in graphql_registry.branch_details_by_hash.keys()
-    assert default_branch.active_schema_hash.main in graphql_registry.branch_name_by_hash.keys()
+    assert default_branch.active_schema_hash.main in graphql_registry._branch_details_by_hash.keys()
+    assert default_branch.active_schema_hash.main in graphql_registry._branch_name_by_hash.keys()
 
-    assert active_branch in graphql_registry.branch_name_by_hash[default_branch.active_schema_hash.main]
-    assert purged_branch in graphql_registry.branch_name_by_hash[default_branch.active_schema_hash.main]
+    assert active_branch in graphql_registry._branch_name_by_hash[default_branch.active_schema_hash.main]
+    assert purged_branch in graphql_registry._branch_name_by_hash[default_branch.active_schema_hash.main]
     purged_branches = graphql_registry.purge_inactive(active_branches=[active_branch, default_branch.name])
-    assert active_branch in graphql_registry.branch_name_by_hash[default_branch.active_schema_hash.main]
-    assert purged_branch not in graphql_registry.branch_name_by_hash[default_branch.active_schema_hash.main]
+    assert active_branch in graphql_registry._branch_name_by_hash[default_branch.active_schema_hash.main]
+    assert purged_branch not in graphql_registry._branch_name_by_hash[default_branch.active_schema_hash.main]
 
     assert purged_branches == {purged_branch}


### PR DESCRIPTION
**Note**: I still have to properly convert the `generate_graphql_object()` method, but that one also forces me to change a number of the unittests and I will tackle that in an upcoming PR instead.

The goal of this PR is to store the hash of GraphQL schema objects within the GraphQL registry to prevent generating the same objects/class types over and over both within the generation of objects within the current schema but also as a way to share definitions across schemas. The work in this PR is not completed as only a few of the GraphQL manager methods have been updated to store a reference to the schema objects. It should be clean enough to highlight a difference between the current behaviour and the changes introduced within this branch, once everything is completed my expectation would be that we'd get down the memory consumption even more.

In order to test this I started with the `develop` branch and loaded the infrastructure base schema, then after that I loaded five additional schema files that followed this pattern:

```yaml
# yaml-language-server: $schema=https://schema.infrahub.app/infrahub/schema/latest.json
---
version: '1.0'

nodes:
  - name: Widget1
    namespace: Test
    label: "Widget1"
    default_filter: name__value
    display_labels:
      - name__value
    attributes:
      - name: name
        kind: Text
      - name: count
        kind: Number
      - name: description
        kind: Text
        optional: true
```

The other four schema files had Widget2->Widget5, by doing so we'd have 7 different schemas loaded (the default one, infrastructure base and 5 widget schemas). The goal of these widget schemas were to introduce a small change where the bulk of the schema would remain the same.

## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Optimized GraphQL type generation with centralized caching and deduplication, improving query performance and memory usage.
  - Ensured deterministic interface ordering for more consistent results.
- Tests
  - Updated tests to validate data presence, align with new schema hashing, and match updated access patterns.
- Chores
  - Privatized internal GraphQL registry structures for safer encapsulation.
  - Simplified GraphQL parameter preparation in helpers to reduce boilerplate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

The results displayed below comes from running `docker stats` and taking a snapshot throughout the process. In this test run after loading all of the schemas the API server container consumed `2.811GiB` memory on the `develop` branch compared to `2.38GiB` on `pog-graphql-types-hash-IFC-1800` and as mentioned before there are still a number of methods that need to be converted to this new approach.

## develop

### Prior to first schema load:

```
CONTAINER ID   NAME                         CPU %     MEM USAGE / LIMIT     MEM %     NET I/O           BLOCK I/O        PIDS
f5e7bf5686b0   infrahub-task-worker-1       0.20%     438.8MiB / 9.704GiB   4.42%     22MB / 321kB      0B / 53MB        26
83256da96987   infrahub-task-worker-2       0.56%     433.2MiB / 9.704GiB   4.36%     21.9MB / 294kB    0B / 53MB        26
f4b35abcc679   infrahub-server-1            6.22%     1.348GiB / 9.704GiB   13.89%    73.7MB / 11.2MB   0B / 68.2MB      28
4dc00a3c5cd4   infrahub-task-manager-1      1.73%     521.4MiB / 9.704GiB   5.25%     4.4MB / 5.95MB    0B / 71.6MB      19
bea15383ec26   infrahub-task-manager-db-1   0.45%     73.97MiB / 9.704GiB   0.74%     5.72MB / 4.07MB   0B / 129MB       12
5398a3d197fc   infrahub-message-queue-1     0.22%     145.4MiB / 9.704GiB   1.46%     38kB / 27.9kB     0B / 844kB       49
35af333c996f   infrahub-cache-1             0.20%     9.121MiB / 9.704GiB   0.09%     306kB / 96.9kB    0B / 0B          5
4165b5b11463   infrahub-git-server-1        0.00%     38.93MiB / 9.704GiB   0.39%     3.16kB / 126B     4.1kB / 57.3kB   20
af0a002b0326   infrahub-database-1          3.83%     1.166GiB / 9.704GiB   12.01%    11MB / 117MB      16.4kB / 398MB   109
```

### After loading Infrastructure base:

```
CONTAINER ID   NAME                         CPU %     MEM USAGE / LIMIT     MEM %     NET I/O           BLOCK I/O        PIDS
f5e7bf5686b0   infrahub-task-worker-1       0.53%     472.9MiB / 9.704GiB   4.76%     33.6MB / 689kB    0B / 53.4MB      29
83256da96987   infrahub-task-worker-2       5.15%     471.7MiB / 9.704GiB   4.75%     33.2MB / 476kB    0B / 53.1MB      26
f4b35abcc679   infrahub-server-1            1.94%     1.522GiB / 9.704GiB   15.68%    121MB / 17.9MB    0B / 69.9MB      30
4dc00a3c5cd4   infrahub-task-manager-1      2.46%     542MiB / 9.704GiB     5.45%     32MB / 12.1MB     0B / 71.6MB      19
bea15383ec26   infrahub-task-manager-db-1   1.36%     83.85MiB / 9.704GiB   0.84%     10.8MB / 29.1MB   0B / 150MB       12
5398a3d197fc   infrahub-message-queue-1     68.63%    155.2MiB / 9.704GiB   1.56%     40.5kB / 32.5kB   0B / 844kB       49
35af333c996f   infrahub-cache-1             0.21%     9.297MiB / 9.704GiB   0.09%     387kB / 161kB     0B / 4.1kB       5
4165b5b11463   infrahub-git-server-1        0.00%     39MiB / 9.704GiB      0.39%     3.21kB / 126B     4.1kB / 57.3kB   20
af0a002b0326   infrahub-database-1          3.13%     1.49GiB / 9.704GiB    15.35%    15.4MB / 186MB    16.4kB / 410MB   122
```

### After loading five additional schemas:

```
CONTAINER ID   NAME                         CPU %     MEM USAGE / LIMIT     MEM %     NET I/O           BLOCK I/O         PIDS
f5e7bf5686b0   infrahub-task-worker-1       1.05%     814.8MiB / 9.704GiB   8.20%     38.1MB / 1.33MB   0B / 53.5MB       29
83256da96987   infrahub-task-worker-2       2.71%     809MiB / 9.704GiB     8.14%     37MB / 1.28MB     0B / 53.4MB       29
f4b35abcc679   infrahub-server-1            1.34%     2.811GiB / 9.704GiB   28.97%    135MB / 34.4MB    459kB / 71.6MB    32
4dc00a3c5cd4   infrahub-task-manager-1      1.65%     554.4MiB / 9.704GiB   5.58%     192MB / 39.7MB    4.02MB / 71.6MB   20
bea15383ec26   infrahub-task-manager-db-1   0.58%     93.77MiB / 9.704GiB   0.94%     32.2MB / 174MB    0B / 211MB        12
5398a3d197fc   infrahub-message-queue-1     2.00%     153.7MiB / 9.704GiB   1.55%     47.4kB / 45.7kB   2.31MB / 844kB    49
35af333c996f   infrahub-cache-1             0.35%     9.586MiB / 9.704GiB   0.10%     653kB / 478kB     0B / 4.1kB        5
4165b5b11463   infrahub-git-server-1        0.00%     40.73MiB / 9.704GiB   0.41%     3.21kB / 126B     4.1kB / 57.3kB    20
af0a002b0326   infrahub-database-1          1.74%     1.476GiB / 9.704GiB   15.21%    17.8MB / 201MB    20.5kB / 426MB    119
```

## on pog-graphql-types-hash-IFC-1800

### Prior to first schema load:

```
CONTAINER ID   NAME                         CPU %     MEM USAGE / LIMIT     MEM %     NET I/O           BLOCK I/O         PIDS
3358b9f364c9   infrahub-task-worker-2       0.04%     340.6MiB / 9.704GiB   3.43%     4.94kB / 5.45kB   332kB / 9.17MB    16
ea1efd8ecd21   infrahub-task-worker-1       0.03%     341.1MiB / 9.704GiB   3.43%     4.9kB / 5.45kB    197kB / 7.7MB     16
a207965cc66e   infrahub-server-1            9.64%     1.34GiB / 9.704GiB    13.81%    74.1MB / 11MB     3.06MB / 67.7MB   28
4ae90f6ecae2   infrahub-task-manager-1      21.41%    519.5MiB / 9.704GiB   5.23%     1.91MB / 1.98MB   71MB / 71.6MB     20
b49c93edb9ba   infrahub-task-manager-db-1   9.49%     65.36MiB / 9.704GiB   0.66%     1.86MB / 1.75MB   4.1kB / 65.8MB    13
f2d33c5129c9   infrahub-message-queue-1     0.53%     143.2MiB / 9.704GiB   1.44%     27.3kB / 17.5kB   28.6MB / 766kB    49
5fe97fe82876   infrahub-cache-1             1.74%     9.359MiB / 9.704GiB   0.09%     273kB / 79.4kB    0B / 0B           5
ae07bdafbe87   infrahub-git-server-1        0.37%     40.51MiB / 9.704GiB   0.41%     3.22kB / 126B     221kB / 57.3kB    17
c112b6527c56   infrahub-database-1          274.02%   1.137GiB / 9.704GiB   11.72%    10.5MB / 73.9MB   69.6kB / 390MB    113
```

### After loading Infrastructure base:

```
CONTAINER ID   NAME                         CPU %     MEM USAGE / LIMIT     MEM %     NET I/O           BLOCK I/O         PIDS
3358b9f364c9   infrahub-task-worker-2       0.19%     464.7MiB / 9.704GiB   4.68%     33.5MB / 403kB    348kB / 53MB      26
ea1efd8ecd21   infrahub-task-worker-1       1.19%     456.1MiB / 9.704GiB   4.59%     33.2MB / 557kB    197kB / 53MB      30
a207965cc66e   infrahub-server-1            6.50%     1.476GiB / 9.704GiB   15.21%    121MB / 17.7MB    3.06MB / 69.3MB   30
4ae90f6ecae2   infrahub-task-manager-1      15.61%    543.1MiB / 9.704GiB   5.47%     32.7MB / 8.29MB   71MB / 71.6MB     21
b49c93edb9ba   infrahub-task-manager-db-1   2.96%     76.95MiB / 9.704GiB   0.77%     6.94MB / 30MB     4.1kB / 96.9MB    12
f2d33c5129c9   infrahub-message-queue-1     0.31%     143.9MiB / 9.704GiB   1.45%     35.1kB / 26.4kB   28.6MB / 840kB    49
5fe97fe82876   infrahub-cache-1             0.26%     9.223MiB / 9.704GiB   0.09%     365kB / 189kB     0B / 0B           5
ae07bdafbe87   infrahub-git-server-1        0.00%     40.52MiB / 9.704GiB   0.41%     3.47kB / 126B     221kB / 57.3kB    17
c112b6527c56   infrahub-database-1          1.01%     1.473GiB / 9.704GiB   15.17%    15.4MB / 186MB    69.6kB / 399MB    123
```


### After loading five additional schemas:

```
CONTAINER ID   NAME                         CPU %     MEM USAGE / LIMIT     MEM %     NET I/O           BLOCK I/O        PIDS
3358b9f364c9   infrahub-task-worker-2       0.22%     705.6MiB / 9.704GiB   7.10%     37.4MB / 1.12MB   348kB / 53.5MB   30
ea1efd8ecd21   infrahub-task-worker-1       1.66%     707MiB / 9.704GiB     7.11%     37.4MB / 1.18MB   197kB / 53.5MB   31
a207965cc66e   infrahub-server-1            1.06%     2.38GiB / 9.704GiB    24.53%    135MB / 34.1MB    3.06MB / 71MB    32
4ae90f6ecae2   infrahub-task-manager-1      20.89%    555.9MiB / 9.704GiB   5.59%     193MB / 35.5MB    71MB / 71.6MB    19
b49c93edb9ba   infrahub-task-manager-db-1   0.73%     83.86MiB / 9.704GiB   0.84%     28MB / 175MB      8.19kB / 148MB   12
f2d33c5129c9   infrahub-message-queue-1     0.23%     144.6MiB / 9.704GiB   1.46%     40.9kB / 38.5kB   28.6MB / 840kB   49
5fe97fe82876   infrahub-cache-1             0.20%     9.234MiB / 9.704GiB   0.09%     534kB / 356kB     0B / 0B          5
ae07bdafbe87   infrahub-git-server-1        0.00%     40.63MiB / 9.704GiB   0.41%     3.47kB / 126B     221kB / 57.3kB   17
c112b6527c56   infrahub-database-1          3.74%     1.453GiB / 9.704GiB   14.97%    17.6MB / 202MB    69.6kB / 418MB   118
```

