### PR TITLE
fix example

### DIFF
--- a/docs/docs/guides/artifact.mdx
+++ b/docs/docs/guides/artifact.mdx
@@ -67,8 +67,8 @@ Add an artifact definition to your repository's `.infrahub.yml` file:
 
 ```yaml
 artifact_definitions:
-  - name: "Device configuration file"
-    artifact_name: "device_configuration"
+  - name: "device_configuration"
+    artifact_name: "Device configuration file"
     parameters:
       name: "name__value"
     content_type: "text/plain"
@@ -78,8 +78,8 @@ artifact_definitions:
 
 This configuration specifies:
 
-- **name**: Human-readable label
-- **artifact_name**: Machine identifier (no spaces)
+- **name**: Machine identifier (no spaces)
+- **artifact_name**: Human-readable label
 - **parameters**: Values passed to the transformation query
 - **content_type**: MIME type of the generated artifact
 - **targets**: Group containing target objects
@@ -130,10 +130,11 @@ Click the download button on any artifact detail page.
 
 ### REST API access
 
-Use the artifact endpoint:
+Download artifacts using the storage object endpoint (authentication required):
 
 ```bash
-http://<INFRAHUB_HOST:INFRAHUB_PORT>/api/artifact/<artifact_id>
+curl -H "X-INFRAHUB-KEY: <your-api-token>" \
+  http://<INFRAHUB_HOST:INFRAHUB_PORT>/api/storage/object/<storage_identifier>
 ```
 
 Copy the Artifact ID from the artifact menu:


### PR DESCRIPTION
Cleanup from https://github.com/opsmill/infrahub/pull/7214#issuecomment-3289645947

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified artifact configuration semantics: name now denotes the machine-friendly identifier (no spaces) and artifact_name is the human-readable label; examples and descriptions updated accordingly.
  * Updated REST API guidance to recommend accessing artifacts via the storage object endpoint with API key authentication; example request revised.
  * Minor formatting cleanups with no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->