### PR TITLE
1.4.8 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 <!-- towncrier release notes start -->
 
+## [Infrahub - v1.4.7](https://github.com/opsmill/infrahub/tree/infrahub-v1.4.7) - 2025-09-23
+
+### Fixed
+
+- Report proper branch when read-only repositories fail to synchronize due to invalid branch ([#5713](https://github.com/opsmill/infrahub/issues/5713))
+- Add an HFID for Attribute and Relationship matches for a Node Trigger Rule ([#6713](https://github.com/opsmill/infrahub/issues/6713))
+- Use the prune flag when fetching updates from remote git reposities to clear deleted remote references locally ([#6884](https://github.com/opsmill/infrahub/issues/6884))
+- Fix branch delete query to avoid out-of-memory error when using the community edition ([#7161](https://github.com/opsmill/infrahub/issues/7161))
+- Fix bug in GraphQL queries that filter on the ID(s) of peer nodes that could cause nodes to be improperly excluded if the peer's schema had its name, namespace, or inheritance updated. ([#7247](https://github.com/opsmill/infrahub/issues/7247))
+- Convert GraphQL query group update tasks to interval to hide it from the task list
+- Ensure the default branch is used when a node is part of the global branch
+- Update a cypher query that did not correctly account for deleted Relationships. It was only used during a delete, so would not have caused any issues visible to the user.
+
 ## [Infrahub - v1.4.7](https://github.com/opsmill/infrahub/tree/infrahub-v1.4.7) - 2025-09-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the chang
 
 - Report proper branch when read-only repositories fail to synchronize due to invalid branch ([#5713](https://github.com/opsmill/infrahub/issues/5713))
 - Add an HFID for Attribute and Relationship matches for a Node Trigger Rule ([#6713](https://github.com/opsmill/infrahub/issues/6713))
-- Use the prune flag when fetching updates from remote git reposities to clear deleted remote references locally ([#6884](https://github.com/opsmill/infrahub/issues/6884))
+- Use the prune flag when fetching updates from remote git repositories to clear deleted remote references locally ([#6884](https://github.com/opsmill/infrahub/issues/6884))
 - Fix branch delete query to avoid out-of-memory error when using the community edition ([#7161](https://github.com/opsmill/infrahub/issues/7161))
 - Fix bug in GraphQL queries that filter on the ID(s) of peer nodes that could cause nodes to be improperly excluded if the peer's schema had its name, namespace, or inheritance updated. ([#7247](https://github.com/opsmill/infrahub/issues/7247))
 - Convert GraphQL query group update tasks to interval to hide it from the task list

--- a/changelog/+global_branch.fixed.md
+++ b/changelog/+global_branch.fixed.md
@@ -1,1 +1,0 @@
-Ensure the default branch is used when a node is part of the global branch

--- a/changelog/+graphqlquery.fixed.md
+++ b/changelog/+graphqlquery.fixed.md
@@ -1,1 +1,0 @@
-Convert GraphQL query group update tasks to interval to hide it from the task list

--- a/changelog/+relationship-query.fixed.md
+++ b/changelog/+relationship-query.fixed.md
@@ -1,1 +1,0 @@
-Update a cypher query that did not correctly account for deleted Relationships. It was only used during a delete, so would not have caused any issues visible to the user.

--- a/changelog/5713.fixed.md
+++ b/changelog/5713.fixed.md
@@ -1,1 +1,0 @@
-Report proper branch when read-only repositories fail to synchronize due to invalid branch

--- a/changelog/6713.fixed.md
+++ b/changelog/6713.fixed.md
@@ -1,1 +1,0 @@
-Add an HFID for Attribute and Relationship matches for a Node Trigger Rule

--- a/changelog/6884.fixed.md
+++ b/changelog/6884.fixed.md
@@ -1,1 +1,0 @@
-Use the prune flag when fetching updates from remote git reposities to clear deleted remote references locally

--- a/changelog/7161.fixed.md
+++ b/changelog/7161.fixed.md
@@ -1,1 +1,0 @@
-Fix branch delete query to avoid out-of-memory error when using the community edition

--- a/changelog/7247.fixed.md
+++ b/changelog/7247.fixed.md
@@ -1,1 +1,0 @@
-Fix bug in GraphQL queries that filter on the ID(s) of peer nodes that could cause nodes to be improperly excluded if the peer's schema had its name, namespace, or inheritance updated.

--- a/docs/docs/release-notes/infrahub/release-1_4_8.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_4_8.mdx
@@ -22,7 +22,7 @@ title: Release 1.4.8
 
 - Report proper branch when read-only repositories fail to synchronize due to invalid branch ([#5713](https://github.com/opsmill/infrahub/issues/5713))
 - Add an HFID for Attribute and Relationship matches for a Node Trigger Rule ([#6713](https://github.com/opsmill/infrahub/issues/6713))
-- Use the prune flag when fetching updates from remote git reposities to clear deleted remote references locally ([#6884](https://github.com/opsmill/infrahub/issues/6884))
+- Use the prune flag when fetching updates from remote git repositories to clear deleted remote references locally ([#6884](https://github.com/opsmill/infrahub/issues/6884))
 - Fix branch delete query to avoid out-of-memory error when using the community edition ([#7161](https://github.com/opsmill/infrahub/issues/7161))
 - Fix bug in GraphQL queries that filter on the ID(s) of peer nodes that could cause nodes to be improperly excluded if the peer's schema had its name, namespace, or inheritance updated. ([#7247](https://github.com/opsmill/infrahub/issues/7247))
 - Convert GraphQL query group update tasks to interval to hide it from the task list

--- a/docs/docs/release-notes/infrahub/release-1_4_8.mdx
+++ b/docs/docs/release-notes/infrahub/release-1_4_8.mdx
@@ -1,0 +1,30 @@
+---
+title: Release 1.4.8
+---
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.4.8</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>September 23rd, 2025</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[infrahub-v1.4.8](https://github.com/opsmill/infrahub/releases/tag/infrahub-v1.4.8)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Fixed
+
+- Report proper branch when read-only repositories fail to synchronize due to invalid branch ([#5713](https://github.com/opsmill/infrahub/issues/5713))
+- Add an HFID for Attribute and Relationship matches for a Node Trigger Rule ([#6713](https://github.com/opsmill/infrahub/issues/6713))
+- Use the prune flag when fetching updates from remote git reposities to clear deleted remote references locally ([#6884](https://github.com/opsmill/infrahub/issues/6884))
+- Fix branch delete query to avoid out-of-memory error when using the community edition ([#7161](https://github.com/opsmill/infrahub/issues/7161))
+- Fix bug in GraphQL queries that filter on the ID(s) of peer nodes that could cause nodes to be improperly excluded if the peer's schema had its name, namespace, or inheritance updated. ([#7247](https://github.com/opsmill/infrahub/issues/7247))
+- Convert GraphQL query group update tasks to interval to hide it from the task list
+- Ensure the default branch is used when a node is part of the global branch
+- Update a cypher query that did not correctly account for deleted Relationships. It was only used during a delete, so would not have caused any issues visible to the user.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -414,6 +414,7 @@ const sidebars: SidebarsConfig = {
             slug: 'release-notes/infrahub',
           },
           items: [
+            'release-notes/infrahub/release-1_4_8',
             'release-notes/infrahub/release-1_4_7',
             'release-notes/infrahub/release-1_4_6',
             'release-notes/infrahub/release-1_4_5',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "infrahub-server"
-version = "1.4.7"
+version = "1.4.8"
 description = "Infrahub is taking a new approach to Infrastructure Management by providing a new generation of datastore to organize and control all the data that defines how an infrastructure should run."
 authors = ["OpsMill <info@opsmill.com>"]
 readme = "README.md"

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "infrahub-testcontainers"
-version = "1.4.7"
+version = "1.4.8"
 requires-python = ">=3.9"
 
 [tool.poetry]
 name = "infrahub-testcontainers"
-version = "1.4.7"
+version = "1.4.8"
 description = "Testcontainers instance for Infrahub to easily build integration tests"
 authors = ["OpsMill <info@opsmill.com>"]
 readme = "README.md"


### PR DESCRIPTION
### Fixed

- Report proper branch when read-only repositories fail to synchronize due to invalid branch ([#5713](https://github.com/opsmill/infrahub/issues/5713))
- Add an HFID for Attribute and Relationship matches for a Node Trigger Rule ([#6713](https://github.com/opsmill/infrahub/issues/6713))
- Use the prune flag when fetching updates from remote git reposities to clear deleted remote references locally ([#6884](https://github.com/opsmill/infrahub/issues/6884))
- Fix branch delete query to avoid out-of-memory error when using the community edition ([#7161](https://github.com/opsmill/infrahub/issues/7161))
- Fix bug in GraphQL queries that filter on the ID(s) of peer nodes that could cause nodes to be improperly excluded if the peer's schema had its name, namespace, or inheritance updated. ([#7247](https://github.com/opsmill/infrahub/issues/7247))
- Convert GraphQL query group update tasks to interval to hide it from the task list
- Ensure the default branch is used when a node is part of the global branch
- Update a cypher query that did not correctly account for deleted Relationships. It was only used during a delete, so would not have caused any issues visible to the user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Correct branch reporting for read-only repo sync failures.
  - Add HFIDs for Node Trigger Rule attribute/relationship matches.
  - Prune deleted remote refs when fetching from git remotes.
  - Prevent OOM on branch deletion in Community Edition.
  - Fix GraphQL filters on peer node IDs after schema changes.
  - Hide query group update tasks from task list.
  - Use default branch for nodes in the global branch.
  - Account for deleted relationships in queries.

- **Documentation**
  - Added Release 1.4.8 notes and updated navigation.

- **Chores**
  - Bumped version to 1.4.8.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->