### PR TITLE
Add missing parts for display label mutation

### DIFF
--- a/backend/infrahub/core/node/__init__.py
+++ b/backend/infrahub/core/node/__init__.py
@@ -1033,7 +1033,7 @@ class Node(BaseNode, metaclass=BaseNodeMeta):
         if self._display_label is None:
             return
 
-        self._display_label.set_value(value=value)
+        self._display_label.set_value(value=value, manually_assigned=True)
 
     def _get_parent_relationship_name(self) -> str | None:
         """Return the name of the parent relationship is one is present"""

--- a/backend/infrahub/core/node/node_property_attribute.py
+++ b/backend/infrahub/core/node/node_property_attribute.py
@@ -29,11 +29,14 @@ class NodePropertyAttribute:
         self.node_schema = node_schema
         self.node_attributes: list[str] = []
         self.node_relationships: list[str] = []
+        self._manually_assigned = False
 
         self.analyze_variables()
 
     def needs_update(self, fields: list[str] | None) -> bool:
-        """Tell if a display label must be recomputed given a list of updated fields of a node."""
+        """Tell if a display label must be recomputed given a list of updated fields of a node or by manual assignment."""
+        if self._manually_assigned:
+            return True
         for field in fields or []:
             if field in self.node_attributes or field in self.node_relationships:
                 return True
@@ -81,12 +84,15 @@ class DisplayLabel(NodePropertyAttribute):
             return self._value.value
         return self._value
 
-    def set_value(self, value: str | None) -> None:
+    def set_value(self, value: str | None, manually_assigned: bool = False) -> None:
         """Force the value of the display label to the given one."""
         if isinstance(self._value, AttributeFromDB):
             self._value.value = value
         else:
             self._value = value
+
+        if manually_assigned:
+            self._manually_assigned = True
 
     def _analyze_plain_value(self) -> None:
         if self.template is None or "__" not in self.template:
@@ -121,7 +127,7 @@ class DisplayLabel(NodePropertyAttribute):
 
     async def compute(self, db: InfrahubDatabase, node: Node) -> None:
         """Update the display label value by recomputing it from the template."""
-        if self.template is None:
+        if self.template is None or self._manually_assigned:
             return
 
         if node.get_schema() != self.node_schema:

--- a/backend/infrahub/display_labels/models.py
+++ b/backend/infrahub/display_labels/models.py
@@ -133,9 +133,9 @@ class DisplayLabelTriggerDefinition(TriggerBranchDefinition):
             workflow=DISPLAY_LABELS_PROCESS_JINJA2,
             parameters={
                 "branch_name": "{{ event.resource['infrahub.branch.name'] }}",
-                "node_kind": "{{ event.resource['infrahub.node.kind'] }}",
+                "node_kind": node_kind,
                 "object_id": "{{ event.resource['infrahub.node.id'] }}",
-                "target_kind": "{{ event.resource['infrahub.node.kind'] }}",
+                "target_kind": target_kind,
                 "context": {
                     "__prefect_kind": "json",
                     "value": {

--- a/backend/infrahub/graphql/mutations/display_label.py
+++ b/backend/infrahub/graphql/mutations/display_label.py
@@ -9,9 +9,13 @@ from infrahub.core.constants import PermissionAction, PermissionDecision
 from infrahub.core.manager import NodeManager
 from infrahub.core.registry import registry
 from infrahub.database import retry_db_transaction
+from infrahub.events import EventMeta
+from infrahub.events.node_action import NodeUpdatedEvent
 from infrahub.exceptions import NodeNotFoundError, ValidationError
 from infrahub.graphql.context import apply_external_context
 from infrahub.graphql.types.context import ContextInput
+from infrahub.log import get_log_data
+from infrahub.worker import WORKER_IDENTITY
 
 if TYPE_CHECKING:
     from graphql import GraphQLResolveInfo
@@ -33,7 +37,7 @@ class UpdateDisplayLabel(Mutation):
     ok = Boolean()
 
     @classmethod
-    @retry_db_transaction(name="update_computed_attribute")
+    @retry_db_transaction(name="update_display_label")
     async def mutate(
         cls,
         _: dict,
@@ -46,7 +50,7 @@ class UpdateDisplayLabel(Mutation):
             name=str(data.kind), branch=graphql_context.branch.name, duplicate=False
         )
         if not node_schema.display_label:
-            raise ValidationError(input_value=f"{node_schema.kind}.display_label has not been defined for this kind")
+            raise ValidationError(input_value=f"{node_schema.kind}.display_label has not been defined for this kind.")
 
         graphql_context.active_permissions.raise_for_permission(
             permission=ObjectPermission(
@@ -70,16 +74,35 @@ class UpdateDisplayLabel(Mutation):
             )
         ):
             raise NodeNotFoundError(
-                node_type="target_node",
+                node_type=node_schema.kind,
                 identifier=str(data.id),
-                message="The indicated node was not found in the database",
+                message="The targeted node was not found in the database",
             )
 
         existing_label = target_node._display_label.value if target_node._display_label else None
-        print(existing_label)
+        if str(data.value) != existing_label:
+            await target_node.set_display_label(value=str(data.value))
 
-        # TODO: Add the proper code here and send the correct event to
-        # indicate that the display_label was updated
+            async with graphql_context.db.start_transaction() as dbt:
+                await target_node.save(db=dbt, fields=["display_label"])
+
+            log_data = get_log_data()
+            request_id = log_data.get("request_id", "")
+
+            event = NodeUpdatedEvent(
+                kind=node_schema.kind,
+                node_id=target_node.get_id(),
+                changelog=target_node.node_changelog.model_dump(),
+                fields=["display_label"],
+                meta=EventMeta(
+                    context=graphql_context.get_context(),
+                    initiator_id=WORKER_IDENTITY,
+                    request_id=request_id,
+                    account_id=graphql_context.active_account_session.account_id,
+                    branch=graphql_context.branch,
+                ),
+            )
+            await graphql_context.active_service.event.send(event=event)
 
         result: dict[str, Any] = {"ok": True}
 

--- a/backend/tests/helpers/schema/tshirt.py
+++ b/backend/tests/helpers/schema/tshirt.py
@@ -9,7 +9,7 @@ TSHIRT = NodeSchema(
     include_in_menu=True,
     label="T-shirt",
     default_filter="name__value",
-    display_labels=["name__value"],
+    display_label="{{ name__value }} {{ color__name__value }}",
     uniqueness_constraints=[["name__value"]],
     attributes=[
         AttributeSchema(name="name", kind="Text"),

--- a/backend/tests/integration_docker/test_computed_attributes.py
+++ b/backend/tests/integration_docker/test_computed_attributes.py
@@ -47,9 +47,9 @@ class TestComputedAttributes(TestInfrahubDockerClient):
     async def test_computed_attribute_update(self, client: InfrahubClient) -> None:
         """Validate that the computed attribute is registered and created and also updated correctly."""
         first_desc = "A Sunset Explorer t-shirt. A bold, vibrant orange that captures the warmth of the setting sun."
-        final_desc = (
-            "A Sunset Explorer t-shirt. A striking, lively shade of orange that radiates the golden warmth of a sunset."
-        )
+        final_desc = "A Sunrise Explorer t-shirt. A striking, lively shade of orange that radiates the golden warmth of a sunrise."
+        first_display_label = "Explorer - Sunset"
+        final_display_label = "Explorer - Sunrise"
         data = {
             "name": "Sunset",
             "description": "A bold, vibrant orange that captures the warmth of the setting sun.",
@@ -74,23 +74,26 @@ class TestComputedAttributes(TestInfrahubDockerClient):
         color1_initial = await client.get(kind="TestingColor", id=color1.id)
 
         assert tshirt1_initial.description.value == first_desc
+        assert tshirt1_initial.display_label == first_display_label
 
         # Validate computed attribute defined on generic
         assert tshirt1_initial.name_code.value == "WEARABLE-EXPLORER"
 
+        color1_initial.name.value = "Sunrise"
         color1_initial.description.value = (
-            "A striking, lively shade of orange that radiates the golden warmth of a sunset."
+            "A striking, lively shade of orange that radiates the golden warmth of a sunrise."
         )
         await color1_initial.save()
 
         for _ in range(20):
             # Give the computed attribute triggers a little while to run
             tshirt1_updated = await client.get(kind="TestingTShirt", id=tshirt1.id)
-            if tshirt1_updated.description.value != first_desc:
+            if tshirt1_updated.description.value != first_desc and tshirt1_updated.display_label != first_display_label:
                 break
             await sleep(1)
 
         assert tshirt1_updated.description.value == final_desc
+        assert tshirt1_updated.display_label == final_display_label
 
         tshirt1_second_update = await client.get(kind="TestingTShirt", id=tshirt1.id)
         tshirt1_second_update.color = color2

--- a/backend/tests/integration_docker/test_files/computed_tshirt.yml
+++ b/backend/tests/integration_docker/test_files/computed_tshirt.yml
@@ -59,8 +59,7 @@ nodes:
     default_filter: "name__value"
     order_by:
       - "name__value"
-    display_labels:
-      - "name__value"
+    display_label: "{{ name__value }} - {{ color__name__value }}"
     inherit_from:
       - TestingWearable
     attributes:

--- a/backend/tests/unit/graphql/mutations/test_display_label.py
+++ b/backend/tests/unit/graphql/mutations/test_display_label.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from infrahub.core.account import ObjectPermission
+from infrahub.core.branch.models import Branch
+from infrahub.core.constants import PermissionAction, PermissionDecision
+from infrahub.core.node import Node
+from infrahub.core.registry import registry
+from infrahub.core.schema import SchemaRoot
+from infrahub.database import InfrahubDatabase
+from infrahub.graphql.initialization import prepare_graphql_params
+from infrahub.services import InfrahubServices
+from tests.adapters.event import MemoryInfrahubEvent
+from tests.helpers.graphql import graphql
+from tests.helpers.permissions import define_permissions
+from tests.helpers.schema import COLOR, TSHIRT
+
+if TYPE_CHECKING:
+    from infrahub.auth import AccountSession
+    from infrahub.core.branch import Branch
+    from infrahub.database import InfrahubDatabase
+
+
+async def test_update_display_label_missing_kind(
+    db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch
+) -> None:
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=UPDATE_DISPLAY_LABEL,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"id": str(uuid4()), "kind": "InvalidNodeKind", "value": "very-new-label"},
+    )
+    assert result.errors
+    assert "Unable to find the schema 'InvalidNodeKind' in the registry" in str(result.errors)
+
+
+async def test_update_display_label_not_defined(
+    db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch
+) -> None:
+    query_kind = "CoreRepository"
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=UPDATE_DISPLAY_LABEL,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"id": str(uuid4()), "kind": query_kind, "value": "very-new-label"},
+    )
+    assert result.errors
+    assert f"{query_kind}.display_label has not been defined for this kind" in str(result.errors)
+
+
+async def test_update_display_label_update(
+    db: InfrahubDatabase,
+    register_core_models_schema: None,
+    default_branch: Branch,
+    default_permission_backend: None,
+    session_first_account: AccountSession,
+    first_account: Node,
+) -> None:
+    schema_root = SchemaRoot(nodes=[COLOR, TSHIRT])
+    registry.schema.register_schema(schema=schema_root, branch=default_branch.name)
+
+    await define_permissions(
+        account=first_account,
+        db=db,
+        object_permissions=[
+            ObjectPermission(
+                namespace=TSHIRT.namespace,
+                name=TSHIRT.name,
+                action=PermissionAction.UPDATE.value,
+                decision=PermissionDecision.ALLOW_ALL.value,
+            ),
+        ],
+    )
+
+    c1 = await Node.init(db=db, schema=COLOR.kind)
+    await c1.new(db=db, name="Blue", description="A vibrant blue")
+    await c1.save(db=db)
+
+    t1 = await Node.init(db=db, schema=TSHIRT.kind)
+    await t1.new(db=db, name="Ocean", color=c1)
+    await t1.save(db=db)
+    default_branch.update_schema_hash()
+    event = MemoryInfrahubEvent()
+    service = await InfrahubServices.new(event=event)
+    gql_params = await prepare_graphql_params(
+        db=db, branch=default_branch, account_session=session_first_account, service=service
+    )
+
+    missing_node = await graphql(
+        schema=gql_params.schema,
+        source=UPDATE_DISPLAY_LABEL,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"id": str(uuid4()), "kind": TSHIRT.kind, "value": "very-new-label"},
+    )
+    assert missing_node.errors
+    assert "The targeted node was not found in the database" in str(missing_node.errors)
+
+    before_change = await graphql(
+        schema=gql_params.schema,
+        source=QUERY_TSHIRT,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"id": t1.get_id()},
+    )
+    assert not before_change.errors
+    assert before_change.data
+    assert before_change.data["TestingTShirt"]["count"] == 1
+    assert before_change.data["TestingTShirt"]["edges"][0]["node"]["display_label"] == "Ocean Blue"
+
+    existing_node = await graphql(
+        schema=gql_params.schema,
+        source=UPDATE_DISPLAY_LABEL,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"id": t1.get_id(), "kind": TSHIRT.kind, "value": "very-new-label"},
+    )
+    assert not existing_node.errors
+    assert existing_node.data
+
+    gql_params = await prepare_graphql_params(
+        db=db, branch=default_branch, account_session=session_first_account, service=service
+    )
+    after_change = await graphql(
+        schema=gql_params.schema,
+        source=QUERY_TSHIRT,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"id": t1.get_id()},
+    )
+    assert not after_change.errors
+    assert after_change.data
+    assert after_change.data["TestingTShirt"]["count"] == 1
+    assert after_change.data["TestingTShirt"]["edges"][0]["node"]["display_label"] == "very-new-label"
+
+
+UPDATE_DISPLAY_LABEL = """
+mutation UpdateDisplayLabel(
+  $id: String!
+  $kind: String!
+  $value: String!
+) {
+  InfrahubUpdateDisplayLabel(data: {id: $id, kind: $kind, value: $value}) {
+    ok
+  }
+}
+"""
+
+
+QUERY_TSHIRT = """
+query MyTShirt($id: ID!) {
+    TestingTShirt(ids: [$id]) {
+        count
+        edges {
+            node {
+                display_label
+            }
+        }
+    }
+}
+"""


### PR DESCRIPTION
Changes in this PR:

* Updates some internal logic within `Node` so that we can update the display label in a manual way that doesn't regenerate the display_label from scratch. This is used when the update is done from a related node.
* Also updates the graphql mutation to update display labels by using the .set_display_label method on the Node objects and then sends an event with the update.
* Added unittests for the display label mutation
* Added integration tests as part of the old computed attribute test where the display label of a node is modified when triggered by a change in a related node.
* Slight change to the computed attribute test logic as we also rename the color of the tshirt (as the color got added to the display label of the tshirt nodes and we needed to get an updated value)