### PR TITLE
Remove docstrings requirement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,6 @@ vale $(find ./docs -type f \( -name "*.mdx" -o -name "*.md" \) -not -path "./doc
 - Use `async def` for asynchronous functions
 - Use `await` for asynchronous calls
 - Use Pydantic models for dataclasses
-- All Python functions must have docstrings
 
 **Python Docstring Standards:**
 


### PR DESCRIPTION
Follow up to #7330

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor/LLM code-generation guidelines by removing the requirement that all Python functions include docstrings.
  * Clarifies expectations for generated code without altering functionality, user experience, or public interfaces.
  * No changes to features, performance, or compatibility; this is a documentation-only update intended to streamline guidance for code generation.
  * End users will not see any behavioral differences as a result of this change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->