### PR TITLE
better error message for schema cache miss

### DIFF
--- a/backend/infrahub/core/schema/schema_branch.py
+++ b/backend/infrahub/core/schema/schema_branch.py
@@ -328,14 +328,23 @@ class SchemaBranch:
         elif name in self.templates:
             key = self.templates[name]
 
-        if key and duplicate:
-            return self._cache[key].duplicate()
-        if key and not duplicate:
-            return self._cache[key]
+        if not key:
+            raise SchemaNotFoundError(
+                branch_name=self.name, identifier=name, message=f"Unable to find the schema {name!r} in the registry"
+            )
 
-        raise SchemaNotFoundError(
-            branch_name=self.name, identifier=name, message=f"Unable to find the schema {name!r} in the registry"
-        )
+        schema: MainSchemaTypes | None = None
+        try:
+            schema = self._cache[key]
+        except KeyError:
+            pass
+
+        if not schema:
+            raise ValueError(f"Schema {name!r} on branch {self.name} has incorrect hash: {key!r}")
+
+        if duplicate:
+            return schema.duplicate()
+        return schema
 
     def get_node(self, name: str, duplicate: bool = True) -> NodeSchema:
         """Access a specific NodeSchema, defined by its kind."""


### PR DESCRIPTION
we've seen this failure in some tests and a better error message might give us some more information for troubleshooting it

I've kept it a `ValueError` so that it won't surface to the end user, but that can be changed