### PR TITLE
IFC-1297: Validate branch is not duplicate before starting workflow

### DIFF
--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -345,7 +345,7 @@ async def create_branch(model: BranchCreateModel, context: InfrahubContext) -> N
     async with database.start_session() as db:
         try:
             await Branch.get_by_name(db=db, name=model.name)
-            raise ValueError(f"The branch {model.name}, already exist")
+            raise ValidationError(f"The branch {model.name}, already exist")
         except BranchNotFoundError:
             pass
 
@@ -356,7 +356,7 @@ async def create_branch(model: BranchCreateModel, context: InfrahubContext) -> N
             obj = Branch(**data_dict)
         except pydantic.ValidationError as exc:
             error_msgs = [f"invalid field {error['loc'][0]}: {error['msg']}" for error in exc.errors()]
-            raise ValueError("\n".join(error_msgs)) from exc
+            raise ValidationError("\n".join(error_msgs)) from exc
 
         async with lock.registry.local_schema_lock():
             # Copy the schema from the origin branch and set the hash and the schema_changed_at value

--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -345,7 +345,7 @@ async def create_branch(model: BranchCreateModel, context: InfrahubContext) -> N
     async with database.start_session() as db:
         try:
             await Branch.get_by_name(db=db, name=model.name)
-            raise ValidationError(f"The branch {model.name}, already exist")
+            raise ValidationError(f"The branch {model.name} already exists")
         except BranchNotFoundError:
             pass
 

--- a/backend/infrahub/graphql/mutations/branch.py
+++ b/backend/infrahub/graphql/mutations/branch.py
@@ -79,7 +79,7 @@ class BranchCreate(Mutation):
 
         try:
             await Branch.get_by_name(db=graphql_context.db, name=model.name)
-            raise ValidationError(f"The branch {model.name}, already exist")
+            raise ValidationError(f"The branch {model.name} already exists")
         except BranchNotFoundError:
             pass
 

--- a/backend/infrahub/graphql/mutations/branch.py
+++ b/backend/infrahub/graphql/mutations/branch.py
@@ -10,6 +10,7 @@ from infrahub.branch.merge_mutation_checker import verify_branch_merge_mutation_
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.database import retry_db_transaction
+from infrahub.exceptions import BranchNotFoundError, ValidationError
 from infrahub.graphql.context import apply_external_context
 from infrahub.graphql.field_extractor import extract_graphql_fields
 from infrahub.graphql.types.context import ContextInput
@@ -75,6 +76,12 @@ class BranchCreate(Mutation):
 
         model = BranchCreateModel(**data)
         await apply_external_context(graphql_context=graphql_context, context_input=context)
+
+        try:
+            await Branch.get_by_name(db=graphql_context.db, name=model.name)
+            raise ValidationError(f"The branch {model.name}, already exist")
+        except BranchNotFoundError:
+            pass
 
         if background_execution or not wait_until_completion:
             workflow = await graphql_context.active_service.workflow.submit_workflow(

--- a/backend/tests/functional/branch/test_graphql_mutation.py
+++ b/backend/tests/functional/branch/test_graphql_mutation.py
@@ -264,6 +264,17 @@ class TestBranchMutations(TestInfrahubApp):
         assert result["BranchCreate"]["object"]["id"] is not None
         assert result["BranchCreate"]["task"] is None
 
+    async def test_branch_create_duplicate_branch_failed(self, initial_dataset: str, client: InfrahubClient) -> None:
+        branch_to_duplicate = await client.branch.create(branch_name="branch_to_duplicate")
+        query = Mutation(
+            mutation="BranchCreate",
+            input_data={"data": {"name": "branch_to_duplicate"}},
+            query={"ok": None, "task": {"id": None}, "object": {"id": None}},
+        )
+        with pytest.raises(GraphQLError) as exc:
+            await client.execute_graphql(query=query.render())
+        assert f"The branch {branch_to_duplicate.name}, already exist" in exc.value.message
+
     async def test_branch_create_async(self, initial_dataset: str, client: InfrahubClient) -> None:
         query = Mutation(
             mutation="BranchCreate",
@@ -273,6 +284,19 @@ class TestBranchMutations(TestInfrahubApp):
         result = await client.execute_graphql(query=query.render())
         assert result["BranchCreate"]["ok"] is True
         assert result["BranchCreate"]["task"]["id"] is not None
+
+    async def test_branch_create_async_duplicate_branch_failed(
+        self, initial_dataset: str, client: InfrahubClient
+    ) -> None:
+        branch_to_duplicate_async = await client.branch.create(branch_name="branch_to_duplicate_async")
+        query = Mutation(
+            mutation="BranchCreate",
+            input_data={"data": {"name": "branch_to_duplicate_async"}, "wait_until_completion": False},
+            query={"ok": None, "task": {"id": None}, "object": {"id": None}},
+        )
+        with pytest.raises(GraphQLError) as exc:
+            await client.execute_graphql(query=query.render())
+        assert f"The branch {branch_to_duplicate_async.name}, already exist" in exc.value.message
 
     async def test_branch_create_async_deprecated(self, initial_dataset: str, client: InfrahubClient) -> None:
         query = Mutation(

--- a/backend/tests/functional/branch/test_graphql_mutation.py
+++ b/backend/tests/functional/branch/test_graphql_mutation.py
@@ -273,7 +273,7 @@ class TestBranchMutations(TestInfrahubApp):
         )
         with pytest.raises(GraphQLError) as exc:
             await client.execute_graphql(query=query.render())
-        assert f"The branch {branch_to_duplicate.name}, already exist" in exc.value.message
+        assert f"The branch {branch_to_duplicate.name} already exists" in exc.value.message
 
     async def test_branch_create_async(self, initial_dataset: str, client: InfrahubClient) -> None:
         query = Mutation(
@@ -296,7 +296,7 @@ class TestBranchMutations(TestInfrahubApp):
         )
         with pytest.raises(GraphQLError) as exc:
             await client.execute_graphql(query=query.render())
-        assert f"The branch {branch_to_duplicate_async.name}, already exist" in exc.value.message
+        assert f"The branch {branch_to_duplicate_async.name} already exists" in exc.value.message
 
     async def test_branch_create_async_deprecated(self, initial_dataset: str, client: InfrahubClient) -> None:
         query = Mutation(

--- a/backend/tests/unit/graphql/mutations/test_branch.py
+++ b/backend/tests/unit/graphql/mutations/test_branch.py
@@ -81,7 +81,7 @@ class TestBranchCreate(TestInfrahubApp):
         )
         assert result.errors
         assert len(result.errors) == 1
-        assert "The branch branch2, already exist" in result.errors[0].message
+        assert "The branch branch2 already exists" in result.errors[0].message
 
         # Create another branch with different inputs
         query = """


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prevent creating branches with duplicate names; GraphQL now rejects duplicates immediately (sync and async).

* **Bug Fixes**
  * Return clear validation errors for branch creation instead of generic exceptions.
  * Consistent, user-facing error message when a branch name already exists.

* **Tests**
  * Added functional and unit tests validating duplicate-branch errors and exact error wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->