### PR TITLE
fix(docs): update installation instructions for docker-compose usage

### DIFF
--- a/changelog/compose.housekeeping.md
+++ b/changelog/compose.housekeeping.md
@@ -1,1 +1,1 @@
-Update docs to download compose file first and then run compose up/down.
+Update docs to download compose file first and then run compose up/down. This change was made due to community members using the one liner for long standing installations without the docker-compose.yml file locally. The new approach is more explicit and easier for the community to maintain their Infrahub instances in the future.

--- a/changelog/compose.housekeeping.md
+++ b/changelog/compose.housekeeping.md
@@ -1,0 +1,1 @@
+Update docs to download compose file first and then run compose up/down.

--- a/docs/docs/guides/installation.mdx
+++ b/docs/docs/guides/installation.mdx
@@ -382,7 +382,7 @@ docker compose -p infrahub up -d
 </TabItem>
 <TabItem value="Linux">
 
-    ```bash
+```bash
 curl https://infrahub.opsmill.io/enterprise > docker-compose.yml
 sudo docker compose -p infrahub up -d
 ```

--- a/docs/docs/guides/installation.mdx
+++ b/docs/docs/guides/installation.mdx
@@ -100,7 +100,7 @@ docker ps | grep infrahub
 
 ```bash
 curl https://infrahub.opsmill.io > docker-compose.yml
-docker compose -p infrahub -f docker-compose.yml down -v
+docker compose -p infrahub down -v
 ```
 
 </TabItem>
@@ -108,7 +108,7 @@ docker compose -p infrahub -f docker-compose.yml down -v
 
 ```bash
 curl https://infrahub.opsmill.io > docker-compose.yml
-sudo docker compose -p infrahub -f docker-compose.yml down -v
+sudo docker compose -p infrahub down -v
 ```
 
 </TabItem>

--- a/docs/docs/guides/installation.mdx
+++ b/docs/docs/guides/installation.mdx
@@ -66,14 +66,16 @@ You can also specify a specific version or the `develop` branch in the URL:
 <TabItem value="macOS" default>
 
 ```bash
-curl https://infrahub.opsmill.io | docker compose -p infrahub -f - up -d
+curl https://infrahub.opsmill.io > docker-compose.yml
+docker compose -p infrahub up -d
 ```
 
 </TabItem>
 <TabItem value="Linux">
 
 ```bash
-curl https://infrahub.opsmill.io | sudo docker compose -p infrahub -f - up -d
+curl https://infrahub.opsmill.io > docker-compose.yml
+sudo docker compose -p infrahub up -d
 ```
 
 </TabItem>
@@ -97,14 +99,27 @@ docker ps | grep infrahub
 <TabItem value="macOS" default>
 
 ```bash
-curl https://infrahub.opsmill.io | docker compose -p infrahub -f - down -v
+curl https://infrahub.opsmill.io > docker-compose.yml
+docker compose -p infrahub -f docker-compose.yml down -v
 ```
 
 </TabItem>
 <TabItem value="Linux">
 
 ```bash
-curl https://infrahub.opsmill.io | sudo docker compose -p infrahub -f - down -v
+curl https://infrahub.opsmill.io > docker-compose.yml
+sudo docker compose -p infrahub -f docker-compose.yml down -v
+```
+
+</TabItem>
+</Tabs>
+
+</TabItem>
+<TabItem value="Local development (git clone)">
+
+```bash
+curl https://infrahub.opsmill.io > docker-compose.yml
+sudo docker compose -p infrahub up -d
 ```
 
 </TabItem>

--- a/docs/docs/guides/installation.mdx
+++ b/docs/docs/guides/installation.mdx
@@ -375,14 +375,16 @@ You can also specify a sizing preset in the URL. This will automatically configu
 <TabItem value="macOS" default>
 
 ```bash
-curl https://infrahub.opsmill.io/enterprise | docker compose -p infrahub -f - up -d
+curl https://infrahub.opsmill.io/enterprise > docker-compose.yml
+docker compose -p infrahub up -d
 ```
 
 </TabItem>
 <TabItem value="Linux">
 
-```bash
-curl https://infrahub.opsmill.io/enterprise | sudo docker compose -p infrahub -f - up -d
+    ```bash
+curl https://infrahub.opsmill.io/enterprise > docker-compose.yml
+sudo docker compose -p infrahub up -d
 ```
 
 </TabItem>
@@ -394,14 +396,16 @@ curl https://infrahub.opsmill.io/enterprise | sudo docker compose -p infrahub -f
 <TabItem value="macOS" default>
 
 ```bash
-curl https://infrahub.opsmill.io/enterprise | docker compose -p infrahub -f - down -v
+curl https://infrahub.opsmill.io/enterprise > docker-compose.yml
+docker compose -p infrahub down -v
 ```
 
 </TabItem>
 <TabItem value="Linux">
 
 ```bash
-curl https://infrahub.opsmill.io/enterprise | sudo docker compose -p infrahub -f - down -v
+curl https://infrahub.opsmill.io/enterprise > docker-compose.yml
+sudo docker compose -p infrahub down -v
 ```
 
 </TabItem>

--- a/docs/docs/guides/installation.mdx
+++ b/docs/docs/guides/installation.mdx
@@ -117,17 +117,6 @@ sudo docker compose -p infrahub down -v
 </TabItem>
 <TabItem value="Local development (git clone)">
 
-```bash
-curl https://infrahub.opsmill.io > docker-compose.yml
-sudo docker compose -p infrahub up -d
-```
-
-</TabItem>
-</Tabs>
-
-</TabItem>
-<TabItem value="Local development (git clone)">
-
 ### Cloning the repository
 
 The recommended method for running Infrahub for development uses the Docker Compose files included with the project combined with helper commands defined in `invoke`.


### PR DESCRIPTION
Update docs to download compose file first and then run compose up/down. This change was made due to community members using the one liner for long standing installations without the docker-compose.yml file locally. The new approach is more explicit and easier for the community to maintain their Infrahub instances in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation guide for macOS and Linux to first download the Docker Compose file, then run docker compose commands separately for starting and stopping.
  * Standardized start (up) and stop (down) instructions with the saved docker-compose.yml across platforms.
  * Clarified steps to improve reliability when running setup and teardown commands.
  * Refreshed changelog to reflect the new flow: download the compose file before running compose up/down.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->