### PR TITLE
IFC-1216: Restrict origin_branch value to the default branch

### DIFF
--- a/backend/infrahub/graphql/mutations/branch.py
+++ b/backend/infrahub/graphql/mutations/branch.py
@@ -7,6 +7,7 @@ from opentelemetry import trace
 from typing_extensions import Self
 
 from infrahub.branch.merge_mutation_checker import verify_branch_merge_mutation_allowed
+from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.database import retry_db_transaction
 from infrahub.graphql.context import apply_external_context
@@ -66,6 +67,9 @@ class BranchCreate(Mutation):
         background_execution: bool = False,
         wait_until_completion: bool = True,
     ) -> Self:
+        if data.origin_branch and data.origin_branch != registry.default_branch:
+            raise ValueError(f"origin_branch must be '{registry.default_branch}'")
+
         graphql_context: GraphqlContext = info.context
         task: dict | None = None
 

--- a/backend/tests/unit/graphql/mutations/test_branch.py
+++ b/backend/tests/unit/graphql/mutations/test_branch.py
@@ -28,7 +28,7 @@ class TestBranchCreate(TestInfrahubApp):
     ):
         query = """
             mutation {
-                BranchCreate(data: { name: "branch2", sync_with_git: false }) {
+                BranchCreate(data: { name: "branch2", sync_with_git: false, origin_branch: "main" }) {
                     ok
                     object {
                         id
@@ -239,6 +239,36 @@ class TestBranchCreate(TestInfrahubApp):
 
         branch2 = await Branch.get_by_name(db=db, name="branch2")
         assert branch2.active_schema_hash.main == default_branch.active_schema_hash.main
+
+    async def test_branch_create_invalid_origin_branch(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        session_admin,
+        service: InfrahubServices,
+    ):
+        query = """
+        mutation AddBranch {
+            BranchCreate(data: {
+                name: "test1"
+                description: "test1 description"
+                sync_with_git: false
+                origin_branch: "test"
+            }) {
+                ok
+                object {
+                    id
+                }
+            }
+        }
+        """
+        result = await graphql_mutation(
+            query=query, db=db, service=service, branch=default_branch, account_session=session_admin
+        )
+
+        assert result.errors
+        assert len(result.errors) == 1
+        assert f"origin_branch must be '{default_branch.name}'" == result.errors[0].message
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description
Restrict origin_branch value to the default branch which is `main` and raise a `ValueError` when it is not

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Branch creation (GraphQL) now accepts an optional origin_branch to specify the source branch; if omitted, the default branch is used.
- Bug Fixes
  - Added validation: if origin_branch is provided and isn’t the default branch, the mutation returns a clear error stating it must match the default branch.
- Tests
  - Added unit tests covering valid and invalid origin_branch scenarios during branch creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->