### PR TITLE
chore: 1.4.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 ### Fixed
 
-- Allow RequestGraphQLQueryGroupUpdate params to accept any type of value, not just strings. ([#7208](https://github.com/opsmill/infrahub/issues/7208))
+- Allow RequestGraphQLQueryGroupUpdate parameters to accept any type of value, not just strings. ([#7208](https://github.com/opsmill/infrahub/issues/7208))
 - The available IPs filter in IPAM list views now stays applied when switching kind.
 
 ## [Infrahub - v1.4.6](https://github.com/opsmill/infrahub/tree/infrahub-v1.4.6) - 2025-09-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
+## [Infrahub - v1.4.7](https://github.com/opsmill/infrahub/tree/infrahub-v1.4.7) - 2025-09-16
+
+### Added
+
+- Added optional configuration to fetch and map groups when using Google as an identity provider for OAuth/OIDC.
+- Added the name of the artifact definition to the payload of artifact webhook events.
+
+### Fixed
+
+- Allow RequestGraphQLQueryGroupUpdate params to accept any type of value, not just strings. ([#7208](https://github.com/opsmill/infrahub/issues/7208))
+- The available IPs filter in IPAM list views now stays applied when switching kind.
+
 ## [Infrahub - v1.4.6](https://github.com/opsmill/infrahub/tree/infrahub-v1.4.6) - 2025-09-10
 
 ### Added

--- a/changelog/+IFC-1771.fixed.md
+++ b/changelog/+IFC-1771.fixed.md
@@ -1,1 +1,0 @@
-The available IPs filter in IPAM list views now stays applied when switching kind.

--- a/changelog/+a2ec144f.added.md
+++ b/changelog/+a2ec144f.added.md
@@ -1,1 +1,0 @@
-Added optional configuration to fetch and map groups when using Google as an identity provider for OAuth/OIDC.

--- a/changelog/+e610424b.added.md
+++ b/changelog/+e610424b.added.md
@@ -1,1 +1,0 @@
-Added the name of the artifact definition to the payload of artifact webhook events.

--- a/changelog/7208.fixed.md
+++ b/changelog/7208.fixed.md
@@ -1,1 +1,0 @@
-Allow RequestGraphQLQueryGroupUpdate params to accept any type of value, not just strings.

--- a/docs/docs/release-notes/infrahub/release-1_4_7.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_4_7.mdx
@@ -1,0 +1,29 @@
+---
+title: Release 1.4.7
+---
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.4.7</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>September 16th, 2025</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[infrahub-v1.4.7](https://github.com/opsmill/infrahub/releases/tag/infrahub-v1.4.7)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Added
+
+- Added optional configuration to fetch and map groups when using Google as an identity provider for OAuth/OIDC.
+- Added the name of the artifact definition to the payload of artifact webhook events.
+
+### Fixed
+
+- Allow RequestGraphQLQueryGroupUpdate params to accept any type of value, not just strings. ([#7208](https://github.com/opsmill/infrahub/issues/7208))
+- The available IPs filter in IPAM list views now stays applied when switching kind.

--- a/docs/docs/release-notes/infrahub/release-1_4_7.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_4_7.mdx
@@ -25,5 +25,5 @@ title: Release 1.4.7
 
 ### Fixed
 
-- Allow RequestGraphQLQueryGroupUpdate params to accept any type of value, not just strings. ([#7208](https://github.com/opsmill/infrahub/issues/7208))
+- Allow RequestGraphQLQueryGroupUpdate parameters to accept any type of value, not just strings. ([#7208](https://github.com/opsmill/infrahub/issues/7208))
 - The available IPs filter in IPAM list views now stays applied when switching kind.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -414,6 +414,7 @@ const sidebars: SidebarsConfig = {
             slug: 'release-notes/infrahub',
           },
           items: [
+            'release-notes/infrahub/release-1_4_7',
             'release-notes/infrahub/release-1_4_6',
             'release-notes/infrahub/release-1_4_5',
             'release-notes/infrahub/release-1_4_4',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "infrahub-server"
-version = "1.4.6"
+version = "1.4.7"
 description = "Infrahub is taking a new approach to Infrastructure Management by providing a new generation of datastore to organize and control all the data that defines how an infrastructure should run."
 authors = ["OpsMill <info@opsmill.com>"]
 readme = "README.md"

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "infrahub-testcontainers"
-version = "1.4.6"
+version = "1.4.7"
 requires-python = ">=3.9"
 
 [tool.poetry]
 name = "infrahub-testcontainers"
-version = "1.4.6"
+version = "1.4.7"
 description = "Testcontainers instance for Infrahub to easily build integration tests"
 authors = ["OpsMill <info@opsmill.com>"]
 readme = "README.md"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Optional config to fetch and map Google groups for OAuth/OIDC sign-in.
  - Artifact webhook payloads now include the artifact definition name.

- Bug Fixes
  - GraphQL group update parameters accept any value type, not just strings.
  - IPAM “available IPs” filter stays applied when switching kind.

- Documentation
  - Added release notes for version 1.4.7.

- Chores
  - Bumped project version to 1.4.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->