### PR TITLE
Run tutorial tests with a single worker after all other E2E tests complete

### DIFF
--- a/frontend/app/playwright.config.ts
+++ b/frontend/app/playwright.config.ts
@@ -56,6 +56,15 @@ export default defineConfig({
       name: "chromium",
       use: { ...devices["Desktop Chrome"], channel: "chromium" },
       dependencies: ["setup"],
+      testIgnore: "**/docs-regression-check/**",
+    },
+    {
+      name: "docs-regression-check",
+      use: { ...devices["Desktop Chrome"], channel: "chromium" },
+      dependencies: ["e2e"],
+      testMatch: "**/docs-regression-check/**/*.spec.ts",
+      fullyParallel: false,
+      workers: 1,
     },
 
     // {

--- a/frontend/app/playwright.config.ts
+++ b/frontend/app/playwright.config.ts
@@ -53,7 +53,7 @@ export default defineConfig({
       testMatch: /.*\.setup\.ts/,
     },
     {
-      name: "chromium",
+      name: "e2e",
       use: { ...devices["Desktop Chrome"], channel: "chromium" },
       dependencies: ["setup"],
       testIgnore: "**/docs-regression-check/**",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a dedicated docs-regression test project that runs on Desktop Chrome with a single-worker, non-parallel setup and a targeted test match pattern.
  * Renamed the existing Chromium test project to "e2e" to clarify purpose.
  * Configured the e2e project to ignore docs-regression paths so test runs remain separated and organized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->