### PR TITLE
Fixed number pool popover position issue on initial render

### DIFF
--- a/changelog/+ui-number-pool.fixed.md
+++ b/changelog/+ui-number-pool.fixed.md
@@ -1,0 +1,1 @@
+Fixed issue with number pool popover stuck in the top-left corner and not expandable during the initial render in some cases.

--- a/frontend/app/src/entities/resource-manager/api/get-number-pools-from-api.ts
+++ b/frontend/app/src/entities/resource-manager/api/get-number-pools-from-api.ts
@@ -9,11 +9,8 @@ export const GET_NUMBER_POOLS = gql`
       edges {
         node {
           id
+          hfid
           display_label
-          name {
-            id
-            value
-          }
           node {
             id
             value

--- a/frontend/app/src/entities/resource-manager/domain/get-number-pools.query.ts
+++ b/frontend/app/src/entities/resource-manager/domain/get-number-pools.query.ts
@@ -1,10 +1,10 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
+import { useAtomValue } from "jotai";
 
 import { ContextParams } from "@/shared/api/types";
-import { store } from "@/shared/stores";
 import { datetimeAtom } from "@/shared/stores/time.atom";
 
-import { getCurrentBranchName } from "@/entities/branches/domain/get-current-branch";
+import { useCurrentBranch } from "@/entities/branches/ui/branches-provider";
 import { NUMBER_POOL_KIND } from "@/entities/resource-manager/constants";
 
 import { GetNumberPoolsParams, getNumberPools } from "./get-number-pools";
@@ -19,12 +19,12 @@ export function getNumberPoolsQueryOptions(params: GetNumberPoolsParams) {
 export function useGetNumberPools({
   objectKinds,
 }: Omit<GetNumberPoolsParams, keyof ContextParams>) {
-  const currentBranchName = getCurrentBranchName();
-  const timeMachineDate = store.get(datetimeAtom);
+  const { currentBranch } = useCurrentBranch();
+  const timeMachineDate = useAtomValue(datetimeAtom);
 
   return useQuery(
     getNumberPoolsQueryOptions({
-      branchName: currentBranchName,
+      branchName: currentBranch.name,
       atDate: timeMachineDate,
       objectKinds,
     })

--- a/frontend/app/src/entities/resource-manager/domain/get-number-pools.ts
+++ b/frontend/app/src/entities/resource-manager/domain/get-number-pools.ts
@@ -16,13 +16,14 @@ export const getNumberPools: GetNumberPools = async (params) => {
     throw new Error(errors[0].message);
   }
 
-  return data[NUMBER_POOL_KIND].edges.map(({ node }: any) => ({
-    id: node.id,
-    label: node.display_label,
-    kind: node.__typename,
-    nodeAttribute: {
-      id: node.node_attribute.id,
-      name: node.node_attribute.value,
-    },
-  }));
+  return data[NUMBER_POOL_KIND].edges.map(
+    ({ node }: any): NumberPool => ({
+      id: node.id,
+      hfid: node.hfid,
+      display_label: node.display_label,
+      __typename: node.__typename,
+      schemaKind: node.node.value,
+      attributeName: node.node_attribute.value,
+    })
+  );
 };

--- a/frontend/app/src/entities/resource-manager/domain/type.ts
+++ b/frontend/app/src/entities/resource-manager/domain/type.ts
@@ -1,9 +1,6 @@
-export type NumberPool = {
-  id: string;
-  label: string;
-  kind: string;
-  nodeAttribute: {
-    id: string;
-    name: string;
-  };
-};
+import { NodeCore } from "@/entities/nodes/types";
+
+export interface NumberPool extends NodeCore {
+  schemaKind: string;
+  attributeName: string;
+}

--- a/frontend/app/src/shared/components/form/fields/input.field.tsx
+++ b/frontend/app/src/shared/components/form/fields/input.field.tsx
@@ -53,7 +53,7 @@ const InputField = ({
               fieldData={fieldData}
             />
 
-            <Row>
+            <Row className="gap-1">
               <FormInput>
                 {!selectedPoolId || override ? (
                   <Input

--- a/frontend/app/src/shared/components/form/pool-selector.tsx
+++ b/frontend/app/src/shared/components/form/pool-selector.tsx
@@ -1,13 +1,18 @@
 import { Icon } from "@iconify-icon/react";
+import { PopoverTriggerProps } from "@radix-ui/react-popover";
 import { Slot } from "@radix-ui/react-slot";
-import React, { forwardRef } from "react";
+import React from "react";
+import { Button as AriaButton } from "react-aria-components";
 
-import { Button } from "@/shared/components/buttons/button-primitive";
+import { Row } from "@/shared/components/container";
 import { FormFieldValue } from "@/shared/components/form/type";
 import { ComboboxContent, ComboboxItem, ComboboxList } from "@/shared/components/ui/combobox";
-import { Popover, PopoverAnchor, PopoverTrigger } from "@/shared/components/ui/popover";
+import { Popover, PopoverTrigger } from "@/shared/components/ui/popover";
+import { inputStyle } from "@/shared/components/ui/style";
 import { Tooltip } from "@/shared/components/ui/tooltip";
+import { classNames } from "@/shared/utils/common";
 
+import { getNodeLabel } from "@/entities/nodes/object/utils/get-node-label";
 import { NumberPool } from "@/entities/resource-manager/domain/type";
 
 export type PoolValue = {
@@ -25,73 +30,67 @@ type PoolSelectorProps = {
   value: FormFieldValue;
 };
 
-export const PoolSelector = forwardRef<HTMLElement, PoolSelectorProps>(
-  ({ children, onChange, value, pools }, ref) => {
-    const [override, setOverride] = React.useState(false);
+export function PoolSelector({ children, onChange, value, pools }: PoolSelectorProps) {
+  const [override, setOverride] = React.useState(false);
 
-    const items = pools.map((pool) => ({
-      label: pool.label,
-      value: {
-        from_pool: {
-          id: pool.id,
-          name: pool.label,
-          kind: pool.kind,
-        },
-      },
-    }));
+  const displayFromPool =
+    typeof value.value === "object" && value.value && "from_pool" in value.value;
 
-    const displayFromPool =
-      typeof value.value === "object" && value.value && "from_pool" in value.value;
+  return (
+    <Popover>
+      <Row className="gap-1">
+        {value.source?.type !== "pool" || override || !displayFromPool ? (
+          <Slot autoFocus={override} onBlur={() => setOverride(false)}>
+            {children}
+          </Slot>
+        ) : (
+          <AriaButton onClick={() => setOverride(true)} className={inputStyle}>
+            Allocated by pool
+          </AriaButton>
+        )}
 
-    return (
-      <Popover>
-        <div className="flex w-full gap-1">
-          <PopoverAnchor asChild>
-            {value.source?.type !== "pool" || override || !displayFromPool ? (
-              <Slot autoFocus={override} onBlur={() => setOverride(false)} ref={ref}>
-                {children}
-              </Slot>
-            ) : (
-              <Button
-                variant="outline"
-                onClick={() => setOverride(true)}
-                className="flex h-10 w-full justify-start gap-2 border-gray-300 px-2 font-normal shadow-none"
-              >
-                <Icon icon="mdi:view-grid-outline" />
-                <span>{value.source.label}</span>
-              </Button>
-            )}
-          </PopoverAnchor>
+        <PoolPopoverTrigger data-testid="number-pool-button" />
+      </Row>
 
-          <Tooltip content="select a pool" enabled>
-            <PopoverTrigger asChild>
-              <Button
-                variant="outline"
-                className="h-10 w-10 border-gray-300"
-                data-testid="number-pool-button"
-              >
-                <Icon icon="mdi:view-grid-outline" className="text-gray-500" />
-              </Button>
-            </PopoverTrigger>
-          </Tooltip>
-        </div>
-
-        <ComboboxContent portal={true}>
-          <ComboboxList>
-            {items.map((item) => (
+      <ComboboxContent align="end" fitTriggerWidth={false} portal>
+        <ComboboxList>
+          {pools.map((pool) => {
+            const poolLabel = getNodeLabel(pool);
+            return (
               <ComboboxItem
-                key={item.value.from_pool.id}
-                value={item.value.from_pool.id}
-                keywords={[item.label]}
-                onSelect={() => onChange(item.value)}
+                key={pool.id}
+                value={pool.id}
+                keywords={[pool.display_label!, pool.id]}
+                onSelect={() =>
+                  onChange({
+                    from_pool: {
+                      id: pool.id,
+                      name: poolLabel,
+                      kind: pool.__typename,
+                    },
+                  })
+                }
                 selectedValue={value?.source?.id}
               >
-                {item.label}
+                {poolLabel}
               </ComboboxItem>
-            ))}
-          </ComboboxList>
-        </ComboboxContent>
-      </Popover>
-    );
-  }
-);
+            );
+          })}
+        </ComboboxList>
+      </ComboboxContent>
+    </Popover>
+  );
+}
+
+export function PoolPopoverTrigger({ className, ...props }: PopoverTriggerProps) {
+  return (
+    <Tooltip content="select a pool" enabled>
+      <PopoverTrigger
+        className={classNames(inputStyle, "size-10 shrink-0 justify-center", className)}
+        {...props}
+      >
+        <Icon icon="mdi:view-grid-outline" className="text-gray-500" />
+      </PopoverTrigger>
+    </Tooltip>
+  );
+}

--- a/frontend/app/src/shared/components/form/pool-selector.tsx
+++ b/frontend/app/src/shared/components/form/pool-selector.tsx
@@ -60,7 +60,7 @@ export function PoolSelector({ children, onChange, value, pools }: PoolSelectorP
               <ComboboxItem
                 key={pool.id}
                 value={pool.id}
-                keywords={[pool.display_label!, pool.id]}
+                keywords={[poolLabel, pool.id]}
                 onSelect={() =>
                   onChange({
                     from_pool: {

--- a/frontend/app/src/shared/components/form/utils/getFormFieldFromAttribute.ts
+++ b/frontend/app/src/shared/components/form/utils/getFormFieldFromAttribute.ts
@@ -150,7 +150,7 @@ export const getFormFieldFromAttribute = ({
   }
 
   if (attributeSchema.kind === ATTRIBUTE_KIND.NUMBER) {
-    const numberPools = pools?.filter((pool) => pool.nodeAttribute.name === attributeSchema.name);
+    const numberPools = pools?.filter((pool) => pool.attributeName === attributeSchema.name);
 
     const dropdownField: DynamicNumberFieldProps = {
       ...basicFormFieldProps,

--- a/frontend/app/src/shared/components/inputs/pool-select.tsx
+++ b/frontend/app/src/shared/components/inputs/pool-select.tsx
@@ -1,11 +1,7 @@
-import { Icon } from "@iconify-icon/react";
 import React from "react";
 
-import { Button } from "@/shared/components/buttons/button-primitive";
-import { PoolValue } from "@/shared/components/form/pool-selector";
+import { PoolPopoverTrigger, PoolValue } from "@/shared/components/form/pool-selector";
 import { Combobox, ComboboxContent } from "@/shared/components/ui/combobox";
-import { PopoverTrigger } from "@/shared/components/ui/popover";
-import { Tooltip } from "@/shared/components/ui/tooltip";
 
 import { RelationshipComboboxList } from "@/entities/nodes/relationships/ui/relationship-combobox-list";
 import { IP_ADDRESS_POOL, IP_PREFIX_POOL } from "@/entities/resource-manager/constants";
@@ -47,17 +43,7 @@ export function PoolSelect({
 
   return (
     <Combobox open={isOpen} onOpenChange={setIsOpen}>
-      <Tooltip content="select a pool" enabled>
-        <PopoverTrigger asChild>
-          <Button
-            variant="outline"
-            className="h-10 w-10 border-gray-300"
-            data-testid="select-open-pool-option-button"
-          >
-            <Icon icon="mdi:view-grid-outline" className="text-gray-500" />
-          </Button>
-        </PopoverTrigger>
-      </Tooltip>
+      <PoolPopoverTrigger data-testid="select-open-pool-option-button" />
 
       <ComboboxContent align="end" fitTriggerWidth={false}>
         <RelationshipComboboxList


### PR DESCRIPTION
Bonus: cleaned up some code related to fetching number pool and types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Fixed number pool popover sometimes appearing in the top-left and not expanding on initial render.

- Improvements
  - Streamlined pool selector trigger and selection flow for a smoother, more consistent experience.
  - More accurate matching of pools for NUMBER fields to show relevant options.

- UI/Style
  - Minor spacing adjustments in input rows for improved layout.

- Documentation
  - Added changelog entry describing the popover fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->