### PR TITLE
fix(backend): remove internal pagination limit

### DIFF
--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -281,7 +281,6 @@ class DatabaseSettings(BaseSettings):
     query_size_limit: int = Field(
         default=5_000,
         ge=1,
-        le=20_000,
         description="The max number of records to fetch in a single query before performing internal pagination.",
     )
     max_depth_search_hierarchy: int = Field(


### PR DESCRIPTION
We might want to use page size above 20k.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration now supports higher query result limits by removing the previous upper bound. This allows larger single-query fetches before internal pagination kicks in, benefiting workloads on large datasets.
  * The default limit remains unchanged, and a minimum value is still enforced to prevent invalid configurations.
  * No other behavior or error handling is affected, ensuring backward compatibility for existing setups while offering expanded flexibility for power users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->