### PR TITLE
IFC-680: Handle processing schema relationship state on creation

### DIFF
--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -508,6 +508,7 @@ class SchemaBranch:
         self.process_default_values()
         self.process_deprecations()
         self.process_cardinality_counts()
+        self.process_relationships_state()
         self.process_inheritance()
         self.process_hierarchy()
         self.process_branch_support()
@@ -1611,6 +1612,18 @@ class SchemaBranch:
                     item.optional = True
 
             self.set(name=name, schema=node)
+
+    def process_relationships_state(self) -> None:
+        for name in self.node_names + self.generic_names_without_templates:
+            node = self.get(name=name, duplicate=False)
+            if node.id or (not node.id and not node.relationships):
+                continue
+
+            relationships = []
+            for relationship in node.relationships:
+                if relationship.state != HashableModelState.ABSENT:
+                    relationships.append(relationship)
+            node.relationships = relationships
 
     def _generate_weight_generics(self) -> None:
         """Generate order_weight for all generic schemas."""

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1619,11 +1619,14 @@ class SchemaBranch:
             if node.id or (not node.id and not node.relationships):
                 continue
 
-            relationships = []
-            for relationship in node.relationships:
-                if relationship.state != HashableModelState.ABSENT:
-                    relationships.append(relationship)
-            node.relationships = relationships
+            filtered_relationships = [
+                relationship for relationship in node.relationships if relationship.state != HashableModelState.ABSENT
+            ]
+            if len(filtered_relationships) == len(node.relationships):
+                continue
+            updated_node = node.duplicate()
+            updated_node.relationships = filtered_relationships
+            self.set(name=name, schema=updated_node)
 
     def _generate_weight_generics(self) -> None:
         """Generate order_weight for all generic schemas."""

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -3022,6 +3022,44 @@ def test_schema_branch_conflicting_required_relationships(schema_all_in_one):
     assert "cannot both have required relationships" in exc.value.args[0]
 
 
+async def test_schema_branch_processes_relationships_state(
+    db: InfrahubDatabase, default_branch: Branch, register_internal_models_schema
+):
+    schema = {
+        "nodes": [
+            {
+                "name": "Thing",
+                "namespace": "Infra",
+                "label": "Thing",
+                "attributes": [{"name": "name", "label": "Name", "kind": "Text", "optional": False, "unique": True}],
+                "relationships": [
+                    {
+                        "name": "other_thing",
+                        "peer": "InfraOtherThing",
+                        "kind": "Attribute",
+                        "state": "absent",
+                        "cardinality": "one",
+                        "optional": True,
+                    },
+                ],
+            },
+            {
+                "name": "OtherThing",
+                "namespace": "Infra",
+                "label": "OtherThing",
+                "attributes": [
+                    {"name": "name", "label": "Name", "kind": "Text", "optional": False, "unique": True},
+                ],
+            },
+        ],
+    }
+    schema_branch = registry.schema.register_schema(schema=SchemaRoot(**schema), branch=default_branch.name)
+    await registry.schema.load_schema_to_db(schema=schema_branch, db=db, branch=default_branch.name)
+    returned_schema = await registry.schema.load_schema_from_db(db=db, branch=default_branch.name)
+
+    assert "other_thing" not in returned_schema.get(name="InfraThing").relationship_names
+
+
 async def test_process_deprecations(organization_schema):
     SCHEMA1 = {
         "name": "Criticality",

--- a/changelog/4302.fixed.md
+++ b/changelog/4302.fixed.md
@@ -1,0 +1,1 @@
+Prevent creation of relationships with state `absent`


### PR DESCRIPTION
Fixes https://github.com/opsmill/infrahub/issues/4302

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented relationships marked "absent" from being created or retained during schema processing and load/reload, improving data consistency.
  * Synchronized relationship-state cleanup earlier in pre-validation to reduce validation issues and unexpected relationship persistence.

* **Tests**
  * Added an end-to-end test verifying absent relationships are filtered out across database round-trips.

* **Changelog**
  * Documented the fix preventing creation of absent relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->