### PR TITLE
small changes to take or disregard

### DIFF
--- a/backend/infrahub/cli/db.py
+++ b/backend/infrahub/cli/db.py
@@ -22,6 +22,7 @@ from rich.table import Table
 from infrahub import config
 from infrahub.core import registry
 from infrahub.core.branch import Branch
+from infrahub.core.branch.enums import BranchStatus
 from infrahub.core.constants import GLOBAL_BRANCH_NAME
 from infrahub.core.graph import GRAPH_VERSION
 from infrahub.core.graph.constraints import ConstraintManagerBase, ConstraintManagerMemgraph, ConstraintManagerNeo4j
@@ -175,7 +176,10 @@ async def migrate_cmd(
     context: CliContext = ctx.obj
     dbdriver = await context.init_db(retry=1)
 
-    migrations = await detect_migration_to_run(db=dbdriver, migration_number=migration_number)
+    root_node = await get_root_node(db=dbdriver)
+    migrations = await detect_migration_to_run(
+        current_graph_version=root_node.graph_version, migration_number=migration_number
+    )
 
     if check or not migrations:
         return
@@ -344,17 +348,16 @@ async def index(
 
 
 async def detect_migration_to_run(
-    db: InfrahubDatabase, migration_number: int | str | None = None
+    current_graph_version: int, migration_number: int | str | None = None
 ) -> Sequence[GraphMigration | InternalSchemaMigration | ArbitraryMigration | MigrationWithRebase]:
     """Return a sequence of migrations to apply to upgrade the database."""
     rprint("Checking current state of the database")
     migrations: list[GraphMigration | InternalSchemaMigration | ArbitraryMigration | MigrationWithRebase] = []
 
-    root_node = await get_root_node(db=db)
     if migration_number:
         migration = get_migration_by_number(migration_number)
         migrations.append(migration)
-        if root_node.graph_version > migration.minimum_version:
+        if current_graph_version > migration.minimum_version:
             rprint(
                 f"Migration {migration_number} already applied. To apply again, run the command without the --check flag."
             )
@@ -363,13 +366,13 @@ async def detect_migration_to_run(
             f"Migration {migration_number} needs to be applied. Run `infrahub db migrate` to apply all outstanding migrations."
         )
     else:
-        migrations.extend(await get_graph_migrations(root=root_node))
+        migrations.extend(await get_graph_migrations(current_graph_version=current_graph_version))
         if not migrations:
-            rprint(f"Database up-to-date (v{root_node.graph_version}), no migration to execute.")
+            rprint(f"Database up-to-date (v{current_graph_version}), no migration to execute.")
             return []
 
     rprint(
-        f"Database needs to be updated (v{root_node.graph_version} -> v{GRAPH_VERSION}), {len(migrations)} migrations pending"
+        f"Database needs to be updated (v{current_graph_version} -> v{GRAPH_VERSION}), {len(migrations)} migrations pending"
     )
     return migrations
 
@@ -387,6 +390,9 @@ async def migrate_database(
         db: The database object.
         migration_number: If provided, the function will only apply the migration with the given number. Defaults to None.
     """
+    if not migrations:
+        return True
+
     if initialize:
         await initialize_registry(db=db)
 
@@ -415,33 +421,49 @@ async def migrate_database(
     return True
 
 
-async def rebase_and_migrate_branches(
-    db: InfrahubDatabase,
-    migrations: Sequence[GraphMigration | InternalSchemaMigration | ArbitraryMigration | MigrationWithRebase],
-) -> bool:
+async def rebase_and_migrate_branches(db: InfrahubDatabase, current_graph_version: int) -> bool:
     """Only applies migrations that aim at rebasing branches."""
-    branches = [b for b in await Branch.get_list(db=db) if b.name not in [registry.default_branch, GLOBAL_BRANCH_NAME]]
+    branches = [
+        b
+        for b in await Branch.get_list(db=db)
+        if b.name not in [registry.default_branch, GLOBAL_BRANCH_NAME]
+        and (not b.graph_version or b.graph_version < current_graph_version)
+    ]
+
+    if not branches:
+        return True
+
     rprint(f"Planning rebase and migrations for {len(branches)} branches: {', '.join([b.name for b in branches])}")
 
-    rebase_migrations = [m for m in migrations if isinstance(m, MigrationWithRebase)]
+    for branch in branches:
+        migrations = [
+            m
+            for m in await detect_migration_to_run(current_graph_version=branch.graph_version or current_graph_version)
+            if isinstance(m, MigrationWithRebase)
+        ]
+        rprint(
+            f"Detected {len(migrations)} migrations to run against '{branch.name}' (ID: {branch.uuid}): {', '.join([m.name for m in migrations])}"
+        )
 
-    for migration in rebase_migrations:
-        execution_result = await migration.execute_against_branches(db=db, branches=branches)
-        validation_result = None
+        for migration in migrations:
+            execution_result = await migration.execute_against_branch(db=db, branch=branch)
+            validation_result = None
 
-        if execution_result.success:
-            validation_result = await migration.validate_migration(db=db)
-            if validation_result.success:
-                rprint(f"Migration: {migration.name} {SUCCESS_BADGE}")
+            if execution_result.success:
+                validation_result = await migration.validate_migration(db=db)
+                if validation_result.success and branch.status != BranchStatus.NEED_UPGRADE_REBASE:
+                    branch.graph_version = migration.minimum_version + 1
+                    await branch.save(db=db)
+                    rprint(f"Migration: {migration.name} {SUCCESS_BADGE}")
 
-        if not execution_result.success or (validation_result and not validation_result.success):
-            rprint(f"Migration: {migration.name} {FAILED_BADGE}")
-            for error in execution_result.errors:
-                rprint(f"  {error}")
-            if validation_result and not validation_result.success:
-                for error in validation_result.errors:
+            if not execution_result.success or (validation_result and not validation_result.success):
+                rprint(f"Migration: {migration.name} {FAILED_BADGE}")
+                for error in execution_result.errors:
                     rprint(f"  {error}")
-            return False
+                if validation_result and not validation_result.success:
+                    for error in validation_result.errors:
+                        rprint(f"  {error}")
+                return False
 
     return True
 

--- a/backend/infrahub/cli/db.py
+++ b/backend/infrahub/cli/db.py
@@ -337,26 +337,10 @@ async def index(
     await dbdriver.close()
 
 
-async def migrate_database(  # noqa: PLR0911
-    db: InfrahubDatabase,
-    initialize: bool = False,
-    check: bool = False,
-    migration_number: int | str | None = None,
-    with_rebase: bool = False,
-) -> bool:
-    """Apply the latest migrations to the database, this function will print the status directly in the console.
-
-    Returns a boolean indicating whether a migration failed or if all migrations succeeded.
-
-    Args:
-        db: The database object.
-        check: If True, the function will only check the status of the database and not apply the migrations. Defaults to False.
-        migration_number: If provided, the function will only apply the migration with the given number. Defaults to None.
-    """
+async def detect_migration_to_run(
+    db: InfrahubDatabase, check: bool = False, migration_number: int | str | None = None
+) -> Sequence[GraphMigration | InternalSchemaMigration | ArbitraryMigration | MigrationWithRebase]:
     rprint("Checking current state of the Database")
-
-    if initialize:
-        await initialize_registry(db=db)
 
     root_node = await get_root_node(db=db)
     if migration_number:
@@ -369,27 +353,42 @@ async def migrate_database(  # noqa: PLR0911
                 rprint(
                     f"Migration {migration_number} already applied. To apply again, run the command without the --check flag."
                 )
-                return True
+                return []
             rprint(
                 f"Migration {migration_number} needs to be applied. Run `infrahub db migrate` to apply all outstanding migrations."
             )
-            return False
+            return migrations
     else:
         migrations = await get_graph_migrations(root=root_node)
         if not migrations:
             rprint(f"Database up-to-date (v{root_node.graph_version}), no migration to execute.")
-            return True
+            return []
 
         rprint(
             f"Database needs to be updated (v{root_node.graph_version} -> v{GRAPH_VERSION}), {len(migrations)} migrations pending"
         )
 
-    if check:
-        return True
+    return migrations
 
-    # Simply exit if we want to apply rebase migrations without having any of them
-    if not [m for m in migrations if isinstance(m, MigrationWithRebase)] and not with_rebase:
-        return True
+
+async def migrate_database(
+    db: InfrahubDatabase,
+    migrations: Sequence[GraphMigration | InternalSchemaMigration | ArbitraryMigration | MigrationWithRebase],
+    initialize: bool = False,
+    with_rebase: bool = False,
+) -> bool:
+    """Apply the latest migrations to the database, this function will print the status directly in the console.
+
+    Returns a boolean indicating whether a migration failed or if all migrations succeeded.
+
+    Args:
+        db: The database object.
+        migration_number: If provided, the function will only apply the migration with the given number. Defaults to None.
+    """
+    if initialize:
+        await initialize_registry(db=db)
+
+    root_node = await get_root_node(db=db)
 
     for migration in migrations:
         # NOTE: this could be a different function
@@ -418,6 +417,22 @@ async def migrate_database(  # noqa: PLR0911
             return False
 
     return True
+
+
+async def rebase_and_migrate_branches(
+    db: InfrahubDatabase,
+    migrations: Sequence[GraphMigration | InternalSchemaMigration | ArbitraryMigration | MigrationWithRebase],
+) -> None:
+    branches = [b for b in await Branch.get_list(db=db) if b.name != registry.default_branch]
+    rebase_migrations = [m for m in migrations if isinstance(m, MigrationWithRebase)]
+
+    for migration in rebase_migrations:
+        execution_result = await migration.execute_against_branches(db=db, branches=branches)
+
+        if execution_result.success:
+            validation_result = await migration.validate_migration(db=db)
+            if validation_result.success:
+                rprint(f"Migration: {migration.name} {SUCCESS_BADGE}")
 
 
 async def initialize_internal_schema() -> None:

--- a/backend/infrahub/cli/db.py
+++ b/backend/infrahub/cli/db.py
@@ -416,6 +416,8 @@ async def rebase_and_migrate_branches(
 ) -> None:
     """Only applies migrations that aim at rebasing branches."""
     branches = [b for b in await Branch.get_list(db=db) if b.name not in [registry.default_branch, GLOBAL_BRANCH_NAME]]
+    rprint(f"Planning rebase and migrations for {len(branches)} branches: {', '.join([b.name for b in branches])}")
+
     rebase_migrations = [m for m in migrations if isinstance(m, MigrationWithRebase)]
 
     for migration in rebase_migrations:

--- a/backend/infrahub/cli/db.py
+++ b/backend/infrahub/cli/db.py
@@ -21,6 +21,7 @@ from rich.table import Table
 
 from infrahub import config
 from infrahub.core import registry
+from infrahub.core.branch import Branch
 from infrahub.core.graph import GRAPH_VERSION
 from infrahub.core.graph.constraints import ConstraintManagerBase, ConstraintManagerMemgraph, ConstraintManagerNeo4j
 from infrahub.core.graph.index import node_indexes, rel_indexes
@@ -41,6 +42,7 @@ from infrahub.core.initialization import (
 from infrahub.core.migrations.graph import get_graph_migrations, get_migration_by_number
 from infrahub.core.migrations.schema.models import SchemaApplyMigrationData
 from infrahub.core.migrations.schema.tasks import schema_apply_migrations
+from infrahub.core.migrations.shared import MigrationWithRebase
 from infrahub.core.schema import SchemaRoot, core_models, internal_schema
 from infrahub.core.schema.definitions.deprecated import deprecated_models
 from infrahub.core.schema.manager import SchemaManager
@@ -335,8 +337,12 @@ async def index(
     await dbdriver.close()
 
 
-async def migrate_database(
-    db: InfrahubDatabase, initialize: bool = False, check: bool = False, migration_number: int | str | None = None
+async def migrate_database(  # noqa: PLR0911
+    db: InfrahubDatabase,
+    initialize: bool = False,
+    check: bool = False,
+    migration_number: int | str | None = None,
+    with_rebase: bool = False,
 ) -> bool:
     """Apply the latest migrations to the database, this function will print the status directly in the console.
 
@@ -355,7 +361,9 @@ async def migrate_database(
     root_node = await get_root_node(db=db)
     if migration_number:
         migration = get_migration_by_number(migration_number)
-        migrations: Sequence[GraphMigration | InternalSchemaMigration | ArbitraryMigration] = [migration]
+        migrations: Sequence[GraphMigration | InternalSchemaMigration | ArbitraryMigration | MigrationWithRebase] = [
+            migration
+        ]
         if check:
             if root_node.graph_version > migration.minimum_version:
                 rprint(
@@ -379,8 +387,18 @@ async def migrate_database(
     if check:
         return True
 
+    # Simply exit if we want to apply rebase migrations without having any of them
+    if not [m for m in migrations if isinstance(m, MigrationWithRebase)] and not with_rebase:
+        return True
+
     for migration in migrations:
-        execution_result = await migration.execute(db=db)
+        # NOTE: this could be a different function
+        if isinstance(migration, MigrationWithRebase) and with_rebase:
+            branches = [b for b in await Branch.get_list(db=db) if b.name != registry.default_branch]
+            execution_result = await migration.execute_against_branches(db=db, branches=branches)
+        else:
+            execution_result = await migration.execute(db=db)
+
         validation_result = None
 
         if execution_result.success:

--- a/backend/infrahub/cli/db.py
+++ b/backend/infrahub/cli/db.py
@@ -438,7 +438,7 @@ async def rebase_and_migrate_branches(db: InfrahubDatabase, current_graph_versio
     for branch in branches:
         migrations = [
             m
-            for m in await detect_migration_to_run(current_graph_version=branch.graph_version or current_graph_version)
+            for m in await detect_migration_to_run(current_graph_version=branch.graph_version or 0)
             if isinstance(m, MigrationWithRebase)
         ]
         rprint(

--- a/backend/infrahub/cli/db.py
+++ b/backend/infrahub/cli/db.py
@@ -175,7 +175,12 @@ async def migrate_cmd(
     context: CliContext = ctx.obj
     dbdriver = await context.init_db(retry=1)
 
-    await migrate_database(db=dbdriver, initialize=True, check=check, migration_number=migration_number)
+    migrations = await detect_migration_to_run(db=dbdriver, migration_number=migration_number)
+
+    if check or not migrations:
+        return
+
+    await migrate_database(db=dbdriver, migrations=migrations, initialize=True)
 
     await dbdriver.close()
 
@@ -343,7 +348,7 @@ async def detect_migration_to_run(
 ) -> Sequence[GraphMigration | InternalSchemaMigration | ArbitraryMigration | MigrationWithRebase]:
     """Return a sequence of migrations to apply to upgrade the database."""
     rprint("Checking current state of the database")
-    migrations: Sequence[GraphMigration | InternalSchemaMigration | ArbitraryMigration | MigrationWithRebase] = []
+    migrations: list[GraphMigration | InternalSchemaMigration | ArbitraryMigration | MigrationWithRebase] = []
 
     root_node = await get_root_node(db=db)
     if migration_number:
@@ -413,7 +418,7 @@ async def migrate_database(
 async def rebase_and_migrate_branches(
     db: InfrahubDatabase,
     migrations: Sequence[GraphMigration | InternalSchemaMigration | ArbitraryMigration | MigrationWithRebase],
-) -> None:
+) -> bool:
     """Only applies migrations that aim at rebasing branches."""
     branches = [b for b in await Branch.get_list(db=db) if b.name not in [registry.default_branch, GLOBAL_BRANCH_NAME]]
     rprint(f"Planning rebase and migrations for {len(branches)} branches: {', '.join([b.name for b in branches])}")
@@ -427,6 +432,17 @@ async def rebase_and_migrate_branches(
             validation_result = await migration.validate_migration(db=db)
             if validation_result.success:
                 rprint(f"Migration: {migration.name} {SUCCESS_BADGE}")
+
+        if not execution_result.success or (validation_result and not validation_result.success):
+            rprint(f"Migration: {migration.name} {FAILED_BADGE}")
+            for error in execution_result.errors:
+                rprint(f"  {error}")
+            if validation_result and not validation_result.success:
+                for error in validation_result.errors:
+                    rprint(f"  {error}")
+            return False
+
+    return True
 
 
 async def initialize_internal_schema() -> None:

--- a/backend/infrahub/cli/db.py
+++ b/backend/infrahub/cli/db.py
@@ -22,6 +22,7 @@ from rich.table import Table
 from infrahub import config
 from infrahub.core import registry
 from infrahub.core.branch import Branch
+from infrahub.core.constants import GLOBAL_BRANCH_NAME
 from infrahub.core.graph import GRAPH_VERSION
 from infrahub.core.graph.constraints import ConstraintManagerBase, ConstraintManagerMemgraph, ConstraintManagerNeo4j
 from infrahub.core.graph.index import node_indexes, rel_indexes
@@ -338,36 +339,33 @@ async def index(
 
 
 async def detect_migration_to_run(
-    db: InfrahubDatabase, check: bool = False, migration_number: int | str | None = None
+    db: InfrahubDatabase, migration_number: int | str | None = None
 ) -> Sequence[GraphMigration | InternalSchemaMigration | ArbitraryMigration | MigrationWithRebase]:
-    rprint("Checking current state of the Database")
+    """Return a sequence of migrations to apply to upgrade the database."""
+    rprint("Checking current state of the database")
+    migrations: Sequence[GraphMigration | InternalSchemaMigration | ArbitraryMigration | MigrationWithRebase] = []
 
     root_node = await get_root_node(db=db)
     if migration_number:
         migration = get_migration_by_number(migration_number)
-        migrations: Sequence[GraphMigration | InternalSchemaMigration | ArbitraryMigration | MigrationWithRebase] = [
-            migration
-        ]
-        if check:
-            if root_node.graph_version > migration.minimum_version:
-                rprint(
-                    f"Migration {migration_number} already applied. To apply again, run the command without the --check flag."
-                )
-                return []
+        migrations.append(migration)
+        if root_node.graph_version > migration.minimum_version:
             rprint(
-                f"Migration {migration_number} needs to be applied. Run `infrahub db migrate` to apply all outstanding migrations."
+                f"Migration {migration_number} already applied. To apply again, run the command without the --check flag."
             )
-            return migrations
+            return []
+        rprint(
+            f"Migration {migration_number} needs to be applied. Run `infrahub db migrate` to apply all outstanding migrations."
+        )
     else:
-        migrations = await get_graph_migrations(root=root_node)
+        migrations.extend(await get_graph_migrations(root=root_node))
         if not migrations:
             rprint(f"Database up-to-date (v{root_node.graph_version}), no migration to execute.")
             return []
 
-        rprint(
-            f"Database needs to be updated (v{root_node.graph_version} -> v{GRAPH_VERSION}), {len(migrations)} migrations pending"
-        )
-
+    rprint(
+        f"Database needs to be updated (v{root_node.graph_version} -> v{GRAPH_VERSION}), {len(migrations)} migrations pending"
+    )
     return migrations
 
 
@@ -375,7 +373,6 @@ async def migrate_database(
     db: InfrahubDatabase,
     migrations: Sequence[GraphMigration | InternalSchemaMigration | ArbitraryMigration | MigrationWithRebase],
     initialize: bool = False,
-    with_rebase: bool = False,
 ) -> bool:
     """Apply the latest migrations to the database, this function will print the status directly in the console.
 
@@ -391,13 +388,7 @@ async def migrate_database(
     root_node = await get_root_node(db=db)
 
     for migration in migrations:
-        # NOTE: this could be a different function
-        if isinstance(migration, MigrationWithRebase) and with_rebase:
-            branches = [b for b in await Branch.get_list(db=db) if b.name != registry.default_branch]
-            execution_result = await migration.execute_against_branches(db=db, branches=branches)
-        else:
-            execution_result = await migration.execute(db=db)
-
+        execution_result = await migration.execute(db=db)
         validation_result = None
 
         if execution_result.success:
@@ -423,7 +414,8 @@ async def rebase_and_migrate_branches(
     db: InfrahubDatabase,
     migrations: Sequence[GraphMigration | InternalSchemaMigration | ArbitraryMigration | MigrationWithRebase],
 ) -> None:
-    branches = [b for b in await Branch.get_list(db=db) if b.name != registry.default_branch]
+    """Only applies migrations that aim at rebasing branches."""
+    branches = [b for b in await Branch.get_list(db=db) if b.name not in [registry.default_branch, GLOBAL_BRANCH_NAME]]
     rebase_migrations = [m for m in migrations if isinstance(m, MigrationWithRebase)]
 
     for migration in rebase_migrations:

--- a/backend/infrahub/cli/db.py
+++ b/backend/infrahub/cli/db.py
@@ -427,6 +427,7 @@ async def rebase_and_migrate_branches(
 
     for migration in rebase_migrations:
         execution_result = await migration.execute_against_branches(db=db, branches=branches)
+        validation_result = None
 
         if execution_result.success:
             validation_result = await migration.validate_migration(db=db)

--- a/backend/infrahub/cli/upgrade.py
+++ b/backend/infrahub/cli/upgrade.py
@@ -26,7 +26,13 @@ from infrahub.workflows.initialization import (
     setup_worker_pools,
 )
 
-from .db import initialize_internal_schema, migrate_database, update_core_schema
+from .db import (
+    detect_migration_to_run,
+    initialize_internal_schema,
+    migrate_database,
+    rebase_and_migrate_branches,
+    update_core_schema,
+)
 
 if TYPE_CHECKING:
     from infrahub.cli.context import CliContext
@@ -67,7 +73,11 @@ async def upgrade_cmd(
     # Upgrade Infrahub Database and Schema
     # -------------------------------------------
 
-    if not await migrate_database(db=dbdriver, initialize=False, check=check, with_rebase=False):
+    migrations = await detect_migration_to_run(db=dbdriver, check=check)
+    if check or not migrations:
+        return
+
+    if not await migrate_database(db=dbdriver, initialize=False, migrations=migrations):
         # A migration failed, stop the upgrade process
         rprint("Upgrade cancelled due to migration failure.")
         await dbdriver.close()
@@ -77,9 +87,9 @@ async def upgrade_cmd(
     await update_core_schema(db=dbdriver, initialize=False)
 
     # FIXME: will not do anything as graph version will be up to date
-    if not await migrate_database(db=dbdriver, initialize=False, check=check, with_rebase=True):
+    if not await rebase_and_migrate_branches(db=dbdriver, migrations=migrations):
         # A migration failed, stop the upgrade process
-        rprint("Upgrade cancelled due to migration failure.")
+        rprint("Upgrade cancelled due to branch rebase and migration failure.")
         await dbdriver.close()
         return
 

--- a/backend/infrahub/cli/upgrade.py
+++ b/backend/infrahub/cli/upgrade.py
@@ -11,7 +11,12 @@ from prefect.client.orchestration import get_client
 from rich import print as rprint
 
 from infrahub import config
-from infrahub.core.initialization import create_anonymous_role, create_default_account_groups, initialize_registry
+from infrahub.core.initialization import (
+    create_anonymous_role,
+    create_default_account_groups,
+    get_root_node,
+    initialize_registry,
+)
 from infrahub.core.manager import NodeManager
 from infrahub.core.protocols import CoreAccount, CoreObjectPermission
 from infrahub.dependencies.registry import build_component_registry
@@ -63,6 +68,8 @@ async def upgrade_cmd(
 
     build_component_registry()
 
+    root_node = await get_root_node(db=dbdriver)
+
     # NOTE add step to validate if the database and the task manager are reachable
 
     # -------------------------------------------
@@ -73,8 +80,8 @@ async def upgrade_cmd(
     # Upgrade Infrahub Database and Schema
     # -------------------------------------------
 
-    migrations = await detect_migration_to_run(db=dbdriver)
-    if check or not migrations:
+    migrations = await detect_migration_to_run(current_graph_version=root_node.graph_version)
+    if check:
         return
 
     if not await migrate_database(db=dbdriver, initialize=False, migrations=migrations):
@@ -86,7 +93,7 @@ async def upgrade_cmd(
     await initialize_internal_schema()
     await update_core_schema(db=dbdriver, initialize=False)
 
-    if not await rebase_and_migrate_branches(db=dbdriver, migrations=migrations):
+    if not await rebase_and_migrate_branches(db=dbdriver, current_graph_version=root_node.graph_version):
         # A migration failed, stop the upgrade process
         rprint("Upgrade cancelled due to branch rebase and migration failure.")
         await dbdriver.close()

--- a/backend/infrahub/cli/upgrade.py
+++ b/backend/infrahub/cli/upgrade.py
@@ -86,7 +86,6 @@ async def upgrade_cmd(
     await initialize_internal_schema()
     await update_core_schema(db=dbdriver, initialize=False)
 
-    # FIXME: will not do anything as graph version will be up to date
     if not await rebase_and_migrate_branches(db=dbdriver, migrations=migrations):
         # A migration failed, stop the upgrade process
         rprint("Upgrade cancelled due to branch rebase and migration failure.")

--- a/backend/infrahub/cli/upgrade.py
+++ b/backend/infrahub/cli/upgrade.py
@@ -67,7 +67,7 @@ async def upgrade_cmd(
     # Upgrade Infrahub Database and Schema
     # -------------------------------------------
 
-    if not await migrate_database(db=dbdriver, initialize=False, check=check):
+    if not await migrate_database(db=dbdriver, initialize=False, check=check, with_rebase=False):
         # A migration failed, stop the upgrade process
         rprint("Upgrade cancelled due to migration failure.")
         await dbdriver.close()
@@ -75,6 +75,13 @@ async def upgrade_cmd(
 
     await initialize_internal_schema()
     await update_core_schema(db=dbdriver, initialize=False)
+
+    # FIXME: will not do anything as graph version will be up to date
+    if not await migrate_database(db=dbdriver, initialize=False, check=check, with_rebase=True):
+        # A migration failed, stop the upgrade process
+        rprint("Upgrade cancelled due to migration failure.")
+        await dbdriver.close()
+        return
 
     # -------------------------------------------
     # Upgrade Internal Objects, generated and managed by Infrahub

--- a/backend/infrahub/cli/upgrade.py
+++ b/backend/infrahub/cli/upgrade.py
@@ -51,6 +51,7 @@ async def upgrade_cmd(
     ctx: typer.Context,
     config_file: str = typer.Argument("infrahub.toml", envvar="INFRAHUB_CONFIG"),
     check: bool = typer.Option(False, help="Check the state of the system without upgrading."),
+    rebase_branches: bool = typer.Option(False, help="Rebase and apply migrations to branches if required."),
 ) -> None:
     """Upgrade Infrahub to the latest version."""
 
@@ -93,12 +94,6 @@ async def upgrade_cmd(
     await initialize_internal_schema()
     await update_core_schema(db=dbdriver, initialize=False)
 
-    if not await rebase_and_migrate_branches(db=dbdriver, current_graph_version=root_node.graph_version):
-        # A migration failed, stop the upgrade process
-        rprint("Upgrade cancelled due to branch rebase and migration failure.")
-        await dbdriver.close()
-        return
-
     # -------------------------------------------
     # Upgrade Internal Objects, generated and managed by Infrahub
     # -------------------------------------------
@@ -113,6 +108,17 @@ async def upgrade_cmd(
         await setup_worker_pools(client=client)
         await setup_deployments(client=client)
         await trigger_configure_all()
+
+    # -------------------------------------------
+    # Perform branch rebase and apply migrations to them
+    # -------------------------------------------
+    if rebase_branches and not await rebase_and_migrate_branches(
+        db=dbdriver, current_graph_version=root_node.graph_version
+    ):
+        # A migration failed, stop the upgrade process
+        rprint("Upgrade cancelled due to branch rebase and migration failure.")
+        await dbdriver.close()
+        return
 
     await dbdriver.close()
 

--- a/backend/infrahub/cli/upgrade.py
+++ b/backend/infrahub/cli/upgrade.py
@@ -73,7 +73,7 @@ async def upgrade_cmd(
     # Upgrade Infrahub Database and Schema
     # -------------------------------------------
 
-    migrations = await detect_migration_to_run(db=dbdriver, check=check)
+    migrations = await detect_migration_to_run(db=dbdriver)
     if check or not migrations:
         return
 

--- a/backend/infrahub/core/branch/enums.py
+++ b/backend/infrahub/core/branch/enums.py
@@ -4,5 +4,6 @@ from infrahub.utils import InfrahubStringEnum
 class BranchStatus(InfrahubStringEnum):
     OPEN = "OPEN"
     NEED_REBASE = "NEED_REBASE"
+    NEED_UPGRADE_REBASE = "NEED_UPGRADE_REBASE"
     CLOSED = "CLOSED"
     DELETING = "DELETING"

--- a/backend/infrahub/core/branch/models.py
+++ b/backend/infrahub/core/branch/models.py
@@ -6,9 +6,8 @@ from typing import TYPE_CHECKING, Any, Optional, Self, Union
 from pydantic import Field, field_validator
 
 from infrahub.core.branch.enums import BranchStatus
-from infrahub.core.constants import (
-    GLOBAL_BRANCH_NAME,
-)
+from infrahub.core.constants import GLOBAL_BRANCH_NAME
+from infrahub.core.graph import GRAPH_VERSION
 from infrahub.core.models import SchemaBranchHash  # noqa: TC001
 from infrahub.core.node.standard import StandardNode
 from infrahub.core.query import QueryType
@@ -261,6 +260,10 @@ class Branch(StandardNode):
             end[self.origin_branch] = end_time.to_string()
 
         return start, end
+
+    async def create(self, db: InfrahubDatabase) -> bool:
+        self.graph_version = GRAPH_VERSION
+        return await super().create(db=db)
 
     async def delete(self, db: InfrahubDatabase) -> None:
         if self.is_default:

--- a/backend/infrahub/core/branch/models.py
+++ b/backend/infrahub/core/branch/models.py
@@ -46,6 +46,7 @@ class Branch(StandardNode):
     is_isolated: bool = True
     schema_changed_at: Optional[str] = None
     schema_hash: Optional[SchemaBranchHash] = None
+    graph_version: int | None = None
 
     _exclude_attrs: list[str] = ["id", "uuid", "owner"]
 

--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -50,7 +50,7 @@ from infrahub.workflows.utils import add_tags
 
 
 @flow(name="branch-rebase", flow_run_name="Rebase branch {branch}")
-async def rebase_branch(branch: str, context: InfrahubContext) -> None:  # noqa: PLR0915
+async def rebase_branch(branch: str, context: InfrahubContext, send_events: bool = True) -> None:  # noqa: PLR0915
     database = await get_database()
     async with database.start_session() as db:
         log = get_run_logger()
@@ -166,30 +166,31 @@ async def rebase_branch(branch: str, context: InfrahubContext) -> None:  # noqa:
         workflow=DIFF_REFRESH_ALL, context=context, parameters={"branch_name": obj.name}
     )
 
-    # -------------------------------------------------------------
-    # Generate an event to indicate that a branch has been rebased
-    # -------------------------------------------------------------
-    rebase_event = BranchRebasedEvent(
-        branch_name=obj.name, branch_id=str(obj.uuid), meta=EventMeta(branch=obj, context=context)
-    )
-    events: list[InfrahubEvent] = [rebase_event]
-    changelog_collector = DiffChangelogCollector(
-        diff=default_branch_diff, branch=obj, db=db, migration_tracker=MigrationTracker(migrations=migrations)
-    )
-    for action, node_changelog in changelog_collector.collect_changelogs():
-        node_event_class = get_node_event(MutationAction.from_diff_action(diff_action=action))
-        mutate_event = node_event_class(
-            kind=node_changelog.node_kind,
-            node_id=node_changelog.node_id,
-            changelog=node_changelog,
-            fields=node_changelog.updated_fields,
-            meta=EventMeta.from_parent(parent=rebase_event, branch=obj),
+    if send_events:
+        # -------------------------------------------------------------
+        # Generate an event to indicate that a branch has been rebased
+        # -------------------------------------------------------------
+        rebase_event = BranchRebasedEvent(
+            branch_name=obj.name, branch_id=str(obj.uuid), meta=EventMeta(branch=obj, context=context)
         )
-        events.append(mutate_event)
+        events: list[InfrahubEvent] = [rebase_event]
+        changelog_collector = DiffChangelogCollector(
+            diff=default_branch_diff, branch=obj, db=db, migration_tracker=MigrationTracker(migrations=migrations)
+        )
+        for action, node_changelog in changelog_collector.collect_changelogs():
+            node_event_class = get_node_event(MutationAction.from_diff_action(diff_action=action))
+            mutate_event = node_event_class(
+                kind=node_changelog.node_kind,
+                node_id=node_changelog.node_id,
+                changelog=node_changelog,
+                fields=node_changelog.updated_fields,
+                meta=EventMeta.from_parent(parent=rebase_event, branch=obj),
+            )
+            events.append(mutate_event)
 
-    event_service = await get_event_service()
-    for event in events:
-        await event_service.send(event)
+        event_service = await get_event_service()
+        for event in events:
+            await event_service.send(event)
 
 
 @flow(name="branch-merge", flow_run_name="Merge branch {branch} into main")

--- a/backend/infrahub/core/branch/tasks.py
+++ b/backend/infrahub/core/branch/tasks.py
@@ -166,31 +166,33 @@ async def rebase_branch(branch: str, context: InfrahubContext, send_events: bool
         workflow=DIFF_REFRESH_ALL, context=context, parameters={"branch_name": obj.name}
     )
 
-    if send_events:
-        # -------------------------------------------------------------
-        # Generate an event to indicate that a branch has been rebased
-        # -------------------------------------------------------------
-        rebase_event = BranchRebasedEvent(
-            branch_name=obj.name, branch_id=str(obj.uuid), meta=EventMeta(branch=obj, context=context)
-        )
-        events: list[InfrahubEvent] = [rebase_event]
-        changelog_collector = DiffChangelogCollector(
-            diff=default_branch_diff, branch=obj, db=db, migration_tracker=MigrationTracker(migrations=migrations)
-        )
-        for action, node_changelog in changelog_collector.collect_changelogs():
-            node_event_class = get_node_event(MutationAction.from_diff_action(diff_action=action))
-            mutate_event = node_event_class(
-                kind=node_changelog.node_kind,
-                node_id=node_changelog.node_id,
-                changelog=node_changelog,
-                fields=node_changelog.updated_fields,
-                meta=EventMeta.from_parent(parent=rebase_event, branch=obj),
-            )
-            events.append(mutate_event)
+    if not send_events:
+        return
 
-        event_service = await get_event_service()
-        for event in events:
-            await event_service.send(event)
+    # -------------------------------------------------------------
+    # Generate an event to indicate that a branch has been rebased
+    # -------------------------------------------------------------
+    rebase_event = BranchRebasedEvent(
+        branch_name=obj.name, branch_id=str(obj.uuid), meta=EventMeta(branch=obj, context=context)
+    )
+    events: list[InfrahubEvent] = [rebase_event]
+    changelog_collector = DiffChangelogCollector(
+        diff=default_branch_diff, branch=obj, db=db, migration_tracker=MigrationTracker(migrations=migrations)
+    )
+    for action, node_changelog in changelog_collector.collect_changelogs():
+        node_event_class = get_node_event(MutationAction.from_diff_action(diff_action=action))
+        mutate_event = node_event_class(
+            kind=node_changelog.node_kind,
+            node_id=node_changelog.node_id,
+            changelog=node_changelog,
+            fields=node_changelog.updated_fields,
+            meta=EventMeta.from_parent(parent=rebase_event, branch=obj),
+        )
+        events.append(mutate_event)
+
+    event_service = await get_event_service()
+    for event in events:
+        await event_service.send(event)
 
 
 @flow(name="branch-merge", flow_run_name="Merge branch {branch} into main")

--- a/backend/infrahub/core/migrations/graph/__init__.py
+++ b/backend/infrahub/core/migrations/graph/__init__.py
@@ -49,9 +49,9 @@ from .m043_backfill_hfid_display_label_in_db import Migration043
 if TYPE_CHECKING:
     from infrahub.core.root import Root
 
-    from ..shared import ArbitraryMigration, GraphMigration, InternalSchemaMigration
+    from ..shared import ArbitraryMigration, GraphMigration, InternalSchemaMigration, MigrationWithRebase
 
-MIGRATIONS: list[type[GraphMigration | InternalSchemaMigration | ArbitraryMigration]] = [
+MIGRATIONS: list[type[GraphMigration | InternalSchemaMigration | ArbitraryMigration | MigrationWithRebase]] = [
     Migration001,
     Migration002,
     Migration003,
@@ -100,7 +100,7 @@ MIGRATIONS: list[type[GraphMigration | InternalSchemaMigration | ArbitraryMigrat
 
 async def get_graph_migrations(
     root: Root,
-) -> Sequence[GraphMigration | InternalSchemaMigration | ArbitraryMigration]:
+) -> Sequence[GraphMigration | InternalSchemaMigration | ArbitraryMigration | MigrationWithRebase]:
     applicable_migrations = []
     for migration_class in MIGRATIONS:
         migration = migration_class.init()
@@ -113,7 +113,7 @@ async def get_graph_migrations(
 
 def get_migration_by_number(
     migration_number: int | str,
-) -> GraphMigration | InternalSchemaMigration | ArbitraryMigration:
+) -> GraphMigration | InternalSchemaMigration | ArbitraryMigration | MigrationWithRebase:
     # Convert to string and pad with zeros if needed
     try:
         num = int(migration_number)

--- a/backend/infrahub/core/migrations/graph/__init__.py
+++ b/backend/infrahub/core/migrations/graph/__init__.py
@@ -47,8 +47,6 @@ from .m042_create_hfid_display_label_in_db import Migration042
 from .m043_backfill_hfid_display_label_in_db import Migration043
 
 if TYPE_CHECKING:
-    from infrahub.core.root import Root
-
     from ..shared import ArbitraryMigration, GraphMigration, InternalSchemaMigration, MigrationWithRebase
 
 MIGRATIONS: list[type[GraphMigration | InternalSchemaMigration | ArbitraryMigration | MigrationWithRebase]] = [
@@ -99,12 +97,12 @@ MIGRATIONS: list[type[GraphMigration | InternalSchemaMigration | ArbitraryMigrat
 
 
 async def get_graph_migrations(
-    root: Root,
+    current_graph_version: int,
 ) -> Sequence[GraphMigration | InternalSchemaMigration | ArbitraryMigration | MigrationWithRebase]:
     applicable_migrations = []
     for migration_class in MIGRATIONS:
         migration = migration_class.init()
-        if root.graph_version > migration.minimum_version:
+        if current_graph_version > migration.minimum_version:
             continue
         applicable_migrations.append(migration)
 

--- a/backend/infrahub/core/migrations/graph/m043_backfill_hfid_display_label_in_db.py
+++ b/backend/infrahub/core/migrations/graph/m043_backfill_hfid_display_label_in_db.py
@@ -447,7 +447,7 @@ class Migration043(MigrationWithRebase):
 
         print("done")
 
-    async def process_branch(self, db: InfrahubDatabase, branch: Branch) -> MigrationResult:
+    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
         root_node = await get_root_node(db=db, initialize=False)
         default_branch = root_node.default_branch
         schema_manager = SchemaManager()
@@ -487,4 +487,8 @@ class Migration043(MigrationWithRebase):
                     )
         except Exception as exc:
             return MigrationResult(errors=[str(exc)])
+        return MigrationResult()
+
+    async def execute_against_branch(self, db: InfrahubDatabase, branch: Branch) -> MigrationResult:
+        # TODO
         return MigrationResult()

--- a/backend/infrahub/core/migrations/graph/m043_backfill_hfid_display_label_in_db.py
+++ b/backend/infrahub/core/migrations/graph/m043_backfill_hfid_display_label_in_db.py
@@ -447,7 +447,7 @@ class Migration043(MigrationWithRebase):
 
         print("done")
 
-    async def execute_against_branch(self, db: InfrahubDatabase, branch: Branch) -> MigrationResult:
+    async def process_branch(self, db: InfrahubDatabase, branch: Branch) -> MigrationResult:
         root_node = await get_root_node(db=db, initialize=False)
         default_branch = root_node.default_branch
         schema_manager = SchemaManager()

--- a/backend/infrahub/core/migrations/graph/m043_backfill_hfid_display_label_in_db.py
+++ b/backend/infrahub/core/migrations/graph/m043_backfill_hfid_display_label_in_db.py
@@ -14,9 +14,10 @@ from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot, intern
 from infrahub.core.schema.manager import SchemaManager
 from infrahub.types import is_large_attribute_type
 
-from ..shared import ArbitraryMigration
+from ..shared import MigrationWithRebase
 
 if TYPE_CHECKING:
+    from infrahub.core.branch import Branch
     from infrahub.core.schema.basenode_schema import SchemaAttributePath
     from infrahub.core.schema.schema_branch import SchemaBranch
     from infrahub.database import InfrahubDatabase
@@ -352,7 +353,7 @@ CALL (n, attr) {
         self.add_to_query(set_value_query)
 
 
-class Migration043(ArbitraryMigration):
+class Migration043(MigrationWithRebase):
     """
     Backfill `human_friendly_id` and `display_label` attributes for nodes with schemas that define them.
     """
@@ -446,7 +447,7 @@ class Migration043(ArbitraryMigration):
 
         print("done")
 
-    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+    async def execute_against_branch(self, db: InfrahubDatabase, branch: Branch) -> MigrationResult:
         root_node = await get_root_node(db=db, initialize=False)
         default_branch = root_node.default_branch
         schema_manager = SchemaManager()

--- a/backend/infrahub/core/migrations/shared.py
+++ b/backend/infrahub/core/migrations/shared.py
@@ -7,6 +7,7 @@ from rich.console import Console
 from typing_extensions import Self
 
 from infrahub.core import registry
+from infrahub.core.branch.enums import BranchStatus
 from infrahub.core.path import SchemaPath  # noqa: TC001
 from infrahub.core.query import Query  # noqa: TC001
 from infrahub.core.schema import (
@@ -257,7 +258,7 @@ class MigrationWithRebase(BaseModel):
         try:
             await branch.rebase(db=db)
             console.print("done")
-        except Exception:
+            branch.graph_version = self.minimum_version + 1
             # NOTE: Narrow to more accurate exception
             console.print("failed")
             branch.status = BranchStatus.NEED_UPGRADE_REBASE

--- a/backend/infrahub/core/migrations/shared.py
+++ b/backend/infrahub/core/migrations/shared.py
@@ -269,29 +269,21 @@ class MigrationWithRebase(BaseModel):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:
         raise NotImplementedError()
 
-    async def execute_against_branch(self, db: InfrahubDatabase, branch: Branch) -> MigrationResult:
+    async def process_branch(self, db: InfrahubDatabase, branch: Branch) -> MigrationResult:
         raise NotImplementedError()
 
-    async def execute_against_branches(self, db: InfrahubDatabase, branches: Sequence[Branch]) -> MigrationResult:
-        result = MigrationResult()
+    async def execute_against_branch(
+        self, db: InfrahubDatabase, branch: Branch, skip_rebase: bool = False
+    ) -> MigrationResult:
+        await registry.schema.load_schema(db=db, branch=branch)
 
-        for branch in branches:
-            await registry.schema.load_schema(db=db, branch=branch)
-
+        if not skip_rebase:
             if not await self.rebase_branch(branch=branch):
                 branch.status = BranchStatus.NEED_UPGRADE_REBASE
                 await branch.save(db=db)
-                continue
+                return MigrationResult()
 
-            r = await self.execute_against_branch(db=db, branch=branch)
-            result.nbr_migrations_executed += 1
-            if r.errors:
-                result.errors.extend(r.errors)
-            if r.success:
-                branch.graph_version = self.minimum_version + 1
-                await branch.save(db=db)
-
-        return result
+        return await self.process_branch(db=db, branch=branch)
 
     async def execute(self, db: InfrahubDatabase) -> MigrationResult:
         from infrahub.core.initialization import initialization
@@ -299,4 +291,4 @@ class MigrationWithRebase(BaseModel):
         initialize_lock()
         await initialization(db=db)
 
-        return await self.execute_against_branch(db=db, branch=registry.get_branch_from_registry())
+        return await self.execute_against_branch(db=db, branch=registry.get_branch_from_registry(), skip_rebase=True)

--- a/backend/infrahub/core/migrations/shared.py
+++ b/backend/infrahub/core/migrations/shared.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Sequence
 
 from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import Self
+from rich.console import Console
 
 from infrahub.auth import AccountSession, AuthType
 from infrahub.context import InfrahubContext
@@ -241,18 +242,23 @@ class MigrationWithRebase(BaseModel):
     def init(cls, **kwargs: dict[str, Any]) -> Self:
         return cls(**kwargs)  # type: ignore[arg-type]
 
-    async def rebase_branch(self, branch: Branch) -> bool:
+    async def rebase_branch(self, db: InfrahubDatabase, branch: Branch) -> bool:
+        console = Console()
+        console.print(f"Rebasing branch '{branch.name}' (ID: {branch.uuid})...", end="")
         # Circular deps if import inside import block
-        from infrahub.core.branch.tasks import rebase_branch
+        # from infrahub.core.branch.tasks import rebase_branch
 
-        await rebase_branch(
-            branch=branch.name,
-            context=InfrahubContext.init(
-                branch=branch,
-                # FIXME: or superuser account?
-                account=AccountSession(auth_type=AuthType.NONE, authenticated=False, account_id=""),
-            ),
-        )
+        # await rebase_branch(
+        #     branch=branch.name,
+        #     context=InfrahubContext.init(
+        #         branch=branch,
+        #         # FIXME: or superuser account?
+        #         account=AccountSession(auth_type=AuthType.NONE, authenticated=False, account_id=""),
+        #     ),
+        # )
+        # NOTE: need service/bus component up and running to use prefect flow
+        await branch.rebase(db=db)
+        console.print("done")
         # FIXME: find out actual rebase result
         return True
 
@@ -266,8 +272,8 @@ class MigrationWithRebase(BaseModel):
         result = MigrationResult()
 
         for branch in branches:
-            if not await self.rebase_branch(branch=branch):
-                result.errors.append(f"Failed to rebase branch '{branch.name}' ({branch.id})")
+            if not await self.rebase_branch(db=db, branch=branch):
+                result.errors.append(f"Failed to rebase branch '{branch.name}' ({branch.uuid})")
                 return result
 
             r = await self.execute_against_branch(db=db, branch=branch)

--- a/backend/infrahub/core/migrations/shared.py
+++ b/backend/infrahub/core/migrations/shared.py
@@ -279,7 +279,6 @@ class MigrationWithRebase(BaseModel):
             await registry.schema.load_schema(db=db, branch=branch)
 
             if not await self.rebase_branch(branch=branch):
-                result.errors.append(f"Failed to rebase branch '{branch.name}' ({branch.uuid})")
                 branch.status = BranchStatus.NEED_UPGRADE_REBASE
                 await branch.save(db=db)
                 continue

--- a/backend/infrahub/core/migrations/shared.py
+++ b/backend/infrahub/core/migrations/shared.py
@@ -17,7 +17,6 @@ from infrahub.core.schema import (
     internal_schema,
 )
 from infrahub.core.timestamp import Timestamp
-from infrahub.lock import initialize_lock
 
 from .query import MigrationBaseQuery  # noqa: TC001
 
@@ -272,12 +271,6 @@ class MigrationWithRebase(BaseModel):
         raise NotImplementedError()
 
     async def execute_against_branches(self, db: InfrahubDatabase, branches: Sequence[Branch]) -> MigrationResult:
-        # Circular import
-        from infrahub.core.initialization import initialization
-
-        initialize_lock()
-        await initialization(db=db)
-
         result = MigrationResult()
 
         for branch in branches:

--- a/backend/infrahub/core/migrations/shared.py
+++ b/backend/infrahub/core/migrations/shared.py
@@ -21,6 +21,7 @@ from infrahub.core.schema import (
 )
 from infrahub.core.timestamp import Timestamp
 from infrahub.exceptions import ValidationError
+from infrahub.lock import initialize_lock
 
 from .query import MigrationBaseQuery  # noqa: TC001
 
@@ -283,6 +284,8 @@ class MigrationWithRebase(BaseModel):
         result = MigrationResult()
 
         for branch in branches:
+            await registry.schema.load_schema(db=db, branch=branch)
+
             if not await self.rebase_branch(db=db, branch=branch):
                 result.errors.append(f"Failed to rebase branch '{branch.name}' ({branch.uuid})")
                 continue
@@ -295,4 +298,9 @@ class MigrationWithRebase(BaseModel):
         return result
 
     async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+        from infrahub.core.initialization import initialization
+
+        initialize_lock()
+        await initialization(db=db)
+
         return await self.execute_against_branch(db=db, branch=registry.get_branch_from_registry())

--- a/backend/infrahub/core/migrations/shared.py
+++ b/backend/infrahub/core/migrations/shared.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING, Any, Sequence
 from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import Self
 
+from infrahub.auth import AccountSession, AuthType
+from infrahub.context import InfrahubContext
 from infrahub.core import registry
 from infrahub.core.path import SchemaPath  # noqa: TC001
 from infrahub.core.query import Query  # noqa: TC001
@@ -228,3 +230,52 @@ class ArbitraryMigration(BaseModel):
 
     async def execute(self, db: InfrahubDatabase) -> MigrationResult:
         raise NotImplementedError()
+
+
+class MigrationWithRebase(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    name: str = Field(..., description="Name of the migration")
+    minimum_version: int = Field(..., description="Minimum version of the graph to execute this migration")
+
+    @classmethod
+    def init(cls, **kwargs: dict[str, Any]) -> Self:
+        return cls(**kwargs)  # type: ignore[arg-type]
+
+    async def rebase_branch(self, branch: Branch) -> bool:
+        # Circular deps if import inside import block
+        from infrahub.core.branch.tasks import rebase_branch
+
+        await rebase_branch(
+            branch=branch.name,
+            context=InfrahubContext.init(
+                branch=branch,
+                # FIXME: or superuser account?
+                account=AccountSession(auth_type=AuthType.NONE, authenticated=False, account_id=""),
+            ),
+        )
+        # FIXME: find out actual rebase result
+        return True
+
+    async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:
+        raise NotImplementedError()
+
+    async def execute_against_branch(self, db: InfrahubDatabase, branch: Branch) -> MigrationResult:
+        raise NotImplementedError()
+
+    async def execute_against_branches(self, db: InfrahubDatabase, branches: Sequence[Branch]) -> MigrationResult:
+        result = MigrationResult()
+
+        for branch in branches:
+            if not await self.rebase_branch(branch=branch):
+                result.errors.append(f"Failed to rebase branch '{branch.name}' ({branch.id})")
+                return result
+
+            r = await self.execute_against_branch(db=db, branch=branch)
+            result.nbr_migrations_executed += 1
+            if r.errors:
+                result.errors.extend(r.errors)
+
+        return result
+
+    async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+        return await self.execute_against_branch(db=db, branch=registry.get_branch_from_registry())

--- a/backend/infrahub/core/migrations/shared.py
+++ b/backend/infrahub/core/migrations/shared.py
@@ -260,7 +260,10 @@ class MigrationWithRebase(BaseModel):
         except Exception:
             # NOTE: Narrow to more accurate exception
             console.print("failed")
+            branch.status = BranchStatus.NEED_UPGRADE_REBASE
             return False
+        finally:
+            await branch.save(db=db)
 
         return True
 

--- a/backend/infrahub/core/migrations/shared.py
+++ b/backend/infrahub/core/migrations/shared.py
@@ -3,13 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Sequence
 
 from pydantic import BaseModel, ConfigDict, Field
-from rich.console import Console
 from typing_extensions import Self
 
-from infrahub.auth import AccountSession, AuthType
-from infrahub.context import InfrahubContext
 from infrahub.core import registry
-from infrahub.core.branch.enums import BranchStatus
 from infrahub.core.path import SchemaPath  # noqa: TC001
 from infrahub.core.query import Query  # noqa: TC001
 from infrahub.core.schema import (
@@ -20,8 +16,6 @@ from infrahub.core.schema import (
     internal_schema,
 )
 from infrahub.core.timestamp import Timestamp
-from infrahub.exceptions import ValidationError
-from infrahub.lock import initialize_lock
 
 from .query import MigrationBaseQuery  # noqa: TC001
 
@@ -245,50 +239,15 @@ class MigrationWithRebase(BaseModel):
     def init(cls, **kwargs: dict[str, Any]) -> Self:
         return cls(**kwargs)  # type: ignore[arg-type]
 
-    async def rebase_branch(self, branch: Branch) -> bool:
-        # Circular deps if imported inside import block
-        from infrahub.core.branch.tasks import rebase_branch
-
-        console = Console()
-        console.print(f"Rebasing branch '{branch.name}' (ID: {branch.uuid})...", end="")
-        try:
-            await rebase_branch(
-                branch=branch.name,
-                context=InfrahubContext.init(
-                    branch=branch, account=AccountSession(auth_type=AuthType.NONE, authenticated=False, account_id="")
-                ),
-                send_events=False,
-            )
-            console.print("done")
-        except ValidationError:
-            console.print("failed")
-            return False
-
-        return True
-
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:
         raise NotImplementedError()
 
-    async def process_branch(self, db: InfrahubDatabase, branch: Branch) -> MigrationResult:
+    async def execute_against_branch(self, db: InfrahubDatabase, branch: Branch) -> MigrationResult:
+        # execute against a non-default, non-global branch
+        # assumes that the branch has been rebased
+        # must be written so that it can be run on a running instance of Infrahub
         raise NotImplementedError()
 
-    async def execute_against_branch(
-        self, db: InfrahubDatabase, branch: Branch, skip_rebase: bool = False
-    ) -> MigrationResult:
-        initialize_lock()
-        await registry.schema.load_schema(db=db, branch=branch)
-
-        if not skip_rebase:
-            if not await self.rebase_branch(branch=branch):
-                branch.status = BranchStatus.NEED_UPGRADE_REBASE
-                await branch.save(db=db)
-                return MigrationResult()
-
-        return await self.process_branch(db=db, branch=branch)
-
     async def execute(self, db: InfrahubDatabase) -> MigrationResult:
-        from infrahub.core.initialization import initialization
-
-        await initialization(db=db)
-
-        return await self.execute_against_branch(db=db, branch=registry.get_branch_from_registry(), skip_rebase=True)
+        # execute against the default and global branches
+        raise NotImplementedError()

--- a/backend/infrahub/core/migrations/shared.py
+++ b/backend/infrahub/core/migrations/shared.py
@@ -19,6 +19,7 @@ from infrahub.core.schema import (
     internal_schema,
 )
 from infrahub.core.timestamp import Timestamp
+from infrahub.lock import initialize_lock
 
 from .query import MigrationBaseQuery  # noqa: TC001
 
@@ -243,11 +244,8 @@ class MigrationWithRebase(BaseModel):
         return cls(**kwargs)  # type: ignore[arg-type]
 
     async def rebase_branch(self, db: InfrahubDatabase, branch: Branch) -> bool:
-        console = Console()
-        console.print(f"Rebasing branch '{branch.name}' (ID: {branch.uuid})...", end="")
         # Circular deps if import inside import block
         # from infrahub.core.branch.tasks import rebase_branch
-
         # await rebase_branch(
         #     branch=branch.name,
         #     context=InfrahubContext.init(
@@ -257,9 +255,16 @@ class MigrationWithRebase(BaseModel):
         #     ),
         # )
         # NOTE: need service/bus component up and running to use prefect flow
-        await branch.rebase(db=db)
-        console.print("done")
-        # FIXME: find out actual rebase result
+        console = Console()
+        console.print(f"Rebasing branch '{branch.name}' (ID: {branch.uuid})...", end="")
+        try:
+            await branch.rebase(db=db)
+            console.print("done")
+        except Exception:
+            # NOTE: Narrow to more accurate exception
+            console.print("failed")
+            return False
+
         return True
 
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:
@@ -269,6 +274,12 @@ class MigrationWithRebase(BaseModel):
         raise NotImplementedError()
 
     async def execute_against_branches(self, db: InfrahubDatabase, branches: Sequence[Branch]) -> MigrationResult:
+        # Circular import
+        from infrahub.core.initialization import initialization
+
+        initialize_lock()
+        await initialization(db=db)
+
         result = MigrationResult()
 
         for branch in branches:

--- a/backend/infrahub/core/migrations/shared.py
+++ b/backend/infrahub/core/migrations/shared.py
@@ -6,6 +6,8 @@ from pydantic import BaseModel, ConfigDict, Field
 from rich.console import Console
 from typing_extensions import Self
 
+from infrahub.auth import AccountSession, AuthType
+from infrahub.context import InfrahubContext
 from infrahub.core import registry
 from infrahub.core.branch.enums import BranchStatus
 from infrahub.core.path import SchemaPath  # noqa: TC001
@@ -18,6 +20,7 @@ from infrahub.core.schema import (
     internal_schema,
 )
 from infrahub.core.timestamp import Timestamp
+from infrahub.exceptions import ValidationError
 
 from .query import MigrationBaseQuery  # noqa: TC001
 
@@ -242,24 +245,26 @@ class MigrationWithRebase(BaseModel):
         return cls(**kwargs)  # type: ignore[arg-type]
 
     async def rebase_branch(self, db: InfrahubDatabase, branch: Branch) -> bool:
-        # Circular deps if import inside import block
-        # from infrahub.core.branch.tasks import rebase_branch
-        # await rebase_branch(
-        #     branch=branch.name,
-        #     context=InfrahubContext.init(
-        #         branch=branch,
-        #         # FIXME: or superuser account?
-        #         account=AccountSession(auth_type=AuthType.NONE, authenticated=False, account_id=""),
-        #     ),
-        # )
+        # Circular deps if imported inside import block
+        from infrahub.core.branch.tasks import rebase_branch
+
         # NOTE: need service/bus component up and running to use prefect flow
         console = Console()
         console.print(f"Rebasing branch '{branch.name}' (ID: {branch.uuid})...", end="")
         try:
-            await branch.rebase(db=db)
+            # await branch.rebase(db=db)
+            await rebase_branch(
+                branch=branch.name,
+                context=InfrahubContext.init(
+                    branch=branch,
+                    # FIXME: or superuser account?
+                    account=AccountSession(auth_type=AuthType.NONE, authenticated=False, account_id=""),
+                ),
+                send_events=False,
+            )
             console.print("done")
             branch.graph_version = self.minimum_version + 1
-            # NOTE: Narrow to more accurate exception
+        except ValidationError:
             console.print("failed")
             branch.status = BranchStatus.NEED_UPGRADE_REBASE
             return False
@@ -280,7 +285,7 @@ class MigrationWithRebase(BaseModel):
         for branch in branches:
             if not await self.rebase_branch(db=db, branch=branch):
                 result.errors.append(f"Failed to rebase branch '{branch.name}' ({branch.uuid})")
-                return result
+                continue
 
             r = await self.execute_against_branch(db=db, branch=branch)
             result.nbr_migrations_executed += 1

--- a/backend/infrahub/core/migrations/shared.py
+++ b/backend/infrahub/core/migrations/shared.py
@@ -3,11 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Sequence
 
 from pydantic import BaseModel, ConfigDict, Field
-from typing_extensions import Self
 from rich.console import Console
+from typing_extensions import Self
 
-from infrahub.auth import AccountSession, AuthType
-from infrahub.context import InfrahubContext
 from infrahub.core import registry
 from infrahub.core.path import SchemaPath  # noqa: TC001
 from infrahub.core.query import Query  # noqa: TC001

--- a/backend/infrahub/core/migrations/shared.py
+++ b/backend/infrahub/core/migrations/shared.py
@@ -275,6 +275,7 @@ class MigrationWithRebase(BaseModel):
     async def execute_against_branch(
         self, db: InfrahubDatabase, branch: Branch, skip_rebase: bool = False
     ) -> MigrationResult:
+        initialize_lock()
         await registry.schema.load_schema(db=db, branch=branch)
 
         if not skip_rebase:
@@ -288,7 +289,6 @@ class MigrationWithRebase(BaseModel):
     async def execute(self, db: InfrahubDatabase) -> MigrationResult:
         from infrahub.core.initialization import initialization
 
-        initialize_lock()
         await initialization(db=db)
 
         return await self.execute_against_branch(db=db, branch=registry.get_branch_from_registry(), skip_rebase=True)

--- a/backend/infrahub/core/migrations/shared.py
+++ b/backend/infrahub/core/migrations/shared.py
@@ -245,32 +245,24 @@ class MigrationWithRebase(BaseModel):
     def init(cls, **kwargs: dict[str, Any]) -> Self:
         return cls(**kwargs)  # type: ignore[arg-type]
 
-    async def rebase_branch(self, db: InfrahubDatabase, branch: Branch) -> bool:
+    async def rebase_branch(self, branch: Branch) -> bool:
         # Circular deps if imported inside import block
         from infrahub.core.branch.tasks import rebase_branch
 
-        # NOTE: need service/bus component up and running to use prefect flow
         console = Console()
         console.print(f"Rebasing branch '{branch.name}' (ID: {branch.uuid})...", end="")
         try:
-            # await branch.rebase(db=db)
             await rebase_branch(
                 branch=branch.name,
                 context=InfrahubContext.init(
-                    branch=branch,
-                    # FIXME: or superuser account?
-                    account=AccountSession(auth_type=AuthType.NONE, authenticated=False, account_id=""),
+                    branch=branch, account=AccountSession(auth_type=AuthType.NONE, authenticated=False, account_id="")
                 ),
                 send_events=False,
             )
             console.print("done")
-            branch.graph_version = self.minimum_version + 1
         except ValidationError:
             console.print("failed")
-            branch.status = BranchStatus.NEED_UPGRADE_REBASE
             return False
-        finally:
-            await branch.save(db=db)
 
         return True
 
@@ -286,14 +278,19 @@ class MigrationWithRebase(BaseModel):
         for branch in branches:
             await registry.schema.load_schema(db=db, branch=branch)
 
-            if not await self.rebase_branch(db=db, branch=branch):
+            if not await self.rebase_branch(branch=branch):
                 result.errors.append(f"Failed to rebase branch '{branch.name}' ({branch.uuid})")
+                branch.status = BranchStatus.NEED_UPGRADE_REBASE
+                await branch.save(db=db)
                 continue
 
             r = await self.execute_against_branch(db=db, branch=branch)
             result.nbr_migrations_executed += 1
             if r.errors:
                 result.errors.extend(r.errors)
+            if r.success:
+                branch.graph_version = self.minimum_version + 1
+                await branch.save(db=db)
 
         return result
 

--- a/backend/tests/unit/workflows/test_models.py
+++ b/backend/tests/unit/workflows/test_models.py
@@ -6,4 +6,5 @@ def test_get_parameters():
     assert BRANCH_REBASE.get_parameters() == {
         "branch": WorkflowParameter(name="branch", type="str", required=True),
         "context": WorkflowParameter(name="context", type="InfrahubContext", required=True),
+        "send_events": WorkflowParameter(name="send_events", type="bool", required=False),
     }


### PR DESCRIPTION
- small change to return early
- removed rebase logic from the migration
  -  I think that having a migration rebase a branch puts the dependencies in the wrong order. I'd say that a migration should not need to have logic related to a rebase. I think that it should be the other way around: our rebase logic can have knowledge of migrations.
  - also the import within a function was going to make all of us sad and that is usually a sign that dependencies need adjusting
- removed all of the logic from `execute` and `execute_against_branch` on the base class
  - we don't know what the migration will or won't need access to, so I think we should let the migration handle loading the registry and schemas  if it is required
- removed `process_branch` b/c it does not do much if we are going to remove the rebase logic from `MigrationWithRebase`

and maybe the class should be `MigrationRequiringRebase` or something instead of we remove the rebase logic from it