### PR TITLE
IFC-1819 Fix utilization percentage of IP prefixes

### DIFF
--- a/backend/infrahub/core/ipam/utilization.py
+++ b/backend/infrahub/core/ipam/utilization.py
@@ -152,4 +152,4 @@ class PrefixUtilizationGetter:
             grand_total_space += prefix_total_space
         if grand_total_space == 0:
             return 0.0
-        return (grand_total_used / grand_total_space) * 100
+        return min((grand_total_used / grand_total_space) * 100, 100)

--- a/changelog/7388.fixed.md
+++ b/changelog/7388.fixed.md
@@ -1,0 +1,1 @@
+Fixed prefix utilization showing as greater than 100% after setting the pool attribute to false


### PR DESCRIPTION
Fixes #7263

If all the IP addresses of a prefix used as a pool has been created, marking the prefix as "not a pool" could end up in showing a percentage of utilisation greater than 100%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected IP address utilization calculation so displayed percentages are capped at 100%, preventing misleading readings above 100%.
  * Ensures utilization displays in dashboards, reports, and alerts reflect realistic values after pool attribute changes.
  * Preserves behavior for zero-capacity cases—utilization remains shown as 0% when total available space is zero.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->