### PR TITLE
Add conflict resolution in proposed changes

### DIFF
--- a/frontend/app/src/entities/diff/api/resolve-conflict-from-api.ts
+++ b/frontend/app/src/entities/diff/api/resolve-conflict-from-api.ts
@@ -13,7 +13,7 @@ mutation RESOLVE_CONFLICT ($id: String, $selection: ConflictSelection) {
 
 export type ResolveConflictFromApiParams = {
   id: string;
-  selection: ConflictSelection;
+  selection: ConflictSelection | null;
 };
 
 export const resolveConflictFromApi = async ({ id, selection }: ResolveConflictFromApiParams) => {

--- a/frontend/app/src/entities/diff/api/resolve-conflict-from-api.ts
+++ b/frontend/app/src/entities/diff/api/resolve-conflict-from-api.ts
@@ -1,0 +1,26 @@
+import { gql } from "@apollo/client";
+
+import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
+
+export const RESOLVE_CONFLICT = gql`
+mutation RESOLVE_CONFLICT ($id: String, $selection: ConflictSelection) {
+  ResolveDiffConflict(data:{conflict_id: $id, selected_branch: $selection}){
+    ok
+  }
+}
+`;
+
+export type ResolveConflictFromApiParams = {
+  id: string;
+  selection: string | null;
+};
+
+export const resolveConflictFromApi = ({ id, selection }: ResolveConflictFromApiParams) => {
+  return graphqlClient.mutate({
+    mutation: RESOLVE_CONFLICT,
+    variables: {
+      id,
+      selection,
+    },
+  });
+};

--- a/frontend/app/src/entities/diff/api/resolve-conflict-from-api.ts
+++ b/frontend/app/src/entities/diff/api/resolve-conflict-from-api.ts
@@ -1,6 +1,6 @@
 import { gql } from "@apollo/client";
 
-import { ConflictSelection } from "@/shared/api/graphql/generated/graphql";
+import type { ConflictSelection } from "@/shared/api/graphql/generated/graphql";
 import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
 
 export const RESOLVE_CONFLICT = gql`

--- a/frontend/app/src/entities/diff/api/resolve-conflict-from-api.ts
+++ b/frontend/app/src/entities/diff/api/resolve-conflict-from-api.ts
@@ -1,5 +1,6 @@
 import { gql } from "@apollo/client";
 
+import { ConflictSelection } from "@/shared/api/graphql/generated/graphql";
 import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
 
 export const RESOLVE_CONFLICT = gql`
@@ -12,7 +13,7 @@ mutation RESOLVE_CONFLICT ($id: String, $selection: ConflictSelection) {
 
 export type ResolveConflictFromApiParams = {
   id: string;
-  selection: string | null;
+  selection: ConflictSelection;
 };
 
 export const resolveConflictFromApi = ({ id, selection }: ResolveConflictFromApiParams) => {

--- a/frontend/app/src/entities/diff/api/resolve-conflict-from-api.ts
+++ b/frontend/app/src/entities/diff/api/resolve-conflict-from-api.ts
@@ -4,11 +4,11 @@ import type { ConflictSelection } from "@/shared/api/graphql/generated/graphql";
 import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
 
 export const RESOLVE_CONFLICT = gql`
-mutation RESOLVE_CONFLICT ($id: String, $selection: ConflictSelection) {
-  ResolveDiffConflict(data:{conflict_id: $id, selected_branch: $selection}){
-    ok
+  mutation RESOLVE_CONFLICT ($id: String, $selection: ConflictSelection) {
+    ResolveDiffConflict(data:{conflict_id: $id, selected_branch: $selection}){
+      ok
+    }
   }
-}
 `;
 
 export type ResolveConflictFromApiParams = {

--- a/frontend/app/src/entities/diff/api/resolve-conflict-from-api.ts
+++ b/frontend/app/src/entities/diff/api/resolve-conflict-from-api.ts
@@ -16,7 +16,7 @@ export type ResolveConflictFromApiParams = {
   selection: ConflictSelection;
 };
 
-export const resolveConflictFromApi = ({ id, selection }: ResolveConflictFromApiParams) => {
+export const resolveConflictFromApi = async ({ id, selection }: ResolveConflictFromApiParams) => {
   return graphqlClient.mutate({
     mutation: RESOLVE_CONFLICT,
     variables: {

--- a/frontend/app/src/entities/diff/domain/diff.query-keys.ts
+++ b/frontend/app/src/entities/diff/domain/diff.query-keys.ts
@@ -5,3 +5,7 @@ export const treeQueryKeys = {
   allWithContext: ({ branchName, filters }: GetDiffTreeParams) =>
     [...treeQueryKeys.all, branchName, filters] as const,
 };
+
+export const updateDiffMutationKeys = {
+  all: ["update-diff"] as const,
+};

--- a/frontend/app/src/entities/diff/domain/diff.query-keys.ts
+++ b/frontend/app/src/entities/diff/domain/diff.query-keys.ts
@@ -1,0 +1,7 @@
+import { GetDiffTreeParams } from "@/entities/diff/domain/get-diff-tree";
+
+export const treeQueryKeys = {
+  all: ["diff-tree"] as const,
+  allWithContext: ({ branchName, filters }: GetDiffTreeParams) =>
+    [...treeQueryKeys.all, branchName, filters] as const,
+};

--- a/frontend/app/src/entities/diff/domain/get-diff-tree.ts
+++ b/frontend/app/src/entities/diff/domain/get-diff-tree.ts
@@ -5,6 +5,8 @@ import { PaginationParams } from "@/shared/api/types";
 
 import { getDiffTreeFromApi } from "@/entities/diff/api/get-diff-tree-from-api";
 
+import { treeQueryKeys } from "./diff.query-keys";
+
 export const DIFF_TREE_PER_PAGE = 300;
 
 export type GetDiffTreeParams = PaginationParams & {
@@ -35,7 +37,7 @@ export const getDiffTreeInfiniteQueryOptions = ({
   filters,
 }: GetDiffTreeInfiniteQueryOptionsParams) => {
   return infiniteQueryOptions({
-    queryKey: ["diff-tree", branchName, filters],
+    queryKey: treeQueryKeys.allWithContext({ branchName, filters }),
     queryFn: ({ pageParam }) => getDiffTree({ branchName, filters, offset: pageParam }),
     initialPageParam: 0,
     getNextPageParam: (lastPage, _, lastPageParam) => {

--- a/frontend/app/src/entities/diff/domain/resolve-conflict.mutation.ts
+++ b/frontend/app/src/entities/diff/domain/resolve-conflict.mutation.ts
@@ -1,6 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 
-import { resolveConflict, type ResolveConflictParams } from "./resolve-conflict";
+import { type ResolveConflictParams, resolveConflict } from "./resolve-conflict";
 
 export const RESOLVE_CONFLICT_KEY = "update-diff";
 

--- a/frontend/app/src/entities/diff/domain/resolve-conflict.mutation.ts
+++ b/frontend/app/src/entities/diff/domain/resolve-conflict.mutation.ts
@@ -7,9 +7,7 @@ import {
 
 export const RESOLVE_CONFLICT_KEY = "update-diff";
 
-export function useResolveConflictMutation(): ReturnType<
-  typeof useMutation<void, Error, ResolveConflictParams>
-> {
+export function useResolveConflictMutation() {
   return useMutation({
     mutationKey: [RESOLVE_CONFLICT_KEY],
     mutationFn: (params: ResolveConflictParams) => resolveConflict(params),

--- a/frontend/app/src/entities/diff/domain/resolve-conflict.mutation.ts
+++ b/frontend/app/src/entities/diff/domain/resolve-conflict.mutation.ts
@@ -5,11 +5,8 @@ import {
   resolveConflict,
 } from "@/entities/diff/domain/resolve-conflict";
 
-export const RESOLVE_CONFLICT_KEY = "update-diff";
-
 export function useResolveConflictMutation() {
   return useMutation({
-    mutationKey: [RESOLVE_CONFLICT_KEY],
     mutationFn: (params: ResolveConflictParams) => resolveConflict(params),
   });
 }

--- a/frontend/app/src/entities/diff/domain/resolve-conflict.mutation.ts
+++ b/frontend/app/src/entities/diff/domain/resolve-conflict.mutation.ts
@@ -1,6 +1,9 @@
 import { useMutation } from "@tanstack/react-query";
 
-import { type ResolveConflictParams, resolveConflict } from "./resolve-conflict";
+import {
+  type ResolveConflictParams,
+  resolveConflict,
+} from "@/entities/diff/domain/resolve-conflict";
 
 export const RESOLVE_CONFLICT_KEY = "update-diff";
 

--- a/frontend/app/src/entities/diff/domain/resolve-conflict.mutation.ts
+++ b/frontend/app/src/entities/diff/domain/resolve-conflict.mutation.ts
@@ -2,7 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 
 import { resolveConflict } from "@/entities/diff/domain/resolve-conflict";
 
-import { ResolveConflictFromApiParams } from "../api/resolve-conflict-from-api";
+import type { ResolveConflictFromApiParams } from "../api/resolve-conflict-from-api";
 
 export function useResolveConflictMutation() {
   return useMutation({

--- a/frontend/app/src/entities/diff/domain/resolve-conflict.mutation.ts
+++ b/frontend/app/src/entities/diff/domain/resolve-conflict.mutation.ts
@@ -7,7 +7,9 @@ import {
 
 export const RESOLVE_CONFLICT_KEY = "update-diff";
 
-export function useResolveConflictMutation() {
+export function useResolveConflictMutation(): ReturnType<
+  typeof useMutation<void, Error, ResolveConflictParams>
+> {
   return useMutation({
     mutationKey: [RESOLVE_CONFLICT_KEY],
     mutationFn: (params: ResolveConflictParams) => resolveConflict(params),

--- a/frontend/app/src/entities/diff/domain/resolve-conflict.mutation.ts
+++ b/frontend/app/src/entities/diff/domain/resolve-conflict.mutation.ts
@@ -1,0 +1,12 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { resolveConflict, type ResolveConflictParams } from "./resolve-conflict";
+
+export const RESOLVE_CONFLICT_KEY = "update-diff";
+
+export function useResolveConflictMutation() {
+  return useMutation({
+    mutationKey: [RESOLVE_CONFLICT_KEY],
+    mutationFn: (params: ResolveConflictParams) => resolveConflict(params),
+  });
+}

--- a/frontend/app/src/entities/diff/domain/resolve-conflict.mutation.ts
+++ b/frontend/app/src/entities/diff/domain/resolve-conflict.mutation.ts
@@ -1,12 +1,11 @@
 import { useMutation } from "@tanstack/react-query";
 
-import {
-  type ResolveConflictParams,
-  resolveConflict,
-} from "@/entities/diff/domain/resolve-conflict";
+import { resolveConflict } from "@/entities/diff/domain/resolve-conflict";
+
+import { ResolveConflictFromApiParams } from "../api/resolve-conflict-from-api";
 
 export function useResolveConflictMutation() {
   return useMutation({
-    mutationFn: (params: ResolveConflictParams) => resolveConflict(params),
+    mutationFn: (params: ResolveConflictFromApiParams) => resolveConflict(params),
   });
 }

--- a/frontend/app/src/entities/diff/domain/resolve-conflict.ts
+++ b/frontend/app/src/entities/diff/domain/resolve-conflict.ts
@@ -4,7 +4,7 @@ import { resolveConflictFromApi } from "@/entities/diff/api/resolve-conflict-fro
 
 export type ResolveConflictParams = {
   id: string;
-  selection: ConflictSelection;
+  selection: ConflictSelection | null;
 };
 
 export type ResolveConflict = (params: ResolveConflictParams) => Promise<void>;

--- a/frontend/app/src/entities/diff/domain/resolve-conflict.ts
+++ b/frontend/app/src/entities/diff/domain/resolve-conflict.ts
@@ -1,13 +1,9 @@
-import { ConflictSelection } from "@/shared/api/graphql/generated/graphql";
+import {
+  ResolveConflictFromApiParams,
+  resolveConflictFromApi,
+} from "@/entities/diff/api/resolve-conflict-from-api";
 
-import { resolveConflictFromApi } from "@/entities/diff/api/resolve-conflict-from-api";
-
-export type ResolveConflictParams = {
-  id: string;
-  selection: ConflictSelection | null;
-};
-
-export type ResolveConflict = (params: ResolveConflictParams) => Promise<void>;
+export type ResolveConflict = (params: ResolveConflictFromApiParams) => Promise<void>;
 
 export const resolveConflict: ResolveConflict = async (params) => {
   await resolveConflictFromApi(params);

--- a/frontend/app/src/entities/diff/domain/resolve-conflict.ts
+++ b/frontend/app/src/entities/diff/domain/resolve-conflict.ts
@@ -6,5 +6,11 @@ import {
 export type ResolveConflict = (params: ResolveConflictFromApiParams) => Promise<void>;
 
 export const resolveConflict: ResolveConflict = async (params) => {
-  await resolveConflictFromApi(params);
+  const { data, errors } = await resolveConflictFromApi(params);
+
+  if (errors?.[0]?.message) {
+    throw new Error(errors[0].message);
+  }
+
+  return data;
 };

--- a/frontend/app/src/entities/diff/domain/resolve-conflict.ts
+++ b/frontend/app/src/entities/diff/domain/resolve-conflict.ts
@@ -1,5 +1,5 @@
 import {
-  ResolveConflictFromApiParams,
+  type ResolveConflictFromApiParams,
   resolveConflictFromApi,
 } from "@/entities/diff/api/resolve-conflict-from-api";
 

--- a/frontend/app/src/entities/diff/domain/resolve-conflict.ts
+++ b/frontend/app/src/entities/diff/domain/resolve-conflict.ts
@@ -6,11 +6,9 @@ import {
 export type ResolveConflict = (params: ResolveConflictFromApiParams) => Promise<void>;
 
 export const resolveConflict: ResolveConflict = async (params) => {
-  const { data, errors } = await resolveConflictFromApi(params);
+  const { errors } = await resolveConflictFromApi(params);
 
   if (errors?.[0]?.message) {
     throw new Error(errors[0].message);
   }
-
-  return data;
 };

--- a/frontend/app/src/entities/diff/domain/resolve-conflict.ts
+++ b/frontend/app/src/entities/diff/domain/resolve-conflict.ts
@@ -1,8 +1,10 @@
-import { resolveConflictFromApi } from "../api/resolve-conflict-from-api";
+import { ConflictSelection } from "@/shared/api/graphql/generated/graphql";
+
+import { resolveConflictFromApi } from "@/entities/diff/api/resolve-conflict-from-api";
 
 export type ResolveConflictParams = {
   id: string;
-  selection: string | null;
+  selection: ConflictSelection;
 };
 
 export type ResolveConflict = (params: ResolveConflictParams) => Promise<void>;

--- a/frontend/app/src/entities/diff/domain/resolve-conflict.ts
+++ b/frontend/app/src/entities/diff/domain/resolve-conflict.ts
@@ -1,0 +1,12 @@
+import { resolveConflictFromApi } from "../api/resolve-conflict-from-api";
+
+export type ResolveConflictParams = {
+  id: string;
+  selection: string | null;
+};
+
+export type ResolveConflict = (params: ResolveConflictParams) => Promise<void>;
+
+export const resolveConflict: ResolveConflict = async (params) => {
+  await resolveConflictFromApi(params);
+};

--- a/frontend/app/src/entities/diff/domain/update-diff.mutation.ts
+++ b/frontend/app/src/entities/diff/domain/update-diff.mutation.ts
@@ -1,12 +1,11 @@
 import { useMutation } from "@tanstack/react-query";
 
+import { updateDiffMutationKeys } from "@/entities/diff/domain/diff.query-keys";
 import { updateDiff } from "@/entities/diff/domain/update-diff";
-
-export const UPDATE_DIFF_KEY = "update-diff";
 
 export function useUpdateDiffMutation() {
   return useMutation({
-    mutationKey: [UPDATE_DIFF_KEY],
+    mutationKey: updateDiffMutationKeys.all,
     mutationFn: (branchName: string) => updateDiff(branchName),
   });
 }

--- a/frontend/app/src/entities/diff/node-diff/conflict.tsx
+++ b/frontend/app/src/entities/diff/node-diff/conflict.tsx
@@ -82,7 +82,7 @@ export const Conflict = ({ id, selectedBranch }: ConflictData) => {
           >
             <Badge variant="green">
               <Icon icon="mdi:layers-triple" className="mr-1" />
-              {proposedChangesDetails.destination_branch?.value}
+              {proposedChangesDetails.destination_branch?.value ?? "Base Branch"}
             </Badge>
           </label>
         </div>
@@ -100,7 +100,7 @@ export const Conflict = ({ id, selectedBranch }: ConflictData) => {
           >
             <Badge variant="blue">
               <Icon icon="mdi:layers-triple" className="mr-1" />
-              {proposedChangesDetails.source_branch?.value}
+              {proposedChangesDetails.source_branch?.value ?? "Diff Branch"}
             </Badge>
           </label>
         </div>

--- a/frontend/app/src/entities/diff/node-diff/conflict.tsx
+++ b/frontend/app/src/entities/diff/node-diff/conflict.tsx
@@ -13,18 +13,23 @@ import { useAuth } from "@/entities/authentication/ui/useAuth";
 import { useResolveConflictMutation } from "@/entities/diff/domain/resolve-conflict.mutation";
 import { proposedChangedState } from "@/entities/proposed-changes/stores/proposedChanges.atom";
 
-export const Conflict = ({ conflict }: any) => {
+interface ConflictData {
+  id: string;
+  selectedBranch: "BASE_BRANCH" | "DIFF_BRANCH" | null;
+}
+
+export const Conflict = ({ id, selectedBranch }: ConflictData) => {
   const proposedChangesDetails = useAtomValue(proposedChangedState);
   const { mutate, isPending } = useResolveConflictMutation();
 
   const { isAuthenticated } = useAuth();
 
   const handleAccept = async (conflictValue: string) => {
-    const newValue = conflictValue === conflict.selected_branch ? null : conflictValue;
+    const newValue = conflictValue === selectedBranch ? null : conflictValue;
 
     mutate(
       {
-        id: conflict.uuid,
+        id,
         selection: newValue,
       },
       {
@@ -67,14 +72,12 @@ export const Conflict = ({ conflict }: any) => {
           <Checkbox
             id={"base"}
             disabled={isPending || !isAuthenticated}
-            checked={conflict.selected_branch === "BASE_BRANCH"}
+            checked={selectedBranch === "BASE_BRANCH"}
             onChange={() => handleAccept("BASE_BRANCH")}
           />
           <label
             htmlFor={"base"}
-            className={
-              conflict.selected_branch === "BASE_BRANCH" ? "cursor-default" : "cursor-pointer"
-            }
+            className={selectedBranch === "BASE_BRANCH" ? "cursor-default" : "cursor-pointer"}
           >
             <Badge variant="green">
               <Icon icon="mdi:layers-triple" className="mr-1" />
@@ -87,14 +90,12 @@ export const Conflict = ({ conflict }: any) => {
           <Checkbox
             id={"diff"}
             disabled={isPending || !isAuthenticated}
-            checked={conflict.selected_branch === "DIFF_BRANCH"}
+            checked={selectedBranch === "DIFF_BRANCH"}
             onChange={() => handleAccept("DIFF_BRANCH")}
           />
           <label
             htmlFor={"diff"}
-            className={
-              conflict.selected_branch === "DIFF_BRANCH" ? "cursor-default" : "cursor-pointer"
-            }
+            className={selectedBranch === "DIFF_BRANCH" ? "cursor-default" : "cursor-pointer"}
           >
             <Badge variant="blue">
               <Icon icon="mdi:layers-triple" className="mr-1" />

--- a/frontend/app/src/entities/diff/node-diff/conflict.tsx
+++ b/frontend/app/src/entities/diff/node-diff/conflict.tsx
@@ -16,7 +16,7 @@ import { proposedChangedState } from "@/entities/proposed-changes/stores/propose
 
 interface ConflictData {
   id: string;
-  selectedBranch: ConflictSelection;
+  selectedBranch?: ConflictSelection;
 }
 
 export const Conflict = ({ id, selectedBranch }: ConflictData) => {

--- a/frontend/app/src/entities/diff/node-diff/conflict.tsx
+++ b/frontend/app/src/entities/diff/node-diff/conflict.tsx
@@ -25,7 +25,7 @@ export const Conflict = ({ id, selectedBranch }: ConflictData) => {
 
   const { isAuthenticated } = useAuth();
 
-  const handleAccept = async (conflictValue: ConflictSelection) => {
+  const handleAccept = (conflictValue: ConflictSelection) => {
     const newValue = conflictValue === selectedBranch ? null : conflictValue;
 
     mutate(

--- a/frontend/app/src/entities/diff/node-diff/conflict.tsx
+++ b/frontend/app/src/entities/diff/node-diff/conflict.tsx
@@ -1,5 +1,5 @@
 import { Icon } from "@iconify-icon/react";
-import { useAtomValue } from "jotai/index";
+import { useAtomValue } from "jotai";
 import { toast } from "react-toastify";
 
 import type { ConflictSelection } from "@/shared/api/graphql/generated/graphql";

--- a/frontend/app/src/entities/diff/node-diff/conflict.tsx
+++ b/frontend/app/src/entities/diff/node-diff/conflict.tsx
@@ -2,6 +2,7 @@ import { Icon } from "@iconify-icon/react";
 import { useAtomValue } from "jotai/index";
 import { toast } from "react-toastify";
 
+import { ConflictSelection } from "@/shared/api/graphql/generated/graphql";
 import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
 import { queryClient } from "@/shared/api/rest/client";
 import { Checkbox } from "@/shared/components/inputs/checkbox";
@@ -15,7 +16,7 @@ import { proposedChangedState } from "@/entities/proposed-changes/stores/propose
 
 interface ConflictData {
   id: string;
-  selectedBranch: "BASE_BRANCH" | "DIFF_BRANCH" | null;
+  selectedBranch: ConflictSelection;
 }
 
 export const Conflict = ({ id, selectedBranch }: ConflictData) => {
@@ -24,7 +25,7 @@ export const Conflict = ({ id, selectedBranch }: ConflictData) => {
 
   const { isAuthenticated } = useAuth();
 
-  const handleAccept = async (conflictValue: string) => {
+  const handleAccept = async (conflictValue: ConflictSelection) => {
     const newValue = conflictValue === selectedBranch ? null : conflictValue;
 
     mutate(

--- a/frontend/app/src/entities/diff/node-diff/conflict.tsx
+++ b/frontend/app/src/entities/diff/node-diff/conflict.tsx
@@ -1,0 +1,102 @@
+import { useAuth } from "@/entities/authentication/ui/useAuth";
+
+import { proposedChangedState } from "@/entities/proposed-changes/stores/proposedChanges.atom";
+import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
+import { queryClient } from "@/shared/api/rest/client";
+import { Checkbox } from "@/shared/components/inputs/checkbox";
+import { ALERT_TYPES, Alert } from "@/shared/components/ui/alert";
+import { Badge } from "@/shared/components/ui/badge";
+import { Spinner } from "@/shared/components/ui/spinner";
+import { Icon } from "@iconify-icon/react";
+import { useAtomValue } from "jotai/index";
+import { toast } from "react-toastify";
+import { useResolveConflictMutation } from "@/entities/diff/domain/resolve-conflict.mutation";
+
+export const Conflict = ({ conflict }: any) => {
+  const proposedChangesDetails = useAtomValue(proposedChangedState);
+  const { mutate, isPending } = useResolveConflictMutation();
+
+  const { isAuthenticated } = useAuth();
+
+  const handleAccept = async (conflictValue: string) => {
+    const newValue = conflictValue === conflict.selected_branch ? null : conflictValue;
+
+      mutate({
+          id: conflict.uuid,
+          selection: newValue,
+        }, {
+        onSuccess: async () => {
+          await queryClient.invalidateQueries({ queryKey: ["diff-tree"] });
+          await graphqlClient.refetchQueries({
+            include: ["TASK_DETAILS_CHECK"],
+          });
+
+          const message = newValue ? "Conflict marked as resolved" : "Conflict marked as not resolved";
+
+          toast(<Alert type={ALERT_TYPES.SUCCESS} message={message} />);
+        },
+        onError: () => {
+          toast(
+            <Alert
+              type={ALERT_TYPES.ERROR}
+              message={
+                newValue
+                  ? "An error occurred while resolving the conflict"
+                  : "An error occurred while marking the conflict as not resolved"
+              }
+            />
+          );
+        },
+      })
+  };
+
+  return (
+    <div className="flex items-center justify-end gap-2 p-2">
+      {isPending && <Spinner />}
+
+      <span className="text-xs">Choose the branch to resolve the conflict:</span>
+
+      <div className="flex gap-2">
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id={"base"}
+            disabled={isPending || !isAuthenticated}
+            checked={conflict.selected_branch === "BASE_BRANCH"}
+            onChange={() => handleAccept("BASE_BRANCH")}
+          />
+          <label
+            htmlFor={"base"}
+            className={
+              conflict.selected_branch === "BASE_BRANCH" ? "cursor-default" : "cursor-pointer"
+            }
+          >
+            <Badge variant="green">
+              <Icon icon="mdi:layers-triple" className="mr-1" />
+              {proposedChangesDetails.destination_branch?.value}
+            </Badge>
+          </label>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id={"diff"}
+            disabled={isPending || !isAuthenticated}
+            checked={conflict.selected_branch === "DIFF_BRANCH"}
+            onChange={() => handleAccept("DIFF_BRANCH")}
+          />
+          <label
+            htmlFor={"diff"}
+            className={
+              conflict.selected_branch === "DIFF_BRANCH" ? "cursor-default" : "cursor-pointer"
+            }
+          >
+            <Badge variant="blue">
+              <Icon icon="mdi:layers-triple" className="mr-1" />
+              {proposedChangesDetails.source_branch?.value}
+            </Badge>
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/app/src/entities/diff/node-diff/conflict.tsx
+++ b/frontend/app/src/entities/diff/node-diff/conflict.tsx
@@ -2,7 +2,7 @@ import { Icon } from "@iconify-icon/react";
 import { useAtomValue } from "jotai/index";
 import { toast } from "react-toastify";
 
-import { ConflictSelection } from "@/shared/api/graphql/generated/graphql";
+import type { ConflictSelection } from "@/shared/api/graphql/generated/graphql";
 import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
 import { queryClient } from "@/shared/api/rest/client";
 import { Checkbox } from "@/shared/components/inputs/checkbox";

--- a/frontend/app/src/entities/diff/node-diff/conflict.tsx
+++ b/frontend/app/src/entities/diff/node-diff/conflict.tsx
@@ -1,16 +1,17 @@
-import { useAuth } from "@/entities/authentication/ui/useAuth";
+import { Icon } from "@iconify-icon/react";
+import { useAtomValue } from "jotai/index";
+import { toast } from "react-toastify";
 
-import { proposedChangedState } from "@/entities/proposed-changes/stores/proposedChanges.atom";
 import graphqlClient from "@/shared/api/graphql/graphqlClientApollo";
 import { queryClient } from "@/shared/api/rest/client";
 import { Checkbox } from "@/shared/components/inputs/checkbox";
 import { ALERT_TYPES, Alert } from "@/shared/components/ui/alert";
 import { Badge } from "@/shared/components/ui/badge";
 import { Spinner } from "@/shared/components/ui/spinner";
-import { Icon } from "@iconify-icon/react";
-import { useAtomValue } from "jotai/index";
-import { toast } from "react-toastify";
+
+import { useAuth } from "@/entities/authentication/ui/useAuth";
 import { useResolveConflictMutation } from "@/entities/diff/domain/resolve-conflict.mutation";
+import { proposedChangedState } from "@/entities/proposed-changes/stores/proposedChanges.atom";
 
 export const Conflict = ({ conflict }: any) => {
   const proposedChangesDetails = useAtomValue(proposedChangedState);
@@ -21,17 +22,21 @@ export const Conflict = ({ conflict }: any) => {
   const handleAccept = async (conflictValue: string) => {
     const newValue = conflictValue === conflict.selected_branch ? null : conflictValue;
 
-      mutate({
-          id: conflict.uuid,
-          selection: newValue,
-        }, {
+    mutate(
+      {
+        id: conflict.uuid,
+        selection: newValue,
+      },
+      {
         onSuccess: async () => {
           await queryClient.invalidateQueries({ queryKey: ["diff-tree"] });
           await graphqlClient.refetchQueries({
             include: ["TASK_DETAILS_CHECK"],
           });
 
-          const message = newValue ? "Conflict marked as resolved" : "Conflict marked as not resolved";
+          const message = newValue
+            ? "Conflict marked as resolved"
+            : "Conflict marked as not resolved";
 
           toast(<Alert type={ALERT_TYPES.SUCCESS} message={message} />);
         },
@@ -47,7 +52,8 @@ export const Conflict = ({ conflict }: any) => {
             />
           );
         },
-      })
+      }
+    );
   };
 
   return (

--- a/frontend/app/src/entities/diff/node-diff/conflict.tsx
+++ b/frontend/app/src/entities/diff/node-diff/conflict.tsx
@@ -46,17 +46,8 @@ export const Conflict = ({ id, selectedBranch }: ConflictData) => {
 
           toast(<Alert type={ALERT_TYPES.SUCCESS} message={message} />);
         },
-        onError: () => {
-          toast(
-            <Alert
-              type={ALERT_TYPES.ERROR}
-              message={
-                newValue
-                  ? "An error occurred while resolving the conflict"
-                  : "An error occurred while marking the conflict as not resolved"
-              }
-            />
-          );
+        onError: ({ message }) => {
+          toast(<Alert type={ALERT_TYPES.ERROR} message={message} />);
         },
       }
     );

--- a/frontend/app/src/entities/diff/node-diff/conflict.tsx
+++ b/frontend/app/src/entities/diff/node-diff/conflict.tsx
@@ -36,7 +36,7 @@ export const Conflict = ({ id, selectedBranch }: ConflictData) => {
       },
       {
         onSuccess: async () => {
-          await queryClient.invalidateQueries({ queryKey: [treeQueryKeys.all] });
+          await queryClient.invalidateQueries({ queryKey: treeQueryKeys.all });
           await graphqlClient.refetchQueries({
             include: ["TASK_DETAILS_CHECK"],
           });

--- a/frontend/app/src/entities/diff/node-diff/conflict.tsx
+++ b/frontend/app/src/entities/diff/node-diff/conflict.tsx
@@ -11,6 +11,7 @@ import { Badge } from "@/shared/components/ui/badge";
 import { Spinner } from "@/shared/components/ui/spinner";
 
 import { useAuth } from "@/entities/authentication/ui/useAuth";
+import { treeQueryKeys } from "@/entities/diff/domain/diff.query-keys";
 import { useResolveConflictMutation } from "@/entities/diff/domain/resolve-conflict.mutation";
 import { proposedChangedState } from "@/entities/proposed-changes/stores/proposedChanges.atom";
 
@@ -35,7 +36,7 @@ export const Conflict = ({ id, selectedBranch }: ConflictData) => {
       },
       {
         onSuccess: async () => {
-          await queryClient.invalidateQueries({ queryKey: ["diff-tree"] });
+          await queryClient.invalidateQueries({ queryKey: [treeQueryKeys.all] });
           await graphqlClient.refetchQueries({
             include: ["TASK_DETAILS_CHECK"],
           });

--- a/frontend/app/src/entities/diff/node-diff/node-attribute.tsx
+++ b/frontend/app/src/entities/diff/node-diff/node-attribute.tsx
@@ -1,12 +1,12 @@
 import { useParams } from "react-router";
 
-import { DataConflict } from "@/entities/diff/checks/data-conflict";
 import { DiffNodeProperty } from "@/entities/diff/node-diff/node-property";
 import { DiffThread } from "@/entities/diff/node-diff/thread";
 import { DiffAttribute, DiffStatus } from "@/entities/diff/node-diff/types";
 import { DiffRow } from "@/entities/diff/node-diff/utils";
 
 import { BadgeConflict } from "../ui/diff-badge";
+import { Conflict } from "./conflict";
 
 type DiffNodeAttributeProps = {
   attribute: DiffAttribute;
@@ -43,7 +43,7 @@ export const DiffNodeAttribute = ({
       right={newValue}
     >
       <div className="divide-y divide-gray-200 border-gray-200 border-t">
-        {attribute.conflict && <DataConflict conflict={attribute.conflict} />}
+        {attribute.conflict && <Conflict conflict={attribute.conflict} />}
 
         {attribute.properties.map((property, index: number) => (
           <DiffNodeProperty key={index} property={property} status={status} />

--- a/frontend/app/src/entities/diff/node-diff/node-attribute.tsx
+++ b/frontend/app/src/entities/diff/node-diff/node-attribute.tsx
@@ -45,7 +45,10 @@ export const DiffNodeAttribute = ({
     >
       <div className="divide-y divide-gray-200 border-gray-200 border-t">
         {attribute.conflict && pathname.includes("/proposed-changes") && (
-          <Conflict conflict={attribute.conflict} />
+          <Conflict
+            id={attribute.conflict.uuid}
+            selectedBranch={attribute.conflict.selected_branch}
+          />
         )}
 
         {attribute.properties.map((property, index: number) => (

--- a/frontend/app/src/entities/diff/node-diff/node-attribute.tsx
+++ b/frontend/app/src/entities/diff/node-diff/node-attribute.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "react-router";
+import { useLocation, useParams } from "react-router";
 
 import { DiffNodeProperty } from "@/entities/diff/node-diff/node-property";
 import { DiffThread } from "@/entities/diff/node-diff/thread";
@@ -22,6 +22,7 @@ export const DiffNodeAttribute = ({
   status,
 }: DiffNodeAttributeProps) => {
   const { "*": branchName } = useParams();
+  const { pathname } = useLocation();
 
   return (
     <DiffRow
@@ -43,7 +44,9 @@ export const DiffNodeAttribute = ({
       right={newValue}
     >
       <div className="divide-y divide-gray-200 border-gray-200 border-t">
-        {attribute.conflict && <Conflict conflict={attribute.conflict} />}
+        {attribute.conflict && pathname.includes("/proposed-changes") && (
+          <Conflict conflict={attribute.conflict} />
+        )}
 
         {attribute.properties.map((property, index: number) => (
           <DiffNodeProperty key={index} property={property} status={status} />

--- a/frontend/app/src/entities/diff/node-diff/node-attribute.tsx
+++ b/frontend/app/src/entities/diff/node-diff/node-attribute.tsx
@@ -1,12 +1,11 @@
 import { useLocation, useParams } from "react-router";
 
+import { Conflict } from "@/entities/diff/node-diff/conflict";
 import { DiffNodeProperty } from "@/entities/diff/node-diff/node-property";
 import { DiffThread } from "@/entities/diff/node-diff/thread";
 import { DiffAttribute, DiffStatus } from "@/entities/diff/node-diff/types";
 import { DiffRow } from "@/entities/diff/node-diff/utils";
-
-import { BadgeConflict } from "../ui/diff-badge";
-import { Conflict } from "./conflict";
+import { BadgeConflict } from "@/entities/diff/ui/diff-badge";
 
 type DiffNodeAttributeProps = {
   attribute: DiffAttribute;

--- a/frontend/app/src/entities/diff/node-diff/types.ts
+++ b/frontend/app/src/entities/diff/node-diff/types.ts
@@ -24,6 +24,7 @@ export type DiffConflict = {
   diff_branch_changed_at: "2024-08-21T19:06:12.429813+00:00";
   diff_branch_value: any;
   uuid: string;
+  selected_branch?: string;
 };
 
 export type DiffProperty = {

--- a/frontend/app/src/entities/diff/node-diff/types.ts
+++ b/frontend/app/src/entities/diff/node-diff/types.ts
@@ -1,4 +1,4 @@
-import { ConflictSelection } from "@/shared/api/graphql/generated/graphql";
+import type { ConflictSelection } from "@/shared/api/graphql/generated/graphql";
 
 export const DIFF_STATUS = {
   ADDED: "ADDED",

--- a/frontend/app/src/entities/diff/node-diff/types.ts
+++ b/frontend/app/src/entities/diff/node-diff/types.ts
@@ -1,3 +1,5 @@
+import { ConflictSelection } from "@/shared/api/graphql/generated/graphql";
+
 export const DIFF_STATUS = {
   ADDED: "ADDED",
   REMOVED: "REMOVED",
@@ -24,7 +26,7 @@ export type DiffConflict = {
   diff_branch_changed_at: "2024-08-21T19:06:12.429813+00:00";
   diff_branch_value: any;
   uuid: string;
-  selected_branch?: string;
+  selected_branch?: ConflictSelection | null;
 };
 
 export type DiffProperty = {

--- a/frontend/app/src/entities/diff/ui/diff-refresh-button.tsx
+++ b/frontend/app/src/entities/diff/ui/diff-refresh-button.tsx
@@ -8,11 +8,8 @@ import { Button, ButtonProps } from "@/shared/components/buttons/button-primitiv
 import { ALERT_TYPES, Alert } from "@/shared/components/ui/alert";
 import { classNames } from "@/shared/utils/common";
 
-import { treeQueryKeys } from "@/entities/diff/domain/diff.query-keys";
-import {
-  UPDATE_DIFF_KEY,
-  useUpdateDiffMutation,
-} from "@/entities/diff/domain/update-diff.mutation";
+import { treeQueryKeys, updateDiffMutationKeys } from "@/entities/diff/domain/diff.query-keys";
+import { useUpdateDiffMutation } from "@/entities/diff/domain/update-diff.mutation";
 
 export interface DiffRefreshButtonProps extends Omit<ButtonProps, "onClick"> {
   branchName: string;
@@ -21,7 +18,7 @@ export interface DiffRefreshButtonProps extends Omit<ButtonProps, "onClick"> {
 export function DiffRefreshButton({ branchName, ...props }: DiffRefreshButtonProps) {
   const updateDiffMutation = useUpdateDiffMutation();
   const allUpdatingDiffs = useMutationState({
-    filters: { status: "pending", mutationKey: [UPDATE_DIFF_KEY] },
+    filters: { status: "pending", mutationKey: updateDiffMutationKeys.all },
     select: (mutation) => mutation.state.variables,
   });
 

--- a/frontend/app/src/entities/diff/ui/diff-refresh-button.tsx
+++ b/frontend/app/src/entities/diff/ui/diff-refresh-button.tsx
@@ -8,6 +8,7 @@ import { Button, ButtonProps } from "@/shared/components/buttons/button-primitiv
 import { ALERT_TYPES, Alert } from "@/shared/components/ui/alert";
 import { classNames } from "@/shared/utils/common";
 
+import { treeQueryKeys } from "@/entities/diff/domain/diff.query-keys";
 import {
   UPDATE_DIFF_KEY,
   useUpdateDiffMutation,
@@ -29,7 +30,7 @@ export function DiffRefreshButton({ branchName, ...props }: DiffRefreshButtonPro
   const handleRefreshDiff = async () => {
     updateDiffMutation.mutate(branchName, {
       onSuccess: () => {
-        queryClient.invalidateQueries({ queryKey: ["diff-tree"] });
+        queryClient.invalidateQueries({ queryKey: [treeQueryKeys.all] });
         graphqlClient.refetchQueries({
           include: ["GET_PROPOSED_CHANGES_DIFF_SUMMARY"],
         });

--- a/frontend/app/src/entities/diff/ui/diff-refresh-button.tsx
+++ b/frontend/app/src/entities/diff/ui/diff-refresh-button.tsx
@@ -30,7 +30,7 @@ export function DiffRefreshButton({ branchName, ...props }: DiffRefreshButtonPro
   const handleRefreshDiff = async () => {
     updateDiffMutation.mutate(branchName, {
       onSuccess: () => {
-        queryClient.invalidateQueries({ queryKey: [treeQueryKeys.all] });
+        queryClient.invalidateQueries({ queryKey: treeQueryKeys.all });
         graphqlClient.refetchQueries({
           include: ["GET_PROPOSED_CHANGES_DIFF_SUMMARY"],
         });

--- a/frontend/app/tests/e2e/proposed-changes/proposed-changes_diff.spec.ts
+++ b/frontend/app/tests/e2e/proposed-changes/proposed-changes_diff.spec.ts
@@ -2,10 +2,10 @@ import { expect, test } from "@playwright/test";
 
 import { ACCOUNT_STATE_PATH } from "../../constants";
 
-test.describe.fixme("/proposed-changes diff data", () => {
+test.describe("/proposed-changes diff data", () => {
   test.describe.configure({ mode: "serial" });
   test.use({ storageState: ACCOUNT_STATE_PATH.ADMIN });
-  test.slow();
+  // test.slow();
 
   test.beforeEach(async function ({ page }) {
     page.on("response", async (response) => {
@@ -14,6 +14,15 @@ test.describe.fixme("/proposed-changes diff data", () => {
       }
     });
   });
+
+  // test.afterAll(async function ({ page }) {
+  //   await page.goto("/proposed-changes");
+  //   await page.getByTestId("actions-row-button-conflict-test").click();
+  //   await page.getByTestId("delete-row-button").click();
+  //   await expect(page.getByTestId("modal-delete")).toBeVisible();
+  //   await page.getByTestId("modal-delete-confirm").click();
+  //   await expect(page.getByText("Proposed changes conflict-test deleted")).toBeVisible();
+  // });
 
   test("should verify the diff data with conflicts", async ({ page }) => {
     await test.step("create a new proposed change with reviewers", async () => {
@@ -25,7 +34,7 @@ test.describe.fixme("/proposed-changes diff data", () => {
       await page.getByLabel("Reviewers").click();
       await page.getByRole("option", { name: "Admin" }).click();
       await page.getByLabel("Reviewers").click();
-      await page.getByRole("button", { name: "Create proposed change" }).click();
+      await page.getByRole("button", { name: "Open" }).click();
       await expect(page.getByText("Proposed change created")).toBeVisible();
       await page.getByText("Data").click();
     });
@@ -37,92 +46,55 @@ test.describe.fixme("/proposed-changes diff data", () => {
     });
 
     await test.step("check diff data", async () => {
+      await expect(page.getByText("UpdatedInterfaceL3Ethernet1")).toBeVisible();
       await expect(page.getByText("UpdatedDeviceden1-edge1")).toBeVisible();
-      await expect(page.getByText("UpdatedInterface L3Ethernet1")).toBeVisible();
-      await page.getByText("UpdatedDeviceden1-edge1").click();
-      await expect(page.getByText("status")).toBeVisible();
-      await expect(page.getByText("active", { exact: true })).toBeVisible();
-      await expect(page.getByText("maintenance", { exact: true }).first()).toBeVisible();
-      await expect(page.getByText("statusConflict")).toBeVisible();
+      await page.getByText("UpdatedInterfaceL3Ethernet1").click();
       await expect(
-        page
-          .locator("div")
-          .filter({ hasText: /^activeprovisioning$/ })
-          .nth(1)
+        page.getByText("UpdatedInterfaceL3Ethernet1 main den1-maintenance-")
       ).toBeVisible();
+      await page.getByText("UpdatedDeviceden1-edge1").click();
+      await page
+        .getByText(
+          "main den1-maintenance-conflictstatusConflictactiveprovisioningmaintenanceChoose"
+        )
+        .click();
     });
 
     await test.step("resolve conflict", async () => {
+      await expect(
+        page.getByText("Choose the branch to resolve the conflict:mainden1-maintenance-conflict")
+      ).toBeVisible();
       await page.getByRole("checkbox", { name: "main", exact: true }).click();
       await expect(page.getByText("Conflict marked as resolved")).toBeVisible();
-    });
-
-    await test.step("filter diff data", async () => {
-      await page.getByRole("button", { name: "1" }).click();
-      await expect(page.getByText("UpdatedDeviceden1-edge1")).toBeVisible();
-      await expect(page.getByText("UpdatedInterface L3Ethernet1")).not.toBeVisible();
-      await page.getByRole("button", { name: "1" }).click();
-      await expect(page.getByText("UpdatedInterface L3Ethernet1")).toBeVisible();
-    });
-  });
-
-  test("should approve a proposed changes", async ({ page }) => {
-    await test.step("got to the proposed changes data tab", async () => {
-      await page.goto("/proposed-changes");
-      await page.getByRole("link", { name: "conflict-test" }).first().click();
-      await expect(page.getByRole("cell", { name: "A", exact: true }).first()).toBeVisible();
-      await expect(page.getByRole("cell", { name: "A", exact: true }).nth(1)).toBeVisible();
-      await page.getByRole("button", { name: "Approve" }).click();
-      await expect(page.getByText("Proposed change approved")).toBeVisible();
-    });
-
-    await test.step("check approval", async () => {
-      await expect(page.getByRole("cell", { name: "A", exact: true }).nth(1)).toBeVisible();
-      await expect(page.getByRole("cell", { name: "A", exact: true }).nth(2)).toBeVisible();
-      await page.getByRole("link", { name: "Proposed Change", exact: true }).click();
-      await expect(page.getByTestId("approved-icon")).toBeVisible();
     });
   });
 
   test("should comment a proposed changes", async ({ page }) => {
     await test.step("access proposed change diff tab", async () => {
       await page.goto("/proposed-changes");
-      await page.getByRole("link", { name: "conflict-test" }).first().click();
-      await expect(
-        page.locator("header").filter({ hasText: "Proposed changesconflict-test" })
-      ).toBeVisible();
+      await page.getByRole("link", { name: "conflict-test" }).click();
+      await expect(page.getByRole("heading", { name: "conflict-test" })).toBeVisible();
       await page.getByText("Data").click();
       await expect(page.getByRole("button", { name: "Refresh diff" })).toBeVisible();
     });
 
     await test.step("comment proposed changes", async () => {
-      await page.locator("span").filter({ hasText: "UpdatedInterface L3Ethernet1" }).hover();
+      await page.locator("span").filter({ hasText: "UpdatedDeviceden1-edge1" }).hover();
       await page
         .locator("span")
-        .filter({ hasText: "UpdatedInterface L3Ethernet1" })
+        .filter({ hasText: "UpdatedDeviceden1-edge1" })
         .getByTestId("data-diff-add-comment")
         .click();
-      await page.getByRole("textbox").fill("test");
+      await expect(page.getByText("Add a comment")).toBeVisible();
+      await page.getByRole("textbox").click();
+      await page.getByRole("textbox").fill("Some comment ");
       await page.getByRole("button", { name: "Comment", exact: true }).click();
-      // await expect(page.getByText("AAdminless than a minute ago")).toBeVisible();
-      await page.getByTestId("comment").getByText("test").click();
-      await page.getByRole("button", { name: "Reply" }).click();
-      await page.getByRole("textbox").fill("test 2");
-      await page.getByRole("button", { name: "Comment", exact: true }).click();
-      // await expect(page.getByText("AAdminless than a minute agotest")).toBeVisible();
+      await expect(page.getByTestId("comment").getByText("AAdmin")).toBeVisible();
+
       await expect(page.getByLabel("Resolve thread")).not.toBeChecked();
       await page.getByLabel("Resolve thread").click();
       await page.getByRole("button", { name: "Confirm", exact: true }).click();
       await expect(page.getByLabel("Resolved")).toBeChecked();
     });
-  });
-
-  test("should delete proposed changes", async ({ page }) => {
-    await page.goto("/proposed-changes");
-    await page.getByTestId("actions-row-button-conflict-test").click();
-    await page.getByTestId("delete-row-button").click();
-    await expect(page.getByTestId("modal-delete")).toBeVisible();
-    await page.getByTestId("modal-delete-confirm").click();
-    await expect(page.getByText("Proposed changes conflict-test deleted")).toBeVisible();
   });
 });

--- a/frontend/app/tests/e2e/proposed-changes/proposed-changes_diff.spec.ts
+++ b/frontend/app/tests/e2e/proposed-changes/proposed-changes_diff.spec.ts
@@ -15,15 +15,6 @@ test.describe("/proposed-changes diff data", () => {
     });
   });
 
-  // test.afterAll(async function ({ page }) {
-  //   await page.goto("/proposed-changes");
-  //   await page.getByTestId("actions-row-button-conflict-test").click();
-  //   await page.getByTestId("delete-row-button").click();
-  //   await expect(page.getByTestId("modal-delete")).toBeVisible();
-  //   await page.getByTestId("modal-delete-confirm").click();
-  //   await expect(page.getByText("Proposed changes conflict-test deleted")).toBeVisible();
-  // });
-
   test("should verify the diff data with conflicts", async ({ page }) => {
     await test.step("create a new proposed change with reviewers", async () => {
       await page.goto("/proposed-changes");
@@ -96,5 +87,14 @@ test.describe("/proposed-changes diff data", () => {
       await page.getByRole("button", { name: "Confirm", exact: true }).click();
       await expect(page.getByLabel("Resolved")).toBeChecked();
     });
+  });
+
+  test("should delete the proposed change", async ({ page }) => {
+    await page.goto("/proposed-changes");
+    await page.getByTestId("actions-row-button-conflict-test").click();
+    await page.getByTestId("delete-row-button").click();
+    await expect(page.getByTestId("modal-delete")).toBeVisible();
+    await page.getByTestId("modal-delete-confirm").click();
+    await expect(page.getByText("Proposed changes conflict-test deleted")).toBeVisible();
   });
 });

--- a/frontend/app/tests/e2e/proposed-changes/proposed-changes_diff.spec.ts
+++ b/frontend/app/tests/e2e/proposed-changes/proposed-changes_diff.spec.ts
@@ -5,7 +5,6 @@ import { ACCOUNT_STATE_PATH } from "../../constants";
 test.describe("/proposed-changes diff data", () => {
   test.describe.configure({ mode: "serial" });
   test.use({ storageState: ACCOUNT_STATE_PATH.ADMIN });
-  // test.slow();
 
   test.beforeEach(async function ({ page }) {
     page.on("response", async (response) => {
@@ -31,7 +30,6 @@ test.describe("/proposed-changes diff data", () => {
     });
 
     await test.step("trigger the diff update", async () => {
-      // await expect(page.getByText("We are computing the diff")).toBeVisible();
       await page.getByRole("button", { name: "Refresh" }).click();
       await expect(page.getByText("Diff updated!")).toBeVisible();
     });


### PR DESCRIPTION
Fix conflict resolution after wrong deletion of the code, only allowed in the proposed changes view

Works also for schema conflict resolution

Upgrade mutation to use FSD framework

Component removals appeared in https://github.com/opsmill/infrahub/pull/6069 and https://github.com/opsmill/infrahub/pull/7159

<img width="1465" height="901" alt="image" src="https://github.com/user-attachments/assets/e8270ad0-dcfe-423d-b9de-4610ffb1680c" />

<img width="1465" height="901" alt="image" src="https://github.com/user-attachments/assets/ccdf35dd-fb4e-4963-937f-5b6b4debefcc" />

<img width="1465" height="901" alt="image" src="https://github.com/user-attachments/assets/2130774f-f94d-4e3a-b003-b967f7e7b850" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conflict resolution UI now persists selections (showing loading, success/error toasts) and displays branch badges and resolved state.

* **Refactor**
  * Conflict UI only appears on proposed-changes pages; controls reflect current selection and are disabled during submission or when unauthenticated.
  * Diff cache/refresh logic centralized for more consistent refreshes after changes.

* **Tests**
  * E2E flows updated to match new diff navigation, conflict-resolution, commenting, and deletion interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->