### PR TITLE
fix: update params type in RequestGraphQLQueryGroupUpdate

### DIFF
--- a/backend/infrahub/groups/models.py
+++ b/backend/infrahub/groups/models.py
@@ -9,4 +9,4 @@ class RequestGraphQLQueryGroupUpdate(BaseModel):
     query_id: str = Field(..., description="The ID of the GraphQLQuery that should be associated with the group")
     related_node_ids: list[str] = Field(..., description="List of nodes related to the GraphQLQuery")
     subscribers: list[str] = Field(..., description="List of subscribers to add to the group")
-    params: dict[str, str] = Field(..., description="Params sent with the query")
+    params: dict[str, any] = Field(..., description="Params sent with the query")

--- a/backend/infrahub/groups/models.py
+++ b/backend/infrahub/groups/models.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field
+from pydantic import Any, BaseModel, Field
 
 
 class RequestGraphQLQueryGroupUpdate(BaseModel):
@@ -9,4 +9,4 @@ class RequestGraphQLQueryGroupUpdate(BaseModel):
     query_id: str = Field(..., description="The ID of the GraphQLQuery that should be associated with the group")
     related_node_ids: list[str] = Field(..., description="List of nodes related to the GraphQLQuery")
     subscribers: list[str] = Field(..., description="List of subscribers to add to the group")
-    params: dict[str, any] = Field(..., description="Params sent with the query")
+    params: dict[str, Any] = Field(..., description="Params sent with the query")

--- a/backend/infrahub/groups/models.py
+++ b/backend/infrahub/groups/models.py
@@ -1,4 +1,6 @@
-from pydantic import Any, BaseModel, Field
+from typing import Any
+
+from pydantic import BaseModel, Field
 
 
 class RequestGraphQLQueryGroupUpdate(BaseModel):

--- a/changelog/7208.fixed.md
+++ b/changelog/7208.fixed.md
@@ -1,0 +1,1 @@
+Allow RequestGraphQLQueryGroupUpdate params to accept any type of value, not just strings.


### PR DESCRIPTION
Fixes #7208 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GraphQL query group updates now accept parameter values of any type (e.g., numbers, booleans, objects) instead of only strings, reducing type-related errors and improving flexibility. No client-side changes required.

* **Documentation**
  * Changelog updated to note the expanded parameter value support for GraphQL query group updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->