### PR TITLE
fix(backend): add info metric for workers

### DIFF
--- a/backend/infrahub/worker.py
+++ b/backend/infrahub/worker.py
@@ -1,3 +1,14 @@
 import uuid
 
+from prometheus_client import Gauge
+
+from infrahub import __version__ as infrahub_version
+
 WORKER_IDENTITY = str(uuid.uuid4())
+
+INFO_METRIC = Gauge(
+    "infrahub_info",
+    "Information about this Infrahub instance",
+    labelnames=["version", "worker_id"],
+)
+INFO_METRIC.labels(version=infrahub_version, worker_id=WORKER_IDENTITY).set(1)


### PR DESCRIPTION
This is useful when troubleshooting a long running instance. We might need to identify a specific worker using its ID.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Prometheus info metric that exposes the running version and worker identifier for each worker process. This enables easier monitoring, instance verification, and fleet-wide visibility in observability dashboards.
  * Metric is initialized automatically on startup, allowing immediate scraping by Prometheus and correlation of workers to deployed versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->