### PR TITLE
Fix flaky E2E test on merge branch + use more workers

### DIFF
--- a/frontend/app/playwright.config.ts
+++ b/frontend/app/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
     toHaveScreenshot: { maxDiffPixels: 5000 },
   },
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 2 : undefined,
+  workers: process.env.CI ? 4 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
     ["list"],

--- a/frontend/app/playwright.config.ts
+++ b/frontend/app/playwright.config.ts
@@ -16,12 +16,12 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   retries: 0,
-  timeout: process.env.CI ? 2 * 60 * 1000 : 60 * 1000,
+  timeout: process.env.CI ? 3 * 60 * 1000 : 60 * 1000,
   expect: {
     timeout: process.env.CI
       ? process.env.INFRAHUB_MISC_RESPONSE_DELAY
         ? 6 * 60 * 1000
-        : 2 * 60 * 1000
+        : 3 * 60 * 1000
       : 1 * 60 * 1000,
     toHaveScreenshot: { maxDiffPixels: 5000 },
   },

--- a/frontend/app/tests/e2e/branches/merge-branch.spec.ts
+++ b/frontend/app/tests/e2e/branches/merge-branch.spec.ts
@@ -2,39 +2,39 @@ import { expect, test } from "@playwright/test";
 
 import { ACCOUNT_STATE_PATH } from "../../constants";
 import { generateRandomBranchName } from "../../utils";
-import { deleteBranchAPI } from "../utils/graphql";
+import { createBranchAPI, deleteBranchAPI } from "../utils/graphql";
 
-test.describe("Verify branch merge button state", () => {
+test.describe("Branch - Merge action", () => {
   test.use({ storageState: ACCOUNT_STATE_PATH.ADMIN });
 
-  const BRANCH_NAME = generateRandomBranchName("merge-action-test");
+  const BRANCH_NAME = generateRandomBranchName("merge-branch");
+
+  test.beforeAll(async ({ request }) => {
+    await createBranchAPI(request, BRANCH_NAME);
+  });
 
   test.afterAll(async ({ request }) => {
     await deleteBranchAPI(request, BRANCH_NAME);
   });
 
-  test("create a branch, merge it and verify button state", async ({ page }) => {
-    await test.step("Create and access a new branch", async () => {
-      await page.goto("/branches");
-      await page.getByTestId("branch-selector-trigger").click();
-      await page.getByTestId("create-branch-button").click();
-      await page.getByRole("textbox", { name: "New branch name *" }).fill(BRANCH_NAME);
-      await page.getByRole("button", { name: "Create a new branch" }).click();
-      await expect(page.getByText("New branch name *")).not.toBeVisible();
-      await expect(page.getByTestId("branches-items").getByText(BRANCH_NAME)).toBeVisible();
-      await page.getByTestId("branches-items").getByText(BRANCH_NAME).click();
-      await expect(page.getByText(`Name${BRANCH_NAME}`)).toBeVisible();
+  test("disable merge button while merge is in progress and re-enable it when complete", async ({
+    page,
+  }) => {
+    await test.step("access a the branch details page", async () => {
+      await page.goto(`/branches/${BRANCH_NAME}`);
       await page.getByText("Tasks").click();
     });
 
     await test.step("Merge the branch and verify button state", async () => {
-      test.slow();
-
       await page.getByRole("button", { name: "Merge", exact: true }).click();
       await expect(page.getByText("Branch merge requested!")).toBeVisible();
-      await expect(page.getByText("RUNNINGMerge branch graphQL")).toBeVisible();
+      await expect(page.getByText("RUNNINGMerge branch graphQL")).toBeVisible({
+        timeout: 2 * 60 * 1000,
+      });
       await expect(page.getByRole("button", { name: "Merge", exact: true })).toBeDisabled();
-      await expect(page.getByText("COMPLETEDMerge branch graphQL")).toBeVisible();
+      await expect(page.getByText("COMPLETEDMerge branch graphQL")).toBeVisible({
+        timeout: 2 * 60 * 1000,
+      });
       await expect(page.getByRole("button", { name: "Merge", exact: true })).toBeEnabled();
     });
   });

--- a/frontend/app/tests/e2e/branches/merge-branch.spec.ts
+++ b/frontend/app/tests/e2e/branches/merge-branch.spec.ts
@@ -17,10 +17,8 @@ test.describe("Branch - Merge action", () => {
     await deleteBranchAPI(request, BRANCH_NAME);
   });
 
-  test("disable merge button while merge is in progress and re-enable it when complete", async ({
-    page,
-  }) => {
-    await test.step("access a the branch details page", async () => {
+  test("disable merge button during merge and re-enable when complete", async ({ page }) => {
+    await test.step("access the branch details page", async () => {
       await page.goto(`/branches/${BRANCH_NAME}`);
       await page.getByText("Tasks").click();
     });

--- a/frontend/app/tests/e2e/branches/merge-branch.spec.ts
+++ b/frontend/app/tests/e2e/branches/merge-branch.spec.ts
@@ -29,11 +29,11 @@ test.describe("Branch - Merge action", () => {
       await page.getByRole("button", { name: "Merge", exact: true }).click();
       await expect(page.getByText("Branch merge requested!")).toBeVisible();
       await expect(page.getByText("RUNNINGMerge branch graphQL")).toBeVisible({
-        timeout: 2 * 60 * 1000,
+        timeout: 5 * 60 * 1000,
       });
       await expect(page.getByRole("button", { name: "Merge", exact: true })).toBeDisabled();
       await expect(page.getByText("COMPLETEDMerge branch graphQL")).toBeVisible({
-        timeout: 2 * 60 * 1000,
+        timeout: 5 * 60 * 1000,
       });
       await expect(page.getByRole("button", { name: "Merge", exact: true })).toBeEnabled();
     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI test workers increased from 2 to 4 to speed up test execution.
  * CI test timeouts increased from 2 to 3 minutes (including conditionally extended expect timeout).

* **Tests**
  * E2E branch-merge test updated: branch is created via API, test flow simplified and renamed, RUNNING/COMPLETED checks extended to 5 minutes, merge button verified disabled during merge and re-enabled after, and post-test cleanup retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->