### PR TITLE
add profile support for schema changes that add or remove attributes

### DIFF
--- a/backend/infrahub/core/migrations/__init__.py
+++ b/backend/infrahub/core/migrations/__init__.py
@@ -1,5 +1,6 @@
 from .schema.attribute_kind_update import AttributeKindUpdateMigration
 from .schema.attribute_name_update import AttributeNameUpdateMigration
+from .schema.attribute_supports_profile import AttributeSupportsProfileUpdateMigration
 from .schema.node_attribute_add import NodeAttributeAddMigration
 from .schema.node_attribute_remove import NodeAttributeRemoveMigration
 from .schema.node_kind_update import NodeKindUpdateMigration
@@ -19,6 +20,8 @@ MIGRATION_MAP: dict[str, type[SchemaMigration] | None] = {
     "attribute.name.update": AttributeNameUpdateMigration,
     "attribute.branch.update": None,
     "attribute.kind.update": AttributeKindUpdateMigration,
+    "attribute.optional.update": AttributeSupportsProfileUpdateMigration,
+    "attribute.read_only.update": AttributeSupportsProfileUpdateMigration,
     "relationship.branch.update": None,
     "relationship.direction.update": None,
     "relationship.identifier.update": PlaceholderDummyMigration,

--- a/backend/infrahub/core/migrations/graph/m013_convert_git_password_credential.py
+++ b/backend/infrahub/core/migrations/graph/m013_convert_git_password_credential.py
@@ -286,7 +286,7 @@ class Migration013AddInternalStatusData(AttributeAddQuery):
         kwargs.pop("branch", None)
 
         super().__init__(
-            node_kind="CoreGenericRepository",
+            node_kinds=["CoreGenericRepository"],
             attribute_name="internal_status",
             attribute_kind="Dropdown",
             branch_support=BranchSupportType.LOCAL.value,

--- a/backend/infrahub/core/migrations/query/__init__.py
+++ b/backend/infrahub/core/migrations/query/__init__.py
@@ -8,7 +8,12 @@ if TYPE_CHECKING:
     from ..shared import AttributeSchemaMigration, SchemaMigration
 
 
-class MigrationQuery(Query):
+class MigrationBaseQuery(Query):
+    def get_nbr_migrations_executed(self) -> int:
+        return self.num_of_results
+
+
+class MigrationQuery(MigrationBaseQuery):
     type: QueryType = QueryType.WRITE
 
     def __init__(
@@ -19,11 +24,8 @@ class MigrationQuery(Query):
         self.migration = migration
         super().__init__(**kwargs)
 
-    def get_nbr_migrations_executed(self) -> int:
-        return self.num_of_results
 
-
-class AttributeMigrationQuery(Query):
+class AttributeMigrationQuery(MigrationBaseQuery):
     type: QueryType = QueryType.WRITE
 
     def __init__(
@@ -33,6 +35,3 @@ class AttributeMigrationQuery(Query):
     ):
         self.migration = migration
         super().__init__(**kwargs)
-
-    def get_nbr_migrations_executed(self) -> int:
-        return self.num_of_results

--- a/backend/infrahub/core/migrations/query/attribute_add.py
+++ b/backend/infrahub/core/migrations/query/attribute_add.py
@@ -17,14 +17,14 @@ class AttributeAddQuery(Query):
 
     def __init__(
         self,
-        node_kind: str,
+        node_kinds: list[str],
         attribute_name: str,
         attribute_kind: str,
         branch_support: str,
         default_value: Any | None = None,
         **kwargs: Any,
     ) -> None:
-        self.node_kind = node_kind
+        self.node_kinds = node_kinds
         self.attribute_name = attribute_name
         self.attribute_kind = attribute_kind
         self.branch_support = branch_support
@@ -36,7 +36,7 @@ class AttributeAddQuery(Query):
         branch_filter, branch_params = self.branch.get_query_filter_path(at=self.at.to_string())
         self.params.update(branch_params)
 
-        self.params["node_kind"] = self.node_kind
+        self.params["node_kinds"] = self.node_kinds
         self.params["attr_name"] = self.attribute_name
         self.params["branch_support"] = self.branch_support
         self.params["current_time"] = self.at.to_string()
@@ -79,12 +79,13 @@ class AttributeAddQuery(Query):
             LIMIT 1
             """ % {"attr_value_label": attr_value_label}
 
+        node_kinds_str = "|".join(self.node_kinds)
         query = """
         %(match_query)s
         MERGE (is_protected_value:Boolean { value: $is_protected_default })
         MERGE (is_visible_value:Boolean { value: $is_visible_default })
         WITH av, is_protected_value, is_visible_value
-        MATCH (n:%(node_kind)s|Profile%(node_kind)s)
+        MATCH (n:%(node_kinds_str)s)
         CALL (n) {
             MATCH (:Root)<-[r:IS_PART_OF]-(n)
             WHERE %(branch_filter)s
@@ -110,7 +111,7 @@ class AttributeAddQuery(Query):
         """ % {
             "match_query": match_query,
             "branch_filter": branch_filter,
-            "node_kind": self.node_kind,
+            "node_kinds_str": node_kinds_str,
             "uuid_generation": db.render_uuid_generation(node_label="a", node_attr="uuid"),
         }
 

--- a/backend/infrahub/core/migrations/query/attribute_add.py
+++ b/backend/infrahub/core/migrations/query/attribute_add.py
@@ -84,7 +84,7 @@ class AttributeAddQuery(Query):
         MERGE (is_protected_value:Boolean { value: $is_protected_default })
         MERGE (is_visible_value:Boolean { value: $is_visible_default })
         WITH av, is_protected_value, is_visible_value
-        MATCH p = (n:%(node_kind)s)
+        MATCH (n:%(node_kind)s|Profile%(node_kind)s)
         CALL (n) {
             MATCH (:Root)<-[r:IS_PART_OF]-(n)
             WHERE %(branch_filter)s

--- a/backend/infrahub/core/migrations/query/attribute_remove.py
+++ b/backend/infrahub/core/migrations/query/attribute_remove.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from infrahub.core.constants import BranchSupportType, RelationshipStatus
+from infrahub.core.graph.schema import GraphAttributeRelationships
+from infrahub.core.query import Query
+from infrahub.core.schema.generic_schema import GenericSchema
+
+if TYPE_CHECKING:
+    from pydantic.fields import FieldInfo
+
+    from infrahub.core.schema.node_schema import NodeSchema
+    from infrahub.database import InfrahubDatabase
+
+
+class AttributeRemoveQuery(Query):
+    name = "attribute_remove"
+    insert_return: bool = False
+
+    def __init__(
+        self,
+        attribute_name: str,
+        new_node_schema: NodeSchema | GenericSchema,
+        branch_support: BranchSupportType,
+        **kwargs: Any,
+    ) -> None:
+        self.attribute_name = attribute_name
+        self.new_node_schema = new_node_schema
+        self.branch_support = branch_support
+        super().__init__(**kwargs)
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
+        branch_filter, branch_params = self.branch.get_query_filter_path(at=self.at.to_string())
+        self.params.update(branch_params)
+
+        kinds_to_ignore = []
+        profile_kinds_to_update = []
+        if isinstance(self.new_node_schema, GenericSchema) and self.attribute_name is not None:
+            for inheriting_schema_kind in self.new_node_schema.used_by:
+                node_schema = db.schema.get_node_schema(
+                    name=inheriting_schema_kind, branch=self.branch, duplicate=False
+                )
+                attr_schema = node_schema.get_attribute_or_none(name=self.attribute_name)
+                if attr_schema and not attr_schema.inherited:
+                    kinds_to_ignore.append(inheriting_schema_kind)
+                else:
+                    profile_kinds_to_update.append(inheriting_schema_kind)
+
+        self.params["kinds_to_ignore"] = kinds_to_ignore
+        self.params["attr_name"] = self.attribute_name
+        self.params["current_time"] = self.at.to_string()
+        self.params["branch_name"] = self.branch.name
+        self.params["branch_support"] = self.branch_support.value
+
+        self.params["rel_props"] = {
+            "branch": self.branch.name,
+            "branch_level": self.branch.hierarchy_level,
+            "status": RelationshipStatus.DELETED.value,
+            "from": self.at.to_string(),
+        }
+
+        def render_sub_query_per_rel_type(rel_type: str, rel_def: FieldInfo) -> str:
+            subquery = [
+                "WITH peer_node, rb, active_attr",
+                f'WHERE type(rb) = "{rel_type}"',
+            ]
+            if rel_def.default.direction.value == "outbound":
+                subquery.append(f"CREATE (active_attr)-[:{rel_type} $rel_props ]->(peer_node)")
+            elif rel_def.default.direction.value == "inbound":
+                subquery.append(f"CREATE (active_attr)<-[:{rel_type} $rel_props ]-(peer_node)")
+            else:
+                subquery.append(f"CREATE (active_attr)-[:{rel_type} $rel_props ]-(peer_node)")
+
+            subquery.append("RETURN peer_node as p2")
+            return "\n".join(subquery)
+
+        sub_queries = [
+            render_sub_query_per_rel_type(rel_type, rel_def)
+            for rel_type, rel_def in GraphAttributeRelationships.model_fields.items()
+        ]
+        sub_query_all = "\nUNION\n".join(sub_queries)
+
+        node_kinds_str = "|".join([self.new_node_schema.kind] + profile_kinds_to_update)
+        query = """
+        // Find all the active nodes
+        MATCH (node:%(node_kinds)s)
+        WHERE (size($kinds_to_ignore) = 0 OR NOT any(l IN labels(node) WHERE l IN $kinds_to_ignore))
+        AND exists((node)-[:HAS_ATTRIBUTE]-(:Attribute { name: $attr_name }))
+        CALL (node) {
+            MATCH (root:Root)<-[r:IS_PART_OF]-(node)
+            WHERE %(branch_filter)s
+            RETURN node as n1, r as r1
+            ORDER BY r.branch_level DESC, r.from DESC
+            LIMIT 1
+        }
+        WITH n1 as active_node, r1 as rb
+        WHERE rb.status = "active"
+        // Find all the attributes that need to be updated
+        CALL (active_node) {
+            MATCH (active_node)-[r:HAS_ATTRIBUTE]-(attr:Attribute { name: $attr_name })
+            WHERE %(branch_filter)s
+            RETURN active_node as n1, r as r1, attr as attr1
+            ORDER BY r.branch_level DESC, r.from DESC
+            LIMIT 1
+        }
+        WITH n1 as active_node, r1 as rb, attr1 as active_attr
+        WHERE rb.status = "active"
+        WITH active_attr
+        MATCH (active_attr)-[]-(peer)
+        WITH DISTINCT active_attr, peer
+        CALL (active_attr, peer) {
+            MATCH (active_attr)-[r]-(peer)
+            WHERE %(branch_filter)s
+            RETURN active_attr as a1, r as r1, peer as p1
+            ORDER BY r.branch_level DESC, r.from DESC
+            LIMIT 1
+        }
+        WITH a1 as active_attr, r1 as rb, p1 as peer_node
+        WHERE rb.status = "active"
+        CALL (peer_node, rb, active_attr) {
+            %(sub_query_all)s
+        }
+        WITH p2 as peer_node, rb, active_attr
+        FOREACH (i in CASE WHEN rb.branch = $branch_name THEN [1] ELSE [] END |
+            SET rb.to = $current_time
+        )
+        RETURN DISTINCT active_attr
+        """ % {
+            "branch_filter": branch_filter,
+            "sub_query_all": sub_query_all,
+            "node_kinds": node_kinds_str,
+        }
+        self.add_to_query(query)

--- a/backend/infrahub/core/migrations/query/attribute_remove.py
+++ b/backend/infrahub/core/migrations/query/attribute_remove.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from infrahub.core.constants import BranchSupportType, RelationshipStatus
+from infrahub.core.constants import RelationshipStatus
 from infrahub.core.graph.schema import GraphAttributeRelationships
 from infrahub.core.query import Query
 from infrahub.core.schema.generic_schema import GenericSchema
@@ -10,7 +10,6 @@ from infrahub.core.schema.generic_schema import GenericSchema
 if TYPE_CHECKING:
     from pydantic.fields import FieldInfo
 
-    from infrahub.core.schema.node_schema import NodeSchema
     from infrahub.database import InfrahubDatabase
 
 
@@ -21,13 +20,11 @@ class AttributeRemoveQuery(Query):
     def __init__(
         self,
         attribute_name: str,
-        new_node_schema: NodeSchema | GenericSchema,
-        branch_support: BranchSupportType,
+        node_kinds: list[str],
         **kwargs: Any,
     ) -> None:
         self.attribute_name = attribute_name
-        self.new_node_schema = new_node_schema
-        self.branch_support = branch_support
+        self.node_kinds = node_kinds
         super().__init__(**kwargs)
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
@@ -36,8 +33,12 @@ class AttributeRemoveQuery(Query):
 
         kinds_to_ignore = []
         profile_kinds_to_update = []
-        if isinstance(self.new_node_schema, GenericSchema) and self.attribute_name is not None:
-            for inheriting_schema_kind in self.new_node_schema.used_by:
+
+        for node_kind in self.node_kinds:
+            new_schema = db.schema.get(name=node_kind, branch=self.branch, duplicate=False)
+
+        if isinstance(new_schema, GenericSchema):
+            for inheriting_schema_kind in new_schema.used_by:
                 node_schema = db.schema.get_node_schema(
                     name=inheriting_schema_kind, branch=self.branch, duplicate=False
                 )
@@ -45,13 +46,12 @@ class AttributeRemoveQuery(Query):
                 if attr_schema and not attr_schema.inherited:
                     kinds_to_ignore.append(inheriting_schema_kind)
                 else:
-                    profile_kinds_to_update.append(inheriting_schema_kind)
+                    profile_kinds_to_update.append(f"Profile{inheriting_schema_kind}")
 
         self.params["kinds_to_ignore"] = kinds_to_ignore
         self.params["attr_name"] = self.attribute_name
         self.params["current_time"] = self.at.to_string()
         self.params["branch_name"] = self.branch.name
-        self.params["branch_support"] = self.branch_support.value
 
         self.params["rel_props"] = {
             "branch": self.branch.name,
@@ -81,7 +81,7 @@ class AttributeRemoveQuery(Query):
         ]
         sub_query_all = "\nUNION\n".join(sub_queries)
 
-        node_kinds_str = "|".join([self.new_node_schema.kind] + profile_kinds_to_update)
+        node_kinds_str = "|".join(self.node_kinds + profile_kinds_to_update)
         query = """
         // Find all the active nodes
         MATCH (node:%(node_kinds)s)

--- a/backend/infrahub/core/migrations/schema/attribute_kind_update.py
+++ b/backend/infrahub/core/migrations/schema/attribute_kind_update.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Sequence
 
 from infrahub.types import is_large_attribute_type
 
-from ..query import AttributeMigrationQuery
+from ..query import AttributeMigrationQuery, MigrationBaseQuery
 from ..shared import AttributeSchemaMigration, MigrationResult
 
 if TYPE_CHECKING:
@@ -147,10 +147,16 @@ class AttributeKindUpdateMigration(AttributeSchemaMigration):
     name: str = "attribute.kind.update"
     queries: Sequence[type[AttributeMigrationQuery]] = [AttributeKindUpdateMigrationQuery]  # type: ignore[assignment]
 
-    async def execute(self, db: InfrahubDatabase, branch: Branch, at: Timestamp | str | None = None) -> MigrationResult:
+    async def execute(
+        self,
+        db: InfrahubDatabase,
+        branch: Branch,
+        at: Timestamp | str | None = None,
+        queries: Sequence[type[MigrationBaseQuery]] | None = None,
+    ) -> MigrationResult:
         is_indexed_previous = is_large_attribute_type(self.previous_attribute_schema.kind)
         is_indexed_new = is_large_attribute_type(self.new_attribute_schema.kind)
         if is_indexed_previous is is_indexed_new:
             return MigrationResult()
 
-        return await super().execute(db=db, branch=branch, at=at)
+        return await super().execute(db=db, branch=branch, at=at, queries=queries)

--- a/backend/infrahub/core/migrations/schema/attribute_supports_profile.py
+++ b/backend/infrahub/core/migrations/schema/attribute_supports_profile.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Sequence
 
 from infrahub.core.migrations.query.attribute_remove import AttributeRemoveQuery
+from infrahub.core.schema.generic_schema import GenericSchema
 from infrahub.core.schema.node_schema import NodeSchema
 
 from ..query import AttributeMigrationQuery, MigrationBaseQuery
@@ -11,12 +12,14 @@ from ..shared import AttributeSchemaMigration, MigrationResult
 
 if TYPE_CHECKING:
     from infrahub.core.branch.models import Branch
-    from infrahub.core.schema.generic_schema import GenericSchema
+    from infrahub.core.schema import MainSchemaTypes
     from infrahub.core.timestamp import Timestamp
     from infrahub.database import InfrahubDatabase
 
 
-def _get_node_kinds(schema: NodeSchema | GenericSchema) -> list[str]:
+def _get_node_kinds(schema: MainSchemaTypes) -> list[str]:
+    if not isinstance(schema, (NodeSchema, GenericSchema)):
+        return [schema.kind]
     schema_kinds = [f"Profile{schema.kind}"]
     if isinstance(schema, NodeSchema) or not schema.used_by:
         return schema_kinds

--- a/backend/infrahub/core/migrations/schema/attribute_supports_profile.py
+++ b/backend/infrahub/core/migrations/schema/attribute_supports_profile.py
@@ -16,27 +16,28 @@ if TYPE_CHECKING:
     from infrahub.database import InfrahubDatabase
 
 
+def _get_node_kinds(schema: NodeSchema | GenericSchema) -> list[str]:
+    schema_kinds = [f"Profile{schema.kind}"]
+    if isinstance(schema, NodeSchema) or not schema.used_by:
+        return schema_kinds
+    return [f"Profile{kind}" for kind in schema.used_by]
+
+
 class ProfilesAttributeAddMigrationQuery(AttributeMigrationQuery, AttributeAddQuery):
     name = "migration_profiles_attribute_add"
-
-    def _get_node_kinds(self, schema: NodeSchema | GenericSchema) -> list[str]:
-        schema_kinds = [f"Profile{schema.kind}"]
-        if isinstance(schema, NodeSchema) or not schema.used_by:
-            return schema_kinds
-        return [f"Profile{kind}" for kind in schema.used_by]
 
     def __init__(
         self,
         migration: AttributeSchemaMigration,
         **kwargs: Any,
     ):
-        node_kinds = self._get_node_kinds(migration.new_schema)
+        node_kinds = _get_node_kinds(migration.new_schema)
         super().__init__(
             migration=migration,
             node_kinds=node_kinds,
             attribute_name=migration.new_attribute_schema.name,
             attribute_kind=migration.new_attribute_schema.kind,
-            branch_support=migration.new_attribute_schema.get_branch().value,
+            branch_support=migration.new_attribute_schema.get_branch(),
             default_value=migration.new_attribute_schema.default_value,
             **kwargs,
         )
@@ -50,11 +51,11 @@ class ProfilesAttributeRemoveMigrationQuery(AttributeMigrationQuery, AttributeRe
         migration: AttributeSchemaMigration,
         **kwargs: Any,
     ):
+        node_kinds = _get_node_kinds(migration.new_schema)
         super().__init__(
             migration=migration,
             attribute_name=migration.new_attribute_schema.name,
-            new_node_schema=migration.new_schema,
-            branch_support=migration.new_attribute_schema.get_branch().value,
+            node_kinds=node_kinds,
             **kwargs,
         )
 

--- a/backend/infrahub/core/migrations/schema/attribute_supports_profile.py
+++ b/backend/infrahub/core/migrations/schema/attribute_supports_profile.py
@@ -21,9 +21,9 @@ def _get_node_kinds(schema: MainSchemaTypes) -> list[str]:
     if not isinstance(schema, (NodeSchema, GenericSchema)):
         return [schema.kind]
     schema_kinds = [f"Profile{schema.kind}"]
-    if isinstance(schema, NodeSchema) or not schema.used_by:
-        return schema_kinds
-    return [f"Profile{kind}" for kind in schema.used_by]
+    if isinstance(schema, GenericSchema) and schema.used_by:
+        schema_kinds += [f"Profile{kind}" for kind in schema.used_by]
+    return schema_kinds
 
 
 class ProfilesAttributeAddMigrationQuery(AttributeMigrationQuery, AttributeAddQuery):

--- a/backend/infrahub/core/migrations/schema/attribute_supports_profile.py
+++ b/backend/infrahub/core/migrations/schema/attribute_supports_profile.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Sequence
+
+from infrahub.core.migrations.query.attribute_remove import AttributeRemoveQuery
+from infrahub.core.schema.node_schema import NodeSchema
+
+from ..query import AttributeMigrationQuery, MigrationBaseQuery
+from ..query.attribute_add import AttributeAddQuery
+from ..shared import AttributeSchemaMigration, MigrationResult
+
+if TYPE_CHECKING:
+    from infrahub.core.branch.models import Branch
+    from infrahub.core.schema.generic_schema import GenericSchema
+    from infrahub.core.timestamp import Timestamp
+    from infrahub.database import InfrahubDatabase
+
+
+class ProfilesAttributeAddMigrationQuery(AttributeMigrationQuery, AttributeAddQuery):
+    name = "migration_profiles_attribute_add"
+
+    def _get_node_kinds(self, schema: NodeSchema | GenericSchema) -> list[str]:
+        schema_kinds = [f"Profile{schema.kind}"]
+        if isinstance(schema, NodeSchema) or not schema.used_by:
+            return schema_kinds
+        return [f"Profile{kind}" for kind in schema.used_by]
+
+    def __init__(
+        self,
+        migration: AttributeSchemaMigration,
+        **kwargs: Any,
+    ):
+        node_kinds = self._get_node_kinds(migration.new_schema)
+        super().__init__(
+            migration=migration,
+            node_kinds=node_kinds,
+            attribute_name=migration.new_attribute_schema.name,
+            attribute_kind=migration.new_attribute_schema.kind,
+            branch_support=migration.new_attribute_schema.get_branch().value,
+            default_value=migration.new_attribute_schema.default_value,
+            **kwargs,
+        )
+
+
+class ProfilesAttributeRemoveMigrationQuery(AttributeMigrationQuery, AttributeRemoveQuery):
+    name = "migration_profiles_attribute_remove"
+
+    def __init__(
+        self,
+        migration: AttributeSchemaMigration,
+        **kwargs: Any,
+    ):
+        super().__init__(
+            migration=migration,
+            attribute_name=migration.new_attribute_schema.name,
+            new_node_schema=migration.new_schema,
+            branch_support=migration.new_attribute_schema.get_branch().value,
+            **kwargs,
+        )
+
+
+class AttributeSupportsProfileUpdateMigration(AttributeSchemaMigration):
+    name: str = "attribute.supports_profile.update"
+    queries: Sequence[type[MigrationBaseQuery]] = []
+
+    async def execute(
+        self,
+        db: InfrahubDatabase,
+        branch: Branch,
+        at: Timestamp | str | None = None,
+        queries: Sequence[type[MigrationBaseQuery]] | None = None,  # noqa: ARG002
+    ) -> MigrationResult:
+        if (
+            # no change in whether the attribute should be used on profiles
+            self.previous_attribute_schema.support_profiles == self.new_attribute_schema.support_profiles
+            # the attribute is new, so there cannot be existing profiles to update
+            or self.previous_attribute_schema.id is None
+        ):
+            return MigrationResult()
+        profiles_queries: list[type[AttributeMigrationQuery]] = []
+        if self.new_attribute_schema.support_profiles:
+            profiles_queries.append(ProfilesAttributeAddMigrationQuery)
+        if not self.new_attribute_schema.support_profiles:
+            profiles_queries.append(ProfilesAttributeRemoveMigrationQuery)
+
+        return await super().execute(db=db, branch=branch, at=at, queries=profiles_queries)

--- a/backend/infrahub/core/migrations/schema/node_attribute_add.py
+++ b/backend/infrahub/core/migrations/schema/node_attribute_add.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Sequence
 from infrahub.core import registry
 from infrahub.core.node import Node
 from infrahub.core.schema.generic_schema import GenericSchema
+from infrahub.core.schema.node_schema import NodeSchema
 from infrahub.exceptions import PoolExhaustedError
 from infrahub.tasks.registry import update_branch_registry
 
@@ -14,8 +15,8 @@ from ..shared import AttributeSchemaMigration, MigrationResult
 
 if TYPE_CHECKING:
     from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
+    from infrahub.core.schema import MainSchemaTypes
     from infrahub.core.schema.attribute_schema import AttributeSchema
-    from infrahub.core.schema.node_schema import NodeSchema
     from infrahub.database import InfrahubDatabase
 
     from ...branch import Branch
@@ -25,8 +26,10 @@ if TYPE_CHECKING:
 class NodeAttributeAddMigrationQuery01(AttributeMigrationQuery, AttributeAddQuery):
     name = "migration_node_attribute_add_01"
 
-    def _get_node_kinds(self, schema: NodeSchema | GenericSchema, new_attribute_schema: AttributeSchema) -> list[str]:
+    def _get_node_kinds(self, schema: MainSchemaTypes, new_attribute_schema: AttributeSchema) -> list[str]:
         schema_kinds = [schema.kind]
+        if not isinstance(schema, (NodeSchema, GenericSchema)):
+            return schema_kinds
         if new_attribute_schema.support_profiles:
             schema_kinds.append(f"Profile{schema.kind}")
             if isinstance(schema, GenericSchema) and schema.used_by:

--- a/backend/infrahub/core/migrations/schema/node_attribute_add.py
+++ b/backend/infrahub/core/migrations/schema/node_attribute_add.py
@@ -9,7 +9,7 @@ from infrahub.core.schema.node_schema import NodeSchema
 from infrahub.exceptions import PoolExhaustedError
 from infrahub.tasks.registry import update_branch_registry
 
-from ..query import AttributeMigrationQuery
+from ..query import AttributeMigrationQuery, MigrationBaseQuery
 from ..query.attribute_add import AttributeAddQuery
 from ..shared import AttributeSchemaMigration, MigrationResult
 
@@ -64,10 +64,11 @@ class NodeAttributeAddMigration(AttributeSchemaMigration):
         db: InfrahubDatabase,
         branch: Branch,
         at: Timestamp | str | None = None,
+        queries: Sequence[type[MigrationBaseQuery]] | None = None,
     ) -> MigrationResult:
         if self.new_attribute_schema.inherited is True:
             return MigrationResult()
-        return await super().execute(db=db, branch=branch, at=at)
+        return await super().execute(db=db, branch=branch, at=at, queries=queries)
 
     async def execute_post_queries(
         self,

--- a/backend/infrahub/core/migrations/schema/node_attribute_add.py
+++ b/backend/infrahub/core/migrations/schema/node_attribute_add.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Sequence
 
 from infrahub.core import registry
 from infrahub.core.node import Node
+from infrahub.core.schema.generic_schema import GenericSchema
 from infrahub.exceptions import PoolExhaustedError
 from infrahub.tasks.registry import update_branch_registry
 
@@ -13,6 +14,8 @@ from ..shared import AttributeSchemaMigration, MigrationResult
 
 if TYPE_CHECKING:
     from infrahub.core.node.resource_manager.number_pool import CoreNumberPool
+    from infrahub.core.schema.attribute_schema import AttributeSchema
+    from infrahub.core.schema.node_schema import NodeSchema
     from infrahub.database import InfrahubDatabase
 
     from ...branch import Branch
@@ -22,14 +25,25 @@ if TYPE_CHECKING:
 class NodeAttributeAddMigrationQuery01(AttributeMigrationQuery, AttributeAddQuery):
     name = "migration_node_attribute_add_01"
 
+    def _get_node_kinds(self, schema: NodeSchema | GenericSchema, new_attribute_schema: AttributeSchema) -> list[str]:
+        schema_kinds = [schema.kind]
+        if new_attribute_schema.support_profiles:
+            schema_kinds.append(f"Profile{schema.kind}")
+            if isinstance(schema, GenericSchema) and schema.used_by:
+                schema_kinds.extend([f"Profile{kind}" for kind in schema.used_by])
+        return schema_kinds
+
     def __init__(
         self,
         migration: AttributeSchemaMigration,
         **kwargs: Any,
     ):
+        node_kinds = self._get_node_kinds(
+            schema=migration.new_schema, new_attribute_schema=migration.new_attribute_schema
+        )
         super().__init__(
             migration=migration,
-            node_kind=migration.new_schema.kind,
+            node_kinds=node_kinds,
             attribute_name=migration.new_attribute_schema.name,
             attribute_kind=migration.new_attribute_schema.kind,
             branch_support=migration.new_attribute_schema.get_branch().value,

--- a/backend/infrahub/core/migrations/schema/node_attribute_remove.py
+++ b/backend/infrahub/core/migrations/schema/node_attribute_remove.py
@@ -71,7 +71,7 @@ class NodeAttributeRemoveMigrationQuery01(AttributeMigrationQuery):
 
         query = """
         // Find all the active nodes
-        MATCH (node:%(node_kind)s)
+        MATCH (node:%(node_kind)s|Profile%(node_kind)s)
         WHERE (size($kinds_to_ignore) = 0 OR NOT any(l IN labels(node) WHERE l IN $kinds_to_ignore))
         AND exists((node)-[:HAS_ATTRIBUTE]-(:Attribute { name: $attr_name }))
         CALL (node) {
@@ -95,6 +95,7 @@ class NodeAttributeRemoveMigrationQuery01(AttributeMigrationQuery):
         WHERE rb.status = "active"
         WITH active_attr
         MATCH (active_attr)-[]-(peer)
+        WITH DISTINCT active_attr, peer
         CALL (active_attr, peer) {
             MATCH (active_attr)-[r]-(peer)
             WHERE %(branch_filter)s

--- a/backend/infrahub/core/migrations/schema/node_attribute_remove.py
+++ b/backend/infrahub/core/migrations/schema/node_attribute_remove.py
@@ -18,9 +18,8 @@ class NodeAttributeRemoveMigrationQuery01(AttributeMigrationQuery, AttributeRemo
     ):
         super().__init__(
             migration=migration,
-            attribute_name=migration.new_attribute_schema.name,
-            new_node_schema=migration.new_schema,
-            branch_support=migration.new_attribute_schema.get_branch().value,
+            attribute_name=migration.previous_attribute_schema.name,
+            node_kinds=[migration.new_schema.kind],
             **kwargs,
         )
 

--- a/backend/infrahub/core/migrations/schema/node_attribute_remove.py
+++ b/backend/infrahub/core/migrations/schema/node_attribute_remove.py
@@ -1,124 +1,28 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence
-
-from infrahub.core.constants import RelationshipStatus
-from infrahub.core.graph.schema import GraphAttributeRelationships
-from infrahub.core.schema.generic_schema import GenericSchema
+from typing import Any, Sequence
 
 from ..query import AttributeMigrationQuery
+from ..query.attribute_remove import AttributeRemoveQuery
 from ..shared import AttributeSchemaMigration
 
-if TYPE_CHECKING:
-    from pydantic.fields import FieldInfo
 
-    from infrahub.database import InfrahubDatabase
-
-
-class NodeAttributeRemoveMigrationQuery01(AttributeMigrationQuery):
+class NodeAttributeRemoveMigrationQuery01(AttributeMigrationQuery, AttributeRemoveQuery):
     name = "migration_node_attribute_remove_01"
     insert_return: bool = False
 
-    async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
-        branch_filter, branch_params = self.branch.get_query_filter_path(at=self.at.to_string())
-        self.params.update(branch_params)
-
-        attr_name = self.migration.schema_path.field_name
-        kinds_to_ignore = []
-        if isinstance(self.migration.new_node_schema, GenericSchema) and attr_name is not None:
-            for inheriting_schema_kind in self.migration.new_node_schema.used_by:
-                node_schema = db.schema.get_node_schema(
-                    name=inheriting_schema_kind, branch=self.branch, duplicate=False
-                )
-                attr_schema = node_schema.get_attribute_or_none(name=attr_name)
-                if attr_schema and not attr_schema.inherited:
-                    kinds_to_ignore.append(inheriting_schema_kind)
-
-        self.params["node_kind"] = self.migration.new_schema.kind
-        self.params["kinds_to_ignore"] = kinds_to_ignore
-        self.params["attr_name"] = attr_name
-        self.params["current_time"] = self.at.to_string()
-        self.params["branch_name"] = self.branch.name
-        self.params["branch_support"] = self.migration.previous_attribute_schema.get_branch().value
-
-        self.params["rel_props"] = {
-            "branch": self.branch.name,
-            "branch_level": self.branch.hierarchy_level,
-            "status": RelationshipStatus.DELETED.value,
-            "from": self.at.to_string(),
-        }
-
-        def render_sub_query_per_rel_type(rel_type: str, rel_def: FieldInfo) -> str:
-            subquery = [
-                "WITH peer_node, rb, active_attr",
-                f'WHERE type(rb) = "{rel_type}"',
-            ]
-            if rel_def.default.direction.value == "outbound":
-                subquery.append(f"CREATE (active_attr)-[:{rel_type} $rel_props ]->(peer_node)")
-            elif rel_def.default.direction.value == "inbound":
-                subquery.append(f"CREATE (active_attr)<-[:{rel_type} $rel_props ]-(peer_node)")
-            else:
-                subquery.append(f"CREATE (active_attr)-[:{rel_type} $rel_props ]-(peer_node)")
-
-            subquery.append("RETURN peer_node as p2")
-            return "\n".join(subquery)
-
-        sub_queries = [
-            render_sub_query_per_rel_type(rel_type, rel_def)
-            for rel_type, rel_def in GraphAttributeRelationships.model_fields.items()
-        ]
-        sub_query_all = "\nUNION\n".join(sub_queries)
-
-        query = """
-        // Find all the active nodes
-        MATCH (node:%(node_kind)s|Profile%(node_kind)s)
-        WHERE (size($kinds_to_ignore) = 0 OR NOT any(l IN labels(node) WHERE l IN $kinds_to_ignore))
-        AND exists((node)-[:HAS_ATTRIBUTE]-(:Attribute { name: $attr_name }))
-        CALL (node) {
-            MATCH (root:Root)<-[r:IS_PART_OF]-(node)
-            WHERE %(branch_filter)s
-            RETURN node as n1, r as r1
-            ORDER BY r.branch_level DESC, r.from DESC
-            LIMIT 1
-        }
-        WITH n1 as active_node, r1 as rb
-        WHERE rb.status = "active"
-        // Find all the attributes that need to be updated
-        CALL (active_node) {
-            MATCH (active_node)-[r:HAS_ATTRIBUTE]-(attr:Attribute { name: $attr_name })
-            WHERE %(branch_filter)s
-            RETURN active_node as n1, r as r1, attr as attr1
-            ORDER BY r.branch_level DESC, r.from DESC
-            LIMIT 1
-        }
-        WITH n1 as active_node, r1 as rb, attr1 as active_attr
-        WHERE rb.status = "active"
-        WITH active_attr
-        MATCH (active_attr)-[]-(peer)
-        WITH DISTINCT active_attr, peer
-        CALL (active_attr, peer) {
-            MATCH (active_attr)-[r]-(peer)
-            WHERE %(branch_filter)s
-            RETURN active_attr as a1, r as r1, peer as p1
-            ORDER BY r.branch_level DESC, r.from DESC
-            LIMIT 1
-        }
-        WITH a1 as active_attr, r1 as rb, p1 as peer_node
-        WHERE rb.status = "active"
-        CALL (peer_node, rb, active_attr) {
-            %(sub_query_all)s
-        }
-        WITH p2 as peer_node, rb, active_attr
-        FOREACH (i in CASE WHEN rb.branch = $branch_name THEN [1] ELSE [] END |
-            SET rb.to = $current_time
+    def __init__(
+        self,
+        migration: AttributeSchemaMigration,
+        **kwargs: Any,
+    ):
+        super().__init__(
+            migration=migration,
+            attribute_name=migration.new_attribute_schema.name,
+            new_node_schema=migration.new_schema,
+            branch_support=migration.new_attribute_schema.get_branch().value,
+            **kwargs,
         )
-        RETURN DISTINCT active_attr
-        """ % {
-            "branch_filter": branch_filter,
-            "sub_query_all": sub_query_all,
-            "node_kind": self.migration.new_schema.kind,
-        }
-        self.add_to_query(query)
 
 
 class NodeAttributeRemoveMigration(AttributeSchemaMigration):

--- a/backend/infrahub/core/migrations/schema/node_kind_update.py
+++ b/backend/infrahub/core/migrations/schema/node_kind_update.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from typing import Any, Sequence
 
+from ..query import MigrationQuery
 from ..query.node_duplicate import NodeDuplicateQuery, SchemaNodeInfo
-from ..shared import MigrationQuery, SchemaMigration
+from ..shared import SchemaMigration
 
 
 class NodeKindUpdateMigrationQuery01(MigrationQuery, NodeDuplicateQuery):

--- a/backend/infrahub/core/migrations/schema/node_remove.py
+++ b/backend/infrahub/core/migrations/schema/node_remove.py
@@ -5,7 +5,8 @@ from typing import TYPE_CHECKING, Any, Sequence
 from infrahub.core.constants import RelationshipStatus
 from infrahub.core.graph.schema import GraphNodeRelationships, GraphRelDirection
 
-from ..shared import MigrationQuery, SchemaMigration
+from ..query import MigrationQuery
+from ..shared import SchemaMigration
 
 if TYPE_CHECKING:
     from pydantic.fields import FieldInfo

--- a/backend/infrahub/core/migrations/schema/placeholder_dummy.py
+++ b/backend/infrahub/core/migrations/schema/placeholder_dummy.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence
+from typing import Sequence
 
 from pydantic import Field
 
+from ..query import MigrationBaseQuery  # noqa: TC001
 from ..shared import SchemaMigration
-
-if TYPE_CHECKING:
-    from ..query import MigrationBaseQuery
 
 
 class PlaceholderDummyMigration(SchemaMigration):

--- a/backend/infrahub/core/migrations/schema/placeholder_dummy.py
+++ b/backend/infrahub/core/migrations/schema/placeholder_dummy.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-from typing import Sequence
+from typing import TYPE_CHECKING, Sequence
 
 from pydantic import Field
 
-from ..shared import MigrationQuery, SchemaMigration
+from ..shared import SchemaMigration
+
+if TYPE_CHECKING:
+    from ..query import MigrationBaseQuery
 
 
 class PlaceholderDummyMigration(SchemaMigration):
     name: str = "dummy.placeholder"
-    queries: Sequence[type[MigrationQuery]] = Field(default_factory=list)
+    queries: Sequence[type[MigrationBaseQuery]] = Field(default_factory=list)

--- a/backend/infrahub/core/migrations/shared.py
+++ b/backend/infrahub/core/migrations/shared.py
@@ -17,12 +17,12 @@ from infrahub.core.schema import (
 )
 from infrahub.core.timestamp import Timestamp
 
+from .query import MigrationBaseQuery  # noqa: TC001
+
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
     from infrahub.core.schema.schema_branch import SchemaBranch
     from infrahub.database import InfrahubDatabase
-
-    from .query import MigrationBaseQuery
 
 
 class MigrationResult(BaseModel):

--- a/backend/infrahub/core/migrations/shared.py
+++ b/backend/infrahub/core/migrations/shared.py
@@ -17,12 +17,12 @@ from infrahub.core.schema import (
 )
 from infrahub.core.timestamp import Timestamp
 
-from .query import MigrationQuery  # noqa: TC001
-
 if TYPE_CHECKING:
     from infrahub.core.branch import Branch
     from infrahub.core.schema.schema_branch import SchemaBranch
     from infrahub.database import InfrahubDatabase
+
+    from .query import MigrationBaseQuery
 
 
 class MigrationResult(BaseModel):
@@ -40,7 +40,9 @@ class MigrationResult(BaseModel):
 class SchemaMigration(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
     name: str = Field(..., description="Name of the migration")
-    queries: Sequence[type[MigrationQuery]] = Field(..., description="List of queries to execute for this migration")
+    queries: Sequence[type[MigrationBaseQuery]] = Field(
+        ..., description="List of queries to execute for this migration"
+    )
 
     new_node_schema: MainSchemaTypes | None = None
     previous_node_schema: MainSchemaTypes | None = None
@@ -65,9 +67,14 @@ class SchemaMigration(BaseModel):
         return result
 
     async def execute_queries(
-        self, db: InfrahubDatabase, result: MigrationResult, branch: Branch, at: Timestamp
+        self,
+        db: InfrahubDatabase,
+        result: MigrationResult,
+        branch: Branch,
+        at: Timestamp,
+        queries: Sequence[type[MigrationBaseQuery]],
     ) -> MigrationResult:
-        for migration_query in self.queries:
+        for migration_query in queries:
             try:
                 query = await migration_query.init(db=db, branch=branch, at=at, migration=self)
                 await query.execute(db=db)
@@ -78,13 +85,20 @@ class SchemaMigration(BaseModel):
 
         return result
 
-    async def execute(self, db: InfrahubDatabase, branch: Branch, at: Timestamp | str | None = None) -> MigrationResult:
+    async def execute(
+        self,
+        db: InfrahubDatabase,
+        branch: Branch,
+        at: Timestamp | str | None = None,
+        queries: Sequence[type[MigrationBaseQuery]] | None = None,
+    ) -> MigrationResult:
         async with db.start_transaction() as ts:
             result = MigrationResult()
             at = Timestamp(at)
 
             await self.execute_pre_queries(db=ts, result=result, branch=branch, at=at)
-            await self.execute_queries(db=ts, result=result, branch=branch, at=at)
+            queries_to_execute = queries or self.queries
+            await self.execute_queries(db=ts, result=result, branch=branch, at=at, queries=queries_to_execute)
             await self.execute_post_queries(db=ts, result=result, branch=branch, at=at)
 
         return result

--- a/backend/infrahub/core/schema/attribute_schema.py
+++ b/backend/infrahub/core/schema/attribute_schema.py
@@ -68,6 +68,10 @@ class AttributeSchema(GeneratedAttributeSchema):
     def is_deprecated(self) -> bool:
         return bool(self.deprecation)
 
+    @property
+    def support_profiles(self) -> bool:
+        return self.read_only is False and self.optional is True
+
     def get_id(self) -> str:
         if self.id is None:
             raise InitializationError("The attribute schema has not been saved yet and doesn't have an id")

--- a/backend/infrahub/core/schema/definitions/internal.py
+++ b/backend/infrahub/core/schema/definitions/internal.py
@@ -568,7 +568,7 @@ attribute_schema = SchemaNode(
             "Mainly relevant for internal object.",
             default_value=False,
             optional=True,
-            extra={"update": UpdateSupport.ALLOWED},
+            extra={"update": UpdateSupport.MIGRATION_REQUIRED},
         ),
         SchemaAttribute(
             name="unique",
@@ -585,7 +585,7 @@ attribute_schema = SchemaNode(
             default_value=False,
             override_default_value=False,
             optional=True,
-            extra={"update": UpdateSupport.VALIDATE_CONSTRAINT},
+            extra={"update": UpdateSupport.MIGRATION_REQUIRED},
         ),
         SchemaAttribute(
             name="branch",

--- a/backend/infrahub/core/schema/generated/attribute_schema.py
+++ b/backend/infrahub/core/schema/generated/attribute_schema.py
@@ -78,7 +78,7 @@ class GeneratedAttributeSchema(HashableModel):
     read_only: bool = Field(
         default=False,
         description="Set the attribute as Read-Only, users won't be able to change its value. Mainly relevant for internal object.",
-        json_schema_extra={"update": "allowed"},
+        json_schema_extra={"update": "migration_required"},
     )
     unique: bool = Field(
         default=False,
@@ -88,7 +88,7 @@ class GeneratedAttributeSchema(HashableModel):
     optional: bool = Field(
         default=False,
         description="Indicate if this attribute is mandatory or optional.",
-        json_schema_extra={"update": "validate_constraint"},
+        json_schema_extra={"update": "migration_required"},
     )
     branch: BranchSupportType | None = Field(
         default=None,

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -2287,7 +2287,7 @@ class SchemaBranch:
         )
 
         for node_attr in node.attributes:
-            if node_attr.read_only or node_attr.optional is False:
+            if not node_attr.support_profiles:
                 continue
             attr_schema_class = get_attribute_schema_class_for_kind(kind=node_attr.kind)
             attr = attr_schema_class(

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -33,6 +33,7 @@ from infrahub.workflows.initialization import setup_task_manager
 from tests.adapters.cache import MemoryCache
 from tests.adapters.message_bus import BusSimulator
 from tests.helpers.events import query_events_by_name
+from infrahub.graphql.registry import registry as graphql_registry
 
 from .test_client import InfrahubTestClient
 
@@ -210,6 +211,7 @@ class TestInfrahubApp(TestInfrahub):
         await create_default_account_groups(db=db, admin_accounts=[admin_account], accounts=[unprivileged_account])
 
         # This call emits a warning related to the fact database index manager has not been initialized.
+        graphql_registry.clear_cache()
         await initialization(db=db)
 
     async def assert_event(self, prefect_client: PrefectClient, event_name: str) -> None:

--- a/backend/tests/helpers/test_app.py
+++ b/backend/tests/helpers/test_app.py
@@ -25,6 +25,7 @@ from infrahub.core.schema.manager import SchemaManager
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.core.utils import delete_all_nodes
 from infrahub.database import InfrahubDatabase
+from infrahub.graphql.registry import registry as graphql_registry
 from infrahub.server import app, lifespan
 from infrahub.services import InfrahubServices
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
@@ -33,7 +34,6 @@ from infrahub.workflows.initialization import setup_task_manager
 from tests.adapters.cache import MemoryCache
 from tests.adapters.message_bus import BusSimulator
 from tests.helpers.events import query_events_by_name
-from infrahub.graphql.registry import registry as graphql_registry
 
 from .test_client import InfrahubTestClient
 

--- a/backend/tests/integration/profiles/test_profile_lifecycle.py
+++ b/backend/tests/integration/profiles/test_profile_lifecycle.py
@@ -14,6 +14,54 @@ from tests.helpers.graphql import graphql
 from tests.helpers.schema import load_schema
 from tests.helpers.test_app import TestInfrahubApp
 
+PERSON_UPDATE_QUERY = """
+mutation ($update_data: TestingPersonUpdateInput!) {
+    TestingPersonUpdate(data: $update_data) {
+        ok
+        object {
+            id
+            profiles { edges { node { id } } }
+            name {
+                value
+                source { id }
+                is_from_profile
+                is_default
+            }
+            height {
+                value
+                source { id }
+                is_from_profile
+                is_default
+            }
+            weight {
+                value
+                source { id }
+                is_from_profile
+                is_default
+            }
+            eye_color {
+                value
+                source { id }
+                is_from_profile
+                is_default
+            }
+            description {
+                value
+                source { id }
+                is_from_profile
+                is_default
+            }
+            nothing {
+                value
+                source { id }
+                is_from_profile
+                is_default
+            }
+        }
+    }
+}
+"""
+
 
 class TestProfileLifecycle(TestInfrahubApp):
     @pytest.fixture(scope="class")
@@ -25,29 +73,45 @@ class TestProfileLifecycle(TestInfrahubApp):
             label="Person",
             attributes=[
                 AttributeSchema(name="name", kind="Text"),
+                # weight will become optional later to test that it is added to profiles
+                AttributeSchema(name="weight", kind="Number", optional=False),
+                # height will become mandatory later to test that it is removed from profiles
+                AttributeSchema(name="height", kind="Number", optional=True, default_value=150),
+                # eye_color will become read_only=False later to test that it is added to profiles
+                AttributeSchema(name="eye_color", kind="Text", optional=True, read_only=True),
+                # description will become read_only=True later to test that it is removed from profiles
                 AttributeSchema(name="description", kind="Text", optional=True),
-                AttributeSchema(name="height", kind="Number", optional=True),
+                # nothing will be removed later to test that it is removed from profiles
+                AttributeSchema(name="nothing", kind="Text", optional=True),
             ],
         )
         return SchemaRoot(version="1.0", nodes=[person_schema])
 
     @pytest.fixture(scope="class")
-    async def person_schema_root_add_attribute(self, person_schema_root: SchemaRoot) -> SchemaRoot:
+    async def person_schema_root_add_attributes_to_profiles(self, person_schema_root: SchemaRoot) -> SchemaRoot:
         person_schema = person_schema_root.nodes[0].model_copy(deep=True)
+        weight_attribute = person_schema.get_attribute("weight")
+        weight_attribute.optional = False
+        eye_color_attribute = person_schema.get_attribute("eye_color")
+        eye_color_attribute.read_only = False
         person_schema.attributes.append(AttributeSchema(name="age", kind="Number", optional=True))
         return SchemaRoot(version="1.0", nodes=[person_schema])
 
     @pytest.fixture(scope="class")
-    async def person_schema_root_remove_attribute(
-        self, default_branch: Branch, person_schema_root_add_attribute: SchemaRoot, client: InfrahubClient
+    async def person_schema_root_remove_attributes_from_profiles(
+        self, default_branch: Branch, person_schema_root_add_attributes_to_profiles: SchemaRoot, client: InfrahubClient
     ) -> SchemaRoot:
         person_schema = await client.schema.get(kind="ProfileTestingPerson", branch=default_branch.name, refresh=True)
-        current_height_attribute = person_schema.get_attribute("height")
+        current_nothing_attribute = person_schema.get_attribute("nothing")
 
-        person_schema = person_schema_root_add_attribute.nodes[0].model_copy(deep=True)
-        updated_height_attribute = person_schema.get_attribute("height")
-        updated_height_attribute.state = "absent"
-        updated_height_attribute.id = current_height_attribute.id
+        person_schema = person_schema_root_add_attributes_to_profiles.nodes[0].model_copy(deep=True)
+        height_attribute = person_schema.get_attribute("height")
+        height_attribute.optional = False
+        description_attribute = person_schema.get_attribute("description")
+        description_attribute.read_only = True
+        nothing_attribute = person_schema.get_attribute("nothing")
+        nothing_attribute.state = "absent"
+        nothing_attribute.id = current_nothing_attribute.id
         return SchemaRoot(version="1.0", nodes=[person_schema])
 
     @pytest.fixture(scope="class")
@@ -60,14 +124,21 @@ class TestProfileLifecycle(TestInfrahubApp):
     async def person_1(self, db: InfrahubDatabase, schema_person_base) -> Node:
         schema = registry.schema.get_node_schema(name="TestingPerson", duplicate=False)
         person_1 = await Node.init(db=db, schema=schema)
-        await person_1.new(db=db, name="Starbuck")
+        await person_1.new(db=db, name="Starbuck", weight=70)
         await person_1.save(db=db)
         return person_1
 
     @pytest.fixture(scope="class")
     async def person_profile_1(self, db: InfrahubDatabase, schema_person_base) -> Node:
         person_profile_1 = await Node.init(db=db, schema="ProfileTestingPerson")
-        await person_profile_1.new(db=db, profile_name="profile-one", profile_priority=10, height=167)
+        await person_profile_1.new(
+            db=db,
+            profile_name="profile-one",
+            profile_priority=10,
+            height=167,
+            description="profile-one description",
+            nothing="profile-one nothing",
+        )
         await person_profile_1.save(db=db)
         return person_profile_1
 
@@ -81,10 +152,14 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person.name.is_from_profile is False
         assert retrieved_person.name.source is None
         assert retrieved_person.name.is_default is False
-        assert retrieved_person.height.value is None
+        assert retrieved_person.height.value == 150
         assert retrieved_person.height.is_from_profile is False
         assert retrieved_person.height.source is None
         assert retrieved_person.height.is_default is True
+        assert retrieved_person.weight.value == 70
+        assert retrieved_person.weight.is_from_profile is False
+        assert retrieved_person.weight.source is None
+        assert retrieved_person.weight.is_default is False
 
     async def test_step_02_one_person_add_profile(
         self,
@@ -92,39 +167,14 @@ class TestProfileLifecycle(TestInfrahubApp):
         default_branch: Branch,
         person_1,
         person_profile_1,
-    ) -> None:
-        mutation = """
-            mutation {
-                TestingPersonUpdate(data: {id: "%(person_id)s", profiles: [{ id: "%(profile_id)s"}]}) {
-                    ok
-                    object {
-                        id
-                        profiles { edges { node { id } } }
-                        name {
-                            value
-                            source { id }
-                            is_from_profile
-                            is_default
-                        }
-                        height {
-                            value
-                            source { id }
-                            is_from_profile
-                            is_default
-                        }
-                    }
-                }
-            }
-        """ % {"person_id": person_1.id, "profile_id": person_profile_1.id}
-
-        default_branch.update_schema_hash()
+    ):
         gql_params = await prepare_graphql_params(db=db, branch=default_branch)
         result = await graphql(
             schema=gql_params.schema,
-            source=mutation,
+            source=PERSON_UPDATE_QUERY,
             context_value=gql_params.context,
             root_value=None,
-            variable_values={},
+            variable_values={"update_data": {"id": person_1.id, "profiles": [{"id": person_profile_1.id}]}},
         )
 
         assert result.errors is None
@@ -147,6 +197,30 @@ class TestProfileLifecycle(TestInfrahubApp):
             "source": {"id": person_profile_1.id},
             "is_default": False,
         }
+        assert attributes["weight"] == {
+            "value": 70,
+            "is_from_profile": False,
+            "source": None,
+            "is_default": False,
+        }
+        assert attributes["eye_color"] == {
+            "value": None,
+            "is_from_profile": False,
+            "source": None,
+            "is_default": True,
+        }
+        assert attributes["description"] == {
+            "value": "profile-one description",
+            "is_from_profile": True,
+            "source": {"id": person_profile_1.id},
+            "is_default": False,
+        }
+        assert attributes["nothing"] == {
+            "value": "profile-one nothing",
+            "is_from_profile": True,
+            "source": {"id": person_profile_1.id},
+            "is_default": False,
+        }
         retrieved_person = await NodeManager.get_one(db=db, id=person_1.id, include_source=True)
         assert retrieved_person.name.value == "Starbuck"
         assert retrieved_person.name.is_from_profile is False
@@ -156,6 +230,22 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person.height.is_from_profile is True
         assert retrieved_person.height.source_id == person_profile_1.id
         assert retrieved_person.height.is_default is False
+        assert retrieved_person.weight.value == 70
+        assert retrieved_person.weight.is_from_profile is False
+        assert retrieved_person.weight.source_id is None
+        assert retrieved_person.weight.is_default is False
+        assert retrieved_person.eye_color.value is None
+        assert retrieved_person.eye_color.is_from_profile is False
+        assert retrieved_person.eye_color.source_id is None
+        assert retrieved_person.eye_color.is_default is True
+        assert retrieved_person.description.value == "profile-one description"
+        assert retrieved_person.description.is_from_profile is True
+        assert retrieved_person.description.source_id == person_profile_1.id
+        assert retrieved_person.description.is_default is False
+        assert retrieved_person.nothing.value == "profile-one nothing"
+        assert retrieved_person.nothing.is_from_profile is True
+        assert retrieved_person.nothing.source_id == person_profile_1.id
+        assert retrieved_person.nothing.is_default is False
 
     async def test_step_03_create_person_with_profile(
         self,
@@ -165,7 +255,11 @@ class TestProfileLifecycle(TestInfrahubApp):
     ) -> None:
         mutation = """
             mutation {
-                TestingPersonCreate(data: {name: {value: "Apollo"}, profiles: [{ id: "%(profile_id)s"}]}) {
+                TestingPersonCreate(data: {
+                    name: {value: "Apollo"},
+                    weight: {value: 85},
+                    profiles: [{ id: "%(profile_id)s"}]
+                }) {
                     ok
                     object {
                         id
@@ -177,6 +271,30 @@ class TestProfileLifecycle(TestInfrahubApp):
                             is_default
                         }
                         height {
+                            value
+                            source { id }
+                            is_from_profile
+                            is_default
+                        }
+                        weight {
+                            value
+                            source { id }
+                            is_from_profile
+                            is_default
+                        }
+                        eye_color {
+                            value
+                            source { id }
+                            is_from_profile
+                            is_default
+                        }
+                        description {
+                            value
+                            source { id }
+                            is_from_profile
+                            is_default
+                        }
+                        nothing {
                             value
                             source { id }
                             is_from_profile
@@ -212,6 +330,30 @@ class TestProfileLifecycle(TestInfrahubApp):
             "source": {"id": person_profile_1.id},
             "is_default": False,
         }
+        assert attributes["weight"] == {
+            "value": 85,
+            "is_from_profile": False,
+            "source": None,
+            "is_default": False,
+        }
+        assert attributes["eye_color"] == {
+            "value": None,
+            "is_from_profile": False,
+            "source": None,
+            "is_default": True,
+        }
+        assert attributes["description"] == {
+            "value": "profile-one description",
+            "is_from_profile": True,
+            "source": {"id": person_profile_1.id},
+            "is_default": False,
+        }
+        assert attributes["nothing"] == {
+            "value": "profile-one nothing",
+            "is_from_profile": True,
+            "source": {"id": person_profile_1.id},
+            "is_default": False,
+        }
         retrieved_person = await NodeManager.get_one(db=db, id=new_person_id, include_source=True)
         assert retrieved_person.name.value == "Apollo"
         assert retrieved_person.name.is_from_profile is False
@@ -221,6 +363,22 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person.height.is_from_profile is True
         assert retrieved_person.height.source_id == person_profile_1.id
         assert retrieved_person.height.is_default is False
+        assert retrieved_person.weight.value == 85
+        assert retrieved_person.weight.is_from_profile is False
+        assert retrieved_person.weight.source_id is None
+        assert retrieved_person.weight.is_default is False
+        assert retrieved_person.eye_color.value is None
+        assert retrieved_person.eye_color.is_from_profile is False
+        assert retrieved_person.eye_color.source_id is None
+        assert retrieved_person.eye_color.is_default is True
+        assert retrieved_person.description.value == "profile-one description"
+        assert retrieved_person.description.is_from_profile is True
+        assert retrieved_person.description.source_id == person_profile_1.id
+        assert retrieved_person.description.is_default is False
+        assert retrieved_person.nothing.value == "profile-one nothing"
+        assert retrieved_person.nothing.is_from_profile is True
+        assert retrieved_person.nothing.source_id == person_profile_1.id
+        assert retrieved_person.nothing.is_default is False
 
     async def test_step_04_update_non_profile_attribute(
         self,
@@ -228,41 +386,14 @@ class TestProfileLifecycle(TestInfrahubApp):
         default_branch: Branch,
         person_1,
         person_profile_1,
-    ) -> None:
-        mutation = """
-            mutation {
-                TestingPersonUpdate(data: {id: "%(person_id)s", name: {value: "Kara Thrace"}}) {
-                    ok
-                    object {
-                        id
-                        profiles { edges { node { id } } }
-                        name {
-                            value
-                            source { id }
-                            is_from_profile
-                            is_default
-                        }
-                        height {
-                            value
-                            source { id }
-                            is_from_profile
-                            is_default
-                        }
-                    }
-                }
-            }
-        """ % {
-            "person_id": person_1.id,
-        }
-
-        default_branch.update_schema_hash()
+    ):
         gql_params = await prepare_graphql_params(db=db, branch=default_branch)
         result = await graphql(
             schema=gql_params.schema,
-            source=mutation,
+            source=PERSON_UPDATE_QUERY,
             context_value=gql_params.context,
             root_value=None,
-            variable_values={},
+            variable_values={"update_data": {"id": person_1.id, "name": {"value": "Kara Thrace"}}},
         )
 
         assert result.errors is None
@@ -325,6 +456,22 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person.height.is_from_profile is True
         assert retrieved_person.height.source.id == person_profile_2.id
         assert retrieved_person.height.is_default is False
+        assert retrieved_person.weight.value == 70
+        assert retrieved_person.weight.is_from_profile is False
+        assert retrieved_person.weight.source is None
+        assert retrieved_person.weight.is_default is False
+        assert retrieved_person.eye_color.value is None
+        assert retrieved_person.eye_color.is_from_profile is False
+        assert retrieved_person.eye_color.source is None
+        assert retrieved_person.eye_color.is_default is True
+        assert retrieved_person.description.value == "profile-one description"
+        assert retrieved_person.description.is_from_profile is True
+        assert retrieved_person.description.source.id == person_profile_1.id
+        assert retrieved_person.description.is_default is False
+        assert retrieved_person.nothing.value == "profile-one nothing"
+        assert retrieved_person.nothing.is_from_profile is True
+        assert retrieved_person.nothing.source.id == person_profile_1.id
+        assert retrieved_person.nothing.is_default is False
 
     async def test_step_07_update_person_delete_profile(
         self,
@@ -333,38 +480,13 @@ class TestProfileLifecycle(TestInfrahubApp):
         client,
     ) -> None:
         person_2 = await client.get(kind="TestingPerson", name__value="Apollo", property=True)
-        mutation = """
-            mutation {
-                TestingPersonUpdate(data: {id: "%(person_id)s", profiles: []}) {
-                    ok
-                    object {
-                        id
-                        profiles { edges { node { id } } }
-                        name {
-                            value
-                            source { id }
-                            is_from_profile
-                            is_default
-                        }
-                        height {
-                            value
-                            source { id }
-                            is_from_profile
-                            is_default
-                        }
-                    }
-                }
-            }
-        """ % {"person_id": person_2.id}
-
-        default_branch.update_schema_hash()
         gql_params = await prepare_graphql_params(db=db, branch=default_branch)
         result = await graphql(
             schema=gql_params.schema,
-            source=mutation,
+            source=PERSON_UPDATE_QUERY,
             context_value=gql_params.context,
             root_value=None,
-            variable_values={},
+            variable_values={"update_data": {"id": person_2.id, "profiles": []}},
         )
 
         assert result.errors is None
@@ -375,14 +497,14 @@ class TestProfileLifecycle(TestInfrahubApp):
         attributes = result.data["TestingPersonUpdate"]["object"]
         assert attributes["id"] == person_2.id
         assert attributes["name"] == {"value": "Apollo", "is_from_profile": False, "source": None, "is_default": False}
-        assert attributes["height"] == {"value": None, "is_from_profile": False, "source": None, "is_default": True}
+        assert attributes["height"] == {"value": 150, "is_from_profile": False, "source": None, "is_default": True}
 
         retrieved_person = await NodeManager.get_one(db=db, id=person_2.id, include_source=True)
         assert retrieved_person.name.value == "Apollo"
         assert retrieved_person.name.is_from_profile is False
         assert retrieved_person.name.source_id is None
         assert retrieved_person.name.is_default is False
-        assert retrieved_person.height.value is None
+        assert retrieved_person.height.value == 150
         assert retrieved_person.height.is_from_profile is False
         assert retrieved_person.height.source_id is None
         assert retrieved_person.height.is_default is True
@@ -412,15 +534,48 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person_1.height.is_from_profile is True
         assert retrieved_person_1.height.source.id == person_profile_1.id
         assert retrieved_person_1.height.is_default is False
+        assert retrieved_person_1.weight.value == 70
+        assert retrieved_person_1.weight.is_from_profile is False
+        assert retrieved_person_1.weight.source is None
+        assert retrieved_person_1.weight.is_default is False
+        assert retrieved_person_1.eye_color.value is None
+        assert retrieved_person_1.eye_color.is_from_profile is False
+        assert retrieved_person_1.eye_color.source is None
+        assert retrieved_person_1.eye_color.is_default is True
+        assert retrieved_person_1.description.value == "profile-one description"
+        assert retrieved_person_1.description.is_from_profile is True
+        assert retrieved_person_1.description.source.id == person_profile_1.id
+        assert retrieved_person_1.description.is_default is False
+        assert retrieved_person_1.nothing.value == "profile-one nothing"
+        assert retrieved_person_1.nothing.is_from_profile is True
+        assert retrieved_person_1.nothing.source.id == person_profile_1.id
+        assert retrieved_person_1.nothing.is_default is False
+
         assert retrieved_person_2.profiles.peer_ids == []
         assert retrieved_person_2.name.value == "Apollo"
         assert retrieved_person_2.name.is_from_profile is False
         assert retrieved_person_2.name.source is None
         assert retrieved_person_2.name.is_default is False
-        assert retrieved_person_2.height.value is None
+        assert retrieved_person_2.height.value == 150
         assert retrieved_person_2.height.is_from_profile is False
         assert retrieved_person_2.height.source is None
         assert retrieved_person_2.height.is_default is True
+        assert retrieved_person_2.weight.value == 85
+        assert retrieved_person_2.weight.is_from_profile is False
+        assert retrieved_person_2.weight.source is None
+        assert retrieved_person_2.weight.is_default is False
+        assert retrieved_person_2.eye_color.value is None
+        assert retrieved_person_2.eye_color.is_from_profile is False
+        assert retrieved_person_2.eye_color.source is None
+        assert retrieved_person_2.eye_color.is_default is True
+        assert retrieved_person_2.description.value is None
+        assert retrieved_person_2.description.is_from_profile is False
+        assert retrieved_person_2.description.source is None
+        assert retrieved_person_2.description.is_default is True
+        assert retrieved_person_2.nothing.value is None
+        assert retrieved_person_2.nothing.is_from_profile is False
+        assert retrieved_person_2.nothing.source is None
+        assert retrieved_person_2.nothing.is_default is True
 
     async def test_step_10_update_person_override_profile(
         self,
@@ -428,39 +583,14 @@ class TestProfileLifecycle(TestInfrahubApp):
         default_branch: Branch,
         person_1,
         person_profile_1,
-    ) -> None:
-        mutation = """
-            mutation {
-                TestingPersonUpdate(data: {id: "%(person_id)s", height: {value: 145}}) {
-                    ok
-                    object {
-                        id
-                        profiles { edges { node { id } } }
-                        name {
-                            value
-                            source { id }
-                            is_from_profile
-                            is_default
-                        }
-                        height {
-                            value
-                            source { id }
-                            is_from_profile
-                            is_default
-                        }
-                    }
-                }
-            }
-        """ % {"person_id": person_1.id}
-
-        default_branch.update_schema_hash()
+    ):
         gql_params = await prepare_graphql_params(db=db, branch=default_branch)
         result = await graphql(
             schema=gql_params.schema,
-            source=mutation,
+            source=PERSON_UPDATE_QUERY,
             context_value=gql_params.context,
             root_value=None,
-            variable_values={},
+            variable_values={"update_data": {"id": person_1.id, "height": {"value": 145}}},
         )
 
         assert result.errors is None
@@ -525,12 +655,13 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person_1.height.is_from_profile is False
         assert retrieved_person_1.height.source is None
         assert retrieved_person_1.height.is_default is False
+
         assert retrieved_person_2.profiles.peer_ids == []
         assert retrieved_person_2.name.value == "Apollo"
         assert retrieved_person_2.name.is_from_profile is False
         assert retrieved_person_2.name.source is None
         assert retrieved_person_2.name.is_default is False
-        assert retrieved_person_2.height.value is None
+        assert retrieved_person_2.height.value == 150
         assert retrieved_person_2.height.is_from_profile is False
         assert retrieved_person_2.height.source is None
         assert retrieved_person_2.height.is_default is True
@@ -584,14 +715,35 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person_2.height.source.id == person_profile_1.id
         assert retrieved_person_2.height.is_default is False
 
-    async def test_step_15_schema_update_add_attribute(
+    async def test_step_15_schema_update_add_attributes(
         self,
         db: InfrahubDatabase,
         default_branch,
-        person_schema_root_add_attribute: SchemaRoot,
+        person_schema_root_add_attributes_to_profiles: SchemaRoot,
+        person_profile_1: Node,
         client: InfrahubClient,
     ):
-        await client.schema.load(schemas=[person_schema_root_add_attribute.model_dump()], branch=default_branch.name)
+        await client.schema.load(
+            schemas=[person_schema_root_add_attributes_to_profiles.model_dump()], branch=default_branch.name
+        )
+
+        updated_schema = await client.schema.get(kind="ProfileTestingPerson", branch=default_branch.name, refresh=True)
+        assert set(updated_schema.attribute_names) == {
+            "profile_name",
+            "profile_priority",
+            "height",
+            "eye_color",
+            "description",
+            "nothing",
+            "age",
+        }
+
+        updated_person_profile_1 = await client.get(kind="ProfileTestingPerson", id=person_profile_1.id)
+        assert updated_person_profile_1.height.value == 134
+        assert updated_person_profile_1.description.value == "profile-one description"
+        assert updated_person_profile_1.nothing.value == "profile-one nothing"
+        assert updated_person_profile_1.age.value is None
+        assert updated_person_profile_1.eye_color.value is None
 
     async def test_step_16_update_profile_with_new_attribute(
         self,
@@ -602,9 +754,11 @@ class TestProfileLifecycle(TestInfrahubApp):
     ):
         updated_schema = await client.schema.get(kind="ProfileTestingPerson", branch=default_branch.name, refresh=True)
         assert updated_schema.get_attribute("age") is not None
+        assert updated_schema.get_attribute("eye_color") is not None
 
         person_profile_1 = await client.get(kind="ProfileTestingPerson", id=person_profile_1.id)
         person_profile_1.age.value = 25
+        person_profile_1.eye_color.value = "blurple"
         await person_profile_1.save()
 
     async def test_step_17_check_persons_again(
@@ -623,6 +777,22 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person_1.height.is_from_profile is False
         assert retrieved_person_1.height.source is None
         assert retrieved_person_1.height.is_default is False
+        assert retrieved_person_1.weight.value == 70
+        assert retrieved_person_1.weight.is_from_profile is False
+        assert retrieved_person_1.weight.source is None
+        assert retrieved_person_1.weight.is_default is False
+        assert retrieved_person_1.eye_color.value is None
+        assert retrieved_person_1.eye_color.is_from_profile is False
+        assert retrieved_person_1.eye_color.source is None
+        assert retrieved_person_1.eye_color.is_default is True
+        assert retrieved_person_1.description.value is None
+        assert retrieved_person_1.description.is_from_profile is False
+        assert retrieved_person_1.description.source is None
+        assert retrieved_person_1.description.is_default is True
+        assert retrieved_person_1.nothing.value is None
+        assert retrieved_person_1.nothing.is_from_profile is False
+        assert retrieved_person_1.nothing.source is None
+        assert retrieved_person_1.nothing.is_default is True
         assert retrieved_person_1.age.value is None
         assert retrieved_person_1.age.is_from_profile is False
         assert retrieved_person_1.age.source is None
@@ -638,19 +808,38 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person_2.height.is_from_profile is True
         assert retrieved_person_2.height.source.id == person_profile_1.id
         assert retrieved_person_2.height.is_default is False
+        assert retrieved_person_2.weight.value == 85
+        assert retrieved_person_2.weight.is_from_profile is False
+        assert retrieved_person_2.weight.source is None
+        assert retrieved_person_2.weight.is_default is False
+        assert retrieved_person_2.eye_color.value == "blurple"
+        assert retrieved_person_2.eye_color.is_from_profile is True
+        assert retrieved_person_2.eye_color.source.id == person_profile_1.id
+        assert retrieved_person_2.eye_color.is_default is False
+        assert retrieved_person_2.description.value == "profile-one description"
+        assert retrieved_person_2.description.is_from_profile is True
+        assert retrieved_person_2.description.source.id == person_profile_1.id
+        assert retrieved_person_2.description.is_default is False
+        assert retrieved_person_2.nothing.value == "profile-one nothing"
+        assert retrieved_person_2.nothing.is_from_profile is True
+        assert retrieved_person_2.nothing.source.id == person_profile_1.id
+        assert retrieved_person_2.nothing.is_default is False
         assert retrieved_person_2.age.value == 25
         assert retrieved_person_2.age.is_from_profile is True
         assert retrieved_person_2.age.source.id == person_profile_1.id
         assert retrieved_person_2.age.is_default is False
 
-    async def test_step_18_schema_update_remove_attribute(
+    async def test_step_18_schema_update_remove_attributes(
         self,
         db: InfrahubDatabase,
         default_branch,
-        person_schema_root_remove_attribute: SchemaRoot,
+        person_schema_root_remove_attributes_from_profiles: SchemaRoot,
         client: InfrahubClient,
     ):
-        await client.schema.load(schemas=[person_schema_root_remove_attribute.model_dump()], branch=default_branch.name)
+        await client.schema.load(
+            schemas=[person_schema_root_remove_attributes_from_profiles.model_dump()], branch=default_branch.name
+        )
+        # TODO: validate schema update
 
     async def test_step_19_check_profile_for_removed_attribute(
         self,
@@ -665,6 +854,7 @@ class TestProfileLifecycle(TestInfrahubApp):
         person_profile_1 = await client.get(kind="ProfileTestingPerson", id=person_profile_1.id)
         with pytest.raises(AttributeError):
             _ = person_profile_1.height
+        # TODO: validate profile updated
 
     async def test_step_20_check_persons_again(
         self, db: InfrahubDatabase, default_branch: Branch, person_1, person_profile_1, client: InfrahubClient

--- a/backend/tests/integration/profiles/test_profile_lifecycle.py
+++ b/backend/tests/integration/profiles/test_profile_lifecycle.py
@@ -3,6 +3,7 @@ from infrahub_sdk.client import InfrahubClient
 
 from infrahub.core import registry
 from infrahub.core.branch.models import Branch
+from infrahub.core.constants import HashableModelState
 from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.schema import SchemaRoot
@@ -76,11 +77,11 @@ class TestProfileLifecycle(TestInfrahubApp):
                 # weight will become optional later to test that it is added to profiles
                 AttributeSchema(name="weight", kind="Number", optional=False),
                 # height will become mandatory later to test that it is removed from profiles
-                AttributeSchema(name="height", kind="Number", optional=True, default_value=150),
+                AttributeSchema(name="height", kind="Number", optional=True),
                 # eye_color will become read_only=False later to test that it is added to profiles
                 AttributeSchema(name="eye_color", kind="Text", optional=True, read_only=True),
                 # description will become read_only=True later to test that it is removed from profiles
-                AttributeSchema(name="description", kind="Text", optional=True),
+                AttributeSchema(name="description", kind="Text", optional=True, default_value="placeholder"),
                 # nothing will be removed later to test that it is removed from profiles
                 AttributeSchema(name="nothing", kind="Text", optional=True),
             ],
@@ -91,7 +92,7 @@ class TestProfileLifecycle(TestInfrahubApp):
     async def person_schema_root_add_attributes_to_profiles(self, person_schema_root: SchemaRoot) -> SchemaRoot:
         person_schema = person_schema_root.nodes[0].model_copy(deep=True)
         weight_attribute = person_schema.get_attribute("weight")
-        weight_attribute.optional = False
+        weight_attribute.optional = True
         eye_color_attribute = person_schema.get_attribute("eye_color")
         eye_color_attribute.read_only = False
         person_schema.attributes.append(AttributeSchema(name="age", kind="Number", optional=True))
@@ -110,7 +111,7 @@ class TestProfileLifecycle(TestInfrahubApp):
         description_attribute = person_schema.get_attribute("description")
         description_attribute.read_only = True
         nothing_attribute = person_schema.get_attribute("nothing")
-        nothing_attribute.state = "absent"
+        nothing_attribute.state = HashableModelState.ABSENT
         nothing_attribute.id = current_nothing_attribute.id
         return SchemaRoot(version="1.0", nodes=[person_schema])
 
@@ -152,7 +153,7 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person.name.is_from_profile is False
         assert retrieved_person.name.source is None
         assert retrieved_person.name.is_default is False
-        assert retrieved_person.height.value == 150
+        assert retrieved_person.height.value is None
         assert retrieved_person.height.is_from_profile is False
         assert retrieved_person.height.source is None
         assert retrieved_person.height.is_default is True
@@ -497,14 +498,14 @@ class TestProfileLifecycle(TestInfrahubApp):
         attributes = result.data["TestingPersonUpdate"]["object"]
         assert attributes["id"] == person_2.id
         assert attributes["name"] == {"value": "Apollo", "is_from_profile": False, "source": None, "is_default": False}
-        assert attributes["height"] == {"value": 150, "is_from_profile": False, "source": None, "is_default": True}
+        assert attributes["height"] == {"value": None, "is_from_profile": False, "source": None, "is_default": True}
 
         retrieved_person = await NodeManager.get_one(db=db, id=person_2.id, include_source=True)
         assert retrieved_person.name.value == "Apollo"
         assert retrieved_person.name.is_from_profile is False
         assert retrieved_person.name.source_id is None
         assert retrieved_person.name.is_default is False
-        assert retrieved_person.height.value == 150
+        assert retrieved_person.height.value is None
         assert retrieved_person.height.is_from_profile is False
         assert retrieved_person.height.source_id is None
         assert retrieved_person.height.is_default is True
@@ -556,7 +557,7 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person_2.name.is_from_profile is False
         assert retrieved_person_2.name.source is None
         assert retrieved_person_2.name.is_default is False
-        assert retrieved_person_2.height.value == 150
+        assert retrieved_person_2.height.value is None
         assert retrieved_person_2.height.is_from_profile is False
         assert retrieved_person_2.height.source is None
         assert retrieved_person_2.height.is_default is True
@@ -568,7 +569,7 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person_2.eye_color.is_from_profile is False
         assert retrieved_person_2.eye_color.source is None
         assert retrieved_person_2.eye_color.is_default is True
-        assert retrieved_person_2.description.value is None
+        assert retrieved_person_2.description.value == "placeholder"
         assert retrieved_person_2.description.is_from_profile is False
         assert retrieved_person_2.description.source is None
         assert retrieved_person_2.description.is_default is True
@@ -661,7 +662,7 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person_2.name.is_from_profile is False
         assert retrieved_person_2.name.source is None
         assert retrieved_person_2.name.is_default is False
-        assert retrieved_person_2.height.value == 150
+        assert retrieved_person_2.height.value is None
         assert retrieved_person_2.height.is_from_profile is False
         assert retrieved_person_2.height.source is None
         assert retrieved_person_2.height.is_default is True
@@ -723,14 +724,17 @@ class TestProfileLifecycle(TestInfrahubApp):
         person_profile_1: Node,
         client: InfrahubClient,
     ):
-        await client.schema.load(
+        response = await client.schema.load(
             schemas=[person_schema_root_add_attributes_to_profiles.model_dump()], branch=default_branch.name
         )
+        assert response.schema_updated
+        assert not response.errors
 
         updated_schema = await client.schema.get(kind="ProfileTestingPerson", branch=default_branch.name, refresh=True)
         assert set(updated_schema.attribute_names) == {
             "profile_name",
             "profile_priority",
+            "weight",
             "height",
             "eye_color",
             "description",
@@ -743,6 +747,7 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert updated_person_profile_1.description.value == "profile-one description"
         assert updated_person_profile_1.nothing.value == "profile-one nothing"
         assert updated_person_profile_1.age.value is None
+        assert updated_person_profile_1.weight.value is None
         assert updated_person_profile_1.eye_color.value is None
 
     async def test_step_16_update_profile_with_new_attribute(
@@ -785,7 +790,7 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person_1.eye_color.is_from_profile is False
         assert retrieved_person_1.eye_color.source is None
         assert retrieved_person_1.eye_color.is_default is True
-        assert retrieved_person_1.description.value is None
+        assert retrieved_person_1.description.value == "placeholder"
         assert retrieved_person_1.description.is_from_profile is False
         assert retrieved_person_1.description.source is None
         assert retrieved_person_1.description.is_default is True
@@ -836,10 +841,11 @@ class TestProfileLifecycle(TestInfrahubApp):
         person_schema_root_remove_attributes_from_profiles: SchemaRoot,
         client: InfrahubClient,
     ):
-        await client.schema.load(
+        response = await client.schema.load(
             schemas=[person_schema_root_remove_attributes_from_profiles.model_dump()], branch=default_branch.name
         )
-        # TODO: validate schema update
+        assert response.schema_updated
+        assert not response.errors
 
     async def test_step_19_check_profile_for_removed_attribute(
         self,
@@ -849,12 +855,21 @@ class TestProfileLifecycle(TestInfrahubApp):
         client: InfrahubClient,
     ):
         updated_schema = await client.schema.get(kind="ProfileTestingPerson", branch=default_branch.name, refresh=True)
-        assert "height" not in updated_schema.attribute_names
+        assert set(updated_schema.attribute_names) == {
+            "profile_name",
+            "profile_priority",
+            "weight",
+            "eye_color",
+            "age",
+        }
 
         person_profile_1 = await client.get(kind="ProfileTestingPerson", id=person_profile_1.id)
         with pytest.raises(AttributeError):
             _ = person_profile_1.height
-        # TODO: validate profile updated
+        with pytest.raises(AttributeError):
+            _ = person_profile_1.description
+        with pytest.raises(AttributeError):
+            _ = person_profile_1.nothing
 
     async def test_step_20_check_persons_again(
         self, db: InfrahubDatabase, default_branch: Branch, person_1, person_profile_1, client: InfrahubClient
@@ -864,8 +879,6 @@ class TestProfileLifecycle(TestInfrahubApp):
 
         await retrieved_person_1.profiles.fetch()
         assert retrieved_person_1.profiles.peer_ids == []
-        with pytest.raises(AttributeError):
-            _ = retrieved_person_1.height
         assert retrieved_person_1.name.value == "Kara Thrace"
         assert retrieved_person_1.name.is_from_profile is False
         assert retrieved_person_1.name.source is None
@@ -874,6 +887,24 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person_1.age.is_from_profile is False
         assert retrieved_person_1.age.source is None
         assert retrieved_person_1.age.is_default is True
+        assert retrieved_person_1.height.value == 145
+        assert retrieved_person_1.height.is_from_profile is False
+        assert retrieved_person_1.height.source is None
+        assert retrieved_person_1.height.is_default is False
+        assert retrieved_person_1.weight.value == 70
+        assert retrieved_person_1.weight.is_from_profile is False
+        assert retrieved_person_1.weight.source is None
+        assert retrieved_person_1.weight.is_default is False
+        assert retrieved_person_1.eye_color.value is None
+        assert retrieved_person_1.eye_color.is_from_profile is False
+        assert retrieved_person_1.eye_color.source is None
+        assert retrieved_person_1.eye_color.is_default is True
+        assert retrieved_person_1.description.value == "placeholder"
+        assert retrieved_person_1.description.is_from_profile is False
+        assert retrieved_person_1.description.source is None
+        assert retrieved_person_1.description.is_default is True
+        with pytest.raises(AttributeError):
+            _ = retrieved_person_1.nothing
 
         await retrieved_person_2.profiles.fetch()
         assert retrieved_person_2.profiles.peer_ids == [person_profile_1.id]
@@ -881,9 +912,25 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person_2.name.is_from_profile is False
         assert retrieved_person_2.name.source is None
         assert retrieved_person_2.name.is_default is False
-        with pytest.raises(AttributeError):
-            _ = retrieved_person_2.height
         assert retrieved_person_2.age.value == 25
         assert retrieved_person_2.age.is_from_profile is True
         assert retrieved_person_2.age.source.id == person_profile_1.id
         assert retrieved_person_2.age.is_default is False
+        assert retrieved_person_2.height.value == 134
+        assert retrieved_person_2.height.is_from_profile is True
+        assert retrieved_person_2.height.source.id == person_profile_1.id
+        assert retrieved_person_2.height.is_default is False
+        assert retrieved_person_2.weight.value == 85
+        assert retrieved_person_2.weight.is_from_profile is False
+        assert retrieved_person_2.weight.source is None
+        assert retrieved_person_2.weight.is_default is False
+        assert retrieved_person_2.eye_color.value == "blurple"
+        assert retrieved_person_2.eye_color.is_from_profile is True
+        assert retrieved_person_2.eye_color.source.id == person_profile_1.id
+        assert retrieved_person_2.eye_color.is_default is False
+        assert retrieved_person_2.description.value == "profile-one description"
+        assert retrieved_person_2.description.is_from_profile is True
+        assert retrieved_person_2.description.source.id == person_profile_1.id
+        assert retrieved_person_2.description.is_default is False
+        with pytest.raises(AttributeError):
+            _ = retrieved_person_2.nothing

--- a/backend/tests/integration/profiles/test_profile_lifecycle.py
+++ b/backend/tests/integration/profiles/test_profile_lifecycle.py
@@ -1150,9 +1150,9 @@ class TestProfileLifecycle(TestInfrahubApp):
     async def test_step_15_schema_update_add_attributes(
         self,
         default_branch,
-        schema_root_02,
         person_profile_1: Node,
         lifeform_profile_1: Node,
+        schema_root_02,
         client: InfrahubClient,
     ):
         updated_person_profile_schema = await client.schema.get(
@@ -1216,15 +1216,21 @@ class TestProfileLifecycle(TestInfrahubApp):
     async def test_step_16_update_profile_with_new_attribute(
         self,
         default_branch,
-        person_profile_1,
+        person_profile_1: Node,
+        lifeform_profile_1: Node,
         client: InfrahubClient,
     ):
-        person_profile_1 = await client.get(kind="ProfilePretendPerson", id=person_profile_1.id)
-        person_profile_1.age.value = 25
-        person_profile_1.eye_color.value = "blurple"
-        person_profile_1.value.value = 42
-        person_profile_1.is_alive.value = True
-        await person_profile_1.save()
+        updated_person_profile_1 = await client.get(kind="ProfilePretendPerson", id=person_profile_1.id)
+        updated_person_profile_1.age.value = 25
+        updated_person_profile_1.eye_color.value = "blurple"
+        updated_person_profile_1.value.value = 42
+        updated_person_profile_1.is_alive.value = True
+        await updated_person_profile_1.save()
+
+        updated_lifeform_profile_1 = await client.get(kind="ProfilePretendLifeform", id=lifeform_profile_1.id)
+        updated_lifeform_profile_1.size.value = "lifeform-profile-big"
+        updated_lifeform_profile_1.value.value = 84
+        await updated_lifeform_profile_1.save()
 
     async def test_step_17_use_generic_profile(
         self,
@@ -1348,9 +1354,9 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person_2.generic_nothing.is_from_profile is True
         assert retrieved_person_2.generic_nothing.source.id == lifeform_profile_1.id
         assert retrieved_person_2.generic_nothing.is_default is False
-        assert retrieved_person_2.value.value == 42
+        assert retrieved_person_2.value.value == 84
         assert retrieved_person_2.value.is_from_profile is True
-        assert retrieved_person_2.value.source.id == person_profile_1.id
+        assert retrieved_person_2.value.source.id == lifeform_profile_1.id
         assert retrieved_person_2.value.is_default is False
 
     async def test_step_18_check_profile_for_removed_attribute(
@@ -1385,6 +1391,13 @@ class TestProfileLifecycle(TestInfrahubApp):
         }
 
         person_profile_1 = await client.get(kind="ProfilePretendPerson", id=person_profile_1.id)
+        assert person_profile_1.age.value == 25
+        assert person_profile_1.eye_color.value == "blurple"
+        assert person_profile_1.is_alive.value is True
+        assert person_profile_1.size.value is None
+        assert person_profile_1.value.value == 42
+        assert person_profile_1.weight.value is None
+
         with pytest.raises(AttributeError):
             _ = person_profile_1.height
         with pytest.raises(AttributeError):
@@ -1399,6 +1412,10 @@ class TestProfileLifecycle(TestInfrahubApp):
             _ = person_profile_1.generic_nothing
 
         lifeform_profile_1 = await client.get(kind="ProfilePretendLifeform", id=lifeform_profile_1.id)
+        assert lifeform_profile_1.size.value == "lifeform-profile-big"
+        assert lifeform_profile_1.is_alive.value is None
+        assert lifeform_profile_1.value.value == 84
+
         with pytest.raises(AttributeError):
             _ = lifeform_profile_1.shape
         with pytest.raises(AttributeError):
@@ -1512,9 +1529,9 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person_2.lifespan.is_from_profile is True
         assert retrieved_person_2.lifespan.source.id == person_profile_1.id
         assert retrieved_person_2.lifespan.is_default is False
-        assert retrieved_person_2.value.value == 42
+        assert retrieved_person_2.value.value == 84
         assert retrieved_person_2.value.is_from_profile is True
-        assert retrieved_person_2.value.source.id == person_profile_1.id
+        assert retrieved_person_2.value.source.id == lifeform_profile_1.id
         assert retrieved_person_2.value.is_default is False
         with pytest.raises(AttributeError):
             _ = retrieved_person_2.nothing

--- a/backend/tests/integration/profiles/test_profile_lifecycle.py
+++ b/backend/tests/integration/profiles/test_profile_lifecycle.py
@@ -16,8 +16,8 @@ from tests.helpers.schema import load_schema
 from tests.helpers.test_app import TestInfrahubApp
 
 PERSON_UPDATE_QUERY = """
-mutation ($update_data: TestingPersonUpdateInput!) {
-    TestingPersonUpdate(data: $update_data) {
+mutation ($update_data: PretendPersonUpdateInput!) {
+    PretendPersonUpdate(data: $update_data) {
         ok
         object {
             id
@@ -69,7 +69,7 @@ class TestProfileLifecycle(TestInfrahubApp):
     async def person_schema_root(self) -> SchemaRoot:
         person_schema = NodeSchema(
             name="Person",
-            namespace="Testing",
+            namespace="Pretend",
             include_in_menu=True,
             label="Person",
             attributes=[
@@ -102,7 +102,7 @@ class TestProfileLifecycle(TestInfrahubApp):
     async def person_schema_root_remove_attributes_from_profiles(
         self, default_branch: Branch, person_schema_root_add_attributes_to_profiles: SchemaRoot, client: InfrahubClient
     ) -> SchemaRoot:
-        person_schema = await client.schema.get(kind="ProfileTestingPerson", branch=default_branch.name, refresh=True)
+        person_schema = await client.schema.get(kind="ProfilePretendPerson", branch=default_branch.name, refresh=True)
         current_nothing_attribute = person_schema.get_attribute("nothing")
 
         person_schema = person_schema_root_add_attributes_to_profiles.nodes[0].model_copy(deep=True)
@@ -123,7 +123,7 @@ class TestProfileLifecycle(TestInfrahubApp):
 
     @pytest.fixture(scope="class")
     async def person_1(self, db: InfrahubDatabase, schema_person_base) -> Node:
-        schema = registry.schema.get_node_schema(name="TestingPerson", duplicate=False)
+        schema = registry.schema.get_node_schema(name="PretendPerson", duplicate=False)
         person_1 = await Node.init(db=db, schema=schema)
         await person_1.new(db=db, name="Starbuck", weight=70)
         await person_1.save(db=db)
@@ -131,7 +131,7 @@ class TestProfileLifecycle(TestInfrahubApp):
 
     @pytest.fixture(scope="class")
     async def person_profile_1(self, db: InfrahubDatabase, schema_person_base) -> Node:
-        person_profile_1 = await Node.init(db=db, schema="ProfileTestingPerson")
+        person_profile_1 = await Node.init(db=db, schema="ProfilePretendPerson")
         await person_profile_1.new(
             db=db,
             profile_name="profile-one",
@@ -146,7 +146,7 @@ class TestProfileLifecycle(TestInfrahubApp):
     async def test_step_01_one_person_no_profile(
         self, db: InfrahubDatabase, schema_person_base, person_1, person_profile_1, client: InfrahubClient
     ):
-        retrieved_person = await client.get(kind="TestingPerson", id=person_1.id, property=True)
+        retrieved_person = await client.get(kind="PretendPerson", id=person_1.id, property=True)
 
         assert retrieved_person.profiles.peer_ids == []
         assert retrieved_person.name.value == "Starbuck"
@@ -180,11 +180,11 @@ class TestProfileLifecycle(TestInfrahubApp):
 
         assert result.errors is None
         assert result.data
-        assert result.data["TestingPersonUpdate"]["ok"] is True
-        profiles = result.data["TestingPersonUpdate"]["object"]["profiles"]["edges"]
+        assert result.data["PretendPersonUpdate"]["ok"] is True
+        profiles = result.data["PretendPersonUpdate"]["object"]["profiles"]["edges"]
         assert len(profiles) == 1
         assert profiles == [{"node": {"id": person_profile_1.id}}]
-        attributes = result.data["TestingPersonUpdate"]["object"]
+        attributes = result.data["PretendPersonUpdate"]["object"]
         assert attributes["id"] == person_1.id
         assert attributes["name"] == {
             "value": "Starbuck",
@@ -256,7 +256,7 @@ class TestProfileLifecycle(TestInfrahubApp):
     ) -> None:
         mutation = """
             mutation {
-                TestingPersonCreate(data: {
+                PretendPersonCreate(data: {
                     name: {value: "Apollo"},
                     weight: {value: 85},
                     profiles: [{ id: "%(profile_id)s"}]
@@ -318,12 +318,12 @@ class TestProfileLifecycle(TestInfrahubApp):
 
         assert result.errors is None
         assert result.data
-        assert result.data["TestingPersonCreate"]["ok"] is True
-        new_person_id = result.data["TestingPersonCreate"]["object"]["id"]
-        profiles = result.data["TestingPersonCreate"]["object"]["profiles"]["edges"]
+        assert result.data["PretendPersonCreate"]["ok"] is True
+        new_person_id = result.data["PretendPersonCreate"]["object"]["id"]
+        profiles = result.data["PretendPersonCreate"]["object"]["profiles"]["edges"]
         assert len(profiles) == 1
         assert profiles == [{"node": {"id": person_profile_1.id}}]
-        attributes = result.data["TestingPersonCreate"]["object"]
+        attributes = result.data["PretendPersonCreate"]["object"]
         assert attributes["name"] == {"value": "Apollo", "is_from_profile": False, "source": None, "is_default": False}
         assert attributes["height"] == {
             "value": 167,
@@ -399,11 +399,11 @@ class TestProfileLifecycle(TestInfrahubApp):
 
         assert result.errors is None
         assert result.data
-        assert result.data["TestingPersonUpdate"]["ok"] is True
-        profiles = result.data["TestingPersonUpdate"]["object"]["profiles"]["edges"]
+        assert result.data["PretendPersonUpdate"]["ok"] is True
+        profiles = result.data["PretendPersonUpdate"]["object"]["profiles"]["edges"]
         assert len(profiles) == 1
         assert profiles == [{"node": {"id": person_profile_1.id}}]
-        attributes = result.data["TestingPersonUpdate"]["object"]
+        attributes = result.data["PretendPersonUpdate"]["object"]
         assert attributes["id"] == person_1.id
         assert attributes["name"] == {
             "value": "Kara Thrace",
@@ -435,7 +435,7 @@ class TestProfileLifecycle(TestInfrahubApp):
         client: InfrahubClient,
     ):
         profile = await client.create(
-            kind="ProfileTestingPerson",
+            kind="ProfilePretendPerson",
             profile_name="profile-two",
             profile_priority=5,
             height=156,
@@ -444,8 +444,8 @@ class TestProfileLifecycle(TestInfrahubApp):
         await profile.save()
 
     async def test_step_06_get_person_multiple_profiles(self, person_1, person_profile_1, client: InfrahubClient):
-        person_profile_2 = await client.get(kind="ProfileTestingPerson", profile_name__value="profile-two")
-        retrieved_person = await client.get(kind="TestingPerson", id=person_1.id, property=True)
+        person_profile_2 = await client.get(kind="ProfilePretendPerson", profile_name__value="profile-two")
+        retrieved_person = await client.get(kind="PretendPerson", id=person_1.id, property=True)
         await retrieved_person.profiles.fetch()
 
         assert set(retrieved_person.profiles.peer_ids) == {person_profile_1.id, person_profile_2.id}
@@ -479,8 +479,8 @@ class TestProfileLifecycle(TestInfrahubApp):
         db: InfrahubDatabase,
         default_branch: Branch,
         client,
-    ) -> None:
-        person_2 = await client.get(kind="TestingPerson", name__value="Apollo", property=True)
+    ):
+        person_2 = await client.get(kind="PretendPerson", name__value="Apollo", property=True)
         gql_params = await prepare_graphql_params(db=db, branch=default_branch)
         result = await graphql(
             schema=gql_params.schema,
@@ -492,10 +492,10 @@ class TestProfileLifecycle(TestInfrahubApp):
 
         assert result.errors is None
         assert result.data
-        assert result.data["TestingPersonUpdate"]["ok"] is True
-        profiles = result.data["TestingPersonUpdate"]["object"]["profiles"]["edges"]
+        assert result.data["PretendPersonUpdate"]["ok"] is True
+        profiles = result.data["PretendPersonUpdate"]["object"]["profiles"]["edges"]
         assert profiles == []
-        attributes = result.data["TestingPersonUpdate"]["object"]
+        attributes = result.data["PretendPersonUpdate"]["object"]
         assert attributes["id"] == person_2.id
         assert attributes["name"] == {"value": "Apollo", "is_from_profile": False, "source": None, "is_default": False}
         assert attributes["height"] == {"value": None, "is_from_profile": False, "source": None, "is_default": True}
@@ -516,15 +516,15 @@ class TestProfileLifecycle(TestInfrahubApp):
         default_branch,
         client: InfrahubClient,
     ):
-        person_profile_2 = await client.get(kind="ProfileTestingPerson", profile_name__value="profile-two")
+        person_profile_2 = await client.get(kind="ProfilePretendPerson", profile_name__value="profile-two")
         await person_profile_2.delete()
 
     async def test_step_09_check_persons(
         self, db: InfrahubDatabase, person_1, person_profile_1, client: InfrahubClient, default_branch: Branch
     ):
-        retrieved_person_1 = await client.get(kind="TestingPerson", id=person_1.id, property=True)
+        retrieved_person_1 = await client.get(kind="PretendPerson", id=person_1.id, property=True)
         await retrieved_person_1.profiles.fetch()
-        retrieved_person_2 = await client.get(kind="TestingPerson", name__value="Apollo", property=True)
+        retrieved_person_2 = await client.get(kind="PretendPerson", name__value="Apollo", property=True)
 
         assert retrieved_person_1.profiles.peer_ids == [person_profile_1.id]
         assert retrieved_person_1.name.value == "Kara Thrace"
@@ -596,10 +596,10 @@ class TestProfileLifecycle(TestInfrahubApp):
 
         assert result.errors is None
         assert result.data
-        assert result.data["TestingPersonUpdate"]["ok"] is True
-        profiles = result.data["TestingPersonUpdate"]["object"]["profiles"]["edges"]
+        assert result.data["PretendPersonUpdate"]["ok"] is True
+        profiles = result.data["PretendPersonUpdate"]["object"]["profiles"]["edges"]
         assert profiles == [{"node": {"id": person_profile_1.id}}]
-        attributes = result.data["TestingPersonUpdate"]["object"]
+        attributes = result.data["PretendPersonUpdate"]["object"]
         assert attributes["id"] == person_1.id
         assert attributes["name"] == {
             "value": "Kara Thrace",
@@ -626,12 +626,12 @@ class TestProfileLifecycle(TestInfrahubApp):
         person_1,
         client: InfrahubClient,
     ):
-        person_profile_1 = await client.get(kind="ProfileTestingPerson", id=person_profile_1.id)
+        person_profile_1 = await client.get(kind="ProfilePretendPerson", id=person_profile_1.id)
         person_profile_1.profile_priority.value = 11
         person_profile_1.height.value = 134
         await person_profile_1.save()
 
-        updated_person_profile_1 = await client.get(kind="ProfileTestingPerson", id=person_profile_1.id)
+        updated_person_profile_1 = await client.get(kind="ProfilePretendPerson", id=person_profile_1.id)
         assert updated_person_profile_1.profile_name.value == "profile-one"
         assert updated_person_profile_1.profile_priority.value == 11
         assert updated_person_profile_1.height.value == 134
@@ -643,9 +643,9 @@ class TestProfileLifecycle(TestInfrahubApp):
     async def test_step_12_check_persons_again(
         self, db: InfrahubDatabase, default_branch: Branch, person_1, person_profile_1, client: InfrahubClient
     ):
-        retrieved_person_1 = await client.get(kind="TestingPerson", id=person_1.id, property=True)
+        retrieved_person_1 = await client.get(kind="PretendPerson", id=person_1.id, property=True)
         await retrieved_person_1.profiles.fetch()
-        retrieved_person_2 = await client.get(kind="TestingPerson", name__value="Apollo", property=True)
+        retrieved_person_2 = await client.get(kind="PretendPerson", name__value="Apollo", property=True)
 
         assert retrieved_person_1.profiles.peer_ids == [person_profile_1.id]
         assert retrieved_person_1.name.value == "Kara Thrace"
@@ -675,14 +675,14 @@ class TestProfileLifecycle(TestInfrahubApp):
         person_1,
         client: InfrahubClient,
     ):
-        person_2 = await client.get(kind="TestingPerson", name__value="Apollo", property=True)
-        person_profile_1 = await client.get(kind="ProfileTestingPerson", id=person_profile_1.id)
+        person_2 = await client.get(kind="PretendPerson", name__value="Apollo", property=True)
+        person_profile_1 = await client.get(kind="ProfilePretendPerson", id=person_profile_1.id)
         await person_profile_1.related_nodes.fetch()
         person_profile_1.related_nodes.remove(person_1.id)
         person_profile_1.related_nodes.add(person_2)
         await person_profile_1.save()
 
-        updated_person_profile_1 = await client.get(kind="ProfileTestingPerson", id=person_profile_1.id)
+        updated_person_profile_1 = await client.get(kind="ProfilePretendPerson", id=person_profile_1.id)
         assert updated_person_profile_1.profile_name.value == "profile-one"
         await updated_person_profile_1.related_nodes.fetch()
         assert len(updated_person_profile_1.related_nodes.peers) == 1
@@ -691,8 +691,8 @@ class TestProfileLifecycle(TestInfrahubApp):
     async def test_step_14_check_persons_again(
         self, db: InfrahubDatabase, default_branch: Branch, person_1, person_profile_1, client: InfrahubClient
     ):
-        retrieved_person_1 = await client.get(kind="TestingPerson", id=person_1.id, property=True)
-        retrieved_person_2 = await client.get(kind="TestingPerson", name__value="Apollo", property=True)
+        retrieved_person_1 = await client.get(kind="PretendPerson", id=person_1.id, property=True)
+        retrieved_person_2 = await client.get(kind="PretendPerson", name__value="Apollo", property=True)
 
         await retrieved_person_1.profiles.fetch()
         assert retrieved_person_1.profiles.peer_ids == []
@@ -730,7 +730,7 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert response.schema_updated
         assert not response.errors
 
-        updated_schema = await client.schema.get(kind="ProfileTestingPerson", branch=default_branch.name, refresh=True)
+        updated_schema = await client.schema.get(kind="ProfilePretendPerson", branch=default_branch.name, refresh=True)
         assert set(updated_schema.attribute_names) == {
             "profile_name",
             "profile_priority",
@@ -742,7 +742,7 @@ class TestProfileLifecycle(TestInfrahubApp):
             "age",
         }
 
-        updated_person_profile_1 = await client.get(kind="ProfileTestingPerson", id=person_profile_1.id)
+        updated_person_profile_1 = await client.get(kind="ProfilePretendPerson", id=person_profile_1.id)
         assert updated_person_profile_1.height.value == 134
         assert updated_person_profile_1.description.value == "profile-one description"
         assert updated_person_profile_1.nothing.value == "profile-one nothing"
@@ -757,11 +757,11 @@ class TestProfileLifecycle(TestInfrahubApp):
         person_profile_1,
         client: InfrahubClient,
     ):
-        updated_schema = await client.schema.get(kind="ProfileTestingPerson", branch=default_branch.name, refresh=True)
+        updated_schema = await client.schema.get(kind="ProfilePretendPerson", branch=default_branch.name, refresh=True)
         assert updated_schema.get_attribute("age") is not None
         assert updated_schema.get_attribute("eye_color") is not None
 
-        person_profile_1 = await client.get(kind="ProfileTestingPerson", id=person_profile_1.id)
+        person_profile_1 = await client.get(kind="ProfilePretendPerson", id=person_profile_1.id)
         person_profile_1.age.value = 25
         person_profile_1.eye_color.value = "blurple"
         await person_profile_1.save()
@@ -769,8 +769,8 @@ class TestProfileLifecycle(TestInfrahubApp):
     async def test_step_17_check_persons_again(
         self, db: InfrahubDatabase, default_branch: Branch, person_1, person_profile_1, client: InfrahubClient
     ):
-        retrieved_person_1 = await client.get(kind="TestingPerson", id=person_1.id, property=True)
-        retrieved_person_2 = await client.get(kind="TestingPerson", name__value="Apollo", property=True)
+        retrieved_person_1 = await client.get(kind="PretendPerson", id=person_1.id, property=True)
+        retrieved_person_2 = await client.get(kind="PretendPerson", name__value="Apollo", property=True)
 
         await retrieved_person_1.profiles.fetch()
         assert retrieved_person_1.profiles.peer_ids == []
@@ -854,7 +854,7 @@ class TestProfileLifecycle(TestInfrahubApp):
         person_profile_1,
         client: InfrahubClient,
     ):
-        updated_schema = await client.schema.get(kind="ProfileTestingPerson", branch=default_branch.name, refresh=True)
+        updated_schema = await client.schema.get(kind="ProfilePretendPerson", branch=default_branch.name, refresh=True)
         assert set(updated_schema.attribute_names) == {
             "profile_name",
             "profile_priority",
@@ -863,7 +863,7 @@ class TestProfileLifecycle(TestInfrahubApp):
             "age",
         }
 
-        person_profile_1 = await client.get(kind="ProfileTestingPerson", id=person_profile_1.id)
+        person_profile_1 = await client.get(kind="ProfilePretendPerson", id=person_profile_1.id)
         with pytest.raises(AttributeError):
             _ = person_profile_1.height
         with pytest.raises(AttributeError):
@@ -874,8 +874,8 @@ class TestProfileLifecycle(TestInfrahubApp):
     async def test_step_20_check_persons_again(
         self, db: InfrahubDatabase, default_branch: Branch, person_1, person_profile_1, client: InfrahubClient
     ):
-        retrieved_person_1 = await client.get(kind="TestingPerson", id=person_1.id, property=True)
-        retrieved_person_2 = await client.get(kind="TestingPerson", name__value="Apollo", property=True)
+        retrieved_person_1 = await client.get(kind="PretendPerson", id=person_1.id, property=True)
+        retrieved_person_2 = await client.get(kind="PretendPerson", name__value="Apollo", property=True)
 
         await retrieved_person_1.profiles.fetch()
         assert retrieved_person_1.profiles.peer_ids == []

--- a/backend/tests/integration/profiles/test_profile_lifecycle.py
+++ b/backend/tests/integration/profiles/test_profile_lifecycle.py
@@ -95,7 +95,12 @@ class TestProfileLifecycle(TestInfrahubApp):
         weight_attribute.optional = True
         eye_color_attribute = person_schema.get_attribute("eye_color")
         eye_color_attribute.read_only = False
+        # new attribute that should be added to profiles
         person_schema.attributes.append(AttributeSchema(name="age", kind="Number", optional=True))
+        # new attribute that should NOT be added to profiles
+        person_schema.attributes.append(
+            AttributeSchema(name="not_for_profiles", kind="Text", optional=True, read_only=True)
+        )
         return SchemaRoot(version="1.0", nodes=[person_schema])
 
     @pytest.fixture(scope="class")
@@ -749,6 +754,8 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert updated_person_profile_1.age.value is None
         assert updated_person_profile_1.weight.value is None
         assert updated_person_profile_1.eye_color.value is None
+        with pytest.raises(AttributeError):
+            _ = updated_person_profile_1.not_for_profiles
 
     async def test_step_16_update_profile_with_new_attribute(
         self,

--- a/backend/tests/integration/profiles/test_profile_lifecycle.py
+++ b/backend/tests/integration/profiles/test_profile_lifecycle.py
@@ -107,7 +107,7 @@ class TestProfileLifecycle(TestInfrahubApp):
             namespace="Pretend",
             attributes=[
                 # size will become optional later to test that it is added to profiles
-                AttributeSchema(name="size", kind="Text", optional=False),
+                AttributeSchema(name="size", kind="TextArea", optional=False),
                 # shape will become mandatory later to test that it is removed from profiles
                 AttributeSchema(name="shape", kind="Text", optional=True),
                 # is_alive will become read_only=False later to test that it is added to profiles
@@ -115,7 +115,7 @@ class TestProfileLifecycle(TestInfrahubApp):
                 # lifespan will become read_only=True later to test that it is removed from profiles
                 AttributeSchema(name="lifespan", kind="Number", optional=True),
                 # generic_nothing will be removed later to test that it is removed from profiles
-                AttributeSchema(name="generic_nothing", kind="Text", optional=True),
+                AttributeSchema(name="generic_nothing", kind="TextArea", optional=True),
             ],
         )
 
@@ -135,9 +135,9 @@ class TestProfileLifecycle(TestInfrahubApp):
                 # eye_color will become read_only=False later to test that it is added to profiles
                 AttributeSchema(name="eye_color", kind="Text", optional=True, read_only=True),
                 # description will become read_only=True later to test that it is removed from profiles
-                AttributeSchema(name="description", kind="Text", optional=True, default_value="placeholder"),
+                AttributeSchema(name="description", kind="TextArea", optional=True, default_value="placeholder"),
                 # nothing will be removed later to test that it is removed from profiles
-                AttributeSchema(name="nothing", kind="Text", optional=True),
+                AttributeSchema(name="nothing", kind="TextArea", optional=True),
             ],
         )
 
@@ -268,8 +268,6 @@ class TestProfileLifecycle(TestInfrahubApp):
         )
         await person_1.save(db=db)
         return person_1
-
-    # TODO: add profile based on generic to test
 
     @pytest.fixture(scope="class")
     async def person_profile_1(self, db: InfrahubDatabase, schema_root_01) -> Node:

--- a/backend/tests/integration/profiles/test_profile_lifecycle.py
+++ b/backend/tests/integration/profiles/test_profile_lifecycle.py
@@ -270,6 +270,19 @@ class TestProfileLifecycle(TestInfrahubApp):
         return person_1
 
     @pytest.fixture(scope="class")
+    async def lifeform_profile_1(self, db: InfrahubDatabase, schema_root_01) -> Node:
+        lifeform_profile_1 = await Node.init(db=db, schema="ProfilePretendLifeform")
+        await lifeform_profile_1.new(
+            db=db,
+            profile_name="lifeform-profile-one",
+            profile_priority=3,
+            shape="lifeform-profile-one shape",
+            generic_nothing="lifeform-profile-one generic nothing",
+        )
+        await lifeform_profile_1.save(db=db)
+        return lifeform_profile_1
+
+    @pytest.fixture(scope="class")
     async def person_profile_1(self, db: InfrahubDatabase, schema_root_01) -> Node:
         person_profile_1 = await Node.init(db=db, schema="ProfilePretendPerson")
         await person_profile_1.new(
@@ -1035,7 +1048,7 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert updated_person_profile_1.related_nodes.peers[0].id == person_2.id
 
     async def test_step_14_check_persons_again(
-        self, db: InfrahubDatabase, default_branch: Branch, person_1, person_profile_1, client: InfrahubClient
+        self, default_branch: Branch, person_1, person_profile_1, client: InfrahubClient
     ):
         retrieved_person_1 = await client.get(kind="PretendPerson", id=person_1.id, property=True)
         retrieved_person_2 = await client.get(kind="PretendPerson", name__value="Apollo", property=True)
@@ -1136,14 +1149,16 @@ class TestProfileLifecycle(TestInfrahubApp):
 
     async def test_step_15_schema_update_add_attributes(
         self,
-        db: InfrahubDatabase,
         default_branch,
         schema_root_02,
         person_profile_1: Node,
+        lifeform_profile_1: Node,
         client: InfrahubClient,
     ):
-        updated_schema = await client.schema.get(kind="ProfilePretendPerson", branch=default_branch.name, refresh=True)
-        assert set(updated_schema.attribute_names) == {
+        updated_person_profile_schema = await client.schema.get(
+            kind="ProfilePretendPerson", branch=default_branch.name, refresh=True
+        )
+        assert set(updated_person_profile_schema.attribute_names) == {
             "age",
             "description",
             "eye_color",
@@ -1158,6 +1173,19 @@ class TestProfileLifecycle(TestInfrahubApp):
             "size",
             "value",
             "weight",
+        }
+        updated_lifeform_profile_schema = await client.schema.get(
+            kind="ProfilePretendLifeform", branch=default_branch.name, refresh=True
+        )
+        assert set(updated_lifeform_profile_schema.attribute_names) == {
+            "size",
+            "shape",
+            "is_alive",
+            "lifespan",
+            "generic_nothing",
+            "profile_name",
+            "profile_priority",
+            "value",
         }
 
         updated_person_profile_1 = await client.get(kind="ProfilePretendPerson", id=person_profile_1.id)
@@ -1175,9 +1203,18 @@ class TestProfileLifecycle(TestInfrahubApp):
         with pytest.raises(AttributeError):
             _ = updated_person_profile_1.generic_not_for_profiles
 
+        updated_lifeform_profile_1 = await client.get(kind="ProfilePretendLifeform", id=lifeform_profile_1.id)
+        assert updated_lifeform_profile_1.size.value is None
+        assert updated_lifeform_profile_1.shape.value == "lifeform-profile-one shape"
+        assert updated_lifeform_profile_1.is_alive.value is None
+        assert updated_lifeform_profile_1.lifespan.value is None
+        assert updated_lifeform_profile_1.generic_nothing.value == "lifeform-profile-one generic nothing"
+        assert updated_lifeform_profile_1.value.value is None
+        with pytest.raises(AttributeError):
+            _ = updated_lifeform_profile_1.generic_not_for_profiles
+
     async def test_step_16_update_profile_with_new_attribute(
         self,
-        db: InfrahubDatabase,
         default_branch,
         person_profile_1,
         client: InfrahubClient,
@@ -1189,8 +1226,19 @@ class TestProfileLifecycle(TestInfrahubApp):
         person_profile_1.is_alive.value = True
         await person_profile_1.save()
 
+    async def test_step_17_use_generic_profile(
+        self,
+        client: InfrahubClient,
+        person_profile_1: Node,
+        lifeform_profile_1: Node,
+    ):
+        person_two = await client.get(kind="PretendPerson", name__value="Apollo")
+        await person_two.profiles.fetch()
+        person_two.profiles.add(lifeform_profile_1.id)
+        await person_two.save()
+
     async def test_step_17_check_persons_again(
-        self, db: InfrahubDatabase, default_branch: Branch, person_1, person_profile_1, client: InfrahubClient
+        self, default_branch: Branch, person_1, person_profile_1: Node, lifeform_profile_1: Node, client: InfrahubClient
     ):
         retrieved_person_1 = await client.get(kind="PretendPerson", id=person_1.id, property=True)
         retrieved_person_2 = await client.get(kind="PretendPerson", name__value="Apollo", property=True)
@@ -1251,7 +1299,7 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person_1.value.is_default is True
 
         await retrieved_person_2.profiles.fetch()
-        assert retrieved_person_2.profiles.peer_ids == [person_profile_1.id]
+        assert set(retrieved_person_2.profiles.peer_ids) == {person_profile_1.id, lifeform_profile_1.id}
         assert retrieved_person_2.name.value == "Apollo"
         assert retrieved_person_2.name.is_from_profile is False
         assert retrieved_person_2.name.source is None
@@ -1296,9 +1344,9 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person_2.lifespan.is_from_profile is True
         assert retrieved_person_2.lifespan.source.id == person_profile_1.id
         assert retrieved_person_2.lifespan.is_default is False
-        assert retrieved_person_2.generic_nothing.value == "profile-one generic nothing updated"
+        assert retrieved_person_2.generic_nothing.value == "lifeform-profile-one generic nothing"
         assert retrieved_person_2.generic_nothing.is_from_profile is True
-        assert retrieved_person_2.generic_nothing.source.id == person_profile_1.id
+        assert retrieved_person_2.generic_nothing.source.id == lifeform_profile_1.id
         assert retrieved_person_2.generic_nothing.is_default is False
         assert retrieved_person_2.value.value == 42
         assert retrieved_person_2.value.is_from_profile is True
@@ -1311,6 +1359,7 @@ class TestProfileLifecycle(TestInfrahubApp):
         schema_root_03,
         default_branch,
         person_profile_1,
+        lifeform_profile_1,
         client: InfrahubClient,
     ):
         updated_schema = await client.schema.get(kind="ProfilePretendPerson", branch=default_branch.name, refresh=True)
@@ -1323,6 +1372,16 @@ class TestProfileLifecycle(TestInfrahubApp):
             "size",
             "value",
             "weight",
+        }
+        updated_lifeform_profile_schema = await client.schema.get(
+            kind="ProfilePretendLifeform", branch=default_branch.name, refresh=True
+        )
+        assert set(updated_lifeform_profile_schema.attribute_names) == {
+            "size",
+            "is_alive",
+            "profile_name",
+            "profile_priority",
+            "value",
         }
 
         person_profile_1 = await client.get(kind="ProfilePretendPerson", id=person_profile_1.id)
@@ -1339,8 +1398,22 @@ class TestProfileLifecycle(TestInfrahubApp):
         with pytest.raises(AttributeError):
             _ = person_profile_1.generic_nothing
 
+        lifeform_profile_1 = await client.get(kind="ProfilePretendLifeform", id=lifeform_profile_1.id)
+        with pytest.raises(AttributeError):
+            _ = lifeform_profile_1.shape
+        with pytest.raises(AttributeError):
+            _ = lifeform_profile_1.lifespan
+        with pytest.raises(AttributeError):
+            _ = lifeform_profile_1.generic_nothing
+
     async def test_step_19_check_persons_again(
-        self, db: InfrahubDatabase, default_branch: Branch, person_1, person_profile_1, client: InfrahubClient
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        person_1,
+        person_profile_1,
+        lifeform_profile_1,
+        client: InfrahubClient,
     ):
         await client.schema.get(kind="PretendPerson", branch=default_branch.name, refresh=True)
         retrieved_person_1 = await client.get(kind="PretendPerson", id=person_1.id, property=True)
@@ -1398,7 +1471,7 @@ class TestProfileLifecycle(TestInfrahubApp):
             _ = retrieved_person_1.generic_nothing
 
         await retrieved_person_2.profiles.fetch()
-        assert retrieved_person_2.profiles.peer_ids == [person_profile_1.id]
+        assert set(retrieved_person_2.profiles.peer_ids) == {person_profile_1.id, lifeform_profile_1.id}
         assert retrieved_person_2.name.value == "Apollo"
         assert retrieved_person_2.name.is_from_profile is False
         assert retrieved_person_2.name.source is None

--- a/backend/tests/integration/profiles/test_profile_lifecycle.py
+++ b/backend/tests/integration/profiles/test_profile_lifecycle.py
@@ -17,7 +17,7 @@ from tests.helpers.test_app import TestInfrahubApp
 
 class TestProfileLifecycle(TestInfrahubApp):
     @pytest.fixture(scope="class")
-    async def schema_person_base(self, db: InfrahubDatabase, initialize_registry) -> None:
+    async def person_schema_root(self) -> SchemaRoot:
         person_schema = NodeSchema(
             name="Person",
             namespace="Testing",
@@ -29,7 +29,32 @@ class TestProfileLifecycle(TestInfrahubApp):
                 AttributeSchema(name="height", kind="Number", optional=True),
             ],
         )
-        await load_schema(db=db, schema=SchemaRoot(version="1.0", nodes=[person_schema]))
+        return SchemaRoot(version="1.0", nodes=[person_schema])
+
+    @pytest.fixture(scope="class")
+    async def person_schema_root_add_attribute(self, person_schema_root: SchemaRoot) -> SchemaRoot:
+        person_schema = person_schema_root.nodes[0].model_copy(deep=True)
+        person_schema.attributes.append(AttributeSchema(name="age", kind="Number", optional=True))
+        return SchemaRoot(version="1.0", nodes=[person_schema])
+
+    @pytest.fixture(scope="class")
+    async def person_schema_root_remove_attribute(
+        self, default_branch: Branch, person_schema_root_add_attribute: SchemaRoot, client: InfrahubClient
+    ) -> SchemaRoot:
+        person_schema = await client.schema.get(kind="ProfileTestingPerson", branch=default_branch.name, refresh=True)
+        current_height_attribute = person_schema.get_attribute("height")
+
+        person_schema = person_schema_root_add_attribute.nodes[0].model_copy(deep=True)
+        updated_height_attribute = person_schema.get_attribute("height")
+        updated_height_attribute.state = "absent"
+        updated_height_attribute.id = current_height_attribute.id
+        return SchemaRoot(version="1.0", nodes=[person_schema])
+
+    @pytest.fixture(scope="class")
+    async def schema_person_base(
+        self, db: InfrahubDatabase, default_branch: Branch, person_schema_root, client: InfrahubClient
+    ) -> None:
+        await load_schema(db=db, schema=person_schema_root, branch_name=default_branch.name, update_db=True)
 
     @pytest.fixture(scope="class")
     async def person_1(self, db: InfrahubDatabase, schema_person_base) -> Node:
@@ -558,3 +583,117 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person_2.height.is_from_profile is True
         assert retrieved_person_2.height.source.id == person_profile_1.id
         assert retrieved_person_2.height.is_default is False
+
+    async def test_step_15_schema_update_add_attribute(
+        self,
+        db: InfrahubDatabase,
+        default_branch,
+        person_schema_root_add_attribute: SchemaRoot,
+        client: InfrahubClient,
+    ):
+        await client.schema.load(schemas=[person_schema_root_add_attribute.model_dump()], branch=default_branch.name)
+
+    async def test_step_16_update_profile_with_new_attribute(
+        self,
+        db: InfrahubDatabase,
+        default_branch,
+        person_profile_1,
+        client: InfrahubClient,
+    ):
+        updated_schema = await client.schema.get(kind="ProfileTestingPerson", branch=default_branch.name, refresh=True)
+        assert updated_schema.get_attribute("age") is not None
+
+        person_profile_1 = await client.get(kind="ProfileTestingPerson", id=person_profile_1.id)
+        person_profile_1.age.value = 25
+        await person_profile_1.save()
+
+    async def test_step_17_check_persons_again(
+        self, db: InfrahubDatabase, default_branch: Branch, person_1, person_profile_1, client: InfrahubClient
+    ):
+        retrieved_person_1 = await client.get(kind="TestingPerson", id=person_1.id, property=True)
+        retrieved_person_2 = await client.get(kind="TestingPerson", name__value="Apollo", property=True)
+
+        await retrieved_person_1.profiles.fetch()
+        assert retrieved_person_1.profiles.peer_ids == []
+        assert retrieved_person_1.name.value == "Kara Thrace"
+        assert retrieved_person_1.name.is_from_profile is False
+        assert retrieved_person_1.name.source is None
+        assert retrieved_person_1.name.is_default is False
+        assert retrieved_person_1.height.value == 145
+        assert retrieved_person_1.height.is_from_profile is False
+        assert retrieved_person_1.height.source is None
+        assert retrieved_person_1.height.is_default is False
+        assert retrieved_person_1.age.value is None
+        assert retrieved_person_1.age.is_from_profile is False
+        assert retrieved_person_1.age.source is None
+        assert retrieved_person_1.age.is_default is True
+
+        await retrieved_person_2.profiles.fetch()
+        assert retrieved_person_2.profiles.peer_ids == [person_profile_1.id]
+        assert retrieved_person_2.name.value == "Apollo"
+        assert retrieved_person_2.name.is_from_profile is False
+        assert retrieved_person_2.name.source is None
+        assert retrieved_person_2.name.is_default is False
+        assert retrieved_person_2.height.value == 134
+        assert retrieved_person_2.height.is_from_profile is True
+        assert retrieved_person_2.height.source.id == person_profile_1.id
+        assert retrieved_person_2.height.is_default is False
+        assert retrieved_person_2.age.value == 25
+        assert retrieved_person_2.age.is_from_profile is True
+        assert retrieved_person_2.age.source.id == person_profile_1.id
+        assert retrieved_person_2.age.is_default is False
+
+    async def test_step_18_schema_update_remove_attribute(
+        self,
+        db: InfrahubDatabase,
+        default_branch,
+        person_schema_root_remove_attribute: SchemaRoot,
+        client: InfrahubClient,
+    ):
+        await client.schema.load(schemas=[person_schema_root_remove_attribute.model_dump()], branch=default_branch.name)
+
+    async def test_step_19_check_profile_for_removed_attribute(
+        self,
+        db: InfrahubDatabase,
+        default_branch,
+        person_profile_1,
+        client: InfrahubClient,
+    ):
+        updated_schema = await client.schema.get(kind="ProfileTestingPerson", branch=default_branch.name, refresh=True)
+        assert "height" not in updated_schema.attribute_names
+
+        person_profile_1 = await client.get(kind="ProfileTestingPerson", id=person_profile_1.id)
+        with pytest.raises(AttributeError):
+            _ = person_profile_1.height
+
+    async def test_step_20_check_persons_again(
+        self, db: InfrahubDatabase, default_branch: Branch, person_1, person_profile_1, client: InfrahubClient
+    ):
+        retrieved_person_1 = await client.get(kind="TestingPerson", id=person_1.id, property=True)
+        retrieved_person_2 = await client.get(kind="TestingPerson", name__value="Apollo", property=True)
+
+        await retrieved_person_1.profiles.fetch()
+        assert retrieved_person_1.profiles.peer_ids == []
+        with pytest.raises(AttributeError):
+            _ = retrieved_person_1.height
+        assert retrieved_person_1.name.value == "Kara Thrace"
+        assert retrieved_person_1.name.is_from_profile is False
+        assert retrieved_person_1.name.source is None
+        assert retrieved_person_1.name.is_default is False
+        assert retrieved_person_1.age.value is None
+        assert retrieved_person_1.age.is_from_profile is False
+        assert retrieved_person_1.age.source is None
+        assert retrieved_person_1.age.is_default is True
+
+        await retrieved_person_2.profiles.fetch()
+        assert retrieved_person_2.profiles.peer_ids == [person_profile_1.id]
+        assert retrieved_person_2.name.value == "Apollo"
+        assert retrieved_person_2.name.is_from_profile is False
+        assert retrieved_person_2.name.source is None
+        assert retrieved_person_2.name.is_default is False
+        with pytest.raises(AttributeError):
+            _ = retrieved_person_2.height
+        assert retrieved_person_2.age.value == 25
+        assert retrieved_person_2.age.is_from_profile is True
+        assert retrieved_person_2.age.source.id == person_profile_1.id
+        assert retrieved_person_2.age.is_default is False

--- a/backend/tests/integration/profiles/test_profile_lifecycle.py
+++ b/backend/tests/integration/profiles/test_profile_lifecycle.py
@@ -8,6 +8,7 @@ from infrahub.core.manager import NodeManager
 from infrahub.core.node import Node
 from infrahub.core.schema import SchemaRoot
 from infrahub.core.schema.attribute_schema import AttributeSchema
+from infrahub.core.schema.generic_schema import GenericSchema
 from infrahub.core.schema.node_schema import NodeSchema
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
@@ -15,10 +16,7 @@ from tests.helpers.graphql import graphql
 from tests.helpers.schema import load_schema
 from tests.helpers.test_app import TestInfrahubApp
 
-PERSON_UPDATE_QUERY = """
-mutation ($update_data: PretendPersonUpdateInput!) {
-    PretendPersonUpdate(data: $update_data) {
-        ok
+PERSON_VALUES = """
         object {
             id
             profiles { edges { node { id } } }
@@ -58,19 +56,75 @@ mutation ($update_data: PretendPersonUpdateInput!) {
                 is_from_profile
                 is_default
             }
+            size {
+                value
+                source { id }
+                is_from_profile
+                is_default
+            }
+            shape {
+                value
+                source { id }
+                is_from_profile
+                is_default
+            }
+            is_alive {
+                value
+                source { id }
+                is_from_profile
+                is_default
+            }
+            lifespan {
+                value
+                source { id }
+                is_from_profile
+                is_default
+            }
+            generic_nothing {
+                value
+                source { id }
+                is_from_profile
+                is_default
+            }
         }
+"""
+
+PERSON_UPDATE_QUERY = """
+mutation ($update_data: PretendPersonUpdateInput!) {
+    PretendPersonUpdate(data: $update_data) {
+        ok
+        %(person_values)s
     }
 }
-"""
+""" % {"person_values": PERSON_VALUES}
 
 
 class TestProfileLifecycle(TestInfrahubApp):
     @pytest.fixture(scope="class")
-    async def person_schema_root(self) -> SchemaRoot:
-        person_schema = NodeSchema(
+    def generic_schema_base(self) -> GenericSchema:
+        return GenericSchema(
+            name="Lifeform",
+            namespace="Pretend",
+            attributes=[
+                # size will become optional later to test that it is added to profiles
+                AttributeSchema(name="size", kind="Text", optional=False),
+                # shape will become mandatory later to test that it is removed from profiles
+                AttributeSchema(name="shape", kind="Text", optional=True),
+                # is_alive will become read_only=False later to test that it is added to profiles
+                AttributeSchema(name="is_alive", kind="Boolean", optional=True, read_only=True),
+                # lifespan will become read_only=True later to test that it is removed from profiles
+                AttributeSchema(name="lifespan", kind="Number", optional=True),
+                # generic_nothing will be removed later to test that it is removed from profiles
+                AttributeSchema(name="generic_nothing", kind="Text", optional=True),
+            ],
+        )
+
+    @pytest.fixture(scope="class")
+    def person_schema_base(self) -> NodeSchema:
+        return NodeSchema(
             name="Person",
             namespace="Pretend",
-            include_in_menu=True,
+            inherit_from=["PretendLifeform"],
             label="Person",
             attributes=[
                 AttributeSchema(name="name", kind="Text"),
@@ -86,56 +140,139 @@ class TestProfileLifecycle(TestInfrahubApp):
                 AttributeSchema(name="nothing", kind="Text", optional=True),
             ],
         )
-        return SchemaRoot(version="1.0", nodes=[person_schema])
 
     @pytest.fixture(scope="class")
-    async def person_schema_root_add_attributes_to_profiles(self, person_schema_root: SchemaRoot) -> SchemaRoot:
-        person_schema = person_schema_root.nodes[0].model_copy(deep=True)
-        weight_attribute = person_schema.get_attribute("weight")
+    async def schema_root_01(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        generic_schema_base: GenericSchema,
+        person_schema_base: NodeSchema,
+        client: InfrahubClient,
+    ) -> None:
+        schema_root = SchemaRoot(version="1.0", generics=[generic_schema_base], nodes=[person_schema_base])
+        await load_schema(db=db, schema=schema_root, branch_name=default_branch.name, update_db=True)
+
+    @pytest.fixture(scope="class")
+    async def generic_schema_add_attributes_to_profiles(self, generic_schema_base: GenericSchema) -> GenericSchema:
+        updated_generic_schema = generic_schema_base.model_copy(deep=True)
+        size_attribute = updated_generic_schema.get_attribute("size")
+        size_attribute.optional = True
+        is_alive_attribute = updated_generic_schema.get_attribute("is_alive")
+        is_alive_attribute.read_only = False
+        # new attribute that should be added to profiles
+        updated_generic_schema.attributes.append(AttributeSchema(name="value", kind="Number", optional=True))
+        # new attribute that should NOT be added to profiles
+        updated_generic_schema.attributes.append(
+            AttributeSchema(name="generic_not_for_profiles", kind="Text", optional=True, read_only=True)
+        )
+        return updated_generic_schema
+
+    @pytest.fixture(scope="class")
+    async def person_schema_add_attributes_to_profiles(self, person_schema_base: NodeSchema) -> NodeSchema:
+        updated_person_schema = person_schema_base.model_copy(deep=True)
+        weight_attribute = updated_person_schema.get_attribute("weight")
         weight_attribute.optional = True
-        eye_color_attribute = person_schema.get_attribute("eye_color")
+        eye_color_attribute = updated_person_schema.get_attribute("eye_color")
         eye_color_attribute.read_only = False
         # new attribute that should be added to profiles
-        person_schema.attributes.append(AttributeSchema(name="age", kind="Number", optional=True))
+        updated_person_schema.attributes.append(AttributeSchema(name="age", kind="Number", optional=True))
         # new attribute that should NOT be added to profiles
-        person_schema.attributes.append(
+        updated_person_schema.attributes.append(
             AttributeSchema(name="not_for_profiles", kind="Text", optional=True, read_only=True)
         )
-        return SchemaRoot(version="1.0", nodes=[person_schema])
+        return updated_person_schema
 
     @pytest.fixture(scope="class")
-    async def person_schema_root_remove_attributes_from_profiles(
-        self, default_branch: Branch, person_schema_root_add_attributes_to_profiles: SchemaRoot, client: InfrahubClient
-    ) -> SchemaRoot:
-        person_schema = await client.schema.get(kind="ProfilePretendPerson", branch=default_branch.name, refresh=True)
-        current_nothing_attribute = person_schema.get_attribute("nothing")
+    async def schema_root_02(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        generic_schema_add_attributes_to_profiles: GenericSchema,
+        person_schema_add_attributes_to_profiles: NodeSchema,
+        client: InfrahubClient,
+    ) -> None:
+        schema_root = SchemaRoot(
+            version="1.0",
+            generics=[generic_schema_add_attributes_to_profiles],
+            nodes=[person_schema_add_attributes_to_profiles],
+        )
+        response = await client.schema.load(schemas=[schema_root.model_dump()], branch=default_branch.name)
+        assert response.schema_updated
+        assert not response.errors
 
-        person_schema = person_schema_root_add_attributes_to_profiles.nodes[0].model_copy(deep=True)
-        height_attribute = person_schema.get_attribute("height")
+    @pytest.fixture(scope="class")
+    async def generic_schema_remove_attributes_from_profiles(
+        self, default_branch: Branch, generic_schema_add_attributes_to_profiles: GenericSchema, client: InfrahubClient
+    ) -> GenericSchema:
+        current_generic_schema = await client.schema.get(
+            kind="ProfilePretendLifeform", branch=default_branch.name, refresh=True
+        )
+        current_generic_nothing_attribute = current_generic_schema.get_attribute("generic_nothing")
+        updated_generic_schema = generic_schema_add_attributes_to_profiles.model_copy(deep=True)
+        shape_attribute = updated_generic_schema.get_attribute("shape")
+        shape_attribute.optional = False
+        lifespan_attribute = updated_generic_schema.get_attribute("lifespan")
+        lifespan_attribute.read_only = True
+        generic_nothing_attribute = updated_generic_schema.get_attribute("generic_nothing")
+        generic_nothing_attribute.state = HashableModelState.ABSENT
+        generic_nothing_attribute.id = current_generic_nothing_attribute.id
+        return updated_generic_schema
+
+    @pytest.fixture(scope="class")
+    async def person_schema_remove_attributes_from_profiles(
+        self, default_branch: Branch, person_schema_add_attributes_to_profiles: NodeSchema, client: InfrahubClient
+    ) -> NodeSchema:
+        current_person_schema = await client.schema.get(
+            kind="ProfilePretendPerson", branch=default_branch.name, refresh=True
+        )
+        current_nothing_attribute = current_person_schema.get_attribute("nothing")
+
+        updated_person_schema = person_schema_add_attributes_to_profiles.model_copy(deep=True)
+        height_attribute = updated_person_schema.get_attribute("height")
         height_attribute.optional = False
-        description_attribute = person_schema.get_attribute("description")
+        description_attribute = updated_person_schema.get_attribute("description")
         description_attribute.read_only = True
-        nothing_attribute = person_schema.get_attribute("nothing")
+        nothing_attribute = updated_person_schema.get_attribute("nothing")
         nothing_attribute.state = HashableModelState.ABSENT
         nothing_attribute.id = current_nothing_attribute.id
-        return SchemaRoot(version="1.0", nodes=[person_schema])
+        return updated_person_schema
 
     @pytest.fixture(scope="class")
-    async def schema_person_base(
-        self, db: InfrahubDatabase, default_branch: Branch, person_schema_root, client: InfrahubClient
+    async def schema_root_03(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        generic_schema_remove_attributes_from_profiles: GenericSchema,
+        person_schema_remove_attributes_from_profiles: NodeSchema,
+        client: InfrahubClient,
     ) -> None:
-        await load_schema(db=db, schema=person_schema_root, branch_name=default_branch.name, update_db=True)
+        schema_root = SchemaRoot(
+            version="1.0",
+            generics=[generic_schema_remove_attributes_from_profiles],
+            nodes=[person_schema_remove_attributes_from_profiles],
+        )
+        response = await client.schema.load(schemas=[schema_root.model_dump()], branch=default_branch.name)
+        assert response.schema_updated
+        assert not response.errors
 
     @pytest.fixture(scope="class")
-    async def person_1(self, db: InfrahubDatabase, schema_person_base) -> Node:
+    async def person_1(self, db: InfrahubDatabase, schema_root_01) -> Node:
         schema = registry.schema.get_node_schema(name="PretendPerson", duplicate=False)
         person_1 = await Node.init(db=db, schema=schema)
-        await person_1.new(db=db, name="Starbuck", weight=70)
+        await person_1.new(
+            db=db,
+            name="Starbuck",
+            size="human",
+            weight=70,
+        )
         await person_1.save(db=db)
         return person_1
 
+    # TODO: add profile based on generic to test
+
     @pytest.fixture(scope="class")
-    async def person_profile_1(self, db: InfrahubDatabase, schema_person_base) -> Node:
+    async def person_profile_1(self, db: InfrahubDatabase, schema_root_01) -> Node:
         person_profile_1 = await Node.init(db=db, schema="ProfilePretendPerson")
         await person_profile_1.new(
             db=db,
@@ -143,13 +280,15 @@ class TestProfileLifecycle(TestInfrahubApp):
             profile_priority=10,
             height=167,
             description="profile-one description",
+            lifespan=85,
             nothing="profile-one nothing",
+            generic_nothing="profile-one generic nothing",
         )
         await person_profile_1.save(db=db)
         return person_profile_1
 
     async def test_step_01_one_person_no_profile(
-        self, db: InfrahubDatabase, schema_person_base, person_1, person_profile_1, client: InfrahubClient
+        self, db: InfrahubDatabase, schema_root_01, person_1, person_profile_1, client: InfrahubClient
     ):
         retrieved_person = await client.get(kind="PretendPerson", id=person_1.id, property=True)
 
@@ -166,6 +305,10 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person.weight.is_from_profile is False
         assert retrieved_person.weight.source is None
         assert retrieved_person.weight.is_default is False
+        assert retrieved_person.size.value == "human"
+        assert retrieved_person.size.is_from_profile is False
+        assert retrieved_person.size.source is None
+        assert retrieved_person.size.is_default is False
 
     async def test_step_02_one_person_add_profile(
         self,
@@ -227,6 +370,37 @@ class TestProfileLifecycle(TestInfrahubApp):
             "source": {"id": person_profile_1.id},
             "is_default": False,
         }
+        assert attributes["size"] == {
+            "value": "human",
+            "is_from_profile": False,
+            "source": None,
+            "is_default": False,
+        }
+        assert attributes["shape"] == {
+            "value": None,
+            "is_from_profile": False,
+            "source": None,
+            "is_default": True,
+        }
+        assert attributes["is_alive"] == {
+            "value": None,
+            "is_from_profile": False,
+            "source": None,
+            "is_default": True,
+        }
+        assert attributes["lifespan"] == {
+            "value": 85,
+            "is_from_profile": True,
+            "source": {"id": person_profile_1.id},
+            "is_default": False,
+        }
+        assert attributes["generic_nothing"] == {
+            "value": "profile-one generic nothing",
+            "is_from_profile": True,
+            "source": {"id": person_profile_1.id},
+            "is_default": False,
+        }
+
         retrieved_person = await NodeManager.get_one(db=db, id=person_1.id, include_source=True)
         assert retrieved_person.name.value == "Starbuck"
         assert retrieved_person.name.is_from_profile is False
@@ -252,6 +426,26 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person.nothing.is_from_profile is True
         assert retrieved_person.nothing.source_id == person_profile_1.id
         assert retrieved_person.nothing.is_default is False
+        assert retrieved_person.size.value == "human"
+        assert retrieved_person.size.is_from_profile is False
+        assert retrieved_person.size.source_id is None
+        assert retrieved_person.size.is_default is False
+        assert retrieved_person.shape.value is None
+        assert retrieved_person.shape.is_from_profile is False
+        assert retrieved_person.shape.source_id is None
+        assert retrieved_person.shape.is_default is True
+        assert retrieved_person.is_alive.value is None
+        assert retrieved_person.is_alive.is_from_profile is False
+        assert retrieved_person.is_alive.source_id is None
+        assert retrieved_person.is_alive.is_default is True
+        assert retrieved_person.lifespan.value == 85
+        assert retrieved_person.lifespan.is_from_profile is True
+        assert retrieved_person.lifespan.source_id == person_profile_1.id
+        assert retrieved_person.lifespan.is_default is False
+        assert retrieved_person.generic_nothing.value == "profile-one generic nothing"
+        assert retrieved_person.generic_nothing.is_from_profile is True
+        assert retrieved_person.generic_nothing.source_id == person_profile_1.id
+        assert retrieved_person.generic_nothing.is_default is False
 
     async def test_step_03_create_person_with_profile(
         self,
@@ -264,52 +458,15 @@ class TestProfileLifecycle(TestInfrahubApp):
                 PretendPersonCreate(data: {
                     name: {value: "Apollo"},
                     weight: {value: 85},
+                    size: {value: "bigger human"}
+                    shape: {value: "bipedal"}
                     profiles: [{ id: "%(profile_id)s"}]
                 }) {
                     ok
-                    object {
-                        id
-                        profiles { edges { node { id } } }
-                        name {
-                            value
-                            source { id }
-                            is_from_profile
-                            is_default
-                        }
-                        height {
-                            value
-                            source { id }
-                            is_from_profile
-                            is_default
-                        }
-                        weight {
-                            value
-                            source { id }
-                            is_from_profile
-                            is_default
-                        }
-                        eye_color {
-                            value
-                            source { id }
-                            is_from_profile
-                            is_default
-                        }
-                        description {
-                            value
-                            source { id }
-                            is_from_profile
-                            is_default
-                        }
-                        nothing {
-                            value
-                            source { id }
-                            is_from_profile
-                            is_default
-                        }
-                    }
+                    %(person_values)s
                 }
             }
-        """ % {"profile_id": person_profile_1.id}
+        """ % {"profile_id": person_profile_1.id, "person_values": PERSON_VALUES}
 
         default_branch.update_schema_hash()
         gql_params = await prepare_graphql_params(db=db, branch=default_branch)
@@ -360,6 +517,37 @@ class TestProfileLifecycle(TestInfrahubApp):
             "source": {"id": person_profile_1.id},
             "is_default": False,
         }
+        assert attributes["size"] == {
+            "value": "bigger human",
+            "is_from_profile": False,
+            "source": None,
+            "is_default": False,
+        }
+        assert attributes["shape"] == {
+            "value": "bipedal",
+            "is_from_profile": False,
+            "source": None,
+            "is_default": False,
+        }
+        assert attributes["is_alive"] == {
+            "value": None,
+            "is_from_profile": False,
+            "source": None,
+            "is_default": True,
+        }
+        assert attributes["lifespan"] == {
+            "value": 85,
+            "is_from_profile": True,
+            "source": {"id": person_profile_1.id},
+            "is_default": False,
+        }
+        assert attributes["generic_nothing"] == {
+            "value": "profile-one generic nothing",
+            "is_from_profile": True,
+            "source": {"id": person_profile_1.id},
+            "is_default": False,
+        }
+
         retrieved_person = await NodeManager.get_one(db=db, id=new_person_id, include_source=True)
         assert retrieved_person.name.value == "Apollo"
         assert retrieved_person.name.is_from_profile is False
@@ -385,6 +573,26 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person.nothing.is_from_profile is True
         assert retrieved_person.nothing.source_id == person_profile_1.id
         assert retrieved_person.nothing.is_default is False
+        assert retrieved_person.size.value == "bigger human"
+        assert retrieved_person.size.is_from_profile is False
+        assert retrieved_person.size.source_id is None
+        assert retrieved_person.size.is_default is False
+        assert retrieved_person.shape.value == "bipedal"
+        assert retrieved_person.shape.is_from_profile is False
+        assert retrieved_person.shape.source_id is None
+        assert retrieved_person.shape.is_default is False
+        assert retrieved_person.is_alive.value is None
+        assert retrieved_person.is_alive.is_from_profile is False
+        assert retrieved_person.is_alive.source_id is None
+        assert retrieved_person.is_alive.is_default is True
+        assert retrieved_person.lifespan.value == 85
+        assert retrieved_person.lifespan.is_from_profile is True
+        assert retrieved_person.lifespan.source_id == person_profile_1.id
+        assert retrieved_person.lifespan.is_default is False
+        assert retrieved_person.generic_nothing.value == "profile-one generic nothing"
+        assert retrieved_person.generic_nothing.is_from_profile is True
+        assert retrieved_person.generic_nothing.source_id == person_profile_1.id
+        assert retrieved_person.generic_nothing.is_default is False
 
     async def test_step_04_update_non_profile_attribute(
         self,
@@ -399,7 +607,9 @@ class TestProfileLifecycle(TestInfrahubApp):
             source=PERSON_UPDATE_QUERY,
             context_value=gql_params.context,
             root_value=None,
-            variable_values={"update_data": {"id": person_1.id, "name": {"value": "Kara Thrace"}}},
+            variable_values={
+                "update_data": {"id": person_1.id, "name": {"value": "Kara Thrace"}, "shape": {"value": "bipedal"}}
+            },
         )
 
         assert result.errors is None
@@ -416,6 +626,12 @@ class TestProfileLifecycle(TestInfrahubApp):
             "source": None,
             "is_default": False,
         }
+        assert attributes["shape"] == {
+            "value": "bipedal",
+            "is_from_profile": False,
+            "source": None,
+            "is_default": False,
+        }
         assert attributes["height"] == {
             "value": 167,
             "is_from_profile": True,
@@ -427,6 +643,10 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person.name.is_from_profile is False
         assert retrieved_person.name.source_id is None
         assert retrieved_person.name.is_default is False
+        assert retrieved_person.shape.value == "bipedal"
+        assert retrieved_person.shape.is_from_profile is False
+        assert retrieved_person.shape.source_id is None
+        assert retrieved_person.shape.is_default is False
         assert retrieved_person.height.value == 167
         assert retrieved_person.height.is_from_profile is True
         assert retrieved_person.height.source_id == person_profile_1.id
@@ -444,6 +664,8 @@ class TestProfileLifecycle(TestInfrahubApp):
             profile_name="profile-two",
             profile_priority=5,
             height=156,
+            shape="regular",
+            size="average",
             related_nodes=[person_1.id],
         )
         await profile.save()
@@ -478,6 +700,14 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person.nothing.is_from_profile is True
         assert retrieved_person.nothing.source.id == person_profile_1.id
         assert retrieved_person.nothing.is_default is False
+        assert retrieved_person.shape.value == "bipedal"
+        assert retrieved_person.shape.is_from_profile is False
+        assert retrieved_person.shape.source is None
+        assert retrieved_person.shape.is_default is False
+        assert retrieved_person.size.value == "human"
+        assert retrieved_person.size.is_from_profile is False
+        assert retrieved_person.size.source is None
+        assert retrieved_person.size.is_default is False
 
     async def test_step_07_update_person_delete_profile(
         self,
@@ -504,6 +734,42 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert attributes["id"] == person_2.id
         assert attributes["name"] == {"value": "Apollo", "is_from_profile": False, "source": None, "is_default": False}
         assert attributes["height"] == {"value": None, "is_from_profile": False, "source": None, "is_default": True}
+        assert attributes["description"] == {
+            "value": "placeholder",
+            "is_from_profile": False,
+            "source": None,
+            "is_default": True,
+        }
+        assert attributes["nothing"] == {
+            "value": None,
+            "is_from_profile": False,
+            "source": None,
+            "is_default": True,
+        }
+        assert attributes["shape"] == {
+            "value": "bipedal",
+            "is_from_profile": False,
+            "source": None,
+            "is_default": False,
+        }
+        assert attributes["size"] == {
+            "value": "bigger human",
+            "is_from_profile": False,
+            "source": None,
+            "is_default": False,
+        }
+        assert attributes["lifespan"] == {
+            "value": None,
+            "is_from_profile": False,
+            "source": None,
+            "is_default": True,
+        }
+        assert attributes["generic_nothing"] == {
+            "value": None,
+            "is_from_profile": False,
+            "source": None,
+            "is_default": True,
+        }
 
         retrieved_person = await NodeManager.get_one(db=db, id=person_2.id, include_source=True)
         assert retrieved_person.name.value == "Apollo"
@@ -514,6 +780,30 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person.height.is_from_profile is False
         assert retrieved_person.height.source_id is None
         assert retrieved_person.height.is_default is True
+        assert retrieved_person.shape.value == "bipedal"
+        assert retrieved_person.shape.is_from_profile is False
+        assert retrieved_person.shape.source_id is None
+        assert retrieved_person.shape.is_default is False
+        assert retrieved_person.size.value == "bigger human"
+        assert retrieved_person.size.is_from_profile is False
+        assert retrieved_person.size.source_id is None
+        assert retrieved_person.size.is_default is False
+        assert retrieved_person.description.value == "placeholder"
+        assert retrieved_person.description.is_from_profile is False
+        assert retrieved_person.description.source_id is None
+        assert retrieved_person.description.is_default is True
+        assert retrieved_person.nothing.value is None
+        assert retrieved_person.nothing.is_from_profile is False
+        assert retrieved_person.nothing.source_id is None
+        assert retrieved_person.nothing.is_default is True
+        assert retrieved_person.lifespan.value is None
+        assert retrieved_person.lifespan.is_from_profile is False
+        assert retrieved_person.lifespan.source_id is None
+        assert retrieved_person.lifespan.is_default is True
+        assert retrieved_person.generic_nothing.value is None
+        assert retrieved_person.generic_nothing.is_from_profile is False
+        assert retrieved_person.generic_nothing.source_id is None
+        assert retrieved_person.generic_nothing.is_default is True
 
     async def test_step_08_delete_profile(
         self,
@@ -556,6 +846,14 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person_1.nothing.is_from_profile is True
         assert retrieved_person_1.nothing.source.id == person_profile_1.id
         assert retrieved_person_1.nothing.is_default is False
+        assert retrieved_person_1.size.value == "human"
+        assert retrieved_person_1.size.is_from_profile is False
+        assert retrieved_person_1.size.source is None
+        assert retrieved_person_1.size.is_default is False
+        assert retrieved_person_1.shape.value == "bipedal"
+        assert retrieved_person_1.shape.is_from_profile is False
+        assert retrieved_person_1.shape.source is None
+        assert retrieved_person_1.shape.is_default is False
 
         assert retrieved_person_2.profiles.peer_ids == []
         assert retrieved_person_2.name.value == "Apollo"
@@ -582,6 +880,14 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person_2.nothing.is_from_profile is False
         assert retrieved_person_2.nothing.source is None
         assert retrieved_person_2.nothing.is_default is True
+        assert retrieved_person_2.size.value == "bigger human"
+        assert retrieved_person_2.size.is_from_profile is False
+        assert retrieved_person_2.size.source is None
+        assert retrieved_person_2.size.is_default is False
+        assert retrieved_person_2.shape.value == "bipedal"
+        assert retrieved_person_2.shape.is_from_profile is False
+        assert retrieved_person_2.shape.source is None
+        assert retrieved_person_2.shape.is_default is False
 
     async def test_step_10_update_person_override_profile(
         self,
@@ -596,7 +902,13 @@ class TestProfileLifecycle(TestInfrahubApp):
             source=PERSON_UPDATE_QUERY,
             context_value=gql_params.context,
             root_value=None,
-            variable_values={"update_data": {"id": person_1.id, "height": {"value": 145}}},
+            variable_values={
+                "update_data": {
+                    "id": person_1.id,
+                    "height": {"value": 145},
+                    "shape": {"value": "symmetrical bilateral"},
+                }
+            },
         )
 
         assert result.errors is None
@@ -613,6 +925,13 @@ class TestProfileLifecycle(TestInfrahubApp):
             "is_default": False,
         }
         assert attributes["height"] == {"value": 145, "is_from_profile": False, "source": None, "is_default": False}
+        assert attributes["shape"] == {
+            "value": "symmetrical bilateral",
+            "is_from_profile": False,
+            "source": None,
+            "is_default": False,
+        }
+
         retrieved_person = await NodeManager.get_one(db=db, id=person_1.id)
         assert retrieved_person.name.value == "Kara Thrace"
         assert retrieved_person.name.is_from_profile is False
@@ -622,6 +941,10 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person.height.is_from_profile is False
         assert retrieved_person.height.source_id is None
         assert retrieved_person.height.is_default is False
+        assert retrieved_person.shape.value == "symmetrical bilateral"
+        assert retrieved_person.shape.is_from_profile is False
+        assert retrieved_person.shape.source_id is None
+        assert retrieved_person.shape.is_default is False
 
     async def test_step_11_update_existing_profile(
         self,
@@ -634,12 +957,16 @@ class TestProfileLifecycle(TestInfrahubApp):
         person_profile_1 = await client.get(kind="ProfilePretendPerson", id=person_profile_1.id)
         person_profile_1.profile_priority.value = 11
         person_profile_1.height.value = 134
+        person_profile_1.nothing.value = "profile-one nothing updated"
+        person_profile_1.generic_nothing.value = "profile-one generic nothing updated"
         await person_profile_1.save()
 
         updated_person_profile_1 = await client.get(kind="ProfilePretendPerson", id=person_profile_1.id)
         assert updated_person_profile_1.profile_name.value == "profile-one"
         assert updated_person_profile_1.profile_priority.value == 11
         assert updated_person_profile_1.height.value == 134
+        assert updated_person_profile_1.nothing.value == "profile-one nothing updated"
+        assert updated_person_profile_1.generic_nothing.value == "profile-one generic nothing updated"
         await updated_person_profile_1.related_nodes.fetch()
 
         assert len(updated_person_profile_1.related_nodes.peers) == 1
@@ -661,6 +988,14 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person_1.height.is_from_profile is False
         assert retrieved_person_1.height.source is None
         assert retrieved_person_1.height.is_default is False
+        assert retrieved_person_1.nothing.value == "profile-one nothing updated"
+        assert retrieved_person_1.nothing.is_from_profile is True
+        assert retrieved_person_1.nothing.source.id == person_profile_1.id
+        assert retrieved_person_1.nothing.is_default is False
+        assert retrieved_person_1.generic_nothing.value == "profile-one generic nothing updated"
+        assert retrieved_person_1.generic_nothing.is_from_profile is True
+        assert retrieved_person_1.generic_nothing.source.id == person_profile_1.id
+        assert retrieved_person_1.generic_nothing.is_default is False
 
         assert retrieved_person_2.profiles.peer_ids == []
         assert retrieved_person_2.name.value == "Apollo"
@@ -671,6 +1006,14 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person_2.height.is_from_profile is False
         assert retrieved_person_2.height.source is None
         assert retrieved_person_2.height.is_default is True
+        assert retrieved_person_2.nothing.value is None
+        assert retrieved_person_2.nothing.is_from_profile is False
+        assert retrieved_person_2.nothing.source is None
+        assert retrieved_person_2.nothing.is_default is True
+        assert retrieved_person_2.generic_nothing.value is None
+        assert retrieved_person_2.generic_nothing.is_from_profile is False
+        assert retrieved_person_2.generic_nothing.source is None
+        assert retrieved_person_2.generic_nothing.is_default is True
 
     async def test_step_13_update_existing_profile_related_nodes(
         self,
@@ -705,10 +1048,46 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person_1.name.is_from_profile is False
         assert retrieved_person_1.name.source is None
         assert retrieved_person_1.name.is_default is False
+        assert retrieved_person_1.weight.value == 70
+        assert retrieved_person_1.weight.is_from_profile is False
+        assert retrieved_person_1.weight.source is None
+        assert retrieved_person_1.weight.is_default is False
         assert retrieved_person_1.height.value == 145
         assert retrieved_person_1.height.is_from_profile is False
         assert retrieved_person_1.height.source is None
         assert retrieved_person_1.height.is_default is False
+        assert retrieved_person_1.eye_color.value is None
+        assert retrieved_person_1.eye_color.is_from_profile is False
+        assert retrieved_person_1.eye_color.source is None
+        assert retrieved_person_1.eye_color.is_default is True
+        assert retrieved_person_1.description.value == "placeholder"
+        assert retrieved_person_1.description.is_from_profile is False
+        assert retrieved_person_1.description.source is None
+        assert retrieved_person_1.description.is_default is True
+        assert retrieved_person_1.nothing.value is None
+        assert retrieved_person_1.nothing.is_from_profile is False
+        assert retrieved_person_1.nothing.source is None
+        assert retrieved_person_1.nothing.is_default is True
+        assert retrieved_person_1.size.value == "human"
+        assert retrieved_person_1.size.is_from_profile is False
+        assert retrieved_person_1.size.source is None
+        assert retrieved_person_1.size.is_default is False
+        assert retrieved_person_1.shape.value == "symmetrical bilateral"
+        assert retrieved_person_1.shape.is_from_profile is False
+        assert retrieved_person_1.shape.source is None
+        assert retrieved_person_1.shape.is_default is False
+        assert retrieved_person_1.is_alive.value is None
+        assert retrieved_person_1.is_alive.is_from_profile is False
+        assert retrieved_person_1.is_alive.source is None
+        assert retrieved_person_1.is_alive.is_default is True
+        assert retrieved_person_1.lifespan.value is None
+        assert retrieved_person_1.lifespan.is_from_profile is False
+        assert retrieved_person_1.lifespan.source is None
+        assert retrieved_person_1.lifespan.is_default is True
+        assert retrieved_person_1.generic_nothing.value is None
+        assert retrieved_person_1.generic_nothing.is_from_profile is False
+        assert retrieved_person_1.generic_nothing.source is None
+        assert retrieved_person_1.generic_nothing.is_default is True
 
         await retrieved_person_2.profiles.fetch()
         assert retrieved_person_2.profiles.peer_ids == [person_profile_1.id]
@@ -716,46 +1095,87 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person_2.name.is_from_profile is False
         assert retrieved_person_2.name.source is None
         assert retrieved_person_2.name.is_default is False
+        assert retrieved_person_2.weight.value == 85
+        assert retrieved_person_2.weight.is_from_profile is False
+        assert retrieved_person_2.weight.source is None
+        assert retrieved_person_2.weight.is_default is False
         assert retrieved_person_2.height.value == 134
         assert retrieved_person_2.height.is_from_profile is True
         assert retrieved_person_2.height.source.id == person_profile_1.id
         assert retrieved_person_2.height.is_default is False
+        assert retrieved_person_2.eye_color.value is None
+        assert retrieved_person_2.eye_color.is_from_profile is False
+        assert retrieved_person_2.eye_color.source is None
+        assert retrieved_person_2.eye_color.is_default is True
+        assert retrieved_person_2.description.value == "profile-one description"
+        assert retrieved_person_2.description.is_from_profile is True
+        assert retrieved_person_2.description.source.id == person_profile_1.id
+        assert retrieved_person_2.description.is_default is False
+        assert retrieved_person_2.nothing.value == "profile-one nothing updated"
+        assert retrieved_person_2.nothing.is_from_profile is True
+        assert retrieved_person_2.nothing.source.id == person_profile_1.id
+        assert retrieved_person_2.nothing.is_default is False
+        assert retrieved_person_2.size.value == "bigger human"
+        assert retrieved_person_2.size.is_from_profile is False
+        assert retrieved_person_2.size.source is None
+        assert retrieved_person_2.size.is_default is False
+        assert retrieved_person_2.shape.value == "bipedal"
+        assert retrieved_person_2.shape.is_from_profile is False
+        assert retrieved_person_2.shape.source is None
+        assert retrieved_person_2.shape.is_default is False
+        assert retrieved_person_2.is_alive.value is None
+        assert retrieved_person_2.is_alive.is_from_profile is False
+        assert retrieved_person_2.is_alive.source is None
+        assert retrieved_person_2.is_alive.is_default is True
+        assert retrieved_person_2.lifespan.value == 85
+        assert retrieved_person_2.lifespan.is_from_profile is True
+        assert retrieved_person_2.lifespan.source.id == person_profile_1.id
+        assert retrieved_person_2.lifespan.is_default is False
+        assert retrieved_person_2.generic_nothing.value == "profile-one generic nothing updated"
+        assert retrieved_person_2.generic_nothing.is_from_profile is True
+        assert retrieved_person_2.generic_nothing.source.id == person_profile_1.id
+        assert retrieved_person_2.generic_nothing.is_default is False
 
     async def test_step_15_schema_update_add_attributes(
         self,
         db: InfrahubDatabase,
         default_branch,
-        person_schema_root_add_attributes_to_profiles: SchemaRoot,
+        schema_root_02,
         person_profile_1: Node,
         client: InfrahubClient,
     ):
-        response = await client.schema.load(
-            schemas=[person_schema_root_add_attributes_to_profiles.model_dump()], branch=default_branch.name
-        )
-        assert response.schema_updated
-        assert not response.errors
-
         updated_schema = await client.schema.get(kind="ProfilePretendPerson", branch=default_branch.name, refresh=True)
         assert set(updated_schema.attribute_names) == {
+            "age",
+            "description",
+            "eye_color",
+            "generic_nothing",
+            "height",
+            "is_alive",
+            "lifespan",
+            "nothing",
             "profile_name",
             "profile_priority",
+            "shape",
+            "size",
+            "value",
             "weight",
-            "height",
-            "eye_color",
-            "description",
-            "nothing",
-            "age",
         }
 
         updated_person_profile_1 = await client.get(kind="ProfilePretendPerson", id=person_profile_1.id)
         assert updated_person_profile_1.height.value == 134
         assert updated_person_profile_1.description.value == "profile-one description"
-        assert updated_person_profile_1.nothing.value == "profile-one nothing"
+        assert updated_person_profile_1.nothing.value == "profile-one nothing updated"
         assert updated_person_profile_1.age.value is None
         assert updated_person_profile_1.weight.value is None
         assert updated_person_profile_1.eye_color.value is None
+        assert updated_person_profile_1.size.value is None
+        assert updated_person_profile_1.is_alive.value is None
+        assert updated_person_profile_1.value.value is None
         with pytest.raises(AttributeError):
             _ = updated_person_profile_1.not_for_profiles
+        with pytest.raises(AttributeError):
+            _ = updated_person_profile_1.generic_not_for_profiles
 
     async def test_step_16_update_profile_with_new_attribute(
         self,
@@ -764,13 +1184,11 @@ class TestProfileLifecycle(TestInfrahubApp):
         person_profile_1,
         client: InfrahubClient,
     ):
-        updated_schema = await client.schema.get(kind="ProfilePretendPerson", branch=default_branch.name, refresh=True)
-        assert updated_schema.get_attribute("age") is not None
-        assert updated_schema.get_attribute("eye_color") is not None
-
         person_profile_1 = await client.get(kind="ProfilePretendPerson", id=person_profile_1.id)
         person_profile_1.age.value = 25
         person_profile_1.eye_color.value = "blurple"
+        person_profile_1.value.value = 42
+        person_profile_1.is_alive.value = True
         await person_profile_1.save()
 
     async def test_step_17_check_persons_again(
@@ -809,6 +1227,30 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person_1.age.is_from_profile is False
         assert retrieved_person_1.age.source is None
         assert retrieved_person_1.age.is_default is True
+        assert retrieved_person_1.size.value == "human"
+        assert retrieved_person_1.size.is_from_profile is False
+        assert retrieved_person_1.size.source is None
+        assert retrieved_person_1.size.is_default is False
+        assert retrieved_person_1.shape.value == "symmetrical bilateral"
+        assert retrieved_person_1.shape.is_from_profile is False
+        assert retrieved_person_1.shape.source is None
+        assert retrieved_person_1.shape.is_default is False
+        assert retrieved_person_1.is_alive.value is None
+        assert retrieved_person_1.is_alive.is_from_profile is False
+        assert retrieved_person_1.is_alive.source is None
+        assert retrieved_person_1.is_alive.is_default is True
+        assert retrieved_person_1.lifespan.value is None
+        assert retrieved_person_1.lifespan.is_from_profile is False
+        assert retrieved_person_1.lifespan.source is None
+        assert retrieved_person_1.lifespan.is_default is True
+        assert retrieved_person_1.generic_nothing.value is None
+        assert retrieved_person_1.generic_nothing.is_from_profile is False
+        assert retrieved_person_1.generic_nothing.source is None
+        assert retrieved_person_1.generic_nothing.is_default is True
+        assert retrieved_person_1.value.value is None
+        assert retrieved_person_1.value.is_from_profile is False
+        assert retrieved_person_1.value.source is None
+        assert retrieved_person_1.value.is_default is True
 
         await retrieved_person_2.profiles.fetch()
         assert retrieved_person_2.profiles.peer_ids == [person_profile_1.id]
@@ -832,7 +1274,7 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person_2.description.is_from_profile is True
         assert retrieved_person_2.description.source.id == person_profile_1.id
         assert retrieved_person_2.description.is_default is False
-        assert retrieved_person_2.nothing.value == "profile-one nothing"
+        assert retrieved_person_2.nothing.value == "profile-one nothing updated"
         assert retrieved_person_2.nothing.is_from_profile is True
         assert retrieved_person_2.nothing.source.id == person_profile_1.id
         assert retrieved_person_2.nothing.is_default is False
@@ -840,34 +1282,49 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person_2.age.is_from_profile is True
         assert retrieved_person_2.age.source.id == person_profile_1.id
         assert retrieved_person_2.age.is_default is False
+        assert retrieved_person_2.size.value == "bigger human"
+        assert retrieved_person_2.size.is_from_profile is False
+        assert retrieved_person_2.size.source is None
+        assert retrieved_person_2.size.is_default is False
+        assert retrieved_person_2.shape.value == "bipedal"
+        assert retrieved_person_2.shape.is_from_profile is False
+        assert retrieved_person_2.shape.source is None
+        assert retrieved_person_2.shape.is_default is False
+        assert retrieved_person_2.is_alive.value is True
+        assert retrieved_person_2.is_alive.is_from_profile is True
+        assert retrieved_person_2.is_alive.source.id == person_profile_1.id
+        assert retrieved_person_2.is_alive.is_default is False
+        assert retrieved_person_2.lifespan.value == 85
+        assert retrieved_person_2.lifespan.is_from_profile is True
+        assert retrieved_person_2.lifespan.source.id == person_profile_1.id
+        assert retrieved_person_2.lifespan.is_default is False
+        assert retrieved_person_2.generic_nothing.value == "profile-one generic nothing updated"
+        assert retrieved_person_2.generic_nothing.is_from_profile is True
+        assert retrieved_person_2.generic_nothing.source.id == person_profile_1.id
+        assert retrieved_person_2.generic_nothing.is_default is False
+        assert retrieved_person_2.value.value == 42
+        assert retrieved_person_2.value.is_from_profile is True
+        assert retrieved_person_2.value.source.id == person_profile_1.id
+        assert retrieved_person_2.value.is_default is False
 
-    async def test_step_18_schema_update_remove_attributes(
+    async def test_step_18_check_profile_for_removed_attribute(
         self,
         db: InfrahubDatabase,
-        default_branch,
-        person_schema_root_remove_attributes_from_profiles: SchemaRoot,
-        client: InfrahubClient,
-    ):
-        response = await client.schema.load(
-            schemas=[person_schema_root_remove_attributes_from_profiles.model_dump()], branch=default_branch.name
-        )
-        assert response.schema_updated
-        assert not response.errors
-
-    async def test_step_19_check_profile_for_removed_attribute(
-        self,
-        db: InfrahubDatabase,
+        schema_root_03,
         default_branch,
         person_profile_1,
         client: InfrahubClient,
     ):
         updated_schema = await client.schema.get(kind="ProfilePretendPerson", branch=default_branch.name, refresh=True)
         assert set(updated_schema.attribute_names) == {
+            "age",
+            "eye_color",
+            "is_alive",
             "profile_name",
             "profile_priority",
+            "size",
+            "value",
             "weight",
-            "eye_color",
-            "age",
         }
 
         person_profile_1 = await client.get(kind="ProfilePretendPerson", id=person_profile_1.id)
@@ -877,10 +1334,17 @@ class TestProfileLifecycle(TestInfrahubApp):
             _ = person_profile_1.description
         with pytest.raises(AttributeError):
             _ = person_profile_1.nothing
+        with pytest.raises(AttributeError):
+            _ = person_profile_1.shape
+        with pytest.raises(AttributeError):
+            _ = person_profile_1.lifespan
+        with pytest.raises(AttributeError):
+            _ = person_profile_1.generic_nothing
 
-    async def test_step_20_check_persons_again(
+    async def test_step_19_check_persons_again(
         self, db: InfrahubDatabase, default_branch: Branch, person_1, person_profile_1, client: InfrahubClient
     ):
+        await client.schema.get(kind="PretendPerson", branch=default_branch.name, refresh=True)
         retrieved_person_1 = await client.get(kind="PretendPerson", id=person_1.id, property=True)
         retrieved_person_2 = await client.get(kind="PretendPerson", name__value="Apollo", property=True)
 
@@ -910,8 +1374,30 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person_1.description.is_from_profile is False
         assert retrieved_person_1.description.source is None
         assert retrieved_person_1.description.is_default is True
+        assert retrieved_person_1.size.value == "human"
+        assert retrieved_person_1.size.is_from_profile is False
+        assert retrieved_person_1.size.source is None
+        assert retrieved_person_1.size.is_default is False
+        assert retrieved_person_1.shape.value == "symmetrical bilateral"
+        assert retrieved_person_1.shape.is_from_profile is False
+        assert retrieved_person_1.shape.source is None
+        assert retrieved_person_1.shape.is_default is False
+        assert retrieved_person_1.is_alive.value is None
+        assert retrieved_person_1.is_alive.is_from_profile is False
+        assert retrieved_person_1.is_alive.source is None
+        assert retrieved_person_1.is_alive.is_default is True
+        assert retrieved_person_1.lifespan.value is None
+        assert retrieved_person_1.lifespan.is_from_profile is False
+        assert retrieved_person_1.lifespan.source is None
+        assert retrieved_person_1.lifespan.is_default is True
+        assert retrieved_person_1.value.value is None
+        assert retrieved_person_1.value.is_from_profile is False
+        assert retrieved_person_1.value.source is None
+        assert retrieved_person_1.value.is_default is True
         with pytest.raises(AttributeError):
             _ = retrieved_person_1.nothing
+        with pytest.raises(AttributeError):
+            _ = retrieved_person_1.generic_nothing
 
         await retrieved_person_2.profiles.fetch()
         assert retrieved_person_2.profiles.peer_ids == [person_profile_1.id]
@@ -939,5 +1425,27 @@ class TestProfileLifecycle(TestInfrahubApp):
         assert retrieved_person_2.description.is_from_profile is True
         assert retrieved_person_2.description.source.id == person_profile_1.id
         assert retrieved_person_2.description.is_default is False
+        assert retrieved_person_2.size.value == "bigger human"
+        assert retrieved_person_2.size.is_from_profile is False
+        assert retrieved_person_2.size.source is None
+        assert retrieved_person_2.size.is_default is False
+        assert retrieved_person_2.shape.value == "bipedal"
+        assert retrieved_person_2.shape.is_from_profile is False
+        assert retrieved_person_2.shape.source is None
+        assert retrieved_person_2.shape.is_default is False
+        assert retrieved_person_2.is_alive.value is True
+        assert retrieved_person_2.is_alive.is_from_profile is True
+        assert retrieved_person_2.is_alive.source.id == person_profile_1.id
+        assert retrieved_person_2.is_alive.is_default is False
+        assert retrieved_person_2.lifespan.value == 85
+        assert retrieved_person_2.lifespan.is_from_profile is True
+        assert retrieved_person_2.lifespan.source.id == person_profile_1.id
+        assert retrieved_person_2.lifespan.is_default is False
+        assert retrieved_person_2.value.value == 42
+        assert retrieved_person_2.value.is_from_profile is True
+        assert retrieved_person_2.value.source.id == person_profile_1.id
+        assert retrieved_person_2.value.is_default is False
         with pytest.raises(AttributeError):
             _ = retrieved_person_2.nothing
+        with pytest.raises(AttributeError):
+            _ = retrieved_person_2.generic_nothing

--- a/changelog/+profile-schema-update.added.md
+++ b/changelog/+profile-schema-update.added.md
@@ -1,1 +1,1 @@
-Add support for updating existing Profiles when the associated node schema is updated to add or remove an attribute
+Add support for updating existing Profiles when the associated node or generic schema is updated to change an attribute's optional or read-only value or when an attribute is added or removed

--- a/changelog/+profile-schema-update.added.md
+++ b/changelog/+profile-schema-update.added.md
@@ -1,0 +1,1 @@
+Add support for updating existing Profiles when the associated node schema is updated to add or remove an attribute

--- a/docs/docs/reference/schema/validator-migration.mdx
+++ b/docs/docs/reference/schema/validator-migration.mdx
@@ -63,9 +63,9 @@ In this context, an element represent either a Node, a Generic, an Attribute or 
 | **min_length** | validate_constraint |
 | **label** | allowed |
 | **description** | allowed |
-| **read_only** | allowed |
+| **read_only** | migration_required |
 | **unique** | validate_constraint |
-| **optional** | validate_constraint |
+| **optional** | migration_required |
 | **branch** | not_supported |
 | **order_weight** | allowed |
 | **default_value** | allowed |


### PR DESCRIPTION
IFC-1887
IFC-1897
`ProfileSchema`s are dynamically generated when a schema is updated and are never saved to the database, so we do not need to worry about migrating `ProfileSchema` when the associated `Node` or `GenericSchema`s are updated.
HOWEVER, we have not been correctly handling existing `Profile` **objects** when the profile's associated `Node` or `Generic` schema is updated.  when an optional (and `read_only=False`) attribute is added, an attribute is updated to become `optional=True` and `read_only=False`, then we need to add that attribute to any existing `Profile` objects for that schema so that it can be used. we also need to handle the reverse case, when an attribute is removed from a `Node`/`Generic` schema and when an attribute is updated to be `optional=False` or `read_only=True`.

handling these cases required updating the existing schema migrations for adding and deleting attributes and adding new schema migrations for changes to `optional` and `read_only` properties.

TODO:
 - [x] add profile based on generic to test case
 - [x] test large-type attribute