### PR TITLE
Switch ruff to target Python 3.12

### DIFF
--- a/backend/infrahub/auth.py
+++ b/backend/infrahub/auth.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime, timedelta
-from enum import Enum
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
 import bcrypt
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 log = get_logger()
 
 
-class AuthType(str, Enum):
+class AuthType(StrEnum):
     NONE = "none"
     JWT = "jwt"
     API = "api"

--- a/backend/infrahub/cli/db.py
+++ b/backend/infrahub/cli/db.py
@@ -6,7 +6,7 @@ import os
 from collections import defaultdict
 from csv import DictReader, DictWriter
 from datetime import UTC, datetime
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Sequence
 
@@ -75,13 +75,13 @@ app.add_typer(patch_app, name="patch")
 PERMISSIONS_AVAILABLE = ["read", "write", "admin"]
 
 
-class ConstraintAction(str, Enum):
+class ConstraintAction(StrEnum):
     SHOW = "show"
     ADD = "add"
     DROP = "drop"
 
 
-class IndexAction(str, Enum):
+class IndexAction(StrEnum):
     SHOW = "show"
     ADD = "add"
     DROP = "drop"

--- a/backend/infrahub/cli/db_commands/clean_duplicate_schema_fields.py
+++ b/backend/infrahub/cli/db_commands/clean_duplicate_schema_fields.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from rich import print as rprint
@@ -11,7 +11,7 @@ from infrahub.core.query import Query, QueryType
 from infrahub.database import InfrahubDatabase
 
 
-class SchemaFieldType(str, Enum):
+class SchemaFieldType(StrEnum):
     ATTRIBUTE = "attribute"
     RELATIONSHIP = "relationship"
 

--- a/backend/infrahub/config.py
+++ b/backend/infrahub/config.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import os
 import ssl
 import sys
+import tomllib
 from dataclasses import dataclass
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-import tomllib
 from infrahub_sdk.utils import generate_uuid
 from pydantic import (
     AliasChoices,
@@ -48,28 +48,28 @@ def default_append_git_suffix_domains() -> list[str]:
     return ["github.com", "gitlab.com"]
 
 
-class EnterpriseFeatures(str, Enum):
+class EnterpriseFeatures(StrEnum):
     PROPOSED_CHANGE_REQUIRE_APPROVAL = "proposed_change_require_approval"
     REVOKE_PROPOSED_CHANGE_APPROVALS = "revoke_proposed_change_approvals"
 
 
-class UserInfoMethod(str, Enum):
+class UserInfoMethod(StrEnum):
     POST = "post"
     GET = "get"
 
 
-class SSOProtocol(str, Enum):
+class SSOProtocol(StrEnum):
     OAUTH2 = "oauth2"
     OIDC = "oidc"
 
 
-class Oauth2Provider(str, Enum):
+class Oauth2Provider(StrEnum):
     GOOGLE = "google"
     PROVIDER1 = "provider1"
     PROVIDER2 = "provider2"
 
 
-class OIDCProvider(str, Enum):
+class OIDCProvider(StrEnum):
     GOOGLE = "google"
     PROVIDER1 = "provider1"
     PROVIDER2 = "provider2"
@@ -98,25 +98,25 @@ class SSOProviderInfo(BaseModel):
         return f"/api/{self.protocol.value}/{self.name}/token"
 
 
-class StorageDriver(str, Enum):
+class StorageDriver(StrEnum):
     FileSystemStorage = "local"
     InfrahubS3ObjectStorage = "s3"
 
 
-class TraceExporterType(str, Enum):
+class TraceExporterType(StrEnum):
     CONSOLE = "console"
     OTLP = "otlp"
     # JAEGER = "jaeger"
     # ZIPKIN = "zipkin"
 
 
-class TraceTransportProtocol(str, Enum):
+class TraceTransportProtocol(StrEnum):
     GRPC = "grpc"
     HTTP_PROTOBUF = "http/protobuf"
     # HTTP_JSON = "http/json"
 
 
-class BrokerDriver(str, Enum):
+class BrokerDriver(StrEnum):
     RabbitMQ = "rabbitmq"
     NATS = "nats"
 
@@ -137,7 +137,7 @@ class BrokerDriver(str, Enum):
                 return "RabbitMQMessageBus"
 
 
-class CacheDriver(str, Enum):
+class CacheDriver(StrEnum):
     Redis = "redis"
     NATS = "nats"
 
@@ -158,12 +158,12 @@ class CacheDriver(str, Enum):
                 return "RedisCache"
 
 
-class WorkflowDriver(str, Enum):
+class WorkflowDriver(StrEnum):
     LOCAL = "local"
     WORKER = "worker"
 
 
-class ExtraLogLevel(str, Enum):
+class ExtraLogLevel(StrEnum):
     CRITICAL = "CRITICAL"
     ERROR = "ERROR"
     WARNING = "WARNING"

--- a/backend/infrahub/constants/database.py
+++ b/backend/infrahub/constants/database.py
@@ -1,12 +1,12 @@
-from enum import Enum
+from enum import StrEnum
 
 
-class DatabaseType(str, Enum):
+class DatabaseType(StrEnum):
     NEO4J = "neo4j"
     MEMGRAPH = "memgraph"
 
 
-class Neo4jRuntime(str, Enum):
+class Neo4jRuntime(StrEnum):
     DEFAULT = "default"
     INTERPRETED = "interpreted"
     SLOTTED = "slotted"
@@ -15,13 +15,13 @@ class Neo4jRuntime(str, Enum):
     UNDEFINED = "undefined"
 
 
-class IndexType(str, Enum):
+class IndexType(StrEnum):
     TEXT = "text"
     RANGE = "range"
     LOOKUP = "lookup"
     NOT_APPLICABLE = "not_applicable"
 
 
-class EntityType(str, Enum):
+class EntityType(StrEnum):
     NODE = "node"
     RELATIONSHIP = "relationship"

--- a/backend/infrahub/core/diff/model/diff.py
+++ b/backend/infrahub/core/diff/model/diff.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from enum import Enum
+from enum import Enum, StrEnum
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -271,7 +271,7 @@ class SchemaConflict(ObjectConflict):
         return self.value
 
 
-class DiffElementType(str, Enum):
+class DiffElementType(StrEnum):
     ATTRIBUTE = "Attribute"
     RELATIONSHIP_ONE = "RelationshipOne"
     RELATIONSHIP_MANY = "RelationshipMany"

--- a/backend/infrahub/core/graph/constraints.py
+++ b/backend/infrahub/core/graph/constraints.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from enum import Enum
+from enum import StrEnum
 from typing import TYPE_CHECKING, ForwardRef, Optional, Union, get_origin
 
 from pydantic import BaseModel
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from infrahub.database import InfrahubDatabase
 
 
-class GraphPropertyType(str, Enum):
+class GraphPropertyType(StrEnum):
     BOOLEAN = "BOOLEAN"
     STRING = "STRING"
     INTEGER = "INTEGER"

--- a/backend/infrahub/core/manager.py
+++ b/backend/infrahub/core/manager.py
@@ -59,7 +59,7 @@ def identify_node_class(node: NodeToProcess) -> type[Node]:
     return Node
 
 
-def get_schema(
+def get_schema[SchemaProtocol](
     db: InfrahubDatabase,
     branch: Branch,
     node_schema: type[SchemaProtocol] | MainSchemaTypes | str,

--- a/backend/infrahub/core/node/node_property_attribute.py
+++ b/backend/infrahub/core/node/node_property_attribute.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from infrahub_sdk.template import Jinja2Template
 
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
-class NodePropertyAttribute(Generic[T]):
+class NodePropertyAttribute[T]:
     """A node property attribute is a construct that seats between a property and an attribute.
 
     View it as a property, set at the node level but stored in the database as an attribute. It usually is something computed from other components of

--- a/backend/infrahub/core/schema/__init__.py
+++ b/backend/infrahub/core/schema/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from typing import Any, TypeAlias
+from typing import Any
 
 from infrahub_sdk.utils import deep_merge_dict
 from pydantic import BaseModel, ConfigDict, Field
@@ -21,8 +21,8 @@ from .profile_schema import ProfileSchema
 from .relationship_schema import RelationshipSchema
 from .template_schema import TemplateSchema
 
-NonGenericSchemaTypes: TypeAlias = NodeSchema | ProfileSchema | TemplateSchema
-MainSchemaTypes: TypeAlias = NonGenericSchemaTypes | GenericSchema
+NonGenericSchemaTypes = NodeSchema | ProfileSchema | TemplateSchema
+MainSchemaTypes = NonGenericSchemaTypes | GenericSchema
 
 
 # -----------------------------------------------------

--- a/backend/infrahub/core/validators/enum.py
+++ b/backend/infrahub/core/validators/enum.py
@@ -1,7 +1,7 @@
-from enum import Enum
+from enum import StrEnum
 
 
-class ConstraintIdentifier(str, Enum):
+class ConstraintIdentifier(StrEnum):
     ATTRIBUTE_PARAMETERS_REGEX_UPDATE = "attribute.parameters.regex.update"
     ATTRIBUTE_PARAMETERS_MIN_LENGTH_UPDATE = "attribute.parameters.min_length.update"
     ATTRIBUTE_PARAMETERS_MAX_LENGTH_UPDATE = "attribute.parameters.max_length.update"

--- a/backend/infrahub/dependencies/interface.py
+++ b/backend/infrahub/dependencies/interface.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Generic, TypeVar
+from typing import TypeVar
 
 from infrahub.core.branch import Branch
 from infrahub.database import InfrahubDatabase
@@ -14,7 +14,7 @@ class DependencyBuilderContext:
     branch: Branch
 
 
-class DependencyBuilder(ABC, Generic[T]):
+class DependencyBuilder[T](ABC):
     @classmethod
     @abstractmethod
     def build(cls, context: DependencyBuilderContext) -> T: ...

--- a/backend/infrahub/events/constants.py
+++ b/backend/infrahub/events/constants.py
@@ -1,8 +1,8 @@
-from enum import Enum
+from enum import StrEnum
 
 EVENT_NAMESPACE = "infrahub"
 
 
-class EventSortOrder(str, Enum):
+class EventSortOrder(StrEnum):
     ASC = "asc"
     DESC = "desc"

--- a/backend/infrahub/graphql/analyzer.py
+++ b/backend/infrahub/graphql/analyzer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import deque
 from copy import deepcopy
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
@@ -49,13 +49,13 @@ if TYPE_CHECKING:
     from infrahub.core.schema.schema_branch import SchemaBranch
 
 
-class MutateAction(str, Enum):
+class MutateAction(StrEnum):
     CREATE = "create"
     DELETE = "delete"
     UPDATE = "update"
 
 
-class ContextType(str, Enum):
+class ContextType(StrEnum):
     EDGE = "edge"
     NODE = "node"
     DIRECT = "direct"
@@ -80,7 +80,7 @@ class ContextType(str, Enum):
                 return cls.NODE
 
 
-class GraphQLOperation(str, Enum):
+class GraphQLOperation(StrEnum):
     QUERY = "query"
     MUTATION = "mutation"
     SUBSCRIPTION = "subscription"

--- a/backend/infrahub/graphql/mutations/relationship.py
+++ b/backend/infrahub/graphql/mutations/relationship.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from enum import Enum
+from enum import StrEnum
 from typing import TYPE_CHECKING, Self
 
 from graphene import Boolean, InputField, InputObjectType, List, Mutation, String
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
 RELATIONSHIP_PEERS_TO_IGNORE = [InfrahubKind.NODE]
 
 
-class GroupUpdateType(str, Enum):
+class GroupUpdateType(StrEnum):
     NONE = "none"
     MEMBERS = "members"
     MEMBER_OF_GROUPS = "member_of_groups"

--- a/backend/infrahub/patch/constants.py
+++ b/backend/infrahub/patch/constants.py
@@ -1,7 +1,7 @@
-from enum import Enum
+from enum import StrEnum
 
 
-class PatchPlanFilename(str, Enum):
+class PatchPlanFilename(StrEnum):
     VERTICES_TO_ADD = "vertices_to_add.json"
     VERTICES_TO_UPDATE = "vertices_to_update.json"
     VERTICES_TO_DELETE = "vertices_to_delete.json"

--- a/backend/infrahub/telemetry/constants.py
+++ b/backend/infrahub/telemetry/constants.py
@@ -1,9 +1,9 @@
-from enum import Enum
+from enum import StrEnum
 
 TELEMETRY_KIND: str = "community"
 TELEMETRY_VERSION: str = "20250318"
 
 
-class InfrahubType(str, Enum):
+class InfrahubType(StrEnum):
     COMMUNITY = "community"
     ENTERPRISE = "enterprise"

--- a/backend/infrahub/trigger/models.py
+++ b/backend/infrahub/trigger/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from enum import Enum
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
 from prefect.events.actions import RunDeployment
@@ -30,7 +30,7 @@ class TriggerSetupReport(BaseModel):
         return len(self.created + self.updated + self.unchanged)
 
 
-class TriggerType(str, Enum):
+class TriggerType(StrEnum):
     ACTION_TRIGGER_RULE = "action_trigger_rule"
     BUILTIN = "builtin"
     WEBHOOK = "webhook"

--- a/backend/infrahub/utils.py
+++ b/backend/infrahub/utils.py
@@ -76,7 +76,7 @@ def get_nested_dict(nested_dict: dict[str, Any], keys: list[str]) -> dict[str, A
     return current_level if isinstance(current_level, dict) else {}
 
 
-def get_all_subclasses(cls: AnyClass) -> list[AnyClass]:
+def get_all_subclasses[AnyClass: type](cls: AnyClass) -> list[AnyClass]:
     """Recursively get all subclasses of the given class."""
     subclasses: list[AnyClass] = []
     for subclass in cls.__subclasses__():

--- a/backend/infrahub/validators/tasks.py
+++ b/backend/infrahub/validators/tasks.py
@@ -12,7 +12,7 @@ from .events import send_start_validator
 ValidatorType = TypeVar("ValidatorType", bound=CoreValidator)
 
 
-async def start_validator(
+async def start_validator[ValidatorType: CoreValidator](
     client: InfrahubClient,
     validator: CoreValidator | None,
     validator_type: type[ValidatorType],

--- a/models/infrastructure_edge.py
+++ b/models/infrastructure_edge.py
@@ -3,7 +3,7 @@ import logging
 import time
 import uuid
 from collections import defaultdict
-from enum import Enum
+from enum import StrEnum
 from ipaddress import IPv4Network, IPv6Network
 from typing import cast
 
@@ -444,7 +444,7 @@ PLATFORMS = (
 )
 
 
-class DevicePatternName(str, Enum):
+class DevicePatternName(StrEnum):
     LEAF = "LEAF"
     CORE = "CORE"
     EDGE = "EDGE"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -459,7 +459,7 @@ disable_error_code = [
 
 [tool.ruff]
 line-length = 120
-target-version = "py310"
+target-version = "py312"
 
 exclude = [
     ".git",
@@ -731,21 +731,22 @@ allow-dunder-method-names = [
     ##################################################################################################
     # Review and change the below later                                                              #
     ##################################################################################################
-    "ANN001",  # Missing type annotation for function argument
-    "ANN002",  # Missing type annotation for `*args`
-    "ANN003",  # Missing type annotation for `**kwargs`
-    "ANN201",  # Missing return type annotation for public function
-    "ANN202",  # Missing return type annotation for private function
-    "ANN401",  # Dynamically typed expressions (typing.Any) are disallowed
-    "PLR0915", # Too many statements
-    "PT003",   # `scope='function'` is implied in `@pytest.fixture()`
-    "PT007",   # Wrong values type in `pytest.mark.parametrize` expected `list` of `tuple`
-    "PT006",   # Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
-    "PT011",   # `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
-    "PT012",   # `pytest.raises()` block should contain a single simple statement
-    "PT013",   # Incorrect import of `pytest`; use `import pytest` instead
-    "PT018",   # Assertion should be broken down into multiple parts
-    "PT021",   # Use `yield` instead of `request.addfinalizer`
+    "ANN001",   # Missing type annotation for function argument
+    "ANN002",   # Missing type annotation for `*args`
+    "ANN003",   # Missing type annotation for `**kwargs`
+    "ANN201",   # Missing return type annotation for public function
+    "ANN202",   # Missing return type annotation for private function
+    "ANN401",   # Dynamically typed expressions (typing.Any) are disallowed
+    "ASYNC109", # Async function definition with a `timeout` parameter
+    "PLR0915",  # Too many statements
+    "PT003",    # `scope='function'` is implied in `@pytest.fixture()`
+    "PT007",    # Wrong values type in `pytest.mark.parametrize` expected `list` of `tuple`
+    "PT006",    # Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
+    "PT011",    # `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
+    "PT012",    # `pytest.raises()` block should contain a single simple statement
+    "PT013",    # Incorrect import of `pytest`; use `import pytest` instead
+    "PT018",    # Assertion should be broken down into multiple parts
+    "PT021",    # Use `yield` instead of `request.addfinalizer`
 ]
 
 "backend/tests/integration_docker/test_schema_migration.py" = [

--- a/python_testcontainers/infrahub_testcontainers/models.py
+++ b/python_testcontainers/infrahub_testcontainers/models.py
@@ -1,11 +1,11 @@
 from datetime import UTC, datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from pydantic import BaseModel, Field
 
 
-class ContextUnit(str, Enum):
+class ContextUnit(StrEnum):
     COUNT = "count"
     TIME = "msec"  # time in milliseconds
     MEMORY = "memory"  # memory in bytes

--- a/tasks/shared.py
+++ b/tasks/shared.py
@@ -4,7 +4,7 @@ import os
 import platform
 import re
 import sys
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -17,12 +17,12 @@ if TYPE_CHECKING:
     from ruamel.yaml.main import YAML
 
 
-class DatabaseType(str, Enum):
+class DatabaseType(StrEnum):
     NEO4J = "neo4j"
     MEMGRAPH = "memgraph"
 
 
-class Namespace(str, Enum):
+class Namespace(StrEnum):
     DEFAULT = "default"  # aka demo
     DEV = "dev"
     TEST = "test"


### PR DESCRIPTION
Mainly an update to pyproject.toml to have Ruff target Python 3.12 as we don't support Infrahub on earlier versions.

The other changes are to introduce new ruff violations due to this along with a number of automated changes to align with our current version of Python.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized codebase to use Python 3.12+ type system features and updated internal type annotations for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->