### PR TITLE
Provide userfriendly error message when branch is not found

### DIFF
--- a/backend/infrahub/display_labels/tasks.py
+++ b/backend/infrahub/display_labels/tasks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import cast
 
+from infrahub_sdk.exceptions import URLNotFoundError
 from infrahub_sdk.template import Jinja2Template
 from prefect import flow
 from prefect.logging import get_run_logger
@@ -53,12 +54,17 @@ async def display_label_jinja2_update_value(
         log.debug(f"Ignoring to update {obj} with existing value on display_label={value}")
         return
 
-    await client.execute_graphql(
-        query=UPDATE_DISPLAY_LABEL,
-        variables={"id": obj.node_id, "kind": node_kind, "value": value},
-        branch_name=branch_name,
-    )
-    log.info(f"Updating {node_kind}.display_label='{value}' ({obj.node_id})")
+    try:
+        await client.execute_graphql(
+            query=UPDATE_DISPLAY_LABEL,
+            variables={"id": obj.node_id, "kind": node_kind, "value": value},
+            branch_name=branch_name,
+        )
+        log.info(f"Updating {node_kind}.display_label='{value}' ({obj.node_id})")
+    except URLNotFoundError:
+        log.warning(
+            f"Updating {node_kind}.display_label='{value}' ({obj.node_id}) failed for branch {branch_name} (branch not found)"
+        )
 
 
 @flow(

--- a/backend/infrahub/hfid/tasks.py
+++ b/backend/infrahub/hfid/tasks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import cast
 
+from infrahub_sdk.exceptions import URLNotFoundError
 from prefect import flow
 from prefect.logging import get_run_logger
 
@@ -56,12 +57,17 @@ async def hfid_update_value(
         log.debug(f"Ignoring to update {obj} with existing value on human_friendly_id={obj.hfid_value}")
         return
 
-    await client.execute_graphql(
-        query=UPDATE_HFID,
-        variables={"id": obj.node_id, "kind": node_kind, "value": rendered_hfid},
-        branch_name=branch_name,
-    )
-    log.info(f"Updating {node_kind}.human_friendly_id='{rendered_hfid}' ({obj.node_id})")
+    try:
+        await client.execute_graphql(
+            query=UPDATE_HFID,
+            variables={"id": obj.node_id, "kind": node_kind, "value": rendered_hfid},
+            branch_name=branch_name,
+        )
+        log.info(f"Updating {node_kind}.human_friendly_id='{rendered_hfid}' ({obj.node_id})")
+    except URLNotFoundError:
+        log.warning(
+            f"Updating {node_kind}.human_friendly_id='{rendered_hfid}' ({obj.node_id}) failed for branch {branch_name} (branch not found)"
+        )
 
 
 @flow(


### PR DESCRIPTION
Catch and log error when trying to update display labels and HFIDs for branches that have been deleted.