### PR TITLE
Warn if the database graph version is incorrect

### DIFF
--- a/backend/infrahub/database/graph.py
+++ b/backend/infrahub/database/graph.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from infrahub.core.graph import GRAPH_VERSION
+from infrahub.core.initialization import get_root_node
+from infrahub.log import get_logger
+
+if TYPE_CHECKING:
+    from infrahub.database import InfrahubDatabase
+
+
+log = get_logger()
+
+
+async def validate_graph_version(db: InfrahubDatabase) -> None:
+    root = await get_root_node(db=db)
+    if root.graph_version != GRAPH_VERSION:
+        log.warning(
+            f"Expected database graph version {GRAPH_VERSION} but got {root.graph_version}, possibly 'infrahub upgrade' has not been executed"
+        )

--- a/backend/infrahub/server.py
+++ b/backend/infrahub/server.py
@@ -24,6 +24,7 @@ from infrahub.api.exception_handlers import generic_api_exception_handler
 from infrahub.components import ComponentType
 from infrahub.constants.environment import INSTALLATION_TYPE
 from infrahub.core.initialization import initialization
+from infrahub.database.graph import validate_graph_version
 from infrahub.dependencies.registry import build_component_registry
 from infrahub.exceptions import Error, ValidationError
 from infrahub.graphql.api.endpoints import router as graphql_router
@@ -84,6 +85,9 @@ async def app_initialization(application: FastAPI, enable_scheduler: bool = True
     # We must initialize DB after initialize lock and initialize lock depends on cache initialization
     async with application.state.db.start_session() as db:
         await initialization(db=db, add_database_indexes=True)
+
+    async with database.start_session() as dbs:
+        await validate_graph_version(db=dbs)
 
     # Initialize the workflow after the registry has been setup
     await service.initialize_workflow()

--- a/backend/infrahub/workers/infrahub_async.py
+++ b/backend/infrahub/workers/infrahub_async.py
@@ -18,6 +18,7 @@ from infrahub import config
 from infrahub.components import ComponentType
 from infrahub.core import registry
 from infrahub.core.initialization import initialization
+from infrahub.database.graph import validate_graph_version
 from infrahub.dependencies.registry import build_component_registry
 from infrahub.git import initialize_repositories_directory
 from infrahub.lock import initialize_lock
@@ -128,6 +129,9 @@ class InfrahubWorkerAsync(BaseWorker):
                 await initialization(db=db)
 
             await self.service.component.refresh_schema_hash()
+
+        async with self.service.database.start_session() as dbs:
+            await validate_graph_version(db=dbs)
 
         initialize_repositories_directory()
         build_component_registry()


### PR DESCRIPTION
This PR adds a warning to Infrahub as well as our Prefect worker so that a warning message gets logged if the database Graph version differs from the expected Graph version. This can happen if someone is using a later version of infrahub but haven't executed `infrahub upgrade`.

The logged message looks like this:

```python
2025-10-16T14:52:30.919309Z [warning  ] Expected database graph version 42 but got 39, possibly 'infrahub upgrade' has not been executed [infrahub]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic validation of database schema version at startup to detect incomplete upgrades and provide diagnostic warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->