### PR TITLE
add blog post

### DIFF
--- a/docs/docs/guides/change-approval-workflow.mdx
+++ b/docs/docs/guides/change-approval-workflow.mdx
@@ -10,6 +10,12 @@ This guide walks you through implementing a change approval workflow in Infrahub
 Some features in this guide require the Enterprise Edition of Infrahub. If you are using the Community Edition, the enforcement mechanisms of the change approval workflow will not be available, though you can still implement a process-based approach.
 :::
 
+:::success Change Management Workflow Blog Post
+
+Want to see how branches can be used in a change management workflow? Read our blog post on [Infrahub’s Change Management Workflow Is Built for Infrastructure Data](https://opsmill.com/blog/infrastructure-change-management-workflow/).
+
+:::
+
 ## What you'll build
 
 By the end of this guide, you'll have a complete governance system for infrastructure changes that includes:
@@ -296,3 +302,4 @@ Users with `Super Administrator` permission can:
 - [Managing users and permissions](../topics/permissions-roles)
 - [Working with branches](../topics/version-control)
 - [Configuring Git repositories](../guides/repository)
+- [Change Management Workflow Blog Post](https://opsmill.com/blog/infrastructure-change-management-workflow/)

--- a/docs/docs/topics/branching.mdx
+++ b/docs/docs/topics/branching.mdx
@@ -28,6 +28,12 @@ Branching in Infrahub supports various infrastructure management workflows:
 - **Experimentation**: Use branches to test new ideas or approaches without affecting the production environment. This provides a safe sandbox to validate new configurations or architectures before committing to them.
 - **Transaction support**: Group related changes into a single branch, ensuring atomic updates and easier rollbacks. This maintains consistency when implementing interdependent infrastructure changes.
 
+:::success Change Management Workflow Blog Post
+
+Want to see how branches can be used in a change management workflow? Read our blog post on [Infrahub’s Change Management Workflow Is Built for Infrastructure Data](https://opsmill.com/blog/infrastructure-change-management-workflow/).
+
+:::
+
 ## Core concepts
 
 Branches in Infrahub serve as isolated workspaces where changes can be prepared, validated, and reviewed before merging into production. Each branch maintains its own independent view of the data while sharing the underlying immutable history.
@@ -192,6 +198,7 @@ This approach means creating a branch has minimal overhead, and storage grows on
 
 ## Related topics
 
+- [Branching Blog Post](https://opsmill.com/blog/infrastructure-change-management-workflow/)
 - [Git Integration](./repository.mdx)
 - [Proposed Change](./proposed-change.mdx)
 - [Immutable History](./version-control.mdx)

--- a/docs/docs/topics/proposed-change.mdx
+++ b/docs/docs/topics/proposed-change.mdx
@@ -187,3 +187,4 @@ The proposed change functionality interconnects with several other key concepts 
 - [Transformations](transformation): Understand how data transformations are managed and reviewed within proposed changes
 - [Generators](generator): Learn about the code generation process that can be triggered by changes in proposed changes
 - [Permissions and roles](permissions-roles): Understand the access controls that govern who can create, review, and merge proposed changes
+- [Change Management Workflow Blog Post](https://opsmill.com/blog/infrastructure-change-management-workflow/)

--- a/docs/docs/tutorials/getting-started/branches.mdx
+++ b/docs/docs/tutorials/getting-started/branches.mdx
@@ -171,6 +171,6 @@ Go back to the detailed page for the Tenant `my-first-tenant`.
 
 :::info Proposed Change
 
-For an in-depth understanding of Infrahub's approach to handling differences between branches and merging them, please consult the  [proposed change topic](../../topics/proposed-change).
+For an in-depth understanding of Infrahub's approach to handling differences between branches and merging them, please consult the [proposed change topic](../../topics/proposed-change).
 
 :::


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Change Management Workflow" blog post callout and reference link across branching, change-approval, proposed-change, and related topics.
  * Added a navigation link entry for the Change Management Workflow blog post.
  * Fixed markdown formatting in the branches getting-started tutorial (removed extra spaces before inline links).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->