### PR TITLE
fix(ci): make dependabot target stable

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
-    target-branch: develop
+    target-branch: stable
     labels:
       - "type/housekeeping"
       - "ci/skip-changelog"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update configuration: Dependabot PRs for GitHub Actions will now target the stable branch. No impact on product functionality or UI. Routine maintenance to align update flow with release branch strategy. Improves predictability of CI updates and reduces noise on development branch. No action required for end-users today.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->