### PR TITLE
fix(backend): get_many regression on big result sets

### DIFF
--- a/backend/infrahub/core/diff/query/artifact.py
+++ b/backend/infrahub/core/diff/query/artifact.py
@@ -201,4 +201,5 @@ CALL (target_node, definition_node){
             "target_checksum",
             "target_storage_id",
         ]
+        self.order_by = ["source_artifact.uuid", "target_node.uuid", "definition_node.uuid"]
         self.add_to_query(query=query)

--- a/backend/infrahub/core/diff/query/field_summary.py
+++ b/backend/infrahub/core/diff/query/field_summary.py
@@ -62,6 +62,7 @@ class EnrichedDiffNodeFieldSummaryQuery(Query):
         }
         """
         self.add_to_query(query=query)
+        self.order_by = ["kind"]
         self.return_labels = ["kind", "attr_names", "rel_names"]
 
     async def get_field_summaries(self) -> list[NodeDiffFieldSummary]:

--- a/backend/infrahub/core/query/ipam.py
+++ b/backend/infrahub/core/query/ipam.py
@@ -688,6 +688,7 @@ class IPPrefixReconcileQuery(Query):
             "ip_address_attribute_kind": ADDRESS_ATTRIBUTE_LABEL,
         }
         self.add_to_query(get_new_children_query)
+        self.order_by = ["ip_node.uuid"]
         self.return_labels = ["ip_node", "current_parent", "current_children", "new_parent", "new_children"]
 
     def _get_uuid_from_query(self, node_name: str) -> str | None:

--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -988,6 +988,7 @@ class NodeListGetInfoQuery(Query):
         )
         self.params.update(branch_params)
         self.params["ids"] = self.ids
+        self.order_by = ["n.uuid"]
 
         query = """
         MATCH p = (root:Root)<-[:IS_PART_OF]-(n:Node)

--- a/backend/infrahub/core/query/relationship.py
+++ b/backend/infrahub/core/query/relationship.py
@@ -1036,6 +1036,7 @@ class RelationshipCountPerNodeQuery(Query):
         """ % {"branch_filter": branch_filter, "path": path}
 
         self.add_to_query(query)
+        self.order_by = ["peer_node.uuid"]
         self.return_labels = ["peer_node.uuid", "COUNT(peer_node.uuid) as nbr_peers"]
 
     async def get_count_per_peer(self) -> dict[str, int]:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -22,6 +22,7 @@ from testcontainers.core.waiting_utils import wait_for_logs
 
 from infrahub import config
 from infrahub.config import load_and_exit
+from infrahub.constants.database import Neo4jRuntime
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import BranchSupportType, InfrahubKind, RelationshipCardinality, RelationshipDirection
@@ -167,6 +168,22 @@ async def do_default_branch(db: InfrahubDatabase) -> Branch:
     await create_global_branch(db=db)
     registry.schema = SchemaManager()
     return branch
+
+
+@pytest.fixture
+def query_limit_of_one() -> Generator[None, None, None]:
+    original_query_size_limit = config.SETTINGS.database.query_size_limit
+    config.SETTINGS.database.query_size_limit = 1
+    yield
+    config.SETTINGS.database.query_size_limit = original_query_size_limit
+
+
+@pytest.fixture
+def neo4j_runtime_parallel(db: InfrahubDatabase) -> Generator[None, None, None]:
+    original_neo4j_runtime = db.default_neo4j_runtime
+    db.default_neo4j_runtime = Neo4jRuntime.PARALLEL
+    yield
+    db.default_neo4j_runtime = original_neo4j_runtime
 
 
 @pytest.fixture

--- a/backend/tests/unit/core/test_manager_node.py
+++ b/backend/tests/unit/core/test_manager_node.py
@@ -3,6 +3,8 @@ import copy
 import pytest
 from infrahub_sdk.uuidt import UUIDT
 
+from infrahub import config
+from infrahub.constants.database import Neo4jRuntime
 from infrahub.core.branch import Branch
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager, identify_node_class
@@ -275,6 +277,39 @@ async def test_get_by_hfid_with_invalid_hfid(db: InfrahubDatabase, branch: Branc
 async def test_get_many(db: InfrahubDatabase, default_branch: Branch, criticality_low, criticality_medium):
     nodes = await NodeManager.get_many(db=db, ids=[criticality_low.id, criticality_medium.id])
     assert len(nodes) == 2
+
+
+async def test_get_many_with_pagination(
+    db: InfrahubDatabase,
+    default_branch: Branch,
+    criticality_schema: NodeSchema,
+    criticality_low: Node,
+    criticality_medium: Node,
+    criticality_high: Node,
+):
+    new_node_ids: list[str] = []
+    for index in range(10):
+        bulk_node = await Node.init(db=db, schema=criticality_schema, branch=default_branch)
+        await bulk_node.new(db=db, name=f"bulk-{index}", level=index)
+        await bulk_node.save(db=db)
+        new_node_ids.append(bulk_node.id)
+
+    original_query_size_limit = config.SETTINGS.database.query_size_limit
+    config.SETTINGS.database.query_size_limit = 1
+    original_neo4j_runtime = db.default_neo4j_runtime
+    db.default_neo4j_runtime = Neo4jRuntime.PARALLEL
+
+    try:
+        target_ids = [criticality_low.id, criticality_medium.id, criticality_high.id, *new_node_ids]
+        nodes = await NodeManager.get_many(db=db, ids=target_ids)
+    finally:
+        config.SETTINGS.database.query_size_limit = original_query_size_limit
+        db.default_neo4j_runtime = original_neo4j_runtime
+
+    expected_ids = set(target_ids)
+    assert set(nodes) == expected_ids
+    assert len(nodes) == len(expected_ids)
+    assert all(isinstance(nodes[node_id], Node) for node_id in expected_ids)
 
 
 async def test_get_many_prefetch(

--- a/backend/tests/unit/core/test_manager_node.py
+++ b/backend/tests/unit/core/test_manager_node.py
@@ -3,8 +3,6 @@ import copy
 import pytest
 from infrahub_sdk.uuidt import UUIDT
 
-from infrahub import config
-from infrahub.constants.database import Neo4jRuntime
 from infrahub.core.branch import Branch
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager, identify_node_class
@@ -286,6 +284,8 @@ async def test_get_many_with_pagination(
     criticality_low: Node,
     criticality_medium: Node,
     criticality_high: Node,
+    query_limit_of_one: None,
+    neo4j_runtime_parallel: None,
 ):
     new_node_ids: list[str] = []
     for index in range(10):
@@ -294,22 +294,12 @@ async def test_get_many_with_pagination(
         await bulk_node.save(db=db)
         new_node_ids.append(bulk_node.id)
 
-    original_query_size_limit = config.SETTINGS.database.query_size_limit
-    config.SETTINGS.database.query_size_limit = 1
-    original_neo4j_runtime = db.default_neo4j_runtime
-    db.default_neo4j_runtime = Neo4jRuntime.PARALLEL
+    target_ids = [criticality_low.id, criticality_medium.id, criticality_high.id, *new_node_ids]
+    nodes = await NodeManager.get_many(db=db, ids=target_ids)
 
-    try:
-        target_ids = [criticality_low.id, criticality_medium.id, criticality_high.id, *new_node_ids]
-        nodes = await NodeManager.get_many(db=db, ids=target_ids)
-    finally:
-        config.SETTINGS.database.query_size_limit = original_query_size_limit
-        db.default_neo4j_runtime = original_neo4j_runtime
-
-    expected_ids = set(target_ids)
-    assert set(nodes) == expected_ids
-    assert len(nodes) == len(expected_ids)
-    assert all(isinstance(nodes[node_id], Node) for node_id in expected_ids)
+    assert set(nodes) == set(target_ids)
+    assert len(nodes) == len(target_ids)
+    assert all(isinstance(nodes[node_id], Node) for node_id in target_ids)
 
 
 async def test_get_many_prefetch(


### PR DESCRIPTION
Due to a missing order by in NodeListGetInfoQuery, we may end up with a smaller result set than expected due to duplicate rows.

it appears as though rows are returned in a non-deterministic manner when using the `parallel` runtime for Neo4j, but the results are deterministic when using the default runtime.
for example, given the below query
```
MATCH (n:Node)
RETURN n
LIMIT 1
```
using the parallel runtime, we don't know what Node will be returned _and_ it can be a different node if we run this query multiple times
using the default runtime, we don't know what Node will be returned, but it will be the same node if we run the query multiple times

so we need to make sure that any queries that could use the parallel runtime will always return their results in a 100% deterministic manner or we could end up duplicating and/or missing results if a query is run with a limit and/or offset

@ajtmccarty went through the queries we use with the parallel runtime and added ordering to those that needed it