### PR TITLE
feat: allow group mapping for google sso

### DIFF
--- a/backend/infrahub/api/oauth2.py
+++ b/backend/infrahub/api/oauth2.py
@@ -11,8 +11,7 @@ from opentelemetry import trace
 
 from infrahub import config, models
 from infrahub.api.dependencies import get_db
-from infrahub.auth import signin_sso_account
-from infrahub.config import SecurityOAuth2Google
+from infrahub.auth import get_groups_from_provider, signin_sso_account
 from infrahub.exceptions import GatewayError, ProcessingError
 from infrahub.log import get_logger
 from infrahub.message_bus.types import KVTTL
@@ -110,17 +109,9 @@ async def token(
 
     _validate_response(response=userinfo_response)
     user_info = userinfo_response.json()
-    sso_groups = user_info.get("groups", [])
-    if not sso_groups and isinstance(provider, SecurityOAuth2Google):
-        # Poor man's workaround to fetch user groups from Google
-        if provider.fetch_groups:
-            groups_response = await service.http.get(
-                f"{provider.cloudidentity_url}?query=member_key_id == '{user_info['email']}'",
-                headers=headers,
-            )
-            group_memberships = groups_response.json()
-            if "memberships" in group_memberships:
-                sso_groups = [membership["groupKey"]["id"] for membership in group_memberships["memberships"]]
+    sso_groups = user_info.get("groups", []) or await get_groups_from_provider(
+        provider=provider, service=service, payload=payload, user_info=user_info
+    )
 
     if not sso_groups and config.SETTINGS.security.sso_user_default_group:
         sso_groups = [config.SETTINGS.security.sso_user_default_group]

--- a/backend/infrahub/api/oauth2.py
+++ b/backend/infrahub/api/oauth2.py
@@ -12,6 +12,7 @@ from opentelemetry import trace
 from infrahub import config, models
 from infrahub.api.dependencies import get_db
 from infrahub.auth import signin_sso_account
+from infrahub.config import SecurityOAuth2Google
 from infrahub.exceptions import GatewayError, ProcessingError
 from infrahub.log import get_logger
 from infrahub.message_bus.types import KVTTL
@@ -110,6 +111,17 @@ async def token(
     _validate_response(response=userinfo_response)
     user_info = userinfo_response.json()
     sso_groups = user_info.get("groups", [])
+    if not sso_groups and isinstance(provider, SecurityOAuth2Google):
+        # Poor man's workaround to fetch user groups from Google
+        if provider.fetch_groups:
+            groups_response = await service.http.get(
+                f"{provider.cloudidentity_url}?query=member_key_id == '{user_info['email']}'",
+                headers=headers,
+            )
+            group_memberships = groups_response.json()
+            if "memberships" in group_memberships:
+                sso_groups = [membership["groupKey"]["id"] for membership in group_memberships["memberships"]]
+
     if not sso_groups and config.SETTINGS.security.sso_user_default_group:
         sso_groups = [config.SETTINGS.security.sso_user_default_group]
 

--- a/backend/infrahub/api/oidc.py
+++ b/backend/infrahub/api/oidc.py
@@ -13,8 +13,7 @@ from pydantic import BaseModel, HttpUrl
 
 from infrahub import config, models
 from infrahub.api.dependencies import get_db
-from infrahub.auth import signin_sso_account
-from infrahub.config import SecurityOIDCGoogle
+from infrahub.auth import get_groups_from_provider, signin_sso_account
 from infrahub.exceptions import GatewayError, ProcessingError
 from infrahub.log import get_logger
 from infrahub.message_bus.types import KVTTL
@@ -150,19 +149,13 @@ async def token(
 
     _validate_response(response=userinfo_response)
     user_info: dict[str, Any] = userinfo_response.json()
-    sso_groups = user_info.get("groups") or await _get_id_token_groups(
-        oidc_config=oidc_config, service=service, payload=payload, client_id=provider.client_id
+    sso_groups = (
+        user_info.get("groups")
+        or await _get_id_token_groups(
+            oidc_config=oidc_config, service=service, payload=payload, client_id=provider.client_id
+        )
+        or await get_groups_from_provider(provider=provider, service=service, payload=payload, user_info=user_info)
     )
-    if not sso_groups and isinstance(provider, SecurityOIDCGoogle):
-        # Poor man's workaround to fetch user groups from Google
-        if provider.fetch_groups:
-            groups_response = await service.http.get(
-                f"{provider.cloudidentity_url}?query=member_key_id == '{user_info['email']}'",
-                headers=headers,
-            )
-            group_memberships = groups_response.json()
-            if "memberships" in group_memberships:
-                sso_groups = [membership["groupKey"]["id"] for membership in group_memberships["memberships"]]
 
     if not sso_groups and config.SETTINGS.security.sso_user_default_group:
         sso_groups = [config.SETTINGS.security.sso_user_default_group]

--- a/backend/infrahub/api/oidc.py
+++ b/backend/infrahub/api/oidc.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, HttpUrl
 from infrahub import config, models
 from infrahub.api.dependencies import get_db
 from infrahub.auth import signin_sso_account
+from infrahub.config import SecurityOIDCGoogle
 from infrahub.exceptions import GatewayError, ProcessingError
 from infrahub.log import get_logger
 from infrahub.message_bus.types import KVTTL
@@ -152,6 +153,16 @@ async def token(
     sso_groups = user_info.get("groups") or await _get_id_token_groups(
         oidc_config=oidc_config, service=service, payload=payload, client_id=provider.client_id
     )
+    if not sso_groups and isinstance(provider, SecurityOIDCGoogle):
+        # Poor man's workaround to fetch user groups from Google
+        if provider.fetch_groups:
+            groups_response = await service.http.get(
+                f"{provider.cloudidentity_url}?query=member_key_id == '{user_info['email']}'",
+                headers=headers,
+            )
+            group_memberships = groups_response.json()
+            if "memberships" in group_memberships:
+                sso_groups = [membership["groupKey"]["id"] for membership in group_memberships["memberships"]]
 
     if not sso_groups and config.SETTINGS.security.sso_user_default_group:
         sso_groups = [config.SETTINGS.security.sso_user_default_group]

--- a/backend/infrahub/auth.py
+++ b/backend/infrahub/auth.py
@@ -10,6 +10,7 @@ import jwt
 from pydantic import BaseModel
 
 from infrahub import config, models
+from infrahub.config import SecurityOAuth2Google, SecurityOAuth2Settings, SecurityOIDCGoogle, SecurityOIDCSettings
 from infrahub.core.account import validate_token
 from infrahub.core.constants import AccountStatus, InfrahubKind
 from infrahub.core.manager import NodeManager
@@ -21,6 +22,7 @@ from infrahub.exceptions import AuthorizationError, NodeNotFoundError
 if TYPE_CHECKING:
     from infrahub.core.protocols import CoreGenericAccount
     from infrahub.database import InfrahubDatabase
+    from infrahub.services import InfrahubServices
 
 
 class AuthType(str, Enum):
@@ -237,3 +239,20 @@ async def invalidate_refresh_token(db: InfrahubDatabase, token_id: str) -> None:
     refresh_token = await NodeManager.get_one(id=token_id, db=db)
     if refresh_token:
         await refresh_token.delete(db=db)
+
+
+async def get_groups_from_provider(
+    provider: SecurityOAuth2Settings | SecurityOIDCSettings, service: InfrahubServices, payload: dict, user_info: dict
+) -> list[str]:
+    if isinstance(provider, (SecurityOAuth2Google, SecurityOIDCGoogle)):
+        # Poor man's workaround to fetch user groups from Google
+        if provider.fetch_groups:
+            groups_response = await service.http.get(
+                f"{provider.cloudidentity_url}?query=member_key_id == '{user_info['email']}'",
+                headers={"Authorization": f"{payload.get('token_type')} {payload.get('access_token')}"},
+            )
+            group_memberships = groups_response.json()
+            if "memberships" in group_memberships:
+                return [membership["groupKey"]["id"] for membership in group_memberships["memberships"]]
+
+    return []

--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -545,6 +545,14 @@ class SecurityOIDCGoogle(SecurityOIDCSettings):
     discovery_url: str = Field(default="https://accounts.google.com/.well-known/openid-configuration")
     icon: str = Field(default="mdi:google")
     display_label: str = Field(default="Google")
+    fetch_groups: bool = Field(
+        default=False,
+        description="Whether to use Cloud Identity API to fetch user groups. Note: requires additional scope: https://www.googleapis.com/auth/cloud-identity.groups.readonly",
+    )
+    cloudidentity_url: str = Field(
+        default="https://cloudidentity.googleapis.com/v1/groups/-/memberships:searchDirectGroups",
+        description="Google Cloud endpoint for Cloud Identity. Using searchDirectGroups by default because it is available for the Free plan",
+    )
 
 
 class SecurityOIDCProvider1(SecurityOIDCSettings):
@@ -605,6 +613,14 @@ class SecurityOAuth2Google(SecurityOAuth2Settings):
     userinfo_url: str = Field(default="https://www.googleapis.com/oauth2/v3/userinfo")
     icon: str = Field(default="mdi:google")
     display_label: str = Field(default="Google")
+    fetch_groups: bool = Field(
+        default=False,
+        description="Whether to use Cloud Identity API to fetch user groups. Note: requires additional scopes: https://www.googleapis.com/auth/cloud-identity.groups.readonly",
+    )
+    cloudidentity_url: str = Field(
+        default="https://cloudidentity.googleapis.com/v1/groups/-/memberships:searchDirectGroups",
+        description="Google Cloud endpoint for Cloud Identity. Using searchDirectGroups by default because it is available for the Free plan",
+    )
 
 
 class SecurityOAuth2ProviderSettings(BaseModel):

--- a/changelog/+a2ec144f.added.md
+++ b/changelog/+a2ec144f.added.md
@@ -1,0 +1,1 @@
+Added optional configuration to fetch and map groups when using Google as an identity provider for OAuth/OIDC.


### PR DESCRIPTION
Google does not include groups within the tokens.
We can only fetch groups through their APIs.
One available API is the Admin SDK/Directory API which requires admin permissions, which would in turn require extra configuration for Infrahub.
Another API is the Cloud Identity API which provides endpoints to fetch group memberships using the user token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved SSO group resolution: when an identity provider omits groups, the system can fetch Google group memberships to better map user groups at login.
  * Falls back to configured group defaults if no groups are found.

* **Configuration**
  * New per-provider settings to enable Cloud Identity group fetching and to customize the Cloud Identity endpoint.
  * Disabled by default; requires appropriate Cloud Identity scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->