### PR TITLE
Remove requirement for docstrings

### DIFF
--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -9,7 +9,6 @@ applyTo: '**/*.py'
 - Use `async def` for asynchronous functions
 - Use `await` for asynchronous calls
 - Use Pydantic models for dataclasses
-- All python functions should have a docstring
 
 ## Formatting and Linting
 


### PR DESCRIPTION
We currently don't require docstrings on all functions and we're not sure we want to do that internally within Infrahub. However as we have this rule in the guidelines for coding style CodeRabbit is constantly complaining about the lack of docstrings in PR reviews even if those functions are not always part of the PR.

It could be that we revisit this at a point where docstrings are added throughout the code base, until then it just generates noise we don't want.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Updated Python contributor guidelines by removing the blanket requirement that all functions include a docstring.
  * No changes to formatting, typing, or tooling recommendations.
  * Clarifies expectations for code comments without altering runtime or interfaces.
  * No impact on app behavior or user-facing features.
  * Users will see no changes in features, performance, or compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->