### PR TITLE
fix: small memory/cpu optimizations

### DIFF
--- a/backend/infrahub/core/registry.py
+++ b/backend/infrahub/core/registry.py
@@ -113,8 +113,8 @@ class Registry:
             return True
         return False
 
-    def get_node_schema(self, name: str, branch: Branch | str | None = None) -> NodeSchema:
-        return self.schema.get_node_schema(name=name, branch=branch)
+    def get_node_schema(self, name: str, branch: Branch | str | None = None, duplicate: bool = False) -> NodeSchema:
+        return self.schema.get_node_schema(name=name, branch=branch, duplicate=duplicate)
 
     def get_data_type(self, name: str) -> type[InfrahubDataType]:
         if name not in self.data_type:

--- a/backend/infrahub/graphql/analyzer.py
+++ b/backend/infrahub/graphql/analyzer.py
@@ -639,7 +639,7 @@ class InfrahubGraphQLQueryAnalyzer(GraphQLQueryAnalyzer):
         self, node: InlineFragmentNode, query_node: GraphQLQueryNode
     ) -> GraphQLQueryNode:
         context_type = query_node.context_type
-        infrahub_model = self.schema_branch.get(name=node.type_condition.name.value)
+        infrahub_model = self.schema_branch.get(name=node.type_condition.name.value, duplicate=False)
         context_type = ContextType.DIRECT
         current_node = GraphQLQueryNode(
             parent=query_node,

--- a/backend/infrahub/middleware.py
+++ b/backend/infrahub/middleware.py
@@ -1,7 +1,8 @@
 from typing import Any
 
+from fastapi.middleware.gzip import GZipMiddleware
 from starlette.middleware.cors import CORSMiddleware
-from starlette.types import ASGIApp
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from infrahub import config
 
@@ -15,3 +16,27 @@ class InfrahubCORSMiddleware(CORSMiddleware):
         kwargs["allow_headers"] = config.SETTINGS.api.cors_allow_headers
 
         super().__init__(app, *args, **kwargs)
+
+
+class ConditionalGZipMiddleware(GZipMiddleware):
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        minimum_size: int = 500,
+        compresslevel: int = 9,
+        include_paths: tuple[str, ...] = (),
+    ) -> None:
+        super().__init__(app, minimum_size=minimum_size, compresslevel=compresslevel)
+        self.include_paths = include_paths
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:  # type: ignore[override]
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+        if any(path.startswith(include) for include in self.include_paths):
+            await super().__call__(scope, receive, send)
+        else:
+            await self.app(scope, receive, send)

--- a/backend/infrahub/server.py
+++ b/backend/infrahub/server.py
@@ -10,7 +10,6 @@ from asgi_correlation_id import CorrelationIdMiddleware
 from asgi_correlation_id.context import correlation_id
 from fastapi import FastAPI, Request, Response
 from fastapi.logger import logger
-from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -30,7 +29,7 @@ from infrahub.exceptions import Error, ValidationError
 from infrahub.graphql.api.endpoints import router as graphql_router
 from infrahub.lock import initialize_lock
 from infrahub.log import clear_log_context, get_logger, set_log_data
-from infrahub.middleware import InfrahubCORSMiddleware
+from infrahub.middleware import ConditionalGZipMiddleware, InfrahubCORSMiddleware
 from infrahub.services import InfrahubServices
 from infrahub.trace import add_span_exception, configure_trace, get_traceid
 from infrahub.worker import WORKER_IDENTITY
@@ -184,7 +183,17 @@ app.add_middleware(
     skip_paths=["/health"],
 )
 app.add_middleware(InfrahubCORSMiddleware)
-app.add_middleware(GZipMiddleware, minimum_size=100_000)
+app.add_middleware(
+    ConditionalGZipMiddleware,
+    minimum_size=100_000,
+    compresslevel=1,
+    include_paths=(
+        "/assets",
+        "/favicons",
+        "/docs",
+        "/api/schema",
+    ),
+)
 
 app.add_exception_handler(Error, generic_api_exception_handler)
 app.add_exception_handler(TimestampFormatError, partial(generic_api_exception_handler, http_code=400))


### PR DESCRIPTION
Measured a rough 10% speedup in my test case with those, with lesser cpu/memory usage.

- missed a duplicate=False

- for the gzip change, here's the commit message:

> During testing, we noticed that all graphql queries were compressed even
> though the size of the response was less than the defined 100kB size.
> It seems compression is always enabled for streamed response, thus
> compressing almost ALL requests toward APIs.
> 
> Introduce a new middleware that enables compression only on specific,
> useful paths.

Also change default compression level to 1 (instead of the default 9) for better CPU usage/compression ratio

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Selective HTTP compression for specified API paths (path-based inclusion).
  - Configurable compression level and minimum size for compressed responses.

- Bug Fixes
  - Fixed GraphQL inline fragment handling to prevent unintended duplication and ensure consistent query results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->