### PR TITLE
Update Prefect=3.4.23

### DIFF
--- a/backend/tests/helpers/utils.py
+++ b/backend/tests/helpers/utils.py
@@ -44,7 +44,7 @@ def start_prefect_server_container(
 
     prefect_base = Path(Path(__file__).parent.resolve() / "./../../infrahub/prefect_server")
     container = (
-        DockerContainer(image="prefecthq/prefect:3.4.22-python3.12")
+        DockerContainer(image="prefecthq/prefect:3.4.23-python3.12")
         .with_command("uvicorn --host 0.0.0.0 --port 4200 --factory prefect_server.app:create_infrahub_prefect")
         .with_exposed_ports(PORT_PREFECT)
         .with_volume_mapping(host=str(prefect_base), container="/opt/prefect/prefect_server", mode="ro")

--- a/poetry.lock
+++ b/poetry.lock
@@ -3843,14 +3843,14 @@ virtualenv = ">=20.10.0"
 
 [[package]]
 name = "prefect"
-version = "3.4.22"
+version = "3.4.23"
 description = "Workflow orchestration and management."
 optional = false
 python-versions = "<3.14,>=3.9"
 groups = ["main"]
 files = [
-    {file = "prefect-3.4.22-py3-none-any.whl", hash = "sha256:41743e2817195e1ef8fdef2e65c4b16da1308cf8f5dd1a85e679c8cbe7186710"},
-    {file = "prefect-3.4.22.tar.gz", hash = "sha256:4b46a793e9907a4c8539b04bb2fdbc609c9810f690d7673a3bc8d0c9aebdfc84"},
+    {file = "prefect-3.4.23-py3-none-any.whl", hash = "sha256:0422861f0d1729d56546501eeebadf255ddf21b8041aa2bc2715168b4eb615bb"},
+    {file = "prefect-3.4.23.tar.gz", hash = "sha256:5c6800737bd577ede070fa3852f608235c715e72a897d41fd3b9317f67fde8c3"},
 ]
 
 [package.dependencies]
@@ -6527,4 +6527,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12, < 3.13"
-content-hash = "5b8d31ecc13ad87dc98da7f2122d2a9979b9a8ea1078cb15941ff3ac26e5c15f"
+content-hash = "c9afd3d7842b1d8a0e8300eb414243b1f7cd136fbebe4c9a52e4cae8312b69b0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ boto3 = "1.34.129"
 email-validator = "~2.1"
 redis = { version = "^6.0.0", extras = ["hiredis"] }
 typer = "0.12.5"
-prefect = "3.4.22"
+prefect = "3.4.23"
 prefect-redis = "0.2.4"
 ujson = "^5"
 Jinja2 = "^3"

--- a/python_testcontainers/poetry.lock
+++ b/python_testcontainers/poetry.lock
@@ -935,14 +935,14 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "prefect-client"
-version = "3.4.22"
+version = "3.4.23"
 description = "Workflow orchestration and management."
 optional = false
 python-versions = "<3.14,>=3.9"
 groups = ["main"]
 files = [
-    {file = "prefect_client-3.4.22-py3-none-any.whl", hash = "sha256:d9232a19f6c43a1bac27ff2689975e3fa43a41977f113bf65d1a8cdbc5afbeaf"},
-    {file = "prefect_client-3.4.22.tar.gz", hash = "sha256:2eef32510aa37e78e74eeb056aff84124752412aa7b4acebbf86bbe90d00168e"},
+    {file = "prefect_client-3.4.23-py3-none-any.whl", hash = "sha256:6d3ac95ced68a3d5d461e13f90df35871ce90e58194b8a354f840c6a8e6c1fa1"},
+    {file = "prefect_client-3.4.23.tar.gz", hash = "sha256:23d035c1e5a9df0c69c701c5f6ad3f8b80530c19a2383b4ca319a2397fe09ac4"},
 ]
 
 [package.dependencies]
@@ -986,7 +986,7 @@ toml = ">=0.10.0"
 typing-extensions = ">=4.10.0,<5.0.0"
 uvicorn = ">=0.14.0,<0.29.0 || >0.29.0"
 websockets = ">=13.0,<16.0"
-whenever = {version = ">=0.7.3,<0.9.0", markers = "python_version >= \"3.13\""}
+whenever = {version = ">=0.7.3,<0.10.0", markers = "python_version >= \"3.13\""}
 
 [package.extras]
 notifications = ["apprise (>=1.1.0,<2.0.0)"]
@@ -2321,4 +2321,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9, < 3.14"
-content-hash = "106bfdd8f953f9f1ac7f0144365cfe0fba069a0f835b1583356242594a6c4e04"
+content-hash = "547912bb80cbcb2b45736214d3653b4a08cc2a12ce6b366abfb6a43c6ba39418"

--- a/python_testcontainers/pyproject.toml
+++ b/python_testcontainers/pyproject.toml
@@ -39,7 +39,7 @@ psutil = "*"
 pytest = "*"
 httpx = "^0.28.1"
 pydantic = "^2.10.6"
-prefect-client = "3.4.22"
+prefect-client = "3.4.23"
 
 [tool.poetry.group.dev.dependencies]
 rich = "^13.9.4"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Bumped Prefect and Prefect Client dependencies to 3.4.23 for improved stability and compatibility.
- Tests
  - Updated the Prefect Docker image used in test utilities to 3.4.23 (Python 3.12), aligning test environment with runtime dependencies.

No user-facing features or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->