### PR TITLE
HFID/display label migration updates

### DIFF
--- a/backend/infrahub/core/migrations/graph/m042_create_hfid_display_label_in_db.py
+++ b/backend/infrahub/core/migrations/graph/m042_create_hfid_display_label_in_db.py
@@ -6,15 +6,45 @@ from rich.progress import Progress
 from typing_extensions import Self
 
 from infrahub.core import registry
+from infrahub.core.branch import Branch
 from infrahub.core.constants import SchemaPathType
-from infrahub.core.initialization import initialization
+from infrahub.core.initialization import get_root_node
 from infrahub.core.migrations.schema.node_attribute_add import NodeAttributeAddMigration
 from infrahub.core.migrations.shared import InternalSchemaMigration, MigrationResult
 from infrahub.core.path import SchemaPath
-from infrahub.lock import initialize_lock
+from infrahub.core.query import Query, QueryType
+from infrahub.core.schema import SchemaRoot, internal_schema
+from infrahub.core.schema.manager import SchemaManager
+from infrahub.exceptions import InitializationError
 
 if TYPE_CHECKING:
+    from infrahub.core.schema.schema_branch import SchemaBranch
     from infrahub.database import InfrahubDatabase
+
+
+class GetAddedNodesByKindForBranchQuery(Query):
+    name = "get_added_nodes_by_kind_for_branch_query"
+    type = QueryType.READ
+    insert_return = True
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
+        self.params["branch"] = self.branch.name
+        query = """
+MATCH (n:Node)-[e:IS_PART_OF {branch: $branch, status: "active"}]->(:Root)
+WHERE e.to IS NULL
+AND NOT exists((n)-[:IS_PART_OF {branch: $branch, status: "deleted"}]->(:Root))
+WITH n.kind AS kind, collect(n.uuid) AS node_ids
+        """
+        self.return_labels = ["kind", "node_ids"]
+        self.add_to_query(query)
+
+    def get_node_ids_by_kind(self) -> dict[str, list[str]]:
+        node_ids_by_kind: dict[str, list[str]] = {}
+        for result in self.get_results():
+            kind = result.get_as_type(label="kind", return_type=str)
+            node_ids: list[str] = result.get_as_type(label="node_ids", return_type=list)
+            node_ids_by_kind[kind] = node_ids
+        return node_ids_by_kind
 
 
 class Migration042(InternalSchemaMigration):
@@ -46,15 +76,25 @@ class Migration042(InternalSchemaMigration):
         ]
         return cls(migrations=cls.migrations, **kwargs)  # type: ignore[arg-type]
 
+    async def _get_or_load_schema_branch(self, db: InfrahubDatabase, branch: Branch) -> SchemaBranch:
+        try:
+            if registry.schema.has_schema_branch(branch.name):
+                return registry.schema.get_schema_branch(branch.name)
+        except InitializationError:
+            pass
+        schema_manager = SchemaManager()
+        internal_schema_root = SchemaRoot(**internal_schema)
+        schema_manager.register_schema(schema=internal_schema_root)
+        registry.schema = schema_manager
+        return await schema_manager.load_schema_from_db(db=db, branch=branch)
+
     async def execute(self, db: InfrahubDatabase) -> MigrationResult:
         result = MigrationResult()
 
-        # load schemas from database into registry
-        initialize_lock()
-        await initialization(db=db)
-
-        default_branch = registry.get_branch_from_registry()
-        schema_branch = await registry.schema.load_schema_from_db(db=db, branch=default_branch)
+        root_node = await get_root_node(db=db, initialize=False)
+        default_branch_name = root_node.default_branch
+        default_branch = await Branch.get_by_name(db=db, name=default_branch_name)
+        schema_branch = await self._get_or_load_schema_branch(db=db, branch=default_branch)
 
         migrations = list(self.migrations)
 
@@ -85,6 +125,55 @@ class Migration042(InternalSchemaMigration):
             for migration in migrations:
                 try:
                     execution_result = await migration.execute(db=db, branch=default_branch)
+                    result.errors.extend(execution_result.errors)
+                    progress.update(update_task, advance=1)
+                except Exception as exc:
+                    result.errors.append(str(exc))
+                    return result
+
+        return result
+
+    async def execute_against_branch(self, db: InfrahubDatabase, branch: Branch) -> MigrationResult:
+        result = MigrationResult()
+
+        schema_branch = await registry.schema.load_schema_from_db(db=db, branch=branch)
+
+        migrations = []
+        get_added_nodes_by_kind_for_branch_query = await GetAddedNodesByKindForBranchQuery.init(db=db, branch=branch)
+        await get_added_nodes_by_kind_for_branch_query.execute(db=db)
+        node_ids_by_kind = get_added_nodes_by_kind_for_branch_query.get_node_ids_by_kind()
+
+        for node_kind, node_ids in node_ids_by_kind.items():
+            schema = schema_branch.get(name=node_kind, duplicate=False)
+            migrations.extend(
+                [
+                    NodeAttributeAddMigration(
+                        uuids=node_ids,
+                        new_node_schema=schema,
+                        previous_node_schema=schema,
+                        schema_path=SchemaPath(
+                            schema_kind=schema.kind, path_type=SchemaPathType.ATTRIBUTE, field_name="human_friendly_id"
+                        ),
+                    ),
+                    NodeAttributeAddMigration(
+                        uuids=node_ids,
+                        new_node_schema=schema,
+                        previous_node_schema=schema,
+                        schema_path=SchemaPath(
+                            schema_kind=schema.kind, path_type=SchemaPathType.ATTRIBUTE, field_name="display_label"
+                        ),
+                    ),
+                ]
+            )
+
+        with Progress() as progress:
+            update_task = progress.add_task(
+                f"Adding HFID and display label to nodes on branch {branch.name}", total=len(migrations)
+            )
+
+            for migration in migrations:
+                try:
+                    execution_result = await migration.execute(db=db, branch=branch)
                     result.errors.extend(execution_result.errors)
                     progress.update(update_task, advance=1)
                 except Exception as exc:

--- a/backend/infrahub/core/migrations/graph/m043_backfill_hfid_display_label_in_db.py
+++ b/backend/infrahub/core/migrations/graph/m043_backfill_hfid_display_label_in_db.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from itertools import chain
 from typing import TYPE_CHECKING, Any
 
 import ujson
@@ -119,17 +120,20 @@ class GetResultMapQuery(Query):
         return result_map
 
 
-class GetUpdatedPathDetailsBranchQuery(GetResultMapQuery):
-    name = "get_updated_path_details_branch"
-    type = QueryType.WRITE
+class GetPathDetailsBranchQuery(GetResultMapQuery):
+    name = "get_path_details_branch"
+    type = QueryType.READ
     insert_limit = False
 
-    def __init__(self, schema_kind: str, schema_paths: list[SchemaAttributePath], **kwargs: Any) -> None:
+    def __init__(
+        self, schema_kind: str, schema_paths: list[SchemaAttributePath], updates_only: bool = True, **kwargs: Any
+    ) -> None:
         super().__init__(**kwargs)
 
         if self.branch.name in [registry.default_branch, GLOBAL_BRANCH_NAME]:
             raise ValueError("This query can only be used on non-default branches")
         self.schema_kind = schema_kind
+        self.updates_only = updates_only
         self.attribute_names = []
         self.bidir_rel_attr_map: dict[str, list[str]] = defaultdict(list)
         self.outbound_rel_attr_map: dict[str, list[str]] = defaultdict(list)
@@ -164,15 +168,27 @@ class GetUpdatedPathDetailsBranchQuery(GetResultMapQuery):
                 "limit": self.limit,
             }
         )
-        get_updated_nodes_by_id_query = """
+        get_active_nodes_query = """
 // ------------
 // Get the active nodes of the given kind on the branches
 // ------------
 MATCH (n:%(schema_kind)s)-[r:IS_PART_OF]->(:Root)
 WHERE %(branch_filter)s
-AND r.to IS NULL
-AND r.status = "active"
-AND NOT exists((n)-[:IS_PART_OF {branch: $branch_name, status: "deleted"}]->(:Root))
+WITH DISTINCT n
+CALL (n) {
+    MATCH (n)-[r:IS_PART_OF]->(:Root)
+    WHERE %(branch_filter)s
+    RETURN r.status = "active" AS is_active
+    ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+    LIMIT 1
+}
+WITH n, is_active
+WHERE is_active = TRUE
+        """ % {"schema_kind": self.schema_kind, "branch_filter": branch_filter}
+        self.add_to_query(get_active_nodes_query)
+
+        if self.updates_only:
+            updated_nodes_filter_query = """
 // ------------
 // filter to any nodes that might have changes on the branch we care about
 // ------------
@@ -194,6 +210,10 @@ WITH n, has_attr_update, attr_val IS NOT NULL AS has_rel_update
 WITH n, any(x IN collect(has_attr_update OR has_rel_update) WHERE x = TRUE) AS has_update
 WITH n, has_update
 WHERE has_update = TRUE
+            """
+            self.add_to_query(updated_nodes_filter_query)
+
+        get_node_details_query = """
 // ------------
 // Order and limit the Nodes
 // ------------
@@ -265,8 +285,8 @@ CALL (rel_name, direction, peer){
 // ------------
 WITH DISTINCT n, attr_vals_list, rel_name, peer, direction, peer_attr_name, peer_attr_value
 WITH n, attr_vals_list, collect([rel_name, direction, peer_attr_name, peer_attr_value]) AS peer_attr_vals_list
-        """ % {"schema_kind": self.schema_kind, "branch_filter": branch_filter}
-        self.add_to_query(get_updated_nodes_by_id_query)
+        """ % {"branch_filter": branch_filter}
+        self.add_to_query(get_node_details_query)
         self.return_labels = ["n.uuid AS n_uuid", "attr_vals_list", "peer_attr_vals_list"]
 
 
@@ -607,77 +627,84 @@ class Migration043(ArbitraryMigration):
         registry.schema = schema_manager
         return await schema_manager.load_schema_from_db(db=db, branch=branch)
 
-    async def _do_one_schema_batch_default_branch(
+    async def _do_one_schema_all(
         self,
         db: InfrahubDatabase,
-        default_branch: Branch,
+        branch: Branch,
         schema: NodeSchema,
         schema_branch: SchemaBranch,
-        display_label_attribute_schema: AttributeSchema,
-        hfid_attribute_schema: AttributeSchema,
-        progress: Progress,
-        update_task: TaskID,
+        attribute_schema_map: dict[AttributeSchema, AttributeSchema],
+        progress: Progress | None = None,
+        update_task: TaskID | None = None,
     ) -> None:
-        if not schema.display_label and not schema.human_friendly_id:
-            return
-
         print(f"Processing {schema.kind}...", end="")
 
-        display_labels_schema_paths = [
-            schema.parse_schema_path(path=display_label, schema=schema_branch)
-            for display_label in schema.display_labels or []
-        ]
-        human_friendly_id_schema_paths = [
-            schema.parse_schema_path(path=human_friendly_id, schema=schema_branch)
-            for human_friendly_id in schema.human_friendly_id or []
-        ]
+        schema_paths_by_name: dict[str, list[SchemaAttributePath]] = {}
+        for source_attribute_schema in attribute_schema_map.keys():
+            node_schema_property = getattr(schema, source_attribute_schema.name)
+            if not node_schema_property:
+                continue
+            if isinstance(node_schema_property, list):
+                schema_paths_by_name[source_attribute_schema.name] = [
+                    schema.parse_schema_path(path=str(path), schema=schema_branch) for path in node_schema_property
+                ]
+            else:
+                schema_paths_by_name[source_attribute_schema.name] = [
+                    schema.parse_schema_path(path=str(node_schema_property), schema=schema_branch)
+                ]
+        all_schema_paths = list(chain(*schema_paths_by_name.values()))
         offset = 0
 
+        # loop until we get no results from the get_details_query
         while True:
-            # loop until we get no results from the get_details_query
-            get_details_query = await GetPathDetailsDefaultBranch.init(
-                db=db,
-                schema_kind=schema.kind,
-                schema_paths=display_labels_schema_paths + human_friendly_id_schema_paths,
-                offset=offset,
-                limit=self.update_batch_size,
-            )
+            if branch.is_default:
+                get_details_query: GetResultMapQuery = await GetPathDetailsDefaultBranch.init(
+                    db=db,
+                    schema_kind=schema.kind,
+                    schema_paths=all_schema_paths,
+                    offset=offset,
+                    limit=self.update_batch_size,
+                )
+            else:
+                get_details_query = await GetPathDetailsBranchQuery.init(
+                    db=db,
+                    branch=branch,
+                    schema_kind=schema.kind,
+                    schema_paths=all_schema_paths,
+                    offset=offset,
+                    limit=self.update_batch_size,
+                )
             await get_details_query.execute(db=db)
 
-            display_label_schema_path_values_map = get_details_query.get_result_map(display_labels_schema_paths)
-            num_updates = len(display_label_schema_path_values_map)
-            if display_label_schema_path_values_map:
+            num_updates = 0
+            for source_attribute_schema, destination_attribute_schema in attribute_schema_map.items():
+                schema_paths = schema_paths_by_name[source_attribute_schema.name]
+                schema_path_values_map = get_details_query.get_result_map(schema_paths)
+                num_updates = max(num_updates, len(schema_path_values_map))
                 formatted_display_label_schema_path_values_map = {}
-                for k, v in display_label_schema_path_values_map.items():
-                    if v:
+                for k, v in schema_path_values_map.items():
+                    if not v:
+                        continue
+                    if destination_attribute_schema.kind == "List":
+                        formatted_display_label_schema_path_values_map[k] = ujson.dumps(v)
+                    else:
                         formatted_display_label_schema_path_values_map[k] = " ".join(v)
+
+                if not formatted_display_label_schema_path_values_map:
+                    continue
 
                 update_display_label_query = await UpdateAttributeValuesQuery.init(
                     db=db,
-                    branch=default_branch,
-                    attribute_schema=display_label_attribute_schema,
+                    branch=branch,
+                    attribute_schema=destination_attribute_schema,
                     values_by_id_map=formatted_display_label_schema_path_values_map,
                 )
                 await update_display_label_query.execute(db=db)
 
-            human_friendly_id_schema_path_values_map = get_details_query.get_result_map(human_friendly_id_schema_paths)
+            if progress and update_task:
+                progress.update(update_task, advance=num_updates)
 
-            if human_friendly_id_schema_path_values_map:
-                formatted_human_friendly_id_schema_path_values_map = {}
-                for k, v in human_friendly_id_schema_path_values_map.items():
-                    if v:
-                        formatted_human_friendly_id_schema_path_values_map[k] = ujson.dumps(v)
-
-                update_human_friendly_id_query = await UpdateAttributeValuesQuery.init(
-                    db=db,
-                    branch=default_branch,
-                    attribute_schema=hfid_attribute_schema,
-                    values_by_id_map=formatted_human_friendly_id_schema_path_values_map,
-                )
-                await update_human_friendly_id_query.execute(db=db)
-            progress.update(update_task, advance=num_updates)
-
-            if not num_updates:
+            if num_updates == 0:
                 break
 
             offset += self.update_batch_size
@@ -685,14 +712,6 @@ class Migration043(ArbitraryMigration):
         print("done")
 
     async def execute(self, db: InfrahubDatabase) -> MigrationResult:
-        # branches = await Branch.get_list(db=db)
-        # for branch in branches:
-        #     if branch.name in [registry.default_branch, GLOBAL_BRANCH_NAME]:
-        #         continue
-        #     await self.execute_against_branch(db=db, branch=branch)
-
-        # return MigrationResult(errors=["pretend error"])
-
         root_node = await get_root_node(db=db, initialize=False)
         default_branch_name = root_node.default_branch
         default_branch = await Branch.get_by_name(db=db, name=default_branch_name)
@@ -705,53 +724,66 @@ class Migration043(ArbitraryMigration):
 
         base_node_schema = main_schema_branch.get("SchemaNode", duplicate=False)
         display_label_attribute_schema = base_node_schema.get_attribute("display_label")
+        display_labels_attribute_schema = base_node_schema.get_attribute("display_labels")
         hfid_attribute_schema = base_node_schema.get_attribute("human_friendly_id")
 
-        # try:
-        with Progress() as progress:
-            update_task = progress.add_task(
-                f"Set display_label and human_friendly_id for {total_nodes_count} nodes on default branch",
-                total=total_nodes_count,
-            )
-            for node_schema_name in main_schema_branch.node_names:
-                if node_schema_name in self.kinds_to_skip:
-                    continue
-
-                node_schema = main_schema_branch.get_node(name=node_schema_name, duplicate=False)
-                await self._do_one_schema_batch_default_branch(
-                    db=db,
-                    default_branch=default_branch,
-                    schema=node_schema,
-                    schema_branch=main_schema_branch,
-                    display_label_attribute_schema=display_label_attribute_schema,
-                    hfid_attribute_schema=hfid_attribute_schema,
-                    progress=progress,
-                    update_task=update_task,
+        try:
+            with Progress() as progress:
+                update_task = progress.add_task(
+                    f"Set display_label and human_friendly_id for {total_nodes_count} nodes on default branch",
+                    total=total_nodes_count,
                 )
+                for node_schema_name in main_schema_branch.node_names:
+                    if node_schema_name in self.kinds_to_skip:
+                        continue
 
-        # except Exception as exc:
-        # return MigrationResult(errors=[str(exc)])
+                    node_schema = main_schema_branch.get_node(name=node_schema_name, duplicate=False)
+                    attribute_schema_map = {}
+                    if node_schema.display_labels:
+                        attribute_schema_map[display_labels_attribute_schema] = display_label_attribute_schema
+                    if node_schema.human_friendly_id:
+                        attribute_schema_map[hfid_attribute_schema] = hfid_attribute_schema
+                    if not attribute_schema_map:
+                        continue
+
+                    await self._do_one_schema_all(
+                        db=db,
+                        branch=default_branch,
+                        schema=node_schema,
+                        schema_branch=main_schema_branch,
+                        attribute_schema_map=attribute_schema_map,
+                        progress=progress,
+                        update_task=update_task,
+                    )
+
+        except Exception as exc:
+            return MigrationResult(errors=[str(exc)])
         return MigrationResult()
 
-    async def _do_one_schema_batch_branch(
+    async def _do_one_schema_branch(
         self,
         db: InfrahubDatabase,
         branch: Branch,
         schema: NodeSchema,
         schema_branch: SchemaBranch,
-        attribute_schema: AttributeSchema,
-        schema_path_strs: list[str],
+        source_attribute_schema: AttributeSchema,
+        destination_attribute_schema: AttributeSchema,
     ) -> None:
-        print(f"Processing {schema.kind}.{attribute_schema.name} for {branch.name}...", end="")
+        print(f"Processing {schema.kind}.{destination_attribute_schema.name} for {branch.name}...", end="")
 
-        schema_paths = [
-            schema.parse_schema_path(path=path_part, schema=schema_branch) for path_part in schema_path_strs
-        ]
+        schema_property = getattr(schema, source_attribute_schema.name)
+        if isinstance(schema_property, list):
+            schema_paths = [
+                schema.parse_schema_path(path=str(path_part), schema=schema_branch) for path_part in schema_property
+            ]
+        else:
+            schema_paths = [schema.parse_schema_path(path=str(schema_property), schema=schema_branch)]
+
         offset = 0
 
         while True:
             # loop until we get no results from the get_details_query
-            get_details_query = await GetUpdatedPathDetailsBranchQuery.init(
+            get_details_query = await GetPathDetailsBranchQuery.init(
                 db=db,
                 branch=branch,
                 schema_kind=schema.kind,
@@ -769,15 +801,15 @@ class Migration043(ArbitraryMigration):
             for k, v in schema_path_values_map.items():
                 if not v:
                     continue
-                formatted_v = ujson.dumps(v) if attribute_schema.kind == "List" else " ".join(v)
+                formatted_v = ujson.dumps(v) if destination_attribute_schema.kind == "List" else " ".join(v)
                 formatted_schema_path_values_map[k] = formatted_v
 
-                print(schema.kind, schema_path_strs, k, v)
+                print(schema.kind, schema_property, k, v)
 
             update_attr_values_query = await UpdateAttributeValuesQuery.init(
                 db=db,
                 branch=branch,
-                attribute_schema=attribute_schema,
+                attribute_schema=destination_attribute_schema,
                 values_by_id_map=formatted_schema_path_values_map,
             )
             await update_attr_values_query.execute(db=db)
@@ -785,10 +817,13 @@ class Migration043(ArbitraryMigration):
             offset += self.update_batch_size
 
     async def execute_against_branch(self, db: InfrahubDatabase, branch: Branch) -> MigrationResult:
+        default_branch = await Branch.get_by_name(db=db, name=registry.default_branch)
+        main_schema_branch = await self._get_or_load_schema_branch(db=db, branch=default_branch)
         schema_branch = await self._get_or_load_schema_branch(db=db, branch=branch)
 
         base_node_schema = schema_branch.get("SchemaNode", duplicate=False)
         display_label_attribute_schema = base_node_schema.get_attribute("display_label")
+        display_labels_attribute_schema = base_node_schema.get_attribute("display_labels")
         hfid_attribute_schema = base_node_schema.get_attribute("human_friendly_id")
 
         try:
@@ -797,28 +832,41 @@ class Migration043(ArbitraryMigration):
                     continue
 
                 node_schema = schema_branch.get_node(name=node_schema_name, duplicate=False)
-                if node_schema.display_labels:
-                    await self._do_one_schema_batch_branch(
+                default_node_schema = main_schema_branch.get_node(name=node_schema_name, duplicate=False)
+                schemas_for_universal_update_map = {}
+                schemas_for_targeted_update_map = {}
+                if default_node_schema.display_label != node_schema.display_label:
+                    schemas_for_universal_update_map[display_labels_attribute_schema] = display_label_attribute_schema
+                elif node_schema.display_labels:
+                    schemas_for_targeted_update_map[display_labels_attribute_schema] = display_label_attribute_schema
+
+                if default_node_schema.human_friendly_id != node_schema.human_friendly_id:
+                    schemas_for_universal_update_map[hfid_attribute_schema] = hfid_attribute_schema
+                elif node_schema.human_friendly_id:
+                    schemas_for_targeted_update_map[hfid_attribute_schema] = hfid_attribute_schema
+
+                if schemas_for_universal_update_map:
+                    await self._do_one_schema_all(
                         db=db,
                         branch=branch,
                         schema=node_schema,
                         schema_branch=schema_branch,
-                        attribute_schema=display_label_attribute_schema,
-                        schema_path_strs=node_schema.display_labels,
+                        attribute_schema_map=schemas_for_universal_update_map,
                     )
-                if node_schema.human_friendly_id:
-                    await self._do_one_schema_batch_branch(
+
+                if not schemas_for_targeted_update_map:
+                    return MigrationResult()
+
+                for source_attribute_schema, destination_attribute_schema in schemas_for_targeted_update_map.items():
+                    await self._do_one_schema_branch(
                         db=db,
                         branch=branch,
                         schema=node_schema,
                         schema_branch=schema_branch,
-                        attribute_schema=hfid_attribute_schema,
-                        schema_path_strs=node_schema.human_friendly_id,
+                        source_attribute_schema=source_attribute_schema,
+                        destination_attribute_schema=destination_attribute_schema,
                     )
 
         except Exception as exc:
             return MigrationResult(errors=[str(exc)])
         return MigrationResult()
-
-
-# TODO: handle update for all nodes of a given type if display_label or human_friendly_id is updated on the schema on the branch

--- a/backend/infrahub/core/migrations/graph/m043_backfill_hfid_display_label_in_db.py
+++ b/backend/infrahub/core/migrations/graph/m043_backfill_hfid_display_label_in_db.py
@@ -6,6 +6,7 @@ import ujson
 from rich.progress import Progress, TaskID
 
 from infrahub.core import registry
+from infrahub.core.branch import Branch
 from infrahub.core.constants import GLOBAL_BRANCH_NAME, BranchSupportType, RelationshipDirection
 from infrahub.core.initialization import get_root_node
 from infrahub.core.migrations.shared import MigrationResult
@@ -32,14 +33,13 @@ class DefaultBranchNodeCount(Query):
     name = "get_branch_node_count"
     type = QueryType.READ
 
-    def __init__(self, branch_names: list[str], kinds_to_skip: list[str], **kwargs: Any) -> None:
+    def __init__(self, kinds_to_skip: list[str], **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self.branch_names = branch_names
         self.kinds_to_skip = kinds_to_skip
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
         self.params = {
-            "branch_names": self.branch_names,
+            "branch_names": [registry.default_branch, GLOBAL_BRANCH_NAME],
             "kinds_to_skip": self.kinds_to_skip,
         }
         query = """
@@ -61,7 +61,212 @@ WITH count(*) AS num_nodes
         return result.get_as_type(label="num_nodes", return_type=int)
 
 
-class GetPathDetailsDefaultBranch(Query):
+class GetResultMapQuery(Query):
+    def get_result_map(self, schema_paths: list[SchemaAttributePath]) -> dict[str, list[str]]:
+        """
+        Get the values for the given schema paths for all the Nodes captured by this query
+        """
+        # the query results for attribute and schema paths are unordered
+        # so we make this list of keys for ordering the results from the query
+        schema_path_keys: list[tuple[str, RelationshipDirection, str] | str] = []
+        for schema_path in schema_paths:
+            if schema_path.is_type_attribute and schema_path.attribute_schema:
+                path_key: str | tuple[str, RelationshipDirection, str] = schema_path.attribute_schema.name
+            elif schema_path.is_type_relationship and schema_path.relationship_schema and schema_path.attribute_schema:
+                path_key = (
+                    schema_path.relationship_schema.get_identifier(),
+                    schema_path.relationship_schema.direction,
+                    schema_path.attribute_schema.name,
+                )
+            schema_path_keys.append(path_key)
+
+        result_map: dict[str, list[str]] = {}
+        for result in self.get_results():
+            node_uuid = result.get_as_type(label="n_uuid", return_type=str)
+
+            # for each node, build a map of the schema path key to value so that they
+            # can be ordered correctly for the input `schema_paths`
+            schema_path_value_map: dict[str | tuple[str, RelationshipDirection, str], Any] = {}
+            attr_values_tuples: list[tuple[str, Any]] = result.get_as_type(label="attr_vals_list", return_type=list)
+            for attr_value_tuple in attr_values_tuples:
+                attr_name = attr_value_tuple[0]
+                attr_value = attr_value_tuple[1]
+                schema_path_value_map[attr_name] = attr_value
+
+            relationship_values_tuples: list[tuple[str, str, str, Any]] = result.get_as_type(
+                label="peer_attr_vals_list", return_type=list
+            )
+            for rel_value_tuple in relationship_values_tuples:
+                rel_name = rel_value_tuple[0]
+                direction_raw = rel_value_tuple[1]
+                direction = RelationshipDirection.BIDIR
+                match direction_raw:
+                    case "outbound":
+                        direction = RelationshipDirection.OUTBOUND
+                    case "inbound":
+                        direction = RelationshipDirection.INBOUND
+                peer_attr_name = rel_value_tuple[2]
+                peer_val = rel_value_tuple[3]
+                schema_path_value_map[rel_name, direction, peer_attr_name] = peer_val
+
+            schema_path_values: list[str] = []
+            for schema_path_key in schema_path_keys:
+                value = schema_path_value_map.get(schema_path_key)
+                schema_path_values.append(str(value))
+            result_map[node_uuid] = schema_path_values
+        return result_map
+
+
+class GetUpdatedPathDetailsBranchQuery(GetResultMapQuery):
+    name = "get_updated_path_details_branch"
+    type = QueryType.WRITE
+    insert_limit = False
+
+    def __init__(self, schema_kind: str, schema_paths: list[SchemaAttributePath], **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+
+        if self.branch.name in [registry.default_branch, GLOBAL_BRANCH_NAME]:
+            raise ValueError("This query can only be used on non-default branches")
+        self.schema_kind = schema_kind
+        self.attribute_names = []
+        self.bidir_rel_attr_map = {}
+        self.outbound_rel_attr_map = {}
+        self.inbound_rel_attr_map = {}
+        for schema_path in schema_paths:
+            if schema_path.is_type_attribute and schema_path.attribute_schema:
+                self.attribute_names.append(schema_path.attribute_schema.name)
+            elif schema_path.is_type_relationship and schema_path.relationship_schema and schema_path.attribute_schema:
+                key = schema_path.relationship_schema.identifier
+                value = schema_path.attribute_schema.name
+                if schema_path.relationship_schema.direction is RelationshipDirection.BIDIR:
+                    self.bidir_rel_attr_map[key] = value
+                elif schema_path.relationship_schema.direction is RelationshipDirection.OUTBOUND:
+                    self.outbound_rel_attr_map[key] = value
+                elif schema_path.relationship_schema.direction is RelationshipDirection.INBOUND:
+                    self.inbound_rel_attr_map[key] = value
+
+    async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
+        branch_filter, branch_filter_params = self.branch.get_query_filter_path(at=self.at)
+        self.params.update(branch_filter_params)
+        self.params.update(
+            {
+                "branch_name": self.branch.name,
+                "attribute_names": self.attribute_names,
+                "outbound_rel_ids": list(self.outbound_rel_attr_map.keys()),
+                "inbound_rel_ids": list(self.inbound_rel_attr_map.keys()),
+                "bidirectional_rel_ids": list(self.bidir_rel_attr_map.keys()),
+                "outbound_rel_attr_map": self.outbound_rel_attr_map,
+                "inbound_rel_attr_map": self.inbound_rel_attr_map,
+                "bidirectional_rel_attr_map": self.bidir_rel_attr_map,
+                "offset": self.offset,
+                "limit": self.limit,
+            }
+        )
+        get_updated_nodes_by_id_query = """
+// ------------
+// Get the active nodes of the given kind on the branches
+// ------------
+MATCH (n:%(schema_kind)s)-[r:IS_PART_OF]->(:Root)
+WHERE %(branch_filter)s
+AND r.to IS NULL
+AND r.status = "active"
+AND NOT exists((n)-[:IS_PART_OF {branch: $branch_name, status: "deleted"}]->(:Root))
+
+// any changes on the branch we care about
+
+OPTIONAL MATCH (n)-[r1:HAS_ATTRIBUTE]->(attr:Attribute)-[r2:HAS_VALUE]->(attr_val:AttributeValue)
+WHERE attr.name in $attribute_names
+AND r2.branch = $branch_name
+AND r2.status = "active"
+AND r2.to IS NULL
+WITH n, attr_val IS NOT NULL AS has_attr_update
+OPTIONAL MATCH (n)-[r1:IS_RELATED]-(rel:Relationship)-[r2:IS_RELATED]-(peer:Node)-[r3:HAS_ATTRIBUTE]-(attr:Attribute)-[r4:HAS_VALUE]->(attr_val)
+WHERE rel.name IN $bidirectional_rel_ids + $outbound_rel_ids + $inbound_rel_ids
+AND (
+    $outbound_rel_attr_map[rel.name] = attr.name
+    OR $inbound_rel_attr_map[rel.name] = attr.name
+    OR $bidirectional_rel_attr_map[rel.name] = attr.name
+)
+AND $branch_name IN [r1.branch, r2.branch, r3.branch, r4.branch]
+WITH n, has_attr_update, attr_val IS NOT NULL AS has_rel_update
+WITH n, any(x IN collect(has_attr_update OR has_rel_update) WHERE x = TRUE) AS has_update
+WITH n, has_update
+WHERE has_update = TRUE
+// ------------
+// Order and limit the Nodes
+// ------------
+ORDER BY elementId(n)
+SKIP toInteger($offset)
+LIMIT toInteger($limit)
+
+
+// get latest attribute with correct branch filtering
+OPTIONAL MATCH (n)-[r:HAS_ATTRIBUTE]->(attr:Attribute)
+WHERE attr.name IN $attribute_names
+WITH DISTINCT n, attr
+CALL (n, attr) {
+    OPTIONAL MATCH (n)-[r1:HAS_ATTRIBUTE]->(attr)-[r2:HAS_VALUE]->(attr_val)
+    WHERE all(r in [r1, r2] WHERE %(branch_filter)s)
+    RETURN attr_val.value AS attr_value, r1.status = "active" AND r2.status = "active" AS is_active
+    ORDER BY r2.branch_level DESC, r2.from DESC, r2.status ASC, r1.branch_level DESC, r1.from DESC, r1.status ASC
+    LIMIT 1
+}
+WITH n, attr, attr_value
+WHERE is_active = TRUE
+WITH n, collect([attr.name, attr_value]) AS attr_vals_list
+
+
+// Get the values for the relationship schema paths of the Nodes, if any
+OPTIONAL MATCH (n)-[:IS_RELATED]-(rel:Relationship)
+WHERE rel.name IN $bidirectional_rel_ids + $outbound_rel_ids + $inbound_rel_ids
+WITH DISTINCT n, attr_vals_list, rel
+CALL (n, rel) {
+    MATCH (n)-[r1:IS_RELATED]-(rel)-[r2:IS_RELATED]-(peer:Node)
+    WHERE all(r in [r1, r2] WHERE %(branch_filter)s)
+    AND (
+        (startNode(r1) = n AND startNode(r2) = rel AND rel.name IN $outbound_rel_ids)
+        OR (startNode(r1) = rel AND startNode(r2) = n AND rel.name IN $inbound_rel_ids)
+        OR (startNode(r1) = n AND startNode(r2) = peer AND rel.name IN $bidirectional_rel_ids)
+    )
+    RETURN
+        peer,
+        r1.status = "active" AND r2.status = "active" AS is_active,
+        CASE
+            WHEN startNode(r1) = n AND startNode(r2) = rel AND rel.name IN $outbound_rel_ids THEN "outbound"
+            WHEN startNode(r1) = rel AND startNode(r2) = n AND rel.name IN $inbound_rel_ids THEN "inbound"
+            ELSE "bidir"
+        END AS direction
+    ORDER BY r2.branch_level DESC, r2.from DESC, r2.status ASC, r1.branch_level DESC, r1.from DESC, r1.status ASC
+    LIMIT 1
+}
+
+WITH n, attr_vals_list, rel.name AS rel_name, direction, peer
+WHERE is_active = TRUE
+
+
+CALL (rel_name, direction, peer){
+    MATCH (peer)-[r1:HAS_ATTRIBUTE]->(attr:Attribute)-[r2:HAS_VALUE]->(attr_val)
+    WHERE (
+        (direction = "outbound" AND attr.name IN $outbound_rel_attr_map[rel_name])
+        OR (direction = "inbound" AND attr.name IN $inbound_rel_attr_map[rel_name])
+        OR (direction = "bidir" AND attr.name IN $bidirectional_rel_attr_map[rel_name])
+    )
+    AND all(r in [r1, r2] WHERE %(branch_filter)s)
+    RETURN attr.name AS peer_attr_name, attr_val.value AS peer_attr_value, r1.status = "active" AND r2.status = "active" AS is_active
+    ORDER BY r2.branch_level DESC, r2.from DESC, r2.status ASC, r1.branch_level DESC, r1.from DESC, r1.status ASC
+    LIMIT 1
+}
+// ------------
+// collect everything to return a pair of lists with each node UUID
+// ------------
+WITH DISTINCT n, attr_vals_list, rel_name, peer, direction, peer_attr_name, peer_attr_value
+WITH n, attr_vals_list, collect([rel_name, direction, peer_attr_name, peer_attr_value]) AS peer_attr_vals_list
+        """ % {"schema_kind": self.schema_kind, "branch_filter": branch_filter}
+        self.add_to_query(get_updated_nodes_by_id_query)
+        self.return_labels = ["n.uuid AS n_uuid", "attr_vals_list", "peer_attr_vals_list"]
+
+
+class GetPathDetailsDefaultBranch(GetResultMapQuery):
     """
     Get the values of the given schema paths for the given kind of node on the default and global branches
     Supports limit and offset for pagination
@@ -177,60 +382,6 @@ WITH n, attr_vals_list, collect([rel_name, direction, peer_attr_name, peer_val])
         self.add_to_query(get_details_query)
         self.return_labels = ["n.uuid AS n_uuid", "attr_vals_list", "peer_attr_vals_list"]
 
-    def get_result_map(self, schema_paths: list[SchemaAttributePath]) -> dict[str, list[str]]:
-        """
-        Get the values for the given schema paths for all the Nodes captured by this query
-        """
-        # the query results for attribute and schema paths are unordered
-        # so we make this list of keys for ordering the results from the query
-        schema_path_keys: list[tuple[str, RelationshipDirection, str] | str] = []
-        for schema_path in schema_paths:
-            if schema_path.is_type_attribute and schema_path.attribute_schema:
-                path_key: str | tuple[str, RelationshipDirection, str] = schema_path.attribute_schema.name
-            elif schema_path.is_type_relationship and schema_path.relationship_schema and schema_path.attribute_schema:
-                path_key = (
-                    schema_path.relationship_schema.get_identifier(),
-                    schema_path.relationship_schema.direction,
-                    schema_path.attribute_schema.name,
-                )
-            schema_path_keys.append(path_key)
-
-        result_map: dict[str, list[str]] = {}
-        for result in self.get_results():
-            node_uuid = result.get_as_type(label="n_uuid", return_type=str)
-
-            # for each node, build a map of the schema path key to value so that they
-            # can be ordered correctly for the input `schema_paths`
-            schema_path_value_map: dict[str | tuple[str, RelationshipDirection, str], Any] = {}
-            attr_values_tuples: list[tuple[str, Any]] = result.get_as_type(label="attr_vals_list", return_type=list)
-            for attr_value_tuple in attr_values_tuples:
-                attr_name = attr_value_tuple[0]
-                attr_value = attr_value_tuple[1]
-                schema_path_value_map[attr_name] = attr_value
-
-            relationship_values_tuples: list[tuple[str, str, str, Any]] = result.get_as_type(
-                label="peer_attr_vals_list", return_type=list
-            )
-            for rel_value_tuple in relationship_values_tuples:
-                rel_name = rel_value_tuple[0]
-                direction_raw = rel_value_tuple[1]
-                direction = RelationshipDirection.BIDIR
-                match direction_raw:
-                    case "outbound":
-                        direction = RelationshipDirection.OUTBOUND
-                    case "inbound":
-                        direction = RelationshipDirection.INBOUND
-                peer_attr_name = rel_value_tuple[2]
-                peer_val = rel_value_tuple[3]
-                schema_path_value_map[rel_name, direction, peer_attr_name] = peer_val
-
-            schema_path_values: list[str] = []
-            for schema_path_key in schema_path_keys:
-                value = schema_path_value_map.get(schema_path_key)
-                schema_path_values.append(str(value))
-            result_map[node_uuid] = schema_path_values
-        return result_map
-
 
 class UpdateAttributeValuesQuery(Query):
     """
@@ -257,10 +408,12 @@ class UpdateAttributeValuesQuery(Query):
             "values_by_id": self.values_by_id_map,
             "default_branch": registry.default_branch,
             "global_branch": GLOBAL_BRANCH_NAME,
-            "branch": GLOBAL_BRANCH_NAME if self.is_branch_agnostic else registry.default_branch,
-            "branch_level": 1,
+            "branch": GLOBAL_BRANCH_NAME if self.is_branch_agnostic else self.branch.name,
+            "branch_level": 1 if self.is_branch_agnostic else self.branch.hierarchy_level,
             "at": self.at.to_string(),
         }
+        branch_filter, branch_filter_params = self.branch.get_query_filter_path(at=self.at)
+        self.params.update(branch_filter_params)
 
         if self.is_large_type_attribute:
             # we make our own index of value to database ID, creating any vertices that are missing
@@ -293,7 +446,8 @@ WITH value_id_pairs + created_value_id_pairs AS value_id_pairs
 
         self.add_to_query(diy_index_query)
 
-        update_value_query = """
+        if self.branch.name in [registry.default_branch, GLOBAL_BRANCH_NAME]:
+            update_value_query = """
 // ------------
 // Find the Nodes and Attributes we need to update
 // ------------
@@ -318,7 +472,48 @@ CALL (attr) {
     AND e.status = "active"
     SET e.to = $at
 }
-        """
+            """
+        else:
+            update_value_query = """
+// ------------
+// Find the Nodes and Attributes we need to update
+// ------------
+MATCH (n:Node)
+WHERE n.uuid IN $node_uuids
+CALL (n) {
+    MATCH (n)-[r:IS_PART_OF]->(:Root)
+    WHERE %(branch_filter)s
+    RETURN r.status = "active" AS is_active
+    ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+    LIMIT 1
+}
+WITH n, value_id_pairs, is_active
+WHERE is_active = TRUE
+WITH DISTINCT n, value_id_pairs
+CALL (n) {
+    MATCH (n)-[r:HAS_ATTRIBUTE]->(attr:Attribute {name: $attribute_name})
+    WHERE %(branch_filter)s
+    RETURN attr, r.status = "active"  AS is_active
+    ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+    LIMIT 1
+}
+WITH DISTINCT n, attr, value_id_pairs, is_active
+WHERE is_active = TRUE
+// ------------
+// If the attribute has an existing value on the branch, then set the to time on it
+// ------------
+CALL (attr) {
+    OPTIONAL MATCH (attr)-[r:HAS_VALUE]->(existing_av)
+    WHERE %(branch_filter)s
+    WITH r
+    ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
+    LIMIT 1
+    WITH r
+    WHERE r.status = "active"
+    AND r.branch = $branch
+    SET r.to = $at
+}
+            """ % {"branch_filter": branch_filter}
         self.add_to_query(update_value_query)
 
         if self.is_large_type_attribute:
@@ -372,9 +567,10 @@ class Migration043(ArbitraryMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
-    async def _do_one_schema_batch(
+    async def _do_one_schema_batch_default_branch(
         self,
         db: InfrahubDatabase,
+        default_branch: Branch,
         schema: NodeSchema,
         schema_branch: SchemaBranch,
         display_label_attribute_schema: AttributeSchema,
@@ -418,6 +614,7 @@ class Migration043(ArbitraryMigration):
 
                 update_display_label_query = await UpdateAttributeValuesQuery.init(
                     db=db,
+                    branch=default_branch,
                     attribute_schema=display_label_attribute_schema,
                     values_by_id_map=formatted_display_label_schema_path_values_map,
                 )
@@ -433,6 +630,7 @@ class Migration043(ArbitraryMigration):
 
                 update_human_friendly_id_query = await UpdateAttributeValuesQuery.init(
                     db=db,
+                    branch=default_branch,
                     attribute_schema=hfid_attribute_schema,
                     values_by_id_map=formatted_human_friendly_id_schema_path_values_map,
                 )
@@ -448,15 +646,14 @@ class Migration043(ArbitraryMigration):
 
     async def execute(self, db: InfrahubDatabase) -> MigrationResult:
         root_node = await get_root_node(db=db, initialize=False)
-        default_branch = root_node.default_branch
+        default_branch_name = root_node.default_branch
+        default_branch = await Branch.get_by_name(db=db, name=default_branch_name)
         schema_manager = SchemaManager()
         internal_schema_root = SchemaRoot(**internal_schema)
         schema_manager.register_schema(schema=internal_schema_root)
         registry.schema = schema_manager
         main_schema_branch = await schema_manager.load_schema_from_db(db=db, branch=default_branch)
-        total_nodes_query = await DefaultBranchNodeCount.init(
-            db=db, branch_names=[default_branch, GLOBAL_BRANCH_NAME], kinds_to_skip=self.kinds_to_skip
-        )
+        total_nodes_query = await DefaultBranchNodeCount.init(db=db, kinds_to_skip=self.kinds_to_skip)
         await total_nodes_query.execute(db=db)
         total_nodes_count = total_nodes_query.get_num_nodes()
 
@@ -475,8 +672,9 @@ class Migration043(ArbitraryMigration):
                         continue
 
                     node_schema = main_schema_branch.get_node(name=node_schema_name, duplicate=False)
-                    await self._do_one_schema_batch(
+                    await self._do_one_schema_batch_default_branch(
                         db=db,
+                        default_branch=default_branch,
                         schema=node_schema,
                         schema_branch=main_schema_branch,
                         display_label_attribute_schema=display_label_attribute_schema,
@@ -484,6 +682,101 @@ class Migration043(ArbitraryMigration):
                         progress=progress,
                         update_task=update_task,
                     )
+
         except Exception as exc:
             return MigrationResult(errors=[str(exc)])
         return MigrationResult()
+
+    async def _do_one_schema_batch_branch(
+        self,
+        db: InfrahubDatabase,
+        branch: Branch,
+        schema: NodeSchema,
+        schema_branch: SchemaBranch,
+        attribute_schema: AttributeSchema,
+        schema_path_strs: list[str],
+    ) -> None:
+        print(f"Processing {schema.kind}.{attribute_schema.name} for {branch.name}...", end="")
+
+        schema_paths = [
+            schema.parse_schema_path(path=path_part, schema=schema_branch) for path_part in schema_path_strs
+        ]
+        offset = 0
+
+        while True:
+            # loop until we get no results from the get_details_query
+            get_details_query = await GetUpdatedPathDetailsBranchQuery.init(
+                db=db,
+                branch=branch,
+                schema_kind=schema.kind,
+                schema_paths=schema_paths,
+                offset=offset,
+                limit=self.update_batch_size,
+            )
+            await get_details_query.execute(db=db)
+
+            schema_path_values_map = get_details_query.get_result_map(schema_paths)
+            if not schema_path_values_map:
+                print("done")
+                break
+            formatted_schema_path_values_map = {}
+            for k, v in schema_path_values_map.items():
+                if not v:
+                    continue
+                formatted_v = ujson.dumps(v) if attribute_schema.kind == "List" else " ".join(v)
+                formatted_schema_path_values_map[k] = formatted_v
+
+                print(schema.kind, schema_path_strs, k, v)
+
+            update_attr_values_query = await UpdateAttributeValuesQuery.init(
+                db=db,
+                branch=branch,
+                attribute_schema=attribute_schema,
+                values_by_id_map=formatted_schema_path_values_map,
+            )
+            await update_attr_values_query.execute(db=db)
+
+            offset += self.update_batch_size
+
+    async def execute_on_branch(self, db: InfrahubDatabase, branch: Branch) -> MigrationResult:
+        schema_manager = SchemaManager()
+        internal_schema_root = SchemaRoot(**internal_schema)
+        schema_manager.register_schema(schema=internal_schema_root)
+        registry.schema = schema_manager
+        schema_branch = await schema_manager.load_schema_from_db(db=db, branch=branch)
+
+        base_node_schema = schema_branch.get("SchemaNode", duplicate=False)
+        display_label_attribute_schema = base_node_schema.get_attribute("display_label")
+        hfid_attribute_schema = base_node_schema.get_attribute("human_friendly_id")
+
+        try:
+            for node_schema_name in schema_branch.node_names:
+                if node_schema_name in self.kinds_to_skip:
+                    continue
+
+                node_schema = schema_branch.get_node(name=node_schema_name, duplicate=False)
+                if node_schema.display_labels:
+                    await self._do_one_schema_batch_branch(
+                        db=db,
+                        branch=branch,
+                        schema=node_schema,
+                        schema_branch=schema_branch,
+                        attribute_schema=display_label_attribute_schema,
+                        schema_path_strs=node_schema.display_labels,
+                    )
+                if node_schema.human_friendly_id:
+                    await self._do_one_schema_batch_branch(
+                        db=db,
+                        branch=branch,
+                        schema=node_schema,
+                        schema_branch=schema_branch,
+                        attribute_schema=hfid_attribute_schema,
+                        schema_path_strs=node_schema.human_friendly_id,
+                    )
+
+        except Exception as exc:
+            return MigrationResult(errors=[str(exc)])
+        return MigrationResult()
+
+
+# TODO: handle update for all nodes of a given type if display_label or human_friendly_id is updated on the schema on the branch

--- a/backend/infrahub/core/migrations/graph/m043_backfill_hfid_display_label_in_db.py
+++ b/backend/infrahub/core/migrations/graph/m043_backfill_hfid_display_label_in_db.py
@@ -676,6 +676,7 @@ class Migration043(ArbitraryMigration):
                     branch=branch,
                     schema_kind=schema.kind,
                     schema_paths=all_schema_paths,
+                    updates_only=False,
                     offset=offset,
                     limit=self.update_batch_size,
                 )

--- a/backend/infrahub/core/migrations/graph/m043_backfill_hfid_display_label_in_db.py
+++ b/backend/infrahub/core/migrations/graph/m043_backfill_hfid_display_label_in_db.py
@@ -541,11 +541,14 @@ CALL (n, attr) {
     WITH r, existing_av
     ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
     LIMIT 1
-    WITH r, existing_av
-    WHERE existing_av.value <> $values_by_id[n.uuid]
-    AND r.status = "active"
-    AND r.branch = $branch
-    RETURN existing_av, r AS existing_has_value
+    WITH CASE
+        WHEN existing_av.value <> $values_by_id[n.uuid]
+        AND r.status = "active"
+        AND r.branch = $branch
+        THEN [r, existing_av]
+        ELSE [NULL, NULL]
+    END AS existing_details
+    RETURN existing_details[0] AS existing_has_value, existing_details[1] AS existing_av
 }
 CALL (existing_has_value) {
     WITH existing_has_value

--- a/backend/infrahub/core/migrations/graph/m043_backfill_hfid_display_label_in_db.py
+++ b/backend/infrahub/core/migrations/graph/m043_backfill_hfid_display_label_in_db.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
 import ujson
@@ -13,6 +14,7 @@ from infrahub.core.migrations.shared import MigrationResult
 from infrahub.core.query import Query, QueryType
 from infrahub.core.schema import AttributeSchema, NodeSchema, SchemaRoot, internal_schema
 from infrahub.core.schema.manager import SchemaManager
+from infrahub.exceptions import InitializationError
 from infrahub.types import is_large_attribute_type
 
 from ..shared import ArbitraryMigration
@@ -129,21 +131,21 @@ class GetUpdatedPathDetailsBranchQuery(GetResultMapQuery):
             raise ValueError("This query can only be used on non-default branches")
         self.schema_kind = schema_kind
         self.attribute_names = []
-        self.bidir_rel_attr_map = {}
-        self.outbound_rel_attr_map = {}
-        self.inbound_rel_attr_map = {}
+        self.bidir_rel_attr_map: dict[str, list[str]] = defaultdict(list)
+        self.outbound_rel_attr_map: dict[str, list[str]] = defaultdict(list)
+        self.inbound_rel_attr_map: dict[str, list[str]] = defaultdict(list)
         for schema_path in schema_paths:
             if schema_path.is_type_attribute and schema_path.attribute_schema:
                 self.attribute_names.append(schema_path.attribute_schema.name)
             elif schema_path.is_type_relationship and schema_path.relationship_schema and schema_path.attribute_schema:
-                key = schema_path.relationship_schema.identifier
+                key = schema_path.relationship_schema.get_identifier()
                 value = schema_path.attribute_schema.name
                 if schema_path.relationship_schema.direction is RelationshipDirection.BIDIR:
-                    self.bidir_rel_attr_map[key] = value
+                    self.bidir_rel_attr_map[key].append(value)
                 elif schema_path.relationship_schema.direction is RelationshipDirection.OUTBOUND:
-                    self.outbound_rel_attr_map[key] = value
+                    self.outbound_rel_attr_map[key].append(value)
                 elif schema_path.relationship_schema.direction is RelationshipDirection.INBOUND:
-                    self.inbound_rel_attr_map[key] = value
+                    self.inbound_rel_attr_map[key].append(value)
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
         branch_filter, branch_filter_params = self.branch.get_query_filter_path(at=self.at)
@@ -171,9 +173,9 @@ WHERE %(branch_filter)s
 AND r.to IS NULL
 AND r.status = "active"
 AND NOT exists((n)-[:IS_PART_OF {branch: $branch_name, status: "deleted"}]->(:Root))
-
-// any changes on the branch we care about
-
+// ------------
+// filter to any nodes that might have changes on the branch we care about
+// ------------
 OPTIONAL MATCH (n)-[r1:HAS_ATTRIBUTE]->(attr:Attribute)-[r2:HAS_VALUE]->(attr_val:AttributeValue)
 WHERE attr.name in $attribute_names
 AND r2.branch = $branch_name
@@ -183,9 +185,9 @@ WITH n, attr_val IS NOT NULL AS has_attr_update
 OPTIONAL MATCH (n)-[r1:IS_RELATED]-(rel:Relationship)-[r2:IS_RELATED]-(peer:Node)-[r3:HAS_ATTRIBUTE]-(attr:Attribute)-[r4:HAS_VALUE]->(attr_val)
 WHERE rel.name IN $bidirectional_rel_ids + $outbound_rel_ids + $inbound_rel_ids
 AND (
-    $outbound_rel_attr_map[rel.name] = attr.name
-    OR $inbound_rel_attr_map[rel.name] = attr.name
-    OR $bidirectional_rel_attr_map[rel.name] = attr.name
+    attr.name IN $outbound_rel_attr_map[rel.name]
+    OR attr.name IN $inbound_rel_attr_map[rel.name]
+    OR attr.name IN $bidirectional_rel_attr_map[rel.name]
 )
 AND $branch_name IN [r1.branch, r2.branch, r3.branch, r4.branch]
 WITH n, has_attr_update, attr_val IS NOT NULL AS has_rel_update
@@ -198,9 +200,10 @@ WHERE has_update = TRUE
 ORDER BY elementId(n)
 SKIP toInteger($offset)
 LIMIT toInteger($limit)
-
-
-// get latest attribute with correct branch filtering
+// ------------
+// for every possibly updated node
+// get all the attribute values on this branch
+// ------------
 OPTIONAL MATCH (n)-[r:HAS_ATTRIBUTE]->(attr:Attribute)
 WHERE attr.name IN $attribute_names
 WITH DISTINCT n, attr
@@ -214,9 +217,10 @@ CALL (n, attr) {
 WITH n, attr, attr_value
 WHERE is_active = TRUE
 WITH n, collect([attr.name, attr_value]) AS attr_vals_list
-
-
-// Get the values for the relationship schema paths of the Nodes, if any
+// ------------
+// for every possibly updated node
+// get all the relationships on this branch
+// ------------
 OPTIONAL MATCH (n)-[:IS_RELATED]-(rel:Relationship)
 WHERE rel.name IN $bidirectional_rel_ids + $outbound_rel_ids + $inbound_rel_ids
 WITH DISTINCT n, attr_vals_list, rel
@@ -239,11 +243,11 @@ CALL (n, rel) {
     ORDER BY r2.branch_level DESC, r2.from DESC, r2.status ASC, r1.branch_level DESC, r1.from DESC, r1.status ASC
     LIMIT 1
 }
-
+// ------------
+// get the attribute values that we care about for each relationship
+// ------------
 WITH n, attr_vals_list, rel.name AS rel_name, direction, peer
 WHERE is_active = TRUE
-
-
 CALL (rel_name, direction, peer){
     MATCH (peer)-[r1:HAS_ATTRIBUTE]->(attr:Attribute)-[r2:HAS_VALUE]->(attr_val)
     WHERE (
@@ -282,21 +286,21 @@ class GetPathDetailsDefaultBranch(GetResultMapQuery):
         self.branch_names = [registry.default_branch, GLOBAL_BRANCH_NAME]
         self.schema_kind = schema_kind
         self.attribute_names = []
-        self.bidir_rel_attr_map = {}
-        self.outbound_rel_attr_map = {}
-        self.inbound_rel_attr_map = {}
+        self.bidir_rel_attr_map: dict[str, list[str]] = defaultdict(list)
+        self.outbound_rel_attr_map: dict[str, list[str]] = defaultdict(list)
+        self.inbound_rel_attr_map: dict[str, list[str]] = defaultdict(list)
         for schema_path in schema_paths:
             if schema_path.is_type_attribute and schema_path.attribute_schema:
                 self.attribute_names.append(schema_path.attribute_schema.name)
             elif schema_path.is_type_relationship and schema_path.relationship_schema and schema_path.attribute_schema:
-                key = schema_path.relationship_schema.identifier
+                key = schema_path.relationship_schema.get_identifier()
                 value = schema_path.attribute_schema.name
                 if schema_path.relationship_schema.direction is RelationshipDirection.BIDIR:
-                    self.bidir_rel_attr_map[key] = value
+                    self.bidir_rel_attr_map[key].append(value)
                 elif schema_path.relationship_schema.direction is RelationshipDirection.OUTBOUND:
-                    self.outbound_rel_attr_map[key] = value
+                    self.outbound_rel_attr_map[key].append(value)
                 elif schema_path.relationship_schema.direction is RelationshipDirection.INBOUND:
-                    self.inbound_rel_attr_map[key] = value
+                    self.inbound_rel_attr_map[key].append(value)
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
         self.params = {
@@ -463,6 +467,7 @@ AND e.to IS NULL
 AND e.status = "active"
 // ------------
 // If the attribute has an existing value on the branch, then set the to time on it
+// but only if the value is different from the new value
 // ------------
 WITH DISTINCT n, attr, value_id_pairs
 CALL (attr) {
@@ -470,7 +475,12 @@ CALL (attr) {
     WHERE e.branch IN [$default_branch, $global_branch]
     AND e.to IS NULL
     AND e.status = "active"
-    SET e.to = $at
+    RETURN existing_av, e AS existing_has_value
+}
+CALL (existing_has_value) {
+    WITH existing_has_value
+    WHERE existing_has_value IS NOT NULL
+    SET existing_has_value.to = $at
 }
             """
         else:
@@ -501,6 +511,7 @@ WITH DISTINCT n, attr, value_id_pairs, is_active
 WHERE is_active = TRUE
 // ------------
 // If the attribute has an existing value on the branch, then set the to time on it
+// but only if the value is different from the new value
 // ------------
 CALL (attr) {
     OPTIONAL MATCH (attr)-[r:HAS_VALUE]->(existing_av)
@@ -509,8 +520,14 @@ CALL (attr) {
     ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
     LIMIT 1
     WITH r
-    WHERE r.status = "active"
+    WHERE existing_av.value <> $values_by_id[n.uuid]
+    AND r.status = "active"
     AND r.branch = $branch
+    RETURN existing_av, r AS existing_has_value
+}
+CALL (existing_has_value) {
+    WITH existing_has_value
+    WHERE existing_has_value IS NOT NULL
     SET r.to = $at
 }
             """ % {"branch_filter": branch_filter}
@@ -520,7 +537,12 @@ CALL (attr) {
             # use the index we created at the start to get the database ID of the AttributeValue vertex
             # and then link the Attribute to the AttributeValue
             set_value_query = """
-WITH attr, value_id_pairs, $values_by_id[n.uuid] AS required_value
+// ------------
+// only make updates if the existing value is not the same as the new value
+// ------------
+WITH attr, existing_av, value_id_pairs, $values_by_id[n.uuid] AS required_value
+WHERE existing_av.value <> required_value
+OR existing_av IS NULL
 WITH attr, value_id_pairs, required_value,
     reduce(av_vertex_id = NULL, pair IN value_id_pairs |
         CASE
@@ -537,6 +559,12 @@ CREATE (attr)-[r:HAS_VALUE { branch: $branch, branch_level: $branch_level, statu
             # if not a large-type attribute, then we can just use the regular MERGE clause
             # that makes use of the index on AttributeValueIndexed
             set_value_query = """
+// ------------
+// only make updates if the existing value is not the same as the new value
+// ------------
+WITH n, attr, existing_av, value_id_pairs, $values_by_id[n.uuid] AS required_value
+WHERE existing_av.value <> required_value
+OR existing_av IS NULL
 CALL (n, attr) {
     MERGE (av:AttributeValue&AttributeValueIndexed {is_default: false, value: $values_by_id[n.uuid]} )
     WITH av, attr
@@ -567,6 +595,18 @@ class Migration043(ArbitraryMigration):
     async def validate_migration(self, db: InfrahubDatabase) -> MigrationResult:  # noqa: ARG002
         return MigrationResult()
 
+    async def _get_or_load_schema_branch(self, db: InfrahubDatabase, branch: Branch) -> SchemaBranch:
+        try:
+            if registry.schema.has_schema_branch(branch.name):
+                return registry.schema.get_schema_branch(branch.name)
+        except InitializationError:
+            pass
+        schema_manager = SchemaManager()
+        internal_schema_root = SchemaRoot(**internal_schema)
+        schema_manager.register_schema(schema=internal_schema_root)
+        registry.schema = schema_manager
+        return await schema_manager.load_schema_from_db(db=db, branch=branch)
+
     async def _do_one_schema_batch_default_branch(
         self,
         db: InfrahubDatabase,
@@ -578,7 +618,7 @@ class Migration043(ArbitraryMigration):
         progress: Progress,
         update_task: TaskID,
     ) -> None:
-        if not schema.display_labels and not schema.human_friendly_id:
+        if not schema.display_label and not schema.human_friendly_id:
             return
 
         print(f"Processing {schema.kind}...", end="")
@@ -645,14 +685,20 @@ class Migration043(ArbitraryMigration):
         print("done")
 
     async def execute(self, db: InfrahubDatabase) -> MigrationResult:
+        # branches = await Branch.get_list(db=db)
+        # for branch in branches:
+        #     if branch.name in [registry.default_branch, GLOBAL_BRANCH_NAME]:
+        #         continue
+        #     await self.execute_against_branch(db=db, branch=branch)
+
+        # return MigrationResult(errors=["pretend error"])
+
         root_node = await get_root_node(db=db, initialize=False)
         default_branch_name = root_node.default_branch
         default_branch = await Branch.get_by_name(db=db, name=default_branch_name)
-        schema_manager = SchemaManager()
-        internal_schema_root = SchemaRoot(**internal_schema)
-        schema_manager.register_schema(schema=internal_schema_root)
-        registry.schema = schema_manager
-        main_schema_branch = await schema_manager.load_schema_from_db(db=db, branch=default_branch)
+
+        main_schema_branch = await self._get_or_load_schema_branch(db=db, branch=default_branch)
+
         total_nodes_query = await DefaultBranchNodeCount.init(db=db, kinds_to_skip=self.kinds_to_skip)
         await total_nodes_query.execute(db=db)
         total_nodes_count = total_nodes_query.get_num_nodes()
@@ -661,30 +707,30 @@ class Migration043(ArbitraryMigration):
         display_label_attribute_schema = base_node_schema.get_attribute("display_label")
         hfid_attribute_schema = base_node_schema.get_attribute("human_friendly_id")
 
-        try:
-            with Progress() as progress:
-                update_task = progress.add_task(
-                    f"Set display_label and human_friendly_id for {total_nodes_count} nodes on default branch",
-                    total=total_nodes_count,
+        # try:
+        with Progress() as progress:
+            update_task = progress.add_task(
+                f"Set display_label and human_friendly_id for {total_nodes_count} nodes on default branch",
+                total=total_nodes_count,
+            )
+            for node_schema_name in main_schema_branch.node_names:
+                if node_schema_name in self.kinds_to_skip:
+                    continue
+
+                node_schema = main_schema_branch.get_node(name=node_schema_name, duplicate=False)
+                await self._do_one_schema_batch_default_branch(
+                    db=db,
+                    default_branch=default_branch,
+                    schema=node_schema,
+                    schema_branch=main_schema_branch,
+                    display_label_attribute_schema=display_label_attribute_schema,
+                    hfid_attribute_schema=hfid_attribute_schema,
+                    progress=progress,
+                    update_task=update_task,
                 )
-                for node_schema_name in main_schema_branch.node_names:
-                    if node_schema_name in self.kinds_to_skip:
-                        continue
 
-                    node_schema = main_schema_branch.get_node(name=node_schema_name, duplicate=False)
-                    await self._do_one_schema_batch_default_branch(
-                        db=db,
-                        default_branch=default_branch,
-                        schema=node_schema,
-                        schema_branch=main_schema_branch,
-                        display_label_attribute_schema=display_label_attribute_schema,
-                        hfid_attribute_schema=hfid_attribute_schema,
-                        progress=progress,
-                        update_task=update_task,
-                    )
-
-        except Exception as exc:
-            return MigrationResult(errors=[str(exc)])
+        # except Exception as exc:
+        # return MigrationResult(errors=[str(exc)])
         return MigrationResult()
 
     async def _do_one_schema_batch_branch(
@@ -738,12 +784,8 @@ class Migration043(ArbitraryMigration):
 
             offset += self.update_batch_size
 
-    async def execute_on_branch(self, db: InfrahubDatabase, branch: Branch) -> MigrationResult:
-        schema_manager = SchemaManager()
-        internal_schema_root = SchemaRoot(**internal_schema)
-        schema_manager.register_schema(schema=internal_schema_root)
-        registry.schema = schema_manager
-        schema_branch = await schema_manager.load_schema_from_db(db=db, branch=branch)
+    async def execute_against_branch(self, db: InfrahubDatabase, branch: Branch) -> MigrationResult:
+        schema_branch = await self._get_or_load_schema_branch(db=db, branch=branch)
 
         base_node_schema = schema_branch.get("SchemaNode", duplicate=False)
         display_label_attribute_schema = base_node_schema.get_attribute("display_label")

--- a/backend/infrahub/core/migrations/graph/m043_backfill_hfid_display_label_in_db.py
+++ b/backend/infrahub/core/migrations/graph/m043_backfill_hfid_display_label_in_db.py
@@ -249,7 +249,7 @@ CALL (n, rel) {
     WHERE all(r in [r1, r2] WHERE %(branch_filter)s)
     AND (
         (startNode(r1) = n AND startNode(r2) = rel AND rel.name IN $outbound_rel_ids)
-        OR (startNode(r1) = rel AND startNode(r2) = n AND rel.name IN $inbound_rel_ids)
+        OR (startNode(r1) = rel AND startNode(r2) = peer AND rel.name IN $inbound_rel_ids)
         OR (startNode(r1) = n AND startNode(r2) = peer AND rel.name IN $bidirectional_rel_ids)
     )
     RETURN
@@ -257,7 +257,7 @@ CALL (n, rel) {
         r1.status = "active" AND r2.status = "active" AS is_active,
         CASE
             WHEN startNode(r1) = n AND startNode(r2) = rel AND rel.name IN $outbound_rel_ids THEN "outbound"
-            WHEN startNode(r1) = rel AND startNode(r2) = n AND rel.name IN $inbound_rel_ids THEN "inbound"
+            WHEN startNode(r1) = rel AND startNode(r2) = peer AND rel.name IN $inbound_rel_ids THEN "inbound"
             ELSE "bidir"
         END AS direction
     ORDER BY r2.branch_level DESC, r2.from DESC, r2.status ASC, r1.branch_level DESC, r1.from DESC, r1.status ASC
@@ -379,12 +379,12 @@ AND e2.to IS NULL
 AND e2.status = "active"
 AND (
     (startNode(e1) = n AND startNode(e2) = rel AND rel.name IN $outbound_rel_ids)
-    OR (startNode(e1) = rel AND startNode(e2) = n AND rel.name IN $inbound_rel_ids)
+    OR (startNode(e1) = rel AND startNode(e2) = peer AND rel.name IN $inbound_rel_ids)
     OR (startNode(e1) = n AND startNode(e2) = peer AND rel.name IN $bidirectional_rel_ids)
 )
 WITH DISTINCT n, attr_vals_list, rel.name AS rel_name, peer,  CASE
     WHEN startNode(e1) = n AND startNode(e2) = rel AND rel.name IN $outbound_rel_ids THEN "outbound"
-    WHEN startNode(e1) = rel AND startNode(e2) = n AND rel.name IN $inbound_rel_ids THEN "inbound"
+    WHEN startNode(e1) = rel AND startNode(e2) = peer AND rel.name IN $inbound_rel_ids THEN "inbound"
     ELSE "bidir"
 END AS direction
 OPTIONAL MATCH (peer)-[e1:HAS_ATTRIBUTE]->(attr:Attribute)-[e2:HAS_VALUE]->(peer_attr_val:AttributeValue)

--- a/backend/infrahub/core/migrations/graph/m043_backfill_hfid_display_label_in_db.py
+++ b/backend/infrahub/core/migrations/graph/m043_backfill_hfid_display_label_in_db.py
@@ -65,7 +65,7 @@ WITH count(*) AS num_nodes
 
 
 class GetResultMapQuery(Query):
-    def get_result_map(self, schema_paths: list[SchemaAttributePath]) -> dict[str, list[str]]:
+    def get_result_map(self, schema_paths: list[SchemaAttributePath]) -> dict[str, list[str | None]]:
         """
         Get the values for the given schema paths for all the Nodes captured by this query
         """
@@ -83,7 +83,7 @@ class GetResultMapQuery(Query):
                 )
             schema_path_keys.append(path_key)
 
-        result_map: dict[str, list[str]] = {}
+        result_map: dict[str, list[str | None]] = {}
         for result in self.get_results():
             node_uuid = result.get_as_type(label="n_uuid", return_type=str)
 
@@ -112,10 +112,10 @@ class GetResultMapQuery(Query):
                 peer_val = rel_value_tuple[3]
                 schema_path_value_map[rel_name, direction, peer_attr_name] = peer_val
 
-            schema_path_values: list[str] = []
+            schema_path_values: list[str | None] = []
             for schema_path_key in schema_path_keys:
                 value = schema_path_value_map.get(schema_path_key)
-                schema_path_values.append(str(value))
+                schema_path_values.append(str(value) if value is not None else None)
             result_map[node_uuid] = schema_path_values
         return result_map
 
@@ -245,7 +245,7 @@ OPTIONAL MATCH (n)-[:IS_RELATED]-(rel:Relationship)
 WHERE rel.name IN $bidirectional_rel_ids + $outbound_rel_ids + $inbound_rel_ids
 WITH DISTINCT n, attr_vals_list, rel
 CALL (n, rel) {
-    MATCH (n)-[r1:IS_RELATED]-(rel)-[r2:IS_RELATED]-(peer:Node)
+    OPTIONAL MATCH (n)-[r1:IS_RELATED]-(rel)-[r2:IS_RELATED]-(peer:Node)
     WHERE all(r in [r1, r2] WHERE %(branch_filter)s)
     AND (
         (startNode(r1) = n AND startNode(r2) = rel AND rel.name IN $outbound_rel_ids)
@@ -267,16 +267,18 @@ CALL (n, rel) {
 // get the attribute values that we care about for each relationship
 // ------------
 WITH n, attr_vals_list, rel.name AS rel_name, direction, peer
-WHERE is_active = TRUE
-CALL (rel_name, direction, peer){
-    MATCH (peer)-[r1:HAS_ATTRIBUTE]->(attr:Attribute)-[r2:HAS_VALUE]->(attr_val)
-    WHERE (
-        (direction = "outbound" AND attr.name IN $outbound_rel_attr_map[rel_name])
-        OR (direction = "inbound" AND attr.name IN $inbound_rel_attr_map[rel_name])
-        OR (direction = "bidir" AND attr.name IN $bidirectional_rel_attr_map[rel_name])
-    )
+WHERE is_active = TRUE OR rel_name IS NULL
+WITH *, CASE
+    WHEN direction = "outbound" THEN $outbound_rel_attr_map[rel_name]
+    WHEN direction = "inbound" THEN $inbound_rel_attr_map[rel_name]
+    ELSE $bidirectional_rel_attr_map[rel_name]
+END AS peer_attr_names
+UNWIND COALESCE(peer_attr_names, [NULL]) AS peer_attr_name
+CALL (rel_name, direction, peer, peer_attr_name){
+    OPTIONAL MATCH (peer)-[r1:HAS_ATTRIBUTE]->(attr:Attribute)-[r2:HAS_VALUE]->(attr_val)
+    WHERE attr.name = peer_attr_name
     AND all(r in [r1, r2] WHERE %(branch_filter)s)
-    RETURN attr.name AS peer_attr_name, attr_val.value AS peer_attr_value, r1.status = "active" AND r2.status = "active" AS is_active
+    RETURN attr_val.value AS peer_attr_value, r1.status = "active" AND r2.status = "active" AS is_active
     ORDER BY r2.branch_level DESC, r2.from DESC, r2.status ASC, r1.branch_level DESC, r1.from DESC, r1.status ASC
     LIMIT 1
 }
@@ -533,13 +535,13 @@ WHERE is_active = TRUE
 // If the attribute has an existing value on the branch, then set the to time on it
 // but only if the value is different from the new value
 // ------------
-CALL (attr) {
+CALL (n, attr) {
     OPTIONAL MATCH (attr)-[r:HAS_VALUE]->(existing_av)
     WHERE %(branch_filter)s
-    WITH r
+    WITH r, existing_av
     ORDER BY r.branch_level DESC, r.from DESC, r.status ASC
     LIMIT 1
-    WITH r
+    WITH r, existing_av
     WHERE existing_av.value <> $values_by_id[n.uuid]
     AND r.status = "active"
     AND r.branch = $branch
@@ -548,7 +550,7 @@ CALL (attr) {
 CALL (existing_has_value) {
     WITH existing_has_value
     WHERE existing_has_value IS NOT NULL
-    SET r.to = $at
+    SET existing_has_value.to = $at
 }
             """ % {"branch_filter": branch_filter}
         self.add_to_query(update_value_query)
@@ -681,23 +683,23 @@ class Migration043(ArbitraryMigration):
                 schema_paths = schema_paths_by_name[source_attribute_schema.name]
                 schema_path_values_map = get_details_query.get_result_map(schema_paths)
                 num_updates = max(num_updates, len(schema_path_values_map))
-                formatted_display_label_schema_path_values_map = {}
+                formatted_schema_path_values_map = {}
                 for k, v in schema_path_values_map.items():
                     if not v:
                         continue
                     if destination_attribute_schema.kind == "List":
-                        formatted_display_label_schema_path_values_map[k] = ujson.dumps(v)
+                        formatted_schema_path_values_map[k] = ujson.dumps(v)
                     else:
-                        formatted_display_label_schema_path_values_map[k] = " ".join(v)
+                        formatted_schema_path_values_map[k] = " ".join(item for item in v if item is not None)
 
-                if not formatted_display_label_schema_path_values_map:
+                if not formatted_schema_path_values_map:
                     continue
 
                 update_display_label_query = await UpdateAttributeValuesQuery.init(
                     db=db,
                     branch=branch,
                     attribute_schema=destination_attribute_schema,
-                    values_by_id_map=formatted_display_label_schema_path_values_map,
+                    values_by_id_map=formatted_schema_path_values_map,
                 )
                 await update_display_label_query.execute(db=db)
 
@@ -801,7 +803,10 @@ class Migration043(ArbitraryMigration):
             for k, v in schema_path_values_map.items():
                 if not v:
                     continue
-                formatted_v = ujson.dumps(v) if destination_attribute_schema.kind == "List" else " ".join(v)
+                if destination_attribute_schema.kind == "List":
+                    formatted_v = ujson.dumps(v)
+                else:
+                    formatted_v = " ".join(item for item in v if item is not None)
                 formatted_schema_path_values_map[k] = formatted_v
 
                 print(schema.kind, schema_property, k, v)
@@ -855,7 +860,7 @@ class Migration043(ArbitraryMigration):
                     )
 
                 if not schemas_for_targeted_update_map:
-                    return MigrationResult()
+                    continue
 
                 for source_attribute_schema, destination_attribute_schema in schemas_for_targeted_update_map.items():
                     await self._do_one_schema_branch(

--- a/backend/infrahub/core/migrations/query/attribute_add.py
+++ b/backend/infrahub/core/migrations/query/attribute_add.py
@@ -22,6 +22,7 @@ class AttributeAddQuery(Query):
         attribute_kind: str,
         branch_support: str,
         default_value: Any | None = None,
+        uuids: list[str] | None = None,
         **kwargs: Any,
     ) -> None:
         self.node_kinds = node_kinds
@@ -29,7 +30,7 @@ class AttributeAddQuery(Query):
         self.attribute_kind = attribute_kind
         self.branch_support = branch_support
         self.default_value = default_value
-
+        self.uuids = uuids
         super().__init__(**kwargs)
 
     async def query_init(self, db: InfrahubDatabase, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002

--- a/backend/infrahub/core/migrations/shared.py
+++ b/backend/infrahub/core/migrations/shared.py
@@ -117,6 +117,8 @@ class SchemaMigration(BaseModel):
 
 
 class AttributeSchemaMigration(SchemaMigration):
+    uuids: list[str] | None = None
+
     @property
     def new_attribute_schema(self) -> AttributeSchema:
         if not self.schema_path.field_name:

--- a/backend/infrahub/core/schema/manager.py
+++ b/backend/infrahub/core/schema/manager.py
@@ -163,6 +163,9 @@ class SchemaManager(NodeManager):
         self._branches[name] = schema
         self._branch_hash_by_name[name] = schema.get_hash()
 
+    def has_schema_branch(self, name: str) -> bool:
+        return name in self._branches
+
     def process_schema_branch(self, name: str) -> None:
         schema_branch = self.get_schema_branch(name=name)
         schema_branch.process()

--- a/backend/tests/unit/core/migrations/graph/test_042_043.py
+++ b/backend/tests/unit/core/migrations/graph/test_042_043.py
@@ -8,6 +8,7 @@ import pytest
 from infrahub.core import registry
 from infrahub.core.branch.models import Branch
 from infrahub.core.constants import RelationshipCardinality
+from infrahub.core.initialization import create_branch
 from infrahub.core.migrations.graph.m042_create_hfid_display_label_in_db import Migration042
 from infrahub.core.migrations.graph.m043_backfill_hfid_display_label_in_db import Migration043
 from infrahub.core.node import Node
@@ -27,6 +28,7 @@ class NodeStatus(StrEnum):
 @dataclass
 class NodeDetails:
     node: Node
+    on_default_branch: bool
     display_label: str | None
     human_friendly_id: list[str] | None
     status: NodeStatus
@@ -102,39 +104,46 @@ class TestMigration042(TestInfrahubApp):
         return registry.schema.get_schema_branch(name=default_branch.name)
 
     @pytest.fixture
-    async def secondary_thing_one_with_details(self, db: InfrahubDatabase, load_schemas: SchemaBranch) -> NodeDetails:
+    async def branch(self, db: InfrahubDatabase, default_branch: Branch) -> Branch:
+        return await create_branch(db=db, branch_name="migration-test-branch")
+
+    @pytest.fixture
+    async def secondary_thing_one_details(self, db: InfrahubDatabase, load_schemas: SchemaBranch) -> NodeDetails:
         secondary_thing = await Node.init(db=db, schema="SecondaryThing")
         await secondary_thing.new(db=db, name="secondary_thing_1", color="not red", size=-1)
         await secondary_thing.save(db=db)
         return NodeDetails(
             node=secondary_thing,
+            on_default_branch=True,
             display_label=f"{secondary_thing.name.value} {secondary_thing.size.value}",
             human_friendly_id=[str(v) for v in (secondary_thing.name.value, secondary_thing.color.value)],
             status=NodeStatus.ACTIVE,
         )
 
     @pytest.fixture
-    async def secondary_thing_two_with_details(self, db: InfrahubDatabase, load_schemas: SchemaBranch) -> NodeDetails:
+    async def secondary_thing_two_details(self, db: InfrahubDatabase, load_schemas: SchemaBranch) -> NodeDetails:
         secondary_thing = await Node.init(db=db, schema="SecondaryThing")
         await secondary_thing.new(db=db, name="secondary_thing_2", color="orange", size=42)
         await secondary_thing.save(db=db)
         return NodeDetails(
             node=secondary_thing,
+            on_default_branch=True,
             display_label=f"{secondary_thing.name.value} {secondary_thing.size.value}",
             human_friendly_id=[str(v) for v in (secondary_thing.name.value, secondary_thing.color.value)],
             status=NodeStatus.ACTIVE,
         )
 
     @pytest.fixture
-    async def primary_thing_one_with_details(
-        self, db: InfrahubDatabase, load_schemas: SchemaBranch, secondary_thing_one_with_details: NodeDetails
+    async def primary_thing_one_details(
+        self, db: InfrahubDatabase, load_schemas: SchemaBranch, secondary_thing_one_details: NodeDetails
     ) -> NodeDetails:
-        secondary_thing_node = secondary_thing_one_with_details.node
+        secondary_thing_node = secondary_thing_one_details.node
         primary_thing = await Node.init(db=db, schema="PrimaryThing")
         await primary_thing.new(db=db, name="primary_thing_1", color="red", size=1, secondary=secondary_thing_node.id)
         await primary_thing.save(db=db)
         return NodeDetails(
             node=primary_thing,
+            on_default_branch=True,
             display_label=f"{primary_thing.name.value} {primary_thing.color.value}",
             human_friendly_id=[
                 str(v)
@@ -144,10 +153,10 @@ class TestMigration042(TestInfrahubApp):
         )
 
     @pytest.fixture
-    async def primary_thing_two_with_details(
-        self, db: InfrahubDatabase, load_schemas: SchemaBranch, secondary_thing_two_with_details: NodeDetails
+    async def primary_thing_two_details(
+        self, db: InfrahubDatabase, load_schemas: SchemaBranch, secondary_thing_two_details: NodeDetails
     ) -> NodeDetails:
-        secondary_thing_node = secondary_thing_two_with_details.node
+        secondary_thing_node = secondary_thing_two_details.node
         primary_thing = await Node.init(db=db, schema="PrimaryThing")
         await primary_thing.new(
             db=db, name="primary_thing_2", color="yellow", size=2, secondary=secondary_thing_node.id
@@ -157,6 +166,7 @@ class TestMigration042(TestInfrahubApp):
         await primary_thing.save(db=db)
         return NodeDetails(
             node=primary_thing,
+            on_default_branch=True,
             display_label=f"{primary_thing.name.value} {primary_thing.color.value}",
             human_friendly_id=[
                 str(v)
@@ -166,19 +176,48 @@ class TestMigration042(TestInfrahubApp):
         )
 
     @pytest.fixture
-    async def primary_thing_three_deleted_with_details(
-        self, db: InfrahubDatabase, load_schemas: SchemaBranch, secondary_thing_two_with_details: NodeDetails
+    async def primary_thing_three_deleted_details(
+        self, db: InfrahubDatabase, load_schemas: SchemaBranch, secondary_thing_two_details: NodeDetails
     ) -> NodeDetails:
-        secondary_thing_node = secondary_thing_two_with_details.node
+        secondary_thing_node = secondary_thing_two_details.node
         primary_thing = await Node.init(db=db, schema="PrimaryThing")
         await primary_thing.new(db=db, name="primary_thing_3", color="green", size=3, secondary=secondary_thing_node.id)
         await primary_thing.save(db=db)
         await primary_thing.delete(db=db)
         return NodeDetails(
             node=primary_thing,
+            on_default_branch=True,
             display_label=None,
             human_friendly_id=None,
             status=NodeStatus.DELETED,
+        )
+
+    @pytest.fixture
+    async def primary_thing_one_branch_details(
+        self,
+        db: InfrahubDatabase,
+        load_schemas: SchemaBranch,
+        secondary_thing_one_details: NodeDetails,
+        branch: Branch,
+    ) -> NodeDetails:
+        primary_thing = await Node.init(db=db, schema="PrimaryThing", branch=branch)
+        await primary_thing.new(
+            db=db, name="primary_thing_1_branch", color="blue", size=1, secondary=secondary_thing_one_details.node.id
+        )
+        await primary_thing.save(db=db)
+        return NodeDetails(
+            node=primary_thing,
+            on_default_branch=False,
+            display_label=f"{primary_thing.name.value} {primary_thing.color.value}",
+            human_friendly_id=[
+                str(v)
+                for v in (
+                    primary_thing.name.value,
+                    secondary_thing_one_details.node.name.value,
+                    secondary_thing_one_details.node.size.value,
+                )
+            ],
+            status=NodeStatus.ACTIVE,
         )
 
     @pytest.fixture
@@ -188,18 +227,21 @@ class TestMigration042(TestInfrahubApp):
         default_branch: Branch,
         register_core_models_schema: SchemaBranch,
         load_schemas: SchemaBranch,
-        primary_thing_one_with_details: NodeDetails,
-        secondary_thing_one_with_details: NodeDetails,
-        primary_thing_two_with_details: NodeDetails,
-        secondary_thing_two_with_details: NodeDetails,
-        primary_thing_three_deleted_with_details: NodeDetails,
+        primary_thing_one_details: NodeDetails,
+        secondary_thing_one_details: NodeDetails,
+        primary_thing_two_details: NodeDetails,
+        secondary_thing_two_details: NodeDetails,
+        primary_thing_three_deleted_details: NodeDetails,
+        branch: Branch,
+        primary_thing_one_branch_details: NodeDetails,
     ) -> dict[str, NodeDetails]:
         return {
-            "secondary_thing": secondary_thing_one_with_details,
-            "primary_thing": primary_thing_one_with_details,
-            "secondary_thing_two": secondary_thing_two_with_details,
-            "primary_thing_two": primary_thing_two_with_details,
-            "primary_thing_three_deleted": primary_thing_three_deleted_with_details,
+            "secondary_thing": secondary_thing_one_details,
+            "primary_thing": primary_thing_one_details,
+            "secondary_thing_two": secondary_thing_two_details,
+            "primary_thing_two": primary_thing_two_details,
+            "primary_thing_three_deleted": primary_thing_three_deleted_details,
+            "primary_thing_one_branch": primary_thing_one_branch_details,
         }
 
     async def erase_hfid_and_display_label(self, db: InfrahubDatabase) -> Node:
@@ -231,11 +273,17 @@ DETACH DELETE attr
         return result_map
 
     async def test_migration_042_043(
-        self, db: InfrahubDatabase, default_branch: Branch, initial_dataset: dict[str, NodeDetails]
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        initial_dataset: dict[str, NodeDetails],
+        branch: Branch,
+        primary_thing_schema: NodeSchema,
+        secondary_thing_schema: NodeSchema,
     ) -> None:
         await self.erase_hfid_and_display_label(db=db)
 
-        # test adding display label and HFID attributes
+        # test adding display label and HFID attributes on default branch
         async with db.start_session() as dbs:
             migration = Migration042(migrations=[])
             execution_result = await migration.execute(db=dbs)
@@ -244,7 +292,7 @@ DETACH DELETE attr
             validation_result = await migration.validate_migration(db=dbs)
             assert not validation_result.errors
 
-        # test backfilling display label and HFID attributes
+        # test backfilling display label and HFID attributes on default branch
         async with db.start_session() as dbs:
             migration = Migration043()
             execution_result = await migration.execute(db=dbs)
@@ -253,21 +301,74 @@ DETACH DELETE attr
             validation_result = await migration.validate_migration(db=dbs)
             assert not validation_result.errors
 
-        attribute_values_map = await self.get_attribute_values_from_db(
+        # validate updates on default branch
+        attribute_values_map_main = await self.get_attribute_values_from_db(
             db=db,
             branch=default_branch,
             attribute_names=["human_friendly_id", "display_label"],
             node_ids=[node_details.node.id for node_details in initial_dataset.values()],
         )
-
-        expected_ids = {node_details.node.id for node_details in initial_dataset.values() if node_details.is_active}
-        assert set(attribute_values_map.keys()) == expected_ids
+        expected_ids = {
+            node_details.node.id
+            for node_details in initial_dataset.values()
+            if node_details.is_active and node_details.on_default_branch
+        }
+        assert set(attribute_values_map_main.keys()) == expected_ids
         for node_details in initial_dataset.values():
-            if not node_details.is_active:
+            if not node_details.is_active or not node_details.on_default_branch:
                 continue
-            assert attribute_values_map[node_details.node.id]["display_label"] == node_details.display_label
+            assert attribute_values_map_main[node_details.node.id]["display_label"] == node_details.display_label
             assert (
-                json.loads(attribute_values_map[node_details.node.id]["human_friendly_id"])
+                json.loads(attribute_values_map_main[node_details.node.id]["human_friendly_id"])
+                == node_details.human_friendly_id
+            )
+
+        # rebase and migrate branch
+        await branch.rebase(db=db)
+        async with db.start_session() as dbs:
+            migration = Migration042(migrations=[])
+            execution_result = await migration.execute_against_branch(db=dbs, branch=branch)
+            assert not execution_result.errors
+
+        branch_schema_branch = SchemaBranch(
+            cache={},
+            name=branch.name,
+        )
+        branch_schema_branch.set(name="PrimaryThing", schema=primary_thing_schema)
+        branch_schema_branch.set(name="SecondaryThing", schema=secondary_thing_schema)
+        for internal_schema_kind in ["SchemaNode", "SchemaAttribute", "SchemaRelationship", "SchemaGeneric"]:
+            branch_schema_branch.set(
+                name=internal_schema_kind,
+                schema=registry.schema.get(name=internal_schema_kind, branch=default_branch, duplicate=False),
+            )
+        branch_schema_branch.process()
+        registry.schema.set_schema_branch(name=branch.name, schema=branch_schema_branch)
+
+        async with db.start_session() as dbs:
+            migration = Migration043()
+            execution_result = await migration.execute_against_branch(db=dbs, branch=branch)
+            assert not execution_result.errors
+
+        attribute_values_map_branch = await self.get_attribute_values_from_db(
+            db=db,
+            branch=branch,
+            attribute_names=["human_friendly_id", "display_label"],
+            node_ids=[
+                node_details.node.id for node_details in initial_dataset.values() if not node_details.on_default_branch
+            ],
+        )
+        expected_ids = {
+            node_details.node.id
+            for node_details in initial_dataset.values()
+            if node_details.is_active and not node_details.on_default_branch
+        }
+        assert set(attribute_values_map_branch.keys()) == expected_ids
+        for node_details in initial_dataset.values():
+            if not node_details.is_active or node_details.on_default_branch:
+                continue
+            assert attribute_values_map_branch[node_details.node.id]["display_label"] == node_details.display_label
+            assert (
+                json.loads(attribute_values_map_branch[node_details.node.id]["human_friendly_id"])
                 == node_details.human_friendly_id
             )
 

--- a/backend/tests/unit/core/migrations/graph/test_042_043.py
+++ b/backend/tests/unit/core/migrations/graph/test_042_043.py
@@ -9,6 +9,7 @@ from infrahub.core import registry
 from infrahub.core.branch.models import Branch
 from infrahub.core.constants import RelationshipCardinality
 from infrahub.core.initialization import create_branch
+from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.graph.m042_create_hfid_display_label_in_db import Migration042
 from infrahub.core.migrations.graph.m043_backfill_hfid_display_label_in_db import Migration043
 from infrahub.core.node import Node
@@ -16,6 +17,7 @@ from infrahub.core.query.node import NodeListGetAttributeQuery
 from infrahub.core.schema import AttributeSchema, NodeSchema, RelationshipSchema, SchemaRoot
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
+from infrahub.database.validation import verify_no_duplicate_relationships, verify_no_edges_added_after_node_delete
 from tests.helpers.schema import load_schema
 from tests.helpers.test_app import TestInfrahubApp
 
@@ -221,6 +223,45 @@ class TestMigration042(TestInfrahubApp):
         )
 
     @pytest.fixture
+    async def primary_thing_two_deleted_on_branch_details(
+        self, db: InfrahubDatabase, load_schemas: SchemaBranch, primary_thing_two_details: NodeDetails, branch: Branch
+    ) -> NodeDetails:
+        primary_thing = await NodeManager.get_one(db=db, branch=branch, id=primary_thing_two_details.node.id)
+        await primary_thing.delete(db=db)
+        return NodeDetails(
+            node=primary_thing,
+            on_default_branch=False,
+            display_label=None,
+            human_friendly_id=None,
+            status=NodeStatus.DELETED,
+        )
+
+    @pytest.fixture
+    async def primary_thing_one_updated_on_branch_details(
+        self, db: InfrahubDatabase, load_schemas: SchemaBranch, primary_thing_one_details: NodeDetails, branch: Branch
+    ) -> NodeDetails:
+        primary_thing = await NodeManager.get_one(db=db, branch=branch, id=primary_thing_one_details.node.id)
+        # Update some attributes on the branch
+        primary_thing.color.value = "purple"
+        primary_thing.size.value = 999
+        await primary_thing.save(db=db)
+        secondary_thing = await primary_thing.secondary.get_peer(db=db)
+        return NodeDetails(
+            node=primary_thing,
+            on_default_branch=False,
+            display_label=f"{primary_thing.name.value} {primary_thing.color.value}",
+            human_friendly_id=[
+                str(v)
+                for v in (
+                    primary_thing.name.value,
+                    secondary_thing.name.value,
+                    secondary_thing.size.value,
+                )
+            ],
+            status=NodeStatus.ACTIVE,
+        )
+
+    @pytest.fixture
     async def initial_dataset(
         self,
         db: InfrahubDatabase,
@@ -231,17 +272,21 @@ class TestMigration042(TestInfrahubApp):
         secondary_thing_one_details: NodeDetails,
         primary_thing_two_details: NodeDetails,
         secondary_thing_two_details: NodeDetails,
+        primary_thing_two_deleted_on_branch_details: NodeDetails,
         primary_thing_three_deleted_details: NodeDetails,
         branch: Branch,
         primary_thing_one_branch_details: NodeDetails,
+        primary_thing_one_updated_on_branch_details: NodeDetails,
     ) -> dict[str, NodeDetails]:
         return {
             "secondary_thing": secondary_thing_one_details,
             "primary_thing": primary_thing_one_details,
             "secondary_thing_two": secondary_thing_two_details,
             "primary_thing_two": primary_thing_two_details,
+            "primary_thing_two_deleted_on_branch": primary_thing_two_deleted_on_branch_details,
             "primary_thing_three_deleted": primary_thing_three_deleted_details,
             "primary_thing_one_branch": primary_thing_one_branch_details,
+            "primary_thing_one_updated_on_branch": primary_thing_one_updated_on_branch_details,
         }
 
     async def erase_hfid_and_display_label(self, db: InfrahubDatabase) -> Node:
@@ -362,6 +407,10 @@ DETACH DELETE attr
             for node_details in initial_dataset.values()
             if node_details.is_active and not node_details.on_default_branch
         }
+
+        # bug in rebase allows attributes added on main to persist on a node that is deleted on a branch
+        expected_ids.add(initial_dataset["primary_thing_two_deleted_on_branch"].node.id)
+
         assert set(attribute_values_map_branch.keys()) == expected_ids
         for node_details in initial_dataset.values():
             if not node_details.is_active or node_details.on_default_branch:
@@ -372,9 +421,12 @@ DETACH DELETE attr
                 == node_details.human_friendly_id
             )
 
+        await verify_no_edges_added_after_node_delete(db=db)
+        await verify_no_duplicate_relationships(db=db)
 
-# TODO: test added/updated/removed nodes on branch
+
 # TODO: test updating relationships and values of peers
 # TODO: test relationships with same name going different directions
 # TODO: test branch-agnostic attributes and relationships
 # TODO: test display labels and HFIDs updated on a branch with the same value on main
+# TODO: test HFID/display labels update on branch

--- a/backend/tests/unit/core/migrations/graph/test_042_043.py
+++ b/backend/tests/unit/core/migrations/graph/test_042_043.py
@@ -1,78 +1,132 @@
-import copy
+import json
+from typing import Any
 
 import pytest
 
 from infrahub.core import registry
 from infrahub.core.branch.models import Branch
-from infrahub.core.manager import NodeManager
+from infrahub.core.constants import RelationshipCardinality
 from infrahub.core.migrations.graph.m042_create_hfid_display_label_in_db import Migration042
 from infrahub.core.migrations.graph.m043_backfill_hfid_display_label_in_db import Migration043
 from infrahub.core.node import Node
-from infrahub.core.schema import SchemaRoot
+from infrahub.core.query.node import NodeListGetAttributeQuery
+from infrahub.core.schema import AttributeSchema, NodeSchema, RelationshipSchema, SchemaRoot
 from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
-from tests.helpers.schema import WIDGET, load_schema
+from tests.helpers.schema import load_schema
 from tests.helpers.test_app import TestInfrahubApp
-
-QUERY_HFID = """
-MATCH (n:TestingWidget)-[:HAS_ATTRIBUTE]->(a:Attribute)-[:HAS_VALUE]->(v:AttributeValue)
-WHERE a.name = "human_friendly_id"
-RETURN n, v
-"""
-
-QUERY_DISPLAY_LABEL = """
-MATCH (n:TestingWidget)-[:HAS_ATTRIBUTE]->(a:Attribute)-[:HAS_VALUE]->(v:AttributeValue)
-WHERE a.name = "display_label"
-RETURN n, v
-"""
 
 
 class TestMigration042(TestInfrahubApp):
     @pytest.fixture
+    def primary_thing_schema(self) -> NodeSchema:
+        return NodeSchema(
+            name="Thing",
+            namespace="Primary",
+            display_labels=["name__value", "color__value"],
+            human_friendly_id=["name__value", "secondary__color__value", "secondary__size__value"],
+            uniqueness_constraints=[["name__value"]],
+            attributes=[
+                AttributeSchema(name="name", kind="Text"),
+                AttributeSchema(name="color", kind="Text"),
+                AttributeSchema(name="size", kind="Number"),
+            ],
+            relationships=[
+                RelationshipSchema(
+                    name="secondary",
+                    optional=False,
+                    peer="SecondaryThing",
+                    cardinality=RelationshipCardinality.ONE,
+                )
+            ],
+        )
+
+    @pytest.fixture
+    def secondary_thing_schema(self) -> NodeSchema:
+        return NodeSchema(
+            name="Thing",
+            namespace="Secondary",
+            attributes=[
+                AttributeSchema(name="name", kind="Text"),
+                AttributeSchema(name="color", kind="Text"),
+                AttributeSchema(name="size", kind="Number"),
+            ],
+        )
+
+    @pytest.fixture
     async def initial_dataset(
-        self, db: InfrahubDatabase, default_branch: Branch, register_core_models_schema: SchemaBranch
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        register_core_models_schema: SchemaBranch,
+        primary_thing_schema: NodeSchema,
+        secondary_thing_schema: NodeSchema,
     ) -> dict[str, Node]:
-        await load_schema(db=db, schema=SchemaRoot(nodes=[WIDGET]), branch_name=default_branch.name, update_db=True)
-        widget_schema = registry.schema.get_node_schema(name=WIDGET.kind, branch=default_branch)
-        # just saving and loading this one schema speeds up the test
-        widget_only_schema_branch = SchemaBranch(cache={widget_schema.kind: widget_schema}, name=default_branch.name)
-        await registry.schema.load_schema_to_db(db=db, schema=widget_only_schema_branch)
+        await load_schema(
+            db=db,
+            schema=SchemaRoot(nodes=[primary_thing_schema, secondary_thing_schema]),
+            branch_name=default_branch.name,
+            update_db=True,
+        )
+        primary_thing_schema = registry.schema.get_node_schema(name="PrimaryThing", branch=default_branch)
+        secondary_thing_schema = registry.schema.get_node_schema(name="SecondaryThing", branch=default_branch)
+        # just saving and loading these two schemas speeds up the test
+        small_schema_branch = SchemaBranch(
+            cache={
+                primary_thing_schema.kind: primary_thing_schema,
+                secondary_thing_schema.kind: secondary_thing_schema,
+            },
+            name=default_branch.name,
+        )
+        await registry.schema.load_schema_to_db(db=db, schema=small_schema_branch)
 
-        nodes: dict[str, Node] = {}
-        for name in [
-            "widget_alpha",
-            "widget_bravo",
-            "widget_charlie",
-            "widget_delta",
-            "widget_echo",
-            "widget_foxtrot",
-            "widget_golf",
-            "widget_hotel",
-            "widget_india",
-            "widget_juliet",
-        ]:
-            node = await Node.init(db=db, schema=widget_schema)
-            await node.new(db=db, name=name)
-            await node.save(db=db)
+        # create secondary things
+        secondary_thing = await Node.init(db=db, schema=secondary_thing_schema)
+        await secondary_thing.new(db=db, name="secondary_thing_1", color="not red", size=-1)
+        await secondary_thing.save(db=db)
 
-            nodes[name] = node
+        # create_primary_things
+        primary_thing = await Node.init(db=db, schema=primary_thing_schema)
+        await primary_thing.new(db=db, name="primary_thing_1", color="red", size=1, secondary=secondary_thing)
+        await primary_thing.save(db=db)
 
-        return nodes
+        return {
+            "secondary_thing": secondary_thing,
+            "primary_thing": primary_thing,
+        }
+
+    async def erase_hfid_and_display_label(self, db: InfrahubDatabase) -> Node:
+        query = """
+MATCH (attr:Attribute)
+WHERE attr.name in ["human_friendly_id", "display_label"]
+DETACH DELETE attr
+        """
+        await db.execute_query(query=query)
+
+    async def get_attribute_values_from_db(
+        self, db: InfrahubDatabase, branch: Branch, attribute_names: list[str], node_ids: list[str]
+    ) -> dict[str, dict[str, Any]]:
+        query = await NodeListGetAttributeQuery.init(
+            db=db,
+            ids=node_ids,
+            fields={attr_name: {True} for attr_name in attribute_names},
+            branch=branch,
+        )
+        await query.execute(db=db)
+        node_attributes_map = query.get_attributes_group_by_node()
+        result_map = {}
+        for node_id in node_ids:
+            result_map[node_id] = {}
+            for attr_name in attribute_names:
+                result_map[node_id][attr_name] = node_attributes_map[node_id].attrs[attr_name].value
+        return result_map
 
     async def test_migration_042_043(
         self, db: InfrahubDatabase, default_branch: Branch, initial_dataset: dict[str, Node]
     ) -> None:
-        results = await db.execute_query(query=QUERY_HFID)
-        assert not results
+        await self.erase_hfid_and_display_label(db=db)
 
-        unique_name_widget = copy.deepcopy(WIDGET)
-        unique_name_widget.human_friendly_id = ["name__value"]
-        unique_name_widget.get_attribute(name="name").unique = True
-        await load_schema(db=db, schema=SchemaRoot(nodes=[unique_name_widget]), update_db=True)
-
-        results = await db.execute_query(query=QUERY_HFID)
-        assert not results
-
+        # test adding display label and HFID attributes
         async with db.start_session() as dbs:
             migration = Migration042(migrations=[])
             execution_result = await migration.execute(db=dbs)
@@ -81,6 +135,7 @@ class TestMigration042(TestInfrahubApp):
             validation_result = await migration.validate_migration(db=dbs)
             assert not validation_result.errors
 
+        # test backfilling display label and HFID attributes
         async with db.start_session() as dbs:
             migration = Migration043()
             execution_result = await migration.execute(db=dbs)
@@ -89,12 +144,23 @@ class TestMigration042(TestInfrahubApp):
             validation_result = await migration.validate_migration(db=dbs)
             assert not validation_result.errors
 
-        results = await db.execute_query(query=QUERY_HFID)
-        assert results
+        attribute_values_map = await self.get_attribute_values_from_db(
+            db=db,
+            branch=default_branch,
+            attribute_names=["human_friendly_id", "display_label"],
+            node_ids=[initial_dataset["primary_thing"].id, initial_dataset["secondary_thing"].id],
+        )
+        assert attribute_values_map[initial_dataset["primary_thing"].id]["display_label"] == "primary_thing_1 red"
+        assert json.loads(attribute_values_map[initial_dataset["primary_thing"].id]["human_friendly_id"]) == [
+            "primary_thing_1",
+            "not red",
+            "-1",
+        ]
 
-        schema_branch = await registry.schema.load_schema_from_db(db=db, branch=default_branch)
-        registry.schema.set_schema_branch(name=default_branch.name, schema=schema_branch)
-        nodes: list[Node] = await NodeManager.query(db=db, schema=WIDGET.kind)
-        assert len(nodes) == 10
-        assert nodes[0].has_human_friendly_id()
-        assert await nodes[0].get_hfid(db=db) == [nodes[0].name.value]
+
+# TODO: test added/updated/removed nodes on default branch
+# TODO: test added/updated/removed nodes on branch
+# TODO: test updating relationships and values of peers
+# TODO: test relationships with same name going different directions
+# TODO: test branch-agnostic attributes and relationships
+# TODO: test display labels and HFIDs updated on a branch with the same value on main

--- a/backend/tests/unit/core/migrations/graph/test_042_043.py
+++ b/backend/tests/unit/core/migrations/graph/test_042_043.py
@@ -136,6 +136,23 @@ class TestMigration042(TestInfrahubApp):
         )
 
     @pytest.fixture
+    async def secondary_thing_three_details(self, db: InfrahubDatabase, load_schemas: SchemaBranch) -> NodeDetails:
+        secondary_thing = await Node.init(db=db, schema="SecondaryThing")
+        await secondary_thing.new(db=db, name="secondary_thing_3", color="inidigo", size=53)
+        await secondary_thing.save(db=db)
+        secondary_thing.color.value = "indigogo"
+        secondary_thing.size.value = 54
+        await secondary_thing.save(db=db)
+
+        return NodeDetails(
+            node=secondary_thing,
+            on_default_branch=True,
+            display_label=f"{secondary_thing.name.value} {secondary_thing.size.value}",
+            human_friendly_id=[str(v) for v in (secondary_thing.name.value, secondary_thing.color.value)],
+            status=NodeStatus.ACTIVE,
+        )
+
+    @pytest.fixture
     async def primary_thing_one_details(
         self, db: InfrahubDatabase, load_schemas: SchemaBranch, secondary_thing_one_details: NodeDetails
     ) -> NodeDetails:
@@ -155,24 +172,29 @@ class TestMigration042(TestInfrahubApp):
         )
 
     @pytest.fixture
-    async def primary_thing_two_details(
-        self, db: InfrahubDatabase, load_schemas: SchemaBranch, secondary_thing_two_details: NodeDetails
+    async def primary_thing_two_main_update_details(
+        self,
+        db: InfrahubDatabase,
+        load_schemas: SchemaBranch,
+        secondary_thing_two_details: NodeDetails,
+        secondary_thing_three_details: NodeDetails,
     ) -> NodeDetails:
-        secondary_thing_node = secondary_thing_two_details.node
+        secondary_node = secondary_thing_two_details.node
         primary_thing = await Node.init(db=db, schema="PrimaryThing")
-        await primary_thing.new(
-            db=db, name="primary_thing_2", color="yellow", size=2, secondary=secondary_thing_node.id
-        )
+        await primary_thing.new(db=db, name="primary_thing_2", color="yellow", size=2, secondary=secondary_node.id)
         await primary_thing.save(db=db)
+
+        new_secondary_node = secondary_thing_three_details.node
         primary_thing.color.value = "double yellow"
+        await primary_thing.secondary.update(db=db, data=new_secondary_node)
         await primary_thing.save(db=db)
+
         return NodeDetails(
             node=primary_thing,
             on_default_branch=True,
             display_label=f"{primary_thing.name.value} {primary_thing.color.value}",
             human_friendly_id=[
-                str(v)
-                for v in (primary_thing.name.value, secondary_thing_node.name.value, secondary_thing_node.size.value)
+                str(v) for v in (primary_thing.name.value, new_secondary_node.name.value, new_secondary_node.size.value)
             ],
             status=NodeStatus.ACTIVE,
         )
@@ -192,6 +214,31 @@ class TestMigration042(TestInfrahubApp):
             display_label=None,
             human_friendly_id=None,
             status=NodeStatus.DELETED,
+        )
+
+    # --------------------------------
+    # Branch creates, updates, deletes
+    # --------------------------------
+
+    @pytest.fixture
+    async def secondary_thing_three_branch_update_details(
+        self,
+        db: InfrahubDatabase,
+        load_schemas: SchemaBranch,
+        branch: Branch,
+        secondary_thing_three_details: NodeDetails,
+    ) -> NodeDetails:
+        secondary_thing = await NodeManager.get_one(db=db, branch=branch, id=secondary_thing_three_details.node.id)
+        secondary_thing.color.value = "indigogogo-branch"
+        secondary_thing.size.value = 55
+        await secondary_thing.save(db=db)
+
+        return NodeDetails(
+            node=secondary_thing,
+            on_default_branch=False,
+            display_label=f"{secondary_thing.name.value} {secondary_thing.size.value}",
+            human_friendly_id=[str(v) for v in (secondary_thing.name.value, secondary_thing.color.value)],
+            status=NodeStatus.ACTIVE,
         )
 
     @pytest.fixture
@@ -224,9 +271,15 @@ class TestMigration042(TestInfrahubApp):
 
     @pytest.fixture
     async def primary_thing_two_deleted_on_branch_details(
-        self, db: InfrahubDatabase, load_schemas: SchemaBranch, primary_thing_two_details: NodeDetails, branch: Branch
+        self,
+        db: InfrahubDatabase,
+        load_schemas: SchemaBranch,
+        primary_thing_two_main_update_details: NodeDetails,
+        branch: Branch,
     ) -> NodeDetails:
-        primary_thing = await NodeManager.get_one(db=db, branch=branch, id=primary_thing_two_details.node.id)
+        primary_thing = await NodeManager.get_one(
+            db=db, branch=branch, id=primary_thing_two_main_update_details.node.id
+        )
         await primary_thing.delete(db=db)
         return NodeDetails(
             node=primary_thing,
@@ -237,15 +290,21 @@ class TestMigration042(TestInfrahubApp):
         )
 
     @pytest.fixture
-    async def primary_thing_one_updated_on_branch_details(
-        self, db: InfrahubDatabase, load_schemas: SchemaBranch, primary_thing_one_details: NodeDetails, branch: Branch
+    async def primary_thing_one_branch_update_details(
+        self,
+        db: InfrahubDatabase,
+        load_schemas: SchemaBranch,
+        primary_thing_one_details: NodeDetails,
+        branch: Branch,
+        secondary_thing_three_branch_update_details: NodeDetails,
     ) -> NodeDetails:
         primary_thing = await NodeManager.get_one(db=db, branch=branch, id=primary_thing_one_details.node.id)
         # Update some attributes on the branch
         primary_thing.color.value = "purple"
         primary_thing.size.value = 999
+        # update secondary relationship on branch
+        await primary_thing.secondary.update(db=db, data=secondary_thing_three_branch_update_details.node)
         await primary_thing.save(db=db)
-        secondary_thing = await primary_thing.secondary.get_peer(db=db)
         return NodeDetails(
             node=primary_thing,
             on_default_branch=False,
@@ -254,8 +313,8 @@ class TestMigration042(TestInfrahubApp):
                 str(v)
                 for v in (
                     primary_thing.name.value,
-                    secondary_thing.name.value,
-                    secondary_thing.size.value,
+                    secondary_thing_three_branch_update_details.node.name.value,
+                    secondary_thing_three_branch_update_details.node.size.value,
                 )
             ],
             status=NodeStatus.ACTIVE,
@@ -268,25 +327,29 @@ class TestMigration042(TestInfrahubApp):
         default_branch: Branch,
         register_core_models_schema: SchemaBranch,
         load_schemas: SchemaBranch,
-        primary_thing_one_details: NodeDetails,
         secondary_thing_one_details: NodeDetails,
-        primary_thing_two_details: NodeDetails,
         secondary_thing_two_details: NodeDetails,
+        secondary_thing_three_details: NodeDetails,
+        primary_thing_one_details: NodeDetails,
+        primary_thing_two_main_update_details: NodeDetails,
         primary_thing_two_deleted_on_branch_details: NodeDetails,
         primary_thing_three_deleted_details: NodeDetails,
         branch: Branch,
+        secondary_thing_three_branch_update_details: NodeDetails,
         primary_thing_one_branch_details: NodeDetails,
-        primary_thing_one_updated_on_branch_details: NodeDetails,
+        primary_thing_one_branch_update_details: NodeDetails,
     ) -> dict[str, NodeDetails]:
         return {
-            "secondary_thing": secondary_thing_one_details,
-            "primary_thing": primary_thing_one_details,
+            "secondary_thing_one": secondary_thing_one_details,
             "secondary_thing_two": secondary_thing_two_details,
-            "primary_thing_two": primary_thing_two_details,
+            "secondary_thing_three": secondary_thing_three_details,
+            "primary_thing_one": primary_thing_one_details,
+            "primary_thing_two": primary_thing_two_main_update_details,
             "primary_thing_two_deleted_on_branch": primary_thing_two_deleted_on_branch_details,
             "primary_thing_three_deleted": primary_thing_three_deleted_details,
+            "secondary_thing_three_branch_update": secondary_thing_three_branch_update_details,
             "primary_thing_one_branch": primary_thing_one_branch_details,
-            "primary_thing_one_updated_on_branch": primary_thing_one_updated_on_branch_details,
+            "primary_thing_one_updated_on_branch": primary_thing_one_branch_update_details,
         }
 
     async def erase_hfid_and_display_label(self, db: InfrahubDatabase) -> Node:
@@ -425,7 +488,6 @@ DETACH DELETE attr
         await verify_no_duplicate_relationships(db=db)
 
 
-# TODO: test updating relationships and values of peers
 # TODO: test relationships with same name going different directions
 # TODO: test branch-agnostic attributes and relationships
 # TODO: test display labels and HFIDs updated on a branch with the same value on main

--- a/backend/tests/unit/core/migrations/graph/test_042_043.py
+++ b/backend/tests/unit/core/migrations/graph/test_042_043.py
@@ -7,7 +7,7 @@ import pytest
 
 from infrahub.core import registry
 from infrahub.core.branch.models import Branch
-from infrahub.core.constants import RelationshipCardinality
+from infrahub.core.constants import RelationshipCardinality, RelationshipDirection
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.graph.m042_create_hfid_display_label_in_db import Migration042
@@ -47,7 +47,12 @@ class TestMigration042(TestInfrahubApp):
             name="Thing",
             namespace="Primary",
             display_labels=["name__value", "color__value"],
-            human_friendly_id=["name__value", "secondary__name__value", "secondary__size__value"],
+            human_friendly_id=[
+                "name__value",
+                "secondary_in__name__value",
+                "secondary_out__name__value",
+                "secondary_in__size__value",
+            ],
             uniqueness_constraints=[["name__value"]],
             attributes=[
                 AttributeSchema(name="name", kind="Text"),
@@ -56,11 +61,21 @@ class TestMigration042(TestInfrahubApp):
             ],
             relationships=[
                 RelationshipSchema(
-                    name="secondary",
+                    name="secondary_in",
                     optional=False,
                     peer="SecondaryThing",
                     cardinality=RelationshipCardinality.ONE,
-                )
+                    direction=RelationshipDirection.INBOUND,
+                    identifier="secondary__oneway",
+                ),
+                RelationshipSchema(
+                    name="secondary_out",
+                    optional=False,
+                    peer="SecondaryThing",
+                    cardinality=RelationshipCardinality.ONE,
+                    direction=RelationshipDirection.OUTBOUND,
+                    identifier="secondary__oneway",
+                ),
             ],
         )
 
@@ -154,11 +169,23 @@ class TestMigration042(TestInfrahubApp):
 
     @pytest.fixture
     async def primary_thing_one_details(
-        self, db: InfrahubDatabase, load_schemas: SchemaBranch, secondary_thing_one_details: NodeDetails
+        self,
+        db: InfrahubDatabase,
+        load_schemas: SchemaBranch,
+        secondary_thing_one_details: NodeDetails,
+        secondary_thing_two_details: NodeDetails,
     ) -> NodeDetails:
-        secondary_thing_node = secondary_thing_one_details.node
+        secondary_one_node = secondary_thing_one_details.node
+        secondary_two_node = secondary_thing_two_details.node
         primary_thing = await Node.init(db=db, schema="PrimaryThing")
-        await primary_thing.new(db=db, name="primary_thing_1", color="red", size=1, secondary=secondary_thing_node.id)
+        await primary_thing.new(
+            db=db,
+            name="primary_thing_1",
+            color="red",
+            size=1,
+            secondary_in=secondary_one_node,
+            secondary_out=secondary_two_node,
+        )
         await primary_thing.save(db=db)
         return NodeDetails(
             node=primary_thing,
@@ -166,7 +193,12 @@ class TestMigration042(TestInfrahubApp):
             display_label=f"{primary_thing.name.value} {primary_thing.color.value}",
             human_friendly_id=[
                 str(v)
-                for v in (primary_thing.name.value, secondary_thing_node.name.value, secondary_thing_node.size.value)
+                for v in (
+                    primary_thing.name.value,
+                    secondary_one_node.name.value,
+                    secondary_two_node.name.value,
+                    secondary_one_node.size.value,
+                )
             ],
             status=NodeStatus.ACTIVE,
         )
@@ -179,14 +211,22 @@ class TestMigration042(TestInfrahubApp):
         secondary_thing_two_details: NodeDetails,
         secondary_thing_three_details: NodeDetails,
     ) -> NodeDetails:
-        secondary_node = secondary_thing_two_details.node
         primary_thing = await Node.init(db=db, schema="PrimaryThing")
-        await primary_thing.new(db=db, name="primary_thing_2", color="yellow", size=2, secondary=secondary_node.id)
+        await primary_thing.new(
+            db=db,
+            name="primary_thing_2",
+            color="yellow",
+            size=2,
+            secondary_in=secondary_thing_two_details.node,
+            secondary_out=secondary_thing_three_details.node,
+        )
         await primary_thing.save(db=db)
 
-        new_secondary_node = secondary_thing_three_details.node
+        new_secondary_in_node = secondary_thing_three_details.node
+        new_secondary_out_node = secondary_thing_two_details.node
         primary_thing.color.value = "double yellow"
-        await primary_thing.secondary.update(db=db, data=new_secondary_node)
+        await primary_thing.secondary_in.update(db=db, data=new_secondary_in_node)
+        await primary_thing.secondary_out.update(db=db, data=new_secondary_out_node)
         await primary_thing.save(db=db)
 
         return NodeDetails(
@@ -194,18 +234,34 @@ class TestMigration042(TestInfrahubApp):
             on_default_branch=True,
             display_label=f"{primary_thing.name.value} {primary_thing.color.value}",
             human_friendly_id=[
-                str(v) for v in (primary_thing.name.value, new_secondary_node.name.value, new_secondary_node.size.value)
+                str(v)
+                for v in (
+                    primary_thing.name.value,
+                    new_secondary_in_node.name.value,
+                    new_secondary_out_node.name.value,
+                    new_secondary_in_node.size.value,
+                )
             ],
             status=NodeStatus.ACTIVE,
         )
 
     @pytest.fixture
     async def primary_thing_three_deleted_details(
-        self, db: InfrahubDatabase, load_schemas: SchemaBranch, secondary_thing_two_details: NodeDetails
+        self,
+        db: InfrahubDatabase,
+        load_schemas: SchemaBranch,
+        secondary_thing_two_details: NodeDetails,
+        secondary_thing_three_details: NodeDetails,
     ) -> NodeDetails:
-        secondary_thing_node = secondary_thing_two_details.node
         primary_thing = await Node.init(db=db, schema="PrimaryThing")
-        await primary_thing.new(db=db, name="primary_thing_3", color="green", size=3, secondary=secondary_thing_node.id)
+        await primary_thing.new(
+            db=db,
+            name="primary_thing_3",
+            color="green",
+            size=3,
+            secondary_in=secondary_thing_two_details.node,
+            secondary_out=secondary_thing_three_details.node,
+        )
         await primary_thing.save(db=db)
         await primary_thing.delete(db=db)
         return NodeDetails(
@@ -247,11 +303,17 @@ class TestMigration042(TestInfrahubApp):
         db: InfrahubDatabase,
         load_schemas: SchemaBranch,
         secondary_thing_one_details: NodeDetails,
+        secondary_thing_two_details: NodeDetails,
         branch: Branch,
     ) -> NodeDetails:
         primary_thing = await Node.init(db=db, schema="PrimaryThing", branch=branch)
         await primary_thing.new(
-            db=db, name="primary_thing_1_branch", color="blue", size=1, secondary=secondary_thing_one_details.node.id
+            db=db,
+            name="primary_thing_1_branch",
+            color="blue",
+            size=1,
+            secondary_in=secondary_thing_one_details.node,
+            secondary_out=secondary_thing_two_details.node,
         )
         await primary_thing.save(db=db)
         return NodeDetails(
@@ -263,6 +325,7 @@ class TestMigration042(TestInfrahubApp):
                 for v in (
                     primary_thing.name.value,
                     secondary_thing_one_details.node.name.value,
+                    secondary_thing_two_details.node.name.value,
                     secondary_thing_one_details.node.size.value,
                 )
             ],
@@ -303,7 +366,9 @@ class TestMigration042(TestInfrahubApp):
         primary_thing.color.value = "purple"
         primary_thing.size.value = 999
         # update secondary relationship on branch
-        await primary_thing.secondary.update(db=db, data=secondary_thing_three_branch_update_details.node)
+        new_secondary_in_node = secondary_thing_three_branch_update_details.node
+        current_secondary_out_node = await primary_thing.secondary_out.get_peer(db=db)
+        await primary_thing.secondary_in.update(db=db, data=new_secondary_in_node)
         await primary_thing.save(db=db)
         return NodeDetails(
             node=primary_thing,
@@ -313,8 +378,9 @@ class TestMigration042(TestInfrahubApp):
                 str(v)
                 for v in (
                     primary_thing.name.value,
-                    secondary_thing_three_branch_update_details.node.name.value,
-                    secondary_thing_three_branch_update_details.node.size.value,
+                    new_secondary_in_node.name.value,
+                    current_secondary_out_node.name.value,
+                    new_secondary_in_node.size.value,
                 )
             ],
             status=NodeStatus.ACTIVE,
@@ -488,7 +554,6 @@ DETACH DELETE attr
         await verify_no_duplicate_relationships(db=db)
 
 
-# TODO: test relationships with same name going different directions
 # TODO: test branch-agnostic attributes and relationships
 # TODO: test display labels and HFIDs updated on a branch with the same value on main
 # TODO: test HFID/display labels update on branch

--- a/backend/tests/unit/core/migrations/graph/test_042_043.py
+++ b/backend/tests/unit/core/migrations/graph/test_042_043.py
@@ -95,10 +95,10 @@ class TestMigration042(TestInfrahubApp):
             display_labels=["name__value", "size__value"],
             human_friendly_id=["name__value", "color__value", "agnostic_smell__value"],
             attributes=[
-                AttributeSchema(name="name", kind="Text"),
+                AttributeSchema(name="name", kind="Text", unique=True),
                 AttributeSchema(name="color", kind="Text"),
                 AttributeSchema(name="size", kind="Number"),
-                AttributeSchema(name="agnostic_smell", kind="Text", branch=BranchSupportType.AGNOSTIC),
+                AttributeSchema(name="agnostic_smell", kind="Text", branch=BranchSupportType.AGNOSTIC, unique=True),
             ],
         )
 

--- a/backend/tests/unit/core/migrations/graph/test_042_043.py
+++ b/backend/tests/unit/core/migrations/graph/test_042_043.py
@@ -24,7 +24,7 @@ class TestMigration042(TestInfrahubApp):
             name="Thing",
             namespace="Primary",
             display_labels=["name__value", "color__value"],
-            human_friendly_id=["name__value", "secondary__color__value", "secondary__size__value"],
+            human_friendly_id=["name__value", "secondary__name__value", "secondary__size__value"],
             uniqueness_constraints=[["name__value"]],
             attributes=[
                 AttributeSchema(name="name", kind="Text"),
@@ -46,6 +46,8 @@ class TestMigration042(TestInfrahubApp):
         return NodeSchema(
             name="Thing",
             namespace="Secondary",
+            display_labels=["name__value", "size__value"],
+            human_friendly_id=["name__value", "color__value"],
             attributes=[
                 AttributeSchema(name="name", kind="Text"),
                 AttributeSchema(name="color", kind="Text"),
@@ -54,14 +56,13 @@ class TestMigration042(TestInfrahubApp):
         )
 
     @pytest.fixture
-    async def initial_dataset(
+    async def load_schemas(
         self,
         db: InfrahubDatabase,
         default_branch: Branch,
-        register_core_models_schema: SchemaBranch,
         primary_thing_schema: NodeSchema,
         secondary_thing_schema: NodeSchema,
-    ) -> dict[str, Node]:
+    ) -> SchemaBranch:
         await load_schema(
             db=db,
             schema=SchemaRoot(nodes=[primary_thing_schema, secondary_thing_schema]),
@@ -79,20 +80,51 @@ class TestMigration042(TestInfrahubApp):
             name=default_branch.name,
         )
         await registry.schema.load_schema_to_db(db=db, schema=small_schema_branch)
+        return registry.schema.get_schema_branch(name=default_branch.name)
 
-        # create secondary things
-        secondary_thing = await Node.init(db=db, schema=secondary_thing_schema)
+    @pytest.fixture
+    async def secondary_thing_one(
+        self, db: InfrahubDatabase, load_schemas: SchemaBranch
+    ) -> tuple[Node, str, list[str]]:
+        secondary_thing = await Node.init(db=db, schema="SecondaryThing")
         await secondary_thing.new(db=db, name="secondary_thing_1", color="not red", size=-1)
         await secondary_thing.save(db=db)
+        return (
+            secondary_thing,
+            f"{secondary_thing.name.value} {secondary_thing.size.value}",
+            [str(v) for v in (secondary_thing.name.value, secondary_thing.color.value)],
+        )
 
-        # create_primary_things
-        primary_thing = await Node.init(db=db, schema=primary_thing_schema)
-        await primary_thing.new(db=db, name="primary_thing_1", color="red", size=1, secondary=secondary_thing)
+    @pytest.fixture
+    async def primary_thing_one(
+        self, db: InfrahubDatabase, load_schemas: SchemaBranch, secondary_thing_one: tuple[Node, str, list[str]]
+    ) -> tuple[Node, str, list[str]]:
+        secondary_thing_node = secondary_thing_one[0]
+        primary_thing = await Node.init(db=db, schema="PrimaryThing")
+        await primary_thing.new(db=db, name="primary_thing_1", color="red", size=1, secondary=secondary_thing_node.id)
         await primary_thing.save(db=db)
+        return (
+            primary_thing,
+            f"{primary_thing.name.value} {primary_thing.color.value}",
+            [
+                str(v)
+                for v in (primary_thing.name.value, secondary_thing_node.name.value, secondary_thing_node.size.value)
+            ],
+        )
 
+    @pytest.fixture
+    async def initial_dataset(
+        self,
+        db: InfrahubDatabase,
+        default_branch: Branch,
+        register_core_models_schema: SchemaBranch,
+        load_schemas: SchemaBranch,
+        primary_thing_one: tuple[Node, str, list[str]],
+        secondary_thing_one: tuple[Node, str, list[str]],
+    ) -> dict[str, tuple[Node, str, list[str]]]:
         return {
-            "secondary_thing": secondary_thing,
-            "primary_thing": primary_thing,
+            "secondary_thing": secondary_thing_one,
+            "primary_thing": primary_thing_one,
         }
 
     async def erase_hfid_and_display_label(self, db: InfrahubDatabase) -> Node:
@@ -122,7 +154,7 @@ DETACH DELETE attr
         return result_map
 
     async def test_migration_042_043(
-        self, db: InfrahubDatabase, default_branch: Branch, initial_dataset: dict[str, Node]
+        self, db: InfrahubDatabase, default_branch: Branch, initial_dataset: dict[str, tuple[Node, str, list[str]]]
     ) -> None:
         await self.erase_hfid_and_display_label(db=db)
 
@@ -148,14 +180,11 @@ DETACH DELETE attr
             db=db,
             branch=default_branch,
             attribute_names=["human_friendly_id", "display_label"],
-            node_ids=[initial_dataset["primary_thing"].id, initial_dataset["secondary_thing"].id],
+            node_ids=[node[0].id for node in initial_dataset.values()],
         )
-        assert attribute_values_map[initial_dataset["primary_thing"].id]["display_label"] == "primary_thing_1 red"
-        assert json.loads(attribute_values_map[initial_dataset["primary_thing"].id]["human_friendly_id"]) == [
-            "primary_thing_1",
-            "not red",
-            "-1",
-        ]
+        for node, display_label, human_friendly_id in initial_dataset.values():
+            assert attribute_values_map[node.id]["display_label"] == display_label
+            assert json.loads(attribute_values_map[node.id]["human_friendly_id"]) == human_friendly_id
 
 
 # TODO: test added/updated/removed nodes on default branch

--- a/backend/tests/unit/core/migrations/graph/test_042_043.py
+++ b/backend/tests/unit/core/migrations/graph/test_042_043.py
@@ -1,4 +1,6 @@
 import json
+from dataclasses import dataclass
+from enum import StrEnum
 from typing import Any
 
 import pytest
@@ -15,6 +17,23 @@ from infrahub.core.schema.schema_branch import SchemaBranch
 from infrahub.database import InfrahubDatabase
 from tests.helpers.schema import load_schema
 from tests.helpers.test_app import TestInfrahubApp
+
+
+class NodeStatus(StrEnum):
+    ACTIVE = "active"
+    DELETED = "deleted"
+
+
+@dataclass
+class NodeDetails:
+    node: Node
+    display_label: str | None
+    human_friendly_id: list[str] | None
+    status: NodeStatus
+
+    @property
+    def is_active(self) -> bool:
+        return self.status is NodeStatus.ACTIVE
 
 
 class TestMigration042(TestInfrahubApp):
@@ -83,33 +102,83 @@ class TestMigration042(TestInfrahubApp):
         return registry.schema.get_schema_branch(name=default_branch.name)
 
     @pytest.fixture
-    async def secondary_thing_one(
-        self, db: InfrahubDatabase, load_schemas: SchemaBranch
-    ) -> tuple[Node, str, list[str]]:
+    async def secondary_thing_one_with_details(self, db: InfrahubDatabase, load_schemas: SchemaBranch) -> NodeDetails:
         secondary_thing = await Node.init(db=db, schema="SecondaryThing")
         await secondary_thing.new(db=db, name="secondary_thing_1", color="not red", size=-1)
         await secondary_thing.save(db=db)
-        return (
-            secondary_thing,
-            f"{secondary_thing.name.value} {secondary_thing.size.value}",
-            [str(v) for v in (secondary_thing.name.value, secondary_thing.color.value)],
+        return NodeDetails(
+            node=secondary_thing,
+            display_label=f"{secondary_thing.name.value} {secondary_thing.size.value}",
+            human_friendly_id=[str(v) for v in (secondary_thing.name.value, secondary_thing.color.value)],
+            status=NodeStatus.ACTIVE,
         )
 
     @pytest.fixture
-    async def primary_thing_one(
-        self, db: InfrahubDatabase, load_schemas: SchemaBranch, secondary_thing_one: tuple[Node, str, list[str]]
-    ) -> tuple[Node, str, list[str]]:
-        secondary_thing_node = secondary_thing_one[0]
+    async def secondary_thing_two_with_details(self, db: InfrahubDatabase, load_schemas: SchemaBranch) -> NodeDetails:
+        secondary_thing = await Node.init(db=db, schema="SecondaryThing")
+        await secondary_thing.new(db=db, name="secondary_thing_2", color="orange", size=42)
+        await secondary_thing.save(db=db)
+        return NodeDetails(
+            node=secondary_thing,
+            display_label=f"{secondary_thing.name.value} {secondary_thing.size.value}",
+            human_friendly_id=[str(v) for v in (secondary_thing.name.value, secondary_thing.color.value)],
+            status=NodeStatus.ACTIVE,
+        )
+
+    @pytest.fixture
+    async def primary_thing_one_with_details(
+        self, db: InfrahubDatabase, load_schemas: SchemaBranch, secondary_thing_one_with_details: NodeDetails
+    ) -> NodeDetails:
+        secondary_thing_node = secondary_thing_one_with_details.node
         primary_thing = await Node.init(db=db, schema="PrimaryThing")
         await primary_thing.new(db=db, name="primary_thing_1", color="red", size=1, secondary=secondary_thing_node.id)
         await primary_thing.save(db=db)
-        return (
-            primary_thing,
-            f"{primary_thing.name.value} {primary_thing.color.value}",
-            [
+        return NodeDetails(
+            node=primary_thing,
+            display_label=f"{primary_thing.name.value} {primary_thing.color.value}",
+            human_friendly_id=[
                 str(v)
                 for v in (primary_thing.name.value, secondary_thing_node.name.value, secondary_thing_node.size.value)
             ],
+            status=NodeStatus.ACTIVE,
+        )
+
+    @pytest.fixture
+    async def primary_thing_two_with_details(
+        self, db: InfrahubDatabase, load_schemas: SchemaBranch, secondary_thing_two_with_details: NodeDetails
+    ) -> NodeDetails:
+        secondary_thing_node = secondary_thing_two_with_details.node
+        primary_thing = await Node.init(db=db, schema="PrimaryThing")
+        await primary_thing.new(
+            db=db, name="primary_thing_2", color="yellow", size=2, secondary=secondary_thing_node.id
+        )
+        await primary_thing.save(db=db)
+        primary_thing.color.value = "double yellow"
+        await primary_thing.save(db=db)
+        return NodeDetails(
+            node=primary_thing,
+            display_label=f"{primary_thing.name.value} {primary_thing.color.value}",
+            human_friendly_id=[
+                str(v)
+                for v in (primary_thing.name.value, secondary_thing_node.name.value, secondary_thing_node.size.value)
+            ],
+            status=NodeStatus.ACTIVE,
+        )
+
+    @pytest.fixture
+    async def primary_thing_three_deleted_with_details(
+        self, db: InfrahubDatabase, load_schemas: SchemaBranch, secondary_thing_two_with_details: NodeDetails
+    ) -> NodeDetails:
+        secondary_thing_node = secondary_thing_two_with_details.node
+        primary_thing = await Node.init(db=db, schema="PrimaryThing")
+        await primary_thing.new(db=db, name="primary_thing_3", color="green", size=3, secondary=secondary_thing_node.id)
+        await primary_thing.save(db=db)
+        await primary_thing.delete(db=db)
+        return NodeDetails(
+            node=primary_thing,
+            display_label=None,
+            human_friendly_id=None,
+            status=NodeStatus.DELETED,
         )
 
     @pytest.fixture
@@ -119,12 +188,18 @@ class TestMigration042(TestInfrahubApp):
         default_branch: Branch,
         register_core_models_schema: SchemaBranch,
         load_schemas: SchemaBranch,
-        primary_thing_one: tuple[Node, str, list[str]],
-        secondary_thing_one: tuple[Node, str, list[str]],
-    ) -> dict[str, tuple[Node, str, list[str]]]:
+        primary_thing_one_with_details: NodeDetails,
+        secondary_thing_one_with_details: NodeDetails,
+        primary_thing_two_with_details: NodeDetails,
+        secondary_thing_two_with_details: NodeDetails,
+        primary_thing_three_deleted_with_details: NodeDetails,
+    ) -> dict[str, NodeDetails]:
         return {
-            "secondary_thing": secondary_thing_one,
-            "primary_thing": primary_thing_one,
+            "secondary_thing": secondary_thing_one_with_details,
+            "primary_thing": primary_thing_one_with_details,
+            "secondary_thing_two": secondary_thing_two_with_details,
+            "primary_thing_two": primary_thing_two_with_details,
+            "primary_thing_three_deleted": primary_thing_three_deleted_with_details,
         }
 
     async def erase_hfid_and_display_label(self, db: InfrahubDatabase) -> Node:
@@ -148,13 +223,15 @@ DETACH DELETE attr
         node_attributes_map = query.get_attributes_group_by_node()
         result_map = {}
         for node_id in node_ids:
+            if node_id not in node_attributes_map:
+                continue
             result_map[node_id] = {}
             for attr_name in attribute_names:
                 result_map[node_id][attr_name] = node_attributes_map[node_id].attrs[attr_name].value
         return result_map
 
     async def test_migration_042_043(
-        self, db: InfrahubDatabase, default_branch: Branch, initial_dataset: dict[str, tuple[Node, str, list[str]]]
+        self, db: InfrahubDatabase, default_branch: Branch, initial_dataset: dict[str, NodeDetails]
     ) -> None:
         await self.erase_hfid_and_display_label(db=db)
 
@@ -180,14 +257,21 @@ DETACH DELETE attr
             db=db,
             branch=default_branch,
             attribute_names=["human_friendly_id", "display_label"],
-            node_ids=[node[0].id for node in initial_dataset.values()],
+            node_ids=[node_details.node.id for node_details in initial_dataset.values()],
         )
-        for node, display_label, human_friendly_id in initial_dataset.values():
-            assert attribute_values_map[node.id]["display_label"] == display_label
-            assert json.loads(attribute_values_map[node.id]["human_friendly_id"]) == human_friendly_id
+
+        expected_ids = {node_details.node.id for node_details in initial_dataset.values() if node_details.is_active}
+        assert set(attribute_values_map.keys()) == expected_ids
+        for node_details in initial_dataset.values():
+            if not node_details.is_active:
+                continue
+            assert attribute_values_map[node_details.node.id]["display_label"] == node_details.display_label
+            assert (
+                json.loads(attribute_values_map[node_details.node.id]["human_friendly_id"])
+                == node_details.human_friendly_id
+            )
 
 
-# TODO: test added/updated/removed nodes on default branch
 # TODO: test added/updated/removed nodes on branch
 # TODO: test updating relationships and values of peers
 # TODO: test relationships with same name going different directions

--- a/backend/tests/unit/core/migrations/graph/test_042_043.py
+++ b/backend/tests/unit/core/migrations/graph/test_042_043.py
@@ -7,7 +7,7 @@ import pytest
 
 from infrahub.core import registry
 from infrahub.core.branch.models import Branch
-from infrahub.core.constants import RelationshipCardinality, RelationshipDirection
+from infrahub.core.constants import BranchSupportType, RelationshipCardinality, RelationshipDirection
 from infrahub.core.initialization import create_branch
 from infrahub.core.manager import NodeManager
 from infrahub.core.migrations.graph.m042_create_hfid_display_label_in_db import Migration042
@@ -46,18 +46,20 @@ class TestMigration042(TestInfrahubApp):
         return NodeSchema(
             name="Thing",
             namespace="Primary",
-            display_labels=["name__value", "color__value"],
+            display_labels=["name__value", "color__value", "agnostic_smell__value"],
             human_friendly_id=[
                 "name__value",
+                "agnostic_smell__value",
                 "secondary_in__name__value",
-                "secondary_out__name__value",
-                "secondary_in__size__value",
+                "secondary_out__size__value",
+                "agnostic_secondary__agnostic_smell__value",
             ],
             uniqueness_constraints=[["name__value"]],
             attributes=[
                 AttributeSchema(name="name", kind="Text"),
                 AttributeSchema(name="color", kind="Text"),
                 AttributeSchema(name="size", kind="Number"),
+                AttributeSchema(name="agnostic_smell", kind="Text", branch=BranchSupportType.AGNOSTIC),
             ],
             relationships=[
                 RelationshipSchema(
@@ -76,6 +78,13 @@ class TestMigration042(TestInfrahubApp):
                     direction=RelationshipDirection.OUTBOUND,
                     identifier="secondary__oneway",
                 ),
+                RelationshipSchema(
+                    name="agnostic_secondary",
+                    optional=False,
+                    peer="SecondaryThing",
+                    cardinality=RelationshipCardinality.ONE,
+                    branch=BranchSupportType.AGNOSTIC,
+                ),
             ],
         )
 
@@ -85,11 +94,12 @@ class TestMigration042(TestInfrahubApp):
             name="Thing",
             namespace="Secondary",
             display_labels=["name__value", "size__value"],
-            human_friendly_id=["name__value", "color__value"],
+            human_friendly_id=["name__value", "color__value", "agnostic_smell__value"],
             attributes=[
                 AttributeSchema(name="name", kind="Text"),
                 AttributeSchema(name="color", kind="Text"),
                 AttributeSchema(name="size", kind="Number"),
+                AttributeSchema(name="agnostic_smell", kind="Text", branch=BranchSupportType.AGNOSTIC),
             ],
         )
 
@@ -127,45 +137,71 @@ class TestMigration042(TestInfrahubApp):
     @pytest.fixture
     async def secondary_thing_one_details(self, db: InfrahubDatabase, load_schemas: SchemaBranch) -> NodeDetails:
         secondary_thing = await Node.init(db=db, schema="SecondaryThing")
-        await secondary_thing.new(db=db, name="secondary_thing_1", color="not red", size=-1)
+        await secondary_thing.new(db=db, name="secondary_thing_1", color="not red", size=-1, agnostic_smell="okay")
         await secondary_thing.save(db=db)
         return NodeDetails(
             node=secondary_thing,
             on_default_branch=True,
             display_label=f"{secondary_thing.name.value} {secondary_thing.size.value}",
-            human_friendly_id=[str(v) for v in (secondary_thing.name.value, secondary_thing.color.value)],
+            human_friendly_id=[
+                str(v)
+                for v in (secondary_thing.name.value, secondary_thing.color.value, secondary_thing.agnostic_smell.value)
+            ],
             status=NodeStatus.ACTIVE,
         )
 
     @pytest.fixture
     async def secondary_thing_two_details(self, db: InfrahubDatabase, load_schemas: SchemaBranch) -> NodeDetails:
         secondary_thing = await Node.init(db=db, schema="SecondaryThing")
-        await secondary_thing.new(db=db, name="secondary_thing_2", color="orange", size=42)
+        await secondary_thing.new(
+            db=db, name="secondary_thing_2", color="orange", size=42, agnostic_smell="pretty good"
+        )
         await secondary_thing.save(db=db)
         return NodeDetails(
             node=secondary_thing,
             on_default_branch=True,
             display_label=f"{secondary_thing.name.value} {secondary_thing.size.value}",
-            human_friendly_id=[str(v) for v in (secondary_thing.name.value, secondary_thing.color.value)],
+            human_friendly_id=[
+                str(v)
+                for v in (secondary_thing.name.value, secondary_thing.color.value, secondary_thing.agnostic_smell.value)
+            ],
             status=NodeStatus.ACTIVE,
         )
 
     @pytest.fixture
-    async def secondary_thing_three_details(self, db: InfrahubDatabase, load_schemas: SchemaBranch) -> NodeDetails:
+    async def secondary_thing_three_agnostic_value_update(self) -> str:
+        return "more okay"
+
+    @pytest.fixture
+    async def secondary_thing_three_details(
+        self, db: InfrahubDatabase, load_schemas: SchemaBranch, secondary_thing_three_agnostic_value_update: str
+    ) -> NodeDetails:
         secondary_thing = await Node.init(db=db, schema="SecondaryThing")
-        await secondary_thing.new(db=db, name="secondary_thing_3", color="inidigo", size=53)
+        await secondary_thing.new(db=db, name="secondary_thing_3", color="inidigo", size=53, agnostic_smell="quite bad")
         await secondary_thing.save(db=db)
         secondary_thing.color.value = "indigogo"
         secondary_thing.size.value = 54
+        secondary_thing.agnostic_smell.value = "really quite bad"
         await secondary_thing.save(db=db)
 
         return NodeDetails(
             node=secondary_thing,
             on_default_branch=True,
             display_label=f"{secondary_thing.name.value} {secondary_thing.size.value}",
-            human_friendly_id=[str(v) for v in (secondary_thing.name.value, secondary_thing.color.value)],
+            human_friendly_id=[
+                str(v)
+                for v in (
+                    secondary_thing.name.value,
+                    secondary_thing.color.value,
+                    secondary_thing_three_agnostic_value_update,
+                )
+            ],
             status=NodeStatus.ACTIVE,
         )
+
+    @pytest.fixture
+    async def primary_thing_one_agnostic_value_update(self) -> str:
+        return "very lilac"
 
     @pytest.fixture
     async def primary_thing_one_details(
@@ -174,30 +210,37 @@ class TestMigration042(TestInfrahubApp):
         load_schemas: SchemaBranch,
         secondary_thing_one_details: NodeDetails,
         secondary_thing_two_details: NodeDetails,
+        secondary_thing_three_details: NodeDetails,
+        secondary_thing_three_agnostic_value_update: str,
+        primary_thing_one_agnostic_value_update: str,
     ) -> NodeDetails:
         secondary_one_node = secondary_thing_one_details.node
         secondary_two_node = secondary_thing_two_details.node
+        secondary_three_node = secondary_thing_three_details.node
         primary_thing = await Node.init(db=db, schema="PrimaryThing")
         await primary_thing.new(
             db=db,
             name="primary_thing_1",
             color="red",
             size=1,
+            agnostic_smell="lilac",
             secondary_in=secondary_one_node,
             secondary_out=secondary_two_node,
+            agnostic_secondary=secondary_three_node,
         )
         await primary_thing.save(db=db)
         return NodeDetails(
             node=primary_thing,
             on_default_branch=True,
-            display_label=f"{primary_thing.name.value} {primary_thing.color.value}",
+            display_label=f"{primary_thing.name.value} {primary_thing.color.value} {primary_thing_one_agnostic_value_update}",
             human_friendly_id=[
                 str(v)
                 for v in (
                     primary_thing.name.value,
+                    primary_thing_one_agnostic_value_update,
                     secondary_one_node.name.value,
-                    secondary_two_node.name.value,
-                    secondary_one_node.size.value,
+                    secondary_two_node.size.value,
+                    secondary_thing_three_agnostic_value_update,
                 )
             ],
             status=NodeStatus.ACTIVE,
@@ -208,6 +251,7 @@ class TestMigration042(TestInfrahubApp):
         self,
         db: InfrahubDatabase,
         load_schemas: SchemaBranch,
+        secondary_thing_one_details: NodeDetails,
         secondary_thing_two_details: NodeDetails,
         secondary_thing_three_details: NodeDetails,
     ) -> NodeDetails:
@@ -217,30 +261,38 @@ class TestMigration042(TestInfrahubApp):
             name="primary_thing_2",
             color="yellow",
             size=2,
+            agnostic_smell="violet",
             secondary_in=secondary_thing_two_details.node,
             secondary_out=secondary_thing_three_details.node,
+            agnostic_secondary=secondary_thing_one_details.node,
         )
         await primary_thing.save(db=db)
 
         new_secondary_in_node = secondary_thing_three_details.node
-        new_secondary_out_node = secondary_thing_two_details.node
+        new_secondary_out_node = secondary_thing_one_details.node
+        new_agnostic_secondary_node = secondary_thing_two_details.node
         primary_thing.color.value = "double yellow"
+        primary_thing.agnostic_smell.value = "ultra violet"
         await primary_thing.secondary_in.update(db=db, data=new_secondary_in_node)
         await primary_thing.secondary_out.update(db=db, data=new_secondary_out_node)
+        await primary_thing.agnostic_secondary.update(db=db, data=new_agnostic_secondary_node)
         await primary_thing.save(db=db)
 
         return NodeDetails(
             node=primary_thing,
             on_default_branch=True,
+            # a bug in deleting branch-aware nodes with branch-agnostic relationships prevents this from working correctly
+            # https://github.com/opsmill/infrahub/issues/7513
+            # display_label=f"{primary_thing.name.value} {primary_thing.color.value} {primary_thing.agnostic_smell.value}",
             display_label=f"{primary_thing.name.value} {primary_thing.color.value}",
             human_friendly_id=[
-                str(v)
-                for v in (
-                    primary_thing.name.value,
-                    new_secondary_in_node.name.value,
-                    new_secondary_out_node.name.value,
-                    new_secondary_in_node.size.value,
-                )
+                str(primary_thing.name.value),
+                # https://github.com/opsmill/infrahub/issues/7513 here too
+                # primary_thing.agnostic_smell.value,
+                None,
+                str(new_secondary_in_node.name.value),
+                str(new_secondary_out_node.size.value),
+                str(new_agnostic_secondary_node.agnostic_smell.value),
             ],
             status=NodeStatus.ACTIVE,
         )
@@ -258,9 +310,11 @@ class TestMigration042(TestInfrahubApp):
             db=db,
             name="primary_thing_3",
             color="green",
+            agnostic_smell="emerald",
             size=3,
             secondary_in=secondary_thing_two_details.node,
             secondary_out=secondary_thing_three_details.node,
+            agnostic_secondary=secondary_thing_two_details.node,
         )
         await primary_thing.save(db=db)
         await primary_thing.delete(db=db)
@@ -283,17 +337,26 @@ class TestMigration042(TestInfrahubApp):
         load_schemas: SchemaBranch,
         branch: Branch,
         secondary_thing_three_details: NodeDetails,
+        secondary_thing_three_agnostic_value_update: str,
     ) -> NodeDetails:
         secondary_thing = await NodeManager.get_one(db=db, branch=branch, id=secondary_thing_three_details.node.id)
         secondary_thing.color.value = "indigogogo-branch"
         secondary_thing.size.value = 55
+        secondary_thing.agnostic_smell.value = secondary_thing_three_agnostic_value_update
         await secondary_thing.save(db=db)
 
         return NodeDetails(
             node=secondary_thing,
             on_default_branch=False,
             display_label=f"{secondary_thing.name.value} {secondary_thing.size.value}",
-            human_friendly_id=[str(v) for v in (secondary_thing.name.value, secondary_thing.color.value)],
+            human_friendly_id=[
+                str(v)
+                for v in (
+                    secondary_thing.name.value,
+                    secondary_thing.color.value,
+                    secondary_thing_three_agnostic_value_update,
+                )
+            ],
             status=NodeStatus.ACTIVE,
         )
 
@@ -311,22 +374,25 @@ class TestMigration042(TestInfrahubApp):
             db=db,
             name="primary_thing_1_branch",
             color="blue",
+            agnostic_smell="blueberry",
             size=1,
             secondary_in=secondary_thing_one_details.node,
             secondary_out=secondary_thing_two_details.node,
+            agnostic_secondary=secondary_thing_two_details.node,
         )
         await primary_thing.save(db=db)
         return NodeDetails(
             node=primary_thing,
             on_default_branch=False,
-            display_label=f"{primary_thing.name.value} {primary_thing.color.value}",
+            display_label=f"{primary_thing.name.value} {primary_thing.color.value} {primary_thing.agnostic_smell.value}",
             human_friendly_id=[
                 str(v)
                 for v in (
                     primary_thing.name.value,
+                    primary_thing.agnostic_smell.value,
                     secondary_thing_one_details.node.name.value,
-                    secondary_thing_two_details.node.name.value,
-                    secondary_thing_one_details.node.size.value,
+                    secondary_thing_two_details.node.size.value,
+                    secondary_thing_two_details.node.agnostic_smell.value,
                 )
             ],
             status=NodeStatus.ACTIVE,
@@ -360,11 +426,14 @@ class TestMigration042(TestInfrahubApp):
         primary_thing_one_details: NodeDetails,
         branch: Branch,
         secondary_thing_three_branch_update_details: NodeDetails,
+        primary_thing_one_agnostic_value_update: str,
+        secondary_thing_three_agnostic_value_update: str,
     ) -> NodeDetails:
         primary_thing = await NodeManager.get_one(db=db, branch=branch, id=primary_thing_one_details.node.id)
         # Update some attributes on the branch
         primary_thing.color.value = "purple"
         primary_thing.size.value = 999
+        primary_thing.agnostic_smell.value = primary_thing_one_agnostic_value_update
         # update secondary relationship on branch
         new_secondary_in_node = secondary_thing_three_branch_update_details.node
         current_secondary_out_node = await primary_thing.secondary_out.get_peer(db=db)
@@ -373,14 +442,15 @@ class TestMigration042(TestInfrahubApp):
         return NodeDetails(
             node=primary_thing,
             on_default_branch=False,
-            display_label=f"{primary_thing.name.value} {primary_thing.color.value}",
+            display_label=f"{primary_thing.name.value} {primary_thing.color.value} {primary_thing_one_agnostic_value_update}",
             human_friendly_id=[
                 str(v)
                 for v in (
                     primary_thing.name.value,
+                    primary_thing_one_agnostic_value_update,
                     new_secondary_in_node.name.value,
-                    current_secondary_out_node.name.value,
-                    new_secondary_in_node.size.value,
+                    current_secondary_out_node.size.value,
+                    secondary_thing_three_agnostic_value_update,
                 )
             ],
             status=NodeStatus.ACTIVE,
@@ -554,6 +624,5 @@ DETACH DELETE attr
         await verify_no_duplicate_relationships(db=db)
 
 
-# TODO: test branch-agnostic attributes and relationships
 # TODO: test display labels and HFIDs updated on a branch with the same value on main
 # TODO: test HFID/display labels update on branch

--- a/backend/tests/unit/core/migrations/graph/test_042_043.py
+++ b/backend/tests/unit/core/migrations/graph/test_042_043.py
@@ -30,7 +30,6 @@ class NodeStatus(StrEnum):
 @dataclass
 class NodeDetails:
     node: Node
-    on_default_branch: bool
     display_label: str | None
     human_friendly_id: list[str] | None
     status: NodeStatus
@@ -103,45 +102,38 @@ class TestMigration042(TestInfrahubApp):
             ],
         )
 
+    async def _do_load_schemas(self, db: InfrahubDatabase, branch: Branch, schemas: list[NodeSchema]) -> SchemaBranch:
+        await load_schema(
+            db=db,
+            schema=SchemaRoot(nodes=schemas),
+            branch_name=branch.name,
+            update_db=True,
+        )
+        return registry.schema.get_schema_branch(name=branch.name)
+
     @pytest.fixture
-    async def load_schemas(
+    async def load_schemas_main(
         self,
         db: InfrahubDatabase,
         default_branch: Branch,
         primary_thing_schema: NodeSchema,
         secondary_thing_schema: NodeSchema,
     ) -> SchemaBranch:
-        await load_schema(
-            db=db,
-            schema=SchemaRoot(nodes=[primary_thing_schema, secondary_thing_schema]),
-            branch_name=default_branch.name,
-            update_db=True,
+        return await self._do_load_schemas(
+            db=db, branch=default_branch, schemas=[primary_thing_schema, secondary_thing_schema]
         )
-        primary_thing_schema = registry.schema.get_node_schema(name="PrimaryThing", branch=default_branch)
-        secondary_thing_schema = registry.schema.get_node_schema(name="SecondaryThing", branch=default_branch)
-        # just saving and loading these two schemas speeds up the test
-        small_schema_branch = SchemaBranch(
-            cache={
-                primary_thing_schema.kind: primary_thing_schema,
-                secondary_thing_schema.kind: secondary_thing_schema,
-            },
-            name=default_branch.name,
-        )
-        await registry.schema.load_schema_to_db(db=db, schema=small_schema_branch)
-        return registry.schema.get_schema_branch(name=default_branch.name)
 
     @pytest.fixture
     async def branch(self, db: InfrahubDatabase, default_branch: Branch) -> Branch:
         return await create_branch(db=db, branch_name="migration-test-branch")
 
     @pytest.fixture
-    async def secondary_thing_one_details(self, db: InfrahubDatabase, load_schemas: SchemaBranch) -> NodeDetails:
+    async def secondary_thing_one_details(self, db: InfrahubDatabase, load_schemas_main: SchemaBranch) -> NodeDetails:
         secondary_thing = await Node.init(db=db, schema="SecondaryThing")
         await secondary_thing.new(db=db, name="secondary_thing_1", color="not red", size=-1, agnostic_smell="okay")
         await secondary_thing.save(db=db)
         return NodeDetails(
             node=secondary_thing,
-            on_default_branch=True,
             display_label=f"{secondary_thing.name.value} {secondary_thing.size.value}",
             human_friendly_id=[
                 str(v)
@@ -151,7 +143,7 @@ class TestMigration042(TestInfrahubApp):
         )
 
     @pytest.fixture
-    async def secondary_thing_two_details(self, db: InfrahubDatabase, load_schemas: SchemaBranch) -> NodeDetails:
+    async def secondary_thing_two_details(self, db: InfrahubDatabase, load_schemas_main: SchemaBranch) -> NodeDetails:
         secondary_thing = await Node.init(db=db, schema="SecondaryThing")
         await secondary_thing.new(
             db=db, name="secondary_thing_2", color="orange", size=42, agnostic_smell="pretty good"
@@ -159,7 +151,6 @@ class TestMigration042(TestInfrahubApp):
         await secondary_thing.save(db=db)
         return NodeDetails(
             node=secondary_thing,
-            on_default_branch=True,
             display_label=f"{secondary_thing.name.value} {secondary_thing.size.value}",
             human_friendly_id=[
                 str(v)
@@ -174,7 +165,7 @@ class TestMigration042(TestInfrahubApp):
 
     @pytest.fixture
     async def secondary_thing_three_details(
-        self, db: InfrahubDatabase, load_schemas: SchemaBranch, secondary_thing_three_agnostic_value_update: str
+        self, db: InfrahubDatabase, load_schemas_main: SchemaBranch, secondary_thing_three_agnostic_value_update: str
     ) -> NodeDetails:
         secondary_thing = await Node.init(db=db, schema="SecondaryThing")
         await secondary_thing.new(db=db, name="secondary_thing_3", color="inidigo", size=53, agnostic_smell="quite bad")
@@ -186,7 +177,6 @@ class TestMigration042(TestInfrahubApp):
 
         return NodeDetails(
             node=secondary_thing,
-            on_default_branch=True,
             display_label=f"{secondary_thing.name.value} {secondary_thing.size.value}",
             human_friendly_id=[
                 str(v)
@@ -207,7 +197,7 @@ class TestMigration042(TestInfrahubApp):
     async def primary_thing_one_details(
         self,
         db: InfrahubDatabase,
-        load_schemas: SchemaBranch,
+        load_schemas_main: SchemaBranch,
         secondary_thing_one_details: NodeDetails,
         secondary_thing_two_details: NodeDetails,
         secondary_thing_three_details: NodeDetails,
@@ -231,7 +221,6 @@ class TestMigration042(TestInfrahubApp):
         await primary_thing.save(db=db)
         return NodeDetails(
             node=primary_thing,
-            on_default_branch=True,
             display_label=f"{primary_thing.name.value} {primary_thing.color.value} {primary_thing_one_agnostic_value_update}",
             human_friendly_id=[
                 str(v)
@@ -250,7 +239,8 @@ class TestMigration042(TestInfrahubApp):
     async def primary_thing_two_main_update_details(
         self,
         db: InfrahubDatabase,
-        load_schemas: SchemaBranch,
+        default_branch: Branch,
+        load_schemas_main: SchemaBranch,
         secondary_thing_one_details: NodeDetails,
         secondary_thing_two_details: NodeDetails,
         secondary_thing_three_details: NodeDetails,
@@ -268,6 +258,7 @@ class TestMigration042(TestInfrahubApp):
         )
         await primary_thing.save(db=db)
 
+        primary_thing = await NodeManager.get_one(db=db, branch=default_branch, id=primary_thing.id)
         new_secondary_in_node = secondary_thing_three_details.node
         new_secondary_out_node = secondary_thing_one_details.node
         new_agnostic_secondary_node = secondary_thing_two_details.node
@@ -280,7 +271,6 @@ class TestMigration042(TestInfrahubApp):
 
         return NodeDetails(
             node=primary_thing,
-            on_default_branch=True,
             # a bug in deleting branch-aware nodes with branch-agnostic relationships prevents this from working correctly
             # https://github.com/opsmill/infrahub/issues/7513
             # display_label=f"{primary_thing.name.value} {primary_thing.color.value} {primary_thing.agnostic_smell.value}",
@@ -301,7 +291,7 @@ class TestMigration042(TestInfrahubApp):
     async def primary_thing_three_deleted_details(
         self,
         db: InfrahubDatabase,
-        load_schemas: SchemaBranch,
+        load_schemas_main: SchemaBranch,
         secondary_thing_two_details: NodeDetails,
         secondary_thing_three_details: NodeDetails,
     ) -> NodeDetails:
@@ -320,7 +310,6 @@ class TestMigration042(TestInfrahubApp):
         await primary_thing.delete(db=db)
         return NodeDetails(
             node=primary_thing,
-            on_default_branch=True,
             display_label=None,
             human_friendly_id=None,
             status=NodeStatus.DELETED,
@@ -334,7 +323,7 @@ class TestMigration042(TestInfrahubApp):
     async def secondary_thing_three_branch_update_details(
         self,
         db: InfrahubDatabase,
-        load_schemas: SchemaBranch,
+        load_schemas_main: SchemaBranch,
         branch: Branch,
         secondary_thing_three_details: NodeDetails,
         secondary_thing_three_agnostic_value_update: str,
@@ -347,7 +336,6 @@ class TestMigration042(TestInfrahubApp):
 
         return NodeDetails(
             node=secondary_thing,
-            on_default_branch=False,
             display_label=f"{secondary_thing.name.value} {secondary_thing.size.value}",
             human_friendly_id=[
                 str(v)
@@ -364,7 +352,7 @@ class TestMigration042(TestInfrahubApp):
     async def primary_thing_one_branch_details(
         self,
         db: InfrahubDatabase,
-        load_schemas: SchemaBranch,
+        load_schemas_main: SchemaBranch,
         secondary_thing_one_details: NodeDetails,
         secondary_thing_two_details: NodeDetails,
         branch: Branch,
@@ -383,7 +371,6 @@ class TestMigration042(TestInfrahubApp):
         await primary_thing.save(db=db)
         return NodeDetails(
             node=primary_thing,
-            on_default_branch=False,
             display_label=f"{primary_thing.name.value} {primary_thing.color.value} {primary_thing.agnostic_smell.value}",
             human_friendly_id=[
                 str(v)
@@ -402,7 +389,7 @@ class TestMigration042(TestInfrahubApp):
     async def primary_thing_two_deleted_on_branch_details(
         self,
         db: InfrahubDatabase,
-        load_schemas: SchemaBranch,
+        load_schemas_main: SchemaBranch,
         primary_thing_two_main_update_details: NodeDetails,
         branch: Branch,
     ) -> NodeDetails:
@@ -412,7 +399,6 @@ class TestMigration042(TestInfrahubApp):
         await primary_thing.delete(db=db)
         return NodeDetails(
             node=primary_thing,
-            on_default_branch=False,
             display_label=None,
             human_friendly_id=None,
             status=NodeStatus.DELETED,
@@ -422,7 +408,7 @@ class TestMigration042(TestInfrahubApp):
     async def primary_thing_one_branch_update_details(
         self,
         db: InfrahubDatabase,
-        load_schemas: SchemaBranch,
+        load_schemas_main: SchemaBranch,
         primary_thing_one_details: NodeDetails,
         branch: Branch,
         secondary_thing_three_branch_update_details: NodeDetails,
@@ -441,7 +427,6 @@ class TestMigration042(TestInfrahubApp):
         await primary_thing.save(db=db)
         return NodeDetails(
             node=primary_thing,
-            on_default_branch=False,
             display_label=f"{primary_thing.name.value} {primary_thing.color.value} {primary_thing_one_agnostic_value_update}",
             human_friendly_id=[
                 str(v)
@@ -456,24 +441,97 @@ class TestMigration042(TestInfrahubApp):
             status=NodeStatus.ACTIVE,
         )
 
+    # --------------------------------
+    # branch with schema updates
+    # --------------------------------
+
     @pytest.fixture
-    async def initial_dataset(
+    async def schema_update_branch(self, db: InfrahubDatabase, default_branch: Branch) -> Branch:
+        return await create_branch(db=db, branch_name="migration-schema-update-branch")
+
+    @pytest.fixture
+    def primary_thing_schema_update(self, primary_thing_schema: NodeSchema, schema_update_branch: Branch) -> NodeSchema:
+        updated_schema = primary_thing_schema.duplicate()
+        updated_schema.display_labels = ["color__value", "name__value"]
+        updated_schema.human_friendly_id = [
+            "name__value",
+            "secondary_in__color__value",
+            "secondary_out__agnostic_smell__value",
+        ]
+        return updated_schema
+
+    @pytest.fixture
+    async def load_schemas_branch_update(
+        self,
+        db: InfrahubDatabase,
+        load_schemas_main: SchemaBranch,
+        schema_update_branch: Branch,
+        primary_thing_schema_update: NodeSchema,
+        secondary_thing_schema: NodeSchema,
+    ) -> SchemaBranch:
+        return await self._do_load_schemas(
+            db=db, branch=schema_update_branch, schemas=[primary_thing_schema_update, secondary_thing_schema]
+        )
+
+    @pytest.fixture
+    def primary_thing_one_schema_update_details(
+        self,
+        primary_thing_one_details: NodeDetails,
+        secondary_thing_one_details: NodeDetails,
+        secondary_thing_two_details: NodeDetails,
+    ) -> NodeDetails:
+        return NodeDetails(
+            node=primary_thing_one_details.node,
+            display_label=f"{primary_thing_one_details.node.color.value} {primary_thing_one_details.node.name.value}",
+            human_friendly_id=[
+                str(v)
+                for v in (
+                    primary_thing_one_details.node.name.value,
+                    secondary_thing_one_details.node.color.value,
+                    secondary_thing_two_details.node.agnostic_smell.value,
+                )
+            ],
+            status=NodeStatus.ACTIVE,
+        )
+
+    @pytest.fixture
+    def primary_thing_two_schema_update_details(
+        self,
+        primary_thing_two_main_update_details: NodeDetails,
+        secondary_thing_one_details: NodeDetails,
+        secondary_thing_three_details: NodeDetails,
+    ) -> NodeDetails:
+        return NodeDetails(
+            node=primary_thing_two_main_update_details.node,
+            display_label=f"{primary_thing_two_main_update_details.node.color.value} {primary_thing_two_main_update_details.node.name.value}",
+            human_friendly_id=[
+                str(v)
+                for v in (
+                    primary_thing_two_main_update_details.node.name.value,
+                    secondary_thing_three_details.node.color.value,
+                    secondary_thing_one_details.node.agnostic_smell.value,
+                )
+            ],
+            status=NodeStatus.ACTIVE,
+        )
+
+    # --------------------------------
+    # datasets for branches
+    # --------------------------------
+
+    @pytest.fixture
+    async def dataset_main(
         self,
         db: InfrahubDatabase,
         default_branch: Branch,
         register_core_models_schema: SchemaBranch,
-        load_schemas: SchemaBranch,
+        load_schemas_main: SchemaBranch,
         secondary_thing_one_details: NodeDetails,
         secondary_thing_two_details: NodeDetails,
         secondary_thing_three_details: NodeDetails,
         primary_thing_one_details: NodeDetails,
         primary_thing_two_main_update_details: NodeDetails,
-        primary_thing_two_deleted_on_branch_details: NodeDetails,
         primary_thing_three_deleted_details: NodeDetails,
-        branch: Branch,
-        secondary_thing_three_branch_update_details: NodeDetails,
-        primary_thing_one_branch_details: NodeDetails,
-        primary_thing_one_branch_update_details: NodeDetails,
     ) -> dict[str, NodeDetails]:
         return {
             "secondary_thing_one": secondary_thing_one_details,
@@ -481,12 +539,47 @@ class TestMigration042(TestInfrahubApp):
             "secondary_thing_three": secondary_thing_three_details,
             "primary_thing_one": primary_thing_one_details,
             "primary_thing_two": primary_thing_two_main_update_details,
-            "primary_thing_two_deleted_on_branch": primary_thing_two_deleted_on_branch_details,
             "primary_thing_three_deleted": primary_thing_three_deleted_details,
-            "secondary_thing_three_branch_update": secondary_thing_three_branch_update_details,
-            "primary_thing_one_branch": primary_thing_one_branch_details,
-            "primary_thing_one_updated_on_branch": primary_thing_one_branch_update_details,
         }
+
+    @pytest.fixture
+    async def dataset_data_update_on_branch(
+        self,
+        dataset_main: dict[str, NodeDetails],
+        branch: Branch,
+        secondary_thing_three_branch_update_details: NodeDetails,
+        primary_thing_two_deleted_on_branch_details: NodeDetails,
+        primary_thing_one_branch_details: NodeDetails,
+        primary_thing_one_branch_update_details: NodeDetails,
+    ) -> dict[str, NodeDetails]:
+        updated_dataset = dataset_main.copy()
+        updated_dataset.update(
+            {
+                "secondary_thing_three": secondary_thing_three_branch_update_details,
+                "primary_thing_two": primary_thing_two_deleted_on_branch_details,
+                "primary_thing_one_branch": primary_thing_one_branch_details,
+                "primary_thing_one": primary_thing_one_branch_update_details,
+            }
+        )
+        return updated_dataset
+
+    @pytest.fixture
+    async def dataset_schema_update_on_branch(
+        self,
+        dataset_main: dict[str, NodeDetails],
+        schema_update_branch: Branch,
+        load_schemas_branch_update: SchemaBranch,
+        primary_thing_one_schema_update_details: NodeDetails,
+        primary_thing_two_schema_update_details: NodeDetails,
+    ) -> dict[str, NodeDetails]:
+        updated_dataset = dataset_main.copy()
+        updated_dataset.update(
+            {
+                "primary_thing_one": primary_thing_one_schema_update_details,
+                "primary_thing_two": primary_thing_two_schema_update_details,
+            }
+        )
+        return updated_dataset
 
     async def erase_hfid_and_display_label(self, db: InfrahubDatabase) -> Node:
         query = """
@@ -516,14 +609,68 @@ DETACH DELETE attr
                 result_map[node_id][attr_name] = node_attributes_map[node_id].attrs[attr_name].value
         return result_map
 
+    async def _rebase_and_migrate_branch(
+        self, db: InfrahubDatabase, default_branch: Branch, branch: Branch, schemas: list[NodeSchema]
+    ) -> None:
+        await branch.rebase(db=db)
+        async with db.start_session() as dbs:
+            migration = Migration042(migrations=[])
+            execution_result = await migration.execute_against_branch(db=dbs, branch=branch)
+            assert not execution_result.errors
+
+        branch_schema_branch = SchemaBranch(
+            cache={},
+            name=branch.name,
+        )
+        for node_schema in schemas:
+            branch_schema_branch.set(name=node_schema.kind, schema=node_schema)
+        for internal_schema_kind in ["SchemaNode", "SchemaAttribute", "SchemaRelationship", "SchemaGeneric"]:
+            branch_schema_branch.set(
+                name=internal_schema_kind,
+                schema=registry.schema.get(name=internal_schema_kind, branch=default_branch, duplicate=False),
+            )
+        branch_schema_branch.process()
+        registry.schema.set_schema_branch(name=branch.name, schema=branch_schema_branch)
+
+        async with db.start_session() as dbs:
+            migration = Migration043()
+            execution_result = await migration.execute_against_branch(db=dbs, branch=branch)
+            assert not execution_result.errors
+
+    async def _validate_branch_updates(
+        self, db: InfrahubDatabase, branch: Branch, node_details_list: list[NodeDetails]
+    ) -> None:
+        attribute_values_map = await self.get_attribute_values_from_db(
+            db=db,
+            branch=branch,
+            attribute_names=["human_friendly_id", "display_label"],
+            node_ids=[node_details.node.id for node_details in node_details_list],
+        )
+        expected_ids = {node_details.node.id for node_details in node_details_list if node_details.is_active}
+        assert set(attribute_values_map.keys()) == expected_ids
+        for node_details in node_details_list:
+            if not node_details.is_active:
+                continue
+            if node_details.display_label is not None:
+                assert attribute_values_map[node_details.node.id]["display_label"] == node_details.display_label
+            if node_details.human_friendly_id is not None:
+                assert (
+                    json.loads(attribute_values_map[node_details.node.id]["human_friendly_id"])
+                    == node_details.human_friendly_id
+                )
+
     async def test_migration_042_043(
         self,
         db: InfrahubDatabase,
         default_branch: Branch,
-        initial_dataset: dict[str, NodeDetails],
-        branch: Branch,
         primary_thing_schema: NodeSchema,
         secondary_thing_schema: NodeSchema,
+        dataset_main: dict[str, NodeDetails],
+        branch: Branch,
+        dataset_data_update_on_branch: dict[str, NodeDetails],
+        schema_update_branch: Branch,
+        dataset_schema_update_on_branch: dict[str, NodeDetails],
+        primary_thing_schema_update: NodeSchema,
     ) -> None:
         await self.erase_hfid_and_display_label(db=db)
 
@@ -544,85 +691,29 @@ DETACH DELETE attr
 
             validation_result = await migration.validate_migration(db=dbs)
             assert not validation_result.errors
-
         # validate updates on default branch
-        attribute_values_map_main = await self.get_attribute_values_from_db(
-            db=db,
-            branch=default_branch,
-            attribute_names=["human_friendly_id", "display_label"],
-            node_ids=[node_details.node.id for node_details in initial_dataset.values()],
-        )
-        expected_ids = {
-            node_details.node.id
-            for node_details in initial_dataset.values()
-            if node_details.is_active and node_details.on_default_branch
-        }
-        assert set(attribute_values_map_main.keys()) == expected_ids
-        for node_details in initial_dataset.values():
-            if not node_details.is_active or not node_details.on_default_branch:
-                continue
-            assert attribute_values_map_main[node_details.node.id]["display_label"] == node_details.display_label
-            assert (
-                json.loads(attribute_values_map_main[node_details.node.id]["human_friendly_id"])
-                == node_details.human_friendly_id
-            )
+        await self._validate_branch_updates(db=db, branch=default_branch, node_details_list=list(dataset_main.values()))
 
         # rebase and migrate branch
-        await branch.rebase(db=db)
-        async with db.start_session() as dbs:
-            migration = Migration042(migrations=[])
-            execution_result = await migration.execute_against_branch(db=dbs, branch=branch)
-            assert not execution_result.errors
-
-        branch_schema_branch = SchemaBranch(
-            cache={},
-            name=branch.name,
+        await self._rebase_and_migrate_branch(
+            db=db, default_branch=default_branch, branch=branch, schemas=[primary_thing_schema, secondary_thing_schema]
         )
-        branch_schema_branch.set(name="PrimaryThing", schema=primary_thing_schema)
-        branch_schema_branch.set(name="SecondaryThing", schema=secondary_thing_schema)
-        for internal_schema_kind in ["SchemaNode", "SchemaAttribute", "SchemaRelationship", "SchemaGeneric"]:
-            branch_schema_branch.set(
-                name=internal_schema_kind,
-                schema=registry.schema.get(name=internal_schema_kind, branch=default_branch, duplicate=False),
-            )
-        branch_schema_branch.process()
-        registry.schema.set_schema_branch(name=branch.name, schema=branch_schema_branch)
-
-        async with db.start_session() as dbs:
-            migration = Migration043()
-            execution_result = await migration.execute_against_branch(db=dbs, branch=branch)
-            assert not execution_result.errors
-
-        attribute_values_map_branch = await self.get_attribute_values_from_db(
-            db=db,
-            branch=branch,
-            attribute_names=["human_friendly_id", "display_label"],
-            node_ids=[
-                node_details.node.id for node_details in initial_dataset.values() if not node_details.on_default_branch
-            ],
-        )
-        expected_ids = {
-            node_details.node.id
-            for node_details in initial_dataset.values()
-            if node_details.is_active and not node_details.on_default_branch
-        }
-
         # bug in rebase allows attributes added on main to persist on a node that is deleted on a branch
-        expected_ids.add(initial_dataset["primary_thing_two_deleted_on_branch"].node.id)
+        dataset_data_update_on_branch["primary_thing_two"].status = NodeStatus.ACTIVE
+        await self._validate_branch_updates(
+            db=db, branch=branch, node_details_list=list(dataset_data_update_on_branch.values())
+        )
 
-        assert set(attribute_values_map_branch.keys()) == expected_ids
-        for node_details in initial_dataset.values():
-            if not node_details.is_active or node_details.on_default_branch:
-                continue
-            assert attribute_values_map_branch[node_details.node.id]["display_label"] == node_details.display_label
-            assert (
-                json.loads(attribute_values_map_branch[node_details.node.id]["human_friendly_id"])
-                == node_details.human_friendly_id
-            )
+        # check updates on schema update branch
+        await self._rebase_and_migrate_branch(
+            db=db,
+            default_branch=default_branch,
+            branch=schema_update_branch,
+            schemas=[primary_thing_schema_update, secondary_thing_schema],
+        )
+        await self._validate_branch_updates(
+            db=db, branch=schema_update_branch, node_details_list=list(dataset_schema_update_on_branch.values())
+        )
 
         await verify_no_edges_added_after_node_delete(db=db)
         await verify_no_duplicate_relationships(db=db)
-
-
-# TODO: test display labels and HFIDs updated on a branch with the same value on main
-# TODO: test HFID/display labels update on branch


### PR DESCRIPTION
update the migrations to create (migration 042) and set (migration 043) `display_label` and `human_friendly_id` attributes so that they work with the new approach to migrate `main`, rebase branches, then migrate only the necessary attributes on each branch

it's a lot of code and a lot of tests. here's the outline of how each migration works

### Migration 042 - add display_label and human_friendly_id attributes to all Nodes

- run the existing migration on the default branch, adding the new attributes to every node that exists on those branches
- for each branch
  - rebase the branch (handled outside of the migration)
  - identify which nodes have been created on the branch
  - run the migration to add the new attributes on only those nodes created on the branch, the rebase will take care of the nodes created on `main` that exist on the branch

### Migration 043 - set the display_label and human_friendly_id attributes on all Nodes

- run the existing migration on the default branch, setting the display_label and HFIDs to the correct values
- for each branch
  - rebase the branch (handled outside of the migration)
  - for each node schema
    - if the display_label or HFID was updated at the schema-level, then update the appropriate attribute(s) for ALL nodes that exist on this branch
    - identify which nodes have updates to attributes or relationships or attributes on peers that would affect the HFID or display label value and run the updates on just those nodes for just the attribute(s) that need it

