### PR TITLE
fix: update redis to latest 7.2

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -279,7 +279,7 @@ def redis_container(request: pytest.FixtureRequest, load_settings_before_session
     if not INFRAHUB_USE_TEST_CONTAINERS or config.SETTINGS.cache.driver != config.CacheDriver.Redis:
         return None
 
-    container = DockerContainer(image="redis:7.2.4").with_exposed_ports(PORT_REDIS)
+    container = DockerContainer(image="redis:7.2.11").with_exposed_ports(PORT_REDIS)
 
     container.start()
     wait_for_logs(container, "Ready to accept connections tcp")  # wait_container_is_ready does not seem to be enough

--- a/development/docker-compose-deps.yml
+++ b/development/docker-compose-deps.yml
@@ -16,7 +16,7 @@ services:
       start_period: 3s
   cache:
     profiles: [demo, dev]
-    image: "${CACHE_DOCKER_IMAGE:-redis:7.2.4}"
+    image: "${CACHE_DOCKER_IMAGE:-redis:7.2.11}"
     healthcheck:
       test: ["CMD-SHELL", "redis-cli ping | grep PONG"]
       interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,7 +170,7 @@ services:
       - 15692:15692
 
   cache:
-    image: ${CACHE_DOCKER_IMAGE:-redis:7.2.4}
+    image: ${CACHE_DOCKER_IMAGE:-redis:7.2.11}
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "redis-cli ping | grep PONG"]

--- a/python_testcontainers/infrahub_testcontainers/container.py
+++ b/python_testcontainers/infrahub_testcontainers/container.py
@@ -29,7 +29,7 @@ INFRAHUB_SERVICES: dict[str, ContainerService] = {
 
 PROJECT_ENV_VARIABLES: dict[str, str] = {
     "MESSAGE_QUEUE_DOCKER_IMAGE": "rabbitmq:3.13.7-management",
-    "CACHE_DOCKER_IMAGE": "redis:7.2.4",
+    "CACHE_DOCKER_IMAGE": "redis:7.2.11",
     "INFRAHUB_TESTING_DOCKER_IMAGE": "registry.opsmill.io/opsmill/infrahub",
     "INFRAHUB_TESTING_DOCKER_ENTRYPOINT": f"gunicorn --config backend/infrahub/serve/gunicorn_config.py -w {os.environ.get('INFRAHUB_TESTING_WEB_CONCURRENCY', 4)} --logger-class infrahub.serve.log.GunicornLogger infrahub.server:app",  # noqa: E501
     "INFRAHUB_TESTING_IMAGE_VERSION": infrahub_version,

--- a/python_testcontainers/infrahub_testcontainers/docker-compose-cluster.test.yml
+++ b/python_testcontainers/infrahub_testcontainers/docker-compose-cluster.test.yml
@@ -37,7 +37,7 @@ services:
       - ${INFRAHUB_TESTING_MESSAGE_QUEUE_PORT:-0}:15692
 
   cache:
-    image: ${CACHE_DOCKER_IMAGE:-redis:7.2.4}
+    image: ${CACHE_DOCKER_IMAGE:-redis:7.2.11}
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "redis-cli ping | grep PONG"]

--- a/python_testcontainers/infrahub_testcontainers/docker-compose.test.yml
+++ b/python_testcontainers/infrahub_testcontainers/docker-compose.test.yml
@@ -20,7 +20,7 @@ services:
       - ${INFRAHUB_TESTING_MESSAGE_QUEUE_PORT:-0}:15692
 
   cache:
-    image: ${CACHE_DOCKER_IMAGE:-redis:7.2.4}
+    image: ${CACHE_DOCKER_IMAGE:-redis:7.2.11}
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "redis-cli ping | grep PONG"]

--- a/tasks/shared.py
+++ b/tasks/shared.py
@@ -48,7 +48,7 @@ MESSAGE_QUEUE_DOCKER_IMAGE = os.getenv(
 )
 CACHE_DOCKER_IMAGE = os.getenv(
     "CACHE_DOCKER_IMAGE",
-    "redis:7.2.4" if not INFRAHUB_USE_NATS else "nats:2.10.14-alpine",
+    "redis:7.2.11" if not INFRAHUB_USE_NATS else "nats:2.10.14-alpine",
 )
 
 here = Path(__file__).parent.resolve()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - None
- Tests
  - Test environments now use Redis 7.2.11 for cache services.
- Chores
  - Updated default Redis image to 7.2.11 across development and CI/docker configurations for improved stability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->