### PR TITLE
improve performance of migration to set HFID/display label (only on default/global branches)

### DIFF
--- a/backend/infrahub/core/migrations/graph/m043_backfill_hfid_display_label_in_db.py
+++ b/backend/infrahub/core/migrations/graph/m043_backfill_hfid_display_label_in_db.py
@@ -2,14 +2,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from rich.progress import Progress
+import ujson
+from rich.progress import Progress, TaskID
 
 from infrahub.core import registry
 from infrahub.core.constants import GLOBAL_BRANCH_NAME, BranchSupportType, RelationshipDirection
 from infrahub.core.initialization import get_root_node
 from infrahub.core.migrations.shared import MigrationResult
 from infrahub.core.query import Query, QueryType
-from infrahub.core.schema import AttributeSchema, SchemaRoot, internal_schema
+from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot, internal_schema
 from infrahub.core.schema.manager import SchemaManager
 from infrahub.types import is_large_attribute_type
 
@@ -17,27 +18,34 @@ from ..shared import ArbitraryMigration
 
 if TYPE_CHECKING:
     from infrahub.core.schema.basenode_schema import SchemaAttributePath
+    from infrahub.core.schema.schema_branch import SchemaBranch
     from infrahub.database import InfrahubDatabase
-
-# TODO: get HFID at same time as display labels
-# TODO: set HFID
 
 
 class DefaultBranchNodeCount(Query):
+    """
+    Get the number of Node vertices on the given branches that are not in the kinds_to_skip list
+    Only works for default and global branches. Non-default branches would only return a count of nodes
+    created on the given branches
+    """
+
     name = "get_branch_node_count"
     type = QueryType.READ
 
-    def __init__(self, branch_names: list[str], **kwargs: Any) -> None:
+    def __init__(self, branch_names: list[str], kinds_to_skip: list[str], **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.branch_names = branch_names
+        self.kinds_to_skip = kinds_to_skip
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
         self.params = {
             "branch_names": self.branch_names,
+            "kinds_to_skip": self.kinds_to_skip,
         }
         query = """
 MATCH (n:Node)-[e:IS_PART_OF]->(:Root)
-WHERE e.branch IN $branch_names
+WHERE NOT n.kind IN $kinds_to_skip
+AND e.branch IN $branch_names
 AND e.status = "active"
 AND e.to IS NULL
 AND NOT exists((n)-[:IS_PART_OF {branch: e.branch, status: "deleted"}]->(:Root))
@@ -54,18 +62,20 @@ WITH count(*) AS num_nodes
 
 
 class GetPathDetailsDefaultBranch(Query):
+    """
+    Get the values of the given schema paths for the given kind of node on the default and global branches
+    Supports limit and offset for pagination
+    """
+
     name = "get_path_details_default_branch"
     type = QueryType.READ
     insert_limit = False
 
-    def __init__(
-        self, branch_names: list[str], schema_kind: str, schema_paths: list[SchemaAttributePath], **kwargs: Any
-    ) -> None:
+    def __init__(self, schema_kind: str, schema_paths: list[SchemaAttributePath], **kwargs: Any) -> None:
         super().__init__(**kwargs)
 
-        self.branch_names = branch_names
+        self.branch_names = [registry.default_branch, GLOBAL_BRANCH_NAME]
         self.schema_kind = schema_kind
-        self.schema_paths = schema_paths
         self.attribute_names = []
         self.bidir_rel_attr_map = {}
         self.outbound_rel_attr_map = {}
@@ -97,16 +107,23 @@ class GetPathDetailsDefaultBranch(Query):
             "limit": self.limit,
         }
         get_details_query = """
+// ------------
+// Get the active nodes of the given kind on the branches
+// ------------
 MATCH (n:%(schema_kind)s)-[e:IS_PART_OF]->(:Root)
 WHERE e.branch IN $branch_names
 AND e.to IS NULL
 AND e.status = "active"
-
+// ------------
+// Order and limit the Nodes
+// ------------
 WITH DISTINCT n
 ORDER BY elementId(n)
 SKIP toInteger($offset)
 LIMIT toInteger($limit)
-
+// ------------
+// Get the values for the attribute schema paths of the Nodes, if any
+// ------------
 OPTIONAL MATCH (n)-[e:HAS_ATTRIBUTE]->(attr:Attribute)
 WHERE attr.name IN $attribute_names
 AND e.branch IN $branch_names
@@ -117,9 +134,10 @@ OPTIONAL MATCH (attr)-[e:HAS_VALUE]->(attr_val:AttributeValue)
 WHERE e.branch IN $branch_names
 AND e.to IS NULL
 AND e.status = "active"
-
 WITH n, collect([attr.name, attr_val.value]) AS attr_vals_list
-
+// ------------
+// Get the values for the relationship schema paths of the Nodes, if any
+// ------------
 OPTIONAL MATCH (n)-[e1:IS_RELATED]-(rel:Relationship)-[e2:IS_RELATED]-(peer:Node)
 WHERE rel.name IN $bidirectional_rel_ids + $outbound_rel_ids + $inbound_rel_ids
 AND e1.branch IN $branch_names
@@ -133,7 +151,6 @@ AND (
     OR (startNode(e1) = rel AND startNode(e2) = n AND rel.name IN $inbound_rel_ids)
     OR (startNode(e1) = n AND startNode(e2) = peer AND rel.name IN $bidirectional_rel_ids)
 )
-
 WITH DISTINCT n, attr_vals_list, rel.name AS rel_name, peer,  CASE
     WHEN startNode(e1) = n AND startNode(e2) = rel AND rel.name IN $outbound_rel_ids THEN "outbound"
     WHEN startNode(e1) = rel AND startNode(e2) = n AND rel.name IN $inbound_rel_ids THEN "inbound"
@@ -151,38 +168,49 @@ AND e1.status = "active"
 AND e2.branch IN $branch_names
 AND e2.to IS NULL
 AND e2.status = "active"
-
+// ------------
+// collect everything to return a pair of lists with each node UUID
+// ------------
 WITH DISTINCT n, attr_vals_list, rel_name, peer, direction, attr.name AS peer_attr_name, peer_attr_val.value AS peer_val
 WITH n, attr_vals_list, collect([rel_name, direction, peer_attr_name, peer_val]) AS peer_attr_vals_list
         """ % {"schema_kind": self.schema_kind}
         self.add_to_query(get_details_query)
         self.return_labels = ["n.uuid AS n_uuid", "attr_vals_list", "peer_attr_vals_list"]
 
-    def get_result_map(self) -> dict[str, list[str]]:
+    def get_result_map(self, schema_paths: list[SchemaAttributePath]) -> dict[str, list[str]]:
+        """
+        Get the values for the given schema paths for all the Nodes captured by this query
+        """
+        # the query results for attribute and schema paths are unordered
+        # so we make this list of keys for ordering the results from the query
         schema_path_keys: list[tuple[str, RelationshipDirection, str] | str] = []
-        for schema_path in self.schema_paths:
+        for schema_path in schema_paths:
             if schema_path.is_type_attribute and schema_path.attribute_schema:
-                schema_path_keys.append(schema_path.attribute_schema.name)
-                continue
-            relationship_key = (
-                schema_path.relationship_schema.identifier,
-                schema_path.relationship_schema.direction,
-                schema_path.attribute_schema.name,
-            )
-            schema_path_keys.append(relationship_key)
+                path_key: str | tuple[str, RelationshipDirection, str] = schema_path.attribute_schema.name
+            elif schema_path.is_type_relationship and schema_path.relationship_schema and schema_path.attribute_schema:
+                path_key = (
+                    schema_path.relationship_schema.get_identifier(),
+                    schema_path.relationship_schema.direction,
+                    schema_path.attribute_schema.name,
+                )
+            schema_path_keys.append(path_key)
 
         result_map: dict[str, list[str]] = {}
         for result in self.get_results():
             node_uuid = result.get_as_type(label="n_uuid", return_type=str)
 
-            schema_path_value_map = {}
-            attr_values_tuples: list[tuple[str, Any]] = result.get(label="attr_vals_list")
+            # for each node, build a map of the schema path key to value so that they
+            # can be ordered correctly for the input `schema_paths`
+            schema_path_value_map: dict[str | tuple[str, RelationshipDirection, str], Any] = {}
+            attr_values_tuples: list[tuple[str, Any]] = result.get_as_type(label="attr_vals_list", return_type=list)
             for attr_value_tuple in attr_values_tuples:
                 attr_name = attr_value_tuple[0]
                 attr_value = attr_value_tuple[1]
                 schema_path_value_map[attr_name] = attr_value
 
-            relationship_values_tuples: list[tuple[str, str, str, Any]] = result.get(label="peer_attr_vals_list")
+            relationship_values_tuples: list[tuple[str, str, str, Any]] = result.get_as_type(
+                label="peer_attr_vals_list", return_type=list
+            )
             for rel_value_tuple in relationship_values_tuples:
                 rel_name = rel_value_tuple[0]
                 direction_raw = rel_value_tuple[1]
@@ -196,20 +224,26 @@ WITH n, attr_vals_list, collect([rel_name, direction, peer_attr_name, peer_val])
                 peer_val = rel_value_tuple[3]
                 schema_path_value_map[rel_name, direction, peer_attr_name] = peer_val
 
-            schema_path_values = ""
+            schema_path_values: list[str] = []
             for schema_path_key in schema_path_keys:
                 value = schema_path_value_map.get(schema_path_key)
-                schema_path_values += " " + str(value)
+                schema_path_values.append(str(value))
             result_map[node_uuid] = schema_path_values
         return result_map
 
 
 class UpdateAttributeValuesQuery(Query):
+    """
+    Update the values of the given attribute schema for the input Node-id-to-value map
+    Includes special handling for updating large-type attributes b/c they are not indexed and will be slow to update
+    on large data sets
+    """
+
     name = "update_attribute_values"
     type = QueryType.WRITE
     insert_return = False
 
-    def __init__(self, attribute_schema: AttributeSchema, values_by_id_map: dict[str, Any], **kwargs) -> None:
+    def __init__(self, attribute_schema: AttributeSchema, values_by_id_map: dict[str, Any], **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.attribute_name = attribute_schema.name
         self.is_large_type_attribute = is_large_attribute_type(attribute_schema.kind)
@@ -228,20 +262,55 @@ class UpdateAttributeValuesQuery(Query):
             "at": self.at.to_string(),
         }
 
+        if self.is_large_type_attribute:
+            # we make our own index of value to database ID, creating any vertices that are missing
+            # the mapping is a list of tuples instead of an actual mapping b/c creating an actual map is not possible
+            # without apoc functions
+            all_distinct_values = list(set(self.values_by_id_map.values()))
+            diy_index_query = """
+MATCH (av:AttributeValue&!AttributeValueIndexed {is_default: false})
+WHERE av.value IN $all_distinct_values
+WITH collect([av.value, elementId(av)]) AS value_id_pairs, collect(av.value) AS found_values
+WITH value_id_pairs, found_values,
+    reduce(
+        missing_distinct_values = [], value IN $all_distinct_values |
+            CASE
+                WHEN value IN found_values THEN missing_distinct_values
+                ELSE missing_distinct_values + [value]
+            END
+    ) AS missing_distinct_values
+CALL (missing_distinct_values) {
+    UNWIND missing_distinct_values AS missing_value
+    CREATE (av:AttributeValue {is_default: false, value: missing_value})
+    RETURN collect([av.value, elementId(av)]) AS created_value_id_pairs
+}
+WITH value_id_pairs + created_value_id_pairs AS value_id_pairs
+            """
+            self.params["all_distinct_values"] = all_distinct_values
+        else:
+            # if this is not a large-type attribute, then just set the map to be empty
+            diy_index_query = """WITH [] AS value_id_pairs"""
+
+        self.add_to_query(diy_index_query)
+
         update_value_query = """
+// ------------
+// Find the Nodes and Attributes we need to update
+// ------------
 MATCH (n:Node)-[e:IS_PART_OF]->(:Root)
 WHERE n.uuid IN $node_uuids
 AND e.branch IN [$default_branch, $global_branch]
 AND e.to IS NULL
 AND e.status = "active"
-
-WITH DISTINCT n
+WITH DISTINCT n, value_id_pairs
 MATCH (n)-[e:HAS_ATTRIBUTE]->(attr:Attribute {name: $attribute_name})
 WHERE e.branch IN [$default_branch, $global_branch]
 AND e.to IS NULL
 AND e.status = "active"
-
-WITH DISTINCT n, attr
+// ------------
+// If the attribute has an existing value on the branch, then set the to time on it
+// ------------
+WITH DISTINCT n, attr, value_id_pairs
 CALL (attr) {
     OPTIONAL MATCH (attr)-[e:HAS_VALUE]->(existing_av)
     WHERE e.branch IN [$default_branch, $global_branch]
@@ -249,15 +318,38 @@ CALL (attr) {
     AND e.status = "active"
     SET e.to = $at
 }
+        """
+        self.add_to_query(update_value_query)
 
+        if self.is_large_type_attribute:
+            # use the index we created at the start to get the database ID of the AttributeValue vertex
+            # and then link the Attribute to the AttributeValue
+            set_value_query = """
+WITH attr, value_id_pairs, $values_by_id[n.uuid] AS required_value
+WITH attr, value_id_pairs, required_value,
+    reduce(av_vertex_id = NULL, pair IN value_id_pairs |
+        CASE
+            WHEN av_vertex_id IS NOT NULL THEN av_vertex_id
+            WHEN pair[0] = required_value THEN pair[1]
+            ELSE av_vertex_id
+        END
+    ) AS av_vertex_id
+MATCH (av:AttributeValue)
+WHERE elementId(av) = av_vertex_id
+CREATE (attr)-[r:HAS_VALUE { branch: $branch, branch_level: $branch_level, status: "active", from: $at }]->(av)
+            """
+        else:
+            # if not a large-type attribute, then we can just use the regular MERGE clause
+            # that makes use of the index on AttributeValueIndexed
+            set_value_query = """
 CALL (n, attr) {
-    MERGE (av:%(attribute_value_type)s {is_default: false, value: $values_by_id[n.uuid]} )
+    MERGE (av:AttributeValue&AttributeValueIndexed {is_default: false, value: $values_by_id[n.uuid]} )
     WITH av, attr
     LIMIT 1
     CREATE (attr)-[r:HAS_VALUE { branch: $branch, branch_level: $branch_level, status: "active", from: $at }]->(av)
 }
-        """ % {"attribute_value_type": "AttributeValue" if self.is_large_type_attribute else "AttributeValueIndexed"}
-        self.add_to_query(update_value_query)
+            """
+        self.add_to_query(set_value_query)
 
 
 class Migration043(ArbitraryMigration):
@@ -267,13 +359,94 @@ class Migration043(ArbitraryMigration):
 
     name: str = "043_backfill_hfid_display_label_in_db"
     minimum_version: int = 42
-    display_label_batch_size: int = 1000
+    update_batch_size: int = 1000
+    # skip these b/c the attributes on these schema-related nodes are used to define the values included in
+    # the human_friendly_id and display_label attributes on instances of these schema, so should not be updated
+    kinds_to_skip: list[str] = [
+        "SchemaNode",
+        "SchemaAttribute",
+        "SchemaRelationship",
+        "SchemaGeneric",
+    ]
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
+    async def _do_one_schema_batch(
+        self,
+        db: InfrahubDatabase,
+        schema: NodeSchema,
+        schema_branch: SchemaBranch,
+        display_label_attribute_schema: AttributeSchema,
+        hfid_attribute_schema: AttributeSchema,
+        progress: Progress,
+        update_task: TaskID,
+    ) -> None:
+        if not schema.display_labels and not schema.human_friendly_id:
+            return
+
+        print(f"Processing {schema.kind}...", end="")
+
+        display_labels_schema_paths = [
+            schema.parse_schema_path(path=display_label, schema=schema_branch)
+            for display_label in schema.display_labels or []
+        ]
+        human_friendly_id_schema_paths = [
+            schema.parse_schema_path(path=human_friendly_id, schema=schema_branch)
+            for human_friendly_id in schema.human_friendly_id or []
+        ]
+        offset = 0
+
+        while True:
+            # loop until we get no results from the get_details_query
+            get_details_query = await GetPathDetailsDefaultBranch.init(
+                db=db,
+                schema_kind=schema.kind,
+                schema_paths=display_labels_schema_paths + human_friendly_id_schema_paths,
+                offset=offset,
+                limit=self.update_batch_size,
+            )
+            await get_details_query.execute(db=db)
+
+            display_label_schema_path_values_map = get_details_query.get_result_map(display_labels_schema_paths)
+            num_updates = len(display_label_schema_path_values_map)
+            if display_label_schema_path_values_map:
+                formatted_display_label_schema_path_values_map = {}
+                for k, v in display_label_schema_path_values_map.items():
+                    if v:
+                        formatted_display_label_schema_path_values_map[k] = " ".join(v)
+
+                update_display_label_query = await UpdateAttributeValuesQuery.init(
+                    db=db,
+                    attribute_schema=display_label_attribute_schema,
+                    values_by_id_map=formatted_display_label_schema_path_values_map,
+                )
+                await update_display_label_query.execute(db=db)
+
+            human_friendly_id_schema_path_values_map = get_details_query.get_result_map(human_friendly_id_schema_paths)
+
+            if human_friendly_id_schema_path_values_map:
+                formatted_human_friendly_id_schema_path_values_map = {}
+                for k, v in human_friendly_id_schema_path_values_map.items():
+                    if v:
+                        formatted_human_friendly_id_schema_path_values_map[k] = ujson.dumps(v)
+
+                update_human_friendly_id_query = await UpdateAttributeValuesQuery.init(
+                    db=db,
+                    attribute_schema=hfid_attribute_schema,
+                    values_by_id_map=formatted_human_friendly_id_schema_path_values_map,
+                )
+                await update_human_friendly_id_query.execute(db=db)
+            progress.update(update_task, advance=num_updates)
+
+            if not num_updates:
+                break
+
+            offset += self.update_batch_size
+
+        print("done")
+
     async def execute(self, db: InfrahubDatabase) -> MigrationResult:
-        # result = MigrationResult()
         root_node = await get_root_node(db=db, initialize=False)
         default_branch = root_node.default_branch
         schema_manager = SchemaManager()
@@ -281,69 +454,36 @@ class Migration043(ArbitraryMigration):
         schema_manager.register_schema(schema=internal_schema_root)
         registry.schema = schema_manager
         main_schema_branch = await schema_manager.load_schema_from_db(db=db, branch=default_branch)
-
-        total_nodes_query = await DefaultBranchNodeCount.init(db=db, branch_names=[default_branch, GLOBAL_BRANCH_NAME])
+        total_nodes_query = await DefaultBranchNodeCount.init(
+            db=db, branch_names=[default_branch, GLOBAL_BRANCH_NAME], kinds_to_skip=self.kinds_to_skip
+        )
         await total_nodes_query.execute(db=db)
         total_nodes_count = total_nodes_query.get_num_nodes()
 
         base_node_schema = main_schema_branch.get("SchemaNode", duplicate=False)
         display_label_attribute_schema = base_node_schema.get_attribute("display_label")
+        hfid_attribute_schema = base_node_schema.get_attribute("human_friendly_id")
 
-        with Progress() as progress:
-            update_task = progress.add_task(
-                f"Set display_label for {total_nodes_count} nodes on default branch", total=total_nodes_count
-            )
-            for node_schema_name in main_schema_branch.node_names:
-                schema = main_schema_branch.get_node(name=node_schema_name)
+        try:
+            with Progress() as progress:
+                update_task = progress.add_task(
+                    f"Set display_label and human_friendly_id for {total_nodes_count} nodes on default branch",
+                    total=total_nodes_count,
+                )
+                for node_schema_name in main_schema_branch.node_names:
+                    if node_schema_name in self.kinds_to_skip:
+                        continue
 
-                if not schema.display_labels:
-                    continue
-
-                display_labels_schema_paths = [
-                    schema.parse_schema_path(path=display_label, schema=main_schema_branch)
-                    for display_label in schema.display_labels
-                ]
-                offset = 0
-
-                while True:
-                    get_details_query = await GetPathDetailsDefaultBranch.init(
+                    node_schema = main_schema_branch.get_node(name=node_schema_name, duplicate=False)
+                    await self._do_one_schema_batch(
                         db=db,
-                        branch_names=[default_branch, GLOBAL_BRANCH_NAME],
-                        schema_kind=node_schema_name,
-                        schema_paths=display_labels_schema_paths,
-                        offset=offset,
-                        limit=self.display_label_batch_size,
+                        schema=node_schema,
+                        schema_branch=main_schema_branch,
+                        display_label_attribute_schema=display_label_attribute_schema,
+                        hfid_attribute_schema=hfid_attribute_schema,
+                        progress=progress,
+                        update_task=update_task,
                     )
-                    await get_details_query.execute(db=db)
-                    schema_path_values_map = get_details_query.get_result_map()
-
-                    if not schema_path_values_map:
-                        break
-
-                    for k, v in schema_path_values_map.items():
-                        print(node_schema_name, schema.display_labels, k, v)
-
-                    update_attribute_values_query = await UpdateAttributeValuesQuery.init(
-                        db=db, attribute_schema=display_label_attribute_schema, values_by_id_map=schema_path_values_map
-                    )
-                    await update_attribute_values_query.execute(db=db)
-
-                    offset += self.display_label_batch_size
-
-                    progress.update(update_task, advance=len(schema_path_values_map))
-
-        return MigrationResult(errors=["this is a pretend error"])
-
-
-params = {
-    "branch": "branch1",
-}
-identify_changed_nodes_query = """
-MATCH (n:%(schema_kind)s)-[e:IS_PART_OF]->(:Root)
-WHERE e.branch = $branch
-AND e.status = "active"
-AND e.to IS NULL
-AND NOT exists((n)-[:IS_PART_OF {branch: $branch, status: "deleted"}]->(:Root))
-
-MATCH
-"""
+        except Exception as exc:
+            return MigrationResult(errors=[str(exc)])
+        return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m043_backfill_hfid_display_label_in_db.py
+++ b/backend/infrahub/core/migrations/graph/m043_backfill_hfid_display_label_in_db.py
@@ -1,21 +1,263 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence
+from typing import TYPE_CHECKING, Any
 
-from rich.progress import Progress, TaskID
+from rich.progress import Progress
 
 from infrahub.core import registry
-from infrahub.core.initialization import initialization
-from infrahub.core.manager import NodeManager
+from infrahub.core.constants import GLOBAL_BRANCH_NAME, BranchSupportType, RelationshipDirection
+from infrahub.core.initialization import get_root_node
 from infrahub.core.migrations.shared import MigrationResult
-from infrahub.lock import initialize_lock
+from infrahub.core.query import Query, QueryType
+from infrahub.core.schema import AttributeSchema, SchemaRoot, internal_schema
+from infrahub.core.schema.manager import SchemaManager
+from infrahub.types import is_large_attribute_type
 
 from ..shared import ArbitraryMigration
 
 if TYPE_CHECKING:
-    from infrahub.core.node import Node
-    from infrahub.core.schema import MainSchemaTypes
+    from infrahub.core.schema.basenode_schema import SchemaAttributePath
     from infrahub.database import InfrahubDatabase
+
+# TODO: get HFID at same time as display labels
+# TODO: set HFID
+
+
+class DefaultBranchNodeCount(Query):
+    name = "get_branch_node_count"
+    type = QueryType.READ
+
+    def __init__(self, branch_names: list[str], **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.branch_names = branch_names
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
+        self.params = {
+            "branch_names": self.branch_names,
+        }
+        query = """
+MATCH (n:Node)-[e:IS_PART_OF]->(:Root)
+WHERE e.branch IN $branch_names
+AND e.status = "active"
+AND e.to IS NULL
+AND NOT exists((n)-[:IS_PART_OF {branch: e.branch, status: "deleted"}]->(:Root))
+WITH count(*) AS num_nodes
+        """
+        self.add_to_query(query)
+        self.return_labels = ["num_nodes"]
+
+    def get_num_nodes(self) -> int:
+        result = self.get_result()
+        if not result:
+            return 0
+        return result.get_as_type(label="num_nodes", return_type=int)
+
+
+class GetPathDetailsDefaultBranch(Query):
+    name = "get_path_details_default_branch"
+    type = QueryType.READ
+    insert_limit = False
+
+    def __init__(
+        self, branch_names: list[str], schema_kind: str, schema_paths: list[SchemaAttributePath], **kwargs: Any
+    ) -> None:
+        super().__init__(**kwargs)
+
+        self.branch_names = branch_names
+        self.schema_kind = schema_kind
+        self.schema_paths = schema_paths
+        self.attribute_names = []
+        self.bidir_rel_attr_map = {}
+        self.outbound_rel_attr_map = {}
+        self.inbound_rel_attr_map = {}
+        for schema_path in schema_paths:
+            if schema_path.is_type_attribute and schema_path.attribute_schema:
+                self.attribute_names.append(schema_path.attribute_schema.name)
+            elif schema_path.is_type_relationship and schema_path.relationship_schema and schema_path.attribute_schema:
+                key = schema_path.relationship_schema.identifier
+                value = schema_path.attribute_schema.name
+                if schema_path.relationship_schema.direction is RelationshipDirection.BIDIR:
+                    self.bidir_rel_attr_map[key] = value
+                elif schema_path.relationship_schema.direction is RelationshipDirection.OUTBOUND:
+                    self.outbound_rel_attr_map[key] = value
+                elif schema_path.relationship_schema.direction is RelationshipDirection.INBOUND:
+                    self.inbound_rel_attr_map[key] = value
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
+        self.params = {
+            "branch_names": self.branch_names,
+            "attribute_names": self.attribute_names,
+            "outbound_rel_ids": list(self.outbound_rel_attr_map.keys()),
+            "inbound_rel_ids": list(self.inbound_rel_attr_map.keys()),
+            "bidirectional_rel_ids": list(self.bidir_rel_attr_map.keys()),
+            "outbound_rel_attr_map": self.outbound_rel_attr_map,
+            "inbound_rel_attr_map": self.inbound_rel_attr_map,
+            "bidirectional_rel_attr_map": self.bidir_rel_attr_map,
+            "offset": self.offset,
+            "limit": self.limit,
+        }
+        get_details_query = """
+MATCH (n:%(schema_kind)s)-[e:IS_PART_OF]->(:Root)
+WHERE e.branch IN $branch_names
+AND e.to IS NULL
+AND e.status = "active"
+
+WITH DISTINCT n
+ORDER BY elementId(n)
+SKIP toInteger($offset)
+LIMIT toInteger($limit)
+
+OPTIONAL MATCH (n)-[e:HAS_ATTRIBUTE]->(attr:Attribute)
+WHERE attr.name IN $attribute_names
+AND e.branch IN $branch_names
+AND e.to IS NULL
+AND e.status = "active"
+WITH n, attr
+OPTIONAL MATCH (attr)-[e:HAS_VALUE]->(attr_val:AttributeValue)
+WHERE e.branch IN $branch_names
+AND e.to IS NULL
+AND e.status = "active"
+
+WITH n, collect([attr.name, attr_val.value]) AS attr_vals_list
+
+OPTIONAL MATCH (n)-[e1:IS_RELATED]-(rel:Relationship)-[e2:IS_RELATED]-(peer:Node)
+WHERE rel.name IN $bidirectional_rel_ids + $outbound_rel_ids + $inbound_rel_ids
+AND e1.branch IN $branch_names
+AND e1.to IS NULL
+AND e1.status = "active"
+AND e2.branch IN $branch_names
+AND e2.to IS NULL
+AND e2.status = "active"
+AND (
+    (startNode(e1) = n AND startNode(e2) = rel AND rel.name IN $outbound_rel_ids)
+    OR (startNode(e1) = rel AND startNode(e2) = n AND rel.name IN $inbound_rel_ids)
+    OR (startNode(e1) = n AND startNode(e2) = peer AND rel.name IN $bidirectional_rel_ids)
+)
+
+WITH DISTINCT n, attr_vals_list, rel.name AS rel_name, peer,  CASE
+    WHEN startNode(e1) = n AND startNode(e2) = rel AND rel.name IN $outbound_rel_ids THEN "outbound"
+    WHEN startNode(e1) = rel AND startNode(e2) = n AND rel.name IN $inbound_rel_ids THEN "inbound"
+    ELSE "bidir"
+END AS direction
+OPTIONAL MATCH (peer)-[e1:HAS_ATTRIBUTE]->(attr:Attribute)-[e2:HAS_VALUE]->(peer_attr_val:AttributeValue)
+WHERE (
+    (direction = "outbound" AND attr.name IN $outbound_rel_attr_map[rel_name])
+    OR (direction = "inbound" AND attr.name IN $inbound_rel_attr_map[rel_name])
+    OR (direction = "bidir" AND attr.name IN $bidirectional_rel_attr_map[rel_name])
+)
+AND e1.branch IN $branch_names
+AND e1.to IS NULL
+AND e1.status = "active"
+AND e2.branch IN $branch_names
+AND e2.to IS NULL
+AND e2.status = "active"
+
+WITH DISTINCT n, attr_vals_list, rel_name, peer, direction, attr.name AS peer_attr_name, peer_attr_val.value AS peer_val
+WITH n, attr_vals_list, collect([rel_name, direction, peer_attr_name, peer_val]) AS peer_attr_vals_list
+        """ % {"schema_kind": self.schema_kind}
+        self.add_to_query(get_details_query)
+        self.return_labels = ["n.uuid AS n_uuid", "attr_vals_list", "peer_attr_vals_list"]
+
+    def get_result_map(self) -> dict[str, list[str]]:
+        schema_path_keys: list[tuple[str, RelationshipDirection, str] | str] = []
+        for schema_path in self.schema_paths:
+            if schema_path.is_type_attribute and schema_path.attribute_schema:
+                schema_path_keys.append(schema_path.attribute_schema.name)
+                continue
+            relationship_key = (
+                schema_path.relationship_schema.identifier,
+                schema_path.relationship_schema.direction,
+                schema_path.attribute_schema.name,
+            )
+            schema_path_keys.append(relationship_key)
+
+        result_map: dict[str, list[str]] = {}
+        for result in self.get_results():
+            node_uuid = result.get_as_type(label="n_uuid", return_type=str)
+
+            schema_path_value_map = {}
+            attr_values_tuples: list[tuple[str, Any]] = result.get(label="attr_vals_list")
+            for attr_value_tuple in attr_values_tuples:
+                attr_name = attr_value_tuple[0]
+                attr_value = attr_value_tuple[1]
+                schema_path_value_map[attr_name] = attr_value
+
+            relationship_values_tuples: list[tuple[str, str, str, Any]] = result.get(label="peer_attr_vals_list")
+            for rel_value_tuple in relationship_values_tuples:
+                rel_name = rel_value_tuple[0]
+                direction_raw = rel_value_tuple[1]
+                direction = RelationshipDirection.BIDIR
+                match direction_raw:
+                    case "outbound":
+                        direction = RelationshipDirection.OUTBOUND
+                    case "inbound":
+                        direction = RelationshipDirection.INBOUND
+                peer_attr_name = rel_value_tuple[2]
+                peer_val = rel_value_tuple[3]
+                schema_path_value_map[rel_name, direction, peer_attr_name] = peer_val
+
+            schema_path_values = ""
+            for schema_path_key in schema_path_keys:
+                value = schema_path_value_map.get(schema_path_key)
+                schema_path_values += " " + str(value)
+            result_map[node_uuid] = schema_path_values
+        return result_map
+
+
+class UpdateAttributeValuesQuery(Query):
+    name = "update_attribute_values"
+    type = QueryType.WRITE
+    insert_return = False
+
+    def __init__(self, attribute_schema: AttributeSchema, values_by_id_map: dict[str, Any], **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.attribute_name = attribute_schema.name
+        self.is_large_type_attribute = is_large_attribute_type(attribute_schema.kind)
+        self.is_branch_agnostic = attribute_schema.get_branch() is BranchSupportType.AGNOSTIC
+        self.values_by_id_map = values_by_id_map
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
+        self.params = {
+            "node_uuids": list(self.values_by_id_map.keys()),
+            "attribute_name": self.attribute_name,
+            "values_by_id": self.values_by_id_map,
+            "default_branch": registry.default_branch,
+            "global_branch": GLOBAL_BRANCH_NAME,
+            "branch": GLOBAL_BRANCH_NAME if self.is_branch_agnostic else registry.default_branch,
+            "branch_level": 1,
+            "at": self.at.to_string(),
+        }
+
+        update_value_query = """
+MATCH (n:Node)-[e:IS_PART_OF]->(:Root)
+WHERE n.uuid IN $node_uuids
+AND e.branch IN [$default_branch, $global_branch]
+AND e.to IS NULL
+AND e.status = "active"
+
+WITH DISTINCT n
+MATCH (n)-[e:HAS_ATTRIBUTE]->(attr:Attribute {name: $attribute_name})
+WHERE e.branch IN [$default_branch, $global_branch]
+AND e.to IS NULL
+AND e.status = "active"
+
+WITH DISTINCT n, attr
+CALL (attr) {
+    OPTIONAL MATCH (attr)-[e:HAS_VALUE]->(existing_av)
+    WHERE e.branch IN [$default_branch, $global_branch]
+    AND e.to IS NULL
+    AND e.status = "active"
+    SET e.to = $at
+}
+
+CALL (n, attr) {
+    MERGE (av:%(attribute_value_type)s {is_default: false, value: $values_by_id[n.uuid]} )
+    WITH av, attr
+    LIMIT 1
+    CREATE (attr)-[r:HAS_VALUE { branch: $branch, branch_level: $branch_level, status: "active", from: $at }]->(av)
+}
+        """ % {"attribute_value_type": "AttributeValue" if self.is_large_type_attribute else "AttributeValueIndexed"}
+        self.add_to_query(update_value_query)
 
 
 class Migration043(ArbitraryMigration):
@@ -25,62 +267,83 @@ class Migration043(ArbitraryMigration):
 
     name: str = "043_backfill_hfid_display_label_in_db"
     minimum_version: int = 42
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
+    display_label_batch_size: int = 1000
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def _update_batch(
-        self,
-        db: InfrahubDatabase,
-        node_schema: MainSchemaTypes,
-        nodes: Sequence[Node],
-        progress: Progress,
-        update_task: TaskID,
-    ) -> None:
-        for node in nodes:
-            fields = []
-            if node_schema.human_friendly_id:
-                await node.add_human_friendly_id(db=db)
-                fields.append("human_friendly_id")
-            if node_schema.display_label:
-                await node.add_display_label(db=db)
-                fields.append("display_label")
-
-            if fields:
-                await node.save(db=db, fields=fields)
-
-            progress.update(task_id=update_task, advance=1)
-
     async def execute(self, db: InfrahubDatabase) -> MigrationResult:
-        result = MigrationResult()
-        # load schemas from database into registry
-        initialize_lock()
-        await initialization(db=db)
+        # result = MigrationResult()
+        root_node = await get_root_node(db=db, initialize=False)
+        default_branch = root_node.default_branch
+        schema_manager = SchemaManager()
+        internal_schema_root = SchemaRoot(**internal_schema)
+        schema_manager.register_schema(schema=internal_schema_root)
+        registry.schema = schema_manager
+        main_schema_branch = await schema_manager.load_schema_from_db(db=db, branch=default_branch)
 
-        schemas_to_update: dict[MainSchemaTypes, int] = {}
-        for node_schema in registry.get_full_schema(duplicate=False).values():
-            if node_schema.is_generic_schema or (not node_schema.human_friendly_id and not node_schema.display_label):
-                continue
+        total_nodes_query = await DefaultBranchNodeCount.init(db=db, branch_names=[default_branch, GLOBAL_BRANCH_NAME])
+        await total_nodes_query.execute(db=db)
+        total_nodes_count = total_nodes_query.get_num_nodes()
 
-            node_count = await NodeManager.count(db=db, schema=node_schema)
-            if node_count:
-                schemas_to_update[node_schema] = node_count
+        base_node_schema = main_schema_branch.get("SchemaNode", duplicate=False)
+        display_label_attribute_schema = base_node_schema.get_attribute("display_label")
 
         with Progress() as progress:
-            batch_size = 1000
             update_task = progress.add_task(
-                "Backfill HFID and display_label for nodes in database", total=sum(schemas_to_update.values())
+                f"Set display_label for {total_nodes_count} nodes on default branch", total=total_nodes_count
             )
+            for node_schema_name in main_schema_branch.node_names:
+                schema = main_schema_branch.get_node(name=node_schema_name)
 
-            for schema, count in schemas_to_update.items():
-                for offset in range(0, count, batch_size):
-                    limit = min(batch_size, count - offset)
-                    nodes: list[Node] = await NodeManager.query(db=db, schema=schema, offset=offset, limit=limit)
-                    await self._update_batch(
-                        db=db, node_schema=schema, nodes=nodes, progress=progress, update_task=update_task
+                if not schema.display_labels:
+                    continue
+
+                display_labels_schema_paths = [
+                    schema.parse_schema_path(path=display_label, schema=main_schema_branch)
+                    for display_label in schema.display_labels
+                ]
+                offset = 0
+
+                while True:
+                    get_details_query = await GetPathDetailsDefaultBranch.init(
+                        db=db,
+                        branch_names=[default_branch, GLOBAL_BRANCH_NAME],
+                        schema_kind=node_schema_name,
+                        schema_paths=display_labels_schema_paths,
+                        offset=offset,
+                        limit=self.display_label_batch_size,
                     )
+                    await get_details_query.execute(db=db)
+                    schema_path_values_map = get_details_query.get_result_map()
 
-        return result
+                    if not schema_path_values_map:
+                        break
+
+                    for k, v in schema_path_values_map.items():
+                        print(node_schema_name, schema.display_labels, k, v)
+
+                    update_attribute_values_query = await UpdateAttributeValuesQuery.init(
+                        db=db, attribute_schema=display_label_attribute_schema, values_by_id_map=schema_path_values_map
+                    )
+                    await update_attribute_values_query.execute(db=db)
+
+                    offset += self.display_label_batch_size
+
+                    progress.update(update_task, advance=len(schema_path_values_map))
+
+        return MigrationResult(errors=["this is a pretend error"])
+
+
+params = {
+    "branch": "branch1",
+}
+identify_changed_nodes_query = """
+MATCH (n:%(schema_kind)s)-[e:IS_PART_OF]->(:Root)
+WHERE e.branch = $branch
+AND e.status = "active"
+AND e.to IS NULL
+AND NOT exists((n)-[:IS_PART_OF {branch: $branch, status: "deleted"}]->(:Root))
+
+MATCH
+"""

--- a/backend/tests/unit/core/migrations/graph/test_042_043.py
+++ b/backend/tests/unit/core/migrations/graph/test_042_043.py
@@ -34,6 +34,9 @@ class TestMigration042(TestInfrahubApp):
     ) -> dict[str, Node]:
         await load_schema(db=db, schema=SchemaRoot(nodes=[WIDGET]), branch_name=default_branch.name, update_db=True)
         widget_schema = registry.schema.get_node_schema(name=WIDGET.kind, branch=default_branch)
+        # just saving and loading this one schema speeds up the test
+        widget_only_schema_branch = SchemaBranch(cache={widget_schema.kind: widget_schema}, name=default_branch.name)
+        await registry.schema.load_schema_to_db(db=db, schema=widget_only_schema_branch)
 
         nodes: dict[str, Node] = {}
         for name in [
@@ -56,7 +59,9 @@ class TestMigration042(TestInfrahubApp):
 
         return nodes
 
-    async def test_migration_042_043(self, db: InfrahubDatabase, initial_dataset: dict[str, Node]) -> None:
+    async def test_migration_042_043(
+        self, db: InfrahubDatabase, default_branch: Branch, initial_dataset: dict[str, Node]
+    ) -> None:
         results = await db.execute_query(query=QUERY_HFID)
         assert not results
 
@@ -87,6 +92,8 @@ class TestMigration042(TestInfrahubApp):
         results = await db.execute_query(query=QUERY_HFID)
         assert results
 
+        schema_branch = await registry.schema.load_schema_from_db(db=db, branch=default_branch)
+        registry.schema.set_schema_branch(name=default_branch.name, schema=schema_branch)
         nodes: list[Node] = await NodeManager.query(db=db, schema=WIDGET.kind)
         assert len(nodes) == 10
         assert nodes[0].has_human_friendly_id()


### PR DESCRIPTION
a few new queries to improve the performance of the migration to set display label and human_friendly_id values for all active nodes on the default and global branches

logic to handle non-default branches will come later. it first requires logic to identify which nodes need to be updated on a given branch

migration works basically like this
- for each node schema that is not a SchemaNode, SchemaGeneric, SchemaRelationship, or SchemaAttribute
  - if this node schema has display_labels or human_friendly_id defined
    - in batches of 1000, do the following
      - get the current attribute values or attribute values of relationships that are used in the display labels/ HFID
      - set the display labels
      - set the HFID

there is some finagling required in the query to set attribute values when working with large-type attributes (List, JSON, TextArea), of which human_friendly_id happens to be one b/c these attributes are not indexed. Looking for an AttributeValue vertex with a particular value in the whole database requires looking at every AttributeValue vertex and, in a large database, this will take a long time if we need to do it once for every node. My solution is probably a little hard to read, but it is effectively building our own index for each batch of 1000 nodes

one thing to please keep an eye out for. I am not sure if I am using `display_label` vs `display_labels` in the correct places.