### PR TITLE
Prevent available IPs filter when switching kind in IPAM list views

### DIFF
--- a/changelog/+IFC-1771.fixed.md
+++ b/changelog/+IFC-1771.fixed.md
@@ -1,0 +1,1 @@
+The available IPs filter in IPAM list views now stays applied when switching kind.

--- a/frontend/app/src/shared/components/filters/utils/remove-filters-not-in-schema.ts
+++ b/frontend/app/src/shared/components/filters/utils/remove-filters-not-in-schema.ts
@@ -13,13 +13,10 @@ export const removeFiltersNotInSchema = (filters: Filter[], schema: ModelSchema 
     return [];
   }
 
+  const isIpamSchema = isOfKind(IP_PREFIX_GENERIC, schema) || isOfKind(IP_ADDRESS_GENERIC, schema);
+
   return filters.filter((filter) => {
-    if (
-      (isOfKind(IP_PREFIX_GENERIC, schema) || isOfKind(IP_ADDRESS_GENERIC, schema)) &&
-      filter.name === AVAILABLE_IP_FILTER_NAME
-    ) {
-      return true;
-    }
+    if (isIpamSchema && filter.name === AVAILABLE_IP_FILTER_NAME) return true;
 
     const [fieldName] = filter.name.split("__");
     return (

--- a/frontend/app/src/shared/components/filters/utils/remove-filters-not-in-schema.ts
+++ b/frontend/app/src/shared/components/filters/utils/remove-filters-not-in-schema.ts
@@ -1,6 +1,12 @@
 import { Filter } from "@/shared/hooks/useFilters";
 
+import {
+  AVAILABLE_IP_FILTER_NAME,
+  IP_ADDRESS_GENERIC,
+  IP_PREFIX_GENERIC,
+} from "@/entities/ipam/constants";
 import { ModelSchema } from "@/entities/schema/types";
+import { isOfKind } from "@/entities/schema/utils/is-of-kind";
 
 export const removeFiltersNotInSchema = (filters: Filter[], schema: ModelSchema | null) => {
   if (!schema) {
@@ -8,6 +14,13 @@ export const removeFiltersNotInSchema = (filters: Filter[], schema: ModelSchema 
   }
 
   return filters.filter((filter) => {
+    if (
+      (isOfKind(IP_PREFIX_GENERIC, schema) || isOfKind(IP_ADDRESS_GENERIC, schema)) &&
+      filter.name === AVAILABLE_IP_FILTER_NAME
+    ) {
+      return true;
+    }
+
     const [fieldName] = filter.name.split("__");
     return (
       schema.attributes?.some((attr) => attr.name === fieldName) ||


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The “Available IPs” filter in IPAM list views now persists when switching between IP Address and Prefix kinds, preventing it from being unintentionally cleared and ensuring consistent filtering and reliable results across kind changes.

* **Documentation**
  * Changelog updated to document the fix for “Available IPs” filter persistence in IPAM list views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->