### PR TITLE
Added 3d button style when a menu item is focused

### DIFF
--- a/frontend/app/src/app/styles/index.css
+++ b/frontend/app/src/app/styles/index.css
@@ -19,6 +19,16 @@
   }
 }
 
+@layer utilities {
+  .no-scrollbar {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+  .no-scrollbar::-webkit-scrollbar {
+    display: none;
+  }
+}
+
 body {
   margin: 0;
   font-family: InterVariable, sans-serif;

--- a/frontend/app/src/shared/components/aria/menu.tsx
+++ b/frontend/app/src/shared/components/aria/menu.tsx
@@ -37,7 +37,7 @@ export const Menu = <T extends object>({ className, ...props }: MenuProps<T>) =>
   return (
     <AriaMenu
       className={classNames(
-        "max-h-[inherit] overflow-auto rounded-md p-1 outline-hidden",
+        "max-h-[inherit] overflow-auto rounded-md p-1 pb-1.5 outline-hidden",
         "space-y-0.5 *:[[role='group']:not(:last-child)]:mb-2",
         className
       )}
@@ -54,14 +54,36 @@ export const MenuItem = ({ children, className, ...props }: MenuItemProps) => {
       className={composeRenderProps(className, (className) =>
         classNames(
           disabledStyle,
-          "flex min-w-40 cursor-pointer select-none items-center gap-2 rounded-md border border-transparent bg-white px-2 py-1 text-sm text-stone-600 shadow-sm outline-hidden transition-colors",
-          "data-focused:border-stone-300",
+          "relative flex cursor-pointer select-none text-sm text-stone-600 outline-hidden",
           className
         )
       )}
       {...props}
     >
-      {children}
+      {composeRenderProps(children, (children, { isFocused, isPressed }) => (
+        <>
+          {isFocused && (
+            <span
+              className={classNames(
+                "absolute inset-0 translate-y-0.75 rounded-lg border-stone-300 border-b bg-button-edge-gradient",
+                isFocused && "shadow-xs",
+                isPressed && "shadow-none"
+              )}
+            />
+          )}
+
+          <div
+            className={classNames(
+              "flex w-full min-w-40 items-center gap-2 rounded-lg bg-white px-2 py-1",
+              "border border-white shadow-sm will-change-transform",
+              isFocused && "border-stone-200 shadow-none",
+              isPressed && "translate-y-0.75 duration-100"
+            )}
+          >
+            {children}
+          </div>
+        </>
+      ))}
     </AriaMenuItem>
   );
 };

--- a/frontend/app/src/shared/components/aria/menu.tsx
+++ b/frontend/app/src/shared/components/aria/menu.tsx
@@ -54,7 +54,7 @@ export const MenuItem = ({ children, className, ...props }: MenuItemProps) => {
       textValue={props.textValue || (typeof children === "string" ? children : undefined)}
       className={classNames(
         disabledStyle,
-        "relative flex cursor-pointer select-none text-sm text-stone-600 outline-hidden"
+        "relative flex cursor-pointer select-none outline-hidden"
       )}
       {...props}
     >
@@ -71,8 +71,7 @@ export const MenuItem = ({ children, className, ...props }: MenuItemProps) => {
 
           <div
             className={classNames(
-              "flex w-full min-w-40 items-center gap-2 rounded-lg bg-white px-2 py-1",
-              "border border-white shadow-xs transition-transform duration-100 will-change-transform",
+              "flex w-full min-w-40 items-center gap-2 rounded-lg border border-white bg-white px-2 py-1 text-sm text-stone-600 shadow-xs transition-transform duration-100 will-change-transform",
               isFocused && "border-stone-300 shadow-none",
               isPressed && "translate-y-0.75",
               className

--- a/frontend/app/src/shared/components/aria/menu.tsx
+++ b/frontend/app/src/shared/components/aria/menu.tsx
@@ -65,7 +65,7 @@ export const MenuItem = ({ children, className, ...props }: MenuItemProps) => {
           {isFocused && (
             <span
               className={classNames(
-                "absolute inset-0 translate-y-0.75 rounded-lg border-stone-300 border-b bg-button-edge-gradient shadow-xs",
+                "absolute inset-0 translate-y-0.75 rounded-lg border-stone-400 border-b bg-button-edge-gradient shadow-xs",
                 isPressed && "shadow-none"
               )}
             />
@@ -74,9 +74,9 @@ export const MenuItem = ({ children, className, ...props }: MenuItemProps) => {
           <div
             className={classNames(
               "flex w-full min-w-40 items-center gap-2 rounded-lg bg-white px-2 py-1",
-              "border border-white shadow-xs will-change-transform",
-              isFocused && "border-stone-200 shadow-none",
-              isPressed && "translate-y-0.75 duration-100"
+              "border border-white shadow-xs transition-transform duration-100 will-change-transform",
+              isFocused && "border-stone-300 shadow-none",
+              isPressed && "translate-y-0.75"
             )}
           >
             {children}

--- a/frontend/app/src/shared/components/aria/menu.tsx
+++ b/frontend/app/src/shared/components/aria/menu.tsx
@@ -65,8 +65,7 @@ export const MenuItem = ({ children, className, ...props }: MenuItemProps) => {
           {isFocused && (
             <span
               className={classNames(
-                "absolute inset-0 translate-y-0.75 rounded-lg border-stone-300 border-b bg-button-edge-gradient",
-                isFocused && "shadow-xs",
+                "absolute inset-0 translate-y-0.75 rounded-lg border-stone-300 border-b bg-button-edge-gradient shadow-xs",
                 isPressed && "shadow-none"
               )}
             />

--- a/frontend/app/src/shared/components/aria/menu.tsx
+++ b/frontend/app/src/shared/components/aria/menu.tsx
@@ -37,7 +37,7 @@ export const Menu = <T extends object>({ className, ...props }: MenuProps<T>) =>
   return (
     <AriaMenu
       className={classNames(
-        "max-h-[inherit] overflow-auto rounded-md p-1 pb-1.5 outline-hidden",
+        "no-scrollbar max-h-[inherit] overflow-auto p-1 pb-1.5 outline-hidden",
         "space-y-0.5 *:[[role='group']:not(:last-child)]:mb-2",
         className
       )}
@@ -47,16 +47,14 @@ export const Menu = <T extends object>({ className, ...props }: MenuProps<T>) =>
 };
 
 export interface MenuItemProps extends AriaMenuItemProps {}
+
 export const MenuItem = ({ children, className, ...props }: MenuItemProps) => {
   return (
     <AriaMenuItem
       textValue={props.textValue || (typeof children === "string" ? children : undefined)}
-      className={composeRenderProps(className, (className) =>
-        classNames(
-          disabledStyle,
-          "relative flex cursor-pointer select-none text-sm text-stone-600 outline-hidden",
-          className
-        )
+      className={classNames(
+        disabledStyle,
+        "relative flex cursor-pointer select-none text-sm text-stone-600 outline-hidden"
       )}
       {...props}
     >
@@ -76,7 +74,8 @@ export const MenuItem = ({ children, className, ...props }: MenuItemProps) => {
               "flex w-full min-w-40 items-center gap-2 rounded-lg bg-white px-2 py-1",
               "border border-white shadow-xs transition-transform duration-100 will-change-transform",
               isFocused && "border-stone-300 shadow-none",
-              isPressed && "translate-y-0.75"
+              isPressed && "translate-y-0.75",
+              className
             )}
           >
             {children}

--- a/frontend/app/src/shared/components/aria/menu.tsx
+++ b/frontend/app/src/shared/components/aria/menu.tsx
@@ -75,7 +75,7 @@ export const MenuItem = ({ children, className, ...props }: MenuItemProps) => {
           <div
             className={classNames(
               "flex w-full min-w-40 items-center gap-2 rounded-lg bg-white px-2 py-1",
-              "border border-white shadow-sm will-change-transform",
+              "border border-white shadow-xs will-change-transform",
               isFocused && "border-stone-200 shadow-none",
               isPressed && "translate-y-0.75 duration-100"
             )}

--- a/frontend/app/src/shared/components/aria/popover.tsx
+++ b/frontend/app/src/shared/components/aria/popover.tsx
@@ -11,22 +11,25 @@ import { classNames } from "@/shared/utils/common";
 
 export const PopoverTrigger = AriaDialogTrigger;
 
-export type PopoverProps = AriaPopoverProps;
-export const Popover = ({ className, offset = 4, ...props }: PopoverProps) => (
-  <AriaPopover
-    offset={offset}
-    className={composeRenderProps(className, (className) =>
-      classNames(
-        "z-50 rounded-xl border border-neutral-200 bg-white shadow-md outline-hidden",
-        "data-entering:fade-in-0 data-entering:zoom-in-95 data-entering:animate-in",
-        "data-exiting:fade-out-0 data-exiting:zoom-out-95 data-exiting:animate-out",
-        "data-[placement=bottom]:slide-in-from-top-2 data-[placement=left]:slide-in-from-right-2 data-[placement=right]:slide-in-from-left-2 data-[placement=top]:slide-in-from-bottom-2",
-        className
-      )
-    )}
-    {...props}
-  />
-);
+export interface PopoverProps extends AriaPopoverProps {}
+
+export function Popover({ className, offset = 4, ...props }: PopoverProps) {
+  return (
+    <AriaPopover
+      offset={offset}
+      className={composeRenderProps(className, (className) =>
+        classNames(
+          "z-50 rounded-xl border border-neutral-200 bg-white shadow-md outline-hidden",
+          "data-entering:fade-in-0 data-entering:zoom-in-95 data-entering:animate-in",
+          "data-exiting:fade-out-0 data-exiting:zoom-out-95 data-exiting:animate-out",
+          "data-[placement=bottom]:slide-in-from-top-2 data-[placement=left]:slide-in-from-right-2 data-[placement=right]:slide-in-from-left-2 data-[placement=top]:slide-in-from-bottom-2",
+          className
+        )
+      )}
+      {...props}
+    />
+  );
+}
 
 export function PopoverDialog({ className, ...props }: AriaDialogProps) {
   return <AriaDialog className={classNames("outline-hidden", className)} {...props} />;

--- a/frontend/app/tailwind.config.js
+++ b/frontend/app/tailwind.config.js
@@ -30,6 +30,10 @@ export default {
         "custom-black": "#000000",
         "custom-white": "#FFFFFF",
       },
+      backgroundImage: {
+        "button-edge-gradient":
+          "linear-gradient(to left, oklch(87% 0 0) 0%, oklch(97% 0 0) 8%, oklch(97% 0 0) 92%, oklch(87% 0 0) 100%)",
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
<img width="836" height="328" alt="image" src="https://github.com/user-attachments/assets/ac40c71a-3f1d-441c-b7c0-c1031465e162" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Increased menu bottom spacing and added a no-scrollbar utility for cleaner scrolling.
  * Refined menu item focus/pressed visuals to an overlay + inner layer for clearer interaction feedback.
  * Added a new button-edge gradient utility for enhanced button styling.

* **Refactor**
  * Popover component declaration updated without changing runtime behavior or public usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->