### PR TITLE
Correct labels on branch list and detailed view

### DIFF
--- a/changelog/+branch-labels.fixed.md
+++ b/changelog/+branch-labels.fixed.md
@@ -1,0 +1,1 @@
+Corrected the labels on the brand list and detailed view to use the correct terminology

--- a/changelog/+branch-labels.fixed.md
+++ b/changelog/+branch-labels.fixed.md
@@ -1,1 +1,1 @@
-Corrected the labels on the brand list and detailed view to use the correct terminology
+Corrected the labels on the branch list and detailed view to use the correct terminology

--- a/frontend/app/src/entities/branches/ui/branch-details.tsx
+++ b/frontend/app/src/entities/branches/ui/branch-details.tsx
@@ -107,10 +107,10 @@ export const BranchDetails = () => {
     {
       name: "branched_at",
       label: "Started at",
+      name: "created_at",
+      label: "Created at",
     },
     {
-      name: "created_at",
-      label: "Completed at",
     },
   ];
 

--- a/frontend/app/src/entities/branches/ui/branch-details.tsx
+++ b/frontend/app/src/entities/branches/ui/branch-details.tsx
@@ -105,12 +105,12 @@ export const BranchDetails = () => {
       label: "Origin branch",
     },
     {
-      name: "branched_at",
-      label: "Started at",
       name: "created_at",
       label: "Created at",
     },
     {
+      name: "branched_from",
+      label: "Last rebase on main",
     },
   ];
 
@@ -118,7 +118,7 @@ export const BranchDetails = () => {
     values: {
       name: branch.name,
       origin_branch: <Badge className="text-sm">{branch.origin_branch}</Badge>,
-      branched_at: <DateDisplay date={branch.branched_at} />,
+      branched_from: <DateDisplay date={branch.branched_from} />,
       created_at: <DateDisplay date={branch.created_at} />,
     },
   };

--- a/frontend/app/src/entities/branches/ui/branches-items.tsx
+++ b/frontend/app/src/entities/branches/ui/branches-items.tsx
@@ -82,7 +82,7 @@ const BranchesItems = () => {
 
                 <div className="flex flex-col items-end">
                   <div className="flex items-center">
-                    <div className="mr-2">Branched:</div>
+                    <div className="mr-2">Last rebase on main:</div>
                     <DateDisplay date={branch.branched_from} />
                   </div>
 


### PR DESCRIPTION
On the branch list view, we updated the `Branched` label to `Last rebase on main`.
<img width="754" height="343" alt="image" src="https://github.com/user-attachments/assets/49ae9fe7-8ad9-4b51-82f4-0547455a31c5" />

On the branch detailed view, the `Completed at` label was updated `Last rebase on main` and the `Started at` label was updated to `Created at` label.
<img width="758" height="382" alt="image" src="https://github.com/user-attachments/assets/7efebf33-2a9a-4002-8baf-821706016d51" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected date fields in Branch Details: now displays “Created at” and “Last rebase on main” with the appropriate dates.
  * Updated branch list item label from “Branched:” to “Last rebase on main:” for clarity and consistency.

* **Documentation**
  * Added a changelog entry highlighting the corrected terminology for labels on branch list and detail views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->