### PR TITLE
Log and return early for branch not found

### DIFF
--- a/backend/infrahub/computed_attribute/tasks.py
+++ b/backend/infrahub/computed_attribute/tasks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from infrahub_sdk.exceptions import URLNotFoundError
 from infrahub_sdk.protocols import CoreTransformPython
 from infrahub_sdk.template import Jinja2Template
 from prefect import flow
@@ -229,7 +230,13 @@ async def process_jinja2(
 
         for id_filter in computed_macro.node_filters:
             query = attribute_graphql.render_graphql_query(query_filter=id_filter, filter_id=object_id)
-            response = await client.execute_graphql(query=query, branch_name=branch_name)
+            try:
+                response = await client.execute_graphql(query=query, branch_name=branch_name)
+            except URLNotFoundError:
+                log.warning(
+                    f"Process computed attributes for {computed_attribute_kind}.{computed_attribute_name} failed for branch {branch_name} (not found)"
+                )
+                return
             output = attribute_graphql.parse_response(response=response)
             found.extend(output)
 


### PR DESCRIPTION
This PR aims to reduce noise in the E2E test logs, and by extension in production environments. The problem is that the E2E tests can trigger actions within Prefect and then delete the branches used by various tasks. If this happens we want to catch such errors, log a warning and return early since there is nothing to be done at this point.