### PR TITLE
IFC-1361: Merge core read only repositories on branch merge

### DIFF
--- a/backend/infrahub/core/merge.py
+++ b/backend/infrahub/core/merge.py
@@ -6,7 +6,7 @@ from infrahub.core.constants import RepositoryInternalStatus
 from infrahub.core.diff.model.path import BranchTrackingId
 from infrahub.core.manager import NodeManager
 from infrahub.core.models import SchemaUpdateValidationResult
-from infrahub.core.protocols import CoreRepository
+from infrahub.core.protocols import CoreReadOnlyRepository, CoreRepository
 from infrahub.core.registry import registry
 from infrahub.core.timestamp import Timestamp
 from infrahub.exceptions import MergeFailedError, ValidationError
@@ -223,6 +223,29 @@ class BranchMerger:
         await self.diff_merger.rollback(at=self._merge_at)
 
     async def merge_repositories(self) -> None:
+        await self.merge_core_read_only_repositories()
+        await self.merge_core_repositories()
+
+    async def merge_core_read_only_repositories(self) -> None:
+        repos_in_main_list = await NodeManager.query(schema=CoreReadOnlyRepository, db=self.db)
+        repos_in_main = {repo.id: repo for repo in repos_in_main_list}
+
+        repos_in_branch_list = await NodeManager.query(
+            schema=CoreReadOnlyRepository, db=self.db, branch=self.source_branch
+        )
+        for repo in repos_in_branch_list:
+            if repo.id not in repos_in_main:
+                continue
+
+            model = GitRepositoryMerge(
+                repository_id=repo.id,
+                repository_name=repo.name.value,
+                source_branch=self.source_branch.name,
+                destination_branch=self.destination_branch.name,
+            )
+            await self.workflow.submit_workflow(workflow=GIT_REPOSITORIES_MERGE, parameters={"model": model})
+
+    async def merge_core_repositories(self) -> None:
         # Collect all Repositories in Main because we'll need the commit in Main for each one.
         repos_in_main_list = await NodeManager.query(schema=CoreRepository, db=self.db)
         repos_in_main = {repo.id: repo for repo in repos_in_main_list}

--- a/backend/infrahub/core/merge.py
+++ b/backend/infrahub/core/merge.py
@@ -242,6 +242,7 @@ class BranchMerger:
                 repository_name=repo.name.value,
                 source_branch=self.source_branch.name,
                 destination_branch=self.destination_branch.name,
+                destination_branch_id=str(self.destination_branch.get_uuid()),
             )
             await self.workflow.submit_workflow(workflow=GIT_REPOSITORIES_MERGE, parameters={"model": model})
 

--- a/backend/infrahub/git/models.py
+++ b/backend/infrahub/git/models.py
@@ -88,11 +88,11 @@ class GitRepositoryMerge(BaseModel):
 
     repository_id: str = Field(..., description="The unique ID of the Repository")
     repository_name: str = Field(..., description="The name of the repository")
-    internal_status: str = Field(..., description="Administrative status of the repository")
+    internal_status: str | None = Field(default=None, description="Administrative status of the repository")
     source_branch: str = Field(..., description="The source branch")
     destination_branch: str = Field(..., description="The destination branch")
-    destination_branch_id: str = Field(..., description="The ID of the destination branch")
-    default_branch: str = Field(..., description="The default branch in Git")
+    destination_branch_id: str | None = Field(default=None, description="The ID of the destination branch")
+    default_branch: str | None = Field(default=None, description="The default branch in Git")
 
 
 class GitRepositoryImportObjects(BaseModel):

--- a/backend/infrahub/git/models.py
+++ b/backend/infrahub/git/models.py
@@ -91,7 +91,7 @@ class GitRepositoryMerge(BaseModel):
     internal_status: str | None = Field(default=None, description="Administrative status of the repository")
     source_branch: str = Field(..., description="The source branch")
     destination_branch: str = Field(..., description="The destination branch")
-    destination_branch_id: str | None = Field(default=None, description="The ID of the destination branch")
+    destination_branch_id: str = Field(..., description="The ID of the destination branch")
     default_branch: str | None = Field(default=None, description="The default branch in Git")
 
 

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -452,6 +452,7 @@ async def pull_read_only(model: GitRepositoryPullReadOnly) -> None:
     flow_run_name="Merge {model.source_branch} > {model.destination_branch} in git repository",
 )
 async def merge_git_repository(model: GitRepositoryMerge) -> None:
+    log = get_run_logger()
     await add_tags(branches=[model.source_branch, model.destination_branch], nodes=[model.repository_id])
 
     client = get_client()
@@ -461,6 +462,7 @@ async def merge_git_repository(model: GitRepositoryMerge) -> None:
     )
 
     if model.internal_status == RepositoryInternalStatus.STAGING.value:
+        log.info(f"Merging {InfrahubKind.GENERICREPOSITORY}")
         repo_source = await client.get(
             kind=InfrahubKind.GENERICREPOSITORY, id=model.repository_id, branch=model.source_branch
         )
@@ -472,6 +474,26 @@ async def merge_git_repository(model: GitRepositoryMerge) -> None:
         repo_main.commit.value = commit
 
         await repo_main.save()
+        log.info(f"Finished merging {InfrahubKind.GENERICREPOSITORY}")
+
+    elif not model.default_branch:
+        log.info(f"Merging {InfrahubKind.READONLYREPOSITORY}")
+        repo_source = await client.get(
+            kind=InfrahubKind.READONLYREPOSITORY, id=model.repository_id, branch=model.source_branch
+        )
+        repo_destination = await client.get(
+            kind=InfrahubKind.READONLYREPOSITORY, id=model.repository_id, branch=model.destination_branch
+        )
+
+        if (
+            repo_destination.ref.value != repo_source.ref.value
+            or repo_destination.commit.value != repo_source.commit.value
+        ):
+            repo_destination.ref.value = repo_source.ref.value
+            repo_destination.commit.value = repo_source.commit.value
+            await repo_destination.save()
+            log.info(f"Finished merging {InfrahubKind.READONLYREPOSITORY}")
+
     else:
         async with lock.registry.get(name=model.repository_name, namespace="repository"):
             await repo.merge(source_branch=model.source_branch, dest_branch=model.destination_branch)

--- a/backend/infrahub/git/tasks.py
+++ b/backend/infrahub/git/tasks.py
@@ -477,7 +477,6 @@ async def merge_git_repository(model: GitRepositoryMerge) -> None:
         log.info(f"Finished merging {InfrahubKind.GENERICREPOSITORY}")
 
     elif not model.default_branch:
-        log.info(f"Merging {InfrahubKind.READONLYREPOSITORY}")
         repo_source = await client.get(
             kind=InfrahubKind.READONLYREPOSITORY, id=model.repository_id, branch=model.source_branch
         )
@@ -489,9 +488,12 @@ async def merge_git_repository(model: GitRepositoryMerge) -> None:
             repo_destination.ref.value != repo_source.ref.value
             or repo_destination.commit.value != repo_source.commit.value
         ):
+            log.info(f"Merging {InfrahubKind.READONLYREPOSITORY}")
+
             repo_destination.ref.value = repo_source.ref.value
             repo_destination.commit.value = repo_source.commit.value
             await repo_destination.save()
+
             log.info(f"Finished merging {InfrahubKind.READONLYREPOSITORY}")
 
     else:

--- a/backend/tests/unit/core/diff/test_coordinator_lock.py
+++ b/backend/tests/unit/core/diff/test_coordinator_lock.py
@@ -16,7 +16,7 @@ from infrahub.core.initialization import create_branch
 from infrahub.core.merge import BranchMerger
 from infrahub.core.node import Node
 from infrahub.core.schema import SchemaRoot
-from infrahub.core.schema.definitions.core.repository import core_repository
+from infrahub.core.schema.definitions.core.repository import core_read_only_repository, core_repository
 from infrahub.core.schema.node_schema import NodeSchema
 from infrahub.core.timestamp import Timestamp
 from infrahub.database import InfrahubDatabase, get_db
@@ -49,6 +49,15 @@ class TestDiffCoordinatorLocks:
         dummy_repository = NodeSchema(
             name=core_repository.name,
             namespace=core_repository.namespace,
+        )
+        schema = SchemaRoot(nodes=[dummy_repository])
+        registry.schema.register_schema(schema=schema, branch=default_branch.name)
+        default_branch.update_schema_hash()
+        await default_branch.save(db=db)
+
+        dummy_repository = NodeSchema(
+            name=core_read_only_repository.name,
+            namespace=core_read_only_repository.namespace,
         )
         schema = SchemaRoot(nodes=[dummy_repository])
         registry.schema.register_schema(schema=schema, branch=default_branch.name)

--- a/changelog/5978.added.md
+++ b/changelog/5978.added.md
@@ -1,0 +1,1 @@
+Merge core read only repositories on branch merge


### PR DESCRIPTION
Fixes https://github.com/opsmill/infrahub/issues/5978

This PR adds functionality for merging modified read only repositories from other branches into main branch. Existing implementation takes care of merging modified core repositories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Merge support for read-only repositories during branch merges.

* **Improvements**
  * Merge model fields made optional for greater flexibility.
  * Enhanced runtime logging and added handling to synchronize read-only repositories that lack a default branch.

* **Tests**
  * Unit tests updated to include read-only repository scenarios.

* **Chores**
  * Added changelog entry documenting the read-only repository merge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->