### PR TITLE
Check out repo with submodules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -570,7 +570,9 @@ jobs:
       group: huge-runners
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: "actions/checkout@v5"
+        with:
+          submodules: true
       - name: Set up Python
         id: python
         uses: actions/setup-python@v6


### PR DESCRIPTION
Ensure that GraphQL job is checked out with submodules. This check has been flaky with the error below and this is probably the reason:

```python
  File "/var/lib/github/ghrunner_3/_tool/Python/3.12.3/x64/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/var/lib/github/ghrunner_3/infrahub/infrahub/tasks/schema.py", line 91, in generate_graphql_schema
    from infrahub.core.initialization import initialization
  File "/var/lib/github/ghrunner_3/infrahub/infrahub/backend/infrahub/core/initialization.py", line 37, in <module>
    from infrahub.graphql.manager import registry as graphql_registry
  File "/var/lib/github/ghrunner_3/infrahub/infrahub/backend/infrahub/graphql/manager.py", line 56, in <module>
    from .schema import InfrahubBaseMutation, InfrahubBaseQuery
  File "/var/lib/github/ghrunner_3/infrahub/infrahub/backend/infrahub/graphql/schema.py", line 19, in <module>
    from .mutations.convert_object_type import ConvertObjectType
  File "/var/lib/github/ghrunner_3/infrahub/infrahub/backend/infrahub/graphql/mutations/convert_object_type.py", line 9, in <module>
    from infrahub.core.convert_object_type.object_conversion import ConversionFieldInput, convert_and_validate_object_type
  File "/var/lib/github/ghrunner_3/infrahub/infrahub/backend/infrahub/core/convert_object_type/object_conversion.py", line 3, in <module>
    from infrahub_sdk.convert_object_type import ConversionFieldInput, ConversionFieldValue
ModuleNotFoundError: No module named 'infrahub_sdk.convert_object_type'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to improve build infrastructure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->