### PR TITLE
Avoid warning for empty doc search

### DIFF
--- a/backend/infrahub/api/internal.py
+++ b/backend/infrahub/api/internal.py
@@ -161,6 +161,8 @@ class SearchResultAPI(BaseModel):
 async def search_docs(
     query: str, limit: int | None = None, _: AccountSession = Depends(get_current_user)
 ) -> list[SearchResultAPI]:
+    if not query:
+        return []
     smart_query = smart_queries(query)
     search_results = search_docs_loader.heading_index.search(smart_query)
     heading_results = [


### PR DESCRIPTION
Return early for empty searches. I.e.

```bash
curl  http://localhost:8000/api/search/docs\?query\=\&limit\=3 -s
```

Without this change we can see this output in the server logs:

```
2025-10-30T07:22:23.273509Z [warning  ] Attempting a query with no clauses. Please add clauses by either using the `callback` argument or using `create_query` to create a preconfigured Query, manually adding clauses and passing it as the `query` argument. [lunr.index] app=infrahub.api request_id=40cfec7578554206ba0da281bf37a7df worker=cefdd7a7-cf2e-4eb4-969a-6118ed5cf2c4
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search API robustness to gracefully handle empty or invalid search queries by returning an empty result list instead of processing further, preventing potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->