### PR TITLE
Added title as props in MenuSection

### DIFF
--- a/frontend/app/src/entities/nodes/object/ui/object-details/object-details-menu.tsx
+++ b/frontend/app/src/entities/nodes/object/ui/object-details/object-details-menu.tsx
@@ -11,7 +11,6 @@ import { constructPath } from "@/shared/api/rest/fetch";
 import {
   CopyToClipboardMenuItem,
   Menu,
-  MenuHeader,
   MenuItem,
   MenuPopover,
   MenuSection,
@@ -71,8 +70,7 @@ export function ObjectDetailsMenu({
 
         <MenuPopover>
           <Menu>
-            <MenuSection>
-              <MenuHeader>Actions</MenuHeader>
+            <MenuSection title="Actions">
               <CopyToClipboardMenuItem textToCopy={objectData.id}>Copy ID</CopyToClipboardMenuItem>
               {objectData.hfid && (
                 <CopyToClipboardMenuItem textToCopy={objectData.hfid.toString()}>
@@ -81,8 +79,7 @@ export function ObjectDetailsMenu({
               )}
             </MenuSection>
 
-            <MenuSection>
-              <MenuHeader>Explore</MenuHeader>
+            <MenuSection title="Explore">
               <MenuItem
                 href={constructPath("/schema", [{ name: "kind", value: objectSchema.kind }])}
               >
@@ -119,8 +116,7 @@ export function ObjectDetailsMenu({
               )}
             </MenuSection>
 
-            <MenuSection>
-              <MenuHeader>Manage</MenuHeader>
+            <MenuSection title="Manage">
               <MenuItem isDisabled={!isEditAllowed} onAction={() => setIsEditModalOpen(true)}>
                 <PencilLineIcon className="size-3.5" />
                 <span>Edit</span>

--- a/frontend/app/src/entities/repository/ui/repository-action-menu.tsx
+++ b/frontend/app/src/entities/repository/ui/repository-action-menu.tsx
@@ -6,13 +6,7 @@ import { toast } from "react-toastify";
 
 import { useMutation } from "@/shared/api/graphql/useQuery";
 import { queryClient } from "@/shared/api/rest/client";
-import {
-  Menu,
-  MenuItem,
-  MenuPopover,
-  MenuSection,
-  MenuTrigger,
-} from "@/shared/components/aria/menu";
+import { Menu, MenuItem, MenuPopover, MenuTrigger } from "@/shared/components/aria/menu";
 import { Button, ButtonWithTooltip } from "@/shared/components/buttons/button-primitive";
 import { ALERT_TYPES, Alert } from "@/shared/components/ui/alert";
 
@@ -42,14 +36,12 @@ const RepositoryActionMenu = ({ repositoryId }: { repositoryId: string }) => {
 
         <MenuPopover placement="bottom end">
           <Menu>
-            <MenuSection>
-              <MenuItem onAction={() => setIsOpen(true)}>
-                <Icon icon="mdi:access-point" className="text-lg" />
-                Check connectivity
-              </MenuItem>
+            <MenuItem onAction={() => setIsOpen(true)}>
+              <Icon icon="mdi:access-point" className="text-lg" />
+              Check connectivity
+            </MenuItem>
 
-              <ReimportLastCommitAction repositoryId={repositoryId} />
-            </MenuSection>
+            <ReimportLastCommitAction repositoryId={repositoryId} />
           </Menu>
         </MenuPopover>
       </MenuTrigger>

--- a/frontend/app/src/entities/repository/ui/repository-action-menu.tsx
+++ b/frontend/app/src/entities/repository/ui/repository-action-menu.tsx
@@ -6,7 +6,13 @@ import { toast } from "react-toastify";
 
 import { useMutation } from "@/shared/api/graphql/useQuery";
 import { queryClient } from "@/shared/api/rest/client";
-import { Menu, MenuItem, MenuPopover, MenuTrigger } from "@/shared/components/aria/menu";
+import {
+  Menu,
+  MenuItem,
+  MenuPopover,
+  MenuSection,
+  MenuTrigger,
+} from "@/shared/components/aria/menu";
 import { Button, ButtonWithTooltip } from "@/shared/components/buttons/button-primitive";
 import { ALERT_TYPES, Alert } from "@/shared/components/ui/alert";
 
@@ -36,12 +42,14 @@ const RepositoryActionMenu = ({ repositoryId }: { repositoryId: string }) => {
 
         <MenuPopover placement="bottom end">
           <Menu>
-            <MenuItem onAction={() => setIsOpen(true)}>
-              <Icon icon="mdi:access-point" className="text-lg" />
-              Check connectivity
-            </MenuItem>
+            <MenuSection title="Repository">
+              <MenuItem onAction={() => setIsOpen(true)}>
+                <Icon icon="mdi:access-point" className="text-lg" />
+                Check connectivity
+              </MenuItem>
 
-            <ReimportLastCommitAction repositoryId={repositoryId} />
+              <ReimportLastCommitAction repositoryId={repositoryId} />
+            </MenuSection>
           </Menu>
         </MenuPopover>
       </MenuTrigger>

--- a/frontend/app/src/entities/schema/ui/schema-help-menu.tsx
+++ b/frontend/app/src/entities/schema/ui/schema-help-menu.tsx
@@ -4,13 +4,7 @@ import { Pressable } from "react-aria-components";
 import { INFRAHUB_DOC_LOCAL } from "@/config/config";
 import { MENU_EXCLUDELIST } from "@/config/constants";
 
-import {
-  Menu,
-  MenuItem,
-  MenuPopover,
-  MenuSection,
-  MenuTrigger,
-} from "@/shared/components/aria/menu";
+import { Menu, MenuItem, MenuPopover, MenuTrigger } from "@/shared/components/aria/menu";
 import { Button } from "@/shared/components/buttons/button-primitive";
 
 import { getObjectDetailsUrl } from "@/entities/nodes/utils";
@@ -37,21 +31,19 @@ export const SchemaHelpMenu = ({ schema }: SchemaHelpMenuProps) => {
 
       <MenuPopover placement="bottom end">
         <Menu data-testid="schema-help-menu-content">
-          <MenuSection>
-            <MenuItem isDisabled={!schema.documentation} href={documentationUrl} target="_blank">
-              <Icon icon="mdi:book-open-variant-outline" className="text-custom-blue-700 text-lg" />
-              Documentation
-              <Icon icon="mdi:open-in-new" />
-            </MenuItem>
+          <MenuItem isDisabled={!schema.documentation} href={documentationUrl} target="_blank">
+            <Icon icon="mdi:book-open-variant-outline" className="text-custom-blue-700 text-lg" />
+            Documentation
+            <Icon icon="mdi:open-in-new" />
+          </MenuItem>
 
-            <MenuItem
-              isDisabled={isListViewDisabled}
-              href={getObjectDetailsUrl(schema.kind as string)}
-            >
-              <Icon icon="mdi:table-eye" className="text-custom-blue-700 text-lg" />
-              Open list view
-            </MenuItem>
-          </MenuSection>
+          <MenuItem
+            isDisabled={isListViewDisabled}
+            href={getObjectDetailsUrl(schema.kind as string)}
+          >
+            <Icon icon="mdi:table-eye" className="text-custom-blue-700 text-lg" />
+            Open list view
+          </MenuItem>
         </Menu>
       </MenuPopover>
     </MenuTrigger>

--- a/frontend/app/src/shared/components/aria/menu.tsx
+++ b/frontend/app/src/shared/components/aria/menu.tsx
@@ -1,7 +1,6 @@
 import { CopyIcon } from "lucide-react";
 import {
   Header as AriaHeader,
-  type HeadingProps as AriaHeadingProps,
   Menu as AriaMenu,
   MenuItem as AriaMenuItem,
   type MenuItemProps as AriaMenuItemProps,
@@ -10,6 +9,7 @@ import {
   type MenuSectionProps as AriaMenuSectionProps,
   MenuTrigger as AriaMenuTrigger,
   type PopoverProps as AriaPopoverProps,
+  Collection,
   composeRenderProps,
 } from "react-aria-components";
 
@@ -38,7 +38,7 @@ export const Menu = <T extends object>({ className, ...props }: MenuProps<T>) =>
     <AriaMenu
       className={classNames(
         "max-h-[inherit] overflow-auto rounded-md outline-hidden",
-        "*:[[role='group']:not(:last-child)]:mb-2",
+        "space-y-0.5 *:[[role='group']:not(:last-child)]:mb-2",
         className
       )}
       {...props}
@@ -66,14 +66,21 @@ export const MenuItem = ({ children, className, ...props }: MenuItemProps) => {
   );
 };
 
-export interface MenuSectionProps<T> extends AriaMenuSectionProps<T> {}
-export const MenuSection = <T extends object>({ className, ...props }: MenuSectionProps<T>) => {
-  return <AriaMenuSection className={classNames("flex flex-col gap-0.5", className)} {...props} />;
-};
-
-export interface MenuHeaderProps extends AriaHeadingProps {}
-export const MenuHeader = ({ className, ...props }: MenuHeaderProps) => {
-  return <AriaHeader className={classNames("px-1 text-stone-500 text-xs", className)} {...props} />;
+export interface MenuSectionProps<T> extends AriaMenuSectionProps<T> {
+  title?: React.ReactNode;
+}
+export const MenuSection = <T extends object>({
+  className,
+  title,
+  children,
+  ...props
+}: MenuSectionProps<T>) => {
+  return (
+    <AriaMenuSection className={classNames("flex flex-col gap-0.5", className)} {...props}>
+      {title && <AriaHeader className="px-1 text-stone-500 text-xs">{title}</AriaHeader>}
+      <Collection items={props.items}>{children}</Collection>
+    </AriaMenuSection>
+  );
 };
 
 export interface CopyToClipboardMenuItemProps extends Omit<MenuItemProps, "onAction" | "children"> {

--- a/frontend/app/src/shared/components/menu/object-details-button.tsx
+++ b/frontend/app/src/shared/components/menu/object-details-button.tsx
@@ -8,7 +8,6 @@ import { constructPath } from "@/shared/api/rest/fetch";
 import {
   CopyToClipboardMenuItem,
   Menu,
-  MenuHeader,
   MenuItem,
   MenuPopover,
   MenuSection,
@@ -49,8 +48,7 @@ export const ObjectDetailsButton = ({
 
       <MenuPopover placement="bottom end">
         <Menu>
-          <MenuSection>
-            <MenuHeader>Actions</MenuHeader>
+          <MenuSection title="Actions">
             <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
 
             {hfid && hfid !== "null" && (
@@ -68,8 +66,7 @@ export const ObjectDetailsButton = ({
             {children}
           </MenuSection>
 
-          <MenuSection>
-            <MenuHeader>Go to</MenuHeader>
+          <MenuSection title="Go to">
             <MenuItem
               href={constructPath("/tasks", [
                 { name: QSP.FILTER, value: JSON.stringify([taskFilter]) },

--- a/frontend/app/src/shared/components/menu/object-help-button.tsx
+++ b/frontend/app/src/shared/components/menu/object-help-button.tsx
@@ -5,13 +5,7 @@ import { INFRAHUB_DOC_LOCAL } from "@/config/config";
 import { QSP } from "@/config/qsp";
 
 import { constructPath } from "@/shared/api/rest/fetch";
-import {
-  Menu,
-  MenuItem,
-  MenuPopover,
-  MenuSection,
-  MenuTrigger,
-} from "@/shared/components/aria/menu";
+import { Menu, MenuItem, MenuPopover, MenuTrigger } from "@/shared/components/aria/menu";
 import { Button, type ButtonProps } from "@/shared/components/buttons/button-primitive";
 
 interface ObjectHelpButtonProps extends ButtonProps {
@@ -37,26 +31,24 @@ export const ObjectHelpButton = ({ documentationUrl, kind, ...props }: ObjectHel
 
       <MenuPopover placement="bottom end">
         <Menu>
-          <MenuSection>
-            <MenuItem
-              isDisabled={!documentationUrl}
-              href={docFullUrl}
-              target="_blank"
-              rel="noreferrer"
-            >
-              <Icon icon="mdi:book-open-variant-outline" className="text-lg" />
-              Documentation
-              <Icon icon="mdi:open-in-new" />
-            </MenuItem>
+          <MenuItem
+            isDisabled={!documentationUrl}
+            href={docFullUrl}
+            target="_blank"
+            rel="noreferrer"
+          >
+            <Icon icon="mdi:book-open-variant-outline" className="text-lg" />
+            Documentation
+            <Icon icon="mdi:open-in-new" />
+          </MenuItem>
 
-            <MenuItem
-              isDisabled={!kind}
-              href={constructPath("/schema", [{ name: QSP.KIND, value: kind }])}
-            >
-              <Icon icon="mdi:code-json" className="text-lg" />
-              Schema
-            </MenuItem>
-          </MenuSection>
+          <MenuItem
+            isDisabled={!kind}
+            href={constructPath("/schema", [{ name: QSP.KIND, value: kind }])}
+          >
+            <Icon icon="mdi:code-json" className="text-lg" />
+            Schema
+          </MenuItem>
         </Menu>
       </MenuPopover>
     </MenuTrigger>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Menu section headers are now rendered directly as section titles, simplifying menu structure across object, repository, schema, and help menus.
  * Some menus now present items without intermediate grouping while preserving item behavior.
  * Minor spacing adjustments for more consistent menu layout and visual consistency across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->