### PR TITLE
fix(workers): use cached tls context for sdk client

### DIFF
--- a/backend/infrahub/workers/dependencies.py
+++ b/backend/infrahub/workers/dependencies.py
@@ -35,7 +35,9 @@ def get_component_type() -> ComponentType:
 
 
 def build_client() -> InfrahubClient:
-    client = InfrahubClient(config=Config(address=config.SETTINGS.main.internal_address, retry_on_failure=True))
+    client_config = Config(address=config.SETTINGS.main.internal_address, retry_on_failure=True)
+    client_config.set_ssl_context(context=get_http().verify_tls())
+    client = InfrahubClient(config=client_config)
     # Populate client schema cache using our internal schema cache
     if registry.schema:
         for branch in registry.schema.get_branches():


### PR DESCRIPTION
Same as https://github.com/opsmill/infrahub/pull/7327 but in a separate PR as it depends on a SDK update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced SSL/TLS verification for client connections to ensure secure encrypted communication with backend services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->