### PR TITLE
Set transform timeout to 60 seconds

### DIFF
--- a/backend/tests/fixtures/repos/infrahub-demo-edge/initial__main/transforms/computed_circuit_description.py
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge/initial__main/transforms/computed_circuit_description.py
@@ -4,6 +4,7 @@ from infrahub_sdk.transforms import InfrahubTransform
 class ComputedCircuitDescription(InfrahubTransform):
     query = "computed_circuit_description"
     url = "computed_circuit_description"
+    timeout: int = 60
 
     async def transform(self, data):
         circuit_dict: dict = data["InfraCircuit"]["edges"][0]["node"]

--- a/backend/tests/fixtures/repos/infrahub-demo-edge/initial__main/transforms/openconfig.py
+++ b/backend/tests/fixtures/repos/infrahub-demo-edge/initial__main/transforms/openconfig.py
@@ -3,6 +3,7 @@ from infrahub_sdk.transforms import InfrahubTransform
 
 class OCInterfaces(InfrahubTransform):
     query = "oc_interfaces"
+    timeout: int = 60
 
     async def transform(self, data):
         response_payload = {}
@@ -52,6 +53,7 @@ class OCInterfaces(InfrahubTransform):
 class OCBGPNeighbors(InfrahubTransform):
     query = "oc_bgp_neighbors"
     url = "openconfig/network-instances/network-instance/protocols/protocol/bgp/neighbors"
+    timeout: int = 60
 
     async def transform(self, data):
         response_payload = {}


### PR DESCRIPTION
Used for the repository that gets imported by the end to end tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated data transform configurations to include timeout settings for improved reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->