### PR TITLE
update ordering in NodeListGetRelationshipsQuery

### DIFF
--- a/backend/infrahub/core/query/node.py
+++ b/backend/infrahub/core/query/node.py
@@ -878,6 +878,7 @@ class NodeListGetRelationshipsQuery(Query):
         RETURN DISTINCT n_uuid, rel_name, peer_uuid, direction
         """ % {"filters": rels_filter}
         self.add_to_query(query)
+        self.order_by = ["n_uuid", "rel_name", "peer_uuid", "direction"]
         self.return_labels = ["n_uuid", "rel_name", "peer_uuid", "direction"]
 
     def get_peers_group_by_node(self) -> GroupedPeerNodes:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -22,6 +22,7 @@ from testcontainers.core.waiting_utils import wait_for_logs
 
 from infrahub import config
 from infrahub.config import load_and_exit
+from infrahub.constants.database import Neo4jRuntime
 from infrahub.core import registry
 from infrahub.core.branch import Branch
 from infrahub.core.constants import BranchSupportType, InfrahubKind, RelationshipCardinality, RelationshipDirection
@@ -164,6 +165,22 @@ async def do_default_branch(db: InfrahubDatabase) -> Branch:
     await create_global_branch(db=db)
     registry.schema = SchemaManager()
     return branch
+
+
+@pytest.fixture
+def query_limit_of_one() -> Generator[None, None, None]:
+    original_query_size_limit = config.SETTINGS.database.query_size_limit
+    config.SETTINGS.database.query_size_limit = 1
+    yield
+    config.SETTINGS.database.query_size_limit = original_query_size_limit
+
+
+@pytest.fixture
+def neo4j_runtime_parallel(db: InfrahubDatabase) -> Generator[None, None, None]:
+    original_neo4j_runtime = db.default_neo4j_runtime
+    db.default_neo4j_runtime = Neo4jRuntime.PARALLEL
+    yield
+    db.default_neo4j_runtime = original_neo4j_runtime
 
 
 @pytest.fixture

--- a/backend/tests/unit/core/test_node_query.py
+++ b/backend/tests/unit/core/test_node_query.py
@@ -428,6 +428,41 @@ async def test_query_NodeListGetRelationshipsQuery_hierarchical(
     assert parent_peer_ids == {europe_id}
 
 
+async def test_query_NodeListGetRelationshipsQuery_pagination_and_parallel_runtime(
+    db: InfrahubDatabase, default_branch: Branch, person_tag_schema, query_limit_of_one, neo4j_runtime_parallel
+):
+    """
+    Test all expected results are returned with pagination and parallel runtime
+    """
+    tags = []
+    for i in range(10):
+        tag = await Node.init(db=db, schema=InfrahubKind.TAG, branch=default_branch)
+        await tag.new(db=db, name=f"Tag{i}", description=f"The Tag{i} tag")
+        await tag.save(db=db)
+        tags.append(tag)
+    person = await Node.init(db=db, schema="TestPerson", branch=default_branch)
+    await person.new(db=db, firstname="Test", lastname="Person", tags=tags)
+    await person.save(db=db)
+
+    query = await NodeListGetRelationshipsQuery.init(
+        db=db,
+        ids=[person.id],
+        branch=default_branch,
+    )
+    await query.execute(db=db)
+
+    # Verify all relationships are returned
+    grouped_peer_nodes = query.get_peers_group_by_node()
+    assert grouped_peer_nodes.has_node(person.id)
+    peer_ids = grouped_peer_nodes.get_peer_ids(
+        node_id=person.id, rel_name="builtintag__testperson", direction=RelationshipDirection.INBOUND
+    )
+    # Verify all 10 tags are returned
+    expected_tag_ids = {tag.id for tag in tags}
+    assert peer_ids == expected_tag_ids
+    assert len(peer_ids) == 10
+
+
 async def test_query_NodeDeleteQuery(
     db: InfrahubDatabase,
     default_branch: Branch,

--- a/changelog/+node-get-rels.fixed.md
+++ b/changelog/+node-get-rels.fixed.md
@@ -1,0 +1,1 @@
+Fix bug in cypher query that could cause relationships in a large result set to be incorrectly set to null. By default, the nodes in the result set would need to collectively have over 5,000 relationships for the issue to appear.


### PR DESCRIPTION
test and fix for ordering in `NodeListGetRelationshipsQuery`

issue could appear as incorrectly `null` values for relationships when retrieving many nodes. by default it would need to be nodes that collectively had over 5,000 relationships

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where relationships in large result sets could be incorrectly set to null. This affected queries returning over 5,000 relationships.
  * Improved query result consistency and determinism for enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->