### PR TITLE
Use correct description for HFID & display label triggers

### DIFF
--- a/backend/infrahub/display_labels/models.py
+++ b/backend/infrahub/display_labels/models.py
@@ -34,6 +34,9 @@ class DisplayLabelTriggerDefinition(TriggerBranchDefinition):
     template_hash: str
     target_kind: str | None = Field(default=None)
 
+    def get_description(self) -> str:
+        return f"{super().get_description()} | hash:{self.template_hash}"
+
     @classmethod
     def from_schema_display_labels(
         cls,

--- a/backend/infrahub/hfid/models.py
+++ b/backend/infrahub/hfid/models.py
@@ -34,6 +34,9 @@ class HFIDTriggerDefinition(TriggerBranchDefinition):
     hfid_hash: str
     target_kind: str | None = Field(default=None)
 
+    def get_description(self) -> str:
+        return f"{super().get_description()} | hash:{self.hfid_hash}"
+
     @classmethod
     def from_schema_hfids(
         cls,


### PR DESCRIPTION
We need to override the description method for these triggers in order to get the hash values which allows us to properly trigger on updates to the schema.