### PR TITLE
Increase default timeout to 60 seconds for transforms.

### DIFF
--- a/backend/infrahub/core/schema/definitions/core/check.py
+++ b/backend/infrahub/core/schema/definitions/core/check.py
@@ -29,7 +29,7 @@ core_check_definition = NodeSchema(
         Attr(name="description", kind="Text", optional=True),
         Attr(name="file_path", kind="Text"),
         Attr(name="class_name", kind="Text"),
-        Attr(name="timeout", kind="Number", default_value=10),
+        Attr(name="timeout", kind="Number", default_value=60),
         Attr(name="parameters", kind="JSON", optional=True),
     ],
     relationships=[

--- a/backend/infrahub/core/schema/definitions/core/transform.py
+++ b/backend/infrahub/core/schema/definitions/core/transform.py
@@ -29,7 +29,7 @@ core_transform = GenericSchema(
         Attr(name="name", kind="Text", unique=True),
         Attr(name="label", kind="Text", optional=True),
         Attr(name="description", kind="Text", optional=True),
-        Attr(name="timeout", kind="Number", default_value=10),
+        Attr(name="timeout", kind="Number", default_value=60),
     ],
     relationships=[
         Rel(

--- a/changelog/increase-timeouts.fixed.md
+++ b/changelog/increase-timeouts.fixed.md
@@ -1,0 +1,1 @@
+- Increase default timeout for transform/checks from 10 to 60 seconds


### PR DESCRIPTION
We believe it may be good to increase the timeout of transforms from 10 seconds to 60 seconds which should give customers enough room for most artifact transforms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Increased the default timeout for core transforms and checks from 10s to 60s. This change applies where defaults are used and may reduce premature timeouts for longer-running operations; any explicit/custom timeouts remain unchanged. Users should experience fewer interruptions during execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->