### PR TITLE
skip a flaky test that will need to change when the migration changes

### DIFF
--- a/backend/tests/unit/core/migrations/graph/test_040.py
+++ b/backend/tests/unit/core/migrations/graph/test_040.py
@@ -36,6 +36,7 @@ class WrappedMigration040(Migration040):
         return wrapped_profile_applier
 
 
+@pytest.mark.skip(reason="Is flaky. And waiting on updates to the migration")
 class TestMigration040(TestInfrahubApp):
     @pytest.fixture
     async def profile_1(self, db: InfrahubDatabase, default_branch: Branch, criticality_schema) -> Node:


### PR DESCRIPTION
apparently this test is flaky in the CI and it is going to need to change when `Migration040` changes to support a mid-migration rebase anyways, so just skipping for now

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Temporarily skipped a flaky migration test to prevent intermittent failures during test runs.
  * Improves consistency of CI results and reduces noise from unreliable test outcomes.
  * No impact on application behavior or user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->