### PR TITLE
IFC-1894: Handle processing schema node state on creation

### DIFF
--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -1632,9 +1632,8 @@ class SchemaBranch:
     def process_nodes_state(self) -> None:
         for name in self.node_names + self.generic_names_without_templates:
             node = self.get(name=name, duplicate=False)
-            if node.id or (not node.id and node.state != HashableModelState.ABSENT):
-                continue
-            self.delete(name=name)
+            if not node.id and node.state == HashableModelState.ABSENT:
+                self.delete(name=name)
 
     def _generate_weight_generics(self) -> None:
         """Generate order_weight for all generic schemas."""

--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -508,6 +508,7 @@ class SchemaBranch:
         self.process_default_values()
         self.process_deprecations()
         self.process_cardinality_counts()
+        self.process_nodes_state()
         self.process_relationships_state()
         self.process_inheritance()
         self.process_hierarchy()
@@ -1627,6 +1628,13 @@ class SchemaBranch:
             updated_node = node.duplicate()
             updated_node.relationships = filtered_relationships
             self.set(name=name, schema=updated_node)
+
+    def process_nodes_state(self) -> None:
+        for name in self.node_names + self.generic_names_without_templates:
+            node = self.get(name=name, duplicate=False)
+            if node.id or (not node.id and node.state != HashableModelState.ABSENT):
+                continue
+            self.delete(name=name)
 
     def _generate_weight_generics(self) -> None:
         """Generate order_weight for all generic schemas."""

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -3064,6 +3064,18 @@ async def test_schema_branch_processes_nodes_state(
     db: InfrahubDatabase, default_branch: Branch, register_internal_models_schema
 ):
     schema = {
+        "generics": [
+            {
+                "namespace": "Test",
+                "name": "GenericInterface",
+                "label": "Generic Interface",
+                "include_in_menu": True,
+                "state": "absent",
+                "attributes": [
+                    {"name": "my_generic_name", "kind": "Text", "label": "My Generic String"},
+                ],
+            },
+        ],
         "nodes": [
             {
                 "name": "Widget",
@@ -3085,6 +3097,10 @@ async def test_schema_branch_processes_nodes_state(
     with pytest.raises(SchemaNotFoundError) as exc:
         returned_schema.get(name="TestWidget")
     assert exc.value.args[0] == "Unable to find the schema 'TestWidget' in the registry"
+
+    with pytest.raises(SchemaNotFoundError) as exc:
+        returned_schema.get(name="TestGenericInterface")
+    assert exc.value.args[0] == "Unable to find the schema 'TestGenericInterface' in the registry"
 
 
 async def test_process_deprecations(organization_schema):

--- a/backend/tests/unit/core/schema_manager/test_manager_schema.py
+++ b/backend/tests/unit/core/schema_manager/test_manager_schema.py
@@ -3060,6 +3060,33 @@ async def test_schema_branch_processes_relationships_state(
     assert "other_thing" not in returned_schema.get(name="InfraThing").relationship_names
 
 
+async def test_schema_branch_processes_nodes_state(
+    db: InfrahubDatabase, default_branch: Branch, register_internal_models_schema
+):
+    schema = {
+        "nodes": [
+            {
+                "name": "Widget",
+                "namespace": "Test",
+                "label": "Widget",
+                "state": "absent",
+                "display_labels": ["name__value"],
+                "attributes": [
+                    {"name": "name", "kind": "Text", "unique": True},
+                    {"name": "description", "kind": "Text"},
+                ],
+            }
+        ],
+    }
+    schema_branch = registry.schema.register_schema(schema=SchemaRoot(**schema), branch=default_branch.name)
+    await registry.schema.load_schema_to_db(schema=schema_branch, db=db, branch=default_branch.name)
+    returned_schema = await registry.schema.load_schema_from_db(db=db, branch=default_branch.name)
+
+    with pytest.raises(SchemaNotFoundError) as exc:
+        returned_schema.get(name="TestWidget")
+    assert exc.value.args[0] == "Unable to find the schema 'TestWidget' in the registry"
+
+
 async def test_process_deprecations(organization_schema):
     SCHEMA1 = {
         "name": "Criticality",

--- a/changelog/7354.fixed.md
+++ b/changelog/7354.fixed.md
@@ -1,0 +1,1 @@
+Prevent creation of nodes with state `absent`


### PR DESCRIPTION
Fixes https://github.com/opsmill/infrahub/issues/7354

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Prevents creation/registration of nodes marked as "absent".
  - Removes absent nodes during schema load via an added pre-validation cleanup, so they no longer interfere with processing or validation.
  - Ensures absent nodes cannot be retrieved from the registry.

- Tests
  - Added a unit test verifying absent nodes are not accessible after schema loading.

- Documentation
  - Added changelog entry noting the fix for "absent" nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->