### PR TITLE
Convert GRAPHQL_QUERY_GROUP_UPDATE workflow to interval

### DIFF
--- a/backend/infrahub/workflows/catalogue.py
+++ b/backend/infrahub/workflows/catalogue.py
@@ -299,7 +299,7 @@ PROPOSED_CHANGE_MERGE = WorkflowDefinition(
 
 GRAPHQL_QUERY_GROUP_UPDATE = WorkflowDefinition(
     name="graphql-query-group-update",
-    type=WorkflowType.CORE,
+    type=WorkflowType.INTERNAL,
     module="infrahub.groups.tasks",
     function="update_graphql_query_group",
 )

--- a/changelog/+graphqlquery.fixed.md
+++ b/changelog/+graphqlquery.fixed.md
@@ -1,0 +1,1 @@
+Convert GraphQL query group update tasks to interval to hide it from the task list


### PR DESCRIPTION
Convert the GraphQL query group update workflow to interval to hide it from the task list, currently it can generate a lot of task entry with low value to the users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - GraphQL query group update tasks are now hidden from the task list to reduce clutter and avoid user confusion.

- Documentation
  - Added a changelog entry describing the change to how GraphQL query group update tasks are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->