### PR TITLE
Fix: Prevent Information disclosure and Apply secure flags to auth cookies

### DIFF
--- a/backend/infrahub/api/auth.py
+++ b/backend/infrahub/api/auth.py
@@ -25,10 +25,10 @@ async def login_user(
 ) -> models.UserToken:
     token = await authenticate_with_password(db=db, credentials=credentials)
     response.set_cookie(
-        "access_token", token.access_token, httponly=True, max_age=config.SETTINGS.security.access_token_lifetime
+        "access_token", token.access_token, httponly=True, secure=True, samesite="Strict", max_age=config.SETTINGS.security.access_token_lifetime
     )
     response.set_cookie(
-        "refresh_token", token.refresh_token, httponly=True, max_age=config.SETTINGS.security.refresh_token_lifetime
+        "refresh_token", token.refresh_token, httponly=True, secure=True, samesite="Strict", max_age=config.SETTINGS.security.refresh_token_lifetime
     )
     return token
 
@@ -41,7 +41,7 @@ async def refresh_jwt_token(
 ) -> models.AccessTokenResponse:
     token = await create_fresh_access_token(db=db, refresh_data=refresh_token)
     response.set_cookie(
-        "access_token", token.access_token, httponly=True, max_age=config.SETTINGS.security.access_token_lifetime
+        "access_token", token.access_token, httponly=True, secure=True, samesite="Strict", max_age=config.SETTINGS.security.access_token_lifetime
     )
 
     return token

--- a/backend/infrahub/api/exception_handlers.py
+++ b/backend/infrahub/api/exception_handlers.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+import logging
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 
@@ -18,7 +19,9 @@ async def generic_api_exception_handler(_: Any, exc: Exception, http_code: int =
     elif isinstance(exc, ValidationError):
         messages = [ed["msg"] for ed in exc.errors()]
     else:
-        messages = [str(exc)]
+        # Log the exception for internal diagnostics; do not expose details to the user
+        logging.exception("Unhandled exception in generic API exception handler:")
+        messages = ["An internal error has occurred."]
     error_dict = {
         "data": None,
         "errors": [{"message": message, "extensions": {"code": http_code}} for message in messages],

--- a/backend/infrahub/api/oauth2.py
+++ b/backend/infrahub/api/oauth2.py
@@ -122,13 +122,20 @@ async def token(
         user_token = await signin_sso_account(db=db, account_name=user_info["name"], sso_groups=sso_groups)
 
     response.set_cookie(
-        "access_token", user_token.access_token, httponly=True, max_age=config.SETTINGS.security.access_token_lifetime
+        "access_token",
+        user_token.access_token,
+        httponly=True,
+        max_age=config.SETTINGS.security.access_token_lifetime,
+        secure=True,
+        samesite="Lax",
     )
     response.set_cookie(
         "refresh_token",
         user_token.refresh_token,
         httponly=True,
         max_age=config.SETTINGS.security.refresh_token_lifetime,
+        secure=True,
+        samesite="Lax",
     )
 
     return models.UserTokenWithUrl(

--- a/backend/infrahub/api/oidc.py
+++ b/backend/infrahub/api/oidc.py
@@ -166,13 +166,20 @@ async def token(
         user_token = await signin_sso_account(db=db, account_name=user_info["name"], sso_groups=sso_groups)
 
     response.set_cookie(
-        "access_token", user_token.access_token, httponly=True, max_age=config.SETTINGS.security.access_token_lifetime
+        "access_token",
+        user_token.access_token,
+        httponly=True,
+        max_age=config.SETTINGS.security.access_token_lifetime,
+        secure=True,
+        samesite="Lax",
     )
     response.set_cookie(
         "refresh_token",
         user_token.refresh_token,
         httponly=True,
         max_age=config.SETTINGS.security.refresh_token_lifetime,
+        secure=True,
+        samesite="Lax",
     )
 
     return models.UserTokenWithUrl(


### PR DESCRIPTION
### Description
This request introduces several important security improvements to the Infrahub backend API by addressing improper exception handling and insecure cookie configurations.

#### 1. Exception Handling (`exception_handlers.py`)

* Updated the `generic_api_exception_handler` to **avoid exposing raw exception details** in API responses.
* Actual exception objects are now logged internally using Python’s `logging` module for diagnostics.
* A **generic, non-informative error message** (e.g., `"An internal error has occurred."`) is returned to clients for uncaught/unknown exceptions.
* This prevents information leakage that could aid attackers while maintaining transparency for controlled/known exceptions (e.g., validation errors).

#### 2. Secure Cookie Settings (`oidc.py`, `oauth2.py`, `auth.py`)

Sensitive cookies such as `access_token` and `refresh_token` have been updated to include **secure attributes**:

* `secure=True` → ensures cookies are only sent over HTTPS.
* `httponly=True` → prevents access via JavaScript, mitigating XSS risks.
* `samesite="Lax"` (or `"Strict"` where viable) → provides CSRF protection without breaking expected authentication flows.

Specifically:

**`oidc.py`**: Added `secure=True` and `samesite="Lax"` to both cookie-setting calls.
**`oauth2.py`**: Added the same attributes to cookie-setting calls for access and refresh tokens.
**`auth.py`**: Updated all `response.set_cookie` calls (lines 27, 30, and 43) to include `secure=True`, `httponly=True`, and `samesite="Strict"` (or `"Lax"` if strict mode causes compatibility issues).



* Prevents **sensitive information disclosure** through exception messages.
* Strengthens **authentication security** by enforcing best practices for cookie handling.
* Improves overall resilience against **XSS** and **CSRF attacks**.



