### PR TITLE
Return early for missing source branch

### DIFF
--- a/backend/infrahub/proposed_change/tasks.py
+++ b/backend/infrahub/proposed_change/tasks.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
-from infrahub_sdk.exceptions import ModuleImportError, NodeNotFoundError
+from infrahub_sdk.exceptions import ModuleImportError, NodeNotFoundError, URLNotFoundError
 from infrahub_sdk.node import InfrahubNode
 from infrahub_sdk.protocols import (
     CoreArtifactValidator,
@@ -1502,8 +1502,14 @@ async def _get_proposed_change_repositories(
     destination_all = await client.execute_graphql(
         query=DESTINATION_ALLREPOSITORIES, branch_name=model.destination_branch
     )
-    source_managed = await client.execute_graphql(query=SOURCE_REPOSITORIES, branch_name=model.source_branch)
-    source_readonly = await client.execute_graphql(query=SOURCE_READONLY_REPOSITORIES, branch_name=model.source_branch)
+    try:
+        source_managed = await client.execute_graphql(query=SOURCE_REPOSITORIES, branch_name=model.source_branch)
+        source_readonly = await client.execute_graphql(
+            query=SOURCE_READONLY_REPOSITORIES, branch_name=model.source_branch
+        )
+    except URLNotFoundError:
+        # If the URL is not found it means that the source branch has been deleted after the proposed change was created
+        return []
 
     destination_all = destination_all[InfrahubKind.GENERICREPOSITORY]["edges"]
     source_all = (


### PR DESCRIPTION
In the e2e tests a PR can be created and then deleted along with the source branch, when this happens there are errors in the logs. This PR addresses a scenario when the source branch doesn't exist when collecting repository information from that branch.

```python
2025-10-29T10:56:22.758118Z [error    ] Encountered exception during execution: URLNotFoundError('`http://server:8000/graphql/main-copy-for-pc-e2edduzcyjs22` not found.') [prefect.flow_runs]
Traceback (most recent call last):
  File "/source/python_sdk/infrahub_sdk/client.py", line 959, in execute_graphql
    resp.raise_for_status()
  File "/usr/local/lib/python3.12/site-packages/httpx/_models.py", line 763, in raise_for_status
    raise HTTPStatusError(message, request=request, response=self)
httpx.HTTPStatusError: Client error '404 Not Found' for url 'http://server:8000/graphql/main-copy-for-pc-e2edduzcyjs22'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/prefect/flow_engine.py", line 1357, in run_context
    yield self
  File "/usr/local/lib/python3.12/site-packages/prefect/flow_engine.py", line 1419, in run_flow_async
    await engine.call_flow_fn()
  File "/usr/local/lib/python3.12/site-packages/prefect/flow_engine.py", line 1371, in call_flow_fn
    result = await call_with_parameters(self.flow.fn, self.parameters)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/source/backend/infrahub/proposed_change/tasks.py", line 1037, in run_proposed_change_pipeline
    repositories = await _get_proposed_change_repositories(model=model, client=client)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/source/backend/infrahub/proposed_change/tasks.py", line 1506, in _get_proposed_change_repositories
    source_readonly = await client.execute_graphql(query=SOURCE_READONLY_REPOSITORIES, branch_name=model.source_branch)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/source/python_sdk/infrahub_sdk/client.py", line 978, in execute_graphql
    raise URLNotFoundError(url=url)
infrahub_sdk.exceptions.URLNotFoundError: `http://server:8000/graphql/main-copy-for-pc-e2edduzcyjs22` not found.

```

If we run into this situation we'll instead return an empty list for the repositories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced system stability by implementing graceful error handling for repository access. The system now continues operation when repositories are unavailable instead of halting with errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->