### PR TITLE
allow attribute properties (source, owner) to be deleted

### DIFF
--- a/backend/infrahub/core/attribute.py
+++ b/backend/infrahub/core/attribute.py
@@ -395,7 +395,6 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin):
 
         Get the current value
          - If the value is the same, do nothing
-         - If the value is inherited and is different, raise error (for now just ignore)
          - If the value is different, create new node and update relationship
 
         """
@@ -470,28 +469,32 @@ class BaseAttribute(FlagPropertyMixin, NodePropertyMixin):
 
         # ---------- Update the Node Properties ----------
         for prop_name in self._node_properties:
-            if getattr(self, f"{prop_name}_id") and not (
-                prop_name in current_attr_data.node_properties
-                and current_attr_data.node_properties[prop_name].uuid == getattr(self, f"{prop_name}_id")
-            ):
-                previous_attribute_node_property = current_attr_data.node_properties.get(prop_name)
-                previous_value = None
-                if previous_attribute_node_property:
-                    previous_value = previous_attribute_node_property.uuid
+            current_prop_id = getattr(self, f"{prop_name}_id")
+            database_prop_id: str | None = None
+            if prop_name in current_attr_data.node_properties:
+                database_prop_id = current_attr_data.node_properties[prop_name].uuid
+            needs_update = current_prop_id is not None and current_prop_id != database_prop_id
+            needs_clear = self.is_clear(prop_name) and database_prop_id
 
-                changelog.add_property(
-                    name=prop_name,
-                    value_current=getattr(self, f"{prop_name}_id"),
-                    value_previous=previous_value,
-                )
+            if not needs_update and not needs_clear:
+                continue
+
+            changelog.add_property(
+                name=prop_name,
+                value_current=current_prop_id,
+                value_previous=database_prop_id,
+            )
+
+            if needs_update:
                 query = await AttributeUpdateNodePropertyQuery.init(
-                    db=db, attr=self, at=update_at, prop_name=prop_name, prop_id=getattr(self, f"{prop_name}_id")
+                    db=db, attr=self, at=update_at, prop_name=prop_name, prop_id=current_prop_id
                 )
                 await query.execute(db=db)
 
-                rel = current_attr_result.get(f"rel_{prop_name}")
-                if rel and rel.get("branch") == branch.name:
-                    await update_relationships_to([rel.element_id], to=update_at, db=db)
+            # set the to time on the previously active edge
+            rel = current_attr_result.get(f"rel_{prop_name}")
+            if rel and rel.get("branch") == branch.name:
+                await update_relationships_to([rel.element_id], to=update_at, db=db)
 
         if changelog.has_updates:
             return changelog

--- a/backend/infrahub/core/property.py
+++ b/backend/infrahub/core/property.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from enum import Enum
 from typing import TYPE_CHECKING
 from uuid import UUID
 
@@ -24,6 +25,10 @@ class ValuePropertyData(BaseModel):
 class NodePropertyData(BaseModel):
     name: str
     peer_id: str
+
+
+class ClearValue(Enum):
+    CLEAR = "clear"
 
 
 class FlagPropertyMixin:
@@ -51,6 +56,7 @@ class NodePropertyMixin:
         for node in self._node_properties:
             setattr(self, f"_{node}", None)
             setattr(self, f"{node}_id", None)
+            setattr(self, f"_clear_{node}", False)
 
         if not kwargs:
             return
@@ -79,12 +85,14 @@ class NodePropertyMixin:
 
     def clear_owner(self) -> None:
         self._set_node_property(name="owner", value=None)
+        self._clear_owner = True
 
     async def get_source(self, db: InfrahubDatabase) -> Node | None:
         return await self._get_node_property(name="source", db=db)
 
     def clear_source(self) -> None:
         self._set_node_property(name="source", value=None)
+        self._clear_source = True
 
     def set_source(self, value: str | Node | UUID) -> None:
         self._set_node_property(name="source", value=value)
@@ -94,6 +102,9 @@ class NodePropertyMixin:
 
     def set_owner(self, value: str | Node | UUID) -> None:
         self._set_node_property(name="owner", value=value)
+
+    def is_clear(self, name: str) -> bool:
+        return getattr(self, f"_clear_{name}", False)
 
     def _get_node_property_from_cache(self, name: str) -> Node:
         """Return the node attribute if it's already present locally,

--- a/backend/infrahub/core/query/attribute.py
+++ b/backend/infrahub/core/query/attribute.py
@@ -133,7 +133,7 @@ class AttributeUpdateNodePropertyQuery(AttributeQuery):
     def __init__(
         self,
         prop_name: str,
-        prop_id: str,
+        prop_id: str | None = None,
         **kwargs: Any,
     ):
         self.prop_name = prop_name
@@ -144,6 +144,8 @@ class AttributeUpdateNodePropertyQuery(AttributeQuery):
     async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
         at = self.at or self.attr.at
 
+        branch_filter, branch_params = self.branch.get_query_filter_path(at=at)
+        self.params.update(branch_params)
         self.params["attr_uuid"] = self.attr.id
         self.params["branch"] = self.branch.name
         self.params["branch_level"] = self.branch.hierarchy_level
@@ -151,18 +153,34 @@ class AttributeUpdateNodePropertyQuery(AttributeQuery):
         self.params["prop_name"] = self.prop_name
         self.params["prop_id"] = self.prop_id
 
-        rel_name = f"HAS_{self.prop_name.upper()}"
+        rel_label = f"HAS_{self.prop_name.upper()}"
 
-        query = (
+        if self.branch.is_default or self.branch.is_global:
+            node_query = """
+        MATCH (np:Node { uuid: $prop_id })-[r:IS_PART_OF]->(:Root)
+        WHERE r.branch IN $branch0
+        AND r.status = "active"
+        AND r.from <= $at AND (r.to IS NULL OR r.to > $at)
+        WITH np
+        LIMIT 1
             """
-        MATCH (a:Attribute { uuid: $attr_uuid })
-        MATCH (np:Node { uuid: $prop_id })
-        CREATE (a)-[r:%s { branch: $branch, branch_level: $branch_level, status: "active", from: $at }]->(np)
-        """
-            % rel_name
-        )
+        else:
+            node_query = """
+        MATCH (np:Node { uuid: $prop_id })-[r:IS_PART_OF]->(:Root)
+        WHERE %(branch_filter)s
+        ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+        LIMIT 1
+        WITH np
+        WHERE r.status = "active"
+            """ % {"branch_filter": branch_filter}
+        self.add_to_query(node_query)
 
-        self.add_to_query(query)
+        attr_query = """
+        MATCH (a:Attribute { uuid: $attr_uuid })
+        CREATE (a)-[r:%(rel_label)s { branch: $branch, branch_level: $branch_level, status: "active", from: $at }]->(np)
+        """ % {"rel_label": rel_label}
+        self.add_to_query(attr_query)
+
         self.return_labels = ["a", "np", "r"]
 
 

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -668,16 +668,32 @@ class NodeListGetAttributeQuery(Query):
 
         if self.include_source:
             query = """
-            OPTIONAL MATCH (a)-[rel_source:HAS_SOURCE]-(source)
-            WHERE all(r IN [rel_source] WHERE ( %(branch_filter)s ))
+            CALL (a) {
+                OPTIONAL MATCH (a)-[rel_source:HAS_SOURCE]-(source)
+                WHERE all(r IN [rel_source] WHERE ( %(branch_filter)s ))
+                RETURN source, rel_source
+                ORDER BY rel_source.branch_level DESC, rel_source.from DESC, rel_source.status ASC
+                LIMIT 1
+            }
+            WITH *,
+                CASE WHEN rel_source.status = "active" THEN source ELSE NULL END AS source,
+                CASE WHEN rel_source.status = "active" THEN rel_source ELSE NULL END AS rel_source
             """ % {"branch_filter": branch_filter}
             self.add_to_query(query)
             self.return_labels.extend(["source", "rel_source"])
 
         if self.include_owner:
             query = """
-            OPTIONAL MATCH (a)-[rel_owner:HAS_OWNER]-(owner)
-            WHERE all(r IN [rel_owner] WHERE ( %(branch_filter)s ))
+            CALL (a) {
+                OPTIONAL MATCH (a)-[rel_owner:HAS_OWNER]-(owner)
+                WHERE all(r IN [rel_owner] WHERE ( %(branch_filter)s ))
+                RETURN owner, rel_owner
+                ORDER BY rel_owner.branch_level DESC, rel_owner.from DESC, rel_owner.status ASC
+                LIMIT 1
+            }
+            WITH *,
+                CASE WHEN rel_owner.status = "active" THEN owner ELSE NULL END AS owner,
+                CASE WHEN rel_owner.status = "active" THEN rel_owner ELSE NULL END AS rel_owner
             """ % {"branch_filter": branch_filter}
             self.add_to_query(query)
             self.return_labels.extend(["owner", "rel_owner"])

--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -350,17 +350,20 @@ class RelationshipUpdatePropertyQuery(RelationshipQuery):
 
     def __init__(
         self,
-        properties_to_update: list[str],
-        data: RelationshipPeerData,
+        rel_node_id: str,
+        flag_properties_to_update: dict[str, bool],
+        node_properties_to_update: dict[str, str],
         **kwargs,
     ):
-        self.properties_to_update = properties_to_update
-        self.data = data
-
+        self.rel_node_id = rel_node_id
+        if not flag_properties_to_update and not node_properties_to_update:
+            raise ValueError("Either flag_properties_to_update or node_properties_to_update must be set")
+        self.flag_properties_to_update = flag_properties_to_update
+        self.node_properties_to_update = node_properties_to_update
         super().__init__(**kwargs)
 
     async def query_init(self, db: InfrahubDatabase, **kwargs) -> None:  # noqa: ARG002
-        self.params["rel_node_id"] = self.data.rel_node_id
+        self.params["rel_node_id"] = self.rel_node_id
         self.params["branch"] = self.branch.name
         self.params["branch_level"] = self.branch.hierarchy_level
         self.params["at"] = self.at.to_string()
@@ -370,36 +373,51 @@ class RelationshipUpdatePropertyQuery(RelationshipQuery):
         """
         self.add_to_query(query)
 
-        self.query_add_all_flag_property_merge()
         self.query_add_all_node_property_merge()
+        self.query_add_all_flag_property_merge()
 
-        self.query_add_all_flag_property_create()
         self.query_add_all_node_property_create()
+        self.query_add_all_flag_property_create()
 
     def query_add_all_flag_property_merge(self) -> None:
-        for prop_name in self.rel._flag_properties:
-            if prop_name in self.properties_to_update:
-                self.query_add_flag_property_merge(name=prop_name)
+        for prop_name, prop_value in self.flag_properties_to_update.items():
+            self.query_add_flag_property_merge(name=prop_name, value=prop_value)
 
-    def query_add_flag_property_merge(self, name: str) -> None:
+    def query_add_flag_property_merge(self, name: str, value: bool) -> None:
         self.add_to_query("MERGE (prop_%s:Boolean { value: $prop_%s })" % (name, name))
-        self.params[f"prop_{name}"] = getattr(self.rel, name)
+        self.params[f"prop_{name}"] = value
         self.return_labels.append(f"prop_{name}")
 
     def query_add_all_node_property_merge(self) -> None:
-        for prop_name in self.rel._node_properties:
-            if prop_name in self.properties_to_update:
-                self.query_add_node_property_merge(name=prop_name)
+        branch_filter, branch_params = self.branch.get_query_filter_path(at=self.at)
+        self.params.update(branch_params)
 
-    def query_add_node_property_merge(self, name: str) -> None:
-        self.add_to_query("MERGE (prop_%s:Node { uuid: $prop_%s })" % (name, name))
-        self.params[f"prop_{name}"] = getattr(self.rel, f"{name}_id")
-        self.return_labels.append(f"prop_{name}")
+        for prop_name, prop_value in self.node_properties_to_update.items():
+            self.params[f"prop_{prop_name}"] = prop_value
+            if self.branch.is_default or self.branch.is_global:
+                node_query = """
+            MATCH (prop_%(prop_name)s:Node {uuid: $prop_%(prop_name)s })-[r_%(prop_name)s:IS_PART_OF]->(:Root)
+            WHERE r_%(prop_name)s.branch IN $branch0
+            AND r_%(prop_name)s.status = "active"
+            AND r_%(prop_name)s.from <= $at AND (r_%(prop_name)s.to IS NULL OR r_%(prop_name)s.to > $at)
+            WITH *
+            LIMIT 1
+                """ % {"prop_name": prop_name}
+            else:
+                node_query = """
+            MATCH (prop_%(prop_name)s:Node {uuid: $prop_%(prop_name)s })-[r_%(prop_name)s:IS_PART_OF]->(:Root)
+            WHERE all(r in [r_%(prop_name)s] WHERE %(branch_filter)s)
+            ORDER BY r_%(prop_name)s.branch_level DESC, r_%(prop_name)s.from DESC, r_%(prop_name)s.status ASC
+            LIMIT 1
+            WITH *
+            WHERE r_%(prop_name)s.status = "active"
+                """ % {"branch_filter": branch_filter, "prop_name": prop_name}
+            self.add_to_query(node_query)
+            self.return_labels.append(f"prop_{prop_name}")
 
     def query_add_all_flag_property_create(self) -> None:
-        for prop_name in self.rel._flag_properties:
-            if prop_name in self.properties_to_update:
-                self.query_add_flag_property_create(name=prop_name)
+        for prop_name in self.flag_properties_to_update:
+            self.query_add_flag_property_create(name=prop_name)
 
     def query_add_flag_property_create(self, name: str) -> None:
         query = """
@@ -411,9 +429,8 @@ class RelationshipUpdatePropertyQuery(RelationshipQuery):
         self.add_to_query(query)
 
     def query_add_all_node_property_create(self) -> None:
-        for prop_name in self.rel._node_properties:
-            if prop_name in self.properties_to_update:
-                self.query_add_node_property_create(name=prop_name)
+        for prop_name in self.node_properties_to_update:
+            self.query_add_node_property_create(name=prop_name)
 
     def query_add_node_property_create(self, name: str) -> None:
         query = """

--- a/backend/infrahub/core/relationship/model.py
+++ b/backend/infrahub/core/relationship/model.py
@@ -381,14 +381,33 @@ class Relationship(FlagPropertyMixin, NodePropertyMixin):
 
         node = await self.get_node(db=db)
 
+        flag_properties_to_update = {}
+        for prop_name in self._flag_properties:
+            if prop_name not in properties_to_update:
+                continue
+            value = getattr(self, prop_name)
+            if value is not None:
+                flag_properties_to_update[prop_name] = value
+
+        node_properties_to_update = {}
+        for prop_name in self._node_properties:
+            if prop_name not in properties_to_update:
+                continue
+            if value := getattr(self, f"{prop_name}_id"):
+                node_properties_to_update[prop_name] = value
+
+        if not flag_properties_to_update and not node_properties_to_update:
+            return
+
         query = await RelationshipUpdatePropertyQuery.init(
             db=db,
+            branch=branch,
             source=node,
             rel=self,
-            properties_to_update=properties_to_update,
-            data=data,
-            branch=branch,
             at=update_at,
+            flag_properties_to_update=flag_properties_to_update,
+            node_properties_to_update=node_properties_to_update,
+            rel_node_id=data.rel_node_id,
         )
         await query.execute(db=db)
 

--- a/backend/tests/unit/core/diff/test_diff_merger.py
+++ b/backend/tests/unit/core/diff/test_diff_merger.py
@@ -641,7 +641,7 @@ class TestMergeDiff:
                 "_relation__source": person_node_main2.id,
             },
         )
-        await car_main.owner.save(db=db)
+        await car_main.save(db=db)
 
         source_branch = await create_branch(db=db, branch_name="source")
 

--- a/backend/tests/unit/core/test_node.py
+++ b/backend/tests/unit/core/test_node.py
@@ -878,22 +878,57 @@ async def test_node_update_local_attrs_with_flags(db: InfrahubDatabase, default_
     assert obj3.level.is_visible is False
 
 
-async def test_node_update_local_attrs_with_source(
-    db: InfrahubDatabase, default_branch: Branch, criticality_schema, first_account, second_account
+async def test_node_update_local_attrs_with_metadata(
+    db: InfrahubDatabase, criticality_schema, first_account, second_account, branch: Branch
 ):
-    obj1 = await Node.init(db=db, schema=criticality_schema)
-    await obj1.new(db=db, name="low", level=4, _source=first_account)
+    obj1 = await Node.init(db=db, branch=branch, schema=criticality_schema)
+    await obj1.new(db=db, name="low", level=4)
+    obj1.name.source = first_account
     await obj1.save(db=db)
 
-    obj2 = await NodeManager.get_one(id=obj1.id, include_source=True, db=db)
+    obj2 = await NodeManager.get_one(id=obj1.id, include_source=True, db=db, branch=branch)
+    assert obj2.name.value == "low"
+    assert obj2.name.source_id == first_account.id
+    assert obj2.name.owner_id is None
+    assert obj2.name.is_visible is True
+    assert obj2.name.is_protected is False
+    # make sure that source can be set when not included in get request
+    obj2 = await NodeManager.get_one(id=obj1.id, db=db, branch=branch)
+    assert obj2.name.value == "low"
+    assert obj2.name.source_id is None
+    assert obj2.name.owner_id is None
+    assert obj2.name.is_visible is True
+    assert obj2.name.is_protected is False
     obj2.name.source = second_account
+    obj2.name.owner = first_account
+    obj2.name.is_visible = False
+    obj2.name.is_protected = True
     await obj2.save(db=db)
 
-    obj3 = await NodeManager.get_one(id=obj1.id, include_source=True, db=db)
+    obj3 = await NodeManager.get_one(id=obj1.id, include_source=True, include_owner=True, db=db, branch=branch)
+    assert obj3.name.value == "low"
     assert obj3.name.source_id == second_account.id
+    assert obj3.name.owner_id == first_account.id
+    assert obj3.name.is_visible is False
+    assert obj3.name.is_protected is True
+    # make sure that source can be cleared when not included in get request
+    obj3 = await NodeManager.get_one(id=obj1.id, db=db, branch=branch)
+    assert obj3.name.value == "low"
+    assert obj3.name.source_id is None
+    obj3.name.clear_source()
+    obj3.name.is_visible = True
+    await obj3.save(db=db)
+
+    obj4 = await NodeManager.get_one(id=obj1.id, include_source=True, include_owner=True, db=db, branch=branch)
+    assert obj4.name.value == "low"
+    assert obj4.name.source_id is None
+    assert obj4.name.owner_id == first_account.id
+    assert obj4.name.is_visible is True
+    assert obj4.name.is_protected is True
 
 
-async def test_update_related_node(db: InfrahubDatabase, default_branch, data_schema):
+@pytest.mark.parametrize("use_branch", [True, False])
+async def test_update_related_node(db: InfrahubDatabase, data_schema, default_branch: Branch, use_branch: bool):
     """
     This test has been written to troubleshoot a specific issue
     where a relationship between 2 nodes was being deleted when one of the node was getting updated.
@@ -933,7 +968,7 @@ async def test_update_related_node(db: InfrahubDatabase, default_branch, data_sc
     }
 
     schema = SchemaRoot(**SCHEMA)
-    registry.schema.register_schema(schema=schema)
+    registry.schema.register_schema(schema=schema, branch=default_branch.name)
 
     # ----------------------------------------------------------------
     # Create objects
@@ -951,11 +986,19 @@ async def test_update_related_node(db: InfrahubDatabase, default_branch, data_sc
     t3 = await Node.init(db=db, schema=InfrahubKind.TAG)
     await t3.new(db=db, name="Black", description="The Black tag", person=p1)
     await t3.save(db=db)
+    t4 = await Node.init(db=db, schema=InfrahubKind.TAG)
+    await t4.new(db=db, name="Blurple", description="The Blurple tag")
+    await t4.save(db=db)
+
+    if use_branch:
+        branch = await create_branch(branch_name="branch1", db=db)
+    else:
+        branch = default_branch
 
     # ----------------------------------------------------------------
     # Query all tags attached to person
     # ----------------------------------------------------------------
-    p11 = await NodeManager.get_one(db=db, id=p1.id)
+    p11 = await NodeManager.get_one(db=db, branch=branch, id=p1.id)
     tags = await p11.tags.get(db=db)
     assert len(tags) == 3
 
@@ -963,16 +1006,73 @@ async def test_update_related_node(db: InfrahubDatabase, default_branch, data_sc
     # Update the description of Tag1 in the main branch
     # ----------------------------------------------------------------
     new_description = "New description in main"
-    t11 = await NodeManager.get_one(db=db, id=t1.id)
+    t11 = await NodeManager.get_one(db=db, branch=branch, id=t1.id)
     t11.description.value = new_description
     await t11.save(db=db)
 
     # ----------------------------------------------------------------
     # Re-query the tag via the related objects to validate that everything is still connected
     # ----------------------------------------------------------------
-    p12 = await NodeManager.get_one(db=db, id=p1.id)
+    p12 = await NodeManager.get_one(db=db, branch=branch, id=p1.id)
     tags = await p12.tags.get(db=db)
     assert len(tags) == 3
+
+    # ----------------------------------------------------------------
+    # Update the properties and flags of one of the tag relationships
+    # ----------------------------------------------------------------
+    p13 = await NodeManager.get_one(db=db, branch=branch, id=p1.id)
+    tag_rels = await p13.tags.get_relationships(db=db)
+    t1_tag_rel = [tag_rel for tag_rel in tag_rels if tag_rel.peer_id == t1.id]
+    assert len(t1_tag_rel) == 1
+    t1_tag_rel[0].source = t2
+    t1_tag_rel[0].owner = t3
+    t1_tag_rel[0].is_visible = False
+    t1_tag_rel[0].is_protected = True
+    await p13.save(db=db)
+    p14 = await NodeManager.get_one(db=db, branch=branch, id=p1.id)
+    tag_rels = await p14.tags.get_relationships(db=db)
+    t1_tag_rel = [tag_rel for tag_rel in tag_rels if tag_rel.peer_id == t1.id]
+    assert len(t1_tag_rel) == 1
+    t1_source = await t1_tag_rel[0].get_source(db=db)
+    assert t1_source.get_id() == t2.id
+    t1_owner = await t1_tag_rel[0].get_owner(db=db)
+    assert t1_owner.get_id() == t3.id
+    assert t1_tag_rel[0].is_visible is False
+    assert t1_tag_rel[0].is_protected is True
+
+    # ----------------------------------------------------------------
+    # Update and clear the properties and flags
+    # ----------------------------------------------------------------
+    t1_tag_rel[0].source = t3
+    t1_tag_rel[0].clear_owner()
+    t1_tag_rel[0].is_visible = True
+    await p14.save(db=db)
+    p15 = await NodeManager.get_one(db=db, branch=branch, id=p1.id)
+    tag_rels = await p15.tags.get_relationships(db=db)
+    t1_tag_rel = [tag_rel for tag_rel in tag_rels if tag_rel.peer_id == t1.id]
+    assert len(t1_tag_rel) == 1
+    t1_source = await t1_tag_rel[0].get_source(db=db)
+    assert t1_source.get_id() == t3.id
+    t1_owner = await t1_tag_rel[0].get_owner(db=db)
+    assert t1_owner is None
+    assert t1_tag_rel[0].is_visible is True
+    assert t1_tag_rel[0].is_protected is True
+
+    # ----------------------------------------------------------------
+    # clear the source node
+    # ----------------------------------------------------------------
+    t1_tag_rel[0].clear_source()
+    await p15.save(db=db)
+    p16 = await NodeManager.get_one(db=db, branch=branch, id=p1.id)
+    tag_rels = await p16.tags.get_relationships(db=db)
+    t1_tag_rel = [tag_rel for tag_rel in tag_rels if tag_rel.peer_id == t1.id]
+    assert len(t1_tag_rel) == 1
+    t1_source = await t1_tag_rel[0].get_source(db=db)
+    assert t1_source is None
+    t1_owner = await t1_tag_rel[0].get_owner(db=db)
+    assert t1_owner is None
+    assert t1_tag_rel[0].is_visible is True
+    assert t1_tag_rel[0].is_protected is True
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
we don't provide a way to delete a source/owner property on an attribute. we only allow updating to a different source/owner. this PR adds the ability to delete the properties



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Explicitly clear property values.
  - Branch-aware updates and retrievals for node and relationship metadata (source, owner, visibility, protection).

- Bug Fixes
  - More accurate change tracking and updates only when needed, reducing unnecessary writes.
  - Correct selection of active relationships and associated metadata during queries.
  - Ensures related relationship timestamps are updated after property changes.
  - Improved consistency when saving nodes after related ownership updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->