### PR TITLE
Always display help button in object convert screen

### DIFF
--- a/frontend/app/src/entities/nodes/object-header.tsx
+++ b/frontend/app/src/entities/nodes/object-header.tsx
@@ -144,14 +144,11 @@ const ObjectConvertHeader = ({ schema, objectId }: ObjectHeaderProps & { objectI
           : `Convert type ${objectDetailsData?.__typename && schemaKindLabel[objectDetailsData?.__typename]}`
       }
       end={
-        objectDetailsData?.hfid &&
-        objectId && (
-          <ObjectHelpButton
-            kind={schema.kind}
-            documentationUrl={schema.documentation}
-            className="ml-auto"
-          />
-        )
+        <ObjectHelpButton
+          kind={schema.kind}
+          documentationUrl={schema.documentation}
+          className="ml-auto"
+        />
       }
       data-testid="object-header"
     />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Ensured the help button is now always available in the object header, regardless of data availability conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->