### PR TITLE
Always display help button in object details view

### DIFF
--- a/frontend/app/src/entities/nodes/object-header.tsx
+++ b/frontend/app/src/entities/nodes/object-header.tsx
@@ -94,14 +94,11 @@ const ObjectDetailsHeader = ({ schema, objectId }: ObjectHeaderProps & { objectI
         await queryClient.invalidateQueries({ queryKey: objectQueryKeys.all });
       }}
       end={
-        objectDetailsData?.hfid &&
-        objectId && (
-          <ObjectHelpButton
-            kind={schema.kind}
-            documentationUrl={schema.documentation}
-            className="ml-auto"
-          />
-        )
+        <ObjectHelpButton
+          kind={schema.kind}
+          documentationUrl={schema.documentation}
+          className="ml-auto"
+        />
       }
       data-testid="object-header"
     />

--- a/frontend/app/src/shared/components/menu/object-help-button.tsx
+++ b/frontend/app/src/shared/components/menu/object-help-button.tsx
@@ -30,7 +30,7 @@ export const ObjectHelpButton = ({ documentationUrl, kind, ...props }: ObjectHel
     <MenuTrigger>
       <Pressable>
         <Button variant="outline" size="icon" {...props}>
-          ?qqqq
+          ?
         </Button>
       </Pressable>
 

--- a/frontend/app/src/shared/components/menu/object-help-button.tsx
+++ b/frontend/app/src/shared/components/menu/object-help-button.tsx
@@ -30,7 +30,7 @@ export const ObjectHelpButton = ({ documentationUrl, kind, ...props }: ObjectHel
     <MenuTrigger>
       <Pressable>
         <Button variant="outline" size="icon" {...props}>
-          ?
+          ?qqqq
         </Button>
       </Pressable>
 


### PR DESCRIPTION

<img width="1465" height="901" alt="image" src="https://github.com/user-attachments/assets/7db5218b-8667-46e2-b0cb-7759fd030855" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Help button is now always displayed in the object details header, providing consistent access from the header actions across all objects and states.
  * Previously, the button could be hidden in some cases; it now appears across all objects and views within the object details page.
  * No other header behavior or layout is changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->