### PR TITLE
Update Prefect to 3.4.22

### DIFF
--- a/backend/tests/helpers/utils.py
+++ b/backend/tests/helpers/utils.py
@@ -44,7 +44,7 @@ def start_prefect_server_container(
 
     prefect_base = Path(Path(__file__).parent.resolve() / "./../../infrahub/prefect_server")
     container = (
-        DockerContainer(image="prefecthq/prefect:3.4.19-python3.12")
+        DockerContainer(image="prefecthq/prefect:3.4.22-python3.12")
         .with_command("uvicorn --host 0.0.0.0 --port 4200 --factory prefect_server.app:create_infrahub_prefect")
         .with_exposed_ports(PORT_PREFECT)
         .with_volume_mapping(host=str(prefect_base), container="/opt/prefect/prefect_server", mode="ro")

--- a/poetry.lock
+++ b/poetry.lock
@@ -3811,14 +3811,14 @@ virtualenv = ">=20.10.0"
 
 [[package]]
 name = "prefect"
-version = "3.4.19"
+version = "3.4.22"
 description = "Workflow orchestration and management."
 optional = false
 python-versions = "<3.14,>=3.9"
 groups = ["main"]
 files = [
-    {file = "prefect-3.4.19-py3-none-any.whl", hash = "sha256:64c1d6c933c750298b5f7a977f1f80bd255943e2c93ee6f2d4a66f55345944b4"},
-    {file = "prefect-3.4.19.tar.gz", hash = "sha256:a42d0ddc1bc14c25d97bbcabe350ef5e2d667beddad977fb6ec60141f666950c"},
+    {file = "prefect-3.4.22-py3-none-any.whl", hash = "sha256:41743e2817195e1ef8fdef2e65c4b16da1308cf8f5dd1a85e679c8cbe7186710"},
+    {file = "prefect-3.4.22.tar.gz", hash = "sha256:4b46a793e9907a4c8539b04bb2fdbc609c9810f690d7673a3bc8d0c9aebdfc84"},
 ]
 
 [package.dependencies]
@@ -3870,7 +3870,7 @@ semver = ">=3.0.4"
 sniffio = ">=1.3.0,<2.0.0"
 sqlalchemy = {version = ">=2.0,<3.0.0", extras = ["asyncio"]}
 toml = ">=0.10.0"
-typer = ">=0.12.0,<0.12.2 || >0.12.2,<0.18.0"
+typer = ">=0.12.0,<0.12.2 || >0.12.2,<0.20.0"
 typing-extensions = ">=4.10.0,<5.0.0"
 uv = ">=0.6.0"
 uvicorn = ">=0.14.0,<0.29.0 || >0.29.0"
@@ -6494,4 +6494,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12, < 3.13"
-content-hash = "30241dc6978e0109cc3b73940f7012a2af0c538724cf0db7204886d4ac5ccc44"
+content-hash = "aad2211d899392c6c56b90f65f1a37e5a69ee06863b9d584b9fa7fd2be65d696"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ boto3 = "1.34.129"
 email-validator = "~2.1"
 redis = { version = "^6.0.0", extras = ["hiredis"] }
 typer = "0.12.5"
-prefect = "3.4.19"
+prefect = "3.4.22"
 prefect-redis = "0.2.4"
 ujson = "^5"
 Jinja2 = "^3"

--- a/python_testcontainers/poetry.lock
+++ b/python_testcontainers/poetry.lock
@@ -935,14 +935,14 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "prefect-client"
-version = "3.4.19"
+version = "3.4.22"
 description = "Workflow orchestration and management."
 optional = false
 python-versions = "<3.14,>=3.9"
 groups = ["main"]
 files = [
-    {file = "prefect_client-3.4.19-py3-none-any.whl", hash = "sha256:65c05e9d54bd1b0768845d781ad6d84c5d4ce355dbb85dbc60577a60c2f25aa3"},
-    {file = "prefect_client-3.4.19.tar.gz", hash = "sha256:ab93d2bf52bf5edc0e3a1e3e19cfc6399b24a6631ee4195a7746b1f6d70f4c0b"},
+    {file = "prefect_client-3.4.22-py3-none-any.whl", hash = "sha256:d9232a19f6c43a1bac27ff2689975e3fa43a41977f113bf65d1a8cdbc5afbeaf"},
+    {file = "prefect_client-3.4.22.tar.gz", hash = "sha256:2eef32510aa37e78e74eeb056aff84124752412aa7b4acebbf86bbe90d00168e"},
 ]
 
 [package.dependencies]
@@ -2321,4 +2321,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9, < 3.14"
-content-hash = "bad23c12ab70fa58954793c1f428f53d124deee499733fefe3375a23d5fa6286"
+content-hash = "106bfdd8f953f9f1ac7f0144365cfe0fba069a0f835b1583356242594a6c4e04"

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -39,7 +39,7 @@ psutil = "*"
 pytest = "*"
 httpx = "^0.28.1"
 pydantic = "^2.10.6"
-prefect-client = "3.4.19"
+prefect-client = "3.4.22"
 
 [tool.poetry.group.dev.dependencies]
 rich = "^13.9.4"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated Prefect and Prefect Client dependencies to version 3.4.22.
  - Refreshed Prefect server Docker image to 3.4.22 (Python 3.12).
  - Aligns local/test environments with the latest Prefect patch for improved compatibility and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->