### PR TITLE
replace deprectated add_delta calls with just add

### DIFF
--- a/backend/tests/unit/core/diff/test_cardinality_one_enricher.py
+++ b/backend/tests/unit/core/diff/test_cardinality_one_enricher.py
@@ -66,12 +66,12 @@ class TestDiffCardinalityOneEnricher:
             conflict=None,
             previous_value=None,
             new_value=peer_id_2,
-            changed_at=is_related_prop_1.changed_at.add_delta(minutes=2),
+            changed_at=is_related_prop_1.changed_at.add(minutes=2),
         )
         diff_rel_element_2 = EnrichedRelationshipElementFactory.build(
             properties={has_source_prop_2, is_related_prop_2},
             peer_id=peer_id_2,
-            changed_at=diff_rel_element_1.changed_at.add_delta(minutes=2),
+            changed_at=diff_rel_element_1.changed_at.add(minutes=2),
             action=DiffAction.UPDATED,
         )
 
@@ -239,12 +239,12 @@ class TestDiffCardinalityOneEnricher:
             conflict=None,
             previous_value=None,
             new_value=peer_id,
-            changed_at=is_related_prop_1.changed_at.add_delta(minutes=2),
+            changed_at=is_related_prop_1.changed_at.add(minutes=2),
         )
         diff_rel_element_2 = EnrichedRelationshipElementFactory.build(
             properties={has_source_prop_2, is_related_prop_2},
             peer_id=peer_id,
-            changed_at=diff_rel_element_1.changed_at.add_delta(minutes=2),
+            changed_at=diff_rel_element_1.changed_at.add(minutes=2),
             action=DiffAction.UPDATED,
         )
 

--- a/backend/tests/unit/core/diff/test_diff_combiner.py
+++ b/backend/tests/unit/core/diff/test_diff_combiner.py
@@ -394,7 +394,7 @@ class TestDiffCombiner:
         later_element = EnrichedRelationshipElementFactory.build(
             action=DiffAction.UPDATED,
             peer_id=new_peer_id,
-            changed_at=early_element.changed_at.add_delta(minutes=1),
+            changed_at=early_element.changed_at.add(minutes=1),
             properties={later_only_property, later_peer_property},
             conflict=EnrichedConflictFactory.build(),
         )
@@ -1045,7 +1045,7 @@ class TestDiffCombiner:
         later_element = EnrichedRelationshipElementFactory.build(
             action=DiffAction.UPDATED,
             peer_id=old_peer_id,
-            changed_at=early_element.changed_at.add_delta(minutes=1),
+            changed_at=early_element.changed_at.add(minutes=1),
             properties={later_only_property, later_peer_property},
         )
         early_relationship = EnrichedRelationshipGroupFactory.build(

--- a/backend/tests/unit/graphql/diff/test_diff_update_mutation.py
+++ b/backend/tests/unit/graphql/diff/test_diff_update_mutation.py
@@ -101,7 +101,7 @@ class TestDiffUpdateMutation:
             variable_values={
                 "branch": diff_branch.name,
                 "name": self.diff_name,
-                "from_time": branched_from_timestamp.add_delta(seconds=-1).to_string(),
+                "from_time": branched_from_timestamp.add(seconds=-1).to_string(),
             },
         )
         assert result.errors is None
@@ -156,7 +156,7 @@ class TestDiffUpdateMutation:
             variable_values={
                 "branch": diff_branch.name,
                 "name": self.diff_name,
-                "from_time": named_diff.from_time.add_delta(microseconds=-1).to_string(),
+                "from_time": named_diff.from_time.add(microseconds=-1).to_string(),
             },
         )
         assert result.errors is not None
@@ -171,7 +171,7 @@ class TestDiffUpdateMutation:
             variable_values={
                 "branch": diff_branch.name,
                 "name": self.diff_name,
-                "to_time": named_diff.to_time.add_delta(seconds=-1).to_string(),
+                "to_time": named_diff.to_time.add(seconds=-1).to_string(),
             },
         )
         assert result.errors is not None

--- a/utilities/proposed_change_faker.py
+++ b/utilities/proposed_change_faker.py
@@ -116,7 +116,7 @@ async def create_validators(
                 )
                 # Mark as complete if in final state
                 if is_final_state(state):
-                    create_data.update({"completed_at": started_at.add_delta(seconds=30).to_string()})
+                    create_data.update({"completed_at": started_at.add(seconds=30).to_string()})
 
                 v = await client.create(validator_kind, data=create_data)
                 await v.save()


### PR DESCRIPTION
`Timestamp.add_delta` is deprecated, we should just use `add` instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Standardized timestamp arithmetic to a new time-addition API for consistency across the codebase.
- Tests
  - Updated tests to use the new time addition method for timestamps; no behavioral changes.
- Refactor
  - Adjusted fake data generation to compute completion times using the unified time-addition approach, maintaining expected outputs.

No user-facing changes; these updates improve internal consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->