### PR TITLE
fix schema integrity check to remove resolved violations

### DIFF
--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -441,9 +441,6 @@ async def run_proposed_change_schema_integrity_check(model: RequestProposedChang
                 )
             )
 
-    if not conflicts:
-        return
-
     database = await get_database()
     async with database.start_transaction() as db:
         object_conflict_validator_recorder = ObjectConflictValidatorRecorder(

--- a/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
+++ b/backend/tests/unit/message_bus/operations/requests/test_proposed_change.py
@@ -10,6 +10,7 @@ from infrahub.core.branch import Branch
 from infrahub.core.constants import DiffAction, InfrahubKind, SchemaPathType
 from infrahub.core.diff.model.diff import DiffElementType
 from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.validators.enum import ConstraintIdentifier
 from infrahub.database import InfrahubDatabase
@@ -282,6 +283,7 @@ async def test_schema_integrity(
         person = await Node.init(db=db, schema="TestPerson", branch=branch2)
         await person.new(db=db, name="ALFRED", height=160, cars=[car_accord_main.id])
         await person.save(db=db)
+        person_john = await NodeManager.get_one(db=db, branch=branch2, id=person_john_main.id)
 
         branch2_schema = registry.schema.get_schema_branch(name=branch2.name)
         person_schema = branch2_schema.get(name="TestPerson")
@@ -329,3 +331,14 @@ async def test_schema_integrity(
                 ),
             }
         ] in all_conflicts
+
+        # verify integrity checks are removed after being fixed
+        person_john.name.value = "JOHN"
+        await person_john.save(db=db)
+
+        await run_proposed_change_schema_integrity_check(model=schema_integrity_01)
+
+        checks = await registry.manager.query(db=db, schema=InfrahubKind.SCHEMACHECK)
+        assert len(checks) == 1
+        assert checks[0].conclusion.value.value == "success"
+        assert checks[0].conflicts.value == []

--- a/changelog/7278.fixed.md
+++ b/changelog/7278.fixed.md
@@ -1,0 +1,1 @@
+Fix bug in schema integrity checks of a proposed change that prevented resolved violations from being removed


### PR DESCRIPTION
fixes #7278 

fix a bug in the schema integrity checks runner that would prevent removing violations if all the violations were resolved

the fix is to just make sure we `ObjectConflictValidatorRecorder.record_conflicts` in `run_proposed_change_schema_integrity_check` even if there are no conflicts b/c there _could_ have been conflicts before and we need to remove the resolved conflicts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Schema integrity checks now correctly clear resolved violations and consistently record results, preventing stale or lingering conflicts after fixes.
- Tests
  - Added a fix-and-validate test flow to ensure conflicts are removed and success is reported after correcting data.
- Documentation
  - Updated changelog to note the schema integrity check fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->