### PR TITLE
fix(devcontainer): use bookworm image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12
+FROM python:3.12-bookworm
 
 RUN apt-get remove -yq docker.io docker-doc docker-compose podman-docker containerd runc 2>&1 || true
 


### PR DESCRIPTION
Trixie does not support docker in docker yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated the development container's Python base image to include the Debian Bookworm release specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->