### PR TITLE
Added a link to hierarchy generic list view above hierarchy tree

### DIFF
--- a/frontend/app/src/entities/nodes/hierarchy/ui/object-hierarchy-tree.tsx
+++ b/frontend/app/src/entities/nodes/hierarchy/ui/object-hierarchy-tree.tsx
@@ -2,6 +2,7 @@ import { Icon } from "@iconify-icon/react";
 import { ListTreeIcon } from "lucide-react";
 import React from "react";
 import { Collection } from "react-aria-components";
+import { Link } from "react-router";
 
 import { Tree, TreeItem, TreeItemContent, TreeItemLoader } from "@/shared/components/aria/tree";
 import { Col, Row } from "@/shared/components/container";
@@ -52,23 +53,34 @@ export function ObjectHierarchyTree({ treeSchema, currentNodeId }: ObjectHierarc
   }
 
   return (
-    <Tree
-      aria-label="Hierarchy tree"
-      selectedKeys={currentNodeId ? [currentNodeId] : undefined}
-      renderEmptyState={() => <Row className="justify-center py-2 text-gray-600">No item</Row>}
-    >
-      <Collection items={items} dependencies={[currentNodeId]}>
-        {(node) => (
-          <ObjectTreeItem
-            node={node}
-            treeObjectKind={treeSchema.kind!}
-            currentNodeId={currentNodeId}
-          />
-        )}
-      </Collection>
+    <>
+      <Link
+        to={getObjectDetailsUrl(treeSchema.kind!)}
+        className="block p-2 text-gray-500 text-sm hover:underline"
+      >
+        {treeSchema.label}
+      </Link>
 
-      {hasNextPage && <TreeItemLoader isLoading={isFetchingNextPage} onLoadMore={fetchNextPage} />}
-    </Tree>
+      <Tree
+        aria-label="Hierarchy tree"
+        selectedKeys={currentNodeId ? [currentNodeId] : undefined}
+        renderEmptyState={() => <Row className="justify-center py-2 text-gray-600">No item</Row>}
+      >
+        <Collection items={items} dependencies={[currentNodeId]}>
+          {(node) => (
+            <ObjectTreeItem
+              node={node}
+              treeObjectKind={treeSchema.kind!}
+              currentNodeId={currentNodeId}
+            />
+          )}
+        </Collection>
+
+        {hasNextPage && (
+          <TreeItemLoader isLoading={isFetchingNextPage} onLoadMore={fetchNextPage} />
+        )}
+      </Tree>
+    </>
   );
 }
 


### PR DESCRIPTION
<img width="702" height="692" alt="image" src="https://github.com/user-attachments/assets/d8d6e8fc-8b49-4173-ac52-fba212048c26" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a link to the object detail page above the object hierarchy tree, making navigation between hierarchy and object details more seamless.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->