### PR TITLE
Fix(UI): Boolean fields now correctly display true or false in the Details view

### DIFF
--- a/changelog/7372.fixed.md
+++ b/changelog/7372.fixed.md
@@ -1,0 +1,1 @@
+Fixed an issue where boolean fields in the object Details view always displayed a checkmark, even when the value was false.

--- a/frontend/app/src/entities/nodes/getObjectItemDisplayValue.tsx
+++ b/frontend/app/src/entities/nodes/getObjectItemDisplayValue.tsx
@@ -202,7 +202,11 @@ export const ObjectAttributeValue = ({
       );
     case ATTRIBUTE_KIND.BOOLEAN:
     case ATTRIBUTE_KIND.CHECKBOX:
-      return attributeValue ? <CheckIcon className="h-4 w-4" /> : <XMarkIcon className="h-4 w-4" />;
+      return attributeValue.value ? (
+        <CheckIcon className="size-4" />
+      ) : (
+        <XMarkIcon className="size-4" />
+      );
     case ATTRIBUTE_KIND.DATETIME:
       return <DateDisplay date={getTextValue(attributeValue)} />;
     case ATTRIBUTE_KIND.TEXTAREA:


### PR DESCRIPTION
Issue:
- #7372 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Boolean fields in the Details view now show a checkmark only for true; false values no longer display a checkmark.
  - Improved consistency of icon rendering for boolean values.

- Documentation
  - Added a changelog entry describing the boolean display fix.
  - Embedded explanatory videos in branching and resource-manager documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->