### PR TITLE
Mark display_labels as deprecated in the YAML language server

### DIFF
--- a/backend/infrahub/core/schema/basenode_schema.py
+++ b/backend/infrahub/core/schema/basenode_schema.py
@@ -9,7 +9,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Literal, overload
 
 from infrahub_sdk.utils import compare_lists, intersection
-from pydantic import field_validator
+from pydantic import ConfigDict, field_validator
 
 from infrahub.core.constants import HashableModelState, RelationshipCardinality, RelationshipKind
 from infrahub.core.models import HashableModel, HashableModelDiff
@@ -19,6 +19,7 @@ from .generated.base_node_schema import GeneratedBaseNodeSchema
 from .relationship_schema import RelationshipSchema
 
 if TYPE_CHECKING:
+    from pydantic.config import JsonDict
     from typing_extensions import Self
 
     from infrahub.core.schema import GenericSchema, NodeSchema
@@ -40,9 +41,37 @@ OPTIONAL_TEXT_FIELDS = [
 ]
 
 
+def _json_schema_extra(schema: JsonDict) -> None:
+    """
+    Mutate the generated JSON Schema in place to:
+      - allow `null` for `display_labels`
+      - mark the non-null branch as deprecated
+    """
+    props = schema.get("properties")
+    if not isinstance(props, dict):
+        return
+    dl = props.get("display_labels")
+    if not isinstance(dl, dict):
+        return
+
+    if "anyOf" in dl:
+        dl["anyOf"] = [
+            {
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "deprecationMessage": "display_labels are deprecated use display_label instead",
+                },
+            },
+            {"type": "null"},
+        ]
+
+
 class BaseNodeSchema(GeneratedBaseNodeSchema):
     _exclude_from_hash: list[str] = ["attributes", "relationships"]
     _sort_by: list[str] = ["namespace", "name"]
+
+    model_config = ConfigDict(extra="forbid", json_schema_extra=_json_schema_extra)
 
     @property
     def is_schema_node(self) -> bool:


### PR DESCRIPTION
This PR adds some custom code to mark display_labels as deprecated within the YAML language server. A deprecation warning will show up when you have a display_labels entry and set it to another value than `null`.

A cleaner way to do this would be to update the pydantic fields within the models directly, however this causes a lot of internal problems due to how the deprecation is treated by pydantic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API/schema now allows display_labels to be null, improving compatibility with records that lack labels.
  * The schema marks the non-null display_labels variant as deprecated, providing a clear migration path for clients.

* **Refactor**
  * Tightened input validation: unexpected/unknown fields are now rejected to ensure stricter data integrity across requests and responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->