### PR TITLE
Refactor GraphQLSchemaManager and add graphql registry

### DIFF
--- a/backend/infrahub/core/initialization.py
+++ b/backend/infrahub/core/initialization.py
@@ -34,7 +34,7 @@ from infrahub.database import InfrahubDatabase
 from infrahub.database.memgraph import IndexManagerMemgraph
 from infrahub.database.neo4j import IndexManagerNeo4j
 from infrahub.exceptions import DatabaseError
-from infrahub.graphql.manager import GraphQLSchemaManager
+from infrahub.graphql.manager import registry as graphql_registry
 from infrahub.log import get_logger
 from infrahub.menu.utils import create_default_menu
 from infrahub.permissions import PermissionBackend, get_or_create_global_permission
@@ -196,7 +196,7 @@ async def initialization(db: InfrahubDatabase, add_database_indexes: bool = Fals
 
     default_branch = registry.get_branch_from_registry(branch=registry.default_branch)
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
-    gqlm = GraphQLSchemaManager.get_manager_for_branch(branch=default_branch, schema_branch=schema_branch)
+    gqlm = graphql_registry.get_manager_for_branch(branch=default_branch, schema_branch=schema_branch)
     gqlm.get_graphql_schema(
         include_query=True,
         include_mutation=True,

--- a/backend/infrahub/graphql/api/endpoints.py
+++ b/backend/infrahub/graphql/api/endpoints.py
@@ -9,7 +9,7 @@ from starlette.routing import Route, WebSocketRoute
 
 from infrahub.api.dependencies import get_branch_dep, get_current_user
 from infrahub.core import registry
-from infrahub.graphql.manager import GraphQLSchemaManager
+from infrahub.graphql.registry import registry as graphql_registry
 
 from .dependencies import build_graphql_app
 
@@ -32,6 +32,6 @@ async def get_graphql_schema(
     branch: Branch = Depends(get_branch_dep), _: AccountSession = Depends(get_current_user)
 ) -> PlainTextResponse:
     schema_branch = registry.schema.get_schema_branch(name=branch.name)
-    gqlm = GraphQLSchemaManager.get_manager_for_branch(branch=branch, schema_branch=schema_branch)
+    gqlm = graphql_registry.get_manager_for_branch(branch=branch, schema_branch=schema_branch)
     graphql_schema = gqlm.get_graphql_schema()
     return PlainTextResponse(content=print_schema(graphql_schema))

--- a/backend/infrahub/graphql/initialization.py
+++ b/backend/infrahub/graphql/initialization.py
@@ -9,11 +9,10 @@ from infrahub.context import InfrahubContext
 from infrahub.core import registry
 from infrahub.core.timestamp import Timestamp
 from infrahub.exceptions import InitializationError
+from infrahub.graphql.registry import registry as graphql_registry
 from infrahub.graphql.resolvers.many_relationship import ManyRelationshipResolver
 from infrahub.graphql.resolvers.single_relationship import SingleRelationshipResolver
 from infrahub.permissions import PermissionManager
-
-from .manager import GraphQLSchemaManager
 
 if TYPE_CHECKING:
     from graphql import GraphQLSchema
@@ -91,7 +90,7 @@ async def prepare_graphql_params(
 ) -> GraphqlParams:
     branch = registry.get_branch_from_registry(branch=branch)
     schema_branch = registry.schema.get_schema_branch(name=branch.name)
-    gqlm = GraphQLSchemaManager.get_manager_for_branch(branch=branch, schema_branch=schema_branch)
+    gqlm = graphql_registry.get_manager_for_branch(branch=branch, schema_branch=schema_branch)
     gql_schema = gqlm.get_graphql_schema(
         include_query=include_query,
         include_mutation=include_mutation,

--- a/backend/infrahub/graphql/manager.py
+++ b/backend/infrahub/graphql/manager.py
@@ -17,7 +17,6 @@ from infrahub.core.schema import (
     RelationshipSchema,
     TemplateSchema,
 )
-from infrahub.core.timestamp import Timestamp
 from infrahub.graphql.mutations.attribute import BaseAttributeCreate, BaseAttributeUpdate
 from infrahub.graphql.mutations.graphql_query import InfrahubGraphQLQueryMutation
 from infrahub.types import ATTRIBUTE_TYPES, InfrahubDataType, get_attribute_type
@@ -40,6 +39,7 @@ from .mutations.resource_manager import (
     InfrahubNumberPoolMutation,
 )
 from .mutations.webhook import InfrahubWebhookMutation
+from .registry import registry
 from .resolvers.ipam import ipam_paginated_list_resolver
 from .resolvers.resolver import (
     account_resolver,
@@ -69,7 +69,6 @@ from .types.event import EVENT_TYPES
 if TYPE_CHECKING:
     from graphql import GraphQLSchema
 
-    from infrahub.core.branch import Branch
     from infrahub.core.schema.schema_branch import SchemaBranch
 
 
@@ -99,79 +98,7 @@ def get_attr_kind(node_schema: MainSchemaTypes, attr_schema: AttributeSchema) ->
     return get_enum_attribute_type_name(node_schema=node_schema, attr_schema=attr_schema)
 
 
-@dataclass
-class BranchDetails:
-    schema_changed_at: Timestamp
-    schema_hash: str
-    gql_manager: GraphQLSchemaManager
-
-
 class GraphQLSchemaManager:
-    _extra_types: dict[str, GraphQLTypes] = {}
-    _branch_details_by_hash: dict[str, BranchDetails] = {}
-    _branch_name_by_hash: dict[str, set[str]] = {}
-    _branch_hash_activation_by_branch_name: dict[str, dict[str, str]] = {}
-
-    @classmethod
-    def clear_cache(cls) -> None:
-        cls._branch_details_by_hash = {}
-        cls._branch_name_by_hash = {}
-        cls._branch_hash_activation_by_branch_name = {}
-
-    @classmethod
-    def purge_inactive(cls, active_branches: list[str]) -> set[str]:
-        """Return inactive branches that were purged"""
-        inactive_branches: set[str] = set()
-        for schema_hash in list(cls._branch_name_by_hash.keys()):
-            branches = list(cls._branch_name_by_hash[schema_hash])
-            for branch in branches:
-                if branch not in active_branches and branch in cls._branch_name_by_hash[schema_hash]:
-                    inactive_branches.add(branch)
-                    cls._branch_name_by_hash[schema_hash].discard(branch)
-
-        for schema_hash in list(cls._branch_name_by_hash.keys()):
-            if not cls._branch_name_by_hash[schema_hash]:
-                # If no remaining branch is using the schema remove it completely
-                del cls._branch_name_by_hash[schema_hash]
-                del cls._branch_details_by_hash[schema_hash]
-
-        return inactive_branches
-
-    @classmethod
-    def _cache_branch(cls, branch: Branch, schema_branch: SchemaBranch, schema_hash: str) -> BranchDetails:
-        branch_details = BranchDetails(
-            schema_changed_at=Timestamp(branch.schema_changed_at) if branch.schema_changed_at else Timestamp(),
-            schema_hash=schema_hash,
-            gql_manager=cls(schema=schema_branch),
-        )
-
-        cls._branch_details_by_hash[schema_hash] = branch_details
-
-        return branch_details
-
-    @classmethod
-    def get_manager_for_branch(cls, branch: Branch, schema_branch: SchemaBranch) -> GraphQLSchemaManager:
-        if branch.schema_hash:
-            schema_hash = branch.schema_hash.main
-        else:
-            schema_hash = schema_branch.get_hash()
-
-        if schema_hash in cls._branch_details_by_hash:
-            branch_details = cls._branch_details_by_hash[schema_hash]
-        else:
-            branch_details = cls._cache_branch(branch=branch, schema_branch=schema_branch, schema_hash=schema_hash)
-
-        cls._add_branch_hash(branch_name=branch.name, schema_hash=schema_hash)
-
-        return branch_details.gql_manager
-
-    @classmethod
-    def _add_branch_hash(cls, branch_name: str, schema_hash: str) -> None:
-        if schema_hash not in cls._branch_name_by_hash:
-            cls._branch_name_by_hash[schema_hash] = set()
-
-        cls._branch_name_by_hash[schema_hash].add(branch_name)
-
     def __init__(self, schema: SchemaBranch) -> None:
         self.schema = schema
 
@@ -281,9 +208,7 @@ class GraphQLSchemaManager:
         raise ValueError(f"Unable to find {name!r}")
 
     def get_all(self) -> dict[str, GraphQLTypes]:
-        infrahub_types = self._graphql_types
-        infrahub_types.update(self._extra_types)
-        return infrahub_types
+        return self._graphql_types
 
     def set_type(self, name: str, graphql_type: GraphQLTypes) -> None:
         self._graphql_types[name] = graphql_type
@@ -740,7 +665,7 @@ class GraphQLSchemaManager:
                 slug = InputField(StringAttributeUpdate, required=False)
                 description = InputField(StringAttributeUpdate, required=False)
         """
-        attrs: dict[str, graphene.String | graphene.InputField] = {
+        attrs: dict[str, graphene.String | graphene.InputField | graphene.List] = {
             "id": graphene.String(required=False),
             "hfid": graphene.List(of_type=graphene.String, required=False),
         }
@@ -781,7 +706,7 @@ class GraphQLSchemaManager:
                 slug = InputField(StringAttributeUpdate, required=True)
                 description = InputField(StringAttributeUpdate, required=False)
         """
-        attrs: dict[str, graphene.String | graphene.InputField] = {
+        attrs: dict[str, graphene.String | graphene.InputField | graphene.List] = {
             "id": graphene.String(required=False),
             "hfid": graphene.List(of_type=graphene.String, required=False),
         }
@@ -1058,3 +983,6 @@ class GraphQLSchemaManager:
         }
 
         return type(f"NestedPaginated{schema.kind}", (InfrahubObject,), main_attrs)
+
+
+registry._register_manager(manager=GraphQLSchemaManager)

--- a/backend/infrahub/graphql/registry.py
+++ b/backend/infrahub/graphql/registry.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from infrahub.core.timestamp import Timestamp
+from infrahub.exceptions import InitializationError
+
+if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
+    from infrahub.core.schema.schema_branch import SchemaBranch
+    from infrahub.graphql.manager import GraphQLSchemaManager
+
+
+@dataclass
+class BranchDetails:
+    schema_changed_at: Timestamp
+    schema_hash: str
+    gql_manager: GraphQLSchemaManager
+
+
+@dataclass
+class GraphQLSchemaRegistry:
+    branch_details_by_hash: dict[str, BranchDetails] = field(default_factory=dict)
+    branch_name_by_hash: dict[str, set[str]] = field(default_factory=dict)
+    branch_hash_activation_by_branch_name: dict[str, dict[str, str]] = field(default_factory=dict)
+    _manager_class: type[GraphQLSchemaManager] | None = None
+
+    def _add_branch_hash(self, branch_name: str, schema_hash: str) -> None:
+        if schema_hash not in self.branch_name_by_hash:
+            self.branch_name_by_hash[schema_hash] = set()
+
+        self.branch_name_by_hash[schema_hash].add(branch_name)
+
+    def _register_manager(self, manager: type[GraphQLSchemaManager]) -> None:
+        self._manager_class = manager
+
+    @property
+    def manager(self) -> type[GraphQLSchemaManager]:
+        if self._manager_class:
+            return self._manager_class
+        raise InitializationError
+
+    def clear_cache(self) -> None:
+        """Clear internal cache stored within this registry."""
+        self.branch_details_by_hash = {}
+        self.branch_name_by_hash = {}
+        self.branch_hash_activation_by_branch_name = {}
+
+    def purge_inactive(self, active_branches: list[str]) -> set[str]:
+        """Return inactive branches that were purged"""
+        inactive_branches: set[str] = set()
+        for schema_hash in list(self.branch_name_by_hash.keys()):
+            branches = list(self.branch_name_by_hash[schema_hash])
+            for branch in branches:
+                if branch not in active_branches and branch in self.branch_name_by_hash[schema_hash]:
+                    inactive_branches.add(branch)
+                    self.branch_name_by_hash[schema_hash].discard(branch)
+
+        for schema_hash in list(self.branch_name_by_hash.keys()):
+            if not self.branch_name_by_hash[schema_hash]:
+                # If no remaining branch is using the schema remove it completely
+                del self.branch_name_by_hash[schema_hash]
+                del self.branch_details_by_hash[schema_hash]
+
+        return inactive_branches
+
+    def cache_branch(self, branch: Branch, schema_branch: SchemaBranch, schema_hash: str) -> BranchDetails:
+        branch_details = BranchDetails(
+            schema_changed_at=Timestamp(branch.schema_changed_at) if branch.schema_changed_at else Timestamp(),
+            schema_hash=schema_hash,
+            gql_manager=self.manager(schema=schema_branch),
+        )
+
+        self.branch_details_by_hash[schema_hash] = branch_details
+
+        return branch_details
+
+    def get_manager_for_branch(self, branch: Branch, schema_branch: SchemaBranch) -> GraphQLSchemaManager:
+        if branch.schema_hash:
+            schema_hash = branch.schema_hash.main
+        else:
+            schema_hash = schema_branch.get_hash()
+
+        if schema_hash in self.branch_details_by_hash:
+            branch_details = self.branch_details_by_hash[schema_hash]
+        else:
+            branch_details = self.cache_branch(branch=branch, schema_branch=schema_branch, schema_hash=schema_hash)
+
+        self._add_branch_hash(branch_name=branch.name, schema_hash=schema_hash)
+
+        return branch_details.gql_manager
+
+
+registry = GraphQLSchemaRegistry()

--- a/backend/infrahub/tasks/registry.py
+++ b/backend/infrahub/tasks/registry.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from infrahub import lock
 from infrahub.core import registry
 from infrahub.core.constants import GLOBAL_BRANCH_NAME
+from infrahub.graphql.registry import registry as graphql_registry
 from infrahub.log import get_logger
 from infrahub.worker import WORKER_IDENTITY
 
@@ -20,9 +21,8 @@ def update_graphql_schema(branch: Branch, schema_branch: SchemaBranch) -> None:
     """
     Update the GraphQL schema for the given branch.
     """
-    from infrahub.graphql.manager import GraphQLSchemaManager
 
-    gqlm = GraphQLSchemaManager.get_manager_for_branch(branch=branch, schema_branch=schema_branch)
+    gqlm = graphql_registry.get_manager_for_branch(branch=branch, schema_branch=schema_branch)
     gqlm.get_graphql_schema(
         include_query=True,
         include_mutation=True,
@@ -89,7 +89,6 @@ async def refresh_branches(db: InfrahubDatabase) -> None:
     If a branch is already present with a different value for the hash
     We pull the new schema from the database and we update the registry.
     """
-    from infrahub.graphql.manager import GraphQLSchemaManager
 
     async with lock.registry.local_schema_lock():
         active_branches = await registry.branch_object.get_list(db=db)
@@ -106,7 +105,7 @@ async def refresh_branches(db: InfrahubDatabase) -> None:
 
         purged_branches = await registry.purge_inactive_branches(db=db, active_branches=active_branches)
         purged_branches.update(
-            GraphQLSchemaManager.purge_inactive(active_branches=[branch.name for branch in active_branches])
+            graphql_registry.purge_inactive(active_branches=[branch.name for branch in active_branches])
         )
         for branch_name in sorted(purged_branches):
             log.info(f"Removed branch {branch_name!r} from the registry", branch=branch_name, worker=WORKER_IDENTITY)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -43,6 +43,7 @@ from infrahub.core.schema.relationship_schema import RelationshipSchema
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.utils import delete_all_nodes
 from infrahub.database import InfrahubDatabase, get_db
+from infrahub.graphql.manager import registry as graphql_registry
 from infrahub.lock import initialize_lock
 from infrahub.message_bus import InfrahubMessage, InfrahubResponse
 from infrahub.message_bus.types import MessageTTL
@@ -69,6 +70,8 @@ ResponseClass = TypeVar("ResponseClass")
 DEFAULT_TESTING_LOG_LEVEL = "WARNING"
 
 pytest.register_assert_rewrite("tests.db_snapshot")
+
+graphql_registry.clear_cache()
 
 
 def pytest_addoption(parser):

--- a/backend/tests/helpers/schema/__init__.py
+++ b/backend/tests/helpers/schema/__init__.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from infrahub.core import registry
 from infrahub.core.schema import SchemaRoot
-from infrahub.graphql.manager import GraphQLSchemaManager
+from infrahub.graphql.registry import registry as graphql_registry
 
 from .car import CAR
 from .child import CHILD
@@ -43,7 +43,7 @@ async def load_schema(
     branch = registry.get_branch_from_registry(branch_name)
     branch.update_schema_hash()
     await branch.save(db=db)
-    GraphQLSchemaManager.clear_cache()
+    graphql_registry.clear_cache()
 
 
 __all__ = [

--- a/backend/tests/integration/user_workflows/test_user_worflow.py
+++ b/backend/tests/integration/user_workflows/test_user_worflow.py
@@ -3,7 +3,7 @@ from deepdiff import DeepDiff
 from whenever import Instant
 
 from infrahub.database import InfrahubDatabase
-from infrahub.graphql.manager import GraphQLSchemaManager
+from infrahub.graphql.registry import registry as graphql_registry
 from tests.helpers.test_app import TestInfrahubApp
 from tests.integration.conftest import load_infrastructure_schema
 from tests.test_data import dataset01 as ds01
@@ -222,7 +222,7 @@ class TestUserWorkflow01(TestInfrahubApp):
     async def dataset01(self, db: InfrahubDatabase, client):
         await load_infrastructure_schema(db=db)
         await ds01.load_data(db=db, nbr_devices=2)
-        GraphQLSchemaManager.clear_cache()
+        graphql_registry.clear_cache()
 
     async def test_initialize_state(self):
         state.data["spine1_id"] = None

--- a/backend/tests/unit/graphql/test_graphql_query.py
+++ b/backend/tests/unit/graphql/test_graphql_query.py
@@ -14,7 +14,7 @@ from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
-from infrahub.graphql.manager import GraphQLSchemaManager
+from infrahub.graphql.registry import registry as graphql_registry
 from tests.helpers.graphql import graphql
 
 
@@ -1028,7 +1028,7 @@ async def test_query_filter_on_enum(
         }
     }
     """ % (enum_value)
-    GraphQLSchemaManager.clear_cache()
+    graphql_registry.clear_cache()
     gql_params = await prepare_graphql_params(
         db=db, include_mutation=False, include_subscription=False, branch=default_branch
     )
@@ -1977,7 +1977,7 @@ async def test_query_attribute_node_property_source(
         }
     }
     """
-    GraphQLSchemaManager.clear_cache()
+    graphql_registry.clear_cache()
     gql_params = await prepare_graphql_params(
         db=db, include_mutation=False, include_subscription=False, branch=default_branch
     )
@@ -2036,7 +2036,7 @@ async def test_query_attribute_node_property_owner(
         }
     }
     """
-    GraphQLSchemaManager.clear_cache()
+    graphql_registry.clear_cache()
     gql_params = await prepare_graphql_params(
         db=db, include_mutation=False, include_subscription=False, branch=default_branch
     )
@@ -2472,7 +2472,7 @@ async def test_query_attribute_flag_property(
         }
     }
     """
-    GraphQLSchemaManager.clear_cache()
+    graphql_registry.clear_cache()
     gql_params = await prepare_graphql_params(
         db=db, include_mutation=False, include_subscription=False, branch=default_branch
     )
@@ -2789,7 +2789,7 @@ async def test_generic_root_with_pagination(
         }
     }
     """
-    GraphQLSchemaManager.clear_cache()
+    graphql_registry.clear_cache()
     gql_params = await prepare_graphql_params(
         db=db, include_mutation=False, include_subscription=False, branch=default_branch
     )
@@ -2831,7 +2831,7 @@ async def test_generic_root_with_filters(
         }
     }
     """
-    GraphQLSchemaManager.clear_cache()
+    graphql_registry.clear_cache()
     gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
@@ -2891,7 +2891,7 @@ async def test_member_of_groups(
         }
     }
     """
-    GraphQLSchemaManager.clear_cache()
+    graphql_registry.clear_cache()
     gql_params = await prepare_graphql_params(
         db=db, include_mutation=False, include_subscription=False, branch=default_branch
     )

--- a/backend/tests/unit/graphql/test_manager.py
+++ b/backend/tests/unit/graphql/test_manager.py
@@ -7,6 +7,7 @@ from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.manager import GraphQLSchemaManager
+from infrahub.graphql.registry import registry as graphql_registry
 from infrahub.graphql.types import InfrahubObject
 
 
@@ -283,8 +284,8 @@ async def test_branch_caching_hit(
         same_branch.schema_hash = None
     schema_branch = registry.schema.get_schema_branch(default_branch.name)
 
-    manager1 = GraphQLSchemaManager.get_manager_for_branch(branch=default_branch, schema_branch=schema_branch)
-    manager2 = GraphQLSchemaManager.get_manager_for_branch(branch=same_branch, schema_branch=schema_branch)
+    manager1 = graphql_registry.get_manager_for_branch(branch=default_branch, schema_branch=schema_branch)
+    manager2 = graphql_registry.get_manager_for_branch(branch=same_branch, schema_branch=schema_branch)
 
     assert manager1 is manager2
 
@@ -302,8 +303,8 @@ async def test_branch_caching_miss(
     default_branch.active_schema_hash.main = "abc"
     same_branch.update_schema_hash()
 
-    manager1 = GraphQLSchemaManager.get_manager_for_branch(branch=default_branch, schema_branch=schema_branch)
-    manager2 = GraphQLSchemaManager.get_manager_for_branch(branch=same_branch, schema_branch=schema_branch)
+    manager1 = graphql_registry.get_manager_for_branch(branch=default_branch, schema_branch=schema_branch)
+    manager2 = graphql_registry.get_manager_for_branch(branch=same_branch, schema_branch=schema_branch)
 
     assert manager1 is not manager2
 
@@ -319,18 +320,18 @@ async def test_branch_purge(
     active_branch = "i-will-not-be-purged"
     schema_branch = registry.schema.get_schema_branch(default_branch.name)
 
-    GraphQLSchemaManager.get_manager_for_branch(branch=default_branch, schema_branch=schema_branch)
-    GraphQLSchemaManager.purge_inactive(active_branches=[default_branch.name])
-    GraphQLSchemaManager._add_branch_hash(branch_name=active_branch, schema_hash=default_branch.active_schema_hash.main)
-    GraphQLSchemaManager._add_branch_hash(branch_name=purged_branch, schema_hash=default_branch.active_schema_hash.main)
+    graphql_registry.get_manager_for_branch(branch=default_branch, schema_branch=schema_branch)
+    graphql_registry.purge_inactive(active_branches=[default_branch.name])
+    graphql_registry._add_branch_hash(branch_name=active_branch, schema_hash=default_branch.active_schema_hash.main)
+    graphql_registry._add_branch_hash(branch_name=purged_branch, schema_hash=default_branch.active_schema_hash.main)
 
-    assert default_branch.active_schema_hash.main in GraphQLSchemaManager._branch_details_by_hash.keys()
-    assert default_branch.active_schema_hash.main in GraphQLSchemaManager._branch_name_by_hash.keys()
+    assert default_branch.active_schema_hash.main in graphql_registry.branch_details_by_hash.keys()
+    assert default_branch.active_schema_hash.main in graphql_registry.branch_name_by_hash.keys()
 
-    assert active_branch in GraphQLSchemaManager._branch_name_by_hash[default_branch.active_schema_hash.main]
-    assert purged_branch in GraphQLSchemaManager._branch_name_by_hash[default_branch.active_schema_hash.main]
-    purged_branches = GraphQLSchemaManager.purge_inactive(active_branches=[active_branch, default_branch.name])
-    assert active_branch in GraphQLSchemaManager._branch_name_by_hash[default_branch.active_schema_hash.main]
-    assert purged_branch not in GraphQLSchemaManager._branch_name_by_hash[default_branch.active_schema_hash.main]
+    assert active_branch in graphql_registry.branch_name_by_hash[default_branch.active_schema_hash.main]
+    assert purged_branch in graphql_registry.branch_name_by_hash[default_branch.active_schema_hash.main]
+    purged_branches = graphql_registry.purge_inactive(active_branches=[active_branch, default_branch.name])
+    assert active_branch in graphql_registry.branch_name_by_hash[default_branch.active_schema_hash.main]
+    assert purged_branch not in graphql_registry.branch_name_by_hash[default_branch.active_schema_hash.main]
 
     assert purged_branches == {purged_branch}

--- a/backend/tests/unit/graphql/test_mutation_create.py
+++ b/backend/tests/unit/graphql/test_mutation_create.py
@@ -15,7 +15,7 @@ from infrahub.core.schema.node_schema import NodeSchema
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
-from infrahub.graphql.manager import GraphQLSchemaManager
+from infrahub.graphql.registry import registry as graphql_registry
 from tests.constants import TestKind
 from tests.helpers.graphql import graphql
 from tests.helpers.schema import DEVICE_SCHEMA
@@ -1555,7 +1555,7 @@ async def test_create_simple_object_with_enum(
         }
     }
     """ % (enum_value)
-    GraphQLSchemaManager.clear_cache()
+    graphql_registry.clear_cache()
     gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
@@ -1640,7 +1640,7 @@ async def test_create_string_when_enums_on_fails(
         }
     }
     """
-    GraphQLSchemaManager.clear_cache()
+    graphql_registry.clear_cache()
     gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,

--- a/backend/tests/unit/graphql/test_mutation_update.py
+++ b/backend/tests/unit/graphql/test_mutation_update.py
@@ -16,7 +16,7 @@ from infrahub.core.schema.definitions.core.group import core_group, core_standar
 from infrahub.database import InfrahubDatabase
 from infrahub.events.node_action import NodeMutatedEvent
 from infrahub.graphql.initialization import prepare_graphql_params
-from infrahub.graphql.manager import GraphQLSchemaManager
+from infrahub.graphql.registry import registry as graphql_registry
 from infrahub.services import InfrahubServices
 from tests.adapters.event import MemoryInfrahubEvent
 from tests.helpers.graphql import graphql
@@ -97,7 +97,7 @@ async def test_update_simple_object_with_enum(
     enum_value,
     response_value,
 ):
-    GraphQLSchemaManager.clear_cache()
+    graphql_registry.clear_cache()
     config.SETTINGS.experimental_features.graphql_enums = graphql_enums_on
     query = """
     mutation {

--- a/backend/tests/unit/graphql/test_query_analyzer.py
+++ b/backend/tests/unit/graphql/test_query_analyzer.py
@@ -7,7 +7,7 @@ from infrahub.core.schema import SchemaRoot
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.analyzer import GraphQLArgument, GraphQLVariable, InfrahubGraphQLQueryAnalyzer, MutateAction
 from infrahub.graphql.initialization import prepare_graphql_params
-from infrahub.graphql.manager import GraphQLSchemaManager
+from infrahub.graphql.registry import registry as graphql_registry
 from tests.helpers.schema.color import COLOR
 from tests.helpers.schema.tshirt import TSHIRT
 
@@ -35,7 +35,7 @@ async def test_is_valid_simple_schema(
     car_person_schema_generics,
 ):
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
-    GraphQLSchemaManager.clear_cache()
+    graphql_registry.clear_cache()
     gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
     gqa = InfrahubGraphQLQueryAnalyzer(
         query=query_01, schema=gql_params.schema, branch=default_branch, schema_branch=schema_branch


### PR DESCRIPTION
This PR refactors the GraphQLSchemaManager class and introduces a GraphQL schema registry that takes over some of the previous responsibilities of the GraphQLSchemaManager.

An issue with the previous state was that the class operated both on the instance level and on a class level in a confusing way where we were mutating the class object itself while we were loading schemas. To avoid this behaviour I've introduced a registry object that stores anything previously handled at the class level within GraphQLSchemaManager. Because of this change we could remove two circular imports within ./tasks/registry.py. However as we still need to set the GraphQLSchemaManager type within this registry we also need the somewhat clunky `registry._register_manager(manager=GraphQLSchemaManager)` within manager.py.

We can do further iterations of this but I think it would be good to start with this separation as we want to do more work with regards to purging old unused schemas to reclaim memory and look at deduplication within the new GraphQL registry.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Centralized GraphQL schema management via a registry, enabling consistent schema resolution across branches.
- Performance
  - Streamlined schema caching and purging may reduce overhead and improve responsiveness when switching branches.
- Refactor
  - Migrated from class-based schema management to a registry-based approach for improved reliability and maintainability.
- Tests
  - Updated test suite to align with the new registry interface; no user-facing changes.
- Chores
  - Internal tasks now use the registry for schema updates and cache maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->