### PR TITLE
Update schema_hash for flaky test

### DIFF
--- a/backend/tests/unit/graphql/test_mutation_relationship.py
+++ b/backend/tests/unit/graphql/test_mutation_relationship.py
@@ -604,7 +604,7 @@ async def test_relationship_groups_remove(
 
     memory_event = MemoryInfrahubEvent()
     service = await InfrahubServices.new(event=memory_event)
-
+    default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(
         db=db, include_subscription=False, branch=default_branch, service=service, account_session=session_first_account
     )
@@ -862,6 +862,7 @@ async def test_relationship_add_busy(db: InfrahubDatabase, default_branch: Branc
         c1.id,
     )
 
+    default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of GraphQL relationship mutation tests by ensuring the schema is up to date before execution, reducing flakiness and increasing consistency.
  * Maintained existing assertions and error handling while refining test setup for relationship add/remove scenarios.

* **Chores**
  * No user-facing changes; internal test stability improvements only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->