### PR TITLE
Fix order for registering HFID

### DIFF
--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -557,6 +557,7 @@ class SchemaBranch:
         self.process_dropdowns()
         self.process_relationships()
         self.process_human_friendly_id()
+        self.register_human_friendly_id()
 
     def _generate_identifier_string(self, node_kind: str, peer_kind: str) -> str:
         return "__".join(sorted([node_kind, peer_kind])).lower()
@@ -892,7 +893,6 @@ class SchemaBranch:
         return False
 
     def validate_human_friendly_id(self) -> None:
-        self.hfids = HFIDs()
         for name in self.generic_names_without_templates + self.node_names:
             node_schema = self.get(name=name, duplicate=False)
 
@@ -925,11 +925,6 @@ class SchemaBranch:
                     if rel_identifier not in rel_schemas_to_paths:
                         rel_schemas_to_paths[rel_identifier] = (schema_path.related_schema, [])
                     rel_schemas_to_paths[rel_identifier][1].append(schema_path.attribute_path_as_str)
-
-                if node_schema.is_node_schema and node_schema.namespace not in ["Schema", "Internal"]:
-                    self.hfids.register_hfid_schema_path(
-                        kind=node_schema.kind, schema_path=schema_path, hfid=node_schema.human_friendly_id
-                    )
 
             if config.SETTINGS.main.schema_strict_mode:
                 # For every relationship referred within hfid, check whether the combination of attributes is unique is the peer schema node
@@ -1531,6 +1526,34 @@ class SchemaBranch:
                 else:
                     node.uniqueness_constraints = [hfid_uniqueness_constraint]
                 self.set(name=node.kind, schema=node)
+
+    def register_human_friendly_id(self) -> None:
+        """Register HFID automations
+
+        Register the HFIDs after all processing and validation has been done.
+        """
+
+        self.hfids = HFIDs()
+        for name in self.generic_names_without_templates + self.node_names:
+            node_schema = self.get(name=name, duplicate=False)
+
+            if not node_schema.human_friendly_id:
+                continue
+
+            allowed_types = SchemaElementPathType.ATTR_WITH_PROP | SchemaElementPathType.REL_ONE_MANDATORY_ATTR
+
+            for hfid_path in node_schema.human_friendly_id:
+                schema_path = self.validate_schema_path(
+                    node_schema=node_schema,
+                    path=hfid_path,
+                    allowed_path_types=allowed_types,
+                    element_name="human_friendly_id",
+                )
+
+                if node_schema.is_node_schema and node_schema.namespace not in ["Schema", "Internal"]:
+                    self.hfids.register_hfid_schema_path(
+                        kind=node_schema.kind, schema_path=schema_path, hfid=node_schema.human_friendly_id
+                    )
 
     def process_hierarchy(self) -> None:
         for name in self.nodes.keys():

--- a/backend/infrahub/display_labels/tasks.py
+++ b/backend/infrahub/display_labels/tasks.py
@@ -152,7 +152,7 @@ async def display_labels_setup_jinja2(
 
 @flow(
     name="trigger-update-display-labels",
-    flow_run_name="Trigger updates for display labels for kind",
+    flow_run_name="Trigger updates for display labels for {kind}",
 )
 async def trigger_update_display_labels(
     branch_name: str,

--- a/backend/infrahub/hfid/tasks.py
+++ b/backend/infrahub/hfid/tasks.py
@@ -151,7 +151,7 @@ async def hfid_setup(context: InfrahubContext, branch_name: str | None = None, e
 
 @flow(
     name="trigger-update-hfid",
-    flow_run_name="Trigger updates for display labels for kind",
+    flow_run_name="Trigger updates for HFID for {kind}",
 )
 async def trigger_update_hfid(
     branch_name: str,


### PR DESCRIPTION
This PR corrects an issue by moving the registration for HFID automations to a new register method, the reason is that we had examples where the HFID was modified after the previous validation step. This caused a problem for scenarios where some HFIDs weren't processed and correctly registered.

I've also modified some docstrings and help for the prefect task to correct some typos and ensure that we use a variable for "{ kind }" instead of typing the word "kind" which is a lot less useful in the logs.