### PR TITLE
Phase out subscription=False when generating GraphQL schema

### DIFF
--- a/backend/tests/benchmark/test_graphql_query.py
+++ b/backend/tests/benchmark/test_graphql_query.py
@@ -73,10 +73,8 @@ def test_query_one_model(exec_async, aio_benchmark, db: InfrahubDatabase, defaul
         }
     }
     """
-
-    gql_params = exec_async(
-        prepare_graphql_params, db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = exec_async(prepare_graphql_params, db=db, branch=default_branch)
 
     for _ in range(NBR_WARMUP):
         exec_async(
@@ -123,10 +121,8 @@ def test_query_rel_many(exec_async, aio_benchmark, db: InfrahubDatabase, default
         }
     }
     """
-
-    gql_params = exec_async(
-        prepare_graphql_params, db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = exec_async(prepare_graphql_params, db=db, branch=default_branch)
 
     for _ in range(NBR_WARMUP):
         exec_async(
@@ -174,9 +170,8 @@ def test_query_rel_one(exec_async, aio_benchmark, db: InfrahubDatabase, default_
     }
     """
 
-    gql_params = exec_async(
-        prepare_graphql_params, db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = exec_async(prepare_graphql_params, db=db, branch=default_branch)
 
     for _ in range(NBR_WARMUP):
         exec_async(
@@ -223,7 +218,7 @@ def test_query_rel_one(exec_async, aio_benchmark, db: InfrahubDatabase, default_
 #     """
 
 #     gql_params = exec_async(
-#         prepare_graphql_params, db=db, include_mutation=False, include_subscription=False, branch=default_branch
+#         prepare_graphql_params, db=db, branch=default_branch
 #     )
 #     aio_benchmark(
 #         graphql,

--- a/backend/tests/functional/ipam/test_ipam_rebase_reconcile.py
+++ b/backend/tests/functional/ipam/test_ipam_rebase_reconcile.py
@@ -89,7 +89,7 @@ class TestIpamRebaseReconcile(TestIpamReconcileBase):
     ) -> None:
         branch = await create_branch(db=db, branch_name="delete_prefix")
 
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=registry.default_branch)
+        gql_params = await prepare_graphql_params(db=db, branch=registry.default_branch)
         result = await graphql(
             schema=gql_params.schema,
             source=CREATE_IPPREFIX,
@@ -145,8 +145,9 @@ class TestIpamRebaseReconcile(TestIpamReconcileBase):
         client: InfrahubClient,
     ) -> None:
         branch = await create_branch(db=db, branch_name="interlinked")
+        branch.update_schema_hash()
 
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=registry.default_branch)
+        gql_params = await prepare_graphql_params(db=db, branch=registry.default_branch)
         result = await graphql(
             schema=gql_params.schema,
             source=CREATE_IPPREFIX,
@@ -160,7 +161,7 @@ class TestIpamRebaseReconcile(TestIpamReconcileBase):
         assert result.data["IpamIPPrefixCreate"]["object"]["id"]
         net_10_0_0_0_7_id = result.data["IpamIPPrefixCreate"]["object"]["id"]
 
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+        gql_params = await prepare_graphql_params(db=db, branch=branch)
         result = await graphql(
             schema=gql_params.schema,
             source=CREATE_IPPREFIX,
@@ -177,7 +178,7 @@ class TestIpamRebaseReconcile(TestIpamReconcileBase):
         assert result.data["IpamIPPrefixCreate"]["object"]["id"]
         net_10_0_0_0_15_id = result.data["IpamIPPrefixCreate"]["object"]["id"]
 
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=registry.default_branch)
+        gql_params = await prepare_graphql_params(db=db, branch=registry.default_branch)
         result = await graphql(
             schema=gql_params.schema,
             source=CREATE_IPPREFIX,
@@ -194,7 +195,7 @@ class TestIpamRebaseReconcile(TestIpamReconcileBase):
         assert result.data["IpamIPPrefixCreate"]["object"]["id"]
         net_10_10_8_0_22_id = result.data["IpamIPPrefixCreate"]["object"]["id"]
 
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+        gql_params = await prepare_graphql_params(db=db, branch=branch)
         result = await graphql(
             schema=gql_params.schema,
             source=CREATE_IPADDRESS,

--- a/backend/tests/functional/ipam/test_ipam_utilization.py
+++ b/backend/tests/functional/ipam/test_ipam_utilization.py
@@ -202,7 +202,7 @@ class TestIpamUtilization(TestIpam):
         container = initial_dataset["container"]
         prefix_pool = initial_dataset["prefix_pool"]
         default_branch.update_schema_hash()
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch)
         result = await graphql(
             schema=gql_params.schema,
             source=POOL_UTILIZATION_QUERY,
@@ -234,7 +234,8 @@ class TestIpamUtilization(TestIpam):
             }
         }
 
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+        default_branch.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch)
         result = await graphql(
             schema=gql_params.schema,
             source=PREFIX_UTILIZATION_QUERY,
@@ -263,7 +264,8 @@ class TestIpamUtilization(TestIpam):
     ):
         prefix = initial_dataset["prefix"]
         address_pool = initial_dataset["address_pool"]
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+        default_branch.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch)
         result = await graphql(
             schema=gql_params.schema,
             source=POOL_UTILIZATION_QUERY,
@@ -294,7 +296,7 @@ class TestIpamUtilization(TestIpam):
                 ],
             }
         }
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch)
         result = await graphql(
             schema=gql_params.schema,
             source=PREFIX_UTILIZATION_QUERY,
@@ -342,11 +344,12 @@ class TestIpamUtilization(TestIpam):
 
     async def test_step02_graphql_prefix_pool_branch_utilization(
         self, db: InfrahubDatabase, default_branch: Branch, branch2: Branch, initial_dataset, step_02_dataset
-    ):
+    ) -> None:
         container = initial_dataset["container"]
         container_branch = step_02_dataset["container_branch"]
         prefix_pool = initial_dataset["prefix_pool"]
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+        default_branch.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch)
         result = await graphql(
             schema=gql_params.schema,
             source=POOL_UTILIZATION_QUERY,
@@ -385,7 +388,8 @@ class TestIpamUtilization(TestIpam):
             }
         } in prefix_details_list
 
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch2)
+        branch2.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=branch2)
         result = await graphql(
             schema=gql_params.schema,
             source=PREFIX_UTILIZATION_QUERY,
@@ -414,11 +418,12 @@ class TestIpamUtilization(TestIpam):
 
     async def test_step02_graphql_address_pool_branch_utilization(
         self, db: InfrahubDatabase, default_branch: Branch, branch2: Branch, initial_dataset, step_02_dataset
-    ):
+    ) -> None:
         prefix = initial_dataset["prefix"]
         prefix_branch = step_02_dataset["prefix_branch"]
         address_pool = initial_dataset["address_pool"]
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+        default_branch.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch)
         result = await graphql(
             schema=gql_params.schema,
             source=POOL_UTILIZATION_QUERY,
@@ -457,7 +462,8 @@ class TestIpamUtilization(TestIpam):
             }
         } in prefix_details_list
 
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch2)
+        branch2.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=branch2)
         result = await graphql(
             schema=gql_params.schema,
             source=PREFIX_UTILIZATION_QUERY,
@@ -520,11 +526,12 @@ class TestIpamUtilization(TestIpam):
         initial_dataset,
         step_02_dataset,
         step_03_dataset,
-    ):
+    ) -> None:
         container = initial_dataset["container"]
         container_branch = step_02_dataset["container_branch"]
         prefix_pool = initial_dataset["prefix_pool"]
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+        default_branch.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch)
         result = await graphql(
             schema=gql_params.schema,
             source=POOL_UTILIZATION_QUERY,
@@ -563,7 +570,8 @@ class TestIpamUtilization(TestIpam):
             }
         } in prefix_details_list
 
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch2)
+        branch2.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=branch2)
         result = await graphql(
             schema=gql_params.schema,
             source=PREFIX_UTILIZATION_QUERY,
@@ -598,11 +606,12 @@ class TestIpamUtilization(TestIpam):
         initial_dataset,
         step_02_dataset,
         step_03_dataset,
-    ):
+    ) -> None:
         prefix = initial_dataset["prefix"]
         prefix_branch = step_02_dataset["prefix_branch"]
         address_pool = initial_dataset["address_pool"]
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+        default_branch.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch)
         result = await graphql(
             schema=gql_params.schema,
             source=POOL_UTILIZATION_QUERY,
@@ -641,7 +650,8 @@ class TestIpamUtilization(TestIpam):
             }
         } in prefix_details_list
 
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch2)
+        branch2.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=branch2)
         result = await graphql(
             schema=gql_params.schema,
             source=PREFIX_UTILIZATION_QUERY,

--- a/backend/tests/helpers/graphql.py
+++ b/backend/tests/helpers/graphql.py
@@ -70,11 +70,10 @@ async def graphql_mutation(
     account_session: AccountSession | None = None,
 ) -> ExecutionResult:
     branch = branch or await Branch.get_by_name(name="main", db=db)
+    branch.update_schema_hash()
     variables = variables or {}
     gql_params = await prepare_graphql_params(
         db=db,
-        include_subscription=False,
-        include_mutation=True,
         branch=branch,
         service=service,
         account_session=account_session,
@@ -98,11 +97,10 @@ async def graphql_query(
 ) -> ExecutionResult:
     branch = branch or await Branch.get_by_name(name="main", db=db)
     variables = variables or {}
+    branch.update_schema_hash()
 
     gql_params = await prepare_graphql_params(
         db=db,
-        include_subscription=False,
-        include_mutation=False,
         branch=branch,
         service=service,
         account_session=account_session,

--- a/backend/tests/integration/profiles/test_profile_lifecycle.py
+++ b/backend/tests/integration/profiles/test_profile_lifecycle.py
@@ -64,10 +64,10 @@ class TestProfileLifecycle(TestInfrahubApp):
     async def test_step_02_one_person_add_profile(
         self,
         db: InfrahubDatabase,
-        default_branch,
+        default_branch: Branch,
         person_1,
         person_profile_1,
-    ):
+    ) -> None:
         mutation = """
             mutation {
                 TestingPersonUpdate(data: {id: "%(person_id)s", profiles: [{ id: "%(profile_id)s"}]}) {
@@ -92,7 +92,8 @@ class TestProfileLifecycle(TestInfrahubApp):
             }
         """ % {"person_id": person_1.id, "profile_id": person_profile_1.id}
 
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+        default_branch.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch)
         result = await graphql(
             schema=gql_params.schema,
             source=mutation,
@@ -134,9 +135,9 @@ class TestProfileLifecycle(TestInfrahubApp):
     async def test_step_03_create_person_with_profile(
         self,
         db: InfrahubDatabase,
-        default_branch,
+        default_branch: Branch,
         person_profile_1,
-    ):
+    ) -> None:
         mutation = """
             mutation {
                 TestingPersonCreate(data: {name: {value: "Apollo"}, profiles: [{ id: "%(profile_id)s"}]}) {
@@ -161,7 +162,8 @@ class TestProfileLifecycle(TestInfrahubApp):
             }
         """ % {"profile_id": person_profile_1.id}
 
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+        default_branch.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch)
         result = await graphql(
             schema=gql_params.schema,
             source=mutation,
@@ -198,10 +200,10 @@ class TestProfileLifecycle(TestInfrahubApp):
     async def test_step_04_update_non_profile_attribute(
         self,
         db: InfrahubDatabase,
-        default_branch,
+        default_branch: Branch,
         person_1,
         person_profile_1,
-    ):
+    ) -> None:
         mutation = """
             mutation {
                 TestingPersonUpdate(data: {id: "%(person_id)s", name: {value: "Kara Thrace"}}) {
@@ -228,7 +230,8 @@ class TestProfileLifecycle(TestInfrahubApp):
             "person_id": person_1.id,
         }
 
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+        default_branch.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch)
         result = await graphql(
             schema=gql_params.schema,
             source=mutation,
@@ -301,9 +304,9 @@ class TestProfileLifecycle(TestInfrahubApp):
     async def test_step_07_update_person_delete_profile(
         self,
         db: InfrahubDatabase,
-        default_branch,
+        default_branch: Branch,
         client,
-    ):
+    ) -> None:
         person_2 = await client.get(kind="TestingPerson", name__value="Apollo", property=True)
         mutation = """
             mutation {
@@ -329,7 +332,8 @@ class TestProfileLifecycle(TestInfrahubApp):
             }
         """ % {"person_id": person_2.id}
 
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+        default_branch.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch)
         result = await graphql(
             schema=gql_params.schema,
             source=mutation,
@@ -396,10 +400,10 @@ class TestProfileLifecycle(TestInfrahubApp):
     async def test_step_10_update_person_override_profile(
         self,
         db: InfrahubDatabase,
-        default_branch,
+        default_branch: Branch,
         person_1,
         person_profile_1,
-    ):
+    ) -> None:
         mutation = """
             mutation {
                 TestingPersonUpdate(data: {id: "%(person_id)s", height: {value: 145}}) {
@@ -424,7 +428,8 @@ class TestProfileLifecycle(TestInfrahubApp):
             }
         """ % {"person_id": person_1.id}
 
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+        default_branch.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch)
         result = await graphql(
             schema=gql_params.schema,
             source=mutation,

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -4,7 +4,7 @@ import subprocess  # noqa: S404
 import sys
 from itertools import islice
 from pathlib import Path
-from typing import Any
+from typing import Any, Generator
 from unittest.mock import patch
 
 import pytest
@@ -64,6 +64,7 @@ from infrahub.core.utils import delete_all_nodes
 from infrahub.database import InfrahubDatabase
 from infrahub.dependencies.registry import build_component_registry
 from infrahub.git import InfrahubRepository
+from infrahub.graphql.registry import registry as graphql_registry
 from infrahub.services.adapters.workflow.local import WorkflowLocalExecution
 from infrahub.workers.dependencies import build_workflow
 from tests.helpers.file_repo import FileRepo
@@ -151,6 +152,14 @@ def git_repos_dir(tmp_path: Path) -> Path:
     config.SETTINGS.git.repositories_directory = str(repos_dir)
 
     return repos_dir
+
+
+@pytest.fixture
+def reset_graphql_schema_between_tests() -> Generator:
+    """This fixture can be used when testing with GraphQL enums as the schema looks completely different."""
+    graphql_registry.clear_cache()
+    yield
+    graphql_registry.clear_cache()
 
 
 @pytest.fixture

--- a/backend/tests/unit/graphql/diff/test_diff_tree_query.py
+++ b/backend/tests/unit/graphql/diff/test_diff_tree_query.py
@@ -220,9 +220,8 @@ async def test_diff_tree_no_changes(
     from_time = Timestamp(diff_branch.branched_from)
     to_time = enriched_diff_metadata.to_time
 
-    params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=params.schema,
         source=DIFF_TREE_QUERY,
@@ -232,6 +231,7 @@ async def test_diff_tree_no_changes(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["DiffTree"] == {
         "base_branch": default_branch.name,
         "diff_branch": diff_branch.name,
@@ -250,9 +250,8 @@ async def test_diff_tree_no_changes(
 async def test_diff_tree_no_diffs(
     db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema, diff_branch: Branch
 ):
-    params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=params.schema,
         source=DIFF_TREE_QUERY,
@@ -262,13 +261,13 @@ async def test_diff_tree_no_diffs(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["DiffTree"] is None
 
 
 async def test_diff_tree_no_branch(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema):
-    params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=params.schema,
         source=DIFF_TREE_QUERY,
@@ -319,9 +318,8 @@ async def test_diff_tree_one_attr_change(
     await main_crit.save(db=db)
     await branch_crit.save(db=db)
 
-    params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=params.schema,
         source=DIFF_TREE_QUERY,
@@ -334,6 +332,7 @@ async def test_diff_tree_one_attr_change(
 
     assert result.errors is None
 
+    assert result.data
     assert result.data["DiffTree"]
     assert result.data["DiffTree"]["nodes"]
     node_diff = result.data["DiffTree"]["nodes"][0]
@@ -436,9 +435,8 @@ async def test_diff_tree_one_relationship_change(
     enriched_diff_metadata = await diff_coordinator.update_branch_diff(
         base_branch=default_branch, diff_branch=diff_branch
     )
-    params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=params.schema,
         source=DIFF_TREE_QUERY,
@@ -451,6 +449,7 @@ async def test_diff_tree_one_relationship_change(
 
     assert result.errors is None
 
+    assert result.data
     assert result.data["DiffTree"]
     diff_tree_response = result.data["DiffTree"].copy()
     nodes_response = diff_tree_response.pop("nodes")
@@ -693,9 +692,8 @@ async def test_diff_tree_hierarchy_change(
     await rack2_branch.save(db=db)
 
     await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=diff_branch)
-    params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=params.schema,
         source=DIFF_TREE_QUERY,
@@ -705,6 +703,7 @@ async def test_diff_tree_hierarchy_change(
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data["DiffTree"]["nodes"]) == 4
 
     nodes_parent = {node["label"]: node["parent"] for node in result.data["DiffTree"]["nodes"]}
@@ -720,9 +719,8 @@ async def test_diff_tree_hierarchy_change(
 async def test_diff_tree_summary_no_diffs(
     db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema, diff_branch: Branch
 ):
-    params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=params.schema,
         source=DIFF_TREE_QUERY_SUMMARY,
@@ -732,6 +730,7 @@ async def test_diff_tree_summary_no_diffs(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["DiffTreeSummary"] is None
 
 
@@ -748,9 +747,8 @@ async def test_diff_tree_summary_no_changes(
     from_time = Timestamp(diff_branch.branched_from)
     to_time = enriched_diff_metadata.to_time
 
-    params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=params.schema,
         source=DIFF_TREE_QUERY_SUMMARY,
@@ -760,6 +758,7 @@ async def test_diff_tree_summary_no_changes(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["DiffTreeSummary"] == {
         "base_branch": default_branch.name,
         "diff_branch": diff_branch.name,
@@ -845,9 +844,8 @@ async def test_diff_summary_filters(
     enriched_diff_metadata = await diff_coordinator.update_branch_diff(
         base_branch=default_branch, diff_branch=diff_branch
     )
-    params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    params = await prepare_graphql_params(db=db, branch=default_branch)
 
     result = await graphql(
         schema=params.schema,
@@ -945,9 +943,8 @@ async def test_diff_get_filters(
     component_registry = get_component_registry()
     diff_coordinator = await component_registry.get_component(DiffCoordinator, db=db, branch=diff_branch)
     await diff_coordinator.update_branch_diff(base_branch=default_branch, diff_branch=diff_branch)
-    params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    params = await prepare_graphql_params(db=db, branch=default_branch)
 
     result = await graphql(
         schema=params.schema,

--- a/backend/tests/unit/graphql/diff/test_diff_update_mutation.py
+++ b/backend/tests/unit/graphql/diff/test_diff_update_mutation.py
@@ -58,9 +58,8 @@ class TestDiffUpdateMutation:
         criticality_schema,
         diff_branch: Branch,
     ) -> EnrichedDiffRootMetadata:
-        params = await prepare_graphql_params(
-            db=db, include_mutation=True, include_subscription=False, branch=default_branch, service=service_testing
-        )
+        default_branch.update_schema_hash()
+        params = await prepare_graphql_params(db=db, branch=default_branch, service=service_testing)
         result = await graphql(
             schema=params.schema,
             source=DIFF_UPDATE_MUTATION,
@@ -69,6 +68,7 @@ class TestDiffUpdateMutation:
             variable_values={"branch": diff_branch.name, "name": self.diff_name},
         )
         assert result.errors is None
+        assert result.data
         assert result.data["DiffUpdate"]["ok"] is True
 
         diff_repo = DiffRepository(db=db, deserializer=EnrichedDiffDeserializer(DiffParentNodeAdder()))
@@ -90,9 +90,8 @@ class TestDiffUpdateMutation:
         diff_branch: Branch,
     ):
         branched_from_timestamp = Timestamp(diff_branch.get_branched_from())
-        params = await prepare_graphql_params(
-            db=db, include_mutation=True, include_subscription=False, branch=default_branch, service=service_testing
-        )
+        default_branch.update_schema_hash()
+        params = await prepare_graphql_params(db=db, branch=default_branch, service=service_testing)
         result = await graphql(
             schema=params.schema,
             source=DIFF_UPDATE_MUTATION,
@@ -105,6 +104,7 @@ class TestDiffUpdateMutation:
             },
         )
         assert result.errors is None
+        assert result.data
         assert result.data["DiffUpdate"]["ok"] is True
 
     async def test_create_time_range_diff_without_name_fails(
@@ -117,9 +117,8 @@ class TestDiffUpdateMutation:
         diff_branch: Branch,
     ):
         branched_from_timestamp = Timestamp(diff_branch.get_branched_from())
-        params = await prepare_graphql_params(
-            db=db, include_mutation=True, include_subscription=False, branch=default_branch, service=service_testing
-        )
+        default_branch.update_schema_hash()
+        params = await prepare_graphql_params(db=db, branch=default_branch, service=service_testing)
         result = await graphql(
             schema=params.schema,
             source=DIFF_UPDATE_MUTATION,
@@ -145,9 +144,8 @@ class TestDiffUpdateMutation:
         diff_branch: Branch,
         named_diff: EnrichedDiffRootMetadata,
     ):
-        params = await prepare_graphql_params(
-            db=db, include_mutation=True, include_subscription=False, branch=default_branch, service=service_testing
-        )
+        default_branch.update_schema_hash()
+        params = await prepare_graphql_params(db=db, branch=default_branch, service=service_testing)
         result = await graphql(
             schema=params.schema,
             source=DIFF_UPDATE_MUTATION,
@@ -189,9 +187,8 @@ class TestDiffUpdateMutation:
         named_diff: EnrichedDiffRootMetadata,
     ):
         branched_from_timestamp = Timestamp(diff_branch.get_branched_from())
-        params = await prepare_graphql_params(
-            db=db, include_mutation=True, include_subscription=False, branch=default_branch, service=service_testing
-        )
+        default_branch.update_schema_hash()
+        params = await prepare_graphql_params(db=db, branch=default_branch, service=service_testing)
         result = await graphql(
             schema=params.schema,
             source=DIFF_UPDATE_MUTATION,
@@ -218,9 +215,8 @@ class TestDiffUpdateMutation:
         named_diff: EnrichedDiffRootMetadata,
     ):
         branched_from_timestamp = Timestamp(diff_branch.get_branched_from())
-        params = await prepare_graphql_params(
-            db=db, include_mutation=True, include_subscription=False, branch=default_branch, service=service_testing
-        )
+        default_branch.update_schema_hash()
+        params = await prepare_graphql_params(db=db, branch=default_branch, service=service_testing)
         result = await graphql(
             schema=params.schema,
             source=DIFF_UPDATE_MUTATION,

--- a/backend/tests/unit/graphql/mutations/test_action.py
+++ b/backend/tests/unit/graphql/mutations/test_action.py
@@ -10,7 +10,8 @@ async def _prepare_group_action(
     db: InfrahubDatabase,
     default_branch: Branch,
 ) -> str:
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     query = """
     mutation {
         CoreStandardGroupCreate(data: {
@@ -64,7 +65,8 @@ async def test_create_node_trigger_failure_states(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None, car_person_schema: None
 ) -> None:
     group_id = await _prepare_group_action(db=db, default_branch=default_branch)
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=CREATE_NODE_TRIGGER,
@@ -92,7 +94,8 @@ async def test_modify_action_node_attribute_matches(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None, car_person_schema: None
 ) -> None:
     group_id = await _prepare_group_action(db=db, default_branch=default_branch)
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
     result = await graphql(
         schema=gql_params.schema,
@@ -153,7 +156,8 @@ async def test_modify_action_node_relationship_matches(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None, car_person_schema: None
 ) -> None:
     group_id = await _prepare_group_action(db=db, default_branch=default_branch)
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
     result = await graphql(
         schema=gql_params.schema,

--- a/backend/tests/unit/graphql/mutations/test_branch.py
+++ b/backend/tests/unit/graphql/mutations/test_branch.py
@@ -65,9 +65,9 @@ class TestBranchCreate(TestInfrahubApp):
         assert branch2.schema_hash == branch2_schema.get_hash_full()
 
         # Validate that we can't create a branch with a name that already exist
+        default_branch.update_schema_hash()
         gql_params = await prepare_graphql_params(
             db=db,
-            include_subscription=False,
             branch=default_branch,
             account_session=session_admin,
             service=service,
@@ -97,9 +97,9 @@ class TestBranchCreate(TestInfrahubApp):
             }
         }
         """
+        default_branch.update_schema_hash()
         gql_params = await prepare_graphql_params(
             db=db,
-            include_subscription=False,
             branch=default_branch,
             account_session=session_admin,
             service=service,
@@ -142,9 +142,9 @@ class TestBranchCreate(TestInfrahubApp):
         }
         """
 
+        default_branch.update_schema_hash()
         gql_params = await prepare_graphql_params(
             db=db,
-            include_subscription=False,
             branch=default_branch,
             account_session=session_admin,
             service=service,
@@ -218,9 +218,9 @@ class TestBranchCreate(TestInfrahubApp):
         }
         """
 
+        default_branch.update_schema_hash()
         gql_params = await prepare_graphql_params(
             db=db,
-            include_subscription=False,
             branch=default_branch,
             account_session=session_admin,
             service=service,
@@ -321,9 +321,9 @@ async def test_branch_rebase_wrong_branch(
     }
     """
 
+    default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(
         db=db,
-        include_subscription=False,
         service=local_services,
         branch=default_branch,
         account_session=session_admin,
@@ -357,7 +357,8 @@ async def test_branch_update_description(db: InfrahubDatabase, base_dataset_02, 
     }
     """
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch4, service=local_services)
+    branch4.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch4, service=local_services)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -391,8 +392,9 @@ async def test_branch_merge_wrong_branch(
     }
     """
 
+    branch1.update_schema_hash()
     gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=branch1, account_session=session_admin, service=local_services
+        db=db, branch=branch1, account_session=session_admin, service=local_services
     )
     result = await graphql(
         schema=gql_params.schema,
@@ -429,8 +431,9 @@ async def test_branch_merge_with_conflict_fails(
     car_branch.name.value += "-branch"
     await car_branch.save(db=db)
 
+    branch2.update_schema_hash()
     gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=branch2, account_session=session_admin, service=local_services
+        db=db, branch=branch2, account_session=session_admin, service=local_services
     )
     result = await graphql(
         schema=gql_params.schema,

--- a/backend/tests/unit/graphql/mutations/test_group_event_collection.py
+++ b/backend/tests/unit/graphql/mutations/test_group_event_collection.py
@@ -35,8 +35,9 @@ async def test_node_mutation_to_group_event(
 
     memory_event = MemoryInfrahubEvent()
     service = await InfrahubServices.new(event=memory_event)
+    default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=default_branch, service=service, account_session=session_first_account
+        db=db, branch=default_branch, service=service, account_session=session_first_account
     )
 
     create_query = """
@@ -102,8 +103,9 @@ async def test_node_mutation_to_group_event(
     """
     memory_event = MemoryInfrahubEvent()
     service = await InfrahubServices.new(event=memory_event)
+    default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=default_branch, service=service, account_session=session_first_account
+        db=db, branch=default_branch, service=service, account_session=session_first_account
     )
     result = await graphql(
         schema=gql_params.schema,
@@ -145,8 +147,9 @@ async def test_node_mutation_to_group_event(
     """
     memory_event = MemoryInfrahubEvent()
     service = await InfrahubServices.new(event=memory_event)
+    default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=default_branch, service=service, account_session=session_first_account
+        db=db, branch=default_branch, service=service, account_session=session_first_account
     )
     result = await graphql(
         schema=gql_params.schema,

--- a/backend/tests/unit/graphql/mutations/test_ipam.py
+++ b/backend/tests/unit/graphql/mutations/test_ipam.py
@@ -272,7 +272,8 @@ mutation NamespaceDelete($namespace_id: String!) {
 
 
 async def test_protected_default_ipnamespace(db: InfrahubDatabase, default_branch: Branch, default_ipnamespace: Node):
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=DELETE_IPNAMESPACE,
@@ -289,7 +290,8 @@ async def test_delete_regular_ipnamespace(db: InfrahubDatabase, default_branch: 
     await ns1.new(db=db, name="ns1")
     await ns1.save(db=db)
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=DELETE_IPNAMESPACE,
@@ -298,6 +300,7 @@ async def test_delete_regular_ipnamespace(db: InfrahubDatabase, default_branch: 
     )
 
     assert not result.errors
+    assert result.data
     assert result.data["IpamNamespaceDelete"]["ok"]
 
 
@@ -309,7 +312,8 @@ async def test_ipprefix_create(
     register_ipam_schema: SchemaBranch,
 ):
     """Make sure prefix can be created and parent/children relationships are set."""
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
     supernet = ipaddress.ip_network("2001:db8::/32")
     result = await graphql(
@@ -320,6 +324,7 @@ async def test_ipprefix_create(
     )
 
     assert not result.errors
+    assert result.data
     assert result.data["IpamIPPrefixCreate"]["ok"]
     assert result.data["IpamIPPrefixCreate"]["object"]["id"]
 
@@ -398,7 +403,8 @@ async def test_ipprefix_create_with_ipnamespace(
     }
     """
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
 
     supernet = ipaddress.ip_network("2001:db8::/32")
     result = await graphql(
@@ -409,6 +415,7 @@ async def test_ipprefix_create_with_ipnamespace(
     )
 
     assert not result.errors
+    assert result.data
     assert result.data["IpamIPPrefixCreate"]["ok"]
     assert result.data["IpamIPPrefixCreate"]["object"]["id"]
 
@@ -465,7 +472,8 @@ async def test_ipprefix_create_reverse(
     register_ipam_schema: SchemaBranch,
 ):
     """Make sure parent/children relationship are set when creating a parent after a child."""
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
     subnet = ipaddress.ip_network("2001:db8::/48")
     result = await graphql(
@@ -476,6 +484,7 @@ async def test_ipprefix_create_reverse(
     )
 
     assert not result.errors
+    assert result.data
     assert result.data["IpamIPPrefixCreate"]["ok"]
 
     supernet = ipaddress.ip_network("2001:db8::/32")
@@ -510,7 +519,8 @@ async def test_ipprefix_update(
     register_ipam_schema: SchemaBranch,
 ):
     """Make sure a prefix can be updated."""
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
     subnet = ipaddress.ip_network("2001:db8::/48")
     result = await graphql(
@@ -521,6 +531,7 @@ async def test_ipprefix_update(
     )
 
     assert not result.errors
+    assert result.data
     assert result.data["IpamIPPrefixCreate"]["ok"]
 
     subnet_id = result.data["IpamIPPrefixCreate"]["object"]["id"]
@@ -548,7 +559,8 @@ async def test_ipprefix_update_within_namespace(
     await test_ns.save(db=db)
 
     ns_hfid = await test_ns.get_hfid_as_string(db=db)
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
 
     subnet = ipaddress.ip_network("2001:db8::/48")
     # Test with namespace by ID
@@ -707,7 +719,8 @@ async def test_ipprefix_upsert(
     register_ipam_schema: SchemaBranch,
 ):
     """Make sure a prefix can be upserted."""
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
     subnet = ipaddress.ip_network("2001:db8::/48")
     result = await graphql(
@@ -718,6 +731,7 @@ async def test_ipprefix_upsert(
     )
 
     assert not result.errors
+    assert result.data
     assert result.data["IpamIPPrefixUpsert"]["ok"]
     assert not result.data["IpamIPPrefixUpsert"]["object"]["description"]["value"]
 
@@ -742,7 +756,8 @@ async def test_ipprefix_delete(
     register_ipam_schema: SchemaBranch,
 ):
     """Make sure deleting a prefix relocates its children."""
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
     networks = [
         ipaddress.ip_network("2001:db8::/32"),
@@ -817,7 +832,8 @@ async def test_ipaddress_create(
     register_ipam_schema: SchemaBranch,
 ):
     """Make sure IP address is properly created and nested under a subnet."""
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
     # Single IP address, no IP prefix
     address = ipaddress.ip_interface("192.0.2.1/24")
@@ -829,6 +845,7 @@ async def test_ipaddress_create(
     )
 
     assert not result.errors
+    assert result.data
     assert result.data["IpamIPAddressCreate"]["ok"]
     assert result.data["IpamIPAddressCreate"]["object"]["id"]
 
@@ -892,7 +909,8 @@ async def test_ipaddress_update(
     register_ipam_schema: SchemaBranch,
 ):
     """Make sure an IP address can be updated."""
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
     address = ipaddress.ip_interface("192.0.2.1/24")
     result = await graphql(
@@ -903,6 +921,7 @@ async def test_ipaddress_update(
     )
 
     assert not result.errors
+    assert result.data
     assert result.data["IpamIPAddressCreate"]["ok"]
 
     address_id = result.data["IpamIPAddressCreate"]["object"]["id"]
@@ -929,7 +948,8 @@ async def test_ipaddress_update_within_namespace(
     await test_ns.new(db=db, name="test")
     await test_ns.save(db=db)
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
     address = ipaddress.ip_interface("192.0.2.1/24")
     result = await graphql(
@@ -965,6 +985,7 @@ async def test_ipaddress_update_within_namespace(
     )
 
     assert not result.errors
+    assert result.data
     assert result.data["IpamIPAddressCreate"]["ok"]
     assert result.data["IpamIPAddressCreate"]["object"]["ip_namespace"]["node"]["name"]["value"] == test_ns.name.value
 
@@ -1012,7 +1033,8 @@ async def test_ipaddress_upsert(
     register_ipam_schema: SchemaBranch,
 ):
     """Make sure an IP address can be upsert."""
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
     address = ipaddress.ip_interface("192.0.2.1/24")
     result = await graphql(
@@ -1023,6 +1045,7 @@ async def test_ipaddress_upsert(
     )
 
     assert not result.errors
+    assert result.data
     assert result.data["IpamIPAddressUpsert"]["ok"]
     assert not result.data["IpamIPAddressUpsert"]["object"]["description"]["value"]
 
@@ -1035,6 +1058,7 @@ async def test_ipaddress_upsert(
     )
 
     assert not result.errors
+    assert result.data
     assert result.data["IpamIPAddressUpsert"]["ok"]
     assert result.data["IpamIPAddressUpsert"]["object"]["description"]["value"] == "RFC 5735"
 
@@ -1047,7 +1071,8 @@ async def test_ipaddress_change_ipprefix(
     register_ipam_schema: SchemaBranch,
 ):
     """Make sure relationship between an address and its prefix is properly managed."""
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
     address = ipaddress.ip_interface("2001:db8::1/64")
     result = await graphql(
@@ -1058,6 +1083,7 @@ async def test_ipaddress_change_ipprefix(
     )
 
     assert not result.errors
+    assert result.data
     assert result.data["IpamIPAddressCreate"]["ok"]
 
     # Create subnet which contains the previously created IP should set relationships
@@ -1070,6 +1096,7 @@ async def test_ipaddress_change_ipprefix(
     )
 
     assert not result.errors
+    assert result.data
     assert result.data["IpamIPPrefixCreate"]["ok"]
 
     result = await graphql(
@@ -1211,7 +1238,8 @@ async def test_prefix_ancestors_descendants(
     await net16.new(db=db, prefix="10.0.0.0/16", parent=net14, ip_namespace=ns1)
     await net16.save(db=db)
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     check_before = await graphql(
         schema=gql_params.schema,
         source=GET_PREFIX_HIERARCHY,
@@ -1219,6 +1247,7 @@ async def test_prefix_ancestors_descendants(
         variable_values={"prefix": str(net12.prefix.value)},
     )
     assert not check_before.errors
+    assert check_before.data
     assert len(check_before.data["IpamIPPrefix"]["edges"]) == 1
     prefix_details = check_before.data["IpamIPPrefix"]["edges"][0]["node"]
     assert prefix_details["id"] == net12.id
@@ -1312,7 +1341,8 @@ async def test_delete_top_level_prefix(
     await net10.new(db=db, prefix="10.0.0.0/10", parent=net8, ip_namespace=ns1)
     await net10.save(db=db)
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     delete_top = await graphql(
         schema=gql_params.schema,
         source=DELETE_IPPREFIX,
@@ -1320,9 +1350,11 @@ async def test_delete_top_level_prefix(
         variable_values={"id": str(net10.id)},
     )
     assert not delete_top.errors
+    assert delete_top.data
     assert delete_top.data["IpamIPPrefixDelete"]["ok"] is True
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     delete_last_prefix = await graphql(
         schema=gql_params.schema,
         source=DELETE_IPPREFIX,
@@ -1330,6 +1362,7 @@ async def test_delete_top_level_prefix(
         variable_values={"id": str(net8.id)},
     )
     assert not delete_last_prefix.errors
+    assert delete_last_prefix.data
     assert delete_last_prefix.data["IpamIPPrefixDelete"]["ok"] is True
 
     ip_prefixes = await NodeManager.query(db=db, branch=default_branch, schema="IpamIPPrefix")

--- a/backend/tests/unit/graphql/mutations/test_mutation_context.py
+++ b/backend/tests/unit/graphql/mutations/test_mutation_context.py
@@ -50,9 +50,8 @@ async def test_add_context_invalid_account(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=default_branch, account_session=session_first_account
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch, account_session=session_first_account)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -98,8 +97,9 @@ async def test_add_context_valid_account(
 
     memory_event = MemoryInfrahubEvent()
     service = await InfrahubServices.new(event=memory_event)
+    default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=default_branch, service=service, account_session=session_first_account
+        db=db, branch=default_branch, service=service, account_session=session_first_account
     )
     result = await graphql(
         schema=gql_params.schema,
@@ -139,9 +139,9 @@ async def test_add_context_missing_permissions(
     }
     """ % (first_account.id)
 
+    default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(
         db=db,
-        include_subscription=False,
         branch=default_branch,
         account_session=session_second_account,
     )

--- a/backend/tests/unit/graphql/mutations/test_proposed_change.py
+++ b/backend/tests/unit/graphql/mutations/test_proposed_change.py
@@ -110,9 +110,9 @@ async def test_create_invalid_branch_combinations(db: InfrahubDatabase, default_
     await account.new(db=db, name="user", password="password")
     await account.save(db=db)
 
+    default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(
         db=db,
-        include_subscription=False,
         branch=default_branch,
         account_session=AccountSession(authenticated=False, account_id=account.get_id(), auth_type=AuthType.NONE),
     )
@@ -175,10 +175,9 @@ async def test_create_invalid_state_combinations(
     account = await Node.init(db=db, schema=InfrahubKind.ACCOUNT)
     await account.new(db=db, name="user", password="password")
     await account.save(db=db)
-
+    default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(
         db=db,
-        include_subscription=False,
         branch=default_branch,
         account_session=AccountSession(authenticated=False, account_id=account.get_id(), auth_type=AuthType.NONE),
     )

--- a/backend/tests/unit/graphql/mutations/test_resource_manager.py
+++ b/backend/tests/unit/graphql/mutations/test_resource_manager.py
@@ -84,7 +84,8 @@ async def test_create_object_and_assign_prefix_from_pool(db: InfrahubDatabase, d
         % pool.id
     )
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -149,7 +150,8 @@ async def test_update_object_and_assign_prefix_from_pool(db: InfrahubDatabase, d
     }
     """ % (obj.id, pool.id)
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -230,7 +232,8 @@ async def test_create_object_and_assign_address_from_pool(
         % pool.id
     )
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -294,7 +297,8 @@ async def test_prefix_pool_get_resource(
         % pool.id
     )
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -358,7 +362,8 @@ async def test_prefix_pool_get_resource_with_identifier(
         % pool.id
     )
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -420,7 +425,8 @@ async def test_prefix_pool_get_resource_with_prefix_length(
         % pool.id
     )
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -478,7 +484,8 @@ async def test_address_pool_get_resource(
         % pool.id
     )
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -541,7 +548,8 @@ async def test_address_pool_get_resource_with_identifier(
         % pool.id
     )
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -602,7 +610,8 @@ async def test_address_pool_get_resource_with_prefix_length(
         % pool.id
     )
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -705,7 +714,8 @@ async def test_test_number_pool_creation_errors(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema
 ):
     await load_schema(db=db, schema=SchemaRoot(nodes=[TICKET]))
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
     no_model = await graphql(
         schema=gql_params.schema,
@@ -789,7 +799,8 @@ async def test_test_number_pool_creation_errors(
 
 async def test_test_number_pool_update(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema):
     await load_schema(db=db, schema=SchemaRoot(nodes=[TICKET]))
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
     create_ok = await graphql(
         schema=gql_params.schema,
@@ -884,7 +895,8 @@ async def test_delete_number_pool_in_use_by_numberpool_attribute(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None
 ) -> None:
     await load_schema(db=db, schema=SNOW_TICKET_SCHEMA)
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     node_schema = registry.schema.get(name="SnowTask", branch=default_branch)
     number_pool_attribute = node_schema.get_attribute(name="number")
     assert isinstance(number_pool_attribute.parameters, NumberPoolParameters)
@@ -971,7 +983,8 @@ async def test_update_schema_number_pool_range(
     db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: None
 ) -> None:
     await load_schema(db=db, schema=SNOW_TICKET_SCHEMA)
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     node_schema = registry.schema.get(name="SnowTask", branch=default_branch)
     number_pool_attribute = node_schema.get_attribute(name="number")
     assert isinstance(number_pool_attribute.parameters, NumberPoolParameters)

--- a/backend/tests/unit/graphql/mutations/test_schema.py
+++ b/backend/tests/unit/graphql/mutations/test_schema.py
@@ -1,5 +1,6 @@
 import pytest
 
+from infrahub.core.branch import Branch
 from infrahub.core.node import Node
 from infrahub.database import InfrahubDatabase
 from infrahub.exceptions import ValidationError
@@ -9,8 +10,8 @@ from tests.helpers.graphql import graphql
 
 
 async def test_delete_last_dropdown_option(
-    db: InfrahubDatabase, default_permission_backend, default_branch, choices_schema, session_admin
-):
+    db: InfrahubDatabase, default_permission_backend, default_branch: Branch, choices_schema, session_admin
+) -> None:
     query = """
     mutation {
         SchemaDropdownRemove(data: {kind: "TestChoice", attribute: "temperature_scale", dropdown: "celsius"}) {
@@ -18,9 +19,8 @@ async def test_delete_last_dropdown_option(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=default_branch, account_session=session_admin
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch, account_session=session_admin)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -34,7 +34,7 @@ async def test_delete_last_dropdown_option(
 
 
 async def test_delete_last_enum_option(
-    db: InfrahubDatabase, default_permission_backend, default_branch, choices_schema, session_admin
+    db: InfrahubDatabase, default_permission_backend, default_branch: Branch, choices_schema, session_admin
 ):
     query = """
     mutation {
@@ -43,9 +43,8 @@ async def test_delete_last_enum_option(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=default_branch, account_session=session_admin
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch, account_session=session_admin)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -59,8 +58,8 @@ async def test_delete_last_enum_option(
 
 
 async def test_delete_enum_option_that_does_not_exist(
-    db: InfrahubDatabase, default_permission_backend, default_branch, choices_schema, session_admin
-):
+    db: InfrahubDatabase, default_permission_backend, default_branch: Branch, choices_schema, session_admin
+) -> None:
     query = """
     mutation {
         SchemaEnumRemove(data: {kind: "BaseChoice", attribute: "color", enum: "yellow"}) {
@@ -68,9 +67,8 @@ async def test_delete_enum_option_that_does_not_exist(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=default_branch, account_session=session_admin
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch, account_session=session_admin)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -84,7 +82,7 @@ async def test_delete_enum_option_that_does_not_exist(
 
 
 async def test_delete_drop_option_that_does_not_exist(
-    db: InfrahubDatabase, default_permission_backend, default_branch, choices_schema, session_admin
+    db: InfrahubDatabase, default_permission_backend, default_branch: Branch, choices_schema, session_admin
 ):
     query = """
     mutation {
@@ -93,9 +91,8 @@ async def test_delete_drop_option_that_does_not_exist(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=default_branch, account_session=session_admin
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch, account_session=session_admin)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -109,7 +106,7 @@ async def test_delete_drop_option_that_does_not_exist(
 
 
 async def test_add_enum_option_that_exist(
-    db: InfrahubDatabase, default_permission_backend, default_branch, choices_schema, session_admin
+    db: InfrahubDatabase, default_permission_backend, default_branch: Branch, choices_schema, session_admin
 ):
     query = """
     mutation {
@@ -118,9 +115,8 @@ async def test_add_enum_option_that_exist(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=default_branch, account_session=session_admin
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch, account_session=session_admin)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -134,7 +130,7 @@ async def test_add_enum_option_that_exist(
 
 
 async def test_delete_dropdown_option_in_use(
-    db: InfrahubDatabase, default_permission_backend, default_branch, choices_schema, session_admin
+    db: InfrahubDatabase, default_permission_backend, default_branch: Branch, choices_schema, session_admin
 ):
     obj1 = await Node.init(db=db, schema="TestChoice")
     await obj1.new(db=db, name="test-passive-01", status="passive", temperature_scale="celsius")
@@ -147,9 +143,8 @@ async def test_delete_dropdown_option_in_use(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=default_branch, account_session=session_admin
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch, account_session=session_admin)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -163,7 +158,7 @@ async def test_delete_dropdown_option_in_use(
 
 
 async def test_delete_enum_option_in_use(
-    db: InfrahubDatabase, default_permission_backend, default_branch, choices_schema, session_admin
+    db: InfrahubDatabase, default_permission_backend, default_branch: Branch, choices_schema, session_admin
 ):
     obj1 = await Node.init(db=db, schema="TestChoice")
     await obj1.new(db=db, name="test-passive-01", status="passive")
@@ -176,9 +171,8 @@ async def test_delete_enum_option_in_use(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=default_branch, account_session=session_admin
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch, account_session=session_admin)
     result = await graphql(
         schema=gql_params.schema,
         source=query,

--- a/backend/tests/unit/graphql/mutations/test_update_generic.py
+++ b/backend/tests/unit/graphql/mutations/test_update_generic.py
@@ -5,7 +5,7 @@ from infrahub.graphql.initialization import prepare_graphql_params
 from tests.helpers.graphql import graphql
 
 
-async def test_display_label_generic(db: InfrahubDatabase, animal_person_schema, branch: Branch):
+async def test_display_label_generic(db: InfrahubDatabase, animal_person_schema, branch: Branch) -> None:
     person_schema = animal_person_schema.get(name="TestPerson")
     dog_schema = animal_person_schema.get(name="TestDog")
     cat_schema = animal_person_schema.get(name="TestCat")
@@ -35,7 +35,8 @@ async def test_display_label_generic(db: InfrahubDatabase, animal_person_schema,
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -45,5 +46,6 @@ async def test_display_label_generic(db: InfrahubDatabase, animal_person_schema,
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestAnimalUpdate"]["ok"] is True
     assert result.data["TestAnimalUpdate"]["object"]["weight"]["value"]

--- a/backend/tests/unit/graphql/mutations/test_webhook.py
+++ b/backend/tests/unit/graphql/mutations/test_webhook.py
@@ -17,7 +17,8 @@ if TYPE_CHECKING:
 async def test_create_webhook_invalid_node(
     db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch
 ) -> None:
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=CREATE_WEBHOOK,
@@ -32,7 +33,8 @@ async def test_create_webhook_invalid_node(
 async def test_create_webhook_invalid_node_event(
     db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch
 ) -> None:
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=CREATE_WEBHOOK,
@@ -47,7 +49,8 @@ async def test_create_webhook_invalid_node_event(
 async def test_create_webhook_with_node_kind_and_valid_node_event(
     db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch
 ) -> None:
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=CREATE_WEBHOOK,
@@ -71,7 +74,8 @@ async def test_create_webhook_with_node_kind_and_valid_node_event(
 async def test_update_webhook_with_optional_node_kind(
     db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch
 ) -> None:
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=CREATE_WEBHOOK,
@@ -105,7 +109,8 @@ async def test_update_webhook_with_optional_node_kind(
 async def test_create_webhook_with_node_kind_and_all_events(
     db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch
 ) -> None:
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=CREATE_WEBHOOK,
@@ -137,7 +142,8 @@ async def test_create_webhook_with_node_kind_and_all_events(
 async def test_update_to_invalid_states(
     db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch
 ) -> None:
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=CREATE_WEBHOOK,
@@ -179,7 +185,8 @@ async def test_update_to_invalid_states(
 async def test_update_to_valid_states(
     db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch
 ) -> None:
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=CREATE_WEBHOOK,
@@ -216,7 +223,8 @@ async def test_update_to_valid_states(
 async def test_update_description_only(
     db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch
 ) -> None:
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=CREATE_WEBHOOK,
@@ -254,7 +262,8 @@ async def test_update_description_only(
 
 
 async def test_upsert_webhook(db: InfrahubDatabase, register_core_models_schema: None, default_branch: Branch) -> None:
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=UPSERT_WEBHOOK,

--- a/backend/tests/unit/graphql/profiles/test_mutation_create.py
+++ b/backend/tests/unit/graphql/profiles/test_mutation_create.py
@@ -21,7 +21,8 @@ async def test_create_profile(db: InfrahubDatabase, default_branch, car_person_s
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     # gql mutation needs function workflow
     gql_params.context.service = await InfrahubServices.new(workflow=WorkflowLocalExecution())
     result = await graphql(

--- a/backend/tests/unit/graphql/profiles/test_query.py
+++ b/backend/tests/unit/graphql/profiles/test_query.py
@@ -75,9 +75,8 @@ async def test_create_profile_in_schema(db: InfrahubDatabase, default_branch: Br
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -87,6 +86,7 @@ async def test_create_profile_in_schema(db: InfrahubDatabase, default_branch: Br
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data["ProfileTestCriticality"]["edges"]) == 1
     assert result.data["ProfileTestCriticality"]["edges"][0]["node"]["display_label"] == obj1.profile_name.value
 
@@ -116,7 +116,8 @@ async def test_upsert_profile_in_schema(db: InfrahubDatabase, default_branch: Br
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     # gql mutation needs function workflow
     gql_params.context.service = await InfrahubServices.new(workflow=WorkflowLocalExecution())
     result = await graphql(
@@ -128,6 +129,7 @@ async def test_upsert_profile_in_schema(db: InfrahubDatabase, default_branch: Br
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["ProfileTestCriticalityUpsert"]["ok"] is True
     gql_object = result.data["ProfileTestCriticalityUpsert"]["object"]
     assert gql_object["profile_name"]["value"] == "prof1"
@@ -182,9 +184,8 @@ async def test_profile_apply(db: InfrahubDatabase, default_branch: Branch, criti
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -194,6 +195,7 @@ async def test_profile_apply(db: InfrahubDatabase, default_branch: Branch, criti
     )
 
     assert result.errors is None
+    assert result.data
     crits = result.data["TestCriticality"]["edges"]
     assert len(crits) == 2
     assert {
@@ -259,9 +261,8 @@ async def test_profile_apply_generic(db: InfrahubDatabase, default_branch: Branc
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -271,6 +272,7 @@ async def test_profile_apply_generic(db: InfrahubDatabase, default_branch: Branc
     )
 
     assert result.errors is None
+    assert result.data
     crits = result.data["TestGenericCriticality"]["edges"]
     assert len(crits) == 2
     assert {
@@ -327,9 +329,8 @@ async def test_setting_illegal_profiles_raises_error(db: InfrahubDatabase, defau
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=True, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
     crit_schema.generate_profile = False
     result = await graphql(
@@ -424,9 +425,8 @@ async def test_is_from_profile_set_correctly(db: InfrahubDatabase, default_branc
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -436,6 +436,7 @@ async def test_is_from_profile_set_correctly(db: InfrahubDatabase, default_branc
     )
 
     assert result.errors is None
+    assert result.data
     crits = result.data["TestCriticality"]["edges"]
     assert len(crits) == 3
     crits_by_id = {crit["node"]["id"]: crit["node"] for crit in crits}
@@ -530,9 +531,8 @@ async def test_is_profile_source_set_correctly(db: InfrahubDatabase, default_bra
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -542,6 +542,7 @@ async def test_is_profile_source_set_correctly(db: InfrahubDatabase, default_bra
     )
 
     assert result.errors is None
+    assert result.data
     crits = result.data["TestCriticality"]["edges"]
     assert len(crits) == 3
     crits_by_id = {crit["node"]["id"]: crit["node"] for crit in crits}

--- a/backend/tests/unit/graphql/queries/test_branch.py
+++ b/backend/tests/unit/graphql/queries/test_branch.py
@@ -28,10 +28,9 @@ class TestBranchQuery(TestInfrahubApp):
             }
         }
         """
-
+        default_branch.update_schema_hash()
         gql_params = await prepare_graphql_params(
             db=db,
-            include_subscription=False,
             branch=default_branch,
             account_session=session_admin,
             service=service,
@@ -61,9 +60,7 @@ class TestBranchQuery(TestInfrahubApp):
             }
         }
         """
-        gql_params = await prepare_graphql_params(
-            db=db, include_subscription=False, branch=default_branch, service=service
-        )
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch, service=service)
         all_branches = await graphql(
             schema=gql_params.schema,
             source=query,
@@ -108,9 +105,7 @@ class TestBranchQuery(TestInfrahubApp):
             }
         }
         """ % branch3["name"]
-        gql_params = await prepare_graphql_params(
-            db=db, include_subscription=False, branch=default_branch, service=service
-        )
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch, service=service)
         name_response = await graphql(
             schema=gql_params.schema,
             source=name_query,
@@ -134,9 +129,7 @@ class TestBranchQuery(TestInfrahubApp):
         """ % [branch3["id"]]
         id_query = id_query.replace("'", '"')
 
-        gql_params = await prepare_graphql_params(
-            db=db, include_subscription=False, branch=default_branch, service=service
-        )
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch, service=service)
         id_response = await graphql(
             schema=gql_params.schema,
             source=id_query,

--- a/backend/tests/unit/graphql/queries/test_display_label.py
+++ b/backend/tests/unit/graphql/queries/test_display_label.py
@@ -43,9 +43,8 @@ async def test_display_label_one_item(db: InfrahubDatabase, default_branch: Bran
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -55,6 +54,7 @@ async def test_display_label_one_item(db: InfrahubDatabase, default_branch: Bran
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data["TestCriticality"]["edges"]) == 1
     assert result.data["TestCriticality"]["edges"][0]["node"]["display_label"] == "Low"
 
@@ -95,9 +95,8 @@ async def test_display_label_multiple_items(db: InfrahubDatabase, default_branch
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -107,6 +106,7 @@ async def test_display_label_multiple_items(db: InfrahubDatabase, default_branch
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data["TestCriticality"]["edges"]) == 2
     assert sorted([node["node"]["display_label"] for node in result.data["TestCriticality"]["edges"]]) == [
         "low 4",
@@ -146,9 +146,8 @@ async def test_display_label_default_value(db: InfrahubDatabase, default_branch:
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -158,6 +157,7 @@ async def test_display_label_default_value(db: InfrahubDatabase, default_branch:
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data["TestCriticality"]["edges"]) == 1
     assert result.data["TestCriticality"]["edges"][0]["node"]["display_label"] == f"TestCriticality(ID: {obj1.id})"
 
@@ -190,9 +190,8 @@ async def test_display_label_generic(db: InfrahubDatabase, default_branch: Branc
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -202,6 +201,7 @@ async def test_display_label_generic(db: InfrahubDatabase, default_branch: Branc
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data["TestAnimal"]["edges"]) == 2
     expected_results = ["Kitty Persian #444444", "Rocky Labrador"]
     assert sorted([item["node"]["display_label"] for item in result.data["TestAnimal"]["edges"]]) == expected_results
@@ -257,9 +257,8 @@ async def test_display_label_nested_query(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -379,9 +378,8 @@ async def test_display_label_computed_attr(db: InfrahubDatabase, default_branch:
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -391,6 +389,7 @@ async def test_display_label_computed_attr(db: InfrahubDatabase, default_branch:
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data["TestObjectA"]["edges"]) == 1
     assert result.data["TestObjectA"]["edges"][0]["node"]["display_label"] == "FIRST"
 
@@ -407,9 +406,8 @@ async def test_display_label_computed_attr(db: InfrahubDatabase, default_branch:
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -419,5 +417,6 @@ async def test_display_label_computed_attr(db: InfrahubDatabase, default_branch:
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data["TestObjectB"]["edges"]) == 1
     assert result.data["TestObjectB"]["edges"][0]["node"]["display_label"] == "first SECOND"

--- a/backend/tests/unit/graphql/queries/test_event.py
+++ b/backend/tests/unit/graphql/queries/test_event.py
@@ -413,7 +413,8 @@ async def prefect_client(prefect_test_fixture):
 
 
 async def run_query(db: InfrahubDatabase, branch: Branch, query: str, variables: dict[str, Any]) -> ExecutionResult:
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     return await graphql(
         schema=gql_params.schema,
         source=query,

--- a/backend/tests/unit/graphql/queries/test_ipam.py
+++ b/backend/tests/unit/graphql/queries/test_ipam.py
@@ -130,7 +130,8 @@ async def test_ipprefix_nextavailable(
 ):
     obj = ip_dataset_01[prefix]
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
     query = """
     query($prefix: String!, $prefix_length: Int) {
@@ -171,7 +172,8 @@ async def test_ipaddress_nextavailable(
 ):
     obj = ip_dataset_02[prefix]
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
     query = """
     query($prefix: String!, $prefix_length: Int) {
@@ -523,7 +525,8 @@ class TestIpamAvailableNodes(TestInfrahubApp):
         prefix: str,
         result: list[str],
     ):
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+        default_branch.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
         query = """
         query($prefix: ID!) {
@@ -574,7 +577,8 @@ class TestIpamAvailableNodes(TestInfrahubApp):
         limit: int,
         kinds: list[str],
     ):
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+        default_branch.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch)
         query = """
         query($prefix: ID!, $limit: Int!, $kinds: [String!]) {
             BuiltinIPAddress(ip_prefix__ids: [$prefix], include_available: true, kinds: $kinds, limit: $limit) {
@@ -628,7 +632,8 @@ class TestIpamAvailableNodes(TestInfrahubApp):
         register_ipam_schema: SchemaBranch,
         ip_dataset_range_various_kinds: dict[str, Node],
     ):
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+        default_branch.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch)
         query = """
         query($prefix: ID!, $kinds: [String!]) {
             BuiltinIPAddress(ip_prefix__ids: [$prefix], include_available: true, kinds: $kinds) {
@@ -733,7 +738,8 @@ class TestIpamAvailableNodes(TestInfrahubApp):
         offset: int,
         result: list[str],
     ):
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+        default_branch.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
         query = """
         query($prefix: ID!, $limit: Int!, $offset: Int!) {
@@ -879,7 +885,8 @@ class TestIpamAvailableNodes(TestInfrahubApp):
         prefix: str,
         result: list[str],
     ):
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+        default_branch.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
         query = """
         query($prefix: ID!) {
@@ -1040,7 +1047,8 @@ class TestIpamAvailableNodes(TestInfrahubApp):
         offset: int,
         result: list[str],
     ):
-        gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+        default_branch.update_schema_hash()
+        gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
         query = """
         query($prefix: ID!, $limit: Int!, $offset: Int!) {

--- a/backend/tests/unit/graphql/queries/test_relationship.py
+++ b/backend/tests/unit/graphql/queries/test_relationship.py
@@ -33,8 +33,8 @@ async def test_relationship(
         }
     }
     """
-
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
 
     # No identifiers
     result = await graphql(

--- a/backend/tests/unit/graphql/queries/test_resource_pool.py
+++ b/backend/tests/unit/graphql/queries/test_resource_pool.py
@@ -187,7 +187,8 @@ async def test_create_ipv6_prefix_and_read_allocations(db: InfrahubDatabase, def
     ipv6_prefix_resource = prefix_pools_02["ipv6_prefix_resource"]
     ipv6_prefix_pool = prefix_pools_02["ipv6_prefix_pool"]
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
     site1_result = await graphql(
         schema=gql_params.schema,
@@ -257,7 +258,8 @@ async def test_create_ipv6_prefix_and_read_allocations(db: InfrahubDatabase, def
     # ------------------------------------------------------------
     # Validate the utilization query in the main Branch
     # ------------------------------------------------------------
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     utilization_result = await graphql(
         schema=gql_params.schema,
         source=POOL_UTILIZATION,
@@ -293,7 +295,8 @@ async def test_create_ipv4_prefix_and_read_allocations(db: InfrahubDatabase, def
     ipv4_prefix_resource = prefix_pools_02["ipv4_prefix_resource"]
     ipv4_prefix_pool = prefix_pools_02["ipv4_prefix_pool"]
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
     site1_result = await graphql(
         schema=gql_params.schema,
@@ -364,7 +367,8 @@ async def test_create_ipv4_address_and_read_allocations(db: InfrahubDatabase, de
     ipv4_address_resource = prefix_pools_02["ipv4_address_resource"]
     ipv4_address_pool = prefix_pools_02["ipv4_address_pool"]
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
     device1_result = await graphql(
         schema=gql_params.schema,
@@ -434,7 +438,8 @@ async def test_read_resources_in_pool_with_branch(db: InfrahubDatabase, default_
     peers = await ipv4_address_pool.resources.get_peers(db=db)
 
     # At first there should be 1 resource
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     resources_result = await graphql(
         schema=gql_params.schema,
         source=RESOURCES,
@@ -464,7 +469,8 @@ async def test_read_resources_in_pool_with_branch(db: InfrahubDatabase, default_
     branched_peer_ids = [peer.id for peer in branched_peers.values()]
 
     # In main there should be 1 resource
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     resources_result = await graphql(
         schema=gql_params.schema,
         source=RESOURCES,
@@ -483,7 +489,8 @@ async def test_read_resources_in_pool_with_branch(db: InfrahubDatabase, default_
     } == set(branched_peer_ids)
 
     # In branch there should be 2 resources
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch.name)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch.name)
     resources_result = await graphql(
         schema=gql_params.schema,
         source=RESOURCES,
@@ -568,7 +575,8 @@ async def test_read_resources_in_pool_new_schema_in_branch(
         }
         """
     # At first there should be 1 resource
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch2)
+    branch2.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch2)
     resources_result = await graphql(
         schema=gql_params.schema,
         source=IP_PREFIX_RESOURCES,
@@ -608,7 +616,8 @@ async def test_read_resources_in_pool_new_schema_in_branch(
     # ------------------------------------------------------------
     # Validate the utilization query in the main Branch
     # ------------------------------------------------------------
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     utilization_result = await graphql(
         schema=gql_params.schema,
         source=POOL_UTILIZATION,
@@ -631,7 +640,8 @@ async def test_read_resources_in_pool_new_schema_in_branch(
     # ------------------------------------------------------------
     # Validate the utilization query in Branch2
     # ------------------------------------------------------------
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch2)
+    branch2.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch2)
     utilization_result = await graphql(
         schema=gql_params.schema,
         source=POOL_UTILIZATION,
@@ -676,7 +686,8 @@ async def test_read_resources_in_pool_with_branch_with_mutations(
     peer_id = peer_ids[0]
 
     # At first there should be 1 resource
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     resources_result = await graphql(
         schema=gql_params.schema,
         source=RESOURCES,
@@ -693,7 +704,8 @@ async def test_read_resources_in_pool_with_branch_with_mutations(
     branch = await create_branch(branch_name="issue-3579", db=db)
 
     # Create a prefix
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     prefix_result = await graphql(
         schema=gql_params.schema,
         source="""
@@ -730,7 +742,8 @@ async def test_read_resources_in_pool_with_branch_with_mutations(
     )
 
     # In main there should be 1 resource
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     resources_result = await graphql(
         schema=gql_params.schema,
         source=RESOURCES,
@@ -749,7 +762,8 @@ async def test_read_resources_in_pool_with_branch_with_mutations(
     } == {peer_id, prefix_id}
 
     # In branch there should be 2 resources
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch.name)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch.name)
     resources_result = await graphql(
         schema=gql_params.schema,
         source=RESOURCES,
@@ -770,7 +784,8 @@ async def test_read_resources_in_pool_with_branch_with_mutations(
 
 async def test_number_pool_utilization(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema):
     await load_schema(db=db, schema=SchemaRoot(nodes=[TICKET]))
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     await initialization(db=db)
     create_ok = await graphql(
         schema=gql_params.schema,

--- a/backend/tests/unit/graphql/queries/test_search.py
+++ b/backend/tests/unit/graphql/queries/test_search.py
@@ -31,8 +31,9 @@ async def test_search_anywhere_by_uuid(
     car_prius_main: Node,
     car_yaris_main: Node,
     branch: Branch,
-):
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+) -> None:
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
 
     result = await graphql(
         schema=gql_params.schema,
@@ -60,7 +61,8 @@ async def test_search_anywhere_by_string(
     car_yaris_main: Node,
     branch: Branch,
 ):
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
 
     result = await graphql(
         schema=gql_params.schema,
@@ -102,8 +104,9 @@ async def test_search_ipv6_address_extended_format(
     db: InfrahubDatabase,
     ip_dataset_01,
     branch: Branch,
-):
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+) -> None:
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
 
     res_collapsed = await graphql(
         schema=gql_params.schema,
@@ -145,7 +148,8 @@ async def test_search_ipv6_network_extended_format(
     ip_dataset_01,
     branch: Branch,
 ):
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
 
     res_collapsed = await graphql(
         schema=gql_params.schema,
@@ -181,8 +185,9 @@ async def test_search_ipv6_partial_address(
     db: InfrahubDatabase,
     ip_dataset_01,
     branch: Branch,
-):
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+) -> None:
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
 
     res_two_segments = await graphql(
         schema=gql_params.schema,
@@ -230,12 +235,12 @@ async def test_search_ipv4(
     db: InfrahubDatabase,
     ip_dataset_01,
     branch: Branch,
-):
+) -> None:
     """
     This only tests that ipv6 search specific behavior does not break ipv4 search.
     """
-
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
 
     result_address = await graphql(
         schema=gql_params.schema,
@@ -301,12 +306,12 @@ async def test_search_groups(
     register_core_models_schema,
     register_builtin_models_schema,
     car_person_data_generic,
-):
+) -> None:
     group1 = await Node.init(db=db, schema=InfrahubKind.STANDARDGROUP)
     await group1.new(db=db, name="group1", members=[car_person_data_generic["c1"], car_person_data_generic["c2"]])
     await group1.save(db=db)
-
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
     result = await graphql(
         schema=gql_params.schema,
@@ -328,7 +333,8 @@ async def test_search_anywhere_by_string_no_results(
     register_builtin_models_schema: None,
 ) -> None:
     """Validate that the GraphQL an empty result is returned as an empty array and not a `null` value"""
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
     result = await graphql(
         schema=gql_params.schema,

--- a/backend/tests/unit/graphql/queries/test_task.py
+++ b/backend/tests/unit/graphql/queries/test_task.py
@@ -230,7 +230,8 @@ async def flow_runs_data(prefect_client: PrefectClient, tag_blue, tag_red, accou
 
 
 async def run_query(db: InfrahubDatabase, branch: Branch, query: str, variables: dict[str, Any]) -> ExecutionResult:
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     return await graphql(
         schema=gql_params.schema,
         source=query,

--- a/backend/tests/unit/graphql/test_core_account.py
+++ b/backend/tests/unit/graphql/test_core_account.py
@@ -10,7 +10,7 @@ from infrahub.graphql.initialization import prepare_graphql_params
 from tests.helpers.graphql import graphql
 
 
-async def test_everyone_can_update_password(db: InfrahubDatabase, default_branch: Branch, first_account):
+async def test_everyone_can_update_password(db: InfrahubDatabase, default_branch: Branch, first_account) -> None:
     new_password = "NewP@ssw0rd"
     new_description = "what a cool description"
     query = """
@@ -21,9 +21,9 @@ async def test_everyone_can_update_password(db: InfrahubDatabase, default_branch
     }
     """ % (new_password, new_description)
 
+    default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(
         db=db,
-        include_subscription=False,
         branch=default_branch,
         account_session=AccountSession(authenticated=True, account_id=first_account.id, auth_type=AuthType.JWT),
     )
@@ -52,7 +52,7 @@ async def test_permissions(
     authentication_base,
     session_admin,
     first_account,
-):
+) -> None:
     query = """
     query {
         InfrahubPermissions {
@@ -74,9 +74,8 @@ async def test_permissions(
     }
     """
 
-    gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=default_branch, account_session=session_admin
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch, account_session=session_admin)
 
     result = await graphql(
         schema=gql_params.schema, source=query, context_value=gql_params.context, root_value=None, variable_values={}
@@ -100,7 +99,6 @@ async def test_permissions(
 
     gql_params = await prepare_graphql_params(
         db=db,
-        include_subscription=False,
         branch=default_branch,
         account_session=AccountSession(authenticated=True, account_id=first_account.id, auth_type=AuthType.JWT),
     )

--- a/backend/tests/unit/graphql/test_graphql_query.py
+++ b/backend/tests/unit/graphql/test_graphql_query.py
@@ -20,7 +20,7 @@ from infrahub.graphql.registry import registry as graphql_registry
 from tests.helpers.graphql import graphql
 
 
-async def test_info_query(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema):
+async def test_info_query(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema) -> None:
     query = """
     query {
         InfrahubInfo {
@@ -28,10 +28,8 @@ async def test_info_query(db: InfrahubDatabase, default_branch: Branch, critical
         }
     }
     """
-
-    params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=params.schema,
         source=query,
@@ -41,10 +39,11 @@ async def test_info_query(db: InfrahubDatabase, default_branch: Branch, critical
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["InfrahubInfo"]["version"] == __version__
 
 
-async def test_simple_query(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema):
+async def test_simple_query(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema) -> None:
     obj1 = await Node.init(db=db, schema=criticality_schema)
     await obj1.new(db=db, name="low", level=4)
     await obj1.save(db=db)
@@ -66,10 +65,8 @@ async def test_simple_query(db: InfrahubDatabase, default_branch: Branch, critic
         }
     }
     """
-
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -79,6 +76,7 @@ async def test_simple_query(db: InfrahubDatabase, default_branch: Branch, critic
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestCriticality"]["count"] == 2
     assert len(result.data["TestCriticality"]["edges"]) == 2
     assert gql_params.context.related_node_ids == {obj1.id, obj2.id}
@@ -86,7 +84,7 @@ async def test_simple_query(db: InfrahubDatabase, default_branch: Branch, critic
 
 async def test_simple_query_with_offset_and_limit(
     db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema
-):
+) -> None:
     obj1 = await Node.init(db=db, schema=criticality_schema)
     await obj1.new(db=db, name="low", level=4)
     await obj1.save(db=db)
@@ -108,9 +106,8 @@ async def test_simple_query_with_offset_and_limit(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -120,11 +117,12 @@ async def test_simple_query_with_offset_and_limit(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestCriticality"]["count"] == 2
     assert len(result.data["TestCriticality"]["edges"]) == 1
 
 
-async def test_display_hfid(db: InfrahubDatabase, default_branch: Branch, animal_person_schema: SchemaBranch):
+async def test_display_hfid(db: InfrahubDatabase, default_branch: Branch, animal_person_schema: SchemaBranch) -> None:
     person_schema = animal_person_schema.get(name="TestPerson")
     dog_schema = animal_person_schema.get(name="TestDog")
 
@@ -149,9 +147,8 @@ async def test_display_hfid(db: InfrahubDatabase, default_branch: Branch, animal
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -161,6 +158,7 @@ async def test_display_hfid(db: InfrahubDatabase, default_branch: Branch, animal
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data["TestDog"]["edges"]) == 1
     assert result.data["TestDog"]["edges"][0] == {
         "node": {
@@ -173,9 +171,9 @@ async def test_display_hfid(db: InfrahubDatabase, default_branch: Branch, animal
 
 async def test_display_hfid_related_node(
     db: InfrahubDatabase, default_branch: Branch, animal_person_schema: SchemaBranch
-):
-    person_schema = animal_person_schema.get(name="TestPerson")
-    dog_schema = animal_person_schema.get(name="TestDog")
+) -> None:
+    person_schema = animal_person_schema.get_node(name="TestPerson")
+    dog_schema = animal_person_schema.get_node(name="TestDog")
 
     person1 = await Node.init(db=db, schema=person_schema, branch=default_branch)
     await person1.new(db=db, name="Jack")
@@ -203,9 +201,8 @@ async def test_display_hfid_related_node(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -215,6 +212,7 @@ async def test_display_hfid_related_node(
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data["TestPerson"]["edges"]) == 1
     assert result.data["TestPerson"]["edges"][0] == {
         "node": {
@@ -226,7 +224,7 @@ async def test_display_hfid_related_node(
 
 async def test_all_attributes(
     db: InfrahubDatabase, default_branch: Branch, data_schema: None, all_attribute_types_schema: NodeSchema
-):
+) -> None:
     obj1 = await Node.init(db=db, schema="TestAllAttributeTypes")
     await obj1.new(
         db=db,
@@ -271,9 +269,8 @@ async def test_all_attributes(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -283,6 +280,7 @@ async def test_all_attributes(
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data["TestAllAttributeTypes"]["edges"]) == 2
 
     results = {item["node"]["name"]["value"]: item["node"] for item in result.data["TestAllAttributeTypes"]["edges"]}
@@ -312,9 +310,9 @@ async def test_all_attributes(
     assert results["obj2"]["prefix"]["prefixlen"] is None
 
 
-async def test_nested_query(db: InfrahubDatabase, default_branch: Branch, car_person_schema: SchemaBranch):
-    car = registry.schema.get(name="TestCar")
-    person = registry.schema.get(name="TestPerson")
+async def test_nested_query(db: InfrahubDatabase, default_branch: Branch, car_person_schema: SchemaBranch) -> None:
+    car = registry.schema.get_node_schema(name="TestCar")
+    person = registry.schema.get_node_schema(name="TestPerson")
 
     p1 = await Node.init(db=db, schema=person)
     await p1.new(db=db, name="John", height=180)
@@ -356,9 +354,8 @@ async def test_nested_query(db: InfrahubDatabase, default_branch: Branch, car_pe
     }
     """
 
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -369,6 +366,7 @@ async def test_nested_query(db: InfrahubDatabase, default_branch: Branch, car_pe
 
     assert result.errors is None
 
+    assert result.data
     result_per_name = {result["node"]["name"]["value"]: result["node"] for result in result.data["TestPerson"]["edges"]}
     assert sorted(result_per_name.keys()) == ["Jane", "John"]
     assert len(result_per_name["John"]["cars"]["edges"]) == 2
@@ -376,9 +374,11 @@ async def test_nested_query(db: InfrahubDatabase, default_branch: Branch, car_pe
     assert gql_params.context.related_node_ids == {p1.id, p2.id, c1.id, c2.id, c3.id}
 
 
-async def test_double_nested_query(db: InfrahubDatabase, default_branch: Branch, car_person_schema: SchemaBranch):
-    car = registry.schema.get(name="TestCar")
-    person = registry.schema.get(name="TestPerson")
+async def test_double_nested_query(
+    db: InfrahubDatabase, default_branch: Branch, car_person_schema: SchemaBranch
+) -> None:
+    car = registry.schema.get_node_schema(name="TestCar")
+    person = registry.schema.get_node_schema(name="TestPerson")
 
     p1 = await Node.init(db=db, schema=person)
     await p1.new(db=db, name="John", height=180)
@@ -427,9 +427,8 @@ async def test_double_nested_query(db: InfrahubDatabase, default_branch: Branch,
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -440,6 +439,7 @@ async def test_double_nested_query(db: InfrahubDatabase, default_branch: Branch,
 
     assert result.errors is None
 
+    assert result.data
     result_per_name = {result["node"]["name"]["value"]: result["node"] for result in result.data["TestPerson"]["edges"]}
     assert sorted(result_per_name.keys()) == ["Jane", "John"]
     assert len(result_per_name["John"]["cars"]["edges"]) == 2
@@ -453,7 +453,7 @@ async def test_double_nested_query(db: InfrahubDatabase, default_branch: Branch,
 
 async def test_nested_query_single_relationship(
     db: InfrahubDatabase, default_branch: Branch, node_group_schema, data_schema
-):
+) -> None:
     raw_schema = {
         "version": "1.0",
         "generics": [
@@ -533,9 +533,8 @@ async def test_nested_query_single_relationship(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -545,7 +544,7 @@ async def test_nested_query_single_relationship(
     )
 
     assert result.errors is None
-
+    assert result.data
     result_per_name = {
         result["node"]["name"]["value"]: result["node"] for result in result.data["InfraDevice"]["edges"]
     }
@@ -640,9 +639,8 @@ async def test_nested_generic_query_many_relationship(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -672,9 +670,9 @@ async def test_nested_generic_query_many_relationship(
     }
 
 
-async def test_query_typename(db: InfrahubDatabase, default_branch: Branch, car_person_schema: SchemaBranch):
-    car = registry.schema.get(name="TestCar")
-    person = registry.schema.get(name="TestPerson")
+async def test_query_typename(db: InfrahubDatabase, default_branch: Branch, car_person_schema: SchemaBranch) -> None:
+    car = registry.schema.get_node_schema(name="TestCar")
+    person = registry.schema.get_node_schema(name="TestPerson")
 
     p1 = await Node.init(db=db, schema=person)
     await p1.new(db=db, name="John", height=180)
@@ -736,9 +734,8 @@ async def test_query_typename(db: InfrahubDatabase, default_branch: Branch, car_
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -747,6 +744,7 @@ async def test_query_typename(db: InfrahubDatabase, default_branch: Branch, car_
         variable_values={},
     )
 
+    assert result.data
     assert result.errors is None
 
     result_per_name = {result["node"]["name"]["value"]: result["node"] for result in result.data["TestPerson"]["edges"]}
@@ -761,7 +759,7 @@ async def test_query_typename(db: InfrahubDatabase, default_branch: Branch, car_
     assert result_per_name["John"]["cars"]["edges"][0]["properties"]["__typename"] == "RelationshipProperty"
 
 
-async def test_query_filter_ids(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema):
+async def test_query_filter_ids(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema) -> None:
     obj1 = await Node.init(db=db, schema=criticality_schema)
     await obj1.new(db=db, name="low", level=4)
     await obj1.save(db=db)
@@ -788,9 +786,8 @@ async def test_query_filter_ids(db: InfrahubDatabase, default_branch: Branch, cr
     """
         % obj1.id
     )
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -800,6 +797,7 @@ async def test_query_filter_ids(db: InfrahubDatabase, default_branch: Branch, cr
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data["TestCriticality"]["edges"]) == 1
 
     query = """
@@ -818,9 +816,8 @@ async def test_query_filter_ids(db: InfrahubDatabase, default_branch: Branch, cr
         obj1.id,
         obj2.id,
     )
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -830,6 +827,7 @@ async def test_query_filter_ids(db: InfrahubDatabase, default_branch: Branch, cr
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data["TestCriticality"]["edges"]) == 2
 
 
@@ -841,7 +839,7 @@ async def test_query_filter_relationship_isnull(
     person_jane_main: Node,
     car_camry_main: Node,
     car_accord_main: Node,
-):
+) -> None:
     query = """
     query {
         TestPerson(cars__isnull: true) {
@@ -854,9 +852,8 @@ async def test_query_filter_relationship_isnull(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -866,6 +863,7 @@ async def test_query_filter_relationship_isnull(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestPerson"]["count"] == 1
     assert len(result.data["TestPerson"]["edges"]) == 1
     assert result.data["TestPerson"]["edges"][0]["node"]["id"] == person_albert_main.id
@@ -891,6 +889,7 @@ async def test_query_filter_relationship_isnull(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestPerson"]["count"] == 2
     assert len(result.data["TestPerson"]["edges"]) == 2
     result_person_ids = {node["node"]["id"] for node in result.data["TestPerson"]["edges"]}
@@ -922,9 +921,8 @@ async def test_query_filter_attribute_isnull(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -934,6 +932,7 @@ async def test_query_filter_attribute_isnull(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestPerson"]["count"] == 1
     assert len(result.data["TestPerson"]["edges"]) == 1
     assert result.data["TestPerson"]["edges"][0]["node"]["id"] == person_albert_main.id
@@ -959,13 +958,16 @@ async def test_query_filter_attribute_isnull(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestPerson"]["count"] == 2
     assert len(result.data["TestPerson"]["edges"]) == 2
     result_person_ids = {node["node"]["id"] for node in result.data["TestPerson"]["edges"]}
     assert result_person_ids == {person_john_main.id, person_jane_main.id}
 
 
-async def test_query_filter_local_attrs(db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema):
+async def test_query_filter_local_attrs(
+    db: InfrahubDatabase, default_branch: Branch, criticality_schema: NodeSchema
+) -> None:
     obj1 = await Node.init(db=db, schema=criticality_schema)
     await obj1.new(db=db, name="low", level=4)
     await obj1.save(db=db)
@@ -986,9 +988,8 @@ async def test_query_filter_local_attrs(db: InfrahubDatabase, default_branch: Br
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -998,6 +999,7 @@ async def test_query_filter_local_attrs(db: InfrahubDatabase, default_branch: Br
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data["TestCriticality"]["edges"]) == 1
 
 
@@ -1009,7 +1011,8 @@ async def test_query_filter_on_enum(
     car_person_schema: SchemaBranch,
     graphql_enums_on: bool,
     enum_value: Literal["MANUAL", '"manual"'],
-):
+    reset_graphql_schema_between_tests: None,
+) -> None:
     config.SETTINGS.experimental_features.graphql_enums = graphql_enums_on
     car = registry.schema.get(name="TestCar")
 
@@ -1030,10 +1033,8 @@ async def test_query_filter_on_enum(
         }
     }
     """ % (enum_value)
-    graphql_registry.clear_cache()
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1043,6 +1044,7 @@ async def test_query_filter_on_enum(
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data["TestCar"]["edges"]) == 1
     assert result.data["TestCar"]["edges"][0]["node"]["name"]["value"] == "GoKart"
 
@@ -1092,9 +1094,8 @@ async def test_query_multiple_filters(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query01,
@@ -1104,6 +1105,7 @@ async def test_query_multiple_filters(
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data["TestCar"]["edges"]) == 1
     assert result.data["TestCar"]["edges"][0]["node"]["id"] == c1.id
 
@@ -1121,9 +1123,8 @@ async def test_query_multiple_filters(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query02,
@@ -1133,6 +1134,7 @@ async def test_query_multiple_filters(
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data["TestCar"]["edges"]) == 1
     assert result.data["TestCar"]["edges"][0]["node"]["id"] == c3.id
 
@@ -1150,9 +1152,8 @@ async def test_query_multiple_filters(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query03,
@@ -1162,6 +1163,7 @@ async def test_query_multiple_filters(
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data["TestCar"]["edges"]) == 1
     assert result.data["TestCar"]["edges"][0]["node"]["id"] == c2.id
 
@@ -1182,9 +1184,8 @@ async def test_query_multiple_filters(
         p1.id,
         m2.id,
     )
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query04,
@@ -1194,6 +1195,7 @@ async def test_query_multiple_filters(
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data["TestCar"]["edges"]) == 1
     assert result.data["TestCar"]["edges"][0]["node"]["id"] == c2.id
 
@@ -1227,9 +1229,8 @@ async def test_query_multiple_filters(
         }
     }
     """ % (p1.id)
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query05,
@@ -1239,6 +1240,7 @@ async def test_query_multiple_filters(
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data["TestCar"]["edges"]) == 2
     assert {node["node"]["id"] for node in result.data["TestCar"]["edges"]} == {c1.id, c2.id}
 
@@ -1290,9 +1292,8 @@ async def test_query_filter_relationships(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1302,6 +1303,7 @@ async def test_query_filter_relationships(
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data["TestPerson"]["edges"]) == 1
     assert result.data["TestPerson"]["count"] == 1
     assert result.data["TestPerson"]["edges"][0]["node"]["name"]["value"] == "John"
@@ -1336,9 +1338,8 @@ async def test_query_filter_relationships_with_generic(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1348,6 +1349,7 @@ async def test_query_filter_relationships_with_generic(
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data["TestPerson"]["edges"]) == 1
     assert result.data["TestPerson"]["edges"][0]["node"]["name"]["value"] == "John"
     assert len(result.data["TestPerson"]["edges"][0]["node"]["cars"]["edges"]) == 1
@@ -1380,9 +1382,8 @@ async def test_query_filter_relationships_with_generic_filter(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1401,6 +1402,7 @@ async def test_query_filter_relationships_with_generic_filter(
             }
         }
     ]
+    assert result.data
     assert DeepDiff(result.data["TestPerson"]["edges"], expected_results, ignore_order=True).to_dict() == {}
 
 
@@ -1455,9 +1457,8 @@ async def test_query_filter_relationship_id(
     """
         % c1.id
     )
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1467,6 +1468,7 @@ async def test_query_filter_relationship_id(
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data["TestPerson"]["edges"]) == 1
     assert result.data["TestPerson"]["edges"][0]["node"]["name"]["value"] == "John"
     assert len(result.data["TestPerson"]["edges"][0]["node"]["cars"]["edges"]) == 1
@@ -1497,9 +1499,8 @@ async def test_query_filter_relationship_id(
         c1.id,
         c4.id,
     )
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1509,6 +1510,7 @@ async def test_query_filter_relationship_id(
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data["TestPerson"]["edges"]) == 1
     assert result.data["TestPerson"]["edges"][0]["node"]["name"]["value"] == "John"
     assert len(result.data["TestPerson"]["edges"][0]["node"]["cars"]["edges"]) == 2
@@ -1564,10 +1566,8 @@ async def test_query_filter_list(
         }
     }
     """ % {"filter": graphql_filter}
-
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1577,6 +1577,7 @@ async def test_query_filter_list(
     )
 
     assert result.errors is None
+    assert result.data
     names = sorted([item["node"]["name"]["value"] for item in result.data["TestCriticality"]["edges"]])
     assert names == expected_results
 
@@ -1601,9 +1602,8 @@ async def test_query_attribute_multiple_values(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1613,6 +1613,7 @@ async def test_query_attribute_multiple_values(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestPerson"]["count"] == 2
 
 
@@ -1665,9 +1666,8 @@ async def test_query_relationship_multiple_values(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1677,6 +1677,7 @@ async def test_query_relationship_multiple_values(
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data["TestPerson"]["edges"]) == 2
     assert result.data["TestPerson"]["edges"][0]["node"]["cars"]["edges"][0]["node"]["name"]["value"] == "volt"
     assert result.data["TestPerson"]["edges"][1]["node"]["cars"]["edges"][0]["node"]["name"]["value"] == "nolt"
@@ -1713,9 +1714,8 @@ async def test_query_oneway_relationship(db: InfrahubDatabase, default_branch: B
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1725,6 +1725,7 @@ async def test_query_oneway_relationship(db: InfrahubDatabase, default_branch: B
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data["TestPerson"]["edges"][0]["node"]["tags"]["edges"]) == 2
 
 
@@ -1754,9 +1755,8 @@ async def test_query_at_specific_time(db: InfrahubDatabase, default_branch: Bran
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1766,6 +1766,7 @@ async def test_query_at_specific_time(db: InfrahubDatabase, default_branch: Bran
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data[InfrahubKind.TAG]["edges"]) == 2
     names = sorted([tag["node"]["name"]["value"] for tag in result.data[InfrahubKind.TAG]["edges"]])
     assert names == ["Blue", "Green"]
@@ -1784,9 +1785,8 @@ async def test_query_at_specific_time(db: InfrahubDatabase, default_branch: Bran
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, at=time1, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, at=time1, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1796,6 +1796,7 @@ async def test_query_at_specific_time(db: InfrahubDatabase, default_branch: Bran
     )
 
     assert result.errors is None
+    assert result.data
     assert len(result.data[InfrahubKind.TAG]["edges"]) == 2
     names = sorted([tag["node"]["name"]["value"] for tag in result.data[InfrahubKind.TAG]["edges"]])
     assert names == ["Blue", "Red"]
@@ -1825,9 +1826,8 @@ async def test_query_attribute_updated_at(db: InfrahubDatabase, default_branch: 
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result1 = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1837,6 +1837,7 @@ async def test_query_attribute_updated_at(db: InfrahubDatabase, default_branch: 
     )
 
     assert result1.errors is None
+    assert result1.data
     assert result1.data["TestPerson"]["edges"][0]["node"]["firstname"]["updated_at"]
     assert (
         result1.data["TestPerson"]["edges"][0]["node"]["firstname"]["updated_at"]
@@ -1847,9 +1848,8 @@ async def test_query_attribute_updated_at(db: InfrahubDatabase, default_branch: 
     p12.firstname.value = "Jim"
     await p12.save(db=db)
 
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result2 = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1859,6 +1859,7 @@ async def test_query_attribute_updated_at(db: InfrahubDatabase, default_branch: 
     )
 
     assert result2.errors is None
+    assert result2.data
     assert result2.data["TestPerson"]["edges"][0]["node"]["firstname"]["updated_at"]
     assert (
         result2.data["TestPerson"]["edges"][0]["node"]["firstname"]["updated_at"]
@@ -1883,9 +1884,8 @@ async def test_query_node_updated_at(db: InfrahubDatabase, default_branch: Branc
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result1 = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1895,15 +1895,15 @@ async def test_query_node_updated_at(db: InfrahubDatabase, default_branch: Branc
     )
 
     assert result1.errors is None
+    assert result1.data
     assert result1.data["TestPerson"]["edges"][0]["node"]["_updated_at"]
 
     p2 = await Node.init(db=db, schema="TestPerson")
     await p2.new(db=db, firstname="Jane", lastname="Doe")
     await p2.save(db=db)
 
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result2 = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1913,6 +1913,7 @@ async def test_query_node_updated_at(db: InfrahubDatabase, default_branch: Branc
     )
 
     assert result2.errors is None
+    assert result2.data
     assert result2.data["TestPerson"]["edges"][0]["node"]["_updated_at"]
     assert result2.data["TestPerson"]["edges"][1]["node"]["_updated_at"]
     assert result2.data["TestPerson"]["edges"][1]["node"]["_updated_at"] == Timestamp(
@@ -1956,9 +1957,8 @@ async def test_query_relationship_updated_at(db: InfrahubDatabase, default_branc
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result1 = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1968,15 +1968,15 @@ async def test_query_relationship_updated_at(db: InfrahubDatabase, default_branc
     )
 
     assert result1.errors is None
+    assert result1.data
     assert result1.data["TestPerson"]["edges"] == []
 
     p1 = await Node.init(db=db, schema="TestPerson")
     await p1.new(db=db, firstname="John", lastname="Doe", tags=[t1, t2])
     await p1.save(db=db)
 
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result2 = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1986,6 +1986,7 @@ async def test_query_relationship_updated_at(db: InfrahubDatabase, default_branc
     )
 
     assert result2.errors is None
+    assert result2.data
     assert len(result2.data["TestPerson"]["edges"][0]["node"]["tags"]["edges"]) == 2
     assert (
         result2.data["TestPerson"]["edges"][0]["node"]["tags"]["edges"][0]["node"]["_updated_at"]
@@ -2024,10 +2025,9 @@ async def test_query_attribute_node_property_source(
         }
     }
     """
-    graphql_registry.clear_cache()
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result1 = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -2037,6 +2037,7 @@ async def test_query_attribute_node_property_source(
     )
 
     assert result1.errors is None
+    assert result1.data
     assert result1.data["TestPerson"]["edges"][0]["node"]["firstname"]["source"]
     assert result1.data["TestPerson"]["edges"][0]["node"]["firstname"]["source"]["id"] == first_account.id
     assert gql_params.context.related_node_ids == {p1.id, first_account.id}
@@ -2083,10 +2084,8 @@ async def test_query_attribute_node_property_owner(
         }
     }
     """
-    graphql_registry.clear_cache()
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result1 = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -2131,9 +2130,8 @@ async def test_query_attribute_node_property_owner(
 
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result2 = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -2219,9 +2217,8 @@ async def test_query_relationship_node_property(
     }
     """
 
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -2230,7 +2227,7 @@ async def test_query_relationship_node_property(
         variable_values={},
     )
     assert result.errors is None
-
+    assert result.data
     results = {item["node"]["name"]["value"]: item["node"] for item in result.data["TestPerson"]["edges"]}
     assert sorted(results.keys()) == ["Jane", "John"]
     assert len(results["John"]["cars"]["edges"]) == 1
@@ -2277,10 +2274,8 @@ async def test_query_relationship_node_property(
         }
     }
     """
-
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -2290,6 +2285,7 @@ async def test_query_relationship_node_property(
     )
     assert result.errors is None
 
+    assert result.data
     results = {item["node"]["name"]["value"]: item["node"] for item in result.data["TestCar"]["edges"]}
     assert set(results.keys()) == {"volt", "bolt"}
 
@@ -2358,9 +2354,8 @@ async def test_query_relationship_node_property(
     }
     """
 
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -2369,6 +2364,7 @@ async def test_query_relationship_node_property(
         variable_values={},
     )
     assert result.errors is None
+    assert result.data
 
     owner_results = {
         item["node"]["name"]["value"]: item["node"] for item in result.data["people_with_cars_and_owners"]["edges"]
@@ -2456,9 +2452,8 @@ async def test_same_many_relationship_with_different_limits_offsets(
     john_cars_by_uuid = sorted([car_accord_main, car_prius_main], key=lambda c: c.id)
     jane_cars_by_uuid = sorted([car_camry_main, car_yaris_main], key=lambda c: c.id)
 
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -2467,6 +2462,7 @@ async def test_same_many_relationship_with_different_limits_offsets(
         variable_values={},
     )
     assert result.errors is None
+    assert result.data
 
     for person_node in result.data["people_with_cars_1"]["edges"]:
         person_name = person_node["node"]["name"]["value"]
@@ -2519,10 +2515,8 @@ async def test_query_attribute_flag_property(
         }
     }
     """
-    graphql_registry.clear_cache()
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result1 = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -2548,9 +2542,8 @@ async def test_query_branches(db: InfrahubDatabase, default_branch: Branch, regi
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result1 = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -2560,6 +2553,7 @@ async def test_query_branches(db: InfrahubDatabase, default_branch: Branch, regi
     )
 
     assert result1.errors is None
+    assert result1.data
     assert result1.data["Branch"][0]["name"] == "main"
 
 
@@ -2582,9 +2576,8 @@ async def test_query_multiple_branches(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result1 = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -2594,6 +2587,7 @@ async def test_query_multiple_branches(
     )
 
     assert result1.errors is None
+    assert result1.data
     assert result1.data["branch1"][0]["name"] == "main"
     assert result1.data["branch2"][0]["name"] == "main"
 
@@ -2632,9 +2626,8 @@ async def test_multiple_queries(db: InfrahubDatabase, default_branch: Branch, pe
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result1 = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -2644,6 +2637,7 @@ async def test_multiple_queries(db: InfrahubDatabase, default_branch: Branch, pe
     )
 
     assert result1.errors is None
+    assert result1.data
     assert result1.data["firstperson"]["edges"][0]["node"]["firstname"]["value"] == "John"
     assert result1.data["secondperson"]["edges"][0]["node"]["firstname"]["value"] == "Jane"
     assert gql_params.context.related_node_ids == {p1.id, p2.id}
@@ -2743,9 +2737,7 @@ async def test_model_rel_interface(db: InfrahubDatabase, default_branch: Branch,
     }
     """
     default_branch.update_schema_hash()
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -2806,9 +2798,7 @@ async def test_model_rel_interface_reverse(db: InfrahubDatabase, default_branch:
     }
     """
     default_branch.update_schema_hash()
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -2840,10 +2830,8 @@ async def test_generic_root_with_pagination(
         }
     }
     """
-    graphql_registry.clear_cache()
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -2942,10 +2930,8 @@ async def test_member_of_groups(
         }
     }
     """
-    graphql_registry.clear_cache()
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -3012,9 +2998,8 @@ async def test_hierarchical_location_parent_filter(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -3022,6 +3007,7 @@ async def test_hierarchical_location_parent_filter(
         root_value=None,
         variable_values={},
     )
+    assert result.data
 
     nodes = [node["node"]["name"]["value"] for node in result.data["LocationRack"]["edges"]]
 
@@ -3064,9 +3050,8 @@ async def test_hierarchical_location_ancestors(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -3076,6 +3061,7 @@ async def test_hierarchical_location_ancestors(
     )
 
     assert result.errors is None
+    assert result.data
     rack = result.data["LocationRack"]["edges"][0]["node"]
     ancestors = rack["ancestors"]["edges"]
     descendants = rack["descendants"]["edges"]
@@ -3120,9 +3106,8 @@ async def test_hierarchical_location_descendants(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -3132,6 +3117,7 @@ async def test_hierarchical_location_descendants(
     )
 
     assert result.errors is None
+    assert result.data
     asia = result.data["LocationRegion"]["edges"][0]["node"]
     ancestors = asia["ancestors"]["edges"]
     descendants = asia["descendants"]["edges"]
@@ -3175,9 +3161,8 @@ async def test_hierarchical_location_descendants_filters_attr(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -3187,6 +3172,7 @@ async def test_hierarchical_location_descendants_filters_attr(
     )
 
     assert result.errors is None
+    assert result.data
     asia = result.data["LocationRegion"]["edges"][0]["node"]
     descendants = asia["descendants"]["edges"]
     descendants_names = [node["node"]["name"]["value"] for node in descendants]
@@ -3228,9 +3214,8 @@ async def test_hierarchical_location_descendants_filters_ids(
         hierarchical_location_data["beijing-r1"].id,
         hierarchical_location_data["singapore-r2"].id,
     )
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -3240,6 +3225,7 @@ async def test_hierarchical_location_descendants_filters_ids(
     )
 
     assert result.errors is None
+    assert result.data
     asia = result.data["LocationRegion"]["edges"][0]["node"]
     descendants = asia["descendants"]["edges"]
     descendants_names = [node["node"]["name"]["value"] for node in descendants]
@@ -3278,9 +3264,8 @@ async def test_hierarchical_location_include_descendants(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -3290,6 +3275,7 @@ async def test_hierarchical_location_include_descendants(
     )
 
     assert result.errors is None
+    assert result.data
     asia = result.data["LocationRegion"]["edges"][0]["node"]
     things = asia["things"]["edges"]
     things_names = [node["node"]["name"]["value"] for node in things]
@@ -3398,9 +3384,8 @@ async def test_properties_on_different_query_paths(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -3410,6 +3395,7 @@ async def test_properties_on_different_query_paths(
     )
 
     assert result.errors is None
+    assert result.data
 
     # check owners are correct
     for rack in result.data["LocationRack"]["edges"]:
@@ -3458,9 +3444,8 @@ async def test_hierarchical_groups_descendants(
         }
     }
     """
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -3470,6 +3455,7 @@ async def test_hierarchical_groups_descendants(
     )
 
     assert result.errors is None
+    assert result.data
     grp1 = result.data["CoreStandardGroup"]["edges"][0]["node"]
     members = grp1["members"]["edges"]
     members_ids = [node["node"]["id"] for node in members]

--- a/backend/tests/unit/graphql/test_graphql_utils.py
+++ b/backend/tests/unit/graphql/test_graphql_utils.py
@@ -27,9 +27,12 @@ def generate_graphql_schema(
     )
 
 
-async def test_schema_models(db: InfrahubDatabase, default_branch: Branch, car_person_schema_generics, query_01: str):
+async def test_schema_models(
+    db: InfrahubDatabase, default_branch: Branch, car_person_schema_generics: None, query_01: str
+) -> None:
     document = parse(query_01)
-    schema = generate_graphql_schema(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    schema = generate_graphql_schema(db=db, branch=default_branch)
     fields = await extract_fields(document.definitions[0].selection_set)
 
     expected_response = {
@@ -49,7 +52,8 @@ async def test_schema_models_generics(
     db: InfrahubDatabase, default_branch: Branch, car_person_schema_generics, query_02: str
 ):
     document = parse(query_02)
-    schema = generate_graphql_schema(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    schema = generate_graphql_schema(db=db, branch=default_branch)
     fields = await extract_fields(document.definitions[0].selection_set)
 
     expected_response = {

--- a/backend/tests/unit/graphql/test_mutation_artifact_definition.py
+++ b/backend/tests/unit/graphql/test_mutation_artifact_definition.py
@@ -175,9 +175,7 @@ async def test_update_artifact_definition(
         authenticated=True, account_id=create_test_admin.id, session_id=None, auth_type=AuthType.API
     )
     branch.update_schema_hash()
-    gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=branch, service=service, account_session=account_session
-    )
+    gql_params = await prepare_graphql_params(db=db, branch=branch, service=service, account_session=account_session)
     with patch(
         "infrahub.services.adapters.workflow.local.WorkflowLocalExecution.submit_workflow"
     ) as mock_submit_workflow:

--- a/backend/tests/unit/graphql/test_mutation_create.py
+++ b/backend/tests/unit/graphql/test_mutation_create.py
@@ -15,13 +15,12 @@ from infrahub.core.schema.node_schema import NodeSchema
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
-from infrahub.graphql.registry import registry as graphql_registry
 from tests.constants import TestKind
 from tests.helpers.graphql import graphql
 from tests.helpers.schema import DEVICE_SCHEMA
 
 
-async def test_create_simple_object(db: InfrahubDatabase, default_branch, car_person_schema):
+async def test_create_simple_object(db: InfrahubDatabase, default_branch: Branch, car_person_schema: None) -> None:
     query = """
     mutation {
         TestPersonCreate(data: {name: { value: "John"}, height: {value: 182}}) {
@@ -32,7 +31,8 @@ async def test_create_simple_object(db: InfrahubDatabase, default_branch, car_pe
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -42,6 +42,7 @@ async def test_create_simple_object(db: InfrahubDatabase, default_branch, car_pe
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestPersonCreate"]["ok"] is True
 
     person_id = result.data["TestPersonCreate"]["object"]["id"]
@@ -52,7 +53,9 @@ async def test_create_simple_object(db: InfrahubDatabase, default_branch, car_pe
     assert person.height.is_default is False
 
 
-async def test_create_simple_object_with_ok_return(db: InfrahubDatabase, default_branch, car_person_schema):
+async def test_create_simple_object_with_ok_return(
+    db: InfrahubDatabase, default_branch: Branch, car_person_schema: None
+) -> None:
     query = """
     mutation {
         TestPersonCreate(data: {name: { value: "John"}, height: {value: 182}}) {
@@ -60,7 +63,8 @@ async def test_create_simple_object_with_ok_return(db: InfrahubDatabase, default
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -69,6 +73,7 @@ async def test_create_simple_object_with_ok_return(db: InfrahubDatabase, default
         variable_values={},
     )
     assert result.errors is None
+    assert result.data
     assert result.data["TestPersonCreate"]["ok"] is True
 
 
@@ -87,7 +92,8 @@ async def test_create_with_id(db: InfrahubDatabase, default_branch, car_person_s
     """
         % uuid1
     )
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -97,6 +103,7 @@ async def test_create_with_id(db: InfrahubDatabase, default_branch, car_person_s
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestPersonCreate"]["ok"] is True
     assert result.data["TestPersonCreate"]["object"]["id"] == uuid1
 
@@ -110,7 +117,8 @@ async def test_create_with_id(db: InfrahubDatabase, default_branch, car_person_s
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -139,7 +147,8 @@ async def test_create_check_unique(db: InfrahubDatabase, default_branch, car_per
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -171,7 +180,8 @@ async def test_create_check_unique_across_branch(db: InfrahubDatabase, default_b
 
     branch1 = await create_branch(branch_name="branch1", db=db)
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch1)
+    branch1.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch1)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -202,7 +212,8 @@ async def test_create_check_unique_in_branch(db: InfrahubDatabase, default_branc
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch1)
+    branch1.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch1)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -233,7 +244,8 @@ async def test_attr_optional_uniqueness_constraint_create(
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -244,7 +256,7 @@ async def test_attr_optional_uniqueness_constraint_create(
 
     assert result.errors is None
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -252,6 +264,7 @@ async def test_attr_optional_uniqueness_constraint_create(
         root_value=None,
         variable_values={},
     )
+    assert result.errors
     assert len(result.errors) == 1
     assert result.errors[0].message == "Violates uniqueness constraint 'name-description'"
 
@@ -277,7 +290,8 @@ async def test_all_attributes(db: InfrahubDatabase, default_branch, all_attribut
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -287,6 +301,7 @@ async def test_all_attributes(db: InfrahubDatabase, default_branch, all_attribut
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestAllAttributeTypesCreate"]["ok"] is True
     assert len(result.data["TestAllAttributeTypesCreate"]["object"]["id"]) == 36  # length of an UUID
 
@@ -326,7 +341,8 @@ async def test_all_attributes_default_value(db: InfrahubDatabase, default_branch
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -336,6 +352,7 @@ async def test_all_attributes_default_value(db: InfrahubDatabase, default_branch
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestAllAttributeTypesCreate"]["ok"] is True
     obj_id = result.data["TestAllAttributeTypesCreate"]["object"]["id"]
     assert len(obj_id) == 36  # length of an UUID
@@ -386,7 +403,8 @@ async def test_create_object_with_flag_property(db: InfrahubDatabase, default_br
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -396,6 +414,7 @@ async def test_create_object_with_flag_property(db: InfrahubDatabase, default_br
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestPersonCreate"]["ok"] is True
     assert len(result.data["TestPersonCreate"]["object"]["id"]) == 36  # length of an UUID
 
@@ -418,7 +437,8 @@ async def test_create_object_with_flag_property(db: InfrahubDatabase, default_br
             }
         }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result1 = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -428,6 +448,7 @@ async def test_create_object_with_flag_property(db: InfrahubDatabase, default_br
     )
 
     assert result1.errors is None
+    assert result1.data
     assert result1.data["TestPerson"]["edges"][0]["node"]["name"]["is_protected"] is True
     assert result1.data["TestPerson"]["edges"][0]["node"]["height"]["is_visible"] is False
 
@@ -454,7 +475,8 @@ async def test_create_object_with_node_property(
         second_account.id,
     )
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -464,6 +486,7 @@ async def test_create_object_with_node_property(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestPersonCreate"]["ok"] is True
     assert len(result.data["TestPersonCreate"]["object"]["id"]) == 36  # length of an UUID
 
@@ -493,7 +516,8 @@ async def test_create_object_with_node_property(
             }
         }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result1 = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -503,6 +527,7 @@ async def test_create_object_with_node_property(
     )
 
     assert result1.errors is None
+    assert result1.data
     assert result1.data["TestPerson"]["edges"][0]["node"]["name"]["source"]["id"] == first_account.id
     assert result1.data["TestPerson"]["edges"][0]["node"]["name"]["source"][
         "display_label"
@@ -535,7 +560,8 @@ async def test_create_object_with_single_relationship(db: InfrahubDatabase, defa
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -545,6 +571,7 @@ async def test_create_object_with_single_relationship(db: InfrahubDatabase, defa
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestCarCreate"]["ok"] is True
     assert len(result.data["TestCarCreate"]["object"]["id"]) == 36  # length of an UUID
 
@@ -567,7 +594,8 @@ async def test_create_object_with_invalid_single_relationship_fails(
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -575,6 +603,7 @@ async def test_create_object_with_invalid_single_relationship_fails(
         root_value=None,
         variable_values={},
     )
+    assert result.errors
     assert len(result.errors) == 1
     gql_error = result.errors[0]
     assert "Unable to find the node pretend region / LocationRegion in the database." in gql_error.message
@@ -602,7 +631,8 @@ async def test_create_object_with_single_relationship_flag_property(
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -612,6 +642,7 @@ async def test_create_object_with_single_relationship_flag_property(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestCarCreate"]["ok"] is True
     assert len(result.data["TestCarCreate"]["object"]["id"]) == 36
 
@@ -647,7 +678,8 @@ async def test_create_object_with_single_relationship_node_property(
     """
         % first_account.id
     )
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -657,6 +689,7 @@ async def test_create_object_with_single_relationship_node_property(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestCarCreate"]["ok"] is True
     assert len(result.data["TestCarCreate"]["object"]["id"]) == 36
 
@@ -693,7 +726,8 @@ async def test_create_object_with_multiple_relationships(db: InfrahubDatabase, d
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -703,6 +737,7 @@ async def test_create_object_with_multiple_relationships(db: InfrahubDatabase, d
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["GardenFruitCreate"]["ok"] is True
     assert len(result.data["GardenFruitCreate"]["object"]["id"]) == 36  # length of an UUID
 
@@ -747,7 +782,8 @@ async def test_create_object_with_multiple_relationships_with_node_property(
         first_account.id,
         second_account.id,
     )
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -757,6 +793,7 @@ async def test_create_object_with_multiple_relationships_with_node_property(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["GardenFruitCreate"]["ok"] is True
     assert len(result.data["GardenFruitCreate"]["object"]["id"]) == 36  # length of an UUID
 
@@ -817,7 +854,8 @@ async def test_create_object_with_multiple_relationships_flag_property(
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -827,6 +865,7 @@ async def test_create_object_with_multiple_relationships_flag_property(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["GardenFruitCreate"]["ok"] is True
     assert len(result.data["GardenFruitCreate"]["object"]["id"]) == 36  # length of an UUID
 
@@ -883,7 +922,8 @@ async def test_create_relationship_for_node_with_migrated_kind(
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=group_create_query,
@@ -896,7 +936,8 @@ async def test_create_relationship_for_node_with_migrated_kind(
     main_group_id = result.data["CoreStandardGroupCreate"]["object"]["id"]
 
     # create group on branch
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=group_create_query,
@@ -924,7 +965,8 @@ async def test_create_relationship_for_node_with_migrated_kind(
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=group_members_query,
@@ -937,7 +979,8 @@ async def test_create_relationship_for_node_with_migrated_kind(
     assert result.data["CoreStandardGroup"]["edges"][0]["node"]["members"]["count"] == 1
 
     # check relationship count on branch
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=group_members_query,
@@ -1032,7 +1075,8 @@ async def test_create_person_not_valid(db: InfrahubDatabase, default_branch, car
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1041,6 +1085,7 @@ async def test_create_person_not_valid(db: InfrahubDatabase, default_branch, car
         variable_values={},
     )
 
+    assert result.errors
     assert len(result.errors) == 1
     assert result.errors[0].message == "Expected value of type 'BigInt', found \"182\"."
 
@@ -1066,7 +1111,8 @@ async def test_create_with_attribute_not_valid(db: InfrahubDatabase, default_bra
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1075,6 +1121,7 @@ async def test_create_with_attribute_not_valid(db: InfrahubDatabase, default_bra
         variable_values={},
     )
 
+    assert result.errors
     assert len(result.errors) == 1
     assert "#44444444 must have a maximum length of 7 at color" in result.errors[0].message
 
@@ -1108,7 +1155,8 @@ async def test_create_with_uniqueness_constraint_violation(db: InfrahubDatabase,
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1116,6 +1164,7 @@ async def test_create_with_uniqueness_constraint_violation(db: InfrahubDatabase,
         root_value=None,
         variable_values={},
     )
+    assert result.errors
     assert len(result.errors) == 1
     assert "Violates uniqueness constraint 'owner-color'" in result.errors[0].message
 
@@ -1142,7 +1191,8 @@ async def test_relationship_with_hfid(db: InfrahubDatabase, default_branch, anim
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1151,6 +1201,7 @@ async def test_relationship_with_hfid(db: InfrahubDatabase, default_branch, anim
         variable_values={},
     )
     assert result.errors is None
+    assert result.data
     assert result.data["TestDogCreate"]["ok"] is True
     assert result.data["TestDogCreate"]["object"]["id"]
 
@@ -1185,7 +1236,8 @@ async def test_incorrect_peer_type_prevented(db: InfrahubDatabase, default_branc
         }
     }
     """ % {"animal_id": person2.id}
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1241,7 +1293,8 @@ async def test_create_valid_datetime_success(db: InfrahubDatabase, default_branc
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1250,6 +1303,7 @@ async def test_create_valid_datetime_success(db: InfrahubDatabase, default_branc
         variable_values={},
     )
     assert result.errors is None
+    assert result.data
     assert result.data["TestCriticalityCreate"]["ok"] is True
     crit = await NodeManager.get_one(db=db, id=result.data["TestCriticalityCreate"]["object"]["id"])
     assert crit.time.value == "2021-01-01T00:00:00Z"
@@ -1266,7 +1320,8 @@ async def test_create_valid_datetime_failure(db: InfrahubDatabase, default_branc
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1274,6 +1329,8 @@ async def test_create_valid_datetime_failure(db: InfrahubDatabase, default_branc
         root_value=None,
         variable_values={},
     )
+    assert result.data
+    assert result.errors
     assert result.errors[0].args[0] == "10:1010 is not a valid DateTime at time"
     assert result.data["TestCriticalityCreate"] is None
 
@@ -1582,6 +1639,7 @@ async def test_create_simple_object_with_enum(
     graphql_enums_on,
     enum_value,
     response_value,
+    reset_graphql_schema_between_tests,
 ):
     config.SETTINGS.experimental_features.graphql_enums = graphql_enums_on
     query = """
@@ -1603,8 +1661,8 @@ async def test_create_simple_object_with_enum(
         }
     }
     """ % (enum_value)
-    graphql_registry.clear_cache()
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1649,7 +1707,8 @@ async def test_create_enum_when_enums_off_fails(
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1658,6 +1717,7 @@ async def test_create_enum_when_enums_off_fails(
         variable_values={},
     )
 
+    assert result.errors
     assert len(result.errors) == 1
     assert "String cannot represent a non string value" in result.errors[0].message
 
@@ -1667,6 +1727,7 @@ async def test_create_string_when_enums_on_fails(
     default_branch,
     person_john_main,
     car_person_schema,
+    reset_graphql_schema_between_tests,
 ):
     config.SETTINGS.experimental_features.graphql_enums = True
     query = """
@@ -1688,8 +1749,8 @@ async def test_create_string_when_enums_on_fails(
         }
     }
     """
-    graphql_registry.clear_cache()
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,

--- a/backend/tests/unit/graphql/test_mutation_create_jinja2_attributes.py
+++ b/backend/tests/unit/graphql/test_mutation_create_jinja2_attributes.py
@@ -45,7 +45,8 @@ async def test_create_with_jinja2_computed_attributes_on_related_node(
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -94,7 +95,8 @@ async def test_create_with_jinja2_computed_attributes_on_hierarchial_node(
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -134,7 +136,8 @@ async def test_create_with_jinja2_with_generics(
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     continent_result = await graphql(
         schema=gql_params.schema,
         source=continent_query,
@@ -166,7 +169,8 @@ async def test_create_with_jinja2_with_generics(
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     country_result = await graphql(
         schema=gql_params.schema,
         source=country_query,
@@ -201,7 +205,8 @@ async def test_create_with_jinja2_with_generics(
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     site_result = await graphql(
         schema=gql_params.schema,
         source=site_query,

--- a/backend/tests/unit/graphql/test_mutation_delete.py
+++ b/backend/tests/unit/graphql/test_mutation_delete.py
@@ -35,7 +35,8 @@ async def test_delete_object(db: InfrahubDatabase, default_branch, car_person_sc
     """
         % obj1.id
     )
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -64,7 +65,8 @@ async def test_delete_prevented(
     """
         % person_jane_main.id
     )
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -110,7 +112,8 @@ async def test_delete_allowed_when_peer_rel_optional_on_generic(
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -149,7 +152,8 @@ async def test_delete_prevented_when_peer_rel_required_on_generic(
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -187,8 +191,9 @@ async def test_delete_events_with_cascade(
 
     memory_event = MemoryInfrahubEvent()
     service = await InfrahubServices.new(event=memory_event)
+    default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=default_branch, service=service, account_session=session_first_account
+        db=db, branch=default_branch, service=service, account_session=session_first_account
     )
     query = """
     mutation DeletePerson($human_id: String!){

--- a/backend/tests/unit/graphql/test_mutation_generator.py
+++ b/backend/tests/unit/graphql/test_mutation_generator.py
@@ -65,7 +65,7 @@ async def test_run_generator_definition(
     )
     default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=default_branch, service=service, account_session=account_session
+        db=db, branch=default_branch, service=service, account_session=account_session
     )
 
     with patch(

--- a/backend/tests/unit/graphql/test_mutation_graphqlquery.py
+++ b/backend/tests/unit/graphql/test_mutation_graphqlquery.py
@@ -112,7 +112,7 @@ async def test_create_query_with_vars(db: InfrahubDatabase, default_branch: Bran
     """ % query_value.replace("\n", " ").replace('"', '\\"')
 
     default_branch.update_schema_hash()
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -209,7 +209,7 @@ async def test_update_query(db: InfrahubDatabase, default_branch: Branch, regist
         query_update.replace("\n", " ").replace('"', '\\"'),
     )
     default_branch.update_schema_hash()
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -272,7 +272,7 @@ async def test_update_query_no_update(db: InfrahubDatabase, default_branch: Bran
     }
     """ % (obj.id)
     default_branch.update_schema_hash()
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,

--- a/backend/tests/unit/graphql/test_mutation_relationship.py
+++ b/backend/tests/unit/graphql/test_mutation_relationship.py
@@ -83,8 +83,9 @@ async def test_relationship_add(
 
     memory_event = MemoryInfrahubEvent()
     service = await InfrahubServices.new(event=memory_event)
+    branch.update_schema_hash()
     gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=branch, service=service, account_session=session_first_account
+        db=db, branch=branch, service=service, account_session=session_first_account
     )
     result = await graphql(
         schema=gql_params.schema,
@@ -140,8 +141,9 @@ async def test_relationship_add(
 
     memory_event = MemoryInfrahubEvent()
     service = await InfrahubServices.new(event=memory_event)
+    branch.update_schema_hash()
     gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=branch, service=service, account_session=session_first_account
+        db=db, branch=branch, service=service, account_session=session_first_account
     )
     result = await graphql(
         schema=gql_params.schema,
@@ -203,7 +205,8 @@ async def test_relationship_remove(
         tag_black_main.id,
     )
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -241,7 +244,8 @@ async def test_relationship_remove(
         tag_red_main.id,
     )
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -281,7 +285,8 @@ async def test_relationship_wrong_name(
         tag_blue_main.id,
     )
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -309,7 +314,8 @@ async def test_relationship_wrong_name(
         tag_blue_main.id,
     )
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -347,7 +353,8 @@ async def test_relationship_wrong_node(
         bad_uuid,
     )
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -375,7 +382,8 @@ async def test_relationship_wrong_node(
         person_jack_main.id,
     )
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -456,7 +464,7 @@ async def test_relationship_groups_add(
     service = await InfrahubServices.new(event=memory_event)
     default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=default_branch, service=service, account_session=session_first_account
+        db=db, branch=default_branch, service=service, account_session=session_first_account
     )
     result = await graphql(
         schema=gql_params.schema,
@@ -503,8 +511,9 @@ async def test_relationship_groups_add(
     )
     memory_event = MemoryInfrahubEvent()
     service = await InfrahubServices.new(event=memory_event)
+    default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=default_branch, service=service, account_session=session_first_account
+        db=db, branch=default_branch, service=service, account_session=session_first_account
     )
     result = await graphql(
         schema=gql_params.schema,
@@ -606,7 +615,7 @@ async def test_relationship_groups_remove(
     service = await InfrahubServices.new(event=memory_event)
     default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=default_branch, service=service, account_session=session_first_account
+        db=db, branch=default_branch, service=service, account_session=session_first_account
     )
     result = await graphql(
         schema=gql_params.schema,
@@ -649,8 +658,9 @@ async def test_relationship_groups_remove(
     memory_event = MemoryInfrahubEvent()
     service = await InfrahubServices.new(event=memory_event)
 
+    default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=default_branch, service=service, account_session=session_first_account
+        db=db, branch=default_branch, service=service, account_session=session_first_account
     )
 
     result = await graphql(
@@ -712,7 +722,7 @@ async def test_relationship_groups_add_remove(db: InfrahubDatabase, default_bran
         g2.id,
     )
     default_branch.update_schema_hash()
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -747,7 +757,8 @@ async def test_relationship_groups_add_remove(db: InfrahubDatabase, default_bran
         g2.id,
     )
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -786,7 +797,8 @@ async def test_relationship_groups_add_remove(db: InfrahubDatabase, default_bran
         g2.id,
     )
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -821,7 +833,8 @@ async def test_relationship_groups_add_remove(db: InfrahubDatabase, default_bran
         g2.id,
     )
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -863,7 +876,7 @@ async def test_relationship_add_busy(db: InfrahubDatabase, default_branch: Branc
     )
 
     default_branch.update_schema_hash()
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -932,7 +945,8 @@ async def test_relationship_add_for_node_with_migrated_kind(
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=add_members_query,
@@ -943,7 +957,8 @@ async def test_relationship_add_for_node_with_migrated_kind(
     assert not result.errors
 
     # add person to group on branch
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=add_members_query,
@@ -969,7 +984,8 @@ async def test_relationship_add_for_node_with_migrated_kind(
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=group_members_query,
@@ -982,7 +998,8 @@ async def test_relationship_add_for_node_with_migrated_kind(
     assert result.data["CoreStandardGroup"]["edges"][0]["node"]["members"]["count"] == 1
 
     # check relationship count on branch
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=group_members_query,
@@ -1090,7 +1107,8 @@ async def test_relationship_add_from_pool(
     }
     """ % (hugh.id, "ip_prefixes", prefix_pool_01["prefix_pool"].id)
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema, source=query, context_value=gql_params.context, root_value=None, variable_values={}
     )
@@ -1143,7 +1161,8 @@ async def test_add_generic_related_node_with_hfid(
     }
     """ % (person.id)
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
     result = await graphql(
         schema=gql_params.schema,
@@ -1220,9 +1239,7 @@ async def test_with_permissions(
     """
 
     default_branch.update_schema_hash()
-    gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=default_branch, account_session=first_session
-    )
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch, account_session=first_session)
     result = await graphql(
         schema=gql_params.schema,
         source=query % (person_jack_main.id, tag_blue_main.id),
@@ -1326,9 +1343,8 @@ async def test_relationship_read_only(
     await device1.new(db=db, name="device1", location=site1)
     await device1.save(db=db)
 
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=True, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
     add_query = """
     mutation RelationshipAdd(

--- a/backend/tests/unit/graphql/test_mutation_update.py
+++ b/backend/tests/unit/graphql/test_mutation_update.py
@@ -39,7 +39,8 @@ async def test_update_simple_object(db: InfrahubDatabase, person_john_main: Node
     """
         % person_john_main.id
     )
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -49,6 +50,7 @@ async def test_update_simple_object(db: InfrahubDatabase, person_john_main: Node
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestPersonUpdate"]["ok"] is True
 
     obj1 = await NodeManager.get_one(db=db, id=person_john_main.id, branch=branch)
@@ -67,7 +69,8 @@ async def test_update_simple_object_with_ok_return(db: InfrahubDatabase, person_
     """
         % person_john_main.id
     )
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -77,6 +80,7 @@ async def test_update_simple_object_with_ok_return(db: InfrahubDatabase, person_
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestPersonUpdate"]["ok"] is True
 
     obj1 = await NodeManager.get_one(db=db, id=person_john_main.id, branch=branch)
@@ -114,7 +118,8 @@ async def test_update_simple_object_with_enum(
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -122,6 +127,7 @@ async def test_update_simple_object_with_enum(
         root_value=None,
         variable_values={},
     )
+    assert result.data
     car_id = result.data["TestCarCreate"]["object"]["id"]
 
     query = """
@@ -140,7 +146,8 @@ async def test_update_simple_object_with_enum(
         }
     }
     """ % {"car_id": car_id, "enum_value": enum_value}
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -150,6 +157,7 @@ async def test_update_simple_object_with_enum(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestCarUpdate"]["ok"] is True
     assert result.data["TestCarUpdate"]["object"]["transmission"]["value"] == response_value
 
@@ -174,7 +182,8 @@ async def test_update_check_unique(db: InfrahubDatabase, person_john_main: Node,
     """
         % person_john_main.id
     )
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -208,7 +217,8 @@ async def test_update_object_with_flag_property(db: InfrahubDatabase, person_joh
     """
         % person_john_main.id
     )
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -218,6 +228,7 @@ async def test_update_object_with_flag_property(db: InfrahubDatabase, person_joh
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestPersonUpdate"]["ok"] is True
 
     obj1 = await NodeManager.get_one(db=db, id=person_john_main.id, branch=branch)
@@ -271,8 +282,9 @@ async def test_update_all_attributes(
 
     memory_event = MemoryInfrahubEvent()
     service = await InfrahubServices.new(event=memory_event)
+    default_branch.update_schema_hash()
     gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=default_branch, service=service, account_session=session_first_account
+        db=db, branch=default_branch, service=service, account_session=session_first_account
     )
     result = await graphql(
         schema=gql_params.schema,
@@ -342,7 +354,8 @@ async def test_update_object_with_node_property(
         second_account.id,
         second_account.id,
     )
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -352,6 +365,7 @@ async def test_update_object_with_node_property(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestPersonUpdate"]["ok"] is True
 
     obj1 = await NodeManager.get_one(db=db, id=person_john_with_source_main.id, include_source=True, branch=branch)
@@ -373,7 +387,8 @@ async def test_update_invalid_object(db: InfrahubDatabase, default_branch: Branc
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -382,6 +397,7 @@ async def test_update_invalid_object(db: InfrahubDatabase, default_branch: Branc
         variable_values={},
     )
 
+    assert result.errors
     assert len(result.errors) == 1
     assert "Unable to find the node XXXXXX / TestPerson in the database." in result.errors[0].message
 
@@ -403,7 +419,8 @@ async def test_update_invalid_input(db: InfrahubDatabase, person_john_main: Node
     """
         % person_john_main.id
     )
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -412,6 +429,7 @@ async def test_update_invalid_input(db: InfrahubDatabase, person_john_main: Node
         variable_values={},
     )
 
+    assert result.errors
     assert len(result.errors) == 1
     assert "String cannot represent a non string value" in result.errors[0].message
 
@@ -447,8 +465,9 @@ async def test_update_single_relationship(
     )
     memory_event = MemoryInfrahubEvent()
     service = await InfrahubServices.new(event=memory_event)
+    branch.update_schema_hash()
     gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=branch, service=service, account_session=session_first_account
+        db=db, branch=branch, service=service, account_session=session_first_account
     )
     result = await graphql(
         schema=gql_params.schema,
@@ -510,7 +529,8 @@ async def test_update_default_value(
         }
     }
     """ % (car_accord_main.id)
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -520,6 +540,7 @@ async def test_update_default_value(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestCarUpdate"]["ok"] is True
     assert result.data["TestCarUpdate"]["object"]["color"]["is_default"] is False
 
@@ -543,7 +564,8 @@ async def test_update_default_value(
     }
     """ % (car_accord_main.id)
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -553,6 +575,7 @@ async def test_update_default_value(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestCarUpdate"]["ok"] is True
     assert result.data["TestCarUpdate"]["object"]["color"]["is_default"] is False
 
@@ -580,7 +603,8 @@ async def test_update_default_value(
     }
     """ % (car_accord_main.id)
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -590,6 +614,7 @@ async def test_update_default_value(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestCarUpdate"]["ok"] is True
     assert result.data["TestCarUpdate"]["object"]["color"]["is_default"] is True
     assert result.data["TestCarUpdate"]["object"]["transmission"]["value"] is None
@@ -626,7 +651,8 @@ async def test_update_new_single_relationship_flag_property(
         car_accord_main.id,
         person_jim_main.id,
     )
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -636,6 +662,7 @@ async def test_update_new_single_relationship_flag_property(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestCarUpdate"]["ok"] is True
     assert result.data["TestCarUpdate"]["object"]["owner"]["node"]["name"]["value"] == "Jim"
 
@@ -669,7 +696,8 @@ async def test_update_delete_optional_relationship_cardinality_one(
         car_accord_main.id,
         person_jim_main.id,
     )
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -679,6 +707,7 @@ async def test_update_delete_optional_relationship_cardinality_one(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestCarUpdate"]["ok"] is True
     assert result.data["TestCarUpdate"]["object"]["owner"]["node"]["name"]["value"] == "Jim"
 
@@ -705,7 +734,8 @@ async def test_update_delete_optional_relationship_cardinality_one(
         }
     }
     """ % (car_accord_main.id,)
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -715,6 +745,7 @@ async def test_update_delete_optional_relationship_cardinality_one(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestCarUpdate"]["ok"] is True
     assert result.data["TestCarUpdate"]["object"]["owner"]["node"] is None
     car = await NodeManager.get_one(db=db, id=car_accord_main.id, branch=branch)
@@ -745,7 +776,8 @@ async def test_update_existing_single_relationship_flag_property(
         car_accord_main.id,
         person_john_main.id,
     )
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -755,6 +787,7 @@ async def test_update_existing_single_relationship_flag_property(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestCarUpdate"]["ok"] is True
     assert result.data["TestCarUpdate"]["object"]["owner"]["node"]["name"]["value"] == "John"
 
@@ -811,7 +844,8 @@ async def test_update_existing_single_relationship_node_property(
         person_john_main.id,
         second_account.id,
     )
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -821,6 +855,7 @@ async def test_update_existing_single_relationship_node_property(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestCarUpdate"]["ok"] is True
     assert result.data["TestCarUpdate"]["object"]["owner"]["node"]["name"]["value"] == "John"
 
@@ -863,7 +898,8 @@ async def test_update_relationship_many(
         person_jack_main.id,
         tag_blue_main.id,
     )
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -873,6 +909,7 @@ async def test_update_relationship_many(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestPersonUpdate"]["ok"] is True
     assert len(result.data["TestPersonUpdate"]["object"]["tags"]["edges"]) == 1
 
@@ -903,7 +940,8 @@ async def test_update_relationship_many(
         tag_red_main.id,
         tag_black_main.id,
     )
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -913,6 +951,7 @@ async def test_update_relationship_many(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestPersonUpdate"]["ok"] is True
     assert len(result.data["TestPersonUpdate"]["object"]["tags"]["edges"]) == 2
 
@@ -945,7 +984,8 @@ async def test_update_relationship_many(
         tag_blue_main.id,
         tag_black_main.id,
     )
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -955,6 +995,7 @@ async def test_update_relationship_many(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestPersonUpdate"]["ok"] is True
     assert len(result.data["TestPersonUpdate"]["object"]["tags"]["edges"]) == 2
 
@@ -994,7 +1035,8 @@ async def test_update_relationship_many2(
         person_jack_main.id,
         tag_blue_main.id,
     )
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1004,6 +1046,7 @@ async def test_update_relationship_many2(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestPersonUpdate"]["ok"] is True
     assert len(result.data["TestPersonUpdate"]["object"]["tags"]["edges"]) == 1
 
@@ -1034,7 +1077,8 @@ async def test_update_relationship_many2(
         tag_red_main.id,
         tag_black_main.id,
     )
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1044,6 +1088,7 @@ async def test_update_relationship_many2(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestPersonUpdate"]["ok"] is True
     assert len(result.data["TestPersonUpdate"]["object"]["tags"]["edges"]) == 2
 
@@ -1080,7 +1125,8 @@ async def test_update_relationship_previously_deleted(
         person_jack_main.id,
         tag_blue_main.id,
     )
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1090,6 +1136,7 @@ async def test_update_relationship_previously_deleted(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestPersonUpdate"]["ok"] is True
     assert len(result.data["TestPersonUpdate"]["object"]["tags"]) == 1
 
@@ -1116,7 +1163,8 @@ async def test_update_relationship_previously_deleted(
         tag_red_main.id,
         tag_black_main.id,
     )
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1126,6 +1174,7 @@ async def test_update_relationship_previously_deleted(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestPersonUpdate"]["ok"] is True
     assert len(result.data["TestPersonUpdate"]["object"]["tags"]) == 2
 
@@ -1153,7 +1202,8 @@ async def test_update_relationship_previously_deleted(
         tag_blue_main.id,
         tag_black_main.id,
     )
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1163,6 +1213,7 @@ async def test_update_relationship_previously_deleted(
     )
 
     assert result.errors is None
+    assert result.data
     assert result.data["TestPersonUpdate"]["ok"] is True
     assert len(result.data["TestPersonUpdate"]["object"]["tags"]) == 2
 
@@ -1227,7 +1278,8 @@ async def test_update_for_node_with_migrated_kind(
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=update_group_query,
@@ -1238,7 +1290,8 @@ async def test_update_for_node_with_migrated_kind(
     assert not result.errors
 
     # add person to group on branch
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=update_group_query,
@@ -1264,7 +1317,8 @@ async def test_update_for_node_with_migrated_kind(
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=group_members_query,
@@ -1277,7 +1331,8 @@ async def test_update_for_node_with_migrated_kind(
     assert result.data["CoreStandardGroup"]["edges"][0]["node"]["members"]["count"] == 1
 
     # check relationship count on branch
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=group_members_query,
@@ -1389,7 +1444,8 @@ async def test_update_with_uniqueness_constraint_violation(db: InfrahubDatabase,
         % c2.id
     )
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1397,6 +1453,7 @@ async def test_update_with_uniqueness_constraint_violation(db: InfrahubDatabase,
         root_value=None,
         variable_values={},
     )
+    assert result.errors
     assert len(result.errors) == 1
     assert "Violates uniqueness constraint 'owner-color'" in result.errors[0].message
 
@@ -1429,7 +1486,8 @@ async def test_with_hfid(db: InfrahubDatabase, default_branch, animal_person_sch
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1438,6 +1496,7 @@ async def test_with_hfid(db: InfrahubDatabase, default_branch, animal_person_sch
         variable_values={},
     )
     assert result.errors is None
+    assert result.data
     assert result.data["TestDogUpdate"]["ok"] is True
     assert result.data["TestDogUpdate"]["object"] == {"color": {"value": "black"}, "id": dog1.id}
 
@@ -1472,7 +1531,8 @@ async def test_incorrect_peer_type_prevented(db: InfrahubDatabase, default_branc
         }
     }
     """ % {"person_id": person1.id, "animal_id": person2.id}
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1544,7 +1604,8 @@ async def test_removing_mandatory_relationship_not_allowed(db: InfrahubDatabase,
         }
     }
     """ % {"animal_id": dog1.id}
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1590,7 +1651,8 @@ async def test_updating_relationship_when_peer_side_is_required(
         }
     }
     """ % {"person_id": person1.id, "animal1_id": dog1.id, "animal2_id": dog2.id}
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1636,7 +1698,8 @@ async def test_updating_relationship_when_peer_side_is_optional(
         }
     }
     """ % {"person_id": person1.id, "animal1_id": dog1.id, "animal2_id": dog2.id}
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -1645,6 +1708,7 @@ async def test_updating_relationship_when_peer_side_is_optional(
         variable_values={},
     )
     assert result.errors is None
+    assert result.data
     assert result.data["TestPersonUpdate"]["ok"]
 
     updated_nodes = await NodeManager.get_many(db=db, ids=[person1.id, person2.id, dog1.id, dog2.id])

--- a/backend/tests/unit/graphql/test_mutation_upsert.py
+++ b/backend/tests/unit/graphql/test_mutation_upsert.py
@@ -27,7 +27,8 @@ async def test_upsert_existing_simple_object_by_id(db: InfrahubDatabase, person_
     """
         % person_john_main.id
     )
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -68,7 +69,8 @@ async def test_upsert_existing_simple_object_by_default_filter(
     }
     """
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -106,8 +108,9 @@ async def test_upsert_event_on_no_change(
     """
     memory_event = MemoryInfrahubEvent()
     service = await InfrahubServices.new(event=memory_event)
+    branch.update_schema_hash()
     gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=branch, service=service, account_session=session_first_account
+        db=db, branch=branch, service=service, account_session=session_first_account
     )
     result = await graphql(
         schema=gql_params.schema,
@@ -135,8 +138,9 @@ async def test_upsert_event_on_no_change(
 
     memory_event = MemoryInfrahubEvent()
     service = await InfrahubServices.new(event=memory_event)
+    branch.update_schema_hash()
     gql_params = await prepare_graphql_params(
-        db=db, include_subscription=False, branch=branch, service=service, account_session=session_first_account
+        db=db, branch=branch, service=service, account_session=session_first_account
     )
     result_second_time = await graphql(
         schema=gql_params.schema,
@@ -166,7 +170,8 @@ async def test_upsert_create_simple_object_no_id(db: InfrahubDatabase, person_jo
     }
     """ % ("Ellen Ripley", 179)
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -198,7 +203,8 @@ async def test_id_for_other_schema_raises_error(
     """
         % car_accord_main.id
     )
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -225,7 +231,8 @@ async def test_update_by_id_to_nonunique_value_raises_error(
     """
         % person_john_main.id
     )
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -251,7 +258,8 @@ async def test_non_unique_value_raises_error(db: InfrahubDatabase, person_schema
     }
     """
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -259,6 +267,7 @@ async def test_non_unique_value_raises_error(db: InfrahubDatabase, person_schema
         root_value=None,
         variable_values={},
     )
+    assert result.errors
     assert len(result.errors) == 1
     assert "Violates uniqueness constraint 'bag'" in result.errors[0].message
 
@@ -302,7 +311,8 @@ async def test_upsert_existing_with_enough_information_for_hfid(
         }
     }
     """ % {"id1": thing1.id}
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -335,7 +345,8 @@ async def test_upsert_existing_with_enough_information_for_hfid(
         }
     }
     """ % {"id1": thing1.id, "id2": thing2.id}
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -349,7 +360,8 @@ async def test_upsert_existing_with_enough_information_for_hfid(
     # delete the TestThing.car relationship and try again
     await thing2.car.update(db=db, data=[None])
     await thing2.save(db=db)
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -358,6 +370,7 @@ async def test_upsert_existing_with_enough_information_for_hfid(
         variable_values={"car_name": car_name, "owner_id": fred.id, "color": car_color_2},
     )
     assert not result.errors
+    assert result.data
     assert result.data["TestCarUpsert"]["object"]["id"] == car.id
     assert result.data["TestCarUpsert"]["object"]["color"]["value"] == car_color_2
     assert result.data["TestCarUpsert"]["object"]["owner"]["node"]["id"] == fred.id
@@ -386,8 +399,8 @@ async def test_upsert_existing_hfid_with_non_hfid_unique_attr(
         }
     }
     """
-
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -432,7 +445,8 @@ async def test_with_hfid_existing(db: InfrahubDatabase, default_branch, animal_p
     """
         % person1.id
     )
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -487,7 +501,8 @@ async def test_with_hfid_new(db: InfrahubDatabase, default_branch, animal_person
         % person1.id
     )
 
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -544,7 +559,8 @@ async def test_with_constructed_hfid(db: InfrahubDatabase, default_branch, anima
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
     # Create initial node
     initial_weight = 14
@@ -622,7 +638,8 @@ async def test_with_constructed_hfid_with_numbers(
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
     update_result = await graphql(
         schema=gql_params.schema,
@@ -657,7 +674,8 @@ async def test_upsert_node_on_branch_with_hfid_on_default(db: InfrahubDatabase, 
         }
     }
     """
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=branch)
+    branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,

--- a/backend/tests/unit/graphql/test_parser.py
+++ b/backend/tests/unit/graphql/test_parser.py
@@ -5,7 +5,7 @@ from infrahub.graphql.initialization import prepare_graphql_params
 from tests.helpers.graphql import graphql
 
 
-async def test_simple_directive(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_simple_directive(db: InfrahubDatabase, default_branch: Branch, criticality_schema) -> None:
     obj1 = await Node.init(db=db, schema=criticality_schema)
     await obj1.new(db=db, name="low", level=4)
     await obj1.save(db=db)
@@ -32,9 +32,8 @@ async def test_simple_directive(db: InfrahubDatabase, default_branch: Branch, cr
     }
     """
 
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,
@@ -68,7 +67,7 @@ async def test_simple_directive(db: InfrahubDatabase, default_branch: Branch, cr
     } in result.data["TestCriticality"]["edges"]
 
 
-async def test_directive_exclude(db: InfrahubDatabase, default_branch: Branch, criticality_schema):
+async def test_directive_exclude(db: InfrahubDatabase, default_branch: Branch, criticality_schema) -> None:
     obj1 = await Node.init(db=db, schema=criticality_schema)
     await obj1.new(db=db, name="low", level=4)
     await obj1.save(db=db)
@@ -89,9 +88,8 @@ async def test_directive_exclude(db: InfrahubDatabase, default_branch: Branch, c
     }
     """
 
-    gql_params = await prepare_graphql_params(
-        db=db, include_mutation=False, include_subscription=False, branch=default_branch
-    )
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     result = await graphql(
         schema=gql_params.schema,
         source=query,

--- a/backend/tests/unit/graphql/test_query.py
+++ b/backend/tests/unit/graphql/test_query.py
@@ -41,7 +41,9 @@ async def execute_query(
         raise ValueError(f"Unable to find the {InfrahubKind.GRAPHQLQUERY} {name}")
 
     gql_params = await prepare_graphql_params(
-        branch=branch, db=db, at=at, include_mutation=False, include_subscription=False
+        branch=branch,
+        db=db,
+        at=at,
     )
 
     result = await graphql(
@@ -55,7 +57,7 @@ async def execute_query(
     return result
 
 
-async def test_execute_query(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema):
+async def test_execute_query(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema) -> None:
     t1 = await Node.init(db=db, schema=InfrahubKind.TAG, branch=default_branch)
     await t1.new(db=db, name="Blue", description="The Blue tag")
     await t1.save(db=db)
@@ -68,13 +70,15 @@ async def test_execute_query(db: InfrahubDatabase, default_branch: Branch, regis
     await q1.new(db=db, name="query01", query="query { BuiltinTag { count }}")
     await q1.save(db=db)
 
+    default_branch.update_schema_hash()
     result = await execute_query(name="query01", db=db, branch=default_branch)
 
     assert result.errors is None
     assert result.data == {"BuiltinTag": {"count": 2}}
 
 
-async def test_execute_missing_query(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema):
+async def test_execute_missing_query(db: InfrahubDatabase, default_branch: Branch, register_core_models_schema) -> None:
+    default_branch.update_schema_hash()
     with pytest.raises(ValueError) as exc:
         await execute_query(name="query02", db=db, branch=default_branch)
 

--- a/backend/tests/unit/graphql/test_query_analyzer.py
+++ b/backend/tests/unit/graphql/test_query_analyzer.py
@@ -7,7 +7,6 @@ from infrahub.core.schema import SchemaRoot
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.analyzer import GraphQLArgument, GraphQLVariable, InfrahubGraphQLQueryAnalyzer, MutateAction
 from infrahub.graphql.initialization import prepare_graphql_params
-from infrahub.graphql.registry import registry as graphql_registry
 from tests.helpers.schema.color import COLOR
 from tests.helpers.schema.tshirt import TSHIRT
 
@@ -16,7 +15,8 @@ async def test_analyzer_init_with_schema(
     db: InfrahubDatabase, default_branch: Branch, car_person_schema_generics, query_01: str, bad_query_01: str
 ):
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     gqa = InfrahubGraphQLQueryAnalyzer(
         query=query_01, schema=gql_params.schema, branch=default_branch, schema_branch=schema_branch
     )
@@ -35,8 +35,8 @@ async def test_is_valid_simple_schema(
     car_person_schema_generics,
 ):
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
-    graphql_registry.clear_cache()
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     gqa = InfrahubGraphQLQueryAnalyzer(
         query=query_01, schema=gql_params.schema, branch=default_branch, schema_branch=schema_branch
     )
@@ -80,7 +80,8 @@ async def test_is_valid_core_schema(
     register_core_models_schema,
 ):
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
     gqa = InfrahubGraphQLQueryAnalyzer(
         query=query_05, schema=gql_params.schema, branch=default_branch, schema_branch=schema_branch
@@ -99,7 +100,8 @@ async def test_get_models_in_use(
     car_person_schema_generics,
 ):
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
     gqa = InfrahubGraphQLQueryAnalyzer(
         query=query_01, schema=gql_params.schema, branch=default_branch, schema_branch=schema_branch
     )
@@ -183,7 +185,8 @@ async def test_get_models_in_use(
 
 async def test_query_report(db: InfrahubDatabase, default_branch: Branch, car_person_schema_generics):
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
     mutation_query_no_return_data = """
     mutation {
@@ -409,7 +412,8 @@ async def test_query_report_single_target(
 
     schema_branch = registry.schema.get_schema_branch(name=default_branch.name)
 
-    gql_params = await prepare_graphql_params(db=db, branch=default_branch, include_subscription=False)
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
 
     query_name_variable_required = """
     query TshirtQuery($name: String!) {

--- a/backend/tests/unit/graphql/test_schema.py
+++ b/backend/tests/unit/graphql/test_schema.py
@@ -1,11 +1,15 @@
 from graphql.type.definition import GraphQLList, GraphQLNonNull, GraphQLObjectType
 
+from infrahub.core.branch import Branch
 from infrahub.database import InfrahubDatabase
 from infrahub.graphql.initialization import prepare_graphql_params
 
 
-async def test_schema_is_nonnull(db: InfrahubDatabase, default_branch, car_person_schema):
-    gql_params = await prepare_graphql_params(db=db, include_subscription=False, branch=default_branch)
+async def test_schema_is_nonnull(db: InfrahubDatabase, default_branch: Branch, car_person_schema: None) -> None:
+    default_branch.update_schema_hash()
+    gql_params = await prepare_graphql_params(db=db, branch=default_branch)
+
+    assert gql_params.schema.query_type
 
     for name, field in gql_params.schema.query_type.fields.items():
         # ------------------------------------------------------------


### PR DESCRIPTION
This PR aims to phase out the use of subscription=False and mutations=False within the unittests. These parameters was at some point used to speed up the generation of the GraphQL schema, but since we cache the GraphQL schema by hash it's instead a source of flaky tests and can actually slow the CI down as we might end up regenerating the GraphQL schema even though we don't need to (the use of subscription=False or mutations=False causes the schema to be regenerated each time). In production we never use these parameters, it's only within the tests and I think the next step is to remove them completely.

Hopefully this will fix the occasionally flaky tests that we've observed in the unittests.

As part of this fix I introduced a new fixture that forces the regeneration of the schema for tests using GraphQL enums (an experimental feature) as tests might get unreliable without them, the fixture also resets the graphql registry afterwards to avoid impacting other tests.

As part of this PR I've also made some slight fixes to typing where applicable, things like `assert result.data` is because result.data is an optional dictionary and we tend to have a lot of typing violations which are not currently reported but listed as errors in the file by pylance, the problem is when we try to access a dictionary within data while not knowing if data is `None`.

We might be using the `branch.update_schema_hash()` call a bit excessively in this PR, but it will still be faster than a complete regeneration of the GraphQL schema in all of these tests.

Note there could still potentially be sone areas where test issues comes up as we run some of the tests in an async loop that's updating the global objects (registry), if this happens we might need to reconsider how we approach these tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored GraphQL test infrastructure with improved schema state management and type safety in test signatures.
  * Enhanced test isolation through schema cache reset mechanisms between test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->