### PR TITLE
Add artifact definition name to artifact webhook events

### DIFF
--- a/backend/infrahub/artifacts/models.py
+++ b/backend/infrahub/artifacts/models.py
@@ -7,7 +7,8 @@ class CheckArtifactCreate(BaseModel):
     """Runs a check to verify the creation of an artifact."""
 
     artifact_name: str = Field(..., description="Name of the artifact")
-    artifact_definition: str = Field(..., description="The the ID of the artifact definition")
+    artifact_definition: str = Field(..., description="The ID of the artifact definition")
+    artifact_definition_name: str = Field(..., description="The name of the artifact definition")
     commit: str = Field(..., description="The commit to target")
     content_type: str = Field(..., description="Content type of the artifact")
     transform_type: str = Field(..., description="The type of transform associated with this artifact")

--- a/backend/infrahub/events/artifact_action.py
+++ b/backend/infrahub/events/artifact_action.py
@@ -11,6 +11,7 @@ class ArtifactEvent(InfrahubEvent):
 
     node_id: str = Field(..., description="The ID of the artifact")
     artifact_definition_id: str = Field(..., description="The ID of the artifact definition")
+    artifact_definition_name: str = Field(..., description="The name of the artifact definition")
     target_id: str = Field(..., description="The ID of the target of the artifact")
     target_kind: str = Field(..., description="The kind of the target of the artifact")
     checksum: str = Field(..., description="The current checksum of the artifact")
@@ -36,6 +37,7 @@ class ArtifactEvent(InfrahubEvent):
                 "infrahub.artifact.storage_id": self.storage_id,
                 "infrahub.artifact.storage_id_previous": self.storage_id_previous or "",
                 "infrahub.artifact.artifact_definition_id": self.artifact_definition_id,
+                "infrahub.artifact.artifact_definition_name": self.artifact_definition_name,
             }
         )
 

--- a/backend/infrahub/git/integrator.py
+++ b/backend/infrahub/git/integrator.py
@@ -1422,6 +1422,7 @@ class InfrahubRepositoryIntegrator(InfrahubRepositoryBase):
             target_id=message.target_id,
             target_kind=message.target_kind,
             artifact_definition_id=message.artifact_definition,
+            artifact_definition_name=message.artifact_definition_name,
             meta=EventMeta.from_context(context=message.context, branch=branch),
             checksum=checksum,
             checksum_previous=previous_checksum,

--- a/backend/infrahub/git/models.py
+++ b/backend/infrahub/git/models.py
@@ -21,6 +21,7 @@ class RequestArtifactGenerate(BaseModel):
 
     artifact_name: str = Field(..., description="Name of the artifact")
     artifact_definition: str = Field(..., description="The ID of the artifact definition")
+    artifact_definition_name: str = Field(..., description="The name of the artifact definition")
     commit: str = Field(..., description="The commit to target")
     content_type: str = Field(..., description="Content type of the artifact")
     transform_type: str = Field(..., description="The type of transform associated with this artifact")

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -366,6 +366,7 @@ async def generate_request_artifact_definition(
             artifact_name=artifact_definition.artifact_name.value,
             artifact_id=artifact_id,
             artifact_definition=model.artifact_definition_id,
+            artifact_definition_name=model.artifact_definition_name,
             commit=repository.commit.value,
             content_type=artifact_definition.content_type.value,
             transform_type=str(transform.typename),

--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -683,6 +683,7 @@ async def validate_artifacts_generation(model: RequestArtifactDefinitionCheck, c
                 artifact_name=model.artifact_definition.artifact_name,
                 artifact_id=artifact_id,
                 artifact_definition=model.artifact_definition.definition_id,
+                artifact_definition_name=model.artifact_definition.definition_name,
                 commit=repository.source_commit,
                 content_type=model.artifact_definition.content_type,
                 transform_type=model.artifact_definition.transform_kind,

--- a/changelog/+e610424b.added.md
+++ b/changelog/+e610424b.added.md
@@ -1,0 +1,1 @@
+Added the name of the artifact definition to the payload of artifact webhook events.

--- a/docs/docs/reference/infrahub-events.mdx
+++ b/docs/docs/reference/infrahub-events.mdx
@@ -39,6 +39,7 @@ For more detailed explanations on how these events are used within Infrahub, see
 | **meta.ancestors** | Any event used to trigger this event |
 | **node_id** | The ID of the artifact |
 | **artifact_definition_id** | The ID of the artifact definition |
+| **artifact_definition_name** | The name of the artifact definition |
 | **target_id** | The ID of the target of the artifact |
 | **target_kind** | The kind of the target of the artifact |
 | **checksum** | The current checksum of the artifact |
@@ -71,6 +72,7 @@ For more detailed explanations on how these events are used within Infrahub, see
 | **meta.ancestors** | Any event used to trigger this event |
 | **node_id** | The ID of the artifact |
 | **artifact_definition_id** | The ID of the artifact definition |
+| **artifact_definition_name** | The name of the artifact definition |
 | **target_id** | The ID of the target of the artifact |
 | **target_kind** | The kind of the target of the artifact |
 | **checksum** | The current checksum of the artifact |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Artifact webhook events now include artifact_definition_name alongside artifact_definition_id.
  * Artifact generation requests now accept and propagate artifact_definition_name.

* **Documentation**
  * Updated event reference to document artifact_definition_name for Artifact Created/Updated events.
  * Corrected a typo in the artifact_definition field description.

* **Chores**
  * Added a changelog entry announcing inclusion of artifact_definition_name in artifact event payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->