### PR TITLE
Autofocus 1st field in login form

### DIFF
--- a/changelog/+autofocus-login.added.md
+++ b/changelog/+autofocus-login.added.md
@@ -1,0 +1,1 @@
+The login form now automatically focuses on the first field.

--- a/frontend/app/src/entities/authentication/ui/login.tsx
+++ b/frontend/app/src/entities/authentication/ui/login.tsx
@@ -58,7 +58,12 @@ export const LoginForm = ({ className }: { className?: string }) => {
         await login(data);
       }}
     >
-      <InputField name="username" label="Username" rules={{ validate: { required: isRequired } }} />
+      <InputField
+        name="username"
+        label="Username"
+        rules={{ validate: { required: isRequired } }}
+        autoFocus
+      />
 
       <PasswordInputField
         name="password"

--- a/frontend/app/src/shared/components/form/fields/input.field.tsx
+++ b/frontend/app/src/shared/components/form/fields/input.field.tsx
@@ -39,7 +39,7 @@ const InputField = ({
       rules={rules}
       defaultValue={defaultValue}
       render={({ field }) => {
-        const [override, setOverride] = React.useState(autoFocus);
+        const [override, setOverride] = React.useState(false);
         const fieldData: FormAttributeValue = field.value;
         const selectedPoolId = fieldData?.source?.type === "pool" ? fieldData.source.id : null;
 
@@ -63,7 +63,7 @@ const InputField = ({
                     onChange={(event) => {
                       field.onChange(updateFormFieldValue(event.target.value, defaultValue));
                     }}
-                    autoFocus={override}
+                    autoFocus={autoFocus || override}
                     onBlur={() => setOverride(false)}
                   />
                 ) : (

--- a/frontend/app/src/shared/components/form/fields/input.field.tsx
+++ b/frontend/app/src/shared/components/form/fields/input.field.tsx
@@ -29,6 +29,7 @@ const InputField = ({
   unique,
   pool,
   isBulkUpdate,
+  autoFocus,
   ...props
 }: InputFieldProps) => {
   return (
@@ -38,7 +39,7 @@ const InputField = ({
       rules={rules}
       defaultValue={defaultValue}
       render={({ field }) => {
-        const [override, setOverride] = React.useState(false);
+        const [override, setOverride] = React.useState(autoFocus);
         const fieldData: FormAttributeValue = field.value;
         const selectedPoolId = fieldData?.source?.type === "pool" ? fieldData.source.id : null;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Login form now automatically focuses the first field (username) on open, enabling faster keyboard entry and a smoother sign-in experience.

- Documentation
  - Added a changelog entry documenting the new auto-focus behavior on the login form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->