### PR TITLE
Assign the correct type to StandardNode (branches)

### DIFF
--- a/backend/infrahub/core/node/standard.py
+++ b/backend/infrahub/core/node/standard.py
@@ -111,7 +111,7 @@ class StandardNode(BaseModel):
         node = result.get("n")
 
         self.id = node.element_id
-        self.uuid = node["uuid"]
+        self.uuid = UUID(node["uuid"])
 
         return True
 

--- a/backend/tests/functional/branch/test_graphql_mutation.py
+++ b/backend/tests/functional/branch/test_graphql_mutation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from uuid import UUID
 
 import pytest
 from infrahub_sdk.exceptions import BranchNotFoundError, GraphQLError
@@ -106,8 +107,8 @@ class TestBranchMutations(TestInfrahubApp):
         with pytest.raises(BranchNotFoundError):
             await client.branch.get(branch_name=branch.name)
 
-        assert isinstance(branch_server_id, str)
-        remove_git_worktree_branch(repository_id=initial_dataset, branch_id=branch_server_id)
+        assert isinstance(branch_server_id, UUID)
+        remove_git_worktree_branch(repository_id=initial_dataset, branch_id=str(branch_server_id))
 
     async def test_branch_delete(self, initial_dataset: str, client: InfrahubClient) -> None:
         branch = await client.branch.create(branch_name="branch_to_delete_sync")
@@ -124,8 +125,8 @@ class TestBranchMutations(TestInfrahubApp):
         with pytest.raises(BranchNotFoundError):
             await client.branch.get(branch_name=branch.name)
 
-        assert isinstance(branch_server_id, str)
-        remove_git_worktree_branch(repository_id=initial_dataset, branch_id=branch_server_id)
+        assert isinstance(branch_server_id, UUID)
+        remove_git_worktree_branch(repository_id=initial_dataset, branch_id=str(branch_server_id))
 
     async def test_branch_rebase_async(self, initial_dataset: str, client: InfrahubClient) -> None:
         branch = await client.branch.create(branch_name="branch_to_rebase")

--- a/backend/tests/unit/core/test_node_standard.py
+++ b/backend/tests/unit/core/test_node_standard.py
@@ -59,7 +59,7 @@ async def test_node_standard_get(db: InfrahubDatabase, empty_database):
     )
     assert await obj1.save(db=db)
 
-    obj11 = await MyStdNode.get(id=obj1.uuid, db=db)
+    obj11 = await MyStdNode.get(id=str(obj1.uuid), db=db)
     assert obj11.model_dump(exclude={"uuid"}) == obj1.model_dump(exclude={"uuid"})
     assert str(obj11.uuid) == str(obj1.uuid)
     assert obj11.attr3_int is None
@@ -70,7 +70,7 @@ async def test_node_standard_update(db: InfrahubDatabase, empty_database):
     obj1 = MyStdNode(attr1_str="obj1", attr2_int=1, attr4_bool=True, attr5_dict=attr5_value)
     assert await obj1.save(db=db)
 
-    obj11 = await MyStdNode.get(id=obj1.uuid, db=db)
+    obj11 = await MyStdNode.get(id=str(obj1.uuid), db=db)
     assert obj11.model_dump(exclude={"uuid"}) == obj1.model_dump(exclude={"uuid"})
     assert str(obj11.uuid) == str(obj1.uuid)
     assert obj11.attr3_int is None
@@ -81,7 +81,7 @@ async def test_node_standard_update(db: InfrahubDatabase, empty_database):
     obj11.attr5_dict = {"key11": "value12", "key2": {"key21": "Value21"}}
     await obj11.save(db=db)
 
-    obj12 = await MyStdNode.get(id=obj1.uuid, db=db)
+    obj12 = await MyStdNode.get(id=str(obj1.uuid), db=db)
     assert obj12.model_dump(exclude={"uuid"}) == obj11.model_dump(exclude={"uuid"})
 
 
@@ -97,7 +97,7 @@ async def test_node_standard_list(db: InfrahubDatabase, empty_database):
     assert len(objs) == 3
     assert isinstance(objs[0], OtherStdNode)
 
-    objs = await OtherStdNode.get_list(db=db, ids=[obj1.uuid, obj3.uuid])
+    objs = await OtherStdNode.get_list(db=db, ids=[str(obj1.uuid), str(obj3.uuid)])
     assert len(objs) == 2
 
     objs = await OtherStdNode.get_list(db=db, name=obj2.name)
@@ -114,5 +114,5 @@ async def test_node_standard_pydantic(db: InfrahubDatabase, empty_database):
     )
     await obj1.save(db=db)
 
-    obj11 = await PadanticStdNode.get(id=obj1.uuid, db=db)
+    obj11 = await PadanticStdNode.get(id=str(obj1.uuid), db=db)
     assert obj11.model_dump(exclude={"uuid"}) == obj1.model_dump(exclude={"uuid"})


### PR DESCRIPTION
Prevents a lot of warnings during tests (and probably when creating branches depending on console logging.

Example:

```python
pytest backend/tests/unit/core/diff/test_diff_and_merge.py::TestDiffAndMerge

backend/tests/unit/core/diff/test_diff_and_merge.py::TestDiffAndMerge::test_delete_with_many_relationship_added
  /Users/patrick/.virtualenvs/infrahub/lib/python3.12/site-packages/pydantic/main.py:426: UserWarning: Pydantic serializer warnings:
    Expected `uuid` but got `str` with value `'186e12e8-cdad-7808-58d1-174637038718'` - serialized value may not be as expected
    return self.__pydantic_serializer__.to_python(

backend/tests/unit/core/diff/test_diff_and_merge.py::TestDiffAndMerge::test_attribute_update_with_conflict[ConflictSelection.BASE_BRANCH]
  /Users/patrick/.virtualenvs/infrahub/lib/python3.12/site-packages/pydantic/main.py:426: UserWarning: Pydantic serializer warnings:
    Expected `uuid` but got `str` with value `'186e12e9-0ae5-4098-58d4-1746880a06c4'` - serialized value may not be as expected
    return self.__pydantic_serializer__.to_python(

backend/tests/unit/core/diff/test_diff_and_merge.py::TestDiffAndMerge::test_attribute_update_with_conflict[ConflictSelection.BASE_BRANCH]
  /Users/patrick/.virtualenvs/infrahub/lib/python3.12/site-packages/pydantic/main.py:426: UserWarning: Pydantic serializer warnings:
    Expected `uuid` but got `str` with value `'186e12e9-1035-f858-58df-17469c1222fa'` - serialized value may not be as expected
    return self.__pydantic_serializer__.to_python(

backend/tests/unit/core/diff/test_diff_and_merge.py::TestDiffAndMerge::test_attribute_u
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Consistent UUID handling across the app for node and branch identifiers, improving reliability and interoperability.
- Bug Fixes
  - GraphQL mutations and related operations now validate and return UUIDs consistently, reducing type-related errors.
- Refactor
  - Internal ID representation standardized to UUID, enhancing type safety without changing visible behavior.
- Tests
  - Updated test coverage to reflect UUID consistency, ensuring correct behavior across create, update, list, and retrieval flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->