### PR TITLE
Update schema for flaky relationship test

### DIFF
--- a/backend/tests/unit/graphql/test_mutation_relationship.py
+++ b/backend/tests/unit/graphql/test_mutation_relationship.py
@@ -1219,6 +1219,7 @@ async def test_with_permissions(
     }
     """
 
+    default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(
         db=db, include_subscription=False, branch=default_branch, account_session=first_session
     )


### PR DESCRIPTION
It feels like we might need to refactor how the registry works in general to avoid these issues that keep popping up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of GraphQL mutation tests by updating the schema hash before preparing parameters, reducing flakiness and false negatives when branch schemas change.
* **Chores**
  * No user-facing changes; internal test robustness enhanced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->