### PR TITLE
Update display label/hfid triggers for local nodes

### DIFF
--- a/backend/infrahub/display_labels/models.py
+++ b/backend/infrahub/display_labels/models.py
@@ -53,7 +53,9 @@ class DisplayLabelTriggerDefinition(TriggerBranchDefinition):
                     branch=branch,
                     node_kind=node_kind,
                     target_kind=node_kind,
-                    fields=template_label.fields + ["!display_label"],
+                    fields=[
+                        "_trigger_placeholder"
+                    ],  # Triggers for the nodes themselves are only used to determine if all nodes should be regenerated
                     template_hash=template_label.get_hash(),
                     branches_out_of_scope=branches_out_of_scope,
                 )

--- a/backend/infrahub/hfid/models.py
+++ b/backend/infrahub/hfid/models.py
@@ -53,7 +53,9 @@ class HFIDTriggerDefinition(TriggerBranchDefinition):
                     branch=branch,
                     node_kind=node_kind,
                     target_kind=node_kind,
-                    fields=hfid_definition.fields + ["!human_friendly_id"],
+                    fields=[
+                        "_trigger_placeholder"
+                    ],  # Triggers for the nodes themselves are only used to determine if all nodes should be regenerated
                     hfid_hash=hfid_definition.get_hash(),
                     branches_out_of_scope=branches_out_of_scope,
                 )

--- a/backend/tests/unit/display_labels/test_gather.py
+++ b/backend/tests/unit/display_labels/test_gather.py
@@ -99,4 +99,4 @@ async def test_gather_trigger_gather_trigger_display_labels_jinja2_custom_schema
     assert test_car_trigger.trigger.match == {"infrahub.node.kind": "TestCar"}
     assert isinstance(test_car_trigger.trigger.match_related, dict)
     assert "infrahub.field.name" in test_car_trigger.trigger.match_related
-    assert sorted(test_car_trigger.trigger.match_related["infrahub.field.name"]) == ["!display_label", "name", "owner"]
+    assert sorted(test_car_trigger.trigger.match_related["infrahub.field.name"]) == ["_trigger_placeholder"]


### PR DESCRIPTION
The exclusion of `display_label` or `human_friendly_id` as previously implemented was incorrect and caused excessive updates with the triggers. This PR changes the previous behaviour so that these triggers are never fired. The reason being that updates for direct node mutations are always managed directly by the API worker.

The reason for now to keep them as jobs is that if the schema changes we want to trigger on this to re-render all nodes of a given type. At some point we'll want to have this behaviour live elsewhere to avoid having triggers within Prefect that are only used for tracking.