### PR TITLE
Fix: prevent query docs with query is an empty string

### DIFF
--- a/frontend/app/src/entities/search-anywhere/domain/search-docs.query.ts
+++ b/frontend/app/src/entities/search-anywhere/domain/search-docs.query.ts
@@ -9,6 +9,7 @@ export function searchDocsQueryOptions({ query, limit = 3 }: SearchDocsParams) {
   return queryOptions({
     queryKey: searchAnywhereQueryKeys.docs({ query, limit }),
     queryFn: () => searchDocs({ query, limit }),
+    enabled: !!query, // prevent sending query with empty string
   });
 }
 

--- a/frontend/app/src/entities/search-anywhere/ui/search-actions.tsx
+++ b/frontend/app/src/entities/search-anywhere/ui/search-actions.tsx
@@ -19,7 +19,7 @@ export const SearchActions = () => {
   const generics = useAtomValue(genericSchemasAtom);
   const models: ModelSchema[] = [...nodes, ...generics];
 
-  const { data: menuData, isPending, isError } = useMenu();
+  const { data: menuData, isPending, isError } = useMenu({ enabled: false });
 
   const menuItems = useMemo(() => {
     if (!menuData) return [];

--- a/frontend/app/src/entities/search-anywhere/ui/search-actions.tsx
+++ b/frontend/app/src/entities/search-anywhere/ui/search-actions.tsx
@@ -19,7 +19,7 @@ export const SearchActions = () => {
   const generics = useAtomValue(genericSchemasAtom);
   const models: ModelSchema[] = [...nodes, ...generics];
 
-  const { data: menuData, isPending, isError } = useMenu({ enabled: false });
+  const { data: menuData, isPending, isError } = useMenu({ enabled: false }); // prevent fetching menu, data should be already cached
 
   const menuItems = useMemo(() => {
     if (!menuData) return [];

--- a/frontend/app/src/shared/components/menu/domain/get-menu.query.ts
+++ b/frontend/app/src/shared/components/menu/domain/get-menu.query.ts
@@ -1,7 +1,7 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import { useAtomValue } from "jotai";
 
-import type { ContextParams } from "@/shared/api/types";
+import type { ContextParams, QueryConfig } from "@/shared/api/types";
 import { getMenu } from "@/shared/components/menu/domain/get-menu";
 import { datetimeAtom } from "@/shared/stores/time.atom";
 
@@ -14,14 +14,15 @@ export function menuQueryOptions({ branchName, atDate }: ContextParams) {
   });
 }
 
-export function useMenu() {
+export function useMenu(config?: QueryConfig<typeof menuQueryOptions>) {
   const { currentBranch } = useCurrentBranch();
   const timeMachineDate = useAtomValue(datetimeAtom);
 
-  return useQuery(
-    menuQueryOptions({
+  return useQuery({
+    ...menuQueryOptions({
       branchName: currentBranch.name,
       atDate: timeMachineDate,
-    })
-  );
+    }),
+    ...config,
+  });
 }


### PR DESCRIPTION
fix regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Search queries now only execute when search terms are provided, reducing unnecessary requests.
  * Menu data now relies on existing cache instead of triggering automatic fetches, improving overall efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->