### PR TITLE
fix(ci): ensure poetry is correctly installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -986,6 +986,7 @@ jobs:
   # ------------------------------------------ Benchmarks ------------------------------------------------
   backend-benchmark:
     needs:
+      - prepare-environment
       - javascript-lint
       - files-changed
       - yaml-lint
@@ -1018,6 +1019,7 @@ jobs:
               git config --global credential.helper /usr/local/bin/infrahub-git-credential"
       - name: "Setup Python environment"
         run: |
+          pipx install -f poetry==${{ needs.prepare-environment.outputs.POETRY_VERSION }}
           poetry config virtualenvs.create true --local
           poetry env use 3.12
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,7 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
       needs.files-changed.outputs.backend == 'true'
-    needs: ["files-changed", "yaml-lint", "python-lint", "infrahub-testcontainers-check"]
+    needs: ["prepare-environment", "files-changed", "yaml-lint", "python-lint", "infrahub-testcontainers-check"]
     runs-on:
       group: huge-runners
     timeout-minutes: 45
@@ -238,6 +238,7 @@ jobs:
         with:
           submodules: true
       - name: Set up Python
+        id: python
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -249,8 +250,11 @@ jobs:
               git config --global credential.helper /usr/local/bin/infrahub-git-credential"
       - name: "Setup Python environment"
         run: |
+          pipx install -f poetry==${{ needs.prepare-environment.outputs.POETRY_VERSION }}
           poetry config virtualenvs.create true --local
           poetry env use 3.12
+        env:
+          PIPX_DEFAULT_PYTHON: ${{ steps.python.outputs.python-path }}
       - name: "Install dependencies"
         run: "poetry install --no-interaction --no-ansi"
       - name: "Unit Tests"
@@ -279,7 +283,7 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
       needs.files-changed.outputs.backend == 'true'
-    needs: ["files-changed", "yaml-lint", "python-lint", "infrahub-testcontainers-check"]
+    needs: ["prepare-environment", "files-changed", "yaml-lint", "python-lint", "infrahub-testcontainers-check"]
     runs-on:
       group: "huge-runners"
     timeout-minutes: 30
@@ -291,6 +295,7 @@ jobs:
         with:
           submodules: true
       - name: Set up Python
+        id: python
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -302,8 +307,11 @@ jobs:
               git config --global credential.helper /usr/local/bin/infrahub-git-credential"
       - name: "Setup Python environment"
         run: |
+          pipx install -f poetry==${{ needs.prepare-environment.outputs.POETRY_VERSION }}
           poetry config virtualenvs.create true --local
           poetry env use 3.12
+        env:
+          PIPX_DEFAULT_PYTHON: ${{ steps.python.outputs.python-path }}
       - name: "Install dependencies"
         run: "poetry install --no-interaction --no-ansi"
       - name: "Mypy Tests"
@@ -325,7 +333,7 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
       needs.files-changed.outputs.backend == 'true'
-    needs: ["files-changed", "yaml-lint", "python-lint", "infrahub-testcontainers-check"]
+    needs: ["prepare-environment", "files-changed", "yaml-lint", "python-lint", "infrahub-testcontainers-check"]
     runs-on:
       group: "huge-runners"
     timeout-minutes: 30
@@ -337,6 +345,7 @@ jobs:
         with:
           submodules: true
       - name: Set up Python
+        id: python
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -348,8 +357,11 @@ jobs:
               git config --global credential.helper /usr/local/bin/infrahub-git-credential"
       - name: "Setup Python environment"
         run: |
+          pipx install -f poetry==${{ needs.prepare-environment.outputs.POETRY_VERSION }}
           poetry config virtualenvs.create true --local
           poetry env use 3.12
+        env:
+          PIPX_DEFAULT_PYTHON: ${{ steps.python.outputs.python-path }}
       - name: "Install dependencies"
         run: "poetry install --no-interaction --no-ansi"
       - name: "Mypy Tests"
@@ -386,6 +398,7 @@ jobs:
         with:
           submodules: true
       - name: Set up Python
+        id: python
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -412,8 +425,11 @@ jobs:
         run: "invoke dev.build"
       - name: "Setup Python environment"
         run: |
+          pipx install -f poetry==${{ needs.prepare-environment.outputs.POETRY_VERSION }}
           poetry config virtualenvs.create true --local
           poetry env use 3.12
+        env:
+          PIPX_DEFAULT_PYTHON: ${{ steps.python.outputs.python-path }}
       - name: "Install dependencies"
         run: "poetry install --no-interaction --no-ansi"
       - name: "Run tests"
@@ -725,6 +741,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: frontend/app/package-lock.json
       - name: Set up Python
+        id: python
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
@@ -897,6 +914,7 @@ jobs:
           submodules: true
 
       - name: Set up Python
+        id: python
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -988,6 +1006,7 @@ jobs:
         with:
           submodules: true
       - name: Set up Python
+        id: python
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -1001,6 +1020,8 @@ jobs:
         run: |
           poetry config virtualenvs.create true --local
           poetry env use 3.12
+        env:
+          PIPX_DEFAULT_PYTHON: ${{ steps.python.outputs.python-path }}
       - name: "Install dependencies"
         run: "poetry install --no-interaction --no-ansi"
       - name: Update PATH

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -39,16 +39,19 @@ jobs:
     needs: prepare-environment
     steps:
       - name: "Set up Python"
+        id: python
         uses: "actions/setup-python@v5"
         with:
           python-version: "3.12"
-      - name: "Install Poetry"
-        uses: "snok/install-poetry@v1"
-        with:
-          version: ${{ needs.prepare-environment.outputs.POETRY_VERSION }}
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-          installer-parallel: true
+
+      - name: "Setup Python environment"
+        run: |
+          pipx install -f poetry==${{ needs.prepare-environment.outputs.POETRY_VERSION }}
+          poetry config virtualenvs.create true --local
+          poetry env use 3.12
+        env:
+          PIPX_DEFAULT_PYTHON: ${{ steps.python.outputs.python-path }}
+
       - name: "Check out repository code"
         uses: "actions/checkout@v5"
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,22 +26,18 @@ jobs:
           submodules: true
 
       - name: "Set up Python"
+        id: python
         uses: "actions/setup-python@v5"
         with:
           python-version: "3.12"
 
-      - name: "Install Poetry"
-        uses: "snok/install-poetry@v1"
-        with:
-          version: ${{ needs.prepare-environment.outputs.POETRY_VERSION }}
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-          installer-parallel: true
-
       - name: "Setup Python environment"
         run: |
+          pipx install -f poetry==${{ needs.prepare-environment.outputs.POETRY_VERSION }}
           poetry config virtualenvs.create true --local
           poetry env use 3.12
+        env:
+          PIPX_DEFAULT_PYTHON: ${{ steps.python.outputs.python-path }}
       - name: "Install dependencies"
         run: "poetry install --no-interaction --no-ansi"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI and release workflows now use a unified Python/Poetry setup: Poetry is installed via pipx with a pinned version, configured to create local virtual environments targeting Python 3.12, and the resolved Python interpreter path is propagated into the pipx environment. This standardizes environment setup across build, test, and publish jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->