### PR TITLE
Catch and log branch not found error for computed attributes

### DIFF
--- a/backend/infrahub/computed_attribute/tasks.py
+++ b/backend/infrahub/computed_attribute/tasks.py
@@ -178,12 +178,17 @@ async def computed_attribute_jinja2_update_value(
         log.debug(f"Ignoring to update {obj} with existing value on {attribute_name}={value}")
         return
 
-    await client.execute_graphql(
-        query=UPDATE_ATTRIBUTE,
-        variables={"id": obj.node_id, "kind": node_kind, "attribute": attribute_name, "value": value},
-        branch_name=branch_name,
-    )
-    log.info(f"Updating computed attribute {node_kind}.{attribute_name}='{value}' ({obj.node_id})")
+    try:
+        await client.execute_graphql(
+            query=UPDATE_ATTRIBUTE,
+            variables={"id": obj.node_id, "kind": node_kind, "attribute": attribute_name, "value": value},
+            branch_name=branch_name,
+        )
+        log.info(f"Updating computed attribute {node_kind}.{attribute_name}='{value}' ({obj.node_id})")
+    except URLNotFoundError:
+        log.warning(
+            f"Update of computed attribute {node_kind}.{attribute_name} failed for branch {branch_name} (not found)"
+        )
 
 
 @flow(


### PR DESCRIPTION
Catch error if the branch has been deleted and return early.

This is mainly something we see in the end to end tests when active tasks are running and the tests delete a branch which leads to errors in the logs when we try to update computed attributes on nodes where the branch no longer exists. It should also clear up these ugly errors in production environments but typically that will happen a lot less often than within the testing environment.