### PR TITLE
fix(docs): add missing permission to approval guide

### DIFF
--- a/docs/docs/guides/change-approval-workflow.mdx
+++ b/docs/docs/guides/change-approval-workflow.mdx
@@ -77,6 +77,11 @@ For a complete list of available global and object permissions, see the [Permiss
       - Decision `Allow in all branches`
    - Create the following permission
       - Namespace `Core`
+      - Name `Proposed Change`
+      - Action `Create`
+      - Decision `Allow in all branches`
+   - Create the following permission
+      - Namespace `Core`
       - Name `Change Comment`
       - Action `*`
       - Decision `Allow in all branches`
@@ -99,6 +104,7 @@ For a complete list of available global and object permissions, see the [Permiss
       - Add permission: `object:Core:ChangeComment:any:allow_all`
       - Add permission: `object:Core:ChangeThread:any:allow_all`
       - Add permission: `object:Core:ThreadComment:any:allow_all`
+      - Add permission: `object:Core:ProposedChange:create:allow_all`
    - Role name: `Network Change Reviewer` (this role allows full review, approve and merge changes)
       - Add group `Network team`
       - Add permission: `global:review_proposed_change:allow_all`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a separate “Proposed Change: Create” permission available across all branches.
  - Granted create permission to users with the Restricted Access role.
  - Retained the existing “Proposed Change: Update” permission; both Create and Update are now listed separately.
  - No changes to Change Comment, Change Thread, or Thread Comment permissions.

- Documentation
  - Updated the Change Approval Workflow guide to document the new create permission and role access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->