### PR TITLE
New breadcrumb for Branch list and details page

### DIFF
--- a/changelog/+breadcrumb.added.md
+++ b/changelog/+breadcrumb.added.md
@@ -1,2 +1,3 @@
 New breadcrumb navigation:
+
 - Select and switch branches directly from the breadcrumb

--- a/changelog/+breadcrumb.added.md
+++ b/changelog/+breadcrumb.added.md
@@ -1,0 +1,2 @@
+New breadcrumb navigation:
+- Select and switch branches directly from the breadcrumb

--- a/frontend/app/src/app/router.tsx
+++ b/frontend/app/src/app/router.tsx
@@ -91,15 +91,6 @@ export const router = createBrowserRouter([
               },
               {
                 path: "/branches",
-                handle: {
-                  breadcrumb: () => {
-                    return {
-                      type: "link",
-                      label: "Branches",
-                      to: constructPath("/branches"),
-                    };
-                  },
-                },
                 children: [
                   {
                     index: true,
@@ -108,14 +99,6 @@ export const router = createBrowserRouter([
                   {
                     path: "*",
                     lazy: () => import("@/pages/branches/details"),
-                    handle: {
-                      breadcrumb: (match: UIMatch) => {
-                        return {
-                          type: "branch",
-                          value: match.params["*"],
-                        };
-                      },
-                    },
                   },
                 ],
               },

--- a/frontend/app/src/shared/components/aria/autocomplete.tsx
+++ b/frontend/app/src/shared/components/aria/autocomplete.tsx
@@ -1,0 +1,57 @@
+import { SearchIcon, XIcon } from "lucide-react";
+import {
+  Autocomplete as AriaAutocomplete,
+  type AutocompleteProps as AriaAutocompleteProps,
+  Button as AriaButton,
+  Input as AriaInput,
+  type InputProps as AriaInputProps,
+  SearchField as AriaSearchField,
+  type SearchFieldProps as AriaSearchFieldProps,
+} from "react-aria-components";
+
+import { classNames } from "@/shared/utils/common";
+
+export function Autocomplete({ children, ...props }: AriaAutocompleteProps) {
+  return (
+    <AriaAutocomplete {...props}>
+      <div className="max-h-[inherit] overflow-hidden">
+        <AutocompleteSearchField placeholder="Search..." />
+        {children}
+      </div>
+    </AriaAutocomplete>
+  );
+}
+
+export interface SearchInputProps extends AriaSearchFieldProps {
+  placeholder?: AriaInputProps["placeholder"];
+}
+
+export function AutocompleteSearchField({ className, placeholder, ...props }: SearchInputProps) {
+  return (
+    <AriaSearchField
+      className="group sticky flex items-center border-neutral-200 border-b px-2 text-sm"
+      aria-label="Search"
+      autoFocus
+      {...props}
+    >
+      <SearchIcon aria-hidden className="size-3.5 text-neutral-400" />
+      <AriaInput
+        className={classNames(
+          "min-w-0 flex-1 border-none px-2 py-1.5 outline-hidden placeholder:text-neutral-400 [&::-webkit-search-cancel-button]:hidden",
+          className
+        )}
+        placeholder={placeholder}
+      />
+      <AriaButton
+        className={classNames(
+          "inline-flex rounded-full p-1 opacity-70 transition-all",
+          "hover:bg-neutral-200 hover:opacity-100",
+          "data-disabled:pointer-events-none",
+          "group-data-empty:invisible"
+        )}
+      >
+        <XIcon aria-hidden className="size-3.5" />
+      </AriaButton>
+    </AriaSearchField>
+  );
+}

--- a/frontend/app/src/shared/components/aria/list-box.tsx
+++ b/frontend/app/src/shared/components/aria/list-box.tsx
@@ -1,0 +1,77 @@
+import { CheckIcon } from "lucide-react";
+import {
+  ListBox as AriaListBox,
+  ListBoxItem as AriaListBoxItem,
+  type ListBoxItemProps as AriaListBoxItemProps,
+  type ListBoxProps as AriaListBoxProps,
+  composeRenderProps,
+} from "react-aria-components";
+
+import { disabledStyle } from "@/shared/components/style-rac";
+import { classNames } from "@/shared/utils/common";
+
+export interface ListBoxProps<T> extends AriaListBoxProps<T> {
+  emptyMessage?: string;
+}
+
+export function ListBox<T extends object>({ className, emptyMessage, ...props }: ListBoxProps<T>) {
+  return (
+    <AriaListBox
+      shouldFocusOnHover
+      className={classNames("no-scrollbar max-h-[inherit] overflow-auto p-1 pb-1.5", className)}
+      renderEmptyState={
+        emptyMessage
+          ? () => <div className="px-2 py-1.5 text-neutral-600 text-sm">{emptyMessage}</div>
+          : undefined
+      }
+      {...props}
+    />
+  );
+}
+
+export function ListBoxItem<T extends object>({
+  children,
+  className,
+  textValue,
+  ...props
+}: AriaListBoxItemProps<T>) {
+  return (
+    <AriaListBoxItem
+      textValue={textValue || (typeof children === "string" ? children : undefined)}
+      className={classNames(
+        disabledStyle,
+        "relative flex cursor-pointer select-none outline-hidden"
+      )}
+      {...props}
+    >
+      {composeRenderProps(
+        children,
+        (children, { isFocused, isSelected, isPressed, selectionMode }) => (
+          <>
+            {isFocused && (
+              <span
+                className={classNames(
+                  "absolute inset-0 translate-y-0.75 rounded-lg border-stone-400 border-b bg-button-edge-gradient shadow-xs",
+                  isPressed && "shadow-none"
+                )}
+              />
+            )}
+
+            <div
+              className={classNames(
+                "flex w-full items-center gap-2 rounded-lg border border-transparent px-2 py-1 text-sm transition-transform duration-100 will-change-transform",
+                isFocused && "border-stone-300 bg-white",
+                isPressed && "translate-y-0.75",
+                selectionMode !== "none" && "pl-8",
+                className
+              )}
+            >
+              {isSelected && <CheckIcon className="absolute left-2 size-4" />}
+              {children}
+            </div>
+          </>
+        )
+      )}
+    </AriaListBoxItem>
+  );
+}

--- a/frontend/app/src/shared/components/aria/list-box.tsx
+++ b/frontend/app/src/shared/components/aria/list-box.tsx
@@ -18,7 +18,7 @@ export function ListBox<T extends object>({ className, emptyMessage, ...props }:
   return (
     <AriaListBox
       shouldFocusOnHover
-      className={classNames("no-scrollbar max-h-[inherit] overflow-auto p-1", className)}
+      className={classNames("no-scrollbar max-h-[inherit] overflow-auto", className)}
       renderEmptyState={
         emptyMessage
           ? () => <div className="px-2 py-1.5 text-neutral-600 text-sm">{emptyMessage}</div>

--- a/frontend/app/src/shared/components/aria/list-box.tsx
+++ b/frontend/app/src/shared/components/aria/list-box.tsx
@@ -4,7 +4,6 @@ import {
   ListBoxItem as AriaListBoxItem,
   type ListBoxItemProps as AriaListBoxItemProps,
   type ListBoxProps as AriaListBoxProps,
-  composeRenderProps,
 } from "react-aria-components";
 
 import { disabledStyle } from "@/shared/components/style-rac";
@@ -39,9 +38,7 @@ export function ListBoxItem<T extends object>({
   return (
     <AriaListBoxItem
       textValue={textValue || (typeof children === "string" ? children : undefined)}
-      className={composeRenderProps(className, (className) =>
-        classNames(disabledStyle, pushableItemContainerStyle, className)
-      )}
+      className={classNames(disabledStyle, pushableItemContainerStyle)}
       {...props}
     >
       {(renderProps) => (
@@ -49,7 +46,7 @@ export function ListBoxItem<T extends object>({
           variant="ghost"
           isElevated={renderProps.isFocused}
           isPressed={renderProps.isPressed}
-          className={classNames(renderProps.selectionMode !== "none" && "pl-8")}
+          className={classNames(renderProps.selectionMode !== "none" && "pl-8", className)}
         >
           {renderProps.isSelected && <CheckIcon className="absolute left-2 size-4" />}
           {typeof children === "function" ? children(renderProps) : children}

--- a/frontend/app/src/shared/components/aria/list-box.tsx
+++ b/frontend/app/src/shared/components/aria/list-box.tsx
@@ -46,7 +46,12 @@ export function ListBoxItem<T extends object>({
           variant="ghost"
           isElevated={renderProps.isFocused}
           isPressed={renderProps.isPressed}
-          className={classNames(renderProps.selectionMode !== "none" && "pl-8", className)}
+          className={classNames(
+            renderProps.selectionMode !== "none" && "pl-8",
+            typeof className === "function"
+              ? className({ ...renderProps, defaultClassName: undefined })
+              : className
+          )}
         >
           {renderProps.isSelected && <CheckIcon className="absolute left-2 size-4" />}
           {typeof children === "function" ? children(renderProps) : children}

--- a/frontend/app/src/shared/components/aria/list-box.tsx
+++ b/frontend/app/src/shared/components/aria/list-box.tsx
@@ -39,22 +39,21 @@ export function ListBoxItem<T extends object>({
   return (
     <AriaListBoxItem
       textValue={textValue || (typeof children === "string" ? children : undefined)}
-      className={classNames(disabledStyle, pushableItemContainerStyle)}
+      className={composeRenderProps(className, (className) =>
+        classNames(disabledStyle, pushableItemContainerStyle, className)
+      )}
       {...props}
     >
-      {composeRenderProps(
-        children,
-        (children, { isFocused, isSelected, isPressed, selectionMode }) => (
-          <PushableItem
-            variant="ghost"
-            isFocused={isFocused}
-            isPressed={isPressed}
-            className={classNames(selectionMode !== "none" && "pl-8", className)}
-          >
-            {isSelected && <CheckIcon className="absolute left-2 size-4" />}
-            {children}
-          </PushableItem>
-        )
+      {(renderProps) => (
+        <PushableItem
+          variant="ghost"
+          isElevated={renderProps.isFocused}
+          isPressed={renderProps.isPressed}
+          className={classNames(renderProps.selectionMode !== "none" && "pl-8")}
+        >
+          {renderProps.isSelected && <CheckIcon className="absolute left-2 size-4" />}
+          {typeof children === "function" ? children(renderProps) : children}
+        </PushableItem>
       )}
     </AriaListBoxItem>
   );

--- a/frontend/app/src/shared/components/aria/list-box.tsx
+++ b/frontend/app/src/shared/components/aria/list-box.tsx
@@ -8,6 +8,7 @@ import {
 } from "react-aria-components";
 
 import { disabledStyle } from "@/shared/components/style-rac";
+import { PushableItem, pushableItemContainerStyle } from "@/shared/components/ui/pushable-item";
 import { classNames } from "@/shared/utils/common";
 
 export interface ListBoxProps<T> extends AriaListBoxProps<T> {
@@ -38,38 +39,21 @@ export function ListBoxItem<T extends object>({
   return (
     <AriaListBoxItem
       textValue={textValue || (typeof children === "string" ? children : undefined)}
-      className={classNames(
-        disabledStyle,
-        "relative flex cursor-pointer select-none outline-hidden"
-      )}
+      className={classNames(disabledStyle, pushableItemContainerStyle)}
       {...props}
     >
       {composeRenderProps(
         children,
         (children, { isFocused, isSelected, isPressed, selectionMode }) => (
-          <>
-            {isFocused && (
-              <span
-                className={classNames(
-                  "absolute inset-0 translate-y-0.75 rounded-lg border-stone-400 border-b bg-button-edge-gradient shadow-xs",
-                  isPressed && "shadow-none"
-                )}
-              />
-            )}
-
-            <div
-              className={classNames(
-                "flex w-full items-center gap-2 rounded-lg border border-transparent px-2 py-1 text-sm transition-transform duration-100 will-change-transform",
-                isFocused && "border-stone-300 bg-white",
-                isPressed && "translate-y-0.75",
-                selectionMode !== "none" && "pl-8",
-                className
-              )}
-            >
-              {isSelected && <CheckIcon className="absolute left-2 size-4" />}
-              {children}
-            </div>
-          </>
+          <PushableItem
+            variant="ghost"
+            isFocused={isFocused}
+            isPressed={isPressed}
+            className={classNames(selectionMode !== "none" && "pl-8", className)}
+          >
+            {isSelected && <CheckIcon className="absolute left-2 size-4" />}
+            {children}
+          </PushableItem>
         )
       )}
     </AriaListBoxItem>

--- a/frontend/app/src/shared/components/aria/list-box.tsx
+++ b/frontend/app/src/shared/components/aria/list-box.tsx
@@ -19,7 +19,7 @@ export function ListBox<T extends object>({ className, emptyMessage, ...props }:
   return (
     <AriaListBox
       shouldFocusOnHover
-      className={classNames("no-scrollbar max-h-[inherit] overflow-auto p-1 pb-1.5", className)}
+      className={classNames("no-scrollbar max-h-[inherit] overflow-auto p-1", className)}
       renderEmptyState={
         emptyMessage
           ? () => <div className="px-2 py-1.5 text-neutral-600 text-sm">{emptyMessage}</div>

--- a/frontend/app/src/shared/components/aria/menu.tsx
+++ b/frontend/app/src/shared/components/aria/menu.tsx
@@ -53,14 +53,16 @@ export const MenuItem = ({ children, className, textValue, ...props }: MenuItemP
   return (
     <AriaMenuItem
       textValue={textValue ?? (typeof children === "string" ? children : undefined)}
-      className={classNames(disabledStyle, pushableItemContainerStyle)}
+      className={composeRenderProps(className, (className) =>
+        classNames(disabledStyle, pushableItemContainerStyle, className)
+      )}
       {...props}
     >
-      {composeRenderProps(children, (children, { isFocused, isPressed }) => (
-        <PushableItem isFocused={isFocused} isPressed={isPressed} className={classNames(className)}>
-          {children}
+      {(renderProps) => (
+        <PushableItem isElevated={renderProps.isFocused} isPressed={renderProps.isPressed}>
+          {typeof children === "function" ? children(renderProps) : children}
         </PushableItem>
-      ))}
+      )}
     </AriaMenuItem>
   );
 };

--- a/frontend/app/src/shared/components/aria/menu.tsx
+++ b/frontend/app/src/shared/components/aria/menu.tsx
@@ -38,7 +38,7 @@ export const Menu = <T extends object>({ className, ...props }: MenuProps<T>) =>
   return (
     <AriaMenu
       className={classNames(
-        "no-scrollbar max-h-[inherit] overflow-auto p-1 pb-1.5 outline-hidden",
+        "no-scrollbar max-h-[inherit] overflow-auto p-1 outline-hidden",
         "space-y-0.75 *:[[role='group']:not(:last-child)]:mb-2",
         className
       )}

--- a/frontend/app/src/shared/components/aria/menu.tsx
+++ b/frontend/app/src/shared/components/aria/menu.tsx
@@ -15,6 +15,7 @@ import {
 
 import { Popover } from "@/shared/components/aria/popover";
 import { disabledStyle } from "@/shared/components/style-rac";
+import { PushableItem, pushableItemContainerStyle } from "@/shared/components/ui/pushable-item";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 import { classNames } from "@/shared/utils/common";
 
@@ -52,34 +53,13 @@ export const MenuItem = ({ children, className, textValue, ...props }: MenuItemP
   return (
     <AriaMenuItem
       textValue={textValue ?? (typeof children === "string" ? children : undefined)}
-      className={classNames(
-        disabledStyle,
-        "relative flex cursor-pointer select-none outline-hidden"
-      )}
+      className={classNames(disabledStyle, pushableItemContainerStyle)}
       {...props}
     >
       {composeRenderProps(children, (children, { isFocused, isPressed }) => (
-        <>
-          {isFocused && (
-            <span
-              className={classNames(
-                "absolute inset-0 translate-y-0.75 rounded-lg border-stone-400 border-b bg-button-edge-gradient shadow-xs",
-                isPressed && "shadow-none"
-              )}
-            />
-          )}
-
-          <div
-            className={classNames(
-              "flex w-full min-w-40 items-center gap-2 rounded-lg border border-white bg-white px-2 py-1 text-sm text-stone-600 shadow-xs transition-transform duration-100 will-change-transform",
-              isFocused && "border-stone-300 shadow-none",
-              isPressed && "translate-y-0.75",
-              className
-            )}
-          >
-            {children}
-          </div>
-        </>
+        <PushableItem isFocused={isFocused} isPressed={isPressed} className={classNames(className)}>
+          {children}
+        </PushableItem>
       ))}
     </AriaMenuItem>
   );

--- a/frontend/app/src/shared/components/aria/menu.tsx
+++ b/frontend/app/src/shared/components/aria/menu.tsx
@@ -39,7 +39,7 @@ export const Menu = <T extends object>({ className, ...props }: MenuProps<T>) =>
     <AriaMenu
       className={classNames(
         "no-scrollbar max-h-[inherit] overflow-auto p-1 outline-hidden",
-        "space-y-0.75 *:[[role='group']:not(:last-child)]:mb-2",
+        "space-y-0.5 *:[[role='group']:not(:last-child)]:mb-2",
         className
       )}
       {...props}
@@ -47,19 +47,23 @@ export const Menu = <T extends object>({ className, ...props }: MenuProps<T>) =>
   );
 };
 
-export interface MenuItemProps extends AriaMenuItemProps {}
+export interface MenuItemProps extends AriaMenuItemProps {
+  className?: string;
+}
 
 export const MenuItem = ({ children, className, textValue, ...props }: MenuItemProps) => {
   return (
     <AriaMenuItem
       textValue={textValue ?? (typeof children === "string" ? children : undefined)}
-      className={composeRenderProps(className, (className) =>
-        classNames(disabledStyle, pushableItemContainerStyle, className)
-      )}
+      className={classNames(disabledStyle, pushableItemContainerStyle)}
       {...props}
     >
       {(renderProps) => (
-        <PushableItem isElevated={renderProps.isFocused} isPressed={renderProps.isPressed}>
+        <PushableItem
+          isElevated={renderProps.isFocused}
+          isPressed={renderProps.isPressed}
+          className={className}
+        >
           {typeof children === "function" ? children(renderProps) : children}
         </PushableItem>
       )}
@@ -77,7 +81,7 @@ export const MenuSection = <T extends object>({
   ...props
 }: MenuSectionProps<T>) => {
   return (
-    <AriaMenuSection className={classNames("flex flex-col gap-0.75", className)} {...props}>
+    <AriaMenuSection className={classNames("flex flex-col gap-0.5", className)} {...props}>
       {title && <AriaHeader className="px-1 text-stone-500 text-xs">{title}</AriaHeader>}
       <Collection items={props.items}>{children}</Collection>
     </AriaMenuSection>

--- a/frontend/app/src/shared/components/aria/menu.tsx
+++ b/frontend/app/src/shared/components/aria/menu.tsx
@@ -47,9 +47,7 @@ export const Menu = <T extends object>({ className, ...props }: MenuProps<T>) =>
   );
 };
 
-export interface MenuItemProps extends AriaMenuItemProps {
-  className?: string;
-}
+export interface MenuItemProps extends AriaMenuItemProps {}
 
 export const MenuItem = ({ children, className, textValue, ...props }: MenuItemProps) => {
   return (
@@ -62,7 +60,11 @@ export const MenuItem = ({ children, className, textValue, ...props }: MenuItemP
         <PushableItem
           isElevated={renderProps.isFocused}
           isPressed={renderProps.isPressed}
-          className={className}
+          className={
+            typeof className === "function"
+              ? className({ ...renderProps, defaultClassName: undefined })
+              : className
+          }
         >
           {typeof children === "function" ? children(renderProps) : children}
         </PushableItem>

--- a/frontend/app/src/shared/components/aria/menu.tsx
+++ b/frontend/app/src/shared/components/aria/menu.tsx
@@ -38,7 +38,7 @@ export const Menu = <T extends object>({ className, ...props }: MenuProps<T>) =>
     <AriaMenu
       className={classNames(
         "no-scrollbar max-h-[inherit] overflow-auto p-1 pb-1.5 outline-hidden",
-        "space-y-0.5 *:[[role='group']:not(:last-child)]:mb-2",
+        "space-y-0.75 *:[[role='group']:not(:last-child)]:mb-2",
         className
       )}
       {...props}
@@ -95,7 +95,7 @@ export const MenuSection = <T extends object>({
   ...props
 }: MenuSectionProps<T>) => {
   return (
-    <AriaMenuSection className={classNames("flex flex-col gap-0.5", className)} {...props}>
+    <AriaMenuSection className={classNames("flex flex-col gap-0.75", className)} {...props}>
       {title && <AriaHeader className="px-1 text-stone-500 text-xs">{title}</AriaHeader>}
       <Collection items={props.items}>{children}</Collection>
     </AriaMenuSection>

--- a/frontend/app/src/shared/components/aria/popover.tsx
+++ b/frontend/app/src/shared/components/aria/popover.tsx
@@ -19,7 +19,7 @@ export function Popover({ className, offset = 4, ...props }: PopoverProps) {
       offset={offset}
       className={composeRenderProps(className, (className) =>
         classNames(
-          "z-50 rounded-xl border border-neutral-200 bg-white shadow-md outline-hidden",
+          "z-50 rounded-xl border border-neutral-200 bg-white shadow-md outline-hidden duration-50",
           "data-entering:fade-in-0 data-entering:zoom-in-95 data-entering:animate-in",
           "data-exiting:fade-out-0 data-exiting:zoom-out-95 data-exiting:animate-out",
           "data-[placement=bottom]:slide-in-from-top-2 data-[placement=left]:slide-in-from-right-2 data-[placement=right]:slide-in-from-left-2 data-[placement=top]:slide-in-from-bottom-2",

--- a/frontend/app/src/shared/components/layout/breadcrumb-navigation/breadcrumb-branches.tsx
+++ b/frontend/app/src/shared/components/layout/breadcrumb-navigation/breadcrumb-branches.tsx
@@ -9,6 +9,7 @@ export function BreadcrumbBranches() {
 
   return (
     <Breadcrumb data-testid="breadcrumb-branches">
+      <BreadcrumbSeparator />
       <BreadcrumbItem href={constructPath("/branches")}>Branches</BreadcrumbItem>
       {branchName && (
         <>

--- a/frontend/app/src/shared/components/layout/breadcrumb-navigation/breadcrumb-branches.tsx
+++ b/frontend/app/src/shared/components/layout/breadcrumb-navigation/breadcrumb-branches.tsx
@@ -1,0 +1,21 @@
+import { useParams } from "react-router";
+
+import { constructPath } from "@/shared/api/rest/fetch";
+import BreadcrumbBranchSelector from "@/shared/components/layout/breadcrumb-navigation/items/breadcrumb-branch-selector";
+import { Breadcrumb, BreadcrumbItem, BreadcrumbSeparator } from "@/shared/components/ui/breadcrumb";
+
+export function BreadcrumbBranches() {
+  const { "*": branchName } = useParams();
+
+  return (
+    <Breadcrumb data-testid="breadcrumb-branches">
+      <BreadcrumbItem href={constructPath("branches")}>Branches</BreadcrumbItem>
+      {branchName && (
+        <>
+          <BreadcrumbSeparator />
+          <BreadcrumbBranchSelector currentBranchName={branchName} />
+        </>
+      )}
+    </Breadcrumb>
+  );
+}

--- a/frontend/app/src/shared/components/layout/breadcrumb-navigation/breadcrumb-branches.tsx
+++ b/frontend/app/src/shared/components/layout/breadcrumb-navigation/breadcrumb-branches.tsx
@@ -9,7 +9,7 @@ export function BreadcrumbBranches() {
 
   return (
     <Breadcrumb data-testid="breadcrumb-branches">
-      <BreadcrumbItem href={constructPath("branches")}>Branches</BreadcrumbItem>
+      <BreadcrumbItem href={constructPath("/branches")}>Branches</BreadcrumbItem>
       {branchName && (
         <>
           <BreadcrumbSeparator />

--- a/frontend/app/src/shared/components/layout/breadcrumb-navigation/breadcrumb-navigation.tsx
+++ b/frontend/app/src/shared/components/layout/breadcrumb-navigation/breadcrumb-navigation.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { type UIMatch, useMatches } from "react-router";
+import { matchPath, type UIMatch, useLocation, useMatches } from "react-router";
 
+import { BreadcrumbBranches } from "@/shared/components/layout/breadcrumb-navigation/breadcrumb-branches";
 import {
   BreadcrumbDynamicElement,
   type BreadcrumbDynamicElementProps,
@@ -10,10 +11,15 @@ import { Breadcrumb, BreadcrumbSeparator } from "@/shared/components/ui/breadcru
 import { classNames } from "@/shared/utils/common";
 
 export default function BreadcrumbNavigation() {
+  const { pathname } = useLocation();
   const matches = useMatches() as UIMatch<
     unknown,
     { breadcrumb?: (match: UIMatch) => BreadcrumbDynamicElementProps }
   >[];
+
+  if (matchPath({ path: "/branches", end: false }, pathname)) {
+    return <BreadcrumbBranches />;
+  }
 
   const crumbs = matches
     .map((match) => match.handle?.breadcrumb?.(match))

--- a/frontend/app/src/shared/components/layout/breadcrumb-navigation/items/breadcrumb-branch-selector.tsx
+++ b/frontend/app/src/shared/components/layout/breadcrumb-navigation/items/breadcrumb-branch-selector.tsx
@@ -35,7 +35,7 @@ export default function BreadcrumbBranchSelector({
               <ListBox
                 items={branches}
                 emptyMessage="No branches found."
-                className="space-y-0"
+                className="p-1"
                 onAction={close}
               >
                 {(branch) => (

--- a/frontend/app/src/shared/components/layout/breadcrumb-navigation/items/breadcrumb-branch-selector.tsx
+++ b/frontend/app/src/shared/components/layout/breadcrumb-navigation/items/breadcrumb-branch-selector.tsx
@@ -1,65 +1,56 @@
-import { useAtomValue } from "jotai";
-import { useEffect, useState } from "react";
-import { Link, useNavigate } from "react-router";
+import { Icon } from "@iconify-icon/react";
+import { ChevronsUpDownIcon } from "lucide-react";
+import { useFilter } from "react-aria-components";
 
-import { queryClient } from "@/shared/api/rest/client";
 import { constructPath } from "@/shared/api/rest/fetch";
-import { breadcrumbItemStyle } from "@/shared/components/layout/breadcrumb-navigation/style";
-import {
-  Combobox,
-  ComboboxContent,
-  ComboboxList,
-  ComboboxTrigger,
-} from "@/shared/components/ui/combobox";
-import { CommandEmpty, CommandItem } from "@/shared/components/ui/command";
-import { classNames } from "@/shared/utils/common";
+import { Autocomplete } from "@/shared/components/aria/autocomplete";
+import { ListBox, ListBoxItem } from "@/shared/components/aria/list-box";
+import { Popover, PopoverDialog, PopoverTrigger } from "@/shared/components/aria/popover";
+import { BreadcrumbItem } from "@/shared/components/ui/breadcrumb";
 
-import { getBranchesQueryOptions } from "@/entities/branches/domain/get-branches.query";
-import { branchesState } from "@/entities/branches/stores";
+import { useGetBranches } from "@/entities/branches/domain/get-branches.query";
+
+interface BreadcrumbBranchSelectorProps {
+  currentBranchName: string;
+}
 
 export default function BreadcrumbBranchSelector({
-  value,
-  className,
+  currentBranchName,
   ...props
-}: {
-  value: string;
-  className?: string;
-}) {
-  const branches = useAtomValue(branchesState);
-  const navigate = useNavigate();
-  const [isOpen, setIsOpen] = useState(false);
-
-  useEffect(() => {
-    if (isOpen) queryClient.invalidateQueries(getBranchesQueryOptions());
-  }, [isOpen]);
+}: BreadcrumbBranchSelectorProps) {
+  const { data: branches } = useGetBranches();
+  let { contains } = useFilter({ sensitivity: "base" });
 
   return (
-    <Combobox open={isOpen} onOpenChange={setIsOpen}>
-      <ComboboxTrigger className={classNames(breadcrumbItemStyle, className)} {...props}>
-        {value}
-      </ComboboxTrigger>
+    <PopoverTrigger>
+      <BreadcrumbItem {...props}>
+        <span className="truncate">{currentBranchName}</span>
+        <ChevronsUpDownIcon className="ml-2 size-4" />
+      </BreadcrumbItem>
 
-      <ComboboxContent align="start" fitTriggerWidth={false}>
-        <ComboboxList>
-          <CommandEmpty>No branch found.</CommandEmpty>
-          {branches.map((branch) => {
-            const branchUrl = constructPath(`/branches/${branch.name}`);
-            return (
-              <CommandItem
-                key={branch.name}
-                value={branch.name}
-                onSelect={() => {
-                  setIsOpen(false);
-                  navigate(branchUrl);
-                }}
-                asChild
+      <Popover className="bg-stone-100/50 backdrop-blur">
+        <PopoverDialog aria-label="Branch selector">
+          {({ close }) => (
+            <Autocomplete filter={contains}>
+              <ListBox
+                items={branches}
+                emptyMessage="No branches found."
+                className="space-y-0"
+                onAction={close}
               >
-                <Link to={branchUrl}>{branch.name}</Link>
-              </CommandItem>
-            );
-          })}
-        </ComboboxList>
-      </ComboboxContent>
-    </Combobox>
+                {(branch) => (
+                  <ListBoxItem
+                    textValue={branch.name}
+                    href={constructPath(`/branches/${branch.name}`)}
+                  >
+                    <Icon icon="mdi:source-branch" /> {branch.name}
+                  </ListBoxItem>
+                )}
+              </ListBox>
+            </Autocomplete>
+          )}
+        </PopoverDialog>
+      </Popover>
+    </PopoverTrigger>
   );
 }

--- a/frontend/app/src/shared/components/layout/breadcrumb-navigation/items/breadcrumb-branch-selector.tsx
+++ b/frontend/app/src/shared/components/layout/breadcrumb-navigation/items/breadcrumb-branch-selector.tsx
@@ -18,8 +18,8 @@ export default function BreadcrumbBranchSelector({
   currentBranchName,
   ...props
 }: BreadcrumbBranchSelectorProps) {
-  const { data: branches } = useGetBranches();
-  let { contains } = useFilter({ sensitivity: "base" });
+  const { data: branches = [] } = useGetBranches();
+  const { contains } = useFilter({ sensitivity: "base" });
 
   return (
     <PopoverTrigger>

--- a/frontend/app/src/shared/components/layout/breadcrumb-navigation/items/breadcrumb-dynamic-element.tsx
+++ b/frontend/app/src/shared/components/layout/breadcrumb-navigation/items/breadcrumb-dynamic-element.tsx
@@ -1,4 +1,3 @@
-import BreadcrumbBranchSelector from "@/shared/components/layout/breadcrumb-navigation/items/breadcrumb-branch-selector";
 import { BreadcrumbLink } from "@/shared/components/layout/breadcrumb-navigation/items/breadcrumb-link";
 import BreadcrumbObjectSelector from "@/shared/components/layout/breadcrumb-navigation/items/breadcrumb-object-selector";
 import BreadcrumbSchemaSelector from "@/shared/components/layout/breadcrumb-navigation/items/breadcrumb-schema-selector";
@@ -30,10 +29,6 @@ export const BreadcrumbDynamicElement = ({ ...props }: BreadcrumbDynamicElementP
     const { value, ...otherProps } = props;
 
     return <BreadcrumbObjectIdDisplay id={value} {...otherProps} />;
-  }
-
-  if (props.type === "branch") {
-    return <BreadcrumbBranchSelector {...props} />;
   }
 
   warnUnexpectedType(props);

--- a/frontend/app/src/shared/components/layout/breadcrumb-navigation/type.ts
+++ b/frontend/app/src/shared/components/layout/breadcrumb-navigation/type.ts
@@ -1,5 +1,4 @@
 export type BreadcrumbItem =
   | { type: "select"; value: string; kind: string }
   | { type: "link"; label: string; to: string }
-  | { type: "branch"; value: string }
   | { type: "id"; value: string; link: string };

--- a/frontend/app/src/shared/components/menu/object-details-button.tsx
+++ b/frontend/app/src/shared/components/menu/object-details-button.tsx
@@ -50,6 +50,26 @@ export const ObjectDetailsButton = ({
         <Menu>
           <MenuSection title="Actions">
             <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
+            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
+            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
+            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
+            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
+            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
+            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
+            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
+            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
+            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
+            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
+            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
+            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
+            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
+            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
+            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
+            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
+            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
+            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
+            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
+            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
 
             {hfid && hfid !== "null" && (
               <CopyToClipboardMenuItem textToCopy={hfid}>Copy HFID</CopyToClipboardMenuItem>

--- a/frontend/app/src/shared/components/menu/object-details-button.tsx
+++ b/frontend/app/src/shared/components/menu/object-details-button.tsx
@@ -50,26 +50,6 @@ export const ObjectDetailsButton = ({
         <Menu>
           <MenuSection title="Actions">
             <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
-            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
-            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
-            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
-            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
-            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
-            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
-            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
-            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
-            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
-            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
-            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
-            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
-            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
-            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
-            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
-            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
-            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
-            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
-            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
-            <CopyToClipboardMenuItem textToCopy={id}>Copy ID</CopyToClipboardMenuItem>
 
             {hfid && hfid !== "null" && (
               <CopyToClipboardMenuItem textToCopy={hfid}>Copy HFID</CopyToClipboardMenuItem>

--- a/frontend/app/src/shared/components/ui/breadcrumb.tsx
+++ b/frontend/app/src/shared/components/ui/breadcrumb.tsx
@@ -1,4 +1,3 @@
-import { Icon } from "@iconify-icon/react";
 import { cva } from "class-variance-authority";
 import type React from "react";
 import { Button, type ButtonProps, Link, type LinkProps } from "react-aria-components";
@@ -6,36 +5,33 @@ import { Button, type ButtonProps, Link, type LinkProps } from "react-aria-compo
 import { focusVisibleStyle } from "@/shared/components/style-rac";
 import { classNames } from "@/shared/utils/common";
 
-export function Breadcrumb({ className, ...props }: React.OlHTMLAttributes<HTMLOListElement>) {
-  return <ol className={classNames("flex items-center text-sm", className)} {...props} />;
+export function Breadcrumb({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={classNames("flex items-center text-sm", className)} {...props} />;
 }
 
 export function BreadcrumbSeparator({
   children,
   className,
   ...props
-}: React.LiHTMLAttributes<HTMLLIElement>) {
+}: React.HTMLAttributes<HTMLDivElement>) {
   return (
-    <li
+    <div
       role="presentation"
       aria-hidden="true"
-      className={classNames("inline-flex", className)}
+      className={classNames("select-none font-medium text-lg text-neutral-300", className)}
       {...props}
     >
-      {children ?? <Icon icon="mdi:slash-forward" className="text-gray-400 text-xl" />}
-    </li>
+      {children ?? "/"}
+    </div>
   );
 }
 const breadcrumbItemStyle = cva(
   [
     focusVisibleStyle,
-    "inline-flex items-center truncate rounded-lg border border-transparent px-2 py-1 text-stone-800",
+    "inline-flex items-center truncate rounded-lg border border-transparent px-2 py-0.5 text-stone-800",
   ],
   {
     variants: {
-      isHovered: {
-        true: "bg-stone-100",
-      },
       isPressed: {
         true: "bg-stone-100",
       },
@@ -49,7 +45,9 @@ export function BreadcrumbItem({ className, ...props }: BreadcrumbItemProps) {
   if ("href" in props) {
     return (
       <Link
-        className={(stylingProps) => classNames(breadcrumbItemStyle(stylingProps), className)}
+        className={(stylingProps) =>
+          classNames(breadcrumbItemStyle(stylingProps), "hover:underline", className)
+        }
         {...props}
       />
     );

--- a/frontend/app/src/shared/components/ui/breadcrumb.tsx
+++ b/frontend/app/src/shared/components/ui/breadcrumb.tsx
@@ -1,6 +1,9 @@
 import { Icon } from "@iconify-icon/react";
-import React from "react";
+import { cva } from "class-variance-authority";
+import type React from "react";
+import { Button, type ButtonProps, Link, type LinkProps } from "react-aria-components";
 
+import { focusVisibleStyle } from "@/shared/components/style-rac";
 import { classNames } from "@/shared/utils/common";
 
 export function Breadcrumb({ className, ...props }: React.OlHTMLAttributes<HTMLOListElement>) {
@@ -23,13 +26,39 @@ export function BreadcrumbSeparator({
     </li>
   );
 }
+const breadcrumbItemStyle = cva(
+  [
+    focusVisibleStyle,
+    "inline-flex items-center truncate rounded-lg border border-transparent px-2 py-1 text-neutral-800",
+  ],
+  {
+    variants: {
+      isPressed: {
+        true: "bg-stone-100",
+      },
+      isHovered: {
+        true: "bg-stone-100",
+      },
+    },
+  }
+);
 
-export const BreadcrumbItem = React.forwardRef<HTMLLIElement, React.ComponentPropsWithoutRef<"li">>(
-  ({ className, ...props }, ref) => (
-    <li
-      ref={ref}
-      className={classNames("inline-flex items-center gap-1.5", className)}
+type BreadcrumbItemProps = ButtonProps | (LinkProps & { href: LinkProps["href"] });
+
+export function BreadcrumbItem({ className, ...props }: BreadcrumbItemProps) {
+  if ("href" in props) {
+    return (
+      <Link
+        className={(stylingProps) => classNames(breadcrumbItemStyle(stylingProps), className)}
+        {...props}
+      />
+    );
+  }
+
+  return (
+    <Button
+      className={(stylingProps) => classNames(breadcrumbItemStyle(stylingProps), className)}
       {...props}
     />
-  )
-);
+  );
+}

--- a/frontend/app/src/shared/components/ui/breadcrumb.tsx
+++ b/frontend/app/src/shared/components/ui/breadcrumb.tsx
@@ -29,14 +29,14 @@ export function BreadcrumbSeparator({
 const breadcrumbItemStyle = cva(
   [
     focusVisibleStyle,
-    "inline-flex items-center truncate rounded-lg border border-transparent px-2 py-1 text-neutral-800",
+    "inline-flex items-center truncate rounded-lg border border-transparent px-2 py-1 text-stone-800",
   ],
   {
     variants: {
-      isPressed: {
+      isHovered: {
         true: "bg-stone-100",
       },
-      isHovered: {
+      isPressed: {
         true: "bg-stone-100",
       },
     },

--- a/frontend/app/src/shared/components/ui/pushable-item.tsx
+++ b/frontend/app/src/shared/components/ui/pushable-item.tsx
@@ -12,6 +12,7 @@ interface PushableItemEdgeProps {
 export function PushableItemEdge({ isPressed }: PushableItemEdgeProps) {
   return (
     <span
+      aria-hidden="true"
       className={classNames(
         "absolute inset-0 rounded-lg border-stone-400 border-b bg-pushable-edge-gradient shadow-xs",
         isPressed && "shadow-none"

--- a/frontend/app/src/shared/components/ui/pushable-item.tsx
+++ b/frontend/app/src/shared/components/ui/pushable-item.tsx
@@ -12,7 +12,7 @@ export function PushableItemEdge({ isPressed }: PushableItemEdgeProps) {
   return (
     <span
       className={classNames(
-        "absolute inset-0 translate-y-0.75 rounded-lg border-stone-400 border-b bg-pushable-edge-gradient shadow-xs",
+        "absolute inset-0 rounded-lg border-stone-400 border-b bg-pushable-edge-gradient shadow-xs",
         isPressed && "shadow-none"
       )}
     />
@@ -20,7 +20,7 @@ export function PushableItemEdge({ isPressed }: PushableItemEdgeProps) {
 }
 
 const pushableItemStyles = cva(
-  "flex w-full min-w-40 items-center gap-2 rounded-lg border px-2 py-1 text-sm text-stone-600 transition-transform duration-100 will-change-transform",
+  "flex w-full min-w-40 items-center gap-2 rounded-lg border px-2 py-1 text-sm text-stone-600 transition-transform will-change-transform",
   {
     variants: {
       variant: {
@@ -28,10 +28,10 @@ const pushableItemStyles = cva(
         ghost: "border-transparent bg-transparent text-stone-800",
       },
       isFocused: {
-        true: "border-stone-300 shadow-none",
+        true: "-translate-y-0.75 border-stone-300 shadow-none duration-150 ease-in-out",
       },
       isPressed: {
-        true: "translate-y-0.75",
+        true: "translate-y-0 duration-80 ease-out",
       },
     },
     compoundVariants: [{ variant: "ghost", isFocused: true, class: "bg-white" }],

--- a/frontend/app/src/shared/components/ui/pushable-item.tsx
+++ b/frontend/app/src/shared/components/ui/pushable-item.tsx
@@ -1,0 +1,65 @@
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { classNames } from "@/shared/utils/common";
+
+export const pushableItemContainerStyle = "relative flex cursor-pointer select-none outline-hidden";
+
+interface PushableItemEdgeProps {
+  isPressed: boolean;
+}
+
+export function PushableItemEdge({ isPressed }: PushableItemEdgeProps) {
+  return (
+    <span
+      className={classNames(
+        "absolute inset-0 translate-y-0.75 rounded-lg border-stone-400 border-b bg-button-edge-gradient shadow-xs",
+        isPressed && "shadow-none"
+      )}
+    />
+  );
+}
+
+const pushableItemStyles = cva(
+  "flex w-full min-w-40 items-center gap-2 rounded-lg border px-2 py-1 text-sm text-stone-600 transition-transform duration-100 will-change-transform",
+  {
+    variants: {
+      variant: {
+        default: "border-white bg-white shadow-xs",
+        ghost: "border-transparent bg-transparent text-stone-800",
+      },
+      isFocused: {
+        true: "border-stone-300 shadow-none",
+      },
+      isPressed: {
+        true: "translate-y-0.75",
+      },
+    },
+    compoundVariants: [{ variant: "ghost", isFocused: true, class: "bg-white" }],
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+interface PushableItemProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof pushableItemStyles> {}
+
+export function PushableItem({
+  variant,
+  isFocused,
+  isPressed,
+  className,
+  ...props
+}: PushableItemProps) {
+  return (
+    <>
+      {isFocused && <PushableItemEdge isPressed={!!isPressed} />}
+
+      <div
+        className={classNames(pushableItemStyles({ variant, isFocused, isPressed }), className)}
+        {...props}
+      />
+    </>
+  );
+}

--- a/frontend/app/src/shared/components/ui/pushable-item.tsx
+++ b/frontend/app/src/shared/components/ui/pushable-item.tsx
@@ -20,21 +20,21 @@ export function PushableItemEdge({ isPressed }: PushableItemEdgeProps) {
 }
 
 const pushableItemStyles = cva(
-  "flex w-full min-w-40 items-center gap-2 rounded-lg border px-2 py-1 text-sm text-stone-600 transition-transform will-change-transform",
+  "flex w-full min-w-40 items-center gap-2 rounded-lg border px-2 py-1 text-sm text-stone-700 transition-transform will-change-transform",
   {
     variants: {
       variant: {
         default: "border-white bg-white shadow-xs",
-        ghost: "border-transparent bg-transparent text-stone-800",
+        ghost: "border-transparent bg-transparent",
       },
-      isFocused: {
+      isElevated: {
         true: "-translate-y-0.75 border-stone-200 shadow-none duration-150 ease-in-out",
       },
       isPressed: {
         true: "translate-y-0 duration-80 ease-out",
       },
     },
-    compoundVariants: [{ variant: "ghost", isFocused: true, class: "bg-white" }],
+    compoundVariants: [{ variant: "ghost", isElevated: true, class: "bg-white" }],
     defaultVariants: {
       variant: "default",
     },
@@ -47,17 +47,17 @@ interface PushableItemProps
 
 export function PushableItem({
   variant,
-  isFocused,
+  isElevated,
   isPressed,
   className,
   ...props
 }: PushableItemProps) {
   return (
     <>
-      {isFocused && <PushableItemEdge isPressed={!!isPressed} />}
+      {isElevated && <PushableItemEdge isPressed={!!isPressed} />}
 
       <div
-        className={classNames(pushableItemStyles({ variant, isFocused, isPressed }), className)}
+        className={classNames(pushableItemStyles({ variant, isElevated, isPressed }), className)}
         {...props}
       />
     </>

--- a/frontend/app/src/shared/components/ui/pushable-item.tsx
+++ b/frontend/app/src/shared/components/ui/pushable-item.tsx
@@ -28,7 +28,7 @@ const pushableItemStyles = cva(
         ghost: "border-transparent bg-transparent text-stone-800",
       },
       isFocused: {
-        true: "-translate-y-0.75 border-stone-300 shadow-none duration-150 ease-in-out",
+        true: "-translate-y-0.75 border-stone-200 shadow-none duration-150 ease-in-out",
       },
       isPressed: {
         true: "translate-y-0 duration-80 ease-out",

--- a/frontend/app/src/shared/components/ui/pushable-item.tsx
+++ b/frontend/app/src/shared/components/ui/pushable-item.tsx
@@ -12,7 +12,7 @@ export function PushableItemEdge({ isPressed }: PushableItemEdgeProps) {
   return (
     <span
       className={classNames(
-        "absolute inset-0 translate-y-0.75 rounded-lg border-stone-400 border-b bg-button-edge-gradient shadow-xs",
+        "absolute inset-0 translate-y-0.75 rounded-lg border-stone-400 border-b bg-pushable-edge-gradient shadow-xs",
         isPressed && "shadow-none"
       )}
     />

--- a/frontend/app/src/shared/components/ui/pushable-item.tsx
+++ b/frontend/app/src/shared/components/ui/pushable-item.tsx
@@ -1,4 +1,5 @@
 import { cva, type VariantProps } from "class-variance-authority";
+import type React from "react";
 
 import { classNames } from "@/shared/utils/common";
 

--- a/frontend/app/tailwind.config.js
+++ b/frontend/app/tailwind.config.js
@@ -31,7 +31,7 @@ export default {
         "custom-white": "#FFFFFF",
       },
       backgroundImage: {
-        "button-edge-gradient":
+        "pushable-edge-gradient":
           "linear-gradient(to left, oklch(87% 0 0) 0%, oklch(97% 0 0) 8%, oklch(97% 0 0) 92%, oklch(87% 0 0) 100%)",
       },
     },


### PR DESCRIPTION
New component:
- list-box for options 
- Autocomplete for search and filtering
- New Breadcrumb Item

New UI:
- Breadcrumb for branches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Branch selection/switching directly from the breadcrumb
  * Accessible autocomplete with search + clear action
  * List component with empty-state messaging and selection indicators
  * New "pushable" UI item with focus/press visuals

* **Refactor**
  * Branch selector rebuilt as a popover-based autocomplete with listbox; routing-provided branch breadcrumbs removed
  * Breadcrumb rendering updated to use a branch-specific component; breadcrumb items now render as link or button
  * Menu items updated to use pushable visuals

* **Style**
  * Slight popover transition applied

* **Documentation**
  * Added changelog entry for breadcrumb feature
<!-- end of auto-generated comment: release notes by coderabbit.ai -->