### PR TITLE
fix(docs): add upgrade path warning

### DIFF
--- a/docs/docs/guides/upgrade.mdx
+++ b/docs/docs/guides/upgrade.mdx
@@ -14,6 +14,10 @@ For installation instructions, please refer to our [Installation Guide](./instal
 
 Follow the instructions below for your current release version and deployment method.
 
+:::warning Upgrade path support
+Upgrades are supported only from the previous minor version (N-1), for example from Infrahub 1.3 to 1.4. If you need to upgrade from N-2 or older, upgrade sequentially one minor version at a time (for example: 1.2 -> 1.3 -> 1.4).
+:::
+
 :::info
 Even though a "smooth" migration is anticipated, we nonetheless strongly suggest creating a backup beforehand. For detailed information, see our [Backup Guide](./database-backup).
 :::


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a clear warning in the upgrade guide (both the general introduction and the Enterprise section) stating that upgrades are only supported from the previous minor release (N‑1); older versions must be upgraded sequentially through each minor release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->