### PR TITLE
IFC-1827 Add global permission to update display label and HFID

### DIFF
--- a/backend/infrahub/core/constants/__init__.py
+++ b/backend/infrahub/core/constants/__init__.py
@@ -99,6 +99,7 @@ class GlobalPermissions(InfrahubStringEnum):
     MANAGE_PERMISSIONS = "manage_permissions"
     MANAGE_REPOSITORIES = "manage_repositories"
     OVERRIDE_CONTEXT = "override_context"
+    UPDATE_OBJECT_HFID_DISPLAY_LABEL = "update_object_hfid_display_label"
 
 
 class PermissionAction(InfrahubStringEnum):

--- a/backend/infrahub/graphql/mutations/display_label.py
+++ b/backend/infrahub/graphql/mutations/display_label.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 from graphene import Boolean, InputObjectType, Mutation, String
 
 from infrahub.core.account import ObjectPermission
-from infrahub.core.constants import PermissionAction, PermissionDecision
+from infrahub.core.constants import GlobalPermissions, PermissionAction, PermissionDecision
 from infrahub.core.manager import NodeManager
 from infrahub.core.registry import registry
 from infrahub.database import retry_db_transaction
@@ -15,6 +15,7 @@ from infrahub.exceptions import NodeNotFoundError, ValidationError
 from infrahub.graphql.context import apply_external_context
 from infrahub.graphql.types.context import ContextInput
 from infrahub.log import get_log_data
+from infrahub.permissions import define_global_permission_from_branch
 from infrahub.worker import WORKER_IDENTITY
 
 if TYPE_CHECKING:
@@ -52,15 +53,21 @@ class UpdateDisplayLabel(Mutation):
         if not node_schema.display_label:
             raise ValidationError(input_value=f"{node_schema.kind}.display_label has not been defined for this kind.")
 
-        graphql_context.active_permissions.raise_for_permission(
-            permission=ObjectPermission(
-                namespace=node_schema.namespace,
-                name=node_schema.name,
-                action=PermissionAction.UPDATE.value,
-                decision=PermissionDecision.ALLOW_DEFAULT.value
-                if graphql_context.branch.name == registry.default_branch
-                else PermissionDecision.ALLOW_OTHER.value,
-            )
+        graphql_context.active_permissions.raise_for_permissions(
+            permissions=[
+                define_global_permission_from_branch(
+                    permission=GlobalPermissions.UPDATE_OBJECT_HFID_DISPLAY_LABEL,
+                    branch_name=graphql_context.branch.name,
+                ),
+                ObjectPermission(
+                    namespace=node_schema.namespace,
+                    name=node_schema.name,
+                    action=PermissionAction.UPDATE.value,
+                    decision=PermissionDecision.ALLOW_DEFAULT.value
+                    if graphql_context.branch.name == registry.default_branch
+                    else PermissionDecision.ALLOW_OTHER.value,
+                ),
+            ]
         )
         await apply_external_context(graphql_context=graphql_context, context_input=context)
 

--- a/backend/infrahub/graphql/mutations/hfid.py
+++ b/backend/infrahub/graphql/mutations/hfid.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, cast
 from graphene import Boolean, InputObjectType, List, Mutation, NonNull, String
 
 from infrahub.core.account import ObjectPermission
-from infrahub.core.constants import PermissionAction, PermissionDecision
+from infrahub.core.constants import GlobalPermissions, PermissionAction, PermissionDecision
 from infrahub.core.manager import NodeManager
 from infrahub.core.registry import registry
 from infrahub.database import retry_db_transaction
@@ -15,6 +15,7 @@ from infrahub.exceptions import NodeNotFoundError, ValidationError
 from infrahub.graphql.context import apply_external_context
 from infrahub.graphql.types.context import ContextInput
 from infrahub.log import get_log_data
+from infrahub.permissions import define_global_permission_from_branch
 from infrahub.worker import WORKER_IDENTITY
 
 if TYPE_CHECKING:
@@ -61,15 +62,21 @@ class UpdateHFID(Mutation):
                 input_value=f"{node_schema.kind}.human_friendly_id requires {len(node_schema.human_friendly_id)} parts data has {len(updated_hfid)}"
             )
 
-        graphql_context.active_permissions.raise_for_permission(
-            permission=ObjectPermission(
-                namespace=node_schema.namespace,
-                name=node_schema.name,
-                action=PermissionAction.UPDATE.value,
-                decision=PermissionDecision.ALLOW_DEFAULT.value
-                if graphql_context.branch.name == registry.default_branch
-                else PermissionDecision.ALLOW_OTHER.value,
-            )
+        graphql_context.active_permissions.raise_for_permissions(
+            permissions=[
+                define_global_permission_from_branch(
+                    permission=GlobalPermissions.UPDATE_OBJECT_HFID_DISPLAY_LABEL,
+                    branch_name=graphql_context.branch.name,
+                ),
+                ObjectPermission(
+                    namespace=node_schema.namespace,
+                    name=node_schema.name,
+                    action=PermissionAction.UPDATE.value,
+                    decision=PermissionDecision.ALLOW_DEFAULT.value
+                    if graphql_context.branch.name == registry.default_branch
+                    else PermissionDecision.ALLOW_OTHER.value,
+                ),
+            ]
         )
         await apply_external_context(graphql_context=graphql_context, context_input=context)
 

--- a/backend/infrahub/permissions/constants.py
+++ b/backend/infrahub/permissions/constants.py
@@ -30,6 +30,7 @@ GLOBAL_PERMISSION_DENIAL_MESSAGE = {
     GlobalPermissions.MANAGE_ACCOUNTS.value: "You are not allowed to manage user accounts, groups or roles",
     GlobalPermissions.MANAGE_PERMISSIONS.value: "You are not allowed to manage permissions",
     GlobalPermissions.MANAGE_REPOSITORIES.value: "You are not allowed to manage repositories",
+    GlobalPermissions.UPDATE_OBJECT_HFID_DISPLAY_LABEL.value: "You are not allowed to update human friendly IDs and display labels ad hoc",
 }
 
 GLOBAL_PERMISSION_DESCRIPTION = {
@@ -42,4 +43,5 @@ GLOBAL_PERMISSION_DESCRIPTION = {
     GlobalPermissions.MANAGE_PERMISSIONS: "Allow a user to manage permissions",
     GlobalPermissions.MANAGE_REPOSITORIES: "Allow a user to manage repositories",
     GlobalPermissions.SUPER_ADMIN: "Allow a user to do anything",
+    GlobalPermissions.UPDATE_OBJECT_HFID_DISPLAY_LABEL: "Allow a user to update objects' display labels and human friendly IDs ad hoc",
 }

--- a/backend/tests/unit/graphql/mutations/test_display_label.py
+++ b/backend/tests/unit/graphql/mutations/test_display_label.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
-from infrahub.core.account import ObjectPermission
+from infrahub.core.account import GlobalPermission, ObjectPermission
 from infrahub.core.branch.models import Branch
-from infrahub.core.constants import PermissionAction, PermissionDecision
+from infrahub.core.constants import GlobalPermissions, PermissionAction, PermissionDecision
 from infrahub.core.node import Node
 from infrahub.core.registry import registry
 from infrahub.core.schema import SchemaRoot
@@ -88,6 +88,12 @@ async def test_update_display_label_update(
     await define_permissions(
         account=first_account,
         db=db,
+        global_permissions=[
+            GlobalPermission(
+                action=GlobalPermissions.UPDATE_OBJECT_HFID_DISPLAY_LABEL.value,
+                decision=PermissionDecision.ALLOW_ALL.value,
+            )
+        ],
         object_permissions=[
             ObjectPermission(
                 namespace=TSHIRT.namespace,

--- a/backend/tests/unit/graphql/mutations/test_hfid.py
+++ b/backend/tests/unit/graphql/mutations/test_hfid.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
-from infrahub.core.account import ObjectPermission
+from infrahub.core.account import GlobalPermission, ObjectPermission
 from infrahub.core.branch.models import Branch
-from infrahub.core.constants import PermissionAction, PermissionDecision
+from infrahub.core.constants import GlobalPermissions, PermissionAction, PermissionDecision
 from infrahub.core.node import Node
 from infrahub.core.registry import registry
 from infrahub.core.schema import SchemaRoot
@@ -71,6 +71,12 @@ async def test_update_hfid_update(
     await define_permissions(
         account=first_account,
         db=db,
+        global_permissions=[
+            GlobalPermission(
+                action=GlobalPermissions.UPDATE_OBJECT_HFID_DISPLAY_LABEL.value,
+                decision=PermissionDecision.ALLOW_ALL.value,
+            )
+        ],
         object_permissions=[
             ObjectPermission(
                 namespace=TSHIRT.namespace,


### PR DESCRIPTION
This change adds a new global permission to be able to prevent the use of the `InfrahubUpdateDisplayLabel` and `InfrahubUpdateHFID` mutations for some users. This permission is not intended to prevent display label or HFID updates when objects are being updated. It is only enforced within the previously mentionned mutations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a global permission to control who can update an object's HFID display label.
  - Update actions now require evaluation of both global and object-level permissions for stronger access control.
- **Documentation**
  - Added user-facing description and denial message for the new global permission.
- **Tests**
  - Unit tests updated to cover combined global and object-level permission checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->