### PR TITLE
Correctly display XML and CSV artifacts in the UI + fallback

### DIFF
--- a/changelog/7294.fixed.md
+++ b/changelog/7294.fixed.md
@@ -1,0 +1,2 @@
+- Correctly display XML and CSV artifacts in the UI.
+- Added a fallback to plain text for unsupported content types.

--- a/frontend/app/src/entities/artifacts/types.ts
+++ b/frontend/app/src/entities/artifacts/types.ts
@@ -6,4 +6,6 @@ export type ArtifactContentType =
   | "application/hcl"
   | "image/svg+xml"
   | "text/plain"
-  | "text/markdown";
+  | "text/markdown"
+  | "application/xml"
+  | "text/csv";

--- a/frontend/app/src/entities/artifacts/ui/artifact-file.tsx
+++ b/frontend/app/src/entities/artifacts/ui/artifact-file.tsx
@@ -30,7 +30,9 @@ const CONTENT_TYPE_CONFIG: Record<
   "application/hcl": { extension: "hcl", language: "hcl", label: "HCL" },
   "image/svg+xml": { extension: "svg", language: "svg", label: "SVG" },
   "text/plain": { extension: "txt", language: "text", label: "text" },
-};
+  "application/xml": { extension: "xml", language: "xml", label: "XML" },
+  "text/csv": { extension: "csv", language: "csv", label: "CSV" },
+} as const;
 
 function FileLayout({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
   return (
@@ -59,7 +61,7 @@ function FileHeader({
   className,
   ...props
 }: FileHeaderProps) {
-  const config = CONTENT_TYPE_CONFIG[contentType];
+  const config = CONTENT_TYPE_CONFIG[contentType] ?? CONTENT_TYPE_CONFIG["text/plain"];
 
   return (
     <div className={classNames("flex items-center gap-1", className)} {...props}>
@@ -84,7 +86,7 @@ function FileContent({
   contentType: ArtifactContentType;
   fileContent: string;
 }) {
-  const config = CONTENT_TYPE_CONFIG[contentType];
+  const config = CONTENT_TYPE_CONFIG[contentType] ?? CONTENT_TYPE_CONFIG["text/plain"];
 
   switch (contentType) {
     case "text/markdown": {

--- a/frontend/app/src/entities/artifacts/ui/artifact-file.tsx
+++ b/frontend/app/src/entities/artifacts/ui/artifact-file.tsx
@@ -4,6 +4,7 @@ import { toast } from "react-toastify";
 import { fetchStream } from "@/shared/api/rest/fetch";
 import { Svg } from "@/shared/components/display/svg";
 import { CodeViewer } from "@/shared/components/editor/code/code-viewer";
+import { CsvTable } from "@/shared/components/editor/csv-table";
 import { MarkdownViewer } from "@/shared/components/editor/markdown/markdown-viewer";
 import NoDataFound from "@/shared/components/errors/no-data-found";
 import { LoadingIndicator } from "@/shared/components/loading/loading-indicator";
@@ -95,6 +96,13 @@ function FileContent({
     case "image/svg+xml": {
       return (
         <Svg value={fileContent} className="grow rounded-lg border border-neutral-700 shadow-sm" />
+      );
+    }
+    case "text/csv": {
+      return (
+        <ScrollArea scrollX scrollBarClassName="bg-transparent">
+          <CsvTable content={fileContent} />
+        </ScrollArea>
       );
     }
     default: {

--- a/frontend/app/src/shared/components/editor/csv-table.tsx
+++ b/frontend/app/src/shared/components/editor/csv-table.tsx
@@ -39,7 +39,7 @@ export function CsvTable({ content }: CsvTableProps) {
   const dataRows = rows.slice(1);
 
   return (
-    <table className="min-w-full border-collapse border border-neutral-700 text-sm">
+    <table className="border-collapse border border-neutral-700 text-sm">
       <thead className="bg-neutral-900">
         <tr>
           {headers.map((header, index) => (

--- a/frontend/app/src/shared/components/editor/csv-table.tsx
+++ b/frontend/app/src/shared/components/editor/csv-table.tsx
@@ -1,0 +1,69 @@
+import { classNames } from "@/shared/utils/common";
+
+interface CsvTableProps {
+  content: string;
+}
+
+const parseCSV = (csv: string): string[][] => {
+  const lines = csv.trim().split("\n");
+  return lines.map((line) => {
+    const values: string[] = [];
+    let current = "";
+    let inQuotes = false;
+
+    for (const char of line) {
+      if (char === '"') {
+        inQuotes = !inQuotes;
+      } else if (char === "," && !inQuotes) {
+        values.push(current.trim());
+        current = "";
+      } else {
+        current += char;
+      }
+    }
+    values.push(current.trim());
+    return values;
+  });
+};
+
+const cellStyle = "whitespace-nowrap border border-neutral-700 px-4 py-3";
+
+export function CsvTable({ content }: CsvTableProps) {
+  const rows = parseCSV(content);
+
+  if (!rows[0]) {
+    return <div className="text-neutral-400 text-sm">No data available</div>;
+  }
+
+  const headers = rows[0];
+  const dataRows = rows.slice(1);
+
+  return (
+    <table className="min-w-full border-collapse border border-neutral-700 text-sm">
+      <thead className="bg-neutral-900">
+        <tr>
+          {headers.map((header, index) => (
+            <th
+              key={index}
+              className={classNames(cellStyle, "font-semibold text-xs uppercase tracking-wider")}
+            >
+              {header}
+            </th>
+          ))}
+        </tr>
+      </thead>
+
+      <tbody>
+        {dataRows.map((row, rowIndex) => (
+          <tr key={rowIndex} className="hover:bg-neutral-900">
+            {row.map((cell, cellIndex) => (
+              <td key={cellIndex} className={cellStyle}>
+                {cell}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}


### PR DESCRIPTION
issue:
- #7294 

<img width="2398" height="552" alt="image" src="https://github.com/user-attachments/assets/bbbaa9a1-e729-4bfa-818b-dfd751c63c63" />
<img width="2398" height="552" alt="image" src="https://github.com/user-attachments/assets/c08f2f5f-a77f-4434-a71f-8d4277de4f83" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added native viewing for XML and CSV artifacts with formatted display (CSV rendered as a table).

- Bug Fixes
  - Unrecognized artifact content types now fall back to plain text to avoid blank or broken displays.
  - Improved robustness of artifact headers and content rendering for consistent display across supported and unsupported types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->