### PR TITLE
bug in NodeGetListQuery if filter includes peer IDs for peers with migrated kind

### DIFF
--- a/backend/infrahub/core/query/subquery.py
+++ b/backend/infrahub/core/query/subquery.py
@@ -90,7 +90,7 @@ async def build_subquery_filter(
         {branch_level_str} AS branch_level,
         {froms_str} AS froms,
         all(r IN relationships(path) WHERE r.status = "active") AS is_active{with_extra}
-    ORDER BY branch_level DESC, froms[-1] DESC, froms[-2] DESC
+    ORDER BY branch_level DESC, froms[-1] DESC, froms[-2] DESC, is_active DESC
     WITH head(collect([is_active, {node_alias}{with_extra}])) AS latest_node_details
     WHERE {is_active_filter}
     WITH latest_node_details[1] AS {prefix}{final_with_extra}
@@ -176,7 +176,7 @@ async def build_subquery_order(
     OPTIONAL MATCH path = {filter_str}
     WHERE {where_str}
     WITH {with_str_to_alias}
-    ORDER BY branch_level DESC, froms[-1] DESC, froms[-2] DESC
+    ORDER BY branch_level DESC, froms[-1] DESC, froms[-2] DESC, is_active DESC
     WITH head(collect([is_active, {with_str_alias}])) AS latest_node_details
     WITH {with_str_from_list}
     RETURN {to_return_str}

--- a/backend/tests/unit/core/test_query_subquery.py
+++ b/backend/tests/unit/core/test_query_subquery.py
@@ -30,7 +30,7 @@ async def test_build_subquery_filter_attribute_text(
         reduce(br_lvl = 0, r in relationships(path) | br_lvl + r.branch_level) AS branch_level,
         %(froms_var)s AS froms,
         all(r IN relationships(path) WHERE r.status = "active") AS is_active
-    ORDER BY branch_level DESC, froms[-1] DESC, froms[-2] DESC
+    ORDER BY branch_level DESC, froms[-1] DESC, froms[-2] DESC, is_active DESC
     WITH head(collect([is_active, n])) AS latest_node_details
     WHERE latest_node_details[0] = TRUE
     WITH latest_node_details[1] AS filter1
@@ -67,7 +67,7 @@ async def test_build_subquery_filter_attribute_text_area(
         reduce(br_lvl = 0, r in relationships(path) | br_lvl + r.branch_level) AS branch_level,
         %(froms_var)s AS froms,
         all(r IN relationships(path) WHERE r.status = "active") AS is_active
-    ORDER BY branch_level DESC, froms[-1] DESC, froms[-2] DESC
+    ORDER BY branch_level DESC, froms[-1] DESC, froms[-2] DESC, is_active DESC
     WITH head(collect([is_active, n])) AS latest_node_details
     WHERE latest_node_details[0] = TRUE
     WITH latest_node_details[1] AS filter1
@@ -104,7 +104,7 @@ async def test_build_subquery_filter_attribute_list(
         reduce(br_lvl = 0, r in relationships(path) | br_lvl + r.branch_level) AS branch_level,
         %(froms_var)s AS froms,
         all(r IN relationships(path) WHERE r.status = "active") AS is_active
-    ORDER BY branch_level DESC, froms[-1] DESC, froms[-2] DESC
+    ORDER BY branch_level DESC, froms[-1] DESC, froms[-2] DESC, is_active DESC
     WITH head(collect([is_active, n])) AS latest_node_details
     WHERE latest_node_details[0] = TRUE
     WITH latest_node_details[1] AS filter1
@@ -141,7 +141,7 @@ async def test_build_subquery_filter_attribute_int(
         reduce(br_lvl = 0, r in relationships(path) | br_lvl + r.branch_level) AS branch_level,
         %(froms_var)s AS froms,
         all(r IN relationships(path) WHERE r.status = "active") AS is_active
-    ORDER BY branch_level DESC, froms[-1] DESC, froms[-2] DESC
+    ORDER BY branch_level DESC, froms[-1] DESC, froms[-2] DESC, is_active DESC
     WITH head(collect([is_active, n])) AS latest_node_details
     WHERE latest_node_details[0] = TRUE
     WITH latest_node_details[1] AS filter2
@@ -178,7 +178,7 @@ async def test_build_subquery_filter_relationship(db: InfrahubDatabase, default_
         reduce(br_lvl = 0, r in relationships(path) | br_lvl + r.branch_level) AS branch_level,
         %(froms_var)s AS froms,
         all(r IN relationships(path) WHERE r.status = "active") AS is_active
-    ORDER BY branch_level DESC, froms[-1] DESC, froms[-2] DESC
+    ORDER BY branch_level DESC, froms[-1] DESC, froms[-2] DESC, is_active DESC
     WITH head(collect([is_active, n])) AS latest_node_details
     WHERE latest_node_details[0] = TRUE
     WITH latest_node_details[1] AS filter1
@@ -219,7 +219,7 @@ async def test_build_subquery_filter_relationship_ids(db: InfrahubDatabase, defa
         reduce(br_lvl = 0, r in relationships(path) | br_lvl + r.branch_level) AS branch_level,
         %(froms_var)s AS froms,
         all(r IN relationships(path) WHERE r.status = "active") AS is_active
-    ORDER BY branch_level DESC, froms[-1] DESC, froms[-2] DESC
+    ORDER BY branch_level DESC, froms[-1] DESC, froms[-2] DESC, is_active DESC
     WITH head(collect([is_active, n])) AS latest_node_details
     WHERE latest_node_details[0] = TRUE
     WITH latest_node_details[1] AS filter1
@@ -249,7 +249,7 @@ async def test_build_subquery_order_relationship(db: InfrahubDatabase, default_b
     OPTIONAL MATCH path = (n:Node {uuid: n.uuid})-[:IS_RELATED]->(:Relationship { name: $order1_rel_name })-[:IS_RELATED]->(:Node)-[:HAS_ATTRIBUTE]-(:Attribute { name: $order1_name })-[:HAS_VALUE]-(last:AttributeValueIndexed)
     WHERE all(r IN relationships(path) WHERE (PLACEHOLDER))
     WITH last, reduce(br_lvl = 0, r in relationships(path) | br_lvl + r.branch_level) AS branch_level, %(froms_var)s AS froms, all(r IN relationships(path) WHERE r.status = "active") AS is_active
-    ORDER BY branch_level DESC, froms[-1] DESC, froms[-2] DESC
+    ORDER BY branch_level DESC, froms[-1] DESC, froms[-2] DESC, is_active DESC
     WITH head(collect([is_active, last])) AS latest_node_details
     WITH latest_node_details[0] AS is_active, latest_node_details[1] AS last
     RETURN CASE WHEN is_active = TRUE THEN last.value ELSE NULL END AS order1
@@ -285,7 +285,7 @@ async def test_build_subquery_filter_attribute_multiple_values(
         reduce(br_lvl = 0, r in relationships(path) | br_lvl + r.branch_level) AS branch_level,
         %(froms_var)s AS froms,
         all(r IN relationships(path) WHERE r.status = "active") AS is_active
-    ORDER BY branch_level DESC, froms[-1] DESC, froms[-2] DESC
+    ORDER BY branch_level DESC, froms[-1] DESC, froms[-2] DESC, is_active DESC
     WITH head(collect([is_active, n])) AS latest_node_details
     WHERE latest_node_details[0] = TRUE
     WITH latest_node_details[1] AS filter1
@@ -324,7 +324,7 @@ async def test_build_subquery_filter_relationship_multiple_values(
         reduce(br_lvl = 0, r in relationships(path) | br_lvl + r.branch_level) AS branch_level,
         %(froms_var)s AS froms,
         all(r IN relationships(path) WHERE r.status = "active") AS is_active
-    ORDER BY branch_level DESC, froms[-1] DESC, froms[-2] DESC
+    ORDER BY branch_level DESC, froms[-1] DESC, froms[-2] DESC, is_active DESC
     WITH head(collect([is_active, n])) AS latest_node_details
     WHERE latest_node_details[0] = TRUE
     WITH latest_node_details[1] AS filter1

--- a/backend/tests/unit/graphql/test_graphql_query.py
+++ b/backend/tests/unit/graphql/test_graphql_query.py
@@ -6,9 +6,11 @@ from deepdiff import DeepDiff
 from infrahub import __version__, config
 from infrahub.core import registry
 from infrahub.core.branch import Branch
-from infrahub.core.constants import InfrahubKind
+from infrahub.core.constants import InfrahubKind, SchemaPathType
 from infrahub.core.manager import NodeManager
+from infrahub.core.migrations.schema.node_kind_update import NodeKindUpdateMigration
 from infrahub.core.node import Node
+from infrahub.core.path import SchemaPath
 from infrahub.core.schema import NodeSchema, SchemaRoot
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.timestamp import Timestamp
@@ -1192,6 +1194,51 @@ async def test_query_multiple_filters(
     assert result.errors is None
     assert len(result.data["TestCar"]["edges"]) == 1
     assert result.data["TestCar"]["edges"][0]["node"]["id"] == c2.id
+
+    # test filter by peer ID after node kind migration
+    person_schema = registry.schema.get("TestPerson", branch=default_branch)
+    person_schema.name = "NewPerson"
+    person_schema.namespace = "Test2"
+    assert person_schema.kind == "Test2NewPerson"
+    registry.schema.set(name="Test2NewPerson", schema=person_schema, branch=default_branch.name)
+    migration = NodeKindUpdateMigration(
+        previous_node_schema=registry.schema.get(name="TestPerson", branch=default_branch),
+        new_node_schema=person_schema,
+        schema_path=SchemaPath(
+            path_type=SchemaPathType.ATTRIBUTE, schema_kind="Test2NewPerson", field_name="namespace"
+        ),
+    )
+    execution_result = await migration.execute(db=db, branch=default_branch)
+    assert not execution_result.errors
+
+    query05 = """
+    query {
+        TestCar(owner__ids: ["%s"]) {
+            edges {
+                node {
+                    id
+                    name {
+                        value
+                    }
+                }
+            }
+        }
+    }
+    """ % (p1.id)
+    gql_params = await prepare_graphql_params(
+        db=db, include_mutation=False, include_subscription=False, branch=default_branch
+    )
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query05,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
+
+    assert result.errors is None
+    assert len(result.data["TestCar"]["edges"]) == 2
+    assert {node["node"]["id"] for node in result.data["TestCar"]["edges"]} == {c1.id, c2.id}
 
 
 async def test_query_filter_relationships(

--- a/changelog/7247.fixed.md
+++ b/changelog/7247.fixed.md
@@ -1,0 +1,1 @@
+Fix bug in GraphQL queries that filter on the ID(s) of peer nodes that could cause nodes to be improperly excluded if the peer's schema had its name, namespace, or inheritance updated.


### PR DESCRIPTION
fixes #7247 

the `NodeGetListQuery` cypher query could incorrectly exclude nodes when filtering on the ID(s) of peers if the schema of a peer had its name, namespace, or inheritance updated. A name/namespace/inheritance update to a schema causes us to run a node kind migration, which results in multiple nodes with the same UUID (one deleted and one active at the same timestamp). when filtering on the IDs of a peer, the `NodeGetListQuery` builds a subquery that looks like this
```
CALL (n) {
    MATCH path = (n:Node {uuid: n.uuid})-[r1:IS_RELATED]->(rl:Relationship { name: $filter1_rel_name })<-[r2:IS_RELATED]-(peer:Node)
    WHERE peer.uuid IN $filter1_peer_ids AND all(r IN relationships(path) WHERE (((r.branch IN $branch0 AND r.from <= $time0 AND r.to IS NULL)
    OR (r.branch IN $branch0 AND r.from <= $time0 AND r.to >= $time0))))
    WITH
    n,
    path,
    reduce(br_lvl = 0, r in relationships(path) | br_lvl + r.branch_level) AS branch_level,
    [i IN relationships(path) | i.from] AS froms,
    all(r IN relationships(path) WHERE r.status = "active") AS is_active, peer
    ORDER BY branch_level DESC, froms[-1] DESC, froms[-2] DESC  <---------------  problem is here
    WITH head(collect([is_active, n, peer])) AS latest_node_details
    WHERE latest_node_details[0] = TRUE
    WITH latest_node_details[1] AS filter1, latest_node_details[2] AS peer
    RETURN filter1, peer.value AS attr1_node_value
}
```

the issue is that the `ORDER BY` clause does not for two paths being created and deleted at the same instant. in that case, the ordering of those two paths is effectively random, when we should prefer the active path to the deleted path. if this sounds familiar, it is because we have fixed the issue in a number of other places, but this one was hard to spot because this query is constructed in a very dynamic manner so you cannot see the final state of the query without a breakpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GraphQL filtering by peer node IDs that could exclude results after schema renames, namespace changes, or inheritance updates.
  * Improved result consistency by including active-status in query ordering, prioritizing active records.

* **Tests**
  * Added migration-based test coverage to validate peer-ID filtering after schema updates.
  * Updated subquery ordering expectations to include active-status.

* **Chores**
  * Added changelog entry documenting the fix for peer-ID-based GraphQL filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->