### PR TITLE
IFC-1496: Check optional node kind value

### DIFF
--- a/backend/infrahub/graphql/mutations/webhook.py
+++ b/backend/infrahub/graphql/mutations/webhook.py
@@ -127,7 +127,7 @@ class InfrahubWebhookMutation(InfrahubMutationMixin, Mutation):
 
 
 def _validate_input(graphql_context: GraphqlContext, branch: Branch, input_data: WebhookCreate) -> None:
-    if input_data.node_kind:
+    if input_data.node_kind and input_data.node_kind.value:
         # Validate that the requested node_kind exists, will raise an error if not
         graphql_context.db.schema.get(name=input_data.node_kind.value, branch=branch, duplicate=False)
 

--- a/backend/tests/unit/graphql/mutations/test_webhook.py
+++ b/backend/tests/unit/graphql/mutations/test_webhook.py
@@ -82,6 +82,9 @@ async def test_update_webhook_with_optional_node_kind(
     assert not result.errors
     assert result.data
     webhook_id = result.data["CoreStandardWebhookCreate"]["object"]["id"]
+    webhook = await NodeManager.get_one_by_id_or_default_filter(db=db, id=webhook_id, kind=CoreStandardWebhook)
+    assert webhook.name.value == "builtin-tag-update-1"
+    assert webhook.node_kind.value == "BuiltinTag"
 
     result = await graphql(
         schema=gql_params.schema,
@@ -96,7 +99,7 @@ async def test_update_webhook_with_optional_node_kind(
     assert not result.errors
     assert result.data
     updated_webhook = await NodeManager.get_one_by_id_or_default_filter(db=db, id=webhook_id, kind=CoreStandardWebhook)
-    assert not updated_webhook.node_kind.value
+    assert updated_webhook.node_kind.value is None
 
 
 async def test_create_webhook_with_node_kind_and_all_events(

--- a/backend/tests/unit/graphql/mutations/test_webhook.py
+++ b/backend/tests/unit/graphql/mutations/test_webhook.py
@@ -68,6 +68,37 @@ async def test_create_webhook_with_node_kind_and_valid_node_event(
     assert webhook.event_type.value.value == "infrahub.node.created"
 
 
+async def test_update_webhook_with_optional_node_kind(
+    db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch
+) -> None:
+    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    result = await graphql(
+        schema=gql_params.schema,
+        source=CREATE_WEBHOOK,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={"name": "builtin-tag-update-1", "node_kind": "BuiltinTag", "event_type": "all"},
+    )
+    assert not result.errors
+    assert result.data
+    webhook_id = result.data["CoreStandardWebhookCreate"]["object"]["id"]
+
+    result = await graphql(
+        schema=gql_params.schema,
+        source=UPDATE_WEBHOOK,
+        context_value=gql_params.context,
+        root_value=None,
+        variable_values={
+            "id": webhook_id,
+            "node_kind": None,
+        },
+    )
+    assert not result.errors
+    assert result.data
+    updated_webhook = await NodeManager.get_one_by_id_or_default_filter(db=db, id=webhook_id, kind=CoreStandardWebhook)
+    assert not updated_webhook.node_kind.value
+
+
 async def test_create_webhook_with_node_kind_and_all_events(
     db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch
 ) -> None:

--- a/changelog/6397.fixed.md
+++ b/changelog/6397.fixed.md
@@ -1,0 +1,1 @@
+Allow optional node kind value

--- a/changelog/6397.fixed.md
+++ b/changelog/6397.fixed.md
@@ -1,1 +1,1 @@
-Allow optional node kind value
+Bugfix to allow updating the node kind to null when creating or updating a webhook


### PR DESCRIPTION
Fixes https://github.com/opsmill/infrahub/issues/6397

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updating or creating a webhook no longer fails when the node type field is omitted or explicitly cleared; empty node kind is now treated as optional to avoid unnecessary validation errors.

* **Tests**
  * Added a test verifying webhooks can be created and updated with the node type removed without errors.

* **Documentation**
  * Added a changelog entry documenting the optional node kind behavior for webhook create/update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->