### PR TITLE
Add display_label and deprecate display_labels in schema view

### DIFF
--- a/frontend/app/src/entities/schema/ui/schema-viewer.tsx
+++ b/frontend/app/src/entities/schema/ui/schema-viewer.tsx
@@ -172,7 +172,8 @@ const Properties = ({ schema }: { schema: ModelSchema }) => {
         <PropertyRow title="Label" value={schema.label} />
         <PropertyRow title="Kind" value={schema.kind} />
         <PropertyRow title="Human Friendly ID" value={schema.human_friendly_id} />
-        <PropertyRow title="Display labels" value={schema.display_labels} />
+        <PropertyRow title="Display label" value={schema.display_label} />
+        <PropertyRow title="Display labels (deprecated)" value={schema.display_labels} />
         <PropertyRow title="Description" value={schema.description} />
       </div>
 

--- a/frontend/app/src/shared/api/rest/types.generated.ts
+++ b/frontend/app/src/shared/api/rest/types.generated.ts
@@ -519,8 +519,13 @@ export interface components {
              */
             human_friendly_id?: string[] | null;
             /**
+             * Display Label
+             * @description Attribute or Jinja2 template to use to generate the display label
+             */
+            display_label?: string | null;
+            /**
              * Display Labels
-             * @description List of attributes to use to generate the display label
+             * @description List of attributes to use to generate the display label (deprecated)
              */
             display_labels?: string[] | null;
             /**
@@ -639,8 +644,13 @@ export interface components {
              */
             human_friendly_id?: string[] | null;
             /**
+             * Display Label
+             * @description Attribute or Jinja2 template to use to generate the display label
+             */
+            display_label?: string | null;
+            /**
              * Display Labels
-             * @description List of attributes to use to generate the display label
+             * @description List of attributes to use to generate the display label (deprecated)
              */
             display_labels?: string[] | null;
             /**
@@ -768,8 +778,13 @@ export interface components {
              */
             human_friendly_id?: string[] | null;
             /**
+             * Display Label
+             * @description Attribute or Jinja2 template to use to generate the display label
+             */
+            display_label?: string | null;
+            /**
              * Display Labels
-             * @description List of attributes to use to generate the display label
+             * @description List of attributes to use to generate the display label (deprecated)
              */
             display_labels?: string[] | null;
             /**
@@ -870,8 +885,13 @@ export interface components {
              */
             human_friendly_id?: string[] | null;
             /**
+             * Display Label
+             * @description Attribute or Jinja2 template to use to generate the display label
+             */
+            display_label?: string | null;
+            /**
              * Display Labels
-             * @description List of attributes to use to generate the display label
+             * @description List of attributes to use to generate the display label (deprecated)
              */
             display_labels?: string[] | null;
             /**
@@ -1368,8 +1388,13 @@ export interface components {
              */
             human_friendly_id?: string[] | null;
             /**
+             * Display Label
+             * @description Attribute or Jinja2 template to use to generate the display label
+             */
+            display_label?: string | null;
+            /**
              * Display Labels
-             * @description List of attributes to use to generate the display label
+             * @description List of attributes to use to generate the display label (deprecated)
              */
             display_labels?: string[] | null;
             /**
@@ -1711,8 +1736,13 @@ export interface components {
              */
             human_friendly_id?: string[] | null;
             /**
+             * Display Label
+             * @description Attribute or Jinja2 template to use to generate the display label
+             */
+            display_label?: string | null;
+            /**
              * Display Labels
-             * @description List of attributes to use to generate the display label
+             * @description List of attributes to use to generate the display label (deprecated)
              */
             display_labels?: string[] | null;
             /**
@@ -1865,9 +1895,7 @@ export interface components {
         /** QueryPayload */
         QueryPayload: {
             /** Variables */
-            variables?: {
-                [key: string]: string;
-            };
+            variables?: Record<string, never>;
         };
         /**
          * RelationshipCardinality


### PR DESCRIPTION
Also regenerates REST API bindings for the frontend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Schema viewer now shows a dedicated “Display label” field for clearer identification.
  * Legacy “Display labels” remains visible as “Display labels (deprecated)” to maintain backward compatibility.

* **Documentation**
  * The UI explicitly marks “Display labels” as deprecated, guiding users toward the new “Display label” field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->