### PR TITLE
handle profile attribute and priority updates

### DIFF
--- a/backend/infrahub/graphql/manager.py
+++ b/backend/infrahub/graphql/manager.py
@@ -20,6 +20,7 @@ from infrahub.core.schema import (
 )
 from infrahub.graphql.mutations.attribute import BaseAttributeCreate, BaseAttributeUpdate
 from infrahub.graphql.mutations.graphql_query import InfrahubGraphQLQueryMutation
+from infrahub.graphql.mutations.profile import InfrahubProfileMutation
 from infrahub.types import ATTRIBUTE_TYPES, InfrahubDataType, get_attribute_type
 
 from .directives import DIRECTIVES
@@ -489,6 +490,8 @@ class GraphQLSchemaManager:
                 base_class = InfrahubIPPrefixMutation
             elif isinstance(node_schema, NodeSchema) and node_schema.is_ip_address:
                 base_class = InfrahubIPAddressMutation
+            elif isinstance(node_schema, ProfileSchema):
+                base_class = InfrahubProfileMutation
             else:
                 base_class = mutation_map.get(node_schema.kind, InfrahubMutation)
 

--- a/backend/infrahub/graphql/mutations/main.py
+++ b/backend/infrahub/graphql/mutations/main.py
@@ -379,6 +379,15 @@ class InfrahubMutationMixin:
             return updated_obj, mutation, False
 
     @classmethod
+    async def _delete_obj(cls, graphql_context: GraphqlContext, branch: Branch, obj: Node) -> list[Node]:
+        db = graphql_context.db
+        async with db.start_transaction() as dbt:
+            deleted = await NodeManager.delete(db=dbt, branch=branch, nodes=[obj])
+        deleted_str = ", ".join([f"{d.get_kind()}({d.get_id()})" for d in deleted])
+        log.info(f"nodes deleted: {deleted_str}")
+        return deleted
+
+    @classmethod
     @retry_db_transaction(name="object_delete")
     async def mutate_delete(
         cls,
@@ -396,11 +405,7 @@ class InfrahubMutationMixin:
             branch=branch,
         )
 
-        async with graphql_context.db.start_transaction() as db:
-            deleted = await NodeManager.delete(db=db, branch=branch, nodes=[obj])
-
-        deleted_str = ", ".join([f"{d.get_kind()}({d.get_id()})" for d in deleted])
-        log.info(f"nodes deleted: {deleted_str}")
+        deleted = await cls._delete_obj(graphql_context=graphql_context, branch=branch, obj=obj)
 
         ok = True
 

--- a/backend/infrahub/graphql/mutations/profile.py
+++ b/backend/infrahub/graphql/mutations/profile.py
@@ -72,7 +72,7 @@ class InfrahubProfileMutation(InfrahubMutationMixin, Mutation):
         attr_values_map = {}
         for attr_schema in obj.get_schema().attributes:
             # profile name update can be ignored
-            if attr_schema.name == "name":
+            if attr_schema.name == "profile_name":
                 continue
             attr_values_map[attr_schema.name] = getattr(obj, attr_schema.name).value
         return attr_values_map

--- a/backend/infrahub/graphql/mutations/profile.py
+++ b/backend/infrahub/graphql/mutations/profile.py
@@ -33,7 +33,7 @@ class InfrahubProfileMutation(InfrahubMutationMixin, Mutation):
     def __init_subclass_with_meta__(
         cls,
         schema: ProfileSchema,
-        _meta: Any | None = None,
+        _meta: InfrahubMutationOptions | None = None,
         **options: dict[str, Any],
     ) -> None:
         # Make sure schema is a valid NodeSchema Node Class

--- a/backend/infrahub/graphql/mutations/profile.py
+++ b/backend/infrahub/graphql/mutations/profile.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from graphene import Boolean, InputObjectType, Mutation, String
+from graphql import GraphQLResolveInfo
+from opentelemetry import trace
+from typing_extensions import Self
+
+from infrahub.core.manager import NodeManager
+from infrahub.core.schema import ProfileSchema
+from infrahub.graphql.types.context import ContextInput
+from infrahub.log import get_logger
+from infrahub.profiles.node_applier import NodeProfilesApplier
+from infrahub.workflows.catalogue import PROFILE_REFRESH_MULTIPLE
+
+from .main import InfrahubMutationMixin, InfrahubMutationOptions
+
+if TYPE_CHECKING:
+    from graphql import GraphQLResolveInfo
+
+    from infrahub.core.branch import Branch
+    from infrahub.core.node import Node
+    from infrahub.database import InfrahubDatabase
+    from infrahub.graphql.initialization import GraphqlContext
+    from infrahub.services.adapters.workflow import InfrahubWorkflow
+
+log = get_logger()
+
+
+class InfrahubProfileMutation(InfrahubMutationMixin, Mutation):
+    @classmethod
+    def __init_subclass_with_meta__(
+        cls,
+        schema: ProfileSchema,
+        _meta: Any | None = None,
+        **options: dict[str, Any],
+    ) -> None:
+        # Make sure schema is a valid NodeSchema Node Class
+        if not isinstance(schema, ProfileSchema):
+            raise ValueError(f"You need to pass a valid ProfileSchema in '{cls.__name__}.Meta', received '{schema}'")
+
+        if not _meta:
+            _meta = InfrahubMutationOptions(cls)
+        _meta.schema = schema
+
+        super().__init_subclass_with_meta__(_meta=_meta, **options)
+
+    @classmethod
+    async def _send_profile_refresh_workflows(
+        cls,
+        db: InfrahubDatabase,
+        workflow_service: InfrahubWorkflow,
+        branch_name: str,
+        obj: Node,
+        node_ids: list[str] | None = None,
+    ) -> None:
+        if not node_ids:
+            related_nodes = await obj.related_nodes.get_relationships(db=db)  # type: ignore[attr-defined]
+            node_ids = [rel.peer_id for rel in related_nodes]
+        if node_ids:
+            await workflow_service.submit_workflow(
+                workflow=PROFILE_REFRESH_MULTIPLE,
+                parameters={
+                    "branch_name": branch_name,
+                    "node_ids": node_ids,
+                },
+            )
+
+    @classmethod
+    def _get_profile_attr_values_map(cls, obj: Node) -> dict[str, Any]:
+        attr_values_map = {}
+        for attr_schema in obj.get_schema().attributes:
+            # profile name update can be ignored
+            if attr_schema.name == "name":
+                continue
+            attr_values_map[attr_schema.name] = getattr(obj, attr_schema.name).value
+        return attr_values_map
+
+    @classmethod
+    async def _get_profile_related_node_ids(cls, db: InfrahubDatabase, obj: Node) -> set[str]:
+        related_nodes = await obj.profiles.get_relationships(db=db)  # type: ignore[attr-defined]
+        if related_nodes:
+            related_node_ids = {rel.peer_id for rel in related_nodes}
+        else:
+            related_node_ids = set()
+        return related_node_ids
+
+    @classmethod
+    async def mutate_create(
+        cls,
+        info: GraphQLResolveInfo,
+        data: InputObjectType,
+        branch: Branch,
+        database: InfrahubDatabase | None = None,
+        override_data: dict[str, Any] | None = None,
+    ) -> tuple[Node, Self]:
+        graphql_context: GraphqlContext = info.context
+        db = database or graphql_context.db
+        workflow_service = graphql_context.active_service.workflow
+
+        obj, mutation = await super().mutate_create(
+            info=info, data=data, branch=branch, database=database, override_data=override_data
+        )
+        await cls._send_profile_refresh_workflows(
+            db=db, workflow_service=workflow_service, branch_name=branch.name, obj=obj
+        )
+
+        return obj, mutation
+
+    @classmethod
+    async def _call_mutate_update(
+        cls,
+        info: GraphQLResolveInfo,
+        data: InputObjectType,
+        branch: Branch,
+        db: InfrahubDatabase,
+        obj: Node,
+        skip_uniqueness_check: bool = False,
+    ) -> tuple[Node, Self]:
+        workflow_service = info.context.active_service.workflow
+        original_attr_values = cls._get_profile_attr_values_map(obj=obj)
+        original_related_node_ids = await cls._get_profile_related_node_ids(db=db, obj=obj)
+
+        obj, mutation = await super().mutate_update(
+            info=info, data=data, branch=branch, db=db, obj=obj, skip_uniqueness_check=skip_uniqueness_check
+        )
+
+        updated_attr_values = cls._get_profile_attr_values_map(obj=obj)
+        updated_related_node_ids = await cls._get_profile_related_node_ids(db=db, obj=obj)
+
+        if original_attr_values != updated_attr_values:
+            await cls._send_profile_refresh_workflows(
+                db=db, workflow_service=workflow_service, branch_name=branch.name, obj=obj
+            )
+        elif updated_related_node_ids != original_related_node_ids:
+            removed_node_ids = original_related_node_ids - updated_related_node_ids
+            added_node_ids = updated_related_node_ids - original_related_node_ids
+            await cls._send_profile_refresh_workflows(
+                db=db,
+                workflow_service=workflow_service,
+                branch_name=branch.name,
+                obj=obj,
+                node_ids=list(removed_node_ids) + list(added_node_ids),
+            )
+
+        return obj, mutation
+
+    @classmethod
+    async def _delete_obj(cls, graphql_context: GraphqlContext, branch: Branch, obj: Node) -> list[Node]:
+        db = graphql_context.db
+        workflow_service = graphql_context.active_service.workflow
+        related_node_ids = await cls._get_profile_related_node_ids(db=db, obj=obj)
+        deleted = await super()._delete_obj(graphql_context=graphql_context, branch=branch, obj=obj)
+        await cls._send_profile_refresh_workflows(
+            db=db, workflow_service=workflow_service, branch_name=branch.name, obj=obj, node_ids=list(related_node_ids)
+        )
+        return deleted
+
+
+class ProfilesRefreshInput(InputObjectType):
+    id = String(required=False)
+
+
+class InfrahubProfilesRefresh(Mutation):
+    class Arguments:
+        data = ProfilesRefreshInput(required=True)
+        context = ContextInput(required=False)
+
+    ok = Boolean()
+
+    @classmethod
+    @trace.get_tracer(__name__).start_as_current_span("profiles_refresh")
+    async def mutate(
+        cls,
+        root: dict,  # noqa: ARG003
+        info: GraphQLResolveInfo,
+        data: ProfilesRefreshInput,
+        context: ContextInput | None = None,  # noqa: ARG003
+    ) -> Self:
+        graphql_context: GraphqlContext = info.context
+        db = graphql_context.db
+        branch = graphql_context.branch
+        obj = await NodeManager.get_one(
+            db=db,
+            branch=branch,
+            id=str(data.id),
+        )
+        node_profiles_applier = NodeProfilesApplier(db=db, branch=branch)
+        await node_profiles_applier.apply_profiles(node=obj)
+        await obj.save(db=db)
+
+        return cls(ok=True)

--- a/backend/infrahub/graphql/mutations/profile.py
+++ b/backend/infrahub/graphql/mutations/profile.py
@@ -79,7 +79,7 @@ class InfrahubProfileMutation(InfrahubMutationMixin, Mutation):
 
     @classmethod
     async def _get_profile_related_node_ids(cls, db: InfrahubDatabase, obj: Node) -> set[str]:
-        related_nodes = await obj.profiles.get_relationships(db=db)  # type: ignore[attr-defined]
+        related_nodes = await obj.related_nodes.get_relationships(db=db)  # type: ignore[attr-defined]
         if related_nodes:
             related_node_ids = {rel.peer_id for rel in related_nodes}
         else:
@@ -122,7 +122,7 @@ class InfrahubProfileMutation(InfrahubMutationMixin, Mutation):
         original_attr_values = cls._get_profile_attr_values_map(obj=obj)
         original_related_node_ids = await cls._get_profile_related_node_ids(db=db, obj=obj)
 
-        obj, mutation = await super().mutate_update(
+        obj, mutation = await super()._call_mutate_update(
             info=info, data=data, branch=branch, db=db, obj=obj, skip_uniqueness_check=skip_uniqueness_check
         )
 
@@ -185,9 +185,11 @@ class InfrahubProfilesRefresh(Mutation):
             db=db,
             branch=branch,
             id=str(data.id),
+            include_source=True,
         )
         node_profiles_applier = NodeProfilesApplier(db=db, branch=branch)
-        await node_profiles_applier.apply_profiles(node=obj)
-        await obj.save(db=db)
+        updated_fields = await node_profiles_applier.apply_profiles(node=obj)
+        if updated_fields:
+            await obj.save(db=db, fields=updated_fields)
 
         return cls(ok=True)

--- a/backend/infrahub/graphql/schema.py
+++ b/backend/infrahub/graphql/schema.py
@@ -20,6 +20,7 @@ from .mutations.convert_object_type import ConvertObjectType
 from .mutations.diff import DiffUpdateMutation
 from .mutations.diff_conflict import ResolveDiffConflict
 from .mutations.generator import GeneratorDefinitionRequestRun
+from .mutations.profile import InfrahubProfilesRefresh
 from .mutations.proposed_change import (
     ProposedChangeCheckForApprovalRevoke,
     ProposedChangeMerge,
@@ -125,3 +126,4 @@ class InfrahubBaseMutation(ObjectType):
 
     ConvertObjectType = ConvertObjectType.Field()
     CoreProposedChangeCheckForApprovalRevoke = ProposedChangeCheckForApprovalRevoke.Field()
+    InfrahubProfilesRefresh = InfrahubProfilesRefresh.Field()

--- a/backend/infrahub/profiles/tasks.py
+++ b/backend/infrahub/profiles/tasks.py
@@ -47,7 +47,6 @@ async def object_profiles_refresh(
 async def objects_profiles_refresh_multiple(
     branch_name: str,
     node_ids: list[str],
-    # context: InfrahubContext,
 ) -> None:
     log = get_run_logger()
 
@@ -57,10 +56,8 @@ async def objects_profiles_refresh_multiple(
         log.info(f"Requesting profile refresh for {node_id}")
         await get_workflow().submit_workflow(
             workflow=PROFILE_REFRESH,
-            # context=context,
             parameters={
                 "branch_name": branch_name,
                 "node_id": node_id,
-                # "context": context,
             },
         )

--- a/backend/infrahub/profiles/tasks.py
+++ b/backend/infrahub/profiles/tasks.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from prefect import flow
+from prefect.logging import get_run_logger
+
+from infrahub.workers.dependencies import get_client, get_workflow
+from infrahub.workflows.catalogue import PROFILE_REFRESH
+from infrahub.workflows.utils import add_tags
+
+REFRESH_PROFILES_MUTATION = """
+mutation RefreshProfiles(
+    $id: String!,
+  ) {
+  InfrahubProfilesRefresh(
+    data: {id: $id}
+  ) {
+    ok
+  }
+}
+"""
+
+
+@flow(
+    name="object-profiles-refresh",
+    flow_run_name="Refresh profiles for {node_id}",
+)
+async def object_profiles_refresh(
+    branch_name: str,
+    node_id: str,
+) -> None:
+    log = get_run_logger()
+    client = get_client()
+
+    await add_tags(branches=[branch_name], nodes=[node_id], db_change=True)
+    await client.execute_graphql(
+        query=REFRESH_PROFILES_MUTATION,
+        variables={"id": node_id},
+        branch_name=branch_name,
+    )
+    log.info(f"Profiles refreshed for {node_id}")
+
+
+@flow(
+    name="objects-profiles-refresh-multiple",
+    flow_run_name="Refresh profiles for multiple objects",
+)
+async def objects_profiles_refresh_multiple(
+    branch_name: str,
+    node_ids: list[str],
+    # context: InfrahubContext,
+) -> None:
+    log = get_run_logger()
+
+    await add_tags(branches=[branch_name])
+
+    for node_id in node_ids:
+        log.info(f"Requesting profile refresh for {node_id}")
+        await get_workflow().submit_workflow(
+            workflow=PROFILE_REFRESH,
+            # context=context,
+            parameters={
+                "branch_name": branch_name,
+                "node_id": node_id,
+                # "context": context,
+            },
+        )

--- a/backend/infrahub/workflows/catalogue.py
+++ b/backend/infrahub/workflows/catalogue.py
@@ -533,6 +533,25 @@ VALIDATE_SCHEMA_NUMBER_POOLS = WorkflowDefinition(
     function="validate_schema_number_pools",
 )
 
+
+PROFILE_REFRESH_MULTIPLE = WorkflowDefinition(
+    name="objects-profiles-refresh-multiple",
+    type=WorkflowType.CORE,
+    module="infrahub.profiles.tasks",
+    function="objects_profiles_refresh_multiple",
+    tags=[WorkflowTag.DATABASE_CHANGE],
+)
+
+
+PROFILE_REFRESH = WorkflowDefinition(
+    name="object-profiles-refresh",
+    type=WorkflowType.CORE,
+    module="infrahub.profiles.tasks",
+    function="object_profiles_refresh",
+    tags=[WorkflowTag.DATABASE_CHANGE],
+)
+
+
 CLEAN_UP_DEADLOCKS = WorkflowDefinition(
     name="clean-up-deadlocks",
     type=WorkflowType.INTERNAL,
@@ -586,6 +605,8 @@ WORKFLOWS = [
     GIT_REPOSITORY_USER_CHECK_RUN,
     GRAPHQL_QUERY_GROUP_UPDATE,
     IPAM_RECONCILIATION,
+    PROFILE_REFRESH,
+    PROFILE_REFRESH_MULTIPLE,
     PROPOSED_CHANGE_MERGE,
     QUERY_COMPUTED_ATTRIBUTE_TRANSFORM_TARGETS,
     REMOVE_ADD_NODE_FROM_GROUP,

--- a/backend/tests/functional/profiles/test_profiles.py
+++ b/backend/tests/functional/profiles/test_profiles.py
@@ -1,0 +1,88 @@
+import pytest
+from infrahub_sdk.client import InfrahubClient
+from infrahub_sdk.node.node import InfrahubNode
+
+from infrahub.core.branch import Branch
+from tests.constants import TestKind
+from tests.helpers.schema import DEVICE_SCHEMA
+from tests.helpers.test_app import TestInfrahubApp
+
+
+class TestProfiles(TestInfrahubApp):
+    @pytest.fixture(scope="class")
+    async def load_schema(self, client: InfrahubClient, default_branch: Branch) -> None:
+        device_schema = DEVICE_SCHEMA.model_dump()
+        device_schema["version"] = "1.0"
+        response = await client.schema.load(schemas=[device_schema])
+        assert not response.errors
+
+    @pytest.fixture(scope="class")
+    async def device_1(self, client: InfrahubClient, load_schema: None) -> InfrahubNode:
+        device = await client.create(
+            kind=TestKind.DEVICE,
+            name="device-1",
+            manufacturer="manufacturer-1",
+            height=1,
+            weight=1,
+            airflow="Front to rear",
+            part_number="part-number-1",
+        )
+        await device.save()
+        return device
+
+    @pytest.fixture(scope="class")
+    async def device_profile_1(self, client: InfrahubClient, load_schema: None) -> InfrahubNode:
+        device_profile = await client.create(
+            kind=f"Profile{TestKind.DEVICE}",
+            profile_name="device-profile-1",
+            profile_priority=1000,
+            manufacturer="manufacturer-profile-1",
+            height=101,
+            weight=201,
+            airflow="Left to right",
+            part_number="part-number-profile-1",
+        )
+        await device_profile.save()
+        return device_profile
+
+    async def test_profile_values_do_not_override_non_default_values(
+        self,
+        device_1: InfrahubNode,
+        device_profile_1: InfrahubNode,
+        client: InfrahubClient,
+    ):
+        await device_profile_1.related_nodes.fetch()
+        device_profile_1.related_nodes.add(device_1.id)
+        await device_profile_1.save()
+
+        updated_device_1 = await client.get(kind=TestKind.DEVICE, id=device_1.id, property=True)
+        assert updated_device_1.manufacturer.value == "manufacturer-1"
+        assert updated_device_1.manufacturer.is_default is False
+        assert updated_device_1.manufacturer.is_from_profile is False
+        assert updated_device_1.manufacturer.source is None
+
+        assert updated_device_1.height.value == 1
+        assert updated_device_1.height.is_default is False
+        assert updated_device_1.height.is_from_profile is False
+        assert updated_device_1.height.source is None
+
+        assert updated_device_1.weight.value == 1
+        assert updated_device_1.weight.is_default is False
+        assert updated_device_1.weight.is_from_profile is False
+        assert updated_device_1.weight.source is None
+
+        assert updated_device_1.airflow.value == "Front to rear"
+        assert updated_device_1.airflow.is_default is False
+        assert updated_device_1.airflow.is_from_profile is False
+        assert updated_device_1.airflow.source is None
+
+        assert updated_device_1.part_number.value == "part-number-1"
+        assert updated_device_1.part_number.is_default is False
+        assert updated_device_1.part_number.is_from_profile is False
+        assert updated_device_1.part_number.source is None
+
+
+# test setting attribute value back to default picks up profile value
+# test profile create with linked node
+# test profile update
+# test profile delete

--- a/backend/tests/functional/profiles/test_profiles.py
+++ b/backend/tests/functional/profiles/test_profiles.py
@@ -20,7 +20,16 @@ class AttributeProfileDetails:
     attribute_name: str
     value: Any
     is_default: bool
-    source_profile_id: str
+    source_profile_id: str | None = None
+    source_template_id: str | None = None
+
+    @property
+    def is_from_profile(self) -> bool:
+        return self.source_profile_id is not None
+
+    @property
+    def source_id(self) -> str | None:
+        return self.source_profile_id or self.source_template_id
 
 
 class TestProfiles(TestInfrahubApp):
@@ -92,6 +101,20 @@ class TestProfiles(TestInfrahubApp):
         await device_profile.save()
         return await client.get(kind=f"Profile{TestKind.DEVICE}", id=device_profile.id, property=True)
 
+    @pytest.fixture(scope="class")
+    async def device_template(
+        self,
+        client: InfrahubClient,
+        load_schema: None,
+    ) -> InfrahubNode:
+        device_template = await client.create(
+            kind=f"Template{TestKind.DEVICE}",
+            template_name="device-template",
+            height=501,
+        )
+        await device_template.save()
+        return await client.get(kind=f"Template{TestKind.DEVICE}", id=device_template.id)
+
     @pytest.fixture
     async def device_profile_2_with_empty_node(
         self, device_2_empty_attribute: InfrahubNode, client: InfrahubClient, load_schema: None, branch: BranchData
@@ -134,11 +157,8 @@ class TestProfiles(TestInfrahubApp):
             if expected_profile_attr := expected_profile_attrs_by_name.get(attribute_name):
                 assert current_attribute.value == expected_profile_attr.value
                 assert current_attribute.is_default == expected_profile_attr.is_default
-                assert current_attribute.is_from_profile == (expected_profile_attr.source_profile_id is not None)
-                if expected_profile_attr.source_profile_id:
-                    assert current_attribute.source.id == expected_profile_attr.source_profile_id
-                else:
-                    assert current_attribute.source is None
+                assert current_attribute.is_from_profile == expected_profile_attr.is_from_profile
+                assert current_attribute.source.id == expected_profile_attr.source_id
                 continue
             original_attribute = getattr(original_node, attribute_name)
             assert current_attribute.value == original_attribute.value
@@ -154,6 +174,7 @@ class TestProfiles(TestInfrahubApp):
         device_1_full_attributes: InfrahubNode,
         device_2_empty_attribute: InfrahubNode,
         device_3: InfrahubNode,
+        device_template: InfrahubNode,
         device_profile_1: InfrahubNode,
         branch: BranchData,
     ):
@@ -350,6 +371,176 @@ class TestProfiles(TestInfrahubApp):
                     value="part-number-profile-3",
                     is_default=False,
                     source_profile_id=device_profile_3_with_all_nodes.id,
+                ),
+            ],
+        )
+
+    async def test_update_profile_priority(
+        self,
+        device_1_full_attributes: InfrahubNode,
+        device_2_empty_attribute: InfrahubNode,
+        device_3: InfrahubNode,
+        device_profile_3_with_all_nodes: InfrahubNode,
+        client: InfrahubClient,
+        branch: BranchData,
+    ):
+        # make profile 3 the highest priority
+        device_profile_3 = await client.get(
+            branch=branch.name, kind=f"Profile{TestKind.DEVICE}", id=device_profile_3_with_all_nodes.id
+        )
+        device_profile_3.profile_priority.value = 999
+        await device_profile_3.save()
+
+        updated_device_1 = await client.get(
+            branch=branch.name, kind=TestKind.DEVICE, id=device_1_full_attributes.id, property=True
+        )
+        self.validate_node(
+            original_node=device_1_full_attributes,
+            updated_node=updated_device_1,
+            expected_profile_attrs=[],
+        )
+
+        expected_profile_3_attrs = [
+            AttributeProfileDetails(
+                attribute_name="height",
+                value=301,
+                is_default=False,
+                source_profile_id=device_profile_3_with_all_nodes.id,
+            ),
+            AttributeProfileDetails(
+                attribute_name="part_number",
+                value="part-number-profile-3",
+                is_default=False,
+                source_profile_id=device_profile_3_with_all_nodes.id,
+            ),
+        ]
+        updated_device_2 = await client.get(
+            branch=branch.name, kind=TestKind.DEVICE, id=device_2_empty_attribute.id, property=True
+        )
+        self.validate_node(
+            original_node=device_2_empty_attribute,
+            updated_node=updated_device_2,
+            expected_profile_attrs=expected_profile_3_attrs,
+        )
+
+        updated_device_3 = await client.get(branch=branch.name, kind=TestKind.DEVICE, id=device_3.id, property=True)
+        self.validate_node(
+            original_node=device_3,
+            updated_node=updated_device_3,
+            expected_profile_attrs=expected_profile_3_attrs,
+        )
+
+    async def test_delete_profile(
+        self,
+        device_1_full_attributes: InfrahubNode,
+        device_2_empty_attribute: InfrahubNode,
+        device_3: InfrahubNode,
+        device_profile_2_updated_values: InfrahubNode,
+        device_profile_3_with_all_nodes: InfrahubNode,
+        client: InfrahubClient,
+        branch: BranchData,
+    ):
+        # delete profile 3
+        device_profile_3 = await client.get(
+            branch=branch.name, kind=f"Profile{TestKind.DEVICE}", id=device_profile_3_with_all_nodes.id
+        )
+        await device_profile_3.delete()
+
+        updated_device_1 = await client.get(
+            branch=branch.name, kind=TestKind.DEVICE, id=device_1_full_attributes.id, property=True
+        )
+        self.validate_node(
+            original_node=device_1_full_attributes,
+            updated_node=updated_device_1,
+            expected_profile_attrs=[],
+        )
+
+        updated_device_2 = await client.get(
+            branch=branch.name, kind=TestKind.DEVICE, id=device_2_empty_attribute.id, property=True
+        )
+        self.validate_node(
+            original_node=device_2_empty_attribute,
+            updated_node=updated_device_2,
+            expected_profile_attrs=[
+                AttributeProfileDetails(
+                    attribute_name="height",
+                    value=1022,
+                    is_default=False,
+                    source_profile_id=device_profile_2_updated_values.id,
+                ),
+                AttributeProfileDetails(
+                    attribute_name="part_number",
+                    value="part-number-profile-2-updated",
+                    is_default=False,
+                    source_profile_id=device_profile_2_updated_values.id,
+                ),
+            ],
+        )
+
+        updated_device_3 = await client.get(branch=branch.name, kind=TestKind.DEVICE, id=device_3.id, property=True)
+        self.validate_node(
+            original_node=device_3,
+            updated_node=updated_device_3,
+            expected_profile_attrs=[],
+        )
+
+    @pytest.fixture
+    async def device_4_with_template(
+        self,
+        device_template: InfrahubNode,
+        device_profile_2_updated_values: InfrahubNode,
+        client: InfrahubClient,
+        load_schema: None,
+        branch: BranchData,
+    ) -> InfrahubNode:
+        try:
+            return await client.get(
+                branch=branch.name,
+                kind=f"{TestKind.DEVICE}",
+                name__value=f"device-4-{branch.name}",
+                property=True,
+            )
+        except NodeNotFoundError:
+            pass
+        device = await client.create(
+            branch=branch.name,
+            kind=f"{TestKind.DEVICE}",
+            name=f"device-4-{branch.name}",
+            manufacturer="manufacturer-4",
+            weight=4,
+            airflow="Passive",
+            profiles=[device_profile_2_updated_values.id],
+            object_template=device_template,
+        )
+        await device.save()
+        return await client.get(branch=branch.name, kind=f"{TestKind.DEVICE}", id=device.id, property=True)
+
+    async def test_create_device_with_template_and_profile(
+        self,
+        device_template: InfrahubNode,
+        device_profile_2_updated_values: InfrahubNode,
+        device_4_with_template: InfrahubNode,
+        client: InfrahubClient,
+        branch: BranchData,
+    ):
+        updated_device_4 = await client.get(
+            branch=branch.name, kind=f"{TestKind.DEVICE}", id=device_4_with_template.id, property=True
+        )
+        self.validate_node(
+            original_node=device_4_with_template,
+            updated_node=updated_device_4,
+            expected_profile_attrs=[
+                AttributeProfileDetails(
+                    attribute_name="height",
+                    value=501,
+                    is_default=False,
+                    source_template_id=device_template.id,
+                ),
+                AttributeProfileDetails(
+                    attribute_name="part_number",
+                    value="part-number-profile-2-updated",
+                    is_default=False,
+                    source_profile_id=device_profile_2_updated_values.id,
                 ),
             ],
         )

--- a/backend/tests/functional/profiles/test_profiles.py
+++ b/backend/tests/functional/profiles/test_profiles.py
@@ -1,5 +1,10 @@
+from typing import Any
+
 import pytest
+from attr import dataclass
+from infrahub_sdk.branch import BranchData
 from infrahub_sdk.client import InfrahubClient
+from infrahub_sdk.exceptions import BranchNotFoundError, NodeNotFoundError
 from infrahub_sdk.node.node import InfrahubNode
 
 from infrahub.core.branch import Branch
@@ -7,8 +12,26 @@ from tests.constants import TestKind
 from tests.helpers.schema import DEVICE_SCHEMA
 from tests.helpers.test_app import TestInfrahubApp
 
+BRANCH_NAMES = ["main", "branch2"]
+
+
+@dataclass
+class AttributeProfileDetails:
+    attribute_name: str
+    value: Any
+    is_default: bool
+    source_profile_id: str
+
 
 class TestProfiles(TestInfrahubApp):
+    @pytest.fixture(params=BRANCH_NAMES)
+    async def branch(self, request, client: InfrahubClient) -> BranchData:
+        branch_name = request.param
+        try:
+            return await client.branch.get(branch_name=branch_name)
+        except BranchNotFoundError:
+            return await client.branch.create(branch_name=branch_name)
+
     @pytest.fixture(scope="class")
     async def load_schema(self, client: InfrahubClient, default_branch: Branch) -> None:
         device_schema = DEVICE_SCHEMA.model_dump()
@@ -17,7 +40,7 @@ class TestProfiles(TestInfrahubApp):
         assert not response.errors
 
     @pytest.fixture(scope="class")
-    async def device_1(self, client: InfrahubClient, load_schema: None) -> InfrahubNode:
+    async def device_1_full_attributes(self, client: InfrahubClient, load_schema: None) -> InfrahubNode:
         device = await client.create(
             kind=TestKind.DEVICE,
             name="device-1",
@@ -28,14 +51,38 @@ class TestProfiles(TestInfrahubApp):
             part_number="part-number-1",
         )
         await device.save()
-        return device
+        return await client.get(kind=TestKind.DEVICE, id=device.id, property=True)
+
+    @pytest.fixture(scope="class")
+    async def device_2_empty_attribute(self, client: InfrahubClient, load_schema: None) -> InfrahubNode:
+        device = await client.create(
+            kind=TestKind.DEVICE,
+            name="device-2",
+            manufacturer="manufacturer-2",
+            weight=2,
+            airflow="Rear to front",
+        )
+        await device.save()
+        return await client.get(kind=TestKind.DEVICE, id=device.id, property=True)
+
+    @pytest.fixture(scope="class")
+    async def device_3(self, client: InfrahubClient, load_schema: None) -> InfrahubNode:
+        device = await client.create(
+            kind=TestKind.DEVICE,
+            name="device-3",
+            manufacturer="manufacturer-3",
+            weight=3,
+            airflow="Bottom to top",
+        )
+        await device.save()
+        return await client.get(kind=TestKind.DEVICE, id=device.id, property=True)
 
     @pytest.fixture(scope="class")
     async def device_profile_1(self, client: InfrahubClient, load_schema: None) -> InfrahubNode:
         device_profile = await client.create(
             kind=f"Profile{TestKind.DEVICE}",
             profile_name="device-profile-1",
-            profile_priority=1000,
+            profile_priority=1001,
             manufacturer="manufacturer-profile-1",
             height=101,
             weight=201,
@@ -43,46 +90,266 @@ class TestProfiles(TestInfrahubApp):
             part_number="part-number-profile-1",
         )
         await device_profile.save()
-        return device_profile
+        return await client.get(kind=f"Profile{TestKind.DEVICE}", id=device_profile.id, property=True)
+
+    @pytest.fixture
+    async def device_profile_2_with_empty_node(
+        self, device_2_empty_attribute: InfrahubNode, client: InfrahubClient, load_schema: None, branch: BranchData
+    ) -> InfrahubNode:
+        try:
+            return await client.get(
+                branch=branch.name,
+                kind=f"Profile{TestKind.DEVICE}",
+                profile_name__value=f"device-profile-2-{branch.name}",
+                property=True,
+            )
+        except NodeNotFoundError:
+            pass
+        device_profile = await client.create(
+            branch=branch.name,
+            kind=f"Profile{TestKind.DEVICE}",
+            profile_name=f"device-profile-2-{branch.name}",
+            profile_priority=1002,
+            manufacturer="manufacturer-profile-2",
+            height=102,
+            weight=202,
+            airflow="Right to left",
+            part_number="part-number-profile-2",
+            related_nodes=[device_2_empty_attribute.id],
+        )
+        await device_profile.save()
+        return await client.get(
+            branch=branch.name, kind=f"Profile{TestKind.DEVICE}", id=device_profile.id, property=True
+        )
+
+    def validate_node(
+        self,
+        original_node: InfrahubNode,
+        updated_node: InfrahubNode,
+        expected_profile_attrs: list[AttributeProfileDetails],
+    ):
+        expected_profile_attrs_by_name = {attr.attribute_name: attr for attr in expected_profile_attrs}
+        for attribute_name in updated_node._attributes:
+            current_attribute = getattr(updated_node, attribute_name)
+            if expected_profile_attr := expected_profile_attrs_by_name.get(attribute_name):
+                assert current_attribute.value == expected_profile_attr.value
+                assert current_attribute.is_default == expected_profile_attr.is_default
+                assert current_attribute.is_from_profile == (expected_profile_attr.source_profile_id is not None)
+                if expected_profile_attr.source_profile_id:
+                    assert current_attribute.source.id == expected_profile_attr.source_profile_id
+                else:
+                    assert current_attribute.source is None
+                continue
+            original_attribute = getattr(original_node, attribute_name)
+            assert current_attribute.value == original_attribute.value
+            assert current_attribute.is_default == original_attribute.is_default
+            assert current_attribute.is_from_profile == original_attribute.is_from_profile
+            if original_attribute.source is not None:
+                assert current_attribute.source.id == original_attribute.source.id
+            else:
+                assert current_attribute.source is None
+
+    async def test_load_data_and_branch(
+        self,
+        device_1_full_attributes: InfrahubNode,
+        device_2_empty_attribute: InfrahubNode,
+        device_3: InfrahubNode,
+        device_profile_1: InfrahubNode,
+        branch: BranchData,
+    ):
+        pass
 
     async def test_profile_values_do_not_override_non_default_values(
         self,
-        device_1: InfrahubNode,
+        device_1_full_attributes: InfrahubNode,
         device_profile_1: InfrahubNode,
         client: InfrahubClient,
+        branch: BranchData,
     ):
+        device_profile_1 = await client.get(
+            branch=branch.name, kind=f"Profile{TestKind.DEVICE}", id=device_profile_1.id, property=True
+        )
         await device_profile_1.related_nodes.fetch()
-        device_profile_1.related_nodes.add(device_1.id)
+        device_profile_1.related_nodes.add(device_1_full_attributes.id)
         await device_profile_1.save()
 
-        updated_device_1 = await client.get(kind=TestKind.DEVICE, id=device_1.id, property=True)
-        assert updated_device_1.manufacturer.value == "manufacturer-1"
-        assert updated_device_1.manufacturer.is_default is False
-        assert updated_device_1.manufacturer.is_from_profile is False
-        assert updated_device_1.manufacturer.source is None
+        updated_device_1 = await client.get(
+            branch=branch.name, kind=TestKind.DEVICE, id=device_1_full_attributes.id, property=True
+        )
+        self.validate_node(
+            original_node=device_1_full_attributes, updated_node=updated_device_1, expected_profile_attrs=[]
+        )
 
-        assert updated_device_1.height.value == 1
-        assert updated_device_1.height.is_default is False
-        assert updated_device_1.height.is_from_profile is False
-        assert updated_device_1.height.source is None
+    async def test_create_profile_with_linked_node(
+        self,
+        device_2_empty_attribute: InfrahubNode,
+        device_profile_2_with_empty_node: InfrahubNode,
+        client: InfrahubClient,
+        branch: BranchData,
+    ):
+        fresh_device_2 = await client.get(branch=branch.name, kind=TestKind.DEVICE, id=device_2_empty_attribute.id)
+        fresh_device_2.manufacturer.is_default = True
+        await fresh_device_2.save()
 
-        assert updated_device_1.weight.value == 1
-        assert updated_device_1.weight.is_default is False
-        assert updated_device_1.weight.is_from_profile is False
-        assert updated_device_1.weight.source is None
+        updated_device_2 = await client.get(
+            branch=branch.name, kind=TestKind.DEVICE, id=device_2_empty_attribute.id, property=True
+        )
+        profile_2_id = device_profile_2_with_empty_node.id
+        self.validate_node(
+            original_node=device_2_empty_attribute,
+            updated_node=updated_device_2,
+            expected_profile_attrs=[
+                AttributeProfileDetails(
+                    attribute_name="height", value=102, is_default=False, source_profile_id=profile_2_id
+                ),
+                AttributeProfileDetails(
+                    attribute_name="part_number",
+                    value="part-number-profile-2",
+                    is_default=False,
+                    source_profile_id=profile_2_id,
+                ),
+            ],
+        )
 
-        assert updated_device_1.airflow.value == "Front to rear"
-        assert updated_device_1.airflow.is_default is False
-        assert updated_device_1.airflow.is_from_profile is False
-        assert updated_device_1.airflow.source is None
+    @pytest.fixture
+    async def device_profile_2_updated_values(
+        self,
+        device_profile_2_with_empty_node: InfrahubNode,
+        client: InfrahubClient,
+        branch: BranchData,
+    ) -> InfrahubNode:
+        device_profile_2_with_empty_node = await client.get(
+            branch=branch.name, kind=f"Profile{TestKind.DEVICE}", id=device_profile_2_with_empty_node.id
+        )
+        device_profile_2_with_empty_node.height.value = 1022
+        device_profile_2_with_empty_node.part_number.value = "part-number-profile-2-updated"
+        await device_profile_2_with_empty_node.save()
+        return await client.get(
+            branch=branch.name, kind=f"Profile{TestKind.DEVICE}", id=device_profile_2_with_empty_node.id, property=True
+        )
 
-        assert updated_device_1.part_number.value == "part-number-1"
-        assert updated_device_1.part_number.is_default is False
-        assert updated_device_1.part_number.is_from_profile is False
-        assert updated_device_1.part_number.source is None
+    async def test_profile_value_update(
+        self,
+        device_profile_2_updated_values: InfrahubNode,
+        device_2_empty_attribute: InfrahubNode,
+        client: InfrahubClient,
+        branch: BranchData,
+    ):
+        updated_device_2 = await client.get(
+            branch=branch.name, kind=TestKind.DEVICE, id=device_2_empty_attribute.id, property=True
+        )
+        self.validate_node(
+            original_node=device_2_empty_attribute,
+            updated_node=updated_device_2,
+            expected_profile_attrs=[
+                AttributeProfileDetails(
+                    attribute_name="height",
+                    value=1022,
+                    is_default=False,
+                    source_profile_id=device_profile_2_updated_values.id,
+                ),
+                AttributeProfileDetails(
+                    attribute_name="part_number",
+                    value="part-number-profile-2-updated",
+                    is_default=False,
+                    source_profile_id=device_profile_2_updated_values.id,
+                ),
+            ],
+        )
 
+    @pytest.fixture
+    async def device_profile_3_with_all_nodes(
+        self,
+        device_1_full_attributes: InfrahubNode,
+        device_2_empty_attribute: InfrahubNode,
+        device_3: InfrahubNode,
+        client: InfrahubClient,
+        load_schema: None,
+        branch: BranchData,
+    ) -> InfrahubNode:
+        try:
+            return await client.get(
+                branch=branch.name,
+                kind=f"Profile{TestKind.DEVICE}",
+                profile_name__value=f"device-profile-3-{branch.name}",
+                property=True,
+            )
+        except NodeNotFoundError:
+            pass
+        device_profile = await client.create(
+            branch=branch.name,
+            kind=f"Profile{TestKind.DEVICE}",
+            profile_name=f"device-profile-3-{branch.name}",
+            profile_priority=1003,
+            manufacturer="manufacturer-profile-3",
+            height=301,
+            weight=302,
+            airflow="Right to left",
+            part_number="part-number-profile-3",
+            related_nodes=[device_1_full_attributes.id, device_2_empty_attribute.id, device_3.id],
+        )
+        await device_profile.save()
+        return await client.get(
+            branch=branch.name, kind=f"Profile{TestKind.DEVICE}", id=device_profile.id, property=True
+        )
 
-# test setting attribute value back to default picks up profile value
-# test profile create with linked node
-# test profile update
-# test profile delete
+    async def test_add_profile_to_all_devices(
+        self,
+        device_1_full_attributes: InfrahubNode,
+        device_2_empty_attribute: InfrahubNode,
+        device_3: InfrahubNode,
+        device_profile_2_updated_values: InfrahubNode,
+        device_profile_3_with_all_nodes: InfrahubNode,
+        client: InfrahubClient,
+        branch: BranchData,
+    ):
+        updated_device_1 = await client.get(
+            branch=branch.name, kind=TestKind.DEVICE, id=device_1_full_attributes.id, property=True
+        )
+        self.validate_node(
+            original_node=device_1_full_attributes,
+            updated_node=updated_device_1,
+            expected_profile_attrs=[],
+        )
+
+        updated_device_2 = await client.get(
+            branch=branch.name, kind=TestKind.DEVICE, id=device_2_empty_attribute.id, property=True
+        )
+        self.validate_node(
+            original_node=device_2_empty_attribute,
+            updated_node=updated_device_2,
+            expected_profile_attrs=[
+                AttributeProfileDetails(
+                    attribute_name="height",
+                    value=1022,
+                    is_default=False,
+                    source_profile_id=device_profile_2_updated_values.id,
+                ),
+                AttributeProfileDetails(
+                    attribute_name="part_number",
+                    value="part-number-profile-2-updated",
+                    is_default=False,
+                    source_profile_id=device_profile_2_updated_values.id,
+                ),
+            ],
+        )
+
+        updated_device_3 = await client.get(branch=branch.name, kind=TestKind.DEVICE, id=device_3.id, property=True)
+        self.validate_node(
+            original_node=device_3,
+            updated_node=updated_device_3,
+            expected_profile_attrs=[
+                AttributeProfileDetails(
+                    attribute_name="height",
+                    value=301,
+                    is_default=False,
+                    source_profile_id=device_profile_3_with_all_nodes.id,
+                ),
+                AttributeProfileDetails(
+                    attribute_name="part_number",
+                    value="part-number-profile-3",
+                    is_default=False,
+                    source_profile_id=device_profile_3_with_all_nodes.id,
+                ),
+            ],
+        )

--- a/backend/tests/integration/profiles/test_profile_lifecycle.py
+++ b/backend/tests/integration/profiles/test_profile_lifecycle.py
@@ -10,7 +10,6 @@ from infrahub.core.schema.attribute_schema import AttributeSchema
 from infrahub.core.schema.node_schema import NodeSchema
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
-from infrahub.profiles.node_applier import NodeProfilesApplier
 from tests.helpers.graphql import graphql
 from tests.helpers.schema import load_schema
 from tests.helpers.test_app import TestInfrahubApp
@@ -366,37 +365,11 @@ class TestProfileLifecycle(TestInfrahubApp):
         client: InfrahubClient,
     ):
         person_profile_2 = await client.get(kind="ProfileTestingPerson", profile_name__value="profile-two")
-        mutation = """
-            mutation {
-                ProfileTestingPersonDelete(data: {id: "%(profile_id)s"}) {
-                    ok
-                }
-            }
-        """ % {"profile_id": person_profile_2.id}
-
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
-        result = await graphql(
-            schema=gql_params.schema,
-            source=mutation,
-            context_value=gql_params.context,
-            root_value=None,
-            variable_values={},
-        )
-
-        assert not result.errors
-        assert result.data
-        assert result.data["ProfileTestingPersonDelete"]["ok"] is True
+        await person_profile_2.delete()
 
     async def test_step_09_check_persons(
         self, db: InfrahubDatabase, person_1, person_profile_1, client: InfrahubClient, default_branch: Branch
     ):
-        # TODO: remove after profile-level update logic
-        persons = await NodeManager.query(db=db, schema="TestingPerson")
-        node_profiles_applier = NodeProfilesApplier(db=db, branch=default_branch)
-        for person in persons:
-            await node_profiles_applier.apply_profiles(node=person)
-            await person.save(db=db)
-
         retrieved_person_1 = await client.get(kind="TestingPerson", id=person_1.id, property=True)
         await retrieved_person_1.profiles.fetch()
         retrieved_person_2 = await client.get(kind="TestingPerson", name__value="Apollo", property=True)
@@ -484,57 +457,31 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person.height.source_id is None
         assert retrieved_person.height.is_default is False
 
-    async def test_step_11_add_profile_with_person(
-        self, db: InfrahubDatabase, default_branch, person_profile_1, person_1
+    async def test_step_11_update_existing_profile(
+        self,
+        db: InfrahubDatabase,
+        default_branch,
+        person_profile_1,
+        person_1,
+        client: InfrahubClient,
     ):
-        mutation = """
-            mutation {
-                ProfileTestingPersonUpdate(data: {
-                    id: "%(profile_id)s"
-                    profile_priority: {value: 11},
-                    height: {value: 134}
-                } ) {
-                    ok
-                    object {
-                        related_nodes { edges { node { id } } }
-                        profile_name { value }
-                        profile_priority { value }
-                        height { value }
-                    }
-                }
-            }
-        """ % {"profile_id": person_profile_1.id}
+        person_profile_1 = await client.get(kind="ProfileTestingPerson", id=person_profile_1.id)
+        person_profile_1.profile_priority.value = 11
+        person_profile_1.height.value = 134
+        await person_profile_1.save()
 
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
-        result = await graphql(
-            schema=gql_params.schema,
-            source=mutation,
-            context_value=gql_params.context,
-            root_value=None,
-            variable_values={},
-        )
+        updated_person_profile_1 = await client.get(kind="ProfileTestingPerson", id=person_profile_1.id)
+        assert updated_person_profile_1.profile_name.value == "profile-one"
+        assert updated_person_profile_1.profile_priority.value == 11
+        assert updated_person_profile_1.height.value == 134
+        await updated_person_profile_1.related_nodes.fetch()
 
-        assert result.errors is None
-        assert result.data
-        assert result.data["ProfileTestingPersonUpdate"]["ok"] is True
-        nodes = result.data["ProfileTestingPersonUpdate"]["object"]["related_nodes"]["edges"]
-        assert len(nodes) == 1
-        assert nodes == [{"node": {"id": person_1.id}}]
-        attributes = result.data["ProfileTestingPersonUpdate"]["object"]
-        assert attributes["profile_name"] == {"value": "profile-one"}
-        assert attributes["profile_priority"] == {"value": 11}
-        assert attributes["height"] == {"value": 134}
+        assert len(updated_person_profile_1.related_nodes.peers) == 1
+        assert updated_person_profile_1.related_nodes.peers[0].id == person_1.id
 
     async def test_step_12_check_persons_again(
         self, db: InfrahubDatabase, default_branch: Branch, person_1, person_profile_1, client: InfrahubClient
     ):
-        # TODO: remove after profile-level update logic
-        persons = await NodeManager.query(db=db, schema="TestingPerson")
-        node_profiles_applier = NodeProfilesApplier(db=db, branch=default_branch)
-        for person in persons:
-            await node_profiles_applier.apply_profiles(node=person)
-            await person.save(db=db)
-
         retrieved_person_1 = await client.get(kind="TestingPerson", id=person_1.id, property=True)
         await retrieved_person_1.profiles.fetch()
         retrieved_person_2 = await client.get(kind="TestingPerson", name__value="Apollo", property=True)

--- a/backend/tests/integration/profiles/test_profile_lifecycle.py
+++ b/backend/tests/integration/profiles/test_profile_lifecycle.py
@@ -504,3 +504,52 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person_2.height.is_from_profile is False
         assert retrieved_person_2.height.source is None
         assert retrieved_person_2.height.is_default is True
+
+    async def test_step_13_update_existing_profile_related_nodes(
+        self,
+        db: InfrahubDatabase,
+        default_branch,
+        person_profile_1,
+        person_1,
+        client: InfrahubClient,
+    ):
+        person_2 = await client.get(kind="TestingPerson", name__value="Apollo", property=True)
+        person_profile_1 = await client.get(kind="ProfileTestingPerson", id=person_profile_1.id)
+        await person_profile_1.related_nodes.fetch()
+        person_profile_1.related_nodes.remove(person_1.id)
+        person_profile_1.related_nodes.add(person_2)
+        await person_profile_1.save()
+
+        updated_person_profile_1 = await client.get(kind="ProfileTestingPerson", id=person_profile_1.id)
+        assert updated_person_profile_1.profile_name.value == "profile-one"
+        await updated_person_profile_1.related_nodes.fetch()
+        assert len(updated_person_profile_1.related_nodes.peers) == 1
+        assert updated_person_profile_1.related_nodes.peers[0].id == person_2.id
+
+    async def test_step_14_check_persons_again(
+        self, db: InfrahubDatabase, default_branch: Branch, person_1, person_profile_1, client: InfrahubClient
+    ):
+        retrieved_person_1 = await client.get(kind="TestingPerson", id=person_1.id, property=True)
+        retrieved_person_2 = await client.get(kind="TestingPerson", name__value="Apollo", property=True)
+
+        await retrieved_person_1.profiles.fetch()
+        assert retrieved_person_1.profiles.peer_ids == []
+        assert retrieved_person_1.name.value == "Kara Thrace"
+        assert retrieved_person_1.name.is_from_profile is False
+        assert retrieved_person_1.name.source is None
+        assert retrieved_person_1.name.is_default is False
+        assert retrieved_person_1.height.value == 145
+        assert retrieved_person_1.height.is_from_profile is False
+        assert retrieved_person_1.height.source is None
+        assert retrieved_person_1.height.is_default is False
+
+        await retrieved_person_2.profiles.fetch()
+        assert retrieved_person_2.profiles.peer_ids == [person_profile_1.id]
+        assert retrieved_person_2.name.value == "Apollo"
+        assert retrieved_person_2.name.is_from_profile is False
+        assert retrieved_person_2.name.source is None
+        assert retrieved_person_2.name.is_default is False
+        assert retrieved_person_2.height.value == 134
+        assert retrieved_person_2.height.is_from_profile is True
+        assert retrieved_person_2.height.source.id == person_profile_1.id
+        assert retrieved_person_2.height.is_default is False

--- a/backend/tests/integration/profiles/test_profile_lifecycle.py
+++ b/backend/tests/integration/profiles/test_profile_lifecycle.py
@@ -273,51 +273,16 @@ class TestProfileLifecycle(TestInfrahubApp):
         db: InfrahubDatabase,
         default_branch,
         person_1,
+        client: InfrahubClient,
     ):
-        mutation = """
-            mutation {
-                ProfileTestingPersonCreate(data: {
-                    profile_name: {value: "profile-two"},
-                    profile_priority: {value: 5},
-                    height: {value: 156}
-                    related_nodes: [{id: "%(person_id)s"}]
-                } ) {
-                    ok
-                    object {
-                        related_nodes { edges { node { id } } }
-                        profile_name { value }
-                        profile_priority { value }
-                        height { value }
-                    }
-                }
-            }
-        """ % {"person_id": person_1.id}
-
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
-        result = await graphql(
-            schema=gql_params.schema,
-            source=mutation,
-            context_value=gql_params.context,
-            root_value=None,
-            variable_values={},
+        profile = await client.create(
+            kind="ProfileTestingPerson",
+            profile_name="profile-two",
+            profile_priority=5,
+            height=156,
+            related_nodes=[person_1.id],
         )
-
-        assert result.errors is None
-        assert result.data
-        assert result.data["ProfileTestingPersonCreate"]["ok"] is True
-        nodes = result.data["ProfileTestingPersonCreate"]["object"]["related_nodes"]["edges"]
-        assert len(nodes) == 1
-        assert nodes == [{"node": {"id": person_1.id}}]
-        attributes = result.data["ProfileTestingPersonCreate"]["object"]
-        assert attributes["profile_name"] == {"value": "profile-two"}
-        assert attributes["profile_priority"] == {"value": 5}
-        assert attributes["height"] == {"value": 156}
-
-        # TODO: remove after profile-level update logic is added
-        retrieved_person = await NodeManager.get_one(db=db, id=person_1.id, include_source=True)
-        node_profile_applier = NodeProfilesApplier(db=db, branch=default_branch)
-        await node_profile_applier.apply_profiles(node=retrieved_person)
-        await retrieved_person.save(db=db)
+        await profile.save()
 
     async def test_step_06_get_person_multiple_profiles(self, person_1, person_profile_1, client: InfrahubClient):
         person_profile_2 = await client.get(kind="ProfileTestingPerson", profile_name__value="profile-two")

--- a/backend/tests/unit/graphql/profiles/test_mutation_create.py
+++ b/backend/tests/unit/graphql/profiles/test_mutation_create.py
@@ -1,6 +1,8 @@
 from infrahub.core.manager import NodeManager
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
+from infrahub.services import InfrahubServices
+from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from tests.helpers.graphql import graphql
 
 
@@ -20,6 +22,8 @@ async def test_create_profile(db: InfrahubDatabase, default_branch, car_person_s
     }
     """
     gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    # gql mutation needs function workflow
+    gql_params.context.service = await InfrahubServices.new(workflow=WorkflowLocalExecution())
     result = await graphql(
         schema=gql_params.schema,
         source=query,

--- a/backend/tests/unit/graphql/profiles/test_query.py
+++ b/backend/tests/unit/graphql/profiles/test_query.py
@@ -10,6 +10,8 @@ from infrahub.core.schema.generic_schema import GenericSchema
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
 from infrahub.profiles.node_applier import NodeProfilesApplier
+from infrahub.services import InfrahubServices
+from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from tests.helpers.graphql import graphql
 
 
@@ -115,6 +117,8 @@ async def test_upsert_profile_in_schema(db: InfrahubDatabase, default_branch: Br
     }
     """
     gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    # gql mutation needs function workflow
+    gql_params.context.service = await InfrahubServices.new(workflow=WorkflowLocalExecution())
     result = await graphql(
         schema=gql_params.schema,
         source=query,


### PR DESCRIPTION
IFC-1809

add logic for handling updates to profile attributes and priority so that all nodes using a given profile are correctly updated when that node is added/updated/deleted

there are a few pieces to this new logic
- a new `InfrahubProfilesRefresh` mutation that accepts a single ID and will refresh the profile values for that particular node
- a new `object_profiles_refresh_multiple` workflow that accepts a list of object IDs to be refreshed
- a new `object_profiles_refresh` workflow that accepts a single ID and calls the `InfrahubProfilesRefresh` mutation on that node
- a new `InfrahubProfileMutation` class that handles submitting the `object_profiles_refresh_multiple` workflow, if necessary. the objects associated with a given profile require a refresh in the following cases
  - a new profile is created and includes `related_nodes`. in this case all `related_nodes` are submitted for a profile refresh
  - a profile is updated and the update includes changes to an attribute (except `profile_name`). in this case, all objects linked to the profile are submitted for a profile refresh
  -  a profile is updated and the update includes changes to the `related_nodes` relationship on the profile. in this case, any nodes added to or removed from the `related_nodes` relationship are submitted for a refresh
  - a profile is deleted. in this case, any `related_nodes` are submitted for a refresh
