### PR TITLE
Avoid regenerating schema if the hash already exists

### DIFF
--- a/backend/tests/unit/graphql/test_mutation_graphqlquery.py
+++ b/backend/tests/unit/graphql/test_mutation_graphqlquery.py
@@ -44,7 +44,7 @@ async def test_create_query_no_vars(db: InfrahubDatabase, default_branch: Branch
     }
     """ % query_value.replace("\n", " ").replace('"', '\\"')
     default_branch.update_schema_hash()
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,


### PR DESCRIPTION
Should fix another flaky test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated GraphQL-related unit tests to align with current parameter default handling, improving consistency and clarity.
  * Refined invocation patterns and assertions to reduce brittleness and better reflect the existing behavior.
  * Enhances test reliability and maintainability with no impact on production functionality, performance, or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->