### PR TITLE
Avoid importing schema from demo edge

### DIFF
--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/.gitignore
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/.gitignore
@@ -1,0 +1,10 @@
+.vscode/*
+*.pyc
+*.tar.gz
+**/.DS_Store
+playbooks/documentation
+playbooks/intended
+
+# Direnv files (https://direnv.net/)
+.direnv/
+.envrc

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/.infrahub.yml
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/.infrahub.yml
@@ -1,4 +1,6 @@
 ---
+schemas:
+  - schemas/demo_edge_fabric.yml
 
 jinja2_transforms:
   - name: "device_startup"

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/checks/check_backbone_link_redundancy.gql
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/checks/check_backbone_link_redundancy.gql
@@ -1,0 +1,41 @@
+query check_backbone_link_redundancy {
+  InfraCircuit(role__value: "backbone") {
+    edges {
+      node {
+        id
+        circuit_id {
+          value
+        }
+        vendor_id {
+          value
+        }
+        status {
+          value
+        }
+        endpoints {
+          edges {
+            node {
+              site {
+                node {
+                  id
+                  name {
+                    value
+                  }
+                }
+              }
+              connected_endpoint {
+                node {
+                  ... on InfraInterface {
+                    enabled {
+                      value
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/checks/check_backbone_link_redundancy.py
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/checks/check_backbone_link_redundancy.py
@@ -1,0 +1,44 @@
+from collections import defaultdict
+
+from infrahub_sdk.checks import InfrahubCheck
+
+
+class InfrahubCheckBackboneLinkRedundancy(InfrahubCheck):
+    query = "check_backbone_link_redundancy"
+
+    def validate(self, data):
+        site_id_by_name = {}
+
+        backbone_links_per_site = defaultdict(lambda: defaultdict(int))
+
+        if data["InfraCircuit"]["edges"]:  # noqa: PLR1702
+            circuits = data["InfraCircuit"]["edges"]
+
+            for circuit in circuits:
+                circuit_node = circuit["node"]
+                circuit_status = circuit_node["status"]["value"]
+
+                if circuit_node["endpoints"]["edges"]:
+                    endpoints = circuit_node["endpoints"]["edges"]
+
+                    for endpoint in endpoints:
+                        endpoint_node = endpoint["node"]
+                        site_name = endpoint_node["site"]["node"]["name"]["value"]
+
+                        site_node = endpoint_node["site"]["node"]
+                        site_id_by_name[site_name] = site_node["id"]
+                        backbone_links_per_site[site_name]["total"] += 1
+
+                        if endpoint_node["connected_endpoint"]:
+                            connected_endpoint_node = endpoint_node["connected_endpoint"]["node"]
+                            if connected_endpoint_node:
+                                if connected_endpoint_node["enabled"]["value"] and circuit_status == "active":
+                                    backbone_links_per_site[site_name]["operational"] += 1
+
+            for site_name, site in backbone_links_per_site.items():
+                if site.get("operational", 0) / site["total"] < 0.6:
+                    self.log_error(
+                        message=f"{site_name} has less than 60% of backbone circuit operational ({site.get('operational', 0)}/{site['total']})",
+                        object_id=site_id_by_name[site_name],
+                        object_type="site",
+                    )

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/generators/backbone_service.gql
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/generators/backbone_service.gql
@@ -1,0 +1,33 @@
+query backbone_service($name: String!) {
+  InfraBackBoneService(name__value: $name) {
+    edges {
+      node {
+        id
+	name {
+	  value
+	}
+        circuit_id {
+          value
+        }
+        internal_circuit_id {
+          value
+        }
+        site_a {
+          node {
+            id
+          }
+        }
+        site_b {
+          node {
+            id
+          }
+        }
+        provider {
+          node {
+            id
+          }
+        }
+      }
+    }
+  }
+}

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/generators/backbone_service.py
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/generators/backbone_service.py
@@ -1,0 +1,138 @@
+import logging
+
+from infrahub_sdk.generator import InfrahubGenerator
+
+
+async def find_interface(client, site_id):
+    # Retrieve all 'edge' router from the site
+    devices = await client.filters(kind="InfraDevice", role__value="edge", site__ids=[site_id])
+
+    if len(devices) == 0:
+        raise ValueError("Couldn't find devices")
+
+    # Take the first one of the list
+    device = devices[0]
+
+    # Retrieve all L3 interfaces from this Device with 'backbone' role
+    interfaces = await client.filters(
+        kind="InfraInterfaceL3",
+        device__ids=[device.id],
+        role__value="backbone",
+        include=["connected_endpoint", "ip_addresses", "device"],
+        prefetch_relationships=True,
+        populate_store=True,
+    )
+
+    if len(interfaces) == 0:
+        raise ValueError("Couldn't find interfaces")
+
+    # Return the first one of the list
+    return interfaces[0]
+
+
+class Generator(InfrahubGenerator):
+    async def generate(self, data: dict) -> None:
+        log = logging.getLogger("infrahub.tasks")
+        service_id = data["InfraBackBoneService"]["edges"][0]["node"]["id"]
+        service_name = data["InfraBackBoneService"]["edges"][0]["node"]["name"]["value"]
+        circuit_id = data["InfraBackBoneService"]["edges"][0]["node"]["circuit_id"]["value"]
+        internal_circuit_id = data["InfraBackBoneService"]["edges"][0]["node"]["internal_circuit_id"]["value"]
+        site_a_id = data["InfraBackBoneService"]["edges"][0]["node"]["site_a"]["node"]["id"]
+        site_b_id = data["InfraBackBoneService"]["edges"][0]["node"]["site_b"]["node"]["id"]
+        provider_id = data["InfraBackBoneService"]["edges"][0]["node"]["provider"]["node"]["id"]
+
+        # Create Circuit
+        log.info("Create Circuit")
+        circuit = await self.client.create(
+            kind="InfraCircuit",
+            provider={"id": provider_id},
+            vendor_id=circuit_id,
+            circuit_id=internal_circuit_id,
+            status="active",
+            role="backbone",
+        )
+
+        await circuit.save(allow_upsert=True)
+
+        # Retrieve one interface per Site to be use for Circuit Endpoints
+        log.info("Retrieve one interface per Site to be use for Circuit Endpoints")
+        interface_a = await find_interface(self.client, site_a_id)
+        interface_b = await find_interface(self.client, site_b_id)
+
+        # Assign the 2 Interfaces as Circuit Endpoints
+        log.info("Assign the 2 Interfaces as Circuit Endpoints")
+        if not interface_a.connected_endpoint.initialized:
+            connected_endpoint_a = await self.client.create(
+                kind="InfraCircuitEndpoint", circuit=circuit, site=site_a_id, connected_endpoint=interface_a
+            )
+            await connected_endpoint_a.save(allow_upsert=True)
+        else:
+            await interface_a.connected_endpoint.fetch()
+
+            if (
+                not interface_a.connected_endpoint.typename == "InfraCircuitEndpoint"
+                or not interface_a.connected_endpoint.peer.circuit.id == circuit.id
+            ):
+                raise ValueError(
+                    f"{interface_a.name.value} on {interface_a.device.peer.name.value} is already connected!"
+                )
+
+        if not interface_b.connected_endpoint.initialized:
+            connected_endpoint_b = await self.client.create(
+                kind="InfraCircuitEndpoint", circuit=circuit, site=site_b_id, connected_endpoint=interface_b
+            )
+            await connected_endpoint_b.save(allow_upsert=True)
+        else:
+            await interface_b.connected_endpoint.fetch()
+
+            if (
+                not interface_b.connected_endpoint.typename == "InfraCircuitEndpoint"
+                or not interface_b.connected_endpoint.peer.circuit.id == circuit.id
+            ):
+                raise ValueError(
+                    f"{interface_b.name.value} on {interface_b.device.peer.name.value} is already connected!"
+                )
+
+        # Retrieve Pool for interconnection subnets
+        log.info("Retrieve Pool for interconnection subnets")
+        internal_networks_pool = await self.client.get(kind="CoreIPPrefixPool", name__value="Internal networks pool")
+
+        # Allocate the next free IP prefix for the service
+        log.info("Allocate the next free IP prefix for the service")
+        prefix = await self.client.allocate_next_ip_prefix(
+            resource_pool=internal_networks_pool,
+            prefix_length=31,
+            member_type="address",
+            data={"is_pool": True},
+            identifier=f"{service_name}-{service_id}",
+        )
+        await prefix.save(allow_upsert=True)
+
+        # Create a new Address Pool for this prefix
+        log.info("Create a new Address Pool for this prefix")
+        circuit_address_pool = await self.client.create(
+            kind="CoreIPAddressPool",
+            name=f"{service_name}-{service_id}",
+            default_address_type="IpamIPAddress",
+            default_prefix_size=31,
+            resources=[prefix],
+            is_pool=True,
+            ip_namespace={"id": "default"},
+        )
+        await circuit_address_pool.save(allow_upsert=True)
+
+        # Use the new pool to allocate 2 IPs on the interfaces
+        log.info("Use the new pool to allocate 2 IPs on the interfaces")
+        interface_a_ip = await self.client.allocate_next_ip_address(
+            resource_pool=circuit_address_pool,
+        )
+        interface_a.ip_addresses.add(interface_a_ip)
+        await interface_a.save(allow_upsert=True)
+
+        interface_b_ip = await self.client.allocate_next_ip_address(
+            resource_pool=circuit_address_pool,
+        )
+        interface_b.ip_addresses.add(interface_b_ip)
+        await interface_b.save(allow_upsert=True)
+
+        log.info("Execution finishes with success")

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/generators/circuit_endpoints.gql
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/generators/circuit_endpoints.gql
@@ -1,0 +1,22 @@
+query circuit_endpoints($circuit_id: String!) {
+  InfraCircuit(circuit_id__value: $circuit_id) {
+    edges {
+      node @expand {
+        __typename
+        id
+        provider {
+          node {
+            __typename
+            id
+            name {value}
+          }
+        }
+        circuit_id {value}
+        vendor_id {value}
+        endpoints {
+          count
+        }
+      }
+    }
+  }
+}

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/generators/circuit_endpoints.py
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/generators/circuit_endpoints.py
@@ -1,0 +1,37 @@
+from infrahub_sdk.generator import InfrahubGenerator
+
+#   In this Generator: We want to create 2 InfraCircuitEndpoints (A & Z)
+#   If the InfraCircuit doesn't have any CircuitEndpoints
+
+
+class Generator(InfrahubGenerator):
+    async def generate(self, data: dict) -> None:
+        # Extract the first node in the 'InfraCircuit' edges array
+        circuits = data["InfraCircuit"]["edges"]
+
+        for circuit in circuits:
+            # There is already endpoints, no need to add more :)
+            if circuit["node"]["endpoints"]["count"] != 0:
+                continue
+
+            # Set local variables to easier manipulation
+            id = circuit["node"]["id"]
+            provider = circuit["node"]["provider"]["node"]["name"]["value"]
+            circuit_id: str = circuit["node"]["circuit_id"]["value"]
+            vendor_id: str = circuit["node"]["vendor_id"]["value"]
+
+            # Manage description
+            description: str = f"{circuit_id} - ({provider.upper()}{' x ' + vendor_id.upper() if vendor_id else ''})"
+
+            for i in range(1, 3):
+                data = {
+                    "circuit": {"id": id},
+                    "description": {"value": description},
+                }
+                if i == 1:
+                    description += " - A Side"
+                elif i == 2:
+                    description += " - Z Side"
+
+                obj = await self.client.create(kind="InfraCircuitEndpoint", data=data)
+                await obj.save(allow_upsert=True)

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/generators/drained_circuit_bgp_sessions.gql
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/generators/drained_circuit_bgp_sessions.gql
@@ -1,0 +1,37 @@
+query drained_circuit_bgp_sessions($circuit_id: String!) {
+  InfraCircuit(circuit_id__value: $circuit_id) {
+    edges {
+      node @expand {
+        __typename
+        id
+        provider {
+          node {
+            __typename
+            id
+          }
+        }
+        status {
+          value
+        }
+        endpoints {
+          count
+          edges {
+            node {
+              __typename
+              id
+            }
+          }
+        }
+        bgp_sessions {
+          count
+          edges {
+            node {
+              __typename
+              id
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/generators/drained_circuit_bgp_sessions.py
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/generators/drained_circuit_bgp_sessions.py
@@ -1,0 +1,27 @@
+from infrahub_sdk.generator import InfrahubGenerator
+
+#   In this Generator: We want to drained the BGP Sessions linked to an InfraCircuit
+#   If the InfraCircuit Status is maintenance:
+#       - We are changing the status of the BGP Sessions to maintenance
+
+
+class Generator(InfrahubGenerator):
+    async def generate(self, data: dict) -> None:
+        # Extract the first node in the 'InfraInterfaceL3' edges array
+        circuits = data["InfraCircuit"]["edges"]
+
+        for circuit in circuits:
+            id = circuit["node"]["id"]  # noqa: F841
+            status: str = circuit["node"]["status"]["value"]
+
+            if status != "maintenance":
+                continue  # No need to change the status of the BGP Sessions
+
+            if circuit["node"]["bgp_sessions"]["count"] == 0:
+                continue  # There is no BGP Sessions associated with this circuit
+
+            bgp_sessions = circuit["node"]["bgp_sessions"]["edges"]
+            for bgp_session in bgp_sessions:
+                obj = await self.client.get(kind=bgp_session["node"]["__typename"], id=bgp_session["node"]["id"])
+                obj.status.value = "maintenance"
+                await obj.save(allow_upsert=True)

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/generators/upstream_interfaces.gql
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/generators/upstream_interfaces.gql
@@ -1,0 +1,41 @@
+query upstream_interfaces($id: ID!) {
+  InfraInterfaceL3(ids: [$id]) {
+    edges {
+      node @expand {
+        device {
+          node {
+            __typename
+            id
+            name {
+              value
+            }
+          }
+        }
+        status { value}
+        connected_endpoint {
+          node {
+            __typename
+            id
+            ... on InfraCircuitEndpoint {
+              __typename
+              circuit {
+                node {
+                  vendor_id {
+                    value
+                  }
+                  provider {
+                    node {
+                      __typename
+                      id
+                      name {value}
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/generators/upstream_interfaces.py
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/generators/upstream_interfaces.py
@@ -1,0 +1,39 @@
+from infrahub_sdk.generator import InfrahubGenerator
+
+#   In this Generator: We are forcing the InterfaceL3 description
+#   If there is a InfraCircuit Connected on it
+#   If the InterfaceL3 status is provisioning
+
+
+class Generator(InfrahubGenerator):
+    async def generate(self, data: dict) -> None:
+        # Extract the first node in the 'InfraInterfaceL3' edges array
+        upstream_interface = data["InfraInterfaceL3"]["edges"][0]["node"]
+
+        # Set local variables to easier manipulation
+        provider = None
+        vendor_id = None
+        role: str = upstream_interface["role"]["value"]
+        status: str = upstream_interface["status"]["value"]
+        speed: int = upstream_interface["speed"]["value"] / 1000
+
+        if status != "provisioning":
+            return  # We enforce it only on new interfaces to avoid "noise"
+
+        # Check and extract data from the connected endpoint
+        if "connected_endpoint" in upstream_interface and "node" in upstream_interface["connected_endpoint"]:
+            connected_endpoint = upstream_interface["connected_endpoint"]["node"]
+            if "circuit" in connected_endpoint and "node" in connected_endpoint["circuit"]:
+                circuit = connected_endpoint["circuit"]["node"]
+                if "provider" in circuit and "node" in circuit["provider"]:
+                    provider = circuit["provider"]["node"]["name"]["value"]
+                if "vendor_id" in circuit:
+                    vendor_id = circuit["vendor_id"]["value"]
+
+        # Update the object description if provider and vendor_id are available
+        if provider and vendor_id:
+            new_description = f"{role.upper()}: ({provider.upper()}x{vendor_id.upper()}) [{speed}Gbps]"
+            # Retrieve the object based on type and ID, then update its description
+            obj = await self.client.get(kind=upstream_interface["__typename"], id=upstream_interface["id"])
+            obj.description.value = new_description
+            await obj.save(allow_upsert=True)

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/playbooks/avd-config.yml
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/playbooks/avd-config.yml
@@ -1,0 +1,31 @@
+---
+- name: Query Interfaces information with the query_graphql module
+  hosts: platform_eos
+  gather_facts: false
+  vars:
+    ansible_connection: httpapi
+    ansible_network_os: eos
+    ansible_httpapi_use_ssl: true
+    ansible_httpapi_validate_certs: false
+    ansible_become: true
+    ansible_become_method: enable
+    ansible_user: admin
+    ansible_password: admin
+
+  tasks:
+    - name: Query Artifact
+      opsmill.infrahub.artifact_fetch:
+        artifact_name: "Config variables for Arista AVD"
+        target_id: "{{ id }}"
+        api_endpoint: "http://localhost:8000"
+        token: 06438eb2-8019-4776-878c-0941b1f1d1ec
+      register: artifact
+
+    - name: Set artifacts as facts
+      set_fact:
+        {"{{ item.key }}": "{{ item.value }}"}
+      loop: "{{ artifact.json | dict2items }}"
+
+    - name: Generate configs
+      import_role:
+        name: arista.avd.eos_cli_config_gen

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/playbooks/inventory.yml
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/playbooks/inventory.yml
@@ -1,0 +1,34 @@
+---
+plugin: opsmill.infrahub.inventory
+api_endpoint: "http://localhost:8000"
+token: 06438eb2-8019-4776-878c-0941b1f1d1ec
+validate_certs: false
+
+# strict: True
+
+branch: "main"
+
+nodes:
+  InfraDevice:
+    include:
+      - name
+      - platform.ansible_network_os
+      - primary_address.address
+      - site.name
+      - role
+      - asn.asn
+
+compose:
+  hostname: name
+  platform: platform.ansible_network_os
+  ansible_host: primary_address.address | ansible.utils.ipaddr('address')
+  site: site.name
+  asn: asn.asn
+
+keyed_groups:
+  - prefix: site
+    key: site
+  - prefix: role
+    key: role.name
+  - prefix: platform
+    key: platform

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/schemas/demo_edge_fabric.yml
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/schemas/demo_edge_fabric.yml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://schema.infrahub.app/develop/schema.schema.json
+---
+version: "1.0"
+
+nodes:
+  - name: EdgeFabric
+    namespace: Demo
+    description: "."
+    label: "EdgeFabric"
+    default_filter: name__value
+    display_labels:
+      - name__value
+    attributes:
+      - name: name
+        kind: Text
+        # unique: true
+      - name: description
+        kind: Text
+        optional: true
+      - name: nbr_racks
+        kind: Number
+    relationships:
+      - name: tags
+        peer: BuiltinTag
+        optional: true
+        cardinality: many
+        kind: Attribute

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/templates/device_startup_config.tpl.j2
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/templates/device_startup_config.tpl.j2
@@ -1,0 +1,113 @@
+{% set ns = namespace(loopback_intf_name=none, loopback_ip=none, management_intf_name=none, management_ip=none) %}
+{% for intf in data.InfraDevice.edges[0].node.interfaces.edges %}
+{%   if intf.node.role.value == "loopback" %}
+{%     set ns.loopback_intf_name = intf.node.name.value %}
+{%     set ns.loopback_ip = intf.node.ip_addresses.edges[0].node.address.value.split('/')[0] %}
+{%   elif intf.node.role.value == "management" %}
+{%     set ns.management_intf_name = intf.node.name.value %}
+{%     set ns.management_ip = intf.node.ip_addresses.edges[0].node.address.value.split('/')[0] %}
+{%   endif %}
+{% endfor %}
+no aaa root
+!
+username admin privilege 15 role network-admin secret sha512 $6$q4ez.aZgB/G/eeWW$ukvRobb5RtYmUlCcY0atxhwPmA6FPoRjR3AxYFJqNFoCRgJjrohKGrBsbY12n1uRZeCer1L8oejx5aPlrf.op0
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname {{ data.InfraDevice.edges[0].node.name.value }}
+!
+spanning-tree mode mstp
+!
+management api http-commands
+   no shutdown
+!
+management api gnmi
+   transport grpc default
+!
+management api netconf
+   transport ssh default
+!
+{% for intf in data.InfraDevice.edges[0].node.interfaces.edges %}
+{%   if intf.node.name.value != ns.management_intf_name and intf.node.name.value != ns.loopback_intf_name %}
+interface {{ intf.node.name.value }}
+{%   if intf.node["description"]["value"] %}
+   description {{ intf.node["description"]["value"] }}
+{%   else %}
+   description role: {{ intf.node.role.value }}
+{%   endif %}
+{%   if "mtu" in intf.node and intf.node["mtu"]["value"] %}
+   mtu {{ intf.node["mtu"]["value"] }}
+{%   endif %}
+{%   if not intf.node["enabled"]["value"] %}
+   shutdown
+{%   endif %}
+{%   if intf.node["ip_addresses"] %}
+{%     for ip in intf.node["ip_addresses"]["edges"] %}
+   ip address {{ ip.node["address"]["value"] }}
+   no switchport
+{%       if intf.node.role.value == "peer" or intf.node.role.value == "backbone" %}
+   ip ospf network point-to-point
+{%       endif %}
+{%     endfor %}
+{%   endif %}
+!
+{%   endif %}
+{% endfor %}
+!
+interface {{ ns.management_intf_name }}
+{% for intf in data.InfraDevice.edges[0]["interfaces"] %}
+{%   if intf.node.name.value == ns.management_intf_name %}
+{%     for ip in intf["ip_addresses"] %}
+   ip address {{ ip["address"]["value"] }}
+{%     endfor %}
+{%   endif %}
+{% endfor %}
+!
+interface {{ ns.loopback_intf_name }}
+{% for intf in data.InfraDevice.edges[0]["interfaces"] %}
+{%   if intf.node.name.value == ns.loopback_intf_name %}
+{%     for ip in intf["ip_addresses"] %}
+   ip address {{ ip["address"]["value"] }}
+{%     endfor %}
+{%   endif %}
+{% endfor %}
+!
+ip prefix-list BOGON-Prefixes seq 10 permit 172.16.0.0/12 le 24
+ip prefix-list BOGON-Prefixes seq 20 permit 192.168.0.0/16 le 24
+ip prefix-list BOGON-Prefixes seq 10 permit 172.16.0.0/12 le 24
+ip prefix-list BOGON-Prefixes seq 20 permit 192.168.0.0/16 le 24
+!
+ip routing
+!
+ip route 0.0.0.0/0 172.20.20.1
+!
+{% if data.InfraDevice.edges[0].node.asn %}
+router bgp {{ data.InfraDevice.edges[0].node.asn.node.asn.value }}
+   router-id {{ loopback_ip }}
+{%   for peer_group in data.InfraBGPPeerGroup.edges %}
+   neighbor {{ peer_group.node.name.value }} peer group
+{%     if peer_group.node.local_as %}
+   neighbor {{ peer_group.node.name.value }} local-as {{ peer_group.node.local_as.node.asn.value }}
+{%     endif %}
+{%     if peer_group.node.remote_as and peer_group.node.remote_as.node %}
+   neighbor {{ peer_group.node.name.value }} remote-as {{ peer_group.node.remote_as.node.asn.value }}
+{%     endif %}
+{%   endfor %}
+!
+{% endif %}
+!
+router ospf 1
+   router-id {{ loopback_ip }}
+   redistribute connected
+   max-lsa 12000
+   passive-interface Loopback0
+   network 0.0.0.0/0 area 0.0.0.0
+!
+route-map BOGONS permit 10
+ match ip address prefix-list BOGON-Prefixes
+!
+route-map BOGONS deny 20
+!
+end

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/templates/device_startup_info.gql
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/templates/device_startup_info.gql
@@ -1,0 +1,75 @@
+query device_startup_info ($device: String!) {
+  InfraDevice(name__value: $device) {
+    edges {
+      node {
+        id
+        name {
+          value
+        }
+        asn {
+          node {
+            asn {
+              value
+            }
+          }
+        }
+        interfaces {
+          edges {
+            node {
+              id
+              name {
+                value
+              }
+              description {
+                value
+              }
+              enabled {
+                value
+              }
+              mtu {
+                value
+              }
+              role {
+                value
+              }
+              ... on InfraInterfaceL3 {
+                ip_addresses {
+                  edges {
+                    node {
+                      address {
+                        value
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  InfraBGPPeerGroup {
+    edges {
+      node {
+        name {
+          value
+        }
+        local_as {
+          node {
+            asn {
+              value
+            }
+          }
+        }
+        remote_as {
+          node {
+            asn {
+              value
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/tests/device_startup/baseline/input.json
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/tests/device_startup/baseline/input.json
@@ -1,0 +1,746 @@
+{
+    "data": {
+      "InfraDevice": {
+        "edges": [
+          {
+            "node": {
+              "id": "17a49cb4-f436-4208-45b0-2fc3e8a69b5e",
+              "name": {
+                "value": "atl-spine1"
+              },
+              "asn": {
+                "node": {
+                  "asn": {
+                    "value": 64496
+                  }
+                }
+              },
+              "interfaces": {
+                "edges": [
+                  {
+                    "node": {
+                      "id": "17a49cb5-40c7-ba98-45bb-2fc35123c445",
+                      "name": {
+                        "value": "Ethernet1"
+                      },
+                      "description": {
+                        "value": null
+                      },
+                      "enabled": {
+                        "value": true
+                      },
+                      "role": {
+                        "value": "transit"
+                      },
+                      "ip_addresses": {
+                        "edges": [
+                          {
+                            "node": {
+                              "address": {
+                                "value": "203.0.113.1/29"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "id": "17a49cb6-58b8-95b8-45bd-2fc344c745a9",
+                      "name": {
+                        "value": "Ethernet10"
+                      },
+                      "description": {
+                        "value": null
+                      },
+                      "enabled": {
+                        "value": true
+                      },
+                      "role": {
+                        "value": "spare"
+                      },
+                      "ip_addresses": {
+                        "edges": []
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "id": "17a49cb6-5fa5-1b58-45ba-2fc31665bddd",
+                      "name": {
+                        "value": "Ethernet11"
+                      },
+                      "description": {
+                        "value": null
+                      },
+                      "enabled": {
+                        "value": true
+                      },
+                      "role": {
+                        "value": "server"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "id": "17a49cb6-66fb-8270-45bf-2fc35467cd2a",
+                      "name": {
+                        "value": "Ethernet12"
+                      },
+                      "description": {
+                        "value": null
+                      },
+                      "enabled": {
+                        "value": true
+                      },
+                      "role": {
+                        "value": "server"
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "id": "17a49cb5-f691-1900-45b3-2fc3f988eccf",
+                      "name": {
+                        "value": "Ethernet2"
+                      },
+                      "description": {
+                        "value": null
+                      },
+                      "enabled": {
+                        "value": true
+                      },
+                      "role": {
+                        "value": "transit"
+                      },
+                      "ip_addresses": {
+                        "edges": [
+                          {
+                            "node": {
+                              "address": {
+                                "value": "203.0.113.9/29"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "id": "17a49cb6-287c-1eb0-45bf-2fc373e12f43",
+                      "name": {
+                        "value": "Ethernet3"
+                      },
+                      "description": {
+                        "value": "Connected to atl-leaf1 Ethernet3"
+                      },
+                      "enabled": {
+                        "value": true
+                      },
+                      "role": {
+                        "value": "backbone"
+                      },
+                      "ip_addresses": {
+                        "edges": []
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "id": "17a49cb6-2f82-98d8-45b0-2fc3e78b8c96",
+                      "name": {
+                        "value": "Ethernet4"
+                      },
+                      "description": {
+                        "value": "Connected to atl-leaf2 Ethernet3"
+                      },
+                      "enabled": {
+                        "value": true
+                      },
+                      "role": {
+                        "value": "backbone"
+                      },
+                      "ip_addresses": {
+                        "edges": []
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "id": "17a49cb6-3642-49e8-45bb-2fc36f860291",
+                      "name": {
+                        "value": "Ethernet5"
+                      },
+                      "description": {
+                        "value": "Connected to atl-leaf3 Ethernet3"
+                      },
+                      "enabled": {
+                        "value": true
+                      },
+                      "role": {
+                        "value": "backbone"
+                      },
+                      "ip_addresses": {
+                        "edges": []
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "id": "17a49cb6-3d1e-aab8-45b5-2fc320d4d273",
+                      "name": {
+                        "value": "Ethernet6"
+                      },
+                      "description": {
+                        "value": "Connected to atl-leaf4 Ethernet3"
+                      },
+                      "enabled": {
+                        "value": true
+                      },
+                      "role": {
+                        "value": "backbone"
+                      },
+                      "ip_addresses": {
+                        "edges": []
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "id": "17a49cb6-43b3-4488-45b3-2fc38bb1050c",
+                      "name": {
+                        "value": "Ethernet7"
+                      },
+                      "description": {
+                        "value": null
+                      },
+                      "enabled": {
+                        "value": true
+                      },
+                      "role": {
+                        "value": "spare"
+                      },
+                      "ip_addresses": {
+                        "edges": []
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "id": "17a49cb6-4a74-4970-45bb-2fc38dbef7e2",
+                      "name": {
+                        "value": "Ethernet8"
+                      },
+                      "description": {
+                        "value": null
+                      },
+                      "enabled": {
+                        "value": true
+                      },
+                      "role": {
+                        "value": "spare"
+                      },
+                      "ip_addresses": {
+                        "edges": []
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "id": "17a49cb6-51ab-16b0-45bb-2fc37efe2d05",
+                      "name": {
+                        "value": "Ethernet9"
+                      },
+                      "description": {
+                        "value": null
+                      },
+                      "enabled": {
+                        "value": true
+                      },
+                      "role": {
+                        "value": "spare"
+                      },
+                      "ip_addresses": {
+                        "edges": []
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "id": "17a49cb5-12b4-f5a8-45bb-2fc3bce2aace",
+                      "name": {
+                        "value": "Loopback0"
+                      },
+                      "description": {
+                        "value": null
+                      },
+                      "enabled": {
+                        "value": true
+                      },
+                      "role": {
+                        "value": "loopback"
+                      },
+                      "ip_addresses": {
+                        "edges": [
+                          {
+                            "node": {
+                              "address": {
+                                "value": "10.0.0.7/32"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "id": "17a49cb5-1e95-ea08-45b4-2fc33f8df0f3",
+                      "name": {
+                        "value": "Management0"
+                      },
+                      "description": {
+                        "value": null
+                      },
+                      "enabled": {
+                        "value": true
+                      },
+                      "role": {
+                        "value": "management"
+                      },
+                      "ip_addresses": {
+                        "edges": [
+                          {
+                            "node": {
+                              "address": {
+                                "value": "172.100.100.23/24"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "InfraBGPPeerGroup": {
+        "edges": [
+          {
+            "node": {
+              "name": {
+                "value": "IX_DEFAULT"
+              },
+              "local_as": {
+                "node": {
+                  "asn": {
+                    "value": 64496
+                  }
+                }
+              },
+              "remote_as": {
+                "node": null
+              }
+            }
+          },
+          {
+            "node": {
+              "name": {
+                "value": "POP_GLOBAL"
+              },
+              "local_as": {
+                "node": {
+                  "asn": {
+                    "value": 64496
+                  }
+                }
+              },
+              "remote_as": {
+                "node": null
+              }
+            }
+          },
+          {
+            "node": {
+              "name": {
+                "value": "POP_INTERNAL"
+              },
+              "local_as": {
+                "node": {
+                  "asn": {
+                    "value": 64496
+                  }
+                }
+              },
+              "remote_as": {
+                "node": {
+                  "asn": {
+                    "value": 64496
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "name": {
+                "value": "TRANSIT_DEFAULT"
+              },
+              "local_as": {
+                "node": {
+                  "asn": {
+                    "value": 64496
+                  }
+                }
+              },
+              "remote_as": {
+                "node": null
+              }
+            }
+          },
+          {
+            "node": {
+              "name": {
+                "value": "TRANSIT_TELIA"
+              },
+              "local_as": {
+                "node": {
+                  "asn": {
+                    "value": 64496
+                  }
+                }
+              },
+              "remote_as": {
+                "node": {
+                  "asn": {
+                    "value": 1299
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "InfraTopology": {
+        "edges": [
+          {
+            "node": {
+              "dns": {
+                "value": "8.8.8.8"
+              },
+              "ntp": {
+                "value": "pool.ntp.org"
+              }
+            }
+          },
+          {
+            "node": {
+              "dns": {
+                "value": "8.8.8.8"
+              },
+              "ntp": {
+                "value": "pool.ntp.org"
+              }
+            }
+          }
+        ]
+      },
+      "InfraBGPSession": {
+        "edges": [
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.7/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-leaf1"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.8/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-leaf1"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.7/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-leaf2"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.8/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-leaf2"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.7/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-leaf3"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.8/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-leaf3"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.7/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-leaf4"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.8/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-leaf4"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.3/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-spine1"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.4/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-spine1"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.5/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-spine1"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.6/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-spine1"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.3/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-spine2"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.4/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-spine2"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.5/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-spine2"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.6/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-spine2"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/tests/device_startup/missing_interfaces/input.json
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/tests/device_startup/missing_interfaces/input.json
@@ -1,0 +1,439 @@
+{
+    "data": {
+      "InfraDevice": {
+        "edges": [
+          {
+            "node": {
+              "id": "17a49cb4-f436-4208-45b0-2fc3e8a69b5e",
+              "name": {
+                "value": "atl-spine1"
+              },
+              "asn": {
+                "node": {
+                  "asn": {
+                    "value": 64496
+                  }
+                }
+              },
+              "interfaces": {
+                "edges": []
+              }
+            }
+          }
+        ]
+      },
+      "InfraBGPPeerGroup": {
+        "edges": [
+          {
+            "node": {
+              "name": {
+                "value": "IX_DEFAULT"
+              },
+              "local_as": {
+                "node": {
+                  "asn": {
+                    "value": 64496
+                  }
+                }
+              },
+              "remote_as": {
+                "node": null
+              }
+            }
+          },
+          {
+            "node": {
+              "name": {
+                "value": "POP_GLOBAL"
+              },
+              "local_as": {
+                "node": {
+                  "asn": {
+                    "value": 64496
+                  }
+                }
+              },
+              "remote_as": {
+                "node": null
+              }
+            }
+          },
+          {
+            "node": {
+              "name": {
+                "value": "POP_INTERNAL"
+              },
+              "local_as": {
+                "node": {
+                  "asn": {
+                    "value": 64496
+                  }
+                }
+              },
+              "remote_as": {
+                "node": {
+                  "asn": {
+                    "value": 64496
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "name": {
+                "value": "TRANSIT_DEFAULT"
+              },
+              "local_as": {
+                "node": {
+                  "asn": {
+                    "value": 64496
+                  }
+                }
+              },
+              "remote_as": {
+                "node": null
+              }
+            }
+          },
+          {
+            "node": {
+              "name": {
+                "value": "TRANSIT_TELIA"
+              },
+              "local_as": {
+                "node": {
+                  "asn": {
+                    "value": 64496
+                  }
+                }
+              },
+              "remote_as": {
+                "node": {
+                  "asn": {
+                    "value": 1299
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "InfraTopology": {
+        "edges": [
+          {
+            "node": {
+              "dns": {
+                "value": "8.8.8.8"
+              },
+              "ntp": {
+                "value": "pool.ntp.org"
+              }
+            }
+          },
+          {
+            "node": {
+              "dns": {
+                "value": "8.8.8.8"
+              },
+              "ntp": {
+                "value": "pool.ntp.org"
+              }
+            }
+          }
+        ]
+      },
+      "InfraBGPSession": {
+        "edges": [
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.7/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-leaf1"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.8/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-leaf1"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.7/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-leaf2"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.8/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-leaf2"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.7/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-leaf3"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.8/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-leaf3"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.7/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-leaf4"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.8/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-leaf4"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.3/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-spine1"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.4/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-spine1"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.5/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-spine1"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.6/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-spine1"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.3/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-spine2"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.4/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-spine2"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.5/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-spine2"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "node": {
+              "remote_ip": {
+                "node": {
+                  "address": {
+                    "value": "10.0.0.6/32"
+                  }
+                }
+              },
+              "device": {
+                "node": {
+                  "name": {
+                    "value": "atl-spine2"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/tests/device_startup/missing_interfaces/output.txt
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/tests/device_startup/missing_interfaces/output.txt
@@ -1,0 +1,121 @@
+!
+no aaa root
+!
+username admin privilege 15 role network-admin secret sha512 $6$q4ez.aZgB/G/eeWW$ukvRobb5RtYmUlCcY0atxhwPmA6FPoRjR3AxYFJqNFoCRgJjrohKGrBsbY12n1uRZeCer1L8oejx5aPlrf.op0
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname atl-spine1
+ip name-server 8.8.8.8
+!
+ntp server pool.ntp.org
+!
+spanning-tree mode mstp
+!
+management api http-commands
+   no shutdown
+!
+management api gnmi
+   transport grpc default
+!
+management api netconf
+   transport ssh default
+!
+interface Ethernet1
+   description role: transit
+   ip address 203.0.113.1/29
+   no switchport
+!
+interface Ethernet10
+   description role: spare
+!
+interface Ethernet11
+   description role: server
+!
+interface Ethernet12
+   description role: server
+!
+interface Ethernet2
+   description role: transit
+   ip address 203.0.113.9/29
+   no switchport
+!
+interface Ethernet3
+   description Connected to atl-leaf1 Ethernet3
+   ip ospf area 1
+   ip ospf network point-to-point
+!
+interface Ethernet4
+   description Connected to atl-leaf2 Ethernet3
+   ip ospf area 1
+   ip ospf network point-to-point
+!
+interface Ethernet5
+   description Connected to atl-leaf3 Ethernet3
+   ip ospf area 1
+   ip ospf network point-to-point
+!
+interface Ethernet6
+   description Connected to atl-leaf4 Ethernet3
+   ip ospf area 1
+   ip ospf network point-to-point
+!
+interface Ethernet7
+   description role: spare
+!
+interface Ethernet8
+   description role: spare
+!
+interface Ethernet9
+   description role: spare
+!
+!
+interface Management0
+   description role: management
+   ip address 172.100.100.23/24
+   no shutdown
+!
+interface Loopback0
+   description role: loopback
+   ip address 10.0.0.7/32
+   no shutdown
+!
+ip prefix-list BOGON-Prefixes seq 10 permit 172.16.0.0/12 le 24
+ip prefix-list BOGON-Prefixes seq 20 permit 192.168.0.0/16 le 24
+ip prefix-list BOGON-Prefixes seq 10 permit 172.16.0.0/12 le 24
+ip prefix-list BOGON-Prefixes seq 20 permit 192.168.0.0/16 le 24
+!
+ip routing
+!
+ip route 0.0.0.0/0 172.20.20.1
+!
+router bgp 64496
+   router-id 10.0.0.7
+   neighbor IX_DEFAULT peer group
+   neighbor POP_GLOBAL peer group
+   neighbor POP_INTERNAL peer group
+   neighbor POP_INTERNAL remote-as 64496
+   neighbor TRANSIT_DEFAULT peer group
+   neighbor TRANSIT_TELIA peer group
+   neighbor TRANSIT_TELIA remote-as 1299
+   neighbor 10.0.0.3 peer group POP_INTERNAL
+   neighbor 10.0.0.4 peer group POP_INTERNAL
+   neighbor 10.0.0.5 peer group POP_INTERNAL
+   neighbor 10.0.0.6 peer group POP_INTERNAL
+!
+!
+router ospf 1
+   router-id 10.0.0.7
+   redistribute connected
+   max-lsa 12000
+   passive-interface Loopback0
+   network 0.0.0.0/0 area 0.0.0.0
+!
+route-map BOGONS permit 10
+   match ip address prefix-list BOGON-Prefixes
+!
+route-map BOGONS deny 20
+!
+end

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/tests/python_transforms/oc_bgp/input.json
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/tests/python_transforms/oc_bgp/input.json
@@ -1,0 +1,481 @@
+{
+  "data": {
+    "InfraBGPSession": {
+      "edges": [
+        {
+          "node": {
+            "id": "d0d47169-b1f3-4255-ab86-c06b39ea8d84",
+            "peer_group": {
+              "node": {
+                "name": {
+                  "value": "TRANSIT_TELIA"
+                }
+              }
+            },
+            "local_ip": {
+              "node": {
+                "address": {
+                  "value": "203.0.113.9/29"
+                }
+              }
+            },
+            "remote_ip": {
+              "node": {
+                "address": {
+                  "value": "203.0.113.10/29"
+                }
+              }
+            },
+            "local_as": {
+              "node": {
+                "asn": {
+                  "value": 64496
+                }
+              }
+            },
+            "remote_as": {
+              "node": {
+                "asn": {
+                  "value": 1299
+                }
+              }
+            },
+            "description": {
+              "value": null
+            }
+          }
+        },
+        {
+          "node": {
+            "id": "d2e49bff-ddf2-484b-a4f5-f1ac076a2a2e",
+            "peer_group": {
+              "node": {
+                "name": {
+                  "value": "TRANSIT_DEFAULT"
+                }
+              }
+            },
+            "local_ip": {
+              "node": {
+                "address": {
+                  "value": "203.0.113.49/29"
+                }
+              }
+            },
+            "remote_ip": {
+              "node": {
+                "address": {
+                  "value": "203.0.113.50/29"
+                }
+              }
+            },
+            "local_as": {
+              "node": {
+                "asn": {
+                  "value": 64496
+                }
+              }
+            },
+            "remote_as": {
+              "node": {
+                "asn": {
+                  "value": 8220
+                }
+              }
+            },
+            "description": {
+              "value": null
+            }
+          }
+        },
+        {
+          "node": {
+            "id": "066cb468-3229-4595-a4a4-a88b3bef082c",
+            "peer_group": {
+              "node": {
+                "name": {
+                  "value": "POP_INTERNAL"
+                }
+              }
+            },
+            "local_ip": {
+              "node": {
+                "address": {
+                  "value": "10.0.0.2/32"
+                }
+              }
+            },
+            "remote_ip": {
+              "node": {
+                "address": {
+                  "value": "10.0.0.7/32"
+                }
+              }
+            },
+            "local_as": {
+              "node": {
+                "asn": {
+                  "value": 64496
+                }
+              }
+            },
+            "remote_as": {
+              "node": {
+                "asn": {
+                  "value": 64496
+                }
+              }
+            },
+            "description": {
+              "value": null
+            }
+          }
+        },
+        {
+          "node": {
+            "id": "4ece88b2-665c-4929-ac3e-96430f91974a",
+            "peer_group": {
+              "node": {
+                "name": {
+                  "value": "POP_GLOBAL"
+                }
+              }
+            },
+            "local_ip": {
+              "node": {
+                "address": {
+                  "value": "10.0.0.2/32"
+                }
+              }
+            },
+            "remote_ip": {
+              "node": {
+                "address": {
+                  "value": "10.0.0.3/32"
+                }
+              }
+            },
+            "local_as": {
+              "node": {
+                "asn": {
+                  "value": 64496
+                }
+              }
+            },
+            "remote_as": {
+              "node": {
+                "asn": {
+                  "value": 64496
+                }
+              }
+            },
+            "description": {
+              "value": null
+            }
+          }
+        },
+        {
+          "node": {
+            "id": "4b566879-b47d-452a-9b5a-2e2cee9190b7",
+            "peer_group": {
+              "node": {
+                "name": {
+                  "value": "POP_GLOBAL"
+                }
+              }
+            },
+            "local_ip": {
+              "node": {
+                "address": {
+                  "value": "10.0.0.2/32"
+                }
+              }
+            },
+            "remote_ip": {
+              "node": {
+                "address": {
+                  "value": "10.0.0.8/32"
+                }
+              }
+            },
+            "local_as": {
+              "node": {
+                "asn": {
+                  "value": 64496
+                }
+              }
+            },
+            "remote_as": {
+              "node": {
+                "asn": {
+                  "value": 64496
+                }
+              }
+            },
+            "description": {
+              "value": null
+            }
+          }
+        },
+        {
+          "node": {
+            "id": "f315994a-0caa-4677-b65d-d9dda58b06f3",
+            "peer_group": {
+              "node": {
+                "name": {
+                  "value": "POP_GLOBAL"
+                }
+              }
+            },
+            "local_ip": {
+              "node": {
+                "address": {
+                  "value": "10.0.0.2/32"
+                }
+              }
+            },
+            "remote_ip": {
+              "node": {
+                "address": {
+                  "value": "10.0.0.4/32"
+                }
+              }
+            },
+            "local_as": {
+              "node": {
+                "asn": {
+                  "value": 64496
+                }
+              }
+            },
+            "remote_as": {
+              "node": {
+                "asn": {
+                  "value": 64496
+                }
+              }
+            },
+            "description": {
+              "value": null
+            }
+          }
+        },
+        {
+          "node": {
+            "id": "1815f356-9f87-41c8-b817-42ecf6501628",
+            "peer_group": {
+              "node": {
+                "name": {
+                  "value": "POP_GLOBAL"
+                }
+              }
+            },
+            "local_ip": {
+              "node": {
+                "address": {
+                  "value": "10.0.0.2/32"
+                }
+              }
+            },
+            "remote_ip": {
+              "node": {
+                "address": {
+                  "value": "10.0.0.5/32"
+                }
+              }
+            },
+            "local_as": {
+              "node": {
+                "asn": {
+                  "value": 64496
+                }
+              }
+            },
+            "remote_as": {
+              "node": {
+                "asn": {
+                  "value": 64496
+                }
+              }
+            },
+            "description": {
+              "value": null
+            }
+          }
+        },
+        {
+          "node": {
+            "id": "8c921dee-fe45-48c7-a940-ef10a2384a19",
+            "peer_group": {
+              "node": {
+                "name": {
+                  "value": "POP_GLOBAL"
+                }
+              }
+            },
+            "local_ip": {
+              "node": {
+                "address": {
+                  "value": "10.0.0.2/32"
+                }
+              }
+            },
+            "remote_ip": {
+              "node": {
+                "address": {
+                  "value": "10.0.0.1/32"
+                }
+              }
+            },
+            "local_as": {
+              "node": {
+                "asn": {
+                  "value": 64496
+                }
+              }
+            },
+            "remote_as": {
+              "node": {
+                "asn": {
+                  "value": 64496
+                }
+              }
+            },
+            "description": {
+              "value": null
+            }
+          }
+        },
+        {
+          "node": {
+            "id": "69a3dc11-5440-403c-8013-40d6d0ebad0a",
+            "peer_group": {
+              "node": {
+                "name": {
+                  "value": "POP_GLOBAL"
+                }
+              }
+            },
+            "local_ip": {
+              "node": {
+                "address": {
+                  "value": "10.0.0.2/32"
+                }
+              }
+            },
+            "remote_ip": {
+              "node": {
+                "address": {
+                  "value": "10.0.0.6/32"
+                }
+              }
+            },
+            "local_as": {
+              "node": {
+                "asn": {
+                  "value": 64496
+                }
+              }
+            },
+            "remote_as": {
+              "node": {
+                "asn": {
+                  "value": 64496
+                }
+              }
+            },
+            "description": {
+              "value": null
+            }
+          }
+        },
+        {
+          "node": {
+            "id": "3c82dabf-977b-4fce-b9a1-2f5f3be52a18",
+            "peer_group": {
+              "node": {
+                "name": {
+                  "value": "POP_GLOBAL"
+                }
+              }
+            },
+            "local_ip": {
+              "node": {
+                "address": {
+                  "value": "10.0.0.2/32"
+                }
+              }
+            },
+            "remote_ip": {
+              "node": {
+                "address": {
+                  "value": "10.0.0.9/32"
+                }
+              }
+            },
+            "local_as": {
+              "node": {
+                "asn": {
+                  "value": 64496
+                }
+              }
+            },
+            "remote_as": {
+              "node": {
+                "asn": {
+                  "value": 64496
+                }
+              }
+            },
+            "description": {
+              "value": null
+            }
+          }
+        },
+        {
+          "node": {
+            "id": "207ea49c-6af7-4a92-9a99-3b38d73d0487",
+            "peer_group": {
+              "node": {
+                "name": {
+                  "value": "POP_GLOBAL"
+                }
+              }
+            },
+            "local_ip": {
+              "node": {
+                "address": {
+                  "value": "10.0.0.2/32"
+                }
+              }
+            },
+            "remote_ip": {
+              "node": {
+                "address": {
+                  "value": "10.0.0.10/32"
+                }
+              }
+            },
+            "local_as": {
+              "node": {
+                "asn": {
+                  "value": 64496
+                }
+              }
+            },
+            "remote_as": {
+              "node": {
+                "asn": {
+                  "value": 64496
+                }
+              }
+            },
+            "description": {
+              "value": null
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/tests/python_transforms/oc_bgp/output.json
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/tests/python_transforms/oc_bgp/output.json
@@ -1,0 +1,105 @@
+{
+    "openconfig-bgp:neighbors": {
+        "neighbor": [
+            {
+                "neighbor-address": "203.0.113.10",
+                "config": {
+                    "neighbor-address": "203.0.113.10",
+                    "peer-group": "TRANSIT_TELIA",
+                    "peer-as": 1299,
+                    "local-as": 64496
+                }
+            },
+            {
+                "neighbor-address": "203.0.113.50",
+                "config": {
+                    "neighbor-address": "203.0.113.50",
+                    "peer-group": "TRANSIT_DEFAULT",
+                    "peer-as": 8220,
+                    "local-as": 64496
+                }
+            },
+            {
+                "neighbor-address": "10.0.0.7",
+                "config": {
+                    "neighbor-address": "10.0.0.7",
+                    "peer-group": "POP_INTERNAL",
+                    "peer-as": 64496,
+                    "local-as": 64496
+                }
+            },
+            {
+                "neighbor-address": "10.0.0.3",
+                "config": {
+                    "neighbor-address": "10.0.0.3",
+                    "peer-group": "POP_GLOBAL",
+                    "peer-as": 64496,
+                    "local-as": 64496
+                }
+            },
+            {
+                "neighbor-address": "10.0.0.8",
+                "config": {
+                    "neighbor-address": "10.0.0.8",
+                    "peer-group": "POP_GLOBAL",
+                    "peer-as": 64496,
+                    "local-as": 64496
+                }
+            },
+            {
+                "neighbor-address": "10.0.0.4",
+                "config": {
+                    "neighbor-address": "10.0.0.4",
+                    "peer-group": "POP_GLOBAL",
+                    "peer-as": 64496,
+                    "local-as": 64496
+                }
+            },
+            {
+                "neighbor-address": "10.0.0.5",
+                "config": {
+                    "neighbor-address": "10.0.0.5",
+                    "peer-group": "POP_GLOBAL",
+                    "peer-as": 64496,
+                    "local-as": 64496
+                }
+            },
+            {
+                "neighbor-address": "10.0.0.1",
+                "config": {
+                    "neighbor-address": "10.0.0.1",
+                    "peer-group": "POP_GLOBAL",
+                    "peer-as": 64496,
+                    "local-as": 64496
+                }
+            },
+            {
+                "neighbor-address": "10.0.0.6",
+                "config": {
+                    "neighbor-address": "10.0.0.6",
+                    "peer-group": "POP_GLOBAL",
+                    "peer-as": 64496,
+                    "local-as": 64496
+                }
+            },
+            {
+                "neighbor-address": "10.0.0.9",
+                "config": {
+                    "neighbor-address": "10.0.0.9",
+                    "peer-group": "POP_GLOBAL",
+                    "peer-as": 64496,
+                    "local-as": 64496
+                }
+            },
+            {
+                "neighbor-address": "10.0.0.10",
+                "config": {
+                    "neighbor-address": "10.0.0.10",
+                    "peer-group": "POP_GLOBAL",
+                    "peer-as": 64496,
+                    "local-as": 64496
+                }
+            }
+        ]
+    }
+}

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/tests/python_transforms/oc_interfaces/input.json
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/tests/python_transforms/oc_interfaces/input.json
@@ -1,0 +1,275 @@
+{
+  "data": {
+    "InfraDevice": {
+      "edges": [
+        {
+          "node": {
+            "id": "67bbcb4f-5ee7-4c9b-a598-58985ff3dbd4",
+            "interfaces": {
+              "edges": [
+                {
+                  "node": {
+                    "name": {
+                      "value": "Ethernet2"
+                    },
+                    "description": {
+                      "value": "Connected to ord1-edge2 Ethernet2"
+                    },
+                    "enabled": {
+                      "value": true
+                    },
+                    "ip_addresses": {
+                      "edges": []
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "name": {
+                      "value": "Ethernet3"
+                    },
+                    "description": {
+                      "value": null
+                    },
+                    "enabled": {
+                      "value": true
+                    },
+                    "ip_addresses": {
+                      "edges": []
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "name": {
+                      "value": "Ethernet12"
+                    },
+                    "description": {
+                      "value": null
+                    },
+                    "enabled": {
+                      "value": true
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "name": {
+                      "value": "Ethernet4"
+                    },
+                    "description": {
+                      "value": null
+                    },
+                    "enabled": {
+                      "value": true
+                    },
+                    "ip_addresses": {
+                      "edges": []
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "name": {
+                      "value": "Ethernet6"
+                    },
+                    "description": {
+                      "value": null
+                    },
+                    "enabled": {
+                      "value": true
+                    },
+                    "ip_addresses": {
+                      "edges": [
+                        {
+                          "node": {
+                            "address": {
+                              "value": "203.0.113.49/29"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "name": {
+                      "value": "Ethernet10"
+                    },
+                    "description": {
+                      "value": null
+                    },
+                    "enabled": {
+                      "value": true
+                    },
+                    "ip_addresses": {
+                      "edges": []
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "name": {
+                      "value": "Ethernet1"
+                    },
+                    "description": {
+                      "value": "Connected to ord1-edge2 Ethernet1"
+                    },
+                    "enabled": {
+                      "value": true
+                    },
+                    "ip_addresses": {
+                      "edges": []
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "name": {
+                      "value": "Ethernet11"
+                    },
+                    "description": {
+                      "value": null
+                    },
+                    "enabled": {
+                      "value": true
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "name": {
+                      "value": "Ethernet9"
+                    },
+                    "description": {
+                      "value": null
+                    },
+                    "enabled": {
+                      "value": true
+                    },
+                    "ip_addresses": {
+                      "edges": [
+                        {
+                          "node": {
+                            "address": {
+                              "value": "203.0.113.81/29"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "name": {
+                      "value": "Loopback0"
+                    },
+                    "description": {
+                      "value": null
+                    },
+                    "enabled": {
+                      "value": true
+                    },
+                    "ip_addresses": {
+                      "edges": [
+                        {
+                          "node": {
+                            "address": {
+                              "value": "10.0.0.2/32"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "name": {
+                      "value": "Ethernet5"
+                    },
+                    "description": {
+                      "value": null
+                    },
+                    "enabled": {
+                      "value": true
+                    },
+                    "ip_addresses": {
+                      "edges": [
+                        {
+                          "node": {
+                            "address": {
+                              "value": "203.0.113.9/29"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "name": {
+                      "value": "Ethernet7"
+                    },
+                    "description": {
+                      "value": null
+                    },
+                    "enabled": {
+                      "value": true
+                    },
+                    "ip_addresses": {
+                      "edges": []
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "name": {
+                      "value": "Management0"
+                    },
+                    "description": {
+                      "value": null
+                    },
+                    "enabled": {
+                      "value": true
+                    },
+                    "ip_addresses": {
+                      "edges": [
+                        {
+                          "node": {
+                            "address": {
+                              "value": "172.20.20.18/24"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "node": {
+                    "name": {
+                      "value": "Ethernet8"
+                    },
+                    "description": {
+                      "value": null
+                    },
+                    "enabled": {
+                      "value": true
+                    },
+                    "ip_addresses": {
+                      "edges": []
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/tests/python_transforms/oc_interfaces/output.json
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/tests/python_transforms/oc_interfaces/output.json
@@ -1,0 +1,226 @@
+{
+  "openconfig-interfaces:interface": [
+    {
+      "name": "Ethernet2",
+      "config": {
+        "enabled": true,
+        "description": "Connected to ord1-edge2 Ethernet2"
+      },
+      "subinterfaces": {
+        "subinterface": []
+      }
+    },
+    {
+      "name": "Ethernet3",
+      "config": {
+        "enabled": true
+      },
+      "subinterfaces": {
+        "subinterface": []
+      }
+    },
+    {
+      "name": "Ethernet12",
+      "config": {
+        "enabled": true
+      }
+    },
+    {
+      "name": "Ethernet4",
+      "config": {
+        "enabled": true
+      },
+      "subinterfaces": {
+        "subinterface": []
+      }
+    },
+    {
+      "name": "Ethernet6",
+      "config": {
+        "enabled": true
+      },
+      "subinterfaces": {
+        "subinterface": [
+          {
+            "index": 0,
+            "openconfig-if-ip:ipv4": {
+              "addresses": {
+                "address": [
+                  {
+                    "ip": "203.0.113.49",
+                    "config": {
+                      "ip": "203.0.113.49",
+                      "prefix-length": "29"
+                    }
+                  }
+                ]
+              },
+              "config": {
+                "enabled": true
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Ethernet10",
+      "config": {
+        "enabled": true
+      },
+      "subinterfaces": {
+        "subinterface": []
+      }
+    },
+    {
+      "name": "Ethernet1",
+      "config": {
+        "enabled": true,
+        "description": "Connected to ord1-edge2 Ethernet1"
+      },
+      "subinterfaces": {
+        "subinterface": []
+      }
+    },
+    {
+      "name": "Ethernet11",
+      "config": {
+        "enabled": true
+      }
+    },
+    {
+      "name": "Ethernet9",
+      "config": {
+        "enabled": true
+      },
+      "subinterfaces": {
+        "subinterface": [
+          {
+            "index": 0,
+            "openconfig-if-ip:ipv4": {
+              "addresses": {
+                "address": [
+                  {
+                    "ip": "203.0.113.81",
+                    "config": {
+                      "ip": "203.0.113.81",
+                      "prefix-length": "29"
+                    }
+                  }
+                ]
+              },
+              "config": {
+                "enabled": true
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Loopback0",
+      "config": {
+        "enabled": true
+      },
+      "subinterfaces": {
+        "subinterface": [
+          {
+            "index": 0,
+            "openconfig-if-ip:ipv4": {
+              "addresses": {
+                "address": [
+                  {
+                    "ip": "10.0.0.2",
+                    "config": {
+                      "ip": "10.0.0.2",
+                      "prefix-length": "32"
+                    }
+                  }
+                ]
+              },
+              "config": {
+                "enabled": true
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Ethernet5",
+      "config": {
+        "enabled": true
+      },
+      "subinterfaces": {
+        "subinterface": [
+          {
+            "index": 0,
+            "openconfig-if-ip:ipv4": {
+              "addresses": {
+                "address": [
+                  {
+                    "ip": "203.0.113.9",
+                    "config": {
+                      "ip": "203.0.113.9",
+                      "prefix-length": "29"
+                    }
+                  }
+                ]
+              },
+              "config": {
+                "enabled": true
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Ethernet7",
+      "config": {
+        "enabled": true
+      },
+      "subinterfaces": {
+        "subinterface": []
+      }
+    },
+    {
+      "name": "Management0",
+      "config": {
+        "enabled": true
+      },
+      "subinterfaces": {
+        "subinterface": [
+          {
+            "index": 0,
+            "openconfig-if-ip:ipv4": {
+              "addresses": {
+                "address": [
+                  {
+                    "ip": "172.20.20.18",
+                    "config": {
+                      "ip": "172.20.20.18",
+                      "prefix-length": "24"
+                    }
+                  }
+                ]
+              },
+              "config": {
+                "enabled": true
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Ethernet8",
+      "config": {
+        "enabled": true
+      },
+      "subinterfaces": {
+        "subinterface": []
+      }
+    }
+  ]
+}

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/tests/test_check.yml
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/tests/test_check.yml
@@ -1,0 +1,9 @@
+---
+version: "1.0"
+infrahub_tests:
+  - resource: Check
+    resource_name: "backbone_link_redundancy"
+    tests:
+      - name: syntax_check
+        spec:
+          kind: check-smoke

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/tests/test_graphql.yml
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/tests/test_graphql.yml
@@ -1,0 +1,34 @@
+---
+version: "1.0"
+infrahub_tests:
+  # --------------------  GraphQLQuery  --------------------
+  - resource: GraphQLQuery
+    resource_name: check_backbone_link_redundancy
+    tests:
+      - name: syntax_check
+        spec:
+          path: checks/check_backbone_link_redundancy.gql
+          kind: graphql-query-smoke
+
+  - resource: GraphQLQuery
+    resource_name: device_startup_info
+    tests:
+      - name: syntax_check
+        spec:
+          path: templates/device_startup_info.gql
+          kind: graphql-query-smoke
+
+  - resource: GraphQLQuery
+    resource_name: oc_interfaces
+    tests:
+      - name: syntax_check
+        spec:
+          path: transforms/oc_interfaces.gql
+          kind: graphql-query-smoke
+  - resource: GraphQLQuery
+    resource_name: oc_bgp_neighbors
+    tests:
+      - name: syntax_check
+        spec:
+          path: transforms/oc_bgp_neighbors.gql
+          kind: graphql-query-smoke

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/tests/test_transform_j2.yml
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/tests/test_transform_j2.yml
@@ -1,0 +1,17 @@
+---
+version: "1.0"
+infrahub_tests:
+  - resource: Jinja2Transform
+    resource_name: "device_startup"
+    tests:
+      - name: "baseline"
+        expect: PASS
+        spec:
+          kind: "jinja2-transform-unit-render"
+          directory: device_startup/baseline
+
+      - name: "missing_interfaces"
+        expect: FAIL
+        spec:
+          kind: "jinja2-transform-unit-render"
+          directory: device_startup/missing_interfaces

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/tests/test_transform_python.yml
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/tests/test_transform_python.yml
@@ -1,0 +1,20 @@
+---
+version: "1.0"
+infrahub_tests:
+  - resource: PythonTransform
+    resource_name: oc_bgp_neighbors
+    tests:
+      - name: oc_bgp
+        expect: PASS
+        spec:
+          kind: python-transform-unit-process
+          directory: python_transforms/oc_bgp
+
+  - resource: PythonTransform
+    resource_name: OCInterfaces
+    tests:
+      - name: oc_interfaces
+        expect: PASS
+        spec:
+          kind: python-transform-unit-process
+          directory: python_transforms/oc_interfaces

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/topology/topo2.clabs.yml
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/topology/topo2.clabs.yml
@@ -1,0 +1,15 @@
+---
+# topology documentation: http://containerlab.srlinux.dev/lab-examples/min-clos/
+name: test_crpd
+
+topology:
+  nodes:
+    crpd:
+      kind: juniper_crpd
+      image: crpd:22.2R1.9
+    srl:
+      kind: srl
+      image: ghcr.io/nokia/srlinux
+
+  links:
+    - endpoints: ["srl:e1-1", "crpd:eth1"]

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/topology/topology.clabs.yml
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/topology/topology.clabs.yml
@@ -1,0 +1,57 @@
+---
+# topology documentation: http://containerlab.srlinux.dev/lab-examples/min-clos/
+name: edge_triangle
+
+topology:
+  kinds:
+    srl:
+      image: ghcr.io/nokia/srlinux
+    linux:
+      image: ghcr.io/hellt/network-multitool
+    ceos:
+      kind: ceos
+      image: ceos:4.27.3F
+  nodes:
+    ord1-edge1:
+      kind: ceos
+      type: ixrd2
+      mgmt_ipv4: 172.20.20.19
+      startup-config: configs/startup/ord1-edge1.cfg
+    ord1-edge2:
+      kind: ceos
+      type: ixrd2
+      mgmt_ipv4: 172.20.20.20
+      startup-config: configs/startup/ord1-edge2.cfg
+    jfk1-edge1:
+      kind: ceos
+      type: ixrd2
+      mgmt_ipv4: 172.20.20.21
+      startup-config: configs/startup/jfk1-edge1.cfg
+    jfk1-edge2:
+      kind: ceos
+      type: ixrd2
+      mgmt_ipv4: 172.20.20.22
+      startup-config: configs/startup/jfk1-edge2.cfg
+    atl1-edge1:
+      kind: ceos
+      type: ixrd2
+      mgmt_ipv4: 172.20.20.17
+      startup-config: configs/startup/atl1-edge1.cfg
+    atl1-edge2:
+      kind: ceos
+      type: ixrd2
+      mgmt_ipv4: 172.20.20.18
+      startup-config: configs/startup/atl1-edge2.cfg
+  links:
+    - endpoints: ["atl1-edge1:eth1", "atl1-edge2:eth1"]
+    - endpoints: ["atl1-edge1:eth2", "atl1-edge2:eth2"]
+    - endpoints: ["ord1-edge1:eth1", "ord1-edge2:eth1"]
+    - endpoints: ["ord1-edge1:eth2", "ord1-edge2:eth2"]
+    - endpoints: ["jfk1-edge1:eth1", "jfk1-edge2:eth1"]
+    - endpoints: ["jfk1-edge1:eth2", "jfk1-edge2:eth2"]
+    - endpoints: ["atl1-edge1:eth4", "ord1-edge1:eth3"]
+    - endpoints: ["atl1-edge1:eth3", "jfk1-edge1:eth3"]
+    - endpoints: ["jfk1-edge1:eth4", "ord1-edge1:eth4"]
+    - endpoints: ["atl1-edge2:eth4", "ord1-edge2:eth3"]
+    - endpoints: ["atl1-edge2:eth3", "jfk1-edge2:eth3"]
+    - endpoints: ["jfk1-edge2:eth4", "ord1-edge2:eth4"]

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/topology/topology.tpl.j2
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/topology/topology.tpl.j2
@@ -1,0 +1,38 @@
+# topology documentation: http://containerlab.srlinux.dev/lab-examples/min-clos/
+name: edge_triangle
+
+topology:
+  kinds:
+    srl:
+      image: ghcr.io/nokia/srlinux
+    linux:
+      image: ghcr.io/hellt/network-multitool
+    ceos:
+      kind: ceos
+      image: ceos:4.27.3F
+  nodes:
+{% for device in data.device.edges %}
+    {{ device.node.name.value }}:
+      kind: ceos
+      type: ixrd2
+{%  for intf in device.node.interfaces.edges %}
+{%    if intf.node.role.value == "management" %}
+{%      set management_ip = intf.node.ip_addresses.edges[0].node.address.value.split('/') %}
+      mgmt_ipv4: {{ management_ip[0] }}
+{%    endif %}
+{%  endfor %}
+      startup-config: configs/startup/{{ device.node.name.value }}.cfg
+{% endfor %}
+  links:
+    - endpoints: ["atl1-edge1:eth1", "atl1-edge2:eth1"]
+    - endpoints: ["atl1-edge1:eth2", "atl1-edge2:eth2"]
+    - endpoints: ["ord1-edge1:eth1", "ord1-edge2:eth1"]
+    - endpoints: ["ord1-edge1:eth2", "ord1-edge2:eth2"]
+    - endpoints: ["jfk1-edge1:eth1", "jfk1-edge2:eth1"]
+    - endpoints: ["jfk1-edge1:eth2", "jfk1-edge2:eth2"]
+    - endpoints: ["atl1-edge1:eth4", "ord1-edge1:eth3"]
+    - endpoints: ["atl1-edge1:eth3", "jfk1-edge1:eth3"]
+    - endpoints: ["jfk1-edge1:eth4", "ord1-edge1:eth4"]
+    - endpoints: ["atl1-edge2:eth4", "ord1-edge2:eth3"]
+    - endpoints: ["atl1-edge2:eth3", "jfk1-edge2:eth3"]
+    - endpoints: ["jfk1-edge2:eth4", "ord1-edge2:eth4"]

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/topology/topology_info.gql
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/topology/topology_info.gql
@@ -1,0 +1,32 @@
+query topology_info {
+  InfraDevice {
+    edges {
+      node {
+        name {
+          value
+        }
+        interfaces {
+          edges {
+            node {
+              id
+              role {
+                value
+              }
+              ... on InfraInterfaceL3 {
+                ip_addresses {
+                  edges {
+                    node {
+                      address {
+                        value
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/transforms/computed_circuit_description.gql
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/transforms/computed_circuit_description.gql
@@ -1,0 +1,44 @@
+query CircuitDescriptionQuery($id: ID!) {
+  InfraCircuit(ids: [$id]) {
+    edges {
+      node {
+        circuit_id {
+          value
+        }
+        role {
+          value
+        }
+
+        provider {
+          node {
+            name {
+              value
+            }
+          }
+        }
+        endpoints {
+          edges {
+            node {
+              connected_endpoint {
+                node {
+                  ... on InfraInterfaceL3 {
+                    name {
+                      value
+                    }
+                    device {
+                      node {
+                        name {
+                          value
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/transforms/computed_circuit_description.py
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/transforms/computed_circuit_description.py
@@ -1,0 +1,23 @@
+from infrahub_sdk.transforms import InfrahubTransform
+
+
+class ComputedCircuitDescription(InfrahubTransform):
+    query = "computed_circuit_description"
+    url = "computed_circuit_description"
+
+    async def transform(self, data):
+        circuit_dict: dict = data["InfraCircuit"]["edges"][0]["node"]
+
+        # If it's a backbone we compute a nice view
+        if circuit_dict["role"]["value"] == "backbone":
+            detailed_endpoints: list[str] = []
+
+            for endpoint in circuit_dict["endpoints"]["edges"]:
+                connected_endpoint: dict = endpoint["node"]["connected_endpoint"]["node"]
+                detailed_endpoints.append(
+                    f"{connected_endpoint['device']['node']['name']['value']}::{connected_endpoint['name']['value']}"
+                )
+
+            return f" < {circuit_dict['circuit_id']['value']} > ".join(detailed_endpoints)
+
+        return f"This {circuit_dict['role']['value']} circuit is provided by {circuit_dict['provider']['node']['name']['value']}"

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/transforms/oc_bgp_neighbors.gql
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/transforms/oc_bgp_neighbors.gql
@@ -1,0 +1,47 @@
+query oc_bgp_neighbors ($device: String!) {
+  InfraBGPSession(device__name__value: $device) {
+    edges {
+      node {
+        id
+        peer_group {
+          node {
+            name {
+              value
+            }
+          }
+        }
+        local_ip {
+          node {
+            address {
+              value
+            }
+          }
+        }
+        remote_ip {
+          node {
+            address {
+              value
+            }
+          }
+        }
+        local_as {
+          node {
+            asn {
+              value
+            }
+          }
+        }
+        remote_as {
+          node {
+            asn {
+              value
+            }
+          }
+        }
+        description {
+          value
+        }
+      }
+    }
+  }
+}

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/transforms/oc_interfaces.gql
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/transforms/oc_interfaces.gql
@@ -1,0 +1,35 @@
+query oc_interfaces ($device: String!) {
+  InfraDevice(name__value: $device) {
+    edges {
+      node {
+        id
+        interfaces {
+          edges {
+            node {
+              name {
+                value
+              }
+              description {
+                value
+              }
+              enabled {
+                value
+              }
+              ... on InfraInterfaceL3 {
+                ip_addresses {
+                  edges {
+                    node {
+                      address {
+                        value
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/transforms/openconfig.py
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge-integration/initial__main/transforms/openconfig.py
@@ -1,0 +1,79 @@
+from infrahub_sdk.transforms import InfrahubTransform
+
+
+class OCInterfaces(InfrahubTransform):
+    query = "oc_interfaces"
+
+    async def transform(self, data):
+        response_payload = {}
+        response_payload["openconfig-interfaces:interface"] = []
+
+        for intf in data["InfraDevice"]["edges"][0]["node"]["interfaces"]["edges"]:
+            intf_name = intf["node"]["name"]["value"]
+
+            intf_config = {
+                "name": intf_name,
+                "config": {"enabled": intf["node"]["enabled"]["value"]},
+            }
+
+            if intf["node"].get("description", None) and intf["node"]["description"]["value"]:
+                intf_config["config"]["description"] = intf["node"]["description"]["value"]
+
+            if intf["node"].get("ip_addresses", None):
+                intf_config["subinterfaces"] = {"subinterface": []}
+
+                for idx, ip in enumerate(intf["node"]["ip_addresses"]["edges"]):
+                    address, mask = ip["node"]["address"]["value"].split("/")
+                    intf_config["subinterfaces"]["subinterface"].append(
+                        {
+                            "index": idx,
+                            "openconfig-if-ip:ipv4": {
+                                "addresses": {
+                                    "address": [
+                                        {
+                                            "ip": address,
+                                            "config": {
+                                                "ip": address,
+                                                "prefix-length": mask,
+                                            },
+                                        }
+                                    ]
+                                },
+                                "config": {"enabled": True},
+                            },
+                        }
+                    )
+
+            response_payload["openconfig-interfaces:interface"].append(intf_config)
+
+        return response_payload
+
+
+class OCBGPNeighbors(InfrahubTransform):
+    query = "oc_bgp_neighbors"
+    url = "openconfig/network-instances/network-instance/protocols/protocol/bgp/neighbors"
+
+    async def transform(self, data):
+        response_payload = {}
+
+        response_payload["openconfig-bgp:neighbors"] = {"neighbor": []}
+
+        for session in data["InfraBGPSession"]["edges"]:
+            neighbor_address = session["node"]["remote_ip"]["node"]["address"]["value"].split("/")[0]
+            session_data = {
+                "neighbor-address": neighbor_address,
+                "config": {"neighbor-address": neighbor_address},
+            }
+
+            if session["node"]["peer_group"]:
+                session_data["config"]["peer-group"] = session["node"]["peer_group"]["node"]["name"]["value"]
+
+            if session["node"]["remote_as"]:
+                session_data["config"]["peer-as"] = session["node"]["remote_as"]["node"]["asn"]["value"]
+
+            if session["node"]["local_as"]:
+                session_data["config"]["local-as"] = session["node"]["local_as"]["node"]["asn"]["value"]
+
+            response_payload["openconfig-bgp:neighbors"]["neighbor"].append(session_data)
+
+        return response_payload

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -119,6 +119,13 @@ def git_repo_infrahub_demo_edge(git_sources_dir: Path) -> FileRepo:
 
 
 @pytest.fixture(scope="session")
+def git_repo_infrahub_demo_edge_integration(git_sources_dir: Path) -> FileRepo:
+    """Git Repository used as part of the  demo-edge tutorial."""
+
+    return FileRepo(name="infrahub-demo-edge-integration", sources_directory=git_sources_dir)
+
+
+@pytest.fixture(scope="session")
 def git_repo_car_dealership(git_sources_dir: Path) -> FileRepo:
     """Simple Git Repository used for testing."""
 

--- a/backend/tests/integration/git/test_git_repository.py
+++ b/backend/tests/integration/git/test_git_repository.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import AsyncGenerator
 
 import pytest
 import yaml
@@ -71,11 +70,10 @@ class TestInfrahubClient:
         return InfrahubTestClient(app=app)
 
     @pytest.fixture
-    async def client(self, test_client: InfrahubTestClient, integration_helper) -> AsyncGenerator[InfrahubClient, None]:
+    async def client(self, test_client: InfrahubTestClient, integration_helper) -> InfrahubClient:
         admin_token = await integration_helper.create_token()
         config = Config(api_token=admin_token, requester=test_client.async_request)
-        sdk_client = InfrahubClient(config=config)
-        return sdk_client
+        return InfrahubClient(config=config)
 
     @pytest.fixture(scope="class")
     async def query_99(self, db: InfrahubDatabase, test_client):
@@ -90,13 +88,18 @@ class TestInfrahubClient:
 
     @pytest.fixture
     async def repo(
-        self, test_client, client, db: InfrahubDatabase, git_repo_infrahub_demo_edge: FileRepo, git_repos_dir
+        self,
+        test_client,
+        client,
+        db: InfrahubDatabase,
+        git_repo_infrahub_demo_edge_integration: FileRepo,
+        git_repos_dir,
     ):
         # Create the repository in the Graph
         obj = await Node.init(schema=InfrahubKind.REPOSITORY, db=db)
         await obj.new(
             db=db,
-            name=git_repo_infrahub_demo_edge.name,
+            name=git_repo_infrahub_demo_edge_integration.name,
             description="test repository",
             location="git@github.com:mock/test.git",
         )
@@ -104,7 +107,10 @@ class TestInfrahubClient:
 
         # Initialize the repository on the file system
         repo = await InfrahubRepository.new(
-            id=obj.id, name=git_repo_infrahub_demo_edge.name, location=git_repo_infrahub_demo_edge.path, client=client
+            id=obj.id,
+            name=git_repo_infrahub_demo_edge_integration.name,
+            location=git_repo_infrahub_demo_edge_integration.path,
+            client=client,
         )
 
         return repo


### PR DESCRIPTION
Due to a recent change in the bundled `infrahub-demo-edge` repository within the test fixtures we were importing a schema update with the repository. This is currently causing a lot of noise in the prefect environment for the end-to-end tests with Playwright as the schema now differs from the main branch and the other branches (this is a separate issue that needs to be resolved)

In this PR I'm reverting the previous change to this `infrahub-demo-edge` repository so it matches what we expect to see there from an end to end test perspective. As the repository was used in an integration test I created a copy of the repository so that the integration test can still use it.