### PR TITLE
remove profiles on read

### DIFF
--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from copy import copy
-from functools import reduce
 from typing import TYPE_CHECKING, Any, Iterable, Literal, TypeVar, overload
 
 from infrahub_sdk.utils import deep_merge_dict, is_valid_uuid
@@ -11,9 +10,7 @@ from infrahub.core.node import Node
 from infrahub.core.node.delete_validator import NodeDeleteValidator
 from infrahub.core.query.node import (
     AttributeFromDB,
-    AttributeNodePropertyFromDB,
     GroupedPeerNodes,
-    NodeAttributesFromDB,
     NodeGetHierarchyQuery,
     NodeGetListQuery,
     NodeListGetAttributeQuery,
@@ -73,60 +70,6 @@ def get_schema(
         raise ValueError(f"Invalid schema provided {node_schema}")
 
     return node_schema
-
-
-class ProfileAttributeIndex:
-    def __init__(
-        self,
-        profile_attributes_id_map: dict[str, NodeAttributesFromDB],
-        profile_ids_by_node_id: dict[str, list[str]],
-    ) -> None:
-        self._profile_attributes_id_map = profile_attributes_id_map
-        self._profile_ids_by_node_id = profile_ids_by_node_id
-
-    def apply_profiles(self, node_data_dict: dict[str, Any]) -> dict[str, Any]:
-        updated_data: dict[str, Any] = {**node_data_dict}
-        node_id = node_data_dict.get("id")
-        profile_ids = self._profile_ids_by_node_id.get(node_id, [])
-        if not profile_ids:
-            return updated_data
-        profiles = [
-            self._profile_attributes_id_map[p_id] for p_id in profile_ids if p_id in self._profile_attributes_id_map
-        ]
-
-        def get_profile_priority(nafd: NodeAttributesFromDB) -> tuple[int | float, str]:
-            try:
-                return (int(nafd.attrs.get("profile_priority").value), nafd.node.get("uuid"))
-            except (TypeError, AttributeError):
-                return (float("inf"), "")
-
-        profiles.sort(key=get_profile_priority)
-
-        for attr_name, attr_data in updated_data.items():
-            if not isinstance(attr_data, AttributeFromDB):
-                continue
-            if not attr_data.is_default:
-                continue
-            profile_value, profile_uuid = None, None
-            index = 0
-
-            while profile_value is None and index <= (len(profiles) - 1):
-                try:
-                    profile_value = profiles[index].attrs[attr_name].value
-                    if profile_value != "NULL":
-                        profile_uuid = profiles[index].node["uuid"]
-                        break
-                    profile_value = None
-                except (IndexError, KeyError, AttributeError):
-                    ...
-                index += 1
-
-            if profile_value is not None:
-                attr_data.value = profile_value
-                attr_data.is_from_profile = True
-                attr_data.is_default = False
-                attr_data.node_properties["source"] = AttributeNodePropertyFromDB(uuid=profile_uuid, labels=[])
-        return updated_data
 
 
 class NodeManager:
@@ -1129,21 +1072,11 @@ class NodeManager:
         )
         await query.execute(db=db)
         nodes_info_by_id: dict[str, NodeToProcess] = {node.node_uuid: node async for node in query.get_nodes(db=db)}
-        profile_ids_by_node_id = query.get_profile_ids_by_node_id()
-        all_profile_ids = reduce(
-            lambda all_ids, these_ids: all_ids | set(these_ids), profile_ids_by_node_id.values(), set()
-        )
-
-        if fields and all_profile_ids:
-            if "profile_priority" not in fields:
-                fields["profile_priority"] = {}
-            if "value" not in fields["profile_priority"]:
-                fields["profile_priority"]["value"] = None
 
         # Query list of all Attributes
         query = await NodeListGetAttributeQuery.init(
             db=db,
-            ids=list(nodes_info_by_id.keys()) + list(all_profile_ids),
+            ids=list(nodes_info_by_id.keys()),
             fields=fields,
             branch=branch,
             include_source=include_source,
@@ -1153,17 +1086,7 @@ class NodeManager:
             branch_agnostic=branch_agnostic,
         )
         await query.execute(db=db)
-        all_node_attributes = query.get_attributes_group_by_node()
-        profile_attributes: dict[str, dict[str, AttributeFromDB]] = {}
-        node_attributes: dict[str, dict[str, AttributeFromDB]] = {}
-        for node_id, attribute_dict in all_node_attributes.items():
-            if node_id in all_profile_ids:
-                profile_attributes[node_id] = attribute_dict
-            else:
-                node_attributes[node_id] = attribute_dict
-        profile_index = ProfileAttributeIndex(
-            profile_attributes_id_map=profile_attributes, profile_ids_by_node_id=profile_ids_by_node_id
-        )
+        node_attributes = query.get_attributes_group_by_node()
 
         nodes: dict[str, Node] = {}
 
@@ -1192,11 +1115,10 @@ class NodeManager:
                 for attr_name, attr in node_attributes[node_id].attrs.items():
                     new_node_data[attr_name] = attr
 
-            new_node_data_with_profile_overrides = profile_index.apply_profiles(new_node_data)
             node_class = identify_node_class(node=node)
             node_branch = await registry.get_branch(db=db, branch=node.branch)
             item = await node_class.init(schema=node.schema, branch=node_branch, at=at, db=db)
-            await item.load(**new_node_data_with_profile_overrides, db=db)
+            await item.load(**new_node_data, db=db)
 
             nodes[node_id] = item
 

--- a/backend/infrahub/core/query/attribute.py
+++ b/backend/infrahub/core/query/attribute.py
@@ -204,7 +204,6 @@ async def default_attribute_query_filter(
     param_prefix: str | None = None,
     db: InfrahubDatabase | None = None,  # noqa: ARG001
     partial_match: bool = False,
-    support_profiles: bool = False,
 ) -> tuple[list[QueryElement], dict[str, Any], list[str]]:
     """Generate Query String Snippet to filter the right node."""
     attribute_value_label = GraphAttributeValueNode.get_default_label()
@@ -251,9 +250,6 @@ async def default_attribute_query_filter(
                 query_where.append(f"toString(av.{filter_name}) =~ ${param_prefix}_{filter_name}")
             elif filter_name == "isnull":
                 query_filter.append(QueryNode(name="av", labels=[attribute_value_label]))
-            elif support_profiles:
-                query_filter.append(QueryNode(name="av", labels=[attribute_value_label]))
-                query_where.append(f"(av.{filter_name} = ${param_prefix}_{filter_name} OR av.is_default)")
             else:
                 query_filter.append(
                     QueryNode(
@@ -271,8 +267,6 @@ async def default_attribute_query_filter(
         if attribute_kind and attribute_kind == "List":
             query_params[f"{param_prefix}_{filter_name}"] = build_regex_attrs(values=filter_value)
             query_where.append(f"toString(av.value) =~ ${param_prefix}_{filter_name}")
-        elif support_profiles:
-            query_where.append(f"(av.value IN ${param_prefix}_value OR av.is_default)")
         else:
             query_where.append(f"av.value IN ${param_prefix}_value")
         query_params[f"{param_prefix}_value"] = filter_value

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -43,7 +43,6 @@ class NodeToProcess:
 
     node_id: str
     node_uuid: str
-    profile_uuids: list[str]
 
     updated_at: str
 
@@ -942,6 +941,7 @@ class NodeListGetInfoQuery(Query):
             at=self.at, branch_agnostic=self.branch_agnostic
         )
         self.params.update(branch_params)
+        self.params["ids"] = self.ids
 
         query = """
         MATCH p = (root:Root)<-[:IS_PART_OF]-(n:Node)
@@ -955,16 +955,11 @@ class NodeListGetInfoQuery(Query):
         }
         WITH n1 as n, r1 as rb
         WHERE rb.status = "active"
-        OPTIONAL MATCH profile_path = (n)-[:IS_RELATED]->(profile_r:Relationship)<-[:IS_RELATED]-(profile:Node)-[:IS_PART_OF]->(:Root)
-        WHERE profile_r.name = "node__profile"
-        AND profile.namespace = "Profile"
-        AND all(r in relationships(profile_path) WHERE %(branch_filter)s and r.status = "active")
         """ % {"branch_filter": branch_filter}
 
         self.add_to_query(query)
-        self.params["ids"] = self.ids
 
-        self.return_labels = ["collect(profile.uuid) as profile_uuids", "n", "rb"]
+        self.return_labels = ["n", "rb"]
 
     async def get_nodes(self, db: InfrahubDatabase, duplicate: bool = False) -> AsyncIterator[NodeToProcess]:
         """Return all the node objects as NodeToProcess."""
@@ -978,23 +973,10 @@ class NodeListGetInfoQuery(Query):
                 schema=schema,
                 node_id=result.get_node("n").element_id,
                 node_uuid=result.get_node("n").get("uuid"),
-                profile_uuids=[str(puuid) for puuid in result.get("profile_uuids")],
                 updated_at=result.get_rel("rb").get("from"),
                 branch=node_branch,
                 labels=list(result.get_node("n").labels),
             )
-
-    def get_profile_ids_by_node_id(self) -> dict[str, list[str]]:
-        profile_id_map: dict[str, list[str]] = {}
-        for result in self.results:
-            node_id = result.get_node("n").get("uuid")
-            profile_ids = result.get("profile_uuids")
-            if not node_id or not profile_ids:
-                continue
-            if node_id not in profile_id_map:
-                profile_id_map[node_id] = []
-            profile_id_map[node_id].extend(profile_ids)
-        return profile_id_map
 
 
 class FieldAttributeRequirementType(Enum):
@@ -1012,7 +994,7 @@ class FieldAttributeRequirement:
     types: list[FieldAttributeRequirementType] = dataclass_field(default_factory=list)
 
     @property
-    def supports_profile(self) -> bool:
+    def is_attribute_value(self) -> bool:
         return bool(self.field and self.field.is_attribute and self.field_attr_name in ("value", "values", "isnull"))
 
     @property
@@ -1024,24 +1006,8 @@ class FieldAttributeRequirement:
         return FieldAttributeRequirementType.ORDER in self.types
 
     @property
-    def is_default_query_variable(self) -> str:
-        return f"attr{self.index}_is_default"
-
-    @property
     def node_value_query_variable(self) -> str:
         return f"attr{self.index}_node_value"
-
-    @property
-    def profile_value_query_variable(self) -> str:
-        return f"attr{self.index}_profile_value"
-
-    @property
-    def profile_final_value_query_variable(self) -> str:
-        return f"attr{self.index}_final_profile_value"
-
-    @property
-    def final_value_query_variable(self) -> str:
-        return f"attr{self.index}_final_value"
 
     @property
     def comparison_operator(self) -> str:
@@ -1178,7 +1144,6 @@ class NodeGetListQuery(Query):
             self.params["node_ids"] = self.filters["ids"]
 
         field_attribute_requirements = self._get_field_requirements(disable_order=disable_order)
-        use_profiles = any(far for far in field_attribute_requirements if far.supports_profile)
         await self._add_node_filter_attributes(
             db=db, field_attribute_requirements=field_attribute_requirements, branch_filter=branch_filter
         )
@@ -1190,20 +1155,10 @@ class NodeGetListQuery(Query):
             for far in field_attribute_requirements:
                 if not far.is_order:
                     continue
-                if far.supports_profile:
-                    self.order_by.append(far.final_value_query_variable)
-                    continue
                 self.order_by.append(far.node_value_query_variable)
 
         # Always order by uuid to guarantee pagination, see https://github.com/opsmill/infrahub/pull/4704.
         self.order_by.append("n.uuid")
-
-        if use_profiles:
-            await self._add_profiles_per_node_query(db=db, branch_filter=branch_filter)
-            await self._add_profile_attributes(
-                db=db, field_attribute_requirements=field_attribute_requirements, branch_filter=branch_filter
-            )
-            await self._add_profile_rollups(field_attribute_requirements=field_attribute_requirements)
 
         self._add_final_filter(field_attribute_requirements=field_attribute_requirements)
 
@@ -1222,8 +1177,6 @@ class NodeGetListQuery(Query):
 
         for far in field_attribute_requirements:
             extra_tail_properties = {far.node_value_query_variable: "value"}
-            if far.supports_profile:
-                extra_tail_properties[far.is_default_query_variable] = "is_default"
             subquery, subquery_params, subquery_result_name = await build_subquery_filter(
                 db=db,
                 field=far.field,
@@ -1234,7 +1187,6 @@ class NodeGetListQuery(Query):
                 branch=self.branch,
                 subquery_idx=far.index,
                 partial_match=self.partial_match,
-                support_profiles=far.supports_profile,
                 extra_tail_properties=extra_tail_properties,
             )
             for query_var in extra_tail_properties:
@@ -1274,9 +1226,6 @@ class NodeGetListQuery(Query):
         for far in field_attribute_requirements:
             if far.field is None:
                 continue
-            extra_tail_properties = {}
-            if far.supports_profile:
-                extra_tail_properties[far.is_default_query_variable] = "is_default"
 
             subquery, subquery_params, _ = await build_subquery_order(
                 db=db,
@@ -1287,11 +1236,7 @@ class NodeGetListQuery(Query):
                 branch=self.branch,
                 subquery_idx=far.index,
                 result_prefix=far.node_value_query_variable,
-                support_profiles=far.supports_profile,
-                extra_tail_properties=extra_tail_properties,
             )
-            for query_var in extra_tail_properties:
-                self._track_variable(query_var)
             self._track_variable(far.node_value_query_variable)
             with_str = ", ".join(self._get_tracked_variables())
 
@@ -1305,122 +1250,11 @@ class NodeGetListQuery(Query):
             self.add_to_query(sort_query)
         self.params.update(sort_params)
 
-    async def _add_profiles_per_node_query(self, db: InfrahubDatabase, branch_filter: str) -> None:
-        with_str = ", ".join(self._get_tracked_variables())
-        froms_str = db.render_list_comprehension(items="relationships(profile_path)", item_name="from")
-        profiles_per_node_query = (
-            """
-            CALL (n) {
-                OPTIONAL MATCH profile_path = (n)-[:IS_RELATED]->(profile_r:Relationship)<-[:IS_RELATED]-(maybe_profile_n:Node)-[:IS_PART_OF]->(:Root)
-                WHERE profile_r.name = "node__profile"
-                AND all(r in relationships(profile_path) WHERE %(branch_filter)s)
-                WITH
-                    maybe_profile_n,
-                    profile_path,
-                    reduce(br_lvl = 0, r in relationships(profile_path) | br_lvl + r.branch_level) AS branch_level,
-                    %(froms_str)s AS froms,
-                    all(r in relationships(profile_path) WHERE r.status = "active") AS is_active
-                RETURN maybe_profile_n, is_active, branch_level, froms
-            }
-            WITH %(with_str)s, maybe_profile_n, branch_level, froms, is_active
-            ORDER BY n.uuid, maybe_profile_n.uuid, branch_level DESC, froms[-1] DESC, froms[-2] DESC, froms[-3] DESC
-            WITH %(with_str)s, maybe_profile_n, collect(is_active) as ordered_is_actives
-            WITH %(with_str)s, CASE
-                WHEN ordered_is_actives[0] = True THEN maybe_profile_n ELSE NULL
-            END AS profile_n
-            CALL (profile_n) {
-                OPTIONAL MATCH profile_priority_path = (profile_n)-[pr1:HAS_ATTRIBUTE]->(a:Attribute)-[pr2:HAS_VALUE]->(av:AttributeValue)
-                WHERE a.name = "profile_priority"
-                AND all(r in relationships(profile_priority_path) WHERE %(branch_filter)s and r.status = "active")
-                RETURN av.value as profile_priority
-                ORDER BY pr1.branch_level + pr2.branch_level DESC, pr2.from DESC, pr1.from DESC
-                LIMIT 1
-            }
-            WITH %(with_str)s, profile_n, profile_priority
-            """
-        ) % {"branch_filter": branch_filter, "with_str": with_str, "froms_str": froms_str}
-        self.add_to_query(profiles_per_node_query)
-        self._track_variable("profile_n")
-        self._track_variable("profile_priority")
-
-    async def _add_profile_attributes(
-        self, db: InfrahubDatabase, field_attribute_requirements: list[FieldAttributeRequirement], branch_filter: str
-    ) -> None:
-        attributes_queries: list[str] = []
-        attributes_params: dict[str, Any] = {}
-        profile_attributes = [far for far in field_attribute_requirements if far.supports_profile]
-
-        for profile_attr in profile_attributes:
-            if not profile_attr.field:
-                continue
-            subquery, subquery_params, _ = await build_subquery_order(
-                db=db,
-                field=profile_attr.field,
-                node_alias="profile_n",
-                name=profile_attr.field_name,
-                order_by=profile_attr.field_attr_name,
-                branch_filter=branch_filter,
-                branch=self.branch,
-                subquery_idx=profile_attr.index,
-                result_prefix=profile_attr.profile_value_query_variable,
-                support_profiles=False,
-            )
-            attributes_params.update(subquery_params)
-            self._track_variable(profile_attr.profile_value_query_variable)
-            with_str = ", ".join(self._get_tracked_variables())
-
-            attributes_queries.append("CALL (profile_n) {")
-            attributes_queries.append(subquery)
-            attributes_queries.append("}")
-            attributes_queries.append(f"WITH {with_str}")
-
-        self.add_to_query(attributes_queries)
-        self.params.update(attributes_params)
-
-    async def _add_profile_rollups(self, field_attribute_requirements: list[FieldAttributeRequirement]) -> None:
-        profile_attributes = [far for far in field_attribute_requirements if far.supports_profile]
-        profile_value_collects = []
-        for profile_attr in profile_attributes:
-            self._untrack_variable(profile_attr.profile_value_query_variable)
-            profile_value_collects.append(
-                f"""head(
-                    reduce(
-                        non_null_values = [], v in collect({profile_attr.profile_value_query_variable}) |
-                        CASE WHEN v IS NOT NULL AND v <> "NULL" THEN non_null_values + [v] ELSE non_null_values END
-                    )
-                ) as {profile_attr.profile_final_value_query_variable}"""
-            )
-        self._untrack_variable("profile_n")
-        self._untrack_variable("profile_priority")
-        profile_rollup_with_str = ", ".join(self._get_tracked_variables() + profile_value_collects)
-        profile_rollup_query = f"""
-        ORDER BY n.uuid, profile_priority ASC, profile_n.uuid ASC
-        WITH {profile_rollup_with_str}
-        """
-        self.add_to_query(profile_rollup_query)
-        for profile_attr in profile_attributes:
-            self._track_variable(profile_attr.profile_final_value_query_variable)
-
-        final_value_with = []
-        for profile_attr in profile_attributes:
-            final_value_with.append(f"""
-            CASE
-                WHEN {profile_attr.is_default_query_variable} AND {profile_attr.profile_final_value_query_variable} IS NOT NULL
-                THEN {profile_attr.profile_final_value_query_variable}
-                ELSE {profile_attr.node_value_query_variable}
-            END AS {profile_attr.final_value_query_variable}
-            """)
-            self._untrack_variable(profile_attr.is_default_query_variable)
-            self._untrack_variable(profile_attr.profile_final_value_query_variable)
-            self._untrack_variable(profile_attr.node_value_query_variable)
-        final_value_with_str = ", ".join(self._get_tracked_variables() + final_value_with)
-        self.add_to_query(f"WITH {final_value_with_str}")
-
     def _add_final_filter(self, field_attribute_requirements: list[FieldAttributeRequirement]) -> None:
         where_parts = []
         where_str = ""
         for far in field_attribute_requirements:
-            if not far.is_filter or not far.supports_profile:
+            if not far.is_filter or not far.is_attribute_value:
                 continue
             var_name = f"final_attr_value{far.index}"
             self.params[var_name] = far.field_attr_comparison_value
@@ -1429,11 +1263,11 @@ class NodeGetListQuery(Query):
                     # If the any filter is an array/list
                     var_array = f"{var_name}_array"
                     where_parts.append(
-                        f"any({var_array} IN ${var_name} WHERE toLower(toString({far.final_value_query_variable})) CONTAINS toLower({var_array}))"
+                        f"any({var_array} IN ${var_name} WHERE toLower(toString({far.node_value_query_variable})) CONTAINS toLower({var_array}))"
                     )
                 else:
                     where_parts.append(
-                        f"toLower(toString({far.final_value_query_variable})) CONTAINS toLower(toString(${var_name}))"
+                        f"toLower(toString({far.node_value_query_variable})) CONTAINS toLower(toString(${var_name}))"
                     )
                 continue
             if far.field and isinstance(far.field, AttributeSchema) and far.field.kind == "List":
@@ -1442,10 +1276,10 @@ class NodeGetListQuery(Query):
                 else:
                     self.params[var_name] = build_regex_attrs(values=[far.field_attr_comparison_value])
 
-                where_parts.append(f"toString({far.final_value_query_variable}) =~ ${var_name}")
+                where_parts.append(f"toString({far.node_value_query_variable}) =~ ${var_name}")
                 continue
 
-            where_parts.append(f"{far.final_value_query_variable} {far.comparison_operator} ${var_name}")
+            where_parts.append(f"{far.node_value_query_variable} {far.comparison_operator} ${var_name}")
         if where_parts:
             where_str = "WHERE " + " AND ".join(where_parts)
         self.add_to_query(where_str)

--- a/backend/infrahub/core/query/subquery.py
+++ b/backend/infrahub/core/query/subquery.py
@@ -25,12 +25,8 @@ async def build_subquery_filter(
     partial_match: bool = False,
     optional_match: bool = False,
     result_prefix: str = "filter",
-    support_profiles: bool = False,
     extra_tail_properties: dict[str, str] | None = None,
 ) -> tuple[str, dict[str, Any], str]:
-    support_profiles = (
-        support_profiles and field and field.is_attribute and filter_name in ("value", "values", "isnull")
-    )
     params = {}
     prefix = f"{result_prefix}{subquery_idx}"
 
@@ -52,7 +48,6 @@ async def build_subquery_filter(
         param_prefix=prefix,
         db=db,
         partial_match=partial_match,
-        support_profiles=support_profiles,
     )
     params.update(field_params)
 
@@ -109,10 +104,8 @@ async def build_subquery_order(
     branch: Branch = None,
     subquery_idx: int = 1,
     result_prefix: str | None = None,
-    support_profiles: bool = False,
     extra_tail_properties: dict[str, str] | None = None,
 ) -> tuple[str, dict[str, Any], str]:
-    support_profiles = support_profiles and field and field.is_attribute and order_by in ("value", "values")
     params = {}
     prefix = result_prefix or f"order{subquery_idx}"
 
@@ -124,7 +117,6 @@ async def build_subquery_order(
         filter_value=None,
         branch=branch,
         param_prefix=prefix,
-        support_profiles=support_profiles,
     )
     params.update(field_params)
 

--- a/backend/infrahub/core/schema/attribute_schema.py
+++ b/backend/infrahub/core/schema/attribute_schema.py
@@ -202,7 +202,7 @@ class AttributeSchema(GeneratedAttributeSchema):
         param_prefix: str | None = None,
         db: InfrahubDatabase | None = None,
         partial_match: bool = False,
-        support_profiles: bool = False,
+        # support_profiles: bool = False,
     ) -> tuple[list[QueryElement], dict[str, Any], list[str]]:
         if self.enum:
             filter_value = self.convert_enum_to_value(filter_value)
@@ -217,7 +217,7 @@ class AttributeSchema(GeneratedAttributeSchema):
             param_prefix=param_prefix,
             db=db,
             partial_match=partial_match,
-            support_profiles=support_profiles,
+            # support_profiles=support_profiles,
         )
 
 

--- a/backend/infrahub/core/schema/attribute_schema.py
+++ b/backend/infrahub/core/schema/attribute_schema.py
@@ -202,7 +202,6 @@ class AttributeSchema(GeneratedAttributeSchema):
         param_prefix: str | None = None,
         db: InfrahubDatabase | None = None,
         partial_match: bool = False,
-        # support_profiles: bool = False,
     ) -> tuple[list[QueryElement], dict[str, Any], list[str]]:
         if self.enum:
             filter_value = self.convert_enum_to_value(filter_value)
@@ -217,7 +216,6 @@ class AttributeSchema(GeneratedAttributeSchema):
             param_prefix=param_prefix,
             db=db,
             partial_match=partial_match,
-            # support_profiles=support_profiles,
         )
 
 

--- a/backend/infrahub/core/schema/relationship_schema.py
+++ b/backend/infrahub/core/schema/relationship_schema.py
@@ -91,7 +91,6 @@ class RelationshipSchema(GeneratedRelationshipSchema):
         include_match: bool = True,
         param_prefix: str | None = None,
         partial_match: bool = False,
-        support_profiles: bool = False,  # noqa: ARG002
     ) -> tuple[list[QueryElement], dict[str, Any], list[str]]:
         """Generate Query String Snippet to filter the right node."""
 

--- a/backend/tests/integration/profiles/test_profile_lifecycle.py
+++ b/backend/tests/integration/profiles/test_profile_lifecycle.py
@@ -13,6 +13,7 @@ from tests.helpers.schema import load_schema
 from tests.helpers.test_app import TestInfrahubApp
 
 
+@pytest.mark.skip(reason="profile refactoring")
 class TestProfileLifecycle(TestInfrahubApp):
     @pytest.fixture(scope="class")
     async def schema_person_base(self, db: InfrahubDatabase, initialize_registry) -> None:

--- a/backend/tests/unit/core/test_manager_node.py
+++ b/backend/tests/unit/core/test_manager_node.py
@@ -338,67 +338,70 @@ async def test_get_many_prefetch_hierarchical(
     assert parent_europe is None
 
 
-# async def test_get_many_with_profile(db: InfrahubDatabase, default_branch: Branch, criticality_low, criticality_medium):
-#     profile_schema = registry.schema.get("ProfileTestCriticality", branch=default_branch)
-#     crit_profile_1 = await Node.init(db=db, schema=profile_schema)
-#     await crit_profile_1.new(db=db, profile_name="crit_profile_1", color="green", profile_priority=1001)
-#     await crit_profile_1.save(db=db)
-#     crit_profile_2 = await Node.init(db=db, schema=profile_schema)
-#     await crit_profile_2.new(db=db, profile_name="crit_profile_2", color="blue", profile_priority=1002)
-#     await crit_profile_2.save(db=db)
-#     crit_low = await NodeManager.get_one(db=db, id=criticality_low.id, branch=default_branch)
-#     await crit_low.profiles.update(db=db, data=[crit_profile_1, crit_profile_2])
-#     await crit_low.save(db=db)
+@pytest.mark.skip(reason="profile refactoring")
+async def test_get_many_with_profile(db: InfrahubDatabase, default_branch: Branch, criticality_low, criticality_medium):
+    profile_schema = registry.schema.get("ProfileTestCriticality", branch=default_branch)
+    crit_profile_1 = await Node.init(db=db, schema=profile_schema)
+    await crit_profile_1.new(db=db, profile_name="crit_profile_1", color="green", profile_priority=1001)
+    await crit_profile_1.save(db=db)
+    crit_profile_2 = await Node.init(db=db, schema=profile_schema)
+    await crit_profile_2.new(db=db, profile_name="crit_profile_2", color="blue", profile_priority=1002)
+    await crit_profile_2.save(db=db)
+    crit_low = await NodeManager.get_one(db=db, id=criticality_low.id, branch=default_branch)
+    await crit_low.profiles.update(db=db, data=[crit_profile_1, crit_profile_2])
+    await crit_low.save(db=db)
 
-#     node_map = await NodeManager.get_many(db=db, ids=[criticality_low.id, criticality_medium.id])
-#     assert len(node_map) == 2
-#     assert node_map[criticality_low.id].color.value == "green"
-#     source = await node_map[criticality_low.id].color.get_source(db=db)
-#     assert source.id == crit_profile_1.id
-
-
-# async def test_get_many_with_profile_generic(
-#     db: InfrahubDatabase, default_branch: Branch, criticality_low, criticality_medium
-# ):
-#     generic_profile_schema = registry.schema.get("ProfileTestGenericCriticality", branch=default_branch)
-#     generic_profile = await Node.init(db=db, schema=generic_profile_schema)
-#     await generic_profile.new(db=db, profile_name="generic_profile", color="green", profile_priority=1001)
-#     await generic_profile.save(db=db)
-#     crit_profile_schema = registry.schema.get("ProfileTestCriticality", branch=default_branch)
-#     crit_profile = await Node.init(db=db, schema=crit_profile_schema)
-#     await crit_profile.new(db=db, profile_name="crit_profile", color="blue", profile_priority=1002)
-#     await crit_profile.save(db=db)
-#     crit_low = await NodeManager.get_one(db=db, id=criticality_low.id, branch=default_branch)
-#     await crit_low.profiles.update(db=db, data=[crit_profile, generic_profile])
-#     await crit_low.save(db=db)
-
-#     node_map = await NodeManager.get_many(db=db, ids=[criticality_low.id, criticality_medium.id])
-#     assert len(node_map) == 2
-#     assert node_map[criticality_low.id].color.value == "green"
-#     source = await node_map[criticality_low.id].color.get_source(db=db)
-#     assert source.id == generic_profile.id
+    node_map = await NodeManager.get_many(db=db, ids=[criticality_low.id, criticality_medium.id])
+    assert len(node_map) == 2
+    assert node_map[criticality_low.id].color.value == "green"
+    source = await node_map[criticality_low.id].color.get_source(db=db)
+    assert source.id == crit_profile_1.id
 
 
-# async def test_get_many_with_multiple_profiles_same_priority(
-#     db: InfrahubDatabase, default_branch: Branch, criticality_low, criticality_medium
-# ):
-#     profile_schema = registry.schema.get("ProfileTestCriticality", branch=default_branch)
-#     crit_profiles = []
-#     for i in range(1, 10):
-#         crit_profile = await Node.init(db=db, schema=profile_schema)
-#         await crit_profile.new(db=db, profile_name=f"crit_profile_{i}", color=f"green{i}", profile_priority=1000)
-#         await crit_profile.save(db=db)
-#         crit_profiles.append(crit_profile)
-#     crit_low = await NodeManager.get_one(db=db, id=criticality_low.id, branch=default_branch)
-#     await crit_low.profiles.update(db=db, data=crit_profiles)
-#     await crit_low.save(db=db)
+@pytest.mark.skip(reason="profile refactoring")
+async def test_get_many_with_profile_generic(
+    db: InfrahubDatabase, default_branch: Branch, criticality_low, criticality_medium
+):
+    generic_profile_schema = registry.schema.get("ProfileTestGenericCriticality", branch=default_branch)
+    generic_profile = await Node.init(db=db, schema=generic_profile_schema)
+    await generic_profile.new(db=db, profile_name="generic_profile", color="green", profile_priority=1001)
+    await generic_profile.save(db=db)
+    crit_profile_schema = registry.schema.get("ProfileTestCriticality", branch=default_branch)
+    crit_profile = await Node.init(db=db, schema=crit_profile_schema)
+    await crit_profile.new(db=db, profile_name="crit_profile", color="blue", profile_priority=1002)
+    await crit_profile.save(db=db)
+    crit_low = await NodeManager.get_one(db=db, id=criticality_low.id, branch=default_branch)
+    await crit_low.profiles.update(db=db, data=[crit_profile, generic_profile])
+    await crit_low.save(db=db)
 
-#     lowest_uuid_profile = sorted(crit_profiles, key=lambda p: p.id)[0]
-#     node_map = await NodeManager.get_many(db=db, ids=[criticality_low.id, criticality_medium.id])
-#     assert len(node_map) == 2
-#     assert node_map[criticality_low.id].color.value == lowest_uuid_profile.color.value
-#     source = await node_map[criticality_low.id].color.get_source(db=db)
-#     assert source.id == lowest_uuid_profile.id
+    node_map = await NodeManager.get_many(db=db, ids=[criticality_low.id, criticality_medium.id])
+    assert len(node_map) == 2
+    assert node_map[criticality_low.id].color.value == "green"
+    source = await node_map[criticality_low.id].color.get_source(db=db)
+    assert source.id == generic_profile.id
+
+
+@pytest.mark.skip(reason="profile refactoring")
+async def test_get_many_with_multiple_profiles_same_priority(
+    db: InfrahubDatabase, default_branch: Branch, criticality_low, criticality_medium
+):
+    profile_schema = registry.schema.get("ProfileTestCriticality", branch=default_branch)
+    crit_profiles = []
+    for i in range(1, 10):
+        crit_profile = await Node.init(db=db, schema=profile_schema)
+        await crit_profile.new(db=db, profile_name=f"crit_profile_{i}", color=f"green{i}", profile_priority=1000)
+        await crit_profile.save(db=db)
+        crit_profiles.append(crit_profile)
+    crit_low = await NodeManager.get_one(db=db, id=criticality_low.id, branch=default_branch)
+    await crit_low.profiles.update(db=db, data=crit_profiles)
+    await crit_low.save(db=db)
+
+    lowest_uuid_profile = sorted(crit_profiles, key=lambda p: p.id)[0]
+    node_map = await NodeManager.get_many(db=db, ids=[criticality_low.id, criticality_medium.id])
+    assert len(node_map) == 2
+    assert node_map[criticality_low.id].color.value == lowest_uuid_profile.color.value
+    source = await node_map[criticality_low.id].color.get_source(db=db)
+    assert source.id == lowest_uuid_profile.id
 
 
 async def test_get_many_branch_agnostic(

--- a/backend/tests/unit/core/test_manager_node.py
+++ b/backend/tests/unit/core/test_manager_node.py
@@ -338,67 +338,67 @@ async def test_get_many_prefetch_hierarchical(
     assert parent_europe is None
 
 
-async def test_get_many_with_profile(db: InfrahubDatabase, default_branch: Branch, criticality_low, criticality_medium):
-    profile_schema = registry.schema.get("ProfileTestCriticality", branch=default_branch)
-    crit_profile_1 = await Node.init(db=db, schema=profile_schema)
-    await crit_profile_1.new(db=db, profile_name="crit_profile_1", color="green", profile_priority=1001)
-    await crit_profile_1.save(db=db)
-    crit_profile_2 = await Node.init(db=db, schema=profile_schema)
-    await crit_profile_2.new(db=db, profile_name="crit_profile_2", color="blue", profile_priority=1002)
-    await crit_profile_2.save(db=db)
-    crit_low = await NodeManager.get_one(db=db, id=criticality_low.id, branch=default_branch)
-    await crit_low.profiles.update(db=db, data=[crit_profile_1, crit_profile_2])
-    await crit_low.save(db=db)
+# async def test_get_many_with_profile(db: InfrahubDatabase, default_branch: Branch, criticality_low, criticality_medium):
+#     profile_schema = registry.schema.get("ProfileTestCriticality", branch=default_branch)
+#     crit_profile_1 = await Node.init(db=db, schema=profile_schema)
+#     await crit_profile_1.new(db=db, profile_name="crit_profile_1", color="green", profile_priority=1001)
+#     await crit_profile_1.save(db=db)
+#     crit_profile_2 = await Node.init(db=db, schema=profile_schema)
+#     await crit_profile_2.new(db=db, profile_name="crit_profile_2", color="blue", profile_priority=1002)
+#     await crit_profile_2.save(db=db)
+#     crit_low = await NodeManager.get_one(db=db, id=criticality_low.id, branch=default_branch)
+#     await crit_low.profiles.update(db=db, data=[crit_profile_1, crit_profile_2])
+#     await crit_low.save(db=db)
 
-    node_map = await NodeManager.get_many(db=db, ids=[criticality_low.id, criticality_medium.id])
-    assert len(node_map) == 2
-    assert node_map[criticality_low.id].color.value == "green"
-    source = await node_map[criticality_low.id].color.get_source(db=db)
-    assert source.id == crit_profile_1.id
-
-
-async def test_get_many_with_profile_generic(
-    db: InfrahubDatabase, default_branch: Branch, criticality_low, criticality_medium
-):
-    generic_profile_schema = registry.schema.get("ProfileTestGenericCriticality", branch=default_branch)
-    generic_profile = await Node.init(db=db, schema=generic_profile_schema)
-    await generic_profile.new(db=db, profile_name="generic_profile", color="green", profile_priority=1001)
-    await generic_profile.save(db=db)
-    crit_profile_schema = registry.schema.get("ProfileTestCriticality", branch=default_branch)
-    crit_profile = await Node.init(db=db, schema=crit_profile_schema)
-    await crit_profile.new(db=db, profile_name="crit_profile", color="blue", profile_priority=1002)
-    await crit_profile.save(db=db)
-    crit_low = await NodeManager.get_one(db=db, id=criticality_low.id, branch=default_branch)
-    await crit_low.profiles.update(db=db, data=[crit_profile, generic_profile])
-    await crit_low.save(db=db)
-
-    node_map = await NodeManager.get_many(db=db, ids=[criticality_low.id, criticality_medium.id])
-    assert len(node_map) == 2
-    assert node_map[criticality_low.id].color.value == "green"
-    source = await node_map[criticality_low.id].color.get_source(db=db)
-    assert source.id == generic_profile.id
+#     node_map = await NodeManager.get_many(db=db, ids=[criticality_low.id, criticality_medium.id])
+#     assert len(node_map) == 2
+#     assert node_map[criticality_low.id].color.value == "green"
+#     source = await node_map[criticality_low.id].color.get_source(db=db)
+#     assert source.id == crit_profile_1.id
 
 
-async def test_get_many_with_multiple_profiles_same_priority(
-    db: InfrahubDatabase, default_branch: Branch, criticality_low, criticality_medium
-):
-    profile_schema = registry.schema.get("ProfileTestCriticality", branch=default_branch)
-    crit_profiles = []
-    for i in range(1, 10):
-        crit_profile = await Node.init(db=db, schema=profile_schema)
-        await crit_profile.new(db=db, profile_name=f"crit_profile_{i}", color=f"green{i}", profile_priority=1000)
-        await crit_profile.save(db=db)
-        crit_profiles.append(crit_profile)
-    crit_low = await NodeManager.get_one(db=db, id=criticality_low.id, branch=default_branch)
-    await crit_low.profiles.update(db=db, data=crit_profiles)
-    await crit_low.save(db=db)
+# async def test_get_many_with_profile_generic(
+#     db: InfrahubDatabase, default_branch: Branch, criticality_low, criticality_medium
+# ):
+#     generic_profile_schema = registry.schema.get("ProfileTestGenericCriticality", branch=default_branch)
+#     generic_profile = await Node.init(db=db, schema=generic_profile_schema)
+#     await generic_profile.new(db=db, profile_name="generic_profile", color="green", profile_priority=1001)
+#     await generic_profile.save(db=db)
+#     crit_profile_schema = registry.schema.get("ProfileTestCriticality", branch=default_branch)
+#     crit_profile = await Node.init(db=db, schema=crit_profile_schema)
+#     await crit_profile.new(db=db, profile_name="crit_profile", color="blue", profile_priority=1002)
+#     await crit_profile.save(db=db)
+#     crit_low = await NodeManager.get_one(db=db, id=criticality_low.id, branch=default_branch)
+#     await crit_low.profiles.update(db=db, data=[crit_profile, generic_profile])
+#     await crit_low.save(db=db)
 
-    lowest_uuid_profile = sorted(crit_profiles, key=lambda p: p.id)[0]
-    node_map = await NodeManager.get_many(db=db, ids=[criticality_low.id, criticality_medium.id])
-    assert len(node_map) == 2
-    assert node_map[criticality_low.id].color.value == lowest_uuid_profile.color.value
-    source = await node_map[criticality_low.id].color.get_source(db=db)
-    assert source.id == lowest_uuid_profile.id
+#     node_map = await NodeManager.get_many(db=db, ids=[criticality_low.id, criticality_medium.id])
+#     assert len(node_map) == 2
+#     assert node_map[criticality_low.id].color.value == "green"
+#     source = await node_map[criticality_low.id].color.get_source(db=db)
+#     assert source.id == generic_profile.id
+
+
+# async def test_get_many_with_multiple_profiles_same_priority(
+#     db: InfrahubDatabase, default_branch: Branch, criticality_low, criticality_medium
+# ):
+#     profile_schema = registry.schema.get("ProfileTestCriticality", branch=default_branch)
+#     crit_profiles = []
+#     for i in range(1, 10):
+#         crit_profile = await Node.init(db=db, schema=profile_schema)
+#         await crit_profile.new(db=db, profile_name=f"crit_profile_{i}", color=f"green{i}", profile_priority=1000)
+#         await crit_profile.save(db=db)
+#         crit_profiles.append(crit_profile)
+#     crit_low = await NodeManager.get_one(db=db, id=criticality_low.id, branch=default_branch)
+#     await crit_low.profiles.update(db=db, data=crit_profiles)
+#     await crit_low.save(db=db)
+
+#     lowest_uuid_profile = sorted(crit_profiles, key=lambda p: p.id)[0]
+#     node_map = await NodeManager.get_many(db=db, ids=[criticality_low.id, criticality_medium.id])
+#     assert len(node_map) == 2
+#     assert node_map[criticality_low.id].color.value == lowest_uuid_profile.color.value
+#     source = await node_map[criticality_low.id].color.get_source(db=db)
+#     assert source.id == lowest_uuid_profile.id
 
 
 async def test_get_many_branch_agnostic(
@@ -623,7 +623,6 @@ async def test_identify_node_class(db: InfrahubDatabase, car_schema, default_bra
         schema=car_schema,
         node_id=33,
         node_uuid=str(UUIDT()),
-        profile_uuids=[],
         updated_at=Timestamp().to_string(),
         branch=default_branch,
         labels=["Node", "TestCar"],

--- a/backend/tests/unit/core/test_node_get_list_query.py
+++ b/backend/tests/unit/core/test_node_get_list_query.py
@@ -1,5 +1,3 @@
-from random import randint
-
 import pytest
 
 from infrahub.core.branch import Branch
@@ -502,358 +500,358 @@ async def test_query_NodeGetListQuery_order_by_relationship_value_with_update(
     assert set(retrieved_node_ids[2:]) == {car_yaris_main.id, car_volt_main.id}
 
 
-async def test_query_NodeGetListQuery_filter_with_profiles(
-    db: InfrahubDatabase, person_john_main, person_jim_main, person_albert_main, person_alfred_main, branch: Branch
-):
-    profile_schema = registry.schema.get("ProfileTestPerson", branch=branch, duplicate=False)
-    person_profile = await Node.init(db=db, schema=profile_schema, branch=branch)
-    await person_profile.new(db=db, profile_name="person_profile_1", height=172, profile_priority=1001)
-    await person_profile.save(db=db)
-    person_profile_2 = await Node.init(db=db, schema=profile_schema, branch=branch)
-    await person_profile_2.new(db=db, profile_name="person_profile_2", height=177, profile_priority=1002)
-    await person_profile_2.save(db=db)
+# async def test_query_NodeGetListQuery_filter_with_profiles(
+#     db: InfrahubDatabase, person_john_main, person_jim_main, person_albert_main, person_alfred_main, branch: Branch
+# ):
+#     profile_schema = registry.schema.get("ProfileTestPerson", branch=branch, duplicate=False)
+#     person_profile = await Node.init(db=db, schema=profile_schema, branch=branch)
+#     await person_profile.new(db=db, profile_name="person_profile_1", height=172, profile_priority=1001)
+#     await person_profile.save(db=db)
+#     person_profile_2 = await Node.init(db=db, schema=profile_schema, branch=branch)
+#     await person_profile_2.new(db=db, profile_name="person_profile_2", height=177, profile_priority=1002)
+#     await person_profile_2.save(db=db)
 
-    person_schema = registry.schema.get("TestPerson", branch=branch, duplicate=False)
-    person_schema.order_by = ["height__value", "name__value"]
-    person = await NodeManager.get_one(db=db, id=person_john_main.id, branch=branch)
-    person.height.value = None
-    person.height.is_default = True
-    await person.profiles.update(data=[person_profile, person_profile_2], db=db)
-    await person.save(db=db)
-    person = await NodeManager.get_one(db=db, id=person_jim_main.id, branch=branch)
-    person.height.value = None
-    person.height.is_default = True
-    await person.profiles.update(data=[person_profile], db=db)
-    await person.save(db=db)
-    person = await NodeManager.get_one(db=db, id=person_albert_main.id, branch=branch)
-    await person.profiles.update(data=[person_profile_2], db=db)
-    await person.save(db=db)
-    person = await NodeManager.get_one(db=db, id=person_alfred_main.id, branch=branch)
-    person.height.value = 172
-    await person.save(db=db)
+#     person_schema = registry.schema.get("TestPerson", branch=branch, duplicate=False)
+#     person_schema.order_by = ["height__value", "name__value"]
+#     person = await NodeManager.get_one(db=db, id=person_john_main.id, branch=branch)
+#     person.height.value = None
+#     person.height.is_default = True
+#     await person.profiles.update(data=[person_profile, person_profile_2], db=db)
+#     await person.save(db=db)
+#     person = await NodeManager.get_one(db=db, id=person_jim_main.id, branch=branch)
+#     person.height.value = None
+#     person.height.is_default = True
+#     await person.profiles.update(data=[person_profile], db=db)
+#     await person.save(db=db)
+#     person = await NodeManager.get_one(db=db, id=person_albert_main.id, branch=branch)
+#     await person.profiles.update(data=[person_profile_2], db=db)
+#     await person.save(db=db)
+#     person = await NodeManager.get_one(db=db, id=person_alfred_main.id, branch=branch)
+#     person.height.value = 172
+#     await person.save(db=db)
 
-    person_schema = registry.schema.get(name="TestPerson", branch=branch)
-    query = await NodeGetListQuery.init(db=db, branch=branch, schema=person_schema, filters={"height__value": 172})
+#     person_schema = registry.schema.get(name="TestPerson", branch=branch)
+#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=person_schema, filters={"height__value": 172})
 
-    await query.execute(db=db)
+#     await query.execute(db=db)
 
-    assert query.get_node_ids() == [person_alfred_main.id, person_jim_main.id, person_john_main.id]
-
-
-async def test_query_NodeGetListQuery_filter_with_generic_profiles(
-    db: InfrahubDatabase, animal_person_schema, default_branch: Branch
-):
-    animal_profile_schema = registry.schema.get("ProfileTestAnimal", duplicate=False)
-    animal_profile = await Node.init(db=db, schema=animal_profile_schema)
-    await animal_profile.new(db=db, profile_name="animal_profile", profile_priority=1000, weight=100)
-    await animal_profile.save(db=db)
-    cat_profile_schema = registry.schema.get("ProfileTestCat", duplicate=False)
-    cat_profile = await Node.init(db=db, schema=cat_profile_schema)
-    await cat_profile.new(db=db, profile_name="cat_profile", profile_priority=1001, weight=10)
-    await cat_profile.save(db=db)
-    dog_profile_schema = registry.schema.get("ProfileTestDog", duplicate=False)
-    dog_profile = await Node.init(db=db, schema=dog_profile_schema)
-    await dog_profile.new(db=db, profile_name="dog_profile", profile_priority=1002, weight=50)
-    await dog_profile.save(db=db)
-    person_schema = registry.schema.get("TestPerson", duplicate=False)
-    person = await Node.init(db=db, schema=person_schema)
-    await person.new(db=db, name="Ernest")
-    await person.save(db=db)
-    dog_schema = registry.schema.get("TestDog", duplicate=False)
-    big_dog = await Node.init(db=db, schema=dog_schema)
-    await big_dog.new(db=db, name="bigdog", breed="mixed", owner=person, profiles=[animal_profile, dog_profile])
-    await big_dog.save(db=db)
-    medium_dog = await Node.init(db=db, schema=dog_schema)
-    await medium_dog.new(db=db, name="mediumdog", breed="mixed", owner=person, profiles=[dog_profile])
-    await medium_dog.save(db=db)
-    cat_schema = registry.schema.get("TestCat", duplicate=False)
-    gigantic_cat = await Node.init(db=db, schema=cat_schema)
-    await gigantic_cat.new(
-        db=db, name="giganticcat", breed="orange", owner=person, profiles=[cat_profile, animal_profile]
-    )
-    await gigantic_cat.save(db=db)
-    small_cat = await Node.init(db=db, schema=cat_schema)
-    await small_cat.new(db=db, name="smallcat", breed="orange", owner=person, weight=7)
-    await small_cat.save(db=db)
-    animal_schema = registry.schema.get("TestAnimal", duplicate=False)
-
-    animal_profile_query = await NodeGetListQuery.init(
-        db=db, schema=animal_schema, branch=default_branch, filters={"weight__value": 100}
-    )
-    await animal_profile_query.execute(db=db)
-    assert set(animal_profile_query.get_node_ids()) == {big_dog.id, gigantic_cat.id}
-    medium_dog_query = await NodeGetListQuery.init(
-        db=db, schema=animal_schema, branch=default_branch, filters={"weight__value": 50}
-    )
-    await medium_dog_query.execute(db=db)
-    assert medium_dog_query.get_node_ids() == [medium_dog.id]
-    small_cat_query = await NodeGetListQuery.init(
-        db=db, schema=animal_schema, branch=default_branch, filters={"weight__value": 7}
-    )
-    await small_cat_query.execute(db=db)
-    assert small_cat_query.get_node_ids() == [small_cat.id]
+#     assert query.get_node_ids() == [person_alfred_main.id, person_jim_main.id, person_john_main.id]
 
 
-async def test_query_NodeGetListQuery_order_with_profiles(
-    db: InfrahubDatabase, car_camry_main, car_accord_main, car_volt_main, branch: Branch
-):
-    profile_schema = registry.schema.get("ProfileTestCar", branch=branch, duplicate=False)
-    car_profile_black = await Node.init(db=db, schema=profile_schema, branch=branch)
-    await car_profile_black.new(db=db, profile_name="car_profile_black", color="#000000", profile_priority=1001)
-    await car_profile_black.save(db=db)
-    car_profile_white = await Node.init(db=db, schema=profile_schema, branch=branch)
-    await car_profile_white.new(db=db, profile_name="car_profile_white", color="#ffffff", profile_priority=1002)
-    await car_profile_white.save(db=db)
+# async def test_query_NodeGetListQuery_filter_with_generic_profiles(
+#     db: InfrahubDatabase, animal_person_schema, default_branch: Branch
+# ):
+#     animal_profile_schema = registry.schema.get("ProfileTestAnimal", duplicate=False)
+#     animal_profile = await Node.init(db=db, schema=animal_profile_schema)
+#     await animal_profile.new(db=db, profile_name="animal_profile", profile_priority=1000, weight=100)
+#     await animal_profile.save(db=db)
+#     cat_profile_schema = registry.schema.get("ProfileTestCat", duplicate=False)
+#     cat_profile = await Node.init(db=db, schema=cat_profile_schema)
+#     await cat_profile.new(db=db, profile_name="cat_profile", profile_priority=1001, weight=10)
+#     await cat_profile.save(db=db)
+#     dog_profile_schema = registry.schema.get("ProfileTestDog", duplicate=False)
+#     dog_profile = await Node.init(db=db, schema=dog_profile_schema)
+#     await dog_profile.new(db=db, profile_name="dog_profile", profile_priority=1002, weight=50)
+#     await dog_profile.save(db=db)
+#     person_schema = registry.schema.get("TestPerson", duplicate=False)
+#     person = await Node.init(db=db, schema=person_schema)
+#     await person.new(db=db, name="Ernest")
+#     await person.save(db=db)
+#     dog_schema = registry.schema.get("TestDog", duplicate=False)
+#     big_dog = await Node.init(db=db, schema=dog_schema)
+#     await big_dog.new(db=db, name="bigdog", breed="mixed", owner=person, profiles=[animal_profile, dog_profile])
+#     await big_dog.save(db=db)
+#     medium_dog = await Node.init(db=db, schema=dog_schema)
+#     await medium_dog.new(db=db, name="mediumdog", breed="mixed", owner=person, profiles=[dog_profile])
+#     await medium_dog.save(db=db)
+#     cat_schema = registry.schema.get("TestCat", duplicate=False)
+#     gigantic_cat = await Node.init(db=db, schema=cat_schema)
+#     await gigantic_cat.new(
+#         db=db, name="giganticcat", breed="orange", owner=person, profiles=[cat_profile, animal_profile]
+#     )
+#     await gigantic_cat.save(db=db)
+#     small_cat = await Node.init(db=db, schema=cat_schema)
+#     await small_cat.new(db=db, name="smallcat", breed="orange", owner=person, weight=7)
+#     await small_cat.save(db=db)
+#     animal_schema = registry.schema.get("TestAnimal", duplicate=False)
 
-    car_schema = registry.schema.get("TestCar", branch=branch, duplicate=False)
-    car_schema.order_by = ["color__value", "name__value"]
-    car = await NodeManager.get_one(db=db, id=car_camry_main.id, branch=branch)
-    await car.profiles.update(data=[car_profile_white], db=db)
-    await car.save(db=db)
-    car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=branch)
-    await car.profiles.update(data=[car_profile_black], db=db)
-    await car.save(db=db)
-    car = await NodeManager.get_one(db=db, id=car_volt_main.id, branch=branch)
-    await car.profiles.update(data=[car_profile_black, car_profile_white], db=db)
-    await car.save(db=db)
-
-    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema)
-
-    await query.execute(db=db)
-
-    assert query.get_node_ids() == [car_accord_main.id, car_volt_main.id, car_camry_main.id]
-
-
-async def test_query_NodeGetListQuery_with_profiles_deleted(
-    db: InfrahubDatabase,
-    default_branch: Branch,
-    car_camry_main,
-    car_accord_main,
-    car_volt_main,
-    branch: Branch,
-):
-    profile_schema = registry.schema.get("ProfileTestCar", branch=branch, duplicate=False)
-    car_profile_black = await Node.init(db=db, schema=profile_schema, branch=branch)
-    await car_profile_black.new(db=db, profile_name="car_profile_black", color="#000000", profile_priority=1001)
-    await car_profile_black.save(db=db)
-    car_profile_white = await Node.init(db=db, schema=profile_schema, branch=branch)
-    await car_profile_white.new(db=db, profile_name="car_profile_white", color="#ffffff", profile_priority=1002)
-    await car_profile_white.save(db=db)
-    await branch.rebase(db=db)
-
-    car_schema = registry.schema.get("TestCar", branch=branch, duplicate=False)
-    car = await NodeManager.get_one(db=db, id=car_camry_main.id, branch=branch)
-    await car.profiles.update(data=[car_profile_white], db=db)
-    await car.save(db=db)
-    car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=branch)
-    await car.profiles.update(data=[car_profile_black], db=db)
-    await car.save(db=db)
-    car = await NodeManager.get_one(db=db, id=car_volt_main.id, branch=branch)
-    await car.profiles.update(data=[car_profile_black, car_profile_white], db=db)
-    await car.save(db=db)
-
-    car_profile_white_branch = await NodeManager.get_one(db=db, id=car_profile_white.id, branch=branch)
-    await car_profile_white_branch.delete(db=db)
-
-    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#444444"})
-    await query.execute(db=db)
-    assert query.get_node_ids() == [car_camry_main.id]
-    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#000000"})
-    await query.execute(db=db)
-    assert set(query.get_node_ids()) == {car_accord_main.id, car_volt_main.id}
-    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#ffffff"})
-    await query.execute(db=db)
-    assert query.get_node_ids() == []
+#     animal_profile_query = await NodeGetListQuery.init(
+#         db=db, schema=animal_schema, branch=default_branch, filters={"weight__value": 100}
+#     )
+#     await animal_profile_query.execute(db=db)
+#     assert set(animal_profile_query.get_node_ids()) == {big_dog.id, gigantic_cat.id}
+#     medium_dog_query = await NodeGetListQuery.init(
+#         db=db, schema=animal_schema, branch=default_branch, filters={"weight__value": 50}
+#     )
+#     await medium_dog_query.execute(db=db)
+#     assert medium_dog_query.get_node_ids() == [medium_dog.id]
+#     small_cat_query = await NodeGetListQuery.init(
+#         db=db, schema=animal_schema, branch=default_branch, filters={"weight__value": 7}
+#     )
+#     await small_cat_query.execute(db=db)
+#     assert small_cat_query.get_node_ids() == [small_cat.id]
 
 
-async def test_query_NodeGetListQuery_updated_profile_priorities_on_branch(
-    db: InfrahubDatabase,
-    car_camry_main,
-    car_accord_main,
-    car_volt_main,
-    branch: Branch,
-    default_branch: Branch,
-):
-    profile_schema = registry.schema.get("ProfileTestCar", branch=branch, duplicate=False)
-    car_profile_black = await Node.init(db=db, schema=profile_schema)
-    await car_profile_black.new(db=db, profile_name="car_profile_black", color="#000000", profile_priority=1001)
-    await car_profile_black.save(db=db)
-    car_profile_white = await Node.init(db=db, schema=profile_schema)
-    await car_profile_white.new(db=db, profile_name="car_profile_white", color="#ffffff", profile_priority=1002)
-    await car_profile_white.save(db=db)
-    car_schema = registry.schema.get("TestCar", branch=branch, duplicate=False)
-    car = await NodeManager.get_one(db=db, id=car_camry_main.id, branch=default_branch)
-    await car.profiles.update(data=[car_profile_white], db=db)
-    await car.save(db=db)
-    car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=default_branch)
-    await car.profiles.update(data=[car_profile_black], db=db)
-    await car.save(db=db)
-    car = await NodeManager.get_one(db=db, id=car_volt_main.id, branch=default_branch)
-    await car.profiles.update(data=[car_profile_black, car_profile_white], db=db)
-    await car.save(db=db)
-    await branch.rebase(db=db)
+# async def test_query_NodeGetListQuery_order_with_profiles(
+#     db: InfrahubDatabase, car_camry_main, car_accord_main, car_volt_main, branch: Branch
+# ):
+#     profile_schema = registry.schema.get("ProfileTestCar", branch=branch, duplicate=False)
+#     car_profile_black = await Node.init(db=db, schema=profile_schema, branch=branch)
+#     await car_profile_black.new(db=db, profile_name="car_profile_black", color="#000000", profile_priority=1001)
+#     await car_profile_black.save(db=db)
+#     car_profile_white = await Node.init(db=db, schema=profile_schema, branch=branch)
+#     await car_profile_white.new(db=db, profile_name="car_profile_white", color="#ffffff", profile_priority=1002)
+#     await car_profile_white.save(db=db)
 
-    car_profile_black_branch = await NodeManager.get_one(db=db, branch=branch, id=car_profile_black.id)
-    car_profile_black_branch.profile_priority.value = 3000
-    await car_profile_black_branch.save(db=db)
-    car_profile_white_branch = await NodeManager.get_one(db=db, branch=branch, id=car_profile_white.id)
-    car_profile_white_branch.profile_priority.value = 2000
-    await car_profile_white_branch.save(db=db)
+#     car_schema = registry.schema.get("TestCar", branch=branch, duplicate=False)
+#     car_schema.order_by = ["color__value", "name__value"]
+#     car = await NodeManager.get_one(db=db, id=car_camry_main.id, branch=branch)
+#     await car.profiles.update(data=[car_profile_white], db=db)
+#     await car.save(db=db)
+#     car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=branch)
+#     await car.profiles.update(data=[car_profile_black], db=db)
+#     await car.save(db=db)
+#     car = await NodeManager.get_one(db=db, id=car_volt_main.id, branch=branch)
+#     await car.profiles.update(data=[car_profile_black, car_profile_white], db=db)
+#     await car.save(db=db)
 
-    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#444444"})
-    await query.execute(db=db)
-    assert query.get_node_ids() == []
-    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#000000"})
-    await query.execute(db=db)
-    assert query.get_node_ids() == [car_accord_main.id]
-    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#ffffff"})
-    await query.execute(db=db)
-    assert set(query.get_node_ids()) == {car_camry_main.id, car_volt_main.id}
+#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema)
+
+#     await query.execute(db=db)
+
+#     assert query.get_node_ids() == [car_accord_main.id, car_volt_main.id, car_camry_main.id]
 
 
-async def test_query_NodeGetListQuery_updated_profile_attributes_on_branch(
-    db: InfrahubDatabase,
-    car_camry_main,
-    car_accord_main,
-    car_volt_main,
-    branch: Branch,
-    default_branch: Branch,
-):
-    profile_schema = registry.schema.get("ProfileTestCar", branch=branch, duplicate=False)
-    car_profile_black = await Node.init(db=db, schema=profile_schema)
-    await car_profile_black.new(db=db, profile_name="car_profile_black", color="#000000", profile_priority=1001)
-    await car_profile_black.save(db=db)
-    car_profile_white = await Node.init(db=db, schema=profile_schema)
-    await car_profile_white.new(db=db, profile_name="car_profile_white", color="#ffffff", profile_priority=1002)
-    await car_profile_white.save(db=db)
-    car_schema = registry.schema.get("TestCar", branch=branch, duplicate=False)
-    car = await NodeManager.get_one(db=db, id=car_camry_main.id, branch=default_branch)
-    await car.profiles.update(data=[car_profile_white], db=db)
-    await car.save(db=db)
-    car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=default_branch)
-    await car.profiles.update(data=[car_profile_black], db=db)
-    await car.save(db=db)
-    car = await NodeManager.get_one(db=db, id=car_volt_main.id, branch=default_branch)
-    await car.profiles.update(data=[car_profile_black, car_profile_white], db=db)
-    await car.save(db=db)
-    await branch.rebase(db=db)
+# async def test_query_NodeGetListQuery_with_profiles_deleted(
+#     db: InfrahubDatabase,
+#     default_branch: Branch,
+#     car_camry_main,
+#     car_accord_main,
+#     car_volt_main,
+#     branch: Branch,
+# ):
+#     profile_schema = registry.schema.get("ProfileTestCar", branch=branch, duplicate=False)
+#     car_profile_black = await Node.init(db=db, schema=profile_schema, branch=branch)
+#     await car_profile_black.new(db=db, profile_name="car_profile_black", color="#000000", profile_priority=1001)
+#     await car_profile_black.save(db=db)
+#     car_profile_white = await Node.init(db=db, schema=profile_schema, branch=branch)
+#     await car_profile_white.new(db=db, profile_name="car_profile_white", color="#ffffff", profile_priority=1002)
+#     await car_profile_white.save(db=db)
+#     await branch.rebase(db=db)
 
-    car_profile_black_branch = await NodeManager.get_one(db=db, branch=branch, id=car_profile_black.id)
-    car_profile_black_branch.color.value = "#000001"
-    await car_profile_black_branch.save(db=db)
-    car_profile_white_branch = await NodeManager.get_one(db=db, branch=branch, id=car_profile_white.id)
-    car_profile_white_branch.color.value = "#fffffe"
-    await car_profile_white_branch.save(db=db)
+#     car_schema = registry.schema.get("TestCar", branch=branch, duplicate=False)
+#     car = await NodeManager.get_one(db=db, id=car_camry_main.id, branch=branch)
+#     await car.profiles.update(data=[car_profile_white], db=db)
+#     await car.save(db=db)
+#     car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=branch)
+#     await car.profiles.update(data=[car_profile_black], db=db)
+#     await car.save(db=db)
+#     car = await NodeManager.get_one(db=db, id=car_volt_main.id, branch=branch)
+#     await car.profiles.update(data=[car_profile_black, car_profile_white], db=db)
+#     await car.save(db=db)
 
-    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#444444"})
-    await query.execute(db=db)
-    assert query.get_node_ids() == []
-    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#000000"})
-    await query.execute(db=db)
-    assert query.get_node_ids() == []
-    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#ffffff"})
-    await query.execute(db=db)
-    assert query.get_node_ids() == []
-    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#000001"})
-    await query.execute(db=db)
-    assert set(query.get_node_ids()) == {car_accord_main.id, car_volt_main.id}
-    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#fffffe"})
-    await query.execute(db=db)
-    assert query.get_node_ids() == [car_camry_main.id]
+#     car_profile_white_branch = await NodeManager.get_one(db=db, id=car_profile_white.id, branch=branch)
+#     await car_profile_white_branch.delete(db=db)
+
+#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#444444"})
+#     await query.execute(db=db)
+#     assert query.get_node_ids() == [car_camry_main.id]
+#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#000000"})
+#     await query.execute(db=db)
+#     assert set(query.get_node_ids()) == {car_accord_main.id, car_volt_main.id}
+#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#ffffff"})
+#     await query.execute(db=db)
+#     assert query.get_node_ids() == []
 
 
-async def test_query_NodeGetListQuery_updated_profile_attributes_nulled_on_branch(
-    db: InfrahubDatabase,
-    car_camry_main,
-    car_accord_main,
-    car_volt_main,
-    branch: Branch,
-):
-    profile_schema = registry.schema.get("ProfileTestCar", branch=branch, duplicate=False)
-    car_profile_black = await Node.init(db=db, schema=profile_schema, branch=branch)
-    await car_profile_black.new(db=db, profile_name="car_profile_black", color="#000000", profile_priority=1001)
-    await car_profile_black.save(db=db)
-    car_profile_white = await Node.init(db=db, schema=profile_schema, branch=branch)
-    await car_profile_white.new(db=db, profile_name="car_profile_white", color="#ffffff", profile_priority=1002)
-    await car_profile_white.save(db=db)
-    car_schema = registry.schema.get("TestCar", branch=branch, duplicate=False)
-    car = await NodeManager.get_one(db=db, id=car_camry_main.id, branch=branch)
-    await car.profiles.update(data=[car_profile_white], db=db)
-    await car.save(db=db)
-    car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=branch)
-    await car.profiles.update(data=[car_profile_black], db=db)
-    await car.save(db=db)
-    car = await NodeManager.get_one(db=db, id=car_volt_main.id, branch=branch)
-    await car.profiles.update(data=[car_profile_black, car_profile_white], db=db)
-    await car.save(db=db)
-    await branch.rebase(db=db)
+# async def test_query_NodeGetListQuery_updated_profile_priorities_on_branch(
+#     db: InfrahubDatabase,
+#     car_camry_main,
+#     car_accord_main,
+#     car_volt_main,
+#     branch: Branch,
+#     default_branch: Branch,
+# ):
+#     profile_schema = registry.schema.get("ProfileTestCar", branch=branch, duplicate=False)
+#     car_profile_black = await Node.init(db=db, schema=profile_schema)
+#     await car_profile_black.new(db=db, profile_name="car_profile_black", color="#000000", profile_priority=1001)
+#     await car_profile_black.save(db=db)
+#     car_profile_white = await Node.init(db=db, schema=profile_schema)
+#     await car_profile_white.new(db=db, profile_name="car_profile_white", color="#ffffff", profile_priority=1002)
+#     await car_profile_white.save(db=db)
+#     car_schema = registry.schema.get("TestCar", branch=branch, duplicate=False)
+#     car = await NodeManager.get_one(db=db, id=car_camry_main.id, branch=default_branch)
+#     await car.profiles.update(data=[car_profile_white], db=db)
+#     await car.save(db=db)
+#     car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=default_branch)
+#     await car.profiles.update(data=[car_profile_black], db=db)
+#     await car.save(db=db)
+#     car = await NodeManager.get_one(db=db, id=car_volt_main.id, branch=default_branch)
+#     await car.profiles.update(data=[car_profile_black, car_profile_white], db=db)
+#     await car.save(db=db)
+#     await branch.rebase(db=db)
 
-    car_profile_black_branch = await NodeManager.get_one(db=db, branch=branch, id=car_profile_black.id)
-    car_profile_black_branch.color.value = None
-    await car_profile_black_branch.save(db=db)
+#     car_profile_black_branch = await NodeManager.get_one(db=db, branch=branch, id=car_profile_black.id)
+#     car_profile_black_branch.profile_priority.value = 3000
+#     await car_profile_black_branch.save(db=db)
+#     car_profile_white_branch = await NodeManager.get_one(db=db, branch=branch, id=car_profile_white.id)
+#     car_profile_white_branch.profile_priority.value = 2000
+#     await car_profile_white_branch.save(db=db)
 
-    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#444444"})
-    await query.execute(db=db)
-    assert query.get_node_ids() == [car_accord_main.id]
-    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#000000"})
-    await query.execute(db=db)
-    assert query.get_node_ids() == []
-    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#ffffff"})
-    await query.execute(db=db)
-    assert set(query.get_node_ids()) == {car_camry_main.id, car_volt_main.id}
+#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#444444"})
+#     await query.execute(db=db)
+#     assert query.get_node_ids() == []
+#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#000000"})
+#     await query.execute(db=db)
+#     assert query.get_node_ids() == [car_accord_main.id]
+#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#ffffff"})
+#     await query.execute(db=db)
+#     assert set(query.get_node_ids()) == {car_camry_main.id, car_volt_main.id}
 
 
-async def test_query_NodeGetListQuery_multiple_profiles_same_priority_filter_and_order(
-    db: InfrahubDatabase,
-    car_camry_main,
-    car_accord_main,
-    branch: Branch,
-):
-    profile_schema = registry.schema.get("ProfileTestCar", branch=branch, duplicate=False)
-    profiles_group_1 = []
-    expected_profile_1 = None
-    for i in range(10):
-        car_profile = await Node.init(db=db, schema=profile_schema, branch=branch)
-        await car_profile.new(
-            db=db, profile_name=f"car_profile_{i}", color=f"#{randint(100000, 499999)}", profile_priority=1000
-        )
-        await car_profile.save(db=db)
-        if not expected_profile_1 or car_profile.id < expected_profile_1.id:
-            expected_profile_1 = car_profile
-            profiles_group_1.append(car_profile)
-    profiles_group_2 = []
-    expected_profile_2 = None
-    for i in range(10, 20):
-        car_profile = await Node.init(db=db, schema=profile_schema, branch=branch)
-        await car_profile.new(
-            db=db, profile_name=f"car_profile_{i}", color=f"#{randint(500000, 999999)}", profile_priority=1000
-        )
-        await car_profile.save(db=db)
-        if not expected_profile_2 or car_profile.id < expected_profile_2.id:
-            expected_profile_2 = car_profile
-            profiles_group_2.append(car_profile)
-    car_schema = registry.schema.get("TestCar", branch=branch, duplicate=False)
-    car_schema.order_by = ["color__value"]
-    car = await NodeManager.get_one(db=db, id=car_camry_main.id, branch=branch)
-    await car.profiles.update(data=profiles_group_1, db=db)
-    await car.save(db=db)
-    car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=branch)
-    await car.profiles.update(data=profiles_group_2, db=db)
-    await car.save(db=db)
+# async def test_query_NodeGetListQuery_updated_profile_attributes_on_branch(
+#     db: InfrahubDatabase,
+#     car_camry_main,
+#     car_accord_main,
+#     car_volt_main,
+#     branch: Branch,
+#     default_branch: Branch,
+# ):
+#     profile_schema = registry.schema.get("ProfileTestCar", branch=branch, duplicate=False)
+#     car_profile_black = await Node.init(db=db, schema=profile_schema)
+#     await car_profile_black.new(db=db, profile_name="car_profile_black", color="#000000", profile_priority=1001)
+#     await car_profile_black.save(db=db)
+#     car_profile_white = await Node.init(db=db, schema=profile_schema)
+#     await car_profile_white.new(db=db, profile_name="car_profile_white", color="#ffffff", profile_priority=1002)
+#     await car_profile_white.save(db=db)
+#     car_schema = registry.schema.get("TestCar", branch=branch, duplicate=False)
+#     car = await NodeManager.get_one(db=db, id=car_camry_main.id, branch=default_branch)
+#     await car.profiles.update(data=[car_profile_white], db=db)
+#     await car.save(db=db)
+#     car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=default_branch)
+#     await car.profiles.update(data=[car_profile_black], db=db)
+#     await car.save(db=db)
+#     car = await NodeManager.get_one(db=db, id=car_volt_main.id, branch=default_branch)
+#     await car.profiles.update(data=[car_profile_black, car_profile_white], db=db)
+#     await car.save(db=db)
+#     await branch.rebase(db=db)
 
-    query = await NodeGetListQuery.init(
-        db=db, branch=branch, schema=car_schema, filters={"color__value": expected_profile_1.color.value}
-    )
-    await query.execute(db=db)
-    assert query.get_node_ids() == [car_camry_main.id]
-    query = await NodeGetListQuery.init(
-        db=db, branch=branch, schema=car_schema, filters={"color__value": expected_profile_2.color.value}
-    )
-    await query.execute(db=db)
-    assert query.get_node_ids() == [car_accord_main.id]
-    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema)
-    await query.execute(db=db)
-    assert query.get_node_ids() == [car_camry_main.id, car_accord_main.id]
+#     car_profile_black_branch = await NodeManager.get_one(db=db, branch=branch, id=car_profile_black.id)
+#     car_profile_black_branch.color.value = "#000001"
+#     await car_profile_black_branch.save(db=db)
+#     car_profile_white_branch = await NodeManager.get_one(db=db, branch=branch, id=car_profile_white.id)
+#     car_profile_white_branch.color.value = "#fffffe"
+#     await car_profile_white_branch.save(db=db)
+
+#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#444444"})
+#     await query.execute(db=db)
+#     assert query.get_node_ids() == []
+#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#000000"})
+#     await query.execute(db=db)
+#     assert query.get_node_ids() == []
+#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#ffffff"})
+#     await query.execute(db=db)
+#     assert query.get_node_ids() == []
+#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#000001"})
+#     await query.execute(db=db)
+#     assert set(query.get_node_ids()) == {car_accord_main.id, car_volt_main.id}
+#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#fffffe"})
+#     await query.execute(db=db)
+#     assert query.get_node_ids() == [car_camry_main.id]
+
+
+# async def test_query_NodeGetListQuery_updated_profile_attributes_nulled_on_branch(
+#     db: InfrahubDatabase,
+#     car_camry_main,
+#     car_accord_main,
+#     car_volt_main,
+#     branch: Branch,
+# ):
+#     profile_schema = registry.schema.get("ProfileTestCar", branch=branch, duplicate=False)
+#     car_profile_black = await Node.init(db=db, schema=profile_schema, branch=branch)
+#     await car_profile_black.new(db=db, profile_name="car_profile_black", color="#000000", profile_priority=1001)
+#     await car_profile_black.save(db=db)
+#     car_profile_white = await Node.init(db=db, schema=profile_schema, branch=branch)
+#     await car_profile_white.new(db=db, profile_name="car_profile_white", color="#ffffff", profile_priority=1002)
+#     await car_profile_white.save(db=db)
+#     car_schema = registry.schema.get("TestCar", branch=branch, duplicate=False)
+#     car = await NodeManager.get_one(db=db, id=car_camry_main.id, branch=branch)
+#     await car.profiles.update(data=[car_profile_white], db=db)
+#     await car.save(db=db)
+#     car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=branch)
+#     await car.profiles.update(data=[car_profile_black], db=db)
+#     await car.save(db=db)
+#     car = await NodeManager.get_one(db=db, id=car_volt_main.id, branch=branch)
+#     await car.profiles.update(data=[car_profile_black, car_profile_white], db=db)
+#     await car.save(db=db)
+#     await branch.rebase(db=db)
+
+#     car_profile_black_branch = await NodeManager.get_one(db=db, branch=branch, id=car_profile_black.id)
+#     car_profile_black_branch.color.value = None
+#     await car_profile_black_branch.save(db=db)
+
+#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#444444"})
+#     await query.execute(db=db)
+#     assert query.get_node_ids() == [car_accord_main.id]
+#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#000000"})
+#     await query.execute(db=db)
+#     assert query.get_node_ids() == []
+#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#ffffff"})
+#     await query.execute(db=db)
+#     assert set(query.get_node_ids()) == {car_camry_main.id, car_volt_main.id}
+
+
+# async def test_query_NodeGetListQuery_multiple_profiles_same_priority_filter_and_order(
+#     db: InfrahubDatabase,
+#     car_camry_main,
+#     car_accord_main,
+#     branch: Branch,
+# ):
+#     profile_schema = registry.schema.get("ProfileTestCar", branch=branch, duplicate=False)
+#     profiles_group_1 = []
+#     expected_profile_1 = None
+#     for i in range(10):
+#         car_profile = await Node.init(db=db, schema=profile_schema, branch=branch)
+#         await car_profile.new(
+#             db=db, profile_name=f"car_profile_{i}", color=f"#{randint(100000, 499999)}", profile_priority=1000
+#         )
+#         await car_profile.save(db=db)
+#         if not expected_profile_1 or car_profile.id < expected_profile_1.id:
+#             expected_profile_1 = car_profile
+#             profiles_group_1.append(car_profile)
+#     profiles_group_2 = []
+#     expected_profile_2 = None
+#     for i in range(10, 20):
+#         car_profile = await Node.init(db=db, schema=profile_schema, branch=branch)
+#         await car_profile.new(
+#             db=db, profile_name=f"car_profile_{i}", color=f"#{randint(500000, 999999)}", profile_priority=1000
+#         )
+#         await car_profile.save(db=db)
+#         if not expected_profile_2 or car_profile.id < expected_profile_2.id:
+#             expected_profile_2 = car_profile
+#             profiles_group_2.append(car_profile)
+#     car_schema = registry.schema.get("TestCar", branch=branch, duplicate=False)
+#     car_schema.order_by = ["color__value"]
+#     car = await NodeManager.get_one(db=db, id=car_camry_main.id, branch=branch)
+#     await car.profiles.update(data=profiles_group_1, db=db)
+#     await car.save(db=db)
+#     car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=branch)
+#     await car.profiles.update(data=profiles_group_2, db=db)
+#     await car.save(db=db)
+
+#     query = await NodeGetListQuery.init(
+#         db=db, branch=branch, schema=car_schema, filters={"color__value": expected_profile_1.color.value}
+#     )
+#     await query.execute(db=db)
+#     assert query.get_node_ids() == [car_camry_main.id]
+#     query = await NodeGetListQuery.init(
+#         db=db, branch=branch, schema=car_schema, filters={"color__value": expected_profile_2.color.value}
+#     )
+#     await query.execute(db=db)
+#     assert query.get_node_ids() == [car_accord_main.id]
+#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema)
+#     await query.execute(db=db)
+#     assert query.get_node_ids() == [car_camry_main.id, car_accord_main.id]
 
 
 async def test_query_NodeGetListQuery_pagination_order_by(

--- a/backend/tests/unit/core/test_node_get_list_query.py
+++ b/backend/tests/unit/core/test_node_get_list_query.py
@@ -1,3 +1,5 @@
+from random import randint
+
 import pytest
 
 from infrahub.core.branch import Branch
@@ -500,358 +502,366 @@ async def test_query_NodeGetListQuery_order_by_relationship_value_with_update(
     assert set(retrieved_node_ids[2:]) == {car_yaris_main.id, car_volt_main.id}
 
 
-# async def test_query_NodeGetListQuery_filter_with_profiles(
-#     db: InfrahubDatabase, person_john_main, person_jim_main, person_albert_main, person_alfred_main, branch: Branch
-# ):
-#     profile_schema = registry.schema.get("ProfileTestPerson", branch=branch, duplicate=False)
-#     person_profile = await Node.init(db=db, schema=profile_schema, branch=branch)
-#     await person_profile.new(db=db, profile_name="person_profile_1", height=172, profile_priority=1001)
-#     await person_profile.save(db=db)
-#     person_profile_2 = await Node.init(db=db, schema=profile_schema, branch=branch)
-#     await person_profile_2.new(db=db, profile_name="person_profile_2", height=177, profile_priority=1002)
-#     await person_profile_2.save(db=db)
+@pytest.mark.skip(reason="profile refactoring")
+async def test_query_NodeGetListQuery_filter_with_profiles(
+    db: InfrahubDatabase, person_john_main, person_jim_main, person_albert_main, person_alfred_main, branch: Branch
+):
+    profile_schema = registry.schema.get("ProfileTestPerson", branch=branch, duplicate=False)
+    person_profile = await Node.init(db=db, schema=profile_schema, branch=branch)
+    await person_profile.new(db=db, profile_name="person_profile_1", height=172, profile_priority=1001)
+    await person_profile.save(db=db)
+    person_profile_2 = await Node.init(db=db, schema=profile_schema, branch=branch)
+    await person_profile_2.new(db=db, profile_name="person_profile_2", height=177, profile_priority=1002)
+    await person_profile_2.save(db=db)
 
-#     person_schema = registry.schema.get("TestPerson", branch=branch, duplicate=False)
-#     person_schema.order_by = ["height__value", "name__value"]
-#     person = await NodeManager.get_one(db=db, id=person_john_main.id, branch=branch)
-#     person.height.value = None
-#     person.height.is_default = True
-#     await person.profiles.update(data=[person_profile, person_profile_2], db=db)
-#     await person.save(db=db)
-#     person = await NodeManager.get_one(db=db, id=person_jim_main.id, branch=branch)
-#     person.height.value = None
-#     person.height.is_default = True
-#     await person.profiles.update(data=[person_profile], db=db)
-#     await person.save(db=db)
-#     person = await NodeManager.get_one(db=db, id=person_albert_main.id, branch=branch)
-#     await person.profiles.update(data=[person_profile_2], db=db)
-#     await person.save(db=db)
-#     person = await NodeManager.get_one(db=db, id=person_alfred_main.id, branch=branch)
-#     person.height.value = 172
-#     await person.save(db=db)
+    person_schema = registry.schema.get("TestPerson", branch=branch, duplicate=False)
+    person_schema.order_by = ["height__value", "name__value"]
+    person = await NodeManager.get_one(db=db, id=person_john_main.id, branch=branch)
+    person.height.value = None
+    person.height.is_default = True
+    await person.profiles.update(data=[person_profile, person_profile_2], db=db)
+    await person.save(db=db)
+    person = await NodeManager.get_one(db=db, id=person_jim_main.id, branch=branch)
+    person.height.value = None
+    person.height.is_default = True
+    await person.profiles.update(data=[person_profile], db=db)
+    await person.save(db=db)
+    person = await NodeManager.get_one(db=db, id=person_albert_main.id, branch=branch)
+    await person.profiles.update(data=[person_profile_2], db=db)
+    await person.save(db=db)
+    person = await NodeManager.get_one(db=db, id=person_alfred_main.id, branch=branch)
+    person.height.value = 172
+    await person.save(db=db)
 
-#     person_schema = registry.schema.get(name="TestPerson", branch=branch)
-#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=person_schema, filters={"height__value": 172})
+    person_schema = registry.schema.get(name="TestPerson", branch=branch)
+    query = await NodeGetListQuery.init(db=db, branch=branch, schema=person_schema, filters={"height__value": 172})
 
-#     await query.execute(db=db)
+    await query.execute(db=db)
 
-#     assert query.get_node_ids() == [person_alfred_main.id, person_jim_main.id, person_john_main.id]
-
-
-# async def test_query_NodeGetListQuery_filter_with_generic_profiles(
-#     db: InfrahubDatabase, animal_person_schema, default_branch: Branch
-# ):
-#     animal_profile_schema = registry.schema.get("ProfileTestAnimal", duplicate=False)
-#     animal_profile = await Node.init(db=db, schema=animal_profile_schema)
-#     await animal_profile.new(db=db, profile_name="animal_profile", profile_priority=1000, weight=100)
-#     await animal_profile.save(db=db)
-#     cat_profile_schema = registry.schema.get("ProfileTestCat", duplicate=False)
-#     cat_profile = await Node.init(db=db, schema=cat_profile_schema)
-#     await cat_profile.new(db=db, profile_name="cat_profile", profile_priority=1001, weight=10)
-#     await cat_profile.save(db=db)
-#     dog_profile_schema = registry.schema.get("ProfileTestDog", duplicate=False)
-#     dog_profile = await Node.init(db=db, schema=dog_profile_schema)
-#     await dog_profile.new(db=db, profile_name="dog_profile", profile_priority=1002, weight=50)
-#     await dog_profile.save(db=db)
-#     person_schema = registry.schema.get("TestPerson", duplicate=False)
-#     person = await Node.init(db=db, schema=person_schema)
-#     await person.new(db=db, name="Ernest")
-#     await person.save(db=db)
-#     dog_schema = registry.schema.get("TestDog", duplicate=False)
-#     big_dog = await Node.init(db=db, schema=dog_schema)
-#     await big_dog.new(db=db, name="bigdog", breed="mixed", owner=person, profiles=[animal_profile, dog_profile])
-#     await big_dog.save(db=db)
-#     medium_dog = await Node.init(db=db, schema=dog_schema)
-#     await medium_dog.new(db=db, name="mediumdog", breed="mixed", owner=person, profiles=[dog_profile])
-#     await medium_dog.save(db=db)
-#     cat_schema = registry.schema.get("TestCat", duplicate=False)
-#     gigantic_cat = await Node.init(db=db, schema=cat_schema)
-#     await gigantic_cat.new(
-#         db=db, name="giganticcat", breed="orange", owner=person, profiles=[cat_profile, animal_profile]
-#     )
-#     await gigantic_cat.save(db=db)
-#     small_cat = await Node.init(db=db, schema=cat_schema)
-#     await small_cat.new(db=db, name="smallcat", breed="orange", owner=person, weight=7)
-#     await small_cat.save(db=db)
-#     animal_schema = registry.schema.get("TestAnimal", duplicate=False)
-
-#     animal_profile_query = await NodeGetListQuery.init(
-#         db=db, schema=animal_schema, branch=default_branch, filters={"weight__value": 100}
-#     )
-#     await animal_profile_query.execute(db=db)
-#     assert set(animal_profile_query.get_node_ids()) == {big_dog.id, gigantic_cat.id}
-#     medium_dog_query = await NodeGetListQuery.init(
-#         db=db, schema=animal_schema, branch=default_branch, filters={"weight__value": 50}
-#     )
-#     await medium_dog_query.execute(db=db)
-#     assert medium_dog_query.get_node_ids() == [medium_dog.id]
-#     small_cat_query = await NodeGetListQuery.init(
-#         db=db, schema=animal_schema, branch=default_branch, filters={"weight__value": 7}
-#     )
-#     await small_cat_query.execute(db=db)
-#     assert small_cat_query.get_node_ids() == [small_cat.id]
+    assert query.get_node_ids() == [person_alfred_main.id, person_jim_main.id, person_john_main.id]
 
 
-# async def test_query_NodeGetListQuery_order_with_profiles(
-#     db: InfrahubDatabase, car_camry_main, car_accord_main, car_volt_main, branch: Branch
-# ):
-#     profile_schema = registry.schema.get("ProfileTestCar", branch=branch, duplicate=False)
-#     car_profile_black = await Node.init(db=db, schema=profile_schema, branch=branch)
-#     await car_profile_black.new(db=db, profile_name="car_profile_black", color="#000000", profile_priority=1001)
-#     await car_profile_black.save(db=db)
-#     car_profile_white = await Node.init(db=db, schema=profile_schema, branch=branch)
-#     await car_profile_white.new(db=db, profile_name="car_profile_white", color="#ffffff", profile_priority=1002)
-#     await car_profile_white.save(db=db)
+@pytest.mark.skip(reason="profile refactoring")
+async def test_query_NodeGetListQuery_filter_with_generic_profiles(
+    db: InfrahubDatabase, animal_person_schema, default_branch: Branch
+):
+    animal_profile_schema = registry.schema.get("ProfileTestAnimal", duplicate=False)
+    animal_profile = await Node.init(db=db, schema=animal_profile_schema)
+    await animal_profile.new(db=db, profile_name="animal_profile", profile_priority=1000, weight=100)
+    await animal_profile.save(db=db)
+    cat_profile_schema = registry.schema.get("ProfileTestCat", duplicate=False)
+    cat_profile = await Node.init(db=db, schema=cat_profile_schema)
+    await cat_profile.new(db=db, profile_name="cat_profile", profile_priority=1001, weight=10)
+    await cat_profile.save(db=db)
+    dog_profile_schema = registry.schema.get("ProfileTestDog", duplicate=False)
+    dog_profile = await Node.init(db=db, schema=dog_profile_schema)
+    await dog_profile.new(db=db, profile_name="dog_profile", profile_priority=1002, weight=50)
+    await dog_profile.save(db=db)
+    person_schema = registry.schema.get("TestPerson", duplicate=False)
+    person = await Node.init(db=db, schema=person_schema)
+    await person.new(db=db, name="Ernest")
+    await person.save(db=db)
+    dog_schema = registry.schema.get("TestDog", duplicate=False)
+    big_dog = await Node.init(db=db, schema=dog_schema)
+    await big_dog.new(db=db, name="bigdog", breed="mixed", owner=person, profiles=[animal_profile, dog_profile])
+    await big_dog.save(db=db)
+    medium_dog = await Node.init(db=db, schema=dog_schema)
+    await medium_dog.new(db=db, name="mediumdog", breed="mixed", owner=person, profiles=[dog_profile])
+    await medium_dog.save(db=db)
+    cat_schema = registry.schema.get("TestCat", duplicate=False)
+    gigantic_cat = await Node.init(db=db, schema=cat_schema)
+    await gigantic_cat.new(
+        db=db, name="giganticcat", breed="orange", owner=person, profiles=[cat_profile, animal_profile]
+    )
+    await gigantic_cat.save(db=db)
+    small_cat = await Node.init(db=db, schema=cat_schema)
+    await small_cat.new(db=db, name="smallcat", breed="orange", owner=person, weight=7)
+    await small_cat.save(db=db)
+    animal_schema = registry.schema.get("TestAnimal", duplicate=False)
 
-#     car_schema = registry.schema.get("TestCar", branch=branch, duplicate=False)
-#     car_schema.order_by = ["color__value", "name__value"]
-#     car = await NodeManager.get_one(db=db, id=car_camry_main.id, branch=branch)
-#     await car.profiles.update(data=[car_profile_white], db=db)
-#     await car.save(db=db)
-#     car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=branch)
-#     await car.profiles.update(data=[car_profile_black], db=db)
-#     await car.save(db=db)
-#     car = await NodeManager.get_one(db=db, id=car_volt_main.id, branch=branch)
-#     await car.profiles.update(data=[car_profile_black, car_profile_white], db=db)
-#     await car.save(db=db)
-
-#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema)
-
-#     await query.execute(db=db)
-
-#     assert query.get_node_ids() == [car_accord_main.id, car_volt_main.id, car_camry_main.id]
-
-
-# async def test_query_NodeGetListQuery_with_profiles_deleted(
-#     db: InfrahubDatabase,
-#     default_branch: Branch,
-#     car_camry_main,
-#     car_accord_main,
-#     car_volt_main,
-#     branch: Branch,
-# ):
-#     profile_schema = registry.schema.get("ProfileTestCar", branch=branch, duplicate=False)
-#     car_profile_black = await Node.init(db=db, schema=profile_schema, branch=branch)
-#     await car_profile_black.new(db=db, profile_name="car_profile_black", color="#000000", profile_priority=1001)
-#     await car_profile_black.save(db=db)
-#     car_profile_white = await Node.init(db=db, schema=profile_schema, branch=branch)
-#     await car_profile_white.new(db=db, profile_name="car_profile_white", color="#ffffff", profile_priority=1002)
-#     await car_profile_white.save(db=db)
-#     await branch.rebase(db=db)
-
-#     car_schema = registry.schema.get("TestCar", branch=branch, duplicate=False)
-#     car = await NodeManager.get_one(db=db, id=car_camry_main.id, branch=branch)
-#     await car.profiles.update(data=[car_profile_white], db=db)
-#     await car.save(db=db)
-#     car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=branch)
-#     await car.profiles.update(data=[car_profile_black], db=db)
-#     await car.save(db=db)
-#     car = await NodeManager.get_one(db=db, id=car_volt_main.id, branch=branch)
-#     await car.profiles.update(data=[car_profile_black, car_profile_white], db=db)
-#     await car.save(db=db)
-
-#     car_profile_white_branch = await NodeManager.get_one(db=db, id=car_profile_white.id, branch=branch)
-#     await car_profile_white_branch.delete(db=db)
-
-#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#444444"})
-#     await query.execute(db=db)
-#     assert query.get_node_ids() == [car_camry_main.id]
-#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#000000"})
-#     await query.execute(db=db)
-#     assert set(query.get_node_ids()) == {car_accord_main.id, car_volt_main.id}
-#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#ffffff"})
-#     await query.execute(db=db)
-#     assert query.get_node_ids() == []
+    animal_profile_query = await NodeGetListQuery.init(
+        db=db, schema=animal_schema, branch=default_branch, filters={"weight__value": 100}
+    )
+    await animal_profile_query.execute(db=db)
+    assert set(animal_profile_query.get_node_ids()) == {big_dog.id, gigantic_cat.id}
+    medium_dog_query = await NodeGetListQuery.init(
+        db=db, schema=animal_schema, branch=default_branch, filters={"weight__value": 50}
+    )
+    await medium_dog_query.execute(db=db)
+    assert medium_dog_query.get_node_ids() == [medium_dog.id]
+    small_cat_query = await NodeGetListQuery.init(
+        db=db, schema=animal_schema, branch=default_branch, filters={"weight__value": 7}
+    )
+    await small_cat_query.execute(db=db)
+    assert small_cat_query.get_node_ids() == [small_cat.id]
 
 
-# async def test_query_NodeGetListQuery_updated_profile_priorities_on_branch(
-#     db: InfrahubDatabase,
-#     car_camry_main,
-#     car_accord_main,
-#     car_volt_main,
-#     branch: Branch,
-#     default_branch: Branch,
-# ):
-#     profile_schema = registry.schema.get("ProfileTestCar", branch=branch, duplicate=False)
-#     car_profile_black = await Node.init(db=db, schema=profile_schema)
-#     await car_profile_black.new(db=db, profile_name="car_profile_black", color="#000000", profile_priority=1001)
-#     await car_profile_black.save(db=db)
-#     car_profile_white = await Node.init(db=db, schema=profile_schema)
-#     await car_profile_white.new(db=db, profile_name="car_profile_white", color="#ffffff", profile_priority=1002)
-#     await car_profile_white.save(db=db)
-#     car_schema = registry.schema.get("TestCar", branch=branch, duplicate=False)
-#     car = await NodeManager.get_one(db=db, id=car_camry_main.id, branch=default_branch)
-#     await car.profiles.update(data=[car_profile_white], db=db)
-#     await car.save(db=db)
-#     car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=default_branch)
-#     await car.profiles.update(data=[car_profile_black], db=db)
-#     await car.save(db=db)
-#     car = await NodeManager.get_one(db=db, id=car_volt_main.id, branch=default_branch)
-#     await car.profiles.update(data=[car_profile_black, car_profile_white], db=db)
-#     await car.save(db=db)
-#     await branch.rebase(db=db)
+@pytest.mark.skip(reason="profile refactoring")
+async def test_query_NodeGetListQuery_order_with_profiles(
+    db: InfrahubDatabase, car_camry_main, car_accord_main, car_volt_main, branch: Branch
+):
+    profile_schema = registry.schema.get("ProfileTestCar", branch=branch, duplicate=False)
+    car_profile_black = await Node.init(db=db, schema=profile_schema, branch=branch)
+    await car_profile_black.new(db=db, profile_name="car_profile_black", color="#000000", profile_priority=1001)
+    await car_profile_black.save(db=db)
+    car_profile_white = await Node.init(db=db, schema=profile_schema, branch=branch)
+    await car_profile_white.new(db=db, profile_name="car_profile_white", color="#ffffff", profile_priority=1002)
+    await car_profile_white.save(db=db)
 
-#     car_profile_black_branch = await NodeManager.get_one(db=db, branch=branch, id=car_profile_black.id)
-#     car_profile_black_branch.profile_priority.value = 3000
-#     await car_profile_black_branch.save(db=db)
-#     car_profile_white_branch = await NodeManager.get_one(db=db, branch=branch, id=car_profile_white.id)
-#     car_profile_white_branch.profile_priority.value = 2000
-#     await car_profile_white_branch.save(db=db)
+    car_schema = registry.schema.get("TestCar", branch=branch, duplicate=False)
+    car_schema.order_by = ["color__value", "name__value"]
+    car = await NodeManager.get_one(db=db, id=car_camry_main.id, branch=branch)
+    await car.profiles.update(data=[car_profile_white], db=db)
+    await car.save(db=db)
+    car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=branch)
+    await car.profiles.update(data=[car_profile_black], db=db)
+    await car.save(db=db)
+    car = await NodeManager.get_one(db=db, id=car_volt_main.id, branch=branch)
+    await car.profiles.update(data=[car_profile_black, car_profile_white], db=db)
+    await car.save(db=db)
 
-#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#444444"})
-#     await query.execute(db=db)
-#     assert query.get_node_ids() == []
-#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#000000"})
-#     await query.execute(db=db)
-#     assert query.get_node_ids() == [car_accord_main.id]
-#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#ffffff"})
-#     await query.execute(db=db)
-#     assert set(query.get_node_ids()) == {car_camry_main.id, car_volt_main.id}
+    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema)
+
+    await query.execute(db=db)
+
+    assert query.get_node_ids() == [car_accord_main.id, car_volt_main.id, car_camry_main.id]
 
 
-# async def test_query_NodeGetListQuery_updated_profile_attributes_on_branch(
-#     db: InfrahubDatabase,
-#     car_camry_main,
-#     car_accord_main,
-#     car_volt_main,
-#     branch: Branch,
-#     default_branch: Branch,
-# ):
-#     profile_schema = registry.schema.get("ProfileTestCar", branch=branch, duplicate=False)
-#     car_profile_black = await Node.init(db=db, schema=profile_schema)
-#     await car_profile_black.new(db=db, profile_name="car_profile_black", color="#000000", profile_priority=1001)
-#     await car_profile_black.save(db=db)
-#     car_profile_white = await Node.init(db=db, schema=profile_schema)
-#     await car_profile_white.new(db=db, profile_name="car_profile_white", color="#ffffff", profile_priority=1002)
-#     await car_profile_white.save(db=db)
-#     car_schema = registry.schema.get("TestCar", branch=branch, duplicate=False)
-#     car = await NodeManager.get_one(db=db, id=car_camry_main.id, branch=default_branch)
-#     await car.profiles.update(data=[car_profile_white], db=db)
-#     await car.save(db=db)
-#     car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=default_branch)
-#     await car.profiles.update(data=[car_profile_black], db=db)
-#     await car.save(db=db)
-#     car = await NodeManager.get_one(db=db, id=car_volt_main.id, branch=default_branch)
-#     await car.profiles.update(data=[car_profile_black, car_profile_white], db=db)
-#     await car.save(db=db)
-#     await branch.rebase(db=db)
+@pytest.mark.skip(reason="profile refactoring")
+async def test_query_NodeGetListQuery_with_profiles_deleted(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    car_camry_main,
+    car_accord_main,
+    car_volt_main,
+    branch: Branch,
+):
+    profile_schema = registry.schema.get("ProfileTestCar", branch=branch, duplicate=False)
+    car_profile_black = await Node.init(db=db, schema=profile_schema, branch=branch)
+    await car_profile_black.new(db=db, profile_name="car_profile_black", color="#000000", profile_priority=1001)
+    await car_profile_black.save(db=db)
+    car_profile_white = await Node.init(db=db, schema=profile_schema, branch=branch)
+    await car_profile_white.new(db=db, profile_name="car_profile_white", color="#ffffff", profile_priority=1002)
+    await car_profile_white.save(db=db)
+    await branch.rebase(db=db)
 
-#     car_profile_black_branch = await NodeManager.get_one(db=db, branch=branch, id=car_profile_black.id)
-#     car_profile_black_branch.color.value = "#000001"
-#     await car_profile_black_branch.save(db=db)
-#     car_profile_white_branch = await NodeManager.get_one(db=db, branch=branch, id=car_profile_white.id)
-#     car_profile_white_branch.color.value = "#fffffe"
-#     await car_profile_white_branch.save(db=db)
+    car_schema = registry.schema.get("TestCar", branch=branch, duplicate=False)
+    car = await NodeManager.get_one(db=db, id=car_camry_main.id, branch=branch)
+    await car.profiles.update(data=[car_profile_white], db=db)
+    await car.save(db=db)
+    car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=branch)
+    await car.profiles.update(data=[car_profile_black], db=db)
+    await car.save(db=db)
+    car = await NodeManager.get_one(db=db, id=car_volt_main.id, branch=branch)
+    await car.profiles.update(data=[car_profile_black, car_profile_white], db=db)
+    await car.save(db=db)
 
-#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#444444"})
-#     await query.execute(db=db)
-#     assert query.get_node_ids() == []
-#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#000000"})
-#     await query.execute(db=db)
-#     assert query.get_node_ids() == []
-#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#ffffff"})
-#     await query.execute(db=db)
-#     assert query.get_node_ids() == []
-#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#000001"})
-#     await query.execute(db=db)
-#     assert set(query.get_node_ids()) == {car_accord_main.id, car_volt_main.id}
-#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#fffffe"})
-#     await query.execute(db=db)
-#     assert query.get_node_ids() == [car_camry_main.id]
+    car_profile_white_branch = await NodeManager.get_one(db=db, id=car_profile_white.id, branch=branch)
+    await car_profile_white_branch.delete(db=db)
+
+    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#444444"})
+    await query.execute(db=db)
+    assert query.get_node_ids() == [car_camry_main.id]
+    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#000000"})
+    await query.execute(db=db)
+    assert set(query.get_node_ids()) == {car_accord_main.id, car_volt_main.id}
+    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#ffffff"})
+    await query.execute(db=db)
+    assert query.get_node_ids() == []
 
 
-# async def test_query_NodeGetListQuery_updated_profile_attributes_nulled_on_branch(
-#     db: InfrahubDatabase,
-#     car_camry_main,
-#     car_accord_main,
-#     car_volt_main,
-#     branch: Branch,
-# ):
-#     profile_schema = registry.schema.get("ProfileTestCar", branch=branch, duplicate=False)
-#     car_profile_black = await Node.init(db=db, schema=profile_schema, branch=branch)
-#     await car_profile_black.new(db=db, profile_name="car_profile_black", color="#000000", profile_priority=1001)
-#     await car_profile_black.save(db=db)
-#     car_profile_white = await Node.init(db=db, schema=profile_schema, branch=branch)
-#     await car_profile_white.new(db=db, profile_name="car_profile_white", color="#ffffff", profile_priority=1002)
-#     await car_profile_white.save(db=db)
-#     car_schema = registry.schema.get("TestCar", branch=branch, duplicate=False)
-#     car = await NodeManager.get_one(db=db, id=car_camry_main.id, branch=branch)
-#     await car.profiles.update(data=[car_profile_white], db=db)
-#     await car.save(db=db)
-#     car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=branch)
-#     await car.profiles.update(data=[car_profile_black], db=db)
-#     await car.save(db=db)
-#     car = await NodeManager.get_one(db=db, id=car_volt_main.id, branch=branch)
-#     await car.profiles.update(data=[car_profile_black, car_profile_white], db=db)
-#     await car.save(db=db)
-#     await branch.rebase(db=db)
+@pytest.mark.skip(reason="profile refactoring")
+async def test_query_NodeGetListQuery_updated_profile_priorities_on_branch(
+    db: InfrahubDatabase,
+    car_camry_main,
+    car_accord_main,
+    car_volt_main,
+    branch: Branch,
+    default_branch: Branch,
+):
+    profile_schema = registry.schema.get("ProfileTestCar", branch=branch, duplicate=False)
+    car_profile_black = await Node.init(db=db, schema=profile_schema)
+    await car_profile_black.new(db=db, profile_name="car_profile_black", color="#000000", profile_priority=1001)
+    await car_profile_black.save(db=db)
+    car_profile_white = await Node.init(db=db, schema=profile_schema)
+    await car_profile_white.new(db=db, profile_name="car_profile_white", color="#ffffff", profile_priority=1002)
+    await car_profile_white.save(db=db)
+    car_schema = registry.schema.get("TestCar", branch=branch, duplicate=False)
+    car = await NodeManager.get_one(db=db, id=car_camry_main.id, branch=default_branch)
+    await car.profiles.update(data=[car_profile_white], db=db)
+    await car.save(db=db)
+    car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=default_branch)
+    await car.profiles.update(data=[car_profile_black], db=db)
+    await car.save(db=db)
+    car = await NodeManager.get_one(db=db, id=car_volt_main.id, branch=default_branch)
+    await car.profiles.update(data=[car_profile_black, car_profile_white], db=db)
+    await car.save(db=db)
+    await branch.rebase(db=db)
 
-#     car_profile_black_branch = await NodeManager.get_one(db=db, branch=branch, id=car_profile_black.id)
-#     car_profile_black_branch.color.value = None
-#     await car_profile_black_branch.save(db=db)
+    car_profile_black_branch = await NodeManager.get_one(db=db, branch=branch, id=car_profile_black.id)
+    car_profile_black_branch.profile_priority.value = 3000
+    await car_profile_black_branch.save(db=db)
+    car_profile_white_branch = await NodeManager.get_one(db=db, branch=branch, id=car_profile_white.id)
+    car_profile_white_branch.profile_priority.value = 2000
+    await car_profile_white_branch.save(db=db)
 
-#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#444444"})
-#     await query.execute(db=db)
-#     assert query.get_node_ids() == [car_accord_main.id]
-#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#000000"})
-#     await query.execute(db=db)
-#     assert query.get_node_ids() == []
-#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#ffffff"})
-#     await query.execute(db=db)
-#     assert set(query.get_node_ids()) == {car_camry_main.id, car_volt_main.id}
+    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#444444"})
+    await query.execute(db=db)
+    assert query.get_node_ids() == []
+    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#000000"})
+    await query.execute(db=db)
+    assert query.get_node_ids() == [car_accord_main.id]
+    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#ffffff"})
+    await query.execute(db=db)
+    assert set(query.get_node_ids()) == {car_camry_main.id, car_volt_main.id}
 
 
-# async def test_query_NodeGetListQuery_multiple_profiles_same_priority_filter_and_order(
-#     db: InfrahubDatabase,
-#     car_camry_main,
-#     car_accord_main,
-#     branch: Branch,
-# ):
-#     profile_schema = registry.schema.get("ProfileTestCar", branch=branch, duplicate=False)
-#     profiles_group_1 = []
-#     expected_profile_1 = None
-#     for i in range(10):
-#         car_profile = await Node.init(db=db, schema=profile_schema, branch=branch)
-#         await car_profile.new(
-#             db=db, profile_name=f"car_profile_{i}", color=f"#{randint(100000, 499999)}", profile_priority=1000
-#         )
-#         await car_profile.save(db=db)
-#         if not expected_profile_1 or car_profile.id < expected_profile_1.id:
-#             expected_profile_1 = car_profile
-#             profiles_group_1.append(car_profile)
-#     profiles_group_2 = []
-#     expected_profile_2 = None
-#     for i in range(10, 20):
-#         car_profile = await Node.init(db=db, schema=profile_schema, branch=branch)
-#         await car_profile.new(
-#             db=db, profile_name=f"car_profile_{i}", color=f"#{randint(500000, 999999)}", profile_priority=1000
-#         )
-#         await car_profile.save(db=db)
-#         if not expected_profile_2 or car_profile.id < expected_profile_2.id:
-#             expected_profile_2 = car_profile
-#             profiles_group_2.append(car_profile)
-#     car_schema = registry.schema.get("TestCar", branch=branch, duplicate=False)
-#     car_schema.order_by = ["color__value"]
-#     car = await NodeManager.get_one(db=db, id=car_camry_main.id, branch=branch)
-#     await car.profiles.update(data=profiles_group_1, db=db)
-#     await car.save(db=db)
-#     car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=branch)
-#     await car.profiles.update(data=profiles_group_2, db=db)
-#     await car.save(db=db)
+@pytest.mark.skip(reason="profile refactoring")
+async def test_query_NodeGetListQuery_updated_profile_attributes_on_branch(
+    db: InfrahubDatabase,
+    car_camry_main,
+    car_accord_main,
+    car_volt_main,
+    branch: Branch,
+    default_branch: Branch,
+):
+    profile_schema = registry.schema.get("ProfileTestCar", branch=branch, duplicate=False)
+    car_profile_black = await Node.init(db=db, schema=profile_schema)
+    await car_profile_black.new(db=db, profile_name="car_profile_black", color="#000000", profile_priority=1001)
+    await car_profile_black.save(db=db)
+    car_profile_white = await Node.init(db=db, schema=profile_schema)
+    await car_profile_white.new(db=db, profile_name="car_profile_white", color="#ffffff", profile_priority=1002)
+    await car_profile_white.save(db=db)
+    car_schema = registry.schema.get("TestCar", branch=branch, duplicate=False)
+    car = await NodeManager.get_one(db=db, id=car_camry_main.id, branch=default_branch)
+    await car.profiles.update(data=[car_profile_white], db=db)
+    await car.save(db=db)
+    car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=default_branch)
+    await car.profiles.update(data=[car_profile_black], db=db)
+    await car.save(db=db)
+    car = await NodeManager.get_one(db=db, id=car_volt_main.id, branch=default_branch)
+    await car.profiles.update(data=[car_profile_black, car_profile_white], db=db)
+    await car.save(db=db)
+    await branch.rebase(db=db)
 
-#     query = await NodeGetListQuery.init(
-#         db=db, branch=branch, schema=car_schema, filters={"color__value": expected_profile_1.color.value}
-#     )
-#     await query.execute(db=db)
-#     assert query.get_node_ids() == [car_camry_main.id]
-#     query = await NodeGetListQuery.init(
-#         db=db, branch=branch, schema=car_schema, filters={"color__value": expected_profile_2.color.value}
-#     )
-#     await query.execute(db=db)
-#     assert query.get_node_ids() == [car_accord_main.id]
-#     query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema)
-#     await query.execute(db=db)
-#     assert query.get_node_ids() == [car_camry_main.id, car_accord_main.id]
+    car_profile_black_branch = await NodeManager.get_one(db=db, branch=branch, id=car_profile_black.id)
+    car_profile_black_branch.color.value = "#000001"
+    await car_profile_black_branch.save(db=db)
+    car_profile_white_branch = await NodeManager.get_one(db=db, branch=branch, id=car_profile_white.id)
+    car_profile_white_branch.color.value = "#fffffe"
+    await car_profile_white_branch.save(db=db)
+
+    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#444444"})
+    await query.execute(db=db)
+    assert query.get_node_ids() == []
+    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#000000"})
+    await query.execute(db=db)
+    assert query.get_node_ids() == []
+    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#ffffff"})
+    await query.execute(db=db)
+    assert query.get_node_ids() == []
+    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#000001"})
+    await query.execute(db=db)
+    assert set(query.get_node_ids()) == {car_accord_main.id, car_volt_main.id}
+    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#fffffe"})
+    await query.execute(db=db)
+    assert query.get_node_ids() == [car_camry_main.id]
+
+
+@pytest.mark.skip(reason="profile refactoring")
+async def test_query_NodeGetListQuery_updated_profile_attributes_nulled_on_branch(
+    db: InfrahubDatabase,
+    car_camry_main,
+    car_accord_main,
+    car_volt_main,
+    branch: Branch,
+):
+    profile_schema = registry.schema.get("ProfileTestCar", branch=branch, duplicate=False)
+    car_profile_black = await Node.init(db=db, schema=profile_schema, branch=branch)
+    await car_profile_black.new(db=db, profile_name="car_profile_black", color="#000000", profile_priority=1001)
+    await car_profile_black.save(db=db)
+    car_profile_white = await Node.init(db=db, schema=profile_schema, branch=branch)
+    await car_profile_white.new(db=db, profile_name="car_profile_white", color="#ffffff", profile_priority=1002)
+    await car_profile_white.save(db=db)
+    car_schema = registry.schema.get("TestCar", branch=branch, duplicate=False)
+    car = await NodeManager.get_one(db=db, id=car_camry_main.id, branch=branch)
+    await car.profiles.update(data=[car_profile_white], db=db)
+    await car.save(db=db)
+    car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=branch)
+    await car.profiles.update(data=[car_profile_black], db=db)
+    await car.save(db=db)
+    car = await NodeManager.get_one(db=db, id=car_volt_main.id, branch=branch)
+    await car.profiles.update(data=[car_profile_black, car_profile_white], db=db)
+    await car.save(db=db)
+    await branch.rebase(db=db)
+
+    car_profile_black_branch = await NodeManager.get_one(db=db, branch=branch, id=car_profile_black.id)
+    car_profile_black_branch.color.value = None
+    await car_profile_black_branch.save(db=db)
+
+    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#444444"})
+    await query.execute(db=db)
+    assert query.get_node_ids() == [car_accord_main.id]
+    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#000000"})
+    await query.execute(db=db)
+    assert query.get_node_ids() == []
+    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema, filters={"color__value": "#ffffff"})
+    await query.execute(db=db)
+    assert set(query.get_node_ids()) == {car_camry_main.id, car_volt_main.id}
+
+
+@pytest.mark.skip(reason="profile refactoring")
+async def test_query_NodeGetListQuery_multiple_profiles_same_priority_filter_and_order(
+    db: InfrahubDatabase,
+    car_camry_main,
+    car_accord_main,
+    branch: Branch,
+):
+    profile_schema = registry.schema.get("ProfileTestCar", branch=branch, duplicate=False)
+    profiles_group_1 = []
+    expected_profile_1 = None
+    for i in range(10):
+        car_profile = await Node.init(db=db, schema=profile_schema, branch=branch)
+        await car_profile.new(
+            db=db, profile_name=f"car_profile_{i}", color=f"#{randint(100000, 499999)}", profile_priority=1000
+        )
+        await car_profile.save(db=db)
+        if not expected_profile_1 or car_profile.id < expected_profile_1.id:
+            expected_profile_1 = car_profile
+            profiles_group_1.append(car_profile)
+    profiles_group_2 = []
+    expected_profile_2 = None
+    for i in range(10, 20):
+        car_profile = await Node.init(db=db, schema=profile_schema, branch=branch)
+        await car_profile.new(
+            db=db, profile_name=f"car_profile_{i}", color=f"#{randint(500000, 999999)}", profile_priority=1000
+        )
+        await car_profile.save(db=db)
+        if not expected_profile_2 or car_profile.id < expected_profile_2.id:
+            expected_profile_2 = car_profile
+            profiles_group_2.append(car_profile)
+    car_schema = registry.schema.get("TestCar", branch=branch, duplicate=False)
+    car_schema.order_by = ["color__value"]
+    car = await NodeManager.get_one(db=db, id=car_camry_main.id, branch=branch)
+    await car.profiles.update(data=profiles_group_1, db=db)
+    await car.save(db=db)
+    car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=branch)
+    await car.profiles.update(data=profiles_group_2, db=db)
+    await car.save(db=db)
+
+    query = await NodeGetListQuery.init(
+        db=db, branch=branch, schema=car_schema, filters={"color__value": expected_profile_1.color.value}
+    )
+    await query.execute(db=db)
+    assert query.get_node_ids() == [car_camry_main.id]
+    query = await NodeGetListQuery.init(
+        db=db, branch=branch, schema=car_schema, filters={"color__value": expected_profile_2.color.value}
+    )
+    await query.execute(db=db)
+    assert query.get_node_ids() == [car_accord_main.id]
+    query = await NodeGetListQuery.init(db=db, branch=branch, schema=car_schema)
+    await query.execute(db=db)
+    assert query.get_node_ids() == [car_camry_main.id, car_accord_main.id]
 
 
 async def test_query_NodeGetListQuery_pagination_order_by(

--- a/backend/tests/unit/core/test_node_query.py
+++ b/backend/tests/unit/core/test_node_query.py
@@ -1,3 +1,5 @@
+import pytest
+
 from infrahub.core.branch import Branch
 from infrahub.core.constants import (
     InfrahubKind,
@@ -101,67 +103,69 @@ async def test_query_NodeListGetInfoQuery(
     assert len(list(query.get_results_group_by(("n", "uuid")))) == 3
 
 
-# async def test_query_NodeListGetInfoQuery_with_profiles(
-#     db: InfrahubDatabase, person_john_main, person_jim_main, person_albert_main, person_alfred_main, branch: Branch
-# ):
-#     profile_schema = registry.schema.get("ProfileTestPerson", branch=branch)
-#     person_profile = await Node.init(db=db, schema=profile_schema, branch=branch)
-#     await person_profile.new(db=db, profile_name="person_profile_1", height=172, profile_priority=1001)
-#     await person_profile.save(db=db)
-#     person_profile_2 = await Node.init(db=db, schema=profile_schema, branch=branch)
-#     await person_profile_2.new(db=db, profile_name="person_profile_2", height=177, profile_priority=1002)
-#     await person_profile_2.save(db=db)
-#     person = await NodeManager.get_one(db=db, id=person_john_main.id, branch=branch)
-#     await person.profiles.update(data=[person_profile, person_profile_2], db=db)
-#     await person.save(db=db)
+@pytest.mark.skip(reason="profile refactoring")
+async def test_query_NodeListGetInfoQuery_with_profiles(
+    db: InfrahubDatabase, person_john_main, person_jim_main, person_albert_main, person_alfred_main, branch: Branch
+):
+    profile_schema = registry.schema.get("ProfileTestPerson", branch=branch)
+    person_profile = await Node.init(db=db, schema=profile_schema, branch=branch)
+    await person_profile.new(db=db, profile_name="person_profile_1", height=172, profile_priority=1001)
+    await person_profile.save(db=db)
+    person_profile_2 = await Node.init(db=db, schema=profile_schema, branch=branch)
+    await person_profile_2.new(db=db, profile_name="person_profile_2", height=177, profile_priority=1002)
+    await person_profile_2.save(db=db)
+    person = await NodeManager.get_one(db=db, id=person_john_main.id, branch=branch)
+    await person.profiles.update(data=[person_profile, person_profile_2], db=db)
+    await person.save(db=db)
 
-#     ids = [person_john_main.id, person_jim_main.id, person_albert_main.id]
-#     query = await NodeListGetInfoQuery.init(db=db, branch=branch, ids=ids)
-#     await query.execute(db=db)
+    ids = [person_john_main.id, person_jim_main.id, person_albert_main.id]
+    query = await NodeListGetInfoQuery.init(db=db, branch=branch, ids=ids)
+    await query.execute(db=db)
 
-#     async for node_to_process in query.get_nodes(db=db):
-#         if node_to_process.node_uuid != person_john_main.id:
-#             assert node_to_process.profile_uuids == []
-#         else:
-#             assert set(node_to_process.profile_uuids) == {person_profile.id, person_profile_2.id}
+    async for node_to_process in query.get_nodes(db=db):
+        if node_to_process.node_uuid != person_john_main.id:
+            assert node_to_process.profile_uuids == []
+        else:
+            assert set(node_to_process.profile_uuids) == {person_profile.id, person_profile_2.id}
 
 
-# async def test_query_NodeListGetInfoQuery_with_profiles_some_deleted(
-#     db: InfrahubDatabase, person_john_main, person_jim_main, person_albert_main, person_alfred_main, branch: Branch
-# ):
-#     profile_schema = registry.schema.get("ProfileTestPerson", branch=branch)
-#     person_profile = await Node.init(db=db, schema=profile_schema, branch=branch)
-#     await person_profile.new(db=db, profile_name="person_profile_1", height=172, profile_priority=1001)
-#     await person_profile.save(db=db)
-#     person_profile_2 = await Node.init(db=db, schema=profile_schema, branch=branch)
-#     await person_profile_2.new(db=db, profile_name="person_profile_2", height=177, profile_priority=1002)
-#     await person_profile_2.save(db=db)
-#     for person_id in (person_albert_main.id, person_alfred_main.id, person_john_main.id):
-#         person = await NodeManager.get_one(db=db, id=person_id, branch=branch)
-#         await person.profiles.update(data=[person_profile, person_profile_2], db=db)
-#         await person.save(db=db)
-#     person_albert = await NodeManager.get_one(db=db, id=person_albert_main.id, branch=branch)
-#     await person_albert.profiles.update(data=[person_profile_2], db=db)
-#     await person_albert.save(db=db)
+@pytest.mark.skip(reason="profile refactoring")
+async def test_query_NodeListGetInfoQuery_with_profiles_some_deleted(
+    db: InfrahubDatabase, person_john_main, person_jim_main, person_albert_main, person_alfred_main, branch: Branch
+):
+    profile_schema = registry.schema.get("ProfileTestPerson", branch=branch)
+    person_profile = await Node.init(db=db, schema=profile_schema, branch=branch)
+    await person_profile.new(db=db, profile_name="person_profile_1", height=172, profile_priority=1001)
+    await person_profile.save(db=db)
+    person_profile_2 = await Node.init(db=db, schema=profile_schema, branch=branch)
+    await person_profile_2.new(db=db, profile_name="person_profile_2", height=177, profile_priority=1002)
+    await person_profile_2.save(db=db)
+    for person_id in (person_albert_main.id, person_alfred_main.id, person_john_main.id):
+        person = await NodeManager.get_one(db=db, id=person_id, branch=branch)
+        await person.profiles.update(data=[person_profile, person_profile_2], db=db)
+        await person.save(db=db)
+    person_albert = await NodeManager.get_one(db=db, id=person_albert_main.id, branch=branch)
+    await person_albert.profiles.update(data=[person_profile_2], db=db)
+    await person_albert.save(db=db)
 
-#     ids = [person_john_main.id, person_jim_main.id, person_albert_main.id, person_alfred_main.id]
-#     query = await NodeListGetInfoQuery.init(db=db, branch=branch, ids=ids)
-#     await query.execute(db=db)
+    ids = [person_john_main.id, person_jim_main.id, person_albert_main.id, person_alfred_main.id]
+    query = await NodeListGetInfoQuery.init(db=db, branch=branch, ids=ids)
+    await query.execute(db=db)
 
-#     queried_nodes = [node async for node in query.get_nodes(db=db)]
-#     assert {qn.node_uuid for qn in queried_nodes} == {
-#         person_john_main.id,
-#         person_jim_main.id,
-#         person_albert_main.id,
-#         person_alfred_main.id,
-#     }
-#     for node_to_process in queried_nodes:
-#         if node_to_process.node_uuid in (person_john_main.id, person_alfred_main.id):
-#             assert set(node_to_process.profile_uuids) == {person_profile.id, person_profile_2.id}
-#         elif node_to_process.node_uuid in (person_albert_main.id):
-#             assert node_to_process.profile_uuids == [person_profile_2.id]
-#         elif node_to_process.node_uuid in (person_jim_main.id):
-#             assert node_to_process.profile_uuids == []
+    queried_nodes = [node async for node in query.get_nodes(db=db)]
+    assert {qn.node_uuid for qn in queried_nodes} == {
+        person_john_main.id,
+        person_jim_main.id,
+        person_albert_main.id,
+        person_alfred_main.id,
+    }
+    for node_to_process in queried_nodes:
+        if node_to_process.node_uuid in (person_john_main.id, person_alfred_main.id):
+            assert set(node_to_process.profile_uuids) == {person_profile.id, person_profile_2.id}
+        elif node_to_process.node_uuid in (person_albert_main.id):
+            assert node_to_process.profile_uuids == [person_profile_2.id]
+        elif node_to_process.node_uuid in (person_jim_main.id):
+            assert node_to_process.profile_uuids == []
 
 
 async def test_query_NodeListGetInfoQuery_renamed(

--- a/backend/tests/unit/core/test_node_query.py
+++ b/backend/tests/unit/core/test_node_query.py
@@ -101,67 +101,67 @@ async def test_query_NodeListGetInfoQuery(
     assert len(list(query.get_results_group_by(("n", "uuid")))) == 3
 
 
-async def test_query_NodeListGetInfoQuery_with_profiles(
-    db: InfrahubDatabase, person_john_main, person_jim_main, person_albert_main, person_alfred_main, branch: Branch
-):
-    profile_schema = registry.schema.get("ProfileTestPerson", branch=branch)
-    person_profile = await Node.init(db=db, schema=profile_schema, branch=branch)
-    await person_profile.new(db=db, profile_name="person_profile_1", height=172, profile_priority=1001)
-    await person_profile.save(db=db)
-    person_profile_2 = await Node.init(db=db, schema=profile_schema, branch=branch)
-    await person_profile_2.new(db=db, profile_name="person_profile_2", height=177, profile_priority=1002)
-    await person_profile_2.save(db=db)
-    person = await NodeManager.get_one(db=db, id=person_john_main.id, branch=branch)
-    await person.profiles.update(data=[person_profile, person_profile_2], db=db)
-    await person.save(db=db)
+# async def test_query_NodeListGetInfoQuery_with_profiles(
+#     db: InfrahubDatabase, person_john_main, person_jim_main, person_albert_main, person_alfred_main, branch: Branch
+# ):
+#     profile_schema = registry.schema.get("ProfileTestPerson", branch=branch)
+#     person_profile = await Node.init(db=db, schema=profile_schema, branch=branch)
+#     await person_profile.new(db=db, profile_name="person_profile_1", height=172, profile_priority=1001)
+#     await person_profile.save(db=db)
+#     person_profile_2 = await Node.init(db=db, schema=profile_schema, branch=branch)
+#     await person_profile_2.new(db=db, profile_name="person_profile_2", height=177, profile_priority=1002)
+#     await person_profile_2.save(db=db)
+#     person = await NodeManager.get_one(db=db, id=person_john_main.id, branch=branch)
+#     await person.profiles.update(data=[person_profile, person_profile_2], db=db)
+#     await person.save(db=db)
 
-    ids = [person_john_main.id, person_jim_main.id, person_albert_main.id]
-    query = await NodeListGetInfoQuery.init(db=db, branch=branch, ids=ids)
-    await query.execute(db=db)
+#     ids = [person_john_main.id, person_jim_main.id, person_albert_main.id]
+#     query = await NodeListGetInfoQuery.init(db=db, branch=branch, ids=ids)
+#     await query.execute(db=db)
 
-    async for node_to_process in query.get_nodes(db=db):
-        if node_to_process.node_uuid != person_john_main.id:
-            assert node_to_process.profile_uuids == []
-        else:
-            assert set(node_to_process.profile_uuids) == {person_profile.id, person_profile_2.id}
+#     async for node_to_process in query.get_nodes(db=db):
+#         if node_to_process.node_uuid != person_john_main.id:
+#             assert node_to_process.profile_uuids == []
+#         else:
+#             assert set(node_to_process.profile_uuids) == {person_profile.id, person_profile_2.id}
 
 
-async def test_query_NodeListGetInfoQuery_with_profiles_some_deleted(
-    db: InfrahubDatabase, person_john_main, person_jim_main, person_albert_main, person_alfred_main, branch: Branch
-):
-    profile_schema = registry.schema.get("ProfileTestPerson", branch=branch)
-    person_profile = await Node.init(db=db, schema=profile_schema, branch=branch)
-    await person_profile.new(db=db, profile_name="person_profile_1", height=172, profile_priority=1001)
-    await person_profile.save(db=db)
-    person_profile_2 = await Node.init(db=db, schema=profile_schema, branch=branch)
-    await person_profile_2.new(db=db, profile_name="person_profile_2", height=177, profile_priority=1002)
-    await person_profile_2.save(db=db)
-    for person_id in (person_albert_main.id, person_alfred_main.id, person_john_main.id):
-        person = await NodeManager.get_one(db=db, id=person_id, branch=branch)
-        await person.profiles.update(data=[person_profile, person_profile_2], db=db)
-        await person.save(db=db)
-    person_albert = await NodeManager.get_one(db=db, id=person_albert_main.id, branch=branch)
-    await person_albert.profiles.update(data=[person_profile_2], db=db)
-    await person_albert.save(db=db)
+# async def test_query_NodeListGetInfoQuery_with_profiles_some_deleted(
+#     db: InfrahubDatabase, person_john_main, person_jim_main, person_albert_main, person_alfred_main, branch: Branch
+# ):
+#     profile_schema = registry.schema.get("ProfileTestPerson", branch=branch)
+#     person_profile = await Node.init(db=db, schema=profile_schema, branch=branch)
+#     await person_profile.new(db=db, profile_name="person_profile_1", height=172, profile_priority=1001)
+#     await person_profile.save(db=db)
+#     person_profile_2 = await Node.init(db=db, schema=profile_schema, branch=branch)
+#     await person_profile_2.new(db=db, profile_name="person_profile_2", height=177, profile_priority=1002)
+#     await person_profile_2.save(db=db)
+#     for person_id in (person_albert_main.id, person_alfred_main.id, person_john_main.id):
+#         person = await NodeManager.get_one(db=db, id=person_id, branch=branch)
+#         await person.profiles.update(data=[person_profile, person_profile_2], db=db)
+#         await person.save(db=db)
+#     person_albert = await NodeManager.get_one(db=db, id=person_albert_main.id, branch=branch)
+#     await person_albert.profiles.update(data=[person_profile_2], db=db)
+#     await person_albert.save(db=db)
 
-    ids = [person_john_main.id, person_jim_main.id, person_albert_main.id, person_alfred_main.id]
-    query = await NodeListGetInfoQuery.init(db=db, branch=branch, ids=ids)
-    await query.execute(db=db)
+#     ids = [person_john_main.id, person_jim_main.id, person_albert_main.id, person_alfred_main.id]
+#     query = await NodeListGetInfoQuery.init(db=db, branch=branch, ids=ids)
+#     await query.execute(db=db)
 
-    queried_nodes = [node async for node in query.get_nodes(db=db)]
-    assert {qn.node_uuid for qn in queried_nodes} == {
-        person_john_main.id,
-        person_jim_main.id,
-        person_albert_main.id,
-        person_alfred_main.id,
-    }
-    for node_to_process in queried_nodes:
-        if node_to_process.node_uuid in (person_john_main.id, person_alfred_main.id):
-            assert set(node_to_process.profile_uuids) == {person_profile.id, person_profile_2.id}
-        elif node_to_process.node_uuid in (person_albert_main.id):
-            assert node_to_process.profile_uuids == [person_profile_2.id]
-        elif node_to_process.node_uuid in (person_jim_main.id):
-            assert node_to_process.profile_uuids == []
+#     queried_nodes = [node async for node in query.get_nodes(db=db)]
+#     assert {qn.node_uuid for qn in queried_nodes} == {
+#         person_john_main.id,
+#         person_jim_main.id,
+#         person_albert_main.id,
+#         person_alfred_main.id,
+#     }
+#     for node_to_process in queried_nodes:
+#         if node_to_process.node_uuid in (person_john_main.id, person_alfred_main.id):
+#             assert set(node_to_process.profile_uuids) == {person_profile.id, person_profile_2.id}
+#         elif node_to_process.node_uuid in (person_albert_main.id):
+#             assert node_to_process.profile_uuids == [person_profile_2.id]
+#         elif node_to_process.node_uuid in (person_jim_main.id):
+#             assert node_to_process.profile_uuids == []
 
 
 async def test_query_NodeListGetInfoQuery_renamed(

--- a/backend/tests/unit/graphql/profiles/test_query.py
+++ b/backend/tests/unit/graphql/profiles/test_query.py
@@ -134,150 +134,152 @@ async def test_upsert_profile_in_schema(db: InfrahubDatabase, default_branch: Br
     assert retrieved_object.profile_priority.value == 1234
 
 
-# async def test_profile_apply(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
-#     profile_schema = registry.schema.get("ProfileTestCriticality", branch=default_branch)
-#     prof_1 = await Node.init(db=db, schema=profile_schema)
-#     await prof_1.new(db=db, profile_name="prof1", profile_priority=1, level=8)
-#     await prof_1.save(db=db)
-#     prof_2 = await Node.init(db=db, schema=profile_schema)
-#     await prof_2.new(db=db, profile_name="prof2", profile_priority=2, level=9)
-#     await prof_2.save(db=db)
+@pytest.mark.skip(reason="profile refactoring")
+async def test_profile_apply(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+    profile_schema = registry.schema.get("ProfileTestCriticality", branch=default_branch)
+    prof_1 = await Node.init(db=db, schema=profile_schema)
+    await prof_1.new(db=db, profile_name="prof1", profile_priority=1, level=8)
+    await prof_1.save(db=db)
+    prof_2 = await Node.init(db=db, schema=profile_schema)
+    await prof_2.new(db=db, profile_name="prof2", profile_priority=2, level=9)
+    await prof_2.save(db=db)
 
-#     crit_schema = registry.schema.get("TestCriticality", branch=default_branch)
-#     crit_1 = await Node.init(db=db, schema=crit_schema)
-#     await crit_1.new(db=db, name="crit_1")
-#     crit_1.level.is_default = True
-#     await crit_1.profiles.update(db=db, data=[prof_1])
-#     await crit_1.save(db=db)
-#     crit_2 = await Node.init(db=db, schema=crit_schema)
-#     await crit_2.new(db=db, name="crit_2")
-#     crit_2.level.is_default = True
-#     await crit_2.profiles.update(db=db, data=[prof_2])
-#     await crit_2.save(db=db)
+    crit_schema = registry.schema.get("TestCriticality", branch=default_branch)
+    crit_1 = await Node.init(db=db, schema=crit_schema)
+    await crit_1.new(db=db, name="crit_1")
+    crit_1.level.is_default = True
+    await crit_1.profiles.update(db=db, data=[prof_1])
+    await crit_1.save(db=db)
+    crit_2 = await Node.init(db=db, schema=crit_schema)
+    await crit_2.new(db=db, name="crit_2")
+    crit_2.level.is_default = True
+    await crit_2.profiles.update(db=db, data=[prof_2])
+    await crit_2.save(db=db)
 
-#     query = """
-#     query {
-#         TestCriticality {
-#             edges {
-#                 node {
-#                     name { value }
-#                     level { value }
-#                     id
-#                     profiles {
-#                         edges {
-#                             node { id }
-#                         }
-#                     }
-#                 }
-#             }
-#         }
-#     }
-#     """
-#     gql_params = await prepare_graphql_params(
-#         db=db, include_mutation=False, include_subscription=False, branch=default_branch
-#     )
-#     result = await graphql(
-#         schema=gql_params.schema,
-#         source=query,
-#         context_value=gql_params.context,
-#         root_value=None,
-#         variable_values={},
-#     )
+    query = """
+    query {
+        TestCriticality {
+            edges {
+                node {
+                    name { value }
+                    level { value }
+                    id
+                    profiles {
+                        edges {
+                            node { id }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+    gql_params = await prepare_graphql_params(
+        db=db, include_mutation=False, include_subscription=False, branch=default_branch
+    )
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
 
-#     assert result.errors is None
-#     crits = result.data["TestCriticality"]["edges"]
-#     assert len(crits) == 2
-#     assert {
-#         "node": {
-#             "name": {"value": "crit_1"},
-#             "level": {"value": 8},
-#             "id": crit_1.id,
-#             "profiles": {"edges": [{"node": {"id": prof_1.id}}]},
-#         }
-#     } in crits
-#     assert {
-#         "node": {
-#             "name": {"value": "crit_2"},
-#             "level": {"value": 9},
-#             "id": crit_2.id,
-#             "profiles": {"edges": [{"node": {"id": prof_2.id}}]},
-#         }
-#     } in crits
+    assert result.errors is None
+    crits = result.data["TestCriticality"]["edges"]
+    assert len(crits) == 2
+    assert {
+        "node": {
+            "name": {"value": "crit_1"},
+            "level": {"value": 8},
+            "id": crit_1.id,
+            "profiles": {"edges": [{"node": {"id": prof_1.id}}]},
+        }
+    } in crits
+    assert {
+        "node": {
+            "name": {"value": "crit_2"},
+            "level": {"value": 9},
+            "id": crit_2.id,
+            "profiles": {"edges": [{"node": {"id": prof_2.id}}]},
+        }
+    } in crits
 
 
-# async def test_profile_apply_generic(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
-#     profile_generic_schema = registry.schema.get("ProfileTestGenericCriticality", branch=default_branch)
-#     prof_1 = await Node.init(db=db, schema=profile_generic_schema)
-#     await prof_1.new(db=db, profile_name="prof1", profile_priority=1, level=8)
-#     await prof_1.save(db=db)
-#     prof_2 = await Node.init(db=db, schema=profile_generic_schema)
-#     await prof_2.new(db=db, profile_name="prof2", profile_priority=2, level=9)
-#     await prof_2.save(db=db)
+@pytest.mark.skip(reason="profile refactoring")
+async def test_profile_apply_generic(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+    profile_generic_schema = registry.schema.get("ProfileTestGenericCriticality", branch=default_branch)
+    prof_1 = await Node.init(db=db, schema=profile_generic_schema)
+    await prof_1.new(db=db, profile_name="prof1", profile_priority=1, level=8)
+    await prof_1.save(db=db)
+    prof_2 = await Node.init(db=db, schema=profile_generic_schema)
+    await prof_2.new(db=db, profile_name="prof2", profile_priority=2, level=9)
+    await prof_2.save(db=db)
 
-#     crit_schema = registry.schema.get("TestCriticality", branch=default_branch)
-#     crit_1 = await Node.init(db=db, schema=crit_schema)
-#     await crit_1.new(db=db, name="crit_1")
-#     crit_1.level.is_default = True
-#     await crit_1.profiles.update(db=db, data=[prof_1])
-#     await crit_1.save(db=db)
-#     colorful_crit_schema = registry.schema.get("TestColorfulCriticality", branch=default_branch)
-#     crit_2 = await Node.init(db=db, schema=colorful_crit_schema)
-#     await crit_2.new(db=db, name="crit_2", color="green")
-#     crit_2.level.is_default = True
-#     await crit_2.profiles.update(db=db, data=[prof_2])
-#     await crit_2.save(db=db)
+    crit_schema = registry.schema.get("TestCriticality", branch=default_branch)
+    crit_1 = await Node.init(db=db, schema=crit_schema)
+    await crit_1.new(db=db, name="crit_1")
+    crit_1.level.is_default = True
+    await crit_1.profiles.update(db=db, data=[prof_1])
+    await crit_1.save(db=db)
+    colorful_crit_schema = registry.schema.get("TestColorfulCriticality", branch=default_branch)
+    crit_2 = await Node.init(db=db, schema=colorful_crit_schema)
+    await crit_2.new(db=db, name="crit_2", color="green")
+    crit_2.level.is_default = True
+    await crit_2.profiles.update(db=db, data=[prof_2])
+    await crit_2.save(db=db)
 
-#     query = """
-#     query {
-#         TestGenericCriticality {
-#             edges {
-#                 node {
-#                     __typename
-#                     name { value }
-#                     level { value }
-#                     id
-#                     profiles {
-#                         edges {
-#                             node { id }
-#                         }
-#                     }
-#                 }
-#             }
-#         }
-#     }
-#     """
-#     gql_params = await prepare_graphql_params(
-#         db=db, include_mutation=False, include_subscription=False, branch=default_branch
-#     )
-#     result = await graphql(
-#         schema=gql_params.schema,
-#         source=query,
-#         context_value=gql_params.context,
-#         root_value=None,
-#         variable_values={},
-#     )
+    query = """
+    query {
+        TestGenericCriticality {
+            edges {
+                node {
+                    __typename
+                    name { value }
+                    level { value }
+                    id
+                    profiles {
+                        edges {
+                            node { id }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+    gql_params = await prepare_graphql_params(
+        db=db, include_mutation=False, include_subscription=False, branch=default_branch
+    )
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
 
-#     assert result.errors is None
-#     crits = result.data["TestGenericCriticality"]["edges"]
-#     assert len(crits) == 2
-#     assert {
-#         "node": {
-#             "__typename": "TestCriticality",
-#             "name": {"value": "crit_1"},
-#             "level": {"value": 8},
-#             "id": crit_1.id,
-#             "profiles": {"edges": [{"node": {"id": prof_1.id}}]},
-#         }
-#     } in crits
-#     assert {
-#         "node": {
-#             "__typename": "TestColorfulCriticality",
-#             "name": {"value": "crit_2"},
-#             "level": {"value": 9},
-#             "id": crit_2.id,
-#             "profiles": {"edges": [{"node": {"id": prof_2.id}}]},
-#         }
-#     } in crits
+    assert result.errors is None
+    crits = result.data["TestGenericCriticality"]["edges"]
+    assert len(crits) == 2
+    assert {
+        "node": {
+            "__typename": "TestCriticality",
+            "name": {"value": "crit_1"},
+            "level": {"value": 8},
+            "id": crit_1.id,
+            "profiles": {"edges": [{"node": {"id": prof_1.id}}]},
+        }
+    } in crits
+    assert {
+        "node": {
+            "__typename": "TestColorfulCriticality",
+            "name": {"value": "crit_2"},
+            "level": {"value": 9},
+            "id": crit_2.id,
+            "profiles": {"edges": [{"node": {"id": prof_2.id}}]},
+        }
+    } in crits
 
 
 async def test_setting_illegal_profiles_raises_error(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
@@ -369,195 +371,197 @@ async def test_setting_illegal_profiles_raises_error(db: InfrahubDatabase, defau
     }
 
 
-# async def test_is_from_profile_set_correctly(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
-#     profile_schema = registry.schema.get("ProfileTestCriticality", branch=default_branch)
-#     prof_1 = await Node.init(db=db, schema=profile_schema)
-#     await prof_1.new(db=db, profile_name="prof1", profile_priority=1, level=8)
-#     await prof_1.save(db=db)
-#     prof_2 = await Node.init(db=db, schema=profile_schema)
-#     await prof_2.new(db=db, profile_name="prof2", profile_priority=2, level=9, fancy="sometimes")
-#     await prof_2.save(db=db)
+@pytest.mark.skip(reason="profile refactoring")
+async def test_is_from_profile_set_correctly(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+    profile_schema = registry.schema.get("ProfileTestCriticality", branch=default_branch)
+    prof_1 = await Node.init(db=db, schema=profile_schema)
+    await prof_1.new(db=db, profile_name="prof1", profile_priority=1, level=8)
+    await prof_1.save(db=db)
+    prof_2 = await Node.init(db=db, schema=profile_schema)
+    await prof_2.new(db=db, profile_name="prof2", profile_priority=2, level=9, fancy="sometimes")
+    await prof_2.save(db=db)
 
-#     crit_schema = registry.schema.get("TestCriticality", branch=default_branch)
-#     crit_no_profile = await Node.init(db=db, schema=crit_schema)
-#     await crit_no_profile.new(db=db, name="crit_no_profile", fancy="always")
-#     await crit_no_profile.save(db=db)
+    crit_schema = registry.schema.get("TestCriticality", branch=default_branch)
+    crit_no_profile = await Node.init(db=db, schema=crit_schema)
+    await crit_no_profile.new(db=db, name="crit_no_profile", fancy="always")
+    await crit_no_profile.save(db=db)
 
-#     crit_1_profile = await Node.init(db=db, schema=crit_schema)
-#     await crit_1_profile.new(db=db, name="crit_1_profile", fancy="never")
-#     await crit_1_profile.profiles.update(db=db, data=[prof_1])
-#     await crit_1_profile.save(db=db)
+    crit_1_profile = await Node.init(db=db, schema=crit_schema)
+    await crit_1_profile.new(db=db, name="crit_1_profile", fancy="never")
+    await crit_1_profile.profiles.update(db=db, data=[prof_1])
+    await crit_1_profile.save(db=db)
 
-#     crit_2_profile = await Node.init(db=db, schema=crit_schema)
-#     await crit_2_profile.new(db=db, name="crit_2_profile", level=7)
-#     await crit_2_profile.profiles.update(db=db, data=[prof_1, prof_2])
-#     await crit_2_profile.save(db=db)
+    crit_2_profile = await Node.init(db=db, schema=crit_schema)
+    await crit_2_profile.new(db=db, name="crit_2_profile", level=7)
+    await crit_2_profile.profiles.update(db=db, data=[prof_1, prof_2])
+    await crit_2_profile.save(db=db)
 
-#     query = """
-#     query {
-#         TestCriticality {
-#             edges {
-#                 node {
-#                     name { value, is_from_profile }
-#                     level { value, is_from_profile }
-#                     fancy { value, is_from_profile }
-#                     id
-#                 }
-#             }
-#         }
-#     }
-#     """
-#     gql_params = await prepare_graphql_params(
-#         db=db, include_mutation=False, include_subscription=False, branch=default_branch
-#     )
-#     result = await graphql(
-#         schema=gql_params.schema,
-#         source=query,
-#         context_value=gql_params.context,
-#         root_value=None,
-#         variable_values={},
-#     )
+    query = """
+    query {
+        TestCriticality {
+            edges {
+                node {
+                    name { value, is_from_profile }
+                    level { value, is_from_profile }
+                    fancy { value, is_from_profile }
+                    id
+                }
+            }
+        }
+    }
+    """
+    gql_params = await prepare_graphql_params(
+        db=db, include_mutation=False, include_subscription=False, branch=default_branch
+    )
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
 
-#     assert result.errors is None
-#     crits = result.data["TestCriticality"]["edges"]
-#     assert len(crits) == 3
-#     crits_by_id = {crit["node"]["id"]: crit["node"] for crit in crits}
-#     assert crits_by_id[crit_no_profile.id] == {
-#         "name": {"value": "crit_no_profile", "is_from_profile": False},
-#         "level": {"value": None, "is_from_profile": False},
-#         "fancy": {"value": "always", "is_from_profile": False},
-#         "id": crit_no_profile.id,
-#     }
+    assert result.errors is None
+    crits = result.data["TestCriticality"]["edges"]
+    assert len(crits) == 3
+    crits_by_id = {crit["node"]["id"]: crit["node"] for crit in crits}
+    assert crits_by_id[crit_no_profile.id] == {
+        "name": {"value": "crit_no_profile", "is_from_profile": False},
+        "level": {"value": None, "is_from_profile": False},
+        "fancy": {"value": "always", "is_from_profile": False},
+        "id": crit_no_profile.id,
+    }
 
-#     assert crits_by_id[crit_1_profile.id] == {
-#         "name": {"value": "crit_1_profile", "is_from_profile": False},
-#         "level": {"value": 8, "is_from_profile": True},
-#         "fancy": {"value": "never", "is_from_profile": False},
-#         "id": crit_1_profile.id,
-#     }
+    assert crits_by_id[crit_1_profile.id] == {
+        "name": {"value": "crit_1_profile", "is_from_profile": False},
+        "level": {"value": 8, "is_from_profile": True},
+        "fancy": {"value": "never", "is_from_profile": False},
+        "id": crit_1_profile.id,
+    }
 
-#     assert crits_by_id[crit_2_profile.id] == {
-#         "name": {"value": "crit_2_profile", "is_from_profile": False},
-#         "level": {"value": 7, "is_from_profile": False},
-#         "fancy": {"value": "sometimes", "is_from_profile": True},
-#         "id": crit_2_profile.id,
-#     }
+    assert crits_by_id[crit_2_profile.id] == {
+        "name": {"value": "crit_2_profile", "is_from_profile": False},
+        "level": {"value": 7, "is_from_profile": False},
+        "fancy": {"value": "sometimes", "is_from_profile": True},
+        "id": crit_2_profile.id,
+    }
 
-#     assert crit_1_profile.id in gql_params.context.related_node_ids
-#     assert crit_2_profile.id in gql_params.context.related_node_ids
+    assert crit_1_profile.id in gql_params.context.related_node_ids
+    assert crit_2_profile.id in gql_params.context.related_node_ids
 
 
-# async def test_is_profile_source_set_correctly(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
-#     profile_schema = registry.schema.get("ProfileTestCriticality", branch=default_branch)
-#     prof_1 = await Node.init(db=db, schema=profile_schema)
-#     await prof_1.new(db=db, profile_name="prof1", profile_priority=1, level=8)
-#     await prof_1.save(db=db)
-#     prof_2 = await Node.init(db=db, schema=profile_schema)
-#     await prof_2.new(db=db, profile_name="prof2", profile_priority=2, level=9, fancy="sometimes")
-#     await prof_2.save(db=db)
+@pytest.mark.skip(reason="profile refactoring")
+async def test_is_profile_source_set_correctly(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+    profile_schema = registry.schema.get("ProfileTestCriticality", branch=default_branch)
+    prof_1 = await Node.init(db=db, schema=profile_schema)
+    await prof_1.new(db=db, profile_name="prof1", profile_priority=1, level=8)
+    await prof_1.save(db=db)
+    prof_2 = await Node.init(db=db, schema=profile_schema)
+    await prof_2.new(db=db, profile_name="prof2", profile_priority=2, level=9, fancy="sometimes")
+    await prof_2.save(db=db)
 
-#     crit_schema = registry.schema.get("TestCriticality", branch=default_branch)
-#     crit_no_profile = await Node.init(db=db, schema=crit_schema)
-#     await crit_no_profile.new(db=db, name="crit_no_profile", fancy="always")
-#     await crit_no_profile.save(db=db)
+    crit_schema = registry.schema.get("TestCriticality", branch=default_branch)
+    crit_no_profile = await Node.init(db=db, schema=crit_schema)
+    await crit_no_profile.new(db=db, name="crit_no_profile", fancy="always")
+    await crit_no_profile.save(db=db)
 
-#     crit_1_profile = await Node.init(db=db, schema=crit_schema)
-#     await crit_1_profile.new(db=db, name="crit_1_profile", fancy="never")
-#     await crit_1_profile.profiles.update(db=db, data=[prof_1])
-#     await crit_1_profile.save(db=db)
+    crit_1_profile = await Node.init(db=db, schema=crit_schema)
+    await crit_1_profile.new(db=db, name="crit_1_profile", fancy="never")
+    await crit_1_profile.profiles.update(db=db, data=[prof_1])
+    await crit_1_profile.save(db=db)
 
-#     crit_2_profile = await Node.init(db=db, schema=crit_schema)
-#     await crit_2_profile.new(db=db, name="crit_2_profile", level=7)
-#     await crit_2_profile.profiles.update(db=db, data=[prof_1, prof_2])
-#     await crit_2_profile.save(db=db)
+    crit_2_profile = await Node.init(db=db, schema=crit_schema)
+    await crit_2_profile.new(db=db, name="crit_2_profile", level=7)
+    await crit_2_profile.profiles.update(db=db, data=[prof_1, prof_2])
+    await crit_2_profile.save(db=db)
 
-#     query = """
-#     query {
-#         TestCriticality {
-#             edges {
-#                 node {
-#                     id
-#                     name {
-#                         value
-#                         is_from_profile
-#                         source {
-#                             id
-#                             display_label
-#                             __typename
-#                         }
-#                     }
-#                     level {
-#                         value
-#                         is_from_profile
-#                         source {
-#                             id
-#                             display_label
-#                             __typename
-#                         }
-#                     }
-#                     fancy {
-#                         value
-#                         is_from_profile
-#                         source {
-#                             id
-#                             display_label
-#                             __typename
-#                         }
-#                     }
-#                 }
-#             }
-#         }
-#     }
-#     """
-#     gql_params = await prepare_graphql_params(
-#         db=db, include_mutation=False, include_subscription=False, branch=default_branch
-#     )
-#     result = await graphql(
-#         schema=gql_params.schema,
-#         source=query,
-#         context_value=gql_params.context,
-#         root_value=None,
-#         variable_values={},
-#     )
+    query = """
+    query {
+        TestCriticality {
+            edges {
+                node {
+                    id
+                    name {
+                        value
+                        is_from_profile
+                        source {
+                            id
+                            display_label
+                            __typename
+                        }
+                    }
+                    level {
+                        value
+                        is_from_profile
+                        source {
+                            id
+                            display_label
+                            __typename
+                        }
+                    }
+                    fancy {
+                        value
+                        is_from_profile
+                        source {
+                            id
+                            display_label
+                            __typename
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+    gql_params = await prepare_graphql_params(
+        db=db, include_mutation=False, include_subscription=False, branch=default_branch
+    )
+    result = await graphql(
+        schema=gql_params.schema,
+        source=query,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={},
+    )
 
-#     assert result.errors is None
-#     crits = result.data["TestCriticality"]["edges"]
-#     assert len(crits) == 3
-#     crits_by_id = {crit["node"]["id"]: crit["node"] for crit in crits}
+    assert result.errors is None
+    crits = result.data["TestCriticality"]["edges"]
+    assert len(crits) == 3
+    crits_by_id = {crit["node"]["id"]: crit["node"] for crit in crits}
 
-#     assert crits_by_id[crit_no_profile.id] == {
-#         "name": {"value": "crit_no_profile", "is_from_profile": False, "source": None},
-#         "level": {"value": None, "is_from_profile": False, "source": None},
-#         "fancy": {"value": "always", "is_from_profile": False, "source": None},
-#         "id": crit_no_profile.id,
-#     }
+    assert crits_by_id[crit_no_profile.id] == {
+        "name": {"value": "crit_no_profile", "is_from_profile": False, "source": None},
+        "level": {"value": None, "is_from_profile": False, "source": None},
+        "fancy": {"value": "always", "is_from_profile": False, "source": None},
+        "id": crit_no_profile.id,
+    }
 
-#     assert crits_by_id[crit_1_profile.id] == {
-#         "name": {"value": "crit_1_profile", "is_from_profile": False, "source": None},
-#         "level": {
-#             "value": 8,
-#             "is_from_profile": True,
-#             "source": {
-#                 "id": prof_1.id,
-#                 "display_label": await prof_1.render_display_label(db=db),
-#                 "__typename": "ProfileTestCriticality",
-#             },
-#         },
-#         "fancy": {"value": "never", "is_from_profile": False, "source": None},
-#         "id": crit_1_profile.id,
-#     }
+    assert crits_by_id[crit_1_profile.id] == {
+        "name": {"value": "crit_1_profile", "is_from_profile": False, "source": None},
+        "level": {
+            "value": 8,
+            "is_from_profile": True,
+            "source": {
+                "id": prof_1.id,
+                "display_label": await prof_1.render_display_label(db=db),
+                "__typename": "ProfileTestCriticality",
+            },
+        },
+        "fancy": {"value": "never", "is_from_profile": False, "source": None},
+        "id": crit_1_profile.id,
+    }
 
-#     assert crits_by_id[crit_2_profile.id] == {
-#         "name": {"value": "crit_2_profile", "is_from_profile": False, "source": None},
-#         "level": {"value": 7, "is_from_profile": False, "source": None},
-#         "fancy": {
-#             "value": "sometimes",
-#             "is_from_profile": True,
-#             "source": {
-#                 "id": prof_2.id,
-#                 "display_label": await prof_2.render_display_label(db=db),
-#                 "__typename": "ProfileTestCriticality",
-#             },
-#         },
-#         "id": crit_2_profile.id,
-#     }
+    assert crits_by_id[crit_2_profile.id] == {
+        "name": {"value": "crit_2_profile", "is_from_profile": False, "source": None},
+        "level": {"value": 7, "is_from_profile": False, "source": None},
+        "fancy": {
+            "value": "sometimes",
+            "is_from_profile": True,
+            "source": {
+                "id": prof_2.id,
+                "display_label": await prof_2.render_display_label(db=db),
+                "__typename": "ProfileTestCriticality",
+            },
+        },
+        "id": crit_2_profile.id,
+    }

--- a/backend/tests/unit/graphql/profiles/test_query.py
+++ b/backend/tests/unit/graphql/profiles/test_query.py
@@ -134,150 +134,150 @@ async def test_upsert_profile_in_schema(db: InfrahubDatabase, default_branch: Br
     assert retrieved_object.profile_priority.value == 1234
 
 
-async def test_profile_apply(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
-    profile_schema = registry.schema.get("ProfileTestCriticality", branch=default_branch)
-    prof_1 = await Node.init(db=db, schema=profile_schema)
-    await prof_1.new(db=db, profile_name="prof1", profile_priority=1, level=8)
-    await prof_1.save(db=db)
-    prof_2 = await Node.init(db=db, schema=profile_schema)
-    await prof_2.new(db=db, profile_name="prof2", profile_priority=2, level=9)
-    await prof_2.save(db=db)
+# async def test_profile_apply(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+#     profile_schema = registry.schema.get("ProfileTestCriticality", branch=default_branch)
+#     prof_1 = await Node.init(db=db, schema=profile_schema)
+#     await prof_1.new(db=db, profile_name="prof1", profile_priority=1, level=8)
+#     await prof_1.save(db=db)
+#     prof_2 = await Node.init(db=db, schema=profile_schema)
+#     await prof_2.new(db=db, profile_name="prof2", profile_priority=2, level=9)
+#     await prof_2.save(db=db)
 
-    crit_schema = registry.schema.get("TestCriticality", branch=default_branch)
-    crit_1 = await Node.init(db=db, schema=crit_schema)
-    await crit_1.new(db=db, name="crit_1")
-    crit_1.level.is_default = True
-    await crit_1.profiles.update(db=db, data=[prof_1])
-    await crit_1.save(db=db)
-    crit_2 = await Node.init(db=db, schema=crit_schema)
-    await crit_2.new(db=db, name="crit_2")
-    crit_2.level.is_default = True
-    await crit_2.profiles.update(db=db, data=[prof_2])
-    await crit_2.save(db=db)
+#     crit_schema = registry.schema.get("TestCriticality", branch=default_branch)
+#     crit_1 = await Node.init(db=db, schema=crit_schema)
+#     await crit_1.new(db=db, name="crit_1")
+#     crit_1.level.is_default = True
+#     await crit_1.profiles.update(db=db, data=[prof_1])
+#     await crit_1.save(db=db)
+#     crit_2 = await Node.init(db=db, schema=crit_schema)
+#     await crit_2.new(db=db, name="crit_2")
+#     crit_2.level.is_default = True
+#     await crit_2.profiles.update(db=db, data=[prof_2])
+#     await crit_2.save(db=db)
 
-    query = """
-    query {
-        TestCriticality {
-            edges {
-                node {
-                    name { value }
-                    level { value }
-                    id
-                    profiles {
-                        edges {
-                            node { id }
-                        }
-                    }
-                }
-            }
-        }
-    }
-    """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
-    result = await graphql(
-        schema=gql_params.schema,
-        source=query,
-        context_value=gql_params.context,
-        root_value=None,
-        variable_values={},
-    )
+#     query = """
+#     query {
+#         TestCriticality {
+#             edges {
+#                 node {
+#                     name { value }
+#                     level { value }
+#                     id
+#                     profiles {
+#                         edges {
+#                             node { id }
+#                         }
+#                     }
+#                 }
+#             }
+#         }
+#     }
+#     """
+#     gql_params = await prepare_graphql_params(
+#         db=db, include_mutation=False, include_subscription=False, branch=default_branch
+#     )
+#     result = await graphql(
+#         schema=gql_params.schema,
+#         source=query,
+#         context_value=gql_params.context,
+#         root_value=None,
+#         variable_values={},
+#     )
 
-    assert result.errors is None
-    crits = result.data["TestCriticality"]["edges"]
-    assert len(crits) == 2
-    assert {
-        "node": {
-            "name": {"value": "crit_1"},
-            "level": {"value": 8},
-            "id": crit_1.id,
-            "profiles": {"edges": [{"node": {"id": prof_1.id}}]},
-        }
-    } in crits
-    assert {
-        "node": {
-            "name": {"value": "crit_2"},
-            "level": {"value": 9},
-            "id": crit_2.id,
-            "profiles": {"edges": [{"node": {"id": prof_2.id}}]},
-        }
-    } in crits
+#     assert result.errors is None
+#     crits = result.data["TestCriticality"]["edges"]
+#     assert len(crits) == 2
+#     assert {
+#         "node": {
+#             "name": {"value": "crit_1"},
+#             "level": {"value": 8},
+#             "id": crit_1.id,
+#             "profiles": {"edges": [{"node": {"id": prof_1.id}}]},
+#         }
+#     } in crits
+#     assert {
+#         "node": {
+#             "name": {"value": "crit_2"},
+#             "level": {"value": 9},
+#             "id": crit_2.id,
+#             "profiles": {"edges": [{"node": {"id": prof_2.id}}]},
+#         }
+#     } in crits
 
 
-async def test_profile_apply_generic(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
-    profile_generic_schema = registry.schema.get("ProfileTestGenericCriticality", branch=default_branch)
-    prof_1 = await Node.init(db=db, schema=profile_generic_schema)
-    await prof_1.new(db=db, profile_name="prof1", profile_priority=1, level=8)
-    await prof_1.save(db=db)
-    prof_2 = await Node.init(db=db, schema=profile_generic_schema)
-    await prof_2.new(db=db, profile_name="prof2", profile_priority=2, level=9)
-    await prof_2.save(db=db)
+# async def test_profile_apply_generic(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+#     profile_generic_schema = registry.schema.get("ProfileTestGenericCriticality", branch=default_branch)
+#     prof_1 = await Node.init(db=db, schema=profile_generic_schema)
+#     await prof_1.new(db=db, profile_name="prof1", profile_priority=1, level=8)
+#     await prof_1.save(db=db)
+#     prof_2 = await Node.init(db=db, schema=profile_generic_schema)
+#     await prof_2.new(db=db, profile_name="prof2", profile_priority=2, level=9)
+#     await prof_2.save(db=db)
 
-    crit_schema = registry.schema.get("TestCriticality", branch=default_branch)
-    crit_1 = await Node.init(db=db, schema=crit_schema)
-    await crit_1.new(db=db, name="crit_1")
-    crit_1.level.is_default = True
-    await crit_1.profiles.update(db=db, data=[prof_1])
-    await crit_1.save(db=db)
-    colorful_crit_schema = registry.schema.get("TestColorfulCriticality", branch=default_branch)
-    crit_2 = await Node.init(db=db, schema=colorful_crit_schema)
-    await crit_2.new(db=db, name="crit_2", color="green")
-    crit_2.level.is_default = True
-    await crit_2.profiles.update(db=db, data=[prof_2])
-    await crit_2.save(db=db)
+#     crit_schema = registry.schema.get("TestCriticality", branch=default_branch)
+#     crit_1 = await Node.init(db=db, schema=crit_schema)
+#     await crit_1.new(db=db, name="crit_1")
+#     crit_1.level.is_default = True
+#     await crit_1.profiles.update(db=db, data=[prof_1])
+#     await crit_1.save(db=db)
+#     colorful_crit_schema = registry.schema.get("TestColorfulCriticality", branch=default_branch)
+#     crit_2 = await Node.init(db=db, schema=colorful_crit_schema)
+#     await crit_2.new(db=db, name="crit_2", color="green")
+#     crit_2.level.is_default = True
+#     await crit_2.profiles.update(db=db, data=[prof_2])
+#     await crit_2.save(db=db)
 
-    query = """
-    query {
-        TestGenericCriticality {
-            edges {
-                node {
-                    __typename
-                    name { value }
-                    level { value }
-                    id
-                    profiles {
-                        edges {
-                            node { id }
-                        }
-                    }
-                }
-            }
-        }
-    }
-    """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
-    result = await graphql(
-        schema=gql_params.schema,
-        source=query,
-        context_value=gql_params.context,
-        root_value=None,
-        variable_values={},
-    )
+#     query = """
+#     query {
+#         TestGenericCriticality {
+#             edges {
+#                 node {
+#                     __typename
+#                     name { value }
+#                     level { value }
+#                     id
+#                     profiles {
+#                         edges {
+#                             node { id }
+#                         }
+#                     }
+#                 }
+#             }
+#         }
+#     }
+#     """
+#     gql_params = await prepare_graphql_params(
+#         db=db, include_mutation=False, include_subscription=False, branch=default_branch
+#     )
+#     result = await graphql(
+#         schema=gql_params.schema,
+#         source=query,
+#         context_value=gql_params.context,
+#         root_value=None,
+#         variable_values={},
+#     )
 
-    assert result.errors is None
-    crits = result.data["TestGenericCriticality"]["edges"]
-    assert len(crits) == 2
-    assert {
-        "node": {
-            "__typename": "TestCriticality",
-            "name": {"value": "crit_1"},
-            "level": {"value": 8},
-            "id": crit_1.id,
-            "profiles": {"edges": [{"node": {"id": prof_1.id}}]},
-        }
-    } in crits
-    assert {
-        "node": {
-            "__typename": "TestColorfulCriticality",
-            "name": {"value": "crit_2"},
-            "level": {"value": 9},
-            "id": crit_2.id,
-            "profiles": {"edges": [{"node": {"id": prof_2.id}}]},
-        }
-    } in crits
+#     assert result.errors is None
+#     crits = result.data["TestGenericCriticality"]["edges"]
+#     assert len(crits) == 2
+#     assert {
+#         "node": {
+#             "__typename": "TestCriticality",
+#             "name": {"value": "crit_1"},
+#             "level": {"value": 8},
+#             "id": crit_1.id,
+#             "profiles": {"edges": [{"node": {"id": prof_1.id}}]},
+#         }
+#     } in crits
+#     assert {
+#         "node": {
+#             "__typename": "TestColorfulCriticality",
+#             "name": {"value": "crit_2"},
+#             "level": {"value": 9},
+#             "id": crit_2.id,
+#             "profiles": {"edges": [{"node": {"id": prof_2.id}}]},
+#         }
+#     } in crits
 
 
 async def test_setting_illegal_profiles_raises_error(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
@@ -369,195 +369,195 @@ async def test_setting_illegal_profiles_raises_error(db: InfrahubDatabase, defau
     }
 
 
-async def test_is_from_profile_set_correctly(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
-    profile_schema = registry.schema.get("ProfileTestCriticality", branch=default_branch)
-    prof_1 = await Node.init(db=db, schema=profile_schema)
-    await prof_1.new(db=db, profile_name="prof1", profile_priority=1, level=8)
-    await prof_1.save(db=db)
-    prof_2 = await Node.init(db=db, schema=profile_schema)
-    await prof_2.new(db=db, profile_name="prof2", profile_priority=2, level=9, fancy="sometimes")
-    await prof_2.save(db=db)
+# async def test_is_from_profile_set_correctly(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+#     profile_schema = registry.schema.get("ProfileTestCriticality", branch=default_branch)
+#     prof_1 = await Node.init(db=db, schema=profile_schema)
+#     await prof_1.new(db=db, profile_name="prof1", profile_priority=1, level=8)
+#     await prof_1.save(db=db)
+#     prof_2 = await Node.init(db=db, schema=profile_schema)
+#     await prof_2.new(db=db, profile_name="prof2", profile_priority=2, level=9, fancy="sometimes")
+#     await prof_2.save(db=db)
 
-    crit_schema = registry.schema.get("TestCriticality", branch=default_branch)
-    crit_no_profile = await Node.init(db=db, schema=crit_schema)
-    await crit_no_profile.new(db=db, name="crit_no_profile", fancy="always")
-    await crit_no_profile.save(db=db)
+#     crit_schema = registry.schema.get("TestCriticality", branch=default_branch)
+#     crit_no_profile = await Node.init(db=db, schema=crit_schema)
+#     await crit_no_profile.new(db=db, name="crit_no_profile", fancy="always")
+#     await crit_no_profile.save(db=db)
 
-    crit_1_profile = await Node.init(db=db, schema=crit_schema)
-    await crit_1_profile.new(db=db, name="crit_1_profile", fancy="never")
-    await crit_1_profile.profiles.update(db=db, data=[prof_1])
-    await crit_1_profile.save(db=db)
+#     crit_1_profile = await Node.init(db=db, schema=crit_schema)
+#     await crit_1_profile.new(db=db, name="crit_1_profile", fancy="never")
+#     await crit_1_profile.profiles.update(db=db, data=[prof_1])
+#     await crit_1_profile.save(db=db)
 
-    crit_2_profile = await Node.init(db=db, schema=crit_schema)
-    await crit_2_profile.new(db=db, name="crit_2_profile", level=7)
-    await crit_2_profile.profiles.update(db=db, data=[prof_1, prof_2])
-    await crit_2_profile.save(db=db)
+#     crit_2_profile = await Node.init(db=db, schema=crit_schema)
+#     await crit_2_profile.new(db=db, name="crit_2_profile", level=7)
+#     await crit_2_profile.profiles.update(db=db, data=[prof_1, prof_2])
+#     await crit_2_profile.save(db=db)
 
-    query = """
-    query {
-        TestCriticality {
-            edges {
-                node {
-                    name { value, is_from_profile }
-                    level { value, is_from_profile }
-                    fancy { value, is_from_profile }
-                    id
-                }
-            }
-        }
-    }
-    """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
-    result = await graphql(
-        schema=gql_params.schema,
-        source=query,
-        context_value=gql_params.context,
-        root_value=None,
-        variable_values={},
-    )
+#     query = """
+#     query {
+#         TestCriticality {
+#             edges {
+#                 node {
+#                     name { value, is_from_profile }
+#                     level { value, is_from_profile }
+#                     fancy { value, is_from_profile }
+#                     id
+#                 }
+#             }
+#         }
+#     }
+#     """
+#     gql_params = await prepare_graphql_params(
+#         db=db, include_mutation=False, include_subscription=False, branch=default_branch
+#     )
+#     result = await graphql(
+#         schema=gql_params.schema,
+#         source=query,
+#         context_value=gql_params.context,
+#         root_value=None,
+#         variable_values={},
+#     )
 
-    assert result.errors is None
-    crits = result.data["TestCriticality"]["edges"]
-    assert len(crits) == 3
-    crits_by_id = {crit["node"]["id"]: crit["node"] for crit in crits}
-    assert crits_by_id[crit_no_profile.id] == {
-        "name": {"value": "crit_no_profile", "is_from_profile": False},
-        "level": {"value": None, "is_from_profile": False},
-        "fancy": {"value": "always", "is_from_profile": False},
-        "id": crit_no_profile.id,
-    }
+#     assert result.errors is None
+#     crits = result.data["TestCriticality"]["edges"]
+#     assert len(crits) == 3
+#     crits_by_id = {crit["node"]["id"]: crit["node"] for crit in crits}
+#     assert crits_by_id[crit_no_profile.id] == {
+#         "name": {"value": "crit_no_profile", "is_from_profile": False},
+#         "level": {"value": None, "is_from_profile": False},
+#         "fancy": {"value": "always", "is_from_profile": False},
+#         "id": crit_no_profile.id,
+#     }
 
-    assert crits_by_id[crit_1_profile.id] == {
-        "name": {"value": "crit_1_profile", "is_from_profile": False},
-        "level": {"value": 8, "is_from_profile": True},
-        "fancy": {"value": "never", "is_from_profile": False},
-        "id": crit_1_profile.id,
-    }
+#     assert crits_by_id[crit_1_profile.id] == {
+#         "name": {"value": "crit_1_profile", "is_from_profile": False},
+#         "level": {"value": 8, "is_from_profile": True},
+#         "fancy": {"value": "never", "is_from_profile": False},
+#         "id": crit_1_profile.id,
+#     }
 
-    assert crits_by_id[crit_2_profile.id] == {
-        "name": {"value": "crit_2_profile", "is_from_profile": False},
-        "level": {"value": 7, "is_from_profile": False},
-        "fancy": {"value": "sometimes", "is_from_profile": True},
-        "id": crit_2_profile.id,
-    }
+#     assert crits_by_id[crit_2_profile.id] == {
+#         "name": {"value": "crit_2_profile", "is_from_profile": False},
+#         "level": {"value": 7, "is_from_profile": False},
+#         "fancy": {"value": "sometimes", "is_from_profile": True},
+#         "id": crit_2_profile.id,
+#     }
 
-    assert crit_1_profile.id in gql_params.context.related_node_ids
-    assert crit_2_profile.id in gql_params.context.related_node_ids
+#     assert crit_1_profile.id in gql_params.context.related_node_ids
+#     assert crit_2_profile.id in gql_params.context.related_node_ids
 
 
-async def test_is_profile_source_set_correctly(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
-    profile_schema = registry.schema.get("ProfileTestCriticality", branch=default_branch)
-    prof_1 = await Node.init(db=db, schema=profile_schema)
-    await prof_1.new(db=db, profile_name="prof1", profile_priority=1, level=8)
-    await prof_1.save(db=db)
-    prof_2 = await Node.init(db=db, schema=profile_schema)
-    await prof_2.new(db=db, profile_name="prof2", profile_priority=2, level=9, fancy="sometimes")
-    await prof_2.save(db=db)
+# async def test_is_profile_source_set_correctly(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+#     profile_schema = registry.schema.get("ProfileTestCriticality", branch=default_branch)
+#     prof_1 = await Node.init(db=db, schema=profile_schema)
+#     await prof_1.new(db=db, profile_name="prof1", profile_priority=1, level=8)
+#     await prof_1.save(db=db)
+#     prof_2 = await Node.init(db=db, schema=profile_schema)
+#     await prof_2.new(db=db, profile_name="prof2", profile_priority=2, level=9, fancy="sometimes")
+#     await prof_2.save(db=db)
 
-    crit_schema = registry.schema.get("TestCriticality", branch=default_branch)
-    crit_no_profile = await Node.init(db=db, schema=crit_schema)
-    await crit_no_profile.new(db=db, name="crit_no_profile", fancy="always")
-    await crit_no_profile.save(db=db)
+#     crit_schema = registry.schema.get("TestCriticality", branch=default_branch)
+#     crit_no_profile = await Node.init(db=db, schema=crit_schema)
+#     await crit_no_profile.new(db=db, name="crit_no_profile", fancy="always")
+#     await crit_no_profile.save(db=db)
 
-    crit_1_profile = await Node.init(db=db, schema=crit_schema)
-    await crit_1_profile.new(db=db, name="crit_1_profile", fancy="never")
-    await crit_1_profile.profiles.update(db=db, data=[prof_1])
-    await crit_1_profile.save(db=db)
+#     crit_1_profile = await Node.init(db=db, schema=crit_schema)
+#     await crit_1_profile.new(db=db, name="crit_1_profile", fancy="never")
+#     await crit_1_profile.profiles.update(db=db, data=[prof_1])
+#     await crit_1_profile.save(db=db)
 
-    crit_2_profile = await Node.init(db=db, schema=crit_schema)
-    await crit_2_profile.new(db=db, name="crit_2_profile", level=7)
-    await crit_2_profile.profiles.update(db=db, data=[prof_1, prof_2])
-    await crit_2_profile.save(db=db)
+#     crit_2_profile = await Node.init(db=db, schema=crit_schema)
+#     await crit_2_profile.new(db=db, name="crit_2_profile", level=7)
+#     await crit_2_profile.profiles.update(db=db, data=[prof_1, prof_2])
+#     await crit_2_profile.save(db=db)
 
-    query = """
-    query {
-        TestCriticality {
-            edges {
-                node {
-                    id
-                    name {
-                        value
-                        is_from_profile
-                        source {
-                            id
-                            display_label
-                            __typename
-                        }
-                    }
-                    level {
-                        value
-                        is_from_profile
-                        source {
-                            id
-                            display_label
-                            __typename
-                        }
-                    }
-                    fancy {
-                        value
-                        is_from_profile
-                        source {
-                            id
-                            display_label
-                            __typename
-                        }
-                    }
-                }
-            }
-        }
-    }
-    """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
-    result = await graphql(
-        schema=gql_params.schema,
-        source=query,
-        context_value=gql_params.context,
-        root_value=None,
-        variable_values={},
-    )
+#     query = """
+#     query {
+#         TestCriticality {
+#             edges {
+#                 node {
+#                     id
+#                     name {
+#                         value
+#                         is_from_profile
+#                         source {
+#                             id
+#                             display_label
+#                             __typename
+#                         }
+#                     }
+#                     level {
+#                         value
+#                         is_from_profile
+#                         source {
+#                             id
+#                             display_label
+#                             __typename
+#                         }
+#                     }
+#                     fancy {
+#                         value
+#                         is_from_profile
+#                         source {
+#                             id
+#                             display_label
+#                             __typename
+#                         }
+#                     }
+#                 }
+#             }
+#         }
+#     }
+#     """
+#     gql_params = await prepare_graphql_params(
+#         db=db, include_mutation=False, include_subscription=False, branch=default_branch
+#     )
+#     result = await graphql(
+#         schema=gql_params.schema,
+#         source=query,
+#         context_value=gql_params.context,
+#         root_value=None,
+#         variable_values={},
+#     )
 
-    assert result.errors is None
-    crits = result.data["TestCriticality"]["edges"]
-    assert len(crits) == 3
-    crits_by_id = {crit["node"]["id"]: crit["node"] for crit in crits}
+#     assert result.errors is None
+#     crits = result.data["TestCriticality"]["edges"]
+#     assert len(crits) == 3
+#     crits_by_id = {crit["node"]["id"]: crit["node"] for crit in crits}
 
-    assert crits_by_id[crit_no_profile.id] == {
-        "name": {"value": "crit_no_profile", "is_from_profile": False, "source": None},
-        "level": {"value": None, "is_from_profile": False, "source": None},
-        "fancy": {"value": "always", "is_from_profile": False, "source": None},
-        "id": crit_no_profile.id,
-    }
+#     assert crits_by_id[crit_no_profile.id] == {
+#         "name": {"value": "crit_no_profile", "is_from_profile": False, "source": None},
+#         "level": {"value": None, "is_from_profile": False, "source": None},
+#         "fancy": {"value": "always", "is_from_profile": False, "source": None},
+#         "id": crit_no_profile.id,
+#     }
 
-    assert crits_by_id[crit_1_profile.id] == {
-        "name": {"value": "crit_1_profile", "is_from_profile": False, "source": None},
-        "level": {
-            "value": 8,
-            "is_from_profile": True,
-            "source": {
-                "id": prof_1.id,
-                "display_label": await prof_1.render_display_label(db=db),
-                "__typename": "ProfileTestCriticality",
-            },
-        },
-        "fancy": {"value": "never", "is_from_profile": False, "source": None},
-        "id": crit_1_profile.id,
-    }
+#     assert crits_by_id[crit_1_profile.id] == {
+#         "name": {"value": "crit_1_profile", "is_from_profile": False, "source": None},
+#         "level": {
+#             "value": 8,
+#             "is_from_profile": True,
+#             "source": {
+#                 "id": prof_1.id,
+#                 "display_label": await prof_1.render_display_label(db=db),
+#                 "__typename": "ProfileTestCriticality",
+#             },
+#         },
+#         "fancy": {"value": "never", "is_from_profile": False, "source": None},
+#         "id": crit_1_profile.id,
+#     }
 
-    assert crits_by_id[crit_2_profile.id] == {
-        "name": {"value": "crit_2_profile", "is_from_profile": False, "source": None},
-        "level": {"value": 7, "is_from_profile": False, "source": None},
-        "fancy": {
-            "value": "sometimes",
-            "is_from_profile": True,
-            "source": {
-                "id": prof_2.id,
-                "display_label": await prof_2.render_display_label(db=db),
-                "__typename": "ProfileTestCriticality",
-            },
-        },
-        "id": crit_2_profile.id,
-    }
+#     assert crits_by_id[crit_2_profile.id] == {
+#         "name": {"value": "crit_2_profile", "is_from_profile": False, "source": None},
+#         "level": {"value": 7, "is_from_profile": False, "source": None},
+#         "fancy": {
+#             "value": "sometimes",
+#             "is_from_profile": True,
+#             "source": {
+#                 "id": prof_2.id,
+#                 "display_label": await prof_2.render_display_label(db=db),
+#                 "__typename": "ProfileTestCriticality",
+#             },
+#         },
+#         "id": crit_2_profile.id,
+#     }


### PR DESCRIPTION
targets the new feature branch for the profiles refactoring

delete the logic to apply profiles while reading from the database and skip the affected failing tests. tests will be updated and reactivated as the following PRs come in to support creating/updating nodes using profiles at write time