### PR TITLE
Fix payload for transform webhook to align with other webhooks

### DIFF
--- a/backend/infrahub/webhook/models.py
+++ b/backend/infrahub/webhook/models.py
@@ -231,7 +231,7 @@ class TransformWebhook(Webhook):
             commit=commit,
             location=f"{self.transform_file}::{self.transform_class}",
             convert_query_response=self.convert_query_response,
-            data={"data": data, **context.model_dump()},
+            data={"data": {"data": data, **context.model_dump()}},
             client=client,
         )  # type: ignore[misc]
 

--- a/changelog/6815.fixed.md
+++ b/changelog/6815.fixed.md
@@ -1,0 +1,1 @@
+Breaking change: The format of the data payload has been corrected for transform based webhooks so that they are consistend with standard webhooks as well as custom webhooks (without an attached transform). Due to this change any transforms attached to a webhook needs to be updated to account for the new format.


### PR DESCRIPTION
Fixes #6815

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized webhook payload structure for transform-based webhooks to match standard/custom webhooks. The original payload is now nested under data.data, improving consistency across webhook types. Existing transforms may need updates to handle the new structure.

* **Documentation**
  * Added a changelog entry noting the breaking change and advising users to update transforms to the new payload format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->